### PR TITLE
fix: companion review round 3 (drop size promotion, literal intro assertion, storybook CI filter)

### DIFF
--- a/.github/workflows/ci-main-storybook.yaml
+++ b/.github/workflows/ci-main-storybook.yaml
@@ -10,6 +10,9 @@ on:
       - 'bun.lock'
       - 'patches/**'
       - "packages/design-library/**"
+      # The web's Storybook bundles this contract's values, so a change here
+      # can break the Storybook build with no web file touched.
+      - "packages/ipc-contract/**"
       - "clients/web/**"
       - "packages/local-mode/**"
       - "packages/environments/**"

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_MAX_PILL_WIDTH,
   COMPANION_SIZES,
   COMPANION_SIZE_BOXES,
   companionNearEdgeFor,
@@ -189,7 +190,6 @@ mock.module("@vellumai/electron-desktop/window-state", () => ({
   // load-time failure for the file rather than a failing case.
   readCompanionIntroSeen: () => true,
   writeCompanionIntroSeen: () => {},
-  promoteCompanionSizeToAxes: () => {},
 }));
 
 // Dynamic, so the mocks above are installed before the module graph loads:
@@ -290,9 +290,9 @@ const BIG_OPTIONS = geometryFor("small", "huge");
 
 /**
  * The part of the base reach the geometry does not publish: the pill's widest.
- * Stated once here for the cases that are about it rather than the sum.
+ * Bound to the contract for the cases that are about it rather than the sum.
  */
-const MAX_PILL_WIDTH = 316;
+const MAX_PILL_WIDTH = COMPANION_BASE_MAX_PILL_WIDTH;
 
 /**
  * The growth direction is the only rule in the companion window worth testing

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -39,7 +39,6 @@ import {
   readSetting,
 } from "@vellumai/electron-desktop/settings";
 import {
-  promoteCompanionSizeToAxes,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
@@ -229,12 +228,6 @@ let growth: CompanionGrowth = "right";
  * it to draw the avatar where the window was actually put.
  */
 let cardGrowth: CompanionCardGrowth = "up";
-
-// Module init is the first thing to ask the store for the surface's geometry,
-// so it is where an install carrying only the single size a one-axis build
-// writes has that size copied onto both per-axis keys. Once, ahead of the reads
-// below, and never again for the life of the process.
-promoteCompanionSizeToAxes();
 
 /**
  * The canvas the surface is currently drawn in.

--- a/clients/web/src/components/companion-intro.test.tsx
+++ b/clients/web/src/components/companion-intro.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 
 import { CompanionIntro } from "./companion-intro";
-import { companionLayoutFor } from "./companion-layout";
 import { CompanionSurface } from "./companion-surface";
 
 afterEach(cleanup);
@@ -89,9 +88,8 @@ describe("the companion introduction's clearance", () => {
       />,
     );
 
-    const layout = companionLayoutFor(44, 110);
-    expect(cardOf(container).style.transform).toBe(
-      `translateY(${layout.inUnits(layout.introStepOff("down"))}px)`,
-    );
+    // The step down for 44 under 110 is the creature's half box plus the gap,
+    // 22 + 12 points, over the 2.5 scale the options box leaves the canvas at.
+    expect(cardOf(container).style.transform).toBe("translateY(13.6px)");
   });
 });

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -10,7 +10,7 @@ import type {
 import type { CSSProperties } from "react";
 
 /** As much of a rect as hit-testing a point against it needs. */
