### PR TITLE
fix: pill width contract, size migration, and geometry test cleanup

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -2,12 +2,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   COMPANION_BASE_AVATAR_BOX,
-  COMPANION_BASE_CANVAS_PAD,
   COMPANION_BASE_CARD_HEIGHT,
-  COMPANION_NEAR_EDGE,
   COMPANION_SIZES,
   COMPANION_SIZE_BOXES,
-  companionGapFor,
+  companionNearEdgeFor,
   companionPadFor,
   companionScaleFor,
   type CompanionSize,
@@ -15,6 +13,7 @@ import {
   type CompanionSurfaceState,
   type VellumCommand,
 } from "@vellumai/ipc-contract";
+import { companionSizeSubmenus } from "@vellumai/electron-desktop/companion-menu";
 
 // The module under test reaches `main-window.ts` to hand Talk to the renderer
 // that owns the live-voice session, and that chain loads `electron-store`, a
@@ -48,6 +47,12 @@ let windowsRaised = 0;
 /** Whether the app's window exists, which is what decides between those two. */
 let mainWindowOpen = true;
 
+/** Where the canvas's origin is, which is what the window reports and moves. */
+let origin = { x: 0, y: 0 };
+
+/** Every bounds main has asked the window server for, most recent last. */
+const boundsSet: { x: number; y: number; width: number; height: number }[] = [];
+
 const surface = {
   webContents: {
     send: (_channel: string, state: CompanionSurfaceState) => {
@@ -59,6 +64,20 @@ const surface = {
   // only has to be callable.
   close: () => {},
   on: () => {},
+  isDestroyed: () => false,
+  getPosition: () => [origin.x, origin.y],
+  setPosition: (x: number, y: number) => {
+    origin = { x, y };
+  },
+  setBounds: (bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }) => {
+    boundsSet.push(bounds);
+    origin = { x: bounds.x, y: bounds.y };
+  },
 };
 
 type Invoker = (args: unknown[]) => unknown;
@@ -148,10 +167,24 @@ mock.module("@vellumai/electron-desktop/settings", () => ({
   },
 }));
 
+/**
+ * The size the store holds for each axis.
+ *
+ * A record rather than one answer for both, because the two axes are read and
+ * written separately and a mock that ignored the axis would let a resize apply
+ * a pick to the wrong half of the surface without failing anything.
+ */
+const sizes: Record<CompanionSizeAxis, CompanionSize> = {
+  avatar: "small",
+  options: "small",
+};
+
 mock.module("@vellumai/electron-desktop/window-state", () => ({
-  readCompanionSize: () => "small",
+  readCompanionSize: (axis: CompanionSizeAxis) => sizes[axis],
   readCompanionHidden: () => false,
-  writeCompanionSize: () => {},
+  writeCompanionSize: (axis: CompanionSizeAxis, size: CompanionSize) => {
+    sizes[axis] = size;
+  },
   writeCompanionHidden: () => {},
   // Stubbed rather than omitted, like every other export here: the module
   // under test imports these, and one missing from a whole-module mock is a
@@ -171,11 +204,24 @@ const {
   placeCanvas,
   callOnUpdate,
   introOnAdvance,
+  setCompanionSurfaceSize,
   shouldShowCompanionSurface,
   installCompanionWindow,
 } = await import("./companion-window");
 
 installCompanionWindow();
+
+/**
+ * The module holds the canvas it was last asked for, so a case that picks a
+ * size leaves it there. Put both axes back and forget the window's position.
+ */
+beforeEach(() => {
+  sizes.avatar = "small";
+  sizes.options = "small";
+  setCompanionSurfaceSize("avatar", "small");
+  origin = { x: 0, y: 0 };
+  boundsSet.length = 0;
+});
 
 /** Put a set of evaluated flags in settings and tell main they changed. */
 const setFlags = (next: Record<string, boolean>): void => {
@@ -236,9 +282,16 @@ const START = {
  * scaled, which `geometryFor` has its own cases for.
  */
 const GEOMETRY = geometryFor("small", "small");
-const CANVAS_WIDTH = GEOMETRY.canvasWidth;
 const RISE_ABOVE = GEOMETRY.riseAbove;
 const DROP_BELOW = GEOMETRY.dropBelow;
+
+/**
+ * The two parts of the base reach the geometry does not publish: the pill's
+ * widest, and the room it hangs off the avatar by. Stated once here for the
+ * cases that are about one of them rather than the sum.
+ */
+const MAX_PILL_WIDTH = 316;
+const GAP = 12;
 
 /**
  * The growth direction is the only rule in the companion window worth testing
@@ -286,12 +339,10 @@ describe("growthFor", () => {
    * pass with the pill's leading edge already off the display.
    */
   test("counts the gap and the half box as room the pill needs", () => {
-    expect(NEEDED).toBe(
-      GEOMETRY.avatarBox / 2 + GEOMETRY.gap + GEOMETRY.maxBodyWidth,
+    expect(NEEDED).toBe(350);
+    expect(growthFor(DISPLAY.width - MAX_PILL_WIDTH, DISPLAY, GEOMETRY)).toBe(
+      "left",
     );
-    expect(
-      growthFor(DISPLAY.width - GEOMETRY.maxBodyWidth, DISPLAY, GEOMETRY),
-    ).toBe("left");
   });
 
   /**
@@ -302,9 +353,7 @@ describe("growthFor", () => {
    */
   test("flips when only the avatar's half box is missing on the right", () => {
     const centre = DISPLAY.width - 340;
-    expect(DISPLAY.width - centre).toBeGreaterThan(
-      GEOMETRY.gap + GEOMETRY.maxBodyWidth,
-    );
+    expect(DISPLAY.width - centre).toBeGreaterThan(GAP + MAX_PILL_WIDTH);
     expect(growthFor(centre, DISPLAY, GEOMETRY)).toBe("left");
   });
 
@@ -598,30 +647,27 @@ describe("geometryFor", () => {
 
   /**
    * What the width is actually for: the avatar's half box, the gap the pill
-   * hangs off it by, and the widest body, on both sides so main can flip the
-   * direction without resizing the window, plus the shadow's room.
+   * hangs off it by, and the widest the pill draws, on both sides so main can
+   * flip the direction without resizing the window, plus the shadow's room.
+   *
+   * Stated as the numbers each step comes to rather than as the sum again. Each
+   * one is a canvas that was looked at, and a formula repeated here would pass
+   * against any change to the formula it repeats.
    */
   test("holds the pill's whole reach on both sides of the avatar", () => {
+    const canvases: Record<
+      CompanionSize,
+      { maxReach: number; canvasWidth: number; canvasHeight: number }
+    > = {
+      small: { maxReach: 350, canvasWidth: 748, canvasHeight: 338 },
+      medium: { maxReach: 525, canvasWidth: 1122, canvasHeight: 507 },
+      large: { maxReach: 700, canvasWidth: 1496, canvasHeight: 676 },
+      huge: { maxReach: 875, canvasWidth: 1870, canvasHeight: 845 },
+      ridiculous: { maxReach: 1750, canvasWidth: 3740, canvasHeight: 1690 },
+    };
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size, size);
-      const pad =
-        (COMPANION_BASE_CANVAS_PAD * geometry.avatarBox) /
-        COMPANION_BASE_AVATAR_BOX;
-      expect(geometry.maxReach).toBe(
-        geometry.avatarBox / 2 + geometry.gap + geometry.maxBodyWidth,
-      );
-      expect(geometry.canvasWidth).toBe(
-        Math.round(2 * (geometry.maxReach + pad)),
-      );
-    }
-  });
-
-  test("takes the gap from the contract rather than a copy of it", () => {
-    for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size, size);
-      expect(geometry.gap).toBe(
-        companionGapFor(geometry.avatarBox, geometry.avatarBox),
-      );
+      const { maxReach, canvasWidth, canvasHeight } = geometryFor(size, size);
+      expect({ maxReach, canvasWidth, canvasHeight }).toEqual(canvases[size]);
     }
   });
 
@@ -639,15 +685,13 @@ describe("geometryFor", () => {
   });
 
   /**
-   * Everything beside the creature is the options axis's answer: the pill's box
-   * and the widest body it draws, which is what the canvas's width is spent on.
+   * Everything beside the creature is the options axis's answer, starting with
+   * the pill's own box.
    */
-  test("takes the pill's box and its widest body from the options axis alone", () => {
+  test("takes the pill's box from the options axis alone", () => {
     for (const avatar of COMPANION_SIZES) {
-      const geometry = geometryFor(avatar, "large");
-      expect(geometry.optionsBox).toBe(COMPANION_SIZE_BOXES.large);
-      expect(geometry.maxBodyWidth).toBe(
-        geometryFor("large", "large").maxBodyWidth,
+      expect(geometryFor(avatar, "large").optionsBox).toBe(
+        COMPANION_SIZE_BOXES.large,
       );
     }
   });
@@ -667,8 +711,6 @@ describe("geometryFor", () => {
     expect(large.canvasHeight).toBe(small.canvasHeight * scale);
     expect(large.riseAbove).toBe(small.riseAbove * scale);
     expect(large.dropBelow).toBe(small.dropBelow * scale);
-    expect(large.gap).toBe(small.gap * scale);
-    expect(large.maxBodyWidth).toBe(small.maxBodyWidth * scale);
     expect(large.maxReach).toBe(small.maxReach * scale);
   });
 
@@ -678,15 +720,19 @@ describe("geometryFor", () => {
    * geometry to keep in step.
    */
   test("reduces to the single-scale canvas when the axes agree", () => {
+    // The two sides at the base size, which the whole layout is authored
+    // around: the creature and its shadow below, the card's height above.
+    expect(
+      companionNearEdgeFor(
+        COMPANION_BASE_AVATAR_BOX,
+        COMPANION_BASE_AVATAR_BOX,
+      ),
+    ).toBe(46);
     for (const size of COMPANION_SIZES) {
       const geometry = geometryFor(size, size);
       const scale = companionScaleFor(geometry.avatarBox);
-      expect(geometry.dropBelow).toBe(COMPANION_NEAR_EDGE * scale);
-      expect(geometry.riseAbove).toBe(
-        COMPANION_BASE_CARD_HEIGHT * scale -
-          geometry.avatarBox / 2 +
-          COMPANION_BASE_CANVAS_PAD * scale,
-      );
+      expect(geometry.dropBelow).toBe(46 * scale);
+      expect(geometry.riseAbove).toBe(292 * scale);
     }
   });
 
@@ -791,26 +837,23 @@ describe("geometryFor with the two axes apart", () => {
     }
   });
 
-  test("still holds the pill's reach on both sides of the avatar", () => {
-    for (const geometry of MIXED) {
-      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
-      expect(geometry.maxReach).toBe(
-        geometry.avatarBox / 2 + geometry.gap + geometry.maxBodyWidth,
-      );
-      expect(geometry.canvasWidth).toBe(
-        Math.round(2 * (geometry.maxReach + pad)),
-      );
-    }
-  });
-
   /**
-   * The gap is breathing room, so the smaller of the two decides how much of it
-   * there is: a modest creature beside an enormous pill wants the creature's
-   * clearance rather than the chasm the pill's own scale would ask for.
+   * The reach at each mix, which is also where the gap rule shows. The gap is
+   * breathing room, so the smaller of the two boxes decides how much of it
+   * there is: the creature below takes the base gap rather than the chasm its
+   * own scale would ask for, which would put its reach at 401.
    */
-  test("takes the gap from the smaller of the two", () => {
-    expect(BIG_CREATURE.gap).toBe(geometryFor("small", "small").gap);
-    expect(BIG_OPTIONS.gap).toBe(BIG_CREATURE.gap);
+  test("still holds the pill's reach on both sides of the avatar", () => {
+    // An enormous creature's half box, the base gap, and a base-width pill.
+    expect({
+      maxReach: BIG_CREATURE.maxReach,
+      canvasWidth: BIG_CREATURE.canvasWidth,
+    }).toEqual({ maxReach: 383, canvasWidth: 886 });
+    // A base half box, the same gap, and a pill two and a half times as wide.
+    expect({
+      maxReach: BIG_OPTIONS.maxReach,
+      canvasWidth: BIG_OPTIONS.canvasWidth,
+    }).toEqual({ maxReach: 824, canvasWidth: 1768 });
   });
 
   test("flips the pill at the reach the options size asks for", () => {
@@ -844,11 +887,12 @@ describe("geometryFor with the two axes apart", () => {
  * making it go away.
  *
  * The template rather than the menu: a menu is a native window, and what is
- * worth stating is the wording, which step each axis is marked on, and that a
- * press names the axis it was made under.
+ * worth stating is what this menu adds to the size pickers it shares with the
+ * tray, which is where they sit and the item that takes the surface away. The
+ * pickers themselves have their own suite in `companion-menu.test.ts`.
  */
 describe("companionContextMenuTemplate", () => {
-  /** Only what a menu item is read for here, as `tray-model.test.ts` has it. */
+  /** Only what a menu item is read for here. */
   type MenuItem = {
     label?: string;
     type?: string;
@@ -863,17 +907,14 @@ describe("companionContextMenuTemplate", () => {
       options: "small",
     },
   ) => {
-    const picked: [CompanionSizeAxis, CompanionSize][] = [];
     let hidden = false;
     const items = companionContextMenuTemplate(current, {
-      setSize: (axis: CompanionSizeAxis, size: CompanionSize) => {
-        picked.push([axis, size]);
-      },
+      setSize: () => {},
       hide: () => {
         hidden = true;
       },
     }) as MenuItem[];
-    return { items, picked, wasHidden: () => hidden };
+    return { items, wasHidden: () => hidden };
   };
 
   test("offers the two axes under their own headings, then the way out", () => {
@@ -885,44 +926,16 @@ describe("companionContextMenuTemplate", () => {
     ]);
   });
 
-  test("offers every named step under each heading", () => {
-    for (const heading of build().items.slice(0, 2)) {
-      expect(heading.submenu?.map((item) => item.label)).toEqual([
-        "Small",
-        "Medium",
-        "Large",
-        "Huge",
-        "Ridiculous",
-      ]);
-      expect(heading.submenu?.every((item) => item.type === "radio")).toBe(
-        true,
-      );
-    }
-  });
-
   /**
-   * The whole point of two menus: each one shows where its own axis is, and a
-   * user who has made the creature enormous and left the controls alone can see
-   * exactly that.
+   * The headings are the shared builder's output rather than a second set of
+   * items, so the surface's menu and the tray's cannot describe the same choice
+   * differently. Compared as data, since the clicks are closures.
    */
-  test("marks the step each axis is on, and only that one", () => {
-    const { items } = build({ avatar: "ridiculous", options: "medium" });
-    expect(
-      items[0]?.submenu?.filter((item) => item.checked).map((i) => i.label),
-    ).toEqual(["Ridiculous"]);
-    expect(
-      items[1]?.submenu?.filter((item) => item.checked).map((i) => i.label),
-    ).toEqual(["Medium"]);
-  });
-
-  test("a pick carries the axis it was made under", () => {
-    const menu = build();
-    menu.items[0]?.submenu?.[3]?.click?.();
-    menu.items[1]?.submenu?.[4]?.click?.();
-    expect(menu.picked).toEqual([
-      ["avatar", "huge"],
-      ["options", "ridiculous"],
-    ]);
+  test("draws its two headings from the builder the tray reads", () => {
+    const current = { avatar: "ridiculous", options: "medium" } as const;
+    expect(JSON.stringify(build(current).items.slice(0, 2))).toBe(
+      JSON.stringify(companionSizeSubmenus(current, () => {})),
+    );
   });
 
   test("the last item takes the surface away", () => {
@@ -1020,6 +1033,61 @@ describe("placing a larger companion", () => {
       );
       expect(centre.y).toBe(WORK_AREA.y + geometry.dropBelow);
     }
+  });
+});
+
+/**
+ * A size pick, which is the one moment the canvas is rebuilt.
+ *
+ * What has to survive it is the avatar, not the window. They are not the same
+ * point and the difference is most of the canvas, so a rebuild that kept the
+ * origin would slide the creature by the change in its offset and walk the
+ * thing the user was enlarging off across the desktop.
+ */
+describe("setCompanionSurfaceSize", () => {
+  /**
+   * Where the avatar is parked for the pick: low enough on the display that the
+   * card grows upward at both sizes, and far enough from either side that
+   * nothing is clamped. So the only thing that can move the creature is the
+   * resize itself.
+   */
+  const CENTRE = { x: 722, y: 800 };
+
+  /** The canvas an options pick of `huge` builds, beside `small`'s 748x338. */
+  const HUGE_OPTIONS = { canvasWidth: 1768, canvasHeight: 911, riseAbove: 763 };
+
+  test("rebuilds the canvas around the avatar rather than the origin", () => {
+    // Parked by the path a drag takes. The first delta runs past every edge, so
+    // it lands on a clamp whatever the window was doing beforehand; the second
+    // puts the avatar on `CENTRE`.
+    send("vellum:companion:moveBy", -100000, -100000);
+    send("vellum:companion:moveBy", 700, 754);
+    expect({
+      x: origin.x + GEOMETRY.canvasWidth / 2,
+      y: origin.y + RISE_ABOVE,
+    }).toEqual(CENTRE);
+
+    setCompanionSurfaceSize("options", "huge");
+
+    // One call rather than a size and then a position: two would put the window
+    // at the new size in the old place for a frame.
+    expect(boundsSet).toHaveLength(1);
+    const bounds = boundsSet[0];
+    expect({ width: bounds?.width, height: bounds?.height }).toEqual({
+      width: HUGE_OPTIONS.canvasWidth,
+      height: HUGE_OPTIONS.canvasHeight,
+    });
+    // The avatar read back out of the new canvas the way main reads it: half
+    // the width across, and the offset the card's direction asks for down.
+    expect({
+      x: (bounds?.x ?? 0) + HUGE_OPTIONS.canvasWidth / 2,
+      y: (bounds?.y ?? 0) + HUGE_OPTIONS.riseAbove,
+    }).toEqual(CENTRE);
+  });
+
+  test("leaves the other axis where it was", () => {
+    setCompanionSurfaceSize("options", "huge");
+    expect(sizes).toEqual({ avatar: "small", options: "huge" });
   });
 });
 

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -12,6 +12,7 @@ import {
   voiceActivityContentSchema,
   voiceActivityControlSchema,
   voiceActivityStartSchema,
+  COMPANION_BASE_MAX_PILL_WIDTH,
   COMPANION_INTRO_ACTIONS,
   COMPANION_INTRO_BEATS,
   COMPANION_SIZE_BOXES,
@@ -134,19 +135,6 @@ const COMPANION_KIND = "companion";
 const COMPANION_ROUTE = "/floating/companion";
 
 /**
- * The widest the pill's body gets at the size the surface's layout is authored
- * at, which is the ceiling every entry in the renderer's `FALLBACK_WIDTHS`
- * stays under.
- *
- * The body alone, because the avatar floats beside the pill rather than inside
- * it: what the canvas has to hold on the growth side is the avatar's half box,
- * the gap, and this at the options scale. A ceiling rather than a width, since
- * the pill measures its own content, and content wider than it is clipped by
- * the window. The call's approval row is the widest thing the surface renders.
- */
-const BASE_MAX_BODY_WIDTH = 316;
-
-/**
  * Everything the window's placement depends on, for one pair of companion
  * sizes.
  *
@@ -172,10 +160,6 @@ export interface CompanionGeometry {
    * back past it, and the shadow.
    */
   dropBelow: number;
-  /** The room between the avatar's edge and the pill, at these sizes. */
-  gap: number;
-  /** The widest the pill's body draws at this options size, gap not included. */
-  maxBodyWidth: number;
   /** The pill's far edge at its widest, measured from the avatar's centre. */
   maxReach: number;
 }
@@ -205,13 +189,14 @@ export const geometryFor = (
   const optionsBox = COMPANION_SIZE_BOXES[options];
   const pad = companionPadFor(avatarBox, optionsBox);
   const gap = companionGapFor(avatarBox, optionsBox);
-  const maxBodyWidth = BASE_MAX_BODY_WIDTH * companionScaleFor(optionsBox);
+  const maxPillWidth =
+    COMPANION_BASE_MAX_PILL_WIDTH * companionScaleFor(optionsBox);
   // The avatar holds its place and the pill hangs off one side of it across the
-  // gap, so the reach is the avatar's half box, the gap, and the widest body.
+  // gap, so the reach is the avatar's half box, the gap, and the widest pill.
   // The canvas has to hold it in whichever direction main later picks, so it is
   // sized for both sides, and `growthFor` picks that direction by the same
   // number.
-  const maxReach = avatarBox / 2 + gap + maxBodyWidth;
+  const maxReach = avatarBox / 2 + gap + maxPillWidth;
   // Both distances come from the contract, which is where the renderer reads
   // them too: main places the window by them and the renderer anchors the
   // surface by them, so a second copy of either is the avatar drawn somewhere
@@ -226,8 +211,6 @@ export const geometryFor = (
     canvasHeight: Math.round(riseAbove + dropBelow),
     riseAbove,
     dropBelow,
-    gap,
-    maxBodyWidth,
     maxReach,
   };
 };
@@ -395,7 +378,8 @@ export const callOnUpdate = (
  *
  * The room on each side is measured from the avatar's centre, so the clearance
  * the pill needs is measured from there too: the avatar's half box, then the
- * gap, then its widest body, which is {@link CompanionGeometry.maxReach}.
+ * gap, then the widest the pill draws, which is
+ * {@link CompanionGeometry.maxReach}.
  * Rightward is the default and leftward is what it flips to when the right edge
  * is too close, so the avatar stays exactly where the user put it instead of
  * the controls running off the display.
@@ -645,10 +629,10 @@ let installed = false;
  * The surface's own menu, on a right-click.
  *
  * **Because the tray is the wrong place to look.** The two things a user
- * wants from a floating avatar are to resize it and to make it go away, and
- * both were otherwise reachable only from a menu-bar icon that says nothing
- * about the thing they are actually looking at. A press on the object itself
- * is where people reach first.
+ * wants from a floating avatar are to resize it and to make it go away, and the
+ * tray offers both from a menu-bar icon that says nothing about the thing they
+ * are actually looking at. A press on the object itself is where people reach
+ * first.
  *
  * Built in main rather than in the renderer: a menu is a native window, and
  * main is the side that owns both the sizes and the visibility. The size
@@ -1181,14 +1165,6 @@ export const setCompanionSurfaceVisible = (visible: boolean): void => {
   finishIntro();
   closeCompanionWindow();
 };
-
-/**
- * Which size one axis of the surface is currently drawn at, for the radio items
- * in both menus that offer it.
- */
-export const readCompanionSurfaceSize = (
-  axis: CompanionSizeAxis,
-): CompanionSize => readCompanionSize(axis);
 
 /**
  * Draw the surface at a different size, keeping the avatar where it is.

--- a/clients/macos/src/main/tray.client.ts
+++ b/clients/macos/src/main/tray.client.ts
@@ -9,6 +9,7 @@ import {
 } from "@vellumai/electron-desktop/tray-model";
 import {
   readCompanionHidden,
+  readCompanionSize,
   readOnboardingActive,
 } from "@vellumai/electron-desktop/window-state";
 
@@ -23,7 +24,6 @@ import {
 } from "./assets/menu-icons";
 import { acceleratorOption } from "./commands.client";
 import {
-  readCompanionSurfaceSize,
   setCompanionSurfaceSize,
   setCompanionSurfaceVisible,
 } from "./companion-window";
@@ -53,7 +53,7 @@ export const installTray = (handlers: TrayHandlers): void => {
     // below is the only thing that turns it off.
     companionSupported: () => true,
     companionHidden: readCompanionHidden,
-    companionSize: readCompanionSurfaceSize,
+    companionSize: readCompanionSize,
     dispatch: dispatchToMain,
     featureEnabled: (flag) => readSetting("featureFlags")?.[flag] === true,
     getLockfile: getWatchedLockfile,

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1,9 +1,14 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { COMPANION_BASE_MAX_PILL_WIDTH } from "@vellumai/ipc-contract";
 import type { VoiceActivityState } from "@vellumai/ipc-contract";
 
-import { CompanionSurface, FALLBACK_WIDTHS } from "./companion-surface";
+import {
+  CompanionSurface,
+  FALLBACK_WIDTHS,
+  INNER_GAP,
+} from "./companion-surface";
 
 afterEach(cleanup);
 
@@ -1162,8 +1167,20 @@ describe("the summary a finished watch session leaves on the surface", () => {
 });
 
 describe("the companion surface's width ceiling", () => {
-  /** `BASE_MAX_BODY_WIDTH` in `clients/macos/src/main/companion-window.ts`. */
-  const CANVAS_CEILING = 316;
+  const CANVAS_CEILING = COMPANION_BASE_MAX_PILL_WIDTH;
+
+  /**
+   * The ceiling is on the pill, not on the body inside it, so a body that fits
+   * with the clearance at either end left off is not one that fits. `typing` is
+   * the card's own outer width rather than a measured body, and the case below
+   * holds it exactly at the ceiling.
+   */
+  test("holds for every measured body once the pill's own clearance is on it", () => {
+    const over = Object.entries(FALLBACK_WIDTHS)
+      .filter(([phase]) => phase !== "typing")
+      .filter(([, width]) => width + 2 * INNER_GAP > CANVAS_CEILING);
+    expect(over).toEqual([]);
+  });
 
   test("holds for every phase", () => {
     const over = Object.entries(FALLBACK_WIDTHS).filter(

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -21,7 +21,10 @@ import type {
   Ref,
 } from "react";
 
-import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
+import {
+  COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_MAX_PILL_WIDTH,
+} from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
   CompanionTurn,
@@ -210,7 +213,7 @@ const AVATAR_IMAGE = 28;
  * background runs flush into the pill's border and its corner gets clipped,
  * which reads as the surface being cut off.
  */
-const INNER_GAP = 8;
+export const INNER_GAP = 8;
 
 /**
  * Body widths to use until the content has been measured.
@@ -225,8 +228,9 @@ const INNER_GAP = 8;
  * plugins contribute actions (LUM-3097) no hardcoded number can be correct, and
  * these become nothing but the value for the first frame.
  *
- * **Every entry stays at or under 316**, which is `BASE_MAX_BODY_WIDTH` in
- * `companion-window.ts`. The window is a fixed canvas sized once for the widest
+ * **Every measured body plus an {@link INNER_GAP} at either end stays at or
+ * under {@link COMPANION_BASE_MAX_PILL_WIDTH}**, which is the whole width a
+ * pill actually draws. The window is a fixed canvas sized once for the widest
  * state the surface has, so the ceiling is the host's rather than this file's:
  * a state that wanted more would be clipped by the window, and buying the room
  * back means resizing the canvas, which is the thing a fixed canvas exists to
@@ -262,7 +266,7 @@ export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
  * measuring it would size the card to whatever the last turn happened to say
  * and reflow the whole surface on every message.
  */
-const CARD_WIDTH = 316;
+const CARD_WIDTH = COMPANION_BASE_MAX_PILL_WIDTH;
 
 /**
  * The tallest the conversation gets before it scrolls.

--- a/packages/electron-desktop/src/companion-menu.test.ts
+++ b/packages/electron-desktop/src/companion-menu.test.ts
@@ -13,7 +13,7 @@ import { companionSizeSubmenus } from "./companion-menu";
  * the items sit and whether they stand down.
  */
 describe("companionSizeSubmenus", () => {
-  /** Only what a menu item is read for here, as `tray-model.test.ts` has it. */
+  /** Only what a menu item is read for here. */
   type MenuItem = {
     label?: string;
     enabled?: boolean;

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -33,7 +33,8 @@ const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
  *
  * Sentence case, and the noun first: the submenus sit among items that say what
  * they act on ("Show Companion", "Hide Companion"), and a user scanning for the
- * creature reads "Avatar" before they read "size".
+ * creature reads "Avatar" before they read "size". The sentence case is the
+ * design's wording, against the Title Case of the tray items beside it.
  *
  * Here beside the steps themselves, and for the same reason: both menus that
  * offer the sizes offer them under these two headings, and a user who met
@@ -48,22 +49,10 @@ const COMPANION_SIZE_AXIS_LABELS: Record<CompanionSizeAxis, string> = {
 /**
  * The size pickers, as every menu that offers them draws them.
  *
- * One submenu per axis, since the creature and the controls beside it are sized
- * separately and a single picker could only ever move both. The steps sit under
- * those headings rather than flat: a named submenu says what its five words are
- * before it shows them, and leaves the menu around it short enough to read at a
- * glance.
- *
- * Named steps rather than a slider, because the avatar's box is not a style:
- * the canvas, the pill's reach and the card's height are all derived from it,
- * so a continuous scale would be a layout nobody had ever looked at. Radio
- * items, since each axis is one choice and the menu has to show which step is
- * in effect.
- *
- * Built here rather than in each menu, for the reason the wording above is: a
- * later axis, label, checked state or click behaviour would otherwise reach the
- * tray and leave the surface's own right-click describing the same setting
- * differently.
+ * One submenu per axis, since a single picker could only ever move both. One
+ * builder rather than a literal per menu: an axis, label, checked state or
+ * click behaviour added in one place would otherwise leave the tray and the
+ * surface's own right-click describing the same setting differently.
  *
  * `enabled` is for the menu that offers the sizes beside a way to hide the
  * surface: the items stand down rather than disappear while it is hidden, since

--- a/packages/electron-desktop/src/tray-model.test.ts
+++ b/packages/electron-desktop/src/tray-model.test.ts
@@ -621,23 +621,12 @@ describe("companion toggle", () => {
   });
 
   /**
-   * Named steps rather than a slider (JARVIS-1549). The avatar's box is the
-   * geometry both processes derive from, so the sizes are a fixed set of
-   * layouts and the menu is where one is chosen.
+   * What the tray adds to the pickers, which have their own suite in
+   * `companion-menu.test.ts`: the sizes it shows are the ones it was configured
+   * to read, and a pick lands on the setter it was configured with, under the
+   * axis it was made on.
    */
-  test("offers a size for each named step, under both headings", () => {
-    for (const label of ["Avatar size", "Options size"]) {
-      expect(popSizeItem(label)?.submenu?.map((i) => i.label)).toEqual([
-        "Small",
-        "Medium",
-        "Large",
-        "Huge",
-        "Ridiculous",
-      ]);
-    }
-  });
-
-  test("marks the step each axis is on, since radio items have to show one", () => {
+  test("wires both headings to the tray's own size runtime", () => {
     companionSizes = { avatar: "medium", options: "ridiculous" };
     expect(
       popSizeItem("Avatar size")
@@ -649,17 +638,7 @@ describe("companion toggle", () => {
         ?.submenu?.filter((i) => i.checked)
         .map((i) => i.label),
     ).toEqual(["Ridiculous"]);
-  });
 
-  test("renders each heading's sizes as one radio group", () => {
-    for (const label of ["Avatar size", "Options size"]) {
-      expect(
-        popSizeItem(label)?.submenu?.every((i) => i.type === "radio"),
-      ).toBe(true);
-    }
-  });
-
-  test("applies the size that was picked, to the axis it was picked under", () => {
     popSizeItem("Avatar size")?.submenu?.[3]?.click?.({ checked: true });
     expect(setCompanionSizeMock).toHaveBeenLastCalledWith("avatar", "huge");
     popSizeItem("Options size")?.submenu?.[0]?.click?.({ checked: true });

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -457,13 +457,26 @@ describe("companion surface sizes", () => {
     );
   });
 
-  test("writing skips persisting when the effective value is unchanged", () => {
+  test("writing skips persisting when the axis's own key already says so", () => {
     savedCompanionOptionsSize = "large";
     writeCompanionSize("options", "large");
     expect(storeSetMock).not.toHaveBeenCalled();
 
     writeCompanionSize("options", "small");
     expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "small");
+  });
+
+  /**
+   * The axis's own key, not the effective value that falls back to the shared
+   * one. Someone carrying `huge` from a one-axis build who picks Huge on an
+   * axis is asking for it to be that axis's own answer, and skipping the write
+   * because the fallback already agreed would leave them on the fallback
+   * forever.
+   */
+  test("an explicit pick matching the shared fallback still lands on its axis", () => {
+    savedCompanionSize = "huge";
+    writeCompanionSize("avatar", "huge");
+    expect(storeSetMock).toHaveBeenCalledWith("companionAvatarSize", "huge");
   });
 
   /**

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -145,6 +145,10 @@ const COMPANION_SIZE_KEYS: Record<
 const knownSize = (stored: CompanionSize | undefined): CompanionSize | null =>
   stored !== undefined && COMPANION_SIZES.includes(stored) ? stored : null;
 
+/** The size an axis has of its own, before any fallback. */
+const storedSize = (axis: CompanionSizeAxis): CompanionSize | null =>
+  knownSize(store().get(COMPANION_SIZE_KEYS[axis]));
+
 /**
  * Which named size one axis of the companion surface is drawn at.
  *
@@ -155,7 +159,7 @@ const knownSize = (stored: CompanionSize | undefined): CompanionSize | null =>
  * axes rather than the default on either.
  */
 export const readCompanionSize = (axis: CompanionSizeAxis): CompanionSize =>
-  knownSize(store().get(COMPANION_SIZE_KEYS[axis])) ??
+  storedSize(axis) ??
   knownSize(store().get("companionSize")) ??
   DEFAULT_COMPANION_SIZE;
 
@@ -184,8 +188,13 @@ export const writeCompanionIntroSeen = (): void => {
 };
 
 /**
- * Persist one axis's size. No-op when the effective value is unchanged, as the
- * opt-out is.
+ * Persist one axis's size. No-op only when that axis's own key already says so.
+ *
+ * The axis's own key rather than the effective value, because that value falls
+ * back to the single size a build with one size axis writes. Someone carrying
+ * that legacy size who picks it again on one axis is asking for it to be that
+ * axis's own answer, and comparing against the fallback would leave the
+ * per-axis key empty for as long as they keep agreeing with it.
  *
  * Only ever the axis's own key. Writing the shared one as well would hand a
  * build that reads only that key one axis's answer for both, and turn a user
@@ -195,7 +204,7 @@ export const writeCompanionSize = (
   axis: CompanionSizeAxis,
   size: CompanionSize,
 ): void => {
-  if (readCompanionSize(axis) === size) {
+  if (storedSize(axis) === size) {
     return;
   }
   store().set(COMPANION_SIZE_KEYS[axis], size);

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -785,14 +785,10 @@ export const DEFAULT_COMPANION_SIZE: CompanionSize = "medium";
 /**
  * The two things on the surface a user sizes, sized separately.
  *
- * The creature and the controls beside it are one object to look at and two
- * things to want at different sizes: an avatar big enough to read from across
- * the room does not mean a pill that wide, and a pill sized for its labels does
- * not mean a mascot that small. Both axes take the same five steps
- * ({@link COMPANION_SIZES}), so there is one vocabulary and two answers rather
- * than two scales to learn.
- *
- * `avatar` sizes the creature, its glow and its bob. `options` sizes the pill,
+ * An avatar big enough to read from across the room does not mean a pill that
+ * wide, and both axes take the same five steps ({@link COMPANION_SIZES}), so
+ * there is one vocabulary and two answers rather than two scales to learn.
+ * `avatar` sizes the creature, its glow and its bob; `options` sizes the pill,
  * the typing card, the call's body and the introduction's card.
  */
 export const COMPANION_SIZE_AXES = ["avatar", "options"] as const;
@@ -829,6 +825,21 @@ export const COMPANION_BASE_CANVAS_PAD = 24;
  * it.
  */
 export const COMPANION_BASE_CARD_HEIGHT = 290;
+
+/**
+ * The widest the pill draws at the base size, measured from its avatar-facing
+ * edge.
+ *
+ * An outer width, padding included: the renderer draws a pill as its measured
+ * body plus its own clearance at either end, and that whole width is what has
+ * to fit. The typing card is exactly this wide, being the one state that states
+ * a width rather than measuring one.
+ *
+ * A ceiling rather than a width, since every other state is as wide as its
+ * content. Main sizes the canvas to hold this much beyond the gap, so a state
+ * that wanted more would be clipped by the window.
+ */
+export const COMPANION_BASE_MAX_PILL_WIDTH = 316;
 
 /**
  * The room between the avatar's edge and the options pill beside it, at the
@@ -926,6 +937,9 @@ export const companionNearEdgeFor = (
  * rises its whole height from there; growing down, its composer row holds that
  * line and the rest of the card falls away below it. The avatar's own half box
  * is the floor under both, for a creature taller than the card beside it.
+ *
+ * Only main consumes this: the renderer names that edge with `100%` and lets
+ * main size the canvas. It lives here to sit beside the constants it reads.
  */
 export const companionCardSideFor = (
   avatarBox: number,
@@ -941,21 +955,6 @@ export const companionCardSideFor = (
     ) + companionPadFor(avatarBox, optionsBox)
   );
 };
-
-/**
- * The near edge at the size the surface's layout is authored at.
- *
- * {@link companionNearEdgeFor} with both boxes at the base, which is what that
- * helper comes to whenever the two sizes agree. A name of its own because it is
- * the distance the whole layout is authored around, and because a helper that
- * stopped reducing to it would be one that had quietly moved the avatar.
- *
- * Anything whose answer moves with either size calls the helper instead.
- */
-export const COMPANION_NEAR_EDGE = companionNearEdgeFor(
-  COMPANION_BASE_AVATAR_BOX,
-  COMPANION_BASE_AVATAR_BOX,
-);
 
 /**
  * The assistant's character, as the three trait ids it is composed from.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for companion-avatar-restyle.md.

- COMPANION_BASE_MAX_PILL_WIDTH is the one copy of the pill's outer width ceiling for both processes
- An explicit size pick always persists its per-axis key, even when it equals the legacy size
- Geometry and menu tests assert behaviour instead of restating the implementation; the resize path is now testable per axis