### PR TITLE
feat(image-fallback): image_ask tool for text-only models

### DIFF
--- a/assistant/src/__tests__/image-ask-tool-surface.test.ts
+++ b/assistant/src/__tests__/image-ask-tool-surface.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The shipped `image_ask` surface, exercised through the real registration and
+ * gating path rather than the plugin's own mocks.
+ *
+ * The tool only earns its place if it is genuinely absent from a turn whose
+ * model can see images, so these tests register the default plugin's actual
+ * tool contribution into the real registry and run the host's own
+ * `isToolActiveForContext` over real catalog model ids.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test";
+
+import type { Conversation } from "../daemon/conversation.js";
+import { isToolActiveForContext } from "../daemon/conversation-tool-setup.js";
+import { defaultImageFallbackPlugin } from "../plugins/defaults/index.js";
+import {
+  getTool,
+  getToolOwner,
+  registerPluginTools,
+  unregisterPluginTools,
+} from "../tools/registry.js";
+import { RiskLevel } from "../tools/tool-types.js";
+
+/** A catalog model that can process image input, and one that cannot. */
+const VISION_MODEL = "claude-opus-5";
+const TEXT_ONLY_MODEL = "accounts/fireworks/models/glm-5p2";
+
+const PLUGIN_NAME = defaultImageFallbackPlugin.manifest.name;
+
+registerPluginTools(PLUGIN_NAME, defaultImageFallbackPlugin.tools ?? []);
+
+afterAll(() => {
+  unregisterPluginTools(PLUGIN_NAME);
+});
+
+function conversation(currentTurnModel: string): Conversation {
+  return {
+    skillProjectionState: new Map(),
+    skillProjectionCache: {},
+    toolsDisabledDepth: 0,
+    hasNoClient: false,
+    currentTurnModel,
+  } as unknown as Conversation;
+}
+
+describe("image_ask on the shipped tool surface", () => {
+  test("the image-fallback plugin contributes it", () => {
+    expect(getTool("image_ask")).toBeDefined();
+    expect(getToolOwner("image_ask")).toEqual({
+      kind: "plugin",
+      id: PLUGIN_NAME,
+    });
+  });
+
+  test("stays off the wire for a model that can see images", () => {
+    expect(
+      isToolActiveForContext("image_ask", conversation(VISION_MODEL)),
+    ).toBe(false);
+  });
+
+  test("reaches the wire for a text-only model", () => {
+    expect(
+      isToolActiveForContext("image_ask", conversation(TEXT_ONLY_MODEL)),
+    ).toBe(true);
+  });
+
+  test("declares the low risk band and runs in the sandbox", () => {
+    const tool = getTool("image_ask");
+    expect(tool?.defaultRiskLevel).toBe(RiskLevel.Low);
+    expect(tool?.executionTarget).toBe("sandbox");
+  });
+});

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -31,6 +31,7 @@ import { ConversationsConfigSchema } from "./schemas/conversations.js";
 import { FilingConfigSchema } from "./schemas/filing.js";
 import { HeartbeatConfigSchema } from "./schemas/heartbeat.js";
 import { HostBrowserConfigSchema } from "./schemas/host-browser.js";
+import { ImageFallbackConfigSchema } from "./schemas/image-fallback.js";
 import { IngressConfigSchema } from "./schemas/ingress.js";
 import { JournalConfigSchema } from "./schemas/journal.js";
 import { LiveVoiceConfigSchema } from "./schemas/live-voice.js";
