### PR TITLE
feat(inference): add developer-mode Qwen3 8B hosted model

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15038,7 +15038,7 @@ paths:
             type: string
           description:
             "Filter by provider id. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, litellm, opencode, openai-compatible, minimax, atlascloud, baseten, poolside, hosted"
+            vercel-ai-gateway, litellm, opencode, openai-compatible, minimax, atlascloud, baseten, poolside, vellum"
       responses:
         "200":
           description: Successful response
@@ -15310,8 +15310,8 @@ paths:
             type: string
           description:
             "Filter by provider. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, litellm, opencode, openai-compatible, minimax, atlascloud, baseten, poolside, hosted,
-            vellum, chatgpt"
+            vercel-ai-gateway, litellm, opencode, openai-compatible, minimax, atlascloud, baseten, poolside, vellum,
+            chatgpt"
       responses:
         "200":
           description: Successful response
@@ -35299,7 +35299,6 @@ components:
         - atlascloud
         - baseten
         - poolside
-        - hosted
         - vellum
         - chatgpt
     Auth:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15038,7 +15038,7 @@ paths:
             type: string
           description:
             "Filter by provider id. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, litellm, opencode, openai-compatible, minimax, atlascloud, baseten, poolside"
+            vercel-ai-gateway, litellm, opencode, openai-compatible, minimax, atlascloud, baseten, poolside, hosted"
       responses:
         "200":
           description: Successful response
@@ -15310,8 +15310,8 @@ paths:
             type: string
           description:
             "Filter by provider. One of: anthropic, openai, gemini, ollama, fireworks, together, openrouter,
-            vercel-ai-gateway, litellm, opencode, openai-compatible, minimax, atlascloud, baseten, poolside, vellum,
-            chatgpt"
+            vercel-ai-gateway, litellm, opencode, openai-compatible, minimax, atlascloud, baseten, poolside, hosted,
+            vellum, chatgpt"
       responses:
         "200":
           description: Successful response
@@ -35299,6 +35299,7 @@ components:
         - atlascloud
         - baseten
         - poolside
+        - hosted
         - vellum
         - chatgpt
     Auth:

--- a/assistant/scripts/sync-llm-catalog.ts
+++ b/assistant/scripts/sync-llm-catalog.ts
@@ -86,6 +86,9 @@ function projectModel(model: CatalogModel): Record<string, unknown> {
   if (model.pricing !== undefined) {
     projected.pricing = model.pricing;
   }
+  if (model.featureFlag !== undefined) {
+    projected.featureFlag = model.featureFlag;
+  }
   return projected;
 }
 
@@ -114,6 +117,9 @@ function projectProvider(entry: ProviderCatalogEntry): Record<string, unknown> {
   }
   if (entry.supportsPlatformAuth !== undefined) {
     projected.supportsPlatformAuth = entry.supportsPlatformAuth;
+  }
+  if (entry.featureFlag !== undefined) {
+    projected.featureFlag = entry.featureFlag;
   }
   projected.defaultModel = entry.defaultModel;
   projected.models = entry.models.map(projectModel);

--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -67,6 +67,7 @@ interface ClientCatalogModel {
       cacheWritePer1mTokens?: number;
     }>;
   };
