### PR TITLE
fix(assistant): rebuild stale parents after in-flight subagents finish

### DIFF
--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -154,7 +154,7 @@ describe("evictConversationsForReload", () => {
 
     const result = await getOrCreateConversation("stale-parent");
 
-    expect(result).toBe(parent);
+    expect(result as unknown).toBe(parent);
     expect(parent.disposed).toBe(false);
     expect(abortedParents).toEqual([]);
   });

--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -54,6 +54,8 @@ function register(
     isProcessing: () => state.processing,
     hasQueuedMessages: () => state.queued,
     isStale: () => state.stale === true || fake.markedStale,
+    hasInFlightWork: () =>
+      state.processing || state.queued || activeParents.has(id),
     dispose() {
       fake.disposed = true;
     },

--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -7,8 +7,9 @@
  * releasing and its queued successor being dispatched.
  *
  * In-flight subagents are the other non-idle case: an async spawn leaves the
- * parent idle between its own tool calls while children are still running, and
- * reload must not abort those children.
+ * parent idle between its own tool calls while children are still running.
+ * Reload marks that parent stale without aborting the children, then
+ * `getOrCreateConversation` rebuilds it once every child is terminal.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -32,7 +33,10 @@ import {
   findConversation,
   setConversation,
 } from "../daemon/conversation-registry.js";
-import { evictConversationsForReload } from "../daemon/conversation-store.js";
+import {
+  evictConversationsForReload,
+  getOrCreateConversation,
+} from "../daemon/conversation-store.js";
 
 interface FakeConversation {
   disposed: boolean;
@@ -41,7 +45,7 @@ interface FakeConversation {
 
 function register(
   id: string,
-  state: { processing: boolean; queued: boolean },
+  state: { processing: boolean; queued: boolean; stale?: boolean },
 ): FakeConversation {
   const fake: FakeConversation & Record<string, unknown> = {
     disposed: false,
@@ -49,6 +53,7 @@ function register(
     conversationId: id,
     isProcessing: () => state.processing,
     hasQueuedMessages: () => state.queued,
+    isStale: () => state.stale === true || fake.markedStale,
     dispose() {
       fake.disposed = true;
     },
@@ -103,7 +108,7 @@ describe("evictConversationsForReload", () => {
     expect(abortedParents).toEqual([]);
   });
 
-  test("skips an idle parent with in-flight subagents", () => {
+  test("marks an idle parent with in-flight subagents stale", () => {
     const parent = register("reload-with-children", {
       processing: false,
       queued: false,
@@ -113,7 +118,7 @@ describe("evictConversationsForReload", () => {
     evictConversationsForReload();
 
     expect(parent.disposed).toBe(false);
-    expect(parent.markedStale).toBe(false);
+    expect(parent.markedStale).toBe(true);
     expect(findConversation("reload-with-children")).toBeDefined();
     expect(abortedParents).toEqual([]);
   });
@@ -132,9 +137,42 @@ describe("evictConversationsForReload", () => {
     evictConversationsForReload();
 
     expect(protectedParent.disposed).toBe(false);
+    expect(protectedParent.markedStale).toBe(true);
     expect(findConversation("reload-protected")).toBeDefined();
     expect(idle.disposed).toBe(true);
     expect(findConversation("reload-unprotected")).toBeUndefined();
     expect(abortedParents).toEqual(["reload-unprotected"]);
+  });
+
+  test("defers stale rebuild while subagents are in flight", async () => {
+    const parent = register("stale-parent", {
+      processing: false,
+      queued: false,
+      stale: true,
+    });
+    activeParents.add("stale-parent");
+
+    const result = await getOrCreateConversation("stale-parent");
+
+    expect(result).toBe(parent);
+    expect(parent.disposed).toBe(false);
+    expect(abortedParents).toEqual([]);
+  });
+
+  test("rebuilds a stale parent once every child is terminal", async () => {
+    const parent = register("stale-parent", {
+      processing: false,
+      queued: false,
+      stale: true,
+    });
+
+    try {
+      await getOrCreateConversation("stale-parent");
+    } catch {
+      // Isolated test has no provider wiring; rebuild intent is abort + dispose.
+    }
+
+    expect(parent.disposed).toBe(true);
+    expect(abortedParents).toEqual(["stale-parent"]);
   });
 });

--- a/assistant/src/__tests__/helpers/mock-conversation.ts
+++ b/assistant/src/__tests__/helpers/mock-conversation.ts
@@ -36,6 +36,8 @@ export function asConversation<TExtra extends object = object>(
     getTrustContext: () => merged.trustContext,
     getTurnOrRestingTrust: () =>
       merged.currentTurnTrustContext ?? merged.trustContext,
+    isStale: () => false,
+    hasInFlightWork: () => false,
     ...mock,
   };
   return merged as unknown as Conversation & TExtra;

--- a/assistant/src/__tests__/subagent-fork-notifications.test.ts
+++ b/assistant/src/__tests__/subagent-fork-notifications.test.ts
@@ -13,6 +13,8 @@ const capturedNotifications: {
 
 mock.module("../daemon/conversation-registry.js", () => ({
   findConversation: (id: string) => ({
+    isStale: () => false,
+    hasInFlightWork: () => false,
     enqueueMessage: (options: { content: string }) => {
       capturedNotifications.push({
         parentConversationId: id,

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -13,6 +13,8 @@ const capturedNotifications: {
 
 mock.module("../daemon/conversation-registry.js", () => ({
   findConversation: (id: string) => ({
+    isStale: () => false,
+    hasInFlightWork: () => false,
     enqueueMessage: (options: { content: string }) => {
       capturedNotifications.push({
         parentConversationId: id,

--- a/assistant/src/__tests__/subagent-notify-parent.test.ts
+++ b/assistant/src/__tests__/subagent-notify-parent.test.ts
@@ -56,6 +56,8 @@ mock.module("../daemon/conversation-registry.js", () => ({
   findConversation: (id: string) => {
     capturedParentIds.push(id);
     return {
+      isStale: () => false,
+      hasInFlightWork: () => false,
       enqueueMessage: (options: { content: string }) => {
         capturedMessages.push(options.content);
         return { queued: true };

--- a/assistant/src/__tests__/subagent-notify-stale-rebuild.test.ts
+++ b/assistant/src/__tests__/subagent-notify-stale-rebuild.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Terminal (and other) parent injections rebuild a stale idle parent before
+ * the notification turn, so a reload or credential rotation is visible to
+ * that turn. A parent that still has in-flight work keeps its current
+ * instance so children are not aborted.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const parentState = { stale: false, inFlight: false };
+const rebuilt: string[] = [];
+const delivered: string[] = [];
+
+mock.module("../daemon/conversation-registry.js", () => ({
+  findConversation: (id: string) => {
+    if (id === "missing-parent") {
+      return undefined;
+    }
+    return {
+      isStale: () => parentState.stale,
+      hasInFlightWork: () => parentState.inFlight,
+      enqueueMessage: (options: { content: string }) => {
+        delivered.push(options.content);
+        return { queued: true };
+      },
+      persistUserMessage: async () => ({ id: "mock-msg" }),
+      runAgentLoop: async () => {},
+    };
+  },
+}));
+
+mock.module("../daemon/conversation-store.js", () => ({
+  getOrCreateConversation: async (id: string) => {
+    rebuilt.push(id);
+    return {
+      enqueueMessage: (options: { content: string }) => {
+        delivered.push(`rebuilt:${options.content}`);
+        return { queued: true };
+      },
+      persistUserMessage: async () => ({ id: "rebuilt-msg" }),
+      runAgentLoop: async () => {},
+    };
+  },
+}));
+
+import { injectMessageIntoParent } from "../subagent/notify.js";
+
+describe("injectMessageIntoParent stale rebuild", () => {
+  beforeEach(() => {
+    parentState.stale = false;
+    parentState.inFlight = false;
+    rebuilt.length = 0;
+    delivered.length = 0;
+  });
+
+  test("delivers on the live instance when the parent is not stale", () => {
+    injectMessageIntoParent("parent-1", "child done");
+
+    expect(rebuilt).toEqual([]);
+    expect(delivered).toEqual(["child done"]);
+  });
+
+  test("keeps the live instance while the parent still has in-flight work", () => {
+    parentState.stale = true;
+    parentState.inFlight = true;
+
+    injectMessageIntoParent("parent-1", "child still running");
+
+    expect(rebuilt).toEqual([]);
+    expect(delivered).toEqual(["child still running"]);
+  });
+
+  test("rebuilds a stale idle parent before the notification turn", async () => {
+    parentState.stale = true;
+    parentState.inFlight = false;
+
+    injectMessageIntoParent("parent-1", "child done");
+    const start = Date.now();
+    while (delivered.length === 0 && Date.now() - start < 1000) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(rebuilt).toEqual(["parent-1"]);
+    expect(delivered).toEqual(["rebuilt:child done"]);
+  });
+});

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -147,24 +147,6 @@ function applyTransportMetadata(
 }
 
 /**
- * True when dropping this in-memory instance would lose work that is still
- * in flight: a live turn, a queued successor, or a child subagent.
- */
-function hasInFlightWork(
-  conversation: {
-    isProcessing(): boolean;
-    hasQueuedMessages(): boolean;
-  },
-  conversationId: string,
-): boolean {
-  return (
-    conversation.isProcessing() ||
-    conversation.hasQueuedMessages() ||
-    getSubagentManager().hasActiveChildren(conversationId)
-  );
-}
-
-/**
  * Get or create an active conversation by ID.
  *
  * Handles provider setup, rate limiting, system prompt, memory policy,
@@ -208,7 +190,7 @@ export async function getOrCreateConversation(
   // conversation stays stale and is rebuilt on a later call.
   if (
     !conversation ||
-    (conversation.isStale() && !hasInFlightWork(conversation, conversationId))
+    (conversation.isStale() && !conversation.hasInFlightWork())
   ) {
     if (conversation) {
       // Stale rebuild: the conversation id lives on, so abort any children
@@ -427,7 +409,7 @@ export function clearAllActiveConversations(): number {
 export function evictConversationsForReload(): void {
   const subagentManager = getSubagentManager();
   for (const [id, conversation] of conversationEntries()) {
-    if (hasInFlightWork(conversation, id)) {
+    if (conversation.hasInFlightWork()) {
       conversation.markStale();
       continue;
     }

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -147,6 +147,24 @@ function applyTransportMetadata(
 }
 
 /**
+ * True when dropping this in-memory instance would lose work that is still
+ * in flight: a live turn, a queued successor, or a child subagent.
+ */
+function hasInFlightWork(
+  conversation: {
+    isProcessing(): boolean;
+    hasQueuedMessages(): boolean;
+  },
+  conversationId: string,
+): boolean {
+  return (
+    conversation.isProcessing() ||
+    conversation.hasQueuedMessages() ||
+    getSubagentManager().hasActiveChildren(conversationId)
+  );
+}
+
+/**
  * Get or create an active conversation by ID.
  *
  * Handles provider setup, rate limiting, system prompt, memory policy,
@@ -184,18 +202,18 @@ export async function getOrCreateConversation(
   // messages live in memory on the instance being disposed, and the queue
   // drains via an async dispatch after the current turn releases, so
   // `isProcessing()` can read false while a queued turn is still pending:
-  // rebuilding in that gap would silently drop those messages. The conversation
-  // stays stale and is rebuilt on a later call.
+  // rebuilding in that gap would silently drop those messages. In-flight
+  // subagents are the same: the parent reads idle between its own tool calls
+  // while children still run, and rebuilding would abort them. The
+  // conversation stays stale and is rebuilt on a later call.
   if (
     !conversation ||
-    (conversation.isStale() &&
-      !conversation.isProcessing() &&
-      !conversation.hasQueuedMessages())
+    (conversation.isStale() && !hasInFlightWork(conversation, conversationId))
   ) {
     if (conversation) {
-      // Stale rebuild: the conversation id lives on, so abort in-flight
-      // children but keep terminal subagent results readable for the
-      // retention window.
+      // Stale rebuild: the conversation id lives on, so abort any children
+      // that raced into flight after the idle check and keep terminal
+      // subagent results readable for the retention window.
       getSubagentManager().abortAllForParent(conversationId);
       conversation.dispose();
     }
@@ -400,32 +418,22 @@ export function clearAllActiveConversations(): number {
 
 /**
  * Evict in-memory conversations after a config/prompt/skills reload so the next
- * turn rebuilds them against the new config. Idle conversations are disposed and
- * dropped; busy ones are marked stale so they're rebuilt once their current turn
- * finishes. Conversations with in-flight subagents are left in place so a
- * reload does not abort those children. Also used when provider credentials
+ * turn rebuilds them against the new config. Conversations with in-flight work
+ * (a live turn, a queued successor, or an active subagent) are marked stale
+ * and rebuilt by `getOrCreateConversation` once that work finishes. Idle
+ * conversations are disposed and dropped. Also used when provider credentials
  * change.
  */
 export function evictConversationsForReload(): void {
   const subagentManager = getSubagentManager();
   for (const [id, conversation] of conversationEntries()) {
-    // A conversation with queued messages is not idle: the queue drains via an
-    // async dispatch after the current turn releases, so `isProcessing()` can
-    // read false while a queued turn is still pending. Disposing in that gap
-    // would silently drop the queued messages, so mark it stale instead and
-    // let it rebuild once the queue has run.
-    if (!conversation.isProcessing() && !conversation.hasQueuedMessages()) {
-      // Same protection the TTL/LRU evictor applies: an idle parent still
-      // owns mid-task children, and aborting them here would kill that work.
-      if (subagentManager.hasActiveChildren(id)) {
-        continue;
-      }
-      subagentManager.abortAllForParent(id);
-      conversation.dispose();
-      deleteConversation(id);
-      removeFromEvictor(id);
-    } else {
+    if (hasInFlightWork(conversation, id)) {
       conversation.markStale();
+      continue;
     }
+    subagentManager.abortAllForParent(id);
+    conversation.dispose();
+    deleteConversation(id);
+    removeFromEvictor(id);
   }
 }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1878,6 +1878,18 @@ export class Conversation {
     return !this.queue.isEmpty;
   }
 
+  /**
+   * True when dropping this instance would lose work that is still in flight:
+   * a live turn, a queued successor, or a child subagent.
+   */
+  hasInFlightWork(): boolean {
+    return (
+      this.isProcessing() ||
+      this.hasQueuedMessages() ||
+      getSubagentManager().hasActiveChildren(this.conversationId)
+    );
+  }
+
   /** FIFO snapshot of the messages currently waiting in the in-memory queue.
    * Read-only — used to surface queued user messages in history responses. */
   snapshotQueuedMessages(): QueuedMessage[] {

--- a/assistant/src/subagent/notify.ts
+++ b/assistant/src/subagent/notify.ts
@@ -9,7 +9,9 @@
  * pulling in the conversation/agent-loop core.
  *
  * Delivery targets the parent's in-process `Conversation` via the conversation
- * registry: a notification is injected only when the parent is live here.
+ * registry: a notification is injected only when the parent is live here. A
+ * stale idle parent is rebuilt through `getOrCreateConversation` first so the
+ * injected turn uses the current provider, prompt, and credentials.
  */
 
 import {
@@ -36,14 +38,58 @@ export function injectMessageIntoParent(
   message: string,
   metadata?: Record<string, unknown>,
 ): void {
-  const parentConversation = findConversation(parentConversationId);
-  if (!parentConversation) {
+  const existing = findConversation(parentConversationId);
+  if (!existing) {
     log.warn(
       { parentConversationId },
       "Subagent notification target parent conversation not found",
     );
     return;
   }
+  // A reload can mark the parent stale while children still run. Terminal
+  // injection is the first parent turn after the last child settles, so
+  // rebuild first when the instance is idle. Otherwise the completion turn
+  // would run on the construction-time provider, prompt, and credentials.
+  if (existing.isStale() && !existing.hasInFlightWork()) {
+    void import("../daemon/conversation-store.js")
+      .then(({ getOrCreateConversation }) =>
+        getOrCreateConversation(parentConversationId),
+      )
+      .then((parent) =>
+        deliverToParent(parent, parentConversationId, message, metadata),
+      )
+      .catch((err) => {
+        log.error(
+          { parentConversationId, err },
+          "Failed to rebuild stale parent before subagent notification",
+        );
+      });
+    return;
+  }
+  deliverToParent(existing, parentConversationId, message, metadata);
+}
+
+function deliverToParent(
+  parentConversation: {
+    enqueueMessage: (options: {
+      content: string;
+      metadata?: Record<string, unknown>;
+      isInteractive: boolean;
+    }) => { queued: boolean; rejected?: boolean };
+    persistUserMessage: (options: {
+      content: string;
+      metadata?: Record<string, unknown>;
+    }) => Promise<{ id: string }>;
+    runAgentLoop: (
+      message: string,
+      messageId: string,
+      options: { isInteractive: boolean },
+    ) => Promise<unknown>;
+  },
+  parentConversationId: string,
+  message: string,
+  metadata?: Record<string, unknown>,
+): void {
   // Machine-injected with no human asserted present, so the notification
   // turn runs non-interactive; it still streams to whoever is watching
   // through the parent's sink.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Follow-up to #41523 (merged). Codex asked that protected reload parents be scheduled for a later rebuild. Review asked to move the in-flight check onto `Conversation` and to rebuild the parent before a terminal subagent notification, since that path used `findConversation` and skipped `getOrCreateConversation`.

## Summary
- `Conversation.hasInFlightWork()` owns the processing / queued / active-child check. `isStale()` stays separate (rebuild flag vs in-flight work).
- Reload eviction marks in-flight conversations stale. `getOrCreateConversation` rebuilds when `isStale() && !hasInFlightWork()`.
- `injectMessageIntoParent` rebuilds a stale idle parent before the notification turn so completion uses the current provider, prompt, and credentials.
- Conversation test doubles from `asConversation` default `isStale()` / `hasInFlightWork()` so fire-and-forget spawn notify still enqueues.

## Test plan
- [x] `cd assistant && bun test src/__tests__/evict-conversations-for-reload.test.ts`
- [x] `cd assistant && bun test src/__tests__/subagent-notify-stale-rebuild.test.ts`
- [x] `cd assistant && bun test src/__tests__/subagent-notify-parent.test.ts`
- [x] `cd assistant && bun test src/__tests__/subagent-manager-notify.test.ts`
- [x] `cd assistant && bun test src/__tests__/subagent-spawn-and-await.test.ts`
- [x] `cd assistant && bunx tsc --noEmit`

## Risk
- Low. Idle parents without children still evict immediately.
- A stale parent with in-flight children keeps its current instance until the last child settles. The completion notify then rebuilds before running the parent turn.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be32a5d6-8bfa-4f51-932e-d5656a0f7c29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be32a5d6-8bfa-4f51-932e-d5656a0f7c29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