-export type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
+type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
 
 /**
  * Whether a point is on a rect, its edges included.

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -65,7 +65,6 @@ mock.module("electron", () => ({
 const {
   restoreBounds,
   track,
-  promoteCompanionSizeToAxes,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
@@ -489,68 +488,6 @@ describe("companion surface sizes", () => {
     savedCompanionSize = "small";
     writeCompanionSize("avatar", "ridiculous");
     writeCompanionSize("options", "huge");
-    expect(
-      storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
-    ).toBe(false);
-  });
-});
-
-/**
- * Neither axis is left sized from the shared key alone.
- *
- * `readCompanionSize` falls back to it either way, so what these state is that
- * an install cannot sit half way across: an avatar resized on a build with two
- * axes must not leave the pill governed by a key nothing writes.
- */
-describe("promoting the single-axis size onto both axes", () => {
-  test("fills both axes when neither has a key of its own", () => {
-    savedCompanionSize = "huge";
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).toHaveBeenCalledWith("companionAvatarSize", "huge");
-    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
-  });
-
-  test("fills only the axis that is missing one", () => {
-    savedCompanionSize = "huge";
-    savedCompanionAvatarSize = "small";
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
-    expect(
-      storeSetMock.mock.calls.some(([key]) => key === "companionAvatarSize"),
-    ).toBe(false);
-  });
-
-  test("writes nothing when both axes already have their own key", () => {
-    savedCompanionSize = "huge";
-    savedCompanionAvatarSize = "small";
-    savedCompanionOptionsSize = "large";
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).not.toHaveBeenCalled();
-  });
-
-  test("writes nothing when there is no shared key to promote", () => {
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).not.toHaveBeenCalled();
-  });
-
-  /**
-   * A size this build cannot draw is not a size to spread onto both axes. It
-   * would put a canvas sized from `undefined` on screen twice over.
-   */
-  test("writes nothing when the shared key holds a size this build does not know", () => {
-    savedCompanionSize = "enormous";
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).not.toHaveBeenCalled();
-  });
-
-  /**
-   * The shared key stays where it is in every case. A build with one size axis
-   * still reads it, so a user who moves back to one finds the size they picked.
-   */
-  test("leaves the shared key in place", () => {
-    savedCompanionSize = "huge";
-    savedCompanionOptionsSize = "large";
-    promoteCompanionSizeToAxes();
     expect(
       storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
     ).toBe(false);

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -2,7 +2,6 @@ import { BrowserWindow, screen, type Rectangle } from "electron";
 import Store from "electron-store";
 
 import {
-  COMPANION_SIZE_AXES,
   COMPANION_SIZES,
   DEFAULT_COMPANION_SIZE,
   titleBarOverlayThemeSchema,
@@ -157,7 +156,8 @@ const storedSize = (axis: CompanionSizeAxis): CompanionSize | null =>
  * writes, then the default. That middle step is what keeps an install from
  * being resized under its user: someone who picked `huge` from a menu offering
  * one size meant the thing they were looking at, so they get `huge` on both
- * axes rather than the default on either.
+ * axes rather than the default on either. Nothing promotes that key onto the
+ * per-axis ones, so reading through it is the permanent compatibility path.
  */
 export const readCompanionSize = (axis: CompanionSizeAxis): CompanionSize =>
   storedSize(axis) ??
@@ -209,33 +209,6 @@ export const writeCompanionSize = (
     return;
   }
   store().set(COMPANION_SIZE_KEYS[axis], size);
-};
-
-/**
- * Copy the single size a build with one size axis records into whichever
- * per-axis keys are still empty. Called once, before anything reads the
- * geometry.
- *
- * `readCompanionSize` already falls back to that key, so nobody sees the
- * surface change. What this settles is the install stuck half way across:
- * someone carrying `huge` who resizes the avatar alone ends with one axis's own
- * key written and the other governed by the shared key for as long as they keep
- * it, which leaves half their surface sized from a key nothing writes.
- *
- * The shared key is left in place, and this writes only the per-axis ones. A
- * build with one size axis still reads it, so a user who goes back to one finds
- * the size they picked rather than the default.
- */
-export const promoteCompanionSizeToAxes = (): void => {
-  const shared = knownSize(store().get("companionSize"));
-  if (shared === null) {
-    return;
-  }
-  for (const axis of COMPANION_SIZE_AXES) {
-    if (storedSize(axis) === null) {
-      store().set(COMPANION_SIZE_KEYS[axis], shared);
-    }
-  }
 };
 
 /**


### PR DESCRIPTION
## Summary
Fixes gaps identified during the third plan-review round for companion-avatar-restyle.md.

- The legacy companionSize is read through the per-axis fallback and never promoted: promotion was unobservable, shadowed a newer pick after a rollback, and ran at module load before userData and the single-instance lock
- The intro placement test asserts a literal again; the macOS geometry test binds its pill width ceiling to the contract; SurfaceRect is module-private
- packages/ipc-contract joins the web Storybook CI path filter