### PR TITLE
fix(schedule): lower schedule_delete risk from high to medium

### DIFF
--- a/assistant/src/config/bundled-skills/schedule/TOOLS.json
+++ b/assistant/src/config/bundled-skills/schedule/TOOLS.json
@@ -249,7 +249,7 @@
       "name": "schedule_delete",
       "description": "Delete a scheduled automation and all its run history",
       "category": "schedule",
-      "risk": "high",
+      "risk": "medium",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/gateway/src/risk/schedule-risk-classifier.ts
+++ b/gateway/src/risk/schedule-risk-classifier.ts
@@ -44,7 +44,7 @@ const SCRIPT_MODE_REASON =
  *
  * Only `schedule_create` and `schedule_update` route through here. Other
  * schedule tools (`schedule_list`, `schedule_delete`) keep their static
- * registry risk (low / high respectively).
+ * registry risk (low / medium respectively).
  */
 export class ScheduleRiskClassifier implements RiskClassifier<ScheduleClassifierInput> {
   async classify(input: ScheduleClassifierInput): Promise<RiskAssessment> {


### PR DESCRIPTION
## Summary
- `schedule_delete` was tagged `risk: high`, so it prompted on every call even under the **Relaxed** preset (auto-approve ≤ medium). Lower it to `medium`, matching `schedule_create`/`schedule_update`.
- Update the gateway classifier comment that documented the old level.

## Why
Prod trace (`telemetry.pii_turn_raw`) for a LogRocket session on 2026-08-19: a Relaxed-mode user got ~13 permission prompts in one voice conversation, all `schedule_delete` (one per reminder, repeated as the reminder set was reworked). No `bash` call prompted. The tool only deletes assistant-owned jobs and run history; it is no more consequential than creating a job that will act in the future, which is already medium.

## Behavior change
Relaxed users no longer see a prompt for `schedule_delete`. Strict/Conservative still prompt. `schedule_delete` remains a side-effect tool, so `forcePromptSideEffects` and background-context handling are unchanged.

## Verification
- `cd assistant && bun run typecheck:fast && bun run lint` ✅
- `bun test src/__tests__/schedule-tools.test.ts src/__tests__/tool-executor.test.ts src/tools/__tests__/schedule-tool-input-schemas.test.ts` — 191 pass ✅
- `cd gateway && bun run typecheck` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYwAHZb2PnyEy9Z6VrCRvc