### PR TITLE
fix: companion review round 2 (left-growth alignment, size promotion, shared hit-test, CI filters)

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -10,6 +10,9 @@ on:
       - 'clients/macos/**'
       - 'packages/electron-utils/**'
       - 'packages/electron-desktop/**'
+      # The macOS main process imports this contract's types directly, so a
+      # change here can break the macOS type check with no macOS file touched.
+      - 'packages/ipc-contract/**'
       - 'packages/native-sidecar/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -14,6 +14,9 @@ on:
       # schema change here can break the web build with no web file touched.
       - 'assistant/openapi.yaml'
       - 'packages/design-library/**'
+      # The web imports this contract's types directly, so a change here can
+      # break the web type check with no web file touched.
+      - 'packages/ipc-contract/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
       - 'packages/avatar-manifest/**'

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -10,6 +10,9 @@ on:
       - 'clients/macos/**'
       - 'packages/electron-utils/**'
       - 'packages/electron-desktop/**'
+      # The macOS main process imports this contract's types directly, so a
+      # change here can break the macOS type check with no macOS file touched.
+      - 'packages/ipc-contract/**'
       - 'packages/native-sidecar/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -13,6 +13,9 @@ on:
       # schema change here can break the web build with no web file touched.
       - 'assistant/openapi.yaml'
       - 'packages/design-library/**'
+      # The web imports this contract's types directly, so a change here can
+      # break the web type check with no web file touched.
+      - 'packages/ipc-contract/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
       - 'packages/avatar-manifest/**'

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -2,11 +2,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   COMPANION_BASE_AVATAR_BOX,
-  COMPANION_BASE_CARD_HEIGHT,
   COMPANION_SIZES,
   COMPANION_SIZE_BOXES,
   companionNearEdgeFor,
-  companionPadFor,
   companionScaleFor,
   type CompanionSize,
   type CompanionSizeAxis,
@@ -191,6 +189,7 @@ mock.module("@vellumai/electron-desktop/window-state", () => ({
   // load-time failure for the file rather than a failing case.
   readCompanionIntroSeen: () => true,
   writeCompanionIntroSeen: () => {},
+  promoteCompanionSizeToAxes: () => {},
 }));
 
 // Dynamic, so the mocks above are installed before the module graph loads:
@@ -285,13 +284,15 @@ const GEOMETRY = geometryFor("small", "small");
 const RISE_ABOVE = GEOMETRY.riseAbove;
 const DROP_BELOW = GEOMETRY.dropBelow;
 
+/** A creature far larger than the controls beside it, and the reverse. */
+const BIG_CREATURE = geometryFor("huge", "small");
+const BIG_OPTIONS = geometryFor("small", "huge");
+
 /**
- * The two parts of the base reach the geometry does not publish: the pill's
- * widest, and the room it hangs off the avatar by. Stated once here for the
- * cases that are about one of them rather than the sum.
+ * The part of the base reach the geometry does not publish: the pill's widest.
+ * Stated once here for the cases that are about it rather than the sum.
  */
 const MAX_PILL_WIDTH = 316;