+  featureFlag?: string;
 }
 
 interface ClientCatalogEntry {
@@ -79,6 +80,7 @@ interface ClientCatalogEntry {
   apiKeyPlaceholder?: string;
   credentialsGuide?: ClientCatalogCredentialsGuide;
   supportsPlatformAuth?: boolean;
+  featureFlag?: string;
   defaultModel: string;
   models: ClientCatalogModel[];
 }
@@ -133,6 +135,7 @@ describe("LLM catalog parity: daemon vs client", () => {
       expect(clientEntry.supportsPlatformAuth).toBe(
         daemonEntry.supportsPlatformAuth,
       );
+      expect(clientEntry.featureFlag).toBe(daemonEntry.featureFlag);
       expect(clientEntry.credentialsGuide).toEqual(
         daemonEntry.credentialsGuide,
       );
@@ -199,6 +202,7 @@ describe("LLM catalog parity: daemon vs client", () => {
         expect(clientModel.supportsVision).toBe(daemonModel.supportsVision);
         expect(clientModel.supportsToolUse).toBe(daemonModel.supportsToolUse);
         expect(clientModel.pricing).toEqual(daemonModel.pricing);
+        expect(clientModel.featureFlag).toBe(daemonModel.featureFlag);
       }
     }
   });

--- a/assistant/src/__tests__/provider-catalog-visibility.test.ts
+++ b/assistant/src/__tests__/provider-catalog-visibility.test.ts
@@ -19,6 +19,23 @@ function makeConfig(): AssistantConfig {
 }
 
 describe("getVisibleProviderCatalog", () => {
+  test("hides the hosted catalog unless developer mode is on", () => {
+    setOverridesForTesting({});
+    const hidden = getVisibleProviderCatalog(makeConfig());
+    expect(hidden.find((p) => p.id === "hosted")).toBeUndefined();
+    expect(
+      hidden
+        .flatMap((p) => p.models)
+        .some((m) => m.id === "qwen/qwen3-8b"),
+    ).toBe(false);
+
+    setOverridesForTesting({ "settings-developer-nav": true });
+    const visible = getVisibleProviderCatalog(makeConfig());
+    const hosted = visible.find((p) => p.id === "hosted");
+    expect(hosted).toBeDefined();
+    expect(hosted!.models.map((m) => m.id)).toEqual(["qwen/qwen3-8b"]);
+  });
+
   test("shows openai-compatible endpoints unconditionally (GA'ed)", () => {
     setOverridesForTesting({});
 

--- a/assistant/src/__tests__/provider-catalog-visibility.test.ts
+++ b/assistant/src/__tests__/provider-catalog-visibility.test.ts
@@ -19,10 +19,10 @@ function makeConfig(): AssistantConfig {
 }
 
 describe("getVisibleProviderCatalog", () => {
-  test("hides the hosted catalog unless developer mode is on", () => {
+  test("hides Vellum-hosted GPU models unless developer mode is on", () => {
     setOverridesForTesting({});
     const hidden = getVisibleProviderCatalog(makeConfig());
-    expect(hidden.find((p) => p.id === "hosted")).toBeUndefined();
+    expect(hidden.find((p) => p.id === "vellum")).toBeUndefined();
     expect(
       hidden
         .flatMap((p) => p.models)
@@ -31,9 +31,9 @@ describe("getVisibleProviderCatalog", () => {
 
     setOverridesForTesting({ "settings-developer-nav": true });
     const visible = getVisibleProviderCatalog(makeConfig());
-    const hosted = visible.find((p) => p.id === "hosted");
-    expect(hosted).toBeDefined();
-    expect(hosted!.models.map((m) => m.id)).toEqual(["qwen/qwen3-8b"]);
+    const vellum = visible.find((p) => p.id === "vellum");
+    expect(vellum).toBeDefined();
+    expect(vellum!.models.map((m) => m.id)).toEqual(["qwen/qwen3-8b"]);
   });
 
   test("shows openai-compatible endpoints unconditionally (GA'ed)", () => {

--- a/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
@@ -665,13 +665,14 @@ describe("config mode flip → provider reinit", () => {
 });
 
 describe("managed proxy integration — constants integrity", () => {
-  test("anthropic, openai, gemini, fireworks, and together have metadata with managed=true and a proxyPath", () => {
+  test("anthropic, openai, gemini, fireworks, together, and hosted have metadata with managed=true and a proxyPath", () => {
     for (const provider of [
       "anthropic",
       "openai",
       "gemini",
       "fireworks",
       "together",
+      "hosted",
     ]) {
       const meta = PLATFORM_PROVIDER_META[provider];
       expect(meta).toBeDefined();
@@ -708,6 +709,12 @@ describe("managed proxy integration — constants integrity", () => {
   test("together routes through together proxy path", () => {
     expect(PLATFORM_PROVIDER_META.together.proxyPath).toBe(
       "/v1/runtime-proxy/together",
+    );
+  });
+
+  test("hosted routes through the vellum runtime-proxy path", () => {
+    expect(PLATFORM_PROVIDER_META.hosted.proxyPath).toBe(
+      "/v1/runtime-proxy/vellum",
     );
   });
 

--- a/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
+++ b/assistant/src/__tests__/provider-platform-proxy-integration.test.ts
@@ -665,14 +665,14 @@ describe("config mode flip → provider reinit", () => {
 });
 
 describe("managed proxy integration — constants integrity", () => {
-  test("anthropic, openai, gemini, fireworks, together, and hosted have metadata with managed=true and a proxyPath", () => {
+  test("anthropic, openai, gemini, fireworks, together, and vellum have metadata with managed=true and a proxyPath", () => {
     for (const provider of [
       "anthropic",
       "openai",
       "gemini",
       "fireworks",
       "together",
-      "hosted",
+      "vellum",
     ]) {
       const meta = PLATFORM_PROVIDER_META[provider];
       expect(meta).toBeDefined();
@@ -712,8 +712,8 @@ describe("managed proxy integration — constants integrity", () => {
     );
   });
 
-  test("hosted routes through the vellum runtime-proxy path", () => {
-    expect(PLATFORM_PROVIDER_META.hosted.proxyPath).toBe(
+  test("vellum routes through the vellum runtime-proxy path", () => {
+    expect(PLATFORM_PROVIDER_META.vellum.proxyPath).toBe(
       "/v1/runtime-proxy/vellum",
     );
   });

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -58,10 +58,10 @@ export const KNOWN_LLM_PROVIDERS = [
   "opencode",
   "baseten",
   "poolside",
-  // Routing identities rather than adapters: "vellum" = the platform-managed
-  // route (upstream derived from the model at dispatch), "chatgpt" = the
-  // subscription route to OpenAI. Neither has a PROVIDER_CATALOG entry;
-  // dispatch substitutes the real upstream before any adapter lookup.
+  // Routing identities: "vellum" = the platform-managed route (upstream
+  // derived from the model at dispatch) and the catalog owner of
+  // Vellum-hosted GPU models; "chatgpt" = the subscription route to OpenAI.
+  // Dispatch substitutes a concrete upstream before adapter lookup.
   "vellum",
   "chatgpt",
 ] as const;

--- a/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
+++ b/assistant/src/providers/__tests__/provider-secret-catalog.test.ts
@@ -38,6 +38,7 @@ describe("API_KEY_PROVIDERS", () => {
     expect(API_KEY_PROVIDERS).toContain("anthropic");
     expect(API_KEY_PROVIDERS).toContain("openai");
     expect(API_KEY_PROVIDERS).toContain("gemini");
+    expect(API_KEY_PROVIDERS).not.toContain("vellum");
   });
 
   test("includes search providers", () => {

--- a/assistant/src/providers/__tests__/vellum-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-connection-routing.test.ts
@@ -52,9 +52,10 @@ describe("vellum connection routing", () => {
     expect(isVellumManagedConnection({ provider: "vellum" })).toBe(true);
   });
 
-  test("the vellum sentinel is not a real provider without an override", () => {
-    // No `provider` override → effective provider is the `vellum` sentinel,
-    // which has no catalog entry / adapter → null.
+  test("the vellum sentinel does not dispatch without an override", () => {
+    // No `provider` override → the connection column is the routing
+    // sentinel and must not build an adapter, even though Vellum-hosted
+    // GPU models share this catalog id.
     const adapter = createAdapterFromConnection(
       vellumConnection,
       resolvedAuth,
@@ -75,6 +76,23 @@ describe("vellum connection routing", () => {
       },
     );
     expect(adapter).not.toBeNull();
+  });
+
+  test("provider override vellum routes GPU models through VellumProvider", () => {
+    const adapter = createAdapterFromConnection(
+      vellumConnection,
+      {
+        kind: "header",
+        headers: { Authorization: "Bearer test-key" },
+        baseUrl: "https://platform.example/v1/runtime-proxy/vellum",
+      },
+      {
+        model: "qwen/qwen3-8b",
+        provider: "vellum",
+      },
+    );
+    expect(adapter).not.toBeNull();
+    expect(adapter?.name).toBe("vellum");
   });
 });
 

--- a/assistant/src/providers/hosted/client.ts
+++ b/assistant/src/providers/hosted/client.ts
@@ -21,7 +21,6 @@ export class HostedProvider extends OpenAIChatCompletionsProvider {
       providerName: "hosted",
       providerLabel: "Vellum Hosted",
       streamTimeoutMs: options.streamTimeoutMs,
-      backfillEmptyAssistantContent: true,
       omitToolChoiceWhenReasoning: true,
       ...(options.baseURL ? { baseURL: options.baseURL } : {}),
     });

--- a/assistant/src/providers/hosted/client.ts
+++ b/assistant/src/providers/hosted/client.ts
@@ -1,0 +1,29 @@
+import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
+
+export interface HostedProviderOptions {
+  apiKey?: string;
+  baseURL?: string;
+  streamTimeoutMs?: number;
+}
+
+/**
+ * OpenAI-compatible client for Vellum-hosted GPU inference (vLLM).
+ * Managed requests set `baseURL` to the platform `/v1/runtime-proxy/vellum`
+ * path; the platform forwards to the online node's vLLM server.
+ */
+export class HostedProvider extends OpenAIChatCompletionsProvider {
+  constructor(
+    apiKey: string,
+    model: string,
+    options: HostedProviderOptions = {},
+  ) {
+    super(apiKey || "not-needed", model, {
+      providerName: "hosted",
+      providerLabel: "Vellum Hosted",
+      streamTimeoutMs: options.streamTimeoutMs,
+      backfillEmptyAssistantContent: true,
+      omitToolChoiceWhenReasoning: true,
+      ...(options.baseURL ? { baseURL: options.baseURL } : {}),
+    });
+  }
+}

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -35,7 +35,6 @@ import { AtlasCloudProvider } from "../atlascloud/client.js";
 import { BasetenProvider } from "../baseten/client.js";
 import { FireworksProvider } from "../fireworks/client.js";
 import { GeminiProvider } from "../gemini/client.js";
-import { HostedProvider } from "../hosted/client.js";
 import { MinimaxProvider } from "../minimax/client.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { OllamaProvider } from "../ollama/client.js";
@@ -55,6 +54,7 @@ import {
   MANAGED_ROUTABLE_PROVIDERS,
   VELLUM_MANAGED_PROVIDER,
 } from "../vellum-model-routing.js";
+import { VellumProvider } from "../vellum/client.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
 import type { ResolvedAuth } from "./auth.js";
 import type { ProviderConnection } from "./auth.js";
@@ -205,8 +205,8 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
       streamTimeoutMs,
       ...(baseURL ? { baseURL } : {}),
     }),
-  hosted: ({ apiKey, model, streamTimeoutMs, baseURL }) =>
-    new HostedProvider(apiKey, model, {
+  vellum: ({ apiKey, model, streamTimeoutMs, baseURL }) =>
+    new VellumProvider(apiKey, model, {
       streamTimeoutMs,
       ...(baseURL ? { baseURL } : {}),
     }),
@@ -557,6 +557,15 @@ function buildConnectionAdapter(
   },
 ): Provider | null {
   const provider = opts.provider ?? connection.provider;
+  // The connection's own `vellum` column is a routing sentinel. Dispatch
+  // only when the caller names an upstream, including Vellum-hosted GPU
+  // models whose catalog id is also `vellum`.
+  if (
+    connection.provider === VELLUM_MANAGED_PROVIDER &&
+    opts.provider === undefined
+  ) {
+    return null;
+  }
   const entry = PROVIDER_CATALOG.find((e) => e.id === provider);
   if (!entry) {
     return null;

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -35,6 +35,7 @@ import { AtlasCloudProvider } from "../atlascloud/client.js";
 import { BasetenProvider } from "../baseten/client.js";
 import { FireworksProvider } from "../fireworks/client.js";
 import { GeminiProvider } from "../gemini/client.js";
+import { HostedProvider } from "../hosted/client.js";
 import { MinimaxProvider } from "../minimax/client.js";
 import { PROVIDER_CATALOG } from "../model-catalog.js";
 import { OllamaProvider } from "../ollama/client.js";
@@ -201,6 +202,11 @@ const ADAPTER_FACTORIES: Record<string, AdapterFactory> = {
     }),
   poolside: ({ apiKey, model, streamTimeoutMs, baseURL }) =>
     new PoolsideProvider(apiKey, model, {
+      streamTimeoutMs,
+      ...(baseURL ? { baseURL } : {}),
+    }),
+  hosted: ({ apiKey, model, streamTimeoutMs, baseURL }) =>
+    new HostedProvider(apiKey, model, {
       streamTimeoutMs,
       ...(baseURL ? { baseURL } : {}),
     }),

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -48,13 +48,13 @@ import { RetryProvider } from "../retry.js";
 import { TogetherProvider } from "../together/client.js";
 import type { Provider, SendMessageOptions } from "../types.js";
 import { UsageTrackingProvider } from "../usage-tracking.js";
+import { VellumProvider } from "../vellum/client.js";
 import {
   getManagedUpstream,
   isVellumManagedConnection,
   MANAGED_ROUTABLE_PROVIDERS,
   VELLUM_MANAGED_PROVIDER,
 } from "../vellum-model-routing.js";
-import { VellumProvider } from "../vellum/client.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
 import type { ResolvedAuth } from "./auth.js";
 import type { ProviderConnection } from "./auth.js";

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -118,20 +118,20 @@ export type ResolvedAuth =
 // providers at runtime.
 
 export const VALID_CONNECTION_PROVIDERS: readonly string[] = [
-  ...PROVIDER_CATALOG.map((p) => p.id),
-  // The provider-agnostic Vellum-managed connection stores this sentinel in its
-  // `provider` column. It is intentionally not a PROVIDER_CATALOG entry (it
-  // names no single upstream), so it must be allowlisted explicitly or the DB
-  // loaders (getConnection/listConnections) and the create route would reject
-  // persisted `vellum` rows — the routing threaded in via `providerOverride`
-  // never runs on a row that fails to load.
-  VELLUM_MANAGED_PROVIDER,
-  // The ChatGPT-subscription row stores the "chatgpt" routing identity in its
-  // `provider` column for the same reason: the row IS the subscription route
-  // (auth modality = provider identity), and dispatch derives the openai
-  // upstream per-request. Allowlisted explicitly or the DB loaders would drop
-  // the persisted row.
-  "chatgpt",
+  ...new Set([
+    ...PROVIDER_CATALOG.map((p) => p.id),
+    // The provider-agnostic Vellum-managed connection stores this sentinel in
+    // its `provider` column. The same id owns Vellum-hosted GPU models in the
+    // catalog. Keep it allowlisted explicitly so a future catalog rename
+    // cannot drop persisted `vellum` rows from the DB loaders.
+    VELLUM_MANAGED_PROVIDER,
+    // The ChatGPT-subscription row stores the "chatgpt" routing identity in
+    // its `provider` column: the row IS the subscription route (auth
+    // modality = provider identity), and dispatch derives the openai
+    // upstream per-request. Allowlisted explicitly or the DB loaders would
+    // drop the persisted row.
+    "chatgpt",
+  ]),
 ];
 
 export type ConnectionProvider = string;

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -2216,13 +2216,13 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     apiKeyPlaceholder: "Your Poolside API key",
   },
   {
-    id: "hosted",
-    displayName: "Vellum Hosted",
+    id: "vellum",
+    displayName: "Vellum",
     subtitle:
       "Models served on Vellum GPU nodes through the managed connection.",
-    setupMode: "keyless",
+    setupMode: "api-key",
     setupHint:
-      "Available on the Vellum managed connection when developer mode is on.",
+      "Uses the assistant API key through the Vellum managed connection. These models cannot use a bring-your-own key.",
     featureFlag: "settings-developer-nav",
     models: [
       {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -2215,6 +2215,31 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     apiKeyUrl: "https://poolside.ai",
     apiKeyPlaceholder: "Your Poolside API key",
   },
+  {
+    id: "hosted",
+    displayName: "Vellum Hosted",
+    subtitle:
+      "Models served on Vellum GPU nodes through the managed connection.",
+    setupMode: "keyless",
+    setupHint:
+      "Available on the Vellum managed connection when developer mode is on.",
+    featureFlag: "settings-developer-nav",
+    models: [
+      {
+        id: "qwen/qwen3-8b",
+        displayName: "Qwen3 8B",
+        contextWindowTokens: 32768,
+        maxOutputTokens: 32768,
+        supportsThinking: false,
+        supportsCaching: false,
+        supportsVision: false,
+        supportsToolUse: true,
+        pricing: { inputPer1mTokens: 0.3, outputPer1mTokens: 0.3 },
+        featureFlag: "settings-developer-nav",
+      },
+    ],
+    defaultModel: "qwen/qwen3-8b",
+  },
 ];
 
 export const PROVIDER_CATALOG: ProviderCatalogEntry[] =

--- a/assistant/src/providers/platform-proxy/constants.ts
+++ b/assistant/src/providers/platform-proxy/constants.ts
@@ -51,6 +51,11 @@ export const PLATFORM_PROVIDER_META: Record<string, ManagedProviderMeta> = {
     managed: true,
     proxyPath: "/v1/runtime-proxy/together",
   },
+  hosted: {
+    name: "hosted",
+    managed: true,
+    proxyPath: "/v1/runtime-proxy/vellum",
+  },
   poolside: {
     name: "poolside",
     managed: false,

--- a/assistant/src/providers/platform-proxy/constants.ts
+++ b/assistant/src/providers/platform-proxy/constants.ts
@@ -51,8 +51,8 @@ export const PLATFORM_PROVIDER_META: Record<string, ManagedProviderMeta> = {
     managed: true,
     proxyPath: "/v1/runtime-proxy/together",
   },
-  hosted: {
-    name: "hosted",
+  vellum: {
+    name: "vellum",
     managed: true,
     proxyPath: "/v1/runtime-proxy/vellum",
   },

--- a/assistant/src/providers/provider-secret-catalog.ts
+++ b/assistant/src/providers/provider-secret-catalog.ts
@@ -39,14 +39,15 @@ import { listCredentialProviderNames as listSttCredentialProviderNames } from ".
  * `ollama` is intentionally included here even though it is `setupMode:
  * "keyless"` — the keyless mode is enforced elsewhere; this list is purely
  * about the set of bare-name credential-store keys accepted by
- * `assistant keys ...`.
+ * `assistant keys ...`. `vellum` is excluded: those models authenticate
+ * with the assistant API key on the managed connection, not a user key.
  *
  * Search providers (`brave`, `perplexity`, `tavily`) have no catalog module
  * yet and remain statically declared below.
  */
 const LLM_API_KEY_PROVIDERS: readonly string[] = PROVIDER_CATALOG.map(
   (p) => p.id,
-);
+).filter((id) => id !== "vellum");
 
 /**
  * Search API providers, derived from `SEARCH_PROVIDER_CATALOG`. Managed

--- a/assistant/src/providers/vellum-model-routing.test.ts
+++ b/assistant/src/providers/vellum-model-routing.test.ts
@@ -71,9 +71,9 @@ describe("vellum-model-routing", () => {
       "anthropic",
       "fireworks",
       "gemini",
-      "vellum",
       "openai",
       "together",
+      "vellum",
     ]);
   });
 });

--- a/assistant/src/providers/vellum-model-routing.test.ts
+++ b/assistant/src/providers/vellum-model-routing.test.ts
@@ -41,6 +41,7 @@ describe("vellum-model-routing", () => {
 
   test("getManagedUpstream resolves a bare catalog id to its owner", () => {
     expect(getManagedUpstream("claude-fable-5")).toBe("anthropic");
+    expect(getManagedUpstream("qwen/qwen3-8b")).toBe("hosted");
   });
 
   test("getManagedUpstream resolves a routing string by its prefix", () => {
@@ -70,6 +71,7 @@ describe("vellum-model-routing", () => {
       "anthropic",
       "fireworks",
       "gemini",
+      "hosted",
       "openai",
       "together",
     ]);

--- a/assistant/src/providers/vellum-model-routing.test.ts
+++ b/assistant/src/providers/vellum-model-routing.test.ts
@@ -41,7 +41,7 @@ describe("vellum-model-routing", () => {
 
   test("getManagedUpstream resolves a bare catalog id to its owner", () => {
     expect(getManagedUpstream("claude-fable-5")).toBe("anthropic");
-    expect(getManagedUpstream("qwen/qwen3-8b")).toBe("hosted");
+    expect(getManagedUpstream("qwen/qwen3-8b")).toBe("vellum");
   });
 
   test("getManagedUpstream resolves a routing string by its prefix", () => {
@@ -71,7 +71,7 @@ describe("vellum-model-routing", () => {
       "anthropic",
       "fireworks",
       "gemini",
-      "hosted",
+      "vellum",
       "openai",
       "together",
     ]);

--- a/assistant/src/providers/vellum-model-routing.ts
+++ b/assistant/src/providers/vellum-model-routing.ts
@@ -36,9 +36,9 @@ export const MANAGED_ROUTABLE_PROVIDERS: ReadonlySet<string> = new Set(
  * Sentinel provider id for the single, provider-agnostic Vellum-managed
  * connection. Unlike the per-provider `*-managed` connections, this one does
  * not name an upstream provider on its DB row — the upstream is determined
- * per-request from the resolving profile. This id is never a real catalog
- * entry, so routing code must substitute the effective provider before any
- * catalog/adapter lookup.
+ * per-request from the resolving profile. The same id is the catalog owner
+ * of Vellum-hosted GPU models. Dispatch still substitutes a concrete
+ * upstream (including `vellum` for those GPU models) before adapter lookup.
  */
 export const VELLUM_MANAGED_PROVIDER = "vellum";
 

--- a/assistant/src/providers/vellum/client.ts
+++ b/assistant/src/providers/vellum/client.ts
@@ -1,6 +1,6 @@
 import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
 
-export interface HostedProviderOptions {
+export interface VellumProviderOptions {
   apiKey?: string;
   baseURL?: string;
   streamTimeoutMs?: number;
@@ -9,17 +9,18 @@ export interface HostedProviderOptions {
 /**
  * OpenAI-compatible client for Vellum-hosted GPU inference (vLLM).
  * Managed requests set `baseURL` to the platform `/v1/runtime-proxy/vellum`
- * path; the platform forwards to the online node's vLLM server.
+ * path and authenticate with the assistant API key. These models have no
+ * bring-your-own-key path.
  */
-export class HostedProvider extends OpenAIChatCompletionsProvider {
+export class VellumProvider extends OpenAIChatCompletionsProvider {
   constructor(
     apiKey: string,
     model: string,
-    options: HostedProviderOptions = {},
+    options: VellumProviderOptions = {},
   ) {
     super(apiKey || "not-needed", model, {
-      providerName: "hosted",
-      providerLabel: "Vellum Hosted",
+      providerName: "vellum",
+      providerLabel: "Vellum",
       streamTimeoutMs: options.streamTimeoutMs,
       omitToolChoiceWhenReasoning: true,
       ...(options.baseURL ? { baseURL: options.baseURL } : {}),

--- a/clients/web/src/assistant/llm-model-catalog.test.ts
+++ b/clients/web/src/assistant/llm-model-catalog.test.ts
@@ -118,19 +118,19 @@ describe("parity with meta/llm-provider-catalog.json", () => {
   );
   const webProviderIds = (
     Object.keys(MODELS_BY_PROVIDER) as LlmProviderId[]
-  ).filter((id) => id !== "openai-compatible");
-  const pickerProviderIds = webProviderIds.filter((id) => id !== "hosted");
+  ).filter((id) => id !== "openai-compatible" && id !== "vellum");
+  const pickerProviderIds = webProviderIds;
 
-  test("vellum is a picker-only entry: absent from the catalogs by design", () => {
-    // The Vellum entry is the managed routing identity, not a provider with
-    // its own catalog — it must never gain a MODELS_BY_PROVIDER key or a
-    // meta-catalog entry. Its model list is the union of the providers it
-    // serves, exposed only through getModelsForProvider.
-    expect(Object.keys(MODELS_BY_PROVIDER)).not.toContain("vellum");
-    expect(metaProvidersById.has("vellum")).toBe(false);
+  test("vellum picker is the union of served catalogs, including GPU models", () => {
+    // MODELS_BY_PROVIDER.vellum lists only Vellum-hosted GPU models. The
+    // picker still exposes the union of every served catalog through
+    // getModelsForProvider("vellum").
+    expect(MODELS_BY_PROVIDER.vellum.map((model) => model.id)).toEqual([
+      "qwen/qwen3-8b",
+    ]);
+    expect(metaProvidersById.get("vellum")?.id).toBe("vellum");
 
     const vellumModels = getModelsForProvider("vellum");
-    // Every entry comes from a served provider's catalog…
     const servedIds = new Set<string>(
       VELLUM_SERVED_PROVIDERS.flatMap((p) =>
         MODELS_BY_PROVIDER[p].map((m) => m.id),
@@ -139,11 +139,8 @@ describe("parity with meta/llm-provider-catalog.json", () => {
     for (const model of vellumModels) {
       expect(servedIds.has(model.id)).toBe(true);
     }
-    // …labels are unique (the picker renders labels only, so duplicates
-    // would be indistinguishable options)…
     const labels = vellumModels.map((m) => m.displayName);
     expect(new Set(labels).size).toBe(labels.length);
-    // …and no distinct label from any served catalog is missing.
     const servedLabels = new Set(
       VELLUM_SERVED_PROVIDERS.flatMap((p) =>
         MODELS_BY_PROVIDER[p].map((m) => m.displayName),
@@ -157,14 +154,14 @@ describe("parity with meta/llm-provider-catalog.json", () => {
     expect(
       getManagedUpstreamForModel("accounts/fireworks/models/glm-5p2"),
     ).toBe("fireworks");
-    expect(getManagedUpstreamForModel("qwen/qwen3-8b")).toBe("hosted");
+    expect(getManagedUpstreamForModel("qwen/qwen3-8b")).toBe("vellum");
     expect(getManagedUpstreamForModel("not-a-real-model")).toBeUndefined();
   });
 
-  test("hosted models stay out of pickers and hide without developer mode", () => {
-    expect(Object.keys(MODELS_BY_PROVIDER)).toContain("hosted");
-    expect(INFERENCE_PROVIDERS).not.toContain("hosted");
-    expect(CONNECTION_PROVIDERS).not.toContain("hosted");
+  test("vellum GPU models stay out of pickers and hide without developer mode", () => {
+    expect(Object.keys(MODELS_BY_PROVIDER)).toContain("vellum");
+    expect(INFERENCE_PROVIDERS).not.toContain("vellum");
+    expect(CONNECTION_PROVIDERS).not.toContain("vellum");
     expect(
       getVisibleModelsForProvider("vellum", false).some(
         (model) => model.id === "qwen/qwen3-8b",
@@ -225,19 +222,21 @@ describe("parity with meta/llm-provider-catalog.json", () => {
     );
   });
 
-  test("CONNECTION_PROVIDERS covers every meta catalog provider except hosted", () => {
+  test("CONNECTION_PROVIDERS covers every meta catalog provider except vellum", () => {
     // The connection-creation picker is driven by CONNECTION_PROVIDERS in
     // provider-editor-constants.ts. Unlike INFERENCE_PROVIDERS, it
     // intentionally includes daemon-only providers (ollama) and the
     // free-form openai-compatible escape hatch — any daemon provider can
     // back a connection — so it must list exactly the meta catalog's
     // provider ids or a provider becomes un-creatable as a connection.
+    // `vellum` is excluded: those models use the assistant API key on the
+    // existing managed connection and have no BYOK create path.
     // Order is not asserted: the list's order is the picker's display order.
     const connectionProviderIds: string[] = [...CONNECTION_PROVIDERS];
     expect(connectionProviderIds.sort()).toEqual(
       metaCatalog.providers
         .map((provider) => provider.id)
-        .filter((id) => id !== "hosted")
+        .filter((id) => id !== "vellum")
         .sort(),
     );
   });

--- a/clients/web/src/assistant/llm-model-catalog.test.ts
+++ b/clients/web/src/assistant/llm-model-catalog.test.ts
@@ -26,6 +26,7 @@ import {
   PROVIDER_DISPLAY_NAMES,
   PROVIDER_SUPPORTS_PLATFORM_AUTH,
   getModelsForProvider,
+  getVisibleModelsForProvider,
   getManagedUpstreamForModel,
   VELLUM_SERVED_PROVIDERS,
   type LlmProviderId,
@@ -118,6 +119,7 @@ describe("parity with meta/llm-provider-catalog.json", () => {
   const webProviderIds = (
     Object.keys(MODELS_BY_PROVIDER) as LlmProviderId[]
   ).filter((id) => id !== "openai-compatible");
+  const pickerProviderIds = webProviderIds.filter((id) => id !== "hosted");
 
   test("vellum is a picker-only entry: absent from the catalogs by design", () => {
     // The Vellum entry is the managed routing identity, not a provider with
@@ -155,7 +157,24 @@ describe("parity with meta/llm-provider-catalog.json", () => {
     expect(
       getManagedUpstreamForModel("accounts/fireworks/models/glm-5p2"),
     ).toBe("fireworks");
+    expect(getManagedUpstreamForModel("qwen/qwen3-8b")).toBe("hosted");
     expect(getManagedUpstreamForModel("not-a-real-model")).toBeUndefined();
+  });
+
+  test("hosted models stay out of pickers and hide without developer mode", () => {
+    expect(Object.keys(MODELS_BY_PROVIDER)).toContain("hosted");
+    expect(INFERENCE_PROVIDERS).not.toContain("hosted");
+    expect(CONNECTION_PROVIDERS).not.toContain("hosted");
+    expect(
+      getVisibleModelsForProvider("vellum", false).some(
+        (model) => model.id === "qwen/qwen3-8b",
+      ),
+    ).toBe(false);
+    expect(
+      getVisibleModelsForProvider("vellum", true).some(
+        (model) => model.id === "qwen/qwen3-8b",
+      ),
+    ).toBe(true);
   });
 
   test("every meta provider exists in the web mirror", () => {
@@ -201,10 +220,12 @@ describe("parity with meta/llm-provider-catalog.json", () => {
     // unselectable there. Order is not asserted: the list's order is the
     // picker's display order (a UI choice, with index 0 as the default
     // fallback), not the catalog's.
-    expect([...INFERENCE_PROVIDERS].sort()).toEqual([...webProviderIds].sort());
+    expect([...INFERENCE_PROVIDERS].sort()).toEqual(
+      [...pickerProviderIds].sort(),
+    );
   });
 
-  test("CONNECTION_PROVIDERS covers every meta catalog provider", () => {
+  test("CONNECTION_PROVIDERS covers every meta catalog provider except hosted", () => {
     // The connection-creation picker is driven by CONNECTION_PROVIDERS in
     // provider-editor-constants.ts. Unlike INFERENCE_PROVIDERS, it
     // intentionally includes daemon-only providers (ollama) and the
@@ -214,7 +235,10 @@ describe("parity with meta/llm-provider-catalog.json", () => {
     // Order is not asserted: the list's order is the picker's display order.
     const connectionProviderIds: string[] = [...CONNECTION_PROVIDERS];
     expect(connectionProviderIds.sort()).toEqual(
-      metaCatalog.providers.map((provider) => provider.id).sort(),
+      metaCatalog.providers
+        .map((provider) => provider.id)
+        .filter((id) => id !== "hosted")
+        .sort(),
     );
   });
 

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -894,7 +894,7 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
   ],
-  hosted: [
+  vellum: [
     {
       id: "qwen/qwen3-8b",
       displayName: "Qwen3 8B",
@@ -924,7 +924,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   opencode: "",
   baseten: "thinkingmachines/inkling",
   poolside: "poolside/laguna-s-2.1",
-  hosted: "qwen/qwen3-8b",
+  vellum: "qwen/qwen3-8b",
   "openai-compatible": "",
 };
 
@@ -934,9 +934,8 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
  *   PROVIDER_DISPLAY_NAMES[id] ?? id
  */
 export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  // Not catalog providers: the platform-managed routing sentinel and the
-  // subscription-auth pseudo-provider. Cards and pickers render both as
-  // providers, so they need display names.
+  // Routing identities that cards and pickers render as providers.
+  // `vellum` is also the catalog owner of Vellum-hosted GPU models.
   vellum: "Vellum",
   chatgpt: "ChatGPT Subscription",
   anthropic: "Anthropic",
@@ -954,7 +953,6 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   opencode: "OpenCode",
   baseten: "Baseten",
   poolside: "Poolside",
-  hosted: "Vellum Hosted",
 };
 
 /**
@@ -980,7 +978,7 @@ export const PROVIDER_SUPPORTS_PLATFORM_AUTH: Record<string, boolean> = {
   opencode: false,
   baseten: false,
   poolside: false,
-  hosted: true,
+  vellum: true,
 };
 
 export const MANAGED_MODELS = MODELS_BY_PROVIDER.anthropic;
@@ -997,7 +995,7 @@ export const VELLUM_SERVED_PROVIDERS = [
   "gemini",
   "fireworks",
   "together",
-  "hosted",
+  "vellum",
 ] as const;
 
 /**
@@ -1124,6 +1122,11 @@ export function getDefaultModelForProvider(
   // users see one consistent "default" for the subscription.
   if (provider === "chatgpt") {
     return "gpt-5.6-luna";
+  }
+  // The Vellum picker serves the union of managed catalogs. The GPU
+  // catalog's defaultModel is not the Vellum connection default.
+  if (provider === "vellum") {
+    return undefined;
   }
   return DEFAULT_MODEL_BY_PROVIDER[provider as LlmProviderId];
 }

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -18,6 +18,8 @@ export interface LlmCatalogModel {
   supportsThinking?: boolean;
   adaptiveThinkingOnly?: boolean;
   longContextPricingThresholdTokens?: number;
+  /** When set, the model is hidden unless that assistant flag is on. */
+  featureFlag?: string;
 }
 
 export const MODELS_BY_PROVIDER = {
@@ -892,6 +894,16 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
   ],
+  hosted: [
+    {
+      id: "qwen/qwen3-8b",
+      displayName: "Qwen3 8B",
+      contextWindowTokens: 32_768,
+      defaultContextWindowTokens: 32_768,
+      maxOutputTokens: 32_768,
+      featureFlag: "settings-developer-nav",
+    },
+  ],
   "openai-compatible": [],
 } as const satisfies Record<string, readonly LlmCatalogModel[]>;
 
@@ -912,6 +924,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Record<LlmProviderId, string> = {
   opencode: "",
   baseten: "thinkingmachines/inkling",
   poolside: "poolside/laguna-s-2.1",
+  hosted: "qwen/qwen3-8b",
   "openai-compatible": "",
 };
 
@@ -941,6 +954,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   opencode: "OpenCode",
   baseten: "Baseten",
   poolside: "Poolside",
+  hosted: "Vellum Hosted",
 };
 
 /**
@@ -966,6 +980,7 @@ export const PROVIDER_SUPPORTS_PLATFORM_AUTH: Record<string, boolean> = {
   opencode: false,
   baseten: false,
   poolside: false,
+  hosted: true,
 };
 
 export const MANAGED_MODELS = MODELS_BY_PROVIDER.anthropic;
@@ -982,6 +997,7 @@ export const VELLUM_SERVED_PROVIDERS = [
   "gemini",
   "fireworks",
   "together",
+  "hosted",
 ] as const;
 
 /**
@@ -1062,6 +1078,27 @@ export const CODEX_SUBSCRIPTION_MODEL_IDS: ReadonlySet<string> = new Set([
   "gpt-5.4",
   "gpt-5.4-mini",
 ]);
+
+export const DEVELOPER_MODE_CATALOG_FLAG = "settings-developer-nav";
+
+export function isCatalogModelVisible(
+  model: Pick<LlmCatalogModel, "featureFlag">,
+  developerMode: boolean,
+): boolean {
+  if (!model.featureFlag) {
+    return true;
+  }
+  return model.featureFlag === DEVELOPER_MODE_CATALOG_FLAG && developerMode;
+}
+
+export function getVisibleModelsForProvider(
+  provider: string,
+  developerMode: boolean,
+): readonly LlmCatalogModel[] {
+  return getModelsForProvider(provider).filter((model) =>
+    isCatalogModelVisible(model, developerMode),
+  );
+}
 
 export function getModelsForProvider(
   provider: string,

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -8,8 +8,10 @@ import { useTranslation } from "@/i18n";
 import {
   getDefaultModelForProvider,
   getModelsForProvider,
+  getVisibleModelsForProvider,
   PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import type {
   CallSiteOverrideDraft,
   ProviderConnection,
@@ -80,6 +82,8 @@ export function CallSiteOverrideRow({
   onToggle,
 }: CallSiteOverrideRowProps) {
   const { t } = useTranslation("settings");
+  const developerMode =
+    useAssistantFeatureFlagStore.use.settingsDeveloperNav();
   const overrideOn = isDraftActive(draft);
 
   const profileVal = (() => {
@@ -148,7 +152,7 @@ export function CallSiteOverrideRow({
     connectionsForProvider,
   )
     ? codexServableModels(currentProvider)
-    : getModelsForProvider(currentProvider);
+    : getVisibleModelsForProvider(currentProvider, developerMode);
   const modelOptions = availableModels.map((m) => ({
     value: m.id,
     label: m.displayName,

--- a/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-provider-section.tsx
@@ -10,8 +10,10 @@ import { Typography } from "@vellumai/design-library/components/typography";
 
 import {
   getModelsForProvider,
+  getVisibleModelsForProvider,
   PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 import {
   codexServableModels,
@@ -122,6 +124,8 @@ export function ProfileEditorProviderSection({
   // fixed model set.
   const { t } = useTranslation("settings");
   const [isEnteringCustomModel, setIsEnteringCustomModel] = useState(false);
+  const developerMode =
+    useAssistantFeatureFlagStore.use.settingsDeveloperNav();
 
   const subscriptionRestricted = restrictsToSubscriptionModels(
     provider,
@@ -205,7 +209,10 @@ export function ProfileEditorProviderSection({
       if (!provider) {
         return [];
       }
-      const catalogModels = getModelsForProvider(provider);
+      const catalogModels = getVisibleModelsForProvider(
+        provider,
+        developerMode,
+      );
       if (catalogModels.length > 0) {
         if (
           restrictsToSubscriptionModels(
@@ -238,7 +245,12 @@ export function ProfileEditorProviderSection({
         }
       }
       return merged;
-    }, [provider, providerConnection, availableConnectionsForProvider]);
+    }, [
+      provider,
+      providerConnection,
+      availableConnectionsForProvider,
+      developerMode,
+    ]);
 
   // The Model dropdown always offers the profile's currently-bound model, even
   // when it's absent from the static catalog — a profile can be bound (via Chat)
@@ -313,7 +325,7 @@ export function ProfileEditorProviderSection({
     if (isEnteringCustomModel) {
       return;
     }
-    const catalogModels = getModelsForProvider(provider);
+    const catalogModels = getVisibleModelsForProvider(provider, developerMode);
     // Connection-derived providers (openai-compatible) have an empty catalog.
     // An id the connection does not list is still a valid bound model.
     if (catalogModels.length === 0) {
@@ -329,7 +341,14 @@ export function ProfileEditorProviderSection({
     ) {
       onModelChange("");
     }
-  }, [model, availableModels, onModelChange, provider, isEnteringCustomModel]);
+  }, [
+    model,
+    availableModels,
+    onModelChange,
+    provider,
+    isEnteringCustomModel,
+    developerMode,
+  ]);
 
   const defaultEntryMetaLabel = t("aiProviderPicker.defaultEntryMeta");
 

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -2163,6 +2163,35 @@
           "supportsToolUse": true
         }
       ]
+    },
+    {
+      "id": "hosted",
+      "displayName": "Vellum Hosted",
+      "subtitle": "Models served on Vellum GPU nodes through the managed connection.",
+      "setupMode": "keyless",
+      "setupHint": "Available on the Vellum managed connection when developer mode is on.",
+      "supportsPlatformAuth": true,
+      "featureFlag": "settings-developer-nav",
+      "defaultModel": "qwen/qwen3-8b",
+      "models": [
+        {
+          "id": "qwen/qwen3-8b",
+          "displayName": "Qwen3 8B",
+          "contextWindowTokens": 32768,
+          "maxOutputTokens": 32768,
+          "defaultContextWindowTokens": 32768,
+          "longContextMode": "unsupported",
+          "supportsThinking": false,
+          "supportsCaching": false,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.3,
+            "outputPer1mTokens": 0.3
+          },
+          "featureFlag": "settings-developer-nav"
+        }
+      ]
     }
   ]
 }

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -2165,11 +2165,11 @@
       ]
     },
     {
-      "id": "hosted",
-      "displayName": "Vellum Hosted",
+      "id": "vellum",
+      "displayName": "Vellum",
       "subtitle": "Models served on Vellum GPU nodes through the managed connection.",
-      "setupMode": "keyless",
-      "setupHint": "Available on the Vellum managed connection when developer mode is on.",
+      "setupMode": "api-key",
+      "setupHint": "Uses the assistant API key through the Vellum managed connection. These models cannot use a bring-your-own key.",
       "supportsPlatformAuth": true,
       "featureFlag": "settings-developer-nav",
       "defaultModel": "qwen/qwen3-8b",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

The platform `vellum` runtime-proxy route is live. Curl still needs an assistant API key, and we want to test hosted inference from the assistant itself.

This adds `qwen/qwen3-8b` as a Vellum-managed model. The catalog id is `vellum`: that is both the managed-connection sentinel and the catalog owner of Vellum-hosted GPU models. Dispatch goes to `{platform}/v1/runtime-proxy/vellum` and authenticates with the assistant API key. There is no BYOK path.

The model is hidden unless developer mode is on (`settings-developer-nav`, the 7-tap version unlock). It does not appear as its own provider or connection. Users pick Vellum, then Qwen3 8B.

## Test plan

- `cd assistant && bun test` on catalog, routing, visibility, connection, secret-catalog, and managed-proxy tests
- `cd clients/web && bun test` on catalog parity and settings AI tests
- `cd assistant && bun run typecheck:fast`
- Regenerated `meta/llm-provider-catalog.json` and `assistant/openapi.yaml`

To try it after merge:

1. Enable developer mode (7 taps on the settings version string)
2. Spin up a GPU node for `qwen/qwen3-8b` and wait until it is online
3. In AI settings, pick the Vellum connection and Qwen3 8B
4. Send a chat turn

## CLI verb checklist

No new IPC routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a029d5-1006-73b1-ada3-172e9fcf7b4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a029d5-1006-73b1-ada3-172e9fcf7b4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

