### PR TITLE
feat(companion): float the avatar beside the options pill with independent sizes

### DIFF
--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -10,6 +10,9 @@ on:
       - 'clients/macos/**'
       - 'packages/electron-utils/**'
       - 'packages/electron-desktop/**'
+      # The macOS main process imports this contract's types directly, so a
+      # change here can break the macOS type check with no macOS file touched.
+      - 'packages/ipc-contract/**'
       - 'packages/native-sidecar/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'

--- a/.github/workflows/ci-main-storybook.yaml
+++ b/.github/workflows/ci-main-storybook.yaml
@@ -10,6 +10,9 @@ on:
       - 'bun.lock'
       - 'patches/**'
       - "packages/design-library/**"
+      # The web's Storybook bundles this contract's values, so a change here
+      # can break the Storybook build with no web file touched.
+      - "packages/ipc-contract/**"
       - "clients/web/**"
       - "packages/local-mode/**"
       - "packages/environments/**"

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -14,6 +14,9 @@ on:
       # schema change here can break the web build with no web file touched.
       - 'assistant/openapi.yaml'
       - 'packages/design-library/**'
+      # The web imports this contract's types directly, so a change here can
+      # break the web type check with no web file touched.
+      - 'packages/ipc-contract/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
       - 'packages/avatar-manifest/**'

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -10,6 +10,9 @@ on:
       - 'clients/macos/**'
       - 'packages/electron-utils/**'
       - 'packages/electron-desktop/**'
+      # The macOS main process imports this contract's types directly, so a
+      # change here can break the macOS type check with no macOS file touched.
+      - 'packages/ipc-contract/**'
       - 'packages/native-sidecar/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -13,6 +13,9 @@ on:
       # schema change here can break the web build with no web file touched.
       - 'assistant/openapi.yaml'
       - 'packages/design-library/**'
+      # The web imports this contract's types directly, so a change here can
+      # break the web type check with no web file touched.
+      - 'packages/ipc-contract/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
       - 'packages/avatar-manifest/**'

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -3,8 +3,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   COMPANION_BASE_AVATAR_BOX,
   COMPANION_BASE_CANVAS_PAD,
+  COMPANION_BASE_CARD_HEIGHT,
+  COMPANION_NEAR_EDGE,
   COMPANION_SIZES,
+  COMPANION_SIZE_BOXES,
   companionGapFor,
+  companionPadFor,
+  companionScaleFor,
+  type CompanionSize,
+  type CompanionSizeAxis,
   type CompanionSurfaceState,
   type VellumCommand,
 } from "@vellumai/ipc-contract";
@@ -159,6 +166,7 @@ const {
   growthFor,
   cardGrowthFor,
   avatarOffsetFor,
+  companionContextMenuTemplate,
   geometryFor,
   placeCanvas,
   callOnUpdate,
@@ -227,7 +235,7 @@ const START = {
  * renderer's layout is authored at. Every other size is the same arithmetic
  * scaled, which `geometryFor` has its own cases for.
  */
-const GEOMETRY = geometryFor("small");
+const GEOMETRY = geometryFor("small", "small");
 const CANVAS_WIDTH = GEOMETRY.canvasWidth;
 const RISE_ABOVE = GEOMETRY.riseAbove;
 const DROP_BELOW = GEOMETRY.dropBelow;
@@ -580,8 +588,9 @@ describe("shouldShowCompanionSurface", () => {
  */
 describe("geometryFor", () => {
   test("draws `small` at the size the renderer's layout is authored at", () => {
-    const small = geometryFor("small");
+    const small = geometryFor("small", "small");
     expect(small.avatarBox).toBe(44);
+    expect(small.optionsBox).toBe(44);
     expect(small.canvasWidth).toBe(748);
     expect(small.canvasHeight).toBe(338);
     expect(small.maxReach).toBe(350);
@@ -594,7 +603,7 @@ describe("geometryFor", () => {
    */
   test("holds the pill's whole reach on both sides of the avatar", () => {
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size);
+      const geometry = geometryFor(size, size);
       const pad =
         (COMPANION_BASE_CANVAS_PAD * geometry.avatarBox) /
         COMPANION_BASE_AVATAR_BOX;
@@ -609,7 +618,7 @@ describe("geometryFor", () => {
 
   test("takes the gap from the contract rather than a copy of it", () => {
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size);
+      const geometry = geometryFor(size, size);
       expect(geometry.gap).toBe(
         companionGapFor(geometry.avatarBox, geometry.avatarBox),
       );
@@ -617,13 +626,41 @@ describe("geometryFor", () => {
   });
 
   /**
-   * The whole surface is one layout multiplied, so every length has to move
-   * together. A canvas that scaled while the pill's reach did not would clip
-   * the controls; the reverse would swallow clicks over empty desktop.
+   * The creature's box is the avatar axis's answer and nothing else's. It is
+   * what main clamps by, so a pill size leaking into it would move where the
+   * mascot is allowed to sit.
    */
-  test("scales every length by the same factor", () => {
-    const small = geometryFor("small");
-    const large = geometryFor("large");
+  test("takes the creature's box from the avatar axis alone", () => {
+    for (const options of COMPANION_SIZES) {
+      expect(geometryFor("large", options).avatarBox).toBe(
+        COMPANION_SIZE_BOXES.large,
+      );
+    }
+  });
+
+  /**
+   * Everything beside the creature is the options axis's answer: the pill's box
+   * and the widest body it draws, which is what the canvas's width is spent on.
+   */
+  test("takes the pill's box and its widest body from the options axis alone", () => {
+    for (const avatar of COMPANION_SIZES) {
+      const geometry = geometryFor(avatar, "large");
+      expect(geometry.optionsBox).toBe(COMPANION_SIZE_BOXES.large);
+      expect(geometry.maxBodyWidth).toBe(
+        geometryFor("large", "large").maxBodyWidth,
+      );
+    }
+  });
+
+  /**
+   * With one size on both axes the surface is still one layout multiplied, so
+   * every length moves together. A canvas that scaled while the pill's reach
+   * did not would clip the controls; the reverse would swallow clicks over
+   * empty desktop.
+   */
+  test("scales every length by the same factor when the axes agree", () => {
+    const small = geometryFor("small", "small");
+    const large = geometryFor("large", "large");
     const scale = large.avatarBox / small.avatarBox;
     expect(scale).toBe(2);
     expect(large.canvasWidth).toBe(small.canvasWidth * scale);
@@ -635,8 +672,28 @@ describe("geometryFor", () => {
     expect(large.maxReach).toBe(small.maxReach * scale);
   });
 
+  /**
+   * The two-box distances are the one-box ones wherever there is only one size,
+   * which is what makes the second axis a widening rather than a second
+   * geometry to keep in step.
+   */
+  test("reduces to the single-scale canvas when the axes agree", () => {
+    for (const size of COMPANION_SIZES) {
+      const geometry = geometryFor(size, size);
+      const scale = companionScaleFor(geometry.avatarBox);
+      expect(geometry.dropBelow).toBe(COMPANION_NEAR_EDGE * scale);
+      expect(geometry.riseAbove).toBe(
+        COMPANION_BASE_CARD_HEIGHT * scale -
+          geometry.avatarBox / 2 +
+          COMPANION_BASE_CANVAS_PAD * scale,
+      );
+    }
+  });
+
   test("grows monotonically through the named steps", () => {
-    const boxes = COMPANION_SIZES.map((size) => geometryFor(size).avatarBox);
+    const boxes = COMPANION_SIZES.map(
+      (size) => geometryFor(size, size).avatarBox,
+    );
     expect(boxes).toEqual([...boxes].sort((a, b) => a - b));
     expect(new Set(boxes).size).toBe(boxes.length);
   });
@@ -648,7 +705,7 @@ describe("geometryFor", () => {
    */
   test("gives every size a whole-point canvas", () => {
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size);
+      const geometry = geometryFor(size, size);
       expect(Number.isInteger(geometry.canvasWidth)).toBe(true);
       expect(Number.isInteger(geometry.canvasHeight)).toBe(true);
     }
@@ -661,12 +718,217 @@ describe("geometryFor", () => {
    */
   test("keeps the canvas asymmetric about the avatar at every size", () => {
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size);
+      const geometry = geometryFor(size, size);
       expect(geometry.dropBelow).toBeLessThan(geometry.riseAbove);
       expect(geometry.riseAbove + geometry.dropBelow).toBe(
         geometry.canvasHeight,
       );
     }
+  });
+});
+
+/**
+ * The canvas when the creature and the controls are sized apart, which is the
+ * shape the two axes exist for.
+ *
+ * Both sides of the avatar are sized for whichever card direction needs more,
+ * so main can still flip the direction by moving the window rather than
+ * rebuilding it. The cost is a few transparent points of slack in the direction
+ * that needed less, and what these cases hold is that the slack is never
+ * negative: a side short by a point clips the pill or the card.
+ */
+describe("geometryFor with the two axes apart", () => {
+  /** A creature far larger than the controls beside it, and the reverse. */
+  const BIG_CREATURE = geometryFor("huge", "small");
+  const BIG_OPTIONS = geometryFor("small", "huge");
+  const MIXED = [BIG_CREATURE, BIG_OPTIONS];
+
+  /**
+   * The near edge answers for both card directions at once. Growing up, the
+   * lowest thing drawn is the creature's own bottom; growing down, the pill
+   * stands on that same line and its top reaches a whole options box back up
+   * past it, over the head of a smaller creature.
+   */
+  test("clears the creature's bottom and the pill's top alike", () => {
+    for (const geometry of MIXED) {
+      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
+      expect(
+        geometry.dropBelow - geometry.avatarBox / 2,
+      ).toBeGreaterThanOrEqual(pad);
+      expect(
+        geometry.dropBelow + geometry.avatarBox / 2 - geometry.optionsBox,
+      ).toBeGreaterThanOrEqual(pad);
+    }
+  });
+
+  /**
+   * The far side, the same way. The card stands on the creature's bottom line
+   * and rises its whole height growing up; growing down its composer row holds
+   * that line and the rest of it falls away below.
+   */
+  test("clears the card in whichever direction it grows", () => {
+    for (const geometry of MIXED) {
+      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
+      const cardHeight =
+        COMPANION_BASE_CARD_HEIGHT * companionScaleFor(geometry.optionsBox);
+      expect(
+        geometry.riseAbove - (cardHeight - geometry.avatarBox / 2),
+      ).toBeGreaterThanOrEqual(pad);
+      expect(
+        geometry.riseAbove -
+          (geometry.avatarBox / 2 + cardHeight - geometry.optionsBox),
+      ).toBeGreaterThanOrEqual(pad);
+    }
+  });
+
+  test("spends the whole canvas on the two sides of the avatar", () => {
+    for (const geometry of MIXED) {
+      expect(geometry.riseAbove + geometry.dropBelow).toBe(
+        geometry.canvasHeight,
+      );
+      expect(geometry.dropBelow).toBeLessThan(geometry.riseAbove);
+      expect(Number.isInteger(geometry.canvasHeight)).toBe(true);
+    }
+  });
+
+  test("still holds the pill's reach on both sides of the avatar", () => {
+    for (const geometry of MIXED) {
+      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
+      expect(geometry.maxReach).toBe(
+        geometry.avatarBox / 2 + geometry.gap + geometry.maxBodyWidth,
+      );
+      expect(geometry.canvasWidth).toBe(
+        Math.round(2 * (geometry.maxReach + pad)),
+      );
+    }
+  });
+
+  /**
+   * The gap is breathing room, so the smaller of the two decides how much of it
+   * there is: a modest creature beside an enormous pill wants the creature's
+   * clearance rather than the chasm the pill's own scale would ask for.
+   */
+  test("takes the gap from the smaller of the two", () => {
+    expect(BIG_CREATURE.gap).toBe(geometryFor("small", "small").gap);
+    expect(BIG_OPTIONS.gap).toBe(BIG_CREATURE.gap);
+  });
+
+  test("flips the pill at the reach the options size asks for", () => {
+    expect(
+      growthFor(DISPLAY.width - BIG_CREATURE.maxReach, DISPLAY, BIG_CREATURE),
+    ).toBe("right");
+    expect(
+      growthFor(
+        DISPLAY.width - BIG_CREATURE.maxReach + 1,
+        DISPLAY,
+        BIG_CREATURE,
+      ),
+    ).toBe("left");
+  });
+
+  /**
+   * A display too narrow for the pill either way still grows the designed way,
+   * and an enormous options size beside a small creature is how a 1440pt
+   * display gets there.
+   */
+  test("still grows the designed way where neither side can hold the pill", () => {
+    expect(
+      growthFor(DISPLAY.width - BIG_OPTIONS.maxReach + 1, DISPLAY, BIG_OPTIONS),
+    ).toBe("right");
+  });
+});
+
+/**
+ * The menu a right-click on the surface pops, which is where a user actually
+ * reaches for the two things a floating avatar offers: a different size, and
+ * making it go away.
+ *
+ * The template rather than the menu: a menu is a native window, and what is
+ * worth stating is the wording, which step each axis is marked on, and that a
+ * press names the axis it was made under.
+ */
+describe("companionContextMenuTemplate", () => {
+  /** Only what a menu item is read for here, as `tray-model.test.ts` has it. */
+  type MenuItem = {
+    label?: string;
+    type?: string;
+    checked?: boolean;
+    click?: () => void;
+    submenu?: MenuItem[];
+  };
+
+  const build = (
+    current: Record<CompanionSizeAxis, CompanionSize> = {
+      avatar: "small",
+      options: "small",
+    },
+  ) => {
+    const picked: [CompanionSizeAxis, CompanionSize][] = [];
+    let hidden = false;
+    const items = companionContextMenuTemplate(current, {
+      setSize: (axis: CompanionSizeAxis, size: CompanionSize) => {
+        picked.push([axis, size]);
+      },
+      hide: () => {
+        hidden = true;
+      },
+    }) as MenuItem[];
+    return { items, picked, wasHidden: () => hidden };
+  };
+
+  test("offers the two axes under their own headings, then the way out", () => {
+    expect(build().items.map((item) => item.label ?? item.type)).toEqual([
+      "Avatar size",
+      "Options size",
+      "separator",
+      "Hide Companion",
+    ]);
+  });
+
+  test("offers every named step under each heading", () => {
+    for (const heading of build().items.slice(0, 2)) {
+      expect(heading.submenu?.map((item) => item.label)).toEqual([
+        "Small",
+        "Medium",
+        "Large",
+        "Huge",
+        "Ridiculous",
+      ]);
+      expect(heading.submenu?.every((item) => item.type === "radio")).toBe(
+        true,
+      );
+    }
+  });
+
+  /**
+   * The whole point of two menus: each one shows where its own axis is, and a
+   * user who has made the creature enormous and left the controls alone can see
+   * exactly that.
+   */
+  test("marks the step each axis is on, and only that one", () => {
+    const { items } = build({ avatar: "ridiculous", options: "medium" });
+    expect(
+      items[0]?.submenu?.filter((item) => item.checked).map((i) => i.label),
+    ).toEqual(["Ridiculous"]);
+    expect(
+      items[1]?.submenu?.filter((item) => item.checked).map((i) => i.label),
+    ).toEqual(["Medium"]);
+  });
+
+  test("a pick carries the axis it was made under", () => {
+    const menu = build();
+    menu.items[0]?.submenu?.[3]?.click?.();
+    menu.items[1]?.submenu?.[4]?.click?.();
+    expect(menu.picked).toEqual([
+      ["avatar", "huge"],
+      ["options", "ridiculous"],
+    ]);
+  });
+
+  test("the last item takes the surface away", () => {
+    const menu = build();
+    menu.items[3]?.click?.();
+    expect(menu.wasHidden()).toBe(true);
   });
 });
 
@@ -679,7 +941,7 @@ describe("geometryFor", () => {
  * the canvas, at whatever size.
  */
 describe("placing a larger companion", () => {
-  const LARGE = geometryFor("large");
+  const LARGE = geometryFor("large", "large");
 
   test("holds the avatar at the edges by its own box, not the canvas", () => {
     const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, LARGE);
@@ -715,6 +977,49 @@ describe("placing a larger companion", () => {
     expect(
       cardGrowthFor(WORK_AREA.y + LARGE.riseAbove - 1, WORK_AREA, LARGE),
     ).toBe("down");
+  });
+
+  /**
+   * The same rules with the two axes apart. The clamp binds on the creature,
+   * which is the avatar axis's answer, so an enormous pill beside a small
+   * creature must not hold that creature away from the edge, and an enormous
+   * creature beside a small pill must be held by its own whole box.
+   */
+  const BIG_CREATURE = geometryFor("huge", "small");
+  const BIG_OPTIONS = geometryFor("small", "huge");
+
+  test("holds a large creature at the edge by its own box", () => {
+    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, BIG_CREATURE);
+    expect(centreOf(placed, BIG_CREATURE).x).toBe(
+      WORK_AREA.x + WORK_AREA.width - BIG_CREATURE.avatarBox / 2,
+    );
+  });
+
+  test("lets a small creature reach the edge beside an enormous pill", () => {
+    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, BIG_OPTIONS);
+    expect(centreOf(placed, BIG_OPTIONS).x).toBe(
+      WORK_AREA.x + WORK_AREA.width - BIG_OPTIONS.avatarBox / 2,
+    );
+  });
+
+  test("never asks for an origin above the work area at either mix", () => {
+    for (const geometry of [BIG_CREATURE, BIG_OPTIONS]) {
+      for (const y of [-9000, 0, 25, 100, 400]) {
+        expect(
+          placeCanvas({ x: 700, y }, WORK_AREA, geometry).origin.y,
+        ).toBeGreaterThanOrEqual(WORK_AREA.y);
+      }
+    }
+  });
+
+  test("reaches the top, short by the near edge its own mix asks for", () => {
+    for (const geometry of [BIG_CREATURE, BIG_OPTIONS]) {
+      const centre = centreOf(
+        placeCanvas({ x: 700, y: -9000 }, WORK_AREA, geometry),
+        geometry,
+      );
+      expect(centre.y).toBe(WORK_AREA.y + geometry.dropBelow);
+    }
   });
 });
 

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -2,11 +2,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   COMPANION_BASE_AVATAR_BOX,
-  COMPANION_BASE_CARD_HEIGHT,
   COMPANION_SIZES,
   COMPANION_SIZE_BOXES,
   companionNearEdgeFor,
-  companionPadFor,
   companionScaleFor,
   type CompanionSize,
   type CompanionSizeAxis,
@@ -191,6 +189,7 @@ mock.module("@vellumai/electron-desktop/window-state", () => ({
   // load-time failure for the file rather than a failing case.
   readCompanionIntroSeen: () => true,
   writeCompanionIntroSeen: () => {},
+  promoteCompanionSizeToAxes: () => {},
 }));
 
 // Dynamic, so the mocks above are installed before the module graph loads:
@@ -285,13 +284,15 @@ const GEOMETRY = geometryFor("small", "small");
 const RISE_ABOVE = GEOMETRY.riseAbove;
 const DROP_BELOW = GEOMETRY.dropBelow;
 
+/** A creature far larger than the controls beside it, and the reverse. */
+const BIG_CREATURE = geometryFor("huge", "small");
+const BIG_OPTIONS = geometryFor("small", "huge");
+
 /**
- * The two parts of the base reach the geometry does not publish: the pill's
- * widest, and the room it hangs off the avatar by. Stated once here for the
- * cases that are about one of them rather than the sum.
+ * The part of the base reach the geometry does not publish: the pill's widest.
+ * Stated once here for the cases that are about it rather than the sum.
  */
 const MAX_PILL_WIDTH = 316;
-const GAP = 12;
 
 /**
  * The growth direction is the only rule in the companion window worth testing
@@ -339,7 +340,6 @@ describe("growthFor", () => {
    * pass with the pill's leading edge already off the display.
    */
   test("counts the gap and the half box as room the pill needs", () => {
-    expect(NEEDED).toBe(350);
     expect(growthFor(DISPLAY.width - MAX_PILL_WIDTH, DISPLAY, GEOMETRY)).toBe(
       "left",
     );
@@ -352,9 +352,7 @@ describe("growthFor", () => {
    * cuts the controls off.
    */
   test("flips when only the avatar's half box is missing on the right", () => {
-    const centre = DISPLAY.width - 340;
-    expect(DISPLAY.width - centre).toBeGreaterThan(GAP + MAX_PILL_WIDTH);
-    expect(growthFor(centre, DISPLAY, GEOMETRY)).toBe("left");
+    expect(growthFor(DISPLAY.width - 340, DISPLAY, GEOMETRY)).toBe("left");
   });
 
   test("measures against the display's own origin, not the screen's", () => {
@@ -636,15 +634,6 @@ describe("shouldShowCompanionSurface", () => {
  * nobody ever looked at.
  */
 describe("geometryFor", () => {
-  test("draws `small` at the size the renderer's layout is authored at", () => {
-    const small = geometryFor("small", "small");
-    expect(small.avatarBox).toBe(44);
-    expect(small.optionsBox).toBe(44);
-    expect(small.canvasWidth).toBe(748);
-    expect(small.canvasHeight).toBe(338);
-    expect(small.maxReach).toBe(350);
-  });
-
   /**
    * What the width is actually for: the avatar's half box, the gap the pill
    * hangs off it by, and the widest the pill draws, on both sides so main can
@@ -694,24 +683,6 @@ describe("geometryFor", () => {
         COMPANION_SIZE_BOXES.large,
       );
     }
-  });
-
-  /**
-   * With one size on both axes the surface is still one layout multiplied, so
-   * every length moves together. A canvas that scaled while the pill's reach
-   * did not would clip the controls; the reverse would swallow clicks over
-   * empty desktop.
-   */
-  test("scales every length by the same factor when the axes agree", () => {
-    const small = geometryFor("small", "small");
-    const large = geometryFor("large", "large");
-    const scale = large.avatarBox / small.avatarBox;
-    expect(scale).toBe(2);
-    expect(large.canvasWidth).toBe(small.canvasWidth * scale);
-    expect(large.canvasHeight).toBe(small.canvasHeight * scale);
-    expect(large.riseAbove).toBe(small.riseAbove * scale);
-    expect(large.dropBelow).toBe(small.dropBelow * scale);
-    expect(large.maxReach).toBe(small.maxReach * scale);
   });
 
   /**
@@ -780,52 +751,11 @@ describe("geometryFor", () => {
  * Both sides of the avatar are sized for whichever card direction needs more,
  * so main can still flip the direction by moving the window rather than
  * rebuilding it. The cost is a few transparent points of slack in the direction
- * that needed less, and what these cases hold is that the slack is never
- * negative: a side short by a point clips the pill or the card.
+ * that needed less, which is what the stated canvases carry: a side short by a
+ * point clips the pill or the card.
  */
 describe("geometryFor with the two axes apart", () => {
-  /** A creature far larger than the controls beside it, and the reverse. */
-  const BIG_CREATURE = geometryFor("huge", "small");
-  const BIG_OPTIONS = geometryFor("small", "huge");
   const MIXED = [BIG_CREATURE, BIG_OPTIONS];
-
-  /**
-   * The near edge answers for both card directions at once. Growing up, the
-   * lowest thing drawn is the creature's own bottom; growing down, the pill
-   * stands on that same line and its top reaches a whole options box back up
-   * past it, over the head of a smaller creature.
-   */
-  test("clears the creature's bottom and the pill's top alike", () => {
-    for (const geometry of MIXED) {
-      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
-      expect(
-        geometry.dropBelow - geometry.avatarBox / 2,
-      ).toBeGreaterThanOrEqual(pad);
-      expect(
-        geometry.dropBelow + geometry.avatarBox / 2 - geometry.optionsBox,
-      ).toBeGreaterThanOrEqual(pad);
-    }
-  });
-
-  /**
-   * The far side, the same way. The card stands on the creature's bottom line
-   * and rises its whole height growing up; growing down its composer row holds
-   * that line and the rest of it falls away below.
-   */
-  test("clears the card in whichever direction it grows", () => {
-    for (const geometry of MIXED) {
-      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
-      const cardHeight =
-        COMPANION_BASE_CARD_HEIGHT * companionScaleFor(geometry.optionsBox);
-      expect(
-        geometry.riseAbove - (cardHeight - geometry.avatarBox / 2),
-      ).toBeGreaterThanOrEqual(pad);
-      expect(
-        geometry.riseAbove -
-          (geometry.avatarBox / 2 + cardHeight - geometry.optionsBox),
-      ).toBeGreaterThanOrEqual(pad);
-    }
-  });
 
   test("spends the whole canvas on the two sides of the avatar", () => {
     for (const geometry of MIXED) {
@@ -838,22 +768,38 @@ describe("geometryFor with the two axes apart", () => {
   });
 
   /**
-   * The reach at each mix, which is also where the gap rule shows. The gap is
-   * breathing room, so the smaller of the two boxes decides how much of it
-   * there is: the creature below takes the base gap rather than the chasm its
-   * own scale would ask for, which would put its reach at 401.
+   * Each mix as the canvas it comes to rather than as the formula repeated,
+   * since a formula restated here would pass against any change to the formula
+   * it restates.
+   *
+   * The width is where the gap rule shows: the gap is breathing room, so the
+   * smaller of the two boxes decides how much of it there is, and the creature
+   * below takes the base gap rather than the chasm its own scale would ask for,
+   * which would put its reach at 401. The two heights are the two sides of the
+   * avatar: the near edge clears the creature's bottom and the pill's top
+   * alike, and the far edge clears the card growing either way.
    */
-  test("still holds the pill's reach on both sides of the avatar", () => {
+  test("holds the pill, the card and the creature at each mix", () => {
     // An enormous creature's half box, the base gap, and a base-width pill.
-    expect({
-      maxReach: BIG_CREATURE.maxReach,
-      canvasWidth: BIG_CREATURE.canvasWidth,
-    }).toEqual({ maxReach: 383, canvasWidth: 886 });
+    expect(BIG_CREATURE).toEqual({
+      avatarBox: 110,
+      optionsBox: 44,
+      maxReach: 383,
+      canvasWidth: 886,
+      riseAbove: 361,
+      dropBelow: 115,
+      canvasHeight: 476,
+    });
     // A base half box, the same gap, and a pill two and a half times as wide.
-    expect({
-      maxReach: BIG_OPTIONS.maxReach,
-      canvasWidth: BIG_OPTIONS.canvasWidth,
-    }).toEqual({ maxReach: 824, canvasWidth: 1768 });
+    expect(BIG_OPTIONS).toEqual({
+      avatarBox: 44,
+      optionsBox: 110,
+      maxReach: 824,
+      canvasWidth: 1768,
+      riseAbove: 763,
+      dropBelow: 148,
+      canvasHeight: 911,
+    });
   });
 
   test("flips the pill at the reach the options size asks for", () => {
@@ -896,9 +842,7 @@ describe("companionContextMenuTemplate", () => {
   type MenuItem = {
     label?: string;
     type?: string;
-    checked?: boolean;
     click?: () => void;
-    submenu?: MenuItem[];
   };
 
   const build = (
@@ -917,13 +861,12 @@ describe("companionContextMenuTemplate", () => {
     return { items, wasHidden: () => hidden };
   };
 
-  test("offers the two axes under their own headings, then the way out", () => {
-    expect(build().items.map((item) => item.label ?? item.type)).toEqual([
-      "Avatar size",
-      "Options size",
-      "separator",
-      "Hide Companion",
-    ]);
+  test("closes with a separator and the way out, past the headings", () => {
+    expect(
+      build()
+        .items.map((item) => item.label ?? item.type)
+        .slice(2),
+    ).toEqual(["separator", "Hide Companion"]);
   });
 
   /**
@@ -956,16 +899,30 @@ describe("companionContextMenuTemplate", () => {
 describe("placing a larger companion", () => {
   const LARGE = geometryFor("large", "large");
 
+  /**
+   * One size on both axes, then the two mixes. The clamp binds on the creature,
+   * which is the avatar axis's answer, so an enormous pill beside a small
+   * creature must not hold that creature away from the edge, and an enormous
+   * creature beside a small pill must be held by its own whole box.
+   */
+  const SIZED = [LARGE, BIG_CREATURE, BIG_OPTIONS];
+
   test("holds the avatar at the edges by its own box, not the canvas", () => {
-    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, LARGE);
-    expect(centreOf(placed, LARGE).x).toBe(1440 - LARGE.avatarBox / 2);
+    for (const geometry of SIZED) {
+      const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, geometry);
+      expect(centreOf(placed, geometry).x).toBe(
+        WORK_AREA.x + WORK_AREA.width - geometry.avatarBox / 2,
+      );
+    }
   });
 
   test("still never asks for an origin above the work area", () => {
-    for (const y of [-9000, 0, 25, 100, 400]) {
-      expect(
-        placeCanvas({ x: 700, y }, WORK_AREA, LARGE).origin.y,
-      ).toBeGreaterThanOrEqual(WORK_AREA.y);
+    for (const geometry of SIZED) {
+      for (const y of [-9000, 0, 25, 100, 400]) {
+        expect(
+          placeCanvas({ x: 700, y }, WORK_AREA, geometry).origin.y,
+        ).toBeGreaterThanOrEqual(WORK_AREA.y);
+      }
     }
   });
 
@@ -974,13 +931,15 @@ describe("placing a larger companion", () => {
    * else. Bigger is a worse ceiling than `small` and still nothing like the
    * canvas half-height the bug was.
    */
-  test("reaches the top, short by its own scaled shadow", () => {
-    const centre = centreOf(
-      placeCanvas({ x: 700, y: -9000 }, WORK_AREA, LARGE),
-      LARGE,
-    );
-    expect(centre.y).toBe(WORK_AREA.y + LARGE.dropBelow);
-    expect(centre.y).toBeLessThan(WORK_AREA.y + LARGE.riseAbove);
+  test("reaches the top, short by the near edge its own canvas asks for", () => {
+    for (const geometry of SIZED) {
+      const centre = centreOf(
+        placeCanvas({ x: 700, y: -9000 }, WORK_AREA, geometry),
+        geometry,
+      );
+      expect(centre.y).toBe(WORK_AREA.y + geometry.dropBelow);
+      expect(centre.y).toBeLessThan(WORK_AREA.y + geometry.riseAbove);
+    }
   });
 
   test("flips the card at its own threshold, not the small one", () => {
@@ -990,49 +949,6 @@ describe("placing a larger companion", () => {
     expect(
       cardGrowthFor(WORK_AREA.y + LARGE.riseAbove - 1, WORK_AREA, LARGE),
     ).toBe("down");
-  });
-
-  /**
-   * The same rules with the two axes apart. The clamp binds on the creature,
-   * which is the avatar axis's answer, so an enormous pill beside a small
-   * creature must not hold that creature away from the edge, and an enormous
-   * creature beside a small pill must be held by its own whole box.
-   */
-  const BIG_CREATURE = geometryFor("huge", "small");
-  const BIG_OPTIONS = geometryFor("small", "huge");
-
-  test("holds a large creature at the edge by its own box", () => {
-    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, BIG_CREATURE);
-    expect(centreOf(placed, BIG_CREATURE).x).toBe(
-      WORK_AREA.x + WORK_AREA.width - BIG_CREATURE.avatarBox / 2,
-    );
-  });
-
-  test("lets a small creature reach the edge beside an enormous pill", () => {
-    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, BIG_OPTIONS);
-    expect(centreOf(placed, BIG_OPTIONS).x).toBe(
-      WORK_AREA.x + WORK_AREA.width - BIG_OPTIONS.avatarBox / 2,
-    );
-  });
-
-  test("never asks for an origin above the work area at either mix", () => {
-    for (const geometry of [BIG_CREATURE, BIG_OPTIONS]) {
-      for (const y of [-9000, 0, 25, 100, 400]) {
-        expect(
-          placeCanvas({ x: 700, y }, WORK_AREA, geometry).origin.y,
-        ).toBeGreaterThanOrEqual(WORK_AREA.y);
-      }
-    }
-  });
-
-  test("reaches the top, short by the near edge its own mix asks for", () => {
-    for (const geometry of [BIG_CREATURE, BIG_OPTIONS]) {
-      const centre = centreOf(
-        placeCanvas({ x: 700, y: -9000 }, WORK_AREA, geometry),
-        geometry,
-      );
-      expect(centre.y).toBe(WORK_AREA.y + geometry.dropBelow);
-    }
   });
 });
 
@@ -1053,9 +969,6 @@ describe("setCompanionSurfaceSize", () => {
    */
   const CENTRE = { x: 722, y: 800 };
 
-  /** The canvas an options pick of `huge` builds, beside `small`'s 748x338. */
-  const HUGE_OPTIONS = { canvasWidth: 1768, canvasHeight: 911, riseAbove: 763 };
-
   test("rebuilds the canvas around the avatar rather than the origin", () => {
     // Parked by the path a drag takes. The first delta runs past every edge, so
     // it lands on a clamp whatever the window was doing beforehand; the second
@@ -1074,14 +987,14 @@ describe("setCompanionSurfaceSize", () => {
     expect(boundsSet).toHaveLength(1);
     const bounds = boundsSet[0];
     expect({ width: bounds?.width, height: bounds?.height }).toEqual({
-      width: HUGE_OPTIONS.canvasWidth,
-      height: HUGE_OPTIONS.canvasHeight,
+      width: BIG_OPTIONS.canvasWidth,
+      height: BIG_OPTIONS.canvasHeight,
     });
     // The avatar read back out of the new canvas the way main reads it: half
     // the width across, and the offset the card's direction asks for down.
     expect({
-      x: (bounds?.x ?? 0) + HUGE_OPTIONS.canvasWidth / 2,
-      y: (bounds?.y ?? 0) + HUGE_OPTIONS.riseAbove,
+      x: (bounds?.x ?? 0) + BIG_OPTIONS.canvasWidth / 2,
+      y: (bounds?.y ?? 0) + BIG_OPTIONS.riseAbove,
     }).toEqual(CENTRE);
   });
 

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -2,12 +2,10 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   COMPANION_BASE_AVATAR_BOX,
-  COMPANION_BASE_CANVAS_PAD,
   COMPANION_BASE_CARD_HEIGHT,
-  COMPANION_NEAR_EDGE,
   COMPANION_SIZES,
   COMPANION_SIZE_BOXES,
-  companionGapFor,
+  companionNearEdgeFor,
   companionPadFor,
   companionScaleFor,
   type CompanionSize,
@@ -15,6 +13,7 @@ import {
   type CompanionSurfaceState,
   type VellumCommand,
 } from "@vellumai/ipc-contract";
+import { companionSizeSubmenus } from "@vellumai/electron-desktop/companion-menu";
 
 // The module under test reaches `main-window.ts` to hand Talk to the renderer
 // that owns the live-voice session, and that chain loads `electron-store`, a
@@ -48,6 +47,12 @@ let windowsRaised = 0;
 /** Whether the app's window exists, which is what decides between those two. */
 let mainWindowOpen = true;
 
+/** Where the canvas's origin is, which is what the window reports and moves. */
+let origin = { x: 0, y: 0 };
+
+/** Every bounds main has asked the window server for, most recent last. */
+const boundsSet: { x: number; y: number; width: number; height: number }[] = [];
+
 const surface = {
   webContents: {
     send: (_channel: string, state: CompanionSurfaceState) => {
@@ -59,6 +64,20 @@ const surface = {
   // only has to be callable.
   close: () => {},
   on: () => {},
+  isDestroyed: () => false,
+  getPosition: () => [origin.x, origin.y],
+  setPosition: (x: number, y: number) => {
+    origin = { x, y };
+  },
+  setBounds: (bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }) => {
+    boundsSet.push(bounds);
+    origin = { x: bounds.x, y: bounds.y };
+  },
 };
 
 type Invoker = (args: unknown[]) => unknown;
@@ -148,10 +167,24 @@ mock.module("@vellumai/electron-desktop/settings", () => ({
   },
 }));
 
+/**
+ * The size the store holds for each axis.
+ *
+ * A record rather than one answer for both, because the two axes are read and
+ * written separately and a mock that ignored the axis would let a resize apply
+ * a pick to the wrong half of the surface without failing anything.
+ */
+const sizes: Record<CompanionSizeAxis, CompanionSize> = {
+  avatar: "small",
+  options: "small",
+};
+
 mock.module("@vellumai/electron-desktop/window-state", () => ({
-  readCompanionSize: () => "small",
+  readCompanionSize: (axis: CompanionSizeAxis) => sizes[axis],
   readCompanionHidden: () => false,
-  writeCompanionSize: () => {},
+  writeCompanionSize: (axis: CompanionSizeAxis, size: CompanionSize) => {
+    sizes[axis] = size;
+  },
   writeCompanionHidden: () => {},
   // Stubbed rather than omitted, like every other export here: the module
   // under test imports these, and one missing from a whole-module mock is a
@@ -171,11 +204,24 @@ const {
   placeCanvas,
   callOnUpdate,
   introOnAdvance,
+  setCompanionSurfaceSize,
   shouldShowCompanionSurface,
   installCompanionWindow,
 } = await import("./companion-window");
 
 installCompanionWindow();
+
+/**
+ * The module holds the canvas it was last asked for, so a case that picks a
+ * size leaves it there. Put both axes back and forget the window's position.
+ */
+beforeEach(() => {
+  sizes.avatar = "small";
+  sizes.options = "small";
+  setCompanionSurfaceSize("avatar", "small");
+  origin = { x: 0, y: 0 };
+  boundsSet.length = 0;
+});
 
 /** Put a set of evaluated flags in settings and tell main they changed. */
 const setFlags = (next: Record<string, boolean>): void => {
@@ -236,9 +282,16 @@ const START = {
  * scaled, which `geometryFor` has its own cases for.
  */
 const GEOMETRY = geometryFor("small", "small");
-const CANVAS_WIDTH = GEOMETRY.canvasWidth;
 const RISE_ABOVE = GEOMETRY.riseAbove;
 const DROP_BELOW = GEOMETRY.dropBelow;
+
+/**
+ * The two parts of the base reach the geometry does not publish: the pill's
+ * widest, and the room it hangs off the avatar by. Stated once here for the
+ * cases that are about one of them rather than the sum.
+ */
+const MAX_PILL_WIDTH = 316;
+const GAP = 12;
 
 /**
  * The growth direction is the only rule in the companion window worth testing
@@ -286,12 +339,10 @@ describe("growthFor", () => {
    * pass with the pill's leading edge already off the display.
    */
   test("counts the gap and the half box as room the pill needs", () => {
-    expect(NEEDED).toBe(
-      GEOMETRY.avatarBox / 2 + GEOMETRY.gap + GEOMETRY.maxBodyWidth,
+    expect(NEEDED).toBe(350);
+    expect(growthFor(DISPLAY.width - MAX_PILL_WIDTH, DISPLAY, GEOMETRY)).toBe(
+      "left",
     );
-    expect(
-      growthFor(DISPLAY.width - GEOMETRY.maxBodyWidth, DISPLAY, GEOMETRY),
-    ).toBe("left");
   });
 
   /**
@@ -302,9 +353,7 @@ describe("growthFor", () => {
    */
   test("flips when only the avatar's half box is missing on the right", () => {
     const centre = DISPLAY.width - 340;
-    expect(DISPLAY.width - centre).toBeGreaterThan(
-      GEOMETRY.gap + GEOMETRY.maxBodyWidth,
-    );
+    expect(DISPLAY.width - centre).toBeGreaterThan(GAP + MAX_PILL_WIDTH);
     expect(growthFor(centre, DISPLAY, GEOMETRY)).toBe("left");
   });
 
@@ -598,30 +647,27 @@ describe("geometryFor", () => {
 
   /**
    * What the width is actually for: the avatar's half box, the gap the pill
-   * hangs off it by, and the widest body, on both sides so main can flip the
-   * direction without resizing the window, plus the shadow's room.
+   * hangs off it by, and the widest the pill draws, on both sides so main can
+   * flip the direction without resizing the window, plus the shadow's room.
+   *
+   * Stated as the numbers each step comes to rather than as the sum again. Each
+   * one is a canvas that was looked at, and a formula repeated here would pass
+   * against any change to the formula it repeats.
    */
   test("holds the pill's whole reach on both sides of the avatar", () => {
+    const canvases: Record<
+      CompanionSize,
+      { maxReach: number; canvasWidth: number; canvasHeight: number }
+    > = {
+      small: { maxReach: 350, canvasWidth: 748, canvasHeight: 338 },
+      medium: { maxReach: 525, canvasWidth: 1122, canvasHeight: 507 },
+      large: { maxReach: 700, canvasWidth: 1496, canvasHeight: 676 },
+      huge: { maxReach: 875, canvasWidth: 1870, canvasHeight: 845 },
+      ridiculous: { maxReach: 1750, canvasWidth: 3740, canvasHeight: 1690 },
+    };
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size, size);
-      const pad =
-        (COMPANION_BASE_CANVAS_PAD * geometry.avatarBox) /
-        COMPANION_BASE_AVATAR_BOX;
-      expect(geometry.maxReach).toBe(
-        geometry.avatarBox / 2 + geometry.gap + geometry.maxBodyWidth,
-      );
-      expect(geometry.canvasWidth).toBe(
-        Math.round(2 * (geometry.maxReach + pad)),
-      );
-    }
-  });
-
-  test("takes the gap from the contract rather than a copy of it", () => {
-    for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size, size);
-      expect(geometry.gap).toBe(
-        companionGapFor(geometry.avatarBox, geometry.avatarBox),
-      );
+      const { maxReach, canvasWidth, canvasHeight } = geometryFor(size, size);
+      expect({ maxReach, canvasWidth, canvasHeight }).toEqual(canvases[size]);
     }
   });
 
@@ -639,15 +685,13 @@ describe("geometryFor", () => {
   });
 
   /**
-   * Everything beside the creature is the options axis's answer: the pill's box
-   * and the widest body it draws, which is what the canvas's width is spent on.
+   * Everything beside the creature is the options axis's answer, starting with
+   * the pill's own box.
    */
-  test("takes the pill's box and its widest body from the options axis alone", () => {
+  test("takes the pill's box from the options axis alone", () => {
     for (const avatar of COMPANION_SIZES) {
-      const geometry = geometryFor(avatar, "large");
-      expect(geometry.optionsBox).toBe(COMPANION_SIZE_BOXES.large);
-      expect(geometry.maxBodyWidth).toBe(
-        geometryFor("large", "large").maxBodyWidth,
+      expect(geometryFor(avatar, "large").optionsBox).toBe(
+        COMPANION_SIZE_BOXES.large,
       );
     }
   });
@@ -667,8 +711,6 @@ describe("geometryFor", () => {
     expect(large.canvasHeight).toBe(small.canvasHeight * scale);
     expect(large.riseAbove).toBe(small.riseAbove * scale);
     expect(large.dropBelow).toBe(small.dropBelow * scale);
-    expect(large.gap).toBe(small.gap * scale);
-    expect(large.maxBodyWidth).toBe(small.maxBodyWidth * scale);
     expect(large.maxReach).toBe(small.maxReach * scale);
   });
 
@@ -678,15 +720,19 @@ describe("geometryFor", () => {
    * geometry to keep in step.
    */
   test("reduces to the single-scale canvas when the axes agree", () => {
+    // The two sides at the base size, which the whole layout is authored
+    // around: the creature and its shadow below, the card's height above.
+    expect(
+      companionNearEdgeFor(
+        COMPANION_BASE_AVATAR_BOX,
+        COMPANION_BASE_AVATAR_BOX,
+      ),
+    ).toBe(46);
     for (const size of COMPANION_SIZES) {
       const geometry = geometryFor(size, size);
       const scale = companionScaleFor(geometry.avatarBox);
-      expect(geometry.dropBelow).toBe(COMPANION_NEAR_EDGE * scale);
-      expect(geometry.riseAbove).toBe(
-        COMPANION_BASE_CARD_HEIGHT * scale -
-          geometry.avatarBox / 2 +
-          COMPANION_BASE_CANVAS_PAD * scale,
-      );
+      expect(geometry.dropBelow).toBe(46 * scale);
+      expect(geometry.riseAbove).toBe(292 * scale);
     }
   });
 
@@ -791,26 +837,23 @@ describe("geometryFor with the two axes apart", () => {
     }
   });
 
-  test("still holds the pill's reach on both sides of the avatar", () => {
-    for (const geometry of MIXED) {
-      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
-      expect(geometry.maxReach).toBe(
-        geometry.avatarBox / 2 + geometry.gap + geometry.maxBodyWidth,
-      );
-      expect(geometry.canvasWidth).toBe(
-        Math.round(2 * (geometry.maxReach + pad)),
-      );
-    }
-  });
-
   /**
-   * The gap is breathing room, so the smaller of the two decides how much of it
-   * there is: a modest creature beside an enormous pill wants the creature's
-   * clearance rather than the chasm the pill's own scale would ask for.
+   * The reach at each mix, which is also where the gap rule shows. The gap is
+   * breathing room, so the smaller of the two boxes decides how much of it
+   * there is: the creature below takes the base gap rather than the chasm its
+   * own scale would ask for, which would put its reach at 401.
    */
-  test("takes the gap from the smaller of the two", () => {
-    expect(BIG_CREATURE.gap).toBe(geometryFor("small", "small").gap);
-    expect(BIG_OPTIONS.gap).toBe(BIG_CREATURE.gap);
+  test("still holds the pill's reach on both sides of the avatar", () => {
+    // An enormous creature's half box, the base gap, and a base-width pill.
+    expect({
+      maxReach: BIG_CREATURE.maxReach,
+      canvasWidth: BIG_CREATURE.canvasWidth,
+    }).toEqual({ maxReach: 383, canvasWidth: 886 });
+    // A base half box, the same gap, and a pill two and a half times as wide.
+    expect({
+      maxReach: BIG_OPTIONS.maxReach,
+      canvasWidth: BIG_OPTIONS.canvasWidth,
+    }).toEqual({ maxReach: 824, canvasWidth: 1768 });
   });
 
   test("flips the pill at the reach the options size asks for", () => {
@@ -844,11 +887,12 @@ describe("geometryFor with the two axes apart", () => {
  * making it go away.
  *
  * The template rather than the menu: a menu is a native window, and what is
- * worth stating is the wording, which step each axis is marked on, and that a
- * press names the axis it was made under.
+ * worth stating is what this menu adds to the size pickers it shares with the
+ * tray, which is where they sit and the item that takes the surface away. The
+ * pickers themselves have their own suite in `companion-menu.test.ts`.
  */
 describe("companionContextMenuTemplate", () => {
-  /** Only what a menu item is read for here, as `tray-model.test.ts` has it. */
+  /** Only what a menu item is read for here. */
   type MenuItem = {
     label?: string;
     type?: string;
@@ -863,17 +907,14 @@ describe("companionContextMenuTemplate", () => {
       options: "small",
     },
   ) => {
-    const picked: [CompanionSizeAxis, CompanionSize][] = [];
     let hidden = false;
     const items = companionContextMenuTemplate(current, {
-      setSize: (axis: CompanionSizeAxis, size: CompanionSize) => {
-        picked.push([axis, size]);
-      },
+      setSize: () => {},
       hide: () => {
         hidden = true;
       },
     }) as MenuItem[];
-    return { items, picked, wasHidden: () => hidden };
+    return { items, wasHidden: () => hidden };
   };
 
   test("offers the two axes under their own headings, then the way out", () => {
@@ -885,44 +926,16 @@ describe("companionContextMenuTemplate", () => {
     ]);
   });
 
-  test("offers every named step under each heading", () => {
-    for (const heading of build().items.slice(0, 2)) {
-      expect(heading.submenu?.map((item) => item.label)).toEqual([
-        "Small",
-        "Medium",
-        "Large",
-        "Huge",
-        "Ridiculous",
-      ]);
-      expect(heading.submenu?.every((item) => item.type === "radio")).toBe(
-        true,
-      );
-    }
-  });
-
   /**
-   * The whole point of two menus: each one shows where its own axis is, and a
-   * user who has made the creature enormous and left the controls alone can see
-   * exactly that.
+   * The headings are the shared builder's output rather than a second set of
+   * items, so the surface's menu and the tray's cannot describe the same choice
+   * differently. Compared as data, since the clicks are closures.
    */
-  test("marks the step each axis is on, and only that one", () => {
-    const { items } = build({ avatar: "ridiculous", options: "medium" });
-    expect(
-      items[0]?.submenu?.filter((item) => item.checked).map((i) => i.label),
-    ).toEqual(["Ridiculous"]);
-    expect(
-      items[1]?.submenu?.filter((item) => item.checked).map((i) => i.label),
-    ).toEqual(["Medium"]);
-  });
-
-  test("a pick carries the axis it was made under", () => {
-    const menu = build();
-    menu.items[0]?.submenu?.[3]?.click?.();
-    menu.items[1]?.submenu?.[4]?.click?.();
-    expect(menu.picked).toEqual([
-      ["avatar", "huge"],
-      ["options", "ridiculous"],
-    ]);
+  test("draws its two headings from the builder the tray reads", () => {
+    const current = { avatar: "ridiculous", options: "medium" } as const;
+    expect(JSON.stringify(build(current).items.slice(0, 2))).toBe(
+      JSON.stringify(companionSizeSubmenus(current, () => {})),
+    );
   });
 
   test("the last item takes the surface away", () => {
@@ -1020,6 +1033,61 @@ describe("placing a larger companion", () => {
       );
       expect(centre.y).toBe(WORK_AREA.y + geometry.dropBelow);
     }
+  });
+});
+
+/**
+ * A size pick, which is the one moment the canvas is rebuilt.
+ *
+ * What has to survive it is the avatar, not the window. They are not the same
+ * point and the difference is most of the canvas, so a rebuild that kept the
+ * origin would slide the creature by the change in its offset and walk the
+ * thing the user was enlarging off across the desktop.
+ */
+describe("setCompanionSurfaceSize", () => {
+  /**
+   * Where the avatar is parked for the pick: low enough on the display that the
+   * card grows upward at both sizes, and far enough from either side that
+   * nothing is clamped. So the only thing that can move the creature is the
+   * resize itself.
+   */
+  const CENTRE = { x: 722, y: 800 };
+
+  /** The canvas an options pick of `huge` builds, beside `small`'s 748x338. */
+  const HUGE_OPTIONS = { canvasWidth: 1768, canvasHeight: 911, riseAbove: 763 };
+
+  test("rebuilds the canvas around the avatar rather than the origin", () => {
+    // Parked by the path a drag takes. The first delta runs past every edge, so
+    // it lands on a clamp whatever the window was doing beforehand; the second
+    // puts the avatar on `CENTRE`.
+    send("vellum:companion:moveBy", -100000, -100000);
+    send("vellum:companion:moveBy", 700, 754);
+    expect({
+      x: origin.x + GEOMETRY.canvasWidth / 2,
+      y: origin.y + RISE_ABOVE,
+    }).toEqual(CENTRE);
+
+    setCompanionSurfaceSize("options", "huge");
+
+    // One call rather than a size and then a position: two would put the window
+    // at the new size in the old place for a frame.
+    expect(boundsSet).toHaveLength(1);
+    const bounds = boundsSet[0];
+    expect({ width: bounds?.width, height: bounds?.height }).toEqual({
+      width: HUGE_OPTIONS.canvasWidth,
+      height: HUGE_OPTIONS.canvasHeight,
+    });
+    // The avatar read back out of the new canvas the way main reads it: half
+    // the width across, and the offset the card's direction asks for down.
+    expect({
+      x: (bounds?.x ?? 0) + HUGE_OPTIONS.canvasWidth / 2,
+      y: (bounds?.y ?? 0) + HUGE_OPTIONS.riseAbove,
+    }).toEqual(CENTRE);
+  });
+
+  test("leaves the other axis where it was", () => {
+    setCompanionSurfaceSize("options", "huge");
+    expect(sizes).toEqual({ avatar: "small", options: "huge" });
   });
 });
 

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_CANVAS_PAD,
   COMPANION_SIZES,
+  companionGapFor,
   type CompanionSurfaceState,
   type VellumCommand,
 } from "@vellumai/ipc-contract";
@@ -220,6 +223,16 @@ const START = {
 } as const;
 
 /**
+ * The size the placement cases are written against, which is the one the
+ * renderer's layout is authored at. Every other size is the same arithmetic
+ * scaled, which `geometryFor` has its own cases for.
+ */
+const GEOMETRY = geometryFor("small");
+const CANVAS_WIDTH = GEOMETRY.canvasWidth;
+const RISE_ABOVE = GEOMETRY.riseAbove;
+const DROP_BELOW = GEOMETRY.dropBelow;
+
+/**
  * The growth direction is the only rule in the companion window worth testing
  * without a window server: everything else is Electron plumbing. It decides
  * which way the pill unfurls out of the avatar, and getting it wrong runs the
@@ -230,8 +243,10 @@ const START = {
 // cases readable.
 const DISPLAY = { x: 0, width: 1440 };
 
-// 360 - 44: the clearance the body needs on the side it grows into.
-const NEEDED = 316;
+// The clearance the pill needs on the side it grows into, measured from the
+// avatar's centre the way the room on each side is: the avatar's half box, the
+// gap, then the widest body.
+const NEEDED = GEOMETRY.maxReach;
 
 describe("growthFor", () => {
   test("grows rightward with room to the right", () => {
@@ -255,6 +270,34 @@ describe("growthFor", () => {
     expect(growthFor(DISPLAY.width - NEEDED + 1, DISPLAY, GEOMETRY)).toBe(
       "left",
     );
+  });
+
+  /**
+   * The gap and the avatar's half box are part of the clearance, not slack the
+   * pill can be squeezed into. A test measured against the body alone would
+   * pass with the pill's leading edge already off the display.
+   */
+  test("counts the gap and the half box as room the pill needs", () => {
+    expect(NEEDED).toBe(
+      GEOMETRY.avatarBox / 2 + GEOMETRY.gap + GEOMETRY.maxBodyWidth,
+    );
+    expect(
+      growthFor(DISPLAY.width - GEOMETRY.maxBodyWidth, DISPLAY, GEOMETRY),
+    ).toBe("left");
+  });
+
+  /**
+   * The room is measured from the avatar's centre while the pill starts at the
+   * avatar's edge, so the half box is the difference between fitting and
+   * clipping. 340pt on the right clears the gap and the widest body and still
+   * cuts the controls off.
+   */
+  test("flips when only the avatar's half box is missing on the right", () => {
+    const centre = DISPLAY.width - 340;
+    expect(DISPLAY.width - centre).toBeGreaterThan(
+      GEOMETRY.gap + GEOMETRY.maxBodyWidth,
+    );
+    expect(growthFor(centre, DISPLAY, GEOMETRY)).toBe("left");
   });
 
   test("measures against the display's own origin, not the screen's", () => {
@@ -284,16 +327,6 @@ describe("growthFor", () => {
  * somewhere the user can reach. A surface pushed off the display cannot be
  * dragged back, because there is nothing left on screen to grab.
  */
-
-/**
- * The size the placement cases are written against, which is the one the
- * renderer's layout is authored at. Every other size is the same arithmetic
- * scaled, which `geometryFor` has its own cases for.
- */
-const GEOMETRY = geometryFor("small");
-const CANVAS_WIDTH = GEOMETRY.canvasWidth;
-const RISE_ABOVE = GEOMETRY.riseAbove;
-const DROP_BELOW = GEOMETRY.dropBelow;
 
 /** A 1440x900 display with the menu bar taken off the top. */
 const WORK_AREA = { x: 0, y: 25, width: 1440, height: 875 };
@@ -549,8 +582,38 @@ describe("geometryFor", () => {
   test("draws `small` at the size the renderer's layout is authored at", () => {
     const small = geometryFor("small");
     expect(small.avatarBox).toBe(44);
-    expect(small.canvasWidth).toBe(724);
+    expect(small.canvasWidth).toBe(748);
     expect(small.canvasHeight).toBe(338);
+    expect(small.maxReach).toBe(350);
+  });
+
+  /**
+   * What the width is actually for: the avatar's half box, the gap the pill
+   * hangs off it by, and the widest body, on both sides so main can flip the
+   * direction without resizing the window, plus the shadow's room.
+   */
+  test("holds the pill's whole reach on both sides of the avatar", () => {
+    for (const size of COMPANION_SIZES) {
+      const geometry = geometryFor(size);
+      const pad =
+        (COMPANION_BASE_CANVAS_PAD * geometry.avatarBox) /
+        COMPANION_BASE_AVATAR_BOX;
+      expect(geometry.maxReach).toBe(
+        geometry.avatarBox / 2 + geometry.gap + geometry.maxBodyWidth,
+      );
+      expect(geometry.canvasWidth).toBe(
+        Math.round(2 * (geometry.maxReach + pad)),
+      );
+    }
+  });
+
+  test("takes the gap from the contract rather than a copy of it", () => {
+    for (const size of COMPANION_SIZES) {
+      const geometry = geometryFor(size);
+      expect(geometry.gap).toBe(
+        companionGapFor(geometry.avatarBox, geometry.avatarBox),
+      );
+    }
   });
 
   /**
@@ -567,7 +630,9 @@ describe("geometryFor", () => {
     expect(large.canvasHeight).toBe(small.canvasHeight * scale);
     expect(large.riseAbove).toBe(small.riseAbove * scale);
     expect(large.dropBelow).toBe(small.dropBelow * scale);
-    expect(large.maxPillWidth).toBe(small.maxPillWidth * scale);
+    expect(large.gap).toBe(small.gap * scale);
+    expect(large.maxBodyWidth).toBe(small.maxBodyWidth * scale);
+    expect(large.maxReach).toBe(small.maxReach * scale);
   });
 
   test("grows monotonically through the named steps", () => {

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
   COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_MAX_PILL_WIDTH,
   COMPANION_SIZES,
   COMPANION_SIZE_BOXES,
   companionNearEdgeFor,
@@ -189,7 +190,6 @@ mock.module("@vellumai/electron-desktop/window-state", () => ({
   // load-time failure for the file rather than a failing case.
   readCompanionIntroSeen: () => true,
   writeCompanionIntroSeen: () => {},
-  promoteCompanionSizeToAxes: () => {},
 }));
 
 // Dynamic, so the mocks above are installed before the module graph loads:
@@ -290,9 +290,9 @@ const BIG_OPTIONS = geometryFor("small", "huge");
 
 /**
  * The part of the base reach the geometry does not publish: the pill's widest.
- * Stated once here for the cases that are about it rather than the sum.
+ * Bound to the contract for the cases that are about it rather than the sum.
  */
-const MAX_PILL_WIDTH = 316;
+const MAX_PILL_WIDTH = COMPANION_BASE_MAX_PILL_WIDTH;
 
 /**
  * The growth direction is the only rule in the companion window worth testing

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -39,6 +39,7 @@ import {
   readSetting,
 } from "@vellumai/electron-desktop/settings";
 import {
+  promoteCompanionSizeToAxes,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
@@ -228,6 +229,12 @@ let growth: CompanionGrowth = "right";
  * it to draw the avatar where the window was actually put.
  */
 let cardGrowth: CompanionCardGrowth = "up";
+
+// Module init is the first thing to ask the store for the surface's geometry,
+// so it is where an install carrying only the single size a one-axis build
+// writes has that size copied onto both per-axis keys. Once, ahead of the reads
+// below, and never again for the life of the process.
+promoteCompanionSizeToAxes();
 
 /**
  * The canvas the surface is currently drawn in.

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -12,6 +12,7 @@ import {
   voiceActivityContentSchema,
   voiceActivityControlSchema,
   voiceActivityStartSchema,
+  COMPANION_BASE_MAX_PILL_WIDTH,
   COMPANION_INTRO_ACTIONS,
   COMPANION_INTRO_BEATS,
   COMPANION_SIZE_BOXES,
@@ -134,19 +135,6 @@ const COMPANION_KIND = "companion";
 const COMPANION_ROUTE = "/floating/companion";
 
 /**
- * The widest the pill's body gets at the size the surface's layout is authored
- * at, which is the ceiling every entry in the renderer's `FALLBACK_WIDTHS`
- * stays under.
- *
- * The body alone, because the avatar floats beside the pill rather than inside
- * it: what the canvas has to hold on the growth side is the avatar's half box,
- * the gap, and this at the options scale. A ceiling rather than a width, since
- * the pill measures its own content, and content wider than it is clipped by
- * the window. The call's approval row is the widest thing the surface renders.
- */
-const BASE_MAX_BODY_WIDTH = 316;
-
-/**
  * Everything the window's placement depends on, for one pair of companion
  * sizes.
  *
@@ -172,10 +160,6 @@ export interface CompanionGeometry {
    * back past it, and the shadow.
    */
   dropBelow: number;
-  /** The room between the avatar's edge and the pill, at these sizes. */
-  gap: number;
-  /** The widest the pill's body draws at this options size, gap not included. */
-  maxBodyWidth: number;
   /** The pill's far edge at its widest, measured from the avatar's centre. */
   maxReach: number;
 }
@@ -205,13 +189,14 @@ export const geometryFor = (
   const optionsBox = COMPANION_SIZE_BOXES[options];
   const pad = companionPadFor(avatarBox, optionsBox);
   const gap = companionGapFor(avatarBox, optionsBox);
-  const maxBodyWidth = BASE_MAX_BODY_WIDTH * companionScaleFor(optionsBox);
+  const maxPillWidth =
+    COMPANION_BASE_MAX_PILL_WIDTH * companionScaleFor(optionsBox);
   // The avatar holds its place and the pill hangs off one side of it across the
-  // gap, so the reach is the avatar's half box, the gap, and the widest body.
+  // gap, so the reach is the avatar's half box, the gap, and the widest pill.
   // The canvas has to hold it in whichever direction main later picks, so it is
   // sized for both sides, and `growthFor` picks that direction by the same
   // number.
-  const maxReach = avatarBox / 2 + gap + maxBodyWidth;
+  const maxReach = avatarBox / 2 + gap + maxPillWidth;
   // Both distances come from the contract, which is where the renderer reads
   // them too: main places the window by them and the renderer anchors the
   // surface by them, so a second copy of either is the avatar drawn somewhere
@@ -226,8 +211,6 @@ export const geometryFor = (
     canvasHeight: Math.round(riseAbove + dropBelow),
     riseAbove,
     dropBelow,
-    gap,
-    maxBodyWidth,
     maxReach,
   };
 };
@@ -395,7 +378,8 @@ export const callOnUpdate = (
  *
  * The room on each side is measured from the avatar's centre, so the clearance
  * the pill needs is measured from there too: the avatar's half box, then the
- * gap, then its widest body, which is {@link CompanionGeometry.maxReach}.
+ * gap, then the widest the pill draws, which is
+ * {@link CompanionGeometry.maxReach}.
  * Rightward is the default and leftward is what it flips to when the right edge
  * is too close, so the avatar stays exactly where the user put it instead of
  * the controls running off the display.
@@ -645,10 +629,10 @@ let installed = false;
  * The surface's own menu, on a right-click.
  *
  * **Because the tray is the wrong place to look.** The two things a user
- * wants from a floating avatar are to resize it and to make it go away, and
- * both were otherwise reachable only from a menu-bar icon that says nothing
- * about the thing they are actually looking at. A press on the object itself
- * is where people reach first.
+ * wants from a floating avatar are to resize it and to make it go away, and the
+ * tray offers both from a menu-bar icon that says nothing about the thing they
+ * are actually looking at. A press on the object itself is where people reach
+ * first.
  *
  * Built in main rather than in the renderer: a menu is a native window, and
  * main is the side that owns both the sizes and the visibility. The size
@@ -1181,14 +1165,6 @@ export const setCompanionSurfaceVisible = (visible: boolean): void => {
   finishIntro();
   closeCompanionWindow();
 };
-
-/**
- * Which size one axis of the surface is currently drawn at, for the radio items
- * in both menus that offer it.
- */
-export const readCompanionSurfaceSize = (
-  axis: CompanionSizeAxis,
-): CompanionSize => readCompanionSize(axis);
 
 /**
  * Draw the surface at a different size, keeping the avatar where it is.

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -39,7 +39,6 @@ import {
   readSetting,
 } from "@vellumai/electron-desktop/settings";
 import {
-  promoteCompanionSizeToAxes,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
@@ -229,12 +228,6 @@ let growth: CompanionGrowth = "right";
  * it to draw the avatar where the window was actually put.
  */
 let cardGrowth: CompanionCardGrowth = "up";
-
-// Module init is the first thing to ask the store for the surface's geometry,
-// so it is where an install carrying only the single size a one-axis build
-// writes has that size copied onto both per-axis keys. Once, ahead of the reads
-// below, and never again for the life of the process.
-promoteCompanionSizeToAxes();
 
 /**
  * The canvas the surface is currently drawn in.

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1,4 +1,10 @@
-import { BrowserWindow, Menu, screen, shell } from "electron";
+import {
+  BrowserWindow,
+  Menu,
+  screen,
+  shell,
+  type MenuItemConstructorOptions,
+} from "electron";
 import { z } from "zod";
 
 import {
@@ -6,14 +12,14 @@ import {
   voiceActivityContentSchema,
   voiceActivityControlSchema,
   voiceActivityStartSchema,
-  COMPANION_BASE_AVATAR_BOX,
-  COMPANION_BASE_CANVAS_PAD,
   COMPANION_INTRO_ACTIONS,
   COMPANION_INTRO_BEATS,
-  COMPANION_SIZES,
-  COMPANION_NEAR_EDGE,
   COMPANION_SIZE_BOXES,
+  companionCardSideFor,
   companionGapFor,
+  companionNearEdgeFor,
+  companionPadFor,
+  companionScaleFor,
   WATCH_FLAG,
   type CompanionCardGrowth,
   type CompanionGrowth,
@@ -21,11 +27,12 @@ import {
   type CompanionIntroAction,
   type CompanionIntroBeat,
   type CompanionSize,
+  type CompanionSizeAxis,
   type CompanionSurfaceState,
   type VellumCommand,
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
-import { COMPANION_SIZE_LABELS } from "@vellumai/electron-desktop/companion-menu";
+import { companionSizeSubmenus } from "@vellumai/electron-desktop/companion-menu";
 import {
   onSettingChange,
   readSetting,
@@ -127,65 +134,59 @@ const COMPANION_KIND = "companion";
 const COMPANION_ROUTE = "/floating/companion";
 
 /**
- * The widest the pill's body gets at {@link COMPANION_BASE_AVATAR_BOX}, which
- * is the ceiling every entry in the renderer's `FALLBACK_WIDTHS` stays under.
+ * The widest the pill's body gets at the size the surface's layout is authored
+ * at, which is the ceiling every entry in the renderer's `FALLBACK_WIDTHS`
+ * stays under.
  *
  * The body alone, because the avatar floats beside the pill rather than inside
  * it: what the canvas has to hold on the growth side is the avatar's half box,
- * the gap, and this. A ceiling rather than a width, since the pill measures its
- * own content, and content wider than it is clipped by the window. The call's
- * approval row is the widest thing the surface renders.
+ * the gap, and this at the options scale. A ceiling rather than a width, since
+ * the pill measures its own content, and content wider than it is clipped by
+ * the window. The call's approval row is the widest thing the surface renders.
  */
 const BASE_MAX_BODY_WIDTH = 316;
 
 /**
- * The tallest the surface gets, which is the typing card.
- *
- * Every other state is a pill exactly {@link COMPANION_BASE_AVATAR_BOX} tall. The card
- * stacks the conversation on top of that row, in a viewport that scrolls once
- * it is full, so the card has a ceiling rather than growing with the exchange:
- * the renderer's `TURNS_MAX_HEIGHT` (220) and its padding, over the composer.
- * Rounded up from what that comes to, because the text is laid out in the
- * renderer and a canvas a few points short clips the top of the card off.
- *
- * Matched to `CompanionSurface`'s card in `companion-surface.tsx`, the way
- * {@link BASE_MAX_BODY_WIDTH} is matched to its widths.
- */
-const BASE_MAX_CARD_HEIGHT = 290;
-
-/**
- * Everything the window's placement depends on, for one companion size.
+ * Everything the window's placement depends on, for one pair of companion
+ * sizes.
  *
  * A record rather than a set of module constants because the user picks the
- * size and the whole canvas follows it. Passed to the placement
+ * sizes and the whole canvas follows them. Passed to the placement
  * rules explicitly rather than read off the module, so they stay pure functions
  * of their inputs and every size is a case a test can state.
  */
 export interface CompanionGeometry {
-  /** The avatar's box, and the scale: this over {@link COMPANION_BASE_AVATAR_BOX}. */
+  /** The creature's box, which is the whole of its own scale. */
   avatarBox: number;
+  /**
+   * The pill's box, which is the scale of everything that is not the creature.
+   */
+  optionsBox: number;
   /** The canvas, sized to hold the largest state in either direction. */
   canvasWidth: number;
   canvasHeight: number;
   /** How much canvas the card's side of the avatar needs, shadow included. */
   riseAbove: number;
-  /** How much the other side needs: the avatar and its shadow, and no more. */
+  /**
+   * How much the other side needs: the avatar, whatever of the pill reaches
+   * back past it, and the shadow.
+   */
   dropBelow: number;
-  /** The room between the avatar's edge and the pill, at this size. */
+  /** The room between the avatar's edge and the pill, at these sizes. */
   gap: number;
-  /** The widest the pill's body draws at this size, gap not included. */
+  /** The widest the pill's body draws at this options size, gap not included. */
   maxBodyWidth: number;
   /** The pill's far edge at its widest, measured from the avatar's centre. */
   maxReach: number;
 }
 
 /**
- * The canvas for a named size.
+ * The canvas for a pair of named sizes.
  *
  * The asymmetry between {@link CompanionGeometry.riseAbove} and `dropBelow` is
  * the point of the shape. Sizing both sides for the card, which is what pinning
  * the avatar to the canvas's centre amounts to, spends the card's whole height
- * on a side that never draws anything taller than the avatar, and macOS
+ * on a side that never draws anything taller than the pill, and macOS
  * refuses a window origin above the top of the work area, so that spend is
  * exactly how far short of the top the avatar would stop.
  *
@@ -193,27 +194,34 @@ export interface CompanionGeometry {
  * the same bargain the width makes. A canvas that grew with the card would move
  * the window under the pointer mid-press and put the expansion back on the main
  * process, which is what the fixed canvas exists to avoid. It *is* resized when
- * the user picks a different size, which is a deliberate, one-off event rather
- * than something that happens mid-gesture.
+ * the user picks a different size on either axis, which is a deliberate,
+ * one-off event rather than something that happens mid-gesture.
  */
-export const geometryFor = (size: CompanionSize): CompanionGeometry => {
-  const avatarBox = COMPANION_SIZE_BOXES[size];
-  const scale = avatarBox / COMPANION_BASE_AVATAR_BOX;
-  const pad = COMPANION_BASE_CANVAS_PAD * scale;
-  const gap = companionGapFor(avatarBox, avatarBox);
-  const maxBodyWidth = BASE_MAX_BODY_WIDTH * scale;
+export const geometryFor = (
+  avatar: CompanionSize,
+  options: CompanionSize,
+): CompanionGeometry => {
+  const avatarBox = COMPANION_SIZE_BOXES[avatar];
+  const optionsBox = COMPANION_SIZE_BOXES[options];
+  const pad = companionPadFor(avatarBox, optionsBox);
+  const gap = companionGapFor(avatarBox, optionsBox);
+  const maxBodyWidth = BASE_MAX_BODY_WIDTH * companionScaleFor(optionsBox);
   // The avatar holds its place and the pill hangs off one side of it across the
   // gap, so the reach is the avatar's half box, the gap, and the widest body.
   // The canvas has to hold it in whichever direction main later picks, so it is
   // sized for both sides, and `growthFor` picks that direction by the same
   // number.
   const maxReach = avatarBox / 2 + gap + maxBodyWidth;
-  const riseAbove = BASE_MAX_CARD_HEIGHT * scale - avatarBox / 2 + pad;
-  // The invariant the renderer anchors by, at this size. Scaled rather than
-  // recomputed, so the formula lives in one place for both processes.
-  const dropBelow = COMPANION_NEAR_EDGE * scale;
+  // Both distances come from the contract, which is where the renderer reads
+  // them too: main places the window by them and the renderer anchors the
+  // surface by them, so a second copy of either is the avatar drawn somewhere
+  // main did not put it. Each already answers for both card directions, which
+  // is what lets a flip move the canvas rather than resize it.
+  const riseAbove = companionCardSideFor(avatarBox, optionsBox);
+  const dropBelow = companionNearEdgeFor(avatarBox, optionsBox);
   return {
     avatarBox,
+    optionsBox,
     canvasWidth: Math.round(maxReach * 2 + pad * 2),
     canvasHeight: Math.round(riseAbove + dropBelow),
     riseAbove,
@@ -246,7 +254,10 @@ let cardGrowth: CompanionCardGrowth = "up";
  * computed here is measured in, and reading the store on each mouse-move of a
  * drag would be a file read per frame.
  */
-let geometry: CompanionGeometry = geometryFor(readCompanionSize());
+let geometry: CompanionGeometry = geometryFor(
+  readCompanionSize("avatar"),
+  readCompanionSize("options"),
+);
 
 /**
  * The beat of the one-time introduction the surface is on, or `null` when it is
@@ -338,6 +349,7 @@ const currentState = (): CompanionSurfaceState => {
     growth,
     cardGrowth,
     avatarBox: geometry.avatarBox,
+    optionsBox: geometry.optionsBox,
     character: character === null ? undefined : character,
     avatarBase64: png === null ? undefined : png.toString("base64"),
     call,
@@ -629,6 +641,47 @@ export const dispatchWithoutRaising = (command: VellumCommand): void => {
 
 let installed = false;
 
+/**
+ * The surface's own menu, on a right-click.
+ *
+ * **Because the tray is the wrong place to look.** The two things a user
+ * wants from a floating avatar are to resize it and to make it go away, and
+ * both were otherwise reachable only from a menu-bar icon that says nothing
+ * about the thing they are actually looking at. A press on the object itself
+ * is where people reach first.
+ *
+ * Built in main rather than in the renderer: a menu is a native window, and
+ * main is the side that owns both the sizes and the visibility. The size
+ * pickers come from the same builder the tray reads, so the two menus cannot
+ * drift into describing the same surface differently.
+ *
+ * A pure template, separately from the press that pops it, because the menu
+ * itself is a native window and what is worth stating is the wording and which
+ * radio is marked.
+ */
+export const companionContextMenuTemplate = (
+  current: Record<CompanionSizeAxis, CompanionSize>,
+  actions: {
+    setSize: (axis: CompanionSizeAxis, size: CompanionSize) => void;
+    hide: () => void;
+  },
+): MenuItemConstructorOptions[] => [
+  // The size pickers the tray offers too, from the one builder both read. They
+  // leave the top level short enough to read at a glance: two headings, and the
+  // one item that is not a size.
+  ...companionSizeSubmenus(current, actions.setSize),
+  { type: "separator" as const },
+  {
+    // Named for what it does to the thing under the cursor. The tray's item is
+    // a checkbox because it is also the way back; here there is a surface in
+    // front of the user, so this only has to take it away.
+    label: "Hide Companion",
+    click: () => {
+      actions.hide();
+    },
+  },
+];
+
 export const installCompanionWindow = (): void => {
   if (installed) {
     return;
@@ -852,55 +905,25 @@ export const installCompanionWindow = (): void => {
     },
   );
 
-  /**
-   * The surface's own menu, on a right-click.
-   *
-   * **Because the tray is the wrong place to look.** The two things a user
-   * wants from a floating avatar are to resize it and to make it go away, and
-   * both were otherwise reachable only from a menu-bar icon that says nothing
-   * about the thing they are actually looking at. A press on the object itself
-   * is where people reach first.
-   *
-   * Built here rather than in the renderer: a menu is a native window, and main
-   * is the side that owns both the size and the visibility. The wording comes
-   * from the tray's own table, so the two menus cannot drift into describing
-   * the same surface differently.
-   */
   on("vellum:companion:contextMenu", z.tuple([]), () => {
     const win = getFloatingWindow(COMPANION_KIND);
     if (!win || win.isDestroyed()) {
       return;
     }
-    const current = readCompanionSize();
-    const menu = Menu.buildFromTemplate([
-      {
-        // The sizes sit under a heading rather than flat at the top level.
-        // Flat, the first thing a right-click offered was four words that only
-        // read as sizes once you had noticed they were sizes, and the one item
-        // that was not a size sat at the end of the same list. A named submenu
-        // says what the four are before it shows them, and leaves the top level
-        // short enough to read at a glance.
-        label: "Size",
-        submenu: COMPANION_SIZES.map((size) => ({
-          label: COMPANION_SIZE_LABELS[size],
-          type: "radio" as const,
-          checked: current === size,
-          click: () => {
-            setCompanionSurfaceSize(size);
-          },
-        })),
-      },
-      { type: "separator" as const },
-      {
-        // Named for what it does to the thing under the cursor. The tray's item
-        // is a checkbox because it is also the way back; here there is a
-        // surface in front of the user, so this only has to take it away.
-        label: "Hide Companion",
-        click: () => {
-          setCompanionSurfaceVisible(false);
+    const menu = Menu.buildFromTemplate(
+      companionContextMenuTemplate(
+        {
+          avatar: readCompanionSize("avatar"),
+          options: readCompanionSize("options"),
         },
-      },
-    ]);
+        {
+          setSize: setCompanionSurfaceSize,
+          hide: () => {
+            setCompanionSurfaceVisible(false);
+          },
+        },
+      ),
+    );
     menu.popup({ window: win });
   });
 
@@ -1159,9 +1182,13 @@ export const setCompanionSurfaceVisible = (visible: boolean): void => {
   closeCompanionWindow();
 };
 
-/** Which size the surface is currently drawn at, for the tray's radio items. */
-export const readCompanionSurfaceSize = (): CompanionSize =>
-  readCompanionSize();
+/**
+ * Which size one axis of the surface is currently drawn at, for the radio items
+ * in both menus that offer it.
+ */
+export const readCompanionSurfaceSize = (
+  axis: CompanionSizeAxis,
+): CompanionSize => readCompanionSize(axis);
 
 /**
  * Draw the surface at a different size, keeping the avatar where it is.
@@ -1177,10 +1204,21 @@ export const readCompanionSurfaceSize = (): CompanionSize =>
  * hundreds of points, and the user would watch the thing they were trying to
  * enlarge walk off across the desktop. So the centre is read in the old
  * geometry, and the window placed in the new one around the same point.
+ *
+ * Both axes take this same path. Sizing the options alone leaves the creature
+ * exactly as it was and still moves every edge around it: the pill's reach and
+ * the card's height are stated in the options size, so the canvas has to be
+ * built again for them.
  */
-export const setCompanionSurfaceSize = (size: CompanionSize): void => {
-  writeCompanionSize(size);
-  const next = geometryFor(size);
+export const setCompanionSurfaceSize = (
+  axis: CompanionSizeAxis,
+  size: CompanionSize,
+): void => {
+  writeCompanionSize(axis, size);
+  const next = geometryFor(
+    readCompanionSize("avatar"),
+    readCompanionSize("options"),
+  );
   const win = getFloatingWindow(COMPANION_KIND);
   if (!win || win.isDestroyed()) {
     geometry = next;

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -13,6 +13,7 @@ import {
   COMPANION_SIZES,
   COMPANION_NEAR_EDGE,
   COMPANION_SIZE_BOXES,
+  companionGapFor,
   WATCH_FLAG,
   type CompanionCardGrowth,
   type CompanionGrowth,
@@ -126,14 +127,16 @@ const COMPANION_KIND = "companion";
 const COMPANION_ROUTE = "/floating/companion";
 
 /**
- * The widest the pill gets at {@link COMPANION_BASE_AVATAR_BOX}, matching
- * `FALLBACK_WIDTHS.call` in the renderer.
+ * The widest the pill's body gets at {@link COMPANION_BASE_AVATAR_BOX}, which
+ * is the ceiling every entry in the renderer's `FALLBACK_WIDTHS` stays under.
  *
- * A ceiling rather than a width: the pill measures its own content, so this is
- * what the canvas is sized to hold, and content wider than it is clipped by the
- * window. The call's approval row is the widest thing the surface renders.
+ * The body alone, because the avatar floats beside the pill rather than inside
+ * it: what the canvas has to hold on the growth side is the avatar's half box,
+ * the gap, and this. A ceiling rather than a width, since the pill measures its
+ * own content, and content wider than it is clipped by the window. The call's
+ * approval row is the widest thing the surface renders.
  */
-const BASE_MAX_PILL_WIDTH = 360;
+const BASE_MAX_BODY_WIDTH = 316;
 
 /**
  * The tallest the surface gets, which is the typing card.
@@ -146,7 +149,7 @@ const BASE_MAX_PILL_WIDTH = 360;
  * renderer and a canvas a few points short clips the top of the card off.
  *
  * Matched to `CompanionSurface`'s card in `companion-surface.tsx`, the way
- * {@link BASE_MAX_PILL_WIDTH} is matched to its widths.
+ * {@link BASE_MAX_BODY_WIDTH} is matched to its widths.
  */
 const BASE_MAX_CARD_HEIGHT = 290;
 
@@ -168,8 +171,12 @@ export interface CompanionGeometry {
   riseAbove: number;
   /** How much the other side needs: the avatar and its shadow, and no more. */
   dropBelow: number;
-  /** What {@link growthFor} measures the room against. */
-  maxPillWidth: number;
+  /** The room between the avatar's edge and the pill, at this size. */
+  gap: number;
+  /** The widest the pill's body draws at this size, gap not included. */
+  maxBodyWidth: number;
+  /** The pill's far edge at its widest, measured from the avatar's centre. */
+  maxReach: number;
 }
 
 /**
@@ -193,11 +200,14 @@ export const geometryFor = (size: CompanionSize): CompanionGeometry => {
   const avatarBox = COMPANION_SIZE_BOXES[size];
   const scale = avatarBox / COMPANION_BASE_AVATAR_BOX;
   const pad = COMPANION_BASE_CANVAS_PAD * scale;
-  const maxPillWidth = BASE_MAX_PILL_WIDTH * scale;
-  // The avatar holds its place and the body runs off one side of it, so the
-  // reach is almost the pill's whole width. The canvas has to hold it in
-  // whichever direction main later picks, so it is sized for both sides.
-  const maxReach = maxPillWidth - avatarBox / 2;
+  const gap = companionGapFor(avatarBox, avatarBox);
+  const maxBodyWidth = BASE_MAX_BODY_WIDTH * scale;
+  // The avatar holds its place and the pill hangs off one side of it across the
+  // gap, so the reach is the avatar's half box, the gap, and the widest body.
+  // The canvas has to hold it in whichever direction main later picks, so it is
+  // sized for both sides, and `growthFor` picks that direction by the same
+  // number.
+  const maxReach = avatarBox / 2 + gap + maxBodyWidth;
   const riseAbove = BASE_MAX_CARD_HEIGHT * scale - avatarBox / 2 + pad;
   // The invariant the renderer anchors by, at this size. Scaled rather than
   // recomputed, so the formula lives in one place for both processes.
@@ -208,7 +218,9 @@ export const geometryFor = (size: CompanionSize): CompanionGeometry => {
     canvasHeight: Math.round(riseAbove + dropBelow),
     riseAbove,
     dropBelow,
-    maxPillWidth,
+    gap,
+    maxBodyWidth,
+    maxReach,
   };
 };
 
@@ -369,10 +381,12 @@ export const callOnUpdate = (
 /**
  * Which way the pill grows, from where the avatar actually sits.
  *
- * The body needs `maxPillWidth - avatarBox` of clearance on the side it
- * grows into. Rightward is the default and leftward is what it flips to when
- * the right edge is too close, so the avatar stays exactly where the user put
- * it instead of the controls running off the display.
+ * The room on each side is measured from the avatar's centre, so the clearance
+ * the pill needs is measured from there too: the avatar's half box, then the
+ * gap, then its widest body, which is {@link CompanionGeometry.maxReach}.
+ * Rightward is the default and leftward is what it flips to when the right edge
+ * is too close, so the avatar stays exactly where the user put it instead of
+ * the controls running off the display.
  *
  * A display too narrow for either direction still grows right, because the
  * clipping is then unavoidable and the user can drag the surface somewhere it
@@ -383,7 +397,7 @@ export const growthFor = (
   workArea: { x: number; width: number },
   geometry: CompanionGeometry,
 ): CompanionGrowth => {
-  const needed = geometry.maxPillWidth - geometry.avatarBox;
+  const needed = geometry.maxReach;
   const roomRight = workArea.x + workArea.width - avatarCentreX;
   const roomLeft = avatarCentreX - workArea.x;
   if (roomRight < needed && roomLeft >= needed) {

--- a/clients/macos/src/main/tray.client.ts
+++ b/clients/macos/src/main/tray.client.ts
@@ -9,6 +9,7 @@ import {
 } from "@vellumai/electron-desktop/tray-model";
 import {
   readCompanionHidden,
+  readCompanionSize,
   readOnboardingActive,
 } from "@vellumai/electron-desktop/window-state";
 
@@ -23,7 +24,6 @@ import {
 } from "./assets/menu-icons";
 import { acceleratorOption } from "./commands.client";
 import {
-  readCompanionSurfaceSize,
   setCompanionSurfaceSize,
   setCompanionSurfaceVisible,
 } from "./companion-window";
@@ -53,7 +53,7 @@ export const installTray = (handlers: TrayHandlers): void => {
     // below is the only thing that turns it off.
     companionSupported: () => true,
     companionHidden: readCompanionHidden,
-    companionSize: readCompanionSurfaceSize,
+    companionSize: readCompanionSize,
     dispatch: dispatchToMain,
     featureEnabled: (flag) => readSetting("featureFlags")?.[flag] === true,
     getLockfile: getWatchedLockfile,

--- a/clients/web/src/components/companion-intro.test.tsx
+++ b/clients/web/src/components/companion-intro.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 
 import { CompanionIntro } from "./companion-intro";
+import { companionLayoutFor } from "./companion-layout";
 import { CompanionSurface } from "./companion-surface";
 
 afterEach(cleanup);
@@ -17,29 +18,11 @@ const cardOf = (container: HTMLElement): HTMLElement => {
   return found;
 };
 
-/** The pill, which is the one element on the surface whose width animates. */
-const pillOf = (container: HTMLElement): HTMLElement => {
-  const found = container.querySelector<HTMLElement>(".transition-\\[width\\]");
-  if (!found) {
-    throw new Error("Expected the surface to render");
-  }
-  return found;
-};
-
 /** How far a `calc(100% - Npx)` anchor holds its element off the canvas's bottom. */
 const offCanvasBottom = (top: string): number => {
   const found = /^calc\(100% - ([\d.]+)px\)$/.exec(top);
   if (!found?.[1]) {
     throw new Error(`Expected an anchor off the canvas's bottom, got ${top}`);
-  }
-  return Number(found[1]);
-};
-
-/** How far the card is then stepped up off that anchor. */
-const steppedUp = (transform: string): number => {
-  const found = /^translateY\(calc\(-100% - ([\d.]+)px\)\)$/.exec(transform);
-  if (!found?.[1]) {
-    throw new Error(`Expected a step up off the anchor, got ${transform}`);
   }
   return Number(found[1]);
 };
@@ -66,35 +49,37 @@ describe("the companion introduction's clearance", () => {
       <CompanionIntro beat="talk" avatarBox={44} optionsBox={110} />,
     );
 
-    // The pill hangs off its own line by a whole row, so its top edge is that
-    // much further off the canvas's bottom edge than its anchor.
-    const pillTop =
-      offCanvasBottom(pillOf(surface).style.top) + COMPANION_BASE_AVATAR_BOX;
-    const cardBottom =
-      offCanvasBottom(cardOf(intro).style.top) +
-      steppedUp(cardOf(intro).style.transform);
+    // The pill is the one element on the surface whose width animates. It
+    // hangs off its own line by a whole row, so its top edge is that much
+    // further off the canvas's bottom edge than its anchor.
+    const pill = surface.querySelector<HTMLElement>(".transition-\\[width\\]");
+    if (!pill) {
+      throw new Error("Expected the surface to render");
+    }
+    const pillTop = offCanvasBottom(pill.style.top) + COMPANION_BASE_AVATAR_BOX;
+
+    // How far the card is then stepped up off its own anchor.
+    const card = cardOf(intro);
+    const step = /^translateY\(calc\(-100% - ([\d.]+)px\)\)$/.exec(
+      card.style.transform,
+    );
+    if (!step?.[1]) {
+      throw new Error(
+        `Expected a step up off the anchor, got ${card.style.transform}`,
+      );
+    }
+    const cardBottom = offCanvasBottom(card.style.top) + Number(step[1]);
 
     expect(cardBottom).toBeGreaterThan(pillTop);
   });
 
   /**
-   * The pair the layout is authored at, where the creature and the pill reach
-   * the same line: the card steps off the creature's own half box and the gap,
-   * exactly as the pill does.
+   * How far the card steps off the creature is `companionLayoutFor`'s to say,
+   * and `companion-layout.test.ts` states it. What the card owns is being
+   * placed by that distance, converted into the units the wrapper's scale
+   * leaves the canvas in.
    */
-  test("steps off the creature itself when the two boxes agree", () => {
-    const { container } = render(<CompanionIntro beat="talk" />);
-
-    expect(cardOf(container).style.transform).toBe(
-      "translateY(calc(-100% - 34px))",
-    );
-  });
-
-  /**
-   * Growing downward there is nothing above the creature's own bottom to
-   * clear, since that line is the pill's bottom too whichever is larger.
-   */
-  test("takes the creature's own bottom growing downward", () => {
+  test("places the card at the layout's step off the creature", () => {
     const { container } = render(
       <CompanionIntro
         beat="talk"
@@ -104,7 +89,9 @@ describe("the companion introduction's clearance", () => {
       />,
     );
 
-    // 34 points at a scale of two and a half.
-    expect(cardOf(container).style.transform).toBe("translateY(13.6px)");
+    const layout = companionLayoutFor(44, 110);
+    expect(cardOf(container).style.transform).toBe(
+      `translateY(${layout.inUnits(layout.introStepOff("down"))}px)`,
+    );
   });
 });

--- a/clients/web/src/components/companion-intro.test.tsx
+++ b/clients/web/src/components/companion-intro.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 
 import { CompanionIntro } from "./companion-intro";
-import { companionLayoutFor } from "./companion-layout";
 import { CompanionSurface } from "./companion-surface";
 
 afterEach(cleanup);
@@ -89,9 +88,8 @@ describe("the companion introduction's clearance", () => {
       />,
     );
 
-    const layout = companionLayoutFor(44, 110);
-    expect(cardOf(container).style.transform).toBe(
-      `translateY(${layout.inUnits(layout.introStepOff("down"))}px)`,
-    );
+    // The step down for 44 under 110 is the creature's half box plus the gap,
+    // 22 + 12 points, over the 2.5 scale the options box leaves the canvas at.
+    expect(cardOf(container).style.transform).toBe("translateY(13.6px)");
   });
 });

--- a/clients/web/src/components/companion-intro.test.tsx
+++ b/clients/web/src/components/companion-intro.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
+
+import { CompanionIntro } from "./companion-intro";
+import { CompanionSurface } from "./companion-surface";
+
+afterEach(cleanup);
+
+/** The introduction's card, which hangs off the avatar rather than the pill. */
+const cardOf = (container: HTMLElement): HTMLElement => {
+  const found = container.querySelector<HTMLElement>("[role='group']");
+  if (!found) {
+    throw new Error("Expected the introduction's card to render");
+  }
+  return found;
+};
+
+/** The pill, which is the one element on the surface whose width animates. */
+const pillOf = (container: HTMLElement): HTMLElement => {
+  const found = container.querySelector<HTMLElement>(".transition-\\[width\\]");
+  if (!found) {
+    throw new Error("Expected the surface to render");
+  }
+  return found;
+};
+
+/** How far a `calc(100% - Npx)` anchor holds its element off the canvas's bottom. */
+const offCanvasBottom = (top: string): number => {
+  const found = /^calc\(100% - ([\d.]+)px\)$/.exec(top);
+  if (!found?.[1]) {
+    throw new Error(`Expected an anchor off the canvas's bottom, got ${top}`);
+  }
+  return Number(found[1]);
+};
+
+/** How far the card is then stepped up off that anchor. */
+const steppedUp = (transform: string): number => {
+  const found = /^translateY\(calc\(-100% - ([\d.]+)px\)\)$/.exec(transform);
+  if (!found?.[1]) {
+    throw new Error(`Expected a step up off the anchor, got ${transform}`);
+  }
+  return Number(found[1]);
+};
+
+/**
+ * Where the introduction's card lands beside the surface it is describing.
+ *
+ * Every beat but the first holds the pill open, so the card and the pill are on
+ * screen together, and the pill is bottom-flush with the creature rather than
+ * centred on it. A card that only cleared the creature would be drawn over the
+ * controls it is captioning wherever the pill is the taller of the two.
+ */
+describe("the companion introduction's clearance", () => {
+  /**
+   * A small creature under a large pill, which is the pair that separates the
+   * two rules: the creature reaches 22 points above its centre and the pill
+   * 88, so a step off the creature alone lands the card inside the pill.
+   */
+  test("clears a pill that stands taller than the creature", () => {
+    const { container: surface } = render(
+      <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
+    );
+    const { container: intro } = render(
+      <CompanionIntro beat="talk" avatarBox={44} optionsBox={110} />,
+    );
+
+    // The pill hangs off its own line by a whole row, so its top edge is that
+    // much further off the canvas's bottom edge than its anchor.
+    const pillTop =
+      offCanvasBottom(pillOf(surface).style.top) + COMPANION_BASE_AVATAR_BOX;
+    const cardBottom =
+      offCanvasBottom(cardOf(intro).style.top) +
+      steppedUp(cardOf(intro).style.transform);
+
+    expect(cardBottom).toBeGreaterThan(pillTop);
+  });
+
+  /**
+   * The pair the layout is authored at, where the creature and the pill reach
+   * the same line: the card steps off the creature's own half box and the gap,
+   * exactly as the pill does.
+   */
+  test("steps off the creature itself when the two boxes agree", () => {
+    const { container } = render(<CompanionIntro beat="talk" />);
+
+    expect(cardOf(container).style.transform).toBe(
+      "translateY(calc(-100% - 34px))",
+    );
+  });
+
+  /**
+   * Growing downward there is nothing above the creature's own bottom to
+   * clear, since that line is the pill's bottom too whichever is larger.
+   */
+  test("takes the creature's own bottom growing downward", () => {
+    const { container } = render(
+      <CompanionIntro
+        beat="talk"
+        cardGrowth="down"
+        avatarBox={44}
+        optionsBox={110}
+      />,
+    );
+
+    // 34 points at a scale of two and a half.
+    expect(cardOf(container).style.transform).toBe("translateY(13.6px)");
+  });
+});

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -49,9 +49,8 @@ import type {
  * Prose has no natural width, so measuring would size the card to whichever
  * beat happened to say the most and change its shape as the run advanced. This
  * is the same bargain the typing card makes, and it fits the canvas at every
- * size: the window reaches `avatarBox / 2 + gap + maxBodyWidth` past the avatar
- * in both directions (`geometryFor` in `companion-window.ts`), which is 350 at
- * the size this layout is authored at.
+ * size, which main sizes by its own `maxReach` (`geometryFor` in
+ * `companion-window.ts`).
  */
 const CARD_WIDTH = 244;
 
@@ -141,8 +140,8 @@ export interface CompanionIntroProps {
    * The creature's box and the pill's, in points, as `CompanionSurface` takes
    * them.
    *
-   * The card hangs off the creature's edge and steps off it by the same gap the
-   * pill does, so it needs the same two numbers the surface does. Defaulted to
+   * The card hangs off the creature and has to clear whatever the pill draws
+   * beside it, so it needs the same two numbers the surface does. Defaulted to
    * the size the layout is authored at, which is what Storybook draws.
    */
   avatarBox?: number;
@@ -189,41 +188,30 @@ export function CompanionIntro({
   const copy = INTRO_COPY_KEYS[beat];
 
   // The same derivation `CompanionSurface` places the pill by, so the card and
-  // the pill hang off the creature by exactly the same amount.
-  const { inUnits, avatarHalf, gap, nearEdge } = companionLayoutFor(
-    avatarBox,
-    optionsBox,
-  );
-  const avatarHalfUnits = inUnits(avatarHalf);
-  // The creature's half box and then the same room the surface leaves between
-  // the avatar and its pill, so everything hanging off the creature sits the
-  // same distance from it.
-  const stepOff = inUnits(avatarHalf + gap);
-  const nearEdgeUnits = inUnits(nearEdge);
+  // the pill are arranged around one creature rather than two readings of it.
+  const { inUnits, avatarHalf, lineAt, edgeAt, introStepOff } =
+    companionLayoutFor(avatarBox, optionsBox);
+  // Clears whichever of the creature and the pill reaches further on this side,
+  // and then the gap. Stepping off the creature alone would put the card inside
+  // a pill taller than it, since the pill is bottom-flush with the avatar
+  // rather than centred on it and every beat but `meet` holds it open.
+  const stepOff = inUnits(introStepOff(cardGrowth));
 
   // Hung off the avatar's own edge, which is the point the host positioned this
   // window around and the point the pill is measured from too. Not off the
   // pill: that box changes width from beat to beat as controls are spotlighted,
   // and a card pinned to it would slide about while being read.
-  const placement: CSSProperties =
-    growth === "left"
-      ? { right: "50%", marginRight: -avatarHalfUnits }
-      : { left: "50%", marginLeft: -avatarHalfUnits };
+  const placement: CSSProperties = edgeAt(growth, -avatarHalf);
 
-  // The vertical half: sit against the canvas edge the avatar is near, then
-  // step off the avatar by its own half box plus the gap. `100%` names the
-  // canvas without this side having to know how tall the host made it, which is
-  // the same trick the surface's own anchor uses.
-  const anchor: CSSProperties =
-    cardGrowth === "up"
-      ? {
-          top: `calc(100% - ${nearEdgeUnits}px)`,
-          transform: `translateY(calc(-100% - ${stepOff}px))`,
-        }
-      : {
-          top: nearEdgeUnits,
-          transform: `translateY(${stepOff}px)`,
-        };
+  // The vertical half: sit on the avatar's own line, then step off it far
+  // enough to clear what is drawn there.
+  const anchor: CSSProperties = {
+    top: lineAt(cardGrowth, 0),
+    transform:
+      cardGrowth === "up"
+        ? `translateY(calc(-100% - ${stepOff}px))`
+        : `translateY(${stepOff}px)`,
+  };
 
   return (
     <div

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -1,7 +1,6 @@
 import {
+  COMPANION_BASE_AVATAR_BOX,
   COMPANION_INTRO_BEATS,
-  COMPANION_NEAR_EDGE,
-  companionGapFor,
 } from "@vellumai/ipc-contract";
 import type {
   CompanionIntroAction,
@@ -11,6 +10,7 @@ import type { CSSProperties, Ref } from "react";
 
 import { useTranslation } from "@/i18n";
 
+import { companionLayoutFor } from "@/components/companion-layout";
 import type {
   CompanionSurfaceCardGrowth,
   CompanionSurfaceGrowth,
@@ -42,17 +42,6 @@ import type {
  * moving it, and moving it would have meant re-deciding growth and placement in
  * the main process for a card that is on screen once in an install's life.
  */
-
-/** The avatar's box the layout is authored at, as `CompanionSurface` has it. */
-const AVATAR_BOX = 44;
-
-/**
- * The room between the avatar's edge and the card, which is the same room the
- * surface leaves between the avatar and its pill. One number from the contract
- * rather than one per neighbour, so everything hanging off the creature sits
- * the same distance from it.
- */
-const AVATAR_GAP = companionGapFor(AVATAR_BOX, AVATAR_BOX);
 
 /**
  * The card's width, fixed rather than measured.
@@ -148,6 +137,16 @@ export interface CompanionIntroProps {
   growth?: CompanionSurfaceGrowth;
   /** Which side of the avatar has the canvas to hold the card. */
   cardGrowth?: CompanionSurfaceCardGrowth;
+  /**
+   * The creature's box and the pill's, in points, as `CompanionSurface` takes
+   * them.
+   *
+   * The card hangs off the creature's edge and steps off it by the same gap the
+   * pill does, so it needs the same two numbers the surface does. Defaulted to
+   * the size the layout is authored at, which is what Storybook draws.
+   */
+  avatarBox?: number;
+  optionsBox?: number;
   /** The assistant's avatar colour, for the progress dots. */
   accentHex?: string;
   /**
@@ -177,6 +176,8 @@ export function CompanionIntro({
   beat,
   growth = "right",
   cardGrowth = "up",
+  avatarBox = COMPANION_BASE_AVATAR_BOX,
+  optionsBox = COMPANION_BASE_AVATAR_BOX,
   accentHex,
   assistantName,
   cardRef,
@@ -187,14 +188,27 @@ export function CompanionIntro({
   const isLast = index === COMPANION_INTRO_BEATS.length - 1;
   const copy = INTRO_COPY_KEYS[beat];
 
+  // The same derivation `CompanionSurface` places the pill by, so the card and
+  // the pill hang off the creature by exactly the same amount.
+  const { inUnits, avatarHalf, gap, nearEdge } = companionLayoutFor(
+    avatarBox,
+    optionsBox,
+  );
+  const avatarHalfUnits = inUnits(avatarHalf);
+  // The creature's half box and then the same room the surface leaves between
+  // the avatar and its pill, so everything hanging off the creature sits the
+  // same distance from it.
+  const stepOff = inUnits(avatarHalf + gap);
+  const nearEdgeUnits = inUnits(nearEdge);
+
   // Hung off the avatar's own edge, which is the point the host positioned this
   // window around and the point the pill is measured from too. Not off the
   // pill: that box changes width from beat to beat as controls are spotlighted,
   // and a card pinned to it would slide about while being read.
   const placement: CSSProperties =
     growth === "left"
-      ? { right: "50%", marginRight: -(AVATAR_BOX / 2) }
-      : { left: "50%", marginLeft: -(AVATAR_BOX / 2) };
+      ? { right: "50%", marginRight: -avatarHalfUnits }
+      : { left: "50%", marginLeft: -avatarHalfUnits };
 
   // The vertical half: sit against the canvas edge the avatar is near, then
   // step off the avatar by its own half box plus the gap. `100%` names the
@@ -203,12 +217,12 @@ export function CompanionIntro({
   const anchor: CSSProperties =
     cardGrowth === "up"
       ? {
-          top: `calc(100% - ${COMPANION_NEAR_EDGE}px)`,
-          transform: `translateY(calc(-100% - ${AVATAR_BOX / 2 + AVATAR_GAP}px))`,
+          top: `calc(100% - ${nearEdgeUnits}px)`,
+          transform: `translateY(calc(-100% - ${stepOff}px))`,
         }
       : {
-          top: COMPANION_NEAR_EDGE,
-          transform: `translateY(${AVATAR_BOX / 2 + AVATAR_GAP}px)`,
+          top: nearEdgeUnits,
+          transform: `translateY(${stepOff}px)`,
         };
 
   return (

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -1,6 +1,7 @@
 import {
   COMPANION_INTRO_BEATS,
   COMPANION_NEAR_EDGE,
+  companionGapFor,
 } from "@vellumai/ipc-contract";
 import type {
   CompanionIntroAction,
@@ -42,11 +43,16 @@ import type {
  * the main process for a card that is on screen once in an install's life.
  */
 
-/** Gap between the avatar's edge and the card, in base layout points. */
-const AVATAR_GAP = 12;
-
 /** The avatar's box the layout is authored at, as `CompanionSurface` has it. */
 const AVATAR_BOX = 44;
+
+/**
+ * The room between the avatar's edge and the card, which is the same room the
+ * surface leaves between the avatar and its pill. One number from the contract
+ * rather than one per neighbour, so everything hanging off the creature sits
+ * the same distance from it.
+ */
+const AVATAR_GAP = companionGapFor(AVATAR_BOX, AVATAR_BOX);
 
 /**
  * The card's width, fixed rather than measured.
@@ -54,9 +60,9 @@ const AVATAR_BOX = 44;
  * Prose has no natural width, so measuring would size the card to whichever
  * beat happened to say the most and change its shape as the run advanced. This
  * is the same bargain the typing card makes, and it fits the canvas at every
- * size: the window reaches `maxPillWidth - avatarBox / 2` past the avatar in
- * both directions (`geometryFor` in `companion-window.ts`), which is 338 at the
- * size this layout is authored at.
+ * size: the window reaches `avatarBox / 2 + gap + maxBodyWidth` past the avatar
+ * in both directions (`geometryFor` in `companion-window.ts`), which is 350 at
+ * the size this layout is authored at.
  */
 const CARD_WIDTH = 244;
 
@@ -181,10 +187,10 @@ export function CompanionIntro({
   const isLast = index === COMPANION_INTRO_BEATS.length - 1;
   const copy = INTRO_COPY_KEYS[beat];
 
-  // The pill's own horizontal anchoring, repeated rather than shared, because
-  // the card is a sibling of the pill and not inside it: it must not inherit
-  // the width that animates from beat to beat. Anchoring to the same edge is
-  // what makes the card and the pill read as one object being annotated.
+  // Hung off the avatar's own edge, which is the point the host positioned this
+  // window around and the point the pill is measured from too. Not off the
+  // pill: that box changes width from beat to beat as controls are spotlighted,
+  // and a card pinned to it would slide about while being read.
   const placement: CSSProperties =
     growth === "left"
       ? { right: "50%", marginRight: -(AVATAR_BOX / 2) }

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { companionLayoutFor } from "./companion-layout";
+import { bridgeRect, companionLayoutFor } from "./companion-layout";
 
 /**
  * The one derivation the pill and the introduction card are both placed by.
@@ -13,13 +13,11 @@ import { companionLayoutFor } from "./companion-layout";
 describe("companionLayoutFor", () => {
   /**
    * The authored pair. Every length on the surface is stated at this size, so
-   * the layout has to reduce to itself here: the scale is one, the creature
-   * carries no difference of its own, and the distances are the points they
-   * were written as.
+   * the layout has to reduce to itself here: the creature carries no difference
+   * of its own, and the distances are the points they were written as.
    */
   test("hands back the authored numbers when the two boxes agree", () => {
     const layout = companionLayoutFor(44, 44);
-    expect(layout.scale).toBe(1);
     expect(layout.avatarRel).toBe(1);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
@@ -32,26 +30,18 @@ describe("companionLayoutFor", () => {
    * the smaller box's, the creature is drawn at the ratio between the two, and
    * every point distance is divided by the scale the wrapper has already
    * applied.
+   *
+   * The conversion divides by that scale rather than multiplying by the base
+   * box over the pill's, because these numbers are written straight into CSS.
+   * The other order comes out a float's width away, and `calc(50% +
+   * 13.600000000000001px)` is what the user would read in the inspector.
    */
   test("states a mixed pair in the pill's units", () => {
     const layout = companionLayoutFor(44, 110);
-    expect(layout.scale).toBe(2.5);
     expect(layout.avatarRel).toBe(0.4);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
     expect(layout.nearEdge).toBe(148);
-    expect(layout.inUnits(34)).toBe(13.6);
-    expect(layout.inUnits(148)).toBe(59.2);
-  });
-
-  /**
-   * The conversion divides by the scale rather than multiplying by the base box
-   * over the pill's, because the numbers here are written straight into CSS.
-   * The other order comes out a float's width away, and `calc(50% +
-   * 13.600000000000001px)` is what the user would read in the inspector.
-   */
-  test("converts to the exact numbers CSS is handed", () => {
-    const layout = companionLayoutFor(44, 110);
     expect(`${layout.inUnits(34)}`).toBe("13.6");
     expect(`${layout.inUnits(148)}`).toBe("59.2");
   });
@@ -63,11 +53,154 @@ describe("companionLayoutFor", () => {
    */
   test("keeps the smaller box's gap when the creature is the larger", () => {
     const layout = companionLayoutFor(110, 44);
-    expect(layout.scale).toBe(1);
     expect(layout.avatarRel).toBe(2.5);
     expect(layout.avatarHalf).toBe(55);
     expect(layout.gap).toBe(12);
     expect(layout.nearEdge).toBe(115);
     expect(layout.inUnits(67)).toBe(67);
+  });
+
+  /**
+   * The canvas is anchored to whichever edge the card does not grow into, so a
+   * line is named from that edge and `100%` covers the other without this side
+   * knowing how tall main made the window.
+   */
+  test("names a line from the canvas edge the avatar is near", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.lineAt("up", 0)).toBe("calc(100% - 46px)");
+    expect(layout.lineAt("up", 22)).toBe("calc(100% - 24px)");
+    expect(layout.lineAt("down", 0)).toBe("46px");
+    expect(layout.lineAt("down", 22)).toBe("68px");
+  });
+
+  /** A flip anchors the other edge and moves nothing else. */
+  test("anchors the edge the surface grows from", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.edgeAt("right", 34)).toEqual({ left: "calc(50% + 34px)" });
+    expect(layout.edgeAt("left", 34)).toEqual({ right: "calc(50% + 34px)" });
+  });
+
+  /** Back towards the avatar's own edge, which the introduction's card hangs on. */
+  test("states a step back across the centre as a subtraction", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.edgeAt("right", -22)).toEqual({ left: "calc(50% - 22px)" });
+  });
+});
+
+/**
+ * How far the introduction's card starts from the avatar's centre.
+ *
+ * Its own distance rather than the pill's, because the pill is bottom-flush
+ * with the creature rather than centred on it. Every beat but the first holds
+ * the pill open, so a card that only cleared the creature would be drawn over
+ * the thing it is describing.
+ */
+describe("the introduction's step off the creature", () => {
+  test("clears the creature itself when the two boxes agree", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.introStepOff("up")).toBe(34);
+    expect(layout.introStepOff("down")).toBe(34);
+  });
+
+  /**
+   * A small creature under a large pill: bottom-flush puts the pill's top 88
+   * points above the avatar's centre where the creature reaches only 22, so
+   * the card has to start past the pill.
+   */
+  test("clears a pill that stands taller than the creature", () => {
+    const layout = companionLayoutFor(44, 110);
+    const pillTop = 110 - 22;
+    expect(layout.introStepOff("up")).toBe(pillTop + 12);
+    expect(layout.introStepOff("up")).toBeGreaterThan(pillTop);
+  });
+
+  /**
+   * Downward there is nothing to clear but the creature: the pill's bottom
+   * edge *is* the creature's bottom edge, whichever of the two is larger.
+   */
+  test("takes the creature's own bottom growing downward", () => {
+    expect(companionLayoutFor(44, 110).introStepOff("down")).toBe(34);
+    expect(companionLayoutFor(110, 44).introStepOff("down")).toBe(67);
+  });
+});
+
+/**
+ * The strip between the avatar and the pill, as arithmetic. The rects it is
+ * handed come from the DOM, so these are about the shape it makes of them:
+ * between the facing edges, and no taller than the composer row.
+ */
+describe("bridgeRect", () => {
+  const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
+  const ROW = { rowHeight: 44, cardGrowth: "up" } as const;
+
+  test("spans the facing edges when the pill grows rightward", () => {
+    const pill = { left: 156, right: 356, top: 100, bottom: 144 };
+    expect(bridgeRect(AVATAR, pill, ROW)).toEqual({
+      left: 144,
+      right: 156,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  test("spans them the other way when it grows leftward", () => {
+    const pill = { left: -100, right: 88, top: 100, bottom: 144 };
+    expect(bridgeRect(AVATAR, pill, ROW)).toEqual({
+      left: 88,
+      right: 100,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  /**
+   * The pill's height, never the avatar's. A strip as tall as a larger creature
+   * would claim the dead corners beside it, which is the bounding box this
+   * exists instead of.
+   */
+  test("takes the pill's height rather than a taller avatar's", () => {
+    const tall = { left: 100, right: 200, top: 40, bottom: 200 };
+    const pill = { left: 212, right: 412, top: 156, bottom: 200 };
+    expect(bridgeRect(tall, pill, ROW)).toEqual({
+      left: 200,
+      right: 212,
+      top: 156,
+      bottom: 200,
+    });
+  });
+
+  /**
+   * The card is the one state that is not its own row. A strip drawn to its
+   * full height would hand the window a column of empty canvas beside the card
+   * to swallow desktop presses in, so it stops at the composer row: the card's
+   * last child growing up, and its first growing down.
+   */
+  test("covers only the composer row of a card growing up", () => {
+    const card = { left: 156, right: 472, top: -146, bottom: 144 };
+    expect(bridgeRect(AVATAR, card, ROW)).toEqual({
+      left: 144,
+      right: 156,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  test("covers only the composer row of a card growing down", () => {
+    const card = { left: 156, right: 472, top: 100, bottom: 390 };
+    expect(
+      bridgeRect(AVATAR, card, { rowHeight: 44, cardGrowth: "down" }),
+    ).toEqual({
+      left: 144,
+      right: 156,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  /** Overlapping rects have no gap between them, and an empty strip says so. */
+  test("is empty when the two overlap", () => {
+    const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
+    const bridge = bridgeRect(AVATAR, overlapping, ROW);
+    expect(bridge.left).toBeGreaterThan(bridge.right);
   });
 });

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -22,6 +22,7 @@ describe("companionLayoutFor", () => {
    */
   test("hands back the authored numbers when the two boxes agree", () => {
     const layout = companionLayoutFor(44, 44);
+    expect(layout.scale).toBe(1);
     expect(layout.avatarRel).toBe(1);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
@@ -41,6 +42,7 @@ describe("companionLayoutFor", () => {
    */
   test("states a mixed pair in the pill's units", () => {
     const layout = companionLayoutFor(44, 110);
+    expect(layout.scale).toBe(2.5);
     expect(layout.avatarRel).toBe(0.4);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
@@ -53,8 +55,14 @@ describe("companionLayoutFor", () => {
    * the smaller box's gap, and the canvas holds the creature's own half box
    * plus a pad sized by the larger of the two.
    */
+  /**
+   * The options box alone drives the surface's own scale, so a creature grown
+   * on its own leaves it at the identity and carries the whole difference in
+   * `avatarRel`.
+   */
   test("keeps the smaller box's gap when the creature is the larger", () => {
     const layout = companionLayoutFor(110, 44);
+    expect(layout.scale).toBe(1);
     expect(layout.avatarRel).toBe(2.5);
     expect(layout.avatarHalf).toBe(55);
     expect(layout.gap).toBe(12);

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { companionLayoutFor } from "./companion-layout";
+
+/**
+ * The one derivation the pill and the introduction card are both placed by.
+ *
+ * What is worth stating is the pair the layout is authored at coming out as the
+ * numbers the layout is written in, a mixed pair holding the same rules in the
+ * pill's units, and the conversion landing on the numbers CSS is handed rather
+ * than on their floating-point neighbours.
+ */
+describe("companionLayoutFor", () => {
+  /**
+   * The authored pair. Every length on the surface is stated at this size, so
+   * the layout has to reduce to itself here: the scale is one, the creature
+   * carries no difference of its own, and the distances are the points they
+   * were written as.
+   */
+  test("hands back the authored numbers when the two boxes agree", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.scale).toBe(1);
+    expect(layout.avatarRel).toBe(1);
+    expect(layout.avatarHalf).toBe(22);
+    expect(layout.gap).toBe(12);
+    expect(layout.nearEdge).toBe(46);
+    expect(layout.inUnits(34)).toBe(34);
+  });
+
+  /**
+   * A small creature beside a large pill, read in the pill's units. The gap is
+   * the smaller box's, the creature is drawn at the ratio between the two, and
+   * every point distance is divided by the scale the wrapper has already
+   * applied.
+   */
+  test("states a mixed pair in the pill's units", () => {
+    const layout = companionLayoutFor(44, 110);
+    expect(layout.scale).toBe(2.5);
+    expect(layout.avatarRel).toBe(0.4);
+    expect(layout.avatarHalf).toBe(22);
+    expect(layout.gap).toBe(12);
+    expect(layout.nearEdge).toBe(148);
+    expect(layout.inUnits(34)).toBe(13.6);
+    expect(layout.inUnits(148)).toBe(59.2);
+  });
+
+  /**
+   * The conversion divides by the scale rather than multiplying by the base box
+   * over the pill's, because the numbers here are written straight into CSS.
+   * The other order comes out a float's width away, and `calc(50% +
+   * 13.600000000000001px)` is what the user would read in the inspector.
+   */
+  test("converts to the exact numbers CSS is handed", () => {
+    const layout = companionLayoutFor(44, 110);
+    expect(`${layout.inUnits(34)}`).toBe("13.6");
+    expect(`${layout.inUnits(148)}`).toBe("59.2");
+  });
+
+  /**
+   * The same rules the other way round: a creature larger than the pill keeps
+   * the smaller box's gap, and the canvas holds the creature's own half box
+   * plus a pad sized by the larger of the two.
+   */
+  test("keeps the smaller box's gap when the creature is the larger", () => {
+    const layout = companionLayoutFor(110, 44);
+    expect(layout.scale).toBe(1);
+    expect(layout.avatarRel).toBe(2.5);
+    expect(layout.avatarHalf).toBe(55);
+    expect(layout.gap).toBe(12);
+    expect(layout.nearEdge).toBe(115);
+    expect(layout.inUnits(67)).toBe(67);
+  });
+});

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { bridgeRect, companionLayoutFor } from "./companion-layout";
+import {
+  bridgeRect,
+  companionLayoutFor,
+  onCompanionSurface,
+} from "./companion-layout";
 
 /**
  * The one derivation the pill and the introduction card are both placed by.
@@ -21,7 +25,6 @@ describe("companionLayoutFor", () => {
     expect(layout.avatarRel).toBe(1);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
-    expect(layout.nearEdge).toBe(46);
     expect(layout.inUnits(34)).toBe(34);
   });
 
@@ -41,7 +44,6 @@ describe("companionLayoutFor", () => {
     expect(layout.avatarRel).toBe(0.4);
     expect(layout.avatarHalf).toBe(22);
     expect(layout.gap).toBe(12);
-    expect(layout.nearEdge).toBe(148);
     expect(`${layout.inUnits(34)}`).toBe("13.6");
     expect(`${layout.inUnits(148)}`).toBe("59.2");
   });
@@ -56,7 +58,6 @@ describe("companionLayoutFor", () => {
     expect(layout.avatarRel).toBe(2.5);
     expect(layout.avatarHalf).toBe(55);
     expect(layout.gap).toBe(12);
-    expect(layout.nearEdge).toBe(115);
     expect(layout.inUnits(67)).toBe(67);
   });
 
@@ -129,10 +130,10 @@ describe("the introduction's step off the creature", () => {
  * handed come from the DOM, so these are about the shape it makes of them:
  * between the facing edges, and no taller than the composer row.
  */
-describe("bridgeRect", () => {
-  const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
-  const ROW = { rowHeight: 44, cardGrowth: "up" } as const;
+const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
+const ROW = { rowHeight: 44, cardGrowth: "up" } as const;
 
+describe("bridgeRect", () => {
   test("spans the facing edges when the pill grows rightward", () => {
     const pill = { left: 156, right: 356, top: 100, bottom: 144 };
     expect(bridgeRect(AVATAR, pill, ROW)).toEqual({
@@ -202,5 +203,44 @@ describe("bridgeRect", () => {
     const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
     const bridge = bridgeRect(AVATAR, overlapping, ROW);
     expect(bridge.left).toBeGreaterThan(bridge.right);
+  });
+});
+
+/**
+ * The union the window is armed by, which is the one answer the renderer and
+ * the `Interactive` story both hit-test with.
+ */
+describe("onCompanionSurface", () => {
+  const PILL = { left: 156, right: 356, top: 100, bottom: 144 };
+  const at = (x: number, y: number, pill: typeof PILL | null = null): boolean =>
+    onCompanionSurface({ x, y }, { avatar: AVATAR, pill, ...ROW });
+
+  test("is the creature alone when there is no pill", () => {
+    expect(at(120, 120)).toBe(true);
+    expect(at(200, 120)).toBe(false);
+  });
+
+  /**
+   * The creature's box and nothing above it. The artwork is inset inside that
+   * box and the bob stays within the inset, so a rect reaching past the top
+   * would arm the window over empty canvas and swallow the presses meant for
+   * whatever is behind it.
+   */
+  test("leaves the canvas above the creature to the desktop", () => {
+    expect(at(120, AVATAR.top)).toBe(true);
+    expect(at(120, AVATAR.top - 2)).toBe(false);
+  });
+
+  test("carries the pointer across the gap to the pill", () => {
+    expect(at(150, 120, PILL)).toBe(true);
+    expect(at(200, 120, PILL)).toBe(true);
+  });
+
+  /**
+   * The gap is a strip, not a column. Above the row it is desktop, or the
+   * window swallows presses in the empty canvas beside a card.
+   */
+  test("does not claim the canvas above the gap", () => {
+    expect(at(150, 90, PILL)).toBe(false);
   });
 });

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -58,7 +58,7 @@ export const bridgeRect = (
   }: {
     /**
      * The composer row's height in screen pixels, which is the options box: the
-     * row is one base box tall and the page's wrapper is scaled by that box.
+     * row is one base box tall and the surface is drawn scaled by that box.
      */
     rowHeight: number;
     cardGrowth: CompanionCardGrowth;
@@ -132,7 +132,9 @@ export const onCompanionSurface = (
  * behind it.
  */
 export interface CompanionLayout {
-  /** The creature's own scale, the page's wrapper having spent the options box already. */
+  /** The scale the whole surface is drawn at, which is the options box over the authored one. */
+  scale: number;
+  /** The creature's own scale, on top of the options scale the surface already carries. */
   avatarRel: number;
   /** Half the creature's box, which is what everything beside it steps off from. */
   avatarHalf: number;
@@ -195,6 +197,7 @@ export function companionLayoutFor(
   const reachUp = Math.max(avatarHalf, optionsBox - avatarHalf);
   const reachDown = avatarHalf;
   return {
+    scale,
     avatarRel: avatarBox / optionsBox,
     avatarHalf,
     gap,

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -9,17 +9,6 @@ import type {
 } from "@vellumai/ipc-contract";
 import type { CSSProperties } from "react";
 
-/**
- * How far the bob lifts the creature off its baseline, at the base size.
- *
- * The animation itself is `companion-avatar-bob` in `index.css` and the lift is
- * written there as a literal. It is stated here as well because the host
- * hit-tests the avatar against a rect the DOM box does not include: the
- * artwork rides above its own box for most of the cycle, and a pointer on the
- * drawn creature has to count as a pointer on the creature.
- */
-export const COMPANION_BOB_LIFT = 3;
-
 /** As much of a rect as hit-testing a point against it needs. */
 export type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
 
@@ -85,6 +74,56 @@ export const bridgeRect = (
 };
 
 /**
+ * Whether a point is on the companion surface.
+ *
+ * **The surface is a union of rects, never the box around them:** the creature,
+ * the pill beside it, and the strip of gap the pointer crosses between the two.
+ * See {@link bridgeRect} for why the box around the pair is the wrong shape.
+ *
+ * The creature's rect is its own box as measured. The bob rides inside that
+ * box: the artwork is inset well short of the top and the lift is smaller than
+ * the slack, so a rect stretched to meet the raised creature would only claim
+ * empty canvas above it, which is the click-through window swallowing presses
+ * meant for whatever is behind it.
+ *
+ * The renderer hit-tests this way and so does the `Interactive` story, and one
+ * answer for both is what keeps the story honest about where the real window
+ * arms and where the desktop is left alone.
+ */
+export const onCompanionSurface = (
+  point: { x: number; y: number },
+  {
+    avatar,
+    pill,
+    rowHeight,
+    cardGrowth,
+  }: {
+    avatar: SurfaceRect;
+    /**
+     * The pill's rect, or null when there is no pill. At rest its box is
+     * nothing, and a rect of nothing beside the avatar is not somewhere a
+     * pointer can be.
+     */
+    pill: SurfaceRect | null;
+    /** The composer row's height in screen pixels. See {@link bridgeRect}. */
+    rowHeight: number;
+    cardGrowth: CompanionCardGrowth;
+  },
+): boolean => {
+  const inside = (rect: SurfaceRect): boolean =>
+    containsPoint(rect, point.x, point.y);
+  if (inside(avatar)) {
+    return true;
+  }
+  if (pill === null) {
+    return false;
+  }
+  return (
+    inside(pill) || inside(bridgeRect(avatar, pill, { rowHeight, cardGrowth }))
+  );
+};
+
+/**
  * The numbers everything on the companion surface is placed by, in points.
  *
  * Points because that is what the contract's helpers answer in and what main
@@ -99,8 +138,6 @@ export interface CompanionLayout {
   avatarHalf: number;
   /** The room the creature keeps from anything drawn beside it. */
   gap: number;
-  /** The creature's centre to the canvas edge it is near, which is what main places the window by. */
-  nearEdge: number;
   /** The one conversion into the units the layout is stated in. */
   inUnits: (points: number) => number;
   /**
@@ -161,7 +198,6 @@ export function companionLayoutFor(
     avatarRel: avatarBox / optionsBox,
     avatarHalf,
     gap,
-    nearEdge,
     inUnits,
     lineAt: (cardGrowth, offset) =>
       cardGrowth === "up"

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -1,0 +1,60 @@
+import {
+  companionGapFor,
+  companionNearEdgeFor,
+  companionScaleFor,
+} from "@vellumai/ipc-contract";
+
+/** The numbers everything on the companion surface is placed by. */
+export interface CompanionLayout {
+  /** The pill's box over the size the layout is authored at. */
+  scale: number;
+  /**
+   * What the creature carries itself: the difference between the two boxes,
+   * since the wrapper has spent the options one already.
+   */
+  avatarRel: number;
+  /** The creature's half box, in points. */
+  avatarHalf: number;
+  /** The room between the creature's edge and anything beside it, in points. */
+  gap: number;
+  /**
+   * How far the creature's centre sits from the canvas edge it is near, in
+   * points.
+   */
+  nearEdge: number;
+  /**
+   * A distance in points, in the units the layout is stated in.
+   *
+   * The one conversion, and the reason the distances above are held in points:
+   * the page's wrapper has already scaled the whole canvas by the options size,
+   * and the contract answers in points because that is what main sizes the
+   * window in. Dividing once at the end keeps the numbers that reach CSS as
+   * exact as the arithmetic that made them.
+   */
+  inUnits: (points: number) => number;
+}
+
+/**
+ * The surface's geometry for one pair of boxes.
+ *
+ * Derived here rather than in each component, because the pill and the
+ * introduction card both hang off the creature by these same distances:
+ * `CompanionSurface` steps the pill off the avatar's edge across the gap, and
+ * `CompanionIntro` steps its card off the same edge by the same amount. Two
+ * copies of this arithmetic drifting is a card placed somewhere other than
+ * beside the pill it describes.
+ */
+export function companionLayoutFor(
+  avatarBox: number,
+  optionsBox: number,
+): CompanionLayout {
+  const scale = companionScaleFor(optionsBox);
+  return {
+    scale,
+    avatarRel: avatarBox / optionsBox,
+    avatarHalf: avatarBox / 2,
+    gap: companionGapFor(avatarBox, optionsBox),
+    nearEdge: companionNearEdgeFor(avatarBox, optionsBox),
+    inUnits: (points: number): number => points / scale,
+  };
+}

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -10,7 +10,7 @@ import type {
 import type { CSSProperties } from "react";
 
 /** As much of a rect as hit-testing a point against it needs. */
-export type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
+type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
 
 /**
  * Whether a point is on a rect, its edges included.

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -3,35 +3,133 @@ import {
   companionNearEdgeFor,
   companionScaleFor,
 } from "@vellumai/ipc-contract";
+import type {
+  CompanionCardGrowth,
+  CompanionGrowth,
+} from "@vellumai/ipc-contract";
+import type { CSSProperties } from "react";
 
-/** The numbers everything on the companion surface is placed by. */
+/**
+ * How far the bob lifts the creature off its baseline, at the base size.
+ *
+ * The animation itself is `companion-avatar-bob` in `index.css` and the lift is
+ * written there as a literal. It is stated here as well because the host
+ * hit-tests the avatar against a rect the DOM box does not include: the
+ * artwork rides above its own box for most of the cycle, and a pointer on the
+ * drawn creature has to count as a pointer on the creature.
+ */
+export const COMPANION_BOB_LIFT = 3;
+
+/** As much of a rect as hit-testing a point against it needs. */
+export type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
+
+/**
+ * Whether a point is on a rect, its edges included.
+ *
+ * Inclusive because the surface is a union of touching rects: a pointer exactly
+ * on the line where the gap meets the pill is on the surface, and an exclusive
+ * test would drop it into the desktop for one pixel of travel.
+ */
+export const containsPoint = (
+  rect: SurfaceRect,
+  x: number,
+  y: number,
+): boolean =>
+  x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+
+/**
+ * The gap between the avatar and the pill, as a rect of its own.
+ *
+ * **The surface is a union of rects, never the box around them.** The avatar
+ * and the pill are separate elements, and a bounding box over the pair would
+ * claim the empty canvas above and below the gap as well: a click-through
+ * window told it is interactive there swallows the presses meant for whatever
+ * is behind it. So the gap is tested as exactly what it is, a strip between the
+ * two facing edges.
+ *
+ * It has to be part of the surface at all because the pointer crosses it on the
+ * way from the creature to the controls. A window that went click-through
+ * halfway would drop the press the user was travelling to make.
+ *
+ * **Vertically it is the composer row and nothing above it.** Every phase but
+ * `typing` draws a pill that is that row, so `rowHeight` costs those nothing;
+ * the card stands a whole panel higher, and a strip drawn to its full height
+ * would hand the window a column of empty canvas beside it to swallow presses
+ * in.
+ *
+ * Degenerate when the two overlap, which reads as no bridge at all: the strip's
+ * left edge lands past its right, and no point is inside it.
+ */
+export const bridgeRect = (
+  avatar: SurfaceRect,
+  pill: SurfaceRect,
+  {
+    rowHeight,
+    cardGrowth,
+  }: {
+    /**
+     * The composer row's height in screen pixels, which is the options box: the
+     * row is one base box tall and the page's wrapper is scaled by that box.
+     */
+    rowHeight: number;
+    cardGrowth: CompanionCardGrowth;
+  },
+): SurfaceRect => {
+  // The row holds the avatar's line either way: it is the card's last child
+  // growing up and its first growing down.
+  const top = cardGrowth === "up" ? pill.bottom - rowHeight : pill.top;
+  const row = { top, bottom: top + rowHeight };
+  return pill.left >= avatar.right
+    ? { left: avatar.right, right: pill.left, ...row }
+    : { left: pill.right, right: avatar.left, ...row };
+};
+
+/**
+ * The numbers everything on the companion surface is placed by, in points.
+ *
+ * Points because that is what the contract's helpers answer in and what main
+ * sizes the window with. {@link CompanionLayout.inUnits} does the one
+ * conversion at the end, so what reaches CSS is as exact as the arithmetic
+ * behind it.
+ */
 export interface CompanionLayout {
-  /** The pill's box over the size the layout is authored at. */
-  scale: number;
-  /**
-   * What the creature carries itself: the difference between the two boxes,
-   * since the wrapper has spent the options one already.
-   */
+  /** The creature's own scale, the page's wrapper having spent the options box already. */
   avatarRel: number;
-  /** The creature's half box, in points. */
+  /** Half the creature's box, which is what everything beside it steps off from. */
   avatarHalf: number;
-  /** The room between the creature's edge and anything beside it, in points. */
+  /** The room the creature keeps from anything drawn beside it. */
   gap: number;
-  /**
-   * How far the creature's centre sits from the canvas edge it is near, in
-   * points.
-   */
+  /** The creature's centre to the canvas edge it is near, which is what main places the window by. */
   nearEdge: number;
-  /**
-   * A distance in points, in the units the layout is stated in.
-   *
-   * The one conversion, and the reason the distances above are held in points:
-   * the page's wrapper has already scaled the whole canvas by the options size,
-   * and the contract answers in points because that is what main sizes the
-   * window in. Dividing once at the end keeps the numbers that reach CSS as
-   * exact as the arithmetic that made them.
-   */
+  /** The one conversion into the units the layout is stated in. */
   inUnits: (points: number) => number;
+  /**
+   * A line in the canvas, given how far in points it sits from the avatar's
+   * centre.
+   *
+   * The canvas is *not* symmetric about the avatar: the card's height is
+   * reserved on whichever side it grows into, so the avatar sits the near edge
+   * from the other one, and that edge is the one worth anchoring to. `100%`
+   * names the canvas without this side having to know how tall main made it.
+   */
+  lineAt: (cardGrowth: CompanionCardGrowth, offset: number) => string;
+  /**
+   * The horizontal anchor for something hanging that far off the avatar's
+   * centre, as the CSS edge `growth` runs from.
+   *
+   * The avatar holds one spot in the canvas and the pill and the card hang off
+   * one side of it, so a flip is the anchored edge changing rather than the
+   * creature moving.
+   */
+  edgeAt: (growth: CompanionGrowth, offset: number) => CSSProperties;
+  /**
+   * How far past the avatar's centre the introduction's card starts, in points.
+   *
+   * Its own distance rather than the pill's, because the pill is bottom-flush
+   * with the creature rather than centred on it: a card stepped off the
+   * creature alone lands inside a pill that stands taller than the creature.
+   */
+  introStepOff: (cardGrowth: CompanionCardGrowth) => number;
 }
 
 /**
@@ -40,21 +138,42 @@ export interface CompanionLayout {
  * Derived here rather than in each component, because the pill and the
  * introduction card both hang off the creature by these same distances:
  * `CompanionSurface` steps the pill off the avatar's edge across the gap, and
- * `CompanionIntro` steps its card off the same edge by the same amount. Two
- * copies of this arithmetic drifting is a card placed somewhere other than
- * beside the pill it describes.
+ * `CompanionIntro` clears whatever that leaves standing on its side. Two copies
+ * of this arithmetic drifting is a card placed somewhere other than beside the
+ * pill it describes.
  */
 export function companionLayoutFor(
   avatarBox: number,
   optionsBox: number,
 ): CompanionLayout {
   const scale = companionScaleFor(optionsBox);
+  const avatarHalf = avatarBox / 2;
+  const gap = companionGapFor(avatarBox, optionsBox);
+  const nearEdge = companionNearEdgeFor(avatarBox, optionsBox);
+  const inUnits = (points: number): number => points / scale;
+  // What is drawn beside the creature, measured from the creature's centre.
+  // The pill is bottom-flush with the avatar, so downward the two stop on the
+  // same line and upward the pill reaches a whole options box back past it,
+  // which stands above a creature smaller than the pill.
+  const reachUp = Math.max(avatarHalf, optionsBox - avatarHalf);
+  const reachDown = avatarHalf;
   return {
-    scale,
     avatarRel: avatarBox / optionsBox,
-    avatarHalf: avatarBox / 2,
-    gap: companionGapFor(avatarBox, optionsBox),
-    nearEdge: companionNearEdgeFor(avatarBox, optionsBox),
-    inUnits: (points: number): number => points / scale,
+    avatarHalf,
+    gap,
+    nearEdge,
+    inUnits,
+    lineAt: (cardGrowth, offset) =>
+      cardGrowth === "up"
+        ? `calc(100% - ${inUnits(nearEdge - offset)}px)`
+        : `${inUnits(nearEdge + offset)}px`,
+    edgeAt: (growth, offset) => {
+      const units = inUnits(offset);
+      const line =
+        units < 0 ? `calc(50% - ${-units}px)` : `calc(50% + ${units}px)`;
+      return growth === "left" ? { right: line } : { left: line };
+    },
+    introStepOff: (cardGrowth) =>
+      (cardGrowth === "up" ? reachUp : reachDown) + gap,
   };
 }

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -299,23 +299,30 @@ describe("the pill while it is collapsing", () => {
 /**
  * The two sizes, which are one choice each.
  *
- * The wrapper is scaled by the options size and the creature carries the
- * difference between the two itself, which is what lets the pill's every length
- * stay stated once. The hit-test needs nothing new for it, since it reads rects
- * off the DOM after the transforms, and the case that proves it is the dead
- * corner beside a creature far taller than the pill beside it.
+ * The page holds no dimensions of its own: it hands the surface both boxes and
+ * the surface scales its own outermost element by the options one. What is
+ * worth holding here is that the surface is what fills the canvas and that the
+ * sizes main pushes reach it. The hit-test needs nothing new for either, since
+ * it reads rects off the DOM after the transforms, and the case that proves it
+ * is the dead corner beside a creature far taller than the pill beside it.
  */
 describe("the companion surface at two sizes", () => {
-  /** The wrapper the whole layout is drawn inside, scaled to the window. */
+  /**
+   * The surface's own outermost element, which the page draws straight into the
+   * canvas rather than inside a scaled box of its own.
+   */
   const wrapperOf = (container: HTMLElement): HTMLElement => {
-    const found = container.querySelector<HTMLElement>(".origin-top-left");
-    if (!found) {
-      throw new Error("Expected the scaled wrapper to render");
+    const found = canvasOf(container).firstElementChild;
+    if (!(found instanceof HTMLElement)) {
+      throw new Error("Expected the surface to render inside the canvas");
+    }
+    if (!found.className.includes("origin-top-left")) {
+      throw new Error("Expected the surface's scaled box to be that element");
     }
     return found;
   };
 
-  test("scales the canvas by the options size rather than the creature's", async () => {
+  test("draws the surface itself into the canvas at the pushed options size", async () => {
     STATE.avatarBox = 44;
     STATE.optionsBox = 110;
     const { container } = render(<CompanionSurfacePage />);
@@ -323,7 +330,8 @@ describe("the companion surface at two sizes", () => {
     await waitFor(() => {
       expect(wrapperOf(container).style.transform).toBe("scale(2.5)");
     });
-    expect(wrapperOf(container).style.width).toBe("40%");
+    // Nothing of the page's own between the canvas and the surface.
+    expect(canvasOf(container).children).toHaveLength(1);
   });
 
   /**
@@ -348,7 +356,7 @@ describe("the companion surface at two sizes", () => {
     });
   });
 
-  test("leaves that canvas alone when only the creature grows", async () => {
+  test("leaves that scale alone when only the creature grows", async () => {
     STATE.avatarBox = 220;
     STATE.optionsBox = 44;
     const { container } = render(<CompanionSurfacePage />);

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -41,6 +41,7 @@ const resetState = () => {
   STATE.watchEnabled = true;
   STATE.intro = null;
   STATE.assistantName = "Ziggy";
+  delete STATE.character;
 };
 
 /**
@@ -779,5 +780,103 @@ describe("the companion's own menu", () => {
     });
 
     expect(moveByMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The glow is the assistant's own light, not the surface's: an idle companion
+ * with no call running glows its character's accent, and a running call's
+ * accent wins over it.
+ */
+describe("the companion's accent colour", () => {
+  const CHARACTER = {
+    bodyShape: "blob",
+    eyeStyle: "curious",
+    color: "orange",
+  } as const;
+
+  /** A call running, carrying whatever accent the case is about. */
+  const listening = (accentHex: string): CompanionSurfaceState["call"] => ({
+    phase: "listening",
+    label: "Listening",
+    accentHex,
+    muted: false,
+    outputMuted: false,
+    detail: "",
+    approvalRequestId: "",
+    assistantName: "Ziggy",
+  });
+
+  /**
+   * The pill carries `--accent` in every phase; the glow only draws at rest.
+   *
+   * Awaited, because the state the colour comes from arrives after mount, so
+   * the first render is always the default.
+   */
+  const expectAccent = async (
+    container: HTMLElement,
+    hex: string,
+  ): Promise<void> => {
+    await waitFor(() => {
+      const pill = container.querySelector<HTMLElement>(".cursor-grab");
+      if (!pill) {
+        throw new Error("Expected the pill to render");
+      }
+      expect(pill.style.getPropertyValue("--accent").trim().toLowerCase()).toBe(
+        hex,
+      );
+    });
+  };
+
+  const expectGlow = async (
+    container: HTMLElement,
+    hex: string,
+  ): Promise<void> => {
+    await waitFor(() => {
+      const glow = container.querySelector<HTMLElement>(".companion-glow");
+      if (!glow) {
+        throw new Error("Expected the glow to render");
+      }
+      expect(glow.style.background.trim().toLowerCase()).toContain(hex);
+    });
+  };
+
+  test("resolves the character's palette colour with no call running", async () => {
+    STATE.character = { ...CHARACTER };
+    const { container } = render(<CompanionSurfacePage />);
+
+    await expectAccent(container, "#e9642f");
+    await expectGlow(container, "#e9642f");
+  });
+
+  test("lets a running call's accent win", async () => {
+    STATE.character = { ...CHARACTER };
+    STATE.call = listening("#123456");
+    const { container } = render(<CompanionSurfacePage />);
+
+    await expectAccent(container, "#123456");
+  });
+
+  /**
+   * The contract makes no promise the call's hex parses, and CSS drops an
+   * invalid custom property silently, so an unusable accent falls through to
+   * the character rather than being handed on.
+   */
+  test("ignores a call accent that is not a hex", async () => {
+    STATE.character = { ...CHARACTER };
+    STATE.call = listening("");
+    const { container } = render(<CompanionSurfacePage />);
+
+    await expectAccent(container, "#e9642f");
+  });
+
+  /**
+   * An uploaded image has no palette colour to resolve, so the component's own
+   * default is the last word rather than a colour guessed from nothing.
+   */
+  test("falls back to the component default without a character", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+
+    await expectAccent(container, "#5eead4");
   });
 });

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -238,12 +238,58 @@ describe("the gap between the avatar and the pill", () => {
     }
   });
 
-  /** At rest there is no pill, and so nothing to bridge to. */
+  /** At rest the pill's box is nothing, so there is nothing to bridge to. */
   test("is not part of the surface while the pill is closed", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinSurface(container);
+    // The collapsed pill as the surface draws it: across the gap from the
+    // creature at no width at all.
+    await pinSurface(container, {
+      avatar: { left: 100, right: 144, top: 100, bottom: 144 },
+      pill: { left: 156, right: 156, top: 100, bottom: 144 },
+    });
 
     fireEvent.mouseMove(canvasOf(container), { clientX: 150, clientY: 122 });
+
+    expect(setInteractiveMock).not.toHaveBeenCalledWith(true);
+    expect(closed(container)).toBe(true);
+  });
+});
+
+/**
+ * The pill outlives the phase that opened it.
+ *
+ * The pointer leaving puts the phase back to resting at once, and the pill
+ * spends the next 300ms giving its width back. A window that stopped
+ * hit-testing it there would be click-through over controls that are still on
+ * screen, and a press aimed at one of them would land in whatever application
+ * is behind the surface. So the measured width is what decides, and a pointer
+ * that comes back finds the pill and re-opens it.
+ */
+describe("the pill while it is collapsing", () => {
+  test("is still part of the surface under a returning pointer", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    // Resting, with the pill still drawn at a width it has not finished giving
+    // back: the state the surface holds for the length of the transition.
+    await pinSurface(container);
+
+    fireEvent.mouseMove(canvasOf(container), { clientX: 200, clientY: 122 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
+    await waitFor(() => {
+      if (closed(container)) {
+        throw new Error("Expected the pill to open again");
+      }
+    });
+  });
+
+  test("gives the desktop back once that width is gone", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container, {
+      avatar: { left: 100, right: 144, top: 100, bottom: 144 },
+      pill: { left: 156, right: 156, top: 100, bottom: 144 },
+    });
+
+    fireEvent.mouseMove(canvasOf(container), { clientX: 200, clientY: 122 });
 
     expect(setInteractiveMock).not.toHaveBeenCalledWith(true);
     expect(closed(container)).toBe(true);

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -122,6 +122,26 @@ const canvasOf = (container: HTMLElement): HTMLElement => {
   return canvas;
 };
 
+/**
+ * Whether the pill is open, read off the collapsed body's `inert`: the controls
+ * stay mounted at rest so they can be measured, so their presence says nothing
+ * and their being out of the tree says everything.
+ */
+const closed = (container: HTMLElement): boolean =>
+  container.querySelector("[inert]") !== null;
+
+/** Open the surface by putting the pointer on the creature. */
+const open = async (container: HTMLElement): Promise<HTMLElement> => {
+  const canvas = canvasOf(container);
+  fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+  await waitFor(() => {
+    if (closed(container)) {
+      throw new Error("Expected the pill to open");
+    }
+  });
+  return canvas;
+};
+
 /** A box the hit-test can read, which jsdom otherwise reports as all zeroes. */
 type Box = { left: number; right: number; top: number; bottom: number };
 
@@ -142,11 +162,16 @@ const pin = (element: HTMLElement, box: Box): void => {
  *
  * The surface measures itself live and nothing lays out in the test DOM, so
  * every rect would otherwise be zero and the pointer would never be over any of
- * it. Pinned as the surface draws them: the avatar's 44pt box, and the pill
- * bottom-flush across a 12pt gap to its right.
+ * it. Pinned by default as the surface draws them at the pair the layout is
+ * authored at: the avatar's 44pt box, and the pill bottom-flush across a 12pt
+ * gap to its right. A case drawing another pair hands in its own boxes.
  */
 const pinSurface = async (
   container: HTMLElement,
+  boxes: { avatar: Box; pill: Box } = {
+    avatar: { left: 100, right: 144, top: 100, bottom: 144 },
+    pill: { left: 156, right: 356, top: 100, bottom: 144 },
+  },
 ): Promise<{ avatar: HTMLElement; pill: HTMLElement }> => {
   const found = await waitFor(() => {
     const avatar = container.querySelector<HTMLElement>(".size-11");
@@ -158,8 +183,8 @@ const pinSurface = async (
     }
     return { avatar, pill };
   });
-  pin(found.avatar, { left: 100, right: 144, top: 100, bottom: 144 });
-  pin(found.pill, { left: 156, right: 356, top: 100, bottom: 144 });
+  pin(found.avatar, boxes.avatar);
+  pin(found.pill, boxes.pill);
   return found;
 };
 
@@ -173,27 +198,7 @@ const pinSurface = async (
  * swallow desktop presses in the empty canvas above and below it.
  */
 describe("the gap between the avatar and the pill", () => {
-  /**
-   * Whether the pill is open, read off the collapsed body's `inert`: the
-   * controls stay mounted at rest so they can be measured, so their presence
-   * says nothing and their being out of the tree says everything.
-   */
-  const closed = (container: HTMLElement): boolean =>
-    container.querySelector("[inert]") !== null;
-
-  /** Open the surface by putting the pointer on the creature. */
-  const open = async (container: HTMLElement): Promise<HTMLElement> => {
-    const canvas = canvasOf(container);
-    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
-    await waitFor(() => {
-      if (closed(container)) {
-        throw new Error("Expected the pill to open");
-      }
-    });
-    return canvas;
-  };
-
-  test("keeps the window clickable while the pointer crosses it", async () => {
+  test("keeps the window clickable and the pill open as it is crossed", async () => {
     const { container } = render(<CompanionSurfacePage />);
     await pinSurface(container);
     const canvas = await open(container);
@@ -201,15 +206,6 @@ describe("the gap between the avatar and the pill", () => {
     fireEvent.mouseMove(canvas, { clientX: 150, clientY: 122 });
 
     expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
-  });
-
-  test("does not collapse the pill out from under the hand", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    await pinSurface(container);
-    const canvas = await open(container);
-
-    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 122 });
-
     expect(closed(container)).toBe(false);
   });
 
@@ -255,33 +251,6 @@ describe("the gap between the avatar and the pill", () => {
 });
 
 /**
- * The creature is drawn where the bob has lifted it to, and the box it belongs
- * to holds still underneath. A hit-test against the box alone leaves the
- * creature's own head outside the surface for most of the cycle, so the pointer
- * falls through the thing it is plainly on.
- */
-describe("the avatar's rect and the bob", () => {
-  test("takes in the strip the lift raises the creature into", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    await pinSurface(container);
-
-    // Two points above the box's top edge, inside the three the bob lifts.
-    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 98 });
-
-    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
-  });
-
-  test("gives the desktop back above the lift", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    await pinSurface(container);
-
-    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 96 });
-
-    expect(setInteractiveMock).not.toHaveBeenCalledWith(true);
-  });
-});
-
-/**
  * The two sizes, which are one choice each.
  *
  * The wrapper is scaled by the options size and the creature carries the
@@ -299,9 +268,6 @@ describe("the companion surface at two sizes", () => {
     }
     return found;
   };
-
-  const avatarOf = (container: HTMLElement): HTMLElement | null =>
-    container.querySelector<HTMLElement>(".size-11");
 
   test("scales the canvas by the options size rather than the creature's", async () => {
     STATE.avatarBox = 44;
@@ -328,7 +294,7 @@ describe("the companion surface at two sizes", () => {
     pushState({
       ...STATE,
       avatarBox: 110,
-      optionsBox: undefined as unknown as number,
+      optionsBox: undefined,
     });
 
     await waitFor(() => {
@@ -344,9 +310,9 @@ describe("the companion surface at two sizes", () => {
     // The creature's own node is where the change lands, so waiting on it is
     // waiting for the state to have arrived at all.
     await waitFor(() => {
-      expect(avatarOf(container)?.style.transform).toBe(
-        "translate(-50%, -50%) scale(5)",
-      );
+      expect(
+        container.querySelector<HTMLElement>(".size-11")?.style.transform,
+      ).toBe("translate(-50%, -50%) scale(5)");
     });
     expect(wrapperOf(container).style.transform).toBe("scale(1)");
   });
@@ -362,29 +328,15 @@ describe("the companion surface at two sizes", () => {
     STATE.avatarBox = 110;
     STATE.optionsBox = 44;
     const { container } = render(<CompanionSurfacePage />);
-    const found = await waitFor(() => {
-      const avatar = container.querySelector<HTMLElement>(".size-11");
-      const pill = container.querySelector<HTMLElement>(
-        ".transition-\\[width\\]",
-      );
-      if (!avatar || !pill) {
-        throw new Error("Expected the surface to render");
-      }
-      return { avatar, pill };
-    });
     // As the surface draws them at this pair: a 110pt creature, and the pill
     // bottom-flush across the gap, 44pt tall in the creature's lower portion.
-    pin(found.avatar, { left: 100, right: 210, top: 100, bottom: 210 });
-    pin(found.pill, { left: 222, right: 422, top: 166, bottom: 210 });
-    const canvas = canvasOf(container);
+    await pinSurface(container, {
+      avatar: { left: 100, right: 210, top: 100, bottom: 210 },
+      pill: { left: 222, right: 422, top: 166, bottom: 210 },
+    });
 
     // Open it from the creature, which is the only part drawn at rest.
-    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 150 });
-    await waitFor(() => {
-      if (container.querySelector("[inert]") !== null) {
-        throw new Error("Expected the pill to open");
-      }
-    });
+    const canvas = await open(container);
     setInteractiveMock.mockClear();
 
     fireEvent.mouseMove(canvas, { clientX: 216, clientY: 120 });
@@ -889,12 +841,7 @@ describe("the Watch flag on the companion surface", () => {
   /** Open the pill, which is where the way into a session would be drawn. */
   const openPill = async (container: HTMLElement): Promise<void> => {
     await pinSurface(container);
-    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
-    await waitFor(() => {
-      if (!container.querySelector('button[aria-label="Talk"]')) {
-        throw new Error("Expected the pill to open");
-      }
-    });
+    await open(container);
   };
 
   test("draws no way in when the pushed state says nothing about it", async () => {

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -100,8 +100,7 @@ mock.module("@/runtime/desktop-voice-activity", () => ({
   sendVoiceActivityControl: () => undefined,
 }));
 
-const { CompanionSurfacePage, bridgeRect } =
-  await import("./companion-surface-page");
+const { CompanionSurfacePage } = await import("./companion-surface-page");
 
 afterEach(() => {
   cleanup();
@@ -256,54 +255,29 @@ describe("the gap between the avatar and the pill", () => {
 });
 
 /**
- * The strip itself, as arithmetic. The rects it is handed come from the DOM, so
- * these are about the shape it makes of them: between the facing edges, and no
- * taller than the pill.
+ * The creature is drawn where the bob has lifted it to, and the box it belongs
+ * to holds still underneath. A hit-test against the box alone leaves the
+ * creature's own head outside the surface for most of the cycle, so the pointer
+ * falls through the thing it is plainly on.
  */
-describe("bridgeRect", () => {
-  const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
+describe("the avatar's rect and the bob", () => {
+  test("takes in the strip the lift raises the creature into", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
 
-  test("spans the facing edges when the pill grows rightward", () => {
-    const pill = { left: 156, right: 356, top: 100, bottom: 144 };
-    expect(bridgeRect(AVATAR, pill)).toEqual({
-      left: 144,
-      right: 156,
-      top: 100,
-      bottom: 144,
-    });
+    // Two points above the box's top edge, inside the three the bob lifts.
+    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 98 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
   });
 
-  test("spans them the other way when it grows leftward", () => {
-    const pill = { left: -100, right: 88, top: 100, bottom: 144 };
-    expect(bridgeRect(AVATAR, pill)).toEqual({
-      left: 88,
-      right: 100,
-      top: 100,
-      bottom: 144,
-    });
-  });
+  test("gives the desktop back above the lift", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
 
-  /**
-   * The pill's height, never the avatar's. A strip as tall as a larger creature
-   * would claim the dead corners beside it, which is the bounding box this
-   * exists instead of.
-   */
-  test("takes the pill's height rather than a taller avatar's", () => {
-    const tall = { left: 100, right: 200, top: 40, bottom: 200 };
-    const pill = { left: 212, right: 412, top: 156, bottom: 200 };
-    expect(bridgeRect(tall, pill)).toEqual({
-      left: 200,
-      right: 212,
-      top: 156,
-      bottom: 200,
-    });
-  });
+    fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 96 });
 
-  /** Overlapping rects have no gap between them, and an empty strip says so. */
-  test("is empty when the two overlap", () => {
-    const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
-    const bridge = bridgeRect(AVATAR, overlapping);
-    expect(bridge.left).toBeGreaterThan(bridge.right);
+    expect(setInteractiveMock).not.toHaveBeenCalledWith(true);
   });
 });
 
@@ -338,6 +312,28 @@ describe("the companion surface at two sizes", () => {
       expect(wrapperOf(container).style.transform).toBe("scale(2.5)");
     });
     expect(wrapperOf(container).style.width).toBe("40%");
+  });
+
+  /**
+   * A shell that predates the second axis publishes one box for the surface.
+   * Falling back to the authored size instead would draw a 44pt pill beside a
+   * creature the user had sized well past it.
+   */
+  test("sizes the pill by the creature when the state carries one box", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await waitFor(() => {
+      expect(wrapperOf(container).style.transform).toBe("scale(1)");
+    });
+
+    pushState({
+      ...STATE,
+      avatarBox: 110,
+      optionsBox: undefined as unknown as number,
+    });
+
+    await waitFor(() => {
+      expect(wrapperOf(container).style.transform).toBe("scale(2.5)");
+    });
   });
 
   test("leaves that canvas alone when only the creature grows", async () => {
@@ -1053,28 +1049,12 @@ describe("the companion's accent colour", () => {
   });
 
   /**
-   * The pill carries `--accent` in every phase; the glow only draws at rest.
+   * The glow is the only thing on the surface painted in the accent, so it is
+   * where the resolved colour is read back from.
    *
    * Awaited, because the state the colour comes from arrives after mount, so
    * the first render is always the default.
    */
-  const expectAccent = async (
-    container: HTMLElement,
-    hex: string,
-  ): Promise<void> => {
-    await waitFor(() => {
-      const pill = container.querySelector<HTMLElement>(
-        ".transition-\\[width\\]",
-      );
-      if (!pill) {
-        throw new Error("Expected the pill to render");
-      }
-      expect(pill.style.getPropertyValue("--accent").trim().toLowerCase()).toBe(
-        hex,
-      );
-    });
-  };
-
   const expectGlow = async (
     container: HTMLElement,
     hex: string,
@@ -1092,7 +1072,6 @@ describe("the companion's accent colour", () => {
     STATE.character = { ...CHARACTER };
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectAccent(container, "#e9642f");
     await expectGlow(container, "#e9642f");
   });
 
@@ -1101,7 +1080,7 @@ describe("the companion's accent colour", () => {
     STATE.call = listening("#123456");
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectAccent(container, "#123456");
+    await expectGlow(container, "#123456");
   });
 
   /**
@@ -1114,7 +1093,7 @@ describe("the companion's accent colour", () => {
     STATE.call = listening("");
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectAccent(container, "#e9642f");
+    await expectGlow(container, "#e9642f");
   });
 
   /**
@@ -1124,6 +1103,6 @@ describe("the companion's accent colour", () => {
   test("falls back to the component default without a character", async () => {
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectAccent(container, "#5eead4");
+    await expectGlow(container, "#5eead4");
   });
 });

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -21,6 +21,7 @@ const STATE: CompanionSurfaceState = {
   growth: "right",
   cardGrowth: "up",
   avatarBox: 44,
+  optionsBox: 44,
   call: null,
   assistantName: "Ziggy",
   turns: [],
@@ -34,6 +35,8 @@ const STATE: CompanionSurfaceState = {
 
 /** Reset between cases, since `STATE` is what the mocked bridge hands back. */
 const resetState = () => {
+  STATE.avatarBox = 44;
+  STATE.optionsBox = 44;
   STATE.working = false;
   STATE.call = null;
   delete STATE.watching;
@@ -301,6 +304,96 @@ describe("bridgeRect", () => {
     const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
     const bridge = bridgeRect(AVATAR, overlapping);
     expect(bridge.left).toBeGreaterThan(bridge.right);
+  });
+});
+
+/**
+ * The two sizes, which are one choice each.
+ *
+ * The wrapper is scaled by the options size and the creature carries the
+ * difference between the two itself, which is what lets the pill's every length
+ * stay stated once. The hit-test needs nothing new for it, since it reads rects
+ * off the DOM after the transforms, and the case that proves it is the dead
+ * corner beside a creature far taller than the pill beside it.
+ */
+describe("the companion surface at two sizes", () => {
+  /** The wrapper the whole layout is drawn inside, scaled to the window. */
+  const wrapperOf = (container: HTMLElement): HTMLElement => {
+    const found = container.querySelector<HTMLElement>(".origin-top-left");
+    if (!found) {
+      throw new Error("Expected the scaled wrapper to render");
+    }
+    return found;
+  };
+
+  const avatarOf = (container: HTMLElement): HTMLElement | null =>
+    container.querySelector<HTMLElement>(".size-11");
+
+  test("scales the canvas by the options size rather than the creature's", async () => {
+    STATE.avatarBox = 44;
+    STATE.optionsBox = 110;
+    const { container } = render(<CompanionSurfacePage />);
+
+    await waitFor(() => {
+      expect(wrapperOf(container).style.transform).toBe("scale(2.5)");
+    });
+    expect(wrapperOf(container).style.width).toBe("40%");
+  });
+
+  test("leaves that canvas alone when only the creature grows", async () => {
+    STATE.avatarBox = 220;
+    STATE.optionsBox = 44;
+    const { container } = render(<CompanionSurfacePage />);
+
+    // The creature's own node is where the change lands, so waiting on it is
+    // waiting for the state to have arrived at all.
+    await waitFor(() => {
+      expect(avatarOf(container)?.style.transform).toBe(
+        "translate(-50%, -50%) scale(5)",
+      );
+    });
+    expect(wrapperOf(container).style.transform).toBe("scale(1)");
+  });
+
+  /**
+   * The dead corner: outside the creature's own box, above everything the pill
+   * occupies, and well inside the box drawn around the pair. A window that
+   * claimed it would swallow the presses meant for whatever the user actually
+   * has behind the surface, which is the failure every note in this file is
+   * about.
+   */
+  test("gives the desktop back beside a creature taller than the pill", async () => {
+    STATE.avatarBox = 110;
+    STATE.optionsBox = 44;
+    const { container } = render(<CompanionSurfacePage />);
+    const found = await waitFor(() => {
+      const avatar = container.querySelector<HTMLElement>(".size-11");
+      const pill = container.querySelector<HTMLElement>(
+        ".transition-\\[width\\]",
+      );
+      if (!avatar || !pill) {
+        throw new Error("Expected the surface to render");
+      }
+      return { avatar, pill };
+    });
+    // As the surface draws them at this pair: a 110pt creature, and the pill
+    // bottom-flush across the gap, 44pt tall in the creature's lower portion.
+    pin(found.avatar, { left: 100, right: 210, top: 100, bottom: 210 });
+    pin(found.pill, { left: 222, right: 422, top: 166, bottom: 210 });
+    const canvas = canvasOf(container);
+
+    // Open it from the creature, which is the only part drawn at rest.
+    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 150 });
+    await waitFor(() => {
+      if (container.querySelector("[inert]") !== null) {
+        throw new Error("Expected the pill to open");
+      }
+    });
+    setInteractiveMock.mockClear();
+
+    fireEvent.mouseMove(canvas, { clientX: 216, clientY: 120 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
   });
 });
 

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -97,7 +97,8 @@ mock.module("@/runtime/desktop-voice-activity", () => ({
   sendVoiceActivityControl: () => undefined,
 }));
 
-const { CompanionSurfacePage } = await import("./companion-surface-page");
+const { CompanionSurfacePage, bridgeRect } =
+  await import("./companion-surface-page");
 
 afterEach(() => {
   cleanup();
@@ -119,62 +120,216 @@ const canvasOf = (container: HTMLElement): HTMLElement => {
   return canvas;
 };
 
-/**
- * The pill, pinned somewhere the hit-test can find it.
- *
- * The surface measures itself live, and nothing lays out in the test DOM, so
- * every rect would otherwise be zero and the pointer would never be over the
- * pill at all.
- */
-const pinPill = async (container: HTMLElement): Promise<HTMLElement> => {
-  const pill = await waitFor(() => {
-    const found = container.querySelector<HTMLElement>(".cursor-grab");
-    if (!found) {
-      throw new Error("Expected the pill to render");
-    }
-    return found;
-  });
-  pill.getBoundingClientRect = () =>
+/** A box the hit-test can read, which jsdom otherwise reports as all zeroes. */
+type Box = { left: number; right: number; top: number; bottom: number };
+
+const pin = (element: HTMLElement, box: Box): void => {
+  element.getBoundingClientRect = () =>
     ({
-      left: 100,
-      right: 144,
-      top: 100,
-      bottom: 144,
-      x: 100,
-      y: 100,
-      width: 44,
-      height: 44,
+      ...box,
+      x: box.left,
+      y: box.top,
+      width: box.right - box.left,
+      height: box.bottom - box.top,
       toJSON: () => ({}),
     }) as DOMRect;
-  return pill;
 };
 
-/** The avatar inside the pill, which is what a press "goes back to Vellum". */
-const avatarOf = (container: HTMLElement): HTMLElement => {
-  const avatar = container.querySelector<HTMLElement>(".place-items-center");
-  if (!avatar) {
-    throw new Error("Expected the avatar to render");
-  }
-  return avatar;
+/**
+ * The avatar and the pill, pinned somewhere the hit-test can find them.
+ *
+ * The surface measures itself live and nothing lays out in the test DOM, so
+ * every rect would otherwise be zero and the pointer would never be over any of
+ * it. Pinned as the surface draws them: the avatar's 44pt box, and the pill
+ * bottom-flush across a 12pt gap to its right.
+ */
+const pinSurface = async (
+  container: HTMLElement,
+): Promise<{ avatar: HTMLElement; pill: HTMLElement }> => {
+  const found = await waitFor(() => {
+    const avatar = container.querySelector<HTMLElement>(".size-11");
+    const pill = container.querySelector<HTMLElement>(
+      ".transition-\\[width\\]",
+    );
+    if (!avatar || !pill) {
+      throw new Error("Expected the surface to render");
+    }
+    return { avatar, pill };
+  });
+  pin(found.avatar, { left: 100, right: 144, top: 100, bottom: 144 });
+  pin(found.pill, { left: 156, right: 356, top: 100, bottom: 144 });
+  return found;
 };
+
+/**
+ * The surface is a union of rects, and this is the one nothing draws into.
+ *
+ * The avatar and the pill are separate elements with a gap between them, and
+ * the pointer crosses that gap on the way from the creature to the controls. A
+ * window that went click-through halfway would drop the press the user was
+ * travelling to make, and one that claimed the whole box around the pair would
+ * swallow desktop presses in the empty canvas above and below it.
+ */
+describe("the gap between the avatar and the pill", () => {
+  /**
+   * Whether the pill is open, read off the collapsed body's `inert`: the
+   * controls stay mounted at rest so they can be measured, so their presence
+   * says nothing and their being out of the tree says everything.
+   */
+  const closed = (container: HTMLElement): boolean =>
+    container.querySelector("[inert]") !== null;
+
+  /** Open the surface by putting the pointer on the creature. */
+  const open = async (container: HTMLElement): Promise<HTMLElement> => {
+    const canvas = canvasOf(container);
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    await waitFor(() => {
+      if (closed(container)) {
+        throw new Error("Expected the pill to open");
+      }
+    });
+    return canvas;
+  };
+
+  test("keeps the window clickable while the pointer crosses it", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    const canvas = await open(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 122 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
+  });
+
+  test("does not collapse the pill out from under the hand", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    const canvas = await open(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 122 });
+
+    expect(closed(container)).toBe(false);
+  });
+
+  test("carries the pointer on to the pill itself", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    const canvas = await open(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 200, clientY: 122 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
+    expect(closed(container)).toBe(false);
+  });
+
+  /**
+   * The bridge runs the pill's own height and no further, so a press aimed past
+   * it lands on whatever the user actually has behind the surface.
+   */
+  test("gives the desktop back above and below it", async () => {
+    for (const clientY of [90, 160]) {
+      const { container } = render(<CompanionSurfacePage />);
+      await pinSurface(container);
+      const canvas = await open(container);
+
+      fireEvent.mouseMove(canvas, { clientX: 150, clientY });
+
+      expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
+      cleanup();
+      setInteractiveMock.mockClear();
+    }
+  });
+
+  /** At rest there is no pill, and so nothing to bridge to. */
+  test("is not part of the surface while the pill is closed", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+
+    fireEvent.mouseMove(canvasOf(container), { clientX: 150, clientY: 122 });
+
+    expect(setInteractiveMock).not.toHaveBeenCalledWith(true);
+    expect(closed(container)).toBe(true);
+  });
+});
+
+/**
+ * The strip itself, as arithmetic. The rects it is handed come from the DOM, so
+ * these are about the shape it makes of them: between the facing edges, and no
+ * taller than the pill.
+ */
+describe("bridgeRect", () => {
+  const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
+
+  test("spans the facing edges when the pill grows rightward", () => {
+    const pill = { left: 156, right: 356, top: 100, bottom: 144 };
+    expect(bridgeRect(AVATAR, pill)).toEqual({
+      left: 144,
+      right: 156,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  test("spans them the other way when it grows leftward", () => {
+    const pill = { left: -100, right: 88, top: 100, bottom: 144 };
+    expect(bridgeRect(AVATAR, pill)).toEqual({
+      left: 88,
+      right: 100,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  /**
+   * The pill's height, never the avatar's. A strip as tall as a larger creature
+   * would claim the dead corners beside it, which is the bounding box this
+   * exists instead of.
+   */
+  test("takes the pill's height rather than a taller avatar's", () => {
+    const tall = { left: 100, right: 200, top: 40, bottom: 200 };
+    const pill = { left: 212, right: 412, top: 156, bottom: 200 };
+    expect(bridgeRect(tall, pill)).toEqual({
+      left: 200,
+      right: 212,
+      top: 156,
+      bottom: 200,
+    });
+  });
+
+  /** Overlapping rects have no gap between them, and an empty strip says so. */
+  test("is empty when the two overlap", () => {
+    const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
+    const bridge = bridgeRect(AVATAR, overlapping);
+    expect(bridge.left).toBeGreaterThan(bridge.right);
+  });
+});
 
 describe("dragging the companion surface", () => {
-  test("moves the window by the pointer's travel", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
-    const canvas = canvasOf(container);
+  /**
+   * Both drawn halves are handles. The drag is a window move, so whichever the
+   * hand happens to land on takes the whole surface with it, and a creature
+   * that could not be grabbed would be the part users reach for first.
+   */
+  test("moves the window by the pointer's travel, from either half", async () => {
+    for (const half of ["avatar", "pill"] as const) {
+      const { container } = render(<CompanionSurfacePage />);
+      const pinned = await pinSurface(container);
+      const canvas = canvasOf(container);
 
-    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
-    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
-    fireEvent.mouseMove(canvas, {
-      clientX: 120,
-      clientY: 120,
-      screenX: 530,
-      screenY: 520,
-      buttons: 1,
-    });
+      fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+      fireEvent.mouseDown(pinned[half], { screenX: 500, screenY: 500 });
+      fireEvent.mouseMove(canvas, {
+        clientX: 120,
+        clientY: 120,
+        screenX: 530,
+        screenY: 520,
+        buttons: 1,
+      });
 
-    expect(moveByMock.mock.calls).toEqual([[30, 20]]);
+      expect(moveByMock.mock.calls).toEqual([[30, 20]]);
+      cleanup();
+      moveByMock.mockClear();
+    }
   });
 
   /**
@@ -184,7 +339,7 @@ describe("dragging the companion surface", () => {
    */
   test("ends a drag whose release landed outside the window", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
@@ -213,7 +368,7 @@ describe("dragging the companion surface", () => {
 
   test("hit-tests again once the abandoned drag is dropped", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
@@ -243,7 +398,7 @@ describe("dragging the companion surface", () => {
 
   test("a press that travelled is not a click on the avatar", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { avatar, pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
@@ -256,20 +411,20 @@ describe("dragging the companion surface", () => {
       buttons: 1,
     });
     fireEvent.mouseUp(canvas);
-    fireEvent.click(avatarOf(container));
+    fireEvent.click(avatar);
 
     expect(activateMock).not.toHaveBeenCalled();
   });
 
   test("a press that held still still goes back to Vellum", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { avatar, pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
     fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
     fireEvent.mouseUp(canvas);
-    fireEvent.click(avatarOf(container));
+    fireEvent.click(avatar);
 
     expect(activateMock).toHaveBeenCalledTimes(1);
   });
@@ -294,7 +449,7 @@ describe("the working ring on the page", () => {
 
   test("stays dark when nothing is running", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
 
     expect(container.querySelector(".companion-working-ring")).toBeNull();
   });
@@ -320,7 +475,7 @@ describe("the watch session on the companion surface", () => {
 
   test("hands the press back to the window holding the session", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     const canvas = canvasOf(container);
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
 
@@ -403,7 +558,7 @@ describe("the watch session on the companion surface", () => {
    */
   test("reads a state that says nothing about it as no session", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
 
     await waitFor(() => {
@@ -419,7 +574,7 @@ describe("the watch session on the companion surface", () => {
   test("keeps a way out of the session while the composer is open", async () => {
     STATE.watching = true;
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
     fireEvent.click(
       await waitFor(() => {
@@ -463,26 +618,15 @@ describe("the companion's introduction", () => {
       }
       return found;
     });
-    // Well clear of the pill's box in `pinPill`, so a pointer on one is
-    // provably not on the other.
-    card.getBoundingClientRect = () =>
-      ({
-        left: 300,
-        right: 544,
-        top: 300,
-        bottom: 380,
-        x: 300,
-        y: 300,
-        width: 244,
-        height: 80,
-        toJSON: () => ({}),
-      }) as DOMRect;
+    // Well clear of the boxes `pinSurface` gives the avatar and the pill, so a
+    // pointer on one is provably not on the other.
+    pin(card, { left: 300, right: 544, top: 300, bottom: 380 });
     return card;
   };
 
   test("draws nothing while no run is due", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     expect(container.querySelector('[role="group"]')).toBeNull();
   });
 
@@ -539,7 +683,7 @@ describe("the companion's introduction", () => {
   test("makes the window clickable while the pointer is on the card", async () => {
     STATE.intro = "meet";
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     await pinCard(container);
     const canvas = canvasOf(container);
 
@@ -556,7 +700,7 @@ describe("the companion's introduction", () => {
   test("does not read a pointer on the card as hovering the avatar", async () => {
     STATE.intro = "meet";
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
     await pinCard(container);
     const canvas = canvasOf(container);
 
@@ -577,7 +721,7 @@ describe("the companion's introduction", () => {
   test("gives the desktop back when the run ends under the pointer", async () => {
     STATE.intro = "menu";
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     await pinCard(container);
     const canvas = canvasOf(container);
 
@@ -610,7 +754,7 @@ describe("the companion's introduction", () => {
       assistantName: "Ziggy",
     };
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     expect(container.querySelector('[role="group"]')).toBeNull();
   });
 
@@ -631,7 +775,7 @@ describe("the companion's introduction", () => {
       assistantName: "Ziggy",
     };
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     expect(container.querySelector('[role="group"]')).toBeNull();
 
     STATE.call = null;
@@ -655,7 +799,7 @@ describe("the Watch flag on the companion surface", () => {
 
   /** Open the pill, which is where the way into a session would be drawn. */
   const openPill = async (container: HTMLElement): Promise<void> => {
-    await pinPill(container);
+    await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
     await waitFor(() => {
       if (!container.querySelector('button[aria-label="Talk"]')) {
@@ -697,7 +841,7 @@ describe("the Watch flag on the companion surface", () => {
     STATE.watchEnabled = false;
     STATE.watching = true;
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
 
     const stop = await waitFor(() => {
@@ -721,13 +865,21 @@ describe("the Watch flag on the companion surface", () => {
  * press on the object itself is where a user reaches first.
  */
 describe("the companion's own menu", () => {
-  test("a right-click asks main to open it", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+  /**
+   * On the creature as much as on the pill: a user reaching for "make this go
+   * away" should not have to find the one of the two that carries the menu.
+   */
+  test("a right-click on either half asks main to open it", async () => {
+    for (const half of ["avatar", "pill"] as const) {
+      const { container } = render(<CompanionSurfacePage />);
+      const pinned = await pinSurface(container);
 
-    fireEvent.contextMenu(pill);
+      fireEvent.contextMenu(pinned[half]);
 
-    expect(contextMenuMock).toHaveBeenCalled();
+      expect(contextMenuMock).toHaveBeenCalled();
+      cleanup();
+      contextMenuMock.mockClear();
+    }
   });
 
   /**
@@ -743,7 +895,7 @@ describe("the companion's own menu", () => {
    */
   test("leaves the native text menu alone inside the composer", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
 
     // Open the composer, which is what puts a field on the card.
     const type = Array.from(pill.querySelectorAll("button")).find(
@@ -765,7 +917,7 @@ describe("the companion's own menu", () => {
 
   test("a right-press does not start a drag", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
@@ -818,7 +970,9 @@ describe("the companion's accent colour", () => {
     hex: string,
   ): Promise<void> => {
     await waitFor(() => {
-      const pill = container.querySelector<HTMLElement>(".cursor-grab");
+      const pill = container.querySelector<HTMLElement>(
+        ".transition-\\[width\\]",
+      );
       if (!pill) {
         throw new Error("Expected the pill to render");
       }

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -25,6 +25,10 @@ import {
   toggleCompanionWatch,
 } from "@/runtime/companion-surface";
 import { sendVoiceActivityControl } from "@/runtime/desktop-voice-activity";
+import {
+  COMPANION_BASE_AVATAR_BOX,
+  companionScaleFor,
+} from "@vellumai/ipc-contract";
 import type {
   CompanionCardGrowth,
   CompanionCharacter,
@@ -44,15 +48,6 @@ import type {
  * turn "take me back to Vellum" into a one-pixel nudge that does nothing.
  */
 const DRAG_SLOP = 3;
-
-/**
- * The avatar's box the surface's layout is authored at.
- *
- * Matches `BASE_AVATAR_BOX` in `companion-window.ts`. Main publishes the box it
- * actually sized the window for, and the ratio between the two is the scale:
- * one number, and the surface below is the same layout multiplied.
- */
-const BASE_AVATAR_BOX = 44;
 
 /** As much of a rect as hit-testing a point against it needs. */
 type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
@@ -120,10 +115,11 @@ export function CompanionSurfacePage() {
   // to. Main's call: it owns the window position and is the only side that
   // knows how much room the display has above the surface.
   const [cardGrowth, setCardGrowth] = useState<CompanionCardGrowth>("up");
-  // The avatar's box in points, which is the surface's whole scale. Main sizes
-  // the window from it, so it arrives with the state rather than being a
-  // setting this window reads for itself.
-  const [avatarBox, setAvatarBox] = useState(BASE_AVATAR_BOX);
+  // The creature's box in points and the pill's, which are the surface's whole
+  // scale between them. Main sizes the window from both, so they arrive with
+  // the state rather than being settings this window reads for itself.
+  const [avatarBox, setAvatarBox] = useState(COMPANION_BASE_AVATAR_BOX);
+  const [optionsBox, setOptionsBox] = useState(COMPANION_BASE_AVATAR_BOX);
   const [avatarSrc, setAvatarSrc] = useState<string | undefined>();
   const [character, setCharacter] = useState<CompanionCharacter | undefined>();
   const [call, setCall] = useState<VoiceActivityState | null>(null);
@@ -197,6 +193,7 @@ export function CompanionSurfacePage() {
       setGrowth(state.growth);
       setCardGrowth(state.cardGrowth);
       setAvatarBox(state.avatarBox);
+      setOptionsBox(state.optionsBox);
       setAvatarSrc(
         state.avatarBase64 === undefined
           ? undefined
@@ -466,6 +463,10 @@ export function CompanionSurfacePage() {
     resolveAvatarAccentHex(null, character ?? null) ??
     undefined;
 
+  // The scale the whole canvas is drawn at, which is the options size over the
+  // size the layout is authored at.
+  const optionsScale = companionScaleFor(optionsBox);
+
   return (
     <div
       className="relative h-screen w-screen bg-transparent"
@@ -492,20 +493,30 @@ export function CompanionSurfacePage() {
           them in step with main's arithmetic, which is the drift this avoids
           rather than manages.
 
+          **The options size drives it, not the avatar's.** Almost every length
+          in the layout belongs to the pill, the card or the introduction, so
+          the wrapper is where the options scale is spent; the creature is one
+          element and carries the difference between the two boxes itself.
+
           Nothing else has to know. Hit-testing reads `getBoundingClientRect`,
           which is post-transform, and the drag is in screen deltas. */}
       <div
         className="absolute top-0 left-0 origin-top-left"
         style={{
-          width: `${(100 * BASE_AVATAR_BOX) / avatarBox}%`,
-          height: `${(100 * BASE_AVATAR_BOX) / avatarBox}%`,
-          transform: `scale(${avatarBox / BASE_AVATAR_BOX})`,
+          width: `${100 / optionsScale}%`,
+          height: `${100 / optionsScale}%`,
+          transform: `scale(${optionsScale})`,
         }}
       >
         <CompanionSurface
           phase={phase}
           growth={growth}
           cardGrowth={cardGrowth}
+          // The two boxes main sized the window for. The wrapper above has
+          // spent the options one already; the surface uses both to place the
+          // pill against a creature that may be a different size from it.
+          avatarBox={avatarBox}
+          optionsBox={optionsBox}
           avatarSrc={avatarSrc}
           character={character}
           // The creature notices the hand, in every state including mid-call.
@@ -574,6 +585,10 @@ export function CompanionSurfacePage() {
                 beat={intro}
                 growth={growth}
                 cardGrowth={cardGrowth}
+                // The card steps off the creature by the same gap the pill
+                // does, so it is given the same two boxes.
+                avatarBox={avatarBox}
+                optionsBox={optionsBox}
                 accentHex={accentHex}
                 // Same undefined-not-empty rule as the composer's placeholder
                 // above: the first beat introduces the creature by name, and

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -6,10 +6,8 @@ import {
   introSpotlight,
 } from "@/components/companion-intro";
 import {
-  bridgeRect,
-  COMPANION_BOB_LIFT,
   containsPoint,
-  type SurfaceRect,
+  onCompanionSurface,
 } from "@/components/companion-layout";
 import {
   CompanionSurface,
@@ -333,8 +331,8 @@ export function CompanionSurfacePage() {
    *
    * **The surface is several rects, and the answer is their union.** The
    * creature, the pill beside it, the strip of gap between them, and the
-   * introduction's card while it is drawn; see {@link bridgeRect} for why the
-   * box around them all is the wrong shape.
+   * introduction's card while it is drawn; see {@link onCompanionSurface} for
+   * why the box around them all is the wrong shape.
    */
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
     // **A drag whose release this window never saw ends here.**
@@ -381,55 +379,39 @@ export function CompanionSurfacePage() {
     if (!avatar) {
       return;
     }
-    const inside = (rect: SurfaceRect): boolean =>
-      containsPoint(rect, event.clientX, event.clientY);
     // Reading a box forces layout, and this runs on every pixel of every
     // mouse-move the host forwards, so each is read once and the pill's is not
     // read at all until there is a pill.
-    const drawn = avatar.getBoundingClientRect();
-    // The creature's box, plus the strip above it the bob lifts the artwork
-    // into. The element holds still and the drawing rises off it, so a pointer
-    // on the creature's own head is outside the box it belongs to.
-    const avatarRect: SurfaceRect = {
-      left: drawn.left,
-      right: drawn.right,
-      top:
-        drawn.top -
-        (COMPANION_BOB_LIFT * avatarBox) / COMPANION_BASE_AVATAR_BOX,
-      bottom: drawn.bottom,
-    };
-    const onAvatar = inside(avatarRect);
-    // The pill and the gap only count once there is a pill: at rest its box is
-    // nothing, and a rect of nothing beside the avatar is not somewhere a
-    // pointer can be.
     const pill = expanded ? pillRef.current : null;
-    let onPill = false;
-    let onBridge = false;
-    if (pill !== null) {
-      const pillRect = pill.getBoundingClientRect();
-      onPill = inside(pillRect);
-      onBridge = inside(
-        bridgeRect(avatarRect, pillRect, {
-          // The composer row in screen pixels: one base box at the options
-          // scale, which is the options box itself.
-          rowHeight: optionsBox,
-          cardGrowth,
-        }),
-      );
-    }
+    const onSurface = onCompanionSurface(
+      { x: event.clientX, y: event.clientY },
+      {
+        avatar: avatar.getBoundingClientRect(),
+        pill: pill === null ? null : pill.getBoundingClientRect(),
+        // The composer row in screen pixels: one base box at the options
+        // scale, which is the options box itself.
+        rowHeight: optionsBox,
+        cardGrowth,
+      },
+    );
     // The introduction's card is part of the surface for as long as it is
     // drawn. Testing only the surface would leave the window click-through over
     // Next and Skip, so the presses meant to end the run would land on whatever
     // application is behind it instead.
     const introCard = introRef.current;
     const onIntro =
-      introCard !== null && inside(introCard.getBoundingClientRect());
+      introCard !== null &&
+      containsPoint(
+        introCard.getBoundingClientRect(),
+        event.clientX,
+        event.clientY,
+      );
     // Hover is the creature noticing a hand on *it*, so the card does not feed
     // it: a pointer resting on a paragraph is not a pointer on the avatar, and
     // widening the eyes for it would be the surface reacting to the wrong
     // thing.
-    setHovered(onAvatar || onPill || onBridge);
-    setInteractive(onAvatar || onPill || onBridge || onIntro);
+    setHovered(onSurface);
+    setInteractive(onSurface || onIntro);
   };
 
   // The avatar's own colour. A running call publishes one, and it wins: it is

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -6,6 +6,12 @@ import {
   introSpotlight,
 } from "@/components/companion-intro";
 import {
+  bridgeRect,
+  COMPANION_BOB_LIFT,
+  containsPoint,
+  type SurfaceRect,
+} from "@/components/companion-layout";
+import {
   CompanionSurface,
   type CompanionSurfacePhase,
 } from "@/components/companion-surface";
@@ -48,45 +54,6 @@ import type {
  * turn "take me back to Vellum" into a one-pixel nudge that does nothing.
  */
 const DRAG_SLOP = 3;
-
-/** As much of a rect as hit-testing a point against it needs. */
-type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
-
-/**
- * The gap between the avatar and the pill, as a rect of its own.
- *
- * **The surface is a union of rects, never the box around them.** The avatar
- * and the pill are separate elements, and a bounding box over the pair would
- * claim the empty canvas above and below the gap as well: a click-through
- * window told it is interactive there swallows the presses meant for whatever
- * is behind it, which is the failure every note in this file is about. So the
- * gap is tested as exactly what it is, a strip between the two facing edges,
- * running the pill's own height.
- *
- * It has to be part of the surface at all because the pointer crosses it on the
- * way from the creature to the controls. A window that went click-through
- * halfway would drop the press the user was travelling to make.
- *
- * Degenerate when the two overlap, which reads as no bridge at all: the strip's
- * left edge lands past its right, and no point is inside it.
- */
-export const bridgeRect = (
-  avatar: SurfaceRect,
-  pill: SurfaceRect,
-): SurfaceRect =>
-  pill.left >= avatar.right
-    ? {
-        left: avatar.right,
-        right: pill.left,
-        top: pill.top,
-        bottom: pill.bottom,
-      }
-    : {
-        left: pill.right,
-        right: avatar.left,
-        top: pill.top,
-        bottom: pill.bottom,
-      };
 
 /**
  * The companion surface inside its Electron canvas
@@ -193,7 +160,10 @@ export function CompanionSurfacePage() {
       setGrowth(state.growth);
       setCardGrowth(state.cardGrowth);
       setAvatarBox(state.avatarBox);
-      setOptionsBox(state.optionsBox);
+      // The creature's box unless the pill has one of its own, which covers a
+      // shell that predates the second axis: one box for both is the surface
+      // that side is drawing.
+      setOptionsBox(state.optionsBox ?? state.avatarBox);
       setAvatarSrc(
         state.avatarBase64 === undefined
           ? undefined
@@ -263,7 +233,7 @@ export function CompanionSurfacePage() {
    *
    * **Hover has to be dropped with it.** Hover is derived from hit-testing the
    * pointer against the surface's own box on every move, and the box the last
-   * move tested was the card: a 360pt panel standing well above the pill. The
+   * move tested was the card: a panel standing well above the pill. The
    * moment the card is gone that answer describes a shape that no longer
    * exists, and nothing corrects it, because the correction is a mouse-move and
    * the hand that just pressed "go back" is holding still. Left alone the
@@ -407,26 +377,46 @@ export function CompanionSurfacePage() {
       }
       return;
     }
-    const pill = pillRef.current;
     const avatar = avatarRef.current;
-    if (!pill || !avatar) {
+    if (!avatar) {
       return;
     }
     const inside = (rect: SurfaceRect): boolean =>
-      event.clientX >= rect.left &&
-      event.clientX <= rect.right &&
-      event.clientY >= rect.top &&
-      event.clientY <= rect.bottom;
-    // Each box read once. Reading one forces layout, and this runs on every
-    // pixel of every mouse-move the host forwards.
-    const avatarRect = avatar.getBoundingClientRect();
-    const pillRect = pill.getBoundingClientRect();
+      containsPoint(rect, event.clientX, event.clientY);
+    // Reading a box forces layout, and this runs on every pixel of every
+    // mouse-move the host forwards, so each is read once and the pill's is not
+    // read at all until there is a pill.
+    const drawn = avatar.getBoundingClientRect();
+    // The creature's box, plus the strip above it the bob lifts the artwork
+    // into. The element holds still and the drawing rises off it, so a pointer
+    // on the creature's own head is outside the box it belongs to.
+    const avatarRect: SurfaceRect = {
+      left: drawn.left,
+      right: drawn.right,
+      top:
+        drawn.top -
+        (COMPANION_BOB_LIFT * avatarBox) / COMPANION_BASE_AVATAR_BOX,
+      bottom: drawn.bottom,
+    };
     const onAvatar = inside(avatarRect);
     // The pill and the gap only count once there is a pill: at rest its box is
     // nothing, and a rect of nothing beside the avatar is not somewhere a
     // pointer can be.
-    const onPill = expanded && inside(pillRect);
-    const onBridge = expanded && inside(bridgeRect(avatarRect, pillRect));
+    const pill = expanded ? pillRef.current : null;
+    let onPill = false;
+    let onBridge = false;
+    if (pill !== null) {
+      const pillRect = pill.getBoundingClientRect();
+      onPill = inside(pillRect);
+      onBridge = inside(
+        bridgeRect(avatarRect, pillRect, {
+          // The composer row in screen pixels: one base box at the options
+          // scale, which is the options box itself.
+          rowHeight: optionsBox,
+          cardGrowth,
+        }),
+      );
+    }
     // The introduction's card is part of the surface for as long as it is
     // drawn. Testing only the surface would leave the window click-through over
     // Next and Skip, so the presses meant to end the run would land on whatever
@@ -585,8 +575,8 @@ export function CompanionSurfacePage() {
                 beat={intro}
                 growth={growth}
                 cardGrowth={cardGrowth}
-                // The card steps off the creature by the same gap the pill
-                // does, so it is given the same two boxes.
+                // The card clears whatever the pill draws beside the creature,
+                // so it is given the same two boxes.
                 avatarBox={avatarBox}
                 optionsBox={optionsBox}
                 accentHex={accentHex}

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -317,7 +317,6 @@ export function CompanionSurfacePage() {
         : watchRetro !== undefined
           ? "summary"
           : (introHeld ?? (hovered ? "hover" : "resting"));
-  const expanded = phase !== "resting";
 
   /**
    * Hit-test the pointer against the surface on every move.
@@ -379,15 +378,23 @@ export function CompanionSurfacePage() {
     if (!avatar) {
       return;
     }
+    // **The pill is part of the surface for as long as it is drawn**, and that
+    // outlasts the expanded phase by the width transition: the moment the
+    // pointer leaves, the phase is resting while the pill is still on screen
+    // collapsing through 300ms of width. So the measured width decides, not the
+    // phase, and a pointer coming back over what is still drawn arms the window
+    // and re-opens the pill rather than clicking into the application behind
+    // it. At rest the width is zero, and a rect of nothing beside the creature
+    // is not somewhere a pointer can be.
+    //
     // Reading a box forces layout, and this runs on every pixel of every
-    // mouse-move the host forwards, so each is read once and the pill's is not
-    // read at all until there is a pill.
-    const pill = expanded ? pillRef.current : null;
+    // mouse-move the host forwards, so each is read exactly once.
+    const pillRect = pillRef.current?.getBoundingClientRect() ?? null;
     const onSurface = onCompanionSurface(
       { x: event.clientX, y: event.clientY },
       {
         avatar: avatar.getBoundingClientRect(),
-        pill: pill === null ? null : pill.getBoundingClientRect(),
+        pill: pillRect !== null && pillRect.width > 0 ? pillRect : null,
         // The composer row in screen pixels: one base box at the options
         // scale, which is the options box itself.
         rowHeight: optionsBox,

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -9,6 +9,7 @@ import {
   CompanionSurface,
   type CompanionSurfacePhase,
 } from "@/components/companion-surface";
+import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import {
   activateCompanionApp,
   answerCompanionWatchRetro,
@@ -390,15 +391,26 @@ export function CompanionSurfacePage() {
           ? "summary"
           : (introHeld ?? (hovered ? "hover" : "resting"));
 
-  // The avatar's own colour, which arrives with the session. It is `""` until
-  // the avatar resolves and the contract makes no promise it parses, so
-  // anything that is not an obvious `#RRGGBB` falls back to the component's
-  // default rather than being handed to CSS, where an invalid value silently
-  // drops the custom property and takes the glyph's colour with it.
-  const accentHex =
+  // The avatar's own colour. A running call publishes one, and it wins: it is
+  // the colour the call surfaces elsewhere are already tinted with. Outside a
+  // call the character's palette id resolves to the same hex the app draws the
+  // creature in, so the resting glow is the assistant's colour rather than the
+  // component's teal default.
+  //
+  // The call's hex is `""` until the avatar resolves and the contract makes no
+  // promise it parses, so anything that is not an obvious `#RRGGBB` falls
+  // through rather than being handed to CSS, where an invalid value silently
+  // drops the custom property and takes the glyph's colour with it. The
+  // resolver is handed `null` components on purpose: this window has no daemon
+  // query, so the bundled palette is the only one it can read.
+  const callAccentHex =
     call !== null && /^#[0-9a-f]{6}$/i.test(call.accentHex)
       ? call.accentHex
       : undefined;
+  const accentHex =
+    callAccentHex ??
+    resolveAvatarAccentHex(null, character ?? null) ??
+    undefined;
 
   return (
     <div

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -54,6 +54,45 @@ const DRAG_SLOP = 3;
  */
 const BASE_AVATAR_BOX = 44;
 
+/** As much of a rect as hit-testing a point against it needs. */
+type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
+
+/**
+ * The gap between the avatar and the pill, as a rect of its own.
+ *
+ * **The surface is a union of rects, never the box around them.** The avatar
+ * and the pill are separate elements, and a bounding box over the pair would
+ * claim the empty canvas above and below the gap as well: a click-through
+ * window told it is interactive there swallows the presses meant for whatever
+ * is behind it, which is the failure every note in this file is about. So the
+ * gap is tested as exactly what it is, a strip between the two facing edges,
+ * running the pill's own height.
+ *
+ * It has to be part of the surface at all because the pointer crosses it on the
+ * way from the creature to the controls. A window that went click-through
+ * halfway would drop the press the user was travelling to make.
+ *
+ * Degenerate when the two overlap, which reads as no bridge at all: the strip's
+ * left edge lands past its right, and no point is inside it.
+ */
+export const bridgeRect = (
+  avatar: SurfaceRect,
+  pill: SurfaceRect,
+): SurfaceRect =>
+  pill.left >= avatar.right
+    ? {
+        left: avatar.right,
+        right: pill.left,
+        top: pill.top,
+        bottom: pill.bottom,
+      }
+    : {
+        left: pill.right,
+        right: avatar.left,
+        top: pill.top,
+        bottom: pill.bottom,
+      };
+
 /**
  * The companion surface inside its Electron canvas
  * (`clients/macos/src/main/companion-window.ts`).
@@ -134,6 +173,10 @@ export function CompanionSurfacePage() {
   // send the same instruction on every mouse-move.
   const interactiveRef = useRef(false);
   const pillRef = useRef<HTMLDivElement | null>(null);
+  // The creature's own box, hit-tested beside the pill rather than inside it:
+  // the two are siblings with a gap between them, and at rest the avatar is the
+  // only part of the surface drawn at all.
+  const avatarRef = useRef<HTMLDivElement | null>(null);
   // The introduction's card, hit-tested alongside the pill: it carries the only
   // two controls in the run, and a click-through window would drop presses on
   // them onto whatever is behind it.
@@ -273,15 +316,58 @@ export function CompanionSurfacePage() {
     setStarted(false);
   };
 
+  // **An open composer outranks everything, and a running call outranks the
+  // pointer.** The surface is otherwise a circle that only becomes a pill while
+  // it is being pointed at, and a live microphone that hides itself the moment
+  // the pointer leaves is a live microphone the user cannot see. So the call
+  // holds the pill open, and hovering it changes nothing: the controls it wants
+  // are already there.
+  //
+  // The composer sits above even that, because it is the one state holding
+  // something of the user's. A call starting from the app while a sentence is
+  // half-typed must not collapse the card and take the sentence with it.
+  //
+  // A watch session holds the pill open for the same reason the call does, and
+  // ranks below both: they are things the user is in the middle of, where this
+  // one runs beside whatever they are doing. Being outranked costs the session
+  // nothing, since the phase is only what the pill is drawing and the indicator
+  // reads `watching` instead.
+  //
+  // The summary of a finished session sits between the two: it outranks hover
+  // because it is a wait the user is owed an answer to and then a question
+  // waiting on one, and it is outranked by a session still recording, which is
+  // the one thing on this surface a user must always be able to see and stop.
+  // The introduction sits above the pointer and below everything the user is in
+  // the middle of. A beat that names a control has to have that control on
+  // screen to name, so it holds the pill open the way a call does; but a run
+  // still going when a call starts or the composer opens must give way, because
+  // those are the user's own business and this is a caption.
+  const introHeld = introPhase(intro);
+  const phase: CompanionSurfacePhase = typing
+    ? "typing"
+    : call !== null
+      ? "call"
+      : watching
+        ? "watching"
+        : watchRetro !== undefined
+          ? "summary"
+          : (introHeld ?? (hovered ? "hover" : "resting"));
+  const expanded = phase !== "resting";
+
   /**
-   * Hit-test the pointer against the pill on every move.
+   * Hit-test the pointer against the surface on every move.
    *
    * Not `mouseenter`: a click-through window delivers forwarded mouse-move and
    * little else, so entering and leaving have to be derived from coordinates.
    * `dictation-overlay-page.tsx` measures its stop button the same way for the
-   * same reason. The rect is read live rather than cached because the pill
+   * same reason. The rects are read live rather than cached because the pill
    * changes width as it expands, and a stale rect would collapse the surface
    * the moment it finished growing.
+   *
+   * **The surface is several rects, and the answer is their union.** The
+   * creature, the pill beside it, the strip of gap between them, and the
+   * introduction's card while it is drawn; see {@link bridgeRect} for why the
+   * box around them all is the wrong shape.
    */
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
     // **A drag whose release this window never saw ends here.**
@@ -325,71 +411,39 @@ export function CompanionSurfacePage() {
       return;
     }
     const pill = pillRef.current;
-    if (!pill) {
+    const avatar = avatarRef.current;
+    if (!pill || !avatar) {
       return;
     }
-    const within = (element: HTMLElement | null): boolean => {
-      if (!element) {
-        return false;
-      }
-      const rect = element.getBoundingClientRect();
-      return (
-        event.clientX >= rect.left &&
-        event.clientX <= rect.right &&
-        event.clientY >= rect.top &&
-        event.clientY <= rect.bottom
-      );
-    };
-    const onPill = within(pill);
+    const inside = (rect: SurfaceRect): boolean =>
+      event.clientX >= rect.left &&
+      event.clientX <= rect.right &&
+      event.clientY >= rect.top &&
+      event.clientY <= rect.bottom;
+    // Each box read once. Reading one forces layout, and this runs on every
+    // pixel of every mouse-move the host forwards.
+    const avatarRect = avatar.getBoundingClientRect();
+    const pillRect = pill.getBoundingClientRect();
+    const onAvatar = inside(avatarRect);
+    // The pill and the gap only count once there is a pill: at rest its box is
+    // nothing, and a rect of nothing beside the avatar is not somewhere a
+    // pointer can be.
+    const onPill = expanded && inside(pillRect);
+    const onBridge = expanded && inside(bridgeRect(avatarRect, pillRect));
     // The introduction's card is part of the surface for as long as it is
-    // drawn. Testing only the pill would leave the window click-through over
+    // drawn. Testing only the surface would leave the window click-through over
     // Next and Skip, so the presses meant to end the run would land on whatever
     // application is behind it instead.
-    const onIntro = within(introRef.current);
+    const introCard = introRef.current;
+    const onIntro =
+      introCard !== null && inside(introCard.getBoundingClientRect());
     // Hover is the creature noticing a hand on *it*, so the card does not feed
     // it: a pointer resting on a paragraph is not a pointer on the avatar, and
     // widening the eyes for it would be the surface reacting to the wrong
     // thing.
-    setHovered(onPill);
-    setInteractive(onPill || onIntro);
+    setHovered(onAvatar || onPill || onBridge);
+    setInteractive(onAvatar || onPill || onBridge || onIntro);
   };
-
-  // **An open composer outranks everything, and a running call outranks the
-  // pointer.** The surface is otherwise a circle that only becomes a pill while
-  // it is being pointed at, and a live microphone that hides itself the moment
-  // the pointer leaves is a live microphone the user cannot see. So the call
-  // holds the pill open, and hovering it changes nothing: the controls it wants
-  // are already there.
-  //
-  // The composer sits above even that, because it is the one state holding
-  // something of the user's. A call starting from the app while a sentence is
-  // half-typed must not collapse the card and take the sentence with it.
-  //
-  // A watch session holds the pill open for the same reason the call does, and
-  // ranks below both: they are things the user is in the middle of, where this
-  // one runs beside whatever they are doing. Being outranked costs the session
-  // nothing, since the phase is only what the pill is drawing and the indicator
-  // reads `watching` instead.
-  //
-  // The summary of a finished session sits between the two: it outranks hover
-  // because it is a wait the user is owed an answer to and then a question
-  // waiting on one, and it is outranked by a session still recording, which is
-  // the one thing on this surface a user must always be able to see and stop.
-  // The introduction sits above the pointer and below everything the user is in
-  // the middle of. A beat that names a control has to have that control on
-  // screen to name, so it holds the pill open the way a call does; but a run
-  // still going when a call starts or the composer opens must give way, because
-  // those are the user's own business and this is a caption.
-  const introHeld = introPhase(intro);
-  const phase: CompanionSurfacePhase = typing
-    ? "typing"
-    : call !== null
-      ? "call"
-      : watching
-        ? "watching"
-        : watchRetro !== undefined
-          ? "summary"
-          : (introHeld ?? (hovered ? "hover" : "resting"));
 
   // The avatar's own colour. A running call publishes one, and it wins: it is
   // the colour the call surfaces elsewhere are already tinted with. Outside a
@@ -532,6 +586,7 @@ export function CompanionSurfacePage() {
             )
           }
           rootRef={pillRef}
+          avatarRef={avatarRef}
           onSurfaceMouseDown={(event) => {
             // A right-click is a menu, not a grab. Left alone it would arm the
             // drag and then never be released by a `mouseup` this window sees,

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -29,10 +29,7 @@ import {
   toggleCompanionWatch,
 } from "@/runtime/companion-surface";
 import { sendVoiceActivityControl } from "@/runtime/desktop-voice-activity";
-import {
-  COMPANION_BASE_AVATAR_BOX,
-  companionScaleFor,
-} from "@vellumai/ipc-contract";
+import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 import type {
   CompanionCardGrowth,
   CompanionCharacter,
@@ -442,10 +439,6 @@ export function CompanionSurfacePage() {
     resolveAvatarAccentHex(null, character ?? null) ??
     undefined;
 
-  // The scale the whole canvas is drawn at, which is the options size over the
-  // size the layout is authored at.
-  const optionsScale = companionScaleFor(optionsBox);
-
   return (
     <div
       className="relative h-screen w-screen bg-transparent"
@@ -461,206 +454,185 @@ export function CompanionSurfacePage() {
         setInteractive(false);
       }}
     >
-      {/* The surface at whatever size the user picked, as the one layout
-          multiplied rather than a second set of dimensions.
+      {/* The surface at whatever size the user picked, which it draws itself:
+          it takes the two boxes and scales its own outermost element by the
+          options one, so this page holds no dimensions of its own.
 
-          The box is the base canvas: the window divided by the scale, blown
-          back up about its own top-left corner, so it covers the window exactly
-          and every length inside (the `100%` the surface anchors to, its
-          paddings, its type) resolves in the units the layout was written in.
-          The alternative was scaling forty hard-coded dimensions and keeping
-          them in step with main's arithmetic, which is the drift this avoids
-          rather than manages.
-
-          **The options size drives it, not the avatar's.** Almost every length
-          in the layout belongs to the pill, the card or the introduction, so
-          the wrapper is where the options scale is spent; the creature is one
-          element and carries the difference between the two boxes itself.
-
-          Nothing else has to know. Hit-testing reads `getBoundingClientRect`,
+          Nothing here has to know. Hit-testing reads `getBoundingClientRect`,
           which is post-transform, and the drag is in screen deltas. */}
-      <div
-        className="absolute top-0 left-0 origin-top-left"
-        style={{
-          width: `${100 / optionsScale}%`,
-          height: `${100 / optionsScale}%`,
-          transform: `scale(${optionsScale})`,
-        }}
-      >
-        <CompanionSurface
-          phase={phase}
-          growth={growth}
-          cardGrowth={cardGrowth}
-          // The two boxes main sized the window for. The wrapper above has
-          // spent the options one already; the surface uses both to place the
-          // pill against a creature that may be a different size from it.
-          avatarBox={avatarBox}
-          optionsBox={optionsBox}
-          avatarSrc={avatarSrc}
-          character={character}
-          // The creature notices the hand, in every state including mid-call.
-          hovered={hovered}
-          accentHex={accentHex}
-          // The conversation, as far as the card shows it. Held by main and
-          // pushed with the rest of the state, so it survives this window
-          // reloading mid-exchange.
-          //
-          // Nothing at all until this composer has sent something: what main is
-          // holding until then belongs to whatever conversation the app has open,
-          // and showing it would promise that the message about to be typed joins
-          // it, which is exactly what pressing Type no longer does.
-          turns={started ? turns : []}
-          // The assistant's own name in the composer's placeholder. Undefined
-          // rather than empty, so the component's fallback is what fills the gap
-          // before the app's window has published one.
-          assistantName={assistantName === "" ? undefined : assistantName}
-          call={call ?? undefined}
-          // Unlike the turns, this is drawn whether or not the exchange on the
-          // card is this surface's own: the question it answers is whether the
-          // assistant is busy, and it is busy on someone else's conversation just
-          // as much as on this one.
-          working={working}
-          // Its own prop rather than something the surface derives from the
-          // phase. The phase above is outranked by `typing` and `call`, and the
-          // indicator and the control that ends the session are not: they
-          // belong to the session, not to whatever the pill is drawing over it.
-          watching={watching}
-          // Its own prop rather than something derived from the phase, for the
-          // reason `watching` is: a call or an open composer outranks the
-          // phase, and a question the user has been asked must not lose its
-          // answer because they picked up the phone.
-          watchRetro={watchRetro}
-          // Out through main and into the window that ran the retrospective. A
-          // yes raises the app on the report; a no leaves the window where it
-          // is. Neither is handled here: this page has no conversation and no
-          // router, and the answer has to reach the side holding the question
-          // or the prompt comes back on the next push.
-          onWatchRetro={answerCompanionWatchRetro}
-          // The reads that session has taken, which is what turns a running
-          // session into something the user can see happening rather than
-          // something they are told is on.
-          captureCount={captureCount}
-          // The flag, from main. It hides the way into a session and leaves
-          // everything a running one draws alone, so a session already going
-          // when the flag turns off can still be seen and still be stopped.
-          watchEnabled={watchEnabled}
-          // Draws the control the beat is about as though the pointer were on
-          // it. The pill is open on those beats but the pointer is wherever the
-          // user's hand happens to be, so without this the beat names a control
-          // the user then has to hunt for among the others.
-          spotlight={introSpotlight(intro)}
-          // Beside the pill rather than inside it, on the canvas the typing
-          // card would otherwise use. Null between runs, which is every launch
-          // after the first.
-          //
-          // **Withdrawn, not ended, by a call or the composer.** Those states
-          // rebuild the pill out of different controls, so a beat captioning
-          // Talk would be labelling a control that is not on screen. Main
-          // still holds the beat, so the run resumes where it was once the user
-          // is done with whatever they were actually doing.
-          intro={
-            !introShown || intro === null ? null : (
-              <CompanionIntro
-                beat={intro}
-                growth={growth}
-                cardGrowth={cardGrowth}
-                // The card clears whatever the pill draws beside the creature,
-                // so it is given the same two boxes.
-                avatarBox={avatarBox}
-                optionsBox={optionsBox}
-                accentHex={accentHex}
-                // Same undefined-not-empty rule as the composer's placeholder
-                // above: the first beat introduces the creature by name, and
-                // before the app's window has published one there is no name to
-                // introduce it by.
-                assistantName={assistantName === "" ? undefined : assistantName}
-                cardRef={introRef}
-                onAdvance={advanceCompanionIntro}
-              />
-            )
+      <CompanionSurface
+        phase={phase}
+        growth={growth}
+        cardGrowth={cardGrowth}
+        // The two boxes main sized the window for. The surface spends the
+        // options one on its own outermost box and uses both to place the pill
+        // against a creature that may be a different size from it.
+        avatarBox={avatarBox}
+        optionsBox={optionsBox}
+        avatarSrc={avatarSrc}
+        character={character}
+        // The creature notices the hand, in every state including mid-call.
+        hovered={hovered}
+        accentHex={accentHex}
+        // The conversation, as far as the card shows it. Held by main and
+        // pushed with the rest of the state, so it survives this window
+        // reloading mid-exchange.
+        //
+        // Nothing at all until this composer has sent something: what main is
+        // holding until then belongs to whatever conversation the app has open,
+        // and showing it would promise that the message about to be typed joins
+        // it, which is exactly what pressing Type no longer does.
+        turns={started ? turns : []}
+        // The assistant's own name in the composer's placeholder. Undefined
+        // rather than empty, so the component's fallback is what fills the gap
+        // before the app's window has published one.
+        assistantName={assistantName === "" ? undefined : assistantName}
+        call={call ?? undefined}
+        // Unlike the turns, this is drawn whether or not the exchange on the
+        // card is this surface's own: the question it answers is whether the
+        // assistant is busy, and it is busy on someone else's conversation just
+        // as much as on this one.
+        working={working}
+        // Its own prop rather than something the surface derives from the
+        // phase. The phase above is outranked by `typing` and `call`, and the
+        // indicator and the control that ends the session are not: they
+        // belong to the session, not to whatever the pill is drawing over it.
+        watching={watching}
+        // Its own prop rather than something derived from the phase, for the
+        // reason `watching` is: a call or an open composer outranks the
+        // phase, and a question the user has been asked must not lose its
+        // answer because they picked up the phone.
+        watchRetro={watchRetro}
+        // Out through main and into the window that ran the retrospective. A
+        // yes raises the app on the report; a no leaves the window where it
+        // is. Neither is handled here: this page has no conversation and no
+        // router, and the answer has to reach the side holding the question
+        // or the prompt comes back on the next push.
+        onWatchRetro={answerCompanionWatchRetro}
+        // The reads that session has taken, which is what turns a running
+        // session into something the user can see happening rather than
+        // something they are told is on.
+        captureCount={captureCount}
+        // The flag, from main. It hides the way into a session and leaves
+        // everything a running one draws alone, so a session already going
+        // when the flag turns off can still be seen and still be stopped.
+        watchEnabled={watchEnabled}
+        // Draws the control the beat is about as though the pointer were on
+        // it. The pill is open on those beats but the pointer is wherever the
+        // user's hand happens to be, so without this the beat names a control
+        // the user then has to hunt for among the others.
+        spotlight={introSpotlight(intro)}
+        // Beside the pill rather than inside it, on the canvas the typing
+        // card would otherwise use. Null between runs, which is every launch
+        // after the first.
+        //
+        // **Withdrawn, not ended, by a call or the composer.** Those states
+        // rebuild the pill out of different controls, so a beat captioning
+        // Talk would be labelling a control that is not on screen. Main
+        // still holds the beat, so the run resumes where it was once the user
+        // is done with whatever they were actually doing.
+        intro={
+          !introShown || intro === null ? null : (
+            <CompanionIntro
+              beat={intro}
+              growth={growth}
+              cardGrowth={cardGrowth}
+              // The card clears whatever the pill draws beside the creature,
+              // so it is given the same two boxes.
+              avatarBox={avatarBox}
+              optionsBox={optionsBox}
+              accentHex={accentHex}
+              // Same undefined-not-empty rule as the composer's placeholder
+              // above: the first beat introduces the creature by name, and
+              // before the app's window has published one there is no name to
+              // introduce it by.
+              assistantName={assistantName === "" ? undefined : assistantName}
+              cardRef={introRef}
+              onAdvance={advanceCompanionIntro}
+            />
+          )
+        }
+        rootRef={pillRef}
+        avatarRef={avatarRef}
+        onSurfaceMouseDown={(event) => {
+          // A right-click is a menu, not a grab. Left alone it would arm the
+          // drag and then never be released by a `mouseup` this window sees,
+          // because the menu takes the pointer for as long as it is open.
+          if (event.button !== 0) {
+            return;
           }
-          rootRef={pillRef}
-          avatarRef={avatarRef}
-          onSurfaceMouseDown={(event) => {
-            // A right-click is a menu, not a grab. Left alone it would arm the
-            // drag and then never be released by a `mouseup` this window sees,
-            // because the menu takes the pointer for as long as it is open.
-            if (event.button !== 0) {
-              return;
-            }
-            dragRef.current = { x: event.screenX, y: event.screenY };
-            pressOriginRef.current = { x: event.screenX, y: event.screenY };
-            draggedRef.current = false;
-          }}
-          onSurfaceContextMenu={(event) => {
-            // **Text keeps its own menu.** A right-click in the composer, or
-            // on a reply the user has selected, wants Cut/Copy/Paste and the
-            // spelling suggestions the host already provides. Swallowing that
-            // to offer "Small / Medium / Large" would take away the only way
-            // to copy something off this card.
-            const target = event.target as HTMLElement | null;
-            const onEditable =
-              target?.closest("input, textarea, [contenteditable='true']") !==
-              null;
-            const onSelection =
-              (window.getSelection()?.toString().trim().length ?? 0) > 0;
-            if (onEditable || onSelection) {
-              return;
-            }
-            event.preventDefault();
-            // Main pops the menu at the pointer, so the window has to still be
-            // clickable when it does. It is: the pointer is on the pill, which
-            // is the only thing that makes this window interactive at all.
-            showCompanionContextMenu();
-          }}
-          // A press that never became a drag. The window comes forward on the
-          // conversation this surface belongs to; main decides what that means.
-          onAvatarClick={() => {
-            if (draggedRef.current) {
-              return;
-            }
-            activateCompanionApp();
-          }}
-          // The press leaves this window immediately: the session lives in the
-          // renderer holding the chat layout, and this page only asks for one.
-          // What comes back is `call`, once that renderer has a session to
-          // report.
-          onTalk={startCompanionVoice}
-          // One press for both edges, and it leaves this window the way Talk
-          // does: the session lives in the renderer holding the chat layout,
-          // and this page only asks for it. What comes back is `watching`.
-          onWatch={toggleCompanionWatch}
-          // Type opens the composer here rather than leaving this window, since
-          // the field it opens is on this surface. What leaves is the message.
-          onType={() => {
-            setTyping(true);
-          }}
-          // Out through main and into whichever renderer holds a conversation to
-          // put it in. **The card stays open**, because this is where the answer
-          // arrives: the turns mirror pushes the sent message back within the
-          // frame and the reply behind it, so the whole exchange reads here
-          // rather than in an app the user deliberately did not go back to.
-          onSubmit={(message) => {
-            // The first message of a composer's life starts the conversation and
-            // the rest continue it. The old tail is dropped on the way out rather
-            // than left to be replaced, so the card never shows the previous
-            // conversation's words underneath the one just sent.
-            if (!started) {
-              setTurns([]);
-              setStarted(true);
-            }
-            submitCompanionMessage(message, !started);
-          }}
-          onCancelTyping={closeComposer}
-          // Out through main and back down into whichever renderer holds the
-          // session. This page has no session to act on: it draws one.
-          onControl={(action, requestId) => {
-            sendVoiceActivityControl(
-              requestId === undefined ? { action } : { action, requestId },
-            );
-          }}
-        />
-      </div>
+          dragRef.current = { x: event.screenX, y: event.screenY };
+          pressOriginRef.current = { x: event.screenX, y: event.screenY };
+          draggedRef.current = false;
+        }}
+        onSurfaceContextMenu={(event) => {
+          // **Text keeps its own menu.** A right-click in the composer, or
+          // on a reply the user has selected, wants Cut/Copy/Paste and the
+          // spelling suggestions the host already provides. Swallowing that
+          // to offer "Small / Medium / Large" would take away the only way
+          // to copy something off this card.
+          const target = event.target as HTMLElement | null;
+          const onEditable =
+            target?.closest("input, textarea, [contenteditable='true']") !==
+            null;
+          const onSelection =
+            (window.getSelection()?.toString().trim().length ?? 0) > 0;
+          if (onEditable || onSelection) {
+            return;
+          }
+          event.preventDefault();
+          // Main pops the menu at the pointer, so the window has to still be
+          // clickable when it does. It is: the pointer is on the pill, which
+          // is the only thing that makes this window interactive at all.
+          showCompanionContextMenu();
+        }}
+        // A press that never became a drag. The window comes forward on the
+        // conversation this surface belongs to; main decides what that means.
+        onAvatarClick={() => {
+          if (draggedRef.current) {
+            return;
+          }
+          activateCompanionApp();
+        }}
+        // The press leaves this window immediately: the session lives in the
+        // renderer holding the chat layout, and this page only asks for one.
+        // What comes back is `call`, once that renderer has a session to
+        // report.
+        onTalk={startCompanionVoice}
+        // One press for both edges, and it leaves this window the way Talk
+        // does: the session lives in the renderer holding the chat layout,
+        // and this page only asks for it. What comes back is `watching`.
+        onWatch={toggleCompanionWatch}
+        // Type opens the composer here rather than leaving this window, since
+        // the field it opens is on this surface. What leaves is the message.
+        onType={() => {
+          setTyping(true);
+        }}
+        // Out through main and into whichever renderer holds a conversation to
+        // put it in. **The card stays open**, because this is where the answer
+        // arrives: the turns mirror pushes the sent message back within the
+        // frame and the reply behind it, so the whole exchange reads here
+        // rather than in an app the user deliberately did not go back to.
+        onSubmit={(message) => {
+          // The first message of a composer's life starts the conversation and
+          // the rest continue it. The old tail is dropped on the way out rather
+          // than left to be replaced, so the card never shows the previous
+          // conversation's words underneath the one just sent.
+          if (!started) {
+            setTurns([]);
+            setStarted(true);
+          }
+          submitCompanionMessage(message, !started);
+        }}
+        onCancelTyping={closeComposer}
+        // Out through main and back down into whichever renderer holds the
+        // session. This page has no session to act on: it draws one.
+        onControl={(action, requestId) => {
+          sendVoiceActivityControl(
+            requestId === undefined ? { action } : { action, requestId },
+          );
+        }}
+      />
     </div>
   );
 }

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -37,8 +37,8 @@ const DEMO_CALL: VoiceActivityState = {
 
 /**
  * A real assistant avatar, composed from the same bundled character components
- * the hatching screen uses, so what is on the pill is a genuine avatar rather
- * than a stand-in that happens to be round. Composed once at module scope: it
+ * the hatching screen uses, so what is beside the pill is a genuine avatar
+ * rather than a stand-in that happens to be round. Composed once at module scope: it
  * is a pure function of constants.
  */
 const EXAMPLE_AVATAR = `data:image/svg+xml;utf8,${encodeURIComponent(

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -661,7 +661,6 @@ function HoverDrivenSurface(args: StoryArgs) {
 
   const phase: CompanionSurfacePhase =
     args.phase === "call" ? "call" : hovered ? "hover" : "resting";
-  const expanded = phase !== "resting";
 
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
     const avatar = avatarRef.current;
@@ -669,12 +668,17 @@ function HoverDrivenSurface(args: StoryArgs) {
     if (!avatar || !pill) {
       return;
     }
+    // The same rule the page hit-tests by: the pill is part of the surface for
+    // as long as it is drawn, which outlasts the expanded phase by the width
+    // transition it collapses through. At rest its width is zero and it is no
+    // part of the surface.
+    const pillRect = pill.getBoundingClientRect();
     setHovered(
       onCompanionSurface(
         { x: event.clientX, y: event.clientY },
         {
           avatar: avatar.getBoundingClientRect(),
-          pill: expanded ? pill.getBoundingClientRect() : null,
+          pill: pillRect.width > 0 ? pillRect : null,
           // One base box, since nothing here is scaled the way the page's
           // wrapper scales the real canvas by the options size.
           rowHeight: COMPANION_BASE_AVATAR_BOX,

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -172,7 +172,9 @@ const meta: Meta<StoryArgs> = {
       }
       return (
         <div
-          className="relative h-[340px] w-[560px] overflow-hidden rounded-xl"
+          // Overflow is left visible so a surface drawn at one of the larger
+          // option sizes is reviewable whole rather than cut off at the stage.
+          className="relative h-[340px] w-[560px] overflow-visible rounded-xl"
           style={{
             background:
               BACKDROPS[(context.args as StoryArgs).backdrop ?? "dark"],
@@ -258,12 +260,11 @@ export const TypingWhileWorking: Story = {
  * A creature far larger than the controls beside it, which is the pair the two
  * size axes exist for.
  *
- * The pill keeps its authored size and the creature is scaled up around it, and
- * the two still share a bottom line and a gap: the pill's avatar-facing edge is
- * the creature's own visual edge plus that gap, which is the distance the host
- * sizes the window by. There is no page wrapper here, so what these stories
- * show is the *ratio* between the two rather than the points either would be
- * drawn at on a desktop.
+ * The pill, the card and the gap follow the options size and the creature
+ * follows the avatar size, so the controls here sit at the size the layout is
+ * authored at while the creature runs well past them. The two still share a
+ * bottom line and that gap: the pill's avatar-facing edge is the creature's own
+ * visual edge plus the gap, which is the distance the host sizes the window by.
  */
 export const BigAvatarSmallOptions: Story = {
   args: {
@@ -277,9 +278,11 @@ export const BigAvatarSmallOptions: Story = {
 /**
  * The reverse: a modest creature beside controls sized well past it.
  *
- * The gap is the smaller of the two objects' clearance rather than the larger
- * one's, so a small creature beside an enormous pill is not separated from it
- * by a chasm.
+ * The surface scales its own box by the options size and the creature carries
+ * the difference back down, so the pill and every control on it grow and the
+ * creature does not. The gap is the smaller of the two objects' clearance
+ * rather than the larger one's, so a small creature beside an enormous pill is
+ * not separated from it by a chasm.
  */
 export const SmallAvatarBigOptions: Story = {
   args: {
@@ -293,9 +296,9 @@ export const SmallAvatarBigOptions: Story = {
 /**
  * The same pair at rest, which is the state the surface spends its day in.
  *
- * The pill is gone and the creature holds the spot it holds in every other
- * state, so what these two show is that a mixed pair changes the creature's
- * size and nothing about where it sits.
+ * The pill is gone and the creature is all that is left, so what these two show
+ * is the creature at the avatar size against a canvas whose clearance the
+ * larger of the two boxes earns.
  */
 export const RestingBigAvatarSmallOptions: Story = {
   args: {
@@ -305,7 +308,7 @@ export const RestingBigAvatarSmallOptions: Story = {
   },
 };
 
-/** The reverse pair at rest, where only the glow's own scale changes. */
+/** The reverse pair at rest: a small creature on a canvas sized for the pill. */
 export const RestingSmallAvatarBigOptions: Story = {
   args: {
     phase: "resting",
@@ -679,9 +682,10 @@ function HoverDrivenSurface(args: StoryArgs) {
         {
           avatar: avatar.getBoundingClientRect(),
           pill: pillRect.width > 0 ? pillRect : null,
-          // One base box, since nothing here is scaled the way the page's
-          // wrapper scales the real canvas by the options size.
-          rowHeight: COMPANION_BASE_AVATAR_BOX,
+          // The composer row in stage pixels, which is the options box: the
+          // surface scales its own box by that size and these rects are read
+          // after the transform.
+          rowHeight: args.optionsBox ?? COMPANION_BASE_AVATAR_BOX,
           cardGrowth: args.cardGrowth ?? "up",
         },
       ),

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -14,6 +14,8 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { composeSvg } from "@/utils/avatar-svg-compositor";
 import {
   COMPANION_INTRO_BEATS,
+  COMPANION_SIZE_BOXES,
+  COMPANION_SIZES,
   type CompanionIntroBeat,
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
@@ -73,6 +75,18 @@ const BACKDROPS = {
 
 type Backdrop = keyof typeof BACKDROPS;
 
+/**
+ * The five named steps, as the boxes the surface actually takes.
+ *
+ * The controls offer the names and hand over the numbers, because the names are
+ * what a user picks from a menu and the boxes are what the surface is drawn in.
+ * Both axes read from the same set: one vocabulary, two answers.
+ */
+const SIZE_OPTIONS = COMPANION_SIZES.map((size) => COMPANION_SIZE_BOXES[size]);
+const SIZE_LABELS: Record<number, string> = Object.fromEntries(
+  COMPANION_SIZES.map((size) => [COMPANION_SIZE_BOXES[size], size]),
+);
+
 type StoryArgs = React.ComponentProps<typeof CompanionSurface> & {
   backdrop: Backdrop;
   /**
@@ -108,6 +122,16 @@ const meta: Meta<StoryArgs> = {
     cardGrowth: {
       control: "inline-radio",
       options: ["up", "down"],
+    },
+    avatarBox: {
+      name: "avatarSize",
+      control: { type: "select", labels: SIZE_LABELS },
+      options: SIZE_OPTIONS,
+    },
+    optionsBox: {
+      name: "optionsSize",
+      control: { type: "select", labels: SIZE_LABELS },
+      options: SIZE_OPTIONS,
     },
     accentHex: { control: "color" },
     glow: { control: "boolean" },
@@ -212,6 +236,42 @@ export const TypingWhileWorking: Story = {
     working: true,
     assistantName: "Ziggy",
     turns: [{ role: "user", text: "what is on my calendar tomorrow?" }],
+  },
+};
+
+/**
+ * A creature far larger than the controls beside it, which is the pair the two
+ * size axes exist for.
+ *
+ * The pill keeps its authored size and the creature is scaled up around it, and
+ * the two still share a bottom line and a gap: the pill's avatar-facing edge is
+ * the creature's own visual edge plus that gap, which is the distance the host
+ * sizes the window by. There is no page wrapper here, so what these stories
+ * show is the *ratio* between the two rather than the points either would be
+ * drawn at on a desktop.
+ */
+export const BigAvatarSmallOptions: Story = {
+  args: {
+    phase: "hover",
+    hovered: true,
+    avatarBox: COMPANION_SIZE_BOXES.huge,
+    optionsBox: COMPANION_SIZE_BOXES.small,
+  },
+};
+
+/**
+ * The reverse: a modest creature beside controls sized well past it.
+ *
+ * The gap is the smaller of the two objects' clearance rather than the larger
+ * one's, so a small creature beside an enormous pill is not separated from it
+ * by a chasm.
+ */
+export const SmallAvatarBigOptions: Story = {
+  args: {
+    phase: "hover",
+    hovered: true,
+    avatarBox: COMPANION_SIZE_BOXES.small,
+    optionsBox: COMPANION_SIZE_BOXES.huge,
   },
 };
 

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -1,5 +1,12 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-import { useEffect, useMemo, useState, type ChangeEvent } from "react";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type MouseEvent,
+} from "react";
 
 import {
   CompanionIntro,
@@ -7,12 +14,19 @@ import {
   introSpotlight,
 } from "@/components/companion-intro";
 import {
+  bridgeRect,
+  COMPANION_BOB_LIFT,
+  containsPoint,
+  type SurfaceRect,
+} from "@/components/companion-layout";
+import {
   CompanionSurface,
   type CompanionSurfacePhase,
 } from "@/components/companion-surface";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { composeSvg } from "@/utils/avatar-svg-compositor";
 import {
+  COMPANION_BASE_AVATAR_BOX,
   COMPANION_INTRO_BEATS,
   COMPANION_SIZE_BOXES,
   COMPANION_SIZES,
@@ -134,7 +148,6 @@ const meta: Meta<StoryArgs> = {
       options: SIZE_OPTIONS,
     },
     accentHex: { control: "color" },
-    glow: { control: "boolean" },
     watching: { control: "boolean" },
     watchEnabled: { control: "boolean" },
     introBeat: {
@@ -144,7 +157,6 @@ const meta: Meta<StoryArgs> = {
   },
   args: {
     phase: "resting",
-    glow: true,
     // On here, off everywhere a real user meets it until the flag says
     // otherwise. Design stories are for looking at what the surface can draw,
     // and a control the stories hid would be one nobody could review. Turn it
@@ -270,6 +282,30 @@ export const SmallAvatarBigOptions: Story = {
   args: {
     phase: "hover",
     hovered: true,
+    avatarBox: COMPANION_SIZE_BOXES.small,
+    optionsBox: COMPANION_SIZE_BOXES.huge,
+  },
+};
+
+/**
+ * The same pair at rest, which is the state the surface spends its day in.
+ *
+ * The pill is gone and the creature holds the spot it holds in every other
+ * state, so what these two show is that a mixed pair changes the creature's
+ * size and nothing about where it sits.
+ */
+export const RestingBigAvatarSmallOptions: Story = {
+  args: {
+    phase: "resting",
+    avatarBox: COMPANION_SIZE_BOXES.huge,
+    optionsBox: COMPANION_SIZE_BOXES.small,
+  },
+};
+
+/** The reverse pair at rest, where only the glow's own scale changes. */
+export const RestingSmallAvatarBigOptions: Story = {
+  args: {
+    phase: "resting",
     avatarBox: COMPANION_SIZE_BOXES.small,
     optionsBox: COMPANION_SIZE_BOXES.huge,
   },
@@ -536,6 +572,13 @@ export const AgainstTheLeftEdge: Story = {
   ],
 };
 
+/** A 44px column at the stage's right edge, with the screen ending beside it. */
+const againstTheRightEdge: Decorator = (Story) => (
+  <div className="absolute top-0 right-0 h-full w-11">
+    <Story />
+  </div>
+);
+
 /**
  * The case that needs the flip: the circle parked against the right edge, where
  * the body has nowhere to run.
@@ -547,19 +590,37 @@ export const AgainstTheLeftEdge: Story = {
  */
 export const AgainstTheRightEdge: Story = {
   args: { phase: "call", growth: "left" },
-  decorators: [
-    (Story) => (
-      <div className="absolute top-0 right-0 h-full w-11">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [againstTheRightEdge],
+};
+
+/**
+ * The flip with the two sizes pulling against each other, which is where a
+ * mirrored anchor is easiest to get wrong.
+ *
+ * The pill is pinned by its right edge a gap off a creature more than twice its
+ * height, and the two still share a bottom line. The creature holds the same
+ * spot it holds growing rightward: what a flip moves is the pill.
+ */
+export const BigAvatarAgainstTheRightEdge: Story = {
+  args: {
+    phase: "hover",
+    hovered: true,
+    growth: "left",
+    avatarBox: COMPANION_SIZE_BOXES.huge,
+    optionsBox: COMPANION_SIZE_BOXES.small,
+  },
+  decorators: [againstTheRightEdge],
 };
 
 /**
  * The move itself, which is the thing being designed and the one thing a
- * static story cannot show. Expansion arms on the avatar alone, so the rest of
- * the desktop is dead space exactly as it is in the real window.
+ * static story cannot show.
+ *
+ * Hover is hit-tested against the avatar, the pill and the strip between them,
+ * which is how the Electron host derives it: that window is click-through and
+ * receives forwarded mouse-move rather than `mouseenter`, so it works in
+ * coordinates. Doing the same here keeps the story honest about where the
+ * surface actually arms and where the desktop is left alone.
  *
  * Drop in an image to see the surface wearing a particular assistant. It never
  * leaves the browser: the file is read to a data URL and handed straight to the
@@ -578,6 +639,8 @@ export const Interactive: Story = {
 function HoverDrivenSurface(args: StoryArgs) {
   const [hovered, setHovered] = useState(false);
   const [uploaded, setUploaded] = useState<string | undefined>();
+  const avatarRef = useRef<HTMLDivElement | null>(null);
+  const pillRef = useRef<HTMLDivElement | null>(null);
 
   const onFile = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -595,21 +658,70 @@ function HoverDrivenSurface(args: StoryArgs) {
 
   const phase: CompanionSurfacePhase =
     args.phase === "call" ? "call" : hovered ? "hover" : "resting";
+  const expanded = phase !== "resting";
+  // The pair the surface is drawn at, defaulted the way the component defaults
+  // them, since the hit-test has to measure the creature the story is showing.
+  const avatarBox = args.avatarBox ?? COMPANION_BASE_AVATAR_BOX;
+  const optionsBox = args.optionsBox ?? COMPANION_BASE_AVATAR_BOX;
+
+  const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
+    const avatar = avatarRef.current;
+    const pill = pillRef.current;
+    if (!avatar || !pill) {
+      return;
+    }
+    const inside = (rect: SurfaceRect): boolean =>
+      containsPoint(rect, event.clientX, event.clientY);
+    const drawn = avatar.getBoundingClientRect();
+    const avatarRect: SurfaceRect = {
+      left: drawn.left,
+      right: drawn.right,
+      // The bob raises the artwork off its own box, on a wrapper inside the
+      // creature's own scale, so the lift grows with the creature. Nothing
+      // scales the stage itself, which is what the page's wrapper does.
+      top: drawn.top - (COMPANION_BOB_LIFT * avatarBox) / optionsBox,
+      bottom: drawn.bottom,
+    };
+    if (!expanded) {
+      setHovered(inside(avatarRect));
+      return;
+    }
+    const pillRect = pill.getBoundingClientRect();
+    setHovered(
+      inside(avatarRect) ||
+        inside(pillRect) ||
+        inside(
+          bridgeRect(avatarRect, pillRect, {
+            // One base box, since nothing here is scaled the way the page's
+            // wrapper scales the real canvas by the options size.
+            rowHeight: COMPANION_BASE_AVATAR_BOX,
+            cardGrowth: args.cardGrowth ?? "up",
+          }),
+        ),
+    );
+  };
 
   return (
     <>
-      <CompanionSurface
-        {...args}
-        phase={phase}
-        hovered={hovered}
-        avatarSrc={uploaded ?? args.avatarSrc}
-        onHoverStart={() => {
-          setHovered(true);
-        }}
-        onHoverEnd={() => {
+      {/* The canvas, which is where the pointer is tracked. The surface's own
+          elements are all that arm it: everywhere else in here is desktop, the
+          way it is in the real window. */}
+      <div
+        className="absolute inset-0"
+        onMouseMove={onMouseMove}
+        onMouseLeave={() => {
           setHovered(false);
         }}
-      />
+      >
+        <CompanionSurface
+          {...args}
+          phase={phase}
+          hovered={hovered}
+          avatarSrc={uploaded ?? args.avatarSrc}
+          avatarRef={avatarRef}
+          rootRef={pillRef}
+        />
+      </div>
       <label className="absolute bottom-2 left-2 cursor-pointer rounded-md bg-black/50 px-2 py-1 text-[11px] text-white/80 backdrop-blur-sm">
         Use my own avatar
         <input
@@ -875,6 +987,10 @@ function IntroWalkthrough({ introBeat, ...args }: StoryArgs) {
             beat={beat}
             growth={args.growth}
             cardGrowth={args.cardGrowth}
+            // The same pair the surface is drawn at, so a mixed one shows the
+            // card clearing the pill rather than landing inside it.
+            avatarBox={args.avatarBox}
+            optionsBox={args.optionsBox}
             accentHex={args.accentHex}
             onAdvance={(action) => {
               const next =
@@ -902,7 +1018,7 @@ export const Introduction: Story = {
 /**
  * The card with a reply that uses the formatting an assistant actually writes:
  * emphasis, inline code, and a short list. What the card does with markdown is
- * worth looking at rather than reasoning about, since it is 360pt wide and set
+ * worth looking at rather than reasoning about, since it is a pill's width set
  * at 12px, and the primitive is authored for a full-width transcript.
  */
 export const TypingWithMarkdown: Story = {

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -13,12 +13,7 @@ import {
   introPhase,
   introSpotlight,
 } from "@/components/companion-intro";
-import {
-  bridgeRect,
-  COMPANION_BOB_LIFT,
-  containsPoint,
-  type SurfaceRect,
-} from "@/components/companion-layout";
+import { onCompanionSurface } from "@/components/companion-layout";
 import {
   CompanionSurface,
   type CompanionSurfacePhase,
@@ -231,7 +226,13 @@ export const RestingWhileWorking: Story = {
   args: { phase: "resting", working: true },
 };
 
-/** The same turn with the pill open, where the ring follows the wider shape. */
+/**
+ * The same turn with the pill open, where the ring stays on the creature.
+ *
+ * The pill changes shape beside it and the light does not move: the creature
+ * holds one spot in the canvas, so the state stays where the eye already looks
+ * for it.
+ */
 export const HoverWhileWorking: Story = {
   args: { phase: "hover", hovered: true, working: true },
 };
@@ -239,8 +240,10 @@ export const HoverWhileWorking: Story = {
 /**
  * The reply to something typed on the surface, while the card is still open.
  *
- * The card is the tallest and squarest thing the surface draws, so it is where
- * a ring written for a 44pt circle is most likely to come apart.
+ * The card is the tallest thing the surface draws, and the ring is still the
+ * circle on the creature beside it: the widest gap between the two shapes, and
+ * the clearest case that the light belongs to the creature rather than to
+ * whatever is open next to it.
  */
 export const TypingWhileWorking: Story = {
   args: {
@@ -659,10 +662,6 @@ function HoverDrivenSurface(args: StoryArgs) {
   const phase: CompanionSurfacePhase =
     args.phase === "call" ? "call" : hovered ? "hover" : "resting";
   const expanded = phase !== "resting";
-  // The pair the surface is drawn at, defaulted the way the component defaults
-  // them, since the hit-test has to measure the creature the story is showing.
-  const avatarBox = args.avatarBox ?? COMPANION_BASE_AVATAR_BOX;
-  const optionsBox = args.optionsBox ?? COMPANION_BASE_AVATAR_BOX;
 
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
     const avatar = avatarRef.current;
@@ -670,34 +669,18 @@ function HoverDrivenSurface(args: StoryArgs) {
     if (!avatar || !pill) {
       return;
     }
-    const inside = (rect: SurfaceRect): boolean =>
-      containsPoint(rect, event.clientX, event.clientY);
-    const drawn = avatar.getBoundingClientRect();
-    const avatarRect: SurfaceRect = {
-      left: drawn.left,
-      right: drawn.right,
-      // The bob raises the artwork off its own box, on a wrapper inside the
-      // creature's own scale, so the lift grows with the creature. Nothing
-      // scales the stage itself, which is what the page's wrapper does.
-      top: drawn.top - (COMPANION_BOB_LIFT * avatarBox) / optionsBox,
-      bottom: drawn.bottom,
-    };
-    if (!expanded) {
-      setHovered(inside(avatarRect));
-      return;
-    }
-    const pillRect = pill.getBoundingClientRect();
     setHovered(
-      inside(avatarRect) ||
-        inside(pillRect) ||
-        inside(
-          bridgeRect(avatarRect, pillRect, {
-            // One base box, since nothing here is scaled the way the page's
-            // wrapper scales the real canvas by the options size.
-            rowHeight: COMPANION_BASE_AVATAR_BOX,
-            cardGrowth: args.cardGrowth ?? "up",
-          }),
-        ),
+      onCompanionSurface(
+        { x: event.clientX, y: event.clientY },
+        {
+          avatar: avatar.getBoundingClientRect(),
+          pill: expanded ? pill.getBoundingClientRect() : null,
+          // One base box, since nothing here is scaled the way the page's
+          // wrapper scales the real canvas by the options size.
+          rowHeight: COMPANION_BASE_AVATAR_BOX,
+          cardGrowth: args.cardGrowth ?? "up",
+        },
+      ),
     );
   };
 

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -164,6 +164,27 @@ export const Resting: Story = {
 };
 
 /**
+ * The same circle in an assistant's own colour, which is what the desktop
+ * actually shows: the glow is the character's palette hex, not the surface's
+ * teal default. Here so the resting colour is reviewable without a live call.
+ */
+export const RestingInItsOwnColour: Story = {
+  args: {
+    phase: "resting",
+    character: { bodyShape: "burst", eyeStyle: "curious", color: "orange" },
+    accentHex: "#E9642F",
+  },
+};
+
+/**
+ * An uploaded image instead of a composed creature. It has no palette colour to
+ * resolve, so this is the case the component's default accent exists for.
+ */
+export const RestingCustomImage: Story = {
+  args: { phase: "resting", character: undefined, avatarSrc: EXAMPLE_AVATAR },
+};
+
+/**
  * Resting, with a turn running somewhere the user is not looking.
  *
  * The state the working ring exists for: the assistant is doing something and

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -359,7 +359,7 @@ describe("the companion surface's custom avatar", () => {
 });
 
 /**
- * Where the avatar sits inside the canvas.
+ * Where the avatar sits inside the canvas, and where the pill hangs off it.
  *
  * The canvas is not symmetric about the avatar: the card's height is reserved
  * on whichever side it grows into, and only the avatar's own box and its shadow
@@ -368,26 +368,36 @@ describe("the companion surface's custom avatar", () => {
  * main flip the direction near the top of a display without the renderer
  * learning the canvas's height (JARVIS-1548).
  */
-/** The pill itself, which is also the surface's drag handle. */
+/** The pill, which is the one element on the surface whose width animates. */
 const surfaceOf = (container: HTMLElement): HTMLElement => {
-  const found = container.querySelector<HTMLElement>(".cursor-grab");
+  const found = container.querySelector<HTMLElement>(".transition-\\[width\\]");
   if (!found) {
     throw new Error("Expected the surface to render");
   }
   return found;
 };
 
+/** The avatar's own box, which is the point the host positions the window by. */
+const avatarOf = (container: HTMLElement): HTMLElement => {
+  const found = container.querySelector<HTMLElement>(".size-11");
+  if (!found) {
+    throw new Error("Expected the avatar to render");
+  }
+  return found;
+};
+
 describe("the companion surface's anchor in the canvas", () => {
-  test("hangs off the canvas's bottom edge while the card grows up", () => {
+  test("hangs the avatar off the canvas's bottom edge while the card grows up", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 46px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
   });
 
-  test("sits against the canvas's top edge while the card grows down", () => {
+  test("sits the avatar against the canvas's top edge while the card grows down", () => {
     const { container } = render(
       <CompanionSurface phase="resting" cardGrowth="down" />,
     );
-    expect(surfaceOf(container).style.top).toBe("46px");
+    expect(avatarOf(container).style.top).toBe("46px");
   });
 
   test("grows up by default, which is where the surface normally lives", () => {
@@ -395,26 +405,47 @@ describe("the companion surface's anchor in the canvas", () => {
     const { container: explicit } = render(
       <CompanionSurface phase="resting" cardGrowth="up" />,
     );
-    expect(surfaceOf(container).style.top).toBe(surfaceOf(explicit).style.top);
+    expect(avatarOf(container).style.top).toBe(avatarOf(explicit).style.top);
   });
 
   /**
-   * The avatar's line is the fixed point in both directions. Growing up, the
-   * card's bottom row sits on it; growing down, its top row does. Either way
-   * the mascot is where it was before Type was pressed.
+   * The avatar's bottom line is the fixed point. The pill's bottom sits on it,
+   * which at this size puts the pill's own centre on the avatar's centre too,
+   * and the mascot never moves whichever way the pill or the card grows.
+   */
+  test("sits the pill's bottom on the avatar's bottom", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    // 46 from the canvas edge to the avatar's centre, 22 further to its bottom.
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
+  });
+
+  test("keeps that line against the canvas's top edge too", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" cardGrowth="down" />,
+    );
+    expect(surfaceOf(container).style.top).toBe("68px");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
+  });
+
+  /**
+   * The composer row is the card's last child growing up and its first growing
+   * down, so the row's bottom is the avatar's bottom either way and the card
+   * hangs off it in whichever direction the host picked.
    */
   test("hangs the card off the avatar's line when it grows up", () => {
     const { container } = render(<CompanionSurface phase="typing" />);
-    expect(surfaceOf(container).style.transform).toBe(
-      "translateY(calc(-100% + 22px))",
-    );
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   test("drops the card from the avatar's line when it grows down", () => {
     const { container } = render(
       <CompanionSurface phase="typing" cardGrowth="down" />,
     );
-    expect(surfaceOf(container).style.transform).toBe("translateY(-22px)");
+    // The row starts on the avatar's top line and the card falls away from it.
+    expect(surfaceOf(container).style.top).toBe("24px");
+    expect(surfaceOf(container).style.transform).toBe("none");
   });
 
   /**
@@ -436,13 +467,54 @@ describe("the companion surface's anchor in the canvas", () => {
     expect(className).not.toContain("flex-col-reverse");
   });
 
-  /** The pill is centred on the avatar's line whichever way the card would go. */
-  test("centres the resting pill on the avatar's line either way", () => {
+  /**
+   * The two are siblings with a gap between them, which is what the host's
+   * union hit-test is built on. A pill that contained the avatar would make a
+   * bounding box the honest answer and take the gap's dead corners with it.
+   */
+  test("draws the avatar beside the pill rather than inside it", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(surfaceOf(container).contains(avatarOf(container))).toBe(false);
+    expect(avatarOf(container).parentElement).toBe(
+      surfaceOf(container).parentElement,
+    );
+  });
+
+  /** The pill's avatar-facing edge: the avatar's half box, then the gap. */
+  test("steps the pill off the avatar's edge by the gap", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
+  });
+
+  /**
+   * The property everything else here is in service of: the host positions the
+   * window by the creature, so the creature has to sit on the same point in
+   * every state the surface can be in.
+   */
+  test("keeps the avatar's own point in every phase", () => {
+    for (const phase of [
+      "resting",
+      "hover",
+      "watching",
+      "summary",
+      "call",
+      "typing",
+    ] as const) {
+      const { container } = render(<CompanionSurface phase={phase} />);
+      expect(avatarOf(container).style.left).toBe("50%");
+      expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+      expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
+      cleanup();
+    }
+  });
+
+  test("keeps it whichever way the card would go", () => {
     for (const cardGrowth of ["up", "down"] as const) {
       const { container } = render(
         <CompanionSurface phase="resting" cardGrowth={cardGrowth} />,
       );
-      expect(surfaceOf(container).style.transform).toBe("translateY(-50%)");
+      expect(avatarOf(container).style.left).toBe("50%");
+      expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
       cleanup();
     }
   });
@@ -945,8 +1017,8 @@ describe("the summary a finished watch session leaves on the surface", () => {
 });
 
 describe("the companion surface's width ceiling", () => {
-  /** `BASE_MAX_PILL_WIDTH` in `clients/macos/src/main/companion-window.ts`. */
-  const CANVAS_CEILING = 360;
+  /** `BASE_MAX_BODY_WIDTH` in `clients/macos/src/main/companion-window.ts`. */
+  const CANVAS_CEILING = 316;
 
   test("holds for every phase", () => {
     const over = Object.entries(FALLBACK_WIDTHS).filter(
@@ -1016,78 +1088,55 @@ describe("the companion surface's capture indicator across phases", () => {
 });
 
 /**
- * Growing leftward is two halves, and the surface is only in the right place
- * when both happen.
+ * Growing leftward moves the pill and nothing else.
  *
  * Main positions the window by the *avatar's* centre and measures every later
  * drag, clamp and direction check from it. The renderer's half of that bargain
- * is to draw the avatar on the point the host aimed at: the surface anchors by
- * the edge the avatar is on, and the row the avatar sits in mirrors so the
- * avatar ends up against that edge.
- *
- * Anchoring without mirroring is the failure this covers. It draws the avatar
- * at the far end of the pill instead, up to a card's width from where main
- * believes it is, so the mascot teleports at the direction flip, the labels
- * sweep under a held pointer, and the point main hands presses to lands on a
- * control that refuses them. The surface reads as dead (JARVIS-1582).
+ * is to draw the avatar on the point the host aimed at, in both directions: the
+ * avatar keeps its place and the pill swaps which of its edges is pinned to the
+ * gap. A flip that moved the mascot instead would put it up to a card's width
+ * from where main believes it is, so it would teleport at the threshold, the
+ * labels would sweep under a held pointer, and the point main hands presses to
+ * would land on a control that refuses them. The surface reads as dead
+ * (JARVIS-1582).
  */
 describe("the companion surface growing leftward", () => {
-  /**
-   * The row the avatar is on, found through the avatar rather than by its own
-   * classes: it is the row's job to order the avatar, so the avatar is what
-   * says which row it is.
-   */
-  const avatarRowOf = (container: HTMLElement): HTMLElement => {
-    const avatar = container.querySelector<HTMLElement>(".size-11");
-    if (!avatar?.parentElement) {
-      throw new Error("Expected the avatar to render inside a row");
-    }
-    return avatar.parentElement;
-  };
-
-  test("mirrors the row the avatar is on", () => {
+  test("anchors the pill by its right edge, a gap off the avatar", () => {
     const { container } = render(
       <CompanionSurface phase="hover" growth="left" />,
     );
-    expect(avatarRowOf(container).className).toContain("flex-row-reverse");
+    expect(surfaceOf(container).style.right).toBe("calc(50% + 34px)");
+    expect(surfaceOf(container).style.left).toBe("");
   });
 
-  test("leaves that row alone growing the ordinary way", () => {
+  test("anchors it by its left edge growing the ordinary way", () => {
     const { container } = render(
       <CompanionSurface phase="hover" growth="right" />,
     );
-    expect(avatarRowOf(container).className).not.toContain("flex-row-reverse");
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
+    expect(surfaceOf(container).style.right).toBe("");
   });
 
   /**
-   * The card is anchored by the same edge as the pill and is eight times the
-   * avatar's width, so an unmirrored card puts the mascot further from where
-   * main is measuring than any other state.
+   * The card is anchored by the same edge as the pill and is seven times the
+   * avatar's width, so it is the state where a flip that moved the mascot would
+   * move it furthest.
    */
-  test("mirrors the card's row too", () => {
+  test("mirrors the card the same way", () => {
     const { container } = render(
       <CompanionSurface phase="typing" growth="left" />,
     );
-    expect(avatarRowOf(container).className).toContain("flex-row-reverse");
+    expect(surfaceOf(container).style.right).toBe("calc(50% + 34px)");
   });
 
-  /**
-   * The other half. The row is `INNER_GAP` narrower than the pill, because that
-   * gap is trailing space past the last control, so the row has to sit against
-   * the anchored end and leave the slack at the other.
-   */
-  test("holds the row against the edge the pill is anchored by", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" growth="left" />,
-    );
-    expect(surfaceOf(container).className).toContain("flex-row-reverse");
-  });
-
-  test("anchors the pill by its right edge", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" growth="left" />,
-    );
-    expect(surfaceOf(container).style.right).toBe("50%");
+  test("leaves the avatar on its own point either way", () => {
+    for (const growth of ["left", "right"] as const) {
+      const { container } = render(
+        <CompanionSurface phase="hover" growth={growth} />,
+      );
+      expect(avatarOf(container).style.left).toBe("50%");
+      cleanup();
+    }
   });
 });
 
@@ -1242,5 +1291,19 @@ describe("the resting avatar's idle motion", () => {
 
     const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
     expect(bob?.parentElement?.className).toContain("size-11");
+  });
+
+  /**
+   * The glow is the creature's own light and the creature is on screen in every
+   * phase, so it is lit in every phase. Nothing stacks under it: the pill is a
+   * separate shape a gap away rather than a body the halo would read as a
+   * second ring around.
+   */
+  test("glows in every phase, not only at rest", () => {
+    for (const phase of ["resting", "hover", "call", "typing"] as const) {
+      const { container } = render(<CompanionSurface phase={phase} />);
+      expect(container.querySelector(".companion-glow")).not.toBeNull();
+      cleanup();
+    }
   });
 });

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -565,14 +565,64 @@ describe("the companion surface's anchor in the canvas", () => {
 /**
  * The surface with the creature and the controls sized apart.
  *
- * The page's wrapper is scaled by the options size, so everything here is
- * stated in those units and the creature carries the difference between the two
- * boxes itself. What has to hold is that the pill still sits a gap off the
- * creature's *visual* edge and still shares its bottom line, whichever of the
- * two is the larger, because that edge and that line are what the host places
- * the window by.
+ * The surface's own outermost box is scaled by the options size, so everything
+ * inside it is stated in the units the layout is authored in and the creature
+ * carries the difference between the two boxes itself. What has to hold is that
+ * the pill still sits a gap off the creature's *visual* edge and still shares
+ * its bottom line, whichever of the two is the larger, because that edge and
+ * that line are what the host places the window by.
  */
 describe("the companion surface at two sizes", () => {
+  /** The outermost element, which is where the options scale is spent. */
+  const boxOf = (container: HTMLElement): HTMLElement => {
+    const found = container.firstElementChild;
+    if (!(found instanceof HTMLElement)) {
+      throw new Error("Expected the surface's scaled box to render");
+    }
+    return found;
+  };
+
+  /**
+   * The box is the canvas divided by the options scale and blown back up about
+   * its top-left corner, so it covers the canvas exactly and every length
+   * inside resolves in the units the layout is written in. The host is handed
+   * one surface rather than a scale it has to apply itself.
+   */
+  test("scales its own box by the options size rather than the creature's", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarBox={44} optionsBox={110} />,
+    );
+    const box = boxOf(container);
+    expect(box.style.transform).toBe("scale(2.5)");
+    expect(box.style.width).toBe("40%");
+    expect(box.style.height).toBe("40%");
+    expect(box.className).toContain("origin-top-left");
+  });
+
+  /**
+   * The identity, which is still drawn rather than skipped: one code path for
+   * both, and a host that never has to ask whether the box is there.
+   */
+  test("covers the canvas untransformed at the authored options size", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarBox={220} optionsBox={44} />,
+    );
+    const box = boxOf(container);
+    expect(box.style.transform).toBe("scale(1)");
+    expect(box.style.width).toBe("100%");
+    expect(box.style.height).toBe("100%");
+  });
+
+  /** The pill and the creature both hang inside that one box. */
+  test("draws the whole surface inside that box", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
+    );
+    const box = boxOf(container);
+    expect(box.contains(surfaceOf(container))).toBe(true);
+    expect(box.contains(avatarOf(container))).toBe(true);
+  });
+
   /**
    * 55 to a huge creature's edge, then the gap the smaller of the two earns.
    * Bottom-flush with it as well: the near edge is 115 at this pair and the
@@ -670,7 +720,7 @@ describe("the companion surface at two sizes", () => {
     );
   });
 
-  /** With the two agreeing the wrapper has done all of it, at any size. */
+  /** With the two agreeing the surface's own box has done all of it. */
   test("leaves the creature unscaled when the two agree", () => {
     const { container } = render(
       <CompanionSurface phase="resting" avatarBox={110} optionsBox={110} />,

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1,16 +1,30 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as motionReact from "motion/react";
 
 import { COMPANION_BASE_MAX_PILL_WIDTH } from "@vellumai/ipc-contract";
 import type { VoiceActivityState } from "@vellumai/ipc-contract";
 
-import {
-  CompanionSurface,
-  FALLBACK_WIDTHS,
-  INNER_GAP,
-} from "./companion-surface";
+/**
+ * The reduced-motion answer, so one case can render the surface as a reader who
+ * has asked for stillness sees it. Spread over the real module rather than
+ * standing in for it, since the creature's own artwork animates through the
+ * same package.
+ */
+let reducedMotion = false;
 
-afterEach(cleanup);
+mock.module("motion/react", () => ({
+  ...motionReact,
+  useReducedMotion: () => reducedMotion,
+}));
+
+const { CompanionSurface, FALLBACK_WIDTHS, INNER_GAP } =
+  await import("./companion-surface");
+
+afterEach(() => {
+  cleanup();
+  reducedMotion = false;
+});
 
 /** The ordinary middle of a call: unmuted, listening, nothing to decide. */
 const LISTENING_CALL: VoiceActivityState = {
@@ -43,17 +57,40 @@ describe("the companion surface's working ring", () => {
     expect(ringOf(container)).not.toBeNull();
   });
 
-  test("is drawn on the expanded pill too", () => {
+  test("is drawn with the pill open too", () => {
     const { container } = render(<CompanionSurface phase="hover" working />);
     expect(ringOf(container)).not.toBeNull();
   });
 
-  test("follows the card's corner radius while typing", () => {
-    const { container } = render(<CompanionSurface phase="typing" working />);
-    expect(ringOf(container)?.className).toContain("rounded-[24px]");
+  /**
+   * **The ring belongs to the creature.** The avatar is drawn in every phase
+   * and holds one spot in the canvas, so the light stays where the eye already
+   * looks for this surface's state. Handing it to the pill while expanded would
+   * move it to a different parent every time the pointer crossed, which
+   * remounts everything hanging off it.
+   */
+  test("hangs off the avatar in every phase", () => {
+    for (const phase of [
+      "resting",
+      "hover",
+      "watching",
+      "summary",
+      "call",
+      "typing",
+    ] as const) {
+      const { container } = render(<CompanionSurface phase={phase} working />);
+      expect(ringOf(container)?.closest(".size-11")).not.toBeNull();
+      cleanup();
+    }
   });
 
-  test("is round in every state that is not the card", () => {
+  /** Around the creature's own box, so it is a circle whatever the pill is. */
+  test("stays round while the card is open", () => {
+    const { container } = render(<CompanionSurface phase="typing" working />);
+    expect(ringOf(container)?.className).toContain("rounded-full");
+  });
+
+  test("is round in every other state too", () => {
     const { container } = render(<CompanionSurface phase="hover" working />);
     expect(ringOf(container)?.className).toContain("rounded-full");
   });
@@ -299,14 +336,34 @@ describe("the companion surface's capture pulse", () => {
     ).toBe("#ff9f45");
   });
 
-  test("follows the card's corner radius while typing", () => {
+  test("stays round while the card is open", () => {
     const { container, rerender } = render(
       <CompanionSurface phase="typing" watching captureCount={0} />,
     );
 
     rerender(<CompanionSurface phase="typing" watching captureCount={1} />);
 
-    expect(pulseOf(container)?.className).toContain("rounded-[24px]");
+    expect(pulseOf(container)?.className).toContain("rounded-full");
+  });
+
+  /**
+   * The flare is one-shot, so a node unmounted and put back plays it again. The
+   * pointer crosses this surface constantly while a session runs, and none of
+   * those crossings is a screen being read: a flare drawn for one would be the
+   * indicator claiming a capture that did not happen.
+   */
+  test("does not replay when the phase changes under a running session", () => {
+    const { container, rerender } = render(
+      <CompanionSurface phase="resting" watching captureCount={0} />,
+    );
+    rerender(<CompanionSurface phase="resting" watching captureCount={1} />);
+    const flare = pulseOf(container);
+    expect(flare).not.toBeNull();
+
+    rerender(<CompanionSurface phase="hover" watching captureCount={1} />);
+    rerender(<CompanionSurface phase="resting" watching captureCount={1} />);
+
+    expect(pulseOf(container)).toBe(flare);
   });
 });
 
@@ -1171,20 +1228,11 @@ describe("the companion surface's width ceiling", () => {
 
   /**
    * The ceiling is on the pill, not on the body inside it, so a body that fits
-   * with the clearance at either end left off is not one that fits. `typing` is
-   * the card's own outer width rather than a measured body, and the case below
-   * holds it exactly at the ceiling.
+   * with the clearance at either end left off is not one that fits.
    */
   test("holds for every measured body once the pill's own clearance is on it", () => {
-    const over = Object.entries(FALLBACK_WIDTHS)
-      .filter(([phase]) => phase !== "typing")
-      .filter(([, width]) => width + 2 * INNER_GAP > CANVAS_CEILING);
-    expect(over).toEqual([]);
-  });
-
-  test("holds for every phase", () => {
     const over = Object.entries(FALLBACK_WIDTHS).filter(
-      ([, width]) => width > CANVAS_CEILING,
+      ([, width]) => width + 2 * INNER_GAP > CANVAS_CEILING,
     );
     expect(over).toEqual([]);
   });
@@ -1204,8 +1252,14 @@ describe("the companion surface's width ceiling", () => {
     expect(FALLBACK_WIDTHS.call).toBeGreaterThan(FALLBACK_WIDTHS.hover);
   });
 
-  test("leaves the card exactly at the ceiling it was already at", () => {
-    expect(FALLBACK_WIDTHS.typing).toBe(CANVAS_CEILING);
+  /**
+   * The card is the widest state the surface has and it states its width rather
+   * than measuring one, so it is drawn at the ceiling itself: the canvas is
+   * sized for exactly this and a card any wider would be a clipped one.
+   */
+  test("draws the card at the ceiling", () => {
+    const { container } = render(<CompanionSurface phase="typing" />);
+    expect(surfaceOf(container).style.width).toBe(`${CANVAS_CEILING}px`);
   });
 });
 
@@ -1231,9 +1285,9 @@ describe("the companion surface's capture indicator across phases", () => {
     expect(ringOf(container)).not.toBeNull();
   });
 
-  test("follows the card's corner radius while the user types", () => {
+  test("stays on the creature while the user types", () => {
     const { container } = render(<CompanionSurface phase="typing" watching />);
-    expect(ringOf(container)?.className).toContain("rounded-[24px]");
+    expect(ringOf(container)?.closest(".size-11")).not.toBeNull();
   });
 
   test("is absent in the composer with no session running", () => {
@@ -1467,5 +1521,35 @@ describe("the resting avatar's idle motion", () => {
       expect(container.querySelector(".companion-glow")).not.toBeNull();
       cleanup();
     }
+  });
+
+  /**
+   * A reader who has asked for stillness gets it from two places: the
+   * `prefers-reduced-motion` block beside the keyframes, and the inline
+   * `animation: none` here. The doubling is deliberate, since a stylesheet that
+   * failed to load is a surface that moves anyway, and this is the half a
+   * reader of the component can see.
+   *
+   * Held still rather than dropped: the glow is the creature's own light and
+   * the bob's baseline is where the creature belongs, so both stay drawn.
+   */
+  test("holds the bob and the glow still under reduced motion", () => {
+    reducedMotion = true;
+
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    const glow = container.querySelector<HTMLElement>(".companion-glow");
+    expect(bob?.style.animation).toBe("none");
+    expect(glow?.style.animation).toBe("none");
+  });
+
+  test("leaves both running for a reader who asked for nothing", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    const glow = container.querySelector<HTMLElement>(".companion-glow");
+    expect(bob?.style.animation).toBe("");
+    expect(glow?.style.animation).toBe("");
   });
 });

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -521,6 +521,151 @@ describe("the companion surface's anchor in the canvas", () => {
 });
 
 /**
+ * The surface with the creature and the controls sized apart.
+ *
+ * The page's wrapper is scaled by the options size, so everything here is
+ * stated in those units and the creature carries the difference between the two
+ * boxes itself. What has to hold is that the pill still sits a gap off the
+ * creature's *visual* edge and still shares its bottom line, whichever of the
+ * two is the larger, because that edge and that line are what the host places
+ * the window by.
+ */
+describe("the companion surface at two sizes", () => {
+  /**
+   * The pair the layout is authored at, which every other case here is read
+   * against: it has to come out exactly where one size put it.
+   */
+  test("draws the authored pair exactly as a single size does", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={44} optionsBox={44} />,
+    );
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
+  });
+
+  /** 55 to a huge creature's edge, then the gap the smaller of the two earns. */
+  test("steps the pill off a larger creature's own edge", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
+    );
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 67px)");
+  });
+
+  /**
+   * The same rule the other way round, read in the pill's own units: 22 points
+   * to the creature's edge and 12 of gap, at a scale of two and a half.
+   */
+  test("steps it off a smaller creature by the same rule", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
+    );
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 13.6px)");
+  });
+
+  test("mirrors that step when the pill grows the other way", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="hover"
+        growth="left"
+        avatarBox={110}
+        optionsBox={44}
+      />,
+    );
+    expect(surfaceOf(container).style.right).toBe("calc(50% + 67px)");
+  });
+
+  /**
+   * Bottom-flush against a creature that is not the pill's size: the near edge
+   * is 115 at this pair and the creature's bottom is 55 in from its centre, so
+   * the pill's bottom lands 60 from the canvas edge.
+   */
+  test("keeps the pill's bottom on a larger creature's bottom", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
+    );
+    expect(avatarOf(container).style.top).toBe("calc(100% - 115px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 60px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
+  });
+
+  test("keeps it on a smaller creature's bottom too", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
+    );
+    expect(avatarOf(container).style.top).toBe("calc(100% - 59.2px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 50.4px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
+  });
+
+  test("anchors both against the canvas's top edge when the card grows down", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="hover"
+        cardGrowth="down"
+        avatarBox={110}
+        optionsBox={44}
+      />,
+    );
+    expect(avatarOf(container).style.top).toBe("115px");
+    expect(surfaceOf(container).style.top).toBe("170px");
+  });
+
+  /**
+   * The card growing downward starts on its composer row's top line, which is
+   * one options box above the creature's bottom whatever the creature's size.
+   */
+  test("drops the card from the composer row's own line", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="typing"
+        cardGrowth="down"
+        avatarBox={44}
+        optionsBox={110}
+      />,
+    );
+    expect(surfaceOf(container).style.top).toBe("24px");
+    expect(surfaceOf(container).style.transform).toBe("none");
+  });
+
+  /**
+   * The creature's own node carries the difference and nothing else does. It
+   * has to be that node rather than the wrapper below it, which owns the bob's
+   * `transform`: two transforms on one node leave one of them out.
+   */
+  test("scales the creature by the difference between the two boxes", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarBox={110} optionsBox={44} />,
+    );
+    expect(avatarOf(container).style.transform).toBe(
+      "translate(-50%, -50%) scale(2.5)",
+    );
+    expect(
+      avatarOf(container).querySelector(".companion-avatar-bob"),
+    ).not.toBeNull();
+  });
+
+  test("scales it down the same way beside a larger pill", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarBox={44} optionsBox={110} />,
+    );
+    expect(avatarOf(container).style.transform).toBe(
+      "translate(-50%, -50%) scale(0.4)",
+    );
+  });
+
+  /** With the two agreeing the wrapper has done all of it, at any size. */
+  test("leaves the creature unscaled when the two agree", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarBox={110} optionsBox={110} />,
+    );
+    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+  });
+});
+
+/**
  * The idle row's verbs, which are drawn one at a time under the pointer.
  *
  * **The behaviour is a stylesheet, so these hold its contract rather than its

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -38,6 +38,16 @@ const LISTENING_CALL: VoiceActivityState = {
   assistantName: "Ziggy",
 };
 
+/** Every state the surface draws, which several cases here sweep in turn. */
+const PHASES = [
+  "resting",
+  "hover",
+  "watching",
+  "summary",
+  "call",
+  "typing",
+] as const;
+
 /**
  * The working ring: the surface's answer to "is it doing anything", drawn so it
  * can be read without reading. The class is the contract with `index.css`,
@@ -45,6 +55,14 @@ const LISTENING_CALL: VoiceActivityState = {
  */
 const ringOf = (container: HTMLElement): HTMLElement | null =>
   container.querySelector<HTMLElement>(".companion-working-ring");
+
+/** The wrapper the idle bob runs on, which sits inside the avatar's box. */
+const bobOf = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>(".companion-avatar-bob");
+
+/** The creature's own light, which rides inside the bob. */
+const glowOf = (container: HTMLElement): HTMLElement | null =>
+  container.querySelector<HTMLElement>(".companion-glow");
 
 describe("the companion surface's working ring", () => {
   test("is absent while nothing is running", () => {
@@ -70,14 +88,7 @@ describe("the companion surface's working ring", () => {
    * remounts everything hanging off it.
    */
   test("hangs off the avatar in every phase", () => {
-    for (const phase of [
-      "resting",
-      "hover",
-      "watching",
-      "summary",
-      "call",
-      "typing",
-    ] as const) {
+    for (const phase of PHASES) {
       const { container } = render(<CompanionSurface phase={phase} working />);
       expect(ringOf(container)?.closest(".size-11")).not.toBeNull();
       cleanup();
@@ -87,11 +98,6 @@ describe("the companion surface's working ring", () => {
   /** Around the creature's own box, so it is a circle whatever the pill is. */
   test("stays round while the card is open", () => {
     const { container } = render(<CompanionSurface phase="typing" working />);
-    expect(ringOf(container)?.className).toContain("rounded-full");
-  });
-
-  test("is round in every other state too", () => {
-    const { container } = render(<CompanionSurface phase="hover" working />);
     expect(ringOf(container)?.className).toContain("rounded-full");
   });
 
@@ -449,19 +455,6 @@ const avatarOf = (container: HTMLElement): HTMLElement => {
 };
 
 describe("the companion surface's anchor in the canvas", () => {
-  test("hangs the avatar off the canvas's bottom edge while the card grows up", () => {
-    const { container } = render(<CompanionSurface phase="resting" />);
-    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
-    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
-  });
-
-  test("sits the avatar against the canvas's top edge while the card grows down", () => {
-    const { container } = render(
-      <CompanionSurface phase="resting" cardGrowth="down" />,
-    );
-    expect(avatarOf(container).style.top).toBe("46px");
-  });
-
   test("grows up by default, which is where the surface normally lives", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
     const { container: explicit } = render(
@@ -482,14 +475,6 @@ describe("the companion surface's anchor in the canvas", () => {
     expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
-  test("keeps that line against the canvas's top edge too", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" cardGrowth="down" />,
-    );
-    expect(surfaceOf(container).style.top).toBe("68px");
-    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
-  });
-
   /**
    * The composer row is the card's last child growing up and its first growing
    * down, so the row's bottom is the avatar's bottom either way and the card
@@ -501,25 +486,33 @@ describe("the companion surface's anchor in the canvas", () => {
     expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
-  test("drops the card from the avatar's line when it grows down", () => {
-    const { container } = render(
+  /**
+   * The whole column against the other edge: the avatar sits on the canvas's
+   * top line, the pill keeps its bottom on the avatar's, and the card falls
+   * away from the row instead of hanging off it. The column reverses for the
+   * reason the row does when the pill grows left: the row holding the avatar's
+   * line has to end up against the avatar, and the conversation stacks away
+   * from it.
+   */
+  test("anchors everything against the canvas's top edge when the card grows down", () => {
+    const { container: resting } = render(
+      <CompanionSurface phase="resting" cardGrowth="down" />,
+    );
+    expect(avatarOf(resting).style.top).toBe("46px");
+
+    const { container: hover } = render(
+      <CompanionSurface phase="hover" cardGrowth="down" />,
+    );
+    expect(surfaceOf(hover).style.top).toBe("68px");
+    expect(surfaceOf(hover).style.transform).toBe("translateY(-100%)");
+
+    const { container: typing } = render(
       <CompanionSurface phase="typing" cardGrowth="down" />,
     );
     // The row starts on the avatar's top line and the card falls away from it.
-    expect(surfaceOf(container).style.top).toBe("24px");
-    expect(surfaceOf(container).style.transform).toBe("none");
-  });
-
-  /**
-   * The column reverses for the reason the row does when the pill grows left:
-   * the row holding the avatar's line has to end up against the avatar, and the
-   * conversation stacks away from it.
-   */
-  test("reverses the card's column when it grows down", () => {
-    const { container } = render(
-      <CompanionSurface phase="typing" cardGrowth="down" />,
-    );
-    expect(surfaceOf(container).className).toContain("flex-col-reverse");
+    expect(surfaceOf(typing).style.top).toBe("24px");
+    expect(surfaceOf(typing).style.transform).toBe("none");
+    expect(surfaceOf(typing).className).toContain("flex-col-reverse");
   });
 
   test("stacks the card upward in the ordinary direction", () => {
@@ -542,26 +535,13 @@ describe("the companion surface's anchor in the canvas", () => {
     );
   });
 
-  /** The pill's avatar-facing edge: the avatar's half box, then the gap. */
-  test("steps the pill off the avatar's edge by the gap", () => {
-    const { container } = render(<CompanionSurface phase="hover" />);
-    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
-  });
-
   /**
    * The property everything else here is in service of: the host positions the
    * window by the creature, so the creature has to sit on the same point in
    * every state the surface can be in.
    */
   test("keeps the avatar's own point in every phase", () => {
-    for (const phase of [
-      "resting",
-      "hover",
-      "watching",
-      "summary",
-      "call",
-      "typing",
-    ] as const) {
+    for (const phase of PHASES) {
       const { container } = render(<CompanionSurface phase={phase} />);
       expect(avatarOf(container).style.left).toBe("50%");
       expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
@@ -594,36 +574,34 @@ describe("the companion surface's anchor in the canvas", () => {
  */
 describe("the companion surface at two sizes", () => {
   /**
-   * The pair the layout is authored at, which every other case here is read
-   * against: it has to come out exactly where one size put it.
+   * 55 to a huge creature's edge, then the gap the smaller of the two earns.
+   * Bottom-flush with it as well: the near edge is 115 at this pair and the
+   * creature's bottom is 55 in from its centre, so the pill's bottom lands 60
+   * from the canvas edge.
    */
-  test("draws the authored pair exactly as a single size does", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" avatarBox={44} optionsBox={44} />,
-    );
-    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
-    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
-    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
-  });
-
-  /** 55 to a huge creature's edge, then the gap the smaller of the two earns. */
-  test("steps the pill off a larger creature's own edge", () => {
+  test("steps the pill off a larger creature's edge and onto its bottom", () => {
     const { container } = render(
       <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
     );
     expect(surfaceOf(container).style.left).toBe("calc(50% + 67px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 115px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 60px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   /**
-   * The same rule the other way round, read in the pill's own units: 22 points
-   * to the creature's edge and 12 of gap, at a scale of two and a half.
+   * The same rules the other way round, read in the pill's own units: 22 points
+   * to the creature's edge and 12 of gap, at a scale of two and a half, and the
+   * pill's bottom on the creature's own bottom as before.
    */
-  test("steps it off a smaller creature by the same rule", () => {
+  test("steps it off a smaller creature and onto its bottom too", () => {
     const { container } = render(
       <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
     );
     expect(surfaceOf(container).style.left).toBe("calc(50% + 13.6px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 59.2px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 50.4px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   test("mirrors that step when the pill grows the other way", () => {
@@ -636,29 +614,6 @@ describe("the companion surface at two sizes", () => {
       />,
     );
     expect(surfaceOf(container).style.right).toBe("calc(50% + 67px)");
-  });
-
-  /**
-   * Bottom-flush against a creature that is not the pill's size: the near edge
-   * is 115 at this pair and the creature's bottom is 55 in from its centre, so
-   * the pill's bottom lands 60 from the canvas edge.
-   */
-  test("keeps the pill's bottom on a larger creature's bottom", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
-    );
-    expect(avatarOf(container).style.top).toBe("calc(100% - 115px)");
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 60px)");
-    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
-  });
-
-  test("keeps it on a smaller creature's bottom too", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
-    );
-    expect(avatarOf(container).style.top).toBe("calc(100% - 59.2px)");
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 50.4px)");
-    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   test("anchors both against the canvas's top edge when the card grows down", () => {
@@ -703,9 +658,7 @@ describe("the companion surface at two sizes", () => {
     expect(avatarOf(container).style.transform).toBe(
       "translate(-50%, -50%) scale(2.5)",
     );
-    expect(
-      avatarOf(container).querySelector(".companion-avatar-bob"),
-    ).not.toBeNull();
+    expect(bobOf(container)?.parentElement).toBe(avatarOf(container));
   });
 
   test("scales it down the same way beside a larger pill", () => {
@@ -1224,7 +1177,16 @@ describe("the summary a finished watch session leaves on the surface", () => {
 });
 
 describe("the companion surface's width ceiling", () => {
-  const CANVAS_CEILING = COMPANION_BASE_MAX_PILL_WIDTH;
+  /**
+   * The widest the pill may draw, which is what the canvas is sized for.
+   * Written out rather than read from the contract, so the cases below assert a
+   * number instead of restating the constant they are about.
+   */
+  const CANVAS_CEILING = 316;
+
+  test("is the width the shared contract publishes", () => {
+    expect(COMPANION_BASE_MAX_PILL_WIDTH).toBe(CANVAS_CEILING);
+  });
 
   /**
    * The ceiling is on the pill, not on the body inside it, so a body that fits
@@ -1285,11 +1247,6 @@ describe("the companion surface's capture indicator across phases", () => {
     expect(ringOf(container)).not.toBeNull();
   });
 
-  test("stays on the creature while the user types", () => {
-    const { container } = render(<CompanionSurface phase="typing" watching />);
-    expect(ringOf(container)?.closest(".size-11")).not.toBeNull();
-  });
-
   test("is absent in the composer with no session running", () => {
     const { container } = render(<CompanionSurface phase="typing" />);
     expect(ringOf(container)).toBeNull();
@@ -1325,12 +1282,31 @@ describe("the companion surface growing leftward", () => {
     expect(surfaceOf(container).style.left).toBe("");
   });
 
+  /** The pill's avatar-facing edge: the avatar's half box, then the gap. */
   test("anchors it by its left edge growing the ordinary way", () => {
     const { container } = render(
       <CompanionSurface phase="hover" growth="right" />,
     );
     expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
     expect(surfaceOf(container).style.right).toBe("");
+  });
+
+  /**
+   * The row inside the pill ends on the pinned edge too. A row left-aligned in
+   * a box narrower than its own content spills past that edge, across the gap
+   * and over the creature, for as long as the animating width lags the
+   * content: through the unfurl, and again on every label reveal.
+   */
+  test("ends the pill's row on the edge the pill is pinned by", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" growth="left" />,
+    );
+    expect(surfaceOf(container).className).toContain("justify-end");
+
+    const { container: rightward } = render(
+      <CompanionSurface phase="hover" growth="right" />,
+    );
+    expect(surfaceOf(rightward).className).not.toContain("justify-end");
   });
 
   /**
@@ -1476,12 +1452,11 @@ describe("the resting avatar's idle motion", () => {
       <CompanionSurface phase="resting" accentHex="#ff8800" />,
     );
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    const bob = bobOf(container);
     expect(bob).not.toBeNull();
 
-    const glow = bob?.querySelector<HTMLElement>(".companion-glow");
-    expect(glow).not.toBeNull();
-    expect(glow?.className).not.toContain("animate-pulse");
+    const glow = glowOf(container);
+    expect(glow?.parentElement).toBe(bob);
     expect(glow?.style.background.toLowerCase()).toContain("#ff8800");
   });
 
@@ -1497,16 +1472,14 @@ describe("the resting avatar's idle motion", () => {
       />,
     );
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
-    expect(bob?.querySelector("svg")).not.toBeNull();
+    expect(bobOf(container)?.querySelector("svg")).not.toBeNull();
   });
 
   /** The wrapper sits inside the avatar's box, which nothing else may move. */
   test("keeps the avatar box as the wrapper's parent", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
-    expect(bob?.parentElement?.className).toContain("size-11");
+    expect(bobOf(container)?.parentElement?.className).toContain("size-11");
   });
 
   /**
@@ -1516,9 +1489,9 @@ describe("the resting avatar's idle motion", () => {
    * second ring around.
    */
   test("glows in every phase, not only at rest", () => {
-    for (const phase of ["resting", "hover", "call", "typing"] as const) {
+    for (const phase of PHASES) {
       const { container } = render(<CompanionSurface phase={phase} />);
-      expect(container.querySelector(".companion-glow")).not.toBeNull();
+      expect(glowOf(container)).not.toBeNull();
       cleanup();
     }
   });
@@ -1538,18 +1511,14 @@ describe("the resting avatar's idle motion", () => {
 
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
-    const glow = container.querySelector<HTMLElement>(".companion-glow");
-    expect(bob?.style.animation).toBe("none");
-    expect(glow?.style.animation).toBe("none");
+    expect(bobOf(container)?.style.animation).toBe("none");
+    expect(glowOf(container)?.style.animation).toBe("none");
   });
 
   test("leaves both running for a reader who asked for nothing", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
-    const glow = container.querySelector<HTMLElement>(".companion-glow");
-    expect(bob?.style.animation).toBe("");
-    expect(glow?.style.animation).toBe("");
+    expect(bobOf(container)?.style.animation).toBe("");
+    expect(glowOf(container)?.style.animation).toBe("");
   });
 });

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1,9 +1,14 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { COMPANION_BASE_MAX_PILL_WIDTH } from "@vellumai/ipc-contract";
 import type { VoiceActivityState } from "@vellumai/ipc-contract";
 
-import { CompanionSurface, FALLBACK_WIDTHS } from "./companion-surface";
+import {
+  CompanionSurface,
+  FALLBACK_WIDTHS,
+  INNER_GAP,
+} from "./companion-surface";
 
 afterEach(cleanup);
 
@@ -1162,8 +1167,20 @@ describe("the summary a finished watch session leaves on the surface", () => {
 });
 
 describe("the companion surface's width ceiling", () => {
-  /** `BASE_MAX_BODY_WIDTH` in `clients/macos/src/main/companion-window.ts`. */
-  const CANVAS_CEILING = 316;
+  const CANVAS_CEILING = COMPANION_BASE_MAX_PILL_WIDTH;
+
+  /**
+   * The ceiling is on the pill, not on the body inside it, so a body that fits
+   * with the clearance at either end left off is not one that fits. `typing` is
+   * the card's own outer width rather than a measured body, and the case below
+   * holds it exactly at the ceiling.
+   */
+  test("holds for every measured body once the pill's own clearance is on it", () => {
+    const over = Object.entries(FALLBACK_WIDTHS)
+      .filter(([phase]) => phase !== "typing")
+      .filter(([, width]) => width + 2 * INNER_GAP > CANVAS_CEILING);
+    expect(over).toEqual([]);
+  });
 
   test("holds for every phase", () => {
     const over = Object.entries(FALLBACK_WIDTHS).filter(

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1196,3 +1196,51 @@ describe("the companion surface's text selection", () => {
     );
   });
 });
+
+/**
+ * The idle motion, which is two animations that must not become one.
+ *
+ * `AnimatedAvatar` owns `transform` on its own `<svg>` for the breathe and the
+ * morph, so the bob lives on a wrapper. Put both on one node and the browser
+ * silently keeps whichever declaration came last, and the loss is invisible in
+ * a screenshot.
+ */
+describe("the resting avatar's idle motion", () => {
+  test("bobs on a wrapper of its own, with the glow riding inside it", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" accentHex="#ff8800" />,
+    );
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    expect(bob).not.toBeNull();
+
+    const glow = bob?.querySelector<HTMLElement>(".companion-glow");
+    expect(glow).not.toBeNull();
+    expect(glow?.className).not.toContain("animate-pulse");
+    expect(glow?.style.background.toLowerCase()).toContain("#ff8800");
+  });
+
+  /**
+   * The artwork keeps its own animated node under the wrapper, which is what
+   * makes the two transforms compose rather than replace each other.
+   */
+  test("leaves the artwork on a node below the bob", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="resting"
+        character={{ bodyShape: "blob", eyeStyle: "curious", color: "teal" }}
+      />,
+    );
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    expect(bob?.querySelector("svg")).not.toBeNull();
+  });
+
+  /** The wrapper sits inside the avatar's box, which nothing else may move. */
+  test("keeps the avatar box as the wrapper's parent", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    expect(bob?.parentElement?.className).toContain("size-11");
+  });
+});

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -12,6 +12,7 @@ import {
   VolumeX,
   X,
 } from "lucide-react";
+import { useReducedMotion } from "motion/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type {
   CSSProperties,
@@ -1186,6 +1187,12 @@ function Composer({
  * into the desktop rather than ending on an edge. A halo sized to its own
  * source has nowhere to fall off and reads as a ring around the avatar rather
  * than as light coming off it.
+ *
+ * **The bob is a wrapper, not a class on the artwork.** `AnimatedAvatar` owns
+ * `transform` on its own `<svg>` for the breathe and the morph, and a second
+ * animation on that node would silently replace one of them. Everything that
+ * belongs to the creature rides inside the wrapper, glow included, so the light
+ * travels with what is casting it.
  */
 function Avatar({
   glow,
@@ -1206,6 +1213,11 @@ function Avatar({
   onMouseEnter?: () => void;
   onClick?: () => void;
 }) {
+  // Belt and braces alongside the `prefers-reduced-motion` block beside the
+  // keyframes: the class is what a stylesheet-only reader sees, this is what a
+  // reader of the component sees.
+  const reduce = useReducedMotion();
+
   return (
     // A div rather than a button even when it is pressable: it is the drag
     // handle for the whole surface, and the press that starts a drag must not
@@ -1216,51 +1228,59 @@ function Avatar({
       onMouseEnter={onMouseEnter}
       onClick={onClick}
     >
-      {glow && (
-        <span
-          className="absolute size-10 animate-pulse rounded-full blur-lg"
-          style={{ background: accentHex, opacity: 0.4 }}
-          aria-hidden
-        />
-      )}
-      {character !== undefined ? (
-        // The live creature, composed here rather than shipped as pixels. It
-        // blinks, twitches and breathes on its own, which is the whole reason
-        // the traits cross the bridge instead of a still.
-        <div className="relative drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]">
-          <AnimatedAvatar
-            components={BUNDLED_COMPONENTS}
-            traits={character}
-            size={AVATAR_IMAGE}
-            isAssistantBusy={busy}
-            attentive={attentive}
+      <div
+        className="companion-avatar-bob relative grid place-items-center"
+        style={{ animation: reduce ? "none" : undefined }}
+      >
+        {glow && (
+          <span
+            className="companion-glow absolute size-10 rounded-full blur-lg"
+            style={{
+              background: accentHex,
+              animation: reduce ? "none" : undefined,
+            }}
+            aria-hidden
           />
-        </div>
-      ) : avatarSrc === undefined ? (
-        // Until the avatar resolves, a disc in its colour. Same size, so
-        // nothing about the geometry moves when the image lands.
-        <span
-          className="relative size-7 rounded-full drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
-          style={{ background: accentHex }}
-          aria-hidden
-        />
-      ) : (
-        // A custom uploaded image, which has no traits to compose and so no
-        // eyes to animate.
-        //
-        // Undraggable, because the avatar is the surface's drag handle. An
-        // image is natively draggable, and the platform's own HTML5 image drag
-        // takes the pointer and ends the `mousemove` stream the surface's drag
-        // runs on, so pressing a custom avatar would move nothing where
-        // pressing a composed creature moves the window. WebKit honours the CSS
-        // on paths where it ignores the attribute, so both are needed.
-        <img
-          src={avatarSrc}
-          alt=""
-          draggable={false}
-          className="relative size-7 rounded-full object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)] [-webkit-user-drag:none]"
-        />
-      )}
+        )}
+        {character !== undefined ? (
+          // The live creature, composed here rather than shipped as pixels. It
+          // blinks, twitches and breathes on its own, which is the whole reason
+          // the traits cross the bridge instead of a still.
+          <div className="relative drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]">
+            <AnimatedAvatar
+              components={BUNDLED_COMPONENTS}
+              traits={character}
+              size={AVATAR_IMAGE}
+              isAssistantBusy={busy}
+              attentive={attentive}
+            />
+          </div>
+        ) : avatarSrc === undefined ? (
+          // Until the avatar resolves, a disc in its colour. Same size, so
+          // nothing about the geometry moves when the image lands.
+          <span
+            className="relative size-7 rounded-full drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
+            style={{ background: accentHex }}
+            aria-hidden
+          />
+        ) : (
+          // A custom uploaded image, which has no traits to compose and so no
+          // eyes to animate.
+          //
+          // Undraggable, because the avatar is the surface's drag handle. An
+          // image is natively draggable, and the platform's own HTML5 image drag
+          // takes the pointer and ends the `mousemove` stream the surface's drag
+          // runs on, so pressing a custom avatar would move nothing where
+          // pressing a composed creature moves the window. WebKit honours the CSS
+          // on paths where it ignores the attribute, so both are needed.
+          <img
+            src={avatarSrc}
+            alt=""
+            draggable={false}
+            className="relative size-7 rounded-full object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)] [-webkit-user-drag:none]"
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -768,8 +768,8 @@ export function CompanionSurface({
   const edge = (
     <>
       {/* Something running, as a light travelling around the edge. Drawn over
-          the body so it reads as the surface's own border, and outside it by a
-          hair so it never crowds what it is drawn around.
+          the creature so it reads as the creature's own border, and outside
+          the creature's box by a hair so it never crowds the artwork.
 
           A turn burns it in the assistant's colour, a watch session in amber,
           and the session's ring is drawn in every phase rather than only the
@@ -835,7 +835,13 @@ export function CompanionSurface({
               // line has to stay on that line, and the turns stack away from
               // it.
               `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
-            : "flex h-11 items-center rounded-full"
+            : // One row in a box whose width animates, so the row is pinned to
+              // the pill's avatar-facing edge. `growth: "left"` anchors the
+              // pill by its right, and a row left-aligned in a box narrower
+              // than itself spills past that edge, across the gap and over the
+              // creature, every time the width lags the content: through the
+              // unfurl and instantly on each label reveal.
+              `flex h-11 items-center rounded-full ${growth === "left" ? "justify-end" : ""}`
         }`}
         style={style}
         onMouseDown={onSurfaceMouseDown}

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -21,7 +21,7 @@ import type {
   Ref,
 } from "react";
 
-import { COMPANION_NEAR_EDGE, companionGapFor } from "@vellumai/ipc-contract";
+import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
   CompanionTurn,
@@ -35,6 +35,7 @@ import { MarkdownMessage } from "@vellumai/design-library";
 import { openCompanionLink } from "@/runtime/companion-surface";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { companionLayoutFor } from "@/components/companion-layout";
 import { useTranslation } from "@/i18n";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
@@ -44,14 +45,22 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
  * beside it, and unfurling the same way while a call runs.
  *
  * **Two elements, and the mascot is the fixed point.** The creature and the
- * pill are siblings with {@link GAP} between them rather than one box holding
- * the other. The avatar holds one point in the canvas in every state, which is
- * the point the host positions this window around, so the surface reads as one
+ * pill are siblings with a gap between them rather than one box holding the
+ * other. The avatar holds one point in the canvas in every state, which is the
+ * point the host positions this window around, so the surface reads as one
  * object changing shape rather than a series of different objects and the eye
  * and the cursor always have the same target to aim at. The pill hangs off it:
  * its avatar-facing edge sits the avatar's half box plus the gap from that
  * point, and its bottom edge sits on the avatar's bottom, so the two keep one
  * baseline whatever the pill is carrying. Only the pill's `width` animates.
+ *
+ * **Two sizes, and the creature carries the difference.** The host publishes a
+ * box for the avatar and a box for the pill, and the page around this scales
+ * the whole canvas by the second, so every length below is stated once at the
+ * size the layout is authored at. The creature is scaled again inside that by
+ * the ratio between the two boxes, and the handful of distances measured from
+ * its edge (the gap, the near edge, its own half box) are worked out from the
+ * contract's helpers and divided back into these units.
  *
  * **Growth needs clearance on the side it runs into**: the gap, and then a body
  * that reaches 316px at its widest. A circle parked against the right edge does
@@ -175,21 +184,9 @@ const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
  */
 const WATCHING_RING_ACCENT = "#ff9f45";
 
-// The avatar is a fixed 44px disc in every state; only the pill beside it
-// changes. That is what makes this one surface expanding rather than three
-// surfaces that happen to share a colour, and it is the property to protect as
-// the states gain content.
-const AVATAR_BOX = 44;
-
-/**
- * The room between the avatar's edge and the pill.
- *
- * Read from the contract rather than stated here, because main sizes the canvas
- * to hold the same distance: what decides how wide the window has to be is the
- * pill's reach past the avatar, and a second copy of the number is a pill drawn
- * further out than the room main left for it.
- */
-const GAP = companionGapFor(AVATAR_BOX, AVATAR_BOX);
+// The box every length on this surface is stated in: the pill's own height, and
+// the creature's at the size the two agree on.
+const BASE_BOX = COMPANION_BASE_AVATAR_BOX;
 
 /**
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
@@ -348,6 +345,26 @@ export interface CompanionSurfaceProps {
   onHoverEnd?: () => void;
   /** Which way the pill grows. See {@link CompanionSurfaceGrowth}. */
   growth?: CompanionSurfaceGrowth;
+  /**
+   * The creature's box in points, which is the avatar's whole scale.
+   *
+   * Its own size rather than the surface's, because the two are chosen
+   * separately: a mascot big enough to read from across the room is not a pill
+   * that wide. Defaulted to the size the layout is authored at, which is what
+   * Storybook draws and what the host publishes for a surface nobody has
+   * resized.
+   */
+  avatarBox?: number;
+  /**
+   * The pill's box in points, which is the scale of everything that is not the
+   * creature.
+   *
+   * The page's wrapper is already scaled by this, so what it is for here is
+   * converting back: a distance the host and this side have to agree on is
+   * worked out in points from the contract's helpers and divided by this scale
+   * on its way into a style, so both ends are the same expression.
+   */
+  optionsBox?: number;
   /**
    * Which way the card grows, and with it which edge of the canvas the avatar
    * is anchored to. See {@link CompanionSurfaceCardGrowth}.
@@ -623,6 +640,8 @@ export function CompanionSurface({
   onHoverStart,
   onHoverEnd,
   growth = "right",
+  avatarBox = COMPANION_BASE_AVATAR_BOX,
+  optionsBox = COMPANION_BASE_AVATAR_BOX,
   cardGrowth = "up",
   rootRef,
   avatarRef,
@@ -701,19 +720,27 @@ export function CompanionSurface({
       ? 0
       : (contentWidth ?? FALLBACK_WIDTHS[phase]) + 2 * INNER_GAP;
 
+  // The distances everything below is placed by, in points, and the one
+  // conversion into the units this layout is stated in. Shared with
+  // `CompanionIntro`, whose card hangs off the same edge by the same amount.
+  const { inUnits, avatarRel, avatarHalf, gap, nearEdge } = companionLayoutFor(
+    avatarBox,
+    optionsBox,
+  );
+
   /**
-   * A line in the canvas, given how far it sits from the avatar's centre.
+   * A line in the canvas, given how far in points it sits from the avatar's
+   * centre.
    *
    * The canvas is *not* symmetric about the avatar: the card's height is
-   * reserved on whichever side it grows into, so the avatar sits
-   * `COMPANION_NEAR_EDGE` from the other edge, and that edge is the one worth
-   * anchoring to. `100%` names the canvas without this side having to know how
-   * tall main made it.
+   * reserved on whichever side it grows into, so the avatar sits the near edge
+   * from the other one, and that edge is the one worth anchoring to. `100%`
+   * names the canvas without this side having to know how tall main made it.
    */
   const lineAt = (offset: number): string =>
     cardGrowth === "up"
-      ? `calc(100% - ${COMPANION_NEAR_EDGE - offset}px)`
-      : `${COMPANION_NEAR_EDGE + offset}px`;
+      ? `calc(100% - ${inUnits(nearEdge - offset)}px)`
+      : `${inUnits(nearEdge + offset)}px`;
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
   // spot the host positions this window around, and the pill hangs off one side
@@ -728,8 +755,8 @@ export function CompanionSurface({
   // and direction check against is not.
   const placement: CSSProperties =
     growth === "left"
-      ? { right: `calc(50% + ${AVATAR_BOX / 2 + GAP}px)` }
-      : { left: `calc(50% + ${AVATAR_BOX / 2 + GAP}px)` };
+      ? { right: `calc(50% + ${inUnits(avatarHalf + gap)}px)` }
+      : { left: `calc(50% + ${inUnits(avatarHalf + gap)}px)` };
 
   // The card growing downward draws its composer row first, so the row starts
   // on the avatar's top line and the card falls away from it; everything else
@@ -746,8 +773,9 @@ export function CompanionSurface({
     // pressed. Which way the card stacks is the host's call: parked by the Dock
     // a card growing down would grow off the bottom of the screen, and at the
     // top of the display a card growing up has nowhere to be (see
-    // `CompanionSurfaceCardGrowth`).
-    top: lineAt(dropsFromTheRow ? -(AVATAR_BOX / 2) : AVATAR_BOX / 2),
+    // `CompanionSurfaceCardGrowth`). The row is one options box tall, so a card
+    // growing downward starts exactly that far above the line.
+    top: lineAt(dropsFromTheRow ? avatarHalf - optionsBox : avatarHalf),
     transform: dropsFromTheRow ? "none" : "translateY(-100%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
@@ -942,13 +970,16 @@ export function CompanionSurface({
           <span
             className="pointer-events-auto absolute"
             style={{
-              width: GAP,
-              height: AVATAR_BOX,
+              width: inUnits(gap),
+              // The pill's own row, on the pill's own line: the strip is what
+              // the pointer crosses between the two, so it is as tall as what
+              // it leads to rather than as tall as the creature it leaves.
+              height: BASE_BOX,
               ...(growth === "left"
-                ? { right: `calc(50% + ${AVATAR_BOX / 2}px)` }
-                : { left: `calc(50% + ${AVATAR_BOX / 2}px)` }),
-              top: lineAt(0),
-              transform: "translateY(-50%)",
+                ? { right: `calc(50% + ${inUnits(avatarHalf)}px)` }
+                : { left: `calc(50% + ${inUnits(avatarHalf)}px)` }),
+              top: lineAt(avatarHalf),
+              transform: "translateY(-100%)",
             }}
             aria-hidden
           />
@@ -970,7 +1001,16 @@ export function CompanionSurface({
           style={{
             left: "50%",
             top: lineAt(0),
-            transform: "translate(-50%, -50%)",
+            // Centred on the point the host put the window around, then scaled
+            // about that centre by whatever the creature's own size asks for
+            // beyond the scale the page has already applied. Omitted where the
+            // two boxes agree, which is the surface every other length here is
+            // authored for. On this node rather than the one below it: the bob
+            // owns a `transform` of its own, and two transforms on one node
+            // silently leave one of them out.
+            transform: `translate(-50%, -50%)${
+              avatarRel === 1 ? "" : ` scale(${avatarRel})`
+            }`,
           }}
           elementRef={avatarRef}
           onMouseEnter={onHoverStart}

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -65,11 +65,12 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
  * its edge (the gap, the near edge, its own half box) are worked out from the
  * contract's helpers and divided back into these units.
  *
- * **Growth needs clearance on the side it runs into**: the gap, and then a body
- * that reaches 316px at its widest. A circle parked against the right edge does
- * not have it, and unclamped the pill would run straight off the display with
- * the controls the user was reaching for. So the surface flips and grows the
- * other way instead, the way a menu does, through {@link growth}.
+ * **Growth needs clearance on the side it runs into**: the gap, and then a pill
+ * as wide as {@link COMPANION_BASE_MAX_PILL_WIDTH}, which is what the card
+ * draws. A circle parked against the right edge does not have it, and unclamped
+ * the pill would run straight off the display with the controls the user was
+ * reaching for. So the surface flips and grows the other way instead, the way a
+ * menu does, through {@link growth}.
  *
  * **Presentational only.** Phase comes from the caller, so this renders
  * identically in Storybook and in the Electron panel. Hover is a phase rather
@@ -187,10 +188,6 @@ const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
  */
 const WATCHING_RING_ACCENT = "#ff9f45";
 
-// The box every length on this surface is stated in: the pill's own height, and
-// the creature's at the size the two agree on.
-const BASE_BOX = COMPANION_BASE_AVATAR_BOX;
-
 /**
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
  * every side. Both the still and the composed creature draw at this size, so
@@ -235,10 +232,15 @@ export const INNER_GAP = 8;
  * a state that wanted more would be clipped by the window, and buying the room
  * back means resizing the canvas, which is the thing a fixed canvas exists to
  * avoid.
+ *
+ * The two phases that never reach this are absent from it: `resting` has no
+ * pill to measure, and `typing` states {@link CARD_WIDTH} rather than measuring
+ * anything.
  */
-export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
-  // Nothing at all: at rest there is no pill, and its box goes with it.
-  resting: 0,
+export const FALLBACK_WIDTHS: Record<
+  Exclude<CompanionSurfacePhase, "resting" | "typing">,
+  number
+> = {
   // Three icon-only controls, which is the row as it is first drawn: the labels
   // are revealed one at a time under the pointer, and on the first frame there
   // is no pointer on any of them yet.
@@ -254,8 +256,6 @@ export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
   // The row with the stop control on it, which is the widest a call draws: a
   // watch session adds a fifth control to the four the call already has.
   call: 288,
-  // The card's body, which is {@link CARD_WIDTH} rather than anything measured.
-  typing: 316,
 };
 
 /**
@@ -274,8 +274,8 @@ const CARD_WIDTH = COMPANION_BASE_MAX_PILL_WIDTH;
  * The card is still a card, not a chat window: it holds a readable stretch of
  * the exchange and the rest is scrolled to, so a long reply can be read in
  * place without the surface growing until it runs off the top of the display.
- * Whatever this is, `MAX_CARD_HEIGHT` in `companion-window.ts` has to be sized
- * to hold it plus the composer row.
+ * Whatever this is, `COMPANION_BASE_CARD_HEIGHT` in the contract has to be
+ * sized to hold it plus the composer row.
  */
 const TURNS_MAX_HEIGHT = 220;
 
@@ -297,8 +297,6 @@ export interface CompanionSurfaceProps {
   turns?: CompanionTurn[];
   /** The assistant's name, for the composer's placeholder. */
   assistantName?: string;
-  /** The resting circle's ambient halo, in the avatar's own colour. */
-  glow?: boolean;
   /** The assistant's avatar colour. Fills shapes; never carries text. */
   accentHex?: string;
   /**
@@ -332,21 +330,6 @@ export interface CompanionSurfaceProps {
    * still notice a hand arriving over it either way.
    */
   hovered?: boolean;
-  /**
-   * Expand. Wired to the avatar alone, never to the surface: at rest the two
-   * are the same box, but arming from anything larger than what is drawn would
-   * expand the surface from empty space the user cannot see.
-   */
-  onHoverStart?: () => void;
-  /**
-   * Collapse. Wired to the group holding the avatar, the gap and the pill
-   * rather than to the avatar, because once expanded the pointer has to be able
-   * to travel across the gap to the controls. Leaving on the avatar would
-   * collapse the pill out from under the hand reaching for it, and while
-   * resting the avatar is all the group has drawn in it, so the two agree
-   * exactly when it matters.
-   */
-  onHoverEnd?: () => void;
   /** Which way the pill grows. See {@link CompanionSurfaceGrowth}. */
   growth?: CompanionSurfaceGrowth;
   /**
@@ -636,13 +619,10 @@ export function CompanionSurface({
   phase,
   turns = [],
   assistantName = "your assistant",
-  glow = true,
   accentHex = DEFAULT_ACCENT,
   avatarSrc,
   character,
   hovered = false,
-  onHoverStart,
-  onHoverEnd,
   growth = "right",
   avatarBox = COMPANION_BASE_AVATAR_BOX,
   optionsBox = COMPANION_BASE_AVATAR_BOX,
@@ -726,25 +706,11 @@ export function CompanionSurface({
 
   // The distances everything below is placed by, in points, and the one
   // conversion into the units this layout is stated in. Shared with
-  // `CompanionIntro`, whose card hangs off the same edge by the same amount.
-  const { inUnits, avatarRel, avatarHalf, gap, nearEdge } = companionLayoutFor(
+  // `CompanionIntro`, whose card hangs off the same creature.
+  const { avatarRel, avatarHalf, gap, lineAt, edgeAt } = companionLayoutFor(
     avatarBox,
     optionsBox,
   );
-
-  /**
-   * A line in the canvas, given how far in points it sits from the avatar's
-   * centre.
-   *
-   * The canvas is *not* symmetric about the avatar: the card's height is
-   * reserved on whichever side it grows into, so the avatar sits the near edge
-   * from the other one, and that edge is the one worth anchoring to. `100%`
-   * names the canvas without this side having to know how tall main made it.
-   */
-  const lineAt = (offset: number): string =>
-    cardGrowth === "up"
-      ? `calc(100% - ${inUnits(nearEdge - offset)}px)`
-      : `${inUnits(nearEdge + offset)}px`;
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
   // spot the host positions this window around, and the pill hangs off one side
@@ -757,10 +723,7 @@ export function CompanionSurface({
   // centre and lets the body run the rest of the way: the pill is what moves
   // when `growth` flips, and the creature the host measures every drag, clamp
   // and direction check against is not.
-  const placement: CSSProperties =
-    growth === "left"
-      ? { right: `calc(50% + ${inUnits(avatarHalf + gap)}px)` }
-      : { left: `calc(50% + ${inUnits(avatarHalf + gap)}px)` };
+  const placement = edgeAt(growth, avatarHalf + gap);
 
   // The card growing downward draws its composer row first, so the row starts
   // on the avatar's top line and the card falls away from it; everything else
@@ -774,27 +737,33 @@ export function CompanionSurface({
     // avatar's, and the card keeps that line: its composer row is the column's
     // last child growing up and its first growing down, so the row's bottom is
     // the avatar's bottom either way and the mascot does not move when Type is
-    // pressed. Which way the card stacks is the host's call: parked by the Dock
-    // a card growing down would grow off the bottom of the screen, and at the
-    // top of the display a card growing up has nowhere to be (see
+    // pressed. The line is the avatar's *box*, not the artwork inside it, which
+    // is inset by an `INNER_GAP` on every side and so stops short of it. Which
+    // way the card stacks is the host's call: parked by the Dock a card growing
+    // down would grow off the bottom of the screen, and at the top of the
+    // display a card growing up has nowhere to be (see
     // `CompanionSurfaceCardGrowth`). The row is one options box tall, so a card
     // growing downward starts exactly that far above the line.
-    top: lineAt(dropsFromTheRow ? avatarHalf - optionsBox : avatarHalf),
+    top: lineAt(
+      cardGrowth,
+      dropsFromTheRow ? avatarHalf - optionsBox : avatarHalf,
+    ),
     transform: dropsFromTheRow ? "none" : "translateY(-100%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
     transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
-    ["--accent" as string]: accentHex,
   };
 
   /**
-   * The surface's edge, lit for something running and flared for each capture.
+   * The creature's edge, lit for something running and flared for each capture.
    *
-   * Drawn around the avatar at rest and around the pill once there is one. The
-   * pill is nothing at rest, so the avatar is the only edge there is to light,
-   * and it is the state the ring most has to be legible in: the whole point is
-   * being readable from the corner of an eye while the user works elsewhere.
-   * Expanded, the pill is the surface's outline and takes it back.
+   * **On the avatar in every phase.** The creature is the one thing drawn in
+   * all of them and it holds one spot in the canvas, so the light stays where
+   * the eye already looks for this surface's state, and a working creature
+   * reads perfectly well beside an open pill. Handing it to the pill while
+   * expanded would move it to a different parent every time the pointer
+   * crossed, which unmounts the one-shot flare below and replays it for a
+   * capture that never happened.
    */
   const edge = (
     <>
@@ -810,9 +779,7 @@ export function CompanionSurface({
           failures. */}
       {(assistantWorking || watching || summarizing) && (
         <span
-          className={`companion-working-ring pointer-events-none absolute -inset-0.5 ${
-            typing ? "rounded-[24px]" : "rounded-full"
-          }`}
+          className="companion-working-ring pointer-events-none absolute -inset-0.5 rounded-full"
           style={{
             ["--companion-ring-accent" as string]: watching
               ? WATCHING_RING_ACCENT
@@ -841,9 +808,7 @@ export function CompanionSurface({
       {watching && observedCaptures > 0 && (
         <span
           key={observedCaptures}
-          className={`companion-capture-pulse pointer-events-none absolute -inset-0.5 ${
-            typing ? "rounded-[24px]" : "rounded-full"
-          }`}
+          className="companion-capture-pulse pointer-events-none absolute -inset-0.5 rounded-full"
           style={{
             ["--companion-ring-accent" as string]: WATCHING_RING_ACCENT,
           }}
@@ -859,170 +824,129 @@ export function CompanionSurface({
     // from state to state and be clipped by the pill's own rounding; beside it,
     // both hang off the same fixed avatar position in the canvas.
     <>
-      {/* The avatar, the pill, and the gap between them, as one group.
-
-        Its box is the whole canvas so the `50%` and `100%` its children anchor
-        by still name the canvas, and it takes no pointer of its own, so the
-        pointer is inside it exactly when it is on the avatar, the pill or the
-        bridge across the gap. Leaving the group is therefore leaving the whole
-        surface, which is what lets a hand travel from the creature to the
-        controls without the pill collapsing out from under it. */}
+      {/* The pill is a drag handle, as the avatar is. Controls opt out by
+        stopping the press, so everything on it that is not a button can be
+        grabbed. */}
       <div
-        className="pointer-events-none absolute inset-0"
-        onMouseLeave={onHoverEnd}
+        className={`absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
+          typing
+            ? // The composer row is the column's last child, so a card growing
+              // downward reverses the column: the row that holds the avatar's
+              // line has to stay on that line, and the turns stack away from
+              // it.
+              `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
+            : "flex h-11 items-center rounded-full"
+        }`}
+        style={style}
+        onMouseDown={onSurfaceMouseDown}
+        onContextMenu={onSurfaceContextMenu}
+        ref={rootRef}
       >
-        {/* The pill is a drag handle, as the avatar is. Controls opt out by
-          stopping the press, so everything on it that is not a button can be
-          grabbed. */}
-        <div
-          className={`pointer-events-auto absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
-            typing
-              ? // The composer row is the column's last child, so a card growing
-                // downward reverses the column: the row that holds the avatar's
-                // line has to stay on that line, and the turns stack away from
-                // it.
-                `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
-              : "flex h-11 items-center rounded-full"
+        {/* The pill's body, which exists only once there is a pill. At rest
+          there is nothing beside the avatar to draw, and fading the body in
+          as the width grows is what makes the pill unfurl out of the gap
+          rather than appear in it. */}
+        <span
+          className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
+            // Radius follows the same rule as the gap: the controls are 28pt
+            // so their radius is 14, and 8pt of clearance puts the outer
+            // radius at 22. A pill happens to reach that by being 44 tall;
+            // the card has to say it.
+            typing ? "rounded-[22px]" : "rounded-full"
           }`}
-          style={style}
-          onMouseDown={onSurfaceMouseDown}
-          onContextMenu={onSurfaceContextMenu}
-          ref={rootRef}
-        >
-          {/* The pill's body, which exists only once there is a pill. At rest
-            there is nothing beside the avatar to draw, and fading the body in
-            as the width grows is what makes the pill unfurl out of the gap
-            rather than appear in it. */}
-          <span
-            className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
-              // Radius follows the same rule as the gap: the controls are 28pt
-              // so their radius is 14, and 8pt of clearance puts the outer
-              // radius at 22. A pill happens to reach that by being 44 tall;
-              // the card has to say it.
-              typing ? "rounded-[22px]" : "rounded-full"
-            }`}
-            style={{ opacity: expanded ? 1 : 0 }}
-            aria-hidden
-          />
-          {expanded && edge}
-          {typing && turns.length > 0 && <RecentTurns turns={turns} />}
-          {/* The pill's one in-flow row, and where the clearance at either end
-            lives. On the row rather than on the pill, so the pill's own box
-            goes to nothing at rest while the body inside it keeps being
-            measured. */}
-          <div
-            className="relative flex h-11 shrink-0 items-center"
-            style={{ paddingInline: INNER_GAP }}
-          >
-            {typing ? (
-              <Composer
-                assistantName={assistantName}
-                watching={watching}
-                onSubmit={onSubmit}
-                onCancel={onCancelTyping}
-                onWatch={onWatch}
-              />
-            ) : (
-              <div
-                className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
-                ref={contentRef}
-                // Faded out is not gone: the body stays mounted while collapsed
-                // so it can be measured, which would otherwise leave its
-                // controls focusable and announced while nothing is drawn.
-                // `inert` takes them out of the tab order and the accessibility
-                // tree without taking them out of the DOM, so the measurement
-                // still works.
-                inert={!expanded}
-                style={{
-                  opacity: expanded ? 1 : 0,
-                  // Contents fade after the body has somewhere to put them, so
-                  // nothing is ever drawn wider than the pill carrying it.
-                  transitionDelay: expanded ? "120ms" : "0ms",
-                }}
-              >
-                {phase === "call" ? (
-                  <CallBody
-                    call={call}
-                    watching={watching}
-                    onControl={onControl}
-                    onWatch={onWatch}
-                  />
-                ) : phase === "summary" && watchRetro !== undefined ? (
-                  <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
-                ) : (
-                  <IdleBody
-                    spotlight={spotlight}
-                    watching={watching}
-                    watchEnabled={watchEnabled}
-                    onTalk={onTalk}
-                    onType={onType}
-                    onWatch={onWatch}
-                  />
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-        {/* The gap, as an element rather than empty canvas. Nothing is drawn in
-          it and nothing can be grabbed by it: it is here so a pointer crossing
-          from the creature to the controls stays inside the group and the pill
-          is not pulled out from under the hand halfway. The host hit-tests the
-          same span from the two rects (`bridgeRect` in
-          `companion-surface-page.tsx`), since a click-through window is told
-          about the pointer in coordinates rather than in elements. */}
-        {expanded && (
-          <span
-            className="pointer-events-auto absolute"
-            style={{
-              width: inUnits(gap),
-              // The pill's own row, on the pill's own line: the strip is what
-              // the pointer crosses between the two, so it is as tall as what
-              // it leads to rather than as tall as the creature it leaves.
-              height: BASE_BOX,
-              ...(growth === "left"
-                ? { right: `calc(50% + ${inUnits(avatarHalf)}px)` }
-                : { left: `calc(50% + ${inUnits(avatarHalf)}px)` }),
-              top: lineAt(avatarHalf),
-              transform: "translateY(-100%)",
-            }}
-            aria-hidden
-          />
-        )}
-        {/* Drawn last so the glow, which falls off well past the creature,
-          lands over the pill's leading edge rather than under it. */}
-        <Avatar
-          glow={glow}
-          accentHex={accentHex}
-          avatarSrc={avatarSrc}
-          character={character}
-          attentive={hovered}
-          // The assistant's own turn. The creature stops blinking and holds a
-          // focused, morphing pose, which is the same treatment the chat avatar
-          // uses while a reply is streaming: one vocabulary for "it is working"
-          // wherever the user meets it.
-          busy={assistantWorking}
-          edge={expanded ? null : edge}
-          style={{
-            left: "50%",
-            top: lineAt(0),
-            // Centred on the point the host put the window around, then scaled
-            // about that centre by whatever the creature's own size asks for
-            // beyond the scale the page has already applied. Omitted where the
-            // two boxes agree, which is the surface every other length here is
-            // authored for. On this node rather than the one below it: the bob
-            // owns a `transform` of its own, and two transforms on one node
-            // silently leave one of them out.
-            transform: `translate(-50%, -50%)${
-              avatarRel === 1 ? "" : ` scale(${avatarRel})`
-            }`,
-          }}
-          elementRef={avatarRef}
-          onMouseEnter={onHoverStart}
-          onMouseDown={onSurfaceMouseDown}
-          onContextMenu={onSurfaceContextMenu}
-          onClick={onAvatarClick}
+          style={{ opacity: expanded ? 1 : 0 }}
+          aria-hidden
         />
+        {typing && turns.length > 0 && <RecentTurns turns={turns} />}
+        {/* The pill's one in-flow row, and where the clearance at either end
+          lives. On the row rather than on the pill, so the pill's own box
+          goes to nothing at rest while the body inside it keeps being
+          measured. */}
+        <div
+          className="relative flex h-11 shrink-0 items-center"
+          style={{ paddingInline: INNER_GAP }}
+        >
+          {typing ? (
+            <Composer
+              assistantName={assistantName}
+              watching={watching}
+              onSubmit={onSubmit}
+              onCancel={onCancelTyping}
+              onWatch={onWatch}
+            />
+          ) : (
+            <div
+              className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
+              ref={contentRef}
+              // Faded out is not gone: the body stays mounted while collapsed
+              // so it can be measured, which would otherwise leave its
+              // controls focusable and announced while nothing is drawn.
+              // `inert` takes them out of the tab order and the accessibility
+              // tree without taking them out of the DOM, so the measurement
+              // still works.
+              inert={!expanded}
+              style={{
+                opacity: expanded ? 1 : 0,
+                // Contents fade after the body has somewhere to put them, so
+                // nothing is ever drawn wider than the pill carrying it.
+                transitionDelay: expanded ? "120ms" : "0ms",
+              }}
+            >
+              {phase === "call" ? (
+                <CallBody
+                  call={call}
+                  watching={watching}
+                  onControl={onControl}
+                  onWatch={onWatch}
+                />
+              ) : phase === "summary" && watchRetro !== undefined ? (
+                <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
+              ) : (
+                <IdleBody
+                  spotlight={spotlight}
+                  watching={watching}
+                  watchEnabled={watchEnabled}
+                  onTalk={onTalk}
+                  onType={onType}
+                  onWatch={onWatch}
+                />
+              )}
+            </div>
+          )}
+        </div>
       </div>
+      {/* Drawn after the pill so the glow, which falls off well past the
+        creature, lands over the pill's leading edge rather than under it. */}
+      <Avatar
+        accentHex={accentHex}
+        avatarSrc={avatarSrc}
+        character={character}
+        attentive={hovered}
+        // The assistant's own turn. The creature stops blinking and holds a
+        // focused, morphing pose, which is the same treatment the chat avatar
+        // uses while a reply is streaming: one vocabulary for "it is working"
+        // wherever the user meets it.
+        busy={assistantWorking}
+        edge={edge}
+        style={{
+          left: "50%",
+          top: lineAt(cardGrowth, 0),
+          // Centred on the point the host put the window around, then scaled
+          // about that centre by whatever the creature's own size asks for
+          // beyond the scale the page has already applied. Omitted where the
+          // two boxes agree, which is the surface every other length here is
+          // authored for. On this node rather than the one below it: the bob
+          // owns a `transform` of its own, and two transforms on one node
+          // silently leave one of them out.
+          transform: `translate(-50%, -50%)${
+            avatarRel === 1 ? "" : ` scale(${avatarRel})`
+          }`,
+        }}
+        elementRef={avatarRef}
+        onMouseDown={onSurfaceMouseDown}
+        onContextMenu={onSurfaceContextMenu}
+        onClick={onAvatarClick}
+      />
       {intro}
     </>
   );
@@ -1288,7 +1212,7 @@ function Composer({
 }
 
 /**
- * The avatar, and the only part of the surface that arms the expansion.
+ * The avatar, which is the point the whole surface is arranged around.
  *
  * Positioned on the point the host put the window around rather than laid out
  * in the pill, which is what lets the pill change width and shape underneath
@@ -1303,12 +1227,11 @@ function Composer({
  * `transform` on its own `<svg>` for the breathe and the morph, and a second
  * animation on that node would silently replace one of them. Everything that
  * belongs to the creature rides inside the wrapper, glow included, so the light
- * travels with what is casting it. The edge is outside it, because a ring
- * saying the assistant is working belongs to the surface rather than to the
- * creature's own idle motion.
+ * travels with what is casting it. The edge sits outside the wrapper: it is
+ * drawn on the box rather than on the artwork, so a ring saying something is
+ * running holds still while the creature breathes under it.
  */
 function Avatar({
-  glow,
   accentHex,
   avatarSrc,
   character,
@@ -1317,25 +1240,19 @@ function Avatar({
   edge,
   style,
   elementRef,
-  onMouseEnter,
   onMouseDown,
   onContextMenu,
   onClick,
 }: {
-  glow: boolean;
   accentHex: string;
   avatarSrc?: string;
   character?: CompanionCharacter;
   busy?: boolean;
   attentive?: boolean;
-  /**
-   * What the surface's edge is drawing, while the avatar is that edge. Null
-   * once there is a pill, which takes it back.
-   */
+  /** What the creature's edge is drawing. See `edge` in `CompanionSurface`. */
   edge?: ReactNode;
   style?: CSSProperties;
   elementRef?: Ref<HTMLDivElement>;
-  onMouseEnter?: () => void;
   onMouseDown?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onClick?: () => void;
@@ -1351,10 +1268,9 @@ function Avatar({
     // read as activating a control. `onClick` fires only for presses the caller
     // decided were not drags.
     <div
-      className="pointer-events-auto absolute grid size-11 cursor-grab place-items-center active:cursor-grabbing"
+      className="absolute grid size-11 cursor-grab place-items-center active:cursor-grabbing"
       style={style}
       ref={elementRef}
-      onMouseEnter={onMouseEnter}
       onMouseDown={onMouseDown}
       onContextMenu={onContextMenu}
       onClick={onClick}
@@ -1364,16 +1280,14 @@ function Avatar({
         className="companion-avatar-bob relative grid place-items-center"
         style={{ animation: reduce ? "none" : undefined }}
       >
-        {glow && (
-          <span
-            className="companion-glow absolute size-10 rounded-full blur-lg"
-            style={{
-              background: accentHex,
-              animation: reduce ? "none" : undefined,
-            }}
-            aria-hidden
-          />
-        )}
+        <span
+          className="companion-glow absolute size-10 rounded-full blur-lg"
+          style={{
+            background: accentHex,
+            animation: reduce ? "none" : undefined,
+          }}
+          aria-hidden
+        />
         {character !== undefined ? (
           // The live creature, composed here rather than shipped as pixels. It
           // blinks, twitches and breathes on its own, which is the whole reason

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -346,10 +346,10 @@ export interface CompanionSurfaceProps {
    * The pill's box in points, which is the scale of everything that is not the
    * creature.
    *
-   * The page's wrapper is already scaled by this, so what it is for here is
-   * converting back: a distance the host and this side have to agree on is
-   * worked out in points from the contract's helpers and divided by this scale
-   * on its way into a style, so both ends are the same expression.
+   * The surface scales its own outermost box by this, so what it is for beyond
+   * that is converting back: a distance the host and this side have to agree on
+   * is worked out in points from the contract's helpers and divided by this
+   * scale on its way into a style, so both ends are the same expression.
    */
   optionsBox?: number;
   /**
@@ -707,10 +707,8 @@ export function CompanionSurface({
   // The distances everything below is placed by, in points, and the one
   // conversion into the units this layout is stated in. Shared with
   // `CompanionIntro`, whose card hangs off the same creature.
-  const { avatarRel, avatarHalf, gap, lineAt, edgeAt } = companionLayoutFor(
-    avatarBox,
-    optionsBox,
-  );
+  const { scale, avatarRel, avatarHalf, gap, lineAt, edgeAt } =
+    companionLayoutFor(avatarBox, optionsBox);
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
   // spot the host positions this window around, and the pill hangs off one side
@@ -819,11 +817,23 @@ export function CompanionSurface({
   );
 
   return (
-    // A fragment, so the introduction's card is a sibling of the surface rather
-    // than a child of it. Inside, it would sit in the box whose width animates
-    // from state to state and be clipped by the pill's own rounding; beside it,
-    // both hang off the same fixed avatar position in the canvas.
-    <>
+    // The box the whole surface is drawn in: the canvas divided by the options
+    // scale, blown back up about its top-left corner, so every authored length
+    // inside resolves in base units and the host never holds a second set of
+    // dimensions.
+    //
+    // The pill, the creature and the introduction's card are siblings inside it,
+    // never nested: a card inside the pill would sit in the box whose width
+    // animates from state to state and be clipped by the pill's own rounding,
+    // and beside it they all hang off the same fixed avatar position.
+    <div
+      className="absolute top-0 left-0 origin-top-left"
+      style={{
+        width: `${100 / scale}%`,
+        height: `${100 / scale}%`,
+        transform: `scale(${scale})`,
+      }}
+    >
       {/* The pill is a drag handle, as the avatar is. Controls opt out by
         stopping the press, so everything on it that is not a button can be
         grabbed. */}
@@ -937,13 +947,13 @@ export function CompanionSurface({
         style={{
           left: "50%",
           top: lineAt(cardGrowth, 0),
-          // Centred on the point the host put the window around, then scaled
-          // about that centre by whatever the creature's own size asks for
-          // beyond the scale the page has already applied. Omitted where the
-          // two boxes agree, which is the surface every other length here is
-          // authored for. On this node rather than the one below it: the bob
-          // owns a `transform` of its own, and two transforms on one node
-          // silently leave one of them out.
+          // Centred on the point the host put the window around, then
+          // scaled about that centre by whatever the creature's own size
+          // asks for beyond the options scale the box above already carries.
+          // Omitted where the two boxes agree, which is the surface every
+          // other length here is authored for. On this node rather than the
+          // one below it: the bob owns a `transform` of its own, and two
+          // transforms on one node silently leave one of them out.
           transform: `translate(-50%, -50%)${
             avatarRel === 1 ? "" : ` scale(${avatarRel})`
           }`,
@@ -954,7 +964,7 @@ export function CompanionSurface({
         onClick={onAvatarClick}
       />
       {intro}
-    </>
+    </div>
   );
 }
 

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -21,7 +21,10 @@ import type {
   Ref,
 } from "react";
 
-import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
+import {
+  COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_MAX_PILL_WIDTH,
+} from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
   CompanionTurn,
@@ -210,7 +213,7 @@ const AVATAR_IMAGE = 28;
  * background runs flush into the pill's border and its corner gets clipped,
  * which reads as the surface being cut off.
  */
-const INNER_GAP = 8;
+export const INNER_GAP = 8;
 
 /**
  * Body widths to use until the content has been measured.
@@ -225,8 +228,9 @@ const INNER_GAP = 8;
  * plugins contribute actions (LUM-3097) no hardcoded number can be correct, and
  * these become nothing but the value for the first frame.
  *
- * **Every entry stays at or under 316**, which is `BASE_MAX_BODY_WIDTH` in
- * `companion-window.ts`. The window is a fixed canvas sized once for the widest
+ * **Every measured body plus an {@link INNER_GAP} at either end stays at or
+ * under {@link COMPANION_BASE_MAX_PILL_WIDTH}**, which is the whole width a
+ * pill actually draws. The window is a fixed canvas sized once for the widest
  * state the surface has, so the ceiling is the host's rather than this file's:
  * a state that wanted more would be clipped by the window, and buying the room
  * back means resizing the canvas, which is the thing a fixed canvas exists to
@@ -262,7 +266,7 @@ export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
  * measuring it would size the card to whatever the last turn happened to say
  * and reflow the whole surface on every message.
  */
-const CARD_WIDTH = 316;
+const CARD_WIDTH = COMPANION_BASE_MAX_PILL_WIDTH;
 
 /**
  * The tallest the conversation gets before it scrolls.

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -21,7 +21,7 @@ import type {
   Ref,
 } from "react";
 
-import { COMPANION_NEAR_EDGE } from "@vellumai/ipc-contract";
+import { COMPANION_NEAR_EDGE, companionGapFor } from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
   CompanionTurn,
@@ -40,21 +40,24 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
 /**
  * The macOS companion surface (LUM-3086): the assistant's avatar floating from
- * app launch, expanding into a pill that carries the voice and type-chat
- * options, and expanding the same way while a call runs.
+ * app launch, with a pill carrying the voice and type-chat options unfurling
+ * beside it, and unfurling the same way while a call runs.
  *
- * **The mascot is the fixed point.** The body unfurls out of an avatar that
- * holds one x-position in every state, so the surface reads as one object
- * changing shape rather than a series of different objects, and the eye and the
- * cursor always have the same target to aim at. Placement is therefore a
- * position (`left: 50%` plus the avatar's own half-width) rather than a
- * transform, and only `width` animates.
+ * **Two elements, and the mascot is the fixed point.** The creature and the
+ * pill are siblings with {@link GAP} between them rather than one box holding
+ * the other. The avatar holds one point in the canvas in every state, which is
+ * the point the host positions this window around, so the surface reads as one
+ * object changing shape rather than a series of different objects and the eye
+ * and the cursor always have the same target to aim at. The pill hangs off it:
+ * its avatar-facing edge sits the avatar's half box plus the gap from that
+ * point, and its bottom edge sits on the avatar's bottom, so the two keep one
+ * baseline whatever the pill is carrying. Only the pill's `width` animates.
  *
- * **Growth needs clearance on the side it runs into**, `width - 44` of it:
- * 228px expanded and 316px at its widest. A circle parked against the right
- * edge does not have it, and unclamped the body would run straight off the
- * display with the controls the user was reaching for. So the surface flips and
- * grows the other way instead, the way a menu does, through {@link growth}.
+ * **Growth needs clearance on the side it runs into**: the gap, and then a body
+ * that reaches 316px at its widest. A circle parked against the right edge does
+ * not have it, and unclamped the pill would run straight off the display with
+ * the controls the user was reaching for. So the surface flips and grows the
+ * other way instead, the way a menu does, through {@link growth}.
  *
  * **Presentational only.** Phase comes from the caller, so this renders
  * identically in Storybook and in the Electron panel. Hover is a phase rather
@@ -172,11 +175,21 @@ const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
  */
 const WATCHING_RING_ACCENT = "#ff9f45";
 
-// The avatar is a fixed 44px disc in every state; only the body around it
+// The avatar is a fixed 44px disc in every state; only the pill beside it
 // changes. That is what makes this one surface expanding rather than three
 // surfaces that happen to share a colour, and it is the property to protect as
 // the states gain content.
 const AVATAR_BOX = 44;
+
+/**
+ * The room between the avatar's edge and the pill.
+ *
+ * Read from the contract rather than stated here, because main sizes the canvas
+ * to hold the same distance: what decides how wide the window has to be is the
+ * pill's reach past the avatar, and a second copy of the number is a pill drawn
+ * further out than the room main left for it.
+ */
+const GAP = companionGapFor(AVATAR_BOX, AVATAR_BOX);
 
 /**
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
@@ -203,19 +216,19 @@ const AVATAR_IMAGE = 28;
 const INNER_GAP = 8;
 
 /**
- * Widths to use until the content has been measured.
+ * Body widths to use until the content has been measured.
  *
- * The real width is the avatar plus whatever the body actually needs, measured
- * at runtime, because a fixed width is only ever right by accident: the pill
- * was 188pt against a body that wanted less, and `flex-1` piled the difference
- * up after the last control as dead space, so the right end sat further from
- * its content than the left did from the avatar.
+ * The body alone, since the avatar is a sibling of the pill rather than
+ * something inside it: the pill is as wide as its content, plus an
+ * {@link INNER_GAP} at either end, measured at runtime because a fixed width is
+ * only ever right by accident. A pill wider than its body leaves `flex-1` to
+ * pile the difference up after the last control as dead space.
  *
  * Measuring is also what makes the surface survive its own roadmap. Once
  * plugins contribute actions (LUM-3097) no hardcoded number can be correct, and
  * these become nothing but the value for the first frame.
  *
- * **Every entry stays at or under 360**, which is `BASE_MAX_PILL_WIDTH` in
+ * **Every entry stays at or under 316**, which is `BASE_MAX_BODY_WIDTH` in
  * `companion-window.ts`. The window is a fixed canvas sized once for the widest
  * state the surface has, so the ceiling is the host's rather than this file's:
  * a state that wanted more would be clipped by the window, and buying the room
@@ -223,23 +236,25 @@ const INNER_GAP = 8;
  * avoid.
  */
 export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
-  resting: AVATAR_BOX,
+  // Nothing at all: at rest there is no pill, and its box goes with it.
+  resting: 0,
   // Three icon-only controls, which is the row as it is first drawn: the labels
   // are revealed one at a time under the pointer, and on the first frame there
   // is no pointer on any of them yet.
-  hover: 156,
+  hover: 112,
   // The same row of controls hover draws, since the session is run from it
   // rather than from a row of its own, plus the one word the running session
   // pins open on the control holding it.
-  watching: 195,
+  watching: 151,
   // Two labelled controls, both drawn: this row is a question waiting on an
   // answer rather than a set of ways in, so its words are not the pointer's to
   // reveal. That is what makes it wider than the idle row it stands in for.
-  summary: 264,
+  summary: 220,
   // The row with the stop control on it, which is the widest a call draws: a
   // watch session adds a fifth control to the four the call already has.
-  call: 332,
-  typing: 360,
+  call: 288,
+  // The card's body, which is {@link CARD_WIDTH} rather than anything measured.
+  typing: 316,
 };
 
 /**
@@ -250,7 +265,7 @@ export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
  * measuring it would size the card to whatever the last turn happened to say
  * and reflow the whole surface on every message.
  */
-const CARD_WIDTH = 360;
+const CARD_WIDTH = 316;
 
 /**
  * The tallest the conversation gets before it scrolls.
@@ -323,11 +338,12 @@ export interface CompanionSurfaceProps {
    */
   onHoverStart?: () => void;
   /**
-   * Collapse. Wired to the whole surface rather than the avatar, because once
-   * expanded the pointer has to be able to travel from the avatar to the
-   * controls. Leaving on the avatar would collapse the pill out from under the
-   * hand reaching for it, and while resting the surface *is* the avatar, so
-   * the two agree exactly when it matters.
+   * Collapse. Wired to the group holding the avatar, the gap and the pill
+   * rather than to the avatar, because once expanded the pointer has to be able
+   * to travel across the gap to the controls. Leaving on the avatar would
+   * collapse the pill out from under the hand reaching for it, and while
+   * resting the avatar is all the group has drawn in it, so the two agree
+   * exactly when it matters.
    */
   onHoverEnd?: () => void;
   /** Which way the pill grows. See {@link CompanionSurfaceGrowth}. */
@@ -348,16 +364,28 @@ export interface CompanionSurfaceProps {
    */
   rootRef?: Ref<HTMLDivElement>;
   /**
-   * Begin a drag. Everything that is not a control is a handle, so this is
-   * wired to the surface and the controls stop the press from reaching it.
+   * The avatar's own element.
+   *
+   * Handed out for the reason {@link CompanionSurfaceProps.rootRef} is, and
+   * separately from it: the avatar and the pill are siblings with a gap between
+   * them, so the host hit-tests a union of their rects rather than one box. A
+   * box drawn around both would claim the empty canvas above and below the gap
+   * and swallow the presses landing there.
+   */
+  avatarRef?: Ref<HTMLDivElement>;
+  /**
+   * Begin a drag. Everything drawn that is not a control is a handle, so this
+   * is wired to the avatar and to the pill, and the controls stop the press
+   * from reaching it. The gap between the two is not a handle: there is nothing
+   * drawn in it to grab.
    */
   onSurfaceMouseDown?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   /**
-   * Open the surface's own menu, which a right-click anywhere on it asks for.
+   * Open the surface's own menu, which a right-click on the avatar or the pill
+   * asks for.
    *
-   * On the whole surface rather than the avatar: at rest the two are the same
-   * box, and when expanded a user reaching for "make this go away" should not
-   * have to find the mascot inside the pill first.
+   * On both rather than on the avatar alone: a user reaching for "make this go
+   * away" should not have to find the mascot beside the pill first.
    */
   onSurfaceContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   /**
@@ -597,6 +625,7 @@ export function CompanionSurface({
   growth = "right",
   cardGrowth = "up",
   rootRef,
+  avatarRef,
   onSurfaceMouseDown,
   onSurfaceContextMenu,
   spotlight,
@@ -664,123 +693,82 @@ export function CompanionSurface({
     };
   }, [phase]);
 
-  // The avatar's 44pt box sits flush, because its image is already inset by
-  // `INNER_GAP` inside it. Only the trailing end needs the gap added, since the
-  // last control's own box ends where the body does.
+  // The body and the clearance at either end of it, and nothing else: the
+  // avatar has a box of its own beside the pill rather than a column inside it.
   const width = typing
     ? CARD_WIDTH
-    : AVATAR_BOX +
-      (!expanded
-        ? 0
-        : (contentWidth ?? FALLBACK_WIDTHS[phase] - AVATAR_BOX) + INNER_GAP);
+    : !expanded
+      ? 0
+      : (contentWidth ?? FALLBACK_WIDTHS[phase]) + 2 * INNER_GAP;
+
+  /**
+   * A line in the canvas, given how far it sits from the avatar's centre.
+   *
+   * The canvas is *not* symmetric about the avatar: the card's height is
+   * reserved on whichever side it grows into, so the avatar sits
+   * `COMPANION_NEAR_EDGE` from the other edge, and that edge is the one worth
+   * anchoring to. `100%` names the canvas without this side having to know how
+   * tall main made it.
+   */
+  const lineAt = (offset: number): string =>
+    cardGrowth === "up"
+      ? `calc(100% - ${COMPANION_NEAR_EDGE - offset}px)`
+      : `${COMPANION_NEAR_EDGE + offset}px`;
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
-  // spot the host positions this window around, and the body runs off one side
-  // of it. Growing from the pill's centre instead would slide the mascot to a
-  // different x-position in every state, so the surface would read as a series
-  // of different objects rather than one object changing shape, and the user's
-  // eye and cursor would have no fixed target to aim at.
+  // spot the host positions this window around, and the pill hangs off one side
+  // of it across the gap. Growing from the pill's centre instead would slide
+  // the mascot to a different x-position in every state, so the surface would
+  // read as a series of different objects rather than one object changing
+  // shape, and the user's eye and cursor would have no fixed target to aim at.
   //
-  // Each direction therefore fixes the avatar's own edge to the centre and lets
-  // the body run the other way: this anchors the surface by the edge the avatar
-  // is on, and the avatar's own row is mirrored below so the avatar ends up
-  // against that edge. Both halves are required. Anchoring by the right edge without
-  // mirroring puts the avatar at the far end of the pill, which is a different
-  // point from the one the host positioned the window by, and every drag,
-  // clamp and direction check main makes from then on is measured against a
-  // place the avatar is not.
+  // So each direction pins the pill's avatar-facing edge that far out from the
+  // centre and lets the body run the rest of the way: the pill is what moves
+  // when `growth` flips, and the creature the host measures every drag, clamp
+  // and direction check against is not.
   const placement: CSSProperties =
     growth === "left"
-      ? { right: "50%", marginRight: -(AVATAR_BOX / 2) }
-      : { left: "50%", marginLeft: -(AVATAR_BOX / 2) };
+      ? { right: `calc(50% + ${AVATAR_BOX / 2 + GAP}px)` }
+      : { left: `calc(50% + ${AVATAR_BOX / 2 + GAP}px)` };
 
-  // The vertical half of the same idea, against a canvas that is *not*
-  // symmetric about the avatar. The card's height is reserved on whichever side
-  // it grows into, so the avatar sits `COMPANION_NEAR_EDGE` from the other
-  // edge, and that edge is the one worth anchoring to: `100%` names the canvas
-  // without this side having to know how tall main made it.
-  const anchor: CSSProperties =
-    cardGrowth === "up"
-      ? { top: `calc(100% - ${COMPANION_NEAR_EDGE}px)` }
-      : { top: COMPANION_NEAR_EDGE };
+  // The card growing downward draws its composer row first, so the row starts
+  // on the avatar's top line and the card falls away from it; everything else
+  // hangs upward off the avatar's bottom line.
+  const dropsFromTheRow = typing && cardGrowth === "down";
 
   const style: CSSProperties = {
     width,
     ...placement,
-    ...anchor,
-    // The composer row holds the line the pill occupied and the conversation
-    // stacks off it, so the avatar never moves when Type is pressed and never
-    // moves again as turns arrive. Which way it stacks is the host's call:
-    // parked by the Dock a card growing down would grow off the bottom of the
-    // screen, and at the top of the display a card growing up has nowhere to be
-    // (see `CompanionSurfaceCardGrowth`).
-    transform: typing
-      ? cardGrowth === "up"
-        ? `translateY(calc(-100% + ${AVATAR_BOX / 2}px))`
-        : `translateY(-${AVATAR_BOX / 2}px)`
-      : "translateY(-50%)",
+    // **Bottom-flush with the avatar.** The pill's bottom edge sits on the
+    // avatar's, and the card keeps that line: its composer row is the column's
+    // last child growing up and its first growing down, so the row's bottom is
+    // the avatar's bottom either way and the mascot does not move when Type is
+    // pressed. Which way the card stacks is the host's call: parked by the Dock
+    // a card growing down would grow off the bottom of the screen, and at the
+    // top of the display a card growing up has nowhere to be (see
+    // `CompanionSurfaceCardGrowth`).
+    top: lineAt(dropsFromTheRow ? -(AVATAR_BOX / 2) : AVATAR_BOX / 2),
+    transform: dropsFromTheRow ? "none" : "translateY(-100%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
     transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
     ["--accent" as string]: accentHex,
   };
 
-  return (
-    // A fragment, so the introduction's card is a sibling of the pill rather
-    // than a child of it. Inside, it would sit in the box whose width animates
-    // from state to state and be clipped by the pill's own rounding; beside it,
-    // both hang off the same fixed avatar position in the canvas.
+  /**
+   * The surface's edge, lit for something running and flared for each capture.
+   *
+   * Drawn around the avatar at rest and around the pill once there is one. The
+   * pill is nothing at rest, so the avatar is the only edge there is to light,
+   * and it is the state the ring most has to be legible in: the whole point is
+   * being readable from the corner of an eye while the user works elsewhere.
+   * Expanded, the pill is the surface's outline and takes it back.
+   */
+  const edge = (
     <>
-      {/* The whole surface is the drag handle. Controls opt out by stopping the
-        press, so everything that is not a button can be grabbed, which at rest
-        means the avatar and when expanded means the pill around the controls. */}
-      <div
-        className={`absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
-          typing
-            ? // The composer row is the column's last child, so a card growing
-              // downward reverses the column for the same reason a pill growing
-              // leftward reverses the row: the row that holds the avatar's line
-              // has to end up against the avatar, and the turns stack away from
-              // it.
-              `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
-            : "flex h-11 items-center rounded-full"
-        } ${
-          // Alignment, not ordering. The row is `INNER_GAP` narrower than the
-          // pill, because that gap is trailing space past the last control, so
-          // the row has to sit against the end the avatar is anchored to and
-          // leave the slack at the other. Reversing a one-item row is how a
-          // `flex-start` box puts its item at the far end. The card is a column
-          // whose row is stretched to its full width, so it needs no help.
-          growth === "left" && !typing ? "flex-row-reverse" : ""
-        }`}
-        style={style}
-        onMouseLeave={onHoverEnd}
-        onMouseDown={onSurfaceMouseDown}
-        onContextMenu={onSurfaceContextMenu}
-        ref={rootRef}
-      >
-        {/* The pill's body, which exists only once there is a pill. At rest the
-          surface is the avatar and nothing else: a dark disc with a border
-          drawn around a round avatar reads as a hard ring the avatar happens to
-          sit inside, and stacked under the glow it is two rings. Fading the
-          body in with the expansion also gives the avatar something to grow
-          out of. */}
-        <span
-          className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
-            // Radius follows the same rule as the gap: the controls are 28pt so
-            // their radius is 14, and 8pt of clearance puts the outer radius at
-            // 22. A pill happens to reach that by being 44 tall; the card has to
-            // say it.
-            typing ? "rounded-[22px]" : "rounded-full"
-          }`}
-          style={{ opacity: expanded ? 1 : 0 }}
-          aria-hidden
-        />
-        {/* Something running, as a light travelling around the surface's edge.
-          Drawn over the body so it reads as the surface's own border in every
-          state, and outside it by a hair so it never crowds the avatar at rest,
-          which is the state it has to be legible in: the whole point is being
-          readable from the corner of an eye while the user works elsewhere.
+      {/* Something running, as a light travelling around the edge. Drawn over
+          the body so it reads as the surface's own border, and outside it by a
+          hair so it never crowds what it is drawn around.
 
           A turn burns it in the assistant's colour, a watch session in amber,
           and the session's ring is drawn in every phase rather than only the
@@ -788,125 +776,208 @@ export function CompanionSurface({
           true: the creature already carries the turn in its own pose, and a
           capture running with nothing drawn over it is the worse of the two
           failures. */}
-        {(assistantWorking || watching || summarizing) && (
-          <span
-            className={`companion-working-ring pointer-events-none absolute -inset-0.5 ${
-              typing ? "rounded-[24px]" : "rounded-full"
-            }`}
-            style={{
-              ["--companion-ring-accent" as string]: watching
-                ? WATCHING_RING_ACCENT
-                : accentHex,
-            }}
-            aria-hidden
-          />
-        )}
-        {/* One capture, as a single breath of light around the same edge.
-
-            The ring says a session is running, which is a state; this says the
-            screen was read just now, which is an event, and the two need
-            different treatments or the second is invisible inside the first. The
-            same edge rather than a mark of its own, because the edge is already
-            where the user looks for this surface's state and a capture is that
-            state doing something.
-
-            Keyed by the captures this surface has watched arrive, so each one
-            remounts the element and replays a one-shot animation. That is the
-            whole mechanism: a step is a read the runtime took and kept, and
-            there is no other way for this to fire. It cannot pulse in a gap, it
-            cannot pulse for a read that failed, timed out, or was cut off by the
-            session ending, because none of those advance the count, and it
-            cannot pulse for the count a reload handed it, because a first value
-            is a baseline rather than a step. */}
-        {watching && observedCaptures > 0 && (
-          <span
-            key={observedCaptures}
-            className={`companion-capture-pulse pointer-events-none absolute -inset-0.5 ${
-              typing ? "rounded-[24px]" : "rounded-full"
-            }`}
-            style={{
-              ["--companion-ring-accent" as string]: WATCHING_RING_ACCENT,
-            }}
-            aria-hidden
-          />
-        )}
-        {typing && turns.length > 0 && <RecentTurns turns={turns} />}
-        {/* The avatar's own row, and the half of the mirroring that orders it.
-          This row is the surface's only in-flow child, so it is the one place
-          the reversal has any ordering to do: reversing the surface around it
-          moves the row within the box and leaves the avatar wherever the row
-          put it. The avatar has to land against the edge `placement` anchored
-          by, since that edge is derived from the point the host positioned the
-          window by. True of the card as much as the pill, and the card is
-          anchored the same way with a card's width to be wrong by, so this
-          holds whether or not the composer is open. */}
-        <div
-          className={`relative flex h-11 shrink-0 items-center ${
-            growth === "left" ? "flex-row-reverse" : ""
+      {(assistantWorking || watching || summarizing) && (
+        <span
+          className={`companion-working-ring pointer-events-none absolute -inset-0.5 ${
+            typing ? "rounded-[24px]" : "rounded-full"
           }`}
+          style={{
+            ["--companion-ring-accent" as string]: watching
+              ? WATCHING_RING_ACCENT
+              : accentHex,
+          }}
+          aria-hidden
+        />
+      )}
+      {/* One capture, as a single breath of light around the same edge.
+
+          The ring says a session is running, which is a state; this says the
+          screen was read just now, which is an event, and the two need
+          different treatments or the second is invisible inside the first. The
+          same edge rather than a mark of its own, because the edge is already
+          where the user looks for this surface's state and a capture is that
+          state doing something.
+
+          Keyed by the captures this surface has watched arrive, so each one
+          remounts the element and replays a one-shot animation. That is the
+          whole mechanism: a step is a read the runtime took and kept, and
+          there is no other way for this to fire. It cannot pulse in a gap, it
+          cannot pulse for a read that failed, timed out, or was cut off by the
+          session ending, because none of those advance the count, and it
+          cannot pulse for the count a reload handed it, because a first value
+          is a baseline rather than a step. */}
+      {watching && observedCaptures > 0 && (
+        <span
+          key={observedCaptures}
+          className={`companion-capture-pulse pointer-events-none absolute -inset-0.5 ${
+            typing ? "rounded-[24px]" : "rounded-full"
+          }`}
+          style={{
+            ["--companion-ring-accent" as string]: WATCHING_RING_ACCENT,
+          }}
+          aria-hidden
+        />
+      )}
+    </>
+  );
+
+  return (
+    // A fragment, so the introduction's card is a sibling of the surface rather
+    // than a child of it. Inside, it would sit in the box whose width animates
+    // from state to state and be clipped by the pill's own rounding; beside it,
+    // both hang off the same fixed avatar position in the canvas.
+    <>
+      {/* The avatar, the pill, and the gap between them, as one group.
+
+        Its box is the whole canvas so the `50%` and `100%` its children anchor
+        by still name the canvas, and it takes no pointer of its own, so the
+        pointer is inside it exactly when it is on the avatar, the pill or the
+        bridge across the gap. Leaving the group is therefore leaving the whole
+        surface, which is what lets a hand travel from the creature to the
+        controls without the pill collapsing out from under it. */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        onMouseLeave={onHoverEnd}
+      >
+        {/* The pill is a drag handle, as the avatar is. Controls opt out by
+          stopping the press, so everything on it that is not a button can be
+          grabbed. */}
+        <div
+          className={`pointer-events-auto absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
+            typing
+              ? // The composer row is the column's last child, so a card growing
+                // downward reverses the column: the row that holds the avatar's
+                // line has to stay on that line, and the turns stack away from
+                // it.
+                `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
+              : "flex h-11 items-center rounded-full"
+          }`}
+          style={style}
+          onMouseDown={onSurfaceMouseDown}
+          onContextMenu={onSurfaceContextMenu}
+          ref={rootRef}
         >
-          <Avatar
-            glow={glow && !expanded}
-            accentHex={accentHex}
-            avatarSrc={avatarSrc}
-            character={character}
-            attentive={hovered}
-            // The assistant's own turn. The creature stops blinking and holds a
-            // focused, morphing pose, which is the same treatment the chat avatar
-            // uses while a reply is streaming: one vocabulary for "it is working"
-            // wherever the user meets it.
-            busy={assistantWorking}
-            onMouseEnter={onHoverStart}
-            onClick={onAvatarClick}
+          {/* The pill's body, which exists only once there is a pill. At rest
+            there is nothing beside the avatar to draw, and fading the body in
+            as the width grows is what makes the pill unfurl out of the gap
+            rather than appear in it. */}
+          <span
+            className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
+              // Radius follows the same rule as the gap: the controls are 28pt
+              // so their radius is 14, and 8pt of clearance puts the outer
+              // radius at 22. A pill happens to reach that by being 44 tall;
+              // the card has to say it.
+              typing ? "rounded-[22px]" : "rounded-full"
+            }`}
+            style={{ opacity: expanded ? 1 : 0 }}
+            aria-hidden
           />
-          {typing ? (
-            <Composer
-              assistantName={assistantName}
-              growth={growth}
-              watching={watching}
-              onSubmit={onSubmit}
-              onCancel={onCancelTyping}
-              onWatch={onWatch}
-            />
-          ) : (
-            <div
-              className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
-              ref={contentRef}
-              // Faded out is not gone: the body stays mounted while collapsed so
-              // it can be measured, which would otherwise leave its controls
-              // focusable and announced while nothing is drawn. `inert` takes
-              // them out of the tab order and the accessibility tree without
-              // taking them out of the DOM, so the measurement still works.
-              inert={!expanded}
-              style={{
-                opacity: expanded ? 1 : 0,
-                // Contents fade after the body has somewhere to put them, so
-                // nothing is ever drawn wider than the pill carrying it.
-                transitionDelay: expanded ? "120ms" : "0ms",
-              }}
-            >
-              {phase === "call" ? (
-                <CallBody
-                  call={call}
-                  watching={watching}
-                  onControl={onControl}
-                  onWatch={onWatch}
-                />
-              ) : phase === "summary" && watchRetro !== undefined ? (
-                <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
-              ) : (
-                <IdleBody
-                  spotlight={spotlight}
-                  watching={watching}
-                  watchEnabled={watchEnabled}
-                  onTalk={onTalk}
-                  onType={onType}
-                  onWatch={onWatch}
-                />
-              )}
-            </div>
-          )}
+          {expanded && edge}
+          {typing && turns.length > 0 && <RecentTurns turns={turns} />}
+          {/* The pill's one in-flow row, and where the clearance at either end
+            lives. On the row rather than on the pill, so the pill's own box
+            goes to nothing at rest while the body inside it keeps being
+            measured. */}
+          <div
+            className="relative flex h-11 shrink-0 items-center"
+            style={{ paddingInline: INNER_GAP }}
+          >
+            {typing ? (
+              <Composer
+                assistantName={assistantName}
+                watching={watching}
+                onSubmit={onSubmit}
+                onCancel={onCancelTyping}
+                onWatch={onWatch}
+              />
+            ) : (
+              <div
+                className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
+                ref={contentRef}
+                // Faded out is not gone: the body stays mounted while collapsed
+                // so it can be measured, which would otherwise leave its
+                // controls focusable and announced while nothing is drawn.
+                // `inert` takes them out of the tab order and the accessibility
+                // tree without taking them out of the DOM, so the measurement
+                // still works.
+                inert={!expanded}
+                style={{
+                  opacity: expanded ? 1 : 0,
+                  // Contents fade after the body has somewhere to put them, so
+                  // nothing is ever drawn wider than the pill carrying it.
+                  transitionDelay: expanded ? "120ms" : "0ms",
+                }}
+              >
+                {phase === "call" ? (
+                  <CallBody
+                    call={call}
+                    watching={watching}
+                    onControl={onControl}
+                    onWatch={onWatch}
+                  />
+                ) : phase === "summary" && watchRetro !== undefined ? (
+                  <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
+                ) : (
+                  <IdleBody
+                    spotlight={spotlight}
+                    watching={watching}
+                    watchEnabled={watchEnabled}
+                    onTalk={onTalk}
+                    onType={onType}
+                    onWatch={onWatch}
+                  />
+                )}
+              </div>
+            )}
+          </div>
         </div>
+        {/* The gap, as an element rather than empty canvas. Nothing is drawn in
+          it and nothing can be grabbed by it: it is here so a pointer crossing
+          from the creature to the controls stays inside the group and the pill
+          is not pulled out from under the hand halfway. The host hit-tests the
+          same span from the two rects (`bridgeRect` in
+          `companion-surface-page.tsx`), since a click-through window is told
+          about the pointer in coordinates rather than in elements. */}
+        {expanded && (
+          <span
+            className="pointer-events-auto absolute"
+            style={{
+              width: GAP,
+              height: AVATAR_BOX,
+              ...(growth === "left"
+                ? { right: `calc(50% + ${AVATAR_BOX / 2}px)` }
+                : { left: `calc(50% + ${AVATAR_BOX / 2}px)` }),
+              top: lineAt(0),
+              transform: "translateY(-50%)",
+            }}
+            aria-hidden
+          />
+        )}
+        {/* Drawn last so the glow, which falls off well past the creature,
+          lands over the pill's leading edge rather than under it. */}
+        <Avatar
+          glow={glow}
+          accentHex={accentHex}
+          avatarSrc={avatarSrc}
+          character={character}
+          attentive={hovered}
+          // The assistant's own turn. The creature stops blinking and holds a
+          // focused, morphing pose, which is the same treatment the chat avatar
+          // uses while a reply is streaming: one vocabulary for "it is working"
+          // wherever the user meets it.
+          busy={assistantWorking}
+          edge={expanded ? null : edge}
+          style={{
+            left: "50%",
+            top: lineAt(0),
+            transform: "translate(-50%, -50%)",
+          }}
+          elementRef={avatarRef}
+          onMouseEnter={onHoverStart}
+          onMouseDown={onSurfaceMouseDown}
+          onContextMenu={onSurfaceContextMenu}
+          onClick={onAvatarClick}
+        />
       </div>
       {intro}
     </>
@@ -1061,15 +1132,12 @@ function RecentTurns({ turns }: { turns: CompanionTurn[] }) {
  */
 function Composer({
   assistantName,
-  growth = "right",
   watching,
   onSubmit,
   onCancel,
   onWatch,
 }: {
   assistantName: string;
-  /** Which side the avatar sits on, so the padding can go on the other one. */
-  growth?: CompanionSurfaceGrowth;
   /**
    * Whether a watch session is running, so the card can carry the way to end
    * it. The card replaces the pill while it is open, and a session the user
@@ -1106,14 +1174,9 @@ function Composer({
   };
 
   return (
-    // The gap goes on the edge away from the avatar. The avatar's row reverses
-    // with `growth`, so a fixed side would put the whole gap between the field
-    // and the avatar and leave the text flush against the card's outer edge.
-    <div
-      className={`relative flex min-w-0 flex-1 items-center gap-1 ${
-        growth === "left" ? "pl-2" : "pr-2"
-      }`}
-    >
+    // Flush inside the row, which carries the clearance at both ends for the
+    // composer and the control rows alike.
+    <div className="relative flex min-w-0 flex-1 items-center gap-1">
       <input
         ref={inputRef}
         type="text"
@@ -1183,6 +1246,10 @@ function Composer({
 /**
  * The avatar, and the only part of the surface that arms the expansion.
  *
+ * Positioned on the point the host put the window around rather than laid out
+ * in the pill, which is what lets the pill change width and shape underneath
+ * without the creature moving a pixel.
+ *
  * The glow sits behind the image and is blurred well past it, so it falls off
  * into the desktop rather than ending on an edge. A halo sized to its own
  * source has nowhere to fall off and reads as a ring around the avatar rather
@@ -1192,7 +1259,9 @@ function Composer({
  * `transform` on its own `<svg>` for the breathe and the morph, and a second
  * animation on that node would silently replace one of them. Everything that
  * belongs to the creature rides inside the wrapper, glow included, so the light
- * travels with what is casting it.
+ * travels with what is casting it. The edge is outside it, because a ring
+ * saying the assistant is working belongs to the surface rather than to the
+ * creature's own idle motion.
  */
 function Avatar({
   glow,
@@ -1201,7 +1270,12 @@ function Avatar({
   character,
   busy = false,
   attentive = false,
+  edge,
+  style,
+  elementRef,
   onMouseEnter,
+  onMouseDown,
+  onContextMenu,
   onClick,
 }: {
   glow: boolean;
@@ -1210,7 +1284,16 @@ function Avatar({
   character?: CompanionCharacter;
   busy?: boolean;
   attentive?: boolean;
+  /**
+   * What the surface's edge is drawing, while the avatar is that edge. Null
+   * once there is a pill, which takes it back.
+   */
+  edge?: ReactNode;
+  style?: CSSProperties;
+  elementRef?: Ref<HTMLDivElement>;
   onMouseEnter?: () => void;
+  onMouseDown?: (event: ReactMouseEvent<HTMLDivElement>) => void;
+  onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onClick?: () => void;
 }) {
   // Belt and braces alongside the `prefers-reduced-motion` block beside the
@@ -1224,10 +1307,15 @@ function Avatar({
     // read as activating a control. `onClick` fires only for presses the caller
     // decided were not drags.
     <div
-      className="relative grid size-11 shrink-0 place-items-center"
+      className="pointer-events-auto absolute grid size-11 cursor-grab place-items-center active:cursor-grabbing"
+      style={style}
+      ref={elementRef}
       onMouseEnter={onMouseEnter}
+      onMouseDown={onMouseDown}
+      onContextMenu={onContextMenu}
       onClick={onClick}
     >
+      {edge}
       <div
         className="companion-avatar-bob relative grid place-items-center"
         style={{ animation: reduce ? "none" : undefined }}

--- a/clients/web/src/components/dictation-overlay-page.tsx
+++ b/clients/web/src/components/dictation-overlay-page.tsx
@@ -7,6 +7,7 @@ import {
   type RefObject,
 } from "react";
 
+import { containsPoint } from "@/components/companion-layout";
 import {
   getDictationOverlayState,
   requestDictationOverlayStop,
@@ -120,12 +121,12 @@ export function DictationOverlayPage() {
       setInteractive(false);
       return;
     }
-    const rect = button.getBoundingClientRect();
     setInteractive(
-      event.clientX >= rect.left &&
-        event.clientX <= rect.right &&
-        event.clientY >= rect.top &&
-        event.clientY <= rect.bottom,
+      containsPoint(
+        button.getBoundingClientRect(),
+        event.clientX,
+        event.clientY,
+      ),
     );
   };
   const stopRecording = () => {

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -255,9 +255,9 @@ html[data-page-transition="pop"]::view-transition-new(root) {
    its `<svg>` for the breathe and morph, and two animations on one node means
    one of them silently wins.
 
-   The lift is also `COMPANION_BOB_LIFT` in `companion-layout.ts`, which the
-   host's hit-test adds to the avatar's rect so the raised creature is still
-   something the pointer can be on. */
+   The lift stays inside the creature's own box: the artwork is inset well
+   short of the top, so the raised creature is still somewhere the host's
+   hit-test finds the pointer. */
 @keyframes companion-avatar-bob {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-3px); }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -246,6 +246,48 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   75% { transform: rotate(-0.86deg); }
 }
 
+/* Companion avatar bob: the creature lifting off its baseline and settling
+   back, so a surface that otherwise only breathes reads as alive from across
+   the desk. One-directional on purpose: 0% is the avatar's resting position,
+   and the lift is the only departure from it.
+
+   It has to live on a wrapper of its own. `AnimatedAvatar` owns `transform` on
+   its `<svg>` for the breathe and morph, and two animations on one node means
+   one of them silently wins. */
+@keyframes companion-avatar-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+/* The glow's breath, with both ends written out. Tailwind's `animate-pulse`
+   synthesises its 0%/100% from whatever opacity the element already carries,
+   which on a glow this faint is a swing nobody can see. */
+@keyframes companion-glow-breathe {
+  0%, 100% { opacity: 0.32; }
+  50% { opacity: 0.5; }
+}
+
+.companion-avatar-bob {
+  animation: companion-avatar-bob 5s ease-in-out infinite;
+  will-change: transform;
+}
+
+.companion-glow {
+  /* Where the breath starts and where it is held when it cannot run. */
+  opacity: 0.32;
+  animation: companion-glow-breathe 4s ease-in-out infinite;
+}
+
+/* Held still rather than dropped: the glow is the avatar's own colour thrown
+   onto the desktop, so it stays lit at rest, and the creature keeps its
+   baseline rather than disappearing from it. */
+@media (prefers-reduced-motion: reduce) {
+  .companion-avatar-bob,
+  .companion-glow {
+    animation: none;
+  }
+}
+
 /* BusyIndicator — mirrors macOS VBusyIndicator. A filled circle pulsing in
  * opacity (1→0.3) and scale (1→0.85) over 1s easeInOut. Used in
  * ActivityRunCard for active/thinking phases. */

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -253,7 +253,11 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
    It has to live on a wrapper of its own. `AnimatedAvatar` owns `transform` on
    its `<svg>` for the breathe and morph, and two animations on one node means
-   one of them silently wins. */
+   one of them silently wins.
+
+   The lift is also `COMPANION_BOB_LIFT` in `companion-layout.ts`, which the
+   host's hit-test adds to the avatar's rect so the raised creature is still
+   something the pointer can be on. */
 @keyframes companion-avatar-bob {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-3px); }

--- a/packages/electron-desktop/src/companion-menu.test.ts
+++ b/packages/electron-desktop/src/companion-menu.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import type { CompanionSize, CompanionSizeAxis } from "@vellumai/ipc-contract";
+
+import { companionSizeSubmenus } from "./companion-menu";
+
+/**
+ * The size pickers both companion menus draw, built once.
+ *
+ * The tray and the surface's own right-click read this builder, so what is
+ * worth stating here is what a menu is read for: the headings, the steps under
+ * them, which one is marked, and that a press carries the axis it was made
+ * under. The two callers then only have to state what is theirs, which is where
+ * the items sit and whether they stand down.
+ */
+describe("companionSizeSubmenus", () => {
+  /** Only what a menu item is read for here, as `tray-model.test.ts` has it. */
+  type MenuItem = {
+    label?: string;
+    enabled?: boolean;
+    type?: string;
+    checked?: boolean;
+    click?: () => void;
+    submenu?: MenuItem[];
+  };
+
+  const build = (
+    current: Record<CompanionSizeAxis, CompanionSize> = {
+      avatar: "small",
+      options: "small",
+    },
+    options?: { enabled?: boolean },
+  ) => {
+    const picked: [CompanionSizeAxis, CompanionSize][] = [];
+    const items = companionSizeSubmenus(
+      current,
+      (axis, size) => {
+        picked.push([axis, size]);
+      },
+      options,
+    ) as MenuItem[];
+    return { items, picked };
+  };
+
+  test("offers a heading for each thing that is sized", () => {
+    expect(build().items.map((item) => item.label)).toEqual([
+      "Avatar size",
+      "Options size",
+    ]);
+  });
+
+  test("offers every named step under each heading, as one radio group", () => {
+    for (const heading of build().items) {
+      expect(heading.submenu?.map((item) => item.label)).toEqual([
+        "Small",
+        "Medium",
+        "Large",
+        "Huge",
+        "Ridiculous",
+      ]);
+      expect(heading.submenu?.every((item) => item.type === "radio")).toBe(
+        true,
+      );
+    }
+  });
+
+  /**
+   * The whole point of two submenus: each shows where its own axis is, so a
+   * user who has made the creature enormous and left the controls alone can see
+   * exactly that.
+   */
+  test("marks the step each axis is on, and only that one", () => {
+    const { items } = build({ avatar: "ridiculous", options: "medium" });
+    expect(
+      items[0]?.submenu?.filter((item) => item.checked).map((i) => i.label),
+    ).toEqual(["Ridiculous"]);
+    expect(
+      items[1]?.submenu?.filter((item) => item.checked).map((i) => i.label),
+    ).toEqual(["Medium"]);
+  });
+
+  test("a pick carries the axis it was made under", () => {
+    const menu = build();
+    menu.items[0]?.submenu?.[3]?.click?.();
+    menu.items[1]?.submenu?.[4]?.click?.();
+    expect(menu.picked).toEqual([
+      ["avatar", "huge"],
+      ["options", "ridiculous"],
+    ]);
+  });
+
+  /**
+   * The headings stand down rather than disappear for the menu that also offers
+   * a way to hide the surface. Left to itself the builder hands back live items,
+   * which is what a menu drawn on the surface itself wants.
+   */
+  test("is enabled unless the caller says otherwise", () => {
+    expect(build().items.map((item) => item.enabled)).toEqual([true, true]);
+    expect(
+      build(undefined, { enabled: false }).items.map((item) => item.enabled),
+    ).toEqual([false, false]);
+  });
+});

--- a/packages/electron-desktop/src/companion-menu.test.ts
+++ b/packages/electron-desktop/src/companion-menu.test.ts
@@ -13,7 +13,7 @@ import { companionSizeSubmenus } from "./companion-menu";
  * the items sit and whether they stand down.
  */
 describe("companionSizeSubmenus", () => {
-  /** Only what a menu item is read for here, as `tray-model.test.ts` has it. */
+  /** Only what a menu item is read for here. */
   type MenuItem = {
     label?: string;
     enabled?: boolean;

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -33,7 +33,8 @@ const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
  *
  * Sentence case, and the noun first: the submenus sit among items that say what
  * they act on ("Show Companion", "Hide Companion"), and a user scanning for the
- * creature reads "Avatar" before they read "size".
+ * creature reads "Avatar" before they read "size". The sentence case is the
+ * design's wording, against the Title Case of the tray items beside it.
  *
  * Here beside the steps themselves, and for the same reason: both menus that
  * offer the sizes offer them under these two headings, and a user who met
@@ -48,22 +49,10 @@ const COMPANION_SIZE_AXIS_LABELS: Record<CompanionSizeAxis, string> = {
 /**
  * The size pickers, as every menu that offers them draws them.
  *
- * One submenu per axis, since the creature and the controls beside it are sized
- * separately and a single picker could only ever move both. The steps sit under
- * those headings rather than flat: a named submenu says what its five words are
- * before it shows them, and leaves the menu around it short enough to read at a
- * glance.
- *
- * Named steps rather than a slider, because the avatar's box is not a style:
- * the canvas, the pill's reach and the card's height are all derived from it,
- * so a continuous scale would be a layout nobody had ever looked at. Radio
- * items, since each axis is one choice and the menu has to show which step is
- * in effect.
- *
- * Built here rather than in each menu, for the reason the wording above is: a
- * later axis, label, checked state or click behaviour would otherwise reach the
- * tray and leave the surface's own right-click describing the same setting
- * differently.
+ * One submenu per axis, since a single picker could only ever move both. One
+ * builder rather than a literal per menu: an axis, label, checked state or
+ * click behaviour added in one place would otherwise leave the tray and the
+ * surface's own right-click describing the same setting differently.
  *
  * `enabled` is for the menu that offers the sizes beside a way to hide the
  * surface: the items stand down rather than disappear while it is hidden, since

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -15,10 +15,8 @@ import {
  * the labels: "88pt" means nothing next to a floating avatar, and the sizes are
  * meant to be picked by looking at the result.
  *
- * One table rather than a literal per menu, since the tray and the surface's
- * own right-click both offer the steps. A user who met "Large" in one place and
- * "Big" in the other would reasonably wonder whether they were setting the same
- * thing.
+ * The vocabulary {@link companionSizeSubmenus} draws the steps from, which is
+ * the one place the wording is decided for every menu that offers them.
  */
 const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
   small: "Small",
@@ -36,10 +34,9 @@ const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
  * creature reads "Avatar" before they read "size". The sentence case is the
  * design's wording, against the Title Case of the tray items beside it.
  *
- * Here beside the steps themselves, and for the same reason: both menus that
- * offer the sizes offer them under these two headings, and a user who met
- * "Avatar size" in one place and "Creature size" in the other would reasonably
- * wonder whether they were setting the same thing.
+ * The headings' half of the same vocabulary: {@link companionSizeSubmenus}
+ * titles its submenus from here, so every menu that offers the sizes offers
+ * them under these two words.
  */
 const COMPANION_SIZE_AXIS_LABELS: Record<CompanionSizeAxis, string> = {
   avatar: "Avatar size",

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -1,4 +1,11 @@
-import type { CompanionSize } from "@vellumai/ipc-contract";
+import type { MenuItemConstructorOptions } from "electron";
+
+import {
+  COMPANION_SIZE_AXES,
+  COMPANION_SIZES,
+  type CompanionSize,
+  type CompanionSizeAxis,
+} from "@vellumai/ipc-contract";
 
 /**
  * Menu wording for each companion size.
@@ -8,15 +15,74 @@ import type { CompanionSize } from "@vellumai/ipc-contract";
  * the labels: "88pt" means nothing next to a floating avatar, and the sizes are
  * meant to be picked by looking at the result.
  *
- * In a module of its own because two menus offer them now, the tray's and the
- * surface's own right-click, and those live in different packages. A user who
- * met "Large" in one place and "Big" in the other would reasonably wonder
- * whether they were setting the same thing.
+ * One table rather than a literal per menu, since the tray and the surface's
+ * own right-click both offer the steps. A user who met "Large" in one place and
+ * "Big" in the other would reasonably wonder whether they were setting the same
+ * thing.
  */
-export const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
+const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
   small: "Small",
   medium: "Medium",
   large: "Large",
   huge: "Huge",
   ridiculous: "Ridiculous",
 };
+
+/**
+ * Menu wording for each of the two things a user sizes.
+ *
+ * Sentence case, and the noun first: the submenus sit among items that say what
+ * they act on ("Show Companion", "Hide Companion"), and a user scanning for the
+ * creature reads "Avatar" before they read "size".
+ *
+ * Here beside the steps themselves, and for the same reason: both menus that
+ * offer the sizes offer them under these two headings, and a user who met
+ * "Avatar size" in one place and "Creature size" in the other would reasonably
+ * wonder whether they were setting the same thing.
+ */
+const COMPANION_SIZE_AXIS_LABELS: Record<CompanionSizeAxis, string> = {
+  avatar: "Avatar size",
+  options: "Options size",
+};
+
+/**
+ * The size pickers, as every menu that offers them draws them.
+ *
+ * One submenu per axis, since the creature and the controls beside it are sized
+ * separately and a single picker could only ever move both. The steps sit under
+ * those headings rather than flat: a named submenu says what its five words are
+ * before it shows them, and leaves the menu around it short enough to read at a
+ * glance.
+ *
+ * Named steps rather than a slider, because the avatar's box is not a style:
+ * the canvas, the pill's reach and the card's height are all derived from it,
+ * so a continuous scale would be a layout nobody had ever looked at. Radio
+ * items, since each axis is one choice and the menu has to show which step is
+ * in effect.
+ *
+ * Built here rather than in each menu, for the reason the wording above is: a
+ * later axis, label, checked state or click behaviour would otherwise reach the
+ * tray and leave the surface's own right-click describing the same setting
+ * differently.
+ *
+ * `enabled` is for the menu that offers the sizes beside a way to hide the
+ * surface: the items stand down rather than disappear while it is hidden, since
+ * they say the sizes are still something the companion has.
+ */
+export const companionSizeSubmenus = (
+  current: Record<CompanionSizeAxis, CompanionSize>,
+  pick: (axis: CompanionSizeAxis, size: CompanionSize) => void,
+  options?: { enabled?: boolean },
+): MenuItemConstructorOptions[] =>
+  COMPANION_SIZE_AXES.map((axis) => ({
+    label: COMPANION_SIZE_AXIS_LABELS[axis],
+    enabled: options?.enabled ?? true,
+    submenu: COMPANION_SIZES.map((size) => ({
+      label: COMPANION_SIZE_LABELS[size],
+      type: "radio" as const,
+      checked: current[axis] === size,
+      click: () => {
+        pick(axis, size);
+      },
+    })),
+  }));

--- a/packages/electron-desktop/src/tray-model.test.ts
+++ b/packages/electron-desktop/src/tray-model.test.ts
@@ -621,23 +621,12 @@ describe("companion toggle", () => {
   });
 
   /**
-   * Named steps rather than a slider (JARVIS-1549). The avatar's box is the
-   * geometry both processes derive from, so the sizes are a fixed set of
-   * layouts and the menu is where one is chosen.
+   * What the tray adds to the pickers, which have their own suite in
+   * `companion-menu.test.ts`: the sizes it shows are the ones it was configured
+   * to read, and a pick lands on the setter it was configured with, under the
+   * axis it was made on.
    */
-  test("offers a size for each named step, under both headings", () => {
-    for (const label of ["Avatar size", "Options size"]) {
-      expect(popSizeItem(label)?.submenu?.map((i) => i.label)).toEqual([
-        "Small",
-        "Medium",
-        "Large",
-        "Huge",
-        "Ridiculous",
-      ]);
-    }
-  });
-
-  test("marks the step each axis is on, since radio items have to show one", () => {
+  test("wires both headings to the tray's own size runtime", () => {
     companionSizes = { avatar: "medium", options: "ridiculous" };
     expect(
       popSizeItem("Avatar size")
@@ -649,17 +638,7 @@ describe("companion toggle", () => {
         ?.submenu?.filter((i) => i.checked)
         .map((i) => i.label),
     ).toEqual(["Ridiculous"]);
-  });
 
-  test("renders each heading's sizes as one radio group", () => {
-    for (const label of ["Avatar size", "Options size"]) {
-      expect(
-        popSizeItem(label)?.submenu?.every((i) => i.type === "radio"),
-      ).toBe(true);
-    }
-  });
-
-  test("applies the size that was picked, to the axis it was picked under", () => {
     popSizeItem("Avatar size")?.submenu?.[3]?.click?.({ checked: true });
     expect(setCompanionSizeMock).toHaveBeenLastCalledWith("avatar", "huge");
     popSizeItem("Options size")?.submenu?.[0]?.click?.({ checked: true });

--- a/packages/electron-desktop/src/tray-model.test.ts
+++ b/packages/electron-desktop/src/tray-model.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { CompanionSize } from "@vellumai/ipc-contract";
+import type { CompanionSize, CompanionSizeAxis } from "@vellumai/ipc-contract";
 import type { Lockfile } from "@vellumai/local-mode/contract";
 
 // Tray stub: records constructions, event listeners, and image swaps.
@@ -99,8 +99,13 @@ let featureFlags: Record<string, boolean> | null = null;
 let companionSupported = true;
 let companionHidden = false;
 const setCompanionSurfaceVisibleMock = mock((_visible: boolean) => undefined);
-let companionSize: CompanionSize = "large";
-const setCompanionSizeMock = mock((_size: CompanionSize) => undefined);
+let companionSizes: Record<CompanionSizeAxis, CompanionSize> = {
+  avatar: "large",
+  options: "large",
+};
+const setCompanionSizeMock = mock(
+  (_axis: CompanionSizeAxis, _size: CompanionSize) => undefined,
+);
 
 const dispatchToMainMock = mock((_command: unknown) => undefined);
 
@@ -187,7 +192,7 @@ beforeEach(() => {
     onboardingActive: () => false,
     openComponentGallery: () => undefined,
     removePairedLabel: "Remove from this Mac\u2026",
-    companionSize: () => companionSize,
+    companionSize: (axis) => companionSizes[axis],
     setCompanionSize: setCompanionSizeMock,
     setCompanionVisible: setCompanionSurfaceVisibleMock,
   });
@@ -199,7 +204,7 @@ beforeEach(() => {
   featureFlags = null;
   companionSupported = true;
   companionHidden = false;
-  companionSize = "large";
+  companionSizes = { avatar: "large", options: "large" };
   setCompanionSurfaceVisibleMock.mockClear();
   setCompanionSizeMock.mockClear();
   dispatchToMainMock.mockClear();
@@ -565,15 +570,16 @@ describe("companion toggle", () => {
   };
 
   /**
-   * The size picker, which lives beside the toggle and is gated with it: with
-   * no surface there is nothing to size.
+   * The size pickers, which live beside the toggle and are gated with it: with
+   * no surface there is nothing to size. One per axis, since the creature and
+   * the controls beside it are sized separately.
    */
-  const popSizeItem = (): MenuItem | undefined => {
+  const popSizeItem = (label: string): MenuItem | undefined => {
     installTray(handlers);
     handlerFor(trays[0], "right-click")?.();
     const calls = buildFromTemplateMock.mock.calls;
     const template = calls[calls.length - 1]?.[0] as MenuItem[];
-    return template.find((i) => i.label === "Companion Size");
+    return template.find((i) => i.label === label);
   };
 
   test("renders as a checked checkbox while the surface is shown", () => {
@@ -598,47 +604,80 @@ describe("companion toggle", () => {
   });
 
   /**
+   * Two headings rather than one, because a single picker could only ever move
+   * both halves of the surface at once. The wording is the same table the
+   * surface's own right-click reads, so the two menus cannot describe the same
+   * choice differently.
+   */
+  test("offers a heading for each thing that is sized", () => {
+    installTray(handlers);
+    handlerFor(trays[0], "right-click")?.();
+    const calls = buildFromTemplateMock.mock.calls;
+    const template = calls[calls.length - 1]?.[0] as MenuItem[];
+    const headings = template
+      .map((i) => i.label)
+      .filter((label) => label === "Avatar size" || label === "Options size");
+    expect(headings).toEqual(["Avatar size", "Options size"]);
+  });
+
+  /**
    * Named steps rather than a slider (JARVIS-1549). The avatar's box is the
    * geometry both processes derive from, so the sizes are a fixed set of
    * layouts and the menu is where one is chosen.
    */
-  test("offers a size for each named step", () => {
-    expect(popSizeItem()?.submenu?.map((i) => i.label)).toEqual([
-      "Small",
-      "Medium",
-      "Large",
-      "Huge",
-      "Ridiculous",
-    ]);
+  test("offers a size for each named step, under both headings", () => {
+    for (const label of ["Avatar size", "Options size"]) {
+      expect(popSizeItem(label)?.submenu?.map((i) => i.label)).toEqual([
+        "Small",
+        "Medium",
+        "Large",
+        "Huge",
+        "Ridiculous",
+      ]);
+    }
   });
 
-  test("marks the size in effect, since radio items have to show one", () => {
-    companionSize = "medium";
-    const checked = popSizeItem()
-      ?.submenu?.filter((i) => i.checked)
-      .map((i) => i.label);
-    expect(checked).toEqual(["Medium"]);
+  test("marks the step each axis is on, since radio items have to show one", () => {
+    companionSizes = { avatar: "medium", options: "ridiculous" };
+    expect(
+      popSizeItem("Avatar size")
+        ?.submenu?.filter((i) => i.checked)
+        .map((i) => i.label),
+    ).toEqual(["Medium"]);
+    expect(
+      popSizeItem("Options size")
+        ?.submenu?.filter((i) => i.checked)
+        .map((i) => i.label),
+    ).toEqual(["Ridiculous"]);
   });
 
-  test("renders the sizes as one radio group", () => {
-    expect(popSizeItem()?.submenu?.every((i) => i.type === "radio")).toBe(true);
+  test("renders each heading's sizes as one radio group", () => {
+    for (const label of ["Avatar size", "Options size"]) {
+      expect(
+        popSizeItem(label)?.submenu?.every((i) => i.type === "radio"),
+      ).toBe(true);
+    }
   });
 
-  test("applies the size that was picked", () => {
-    popSizeItem()?.submenu?.[3]?.click?.({ checked: true });
-    expect(setCompanionSizeMock).toHaveBeenLastCalledWith("huge");
+  test("applies the size that was picked, to the axis it was picked under", () => {
+    popSizeItem("Avatar size")?.submenu?.[3]?.click?.({ checked: true });
+    expect(setCompanionSizeMock).toHaveBeenLastCalledWith("avatar", "huge");
+    popSizeItem("Options size")?.submenu?.[0]?.click?.({ checked: true });
+    expect(setCompanionSizeMock).toHaveBeenLastCalledWith("options", "small");
   });
 
   /**
-   * Disabled rather than dropped while the surface is hidden. The size is still
-   * something the companion has, and an item that comes and goes with the
-   * checkbox above it reads as a bug rather than as a state.
+   * Disabled rather than dropped while the surface is hidden. The sizes are
+   * still something the companion has, and items that came and went with the
+   * checkbox above them would read as a bug rather than as a state.
    */
   test("stands down while the surface is hidden, without disappearing", () => {
     companionHidden = true;
-    const item = popSizeItem();
-    expect(item).toBeDefined();
-    expect(item?.enabled).toBe(false);
+    for (const label of ["Avatar size", "Options size"]) {
+      const item = popSizeItem(label);
+      expect(item).toBeDefined();
+      expect(item?.enabled).toBe(false);
+    }
   });
 
   test("is absent entirely on a platform with no companion surface", () => {
@@ -647,7 +686,8 @@ describe("companion toggle", () => {
     handlerFor(trays[0], "right-click")?.();
     const calls = buildFromTemplateMock.mock.calls;
     const template = calls[calls.length - 1]?.[0] as MenuItem[];
-    expect(template.find((i) => i.label === "Companion Size")).toBeUndefined();
+    expect(template.find((i) => i.label === "Avatar size")).toBeUndefined();
+    expect(template.find((i) => i.label === "Options size")).toBeUndefined();
   });
 });
 

--- a/packages/electron-desktop/src/tray-model.test.ts
+++ b/packages/electron-desktop/src/tray-model.test.ts
@@ -604,23 +604,6 @@ describe("companion toggle", () => {
   });
 
   /**
-   * Two headings rather than one, because a single picker could only ever move
-   * both halves of the surface at once. The wording is the same table the
-   * surface's own right-click reads, so the two menus cannot describe the same
-   * choice differently.
-   */
-  test("offers a heading for each thing that is sized", () => {
-    installTray(handlers);
-    handlerFor(trays[0], "right-click")?.();
-    const calls = buildFromTemplateMock.mock.calls;
-    const template = calls[calls.length - 1]?.[0] as MenuItem[];
-    const headings = template
-      .map((i) => i.label)
-      .filter((label) => label === "Avatar size" || label === "Options size");
-    expect(headings).toEqual(["Avatar size", "Options size"]);
-  });
-
-  /**
    * What the tray adds to the pickers, which have their own suite in
    * `companion-menu.test.ts`: the sizes it shows are the ones it was configured
    * to read, and a pick lands on the setter it was configured with, under the

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -13,8 +13,8 @@ import {
   type LockfileAssistant,
 } from "@vellumai/local-mode/contract";
 import {
-  COMPANION_SIZES,
   type CompanionSize,
+  type CompanionSizeAxis,
   type VellumCommand,
 } from "@vellumai/ipc-contract";
 
@@ -29,7 +29,7 @@ import {
   type AssistantStatus,
 } from "./status";
 import { invalidateIconCache, statusFrames } from "./status-icon";
-import { COMPANION_SIZE_LABELS } from "./companion-menu";
+import { companionSizeSubmenus } from "./companion-menu";
 
 export type TrayMenuIcon =
   | "check"
@@ -54,8 +54,8 @@ export interface TrayModelRuntime {
    */
   companionSupported: () => boolean;
   companionHidden: () => boolean;
-  /** Which named size the companion surface is drawn at. */
-  companionSize: () => CompanionSize;
+  /** Which named size one axis of the companion surface is drawn at. */
+  companionSize: (axis: CompanionSizeAxis) => CompanionSize;
   dispatch: (command: VellumCommand) => void;
   featureEnabled: (flag: string) => boolean;
   getLockfile: () => Lockfile;
@@ -64,7 +64,7 @@ export interface TrayModelRuntime {
   openComponentGallery: () => void;
   removePairedLabel: string;
   setCompanionVisible: (visible: boolean) => void;
-  setCompanionSize: (size: CompanionSize) => void;
+  setCompanionSize: (axis: CompanionSizeAxis, size: CompanionSize) => void;
 }
 
 let runtime: TrayModelRuntime | null = null;
@@ -374,27 +374,18 @@ const buildTrayMenu = (
               trayRuntime.setCompanionVisible(item.checked);
             },
           },
-          {
-            // Named steps rather than a slider, because the avatar's box is not
-            // a style: the canvas, the pill's reach and the card's height are
-            // all derived from it, so a continuous scale would be a layout
-            // nobody had ever looked at. Radio items, since the sizes are one
-            // choice and the menu has to show which one is in effect.
-            //
-            // Disabled rather than hidden while the surface is hidden: the item
-            // says the size is still something the companion has, and an item
-            // that comes and goes with the checkbox above it reads as a bug.
-            label: "Companion Size",
-            enabled: !trayRuntime.companionHidden(),
-            submenu: COMPANION_SIZES.map((size) => ({
-              label: COMPANION_SIZE_LABELS[size],
-              type: "radio" as const,
-              checked: trayRuntime.companionSize() === size,
-              click: () => {
-                trayRuntime.setCompanionSize(size);
-              },
-            })),
-          },
+          // The size pickers the surface's own right-click offers too, from the
+          // one builder both read. Disabled rather than hidden while the
+          // surface is: items that came and went with the checkbox above them
+          // would read as a bug.
+          ...companionSizeSubmenus(
+            {
+              avatar: trayRuntime.companionSize("avatar"),
+              options: trayRuntime.companionSize("options"),
+            },
+            trayRuntime.setCompanionSize,
+            { enabled: !trayRuntime.companionHidden() },
+          ),
         ]
       : []),
     { type: "separator" },

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -65,6 +65,7 @@ mock.module("electron", () => ({
 const {
   restoreBounds,
   track,
+  promoteCompanionSizeToAxes,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
@@ -488,6 +489,68 @@ describe("companion surface sizes", () => {
     savedCompanionSize = "small";
     writeCompanionSize("avatar", "ridiculous");
     writeCompanionSize("options", "huge");
+    expect(
+      storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
+    ).toBe(false);
+  });
+});
+
+/**
+ * Neither axis is left sized from the shared key alone.
+ *
+ * `readCompanionSize` falls back to it either way, so what these state is that
+ * an install cannot sit half way across: an avatar resized on a build with two
+ * axes must not leave the pill governed by a key nothing writes.
+ */
+describe("promoting the single-axis size onto both axes", () => {
+  test("fills both axes when neither has a key of its own", () => {
+    savedCompanionSize = "huge";
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).toHaveBeenCalledWith("companionAvatarSize", "huge");
+    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
+  });
+
+  test("fills only the axis that is missing one", () => {
+    savedCompanionSize = "huge";
+    savedCompanionAvatarSize = "small";
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
+    expect(
+      storeSetMock.mock.calls.some(([key]) => key === "companionAvatarSize"),
+    ).toBe(false);
+  });
+
+  test("writes nothing when both axes already have their own key", () => {
+    savedCompanionSize = "huge";
+    savedCompanionAvatarSize = "small";
+    savedCompanionOptionsSize = "large";
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).not.toHaveBeenCalled();
+  });
+
+  test("writes nothing when there is no shared key to promote", () => {
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A size this build cannot draw is not a size to spread onto both axes. It
+   * would put a canvas sized from `undefined` on screen twice over.
+   */
+  test("writes nothing when the shared key holds a size this build does not know", () => {
+    savedCompanionSize = "enormous";
+    promoteCompanionSizeToAxes();
+    expect(storeSetMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The shared key stays where it is in every case. A build with one size axis
+   * still reads it, so a user who moves back to one finds the size they picked.
+   */
+  test("leaves the shared key in place", () => {
+    savedCompanionSize = "huge";
+    savedCompanionOptionsSize = "large";
+    promoteCompanionSizeToAxes();
     expect(
       storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
     ).toBe(false);

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -457,13 +457,26 @@ describe("companion surface sizes", () => {
     );
   });
 
-  test("writing skips persisting when the effective value is unchanged", () => {
+  test("writing skips persisting when the axis's own key already says so", () => {
     savedCompanionOptionsSize = "large";
     writeCompanionSize("options", "large");
     expect(storeSetMock).not.toHaveBeenCalled();
 
     writeCompanionSize("options", "small");
     expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "small");
+  });
+
+  /**
+   * The axis's own key, not the effective value that falls back to the shared
+   * one. Someone carrying `huge` from a one-axis build who picks Huge on an
+   * axis is asking for it to be that axis's own answer, and skipping the write
+   * because the fallback already agreed would leave them on the fallback
+   * forever.
+   */
+  test("an explicit pick matching the shared fallback still lands on its axis", () => {
+    savedCompanionSize = "huge";
+    writeCompanionSize("avatar", "huge");
+    expect(storeSetMock).toHaveBeenCalledWith("companionAvatarSize", "huge");
   });
 
   /**

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -399,8 +399,9 @@ describe("companion surface visibility flag", () => {
  *
  * The file is JSON a user can edit and another build can have written, and the
  * values index a table of geometry, so what is worth stating is that only a
- * step this build knows ever reaches the window, and that an install carrying
- * only the single size a one-axis build writes is not resized under its user.
+ * step this build knows ever reaches the window, that an install carrying only
+ * the single size a one-axis build writes is not resized under its user, and
+ * that a downgrade finds that shared key holding whatever both axes agree on.
  */
 describe("companion surface sizes", () => {
   test("absent keys default to the shipped size on both axes", () => {
@@ -480,14 +481,56 @@ describe("companion surface sizes", () => {
   });
 
   /**
-   * The shared key is read and never written. Writing it would hand a build
-   * that reads only that key one axis's answer for both, and turn a user sizing
-   * the pill alone into one whose creature changed too.
+   * Both axes on one size is the whole of what a build with one size axis can
+   * say, so it is said: someone who put the pair at `small` and then opened an
+   * older build should find it small rather than a stale value or the default.
    */
-  test("never writes the key the single-axis build reads", () => {
+  test("axes landing on the same size update the key a single-axis build reads", () => {
+    savedCompanionAvatarSize = "small";
+    writeCompanionSize("options", "small");
+    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "small");
+    expect(storeSetMock).toHaveBeenCalledWith("companionSize", "small");
+  });
+
+  /**
+   * Two different sizes are not representable there, and the shared key is not
+   * asked to pick one: handing that build one axis's answer for both would turn
+   * a user sizing the pill alone into one whose creature changed too.
+   */
+  test("axes that disagree leave that key alone", () => {
     savedCompanionSize = "small";
-    writeCompanionSize("avatar", "ridiculous");
+    savedCompanionAvatarSize = "ridiculous";
     writeCompanionSize("options", "huge");
+    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
+    expect(
+      storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
+    ).toBe(false);
+  });
+
+  /**
+   * Agreement reached through the fallback counts, and there is nothing to
+   * write: the key already holds the size both axes answer with.
+   */
+  test("a pick that agrees with the shared fallback does not rewrite it", () => {
+    savedCompanionSize = "huge";
+    writeCompanionSize("avatar", "huge");
+    expect(storeSetMock).toHaveBeenCalledWith("companionAvatarSize", "huge");
+    expect(
+      storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
+    ).toBe(false);
+  });
+
+  /**
+   * The key keeps the last size the two agreed on rather than being cleared or
+   * dragged after the axis that moved. A build with one size axis then still
+   * opens at a size its user chose.
+   */
+  test("a later disagreement leaves the key where the axes last agreed", () => {
+    savedCompanionSize = "small";
+    savedCompanionAvatarSize = "small";
+    savedCompanionOptionsSize = "small";
+    writeCompanionSize("avatar", "huge");
+    expect(storeSetMock).toHaveBeenCalledWith("companionAvatarSize", "huge");
     expect(
       storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
     ).toBe(false);

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -65,7 +65,6 @@ mock.module("electron", () => ({
 const {
   restoreBounds,
   track,
-  promoteCompanionSizeToAxes,
   readCompanionHidden,
   readCompanionIntroSeen,
   readCompanionSize,
@@ -489,68 +488,6 @@ describe("companion surface sizes", () => {
     savedCompanionSize = "small";
     writeCompanionSize("avatar", "ridiculous");
     writeCompanionSize("options", "huge");
-    expect(
-      storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
-    ).toBe(false);
-  });
-});
-
-/**
- * Neither axis is left sized from the shared key alone.
- *
- * `readCompanionSize` falls back to it either way, so what these state is that
- * an install cannot sit half way across: an avatar resized on a build with two
- * axes must not leave the pill governed by a key nothing writes.
- */
-describe("promoting the single-axis size onto both axes", () => {
-  test("fills both axes when neither has a key of its own", () => {
-    savedCompanionSize = "huge";
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).toHaveBeenCalledWith("companionAvatarSize", "huge");
-    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
-  });
-
-  test("fills only the axis that is missing one", () => {
-    savedCompanionSize = "huge";
-    savedCompanionAvatarSize = "small";
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "huge");
-    expect(
-      storeSetMock.mock.calls.some(([key]) => key === "companionAvatarSize"),
-    ).toBe(false);
-  });
-
-  test("writes nothing when both axes already have their own key", () => {
-    savedCompanionSize = "huge";
-    savedCompanionAvatarSize = "small";
-    savedCompanionOptionsSize = "large";
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).not.toHaveBeenCalled();
-  });
-
-  test("writes nothing when there is no shared key to promote", () => {
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).not.toHaveBeenCalled();
-  });
-
-  /**
-   * A size this build cannot draw is not a size to spread onto both axes. It
-   * would put a canvas sized from `undefined` on screen twice over.
-   */
-  test("writes nothing when the shared key holds a size this build does not know", () => {
-    savedCompanionSize = "enormous";
-    promoteCompanionSizeToAxes();
-    expect(storeSetMock).not.toHaveBeenCalled();
-  });
-
-  /**
-   * The shared key stays where it is in every case. A build with one size axis
-   * still reads it, so a user who moves back to one finds the size they picked.
-   */
-  test("leaves the shared key in place", () => {
-    savedCompanionSize = "huge";
-    savedCompanionOptionsSize = "large";
-    promoteCompanionSizeToAxes();
     expect(
       storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
     ).toBe(false);

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -13,6 +13,9 @@ let savedWindows: Record<string, SavedState> = {};
 let savedOnboardingActive: boolean | undefined = undefined;
 let savedCompanionHidden: boolean | undefined = undefined;
 let savedCompanionIntroSeen: boolean | undefined = undefined;
+let savedCompanionSize: unknown = undefined;
+let savedCompanionAvatarSize: unknown = undefined;
+let savedCompanionOptionsSize: unknown = undefined;
 let savedTitleBarOverlay: unknown = undefined;
 let workArea = { x: 0, y: 0, width: 1920, height: 1080 };
 const storeSetMock = mock((_key: string, _value: unknown) => {});
@@ -30,6 +33,15 @@ mock.module("electron-store", () => ({
       if (key === "companionHidden") return savedCompanionHidden ?? fallback;
       if (key === "companionIntroSeen")
         return savedCompanionIntroSeen ?? fallback;
+      if (key === "companionSize") {
+        return savedCompanionSize ?? fallback;
+      }
+      if (key === "companionAvatarSize") {
+        return savedCompanionAvatarSize ?? fallback;
+      }
+      if (key === "companionOptionsSize") {
+        return savedCompanionOptionsSize ?? fallback;
+      }
       if (key === "titleBarOverlay") return savedTitleBarOverlay ?? fallback;
       if (key === "windows") return savedWindows;
       return fallback;
@@ -55,10 +67,12 @@ const {
   track,
   readCompanionHidden,
   readCompanionIntroSeen,
+  readCompanionSize,
   readOnboardingActive,
   readTitleBarOverlayTheme,
   writeCompanionHidden,
   writeCompanionIntroSeen,
+  writeCompanionSize,
   writeOnboardingActive,
   writeTitleBarOverlayTheme,
 } = await import("./window-state");
@@ -89,6 +103,9 @@ beforeEach(() => {
   savedOnboardingActive = undefined;
   savedCompanionHidden = undefined;
   savedCompanionIntroSeen = undefined;
+  savedCompanionSize = undefined;
+  savedCompanionAvatarSize = undefined;
+  savedCompanionOptionsSize = undefined;
   savedTitleBarOverlay = undefined;
   workArea = { x: 0, y: 0, width: 1920, height: 1080 };
   storeSetMock.mockClear();
@@ -373,6 +390,94 @@ describe("companion surface visibility flag", () => {
 
     writeCompanionHidden(true);
     expect(storeSetMock).toHaveBeenCalledWith("companionHidden", true);
+  });
+});
+
+/**
+ * The two sizes the companion surface is drawn at, which are one choice each
+ * and share a set of steps.
+ *
+ * The file is JSON a user can edit and another build can have written, and the
+ * values index a table of geometry, so what is worth stating is that only a
+ * step this build knows ever reaches the window, and that an install carrying
+ * only the single size a one-axis build writes is not resized under its user.
+ */
+describe("companion surface sizes", () => {
+  test("absent keys default to the shipped size on both axes", () => {
+    expect(readCompanionSize("avatar")).toBe("medium");
+    expect(readCompanionSize("options")).toBe("medium");
+  });
+
+  test("each axis reads its own key", () => {
+    savedCompanionAvatarSize = "ridiculous";
+    savedCompanionOptionsSize = "small";
+    expect(readCompanionSize("avatar")).toBe("ridiculous");
+    expect(readCompanionSize("options")).toBe("small");
+  });
+
+  /**
+   * Nobody is resized by the second axis arriving. Someone who picked `huge`
+   * from a menu that offered one size meant the thing they were looking at, so
+   * they get `huge` on both rather than the default on either.
+   */
+  test("falls back to the one size a single-axis build writes", () => {
+    savedCompanionSize = "huge";
+    expect(readCompanionSize("avatar")).toBe("huge");
+    expect(readCompanionSize("options")).toBe("huge");
+  });
+
+  test("an axis's own key wins over that fallback", () => {
+    savedCompanionSize = "huge";
+    savedCompanionOptionsSize = "small";
+    expect(readCompanionSize("avatar")).toBe("huge");
+    expect(readCompanionSize("options")).toBe("small");
+  });
+
+  test("a value this build does not know never reaches the window", () => {
+    savedCompanionAvatarSize = "gigantic";
+    savedCompanionSize = "enormous";
+    expect(readCompanionSize("avatar")).toBe("medium");
+  });
+
+  test("an unknown axis key still finds the shared fallback", () => {
+    savedCompanionAvatarSize = "gigantic";
+    savedCompanionSize = "large";
+    expect(readCompanionSize("avatar")).toBe("large");
+  });
+
+  test("writing one axis leaves the other alone", () => {
+    writeCompanionSize("avatar", "ridiculous");
+    expect(storeSetMock).toHaveBeenCalledWith(
+      "companionAvatarSize",
+      "ridiculous",
+    );
+    expect(storeSetMock).not.toHaveBeenCalledWith(
+      "companionOptionsSize",
+      "ridiculous",
+    );
+  });
+
+  test("writing skips persisting when the effective value is unchanged", () => {
+    savedCompanionOptionsSize = "large";
+    writeCompanionSize("options", "large");
+    expect(storeSetMock).not.toHaveBeenCalled();
+
+    writeCompanionSize("options", "small");
+    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "small");
+  });
+
+  /**
+   * The shared key is read and never written. Writing it would hand a build
+   * that reads only that key one axis's answer for both, and turn a user sizing
+   * the pill alone into one whose creature changed too.
+   */
+  test("never writes the key the single-axis build reads", () => {
+    savedCompanionSize = "small";
+    writeCompanionSize("avatar", "ridiculous");
+    writeCompanionSize("options", "huge");
+    expect(
+      storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
+    ).toBe(false);
   });
 });
 

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -145,6 +145,10 @@ const COMPANION_SIZE_KEYS: Record<
 const knownSize = (stored: CompanionSize | undefined): CompanionSize | null =>
   stored !== undefined && COMPANION_SIZES.includes(stored) ? stored : null;
 
+/** The size an axis has of its own, before any fallback. */
+const storedSize = (axis: CompanionSizeAxis): CompanionSize | null =>
+  knownSize(store().get(COMPANION_SIZE_KEYS[axis]));
+
 /**
  * Which named size one axis of the companion surface is drawn at.
  *
@@ -155,7 +159,7 @@ const knownSize = (stored: CompanionSize | undefined): CompanionSize | null =>
  * axes rather than the default on either.
  */
 export const readCompanionSize = (axis: CompanionSizeAxis): CompanionSize =>
-  knownSize(store().get(COMPANION_SIZE_KEYS[axis])) ??
+  storedSize(axis) ??
   knownSize(store().get("companionSize")) ??
   DEFAULT_COMPANION_SIZE;
 
@@ -184,8 +188,13 @@ export const writeCompanionIntroSeen = (): void => {
 };
 
 /**
- * Persist one axis's size. No-op when the effective value is unchanged, as the
- * opt-out is.
+ * Persist one axis's size. No-op only when that axis's own key already says so.
+ *
+ * The axis's own key rather than the effective value, because that value falls
+ * back to the single size a build with one size axis writes. Someone carrying
+ * that legacy size who picks it again on one axis is asking for it to be that
+ * axis's own answer, and comparing against the fallback would leave the
+ * per-axis key empty for as long as they keep agreeing with it.
  *
  * Only ever the axis's own key. Writing the shared one as well would hand a
  * build that reads only that key one axis's answer for both, and turn a user
@@ -195,7 +204,7 @@ export const writeCompanionSize = (
   axis: CompanionSizeAxis,
   size: CompanionSize,
 ): void => {
-  if (readCompanionSize(axis) === size) {
+  if (storedSize(axis) === size) {
     return;
   }
   store().set(COMPANION_SIZE_KEYS[axis], size);

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_COMPANION_SIZE,
   titleBarOverlayThemeSchema,
   type CompanionSize,
+  type CompanionSizeAxis,
   type TitleBarOverlayTheme,
 } from "@vellumai/ipc-contract";
 
@@ -41,10 +42,17 @@ interface StoreSchema {
   // before any renderer loads. Optional: absent means shown, so the flag
   // records only the opt-out (see `readCompanionHidden`).
   companionHidden?: boolean;
-  // Which named size the companion surface is drawn at. A main-process concern
-  // for the same reason the opt-out is: the window is built at a size derived
-  // from this before any renderer loads. Optional: absent means the default
-  // (see `readCompanionSize`).
+  // Which named size the companion's avatar is drawn at, and which its options
+  // pill is. A main-process concern for the same reason the opt-out is: the
+  // window is built at a canvas derived from both before any renderer loads.
+  // Optional: absent means whatever `readCompanionSize` falls back to.
+  companionAvatarSize?: CompanionSize;
+  companionOptionsSize?: CompanionSize;
+  // The single size a build with one size axis records for the whole surface.
+  // Read only: `readCompanionSize` falls back to it for an axis with nothing of
+  // its own, so an install carrying only this comes up at the size it chose on
+  // both axes. Nothing writes it, and it stays in the schema so a build that
+  // reads it still finds what it left.
   companionSize?: CompanionSize;
   // Whether the companion's one-time introduction has run. Held here rather
   // than in the surface's renderer because that renderer reloads, and a run
@@ -117,20 +125,39 @@ export const writeCompanionHidden = (hidden: boolean): void => {
   store().set("companionHidden", hidden);
 };
 
-/**
- * Which named size the companion surface is drawn at.
- *
- * Validated on the way out rather than trusted. This file is a JSON store a
- * user can edit and an older build can have written, and the value indexes a
- * table of geometry, and an unknown one would size the window from `undefined`
- * put a canvas of `NaN` on screen.
- */
-export const readCompanionSize = (): CompanionSize => {
-  const stored = store().get("companionSize");
-  return stored !== undefined && COMPANION_SIZES.includes(stored)
-    ? stored
-    : DEFAULT_COMPANION_SIZE;
+/** Where each axis keeps its own chosen size. */
+const COMPANION_SIZE_KEYS: Record<
+  CompanionSizeAxis,
+  "companionAvatarSize" | "companionOptionsSize"
+> = {
+  avatar: "companionAvatarSize",
+  options: "companionOptionsSize",
 };
+
+/**
+ * A stored value if it is a size this build knows, and `null` otherwise.
+ *
+ * Validated rather than trusted. This file is a JSON store a user can edit and
+ * another build can have written, and the value indexes a table of geometry: an
+ * unknown one would size the window from `undefined` and put a canvas of `NaN`
+ * on screen.
+ */
+const knownSize = (stored: CompanionSize | undefined): CompanionSize | null =>
+  stored !== undefined && COMPANION_SIZES.includes(stored) ? stored : null;
+
+/**
+ * Which named size one axis of the companion surface is drawn at.
+ *
+ * The axis's own key first, then the single size a build with one size axis
+ * writes, then the default. That middle step is what keeps an install from
+ * being resized under its user: someone who picked `huge` from a menu offering
+ * one size meant the thing they were looking at, so they get `huge` on both
+ * axes rather than the default on either.
+ */
+export const readCompanionSize = (axis: CompanionSizeAxis): CompanionSize =>
+  knownSize(store().get(COMPANION_SIZE_KEYS[axis])) ??
+  knownSize(store().get("companionSize")) ??
+  DEFAULT_COMPANION_SIZE;
 
 /**
  * Whether the companion's one-time introduction has already run.
@@ -156,12 +183,22 @@ export const writeCompanionIntroSeen = (): void => {
   store().set("companionIntroSeen", true);
 };
 
-/** Persist the companion's size. No-op when unchanged, as the opt-out is. */
-export const writeCompanionSize = (size: CompanionSize): void => {
-  if (readCompanionSize() === size) {
+/**
+ * Persist one axis's size. No-op when the effective value is unchanged, as the
+ * opt-out is.
+ *
+ * Only ever the axis's own key. Writing the shared one as well would hand a
+ * build that reads only that key one axis's answer for both, and turn a user
+ * sizing the pill alone into one whose avatar changed too.
+ */
+export const writeCompanionSize = (
+  axis: CompanionSizeAxis,
+  size: CompanionSize,
+): void => {
+  if (readCompanionSize(axis) === size) {
     return;
   }
-  store().set("companionSize", size);
+  store().set(COMPANION_SIZE_KEYS[axis], size);
 };
 
 /**

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, screen, type Rectangle } from "electron";
 import Store from "electron-store";
 
 import {
+  COMPANION_SIZE_AXES,
   COMPANION_SIZES,
   DEFAULT_COMPANION_SIZE,
   titleBarOverlayThemeSchema,
@@ -208,6 +209,33 @@ export const writeCompanionSize = (
     return;
   }
   store().set(COMPANION_SIZE_KEYS[axis], size);
+};
+
+/**
+ * Copy the single size a build with one size axis records into whichever
+ * per-axis keys are still empty. Called once, before anything reads the
+ * geometry.
+ *
+ * `readCompanionSize` already falls back to that key, so nobody sees the
+ * surface change. What this settles is the install stuck half way across:
+ * someone carrying `huge` who resizes the avatar alone ends with one axis's own
+ * key written and the other governed by the shared key for as long as they keep
+ * it, which leaves half their surface sized from a key nothing writes.
+ *
+ * The shared key is left in place, and this writes only the per-axis ones. A
+ * build with one size axis still reads it, so a user who goes back to one finds
+ * the size they picked rather than the default.
+ */
+export const promoteCompanionSizeToAxes = (): void => {
+  const shared = knownSize(store().get("companionSize"));
+  if (shared === null) {
+    return;
+  }
+  for (const axis of COMPANION_SIZE_AXES) {
+    if (storedSize(axis) === null) {
+      store().set(COMPANION_SIZE_KEYS[axis], shared);
+    }
+  }
 };
 
 /**

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -2,7 +2,6 @@ import { BrowserWindow, screen, type Rectangle } from "electron";
 import Store from "electron-store";
 
 import {
-  COMPANION_SIZE_AXES,
   COMPANION_SIZES,
   DEFAULT_COMPANION_SIZE,
   titleBarOverlayThemeSchema,
@@ -157,7 +156,8 @@ const storedSize = (axis: CompanionSizeAxis): CompanionSize | null =>
  * writes, then the default. That middle step is what keeps an install from
  * being resized under its user: someone who picked `huge` from a menu offering
  * one size meant the thing they were looking at, so they get `huge` on both
- * axes rather than the default on either.
+ * axes rather than the default on either. Nothing promotes that key onto the
+ * per-axis ones, so reading through it is the permanent compatibility path.
  */
 export const readCompanionSize = (axis: CompanionSizeAxis): CompanionSize =>
   storedSize(axis) ??
@@ -209,33 +209,6 @@ export const writeCompanionSize = (
     return;
   }
   store().set(COMPANION_SIZE_KEYS[axis], size);
-};
-
-/**
- * Copy the single size a build with one size axis records into whichever
- * per-axis keys are still empty. Called once, before anything reads the
- * geometry.
- *
- * `readCompanionSize` already falls back to that key, so nobody sees the
- * surface change. What this settles is the install stuck half way across:
- * someone carrying `huge` who resizes the avatar alone ends with one axis's own
- * key written and the other governed by the shared key for as long as they keep
- * it, which leaves half their surface sized from a key nothing writes.
- *
- * The shared key is left in place, and this writes only the per-axis ones. A
- * build with one size axis still reads it, so a user who goes back to one finds
- * the size they picked rather than the default.
- */
-export const promoteCompanionSizeToAxes = (): void => {
-  const shared = knownSize(store().get("companionSize"));
-  if (shared === null) {
-    return;
-  }
-  for (const axis of COMPANION_SIZE_AXES) {
-    if (storedSize(axis) === null) {
-      store().set(COMPANION_SIZE_KEYS[axis], shared);
-    }
-  }
 };
 
 /**

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, screen, type Rectangle } from "electron";
 import Store from "electron-store";
 
 import {
+  COMPANION_SIZE_AXES,
   COMPANION_SIZES,
   DEFAULT_COMPANION_SIZE,
   titleBarOverlayThemeSchema,
@@ -49,10 +50,10 @@ interface StoreSchema {
   companionAvatarSize?: CompanionSize;
   companionOptionsSize?: CompanionSize;
   // The single size a build with one size axis records for the whole surface.
-  // Read only: `readCompanionSize` falls back to it for an axis with nothing of
-  // its own, so an install carrying only this comes up at the size it chose on
-  // both axes. Nothing writes it, and it stays in the schema so a build that
-  // reads it still finds what it left.
+  // `readCompanionSize` falls back to it for an axis with nothing of its own,
+  // so an install carrying only this comes up at the size it chose on both
+  // axes, and `writeCompanionSize` keeps it current for the one state it can
+  // say: both axes on the same size.
   companionSize?: CompanionSize;
   // Whether the companion's one-time introduction has run. Held here rather
   // than in the surface's renderer because that renderer reloads, and a run
@@ -157,7 +158,8 @@ const storedSize = (axis: CompanionSizeAxis): CompanionSize | null =>
  * being resized under its user: someone who picked `huge` from a menu offering
  * one size meant the thing they were looking at, so they get `huge` on both
  * axes rather than the default on either. Nothing promotes that key onto the
- * per-axis ones, so reading through it is the permanent compatibility path.
+ * per-axis ones, so reading through it is the permanent compatibility path, and
+ * the shared key a converged pick leaves behind never outranks an axis's own.
  */
 export const readCompanionSize = (axis: CompanionSizeAxis): CompanionSize =>
   storedSize(axis) ??
@@ -197,9 +199,12 @@ export const writeCompanionIntroSeen = (): void => {
  * axis's own answer, and comparing against the fallback would leave the
  * per-axis key empty for as long as they keep agreeing with it.
  *
- * Only ever the axis's own key. Writing the shared one as well would hand a
- * build that reads only that key one axis's answer for both, and turn a user
- * sizing the pill alone into one whose avatar changed too.
+ * The shared key follows the pick only where both axes land on the same size,
+ * which is the whole of what a build with one size axis can say. Someone who
+ * put both at `small` and then opened an older build should find it small,
+ * rather than a stale value or the shipped default. Axes that differ leave that
+ * key exactly as it was: handing that build one axis's answer for both would
+ * turn a user sizing the pill alone into one whose creature changed too.
  */
 export const writeCompanionSize = (
   axis: CompanionSizeAxis,
@@ -209,6 +214,17 @@ export const writeCompanionSize = (
     return;
   }
   store().set(COMPANION_SIZE_KEYS[axis], size);
+  // The written axis is its own key's answer, so `size` is its effective value
+  // without reading the store back for it. Every other axis is read through the
+  // same fallback the window is built from, so two axes agreeing by way of the
+  // shared key itself counts as agreement.
+  const converged = COMPANION_SIZE_AXES.filter((other) => other !== axis).every(
+    (other) => readCompanionSize(other) === size,
+  );
+  if (!converged || knownSize(store().get("companionSize")) === size) {
+    return;
+  }
+  store().set("companionSize", size);
 };
 
 /**

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -785,14 +785,10 @@ export const DEFAULT_COMPANION_SIZE: CompanionSize = "medium";
 /**
  * The two things on the surface a user sizes, sized separately.
  *
- * The creature and the controls beside it are one object to look at and two
- * things to want at different sizes: an avatar big enough to read from across
- * the room does not mean a pill that wide, and a pill sized for its labels does
- * not mean a mascot that small. Both axes take the same five steps
- * ({@link COMPANION_SIZES}), so there is one vocabulary and two answers rather
- * than two scales to learn.
- *
- * `avatar` sizes the creature, its glow and its bob. `options` sizes the pill,
+ * An avatar big enough to read from across the room does not mean a pill that
+ * wide, and both axes take the same five steps ({@link COMPANION_SIZES}), so
+ * there is one vocabulary and two answers rather than two scales to learn.
+ * `avatar` sizes the creature, its glow and its bob; `options` sizes the pill,
  * the typing card, the call's body and the introduction's card.
  */
 export const COMPANION_SIZE_AXES = ["avatar", "options"] as const;
@@ -829,6 +825,21 @@ export const COMPANION_BASE_CANVAS_PAD = 24;
  * it.
  */
 export const COMPANION_BASE_CARD_HEIGHT = 290;
+
+/**
+ * The widest the pill draws at the base size, measured from its avatar-facing
+ * edge.
+ *
+ * An outer width, padding included: the renderer draws a pill as its measured
+ * body plus its own clearance at either end, and that whole width is what has
+ * to fit. The typing card is exactly this wide, being the one state that states
+ * a width rather than measuring one.
+ *
+ * A ceiling rather than a width, since every other state is as wide as its
+ * content. Main sizes the canvas to hold this much beyond the gap, so a state
+ * that wanted more would be clipped by the window.
+ */
+export const COMPANION_BASE_MAX_PILL_WIDTH = 316;
 
 /**
  * The room between the avatar's edge and the options pill beside it, at the
@@ -926,6 +937,9 @@ export const companionNearEdgeFor = (
  * rises its whole height from there; growing down, its composer row holds that
  * line and the rest of the card falls away below it. The avatar's own half box
  * is the floor under both, for a creature taller than the card beside it.
+ *
+ * Only main consumes this: the renderer names that edge with `100%` and lets
+ * main size the canvas. It lives here to sit beside the constants it reads.
  */
 export const companionCardSideFor = (
   avatarBox: number,
@@ -941,21 +955,6 @@ export const companionCardSideFor = (
     ) + companionPadFor(avatarBox, optionsBox)
   );
 };
-
-/**
- * The near edge at the size the surface's layout is authored at.
- *
- * {@link companionNearEdgeFor} with both boxes at the base, which is what that
- * helper comes to whenever the two sizes agree. A name of its own because it is
- * the distance the whole layout is authored around, and because a helper that
- * stopped reducing to it would be one that had quietly moved the avatar.
- *
- * Anything whose answer moves with either size calls the helper instead.
- */
-export const COMPANION_NEAR_EDGE = companionNearEdgeFor(
-  COMPANION_BASE_AVATAR_BOX,
-  COMPANION_BASE_AVATAR_BOX,
-);
 
 /**
  * The assistant's character, as the three trait ids it is composed from.

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -783,6 +783,23 @@ export const COMPANION_SIZE_BOXES: Record<CompanionSize, number> = {
 export const DEFAULT_COMPANION_SIZE: CompanionSize = "medium";
 
 /**
+ * The two things on the surface a user sizes, sized separately.
+ *
+ * The creature and the controls beside it are one object to look at and two
+ * things to want at different sizes: an avatar big enough to read from across
+ * the room does not mean a pill that wide, and a pill sized for its labels does
+ * not mean a mascot that small. Both axes take the same five steps
+ * ({@link COMPANION_SIZES}), so there is one vocabulary and two answers rather
+ * than two scales to learn.
+ *
+ * `avatar` sizes the creature, its glow and its bob. `options` sizes the pill,
+ * the typing card, the call's body and the introduction's card.
+ */
+export const COMPANION_SIZE_AXES = ["avatar", "options"] as const;
+
+export type CompanionSizeAxis = (typeof COMPANION_SIZE_AXES)[number];
+
+/**
  * The avatar's box the companion's layout is authored at, and the size every
  * other length in that layout is stated in.
  *
@@ -792,24 +809,26 @@ export const DEFAULT_COMPANION_SIZE: CompanionSize = "medium";
  */
 export const COMPANION_BASE_AVATAR_BOX = COMPANION_SIZE_BOXES.small;
 
-/** Room the pill's shadow paints outside its box, at the base size. */
+/**
+ * Room the pill's shadow and the avatar's glow paint outside their own boxes,
+ * at the base size.
+ */
 export const COMPANION_BASE_CANVAS_PAD = 24;
 
 /**
- * How far the avatar's centre sits from the canvas edge the card does *not*
- * grow into: its own half-box, plus the shadow's room.
+ * The tallest the surface draws at the base size, which is the typing card.
  *
- * **The cross-process invariant.** Main places the window by it and the
- * renderer anchors the avatar by it, so the two agreeing is what makes the
- * avatar appear where the window was put. Derived once here rather than on each
- * side, because two copies of this formula drifting is the avatar drawn
- * somewhere other than where main believes it is.
+ * Every other state is a pill exactly {@link COMPANION_BASE_AVATAR_BOX} tall.
+ * The card stacks the conversation above that row in a viewport that scrolls
+ * once it is full, so it has a ceiling rather than growing with the exchange,
+ * and this is that ceiling rounded up: the card's text is laid out in the
+ * renderer, and a canvas a few points short clips the top of it off.
  *
- * The far edge is however far away the canvas is, which neither side has to
- * state: `100%` names the canvas in the renderer, and main sizes it.
+ * Matched to `CompanionSurface`'s card, and held here rather than beside the
+ * placement rules because {@link companionCardSideFor} sizes the canvas from
+ * it.
  */
-export const COMPANION_NEAR_EDGE =
-  COMPANION_BASE_AVATAR_BOX / 2 + COMPANION_BASE_CANVAS_PAD;
+export const COMPANION_BASE_CARD_HEIGHT = 290;
 
 /**
  * The room between the avatar's edge and the options pill beside it, at the
@@ -824,6 +843,15 @@ export const COMPANION_NEAR_EDGE =
 export const COMPANION_BASE_GAP = 12;
 
 /**
+ * The scale a box is drawn at: the box over the size the layout is authored at.
+ *
+ * The one conversion from points into the units every length on the surface is
+ * stated in, so neither side of the bridge divides by the base box on its own.
+ */
+export const companionScaleFor = (box: number): number =>
+  box / COMPANION_BASE_AVATAR_BOX;
+
+/**
  * That gap for a given pair of boxes.
  *
  * Scaled by the smaller of the two, because the gap is breathing room and the
@@ -832,7 +860,7 @@ export const COMPANION_BASE_GAP = 12;
  * chasm the pill's own scale would ask for.
  *
  * Derived here rather than on each side of the bridge, for the reason
- * {@link COMPANION_NEAR_EDGE} is: main sizes the canvas to hold the pill's
+ * {@link companionNearEdgeFor} is: main sizes the canvas to hold the pill's
  * reach past the avatar and the renderer positions the pill by the same
  * distance, so two copies of this drifting is a pill drawn somewhere main did
  * not leave room for.
@@ -843,6 +871,91 @@ export const companionGapFor = (
 ): number =>
   (COMPANION_BASE_GAP * Math.min(avatarBox, optionsBox)) /
   COMPANION_BASE_AVATAR_BOX;
+
+/**
+ * The room the canvas keeps outside everything drawn into it, for a given pair
+ * of boxes.
+ *
+ * The larger of the two scales, because the pad holds two overflows and either
+ * one can be the bigger: the pill's shadow grows with the options size and the
+ * avatar's glow with the avatar's. Sizing it from the smaller would clip
+ * whichever of the two the user made large.
+ */
+export const companionPadFor = (
+  avatarBox: number,
+  optionsBox: number,
+): number =>
+  COMPANION_BASE_CANVAS_PAD *
+  Math.max(companionScaleFor(avatarBox), companionScaleFor(optionsBox));
+
+/**
+ * How far the avatar's centre sits from the canvas edge the card does *not*
+ * grow into, for a given pair of boxes.
+ *
+ * **The cross-process invariant.** Main places the window by it and the
+ * renderer anchors the avatar by it, so the two agreeing is what makes the
+ * avatar appear where the window was put. Derived once here rather than on each
+ * side, because two copies of this formula drifting is the avatar drawn
+ * somewhere other than where main believes it is.
+ *
+ * What has to clear that edge depends on which way the card grows, because the
+ * pill's bottom edge is the avatar's: growing up, the near side holds the
+ * avatar's own half box and nothing else; growing down, the pill stands on that
+ * line and reaches a whole options box back past it, which pokes above a
+ * smaller creature. The larger of the two is taken so the answer is the same
+ * either way, since a flip moves the canvas rather than resizing it, and a near
+ * edge that changed with the direction would shift the avatar by the
+ * difference.
+ *
+ * The far edge is {@link companionCardSideFor}, which the renderer never has to
+ * state: `100%` names the canvas there, and main sizes it.
+ */
+export const companionNearEdgeFor = (
+  avatarBox: number,
+  optionsBox: number,
+): number =>
+  Math.max(avatarBox / 2, optionsBox - avatarBox / 2) +
+  companionPadFor(avatarBox, optionsBox);
+
+/**
+ * How far the avatar's centre sits from the canvas edge the card *does* grow
+ * into, for a given pair of boxes.
+ *
+ * The far half of {@link companionNearEdgeFor}, taken over both growths for the
+ * same reason. Growing up, the card stands on the avatar's bottom line and
+ * rises its whole height from there; growing down, its composer row holds that
+ * line and the rest of the card falls away below it. The avatar's own half box
+ * is the floor under both, for a creature taller than the card beside it.
+ */
+export const companionCardSideFor = (
+  avatarBox: number,
+  optionsBox: number,
+): number => {
+  const scale = companionScaleFor(optionsBox);
+  return (
+    Math.max(
+      COMPANION_BASE_CARD_HEIGHT * scale - avatarBox / 2,
+      (COMPANION_BASE_CARD_HEIGHT - COMPANION_BASE_AVATAR_BOX) * scale +
+        avatarBox / 2,
+      avatarBox / 2,
+    ) + companionPadFor(avatarBox, optionsBox)
+  );
+};
+
+/**
+ * The near edge at the size the surface's layout is authored at.
+ *
+ * {@link companionNearEdgeFor} with both boxes at the base, which is what that
+ * helper comes to whenever the two sizes agree. A name of its own because it is
+ * the distance the whole layout is authored around, and because a helper that
+ * stopped reducing to it would be one that had quietly moved the avatar.
+ *
+ * Anything whose answer moves with either size calls the helper instead.
+ */
+export const COMPANION_NEAR_EDGE = companionNearEdgeFor(
+  COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_AVATAR_BOX,
+);
 
 /**
  * The assistant's character, as the three trait ids it is composed from.
@@ -1031,14 +1144,22 @@ export interface CompanionSurfaceState {
    */
   cardGrowth: CompanionCardGrowth;
   /**
-   * The avatar's box in points, which is the whole of the surface's scale.
+   * The avatar's box in points, which is the creature's whole scale.
    *
-   * One number rather than the named size, because the name is a lookup both
-   * sides would then have to hold the same copy of. Everything the surface
-   * draws derives from this, so the renderer scales itself by this over the
-   * size the layout is authored at. See {@link COMPANION_SIZE_BOXES}.
+   * Numbers rather than the named sizes, because a name is a lookup both sides
+   * would then have to hold the same copy of. See {@link COMPANION_SIZE_BOXES},
+   * and {@link COMPANION_SIZE_AXES} for why there are two of them.
    */
   avatarBox: number;
+  /**
+   * The pill's box in points, which is the scale of everything that is not the
+   * creature: the pill, the typing card, the call's body and the introduction.
+   *
+   * The renderer draws the surface at this over the size its layout is authored
+   * at and scales the creature inside that by the ratio between the two boxes,
+   * so every length beside the avatar stays stated once, at the base size.
+   */
+  optionsBox: number;
   /**
    * The assistant's display name, for the composer's placeholder.
    *

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -1157,8 +1157,11 @@ export interface CompanionSurfaceState {
    * The renderer draws the surface at this over the size its layout is authored
    * at and scales the creature inside that by the ratio between the two boxes,
    * so every length beside the avatar stays stated once, at the base size.
+   *
+   * Optional, and absence means a shell that predates the second axis, which
+   * the renderer reads as {@link CompanionSurfaceState.avatarBox}.
    */
-  optionsBox: number;
+  optionsBox?: number;
   /**
    * The assistant's display name, for the composer's placeholder.
    *

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -812,6 +812,39 @@ export const COMPANION_NEAR_EDGE =
   COMPANION_BASE_AVATAR_BOX / 2 + COMPANION_BASE_CANVAS_PAD;
 
 /**
+ * The room between the avatar's edge and the options pill beside it, at the
+ * base size.
+ *
+ * A gap rather than a shared edge. The avatar is a creature standing on the
+ * desktop and the pill is what it is holding out, so the two read as one
+ * surface by sitting near each other rather than by being fused into a single
+ * outline. It is also what gives the glow somewhere to fall off into, instead
+ * of ending against the pill's border.
+ */
+export const COMPANION_BASE_GAP = 12;
+
+/**
+ * That gap for a given pair of boxes.
+ *
+ * Scaled by the smaller of the two, because the gap is breathing room and the
+ * smaller object is the one that decides how much of it there is: a modest
+ * avatar beside an enormous pill wants the modest avatar's clearance, not the
+ * chasm the pill's own scale would ask for.
+ *
+ * Derived here rather than on each side of the bridge, for the reason
+ * {@link COMPANION_NEAR_EDGE} is: main sizes the canvas to hold the pill's
+ * reach past the avatar and the renderer positions the pill by the same
+ * distance, so two copies of this drifting is a pill drawn somewhere main did
+ * not leave room for.
+ */
+export const companionGapFor = (
+  avatarBox: number,
+  optionsBox: number,
+): number =>
+  (COMPANION_BASE_GAP * Math.min(avatarBox, optionsBox)) /
+  COMPANION_BASE_AVATAR_BOX;
+
+/**
  * The assistant's character, as the three trait ids it is composed from.
  *
  * Structurally the fields of the web layer's `CharacterTraits` that


### PR DESCRIPTION
## Summary
The macOS companion surface is restyled per the two mockups: the avatar floats free of the options pill (bottom-flush, with a gap, the avatar staying the fixed point main places the window by), the avatar and the options pill are sized independently over the same five steps from both the right-click menu and the tray, the glow takes the assistant's own palette colour (a live call's accent still overrides), and the avatar rides a slow one-directional bob. Geometry both processes agree on lives once in `@vellumai/ipc-contract`; renderer hit-testing is a union of avatar, pill, bridge-strip and intro rects, never a bounding box.

## Self-review result
GAPS FOUND in rounds 1 to 3, fixed across four fix PRs; round 4 PASS.

## PRs merged into feature branch
- #41540: feat(companion): glow in the avatar's own colour and a slow bob
- #41544: feat(companion): float the avatar beside the options pill
- #41552: feat(companion): size the avatar and the options pill independently

### Fix PRs
- #41559: pill width contract constant, size migration on explicit picks, geometry test cleanup
- #41560: intro clearance beside a taller pill, working ring pinned to the avatar, bridge bounded to the composer row, web cleanups
- #41561: left-growth alignment, shared hover hit-test, optional `optionsBox`, `packages/ipc-contract` in CI path filters
- #41562: drop the legacy size promotion (read-time fallback is the permanent path), storybook CI filter

## Device QA outstanding (not runnable from CI)
- Right-click menu: Avatar size / Options size submenus, radios per axis, Hide Companion
- Change each axis; the avatar's centre must not move; options-only change still resizes the canvas
- Existing install with only `companionSize` in `window-state.json` comes up at that size on both axes
- Sweep pointer avatar -> gap -> pill without collapse; desktop click just above/below the gap lands on the desktop
- Ridiculous avatar + Small options and the reverse near every screen edge (flip left, flip down)
- Glow on the yellow character over a light desktop; macOS Reduce Motion stops the bob and the glow breathe
- Box-vs-artwork baseline: the pill aligns to the avatar's box, not the artwork (inset by INNER_GAP); confirm against the mockup

Part of plan: companion-avatar-restyle.md