-const GAP = 12;
 
 /**
  * The growth direction is the only rule in the companion window worth testing
@@ -339,7 +340,6 @@ describe("growthFor", () => {
    * pass with the pill's leading edge already off the display.
    */
   test("counts the gap and the half box as room the pill needs", () => {
-    expect(NEEDED).toBe(350);
     expect(growthFor(DISPLAY.width - MAX_PILL_WIDTH, DISPLAY, GEOMETRY)).toBe(
       "left",
     );
@@ -352,9 +352,7 @@ describe("growthFor", () => {
    * cuts the controls off.
    */
   test("flips when only the avatar's half box is missing on the right", () => {
-    const centre = DISPLAY.width - 340;
-    expect(DISPLAY.width - centre).toBeGreaterThan(GAP + MAX_PILL_WIDTH);
-    expect(growthFor(centre, DISPLAY, GEOMETRY)).toBe("left");
+    expect(growthFor(DISPLAY.width - 340, DISPLAY, GEOMETRY)).toBe("left");
   });
 
   test("measures against the display's own origin, not the screen's", () => {
@@ -636,15 +634,6 @@ describe("shouldShowCompanionSurface", () => {
  * nobody ever looked at.
  */
 describe("geometryFor", () => {
-  test("draws `small` at the size the renderer's layout is authored at", () => {
-    const small = geometryFor("small", "small");
-    expect(small.avatarBox).toBe(44);
-    expect(small.optionsBox).toBe(44);
-    expect(small.canvasWidth).toBe(748);
-    expect(small.canvasHeight).toBe(338);
-    expect(small.maxReach).toBe(350);
-  });
-
   /**
    * What the width is actually for: the avatar's half box, the gap the pill
    * hangs off it by, and the widest the pill draws, on both sides so main can
@@ -694,24 +683,6 @@ describe("geometryFor", () => {
         COMPANION_SIZE_BOXES.large,
       );
     }
-  });
-
-  /**
-   * With one size on both axes the surface is still one layout multiplied, so
-   * every length moves together. A canvas that scaled while the pill's reach
-   * did not would clip the controls; the reverse would swallow clicks over
-   * empty desktop.
-   */
-  test("scales every length by the same factor when the axes agree", () => {
-    const small = geometryFor("small", "small");
-    const large = geometryFor("large", "large");
-    const scale = large.avatarBox / small.avatarBox;
-    expect(scale).toBe(2);
-    expect(large.canvasWidth).toBe(small.canvasWidth * scale);
-    expect(large.canvasHeight).toBe(small.canvasHeight * scale);
-    expect(large.riseAbove).toBe(small.riseAbove * scale);
-    expect(large.dropBelow).toBe(small.dropBelow * scale);
-    expect(large.maxReach).toBe(small.maxReach * scale);
   });
 
   /**
@@ -780,52 +751,11 @@ describe("geometryFor", () => {
  * Both sides of the avatar are sized for whichever card direction needs more,
  * so main can still flip the direction by moving the window rather than
  * rebuilding it. The cost is a few transparent points of slack in the direction
- * that needed less, and what these cases hold is that the slack is never
- * negative: a side short by a point clips the pill or the card.
+ * that needed less, which is what the stated canvases carry: a side short by a
+ * point clips the pill or the card.
  */
 describe("geometryFor with the two axes apart", () => {
-  /** A creature far larger than the controls beside it, and the reverse. */
-  const BIG_CREATURE = geometryFor("huge", "small");
-  const BIG_OPTIONS = geometryFor("small", "huge");
   const MIXED = [BIG_CREATURE, BIG_OPTIONS];
-
-  /**
-   * The near edge answers for both card directions at once. Growing up, the
-   * lowest thing drawn is the creature's own bottom; growing down, the pill
-   * stands on that same line and its top reaches a whole options box back up
-   * past it, over the head of a smaller creature.
-   */
-  test("clears the creature's bottom and the pill's top alike", () => {
-    for (const geometry of MIXED) {
-      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
-      expect(
-        geometry.dropBelow - geometry.avatarBox / 2,
-      ).toBeGreaterThanOrEqual(pad);
-      expect(
-        geometry.dropBelow + geometry.avatarBox / 2 - geometry.optionsBox,
-      ).toBeGreaterThanOrEqual(pad);
-    }
-  });
-
-  /**
-   * The far side, the same way. The card stands on the creature's bottom line
-   * and rises its whole height growing up; growing down its composer row holds
-   * that line and the rest of it falls away below.
-   */
-  test("clears the card in whichever direction it grows", () => {
-    for (const geometry of MIXED) {
-      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
-      const cardHeight =
-        COMPANION_BASE_CARD_HEIGHT * companionScaleFor(geometry.optionsBox);
-      expect(
-        geometry.riseAbove - (cardHeight - geometry.avatarBox / 2),
-      ).toBeGreaterThanOrEqual(pad);
-      expect(
-        geometry.riseAbove -
-          (geometry.avatarBox / 2 + cardHeight - geometry.optionsBox),
-      ).toBeGreaterThanOrEqual(pad);
-    }
-  });
 
   test("spends the whole canvas on the two sides of the avatar", () => {
     for (const geometry of MIXED) {
@@ -838,22 +768,38 @@ describe("geometryFor with the two axes apart", () => {
   });
 
   /**
-   * The reach at each mix, which is also where the gap rule shows. The gap is
-   * breathing room, so the smaller of the two boxes decides how much of it
-   * there is: the creature below takes the base gap rather than the chasm its
-   * own scale would ask for, which would put its reach at 401.
+   * Each mix as the canvas it comes to rather than as the formula repeated,
+   * since a formula restated here would pass against any change to the formula
+   * it restates.
+   *
+   * The width is where the gap rule shows: the gap is breathing room, so the
+   * smaller of the two boxes decides how much of it there is, and the creature
+   * below takes the base gap rather than the chasm its own scale would ask for,
+   * which would put its reach at 401. The two heights are the two sides of the
+   * avatar: the near edge clears the creature's bottom and the pill's top
+   * alike, and the far edge clears the card growing either way.
    */
-  test("still holds the pill's reach on both sides of the avatar", () => {
+  test("holds the pill, the card and the creature at each mix", () => {
     // An enormous creature's half box, the base gap, and a base-width pill.
-    expect({
-      maxReach: BIG_CREATURE.maxReach,
-      canvasWidth: BIG_CREATURE.canvasWidth,
-    }).toEqual({ maxReach: 383, canvasWidth: 886 });
+    expect(BIG_CREATURE).toEqual({
+      avatarBox: 110,
+      optionsBox: 44,
+      maxReach: 383,
+      canvasWidth: 886,
+      riseAbove: 361,
+      dropBelow: 115,
+      canvasHeight: 476,
+    });
     // A base half box, the same gap, and a pill two and a half times as wide.
-    expect({
-      maxReach: BIG_OPTIONS.maxReach,
-      canvasWidth: BIG_OPTIONS.canvasWidth,
-    }).toEqual({ maxReach: 824, canvasWidth: 1768 });
+    expect(BIG_OPTIONS).toEqual({
+      avatarBox: 44,
+      optionsBox: 110,
+      maxReach: 824,
+      canvasWidth: 1768,
+      riseAbove: 763,
+      dropBelow: 148,
+      canvasHeight: 911,
+    });
   });
 
   test("flips the pill at the reach the options size asks for", () => {
@@ -896,9 +842,7 @@ describe("companionContextMenuTemplate", () => {
   type MenuItem = {
     label?: string;
     type?: string;
-    checked?: boolean;
     click?: () => void;
-    submenu?: MenuItem[];
   };
 
   const build = (
@@ -917,13 +861,12 @@ describe("companionContextMenuTemplate", () => {
     return { items, wasHidden: () => hidden };
   };
 
-  test("offers the two axes under their own headings, then the way out", () => {
-    expect(build().items.map((item) => item.label ?? item.type)).toEqual([
-      "Avatar size",
-      "Options size",
-      "separator",
-      "Hide Companion",
-    ]);
+  test("closes with a separator and the way out, past the headings", () => {
+    expect(
+      build()
+        .items.map((item) => item.label ?? item.type)
+        .slice(2),
+    ).toEqual(["separator", "Hide Companion"]);
   });
 
   /**
@@ -956,16 +899,30 @@ describe("companionContextMenuTemplate", () => {
 describe("placing a larger companion", () => {
   const LARGE = geometryFor("large", "large");
 
+  /**
+   * One size on both axes, then the two mixes. The clamp binds on the creature,
+   * which is the avatar axis's answer, so an enormous pill beside a small
+   * creature must not hold that creature away from the edge, and an enormous
+   * creature beside a small pill must be held by its own whole box.
+   */
+  const SIZED = [LARGE, BIG_CREATURE, BIG_OPTIONS];
+
   test("holds the avatar at the edges by its own box, not the canvas", () => {
-    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, LARGE);
-    expect(centreOf(placed, LARGE).x).toBe(1440 - LARGE.avatarBox / 2);
+    for (const geometry of SIZED) {
+      const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, geometry);
+      expect(centreOf(placed, geometry).x).toBe(
+        WORK_AREA.x + WORK_AREA.width - geometry.avatarBox / 2,
+      );
+    }
   });
 
   test("still never asks for an origin above the work area", () => {
-    for (const y of [-9000, 0, 25, 100, 400]) {
-      expect(
-        placeCanvas({ x: 700, y }, WORK_AREA, LARGE).origin.y,
-      ).toBeGreaterThanOrEqual(WORK_AREA.y);
+    for (const geometry of SIZED) {
+      for (const y of [-9000, 0, 25, 100, 400]) {
+        expect(
+          placeCanvas({ x: 700, y }, WORK_AREA, geometry).origin.y,
+        ).toBeGreaterThanOrEqual(WORK_AREA.y);
+      }
     }
   });
 
@@ -974,13 +931,15 @@ describe("placing a larger companion", () => {
    * else. Bigger is a worse ceiling than `small` and still nothing like the
    * canvas half-height the bug was.
    */
-  test("reaches the top, short by its own scaled shadow", () => {
-    const centre = centreOf(
-      placeCanvas({ x: 700, y: -9000 }, WORK_AREA, LARGE),
-      LARGE,
-    );
-    expect(centre.y).toBe(WORK_AREA.y + LARGE.dropBelow);
-    expect(centre.y).toBeLessThan(WORK_AREA.y + LARGE.riseAbove);
+  test("reaches the top, short by the near edge its own canvas asks for", () => {
+    for (const geometry of SIZED) {
+      const centre = centreOf(
+        placeCanvas({ x: 700, y: -9000 }, WORK_AREA, geometry),
+        geometry,
+      );
+      expect(centre.y).toBe(WORK_AREA.y + geometry.dropBelow);
+      expect(centre.y).toBeLessThan(WORK_AREA.y + geometry.riseAbove);
+    }
   });
 
   test("flips the card at its own threshold, not the small one", () => {
@@ -990,49 +949,6 @@ describe("placing a larger companion", () => {
     expect(
       cardGrowthFor(WORK_AREA.y + LARGE.riseAbove - 1, WORK_AREA, LARGE),
     ).toBe("down");
-  });
-
-  /**
-   * The same rules with the two axes apart. The clamp binds on the creature,
-   * which is the avatar axis's answer, so an enormous pill beside a small
-   * creature must not hold that creature away from the edge, and an enormous
-   * creature beside a small pill must be held by its own whole box.
-   */
-  const BIG_CREATURE = geometryFor("huge", "small");
-  const BIG_OPTIONS = geometryFor("small", "huge");
-
-  test("holds a large creature at the edge by its own box", () => {
-    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, BIG_CREATURE);
-    expect(centreOf(placed, BIG_CREATURE).x).toBe(
-      WORK_AREA.x + WORK_AREA.width - BIG_CREATURE.avatarBox / 2,
-    );
-  });
-
-  test("lets a small creature reach the edge beside an enormous pill", () => {
-    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, BIG_OPTIONS);
-    expect(centreOf(placed, BIG_OPTIONS).x).toBe(
-      WORK_AREA.x + WORK_AREA.width - BIG_OPTIONS.avatarBox / 2,
-    );
-  });
-
-  test("never asks for an origin above the work area at either mix", () => {
-    for (const geometry of [BIG_CREATURE, BIG_OPTIONS]) {
-      for (const y of [-9000, 0, 25, 100, 400]) {
-        expect(
-          placeCanvas({ x: 700, y }, WORK_AREA, geometry).origin.y,
-        ).toBeGreaterThanOrEqual(WORK_AREA.y);
-      }
-    }
-  });
-
-  test("reaches the top, short by the near edge its own mix asks for", () => {
-    for (const geometry of [BIG_CREATURE, BIG_OPTIONS]) {
-      const centre = centreOf(
-        placeCanvas({ x: 700, y: -9000 }, WORK_AREA, geometry),
-        geometry,
-      );
-      expect(centre.y).toBe(WORK_AREA.y + geometry.dropBelow);
-    }
   });
 });
 
@@ -1053,9 +969,6 @@ describe("setCompanionSurfaceSize", () => {
    */
   const CENTRE = { x: 722, y: 800 };
 
-  /** The canvas an options pick of `huge` builds, beside `small`'s 748x338. */
-  const HUGE_OPTIONS = { canvasWidth: 1768, canvasHeight: 911, riseAbove: 763 };
-
   test("rebuilds the canvas around the avatar rather than the origin", () => {
     // Parked by the path a drag takes. The first delta runs past every edge, so
     // it lands on a clamp whatever the window was doing beforehand; the second
@@ -1074,14 +987,14 @@ describe("setCompanionSurfaceSize", () => {
     expect(boundsSet).toHaveLength(1);
     const bounds = boundsSet[0];
     expect({ width: bounds?.width, height: bounds?.height }).toEqual({
-      width: HUGE_OPTIONS.canvasWidth,
-      height: HUGE_OPTIONS.canvasHeight,
+      width: BIG_OPTIONS.canvasWidth,
+      height: BIG_OPTIONS.canvasHeight,
     });
     // The avatar read back out of the new canvas the way main reads it: half
     // the width across, and the offset the card's direction asks for down.
     expect({
-      x: (bounds?.x ?? 0) + HUGE_OPTIONS.canvasWidth / 2,
-      y: (bounds?.y ?? 0) + HUGE_OPTIONS.riseAbove,
+      x: (bounds?.x ?? 0) + BIG_OPTIONS.canvasWidth / 2,
+      y: (bounds?.y ?? 0) + BIG_OPTIONS.riseAbove,
     }).toEqual(CENTRE);
   });
 

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -39,6 +39,7 @@ import {
   readSetting,
 } from "@vellumai/electron-desktop/settings";
 import {
+  promoteCompanionSizeToAxes,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
@@ -228,6 +229,12 @@ let growth: CompanionGrowth = "right";
  * it to draw the avatar where the window was actually put.
  */
 let cardGrowth: CompanionCardGrowth = "up";
+
+// Module init is the first thing to ask the store for the surface's geometry,
+// so it is where an install carrying only the single size a one-axis build
+// writes has that size copied onto both per-axis keys. Once, ahead of the reads
+// below, and never again for the life of the process.
+promoteCompanionSizeToAxes();
 
 /**
  * The canvas the surface is currently drawn in.

--- a/clients/web/src/components/companion-intro.test.tsx
+++ b/clients/web/src/components/companion-intro.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 
 import { CompanionIntro } from "./companion-intro";
+import { companionLayoutFor } from "./companion-layout";
 import { CompanionSurface } from "./companion-surface";
 
 afterEach(cleanup);
@@ -17,29 +18,11 @@ const cardOf = (container: HTMLElement): HTMLElement => {
   return found;
 };
 
-/** The pill, which is the one element on the surface whose width animates. */
-const pillOf = (container: HTMLElement): HTMLElement => {
-  const found = container.querySelector<HTMLElement>(".transition-\\[width\\]");
-  if (!found) {
-    throw new Error("Expected the surface to render");
-  }
-  return found;
-};
-
 /** How far a `calc(100% - Npx)` anchor holds its element off the canvas's bottom. */
 const offCanvasBottom = (top: string): number => {
   const found = /^calc\(100% - ([\d.]+)px\)$/.exec(top);
   if (!found?.[1]) {
     throw new Error(`Expected an anchor off the canvas's bottom, got ${top}`);
-  }
-  return Number(found[1]);
-};
-
-/** How far the card is then stepped up off that anchor. */
-const steppedUp = (transform: string): number => {
-  const found = /^translateY\(calc\(-100% - ([\d.]+)px\)\)$/.exec(transform);
-  if (!found?.[1]) {
-    throw new Error(`Expected a step up off the anchor, got ${transform}`);
   }
   return Number(found[1]);
 };
@@ -66,35 +49,37 @@ describe("the companion introduction's clearance", () => {
       <CompanionIntro beat="talk" avatarBox={44} optionsBox={110} />,
     );
 
-    // The pill hangs off its own line by a whole row, so its top edge is that
-    // much further off the canvas's bottom edge than its anchor.
-    const pillTop =
-      offCanvasBottom(pillOf(surface).style.top) + COMPANION_BASE_AVATAR_BOX;
-    const cardBottom =
-      offCanvasBottom(cardOf(intro).style.top) +
-      steppedUp(cardOf(intro).style.transform);
+    // The pill is the one element on the surface whose width animates. It
+    // hangs off its own line by a whole row, so its top edge is that much
+    // further off the canvas's bottom edge than its anchor.
+    const pill = surface.querySelector<HTMLElement>(".transition-\\[width\\]");
+    if (!pill) {
+      throw new Error("Expected the surface to render");
+    }
+    const pillTop = offCanvasBottom(pill.style.top) + COMPANION_BASE_AVATAR_BOX;
+
+    // How far the card is then stepped up off its own anchor.
+    const card = cardOf(intro);
+    const step = /^translateY\(calc\(-100% - ([\d.]+)px\)\)$/.exec(
+      card.style.transform,
+    );
+    if (!step?.[1]) {
+      throw new Error(
+        `Expected a step up off the anchor, got ${card.style.transform}`,
+      );
+    }
+    const cardBottom = offCanvasBottom(card.style.top) + Number(step[1]);
 
     expect(cardBottom).toBeGreaterThan(pillTop);
   });
 
   /**
-   * The pair the layout is authored at, where the creature and the pill reach
-   * the same line: the card steps off the creature's own half box and the gap,
-   * exactly as the pill does.
+   * How far the card steps off the creature is `companionLayoutFor`'s to say,
+   * and `companion-layout.test.ts` states it. What the card owns is being
+   * placed by that distance, converted into the units the wrapper's scale
+   * leaves the canvas in.
    */
-  test("steps off the creature itself when the two boxes agree", () => {
-    const { container } = render(<CompanionIntro beat="talk" />);
-
-    expect(cardOf(container).style.transform).toBe(
-      "translateY(calc(-100% - 34px))",
-    );
-  });
-
-  /**
-   * Growing downward there is nothing above the creature's own bottom to
-   * clear, since that line is the pill's bottom too whichever is larger.
-   */
-  test("takes the creature's own bottom growing downward", () => {
+  test("places the card at the layout's step off the creature", () => {
     const { container } = render(
       <CompanionIntro
         beat="talk"
@@ -104,7 +89,9 @@ describe("the companion introduction's clearance", () => {
       />,
     );
 
-    // 34 points at a scale of two and a half.
-    expect(cardOf(container).style.transform).toBe("translateY(13.6px)");
+    const layout = companionLayoutFor(44, 110);
+    expect(cardOf(container).style.transform).toBe(
+      `translateY(${layout.inUnits(layout.introStepOff("down"))}px)`,
+    );
   });
 });

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { bridgeRect, companionLayoutFor } from "./companion-layout";
+import {
+  bridgeRect,
+  companionLayoutFor,
+  onCompanionSurface,
+} from "./companion-layout";
 
 /**
  * The one derivation the pill and the introduction card are both placed by.
@@ -21,7 +25,6 @@ describe("companionLayoutFor", () => {
     expect(layout.avatarRel).toBe(1);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
-    expect(layout.nearEdge).toBe(46);
     expect(layout.inUnits(34)).toBe(34);
   });
 
@@ -41,7 +44,6 @@ describe("companionLayoutFor", () => {
     expect(layout.avatarRel).toBe(0.4);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
-    expect(layout.nearEdge).toBe(148);
     expect(`${layout.inUnits(34)}`).toBe("13.6");
     expect(`${layout.inUnits(148)}`).toBe("59.2");
   });
@@ -56,7 +58,6 @@ describe("companionLayoutFor", () => {
     expect(layout.avatarRel).toBe(2.5);
     expect(layout.avatarHalf).toBe(55);
     expect(layout.gap).toBe(12);
-    expect(layout.nearEdge).toBe(115);
     expect(layout.inUnits(67)).toBe(67);
   });
 
@@ -129,10 +130,10 @@ describe("the introduction's step off the creature", () => {
  * handed come from the DOM, so these are about the shape it makes of them:
  * between the facing edges, and no taller than the composer row.
  */
-describe("bridgeRect", () => {
-  const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
-  const ROW = { rowHeight: 44, cardGrowth: "up" } as const;
+const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
+const ROW = { rowHeight: 44, cardGrowth: "up" } as const;
 
+describe("bridgeRect", () => {
   test("spans the facing edges when the pill grows rightward", () => {
     const pill = { left: 156, right: 356, top: 100, bottom: 144 };
     expect(bridgeRect(AVATAR, pill, ROW)).toEqual({
@@ -202,5 +203,44 @@ describe("bridgeRect", () => {
     const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
     const bridge = bridgeRect(AVATAR, overlapping, ROW);
     expect(bridge.left).toBeGreaterThan(bridge.right);
+  });
+});
+
+/**
+ * The union the window is armed by, which is the one answer the renderer and
+ * the `Interactive` story both hit-test with.
+ */
+describe("onCompanionSurface", () => {
+  const PILL = { left: 156, right: 356, top: 100, bottom: 144 };
+  const at = (x: number, y: number, pill: typeof PILL | null = null): boolean =>
+    onCompanionSurface({ x, y }, { avatar: AVATAR, pill, ...ROW });
+
+  test("is the creature alone when there is no pill", () => {
+    expect(at(120, 120)).toBe(true);
+    expect(at(200, 120)).toBe(false);
+  });
+
+  /**
+   * The creature's box and nothing above it. The artwork is inset inside that
+   * box and the bob stays within the inset, so a rect reaching past the top
+   * would arm the window over empty canvas and swallow the presses meant for
+   * whatever is behind it.
+   */
+  test("leaves the canvas above the creature to the desktop", () => {
+    expect(at(120, AVATAR.top)).toBe(true);
+    expect(at(120, AVATAR.top - 2)).toBe(false);
+  });
+
+  test("carries the pointer across the gap to the pill", () => {
+    expect(at(150, 120, PILL)).toBe(true);
+    expect(at(200, 120, PILL)).toBe(true);
+  });
+
+  /**
+   * The gap is a strip, not a column. Above the row it is desktop, or the
+   * window swallows presses in the empty canvas beside a card.
+   */
+  test("does not claim the canvas above the gap", () => {
+    expect(at(150, 90, PILL)).toBe(false);
   });
 });

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -9,17 +9,6 @@ import type {
 } from "@vellumai/ipc-contract";
 import type { CSSProperties } from "react";
 
-/**
- * How far the bob lifts the creature off its baseline, at the base size.
- *
- * The animation itself is `companion-avatar-bob` in `index.css` and the lift is
- * written there as a literal. It is stated here as well because the host
- * hit-tests the avatar against a rect the DOM box does not include: the
- * artwork rides above its own box for most of the cycle, and a pointer on the
- * drawn creature has to count as a pointer on the creature.
- */
-export const COMPANION_BOB_LIFT = 3;
-
 /** As much of a rect as hit-testing a point against it needs. */
 export type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
 
@@ -85,6 +74,56 @@ export const bridgeRect = (
 };
 
 /**
+ * Whether a point is on the companion surface.
+ *
+ * **The surface is a union of rects, never the box around them:** the creature,
+ * the pill beside it, and the strip of gap the pointer crosses between the two.
+ * See {@link bridgeRect} for why the box around the pair is the wrong shape.
+ *
+ * The creature's rect is its own box as measured. The bob rides inside that
+ * box: the artwork is inset well short of the top and the lift is smaller than
+ * the slack, so a rect stretched to meet the raised creature would only claim
+ * empty canvas above it, which is the click-through window swallowing presses
+ * meant for whatever is behind it.
+ *
+ * The renderer hit-tests this way and so does the `Interactive` story, and one
+ * answer for both is what keeps the story honest about where the real window
+ * arms and where the desktop is left alone.
+ */
+export const onCompanionSurface = (
+  point: { x: number; y: number },
+  {
+    avatar,
+    pill,
+    rowHeight,
+    cardGrowth,
+  }: {
+    avatar: SurfaceRect;
+    /**
+     * The pill's rect, or null when there is no pill. At rest its box is
+     * nothing, and a rect of nothing beside the avatar is not somewhere a
+     * pointer can be.
+     */
+    pill: SurfaceRect | null;
+    /** The composer row's height in screen pixels. See {@link bridgeRect}. */
+    rowHeight: number;
+    cardGrowth: CompanionCardGrowth;
+  },
+): boolean => {
+  const inside = (rect: SurfaceRect): boolean =>
+    containsPoint(rect, point.x, point.y);
+  if (inside(avatar)) {
+    return true;
+  }
+  if (pill === null) {
+    return false;
+  }
+  return (
+    inside(pill) || inside(bridgeRect(avatar, pill, { rowHeight, cardGrowth }))
+  );
+};
+
+/**
  * The numbers everything on the companion surface is placed by, in points.
  *
  * Points because that is what the contract's helpers answer in and what main
@@ -99,8 +138,6 @@ export interface CompanionLayout {
   avatarHalf: number;
   /** The room the creature keeps from anything drawn beside it. */
   gap: number;
-  /** The creature's centre to the canvas edge it is near, which is what main places the window by. */
-  nearEdge: number;
   /** The one conversion into the units the layout is stated in. */
   inUnits: (points: number) => number;
   /**
@@ -161,7 +198,6 @@ export function companionLayoutFor(
     avatarRel: avatarBox / optionsBox,
     avatarHalf,
     gap,
-    nearEdge,
     inUnits,
     lineAt: (cardGrowth, offset) =>
       cardGrowth === "up"

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -122,6 +122,26 @@ const canvasOf = (container: HTMLElement): HTMLElement => {
   return canvas;
 };
 
+/**
+ * Whether the pill is open, read off the collapsed body's `inert`: the controls
+ * stay mounted at rest so they can be measured, so their presence says nothing
+ * and their being out of the tree says everything.
+ */
+const closed = (container: HTMLElement): boolean =>
+  container.querySelector("[inert]") !== null;
+
+/** Open the surface by putting the pointer on the creature. */
+const open = async (container: HTMLElement): Promise<HTMLElement> => {
+  const canvas = canvasOf(container);
+  fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+  await waitFor(() => {
+    if (closed(container)) {
+      throw new Error("Expected the pill to open");
+    }
+  });
+  return canvas;
+};
+
 /** A box the hit-test can read, which jsdom otherwise reports as all zeroes. */
 type Box = { left: number; right: number; top: number; bottom: number };
 
@@ -142,11 +162,16 @@ const pin = (element: HTMLElement, box: Box): void => {
  *
  * The surface measures itself live and nothing lays out in the test DOM, so
  * every rect would otherwise be zero and the pointer would never be over any of
- * it. Pinned as the surface draws them: the avatar's 44pt box, and the pill
- * bottom-flush across a 12pt gap to its right.
+ * it. Pinned by default as the surface draws them at the pair the layout is
+ * authored at: the avatar's 44pt box, and the pill bottom-flush across a 12pt
+ * gap to its right. A case drawing another pair hands in its own boxes.
  */
 const pinSurface = async (
   container: HTMLElement,
+  boxes: { avatar: Box; pill: Box } = {
+    avatar: { left: 100, right: 144, top: 100, bottom: 144 },
+    pill: { left: 156, right: 356, top: 100, bottom: 144 },
+  },
 ): Promise<{ avatar: HTMLElement; pill: HTMLElement }> => {
   const found = await waitFor(() => {
     const avatar = container.querySelector<HTMLElement>(".size-11");
@@ -158,8 +183,8 @@ const pinSurface = async (
     }
     return { avatar, pill };
   });
-  pin(found.avatar, { left: 100, right: 144, top: 100, bottom: 144 });
-  pin(found.pill, { left: 156, right: 356, top: 100, bottom: 144 });
+  pin(found.avatar, boxes.avatar);
+  pin(found.pill, boxes.pill);
   return found;
 };
 
@@ -173,27 +198,7 @@ const pinSurface = async (
  * swallow desktop presses in the empty canvas above and below it.
  */
 describe("the gap between the avatar and the pill", () => {
-  /**
-   * Whether the pill is open, read off the collapsed body's `inert`: the
-   * controls stay mounted at rest so they can be measured, so their presence
-   * says nothing and their being out of the tree says everything.
-   */
-  const closed = (container: HTMLElement): boolean =>
-    container.querySelector("[inert]") !== null;
-
-  /** Open the surface by putting the pointer on the creature. */
-  const open = async (container: HTMLElement): Promise<HTMLElement> => {
-    const canvas = canvasOf(container);
-    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
-    await waitFor(() => {
-      if (closed(container)) {
-        throw new Error("Expected the pill to open");
-      }
-    });
-    return canvas;
-  };
-
-  test("keeps the window clickable while the pointer crosses it", async () => {
+  test("keeps the window clickable and the pill open as it is crossed", async () => {
     const { container } = render(<CompanionSurfacePage />);
     await pinSurface(container);
     const canvas = await open(container);
@@ -201,15 +206,6 @@ describe("the gap between the avatar and the pill", () => {
     fireEvent.mouseMove(canvas, { clientX: 150, clientY: 122 });
 
     expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
-  });
-
-  test("does not collapse the pill out from under the hand", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    await pinSurface(container);
-    const canvas = await open(container);
-
-    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 122 });
-
     expect(closed(container)).toBe(false);
   });
 
@@ -255,33 +251,6 @@ describe("the gap between the avatar and the pill", () => {
 });
 
 /**
- * The creature is drawn where the bob has lifted it to, and the box it belongs
- * to holds still underneath. A hit-test against the box alone leaves the
- * creature's own head outside the surface for most of the cycle, so the pointer
- * falls through the thing it is plainly on.
- */
-describe("the avatar's rect and the bob", () => {
-  test("takes in the strip the lift raises the creature into", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    await pinSurface(container);
-
-    // Two points above the box's top edge, inside the three the bob lifts.
-    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 98 });
-
-    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
-  });
-
-  test("gives the desktop back above the lift", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    await pinSurface(container);
-
-    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 96 });
-
-    expect(setInteractiveMock).not.toHaveBeenCalledWith(true);
-  });
-});
-
-/**
  * The two sizes, which are one choice each.
  *
  * The wrapper is scaled by the options size and the creature carries the
@@ -299,9 +268,6 @@ describe("the companion surface at two sizes", () => {
     }
     return found;
   };
-
-  const avatarOf = (container: HTMLElement): HTMLElement | null =>
-    container.querySelector<HTMLElement>(".size-11");
 
   test("scales the canvas by the options size rather than the creature's", async () => {
     STATE.avatarBox = 44;
@@ -328,7 +294,7 @@ describe("the companion surface at two sizes", () => {
     pushState({
       ...STATE,
       avatarBox: 110,
-      optionsBox: undefined as unknown as number,
+      optionsBox: undefined,
     });
 
     await waitFor(() => {
@@ -344,9 +310,9 @@ describe("the companion surface at two sizes", () => {
     // The creature's own node is where the change lands, so waiting on it is
     // waiting for the state to have arrived at all.
     await waitFor(() => {
-      expect(avatarOf(container)?.style.transform).toBe(
-        "translate(-50%, -50%) scale(5)",
-      );
+      expect(
+        container.querySelector<HTMLElement>(".size-11")?.style.transform,
+      ).toBe("translate(-50%, -50%) scale(5)");
     });
     expect(wrapperOf(container).style.transform).toBe("scale(1)");
   });
@@ -362,29 +328,15 @@ describe("the companion surface at two sizes", () => {
     STATE.avatarBox = 110;
     STATE.optionsBox = 44;
     const { container } = render(<CompanionSurfacePage />);
-    const found = await waitFor(() => {
-      const avatar = container.querySelector<HTMLElement>(".size-11");
-      const pill = container.querySelector<HTMLElement>(
-        ".transition-\\[width\\]",
-      );
-      if (!avatar || !pill) {
-        throw new Error("Expected the surface to render");
-      }
-      return { avatar, pill };
-    });
     // As the surface draws them at this pair: a 110pt creature, and the pill
     // bottom-flush across the gap, 44pt tall in the creature's lower portion.
-    pin(found.avatar, { left: 100, right: 210, top: 100, bottom: 210 });
-    pin(found.pill, { left: 222, right: 422, top: 166, bottom: 210 });
-    const canvas = canvasOf(container);
+    await pinSurface(container, {
+      avatar: { left: 100, right: 210, top: 100, bottom: 210 },
+      pill: { left: 222, right: 422, top: 166, bottom: 210 },
+    });
 
     // Open it from the creature, which is the only part drawn at rest.
-    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 150 });
-    await waitFor(() => {
-      if (container.querySelector("[inert]") !== null) {
-        throw new Error("Expected the pill to open");
-      }
-    });
+    const canvas = await open(container);
     setInteractiveMock.mockClear();
 
     fireEvent.mouseMove(canvas, { clientX: 216, clientY: 120 });
@@ -889,12 +841,7 @@ describe("the Watch flag on the companion surface", () => {
   /** Open the pill, which is where the way into a session would be drawn. */
   const openPill = async (container: HTMLElement): Promise<void> => {
     await pinSurface(container);
-    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
-    await waitFor(() => {
-      if (!container.querySelector('button[aria-label="Talk"]')) {
-        throw new Error("Expected the pill to open");
-      }
-    });
+    await open(container);
   };
 
   test("draws no way in when the pushed state says nothing about it", async () => {

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -6,10 +6,8 @@ import {
   introSpotlight,
 } from "@/components/companion-intro";
 import {
-  bridgeRect,
-  COMPANION_BOB_LIFT,
   containsPoint,
-  type SurfaceRect,
+  onCompanionSurface,
 } from "@/components/companion-layout";
 import {
   CompanionSurface,
@@ -333,8 +331,8 @@ export function CompanionSurfacePage() {
    *
    * **The surface is several rects, and the answer is their union.** The
    * creature, the pill beside it, the strip of gap between them, and the
-   * introduction's card while it is drawn; see {@link bridgeRect} for why the
-   * box around them all is the wrong shape.
+   * introduction's card while it is drawn; see {@link onCompanionSurface} for
+   * why the box around them all is the wrong shape.
    */
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
     // **A drag whose release this window never saw ends here.**
@@ -381,55 +379,39 @@ export function CompanionSurfacePage() {
     if (!avatar) {
       return;
     }
-    const inside = (rect: SurfaceRect): boolean =>
-      containsPoint(rect, event.clientX, event.clientY);
     // Reading a box forces layout, and this runs on every pixel of every
     // mouse-move the host forwards, so each is read once and the pill's is not
     // read at all until there is a pill.
-    const drawn = avatar.getBoundingClientRect();
-    // The creature's box, plus the strip above it the bob lifts the artwork
-    // into. The element holds still and the drawing rises off it, so a pointer
-    // on the creature's own head is outside the box it belongs to.
-    const avatarRect: SurfaceRect = {
-      left: drawn.left,
-      right: drawn.right,
-      top:
-        drawn.top -
-        (COMPANION_BOB_LIFT * avatarBox) / COMPANION_BASE_AVATAR_BOX,
-      bottom: drawn.bottom,
-    };
-    const onAvatar = inside(avatarRect);
-    // The pill and the gap only count once there is a pill: at rest its box is
-    // nothing, and a rect of nothing beside the avatar is not somewhere a
-    // pointer can be.
     const pill = expanded ? pillRef.current : null;
-    let onPill = false;
-    let onBridge = false;
-    if (pill !== null) {
-      const pillRect = pill.getBoundingClientRect();
-      onPill = inside(pillRect);
-      onBridge = inside(
-        bridgeRect(avatarRect, pillRect, {
-          // The composer row in screen pixels: one base box at the options
-          // scale, which is the options box itself.
-          rowHeight: optionsBox,
-          cardGrowth,
-        }),
-      );
-    }
+    const onSurface = onCompanionSurface(
+      { x: event.clientX, y: event.clientY },
+      {
+        avatar: avatar.getBoundingClientRect(),
+        pill: pill === null ? null : pill.getBoundingClientRect(),
+        // The composer row in screen pixels: one base box at the options
+        // scale, which is the options box itself.
+        rowHeight: optionsBox,
+        cardGrowth,
+      },
+    );
     // The introduction's card is part of the surface for as long as it is
     // drawn. Testing only the surface would leave the window click-through over
     // Next and Skip, so the presses meant to end the run would land on whatever
     // application is behind it instead.
     const introCard = introRef.current;
     const onIntro =
-      introCard !== null && inside(introCard.getBoundingClientRect());
+      introCard !== null &&
+      containsPoint(
+        introCard.getBoundingClientRect(),
+        event.clientX,
+        event.clientY,
+      );
     // Hover is the creature noticing a hand on *it*, so the card does not feed
     // it: a pointer resting on a paragraph is not a pointer on the avatar, and
     // widening the eyes for it would be the surface reacting to the wrong
     // thing.
-    setHovered(onAvatar || onPill || onBridge);
-    setInteractive(onAvatar || onPill || onBridge || onIntro);
+    setHovered(onSurface);
+    setInteractive(onSurface || onIntro);
   };
 
   // The avatar's own colour. A running call publishes one, and it wins: it is

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -13,12 +13,7 @@ import {
   introPhase,
   introSpotlight,
 } from "@/components/companion-intro";
-import {
-  bridgeRect,
-  COMPANION_BOB_LIFT,
-  containsPoint,
-  type SurfaceRect,
-} from "@/components/companion-layout";
+import { onCompanionSurface } from "@/components/companion-layout";
 import {
   CompanionSurface,
   type CompanionSurfacePhase,
@@ -231,7 +226,13 @@ export const RestingWhileWorking: Story = {
   args: { phase: "resting", working: true },
 };
 
-/** The same turn with the pill open, where the ring follows the wider shape. */
+/**
+ * The same turn with the pill open, where the ring stays on the creature.
+ *
+ * The pill changes shape beside it and the light does not move: the creature
+ * holds one spot in the canvas, so the state stays where the eye already looks
+ * for it.
+ */
 export const HoverWhileWorking: Story = {
   args: { phase: "hover", hovered: true, working: true },
 };
@@ -239,8 +240,10 @@ export const HoverWhileWorking: Story = {
 /**
  * The reply to something typed on the surface, while the card is still open.
  *
- * The card is the tallest and squarest thing the surface draws, so it is where
- * a ring written for a 44pt circle is most likely to come apart.
+ * The card is the tallest thing the surface draws, and the ring is still the
+ * circle on the creature beside it: the widest gap between the two shapes, and
+ * the clearest case that the light belongs to the creature rather than to
+ * whatever is open next to it.
  */
 export const TypingWhileWorking: Story = {
   args: {
@@ -659,10 +662,6 @@ function HoverDrivenSurface(args: StoryArgs) {
   const phase: CompanionSurfacePhase =
     args.phase === "call" ? "call" : hovered ? "hover" : "resting";
   const expanded = phase !== "resting";
-  // The pair the surface is drawn at, defaulted the way the component defaults
-  // them, since the hit-test has to measure the creature the story is showing.
-  const avatarBox = args.avatarBox ?? COMPANION_BASE_AVATAR_BOX;
-  const optionsBox = args.optionsBox ?? COMPANION_BASE_AVATAR_BOX;
 
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
     const avatar = avatarRef.current;
@@ -670,34 +669,18 @@ function HoverDrivenSurface(args: StoryArgs) {
     if (!avatar || !pill) {
       return;
     }
-    const inside = (rect: SurfaceRect): boolean =>
-      containsPoint(rect, event.clientX, event.clientY);
-    const drawn = avatar.getBoundingClientRect();
-    const avatarRect: SurfaceRect = {
-      left: drawn.left,
-      right: drawn.right,
-      // The bob raises the artwork off its own box, on a wrapper inside the
-      // creature's own scale, so the lift grows with the creature. Nothing
-      // scales the stage itself, which is what the page's wrapper does.
-      top: drawn.top - (COMPANION_BOB_LIFT * avatarBox) / optionsBox,
-      bottom: drawn.bottom,
-    };
-    if (!expanded) {
-      setHovered(inside(avatarRect));
-      return;
-    }
-    const pillRect = pill.getBoundingClientRect();
     setHovered(
-      inside(avatarRect) ||
-        inside(pillRect) ||
-        inside(
-          bridgeRect(avatarRect, pillRect, {
-            // One base box, since nothing here is scaled the way the page's
-            // wrapper scales the real canvas by the options size.
-            rowHeight: COMPANION_BASE_AVATAR_BOX,
-            cardGrowth: args.cardGrowth ?? "up",
-          }),
-        ),
+      onCompanionSurface(
+        { x: event.clientX, y: event.clientY },
+        {
+          avatar: avatar.getBoundingClientRect(),
+          pill: expanded ? pill.getBoundingClientRect() : null,
+          // One base box, since nothing here is scaled the way the page's
+          // wrapper scales the real canvas by the options size.
+          rowHeight: COMPANION_BASE_AVATAR_BOX,
+          cardGrowth: args.cardGrowth ?? "up",
+        },
+      ),
     );
   };
 

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -38,6 +38,16 @@ const LISTENING_CALL: VoiceActivityState = {
   assistantName: "Ziggy",
 };
 
+/** Every state the surface draws, which several cases here sweep in turn. */
+const PHASES = [
+  "resting",
+  "hover",
+  "watching",
+  "summary",
+  "call",
+  "typing",
+] as const;
+
 /**
  * The working ring: the surface's answer to "is it doing anything", drawn so it
  * can be read without reading. The class is the contract with `index.css`,
@@ -45,6 +55,14 @@ const LISTENING_CALL: VoiceActivityState = {
  */
 const ringOf = (container: HTMLElement): HTMLElement | null =>
   container.querySelector<HTMLElement>(".companion-working-ring");
+
+/** The wrapper the idle bob runs on, which sits inside the avatar's box. */
+const bobOf = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>(".companion-avatar-bob");
+
+/** The creature's own light, which rides inside the bob. */
+const glowOf = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>(".companion-glow");
 
 describe("the companion surface's working ring", () => {
   test("is absent while nothing is running", () => {
@@ -70,14 +88,7 @@ describe("the companion surface's working ring", () => {
    * remounts everything hanging off it.
    */
   test("hangs off the avatar in every phase", () => {
-    for (const phase of [
-      "resting",
-      "hover",
-      "watching",
-      "summary",
-      "call",
-      "typing",
-    ] as const) {
+    for (const phase of PHASES) {
       const { container } = render(<CompanionSurface phase={phase} working />);
       expect(ringOf(container)?.closest(".size-11")).not.toBeNull();
       cleanup();
@@ -87,11 +98,6 @@ describe("the companion surface's working ring", () => {
   /** Around the creature's own box, so it is a circle whatever the pill is. */
   test("stays round while the card is open", () => {
     const { container } = render(<CompanionSurface phase="typing" working />);
-    expect(ringOf(container)?.className).toContain("rounded-full");
-  });
-
-  test("is round in every other state too", () => {
-    const { container } = render(<CompanionSurface phase="hover" working />);
     expect(ringOf(container)?.className).toContain("rounded-full");
   });
 
@@ -449,19 +455,6 @@ const avatarOf = (container: HTMLElement): HTMLElement => {
 };
 
 describe("the companion surface's anchor in the canvas", () => {
-  test("hangs the avatar off the canvas's bottom edge while the card grows up", () => {
-    const { container } = render(<CompanionSurface phase="resting" />);
-    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
-    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
-  });
-
-  test("sits the avatar against the canvas's top edge while the card grows down", () => {
-    const { container } = render(
-      <CompanionSurface phase="resting" cardGrowth="down" />,
-    );
-    expect(avatarOf(container).style.top).toBe("46px");
-  });
-
   test("grows up by default, which is where the surface normally lives", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
     const { container: explicit } = render(
@@ -482,14 +475,6 @@ describe("the companion surface's anchor in the canvas", () => {
     expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
-  test("keeps that line against the canvas's top edge too", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" cardGrowth="down" />,
-    );
-    expect(surfaceOf(container).style.top).toBe("68px");
-    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
-  });
-
   /**
    * The composer row is the card's last child growing up and its first growing
    * down, so the row's bottom is the avatar's bottom either way and the card
@@ -501,25 +486,33 @@ describe("the companion surface's anchor in the canvas", () => {
     expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
-  test("drops the card from the avatar's line when it grows down", () => {
-    const { container } = render(
+  /**
+   * The whole column against the other edge: the avatar sits on the canvas's
+   * top line, the pill keeps its bottom on the avatar's, and the card falls
+   * away from the row instead of hanging off it. The column reverses for the
+   * reason the row does when the pill grows left: the row holding the avatar's
+   * line has to end up against the avatar, and the conversation stacks away
+   * from it.
+   */
+  test("anchors everything against the canvas's top edge when the card grows down", () => {
+    const { container: resting } = render(
+      <CompanionSurface phase="resting" cardGrowth="down" />,
+    );
+    expect(avatarOf(resting).style.top).toBe("46px");
+
+    const { container: hover } = render(
+      <CompanionSurface phase="hover" cardGrowth="down" />,
+    );
+    expect(surfaceOf(hover).style.top).toBe("68px");
+    expect(surfaceOf(hover).style.transform).toBe("translateY(-100%)");
+
+    const { container: typing } = render(
       <CompanionSurface phase="typing" cardGrowth="down" />,
     );
     // The row starts on the avatar's top line and the card falls away from it.
-    expect(surfaceOf(container).style.top).toBe("24px");
-    expect(surfaceOf(container).style.transform).toBe("none");
-  });
-
-  /**
-   * The column reverses for the reason the row does when the pill grows left:
-   * the row holding the avatar's line has to end up against the avatar, and the
-   * conversation stacks away from it.
-   */
-  test("reverses the card's column when it grows down", () => {
-    const { container } = render(
-      <CompanionSurface phase="typing" cardGrowth="down" />,
-    );
-    expect(surfaceOf(container).className).toContain("flex-col-reverse");
+    expect(surfaceOf(typing).style.top).toBe("24px");
+    expect(surfaceOf(typing).style.transform).toBe("none");
+    expect(surfaceOf(typing).className).toContain("flex-col-reverse");
   });
 
   test("stacks the card upward in the ordinary direction", () => {
@@ -542,26 +535,13 @@ describe("the companion surface's anchor in the canvas", () => {
     );
   });
 
-  /** The pill's avatar-facing edge: the avatar's half box, then the gap. */
-  test("steps the pill off the avatar's edge by the gap", () => {
-    const { container } = render(<CompanionSurface phase="hover" />);
-    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
-  });
-
   /**
    * The property everything else here is in service of: the host positions the
    * window by the creature, so the creature has to sit on the same point in
    * every state the surface can be in.
    */
   test("keeps the avatar's own point in every phase", () => {
-    for (const phase of [
-      "resting",
-      "hover",
-      "watching",
-      "summary",
-      "call",
-      "typing",
-    ] as const) {
+    for (const phase of PHASES) {
       const { container } = render(<CompanionSurface phase={phase} />);
       expect(avatarOf(container).style.left).toBe("50%");
       expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
@@ -594,36 +574,34 @@ describe("the companion surface's anchor in the canvas", () => {
  */
 describe("the companion surface at two sizes", () => {
   /**
-   * The pair the layout is authored at, which every other case here is read
-   * against: it has to come out exactly where one size put it.
+   * 55 to a huge creature's edge, then the gap the smaller of the two earns.
+   * Bottom-flush with it as well: the near edge is 115 at this pair and the
+   * creature's bottom is 55 in from its centre, so the pill's bottom lands 60
+   * from the canvas edge.
    */
-  test("draws the authored pair exactly as a single size does", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" avatarBox={44} optionsBox={44} />,
-    );
-    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
-    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
-    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
-  });
-
-  /** 55 to a huge creature's edge, then the gap the smaller of the two earns. */
-  test("steps the pill off a larger creature's own edge", () => {
+  test("steps the pill off a larger creature's edge and onto its bottom", () => {
     const { container } = render(
       <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
     );
     expect(surfaceOf(container).style.left).toBe("calc(50% + 67px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 115px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 60px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   /**
-   * The same rule the other way round, read in the pill's own units: 22 points
-   * to the creature's edge and 12 of gap, at a scale of two and a half.
+   * The same rules the other way round, read in the pill's own units: 22 points
+   * to the creature's edge and 12 of gap, at a scale of two and a half, and the
+   * pill's bottom on the creature's own bottom as before.
    */
-  test("steps it off a smaller creature by the same rule", () => {
+  test("steps it off a smaller creature and onto its bottom too", () => {
     const { container } = render(
       <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
     );
     expect(surfaceOf(container).style.left).toBe("calc(50% + 13.6px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 59.2px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 50.4px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   test("mirrors that step when the pill grows the other way", () => {
@@ -636,29 +614,6 @@ describe("the companion surface at two sizes", () => {
       />,
     );
     expect(surfaceOf(container).style.right).toBe("calc(50% + 67px)");
-  });
-
-  /**
-   * Bottom-flush against a creature that is not the pill's size: the near edge
-   * is 115 at this pair and the creature's bottom is 55 in from its centre, so
-   * the pill's bottom lands 60 from the canvas edge.
-   */
-  test("keeps the pill's bottom on a larger creature's bottom", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
-    );
-    expect(avatarOf(container).style.top).toBe("calc(100% - 115px)");
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 60px)");
-    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
-  });
-
-  test("keeps it on a smaller creature's bottom too", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
-    );
-    expect(avatarOf(container).style.top).toBe("calc(100% - 59.2px)");
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 50.4px)");
-    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   test("anchors both against the canvas's top edge when the card grows down", () => {
@@ -703,9 +658,7 @@ describe("the companion surface at two sizes", () => {
     expect(avatarOf(container).style.transform).toBe(
       "translate(-50%, -50%) scale(2.5)",
     );
-    expect(
-      avatarOf(container).querySelector(".companion-avatar-bob"),
-    ).not.toBeNull();
+    expect(bobOf(container)?.parentElement).toBe(avatarOf(container));
   });
 
   test("scales it down the same way beside a larger pill", () => {
@@ -1224,7 +1177,16 @@ describe("the summary a finished watch session leaves on the surface", () => {
 });
 
 describe("the companion surface's width ceiling", () => {
-  const CANVAS_CEILING = COMPANION_BASE_MAX_PILL_WIDTH;
+  /**
+   * The widest the pill may draw, which is what the canvas is sized for.
+   * Written out rather than read from the contract, so the cases below assert a
+   * number instead of restating the constant they are about.
+   */
+  const CANVAS_CEILING = 316;
+
+  test("is the width the shared contract publishes", () => {
+    expect(COMPANION_BASE_MAX_PILL_WIDTH).toBe(CANVAS_CEILING);
+  });
 
   /**
    * The ceiling is on the pill, not on the body inside it, so a body that fits
@@ -1285,11 +1247,6 @@ describe("the companion surface's capture indicator across phases", () => {
     expect(ringOf(container)).not.toBeNull();
   });
 
-  test("stays on the creature while the user types", () => {
-    const { container } = render(<CompanionSurface phase="typing" watching />);
-    expect(ringOf(container)?.closest(".size-11")).not.toBeNull();
-  });
-
   test("is absent in the composer with no session running", () => {
     const { container } = render(<CompanionSurface phase="typing" />);
     expect(ringOf(container)).toBeNull();
@@ -1325,12 +1282,31 @@ describe("the companion surface growing leftward", () => {
     expect(surfaceOf(container).style.left).toBe("");
   });
 
+  /** The pill's avatar-facing edge: the avatar's half box, then the gap. */
   test("anchors it by its left edge growing the ordinary way", () => {
     const { container } = render(
       <CompanionSurface phase="hover" growth="right" />,
     );
     expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
     expect(surfaceOf(container).style.right).toBe("");
+  });
+
+  /**
+   * The row inside the pill ends on the pinned edge too. A row left-aligned in
+   * a box narrower than its own content spills past that edge, across the gap
+   * and over the creature, for as long as the animating width lags the
+   * content: through the unfurl, and again on every label reveal.
+   */
+  test("ends the pill's row on the edge the pill is pinned by", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" growth="left" />,
+    );
+    expect(surfaceOf(container).className).toContain("justify-end");
+
+    const { container: rightward } = render(
+      <CompanionSurface phase="hover" growth="right" />,
+    );
+    expect(surfaceOf(rightward).className).not.toContain("justify-end");
   });
 
   /**
@@ -1476,12 +1452,11 @@ describe("the resting avatar's idle motion", () => {
       <CompanionSurface phase="resting" accentHex="#ff8800" />,
     );
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    const bob = bobOf(container);
     expect(bob).not.toBeNull();
 
-    const glow = bob?.querySelector<HTMLElement>(".companion-glow");
-    expect(glow).not.toBeNull();
-    expect(glow?.className).not.toContain("animate-pulse");
+    const glow = glowOf(container);
+    expect(glow?.parentElement).toBe(bob);
     expect(glow?.style.background.toLowerCase()).toContain("#ff8800");
   });
 
@@ -1497,16 +1472,14 @@ describe("the resting avatar's idle motion", () => {
       />,
     );
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
-    expect(bob?.querySelector("svg")).not.toBeNull();
+    expect(bobOf(container)?.querySelector("svg")).not.toBeNull();
   });
 
   /** The wrapper sits inside the avatar's box, which nothing else may move. */
   test("keeps the avatar box as the wrapper's parent", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
-    expect(bob?.parentElement?.className).toContain("size-11");
+    expect(bobOf(container)?.parentElement?.className).toContain("size-11");
   });
 
   /**
@@ -1516,9 +1489,9 @@ describe("the resting avatar's idle motion", () => {
    * second ring around.
    */
   test("glows in every phase, not only at rest", () => {
-    for (const phase of ["resting", "hover", "call", "typing"] as const) {
+    for (const phase of PHASES) {
       const { container } = render(<CompanionSurface phase={phase} />);
-      expect(container.querySelector(".companion-glow")).not.toBeNull();
+      expect(glowOf(container)).not.toBeNull();
       cleanup();
     }
   });
@@ -1538,18 +1511,14 @@ describe("the resting avatar's idle motion", () => {
 
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
-    const glow = container.querySelector<HTMLElement>(".companion-glow");
-    expect(bob?.style.animation).toBe("none");
-    expect(glow?.style.animation).toBe("none");
+    expect(bobOf(container)?.style.animation).toBe("none");
+    expect(glowOf(container)?.style.animation).toBe("none");
   });
 
   test("leaves both running for a reader who asked for nothing", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
-    const glow = container.querySelector<HTMLElement>(".companion-glow");
-    expect(bob?.style.animation).toBe("");
-    expect(glow?.style.animation).toBe("");
+    expect(bobOf(container)?.style.animation).toBe("");
+    expect(glowOf(container)?.style.animation).toBe("");
   });
 });

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -768,8 +768,8 @@ export function CompanionSurface({
   const edge = (
     <>
       {/* Something running, as a light travelling around the edge. Drawn over
-          the body so it reads as the surface's own border, and outside it by a
-          hair so it never crowds what it is drawn around.
+          the creature so it reads as the creature's own border, and outside
+          the creature's box by a hair so it never crowds the artwork.
 
           A turn burns it in the assistant's colour, a watch session in amber,
           and the session's ring is drawn in every phase rather than only the
@@ -835,7 +835,13 @@ export function CompanionSurface({
               // line has to stay on that line, and the turns stack away from
               // it.
               `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
-            : "flex h-11 items-center rounded-full"
+            : // One row in a box whose width animates, so the row is pinned to
+              // the pill's avatar-facing edge. `growth: "left"` anchors the
+              // pill by its right, and a row left-aligned in a box narrower
+              // than itself spills past that edge, across the gap and over the
+              // creature, every time the width lags the content: through the
+              // unfurl and instantly on each label reveal.
+              `flex h-11 items-center rounded-full ${growth === "left" ? "justify-end" : ""}`
         }`}
         style={style}
         onMouseDown={onSurfaceMouseDown}

--- a/clients/web/src/components/dictation-overlay-page.tsx
+++ b/clients/web/src/components/dictation-overlay-page.tsx
@@ -7,6 +7,7 @@ import {
   type RefObject,
 } from "react";
 
+import { containsPoint } from "@/components/companion-layout";
 import {
   getDictationOverlayState,
   requestDictationOverlayStop,
@@ -120,12 +121,12 @@ export function DictationOverlayPage() {
       setInteractive(false);
       return;
     }
-    const rect = button.getBoundingClientRect();
     setInteractive(
-      event.clientX >= rect.left &&
-        event.clientX <= rect.right &&
-        event.clientY >= rect.top &&
-        event.clientY <= rect.bottom,
+      containsPoint(
+        button.getBoundingClientRect(),
+        event.clientX,
+        event.clientY,
+      ),
     );
   };
   const stopRecording = () => {

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -255,9 +255,9 @@ html[data-page-transition="pop"]::view-transition-new(root) {
    its `<svg>` for the breathe and morph, and two animations on one node means
    one of them silently wins.
 
-   The lift is also `COMPANION_BOB_LIFT` in `companion-layout.ts`, which the
-   host's hit-test adds to the avatar's rect so the raised creature is still
-   something the pointer can be on. */
+   The lift stays inside the creature's own box: the artwork is inset well
+   short of the top, so the raised creature is still somewhere the host's
+   hit-test finds the pointer. */
 @keyframes companion-avatar-bob {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-3px); }

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -15,10 +15,8 @@ import {
  * the labels: "88pt" means nothing next to a floating avatar, and the sizes are
  * meant to be picked by looking at the result.
  *
- * One table rather than a literal per menu, since the tray and the surface's
- * own right-click both offer the steps. A user who met "Large" in one place and
- * "Big" in the other would reasonably wonder whether they were setting the same
- * thing.
+ * The vocabulary {@link companionSizeSubmenus} draws the steps from, which is
+ * the one place the wording is decided for every menu that offers them.
  */
 const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
   small: "Small",
@@ -36,10 +34,9 @@ const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
  * creature reads "Avatar" before they read "size". The sentence case is the
  * design's wording, against the Title Case of the tray items beside it.
  *
- * Here beside the steps themselves, and for the same reason: both menus that
- * offer the sizes offer them under these two headings, and a user who met
- * "Avatar size" in one place and "Creature size" in the other would reasonably
- * wonder whether they were setting the same thing.
+ * The headings' half of the same vocabulary: {@link companionSizeSubmenus}
+ * titles its submenus from here, so every menu that offers the sizes offers
+ * them under these two words.
  */
 const COMPANION_SIZE_AXIS_LABELS: Record<CompanionSizeAxis, string> = {
   avatar: "Avatar size",

--- a/packages/electron-desktop/src/tray-model.test.ts
+++ b/packages/electron-desktop/src/tray-model.test.ts
@@ -604,23 +604,6 @@ describe("companion toggle", () => {
   });
 
   /**
-   * Two headings rather than one, because a single picker could only ever move
-   * both halves of the surface at once. The wording is the same table the
-   * surface's own right-click reads, so the two menus cannot describe the same
-   * choice differently.
-   */
-  test("offers a heading for each thing that is sized", () => {
-    installTray(handlers);
-    handlerFor(trays[0], "right-click")?.();
-    const calls = buildFromTemplateMock.mock.calls;
-    const template = calls[calls.length - 1]?.[0] as MenuItem[];
-    const headings = template
-      .map((i) => i.label)
-      .filter((label) => label === "Avatar size" || label === "Options size");
-    expect(headings).toEqual(["Avatar size", "Options size"]);
-  });
-
-  /**
    * What the tray adds to the pickers, which have their own suite in
    * `companion-menu.test.ts`: the sizes it shows are the ones it was configured
    * to read, and a pick lands on the setter it was configured with, under the

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -65,6 +65,7 @@ mock.module("electron", () => ({
 const {
   restoreBounds,
   track,
+  promoteCompanionSizeToAxes,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
@@ -488,6 +489,68 @@ describe("companion surface sizes", () => {
     savedCompanionSize = "small";
     writeCompanionSize("avatar", "ridiculous");
     writeCompanionSize("options", "huge");
+    expect(
+      storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
+    ).toBe(false);
+  });
+});
+
+/**
+ * Neither axis is left sized from the shared key alone.
+ *
+ * `readCompanionSize` falls back to it either way, so what these state is that
+ * an install cannot sit half way across: an avatar resized on a build with two
+ * axes must not leave the pill governed by a key nothing writes.
+ */
+describe("promoting the single-axis size onto both axes", () => {
+  test("fills both axes when neither has a key of its own", () => {
+    savedCompanionSize = "huge";
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).toHaveBeenCalledWith("companionAvatarSize", "huge");
+    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
+  });
+
+  test("fills only the axis that is missing one", () => {
+    savedCompanionSize = "huge";
+    savedCompanionAvatarSize = "small";
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
+    expect(
+      storeSetMock.mock.calls.some(([key]) => key === "companionAvatarSize"),
+    ).toBe(false);
+  });
+
+  test("writes nothing when both axes already have their own key", () => {
+    savedCompanionSize = "huge";
+    savedCompanionAvatarSize = "small";
+    savedCompanionOptionsSize = "large";
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).not.toHaveBeenCalled();
+  });
+
+  test("writes nothing when there is no shared key to promote", () => {
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A size this build cannot draw is not a size to spread onto both axes. It
+   * would put a canvas sized from `undefined` on screen twice over.
+   */
+  test("writes nothing when the shared key holds a size this build does not know", () => {
+    savedCompanionSize = "enormous";
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The shared key stays where it is in every case. A build with one size axis
+   * still reads it, so a user who moves back to one finds the size they picked.
+   */
+  test("leaves the shared key in place", () => {
+    savedCompanionSize = "huge";
+    savedCompanionOptionsSize = "large";
+    promoteCompanionSizeToAxes();
     expect(
       storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
     ).toBe(false);

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, screen, type Rectangle } from "electron";
 import Store from "electron-store";
 
 import {
+  COMPANION_SIZE_AXES,
   COMPANION_SIZES,
   DEFAULT_COMPANION_SIZE,
   titleBarOverlayThemeSchema,
@@ -208,6 +209,33 @@ export const writeCompanionSize = (
     return;
   }
   store().set(COMPANION_SIZE_KEYS[axis], size);
+};
+
+/**
+ * Copy the single size a build with one size axis records into whichever
+ * per-axis keys are still empty. Called once, before anything reads the
+ * geometry.
+ *
+ * `readCompanionSize` already falls back to that key, so nobody sees the
+ * surface change. What this settles is the install stuck half way across:
+ * someone carrying `huge` who resizes the avatar alone ends with one axis's own
+ * key written and the other governed by the shared key for as long as they keep
+ * it, which leaves half their surface sized from a key nothing writes.
+ *
+ * The shared key is left in place, and this writes only the per-axis ones. A
+ * build with one size axis still reads it, so a user who goes back to one finds
+ * the size they picked rather than the default.
+ */
+export const promoteCompanionSizeToAxes = (): void => {
+  const shared = knownSize(store().get("companionSize"));
+  if (shared === null) {
+    return;
+  }
+  for (const axis of COMPANION_SIZE_AXES) {
+    if (storedSize(axis) === null) {
+      store().set(COMPANION_SIZE_KEYS[axis], shared);
+    }
+  }
 };
 
 /**

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -1157,8 +1157,11 @@ export interface CompanionSurfaceState {
    * The renderer draws the surface at this over the size its layout is authored
    * at and scales the creature inside that by the ratio between the two boxes,
    * so every length beside the avatar stays stated once, at the base size.
+   *
+   * Optional, and absence means a shell that predates the second axis, which
+   * the renderer reads as {@link CompanionSurfaceState.avatarBox}.
    */
-  optionsBox: number;
+  optionsBox?: number;
   /**
    * The assistant's display name, for the composer's placeholder.
    *


### PR DESCRIPTION
## Summary
Fixes gaps identified during the second plan-review round for companion-avatar-restyle.md.

- A left-growing pill keeps its controls against the avatar-facing edge while its width animates; the avatar's hit rect is its own box (the bob never leaves it)
- The legacy companionSize is promoted into both per-axis keys once at startup; optionsBox is optional on the wire like its skew-tolerant siblings
- One hover hit-test helper serves the renderer and the story; packages/ipc-contract joins the web and macOS CI path filters; stale ring docs and duplicated tests removed