### PR TITLE
fix: companion surface review gaps (intro clearance, stable ring, bridge bounds)

### DIFF
--- a/clients/web/src/components/companion-intro.test.tsx
+++ b/clients/web/src/components/companion-intro.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
+
+import { CompanionIntro } from "./companion-intro";
+import { CompanionSurface } from "./companion-surface";
+
+afterEach(cleanup);
+
+/** The introduction's card, which hangs off the avatar rather than the pill. */
+const cardOf = (container: HTMLElement): HTMLElement => {
+  const found = container.querySelector<HTMLElement>("[role='group']");
+  if (!found) {
+    throw new Error("Expected the introduction's card to render");
+  }
+  return found;
+};
+
+/** The pill, which is the one element on the surface whose width animates. */
+const pillOf = (container: HTMLElement): HTMLElement => {
+  const found = container.querySelector<HTMLElement>(".transition-\\[width\\]");
+  if (!found) {
+    throw new Error("Expected the surface to render");
+  }
+  return found;
+};
+
+/** How far a `calc(100% - Npx)` anchor holds its element off the canvas's bottom. */
+const offCanvasBottom = (top: string): number => {
+  const found = /^calc\(100% - ([\d.]+)px\)$/.exec(top);
+  if (!found?.[1]) {
+    throw new Error(`Expected an anchor off the canvas's bottom, got ${top}`);
+  }
+  return Number(found[1]);
+};
+
+/** How far the card is then stepped up off that anchor. */
+const steppedUp = (transform: string): number => {
+  const found = /^translateY\(calc\(-100% - ([\d.]+)px\)\)$/.exec(transform);
+  if (!found?.[1]) {
+    throw new Error(`Expected a step up off the anchor, got ${transform}`);
+  }
+  return Number(found[1]);
+};
+
+/**
+ * Where the introduction's card lands beside the surface it is describing.
+ *
+ * Every beat but the first holds the pill open, so the card and the pill are on
+ * screen together, and the pill is bottom-flush with the creature rather than
+ * centred on it. A card that only cleared the creature would be drawn over the
+ * controls it is captioning wherever the pill is the taller of the two.
+ */
+describe("the companion introduction's clearance", () => {
+  /**
+   * A small creature under a large pill, which is the pair that separates the
+   * two rules: the creature reaches 22 points above its centre and the pill
+   * 88, so a step off the creature alone lands the card inside the pill.
+   */
+  test("clears a pill that stands taller than the creature", () => {
+    const { container: surface } = render(
+      <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
+    );
+    const { container: intro } = render(
+      <CompanionIntro beat="talk" avatarBox={44} optionsBox={110} />,
+    );
+
+    // The pill hangs off its own line by a whole row, so its top edge is that
+    // much further off the canvas's bottom edge than its anchor.
+    const pillTop =
+      offCanvasBottom(pillOf(surface).style.top) + COMPANION_BASE_AVATAR_BOX;
+    const cardBottom =
+      offCanvasBottom(cardOf(intro).style.top) +
+      steppedUp(cardOf(intro).style.transform);
+
+    expect(cardBottom).toBeGreaterThan(pillTop);
+  });
+
+  /**
+   * The pair the layout is authored at, where the creature and the pill reach
+   * the same line: the card steps off the creature's own half box and the gap,
+   * exactly as the pill does.
+   */
+  test("steps off the creature itself when the two boxes agree", () => {
+    const { container } = render(<CompanionIntro beat="talk" />);
+
+    expect(cardOf(container).style.transform).toBe(
+      "translateY(calc(-100% - 34px))",
+    );
+  });
+
+  /**
+   * Growing downward there is nothing above the creature's own bottom to
+   * clear, since that line is the pill's bottom too whichever is larger.
+   */
+  test("takes the creature's own bottom growing downward", () => {
+    const { container } = render(
+      <CompanionIntro
+        beat="talk"
+        cardGrowth="down"
+        avatarBox={44}
+        optionsBox={110}
+      />,
+    );
+
+    // 34 points at a scale of two and a half.
+    expect(cardOf(container).style.transform).toBe("translateY(13.6px)");
+  });
+});

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -49,9 +49,8 @@ import type {
  * Prose has no natural width, so measuring would size the card to whichever
  * beat happened to say the most and change its shape as the run advanced. This
  * is the same bargain the typing card makes, and it fits the canvas at every
- * size: the window reaches `avatarBox / 2 + gap + maxBodyWidth` past the avatar
- * in both directions (`geometryFor` in `companion-window.ts`), which is 350 at
- * the size this layout is authored at.
+ * size, which main sizes by its own `maxReach` (`geometryFor` in
+ * `companion-window.ts`).
  */
 const CARD_WIDTH = 244;
 
@@ -141,8 +140,8 @@ export interface CompanionIntroProps {
    * The creature's box and the pill's, in points, as `CompanionSurface` takes
    * them.
    *
-   * The card hangs off the creature's edge and steps off it by the same gap the
-   * pill does, so it needs the same two numbers the surface does. Defaulted to
+   * The card hangs off the creature and has to clear whatever the pill draws
+   * beside it, so it needs the same two numbers the surface does. Defaulted to
    * the size the layout is authored at, which is what Storybook draws.
    */
   avatarBox?: number;
@@ -189,41 +188,30 @@ export function CompanionIntro({
   const copy = INTRO_COPY_KEYS[beat];
 
   // The same derivation `CompanionSurface` places the pill by, so the card and
-  // the pill hang off the creature by exactly the same amount.
-  const { inUnits, avatarHalf, gap, nearEdge } = companionLayoutFor(
-    avatarBox,
-    optionsBox,
-  );
-  const avatarHalfUnits = inUnits(avatarHalf);
-  // The creature's half box and then the same room the surface leaves between
-  // the avatar and its pill, so everything hanging off the creature sits the
-  // same distance from it.
-  const stepOff = inUnits(avatarHalf + gap);
-  const nearEdgeUnits = inUnits(nearEdge);
+  // the pill are arranged around one creature rather than two readings of it.
+  const { inUnits, avatarHalf, lineAt, edgeAt, introStepOff } =
+    companionLayoutFor(avatarBox, optionsBox);
+  // Clears whichever of the creature and the pill reaches further on this side,
+  // and then the gap. Stepping off the creature alone would put the card inside
+  // a pill taller than it, since the pill is bottom-flush with the avatar
+  // rather than centred on it and every beat but `meet` holds it open.
+  const stepOff = inUnits(introStepOff(cardGrowth));
 
   // Hung off the avatar's own edge, which is the point the host positioned this
   // window around and the point the pill is measured from too. Not off the
   // pill: that box changes width from beat to beat as controls are spotlighted,
   // and a card pinned to it would slide about while being read.
-  const placement: CSSProperties =
-    growth === "left"
-      ? { right: "50%", marginRight: -avatarHalfUnits }
-      : { left: "50%", marginLeft: -avatarHalfUnits };
+  const placement: CSSProperties = edgeAt(growth, -avatarHalf);
 
-  // The vertical half: sit against the canvas edge the avatar is near, then
-  // step off the avatar by its own half box plus the gap. `100%` names the
-  // canvas without this side having to know how tall the host made it, which is
-  // the same trick the surface's own anchor uses.
-  const anchor: CSSProperties =
-    cardGrowth === "up"
-      ? {
-          top: `calc(100% - ${nearEdgeUnits}px)`,
-          transform: `translateY(calc(-100% - ${stepOff}px))`,
-        }
-      : {
-          top: nearEdgeUnits,
-          transform: `translateY(${stepOff}px)`,
-        };
+  // The vertical half: sit on the avatar's own line, then step off it far
+  // enough to clear what is drawn there.
+  const anchor: CSSProperties = {
+    top: lineAt(cardGrowth, 0),
+    transform:
+      cardGrowth === "up"
+        ? `translateY(calc(-100% - ${stepOff}px))`
+        : `translateY(${stepOff}px)`,
+  };
 
   return (
     <div

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { companionLayoutFor } from "./companion-layout";
+import { bridgeRect, companionLayoutFor } from "./companion-layout";
 
 /**
  * The one derivation the pill and the introduction card are both placed by.
@@ -13,13 +13,11 @@ import { companionLayoutFor } from "./companion-layout";
 describe("companionLayoutFor", () => {
   /**
    * The authored pair. Every length on the surface is stated at this size, so
-   * the layout has to reduce to itself here: the scale is one, the creature
-   * carries no difference of its own, and the distances are the points they
-   * were written as.
+   * the layout has to reduce to itself here: the creature carries no difference
+   * of its own, and the distances are the points they were written as.
    */
   test("hands back the authored numbers when the two boxes agree", () => {
     const layout = companionLayoutFor(44, 44);
-    expect(layout.scale).toBe(1);
     expect(layout.avatarRel).toBe(1);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
@@ -32,26 +30,18 @@ describe("companionLayoutFor", () => {
    * the smaller box's, the creature is drawn at the ratio between the two, and
    * every point distance is divided by the scale the wrapper has already
    * applied.
+   *
+   * The conversion divides by that scale rather than multiplying by the base
+   * box over the pill's, because these numbers are written straight into CSS.
+   * The other order comes out a float's width away, and `calc(50% +
+   * 13.600000000000001px)` is what the user would read in the inspector.
    */
   test("states a mixed pair in the pill's units", () => {
     const layout = companionLayoutFor(44, 110);
-    expect(layout.scale).toBe(2.5);
     expect(layout.avatarRel).toBe(0.4);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
     expect(layout.nearEdge).toBe(148);
-    expect(layout.inUnits(34)).toBe(13.6);
-    expect(layout.inUnits(148)).toBe(59.2);
-  });
-
-  /**
-   * The conversion divides by the scale rather than multiplying by the base box
-   * over the pill's, because the numbers here are written straight into CSS.
-   * The other order comes out a float's width away, and `calc(50% +
-   * 13.600000000000001px)` is what the user would read in the inspector.
-   */
-  test("converts to the exact numbers CSS is handed", () => {
-    const layout = companionLayoutFor(44, 110);
     expect(`${layout.inUnits(34)}`).toBe("13.6");
     expect(`${layout.inUnits(148)}`).toBe("59.2");
   });
@@ -63,11 +53,154 @@ describe("companionLayoutFor", () => {
    */
   test("keeps the smaller box's gap when the creature is the larger", () => {
     const layout = companionLayoutFor(110, 44);
-    expect(layout.scale).toBe(1);
     expect(layout.avatarRel).toBe(2.5);
     expect(layout.avatarHalf).toBe(55);
     expect(layout.gap).toBe(12);
     expect(layout.nearEdge).toBe(115);
     expect(layout.inUnits(67)).toBe(67);
+  });
+
+  /**
+   * The canvas is anchored to whichever edge the card does not grow into, so a
+   * line is named from that edge and `100%` covers the other without this side
+   * knowing how tall main made the window.
+   */
+  test("names a line from the canvas edge the avatar is near", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.lineAt("up", 0)).toBe("calc(100% - 46px)");
+    expect(layout.lineAt("up", 22)).toBe("calc(100% - 24px)");
+    expect(layout.lineAt("down", 0)).toBe("46px");
+    expect(layout.lineAt("down", 22)).toBe("68px");
+  });
+
+  /** A flip anchors the other edge and moves nothing else. */
+  test("anchors the edge the surface grows from", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.edgeAt("right", 34)).toEqual({ left: "calc(50% + 34px)" });
+    expect(layout.edgeAt("left", 34)).toEqual({ right: "calc(50% + 34px)" });
+  });
+
+  /** Back towards the avatar's own edge, which the introduction's card hangs on. */
+  test("states a step back across the centre as a subtraction", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.edgeAt("right", -22)).toEqual({ left: "calc(50% - 22px)" });
+  });
+});
+
+/**
+ * How far the introduction's card starts from the avatar's centre.
+ *
+ * Its own distance rather than the pill's, because the pill is bottom-flush
+ * with the creature rather than centred on it. Every beat but the first holds
+ * the pill open, so a card that only cleared the creature would be drawn over
+ * the thing it is describing.
+ */
+describe("the introduction's step off the creature", () => {
+  test("clears the creature itself when the two boxes agree", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.introStepOff("up")).toBe(34);
+    expect(layout.introStepOff("down")).toBe(34);
+  });
+
+  /**
+   * A small creature under a large pill: bottom-flush puts the pill's top 88
+   * points above the avatar's centre where the creature reaches only 22, so
+   * the card has to start past the pill.
+   */
+  test("clears a pill that stands taller than the creature", () => {
+    const layout = companionLayoutFor(44, 110);
+    const pillTop = 110 - 22;
+    expect(layout.introStepOff("up")).toBe(pillTop + 12);
+    expect(layout.introStepOff("up")).toBeGreaterThan(pillTop);
+  });
+
+  /**
+   * Downward there is nothing to clear but the creature: the pill's bottom
+   * edge *is* the creature's bottom edge, whichever of the two is larger.
+   */
+  test("takes the creature's own bottom growing downward", () => {
+    expect(companionLayoutFor(44, 110).introStepOff("down")).toBe(34);
+    expect(companionLayoutFor(110, 44).introStepOff("down")).toBe(67);
+  });
+});
+
+/**
+ * The strip between the avatar and the pill, as arithmetic. The rects it is
+ * handed come from the DOM, so these are about the shape it makes of them:
+ * between the facing edges, and no taller than the composer row.
+ */
+describe("bridgeRect", () => {
+  const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
+  const ROW = { rowHeight: 44, cardGrowth: "up" } as const;
+
+  test("spans the facing edges when the pill grows rightward", () => {
+    const pill = { left: 156, right: 356, top: 100, bottom: 144 };
+    expect(bridgeRect(AVATAR, pill, ROW)).toEqual({
+      left: 144,
+      right: 156,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  test("spans them the other way when it grows leftward", () => {
+    const pill = { left: -100, right: 88, top: 100, bottom: 144 };
+    expect(bridgeRect(AVATAR, pill, ROW)).toEqual({
+      left: 88,
+      right: 100,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  /**
+   * The pill's height, never the avatar's. A strip as tall as a larger creature
+   * would claim the dead corners beside it, which is the bounding box this
+   * exists instead of.
+   */
+  test("takes the pill's height rather than a taller avatar's", () => {
+    const tall = { left: 100, right: 200, top: 40, bottom: 200 };
+    const pill = { left: 212, right: 412, top: 156, bottom: 200 };
+    expect(bridgeRect(tall, pill, ROW)).toEqual({
+      left: 200,
+      right: 212,
+      top: 156,
+      bottom: 200,
+    });
+  });
+
+  /**
+   * The card is the one state that is not its own row. A strip drawn to its
+   * full height would hand the window a column of empty canvas beside the card
+   * to swallow desktop presses in, so it stops at the composer row: the card's
+   * last child growing up, and its first growing down.
+   */
+  test("covers only the composer row of a card growing up", () => {
+    const card = { left: 156, right: 472, top: -146, bottom: 144 };
+    expect(bridgeRect(AVATAR, card, ROW)).toEqual({
+      left: 144,
+      right: 156,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  test("covers only the composer row of a card growing down", () => {
+    const card = { left: 156, right: 472, top: 100, bottom: 390 };
+    expect(
+      bridgeRect(AVATAR, card, { rowHeight: 44, cardGrowth: "down" }),
+    ).toEqual({
+      left: 144,
+      right: 156,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  /** Overlapping rects have no gap between them, and an empty strip says so. */
+  test("is empty when the two overlap", () => {
+    const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
+    const bridge = bridgeRect(AVATAR, overlapping, ROW);
+    expect(bridge.left).toBeGreaterThan(bridge.right);
   });
 });

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -3,35 +3,133 @@ import {
   companionNearEdgeFor,
   companionScaleFor,
 } from "@vellumai/ipc-contract";
+import type {
+  CompanionCardGrowth,
+  CompanionGrowth,
+} from "@vellumai/ipc-contract";
+import type { CSSProperties } from "react";
 
-/** The numbers everything on the companion surface is placed by. */
+/**
+ * How far the bob lifts the creature off its baseline, at the base size.
+ *
+ * The animation itself is `companion-avatar-bob` in `index.css` and the lift is
+ * written there as a literal. It is stated here as well because the host
+ * hit-tests the avatar against a rect the DOM box does not include: the
+ * artwork rides above its own box for most of the cycle, and a pointer on the
+ * drawn creature has to count as a pointer on the creature.
+ */
+export const COMPANION_BOB_LIFT = 3;
+
+/** As much of a rect as hit-testing a point against it needs. */
+export type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
+
+/**
+ * Whether a point is on a rect, its edges included.
+ *
+ * Inclusive because the surface is a union of touching rects: a pointer exactly
+ * on the line where the gap meets the pill is on the surface, and an exclusive
+ * test would drop it into the desktop for one pixel of travel.
+ */
+export const containsPoint = (
+  rect: SurfaceRect,
+  x: number,
+  y: number,
+): boolean =>
+  x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+
+/**
+ * The gap between the avatar and the pill, as a rect of its own.
+ *
+ * **The surface is a union of rects, never the box around them.** The avatar
+ * and the pill are separate elements, and a bounding box over the pair would
+ * claim the empty canvas above and below the gap as well: a click-through
+ * window told it is interactive there swallows the presses meant for whatever
+ * is behind it. So the gap is tested as exactly what it is, a strip between the
+ * two facing edges.
+ *
+ * It has to be part of the surface at all because the pointer crosses it on the
+ * way from the creature to the controls. A window that went click-through
+ * halfway would drop the press the user was travelling to make.
+ *
+ * **Vertically it is the composer row and nothing above it.** Every phase but
+ * `typing` draws a pill that is that row, so `rowHeight` costs those nothing;
+ * the card stands a whole panel higher, and a strip drawn to its full height
+ * would hand the window a column of empty canvas beside it to swallow presses
+ * in.
+ *
+ * Degenerate when the two overlap, which reads as no bridge at all: the strip's
+ * left edge lands past its right, and no point is inside it.
+ */
+export const bridgeRect = (
+  avatar: SurfaceRect,
+  pill: SurfaceRect,
+  {
+    rowHeight,
+    cardGrowth,
+  }: {
+    /**
+     * The composer row's height in screen pixels, which is the options box: the
+     * row is one base box tall and the page's wrapper is scaled by that box.
+     */
+    rowHeight: number;
+    cardGrowth: CompanionCardGrowth;
+  },
+): SurfaceRect => {
+  // The row holds the avatar's line either way: it is the card's last child
+  // growing up and its first growing down.
+  const top = cardGrowth === "up" ? pill.bottom - rowHeight : pill.top;
+  const row = { top, bottom: top + rowHeight };
+  return pill.left >= avatar.right
+    ? { left: avatar.right, right: pill.left, ...row }
+    : { left: pill.right, right: avatar.left, ...row };
+};
+
+/**
+ * The numbers everything on the companion surface is placed by, in points.
+ *
+ * Points because that is what the contract's helpers answer in and what main
+ * sizes the window with. {@link CompanionLayout.inUnits} does the one
+ * conversion at the end, so what reaches CSS is as exact as the arithmetic
+ * behind it.
+ */
 export interface CompanionLayout {
-  /** The pill's box over the size the layout is authored at. */
-  scale: number;
-  /**
-   * What the creature carries itself: the difference between the two boxes,
-   * since the wrapper has spent the options one already.
-   */
+  /** The creature's own scale, the page's wrapper having spent the options box already. */
   avatarRel: number;
-  /** The creature's half box, in points. */
+  /** Half the creature's box, which is what everything beside it steps off from. */
   avatarHalf: number;
-  /** The room between the creature's edge and anything beside it, in points. */
+  /** The room the creature keeps from anything drawn beside it. */
   gap: number;
-  /**
-   * How far the creature's centre sits from the canvas edge it is near, in
-   * points.
-   */
+  /** The creature's centre to the canvas edge it is near, which is what main places the window by. */
   nearEdge: number;
-  /**
-   * A distance in points, in the units the layout is stated in.
-   *
-   * The one conversion, and the reason the distances above are held in points:
-   * the page's wrapper has already scaled the whole canvas by the options size,
-   * and the contract answers in points because that is what main sizes the
-   * window in. Dividing once at the end keeps the numbers that reach CSS as
-   * exact as the arithmetic that made them.
-   */
+  /** The one conversion into the units the layout is stated in. */
   inUnits: (points: number) => number;
+  /**
+   * A line in the canvas, given how far in points it sits from the avatar's
+   * centre.
+   *
+   * The canvas is *not* symmetric about the avatar: the card's height is
+   * reserved on whichever side it grows into, so the avatar sits the near edge
+   * from the other one, and that edge is the one worth anchoring to. `100%`
+   * names the canvas without this side having to know how tall main made it.
+   */
+  lineAt: (cardGrowth: CompanionCardGrowth, offset: number) => string;
+  /**
+   * The horizontal anchor for something hanging that far off the avatar's
+   * centre, as the CSS edge `growth` runs from.
+   *
+   * The avatar holds one spot in the canvas and the pill and the card hang off
+   * one side of it, so a flip is the anchored edge changing rather than the
+   * creature moving.
+   */
+  edgeAt: (growth: CompanionGrowth, offset: number) => CSSProperties;
+  /**
+   * How far past the avatar's centre the introduction's card starts, in points.
+   *
+   * Its own distance rather than the pill's, because the pill is bottom-flush
+   * with the creature rather than centred on it: a card stepped off the
+   * creature alone lands inside a pill that stands taller than the creature.
+   */
+  introStepOff: (cardGrowth: CompanionCardGrowth) => number;
 }
 
 /**
@@ -40,21 +138,42 @@ export interface CompanionLayout {
  * Derived here rather than in each component, because the pill and the
  * introduction card both hang off the creature by these same distances:
  * `CompanionSurface` steps the pill off the avatar's edge across the gap, and
- * `CompanionIntro` steps its card off the same edge by the same amount. Two
- * copies of this arithmetic drifting is a card placed somewhere other than
- * beside the pill it describes.
+ * `CompanionIntro` clears whatever that leaves standing on its side. Two copies
+ * of this arithmetic drifting is a card placed somewhere other than beside the
+ * pill it describes.
  */
 export function companionLayoutFor(
   avatarBox: number,
   optionsBox: number,
 ): CompanionLayout {
   const scale = companionScaleFor(optionsBox);
+  const avatarHalf = avatarBox / 2;
+  const gap = companionGapFor(avatarBox, optionsBox);
+  const nearEdge = companionNearEdgeFor(avatarBox, optionsBox);
+  const inUnits = (points: number): number => points / scale;
+  // What is drawn beside the creature, measured from the creature's centre.
+  // The pill is bottom-flush with the avatar, so downward the two stop on the
+  // same line and upward the pill reaches a whole options box back past it,
+  // which stands above a creature smaller than the pill.
+  const reachUp = Math.max(avatarHalf, optionsBox - avatarHalf);
+  const reachDown = avatarHalf;
   return {
-    scale,
     avatarRel: avatarBox / optionsBox,
-    avatarHalf: avatarBox / 2,
-    gap: companionGapFor(avatarBox, optionsBox),
-    nearEdge: companionNearEdgeFor(avatarBox, optionsBox),
-    inUnits: (points: number): number => points / scale,
+    avatarHalf,
+    gap,
+    nearEdge,
+    inUnits,
+    lineAt: (cardGrowth, offset) =>
+      cardGrowth === "up"
+        ? `calc(100% - ${inUnits(nearEdge - offset)}px)`
+        : `${inUnits(nearEdge + offset)}px`,
+    edgeAt: (growth, offset) => {
+      const units = inUnits(offset);
+      const line =
+        units < 0 ? `calc(50% - ${-units}px)` : `calc(50% + ${units}px)`;
+      return growth === "left" ? { right: line } : { left: line };
+    },
+    introStepOff: (cardGrowth) =>
+      (cardGrowth === "up" ? reachUp : reachDown) + gap,
   };
 }

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -100,8 +100,7 @@ mock.module("@/runtime/desktop-voice-activity", () => ({
   sendVoiceActivityControl: () => undefined,
 }));
 
-const { CompanionSurfacePage, bridgeRect } =
-  await import("./companion-surface-page");
+const { CompanionSurfacePage } = await import("./companion-surface-page");
 
 afterEach(() => {
   cleanup();
@@ -256,54 +255,29 @@ describe("the gap between the avatar and the pill", () => {
 });
 
 /**
- * The strip itself, as arithmetic. The rects it is handed come from the DOM, so
- * these are about the shape it makes of them: between the facing edges, and no
- * taller than the pill.
+ * The creature is drawn where the bob has lifted it to, and the box it belongs
+ * to holds still underneath. A hit-test against the box alone leaves the
+ * creature's own head outside the surface for most of the cycle, so the pointer
+ * falls through the thing it is plainly on.
  */
-describe("bridgeRect", () => {
-  const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
+describe("the avatar's rect and the bob", () => {
+  test("takes in the strip the lift raises the creature into", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
 
-  test("spans the facing edges when the pill grows rightward", () => {
-    const pill = { left: 156, right: 356, top: 100, bottom: 144 };
-    expect(bridgeRect(AVATAR, pill)).toEqual({
-      left: 144,
-      right: 156,
-      top: 100,
-      bottom: 144,
-    });
+    // Two points above the box's top edge, inside the three the bob lifts.
+    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 98 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
   });
 
-  test("spans them the other way when it grows leftward", () => {
-    const pill = { left: -100, right: 88, top: 100, bottom: 144 };
-    expect(bridgeRect(AVATAR, pill)).toEqual({
-      left: 88,
-      right: 100,
-      top: 100,
-      bottom: 144,
-    });
-  });
+  test("gives the desktop back above the lift", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
 
-  /**
-   * The pill's height, never the avatar's. A strip as tall as a larger creature
-   * would claim the dead corners beside it, which is the bounding box this
-   * exists instead of.
-   */
-  test("takes the pill's height rather than a taller avatar's", () => {
-    const tall = { left: 100, right: 200, top: 40, bottom: 200 };
-    const pill = { left: 212, right: 412, top: 156, bottom: 200 };
-    expect(bridgeRect(tall, pill)).toEqual({
-      left: 200,
-      right: 212,
-      top: 156,
-      bottom: 200,
-    });
-  });
+    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 96 });
 
-  /** Overlapping rects have no gap between them, and an empty strip says so. */
-  test("is empty when the two overlap", () => {
-    const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
-    const bridge = bridgeRect(AVATAR, overlapping);
-    expect(bridge.left).toBeGreaterThan(bridge.right);
+    expect(setInteractiveMock).not.toHaveBeenCalledWith(true);
   });
 });
 
@@ -338,6 +312,28 @@ describe("the companion surface at two sizes", () => {
       expect(wrapperOf(container).style.transform).toBe("scale(2.5)");
     });
     expect(wrapperOf(container).style.width).toBe("40%");
+  });
+
+  /**
+   * A shell that predates the second axis publishes one box for the surface.
+   * Falling back to the authored size instead would draw a 44pt pill beside a
+   * creature the user had sized well past it.
+   */
+  test("sizes the pill by the creature when the state carries one box", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await waitFor(() => {
+      expect(wrapperOf(container).style.transform).toBe("scale(1)");
+    });
+
+    pushState({
+      ...STATE,
+      avatarBox: 110,
+      optionsBox: undefined as unknown as number,
+    });
+
+    await waitFor(() => {
+      expect(wrapperOf(container).style.transform).toBe("scale(2.5)");
+    });
   });
 
   test("leaves that canvas alone when only the creature grows", async () => {
@@ -1053,28 +1049,12 @@ describe("the companion's accent colour", () => {
   });
 
   /**
-   * The pill carries `--accent` in every phase; the glow only draws at rest.
+   * The glow is the only thing on the surface painted in the accent, so it is
+   * where the resolved colour is read back from.
    *
    * Awaited, because the state the colour comes from arrives after mount, so
    * the first render is always the default.
    */
-  const expectAccent = async (
-    container: HTMLElement,
-    hex: string,
-  ): Promise<void> => {
-    await waitFor(() => {
-      const pill = container.querySelector<HTMLElement>(
-        ".transition-\\[width\\]",
-      );
-      if (!pill) {
-        throw new Error("Expected the pill to render");
-      }
-      expect(pill.style.getPropertyValue("--accent").trim().toLowerCase()).toBe(
-        hex,
-      );
-    });
-  };
-
   const expectGlow = async (
     container: HTMLElement,
     hex: string,
@@ -1092,7 +1072,6 @@ describe("the companion's accent colour", () => {
     STATE.character = { ...CHARACTER };
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectAccent(container, "#e9642f");
     await expectGlow(container, "#e9642f");
   });
 
@@ -1101,7 +1080,7 @@ describe("the companion's accent colour", () => {
     STATE.call = listening("#123456");
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectAccent(container, "#123456");
+    await expectGlow(container, "#123456");
   });
 
   /**
@@ -1114,7 +1093,7 @@ describe("the companion's accent colour", () => {
     STATE.call = listening("");
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectAccent(container, "#e9642f");
+    await expectGlow(container, "#e9642f");
   });
 
   /**
@@ -1124,6 +1103,6 @@ describe("the companion's accent colour", () => {
   test("falls back to the component default without a character", async () => {
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectAccent(container, "#5eead4");
+    await expectGlow(container, "#5eead4");
   });
 });

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -6,6 +6,12 @@ import {
   introSpotlight,
 } from "@/components/companion-intro";
 import {
+  bridgeRect,
+  COMPANION_BOB_LIFT,
+  containsPoint,
+  type SurfaceRect,
+} from "@/components/companion-layout";
+import {
   CompanionSurface,
   type CompanionSurfacePhase,
 } from "@/components/companion-surface";
@@ -48,45 +54,6 @@ import type {
  * turn "take me back to Vellum" into a one-pixel nudge that does nothing.
  */
 const DRAG_SLOP = 3;
-
-/** As much of a rect as hit-testing a point against it needs. */
-type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
-
-/**
- * The gap between the avatar and the pill, as a rect of its own.
- *
- * **The surface is a union of rects, never the box around them.** The avatar
- * and the pill are separate elements, and a bounding box over the pair would
- * claim the empty canvas above and below the gap as well: a click-through
- * window told it is interactive there swallows the presses meant for whatever
- * is behind it, which is the failure every note in this file is about. So the
- * gap is tested as exactly what it is, a strip between the two facing edges,
- * running the pill's own height.
- *
- * It has to be part of the surface at all because the pointer crosses it on the
- * way from the creature to the controls. A window that went click-through
- * halfway would drop the press the user was travelling to make.
- *
- * Degenerate when the two overlap, which reads as no bridge at all: the strip's
- * left edge lands past its right, and no point is inside it.
- */
-export const bridgeRect = (
-  avatar: SurfaceRect,
-  pill: SurfaceRect,
-): SurfaceRect =>
-  pill.left >= avatar.right
-    ? {
-        left: avatar.right,
-        right: pill.left,
-        top: pill.top,
-        bottom: pill.bottom,
-      }
-    : {
-        left: pill.right,
-        right: avatar.left,
-        top: pill.top,
-        bottom: pill.bottom,
-      };
 
 /**
  * The companion surface inside its Electron canvas
@@ -193,7 +160,10 @@ export function CompanionSurfacePage() {
       setGrowth(state.growth);
       setCardGrowth(state.cardGrowth);
       setAvatarBox(state.avatarBox);
-      setOptionsBox(state.optionsBox);
+      // The creature's box unless the pill has one of its own, which covers a
+      // shell that predates the second axis: one box for both is the surface
+      // that side is drawing.
+      setOptionsBox(state.optionsBox ?? state.avatarBox);
       setAvatarSrc(
         state.avatarBase64 === undefined
           ? undefined
@@ -263,7 +233,7 @@ export function CompanionSurfacePage() {
    *
    * **Hover has to be dropped with it.** Hover is derived from hit-testing the
    * pointer against the surface's own box on every move, and the box the last
-   * move tested was the card: a 360pt panel standing well above the pill. The
+   * move tested was the card: a panel standing well above the pill. The
    * moment the card is gone that answer describes a shape that no longer
    * exists, and nothing corrects it, because the correction is a mouse-move and
    * the hand that just pressed "go back" is holding still. Left alone the
@@ -407,26 +377,46 @@ export function CompanionSurfacePage() {
       }
       return;
     }
-    const pill = pillRef.current;
     const avatar = avatarRef.current;
-    if (!pill || !avatar) {
+    if (!avatar) {
       return;
     }
     const inside = (rect: SurfaceRect): boolean =>
-      event.clientX >= rect.left &&
-      event.clientX <= rect.right &&
-      event.clientY >= rect.top &&
-      event.clientY <= rect.bottom;
-    // Each box read once. Reading one forces layout, and this runs on every
-    // pixel of every mouse-move the host forwards.
-    const avatarRect = avatar.getBoundingClientRect();
-    const pillRect = pill.getBoundingClientRect();
+      containsPoint(rect, event.clientX, event.clientY);
+    // Reading a box forces layout, and this runs on every pixel of every
+    // mouse-move the host forwards, so each is read once and the pill's is not
+    // read at all until there is a pill.
+    const drawn = avatar.getBoundingClientRect();
+    // The creature's box, plus the strip above it the bob lifts the artwork
+    // into. The element holds still and the drawing rises off it, so a pointer
+    // on the creature's own head is outside the box it belongs to.
+    const avatarRect: SurfaceRect = {
+      left: drawn.left,
+      right: drawn.right,
+      top:
+        drawn.top -
+        (COMPANION_BOB_LIFT * avatarBox) / COMPANION_BASE_AVATAR_BOX,
+      bottom: drawn.bottom,
+    };
     const onAvatar = inside(avatarRect);
     // The pill and the gap only count once there is a pill: at rest its box is
     // nothing, and a rect of nothing beside the avatar is not somewhere a
     // pointer can be.
-    const onPill = expanded && inside(pillRect);
-    const onBridge = expanded && inside(bridgeRect(avatarRect, pillRect));
+    const pill = expanded ? pillRef.current : null;
+    let onPill = false;
+    let onBridge = false;
+    if (pill !== null) {
+      const pillRect = pill.getBoundingClientRect();
+      onPill = inside(pillRect);
+      onBridge = inside(
+        bridgeRect(avatarRect, pillRect, {
+          // The composer row in screen pixels: one base box at the options
+          // scale, which is the options box itself.
+          rowHeight: optionsBox,
+          cardGrowth,
+        }),
+      );
+    }
     // The introduction's card is part of the surface for as long as it is
     // drawn. Testing only the surface would leave the window click-through over
     // Next and Skip, so the presses meant to end the run would land on whatever
@@ -585,8 +575,8 @@ export function CompanionSurfacePage() {
                 beat={intro}
                 growth={growth}
                 cardGrowth={cardGrowth}
-                // The card steps off the creature by the same gap the pill
-                // does, so it is given the same two boxes.
+                // The card clears whatever the pill draws beside the creature,
+                // so it is given the same two boxes.
                 avatarBox={avatarBox}
                 optionsBox={optionsBox}
                 accentHex={accentHex}

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -1,5 +1,12 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useEffect, useMemo, useState, type ChangeEvent } from "react";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type MouseEvent,
+} from "react";
 
 import {
   CompanionIntro,
@@ -7,12 +14,19 @@ import {
   introSpotlight,
 } from "@/components/companion-intro";
 import {
+  bridgeRect,
+  COMPANION_BOB_LIFT,
+  containsPoint,
+  type SurfaceRect,
+} from "@/components/companion-layout";
+import {
   CompanionSurface,
   type CompanionSurfacePhase,
 } from "@/components/companion-surface";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { composeSvg } from "@/utils/avatar-svg-compositor";
 import {
+  COMPANION_BASE_AVATAR_BOX,
   COMPANION_INTRO_BEATS,
   COMPANION_SIZE_BOXES,
   COMPANION_SIZES,
@@ -134,7 +148,6 @@ const meta: Meta<StoryArgs> = {
       options: SIZE_OPTIONS,
     },
     accentHex: { control: "color" },
-    glow: { control: "boolean" },
     watching: { control: "boolean" },
     watchEnabled: { control: "boolean" },
     introBeat: {
@@ -144,7 +157,6 @@ const meta: Meta<StoryArgs> = {
   },
   args: {
     phase: "resting",
-    glow: true,
     // On here, off everywhere a real user meets it until the flag says
     // otherwise. Design stories are for looking at what the surface can draw,
     // and a control the stories hid would be one nobody could review. Turn it
@@ -270,6 +282,30 @@ export const SmallAvatarBigOptions: Story = {
   args: {
     phase: "hover",
     hovered: true,
+    avatarBox: COMPANION_SIZE_BOXES.small,
+    optionsBox: COMPANION_SIZE_BOXES.huge,
+  },
+};
+
+/**
+ * The same pair at rest, which is the state the surface spends its day in.
+ *
+ * The pill is gone and the creature holds the spot it holds in every other
+ * state, so what these two show is that a mixed pair changes the creature's
+ * size and nothing about where it sits.
+ */
+export const RestingBigAvatarSmallOptions: Story = {
+  args: {
+    phase: "resting",
+    avatarBox: COMPANION_SIZE_BOXES.huge,
+    optionsBox: COMPANION_SIZE_BOXES.small,
+  },
+};
+
+/** The reverse pair at rest, where only the glow's own scale changes. */
+export const RestingSmallAvatarBigOptions: Story = {
+  args: {
+    phase: "resting",
     avatarBox: COMPANION_SIZE_BOXES.small,
     optionsBox: COMPANION_SIZE_BOXES.huge,
   },
@@ -536,6 +572,13 @@ export const AgainstTheLeftEdge: Story = {
   ],
 };
 
+/** A 44px column at the stage's right edge, with the screen ending beside it. */
+const againstTheRightEdge: Decorator = (Story) => (
+  <div className="absolute top-0 right-0 h-full w-11">
+    <Story />
+  </div>
+);
+
 /**
  * The case that needs the flip: the circle parked against the right edge, where
  * the body has nowhere to run.
@@ -547,19 +590,37 @@ export const AgainstTheLeftEdge: Story = {
  */
 export const AgainstTheRightEdge: Story = {
   args: { phase: "call", growth: "left" },
-  decorators: [
-    (Story) => (
-      <div className="absolute top-0 right-0 h-full w-11">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [againstTheRightEdge],
+};
+
+/**
+ * The flip with the two sizes pulling against each other, which is where a
+ * mirrored anchor is easiest to get wrong.
+ *
+ * The pill is pinned by its right edge a gap off a creature more than twice its
+ * height, and the two still share a bottom line. The creature holds the same
+ * spot it holds growing rightward: what a flip moves is the pill.
+ */
+export const BigAvatarAgainstTheRightEdge: Story = {
+  args: {
+    phase: "hover",
+    hovered: true,
+    growth: "left",
+    avatarBox: COMPANION_SIZE_BOXES.huge,
+    optionsBox: COMPANION_SIZE_BOXES.small,
+  },
+  decorators: [againstTheRightEdge],
 };
 
 /**
  * The move itself, which is the thing being designed and the one thing a
- * static story cannot show. Expansion arms on the avatar alone, so the rest of
- * the desktop is dead space exactly as it is in the real window.
+ * static story cannot show.
+ *
+ * Hover is hit-tested against the avatar, the pill and the strip between them,
+ * which is how the Electron host derives it: that window is click-through and
+ * receives forwarded mouse-move rather than `mouseenter`, so it works in
+ * coordinates. Doing the same here keeps the story honest about where the
+ * surface actually arms and where the desktop is left alone.
  *
  * Drop in an image to see the surface wearing a particular assistant. It never
  * leaves the browser: the file is read to a data URL and handed straight to the
@@ -578,6 +639,8 @@ export const Interactive: Story = {
 function HoverDrivenSurface(args: StoryArgs) {
   const [hovered, setHovered] = useState(false);
   const [uploaded, setUploaded] = useState<string | undefined>();
+  const avatarRef = useRef<HTMLDivElement | null>(null);
+  const pillRef = useRef<HTMLDivElement | null>(null);
 
   const onFile = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -595,21 +658,70 @@ function HoverDrivenSurface(args: StoryArgs) {
 
   const phase: CompanionSurfacePhase =
     args.phase === "call" ? "call" : hovered ? "hover" : "resting";
+  const expanded = phase !== "resting";
+  // The pair the surface is drawn at, defaulted the way the component defaults
+  // them, since the hit-test has to measure the creature the story is showing.
+  const avatarBox = args.avatarBox ?? COMPANION_BASE_AVATAR_BOX;
+  const optionsBox = args.optionsBox ?? COMPANION_BASE_AVATAR_BOX;
+
+  const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
+    const avatar = avatarRef.current;
+    const pill = pillRef.current;
+    if (!avatar || !pill) {
+      return;
+    }
+    const inside = (rect: SurfaceRect): boolean =>
+      containsPoint(rect, event.clientX, event.clientY);
+    const drawn = avatar.getBoundingClientRect();
+    const avatarRect: SurfaceRect = {
+      left: drawn.left,
+      right: drawn.right,
+      // The bob raises the artwork off its own box, on a wrapper inside the
+      // creature's own scale, so the lift grows with the creature. Nothing
+      // scales the stage itself, which is what the page's wrapper does.
+      top: drawn.top - (COMPANION_BOB_LIFT * avatarBox) / optionsBox,
+      bottom: drawn.bottom,
+    };
+    if (!expanded) {
+      setHovered(inside(avatarRect));
+      return;
+    }
+    const pillRect = pill.getBoundingClientRect();
+    setHovered(
+      inside(avatarRect) ||
+        inside(pillRect) ||
+        inside(
+          bridgeRect(avatarRect, pillRect, {
+            // One base box, since nothing here is scaled the way the page's
+            // wrapper scales the real canvas by the options size.
+            rowHeight: COMPANION_BASE_AVATAR_BOX,
+            cardGrowth: args.cardGrowth ?? "up",
+          }),
+        ),
+    );
+  };
 
   return (
     <>
-      <CompanionSurface
-        {...args}
-        phase={phase}
-        hovered={hovered}
-        avatarSrc={uploaded ?? args.avatarSrc}
-        onHoverStart={() => {
-          setHovered(true);
-        }}
-        onHoverEnd={() => {
+      {/* The canvas, which is where the pointer is tracked. The surface's own
+          elements are all that arm it: everywhere else in here is desktop, the
+          way it is in the real window. */}
+      <div
+        className="absolute inset-0"
+        onMouseMove={onMouseMove}
+        onMouseLeave={() => {
           setHovered(false);
         }}
-      />
+      >
+        <CompanionSurface
+          {...args}
+          phase={phase}
+          hovered={hovered}
+          avatarSrc={uploaded ?? args.avatarSrc}
+          avatarRef={avatarRef}
+          rootRef={pillRef}
+        />
+      </div>
       <label className="absolute bottom-2 left-2 cursor-pointer rounded-md bg-black/50 px-2 py-1 text-[11px] text-white/80 backdrop-blur-sm">
         Use my own avatar
         <input
@@ -875,6 +987,10 @@ function IntroWalkthrough({ introBeat, ...args }: StoryArgs) {
             beat={beat}
             growth={args.growth}
             cardGrowth={args.cardGrowth}
+            // The same pair the surface is drawn at, so a mixed one shows the
+            // card clearing the pill rather than landing inside it.
+            avatarBox={args.avatarBox}
+            optionsBox={args.optionsBox}
             accentHex={args.accentHex}
             onAdvance={(action) => {
               const next =
@@ -902,7 +1018,7 @@ export const Introduction: Story = {
 /**
  * The card with a reply that uses the formatting an assistant actually writes:
  * emphasis, inline code, and a short list. What the card does with markdown is
- * worth looking at rather than reasoning about, since it is 360pt wide and set
+ * worth looking at rather than reasoning about, since it is a pill's width set
  * at 12px, and the primitive is authored for a full-width transcript.
  */
 export const TypingWithMarkdown: Story = {

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1,16 +1,30 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as motionReact from "motion/react";
 
 import { COMPANION_BASE_MAX_PILL_WIDTH } from "@vellumai/ipc-contract";
 import type { VoiceActivityState } from "@vellumai/ipc-contract";
 
-import {
-  CompanionSurface,
-  FALLBACK_WIDTHS,
-  INNER_GAP,
-} from "./companion-surface";
+/**
+ * The reduced-motion answer, so one case can render the surface as a reader who
+ * has asked for stillness sees it. Spread over the real module rather than
+ * standing in for it, since the creature's own artwork animates through the
+ * same package.
+ */
+let reducedMotion = false;
 
-afterEach(cleanup);
+mock.module("motion/react", () => ({
+  ...motionReact,
+  useReducedMotion: () => reducedMotion,
+}));
+
+const { CompanionSurface, FALLBACK_WIDTHS, INNER_GAP } =
+  await import("./companion-surface");
+
+afterEach(() => {
+  cleanup();
+  reducedMotion = false;
+});
 
 /** The ordinary middle of a call: unmuted, listening, nothing to decide. */
 const LISTENING_CALL: VoiceActivityState = {
@@ -43,17 +57,40 @@ describe("the companion surface's working ring", () => {
     expect(ringOf(container)).not.toBeNull();
   });
 
-  test("is drawn on the expanded pill too", () => {
+  test("is drawn with the pill open too", () => {
     const { container } = render(<CompanionSurface phase="hover" working />);
     expect(ringOf(container)).not.toBeNull();
   });
 
-  test("follows the card's corner radius while typing", () => {
-    const { container } = render(<CompanionSurface phase="typing" working />);
-    expect(ringOf(container)?.className).toContain("rounded-[24px]");
+  /**
+   * **The ring belongs to the creature.** The avatar is drawn in every phase
+   * and holds one spot in the canvas, so the light stays where the eye already
+   * looks for this surface's state. Handing it to the pill while expanded would
+   * move it to a different parent every time the pointer crossed, which
+   * remounts everything hanging off it.
+   */
+  test("hangs off the avatar in every phase", () => {
+    for (const phase of [
+      "resting",
+      "hover",
+      "watching",
+      "summary",
+      "call",
+      "typing",
+    ] as const) {
+      const { container } = render(<CompanionSurface phase={phase} working />);
+      expect(ringOf(container)?.closest(".size-11")).not.toBeNull();
+      cleanup();
+    }
   });
 
-  test("is round in every state that is not the card", () => {
+  /** Around the creature's own box, so it is a circle whatever the pill is. */
+  test("stays round while the card is open", () => {
+    const { container } = render(<CompanionSurface phase="typing" working />);
+    expect(ringOf(container)?.className).toContain("rounded-full");
+  });
+
+  test("is round in every other state too", () => {
     const { container } = render(<CompanionSurface phase="hover" working />);
     expect(ringOf(container)?.className).toContain("rounded-full");
   });
@@ -299,14 +336,34 @@ describe("the companion surface's capture pulse", () => {
     ).toBe("#ff9f45");
   });
 
-  test("follows the card's corner radius while typing", () => {
+  test("stays round while the card is open", () => {
     const { container, rerender } = render(
       <CompanionSurface phase="typing" watching captureCount={0} />,
     );
 
     rerender(<CompanionSurface phase="typing" watching captureCount={1} />);
 
-    expect(pulseOf(container)?.className).toContain("rounded-[24px]");
+    expect(pulseOf(container)?.className).toContain("rounded-full");
+  });
+
+  /**
+   * The flare is one-shot, so a node unmounted and put back plays it again. The
+   * pointer crosses this surface constantly while a session runs, and none of
+   * those crossings is a screen being read: a flare drawn for one would be the
+   * indicator claiming a capture that did not happen.
+   */
+  test("does not replay when the phase changes under a running session", () => {
+    const { container, rerender } = render(
+      <CompanionSurface phase="resting" watching captureCount={0} />,
+    );
+    rerender(<CompanionSurface phase="resting" watching captureCount={1} />);
+    const flare = pulseOf(container);
+    expect(flare).not.toBeNull();
+
+    rerender(<CompanionSurface phase="hover" watching captureCount={1} />);
+    rerender(<CompanionSurface phase="resting" watching captureCount={1} />);
+
+    expect(pulseOf(container)).toBe(flare);
   });
 });
 
@@ -1171,20 +1228,11 @@ describe("the companion surface's width ceiling", () => {
 
   /**
    * The ceiling is on the pill, not on the body inside it, so a body that fits
-   * with the clearance at either end left off is not one that fits. `typing` is
-   * the card's own outer width rather than a measured body, and the case below
-   * holds it exactly at the ceiling.
+   * with the clearance at either end left off is not one that fits.
    */
   test("holds for every measured body once the pill's own clearance is on it", () => {
-    const over = Object.entries(FALLBACK_WIDTHS)
-      .filter(([phase]) => phase !== "typing")
-      .filter(([, width]) => width + 2 * INNER_GAP > CANVAS_CEILING);
-    expect(over).toEqual([]);
-  });
-
-  test("holds for every phase", () => {
     const over = Object.entries(FALLBACK_WIDTHS).filter(
-      ([, width]) => width > CANVAS_CEILING,
+      ([, width]) => width + 2 * INNER_GAP > CANVAS_CEILING,
     );
     expect(over).toEqual([]);
   });
@@ -1204,8 +1252,14 @@ describe("the companion surface's width ceiling", () => {
     expect(FALLBACK_WIDTHS.call).toBeGreaterThan(FALLBACK_WIDTHS.hover);
   });
 
-  test("leaves the card exactly at the ceiling it was already at", () => {
-    expect(FALLBACK_WIDTHS.typing).toBe(CANVAS_CEILING);
+  /**
+   * The card is the widest state the surface has and it states its width rather
+   * than measuring one, so it is drawn at the ceiling itself: the canvas is
+   * sized for exactly this and a card any wider would be a clipped one.
+   */
+  test("draws the card at the ceiling", () => {
+    const { container } = render(<CompanionSurface phase="typing" />);
+    expect(surfaceOf(container).style.width).toBe(`${CANVAS_CEILING}px`);
   });
 });
 
@@ -1231,9 +1285,9 @@ describe("the companion surface's capture indicator across phases", () => {
     expect(ringOf(container)).not.toBeNull();
   });
 
-  test("follows the card's corner radius while the user types", () => {
+  test("stays on the creature while the user types", () => {
     const { container } = render(<CompanionSurface phase="typing" watching />);
-    expect(ringOf(container)?.className).toContain("rounded-[24px]");
+    expect(ringOf(container)?.closest(".size-11")).not.toBeNull();
   });
 
   test("is absent in the composer with no session running", () => {
@@ -1467,5 +1521,35 @@ describe("the resting avatar's idle motion", () => {
       expect(container.querySelector(".companion-glow")).not.toBeNull();
       cleanup();
     }
+  });
+
+  /**
+   * A reader who has asked for stillness gets it from two places: the
+   * `prefers-reduced-motion` block beside the keyframes, and the inline
+   * `animation: none` here. The doubling is deliberate, since a stylesheet that
+   * failed to load is a surface that moves anyway, and this is the half a
+   * reader of the component can see.
+   *
+   * Held still rather than dropped: the glow is the creature's own light and
+   * the bob's baseline is where the creature belongs, so both stay drawn.
+   */
+  test("holds the bob and the glow still under reduced motion", () => {
+    reducedMotion = true;
+
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    const glow = container.querySelector<HTMLElement>(".companion-glow");
+    expect(bob?.style.animation).toBe("none");
+    expect(glow?.style.animation).toBe("none");
+  });
+
+  test("leaves both running for a reader who asked for nothing", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    const glow = container.querySelector<HTMLElement>(".companion-glow");
+    expect(bob?.style.animation).toBe("");
+    expect(glow?.style.animation).toBe("");
   });
 });

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -65,11 +65,12 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
  * its edge (the gap, the near edge, its own half box) are worked out from the
  * contract's helpers and divided back into these units.
  *
- * **Growth needs clearance on the side it runs into**: the gap, and then a body
- * that reaches 316px at its widest. A circle parked against the right edge does
- * not have it, and unclamped the pill would run straight off the display with
- * the controls the user was reaching for. So the surface flips and grows the
- * other way instead, the way a menu does, through {@link growth}.
+ * **Growth needs clearance on the side it runs into**: the gap, and then a pill
+ * as wide as {@link COMPANION_BASE_MAX_PILL_WIDTH}, which is what the card
+ * draws. A circle parked against the right edge does not have it, and unclamped
+ * the pill would run straight off the display with the controls the user was
+ * reaching for. So the surface flips and grows the other way instead, the way a
+ * menu does, through {@link growth}.
  *
  * **Presentational only.** Phase comes from the caller, so this renders
  * identically in Storybook and in the Electron panel. Hover is a phase rather
@@ -187,10 +188,6 @@ const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
  */
 const WATCHING_RING_ACCENT = "#ff9f45";
 
-// The box every length on this surface is stated in: the pill's own height, and
-// the creature's at the size the two agree on.
-const BASE_BOX = COMPANION_BASE_AVATAR_BOX;
-
 /**
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
  * every side. Both the still and the composed creature draw at this size, so
@@ -235,10 +232,15 @@ export const INNER_GAP = 8;
  * a state that wanted more would be clipped by the window, and buying the room
  * back means resizing the canvas, which is the thing a fixed canvas exists to
  * avoid.
+ *
+ * The two phases that never reach this are absent from it: `resting` has no
+ * pill to measure, and `typing` states {@link CARD_WIDTH} rather than measuring
+ * anything.
  */
-export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
-  // Nothing at all: at rest there is no pill, and its box goes with it.
-  resting: 0,
+export const FALLBACK_WIDTHS: Record<
+  Exclude<CompanionSurfacePhase, "resting" | "typing">,
+  number
+> = {
   // Three icon-only controls, which is the row as it is first drawn: the labels
   // are revealed one at a time under the pointer, and on the first frame there
   // is no pointer on any of them yet.
@@ -254,8 +256,6 @@ export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
   // The row with the stop control on it, which is the widest a call draws: a
   // watch session adds a fifth control to the four the call already has.
   call: 288,
-  // The card's body, which is {@link CARD_WIDTH} rather than anything measured.
-  typing: 316,
 };
 
 /**
@@ -274,8 +274,8 @@ const CARD_WIDTH = COMPANION_BASE_MAX_PILL_WIDTH;
  * The card is still a card, not a chat window: it holds a readable stretch of
  * the exchange and the rest is scrolled to, so a long reply can be read in
  * place without the surface growing until it runs off the top of the display.
- * Whatever this is, `MAX_CARD_HEIGHT` in `companion-window.ts` has to be sized
- * to hold it plus the composer row.
+ * Whatever this is, `COMPANION_BASE_CARD_HEIGHT` in the contract has to be
+ * sized to hold it plus the composer row.
  */
 const TURNS_MAX_HEIGHT = 220;
 
@@ -297,8 +297,6 @@ export interface CompanionSurfaceProps {
   turns?: CompanionTurn[];
   /** The assistant's name, for the composer's placeholder. */
   assistantName?: string;
-  /** The resting circle's ambient halo, in the avatar's own colour. */
-  glow?: boolean;
   /** The assistant's avatar colour. Fills shapes; never carries text. */
   accentHex?: string;
   /**
@@ -332,21 +330,6 @@ export interface CompanionSurfaceProps {
    * still notice a hand arriving over it either way.
    */
   hovered?: boolean;
-  /**
-   * Expand. Wired to the avatar alone, never to the surface: at rest the two
-   * are the same box, but arming from anything larger than what is drawn would
-   * expand the surface from empty space the user cannot see.
-   */
-  onHoverStart?: () => void;
-  /**
-   * Collapse. Wired to the group holding the avatar, the gap and the pill
-   * rather than to the avatar, because once expanded the pointer has to be able
-   * to travel across the gap to the controls. Leaving on the avatar would
-   * collapse the pill out from under the hand reaching for it, and while
-   * resting the avatar is all the group has drawn in it, so the two agree
-   * exactly when it matters.
-   */
-  onHoverEnd?: () => void;
   /** Which way the pill grows. See {@link CompanionSurfaceGrowth}. */
   growth?: CompanionSurfaceGrowth;
   /**
@@ -636,13 +619,10 @@ export function CompanionSurface({
   phase,
   turns = [],
   assistantName = "your assistant",
-  glow = true,
   accentHex = DEFAULT_ACCENT,
   avatarSrc,
   character,
   hovered = false,
-  onHoverStart,
-  onHoverEnd,
   growth = "right",
   avatarBox = COMPANION_BASE_AVATAR_BOX,
   optionsBox = COMPANION_BASE_AVATAR_BOX,
@@ -726,25 +706,11 @@ export function CompanionSurface({
 
   // The distances everything below is placed by, in points, and the one
   // conversion into the units this layout is stated in. Shared with
-  // `CompanionIntro`, whose card hangs off the same edge by the same amount.
-  const { inUnits, avatarRel, avatarHalf, gap, nearEdge } = companionLayoutFor(
+  // `CompanionIntro`, whose card hangs off the same creature.
+  const { avatarRel, avatarHalf, gap, lineAt, edgeAt } = companionLayoutFor(
     avatarBox,
     optionsBox,
   );
-
-  /**
-   * A line in the canvas, given how far in points it sits from the avatar's
-   * centre.
-   *
-   * The canvas is *not* symmetric about the avatar: the card's height is
-   * reserved on whichever side it grows into, so the avatar sits the near edge
-   * from the other one, and that edge is the one worth anchoring to. `100%`
-   * names the canvas without this side having to know how tall main made it.
-   */
-  const lineAt = (offset: number): string =>
-    cardGrowth === "up"
-      ? `calc(100% - ${inUnits(nearEdge - offset)}px)`
-      : `${inUnits(nearEdge + offset)}px`;
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
   // spot the host positions this window around, and the pill hangs off one side
@@ -757,10 +723,7 @@ export function CompanionSurface({
   // centre and lets the body run the rest of the way: the pill is what moves
   // when `growth` flips, and the creature the host measures every drag, clamp
   // and direction check against is not.
-  const placement: CSSProperties =
-    growth === "left"
-      ? { right: `calc(50% + ${inUnits(avatarHalf + gap)}px)` }
-      : { left: `calc(50% + ${inUnits(avatarHalf + gap)}px)` };
+  const placement = edgeAt(growth, avatarHalf + gap);
 
   // The card growing downward draws its composer row first, so the row starts
   // on the avatar's top line and the card falls away from it; everything else
@@ -774,27 +737,33 @@ export function CompanionSurface({
     // avatar's, and the card keeps that line: its composer row is the column's
     // last child growing up and its first growing down, so the row's bottom is
     // the avatar's bottom either way and the mascot does not move when Type is
-    // pressed. Which way the card stacks is the host's call: parked by the Dock
-    // a card growing down would grow off the bottom of the screen, and at the
-    // top of the display a card growing up has nowhere to be (see
+    // pressed. The line is the avatar's *box*, not the artwork inside it, which
+    // is inset by an `INNER_GAP` on every side and so stops short of it. Which
+    // way the card stacks is the host's call: parked by the Dock a card growing
+    // down would grow off the bottom of the screen, and at the top of the
+    // display a card growing up has nowhere to be (see
     // `CompanionSurfaceCardGrowth`). The row is one options box tall, so a card
     // growing downward starts exactly that far above the line.
-    top: lineAt(dropsFromTheRow ? avatarHalf - optionsBox : avatarHalf),
+    top: lineAt(
+      cardGrowth,
+      dropsFromTheRow ? avatarHalf - optionsBox : avatarHalf,
+    ),
     transform: dropsFromTheRow ? "none" : "translateY(-100%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
     transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
-    ["--accent" as string]: accentHex,
   };
 
   /**
-   * The surface's edge, lit for something running and flared for each capture.
+   * The creature's edge, lit for something running and flared for each capture.
    *
-   * Drawn around the avatar at rest and around the pill once there is one. The
-   * pill is nothing at rest, so the avatar is the only edge there is to light,
-   * and it is the state the ring most has to be legible in: the whole point is
-   * being readable from the corner of an eye while the user works elsewhere.
-   * Expanded, the pill is the surface's outline and takes it back.
+   * **On the avatar in every phase.** The creature is the one thing drawn in
+   * all of them and it holds one spot in the canvas, so the light stays where
+   * the eye already looks for this surface's state, and a working creature
+   * reads perfectly well beside an open pill. Handing it to the pill while
+   * expanded would move it to a different parent every time the pointer
+   * crossed, which unmounts the one-shot flare below and replays it for a
+   * capture that never happened.
    */
   const edge = (
     <>
@@ -810,9 +779,7 @@ export function CompanionSurface({
           failures. */}
       {(assistantWorking || watching || summarizing) && (
         <span
-          className={`companion-working-ring pointer-events-none absolute -inset-0.5 ${
-            typing ? "rounded-[24px]" : "rounded-full"
-          }`}
+          className="companion-working-ring pointer-events-none absolute -inset-0.5 rounded-full"
           style={{
             ["--companion-ring-accent" as string]: watching
               ? WATCHING_RING_ACCENT
@@ -841,9 +808,7 @@ export function CompanionSurface({
       {watching && observedCaptures > 0 && (
         <span
           key={observedCaptures}
-          className={`companion-capture-pulse pointer-events-none absolute -inset-0.5 ${
-            typing ? "rounded-[24px]" : "rounded-full"
-          }`}
+          className="companion-capture-pulse pointer-events-none absolute -inset-0.5 rounded-full"
           style={{
             ["--companion-ring-accent" as string]: WATCHING_RING_ACCENT,
           }}
@@ -859,170 +824,129 @@ export function CompanionSurface({
     // from state to state and be clipped by the pill's own rounding; beside it,
     // both hang off the same fixed avatar position in the canvas.
     <>
-      {/* The avatar, the pill, and the gap between them, as one group.
-
-        Its box is the whole canvas so the `50%` and `100%` its children anchor
-        by still name the canvas, and it takes no pointer of its own, so the
-        pointer is inside it exactly when it is on the avatar, the pill or the
-        bridge across the gap. Leaving the group is therefore leaving the whole
-        surface, which is what lets a hand travel from the creature to the
-        controls without the pill collapsing out from under it. */}
+      {/* The pill is a drag handle, as the avatar is. Controls opt out by
+        stopping the press, so everything on it that is not a button can be
+        grabbed. */}
       <div
-        className="pointer-events-none absolute inset-0"
-        onMouseLeave={onHoverEnd}
+        className={`absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
+          typing
+            ? // The composer row is the column's last child, so a card growing
+              // downward reverses the column: the row that holds the avatar's
+              // line has to stay on that line, and the turns stack away from
+              // it.
+              `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
+            : "flex h-11 items-center rounded-full"
+        }`}
+        style={style}
+        onMouseDown={onSurfaceMouseDown}
+        onContextMenu={onSurfaceContextMenu}
+        ref={rootRef}
       >
-        {/* The pill is a drag handle, as the avatar is. Controls opt out by
-          stopping the press, so everything on it that is not a button can be
-          grabbed. */}
-        <div
-          className={`pointer-events-auto absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
-            typing
-              ? // The composer row is the column's last child, so a card growing
-                // downward reverses the column: the row that holds the avatar's
-                // line has to stay on that line, and the turns stack away from
-                // it.
-                `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
-              : "flex h-11 items-center rounded-full"
+        {/* The pill's body, which exists only once there is a pill. At rest
+          there is nothing beside the avatar to draw, and fading the body in
+          as the width grows is what makes the pill unfurl out of the gap
+          rather than appear in it. */}
+        <span
+          className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
+            // Radius follows the same rule as the gap: the controls are 28pt
+            // so their radius is 14, and 8pt of clearance puts the outer
+            // radius at 22. A pill happens to reach that by being 44 tall;
+            // the card has to say it.
+            typing ? "rounded-[22px]" : "rounded-full"
           }`}
-          style={style}
-          onMouseDown={onSurfaceMouseDown}
-          onContextMenu={onSurfaceContextMenu}
-          ref={rootRef}
-        >
-          {/* The pill's body, which exists only once there is a pill. At rest
-            there is nothing beside the avatar to draw, and fading the body in
-            as the width grows is what makes the pill unfurl out of the gap
-            rather than appear in it. */}
-          <span
-            className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
-              // Radius follows the same rule as the gap: the controls are 28pt
-              // so their radius is 14, and 8pt of clearance puts the outer
-              // radius at 22. A pill happens to reach that by being 44 tall;
-              // the card has to say it.
-              typing ? "rounded-[22px]" : "rounded-full"
-            }`}
-            style={{ opacity: expanded ? 1 : 0 }}
-            aria-hidden
-          />
-          {expanded && edge}
-          {typing && turns.length > 0 && <RecentTurns turns={turns} />}
-          {/* The pill's one in-flow row, and where the clearance at either end
-            lives. On the row rather than on the pill, so the pill's own box
-            goes to nothing at rest while the body inside it keeps being
-            measured. */}
-          <div
-            className="relative flex h-11 shrink-0 items-center"
-            style={{ paddingInline: INNER_GAP }}
-          >
-            {typing ? (
-              <Composer
-                assistantName={assistantName}
-                watching={watching}
-                onSubmit={onSubmit}
-                onCancel={onCancelTyping}
-                onWatch={onWatch}
-              />
-            ) : (
-              <div
-                className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
-                ref={contentRef}
-                // Faded out is not gone: the body stays mounted while collapsed
-                // so it can be measured, which would otherwise leave its
-                // controls focusable and announced while nothing is drawn.
-                // `inert` takes them out of the tab order and the accessibility
-                // tree without taking them out of the DOM, so the measurement
-                // still works.
-                inert={!expanded}
-                style={{
-                  opacity: expanded ? 1 : 0,
-                  // Contents fade after the body has somewhere to put them, so
-                  // nothing is ever drawn wider than the pill carrying it.
-                  transitionDelay: expanded ? "120ms" : "0ms",
-                }}
-              >
-                {phase === "call" ? (
-                  <CallBody
-                    call={call}
-                    watching={watching}
-                    onControl={onControl}
-                    onWatch={onWatch}
-                  />
-                ) : phase === "summary" && watchRetro !== undefined ? (
-                  <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
-                ) : (
-                  <IdleBody
-                    spotlight={spotlight}
-                    watching={watching}
-                    watchEnabled={watchEnabled}
-                    onTalk={onTalk}
-                    onType={onType}
-                    onWatch={onWatch}
-                  />
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-        {/* The gap, as an element rather than empty canvas. Nothing is drawn in
-          it and nothing can be grabbed by it: it is here so a pointer crossing
-          from the creature to the controls stays inside the group and the pill
-          is not pulled out from under the hand halfway. The host hit-tests the
-          same span from the two rects (`bridgeRect` in
-          `companion-surface-page.tsx`), since a click-through window is told
-          about the pointer in coordinates rather than in elements. */}
-        {expanded && (
-          <span
-            className="pointer-events-auto absolute"
-            style={{
-              width: inUnits(gap),
-              // The pill's own row, on the pill's own line: the strip is what
-              // the pointer crosses between the two, so it is as tall as what
-              // it leads to rather than as tall as the creature it leaves.
-              height: BASE_BOX,
-              ...(growth === "left"
-                ? { right: `calc(50% + ${inUnits(avatarHalf)}px)` }
-                : { left: `calc(50% + ${inUnits(avatarHalf)}px)` }),
-              top: lineAt(avatarHalf),
-              transform: "translateY(-100%)",
-            }}
-            aria-hidden
-          />
-        )}
-        {/* Drawn last so the glow, which falls off well past the creature,
-          lands over the pill's leading edge rather than under it. */}
-        <Avatar
-          glow={glow}
-          accentHex={accentHex}
-          avatarSrc={avatarSrc}
-          character={character}
-          attentive={hovered}
-          // The assistant's own turn. The creature stops blinking and holds a
-          // focused, morphing pose, which is the same treatment the chat avatar
-          // uses while a reply is streaming: one vocabulary for "it is working"
-          // wherever the user meets it.
-          busy={assistantWorking}
-          edge={expanded ? null : edge}
-          style={{
-            left: "50%",
-            top: lineAt(0),
-            // Centred on the point the host put the window around, then scaled
-            // about that centre by whatever the creature's own size asks for
-            // beyond the scale the page has already applied. Omitted where the
-            // two boxes agree, which is the surface every other length here is
-            // authored for. On this node rather than the one below it: the bob
-            // owns a `transform` of its own, and two transforms on one node
-            // silently leave one of them out.
-            transform: `translate(-50%, -50%)${
-              avatarRel === 1 ? "" : ` scale(${avatarRel})`
-            }`,
-          }}
-          elementRef={avatarRef}
-          onMouseEnter={onHoverStart}
-          onMouseDown={onSurfaceMouseDown}
-          onContextMenu={onSurfaceContextMenu}
-          onClick={onAvatarClick}
+          style={{ opacity: expanded ? 1 : 0 }}
+          aria-hidden
         />
+        {typing && turns.length > 0 && <RecentTurns turns={turns} />}
+        {/* The pill's one in-flow row, and where the clearance at either end
+          lives. On the row rather than on the pill, so the pill's own box
+          goes to nothing at rest while the body inside it keeps being
+          measured. */}
+        <div
+          className="relative flex h-11 shrink-0 items-center"
+          style={{ paddingInline: INNER_GAP }}
+        >
+          {typing ? (
+            <Composer
+              assistantName={assistantName}
+              watching={watching}
+              onSubmit={onSubmit}
+              onCancel={onCancelTyping}
+              onWatch={onWatch}
+            />
+          ) : (
+            <div
+              className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
+              ref={contentRef}
+              // Faded out is not gone: the body stays mounted while collapsed
+              // so it can be measured, which would otherwise leave its
+              // controls focusable and announced while nothing is drawn.
+              // `inert` takes them out of the tab order and the accessibility
+              // tree without taking them out of the DOM, so the measurement
+              // still works.
+              inert={!expanded}
+              style={{
+                opacity: expanded ? 1 : 0,
+                // Contents fade after the body has somewhere to put them, so
+                // nothing is ever drawn wider than the pill carrying it.
+                transitionDelay: expanded ? "120ms" : "0ms",
+              }}
+            >
+              {phase === "call" ? (
+                <CallBody
+                  call={call}
+                  watching={watching}
+                  onControl={onControl}
+                  onWatch={onWatch}
+                />
+              ) : phase === "summary" && watchRetro !== undefined ? (
+                <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
+              ) : (
+                <IdleBody
+                  spotlight={spotlight}
+                  watching={watching}
+                  watchEnabled={watchEnabled}
+                  onTalk={onTalk}
+                  onType={onType}
+                  onWatch={onWatch}
+                />
+              )}
+            </div>
+          )}
+        </div>
       </div>
+      {/* Drawn after the pill so the glow, which falls off well past the
+        creature, lands over the pill's leading edge rather than under it. */}
+      <Avatar
+        accentHex={accentHex}
+        avatarSrc={avatarSrc}
+        character={character}
+        attentive={hovered}
+        // The assistant's own turn. The creature stops blinking and holds a
+        // focused, morphing pose, which is the same treatment the chat avatar
+        // uses while a reply is streaming: one vocabulary for "it is working"
+        // wherever the user meets it.
+        busy={assistantWorking}
+        edge={edge}
+        style={{
+          left: "50%",
+          top: lineAt(cardGrowth, 0),
+          // Centred on the point the host put the window around, then scaled
+          // about that centre by whatever the creature's own size asks for
+          // beyond the scale the page has already applied. Omitted where the
+          // two boxes agree, which is the surface every other length here is
+          // authored for. On this node rather than the one below it: the bob
+          // owns a `transform` of its own, and two transforms on one node
+          // silently leave one of them out.
+          transform: `translate(-50%, -50%)${
+            avatarRel === 1 ? "" : ` scale(${avatarRel})`
+          }`,
+        }}
+        elementRef={avatarRef}
+        onMouseDown={onSurfaceMouseDown}
+        onContextMenu={onSurfaceContextMenu}
+        onClick={onAvatarClick}
+      />
       {intro}
     </>
   );
@@ -1288,7 +1212,7 @@ function Composer({
 }
 
 /**
- * The avatar, and the only part of the surface that arms the expansion.
+ * The avatar, which is the point the whole surface is arranged around.
  *
  * Positioned on the point the host put the window around rather than laid out
  * in the pill, which is what lets the pill change width and shape underneath
@@ -1303,12 +1227,11 @@ function Composer({
  * `transform` on its own `<svg>` for the breathe and the morph, and a second
  * animation on that node would silently replace one of them. Everything that
  * belongs to the creature rides inside the wrapper, glow included, so the light
- * travels with what is casting it. The edge is outside it, because a ring
- * saying the assistant is working belongs to the surface rather than to the
- * creature's own idle motion.
+ * travels with what is casting it. The edge sits outside the wrapper: it is
+ * drawn on the box rather than on the artwork, so a ring saying something is
+ * running holds still while the creature breathes under it.
  */
 function Avatar({
-  glow,
   accentHex,
   avatarSrc,
   character,
@@ -1317,25 +1240,19 @@ function Avatar({
   edge,
   style,
   elementRef,
-  onMouseEnter,
   onMouseDown,
   onContextMenu,
   onClick,
 }: {
-  glow: boolean;
   accentHex: string;
   avatarSrc?: string;
   character?: CompanionCharacter;
   busy?: boolean;
   attentive?: boolean;
-  /**
-   * What the surface's edge is drawing, while the avatar is that edge. Null
-   * once there is a pill, which takes it back.
-   */
+  /** What the creature's edge is drawing. See `edge` in `CompanionSurface`. */
   edge?: ReactNode;
   style?: CSSProperties;
   elementRef?: Ref<HTMLDivElement>;
-  onMouseEnter?: () => void;
   onMouseDown?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onClick?: () => void;
@@ -1351,10 +1268,9 @@ function Avatar({
     // read as activating a control. `onClick` fires only for presses the caller
     // decided were not drags.
     <div
-      className="pointer-events-auto absolute grid size-11 cursor-grab place-items-center active:cursor-grabbing"
+      className="absolute grid size-11 cursor-grab place-items-center active:cursor-grabbing"
       style={style}
       ref={elementRef}
-      onMouseEnter={onMouseEnter}
       onMouseDown={onMouseDown}
       onContextMenu={onContextMenu}
       onClick={onClick}
@@ -1364,16 +1280,14 @@ function Avatar({
         className="companion-avatar-bob relative grid place-items-center"
         style={{ animation: reduce ? "none" : undefined }}
       >
-        {glow && (
-          <span
-            className="companion-glow absolute size-10 rounded-full blur-lg"
-            style={{
-              background: accentHex,
-              animation: reduce ? "none" : undefined,
-            }}
-            aria-hidden
-          />
-        )}
+        <span
+          className="companion-glow absolute size-10 rounded-full blur-lg"
+          style={{
+            background: accentHex,
+            animation: reduce ? "none" : undefined,
+          }}
+          aria-hidden
+        />
         {character !== undefined ? (
           // The live creature, composed here rather than shipped as pixels. It
           // blinks, twitches and breathes on its own, which is the whole reason

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -253,7 +253,11 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
    It has to live on a wrapper of its own. `AnimatedAvatar` owns `transform` on
    its `<svg>` for the breathe and morph, and two animations on one node means
-   one of them silently wins. */
+   one of them silently wins.
+
+   The lift is also `COMPANION_BOB_LIFT` in `companion-layout.ts`, which the
+   host's hit-test adds to the avatar's rect so the raised creature is still
+   something the pointer can be on. */
 @keyframes companion-avatar-bob {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-3px); }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for companion-avatar-restyle.md.

- The intro card clears whichever of the avatar or the pill reaches higher; the working ring and capture flare stay mounted on the avatar in every phase
- The bridge hit-test covers only the composer row while the card is open; the avatar's rect includes the bob lift; the pill rect is read only while expanded
- Shared lineAt / edgeAt in companionLayoutFor; dead --accent, glow prop, story-only DOM bridge and unreachable fallback widths removed; stale comments fixed; mixed-size resting and edge stories; reduced-motion test