@@ -100,6 +101,9 @@ export const AssistantConfigSchema = z.object({
   heartbeat: HeartbeatConfigSchema.default(HeartbeatConfigSchema.parse({})),
   hostBrowser: HostBrowserConfigSchema.default(
     HostBrowserConfigSchema.parse({}),
+  ),
+  imageFallback: ImageFallbackConfigSchema.default(
+    ImageFallbackConfigSchema.parse({}),
   ),
   conversations: ConversationsConfigSchema.default(
     ConversationsConfigSchema.parse({}),

--- a/assistant/src/config/schemas/image-fallback.ts
+++ b/assistant/src/config/schemas/image-fallback.ts
@@ -1,0 +1,38 @@
+/**
+ * Configuration for the image-fallback plugin, which stands in for images the
+ * turn's model cannot see.
+ *
+ * `captionMode` picks what the substituted text block carries:
+ *
+ * - `caption` (default) — a vision profile describes each image and the
+ *   description goes into the transcript. The model reasons from the
+ *   description without asking for anything, at the cost of one vision call
+ *   per new image.
+ * - `handle-only` — the block names the image and nothing else. Nothing is
+ *   described up front, so a conversation full of images costs no vision
+ *   calls; the model spends one only when it calls `image_ask` about an image
+ *   it actually needs to see.
+ *
+ * The plugin reads this per sweep, so a change takes effect on the next turn
+ * with no restart.
+ */
+import { z } from "zod";
+
+/** Accepted `imageFallback.captionMode` values. */
+export const CAPTION_MODES = ["caption", "handle-only"] as const;
+
+export const ImageFallbackConfigSchema = z
+  .object({
+    captionMode: z
+      .enum(CAPTION_MODES, {
+        error: `imageFallback.captionMode must be one of: ${CAPTION_MODES.join(", ")}`,
+      })
+      .default("caption")
+      .describe(
+        "How an image is represented to a model that cannot see it: `caption` describes every image via a vision profile up front; `handle-only` names the image and leaves the looking to the `image_ask` tool.",
+      ),
+  })
+  .describe("Image fallback behavior for text-only models");
+
+export type ImageFallbackConfig = z.infer<typeof ImageFallbackConfigSchema>;
+export type CaptionMode = ImageFallbackConfig["captionMode"];

--- a/assistant/src/plugins/AGENTS.md
+++ b/assistant/src/plugins/AGENTS.md
@@ -12,7 +12,9 @@ A plugin owns its state end-to-end. Everything a plugin persists lives in its ow
 - **Purge in `conversation-deleted`**: remove per-conversation rows so derived data (captions, caches, logs) does not outlive the conversation that produced it.
 - **Fail open**: a plugin whose storage cannot be opened should degrade (e.g. to in-memory behavior), not block boot or the turn.
 
-Canonical example: `defaults/image-fallback` — `hooks/init.ts` opens `caption-cache.sqlite` in the storage dir and ensures its schema, `hooks/shutdown.ts` closes it, `hooks/conversation-deleted.ts` purges the conversation's rows (`src/caption-cache.ts`).
+Canonical example: `defaults/image-fallback` — `hooks/init.ts` opens `caption-cache.sqlite` in the storage dir and ensures the schema for both of its tables (the caption cache in `src/caption-cache.ts` and the per-conversation image index in `src/image-index.ts`), `hooks/shutdown.ts` closes the handle, and `hooks/conversation-deleted.ts` purges both tables' rows for the deleted conversation. Sibling tables share the one handle rather than opening files of their own.
+
+It is also the canonical example of a turn-scoped tool: `tools/image_ask.ts` declares an `isActive` predicate so a plugin tool that only matters to some models costs the rest of them nothing. See `src/tools/AGENTS.md`.
 
 **Grandfathered exception**: `defaults/memory` predates this rule and uses main-database tables via `persistence/schema` / `db-connection`. Do not extend that pattern to other plugins or grow memory's main-DB surface. Enforced by `__tests__/plugin-state-boundary-guard.test.ts`.
 

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-ask.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-ask.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Tests for the image-fallback plugin's `image_ask` tool and the
+ * per-conversation image index it resolves filenames through.
+ *
+ * Images are seeded straight into the index over a real temp workspace, which
+ * is the state the caption sweep leaves behind for one image (the sweep's own
+ * write is covered in `image-fallback.test.ts`). Resolution, the workspace
+ * boundary, and the answer path therefore run against files that really exist.
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ConversationDeletedContext,
+  ImageContent,
+  ModelProfileInfo,
+  ToolContext,
+  ToolExecutionResult,
+} from "@vellumai/plugin-api";
+
+import { lastToolResultUserMessageIndex } from "../../../../context/outbound-sanitize.js";
+// The risk-level enum is a real host value the tool imports through
+// `@vellumai/plugin-api`; wire the shipped enum into the mock rather than a
+// stand-in so the tool's declared band is the one the host would gate on.
+import { RiskLevel } from "../../../../tools/tool-types.js";
+import { isVisionNotSupportedError } from "../../../../util/provider-error-patterns.js";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+/** A 1x1 PNG, small enough to inline and real enough to write to disk. */
+const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+const WORKSPACE_DIR = mkdtempSync(join(tmpdir(), "image-ask-workspace-"));
+const STORAGE_DIR = mkdtempSync(join(tmpdir(), "image-ask-store-"));
+const ATTACHMENTS_DIR = join(WORKSPACE_DIR, "data", "attachments");
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+let visionModels: Set<string>;
+let visionProfiles: Set<string>;
+let mockProfiles: ModelProfileInfo[];
+let providerResponse: { content: Array<{ type: string; text?: string }> };
+let providerThrows: Error | null;
+let providerCalls: Array<{ systemPrompt?: string; config?: unknown }>;
+
+const fakeProvider = {
+  name: "mock-vision-provider",
+  async sendMessage(
+    _messages: unknown,
+    options: { systemPrompt?: string; config?: unknown },
+  ) {
+    providerCalls.push({
+      systemPrompt: options.systemPrompt,
+      config: options.config,
+    });
+    if (providerThrows != null) {
+      throw providerThrows;
+    }
+    return providerResponse;
+  },
+};
+
+// The module registry is process-wide, so this surface covers every plugin-api
+// export the plugin's tool and hooks import, not only the ones this file
+// exercises.
+mock.module("@vellumai/plugin-api", () => ({
+  doesSupportVision: (arg: ModelProfileInfo | string) =>
+    typeof arg === "string"
+      ? visionModels.has(arg)
+      : visionProfiles.has(arg.key),
+  getModelProfiles: () => mockProfiles,
+  getWorkspaceDir: () => WORKSPACE_DIR,
+  getAttachmentFilePath: () => null,
+  resolveMediaSourceData: (source: ImageContent["source"]) =>
+    source.type === "base64"
+      ? { data: source.data, media_type: source.media_type }
+      : null,
+  getConfiguredProvider: async () => fakeProvider,
+  persistSystemCard: async () => "card-1",
+  lastToolResultUserMessageIndex,
+  isVisionNotSupportedError,
+  RiskLevel,
+}));
+
+// ─── Imports (after mocks are registered) ───────────────────────────────────
+
+const imageAsk = (await import("../tools/image_ask.js")).default;
+const conversationDeleted = (await import("../hooks/conversation-deleted.js"))
+  .default;
+const { closeCaptionStore, initCaptionStore, resetCaptionCacheForTests } =
+  await import("../src/caption-cache.js");
+const {
+  initImageIndex,
+  listConversationImages,
+  recordConversationImage,
+  resetImageIndexForTests,
+} = await import("../src/image-index.js");
+
+initCaptionStore(STORAGE_DIR);
+initImageIndex();
+
+afterAll(() => {
+  closeCaptionStore();
+  rmSync(STORAGE_DIR, { recursive: true, force: true });
+  rmSync(WORKSPACE_DIR, { recursive: true, force: true });
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const noopLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+/**
+ * Write an image into the workspace and index it for `conversationId`, the
+ * state the caption sweep leaves behind for one image. Returns its path.
+ */
+function seedImage(conversationId: string, filename: string): string {
+  mkdirSync(ATTACHMENTS_DIR, { recursive: true });
+  const filePath = join(ATTACHMENTS_DIR, filename);
+  writeFileSync(filePath, Buffer.from(PNG_BASE64, "base64"));
+  recordConversationImage(conversationId, filePath, "image/png", filename);
+  return filePath;
+}
+
+async function ask(
+  conversationId: string,
+  input: Record<string, unknown>,
+): Promise<ToolExecutionResult> {
+  return imageAsk.execute(input, {
+    conversationId,
+    workingDir: WORKSPACE_DIR,
+  } as ToolContext);
+}
+
+beforeEach(() => {
+  visionModels = new Set(["vision-model"]);
+  visionProfiles = new Set(["vision-profile"]);
+  mockProfiles = [
+    { key: "vision-profile", isDisabled: false } as unknown as ModelProfileInfo,
+  ];
+  providerResponse = { content: [{ type: "text", text: "The total is 42." }] };
+  providerThrows = null;
+  providerCalls = [];
+  resetCaptionCacheForTests();
+  resetImageIndexForTests();
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("image-fallback image index", () => {
+  test("keeps one row per image and reports the newest first", () => {
+    seedImage("c-index", "first.png");
+    seedImage("c-index", "second.png");
+    seedImage("c-index", "first.png");
+
+    const images = listConversationImages("c-index");
+    expect(images).toHaveLength(2);
+    expect(images[0].filePath.endsWith("second.png")).toBe(true);
+    expect(images[0].mediaType).toBe("image/png");
+  });
+
+  test("conversation-deleted purges only that conversation's rows", async () => {
+    seedImage("c-doomed", "doomed.png");
+    seedImage("c-kept", "kept.png");
+
+    await conversationDeleted({
+      conversationId: "c-doomed",
+      logger: noopLogger,
+    } as unknown as ConversationDeletedContext);
+
+    expect(listConversationImages("c-doomed")).toHaveLength(0);
+    expect(listConversationImages("c-kept")).toHaveLength(1);
+  });
+});
+
+describe("image_ask activation", () => {
+  test("is off for a model that can see images itself", () => {
+    expect(imageAsk.isActive({ model: "vision-model" })).toBe(false);
+  });
+
+  test("is on for a text-only model", () => {
+    expect(imageAsk.isActive({ model: "text-only-model" })).toBe(true);
+  });
+
+  test("is on outside a turn, where no model is resolved", () => {
+    expect(imageAsk.isActive({ model: "" })).toBe(true);
+  });
+});
+
+describe("image_ask resolution", () => {
+  test("uses the most recent image when none is named", async () => {
+    seedImage("c-ask", "older.png");
+    seedImage("c-ask", "newer.png");
+
+    const result = await ask("c-ask", { question: "What is the total?" });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("newer.png");
+    expect(result.content).toContain("The total is 42.");
+  });
+
+  test("resolves an image by filename", async () => {
+    seedImage("c-name", "older.png");
+    seedImage("c-name", "newer.png");
+
+    const result = await ask("c-name", {
+      question: "What is the total?",
+      image: "older.png",
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("older.png");
+  });
+
+  test("resolves an image by its stored path", async () => {
+    const filePath = seedImage("c-path", "chart.png");
+
+    const result = await ask("c-path", {
+      question: "What is the total?",
+      image: filePath,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("chart.png");
+  });
+
+  test("lists the known filenames when the named image is unknown", async () => {
+    seedImage("c-unknown", "chart.png");
+
+    const result = await ask("c-unknown", {
+      question: "What is the total?",
+      image: "not-here.png",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("not-here.png");
+    expect(result.content).toContain("chart.png");
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  test("reports when the conversation has no images", async () => {
+    const result = await ask("c-empty", { question: "What is the total?" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No images");
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  test("rejects an image stored outside the workspace", async () => {
+    recordConversationImage("c-outside", "/etc/passwd", "image/png", "hash");
+
+    const result = await ask("c-outside", { question: "What is in it?" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside the workspace");
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  test("reports an image whose file is gone", async () => {
+    const filePath = seedImage("c-gone", "gone.png");
+    unlinkSync(filePath);
+
+    const result = await ask("c-gone", { question: "What is the total?" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("no longer readable");
+    expect(providerCalls).toHaveLength(0);
+  });
+});
+
+describe("image_ask answers", () => {
+  test("requires a question", async () => {
+    seedImage("c-noq", "chart.png");
+
+    const result = await ask("c-noq", { question: "   " });
+
+    expect(result.isError).toBe(true);
+    expect(providerCalls).toHaveLength(0);
+  });
+
+  test("sends the question to the vision call site under a vision profile", async () => {
+    seedImage("c-send", "chart.png");
+
+    await ask("c-send", { question: "What is the exact total?" });
+
+    expect(providerCalls).toHaveLength(1);
+    expect(providerCalls[0].systemPrompt).toContain(
+      "only from what is visible",
+    );
+    const config = providerCalls[0].config as {
+      callSite: string;
+      overrideProfile: string;
+    };
+    expect(config.callSite).toBe("vision");
+    expect(config.overrideProfile).toBe("vision-profile");
+  });
+
+  test("returns text only, never an image block", async () => {
+    seedImage("c-text", "chart.png");
+
+    const result = await ask("c-text", { question: "What is the total?" });
+
+    expect(result.contentBlocks).toBeUndefined();
+    expect(typeof result.content).toBe("string");
+  });
+
+  test("flags an answer the image does not show", async () => {
+    seedImage("c-unseen", "chart.png");
+    providerResponse = {
+      content: [
+        {
+          type: "text",
+          text: "NOT_VISIBLE: the bottom of the table is cut off.",
+        },
+      ],
+    };
+
+    const result = await ask("c-unseen", { question: "What is the total?" });
+
+    expect(result.isError).toBe(false);
+    expect(result.status).toBe("not in image");
+    expect(result.content).toContain("does not show the answer");
+    expect(result.content).toContain("cut off");
+    expect(result.content).not.toContain("NOT_VISIBLE");
+  });
+
+  test("reports a failed vision call without throwing", async () => {
+    seedImage("c-fail", "chart.png");
+    providerThrows = new Error("upstream is down");
+
+    const result = await ask("c-fail", { question: "What is the total?" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Could not get an answer");
+  });
+
+  test("reports an empty vision response", async () => {
+    seedImage("c-blank", "chart.png");
+    providerResponse = { content: [] };
+
+    const result = await ask("c-blank", { question: "What is the total?" });
+
+    expect(result.isError).toBe(true);
+  });
+
+  test("reports when no vision-capable profile is configured", async () => {
+    seedImage("c-noprofile", "chart.png");
+    mockProfiles = [];
+
+    const result = await ask("c-noprofile", { question: "What is the total?" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("No vision-capable model");
+    expect(providerCalls).toHaveLength(0);
+  });
+});
+
+describe("image_ask definition", () => {
+  test("declares the low risk band and a required question", () => {
+    expect(imageAsk.defaultRiskLevel).toBe(RiskLevel.Low);
+    expect((imageAsk.input_schema as { required: string[] }).required).toEqual([
+      "question",
+    ]);
+  });
+
+  test("tells the model the answerer has no conversation context", () => {
+    expect(imageAsk.description).toContain("no conversation");
+    expect(imageAsk.description).toContain("self-contained");
+  });
+});

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
@@ -74,6 +74,9 @@ function installPluginApiMock(overrides: Record<string, unknown> = {}): void {
     getModelProfiles: () => mockProfiles,
     resolveMediaSourceData: mockResolveMediaSourceData,
     getConfiguredProvider: async () => (providerResolves ? fakeProvider : null),
+    getAttachmentFilePath: (attachmentId: string) =>
+      mockAttachmentPaths.get(attachmentId) ?? null,
+    getWorkspaceDir: () => "/workspace",
     lastToolResultUserMessageIndex,
     isVisionNotSupportedError,
     persistSystemCard: async (opts: {
@@ -92,6 +95,9 @@ function installPluginApiMock(overrides: Record<string, unknown> = {}): void {
 }
 
 installPluginApiMock();
+
+// Canonical on-disk paths for `workspace_ref` sources, keyed by attachment id.
+const mockAttachmentPaths = new Map<string, string>();
 
 // Mock the image-persist module to avoid filesystem side effects in tests.
 let mockPersistPath: string | null =
@@ -288,7 +294,7 @@ describe("image-fallback user-prompt-submit hook", () => {
     expect(ctx.latestMessages[0].content[0].type).toBe("text");
     expect(
       (ctx.latestMessages[0].content[0] as { text: string }).text,
-    ).toContain("[Image auto-described");
+    ).toContain('[Image "mock-hash.png" auto-described');
   });
 
   test("replaces image blocks with captions when active model is text-only", async () => {
@@ -297,7 +303,7 @@ describe("image-fallback user-prompt-submit hook", () => {
     await userPromptSubmit(ctx);
     expect(ctx.latestMessages[0].content[0].type).toBe("text");
     expect((ctx.latestMessages[0].content[0] as { text: string }).text).toBe(
-      "[Image auto-described for text-only model: A red chart showing Q3 revenue.]",
+      '[Image "mock-hash.png" auto-described for text-only model: A red chart showing Q3 revenue.]',
     );
   });
 
@@ -346,7 +352,7 @@ describe("image-fallback user-prompt-submit hook", () => {
     // serialize as a plain string
     expect(ctx.latestMessages[0].content).toHaveLength(1);
     expect((ctx.latestMessages[0].content[0] as { text: string }).text).toBe(
-      "Look at this:\n\n[Image auto-described for text-only model: A red chart showing Q3 revenue.]\n\nWhat do you see?",
+      'Look at this:\n\n[Image "mock-hash.png" auto-described for text-only model: A red chart showing Q3 revenue.]\n\nWhat do you see?',
     );
   });
 
@@ -411,7 +417,7 @@ describe("image-fallback user-prompt-submit hook", () => {
     expect(result.type).toBe("tool_result");
     expect(result.contentBlocks![0].type).toBe("text");
     expect((result.contentBlocks![0] as { text: string }).text).toContain(
-      "[Image auto-described",
+      '[Image "mock-hash.png" auto-described',
     );
   });
 
@@ -429,11 +435,11 @@ describe("image-fallback user-prompt-submit hook", () => {
     expect(ctx.latestMessages[0].content[0].type).toBe("text");
     expect(
       (ctx.latestMessages[0].content[0] as { text: string }).text,
-    ).toContain("[Image auto-described");
+    ).toContain('[Image "mock-hash.png" auto-described');
     expect(ctx.latestMessages[2].content).toHaveLength(1);
     expect(
       (ctx.latestMessages[2].content[0] as { text: string }).text,
-    ).toContain("[Image auto-described");
+    ).toContain('[Image "mock-hash.png" auto-described');
     expect(
       (ctx.latestMessages[2].content[0] as { text: string }).text,
     ).toEndWith("\n\nboth?");
@@ -464,7 +470,7 @@ describe("image-fallback dropped-image notice", () => {
     // single text block providers serialize as a plain string
     expect(ctx.latestMessages[0].content).toHaveLength(1);
     expect((ctx.latestMessages[0].content[0] as { text: string }).text).toBe(
-      "look at this\n\n[Image: no vision-capable model configured to describe it]",
+      'look at this\n\n[Image "mock-hash.png": no vision-capable model configured to describe it]',
     );
 
     // AND the transcript carries one card telling the user the image was not sent
@@ -557,7 +563,7 @@ describe("image-fallback dropped-image notice", () => {
     // THEN the image is captioned and nothing is reported to the user
     expect(
       (ctx.latestMessages[0].content[0] as { text: string }).text,
-    ).toContain("[Image auto-described");
+    ).toContain('[Image "mock-hash.png" auto-described');
     expect(persistedCards).toHaveLength(0);
   });
 
@@ -742,7 +748,7 @@ describe("image-fallback post-tool-use hook", () => {
     const block = ctx.toolResponse.contentBlocks![0];
     expect(block.type).toBe("text");
     expect((block as { text: string }).text).toBe(
-      "[Image auto-described for text-only model: A red chart showing Q3 revenue.]",
+      '[Image "mock-hash.png" auto-described for text-only model: A red chart showing Q3 revenue.]',
     );
   });
 
@@ -774,7 +780,7 @@ describe("image-fallback post-tool-use hook", () => {
     expect((blocks[0] as { text: string }).text).toBe("page title");
     expect(blocks[1].type).toBe("text");
     expect((blocks[1] as { text: string }).text).toContain(
-      "[Image auto-described",
+      '[Image "mock-hash.png" auto-described',
     );
   });
 
@@ -852,7 +858,7 @@ describe("image-fallback post-compact hook", () => {
     await postCompact(ctx);
     expect(ctx.history[0].content).toHaveLength(1);
     expect((ctx.history[0].content[0] as { text: string }).text).toBe(
-      "Images retained from the compacted portion of the conversation:\n\n[Image auto-described for text-only model: A red chart showing Q3 revenue.]",
+      'Images retained from the compacted portion of the conversation:\n\n[Image "mock-hash.png" auto-described for text-only model: A red chart showing Q3 revenue.]',
     );
   });
 
@@ -869,7 +875,7 @@ describe("image-fallback post-compact hook", () => {
     const result = ctx.history[1].content[0] as ToolResultContent;
     expect(result.contentBlocks![0].type).toBe("text");
     expect((result.contentBlocks![0] as { text: string }).text).toContain(
-      "[Image auto-described",
+      '[Image "mock-hash.png" auto-described',
     );
   });
 

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/image-fallback.test.ts
@@ -20,6 +20,7 @@ import type {
 // into the mock so the tests exercise the shipped behavior rather than a
 // stand-in.
 import { lastToolResultUserMessageIndex } from "../../../../context/outbound-sanitize.js";
+import { RiskLevel } from "../../../../tools/tool-types.js";
 import { isVisionNotSupportedError } from "../../../../util/provider-error-patterns.js";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -35,20 +36,23 @@ let sendMessageResponse = {
 };
 let providerResolves = true;
 
+let visionCallCount = 0;
+
 const fakeProvider = {
   name: "mock-vision-provider",
   async sendMessage() {
+    visionCallCount++;
     return sendMessageResponse;
   },
 };
 
 // The plugin resolves an image block's bytes via `resolveMediaSourceData`.
-// Media in these tests is inline base64, so mirror the real helper's base64
-// branch; a workspace reference would return null (not exercised here).
+// Mirror the real helper: inline base64 passes through, and a workspace
+// reference reads back the bytes the attachment store holds.
 const mockResolveMediaSourceData = (source: ImageContent["source"]) =>
   source.type === "base64"
     ? { data: source.data, media_type: source.media_type }
-    : null;
+    : { data: "cmVmLWJ5dGVz", media_type: source.media_type };
 
 // System cards the plugin posts, captured instead of persisted.
 let persistedCards: Array<{
@@ -79,6 +83,7 @@ function installPluginApiMock(overrides: Record<string, unknown> = {}): void {
     getWorkspaceDir: () => "/workspace",
     lastToolResultUserMessageIndex,
     isVisionNotSupportedError,
+    RiskLevel,
     persistSystemCard: async (opts: {
       conversationId: string;
       text: string;
@@ -99,6 +104,14 @@ installPluginApiMock();
 // Canonical on-disk paths for `workspace_ref` sources, keyed by attachment id.
 const mockAttachmentPaths = new Map<string, string>();
 
+// The sweep reads `imageFallback.captionMode` from the workspace config;
+// drive it from the test rather than from whatever the developer's own config
+// file happens to hold.
+let captionMode = "caption";
+mock.module("../src/caption-mode.js", () => ({
+  getCaptionMode: () => captionMode,
+}));
+
 // Mock the image-persist module to avoid filesystem side effects in tests.
 let mockPersistPath: string | null =
   "/workspace/data/attachments/mock-hash.png";
@@ -118,11 +131,14 @@ const { findVisionProfile } = await import("../src/vision-caption.js");
 const { flattenTextOnlyBlocks } = await import("../src/caption-blocks.js");
 const { closeCaptionStore, initCaptionStore, resetCaptionCacheForTests } =
   await import("../src/caption-cache.js");
+const { initImageIndex, listConversationImages, resetImageIndexForTests } =
+  await import("../src/image-index.js");
 
 // Back the caption cache's durable layer with a per-file temp store, the way
 // the plugin's `init` hook opens it in production.
 const STORAGE_DIR = mkdtempSync(join(tmpdir(), "image-fallback-test-"));
 initCaptionStore(STORAGE_DIR);
+initImageIndex();
 
 afterAll(() => {
   closeCaptionStore();
@@ -247,10 +263,14 @@ beforeEach(() => {
   };
   providerResolves = true;
   mockPersistPath = "/workspace/data/attachments/mock-hash.png";
+  mockAttachmentPaths.clear();
+  captionMode = "caption";
+  visionCallCount = 0;
   persistedCards = [];
   cardPersistenceFails = false;
   installPluginApiMock();
   resetCaptionCacheForTests();
+  resetImageIndexForTests();
 });
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -314,6 +334,81 @@ describe("image-fallback user-prompt-submit hook", () => {
     const text = (ctx.latestMessages[0].content[0] as { text: string }).text;
     expect(text).toContain("text-only model");
     expect(text).toContain("auto-described");
+  });
+
+  test("names a workspace_ref image by the attachment's stored filename", async () => {
+    mockAttachmentPaths.set(
+      "att-1",
+      "/workspace/conversations/c1/attachments/receipt.png",
+    );
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "workspace_ref",
+              media_type: "image/png",
+              attachmentId: "att-1",
+              sizeBytes: 12,
+            },
+          } as ImageContent,
+        ],
+      },
+    ];
+    const ctx = makeCtx({ latestMessages: messages });
+    await userPromptSubmit(ctx);
+    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toBe(
+      '[Image "receipt.png" auto-described for text-only model: A red chart showing Q3 revenue.]',
+    );
+  });
+
+  test("handle-only mode names the image and spends no vision call", async () => {
+    captionMode = "handle-only";
+    const messages = [imageMsg("img1")];
+    const ctx = makeCtx({ latestMessages: messages });
+    await userPromptSubmit(ctx);
+    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toBe(
+      '[Image "mock-hash.png" available via image_ask]',
+    );
+    expect(visionCallCount).toBe(0);
+  });
+
+  test("handle-only mode says so when the image has no stored copy", async () => {
+    captionMode = "handle-only";
+    mockPersistPath = null;
+    const messages = [imageMsg("img1")];
+    const ctx = makeCtx({ latestMessages: messages });
+    await userPromptSubmit(ctx);
+    expect((ctx.latestMessages[0].content[0] as { text: string }).text).toBe(
+      "[Image: no stored copy available to examine]",
+    );
+  });
+
+  test("handle-only mode still reports a missing vision model", async () => {
+    captionMode = "handle-only";
+    mockProfiles = [
+      profile("text-only", { label: "Text Only", isActive: true }),
+    ];
+    const messages = [imageMsg("img1")];
+    const ctx = makeCtx({ latestMessages: messages });
+    await userPromptSubmit(ctx);
+    expect(
+      (ctx.latestMessages[0].content[0] as { text: string }).text,
+    ).toContain("no vision-capable model configured");
+  });
+
+  test("indexes the image it captioned so image_ask can resolve it", async () => {
+    const messages = [imageMsg("img1")];
+    const ctx = makeCtx({ latestMessages: messages, conversationId: "c-idx" });
+    await userPromptSubmit(ctx);
+    const images = listConversationImages("c-idx");
+    expect(images).toHaveLength(1);
+    expect(images[0].filePath).toBe(
+      "/workspace/data/attachments/mock-hash.png",
+    );
+    expect(images[0].mediaType).toBe("image/png");
   });
 
   test("does not embed the saved image path in the caption text", async () => {

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/vision-recovery.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/vision-recovery.test.ts
@@ -51,6 +51,10 @@ mock.module("@vellumai/plugin-api", () => ({
   getModelProfiles: () => mockProfiles,
   resolveMediaSourceData: mockResolveMediaSourceData,
   getConfiguredProvider: async () => fakeProvider,
+  // Media in these tests is inline base64, so the sweep falls through to the
+  // persisted copy rather than an attachment row.
+  getAttachmentFilePath: () => null,
+  getWorkspaceDir: () => "/workspace",
   isVisionNotSupportedError,
   lastToolResultUserMessageIndex,
   // The module registry is process-wide, so this surface covers every
@@ -161,7 +165,9 @@ describe("image-fallback post-model-call vision recovery", () => {
     const blocks = ctx.messages[0].content;
     expect(blocks.some((b) => b.type === "image")).toBe(false);
     const captioned = blocks.find(
-      (b) => b.type === "text" && b.text.includes("[Image auto-described"),
+      (b) =>
+        b.type === "text" &&
+        b.text.includes('[Image "mock-hash.png" auto-described'),
     );
     expect(captioned).toBeDefined();
     expect(isVisionRecoveryAttempted("conv-vision")).toBe(true);

--- a/assistant/src/plugins/defaults/image-fallback/__tests__/vision-recovery.test.ts
+++ b/assistant/src/plugins/defaults/image-fallback/__tests__/vision-recovery.test.ts
@@ -26,6 +26,7 @@ import type {
 // tests exercise the shipped behavior (broad rejection patterns, media scope)
 // rather than a stand-in.
 import { lastToolResultUserMessageIndex } from "../../../../context/outbound-sanitize.js";
+import { RiskLevel } from "../../../../tools/tool-types.js";
 import { isVisionNotSupportedError } from "../../../../util/provider-error-patterns.js";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -61,6 +62,7 @@ mock.module("@vellumai/plugin-api", () => ({
   // plugin-api export the plugin's hooks import, including the transcript
   // notice only the sibling test file exercises.
   persistSystemCard: async () => "card-1",
+  RiskLevel,
 }));
 
 mock.module("../src/image-persist.js", () => ({

--- a/assistant/src/plugins/defaults/image-fallback/hooks/conversation-deleted.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/conversation-deleted.ts
@@ -1,8 +1,9 @@
 /**
- * Default `conversation-deleted` hook: removes the deleted conversation's
- * rows from the plugin-owned caption store, so derived caption text does not
- * outlive the conversation whose images produced it. A caption shared with a
- * surviving conversation stays resolvable through that conversation's rows.
+ * Default `conversation-deleted` hook: removes the deleted conversation's rows
+ * from the plugin-owned store, cached captions and indexed images alike, so
+ * derived data does not outlive the conversation whose images produced it. A
+ * caption shared with a surviving conversation stays resolvable through that
+ * conversation's rows.
  */
 
 import {
@@ -11,15 +12,17 @@ import {
 } from "@vellumai/plugin-api";
 
 import { deleteConversationCaptions } from "../src/caption-cache.js";
+import { deleteConversationImages } from "../src/image-index.js";
 
 const conversationDeleted: HookFunction<ConversationDeletedContext> = async (
   ctx,
 ) => {
   const removed = deleteConversationCaptions(ctx.conversationId);
-  if (removed > 0) {
+  const removedImages = deleteConversationImages(ctx.conversationId);
+  if (removed > 0 || removedImages > 0) {
     ctx.logger.info(
-      { plugin: "image-fallback", removed },
-      "Removed deleted conversation's cached image captions",
+      { plugin: "image-fallback", removed, removedImages },
+      "Removed deleted conversation's cached image captions and image index",
     );
   }
 };

--- a/assistant/src/plugins/defaults/image-fallback/hooks/init.ts
+++ b/assistant/src/plugins/defaults/image-fallback/hooks/init.ts
@@ -1,16 +1,20 @@
 /**
- * Default `init` hook: opens the plugin-owned caption database
- * (`caption-cache.sqlite` in the plugin's storage dir) and ensures its
- * schema. Fail-open — if the store cannot be opened, captioning degrades to
- * in-memory-only caching and the plugin keeps working.
+ * Default `init` hook: opens the plugin-owned database
+ * (`caption-cache.sqlite` in the plugin's storage dir) and ensures the schema
+ * for both of its tables — the caption cache and the per-conversation image
+ * index the `image_ask` tool resolves filenames through. Fail-open — if the
+ * store cannot be opened, captioning degrades to in-memory-only caching, the
+ * index reads empty, and the plugin keeps working.
  */
 
 import { type HookFunction, type InitContext } from "@vellumai/plugin-api";
 
 import { initCaptionStore } from "../src/caption-cache.js";
+import { initImageIndex } from "../src/image-index.js";
 
 const init: HookFunction<InitContext> = async (ctx) => {
   initCaptionStore(ctx.pluginStorageDir);
+  initImageIndex();
 };
 
 export default init;

--- a/assistant/src/plugins/defaults/image-fallback/package.json
+++ b/assistant/src/plugins/defaults/image-fallback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "default-image-fallback",
   "version": "1.0.0",
-  "description": "First-party default plugin that captions image attachments via a vision-capable profile when the active model is text-only, substituting the caption as a text block so the model can still reason about the image's content.",
+  "description": "First-party default plugin that stands in for images the active model cannot see: it names each image by filename and (by default) substitutes a vision-generated caption as a text block, and contributes the `image_ask` tool so the model can put a specific question about one image to a vision-capable profile.",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -7,9 +7,9 @@
  * browser screenshot) as they arrive, and `post-compact` re-sweeps the rebuilt
  * history after a mid-turn compaction. This module holds what they share —
  * deciding whether a profile needs the fallback ({@link needsImageFallback}),
- * the per-block substitution ({@link captionImageBlocks}): persist the
- * original image to a known location, caption it via a vision-capable
- * profile, and swap in a `[Image …]` text block — and the message-level deep
+ * the per-block substitution ({@link captionImageBlocks}): locate the original
+ * image on disk, index it for `image_ask`, caption it via a vision-capable
+ * profile, and swap in a `[Image "<filename>" …]` text block — and the message-level deep
  * sweep ({@link captionImagesInMessages}) that reaches images nested inside
  * `tool_result` blocks as well as top-level ones. The message-level sweeps
  * close by merging text-only user content into a single text block
@@ -25,16 +25,21 @@
  *
  * The caption text states up front that the model can't view images and the
  * image was auto-described to text, so the model treats the block as a derived
- * description rather than a verbatim transcript.
+ * description rather than a verbatim transcript. It names the image by its
+ * filename, which is the handle the `image_ask` tool resolves back to bytes
+ * when the model needs a detail the caption left out.
  *
  * Fail-open is the dominant error mode: a captioning failure leaves a
  * placeholder text block rather than the raw image (which a text-only provider
  * would reject) or nothing (which would lose information).
  */
 
+import { basename } from "node:path";
+
 import {
   type ContentBlock,
   doesSupportVision,
+  getAttachmentFilePath,
   getModelProfiles,
   type ImageContent,
   lastToolResultUserMessageIndex,
@@ -43,6 +48,8 @@ import {
   resolveMediaSourceData,
 } from "@vellumai/plugin-api";
 
+import { imageHash } from "./caption-cache.js";
+import { recordConversationImage } from "./image-index.js";
 import { persistImage } from "./image-persist.js";
 import { captionImage } from "./vision-caption.js";
 
@@ -61,6 +68,45 @@ export function needsImageFallback(modelProfileKey: string): boolean {
     return !doesSupportVision(modelProfileKey);
   }
   return !doesSupportVision(profile);
+}
+
+/**
+ * On-disk location of an image block, or `null` when it has none.
+ *
+ * A `workspace_ref` block already names a file the host's attachment store
+ * owns, so that path is the canonical one and no second copy is written.
+ * Inline base64 (mid-turn screenshots, legacy rows) has no file yet, so it
+ * lands in the plugin's content-hash-deduped attachments copy.
+ */
+function resolveImageFilePath(
+  image: ImageContent,
+  resolved: { data: string; media_type: string } | null,
+): string | null {
+  if (image.source.type === "workspace_ref") {
+    try {
+      const stored = getAttachmentFilePath(image.source.attachmentId);
+      if (stored != null && stored !== "") {
+        return stored;
+      }
+    } catch {
+      // Attachment store unavailable: fall through to a persisted copy.
+    }
+  }
+  if (resolved != null) {
+    return persistImage(resolved.data, resolved.media_type);
+  }
+  return null;
+}
+
+/**
+ * Opening of the `[Image …]` text that replaces an image block, naming the
+ * image by filename when one is known.
+ *
+ * The filename is the model's only way to point at a specific image, so it is
+ * also what `image_ask` matches its `image` argument against.
+ */
+function imageHandlePrefix(handle: string | null): string {
+  return handle != null ? `[Image "${handle}"` : "[Image";
 }
 
 /**
@@ -93,13 +139,23 @@ export async function captionImageBlocks(
     replaced++;
     const image = block as ImageContent;
 
-    // Persist the original to a known, content-hash-deduped location so it
-    // survives the text substitution and stays findable on disk. Resolve a
-    // reference source to its bytes first (a no-op for inline base64).
-    const resolvedForPersist = resolveMediaSourceData(image.source);
-    if (resolvedForPersist) {
-      persistImage(resolvedForPersist.data, resolvedForPersist.media_type);
+    // Locate the original on disk so it survives the text substitution, stays
+    // findable for the user, and gives the caption a filename to name it by.
+    // Resolve a reference source to its bytes first (a no-op for inline
+    // base64).
+    const resolved = resolveMediaSourceData(image.source);
+    const filePath = resolveImageFilePath(image, resolved);
+    if (filePath != null && resolved != null) {
+      recordConversationImage(
+        conversationId,
+        filePath,
+        resolved.media_type,
+        imageHash(resolved.data),
+      );
     }
+    const prefix = imageHandlePrefix(
+      filePath != null ? basename(filePath) : null,
+    );
 
     if (visionProfileKey != null) {
       const caption = await captionImage(
@@ -112,14 +168,14 @@ export async function captionImageBlocks(
         type: "text",
         text:
           caption != null
-            ? `[Image auto-described for text-only model: ${caption}]`
-            : `[Image: auto-description failed (text-only model)]`,
+            ? `${prefix} auto-described for text-only model: ${caption}]`
+            : `${prefix}: auto-description failed (text-only model)]`,
       };
     } else {
       // No vision profile configured at all: fail-open placeholder.
       blocks[i] = {
         type: "text",
-        text: `[Image: no vision-capable model configured to describe it]`,
+        text: `${prefix}: no vision-capable model configured to describe it]`,
       };
     }
   }

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-blocks.ts
@@ -29,6 +29,10 @@
  * filename, which is the handle the `image_ask` tool resolves back to bytes
  * when the model needs a detail the caption left out.
  *
+ * `imageFallback.captionMode` chooses between the two. `caption` (the default)
+ * describes every image up front. `handle-only` substitutes the name alone and
+ * makes no vision call, leaving every look to `image_ask`.
+ *
  * Fail-open is the dominant error mode: a captioning failure leaves a
  * placeholder text block rather than the raw image (which a text-only provider
  * would reject) or nothing (which would lose information).
@@ -49,6 +53,7 @@ import {
 } from "@vellumai/plugin-api";
 
 import { imageHash } from "./caption-cache.js";
+import { getCaptionMode } from "./caption-mode.js";
 import { recordConversationImage } from "./image-index.js";
 import { persistImage } from "./image-persist.js";
 import { captionImage } from "./vision-caption.js";
@@ -129,6 +134,9 @@ export async function captionImageBlocks(
   logger: PluginLogger,
 ): Promise<number> {
   let replaced = 0;
+  // Read once per block array rather than per image: the setting cannot
+  // change mid-sweep, and the config accessor is a cached read either way.
+  const mode = getCaptionMode();
 
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i];
@@ -157,7 +165,19 @@ export async function captionImageBlocks(
       filePath != null ? basename(filePath) : null,
     );
 
-    if (visionProfileKey != null) {
+    if (visionProfileKey != null && mode === "handle-only") {
+      // The image is named but not described: nothing is spent on it unless
+      // the model calls `image_ask`. An image with no file behind it cannot be
+      // asked about, so say that rather than offering a handle that resolves
+      // to nothing.
+      blocks[i] = {
+        type: "text",
+        text:
+          filePath != null
+            ? `${prefix} available via image_ask]`
+            : `${prefix}: no stored copy available to examine]`,
+      };
+    } else if (visionProfileKey != null) {
       const caption = await captionImage(
         image,
         conversationId,

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-cache.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-cache.ts
@@ -76,6 +76,15 @@ export function initCaptionStore(storageDir: string): void {
   }
 }
 
+/**
+ * The plugin's single SQLite handle, for sibling modules that keep their own
+ * tables in the same file (see `image-index.ts`). `null` before `init` runs
+ * or after a failed open, which every caller treats as "store unavailable".
+ */
+export function getPluginDatabase(): Database | null {
+  return db;
+}
+
 /** Close the caption database. Called by the plugin's `shutdown` hook. */
 export function closeCaptionStore(): void {
   try {

--- a/assistant/src/plugins/defaults/image-fallback/src/caption-mode.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/caption-mode.ts
@@ -1,0 +1,24 @@
+/**
+ * Resolution of `imageFallback.captionMode` for the caption sweep.
+ *
+ * `caption` describes every image the model cannot see, so the description is
+ * already in the transcript when the model reasons about it. `handle-only`
+ * leaves a named placeholder and no description, so nothing is spent until
+ * the model calls `image_ask` about an image it actually needs.
+ *
+ * Read per sweep off the read-only config accessor (never the writing one — a
+ * turn must not rewrite the config file), so a setting change lands on the
+ * next turn. Fails to the shipped `caption` default when the config cannot be
+ * read, which keeps the behavior a workspace already has.
+ */
+
+import { getConfigReadOnly } from "../../../../config/loader.js";
+import type { CaptionMode } from "../../../../config/schemas/image-fallback.js";
+
+export function getCaptionMode(): CaptionMode {
+  try {
+    return getConfigReadOnly().imageFallback.captionMode;
+  } catch {
+    return "caption";
+  }
+}

--- a/assistant/src/plugins/defaults/image-fallback/src/image-index.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/image-index.ts
@@ -1,0 +1,213 @@
+/**
+ * Index of the images a conversation has shown, so the `image_ask` tool can
+ * turn a filename the model read in a caption back into bytes on disk.
+ *
+ * The caption sweep visits every image in the provider-bound history on every
+ * text-only turn, so writing a row there keeps the index complete for exactly
+ * the conversations where the tool is active, with no separate history scan.
+ * A row is the image's on-disk location plus the media type and content hash;
+ * the bytes themselves stay where the host already keeps them (the attachment
+ * store for user uploads, the plugin's content-hash-deduped copy for inline
+ * base64).
+ *
+ * The table lives in the plugin's own SQLite file next to the caption cache
+ * (`caption-cache.sqlite`, opened by `init`), never in the main database.
+ * `conversation-deleted` purges a conversation's rows and `shutdown` closes
+ * the handle. Every operation fails open: an unavailable store makes the
+ * index look empty rather than faulting the sweep or the tool.
+ */
+
+import { basename } from "node:path";
+
+import { getPluginDatabase } from "./caption-cache.js";
+
+/** Cap on indexed rows, evicting the oldest first. */
+const MAX_INDEX_ROWS = 5000;
+
+/** One indexed image. */
+export interface ConversationImage {
+  conversationId: string;
+  filePath: string;
+  mediaType: string;
+  imageHash: string;
+  addedAt: number;
+}
+
+interface ImageRow {
+  conversation_id: string;
+  file_path: string;
+  media_type: string;
+  image_hash: string;
+  added_at: number;
+}
+
+function toConversationImage(row: ImageRow): ConversationImage {
+  return {
+    conversationId: row.conversation_id,
+    filePath: row.file_path,
+    mediaType: row.media_type,
+    imageHash: row.image_hash,
+    addedAt: row.added_at,
+  };
+}
+
+/**
+ * Create the index table in the plugin's database. Called by the plugin's
+ * `init` hook once `initCaptionStore` has opened the handle. Idempotent and
+ * fail-open: without the table every read is empty and every write is dropped.
+ */
+export function initImageIndex(): void {
+  const db = getPluginDatabase();
+  if (db == null) {
+    return;
+  }
+  try {
+    db.exec(/*sql*/ `
+      CREATE TABLE IF NOT EXISTS conversation_images (
+        conversation_id TEXT NOT NULL,
+        file_path       TEXT NOT NULL,
+        media_type      TEXT NOT NULL,
+        image_hash      TEXT NOT NULL,
+        added_at        INTEGER NOT NULL,
+        PRIMARY KEY (conversation_id, file_path)
+      )
+    `);
+    db.exec(
+      /*sql*/ `CREATE INDEX IF NOT EXISTS idx_conversation_images_conversation ON conversation_images(conversation_id, added_at)`,
+    );
+  } catch {
+    // Fail open: the tool reports no known images instead of erroring.
+  }
+}
+
+/**
+ * Record that `conversationId` shows the image stored at `filePath`.
+ *
+ * `added_at` is the first-seen time and is left alone on re-record, so the
+ * newest row stays the image most recently added to the conversation even
+ * though the sweep re-visits every older image each turn.
+ */
+export function recordConversationImage(
+  conversationId: string,
+  filePath: string,
+  mediaType: string,
+  hash: string,
+): void {
+  const db = getPluginDatabase();
+  if (db == null || conversationId === "" || filePath === "") {
+    return;
+  }
+  try {
+    db.query(
+      /*sql*/ `
+      INSERT INTO conversation_images (conversation_id, file_path, media_type, image_hash, added_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(conversation_id, file_path) DO UPDATE SET
+        media_type = excluded.media_type,
+        image_hash = excluded.image_hash
+    `,
+    ).run(conversationId, filePath, mediaType, hash, Date.now());
+    db.query(
+      /*sql*/ `
+      DELETE FROM conversation_images WHERE (conversation_id, file_path) IN (
+        SELECT conversation_id, file_path FROM conversation_images
+        ORDER BY added_at DESC, rowid DESC LIMIT -1 OFFSET ?
+      )
+    `,
+    ).run(MAX_INDEX_ROWS);
+  } catch {
+    // Fail open: an unindexed image is one the tool cannot resolve by name.
+  }
+}
+
+/**
+ * A conversation's indexed images, newest first. `rowid` breaks ties so
+ * images indexed within the same millisecond keep the order the sweep saw
+ * them in.
+ */
+export function listConversationImages(
+  conversationId: string,
+): ConversationImage[] {
+  const db = getPluginDatabase();
+  if (db == null) {
+    return [];
+  }
+  try {
+    const rows = db
+      .query(
+        /*sql*/ `
+        SELECT conversation_id, file_path, media_type, image_hash, added_at
+        FROM conversation_images
+        WHERE conversation_id = ?
+        ORDER BY added_at DESC, rowid DESC
+      `,
+      )
+      .all(conversationId) as ImageRow[];
+    return rows.map(toConversationImage);
+  } catch {
+    // Fail open: behave as a conversation with no indexed images.
+    return [];
+  }
+}
+
+/**
+ * Pick the image a tool call names out of `images` (newest first).
+ *
+ * `ref` is whatever the model wrote: the stored path from the transcript, the
+ * bare filename the caption showed, or nothing at all. Resolution is exact
+ * path, then exact basename, then (with no `ref`) the newest image. Returns
+ * `null` when a named image is not in the list, so the caller can answer with
+ * the names that are.
+ */
+export function resolveConversationImage(
+  images: ConversationImage[],
+  ref?: string,
+): ConversationImage | null {
+  if (images.length === 0) {
+    return null;
+  }
+  const wanted = ref?.trim() ?? "";
+  if (wanted === "") {
+    return images[0];
+  }
+  const byPath = images.find((image) => image.filePath === wanted);
+  if (byPath != null) {
+    return byPath;
+  }
+  const wantedName = basename(wanted);
+  const byName = images.find(
+    (image) => basename(image.filePath) === wantedName,
+  );
+  return byName ?? null;
+}
+
+/**
+ * Remove a deleted conversation's index rows. Returns how many were removed.
+ */
+export function deleteConversationImages(conversationId: string): number {
+  const db = getPluginDatabase();
+  if (db == null) {
+    return 0;
+  }
+  try {
+    const result = db
+      .query(
+        /*sql*/ `DELETE FROM conversation_images WHERE conversation_id = ?`,
+      )
+      .run(conversationId);
+    return Number(result.changes ?? 0);
+  } catch {
+    // Fail open: cleanup is best-effort; rows age out via the row cap.
+    return 0;
+  }
+}
+
+/** Test-only: drop every indexed row. */
+export function resetImageIndexForTests(): void {
+  const db = getPluginDatabase();
+  try {
+    db?.exec(/*sql*/ `DELETE FROM conversation_images`);
+  } catch {
+    // Store not initialized in DB-less test environments — nothing to clear.
+  }
+}

--- a/assistant/src/plugins/defaults/image-fallback/src/image-persist.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/image-persist.ts
@@ -6,15 +6,27 @@
  * content-hash-deduped location means the original survives the text
  * substitution and stays findable on disk for the user (or a subagent with a
  * vision-capable model that reads it via file_read).
+ *
+ * The path is also the handle the caption names, so the model can point
+ * `image_ask` back at a specific image.
  */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { getWorkspaceDir } from "@vellumai/plugin-api";
+
 import { imageHash } from "./caption-cache.js";
 
-/** The workspace attachments directory. */
-const ATTACHMENTS_DIR = "/workspace/data/attachments";
+/**
+ * The workspace attachments directory — the same directory the host's
+ * attachment store writes uploads to. Resolved per call: the workspace root
+ * is a runtime value, so a module-level constant would freeze whatever it
+ * happened to be at import time.
+ */
+function attachmentsDir(): string {
+  return join(getWorkspaceDir(), "data", "attachments");
+}
 
 /** File extension for a given media type, falling back to `.bin`. */
 function extensionForMediaType(mediaType: string): string {
@@ -38,12 +50,13 @@ function extensionForMediaType(mediaType: string): string {
  */
 export function persistImage(data: string, mediaType: string): string | null {
   try {
-    mkdirSync(ATTACHMENTS_DIR, { recursive: true });
+    const dir = attachmentsDir();
+    mkdirSync(dir, { recursive: true });
 
     const hash = imageHash(data);
     const ext = extensionForMediaType(mediaType);
     const filename = `${hash}${ext}`;
-    const filepath = join(ATTACHMENTS_DIR, filename);
+    const filepath = join(dir, filename);
 
     // Skip if already saved (content-hash dedup).
     if (existsSync(filepath)) {

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
@@ -33,7 +33,10 @@ const CAPTION_TIMEOUT_MS = 30_000;
 const CAPTION_SYSTEM_PROMPT =
   "You are a vision assistant. Describe the image concisely in 1-2 sentences. " +
   "Focus on the key visual content, text, charts, or UI elements that would be " +
-  "relevant for a text-based assistant to understand and reason about.";
+  "relevant for a text-based assistant to understand and reason about. " +
+  "Describe only what is visible: quote any text or numbers exactly as they " +
+  "are printed, and do not guess at, complete, or interpret what the image " +
+  "does not show.";
 
 const CAPTION_USER_PROMPT =
   "Describe this image concisely for a text-only assistant.";

--- a/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
+++ b/assistant/src/plugins/defaults/image-fallback/src/vision-caption.ts
@@ -1,11 +1,16 @@
 /**
- * Vision-based image captioning for the image-fallback plugin.
+ * Vision calls for the image-fallback plugin.
  *
  * When the active model cannot process images, this module finds a
- * vision-capable profile in the workspace's configured profiles and runs a
- * one-shot captioning call through the assistant's own inference (no
- * plugin-supplied API key). The caption replaces the image block in the
- * outgoing message history.
+ * vision-capable profile in the workspace's configured profiles
+ * ({@link findVisionProfile}) and runs one-shot calls against it through the
+ * assistant's own inference (no plugin-supplied API key).
+ *
+ * Two callers sit on the shared call ({@link describeImage}): the sweep's
+ * fixed-prompt caption ({@link captionImage}, cached by content hash) that
+ * replaces the image block in the outgoing history, and the `image_ask` tool's
+ * question about one image, whose answers are turn-specific and are not
+ * cached.
  */
 
 import {
@@ -53,6 +58,105 @@ export function findVisionProfile(): string | null {
   return null;
 }
 
+/** One vision call's prompts and limits. */
+export interface DescribeImageRequest {
+  /** System prompt framing what the vision model is being asked for. */
+  systemPrompt: string;
+  /** User-turn text sent alongside the image. */
+  userPrompt: string;
+  /** Response cap, defaulting to whatever the `vision` call site resolves. */
+  maxTokens?: number;
+  /** Wall-clock cap on the call. Defaults to {@link CAPTION_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /** Caller's cancellation, honored alongside the timeout. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Run one vision call over an image and return its text.
+ *
+ * The shared provider path behind every look the plugin takes at an image:
+ * {@link captionImage}'s fixed-prompt caption and the `image_ask` tool's
+ * question both land here, so the profile selection, timeout, tool-free
+ * request shape, and text extraction have one implementation.
+ *
+ * Tool use is disabled on the call, so the response is text; the answer is
+ * whatever text blocks it carries, joined. Returns `null` on a failed or
+ * empty call — callers decide what to show instead, and nothing throws out of
+ * here.
+ *
+ * @param image      The image content block to send.
+ * @param conversationId  Conversation the call is attributed to.
+ * @param profileKey Key of a vision-capable profile (from {@link findVisionProfile}).
+ * @param request    Prompts and limits for this call.
+ * @param logger     Turn-scoped logger for attribution, when the caller has
+ *                   one. Tool calls do not.
+ */
+export async function describeImage(
+  image: ImageContent,
+  conversationId: string,
+  profileKey: string,
+  request: DescribeImageRequest,
+  logger?: PluginLogger | null,
+): Promise<string | null> {
+  const timeout = AbortSignal.timeout(request.timeoutMs ?? CAPTION_TIMEOUT_MS);
+  const signal =
+    request.signal != null
+      ? AbortSignal.any([request.signal, timeout])
+      : timeout;
+
+  try {
+    const provider = await getConfiguredProvider("vision", {
+      overrideProfile: profileKey,
+      forceOverrideProfile: true,
+    });
+    if (!provider) {
+      logger?.warn(
+        { plugin: "image-fallback" },
+        "No provider resolved for vision profile",
+      );
+      return null;
+    }
+
+    const response = await provider.sendMessage(
+      [
+        {
+          role: "user",
+          content: [image, { type: "text", text: request.userPrompt }],
+        },
+      ],
+      {
+        systemPrompt: request.systemPrompt,
+        config: {
+          callSite: "vision",
+          conversationId,
+          overrideProfile: profileKey,
+          forceOverrideProfile: true,
+          tool_choice: { type: "none" },
+          ...(request.maxTokens != null
+            ? { max_tokens: request.maxTokens }
+            : {}),
+        },
+        signal,
+      },
+    );
+
+    const text = response.content
+      .flatMap((block) => (block.type === "text" ? [block.text] : []))
+      .join(" ")
+      .trim();
+    if (text.length > 0) {
+      return text;
+    }
+
+    logger?.warn({ plugin: "image-fallback" }, "Vision call returned no text");
+    return null;
+  } catch (err) {
+    logger?.warn({ plugin: "image-fallback", err }, "Vision call failed");
+    return null;
+  }
+}
+
 /**
  * Caption a single image block via a vision-capable profile.
  *
@@ -82,60 +186,19 @@ export async function captionImage(
     return cached;
   }
 
-  try {
-    const provider = await getConfiguredProvider("vision", {
-      overrideProfile: profileKey,
-      forceOverrideProfile: true,
-    });
-    if (!provider) {
-      logger.warn(
-        { plugin: "image-fallback" },
-        "No provider resolved for vision captioning profile",
-      );
-      return null;
-    }
-
-    const response = await provider.sendMessage(
-      [
-        {
-          role: "user",
-          content: [image, { type: "text", text: CAPTION_USER_PROMPT }],
-        },
-      ],
-      {
-        systemPrompt: CAPTION_SYSTEM_PROMPT,
-        config: {
-          callSite: "vision",
-          conversationId,
-          overrideProfile: profileKey,
-          forceOverrideProfile: true,
-          tool_choice: { type: "none" },
-        },
-        signal: AbortSignal.timeout(CAPTION_TIMEOUT_MS),
-      },
-    );
-
-    // Vision captioning returns text content; concatenate any text blocks
-    // (effectively always one here, since tool use is disabled).
-    const caption = response.content
-      .flatMap((block) => (block.type === "text" ? [block.text] : []))
-      .join(" ")
-      .trim();
-    if (caption.length > 0) {
-      setCachedCaption(hash, conversationId, caption);
-      return caption;
-    }
-
-    logger.warn(
-      { plugin: "image-fallback" },
-      "Vision captioning returned empty text",
-    );
-    return null;
-  } catch (err) {
-    logger.warn(
-      { plugin: "image-fallback", err },
-      "Vision captioning call failed",
-    );
+  const caption = await describeImage(
+    image,
+    conversationId,
+    profileKey,
+    {
+      systemPrompt: CAPTION_SYSTEM_PROMPT,
+      userPrompt: CAPTION_USER_PROMPT,
+    },
+    logger,
+  );
+  if (caption == null) {
     return null;
   }
+  setCachedCaption(hash, conversationId, caption);
+  return caption;
 }

--- a/assistant/src/plugins/defaults/image-fallback/tools/image_ask.ts
+++ b/assistant/src/plugins/defaults/image-fallback/tools/image_ask.ts
@@ -14,6 +14,13 @@
  * that its endpoint rejects) runs without the tool on that call, since the
  * tool list for the call is already built; the next turn gates correctly.
  *
+ * Everything here works against the failure mode that matters: a text-only
+ * model stating a detail it never saw. The vision prompt confines the answer
+ * to what is visible and has it lead with a marker when the image does not
+ * show it; the result relays that as an explicit "not in image" instead of a
+ * value; and the answer is always framed as one model's reading of the image
+ * rather than as fact.
+ *
  * Nothing here throws: every failure comes back as an `isError` result the
  * model can read and act on.
  */
@@ -40,13 +47,44 @@ import { describeImage, findVisionProfile } from "../src/vision-caption.js";
 /** Response cap for one answer: room for quoted text, not for an essay. */
 const ANSWER_MAX_TOKENS = 1024;
 
+/**
+ * Marker the vision model is told to lead with when the image does not
+ * contain the answer.
+ *
+ * A declared protocol, not a guess: the answer is scanned for this exact
+ * prefix and nothing else, so the caller learns the answer is unsupported
+ * without any heuristic reading of the prose. A model that ignores the
+ * instruction just yields an ordinary answer, which is the behavior without
+ * the marker at all.
+ */
+const NOT_VISIBLE_MARKER = "NOT_VISIBLE:";
+
 const ASK_SYSTEM_PROMPT =
   "You are a vision assistant answering one question about one image for a " +
   "text-only assistant that cannot see it. Answer only from what is visible " +
   "in the image. Quote text and numbers exactly as they are printed, " +
-  "including case, punctuation, and units. If the answer is not visible in " +
-  "the image, say so plainly instead of guessing or inferring it from " +
-  "context.";
+  "including case, punctuation, spacing, and units, and never round, " +
+  "reformat, complete, or correct them. Do not infer the answer from context, " +
+  "from what the image is probably of, or from anything you know outside it. " +
+  `If the answer is not visible in the image, or the image is too small, ` +
+  `blurred, or cropped to read it, begin your reply with ${NOT_VISIBLE_MARKER} ` +
+  "and then say what you can see instead. Never guess a value in order to " +
+  "have something to answer with.";
+
+/**
+ * The answer text plus whether the vision model reported the image does not
+ * show it.
+ */
+function readAnswer(raw: string): { answer: string; notVisible: boolean } {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith(NOT_VISIBLE_MARKER)) {
+    return { answer: trimmed, notVisible: false };
+  }
+  return {
+    answer: trimmed.slice(NOT_VISIBLE_MARKER.length).trim(),
+    notVisible: true,
+  };
+}
 
 function errorResult(content: string): ToolExecutionResult {
   return { content, isError: true };
@@ -78,9 +116,16 @@ const imageAsk = {
     'the image with `image` (the filename from the summary, e.g. "chart.png", ' +
     "or its stored path); omit `image` to use the most recent one. The model " +
     "answering sees only the image and your question: it has no conversation " +
-    "history, no memory, and no tools, so make each question self-contained " +
-    "and specific rather than referring to what was said earlier. Ask one " +
-    "question per call. The answer comes back as text, never as an image.",
+    "history, no memory of earlier turns, no access to files, and no tools. " +
+    "Make each question self-contained and specific, naming what to look for " +
+    "rather than referring to anything said earlier. Ask one question per " +
+    "call, and call it again for the next detail rather than asking for " +
+    "several at once. Ask whenever a detail matters instead of working from " +
+    "what the summary implies. The answer is one model's reading of the " +
+    "image, so pass on what it says and do not add detail it did not give; " +
+    "when it reports the answer is not in the image, say that rather than " +
+    "supplying a plausible value. The answer comes back as text, never as an " +
+    "image.",
   input_schema: {
     type: "object",
     properties: {
@@ -182,8 +227,25 @@ const imageAsk = {
         );
       }
 
+      const name = basename(match.filePath);
+      const read = readAnswer(answer);
+      if (read.notVisible) {
+        return {
+          content:
+            `The image "${name}" does not show the answer to that question. ` +
+            `What the vision model could see: ${read.answer}\n\n` +
+            "Do not state the detail you asked for as fact. Ask about " +
+            "something the image does show, or tell the user it is not in " +
+            "the image.",
+          isError: false,
+          status: "not in image",
+        };
+      }
+
       return {
-        content: `Answer about "${basename(match.filePath)}": ${answer}`,
+        content:
+          `Answer about "${name}", read from the image by a vision model: ` +
+          `${read.answer}`,
         isError: false,
       };
     } catch (err) {

--- a/assistant/src/plugins/defaults/image-fallback/tools/image_ask.ts
+++ b/assistant/src/plugins/defaults/image-fallback/tools/image_ask.ts
@@ -1,0 +1,197 @@
+/**
+ * `image_ask` — ask a vision-capable profile one question about one image in
+ * the conversation.
+ *
+ * The plugin's sweep replaces every image with a short `[Image "<filename>"
+ * auto-described …]` caption when the turn's model is text-only. The caption
+ * carries the gist, not the detail: exact text, a number in a corner, how many
+ * rows a table has. This tool re-opens the image for a specific question,
+ * routing it to a vision profile and returning the answer as text.
+ *
+ * It is off the wire whenever the turn's model can see images itself, via the
+ * `isActive` predicate, so a vision model never pays for its schema. The
+ * `post-model-call` recovery path (a model the catalog calls vision-capable
+ * that its endpoint rejects) runs without the tool on that call, since the
+ * tool list for the call is already built; the next turn gates correctly.
+ *
+ * Nothing here throws: every failure comes back as an `isError` result the
+ * model can read and act on.
+ */
+
+import { readFileSync } from "node:fs";
+import { basename, resolve, sep } from "node:path";
+
+import {
+  doesSupportVision,
+  getWorkspaceDir,
+  RiskLevel,
+  type ToolActivationContext,
+  type ToolContext,
+  type ToolDefinition,
+  type ToolExecutionResult,
+} from "@vellumai/plugin-api";
+
+import {
+  listConversationImages,
+  resolveConversationImage,
+} from "../src/image-index.js";
+import { describeImage, findVisionProfile } from "../src/vision-caption.js";
+
+/** Response cap for one answer: room for quoted text, not for an essay. */
+const ANSWER_MAX_TOKENS = 1024;
+
+const ASK_SYSTEM_PROMPT =
+  "You are a vision assistant answering one question about one image for a " +
+  "text-only assistant that cannot see it. Answer only from what is visible " +
+  "in the image. Quote text and numbers exactly as they are printed, " +
+  "including case, punctuation, and units. If the answer is not visible in " +
+  "the image, say so plainly instead of guessing or inferring it from " +
+  "context.";
+
+function errorResult(content: string): ToolExecutionResult {
+  return { content, isError: true };
+}
+
+/** Filenames the model can name, newest first, for an unresolved reference. */
+function knownFilenames(filePaths: string[]): string {
+  return filePaths.map((path) => `"${basename(path)}"`).join(", ");
+}
+
+/** Whether `filePath` resolves inside the workspace root. */
+function isInsideWorkspace(filePath: string): boolean {
+  try {
+    const root = resolve(getWorkspaceDir());
+    const target = resolve(filePath);
+    return target === root || target.startsWith(`${root}${sep}`);
+  } catch {
+    return false;
+  }
+}
+
+const imageAsk = {
+  description:
+    "Ask a vision model one question about an image in this conversation. " +
+    "You cannot see images: each one reaches you as an " +
+    '`[Image "<filename>" auto-described …]` summary, which covers the gist ' +
+    "and omits detail. Use this tool for the detail: exact text or numbers as " +
+    "printed, counts, colors, layout, or anything the summary left out. Name " +
+    'the image with `image` (the filename from the summary, e.g. "chart.png", ' +
+    "or its stored path); omit `image` to use the most recent one. The model " +
+    "answering sees only the image and your question: it has no conversation " +
+    "history, no memory, and no tools, so make each question self-contained " +
+    "and specific rather than referring to what was said earlier. Ask one " +
+    "question per call. The answer comes back as text, never as an image.",
+  input_schema: {
+    type: "object",
+    properties: {
+      question: {
+        type: "string",
+        description:
+          "The self-contained question to answer about the image, e.g. " +
+          '"What is the exact total shown in the bottom-right cell?".',
+      },
+      image: {
+        type: "string",
+        description:
+          "Filename of the image to look at, as it appears in the " +
+          '`[Image "<filename>" …]` summary, or its full stored path. Omit ' +
+          "to use the most recent image in the conversation.",
+      },
+    },
+    required: ["question"],
+    additionalProperties: false,
+  },
+  defaultRiskLevel: RiskLevel.Low,
+  /**
+   * Reading one image costs a vision call, so the tool is offered only to a
+   * model that cannot look at the image itself.
+   */
+  isActive: ({ model }: ToolActivationContext) => !doesSupportVision(model),
+  execute: async (
+    input: Record<string, unknown>,
+    ctx: ToolContext,
+  ): Promise<ToolExecutionResult> => {
+    try {
+      const question = typeof input.question === "string" ? input.question : "";
+      if (question.trim() === "") {
+        return errorResult("image_ask requires a non-empty `question`.");
+      }
+      const requested = typeof input.image === "string" ? input.image : "";
+
+      const images = listConversationImages(ctx.conversationId);
+      if (images.length === 0) {
+        return errorResult(
+          "No images are available in this conversation to ask about.",
+        );
+      }
+
+      const match = resolveConversationImage(images, requested);
+      if (match == null) {
+        return errorResult(
+          `No image named "${requested}" in this conversation. Available images: ${knownFilenames(
+            images.map((image) => image.filePath),
+          )}.`,
+        );
+      }
+
+      if (!isInsideWorkspace(match.filePath)) {
+        return errorResult(
+          `The image "${basename(
+            match.filePath,
+          )}" is stored outside the workspace and cannot be read.`,
+        );
+      }
+
+      let data: string;
+      try {
+        data = readFileSync(match.filePath).toString("base64");
+      } catch {
+        return errorResult(
+          `The image "${basename(
+            match.filePath,
+          )}" is no longer readable on disk.`,
+        );
+      }
+
+      const profileKey = findVisionProfile();
+      if (profileKey == null) {
+        return errorResult(
+          "No vision-capable model is configured, so images cannot be examined. Ask the user to configure one.",
+        );
+      }
+
+      const answer = await describeImage(
+        {
+          type: "image",
+          source: { type: "base64", media_type: match.mediaType, data },
+        },
+        ctx.conversationId,
+        profileKey,
+        {
+          systemPrompt: ASK_SYSTEM_PROMPT,
+          userPrompt: question,
+          maxTokens: ANSWER_MAX_TOKENS,
+          signal: ctx.signal,
+        },
+      );
+      if (answer == null) {
+        return errorResult(
+          `Could not get an answer about "${basename(
+            match.filePath,
+          )}" from the vision model. Retry if the detail matters.`,
+        );
+      }
+
+      return {
+        content: `Answer about "${basename(match.filePath)}": ${answer}`,
+        isError: false,
+      };
+    } catch (err) {
+      return errorResult(
+        `image_ask failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  },
+} satisfies ToolDefinition;
+
+export default imageAsk;

--- a/assistant/src/plugins/defaults/index.ts
+++ b/assistant/src/plugins/defaults/index.ts
@@ -24,6 +24,7 @@
  * {@link registerDefaultPlugins} at call time.
  */
 
+import { finalizeTool } from "../../tools/tool-defaults.js";
 import {
   clearInjectorRegistry,
   registerPluginInjectors,
@@ -54,6 +55,7 @@ import imageFallbackStop from "./image-fallback/hooks/stop.js";
 import imageFallbackUserPromptSubmit from "./image-fallback/hooks/user-prompt-submit.js";
 import imageFallbackPkg from "./image-fallback/package.json" with { type: "json" };
 import { resetCaptionCacheForTests } from "./image-fallback/src/caption-cache.js";
+import imageFallbackImageAsk from "./image-fallback/tools/image_ask.js";
 import imageRecoveryPostModelCall from "./image-recovery/hooks/post-model-call.js";
 import imageRecoveryStop from "./image-recovery/hooks/stop.js";
 import { resetImageRecoveryStoreForTests } from "./image-recovery/image-recovery-state-store.js";
@@ -114,6 +116,11 @@ import workspacePkg from "./workspace/package.json" with { type: "json" };
  * `shutdown`) avoids re-captioning the same image across turns, compactions,
  * and restarts; `conversation-deleted` removes the deleted conversation's
  * cache rows.
+ *
+ * The plugin also contributes the `image_ask` tool, which a text-only model
+ * calls to put one question to a vision profile about an image the sweep
+ * captioned. Its `isActive` predicate keeps it off the wire on every turn
+ * whose model can see images itself.
  */
 export const defaultImageFallbackPlugin: Plugin = {
   manifest: {
@@ -130,6 +137,7 @@ export const defaultImageFallbackPlugin: Plugin = {
     stop: imageFallbackStop,
     "conversation-deleted": imageFallbackConversationDeleted,
   },
+  tools: [finalizeTool(imageFallbackImageAsk, "image_ask")],
 };
 
 /**

--- a/assistant/src/tools/AGENTS.md
+++ b/assistant/src/tools/AGENTS.md
@@ -28,6 +28,8 @@ A plugin tool can declare `isActive({ model })` on its `ToolDefinition`. The too
 
 The predicate must be cheap and synchronous: it runs once per tool per provider call. Throwing counts as inactive; omitting the field means always active. It can only subtract from the surface: the host's own gates (subagent allowlist, disabled tools, disk pressure) run alongside it and still apply. Honored for plugin-owned tools only; core, skill, MCP, and workspace tools are gated by the host rules in `isToolActiveForContext` (`daemon/conversation-tool-setup.ts`).
 
+The shipped example is `image_ask` (`plugins/defaults/image-fallback/tools/image_ask.ts`): it lets a text-only model put one question about an image to a vision profile, and its predicate (`({ model }) => !doesSupportVision(model)`) keeps it out of every turn whose model can see the image itself.
+
 ## If You Have Approval
 
 If the core team has approved your new tool:


### PR DESCRIPTION
Part of JARVIS-1633.

**Stacks on #41300** (`aaron/jarvis-1633-host-tool-activation-gate`), which adds the host-side `isActive` gate this tool needs. Based on that branch, so the diff here is plugin-only; review #41300 first.

## What this does

A text-only turn sees each image as a one-line caption. When the model needs a detail the caption omits (the exact number in a cell, text in a screenshot, how many rows a table has), it has nowhere to go, so it guesses. `image_ask` gives it somewhere to go: name an image, ask one question, get a text answer read off the image by a vision profile.

Four pieces:

**1. Filename handles and a per-conversation image index.** The caption sweep now names each image in the text it substitutes (`[Image "receipt.png" auto-described for text-only model: …]`) and records the image's on-disk location in a `conversation_images` table inside the plugin's existing `caption-cache.sqlite`. A `workspace_ref` image resolves to the attachment store's canonical path via the new `getAttachmentFilePath` export, so no duplicate copy is written; inline base64 lands in the plugin's content-hash-deduped copy. The sweep visits every history image on every text-only turn, so the index is complete exactly where the tool is live, with no history scan. `conversation-deleted` purges the rows, `shutdown` closes the handle, every path fails open. Also fixes `image-persist.ts`, which had `/workspace/data/attachments` hardcoded, to derive the path from `getWorkspaceDir()`.

**2. The tool.** `tools/image_ask.ts`: `{ question (required), image? }`, `defaultRiskLevel: "low"`, `isActive: ({ model }) => !doesSupportVision(model)`. It resolves the named image (exact path, then basename, then newest when omitted, else an `isError` listing the filenames it does know), verifies the path is inside the workspace, reads the bytes, and calls the vision profile through a `describeImage(...)` generalized out of `captionImage`. Returns text only, never image content blocks. Never throws: every failure is an `isError` result.

**3. Hallucination hardening.** The vision prompt confines the answer to what is visible, forbids inferring from context or outside knowledge, and requires quoting text and numbers as printed. When the image does not show the answer, the vision model leads with a declared `NOT_VISIBLE:` marker; the tool matches that exact prefix (a protocol, not a heuristic read of the prose) and returns an explicit "not in image" result telling the model not to state the detail as fact. The description tells the model the answerer sees only the image and the question, with no history, memory, or tools, so questions must be self-contained. The caption prompt gets the same confinement.

**4. `imageFallback.captionMode`.** `caption` (default, unchanged behavior) describes every image up front. `handle-only` substitutes the filename alone and makes no vision call, so a conversation full of images costs nothing until the model asks about one. Read per sweep through the read-only config accessor, so a change lands on the next turn and a turn never rewrites the config file. Key path matches what the evals repo already writes.

## Why a new tool is acceptable here

`src/tools/AGENTS.md` discourages new non-skill tools because each one charges every conversation. This one is a plugin tool behind `isActive`, so it is off the wire on every turn whose model can see images itself, and under `handle-only` it replaces per-image vision calls with on-demand ones. The prompt cost lands only where it buys something.

## Validated

- `bun test src/plugins/defaults/image-fallback/__tests__` — 89 pass (24 new in `image-ask.test.ts`, plus sweep-index, `workspace_ref` filename, and `handle-only` cases added to `image-fallback.test.ts`), and each file also passes run alone.
- `src/__tests__/image-ask-tool-surface.test.ts` — the plugin's own tests run against a mocked plugin-api, so this one registers the **shipped** tool contribution into the real registry and runs the host's `isToolActiveForContext` over real catalog model ids: present and plugin-owned, absent for `claude-opus-5`, present for `accounts/fireworks/models/glm-5p2`. That is the wire-gating claim verified through the real path.
- `bun test` on the host gate, plugin-api export, plugin-state boundary guard, config loader, tool-setup, and tool-schema suites.
- `bun run typecheck:fast`, `bun run lint`, prettier, `bun run generate:openapi` (no spec change).
- Schema behavior checked directly: default `caption`, accepts `handle-only`, rejects anything else.

## Not validated

- **No live E2E.** The `cli-testing` flow needs an LLM provider key in the environment and there is none on this machine (no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `FIREWORKS_API_KEY` / …), so no instance was hatched. What that leaves unverified is real inference: whether a real vision model honors the `NOT_VISIBLE:` protocol, whether a real text-only model reaches for the tool when the caption is thin, and how the answers read in a live transcript. Registration and gating are covered by the surface test above rather than by a live run.
- The `handle-only` mode has not been run against a live conversation. Its substitution and its skipped vision call are unit-covered; how well a model works from filenames alone is exactly the question a live run would answer.
- `post-model-call` vision recovery still runs without the tool on the rejected call, since that call's tool list is already built. Documented in the tool's header; the next turn gates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvZSWuAaVHhMYqCD4aLb8G
