### PR TITLE
feat(web): route chat through ChatGPT after a subscription sign-in

### DIFF
--- a/clients/web/src/domains/settings/ai/chatgpt-default-provider-step.tsx
+++ b/clients/web/src/domains/settings/ai/chatgpt-default-provider-step.tsx
@@ -1,0 +1,214 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@vellumai/design-library/components/button";
+import { Typography } from "@vellumai/design-library/components/typography";
+import { Loader2 } from "lucide-react";
+
+import { useProviderActions } from "@/domains/settings/ai/use-provider-actions";
+import { configLlmDefaultproviderGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import type {
+  DefaultProviderStatus,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
+import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
+import { useTranslation } from "@/i18n";
+
+/**
+ * What a fresh ChatGPT connection should do about the default provider.
+ *
+ * - `adopt`: the standing default cannot serve a turn (no credential, no
+ *   connection, nothing configured at all), so chat is broken until something
+ *   changes. Switching is the only outcome the user could want.
+ * - `offer`: the standing default works, so the choice is the user's.
+ * - `hidden`: ChatGPT already is the default, or this assistant has no
+ *   default-provider routes to write through.
+ */
+export type ChatgptDefaultProviderVerdict = "adopt" | "offer" | "hidden";
+
+/**
+ * `unknown` means the daemon could not check (credential store unreachable),
+ * not that the default is broken. Switching on it would move a working setup
+ * because of a transient read, so it is treated as usable.
+ */
+export function chatgptDefaultProviderVerdict({
+  supportsDefaultProvider,
+  status,
+  connectionName,
+}: {
+  supportsDefaultProvider: boolean;
+  status: DefaultProviderStatus | undefined;
+  connectionName: string;
+}): ChatgptDefaultProviderVerdict {
+  if (!supportsDefaultProvider) {
+    return "hidden";
+  }
+  if (status == null) {
+    return "offer";
+  }
+  if (status.resolvedConnectionName === connectionName) {
+    return "hidden";
+  }
+  const { status: availability } = status.availability;
+  if (availability === "ok" || availability === "unknown") {
+    return "offer";
+  }
+  return "adopt";
+}
+
+type StepPhase = "deciding" | "hidden" | "offer" | "applying" | "applied";
+
+interface ChatgptDefaultProviderStepProps {
+  assistantId: string;
+  /** The subscription row both sign-in paths just stored. */
+  connection: ProviderConnection;
+  /**
+   * Hands the connection to the host, which persists it and closes the
+   * editor. Called on Done, and straight away when there is nothing to
+   * decide.
+   */
+  onDone: (connection: ProviderConnection) => void;
+}
+
+/**
+ * The step a ChatGPT sign-in ends on: whether chat should route through the
+ * new subscription.
+ *
+ * Signing in stores a credential and a connection and nothing else, so on an
+ * assistant whose default provider has no key the next message still fails.
+ * That case switches without asking; a working default is left alone behind a
+ * button, because a user who signed in to add a second option did not ask for
+ * their chat model to change.
+ */
+export function ChatgptDefaultProviderStep({
+  assistantId,
+  connection,
+  onDone,
+}: ChatgptDefaultProviderStepProps) {
+  const { t } = useTranslation("settings");
+  const [phase, setPhase] = useState<StepPhase>("deciding");
+  const { setDefaultAsync } = useProviderActions(assistantId);
+
+  const supportsDefaultProvider = useSupportsDefaultProviderSettings();
+  // Read only until the verdict is in: the switch invalidates this key, and a
+  // step that kept observing it would refetch a status it has already used.
+  const { data: status, isPending } = useQuery({
+    ...configLlmDefaultproviderGetOptions({
+      path: { assistant_id: assistantId },
+    }),
+    enabled: supportsDefaultProvider && phase === "deciding",
+  });
+
+  const apply = useCallback(async () => {
+    setPhase("applying");
+    try {
+      await setDefaultAsync(connection);
+      setPhase("applied");
+    } catch {
+      // The hook has already surfaced the failure as a toast; fall back to
+      // the button so the user can try again.
+      setPhase("offer");
+    }
+  }, [connection, setDefaultAsync]);
+
+  // The host's callback is an unstable prop on both editors, so it is read
+  // through a ref rather than pulled into the decision effect's deps.
+  const onDoneRef = useRef(onDone);
+  useLayoutEffect(() => {
+    onDoneRef.current = onDone;
+  }, [onDone]);
+
+  // Decided once, from the default as it stood before this sign-in: applying
+  // it refreshes the status, which would otherwise re-read as "already the
+  // default" and retract the step the user is looking at.
+  const decidedRef = useRef(false);
+  useEffect(() => {
+    if (decidedRef.current) {
+      return;
+    }
+    if (supportsDefaultProvider && isPending) {
+      return;
+    }
+    decidedRef.current = true;
+    const verdict = chatgptDefaultProviderVerdict({
+      supportsDefaultProvider,
+      status,
+      connectionName: connection.name,
+    });
+    if (verdict === "hidden") {
+      setPhase("hidden");
+      onDoneRef.current(connection);
+      return;
+    }
+    if (verdict === "adopt") {
+      void apply();
+      return;
+    }
+    setPhase("offer");
+  }, [apply, connection, isPending, status, supportsDefaultProvider]);
+
+  if (phase === "deciding" || phase === "hidden") {
+    return null;
+  }
+
+  return (
+    <div className="space-y-3">
+      {phase === "applying" ? (
+        <div className="flex items-center gap-2">
+          <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
+          <Typography
+            variant="body-small-default"
+            className="text-[var(--content-tertiary)]"
+          >
+            {t("chatgptDefaultProviderStep.applying")}
+          </Typography>
+        </div>
+      ) : null}
+
+      {phase === "applied" ? (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--system-positive-strong)]"
+        >
+          {t("chatgptDefaultProviderStep.applied")}
+        </Typography>
+      ) : null}
+
+      {phase === "offer" ? (
+        <div className="space-y-2">
+          <Typography
+            variant="body-small-default"
+            as="p"
+            className="text-[var(--content-secondary)]"
+          >
+            {t("chatgptDefaultProviderStep.offerHint")}
+          </Typography>
+          <Button variant="primary" size="compact" onClick={() => void apply()}>
+            {t("chatgptDefaultProviderStep.useForChat")}
+          </Button>
+        </div>
+      ) : null}
+
+      {/* Withheld mid-write: closing the editor on a switch still in flight
+          would leave the user with no word on how it landed. */}
+      {phase === "applying" ? null : (
+        <div>
+          <Button
+            variant="ghost"
+            size="compact"
+            onClick={() => onDone(connection)}
+          >
+            {t("chatgptDefaultProviderStep.done")}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/ai/chatgpt-default-provider-step.tsx
+++ b/clients/web/src/domains/settings/ai/chatgpt-default-provider-step.tsx
@@ -17,7 +17,7 @@ import type {
   DefaultProviderStatus,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
-import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
+import { useDefaultProviderSettingsSupport } from "@/lib/backwards-compat/default-provider-settings";
 import { useTranslation } from "@/i18n";
 
 /**
@@ -95,7 +95,8 @@ export function ChatgptDefaultProviderStep({
   const [phase, setPhase] = useState<StepPhase>("deciding");
   const { setDefaultAsync } = useProviderActions(assistantId);
 
-  const supportsDefaultProvider = useSupportsDefaultProviderSettings();
+  const { supported: supportsDefaultProvider, versionKnown } =
+    useDefaultProviderSettingsSupport(assistantId);
   // Read only until the verdict is in: the switch invalidates this key, and a
   // step that kept observing it would refetch a status it has already used.
   const { data: status, isPending } = useQuery({
@@ -132,6 +133,12 @@ export function ChatgptDefaultProviderStep({
     if (decidedRef.current) {
       return;
     }
+    // A sign-in that finishes before the identity fetch lands would read the
+    // version-gated support as `false` and latch "no such routes" on an
+    // assistant that has them, closing the editor over a broken default.
+    if (!versionKnown) {
+      return;
+    }
     if (supportsDefaultProvider && isPending) {
       return;
     }
@@ -151,7 +158,14 @@ export function ChatgptDefaultProviderStep({
       return;
     }
     setPhase("offer");
-  }, [apply, connection, isPending, status, supportsDefaultProvider]);
+  }, [
+    apply,
+    connection,
+    isPending,
+    status,
+    supportsDefaultProvider,
+    versionKnown,
+  ]);
 
   if (phase === "deciding" || phase === "hidden") {
     return null;

--- a/clients/web/src/domains/settings/ai/chatgpt-oauth-section.test.tsx
+++ b/clients/web/src/domains/settings/ai/chatgpt-oauth-section.test.tsx
@@ -209,7 +209,9 @@ function resetState() {
   putShouldFail = false;
   invalidatedQueryIds = [];
   toastErrors = [];
-  useAssistantIdentityStore.getState().setIdentity("test-asst", "0.11.0");
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("test-asst", "0.11.0", ASSISTANT_ID);
 }
 
 function renderSection(onConnected: (c: ProviderConnection) => void = () => {}) {
@@ -363,7 +365,7 @@ describe("ChatgptOAuthSection with device-code login on", () => {
     expect(putBodies).toEqual([]);
   });
 
-  test("the switch refreshes the provider, profile and default caches", async () => {
+  test("the switch refreshes the provider, profile, call-site and default caches", async () => {
     defaultProviderState = {
       provider: "anthropic",
       resolvedConnectionName: "anthropic-personal",
@@ -379,6 +381,7 @@ describe("ChatgptOAuthSection with device-code login on", () => {
       "configLlmDefaultproviderGet",
       "configGet",
       "inferenceProfilesGet",
+      "configLlmCallsitesGet",
     ]) {
       expect(invalidatedQueryIds).toContain(id);
     }
@@ -419,8 +422,43 @@ describe("ChatgptOAuthSection with device-code login on", () => {
     expect(putBodies).toEqual([]);
   });
 
+  test("a sign-in that lands before the version does waits for it", async () => {
+    // The identity fetch has not answered yet, so the version-gated support
+    // reads `false` for a reason that says nothing about this assistant.
+    useAssistantIdentityStore.getState().clearIdentity();
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: { status: "missing_credential" },
+    };
+    const connected: ProviderConnection[] = [];
+    renderSection((c) => connected.push(c));
+
+    signIn();
+
+    await screen.findByText("ChatGPT subscription connected successfully.");
+    expect(connected).toEqual([]);
+    expect(putBodies).toEqual([]);
+    expect(screen.queryByText("Done")).toBeNull();
+
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("test-asst", "0.11.0", ASSISTANT_ID);
+    });
+
+    expect(
+      await screen.findByText("ChatGPT is now your default provider for chat."),
+    ).toBeDefined();
+    expect(putBodies).toEqual([
+      { provider: "chatgpt", connectionName: "chatgpt-subscription" },
+    ]);
+  });
+
   test("assistants without the default-provider routes hand over as before", async () => {
-    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.7");
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("test-asst", "0.10.7", ASSISTANT_ID);
     const connected: ProviderConnection[] = [];
     renderSection((c) => connected.push(c));
 

--- a/clients/web/src/domains/settings/ai/chatgpt-oauth-section.test.tsx
+++ b/clients/web/src/domains/settings/ai/chatgpt-oauth-section.test.tsx
@@ -4,17 +4,24 @@
  * With `chatgpt-device-code-login` on, covers the device-code path the section
  * leads with: the code and its destination on screen, the stored connection
  * handed back on success, and a rejection keeping the code visible beside the
- * account-setting hint. The redirect-and-paste path is covered only as far as
- * being reachable behind the disclosure; its own behaviour is unchanged.
+ * account-setting hint. The redirect-and-paste path is covered as far as being
+ * reachable behind the disclosure and taking the section over once it signs
+ * in; its own behaviour is unchanged.
  *
  * With the flag off, covers that redirect-and-paste is the whole section: no
  * code is minted, no disclosure is offered, the flow wears the plain sign-in
  * name rather than the one it narrows to beside the device code, and a value
  * landing after mount leaves that section as it is.
+ *
+ * Both arms cover the step every sign-in ends on: a default provider that
+ * cannot serve a turn is switched to the new subscription without asking, a
+ * working one is left alone behind a button, and the caches the switch
+ * invalidates.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
   cleanup,
@@ -23,8 +30,12 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 
-import type { ProviderConnection } from "@/generated/daemon/types.gen";
+import type {
+  DefaultProviderStatus,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
 import type { PollOutcome } from "@/utils/poll-until-settled";
 
 const ASSISTANT_ID = "asst-1";
@@ -50,6 +61,19 @@ const STORED_CONNECTION: ProviderConnection = {
   isManaged: false,
 };
 
+/** The default provider as the daemon reports it before the sign-in. */
+let defaultProviderState: DefaultProviderStatus = {
+  provider: "anthropic",
+  resolvedConnectionName: "anthropic-personal",
+  availability: { status: "ok" },
+};
+/** Bodies the section PUT to the default-provider route. */
+let putBodies: Array<{ provider: string; connectionName?: string }> = [];
+let putShouldFail = false;
+/** `_id` of every query key the section asked to invalidate. */
+let invalidatedQueryIds: string[] = [];
+let toastErrors: string[] = [];
+
 let startShouldFail = false;
 /** The daemon answers the mint route with a 404. */
 let startUnsupported = false;
@@ -58,6 +82,43 @@ let startCalls = 0;
 let cancelledStates: string[] = [];
 /** How the scripted flow settles. `never` leaves it pending on screen. */
 let settle: PollOutcome | "never" = { kind: "connected" };
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: {
+    success: () => {},
+    error: (message: string) => {
+      toastErrors.push(message);
+    },
+  },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: () => {},
+}));
+
+const actualSdk = await import("@/generated/daemon/sdk.gen");
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...actualSdk,
+  configLlmDefaultproviderGet: async () => ({ data: defaultProviderState }),
+  configLlmDefaultproviderPut: async (options?: {
+    body?: { provider: string; connectionName?: string };
+  }) => {
+    if (putShouldFail) {
+      throw new Error("put failed");
+    }
+    if (options?.body) {
+      putBodies.push(options.body);
+    }
+    return { data: defaultProviderState, response: { ok: true } };
+  },
+  inferenceChatgptsubscriptionAuthPost: async () => ({
+    data: { authorize_url: "https://auth.openai.com/authorize" },
+  }),
+  inferenceChatgptsubscriptionAuthExchangePost: async () => ({ data: {} }),
+}));
 
 mock.module("@/domains/settings/ai/chatgpt-subscription-api", () => ({
   ...actualApi,
@@ -99,32 +160,99 @@ const { useClientFeatureFlagStore } = await import(
 const { ChatgptOAuthSection } = await import(
   "@/domains/settings/ai/chatgpt-oauth-section"
 );
+const { useAssistantIdentityStore } = await import(
+  "@/stores/assistant-identity-store"
+);
+
+// The paste flow opens OpenAI's authorize page in a second tab. There is no
+// tab to open here, and the flow's own state is what is under test.
+window.open = () => null;
+
+/**
+ * A client per render, with `invalidateQueries` recording what it was asked
+ * to refresh: the live-refresh contract of this step is which caches it
+ * marks stale, not what the daemon then answers.
+ */
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  const invalidate = client.invalidateQueries.bind(client);
+  client.invalidateQueries = (filters, options) => {
+    const key = (filters as { queryKey?: Array<{ _id?: string }> } | undefined)
+      ?.queryKey;
+    const id = key?.[0]?._id;
+    if (id) {
+      invalidatedQueryIds.push(id);
+    }
+    return invalidate(filters, options);
+  };
+  return createElement(QueryClientProvider, { client }, children);
+}
 
 function setDeviceCodeLoginFlag(value: boolean) {
   useClientFeatureFlagStore.setState({ chatgptDeviceCodeLogin: value });
 }
 
+function resetState() {
+  startShouldFail = false;
+  startUnsupported = false;
+  startCalls = 0;
+  cancelledStates = [];
+  settle = { kind: "connected" };
+  defaultProviderState = {
+    provider: "anthropic",
+    resolvedConnectionName: "anthropic-personal",
+    availability: { status: "ok" },
+  };
+  putBodies = [];
+  putShouldFail = false;
+  invalidatedQueryIds = [];
+  toastErrors = [];
+  useAssistantIdentityStore.getState().setIdentity("test-asst", "0.11.0");
+}
+
 function renderSection(onConnected: (c: ProviderConnection) => void = () => {}) {
   return render(
-    <ChatgptOAuthSection
-      assistantId={ASSISTANT_ID}
-      onConnected={onConnected}
-    />,
+    <Wrapper>
+      <ChatgptOAuthSection
+        assistantId={ASSISTANT_ID}
+        onConnected={onConnected}
+      />
+    </Wrapper>,
   );
+}
+
+function signIn() {
+  fireEvent.click(screen.getByText("Sign in with ChatGPT"));
+}
+
+/**
+ * Drives the redirect-and-paste flow from its button to a stored credential.
+ * Both clicks settle a promise the flow renders from, so each is awaited
+ * inside `act` rather than leaving the update to land after the assertion.
+ */
+async function completePasteSignIn(signInLabel: string) {
+  await act(async () => {
+    fireEvent.click(screen.getByText(signInLabel));
+  });
+  fireEvent.change(screen.getByPlaceholderText("Paste callback URL here..."), {
+    target: { value: "https://example.com/callback?code=code-1&state=state-1" },
+  });
+  await act(async () => {
+    fireEvent.click(screen.getByText("Complete Sign In"));
+  });
 }
 
 describe("ChatgptOAuthSection with device-code login on", () => {
   beforeEach(() => {
-    startShouldFail = false;
-    startUnsupported = false;
-    startCalls = 0;
-    cancelledStates = [];
-    settle = { kind: "connected" };
+    resetState();
     setDeviceCodeLoginFlag(true);
   });
 
   afterEach(() => {
     cleanup();
+    useAssistantIdentityStore.getState().clearIdentity();
     setDeviceCodeLoginFlag(false);
   });
 
@@ -150,17 +278,157 @@ describe("ChatgptOAuthSection with device-code login on", () => {
     expect(openLink?.getAttribute("rel")).toBe("noopener noreferrer");
   });
 
-  test("hands the stored connection back when the code is authorized", async () => {
+  test("hands the stored connection back once the step is done with it", async () => {
     const connected: ProviderConnection[] = [];
     renderSection((c) => connected.push(c));
 
-    fireEvent.click(screen.getByText("Sign in with ChatGPT"));
+    signIn();
 
-    await waitFor(() => expect(connected.length).toBe(1));
-    expect(connected[0]).toEqual(STORED_CONNECTION);
+    // The working default keeps the step on screen, so the host is not told
+    // (and the editor does not close) until the user is finished with it.
+    const done = await screen.findByText("Done");
     expect(
       screen.getByText("ChatGPT subscription connected successfully."),
     ).toBeDefined();
+    expect(connected.length).toBe(0);
+
+    fireEvent.click(done);
+
+    expect(connected).toEqual([STORED_CONNECTION]);
+  });
+
+  test("a default that cannot serve a turn is switched without asking", async () => {
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: {
+        status: "missing_credential",
+        message:
+          'Connection "anthropic-personal" has no API key stored. Add one.',
+      },
+    };
+    const connected: ProviderConnection[] = [];
+    renderSection((c) => connected.push(c));
+
+    signIn();
+
+    expect(
+      await screen.findByText("ChatGPT is now your default provider for chat."),
+    ).toBeDefined();
+    expect(putBodies).toEqual([
+      { provider: "chatgpt", connectionName: "chatgpt-subscription" },
+    ]);
+    expect(screen.queryByText("Use ChatGPT for chat")).toBeNull();
+    expect(connected.length).toBe(0);
+
+    fireEvent.click(screen.getByText("Done"));
+
+    expect(connected).toEqual([STORED_CONNECTION]);
+  });
+
+  test("a working default is left alone behind a button", async () => {
+    const connected: ProviderConnection[] = [];
+    renderSection((c) => connected.push(c));
+
+    signIn();
+
+    const useForChat = await screen.findByText("Use ChatGPT for chat");
+    expect(putBodies).toEqual([]);
+
+    fireEvent.click(useForChat);
+
+    expect(
+      await screen.findByText("ChatGPT is now your default provider for chat."),
+    ).toBeDefined();
+    expect(putBodies).toEqual([
+      { provider: "chatgpt", connectionName: "chatgpt-subscription" },
+    ]);
+    expect(connected.length).toBe(0);
+  });
+
+  test("an unreadable default is offered rather than overridden", async () => {
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: {
+        status: "unknown",
+        message: "The credential store is unreachable.",
+      },
+    };
+    renderSection();
+
+    signIn();
+
+    expect(await screen.findByText("Use ChatGPT for chat")).toBeDefined();
+    expect(putBodies).toEqual([]);
+  });
+
+  test("the switch refreshes the provider, profile and default caches", async () => {
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: { status: "missing_credential" },
+    };
+    renderSection();
+
+    signIn();
+
+    await screen.findByText("ChatGPT is now your default provider for chat.");
+    for (const id of [
+      "inferenceProviderconnectionsGet",
+      "configLlmDefaultproviderGet",
+      "configGet",
+      "inferenceProfilesGet",
+    ]) {
+      expect(invalidatedQueryIds).toContain(id);
+    }
+  });
+
+  test("a failed switch falls back to the button", async () => {
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: { status: "missing_credential" },
+    };
+    putShouldFail = true;
+    renderSection();
+
+    signIn();
+
+    expect(await screen.findByText("Use ChatGPT for chat")).toBeDefined();
+    expect(toastErrors).toEqual([
+      "Failed to set the default provider. Please try again.",
+    ]);
+  });
+
+  test("nothing is asked when ChatGPT already is the default", async () => {
+    defaultProviderState = {
+      provider: "chatgpt",
+      connectionName: "chatgpt-subscription",
+      resolvedConnectionName: "chatgpt-subscription",
+      availability: { status: "ok" },
+    };
+    const connected: ProviderConnection[] = [];
+    renderSection((c) => connected.push(c));
+
+    signIn();
+
+    await waitFor(() => expect(connected).toEqual([STORED_CONNECTION]));
+    expect(screen.queryByText("Use ChatGPT for chat")).toBeNull();
+    expect(screen.queryByText("Done")).toBeNull();
+    expect(putBodies).toEqual([]);
+  });
+
+  test("assistants without the default-provider routes hand over as before", async () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.10.7");
+    const connected: ProviderConnection[] = [];
+    renderSection((c) => connected.push(c));
+
+    signIn();
+
+    await waitFor(() => expect(connected).toEqual([STORED_CONNECTION]));
+    expect(screen.queryByText("Use ChatGPT for chat")).toBeNull();
+    expect(putBodies).toEqual([]);
   });
 
   test("keeps the code beside the account-setting hint on a rejection", async () => {
@@ -281,16 +549,46 @@ describe("ChatgptOAuthSection with device-code login on", () => {
     ).toBeDefined();
     expect(screen.getByText("Hide other sign-in options")).toBeDefined();
   });
+
+  // The disclosure's sign-in ends on the same step the device code does, and
+  // the device code steps aside once the credential is stored.
+  test("a paste sign-in behind the disclosure reaches the step", async () => {
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: { status: "missing_credential" },
+    };
+    const connected: ProviderConnection[] = [];
+    renderSection((c) => connected.push(c));
+
+    fireEvent.click(screen.getByText("Other sign-in options"));
+    await completePasteSignIn("Open ChatGPT sign-in");
+
+    expect(
+      await screen.findByText("ChatGPT is now your default provider for chat."),
+    ).toBeDefined();
+    expect(putBodies).toEqual([
+      { provider: "chatgpt", connectionName: "chatgpt-subscription" },
+    ]);
+    expect(screen.queryByText("Sign in with ChatGPT")).toBeNull();
+    expect(screen.queryByText("Hide other sign-in options")).toBeNull();
+    expect(connected.length).toBe(0);
+
+    fireEvent.click(screen.getByText("Done"));
+
+    expect(connected).toEqual([STORED_CONNECTION]);
+  });
 });
 
 describe("ChatgptOAuthSection with device-code login off", () => {
   beforeEach(() => {
-    startCalls = 0;
+    resetState();
     setDeviceCodeLoginFlag(false);
   });
 
   afterEach(() => {
     cleanup();
+    useAssistantIdentityStore.getState().clearIdentity();
   });
 
   test("the paste flow is the whole section", () => {
@@ -344,5 +642,49 @@ describe("ChatgptOAuthSection with device-code login off", () => {
       screen.queryByText("Enter this code on the ChatGPT page."),
     ).toBeNull();
     expect(startCalls).toBe(0);
+  });
+
+  test("a default that cannot serve a turn is switched without asking", async () => {
+    defaultProviderState = {
+      provider: "anthropic",
+      resolvedConnectionName: "anthropic-personal",
+      availability: { status: "missing_credential" },
+    };
+    const connected: ProviderConnection[] = [];
+    renderSection((c) => connected.push(c));
+
+    await completePasteSignIn("Sign in with ChatGPT");
+
+    expect(
+      await screen.findByText("ChatGPT is now your default provider for chat."),
+    ).toBeDefined();
+    expect(putBodies).toEqual([
+      { provider: "chatgpt", connectionName: "chatgpt-subscription" },
+    ]);
+    expect(connected.length).toBe(0);
+
+    fireEvent.click(screen.getByText("Done"));
+
+    expect(connected).toEqual([STORED_CONNECTION]);
+  });
+
+  test("a working default is left alone behind a button", async () => {
+    const connected: ProviderConnection[] = [];
+    renderSection((c) => connected.push(c));
+
+    await completePasteSignIn("Sign in with ChatGPT");
+
+    const useForChat = await screen.findByText("Use ChatGPT for chat");
+    expect(putBodies).toEqual([]);
+
+    fireEvent.click(useForChat);
+
+    expect(
+      await screen.findByText("ChatGPT is now your default provider for chat."),
+    ).toBeDefined();
+    expect(putBodies).toEqual([
+      { provider: "chatgpt", connectionName: "chatgpt-subscription" },
+    ]);
+    expect(connected.length).toBe(0);
   });
 });

--- a/clients/web/src/domains/settings/ai/chatgpt-oauth-section.tsx
+++ b/clients/web/src/domains/settings/ai/chatgpt-oauth-section.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
 import { Typography } from "@vellumai/design-library/components/typography";
 
+import { inferenceProviderconnectionsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
 import { useTranslation } from "@/i18n";
 
+import { ChatgptDefaultProviderStep } from "./chatgpt-default-provider-step";
 import { ChatgptDeviceAuthFlow } from "./chatgpt-device-auth-flow";
 import { ChatgptPasteAuthFlow } from "./chatgpt-paste-auth-flow";
 import { useChatgptDeviceCodeLogin } from "./use-chatgpt-device-code-login-flag";
@@ -13,6 +16,14 @@ import { useChatgptDeviceCodeLogin } from "./use-chatgpt-device-code-login-flag"
 interface ChatgptOAuthSectionProps {
   assistantId: string;
   onConnected: (connection: ProviderConnection) => void;
+}
+
+/** Which sign-in stored the credential, so the other one steps aside. */
+type SignInPath = "device" | "paste";
+
+interface ConnectedSignIn {
+  connection: ProviderConnection;
+  via: SignInPath;
 }
 
 /**
@@ -27,14 +38,18 @@ interface ChatgptOAuthSectionProps {
  * paste flow takes the section over outright when the assistant's daemon has
  * no device-auth route at all. Whenever the paste flow is the only sign-in on
  * screen it stands alone, under the plain name it carried before the device
- * code joined it. Every path reports the same stored connection through
- * `onConnected` for the parent to persist.
+ * code joined it.
+ *
+ * Both paths finish here: whichever one stored the credential hands its
+ * connection to the default-provider step, and the host is told about it
+ * (which closes the editor) once that step is done with it.
  */
 export function ChatgptOAuthSection({
   assistantId,
   onConnected,
 }: ChatgptOAuthSectionProps) {
   const { t } = useTranslation("settings");
+  const queryClient = useQueryClient();
   const deviceCodeLoginFlag = useChatgptDeviceCodeLogin();
   // The flag picks the section's shape once, at mount, and a value that lands
   // afterwards never changes it. Swapping the flows mid-visit would unmount
@@ -46,11 +61,34 @@ export function ChatgptOAuthSection({
   const [deviceCodeLoginOn] = useState(deviceCodeLoginFlag);
   const [otherOptionsOpen, setOtherOptionsOpen] = useState(false);
   const [deviceAuthUnsupported, setDeviceAuthUnsupported] = useState(false);
+  const [connected, setConnected] = useState<ConnectedSignIn | null>(null);
   const handleDeviceAuthUnsupported = useCallback(
     () => setDeviceAuthUnsupported(true),
     [],
   );
   const deviceCodeShown = deviceCodeLoginOn && !deviceAuthUnsupported;
+
+  const handleConnected = useCallback(
+    (connection: ProviderConnection, via: SignInPath) => {
+      setConnected({ connection, via });
+      // The row exists on the daemon now, so the Providers list behind the
+      // editor is stale whether or not the user finishes the step below.
+      void queryClient.invalidateQueries({
+        queryKey: inferenceProviderconnectionsGetQueryKey({
+          path: { assistant_id: assistantId },
+        }),
+      });
+    },
+    [assistantId, queryClient],
+  );
+  const handleDeviceConnected = useCallback(
+    (connection: ProviderConnection) => handleConnected(connection, "device"),
+    [handleConnected],
+  );
+  const handlePasteConnected = useCallback(
+    (connection: ProviderConnection) => handleConnected(connection, "paste"),
+    [handleConnected],
+  );
 
   return (
     <div className="space-y-3 rounded-lg border border-[var(--border-base)] p-4">
@@ -62,35 +100,45 @@ export function ChatgptOAuthSection({
         {t("chatgptOauthSection.intro")}
       </Typography>
 
-      {deviceCodeShown ? (
+      {deviceCodeShown && connected?.via !== "paste" ? (
         <>
           <ChatgptDeviceAuthFlow
             assistantId={assistantId}
-            onConnected={onConnected}
+            onConnected={handleDeviceConnected}
             superseded={otherOptionsOpen}
             onUnsupported={handleDeviceAuthUnsupported}
           />
 
-          <div>
-            <Button
-              variant="ghost"
-              size="compact"
-              aria-expanded={otherOptionsOpen}
-              onClick={() => setOtherOptionsOpen((open) => !open)}
-            >
-              {otherOptionsOpen
-                ? t("chatgptOauthSection.hideOtherOptions")
-                : t("chatgptOauthSection.otherOptions")}
-            </Button>
-          </div>
+          {connected ? null : (
+            <div>
+              <Button
+                variant="ghost"
+                size="compact"
+                aria-expanded={otherOptionsOpen}
+                onClick={() => setOtherOptionsOpen((open) => !open)}
+              >
+                {otherOptionsOpen
+                  ? t("chatgptOauthSection.hideOtherOptions")
+                  : t("chatgptOauthSection.otherOptions")}
+              </Button>
+            </div>
+          )}
         </>
       ) : null}
 
-      {!deviceCodeShown || otherOptionsOpen ? (
+      {(!deviceCodeShown || otherOptionsOpen) && connected?.via !== "device" ? (
         <ChatgptPasteAuthFlow
           assistantId={assistantId}
-          onConnected={onConnected}
+          onConnected={handlePasteConnected}
           standalone={!deviceCodeShown}
+        />
+      ) : null}
+
+      {connected ? (
+        <ChatgptDefaultProviderStep
+          assistantId={assistantId}
+          connection={connected.connection}
+          onDone={onConnected}
         />
       ) : null}
     </div>

--- a/clients/web/src/domains/settings/ai/use-provider-actions.ts
+++ b/clients/web/src/domains/settings/ai/use-provider-actions.ts
@@ -1,3 +1,5 @@
+import { useCallback } from "react";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { toast } from "@vellumai/design-library/components/toast";
@@ -18,6 +20,13 @@ import { captureError } from "@/lib/sentry/capture-error";
 export interface ProviderActions {
   /** Point the default provider at this connection. No-op when ineligible. */
   setDefault: (conn: ProviderConnection) => void;
+  /**
+   * `setDefault` for callers that must know when the write landed: resolves
+   * once the config carries the new default, rejects if it did not (the
+   * failure toast is raised either way). Stable across renders, so an effect
+   * can depend on it.
+   */
+  setDefaultAsync: (conn: ProviderConnection) => Promise<void>;
   /** True while the set-default mutation targets `name`. */
   isSettingDefault: (name: string) => boolean;
   deleteConnection: (name: string) => Promise<void>;
@@ -55,14 +64,24 @@ export function useProviderActions(
     },
   });
 
+  const { mutateAsync } = setDefaultMutation;
+
+  const setDefaultAsync = useCallback(
+    async (conn: ProviderConnection) => {
+      if (!isDefaultProviderId(conn.provider)) {
+        return;
+      }
+      await mutateAsync({
+        path: { assistant_id: assistantId },
+        body: { provider: conn.provider, connectionName: conn.name },
+      });
+    },
+    [assistantId, mutateAsync],
+  );
+
   function setDefault(conn: ProviderConnection) {
-    if (!isDefaultProviderId(conn.provider)) {
-      return;
-    }
-    setDefaultMutation.mutate({
-      path: { assistant_id: assistantId },
-      body: { provider: conn.provider, connectionName: conn.name },
-    });
+    // Fire and forget: `onError` already reports the failure as a toast.
+    void setDefaultAsync(conn).catch(() => {});
   }
 
   function isSettingDefault(name: string): boolean {
@@ -94,5 +113,5 @@ export function useProviderActions(
     }
   }
 
-  return { setDefault, isSettingDefault, deleteConnection };
+  return { setDefault, setDefaultAsync, isSettingDefault, deleteConnection };
 }

--- a/clients/web/src/domains/settings/ai/use-provider-actions.ts
+++ b/clients/web/src/domains/settings/ai/use-provider-actions.ts
@@ -8,6 +8,7 @@ import { isDefaultProviderId } from "@/domains/settings/ai/provider-row-meta";
 import { t } from "@/i18n";
 import {
   configGetQueryKey,
+  configLlmCallsitesGetQueryKey,
   configLlmDefaultproviderGetQueryKey,
   configLlmDefaultproviderPutMutation,
   inferenceProviderconnectionsGetQueryKey,
@@ -34,9 +35,9 @@ export interface ProviderActions {
 
 /**
  * Row mutations for the Providers section. Set-default refreshes the
- * default-provider status, the config, and the effective profile catalog
- * (managed tiers resolve their model through the default provider); delete
- * refreshes the connection list. Errors surface as toasts.
+ * default-provider status, the config, and the effective profile and
+ * call-site catalogs (managed tiers resolve their model through the default
+ * provider); delete refreshes the connection list. Errors surface as toasts.
  */
 export function useProviderActions(
   assistantId: string,
@@ -56,6 +57,12 @@ export function useProviderActions(
       });
       void queryClient.invalidateQueries({
         queryKey: inferenceProfilesGetQueryKey(pathOpts),
+      });
+      // The call-site catalog reports each action's winning profile, resolved
+      // through the default provider, so the same write moves it. The sync
+      // handler refreshes it for other clients; this covers the tab that wrote.
+      void queryClient.invalidateQueries({
+        queryKey: configLlmCallsitesGetQueryKey(pathOpts),
       });
     },
     onError: (error) => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -37,6 +37,7 @@ import { invalidatePluginQueries } from "@/domains/intelligence/plugins/invalida
 import {
   configGetQueryKey,
   configLlmCallsitesGetQueryKey,
+  configLlmDefaultproviderGetQueryKey,
   identityGetQueryKey,
   inferenceProfilesGetQueryKey,
   schedulesGetQueryKey,
@@ -134,6 +135,12 @@ export function useAssistantResourceSync(
               // change it. Surfaces treat that winner as authoritative.
               void queryClient.invalidateQueries({
                 queryKey: configLlmCallsitesGetQueryKey(pathOpts),
+              });
+              // The default provider and its availability live in config too,
+              // so the Providers list's Default badge and the "no API key"
+              // notice both go stale on a config write from any client.
+              void queryClient.invalidateQueries({
+                queryKey: configLlmDefaultproviderGetQueryKey(pathOpts),
               });
               // Memory availability is derived from config (`memory.enabled`,
               // `memory.v3.live`), so a config write on any client can change
@@ -298,6 +305,10 @@ function refreshAssistantResources(
   });
   void queryClient.invalidateQueries({
     queryKey: configGetQueryKey(pathOpts),
+    refetchType,
+  });
+  void queryClient.invalidateQueries({
+    queryKey: configLlmDefaultproviderGetQueryKey(pathOpts),
     refetchType,
   });
   invalidateAvatarQueries(queryClient, assistantId, refetchType);

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -381,6 +381,13 @@
     "providerLabel": "Provider",
     "unavailableOption": "{name} (unavailable)"
   },
+  "chatgptDefaultProviderStep": {
+    "applied": "ChatGPT is now your default provider for chat.",
+    "applying": "Making ChatGPT your default provider...",
+    "done": "Done",
+    "offerHint": "Chat still uses your current default provider.",
+    "useForChat": "Use ChatGPT for chat"
+  },
   "chatgptDeviceAuthFlow": {
     "authorizationHint": "You or your team administrator may need to enable device code authorization <settingsLink>in ChatGPT settings</settingsLink>.",
     "connected": "ChatGPT subscription connected successfully.",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -381,6 +381,13 @@
     "providerLabel": "Proveedor",
     "unavailableOption": "{name} (no disponible)"
   },
+  "chatgptDefaultProviderStep": {
+    "applied": "ChatGPT ahora es tu proveedor predeterminado para el chat.",
+    "applying": "Estableciendo ChatGPT como tu proveedor predeterminado...",
+    "done": "Listo",
+    "offerHint": "El chat sigue usando tu proveedor predeterminado actual.",
+    "useForChat": "Usar ChatGPT para el chat"
+  },
   "chatgptDeviceAuthFlow": {
     "authorizationHint": "Puede que tú o el administrador de tu equipo tengáis que activar la autorización por código de dispositivo <settingsLink>en los ajustes de ChatGPT</settingsLink>.",
     "connected": "Suscripción a ChatGPT conectada correctamente.",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -369,6 +369,13 @@
     "providerLabel": "Провайдер",
     "unavailableOption": "{name} (недоступно)"
   },
+  "chatgptDefaultProviderStep": {
+    "applied": "Теперь ChatGPT используется в чате по умолчанию.",
+    "applying": "ChatGPT назначается провайдером по умолчанию...",
+    "done": "Готово",
+    "offerHint": "Чат по-прежнему использует текущего провайдера по умолчанию.",
+    "useForChat": "Использовать ChatGPT для чата"
+  },
   "chatgptDeviceAuthFlow": {
     "authorizationHint": "Вам или администратору команды может потребоваться включить авторизацию по коду устройства <settingsLink>в настройках ChatGPT</settingsLink>.",
     "connected": "Подписка ChatGPT успешно подключена.",

--- a/clients/web/src/lib/backwards-compat/default-provider-settings.test.ts
+++ b/clients/web/src/lib/backwards-compat/default-provider-settings.test.ts
@@ -2,11 +2,22 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import { renderHook } from "@testing-library/react";
 
-import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
+import {
+  useDefaultProviderSettingsSupport,
+  useSupportsDefaultProviderSettings,
+} from "@/lib/backwards-compat/default-provider-settings";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+const ASSISTANT_ID = "asst-1";
 
 function setVersion(version: string | null) {
   useAssistantIdentityStore.getState().setIdentity("test-asst", version);
+}
+
+function setVersionFor(assistantId: string, version: string | null) {
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("test-asst", version, assistantId);
 }
 
 beforeEach(() => {
@@ -43,5 +54,40 @@ describe("useSupportsDefaultProviderSettings", () => {
     setVersion("0.10.8-rc.1");
     const { result } = renderHook(() => useSupportsDefaultProviderSettings());
     expect(result.current).toBe(true);
+  });
+});
+
+// The form for callers that read the gate once: the same verdict, plus
+// whether it was read against a resolved version.
+describe("useDefaultProviderSettingsSupport", () => {
+  test("reports the version as unknown until one hydrates", () => {
+    const { result } = renderHook(() =>
+      useDefaultProviderSettingsSupport(ASSISTANT_ID),
+    );
+    expect(result.current).toEqual({ supported: false, versionKnown: false });
+  });
+
+  test("reports a version hydrated for the assistant asked about", () => {
+    setVersionFor(ASSISTANT_ID, "0.10.8");
+    const { result } = renderHook(() =>
+      useDefaultProviderSettingsSupport(ASSISTANT_ID),
+    );
+    expect(result.current).toEqual({ supported: true, versionKnown: true });
+  });
+
+  test("a version held for another assistant answers nothing about this one", () => {
+    setVersionFor("asst-2", "0.10.8");
+    const { result } = renderHook(() =>
+      useDefaultProviderSettingsSupport(ASSISTANT_ID),
+    );
+    expect(result.current).toEqual({ supported: false, versionKnown: false });
+  });
+
+  test("an older assistant is a known version, not an unknown one", () => {
+    setVersionFor(ASSISTANT_ID, "0.10.7");
+    const { result } = renderHook(() =>
+      useDefaultProviderSettingsSupport(ASSISTANT_ID),
+    );
+    expect(result.current).toEqual({ supported: false, versionKnown: true });
   });
 });

--- a/clients/web/src/lib/backwards-compat/default-provider-settings.ts
+++ b/clients/web/src/lib/backwards-compat/default-provider-settings.ts
@@ -8,10 +8,39 @@
  * the status query entirely — the modal behaves exactly as it did
  * before the feature.
  */
-import { useAssistantSupports } from "@/lib/backwards-compat/utils";
+import {
+  useAssistantScopedSupports,
+  useAssistantSupports,
+  useAssistantVersionKnownFor,
+} from "@/lib/backwards-compat/utils";
 
 const MIN_VERSION = "0.10.8";
 
 export function useSupportsDefaultProviderSettings(): boolean {
   return useAssistantSupports(MIN_VERSION);
+}
+
+export interface DefaultProviderSettingsSupport {
+  /** The gate itself, scoped to `assistantId`. */
+  supported: boolean;
+  /** False while no version has hydrated for `assistantId`. */
+  versionKnown: boolean;
+}
+
+/**
+ * The gate for a caller that reads it once and latches the branch.
+ *
+ * `useSupportsDefaultProviderSettings` answers `false` while the identity
+ * store is still hydrating, which a surface that re-renders when the version
+ * lands can act on. A one-shot decision cannot: it would take the "no such
+ * routes" path and never look again. Such callers wait for `versionKnown`
+ * before reading `supported`.
+ */
+export function useDefaultProviderSettingsSupport(
+  assistantId: string | null | undefined,
+): DefaultProviderSettingsSupport {
+  return {
+    supported: useAssistantScopedSupports(MIN_VERSION, assistantId),
+    versionKnown: useAssistantVersionKnownFor(assistantId),
+  };
 }

--- a/clients/web/src/lib/backwards-compat/utils.ts
+++ b/clients/web/src/lib/backwards-compat/utils.ts
@@ -88,6 +88,33 @@ export function useAssistantScopedSupports(
 }
 
 /**
+ * True once the identity store holds a version fetched for
+ * `ownerAssistantId`: the render-path counterpart to
+ * {@link whenAssistantVersionKnownFor}.
+ *
+ * `useAssistantScopedSupports` collapses "unknown" and "known-old" into one
+ * `false`, which a surface that re-renders when the version lands can act on
+ * safely. A caller that reads the gate once and latches the branch cannot:
+ * unknown would pin it to the legacy path for good. Those callers hold off
+ * until this returns `true`, so the gate is read against a resolved version.
+ *
+ * Scoped for the same reason the gate is: a version still held for the
+ * assistant the user was looking at a moment ago is not an answer about this
+ * one.
+ */
+export function useAssistantVersionKnownFor(
+  ownerAssistantId: string | null | undefined,
+): boolean {
+  const version = useAssistantIdentityStore.use.version();
+  const identityAssistantId = useAssistantIdentityStore.use.assistantId();
+  return (
+    Boolean(version) &&
+    ownerAssistantId != null &&
+    ownerAssistantId === identityAssistantId
+  );
+}
+
+/**
  * Non-hook variant of `useAssistantSupports`: reads the version
  * snapshot via `useAssistantIdentityStore.getState()` so it's safe to
  * call from non-hook contexts (event handlers, async ops, request


### PR DESCRIPTION
## Why

Follow-up to #41299. Connecting a ChatGPT subscription (device-code or paste flow) stored the credential and the `chatgpt-subscription` connection and nothing else. `llm.defaultProvider` stayed on the previous provider, so on a fresh assistant with a keyless default the next message failed with a 422 `ConnectionResolutionError` (shown by the client as "Connection lost"). The only way out was the hidden Providers row action "Set as default". Tracked in [JARVIS-1636](https://linear.app/vellum/issue/JARVIS-1636/make-chatgpt-subscription-login-ux-smoother).

## What

- New `ChatgptDefaultProviderStep`, rendered by `ChatgptOAuthSection` after either sign-in path connects (single seam; both flows share it). It reads `GET /v1/config/llm/default-provider` (the same query the Providers list and the "no API key" notice use) and decides once:
  - default cannot serve a turn (`missing_credential`, `missing_connection`, `missing_default`, `provider_mismatch`, `unsupported_auth`, `vellum_unauthenticated`, `incomplete`): switch to ChatGPT automatically and say so;
  - default is `ok` or `unknown`: leave it alone and offer a "Use ChatGPT for chat" button;
  - ChatGPT already resolves as default, or the daemon has no default-provider routes: skip the step (previous behavior).
- The step waits for this assistant's version to be known before deciding, so a sign-in that finishes while the identity fetch is in flight cannot latch "no such routes" and close the editor over a broken default.
- The write reuses `useProviderActions`' existing set-default mutation (new `setDefaultAsync`, with `setDefault` now a wrapper). No new config write path.
- Live refresh without reload: the mutation invalidates default-provider, config, profiles, and the call-site catalog; the section invalidates connections on connect; and the `assistant:self:config` sync tag now also invalidates the default-provider query so other clients converge.
- en/es/ru strings.

## Interaction with the device-code flag (#41601)

Rebased onto `main` after #41601 landed, so the flag gating and the default-provider step now hold together:

- `chatgpt-device-code-login` still picks the section's shape once at mount. With the flag off, redirect-and-paste is the whole section and stands alone under its plain name; with the flag on, the device code leads and paste stays behind the disclosure.
- Whichever sign-in stores the credential routes into the step through the shared `handleConnected(connection, via)`, and the one that did not sign in steps aside.

## Verification

- `chatgpt-oauth-section.test.tsx`: 24 pass, split into flag-on and flag-off describes. Both arms cover the default-provider step, including a redirect-and-paste sign-in driven to completion (auto-switch on an unusable default, button on a working one, Done handing the connection to the host). `default-provider-settings.test.ts` 9 pass.
- `bun run test:ci` (whole web suite): 1111 test files pass. `bun run typecheck`, `bun run lint` (0 errors), and `bun run audit:cross-domain:check` clean.
- E2E on a hatched dev assistant from this branch: a fresh keyless assistant returns `availability.status: missing_credential` (the auto-switch case); the PUT the step sends is accepted; and after the write the Models & Services page converged in place: the "no API key" notice changed, the four managed profiles flipped to GPT-5.6 Luna/Sol, and the Default badge moved, no reload. The step's own render states are covered by unit tests since `onConnected` needs a real OpenAI authorization.

Part of JARVIS-1636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpHSaE99JnasKWZtjwrhcz

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
