### PR TITLE
fix(watch): keep the teach-session retro out of the collapsed half of its turn

### DIFF
--- a/assistant/src/watch/__tests__/watch-retro.test.ts
+++ b/assistant/src/watch/__tests__/watch-retro.test.ts
@@ -270,6 +270,28 @@ describe("watch retrospective", () => {
     expect(prompt).toContain("no further tool call");
   });
 
+  test("writes the report even when the skill it hands off to will not load", async () => {
+    const summary = recordSession(["filing the receipt"]);
+    const { calls, dispatch } = recordingDispatch();
+
+    await runWatchRetro(summary, { dispatch });
+
+    const { prompt } = calls[0]!;
+    // `skill-management` is a selector, and a managed or workspace skill of the
+    // same id replaces the bundled one in the catalog. Putting the load ahead
+    // of the report is what lets a shadow, or the refusal a clientless wake
+    // gives an inline-command load, land before the user has been told
+    // anything. Neither may become the retro: the session is recorded and the
+    // account of it is what the user is owed.
+    expect(prompt).toContain(
+      "Write the report below whether or not that load succeeds",
+    );
+    expect(prompt).toContain("do not report on the load and do not retry it");
+    // The failure is still named, so a missing handoff does not read as a
+    // report that simply chose not to ask about authoring.
+    expect(prompt).toContain("could not open the skill-authoring flow");
+  });
+
   test("authors nothing until the user has confirmed", async () => {
     const summary = recordSession(["exporting the sheet"]);
     const { calls, dispatch } = recordingDispatch();

--- a/assistant/src/watch/__tests__/watch-retro.test.ts
+++ b/assistant/src/watch/__tests__/watch-retro.test.ts
@@ -247,6 +247,29 @@ describe("watch retrospective", () => {
     );
   });
 
+  test("puts the report last in the turn, after the skill it hands off to", async () => {
+    const summary = recordSession(["renaming the export"]);
+    const { calls, dispatch } = recordingDispatch();
+
+    await runWatchRetro(summary, { dispatch });
+
+    const { prompt } = calls[0]!;
+    // The report is what the user is shown when a session ends, so it has to
+    // be the turn's last prose. A client renders the final text block as the
+    // response and folds everything before it into collapsed intermediate
+    // work, so a `skill_load` issued after the report demotes the report to
+    // an "Earlier activity" row the user has to unfold to read.
+    expect(prompt).toContain("Load the `skill-management` skill first");
+    expect(
+      prompt.indexOf("Load the `skill-management` skill first"),
+    ).toBeLessThan(prompt.indexOf("What I need from you"));
+    expect(prompt).toContain("That report is the last thing you do this turn");
+    // A sign-off is another text block after the report, which puts the report
+    // back on the wrong side of the same rule, so it is refused by name.
+    expect(prompt).toContain("no sign-off");
+    expect(prompt).toContain("no further tool call");
+  });
+
   test("authors nothing until the user has confirmed", async () => {
     const summary = recordSession(["exporting the sheet"]);
     const { calls, dispatch } = recordingDispatch();
@@ -605,7 +628,9 @@ describe("watch retrospective", () => {
     expect(payload).toBeGreaterThan(opened);
     expect(payload).toBeLessThan(closed);
     // The retrospective's own instructions sit outside it.
-    expect(prompt.indexOf("Write back to the user")).toBeGreaterThan(closed);
+    expect(
+      prompt.indexOf("Load the `skill-management` skill first"),
+    ).toBeGreaterThan(closed);
 
     // One real envelope, so nothing in the recording can pass for a second.
     expect(prompt.match(/<external_content/g)).toHaveLength(1);

--- a/assistant/src/watch/watch-retro.ts
+++ b/assistant/src/watch/watch-retro.ts
@@ -76,16 +76,37 @@ const WATCH_RETRO_WAKE_SOURCE = "watch-retro";
  * gap between those two is the whole risk of turning a demonstration into a
  * skill. `skill-management` will not scaffold until that step is settled
  * either, so an unasked one stalls the flow it was meant to feed.
+ *
+ * **The skill loads before the report is written, and nothing follows the
+ * report.** This is about where the report lands on screen, not about the
+ * order the work happens in. A client renders an assistant turn as its final
+ * prose plus the intermediate work that led there, and the web transcript
+ * collapses that intermediate half into an "Earlier activity" disclosure that
+ * a settled turn shows closed (`finalResponseGroupIndex` in
+ * `transcript-message-body.tsx`). Everything before the turn's last non-empty
+ * text block is intermediate by that rule, including prose. Writing the report
+ * first and loading the skill after it puts a `skill_load` and whatever the
+ * model says once the skill is in hand *after* the report, which demotes the
+ * report to intermediate work and hides it behind a collapsed row next to the
+ * reasoning rows. The user presses stop on a session and is shown a folded-up
+ * link where the account of it should be.
+ *
+ * So the load comes first and the report is last. `skill-management` opens on
+ * "Ask before doing anything", so a turn that loads it and then asks is
+ * following it rather than jumping the flow, and the report is the alignment
+ * its first step calls for. The instruction that nothing follows the report is
+ * as load-bearing as the ordering: one trailing line of sign-off is another
+ * text block after it, and the report is intermediate again.
  */
-const RETRO_INSTRUCTIONS = `Write back to the user in two sections, in this order, both as level-2 headings.
+const RETRO_INSTRUCTIONS = `Load the \`skill-management\` skill first, before you write anything, and follow it. Do not author or scaffold a skill until the four points that step names are settled: the report below is the alignment its first step calls for.
+
+Then write back to the user in two sections, in this order, both as level-2 headings. That report is the last thing you do this turn, and nothing follows it: no sign-off, no note about what you loaded, no further tool call. Their answers come back as an ordinary reply and the flow picks up from there.
 
 First, "What I need from you". The questions you cannot answer from the recording, numbered, most consequential first. Each one concrete enough to answer in a sentence, and each one about something you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Always ask what they would say to start this task, in their own words, because the recording cannot tell you that. Ask about the done condition if it is unclear. Always confirm any destructive or irreversible step, even one the recording showed plainly: watching someone do a thing once is not agreement to have it done again unattended, and this is the one place the rule below does not apply. Otherwise do not ask them to confirm something the recording already showed you.
 
 Second, "What I saw". Open with one sentence naming the task and what it is for, on its own and not as a list item. Then the steps in order beneath it, one line each and concrete enough to follow, carrying no purpose of their own. This is the record your questions sit on top of, so state it rather than asking about it.
 
-Open on the first heading. No preamble, no announcing what you are about to do, no narrating which skills you are loading.
-
-Then load the \`skill-management\` skill and follow it, treating the answers to your questions as the alignment its first step calls for. Do not author or scaffold a skill until the four points that step names are settled. Correct your reading against whatever they tell you. If they decide this is not worth keeping, say so and stop.`;
+Open on the first heading. No preamble, no announcing what you are about to do, no narrating which skills you are loading. Correct your reading against whatever they tell you. If they decide this is not worth keeping, say so and stop.`;
 
 /**
  * Told to the model whenever the render was bounded, naming the bound that

--- a/assistant/src/watch/watch-retro.ts
+++ b/assistant/src/watch/watch-retro.ts
@@ -97,8 +97,29 @@ const WATCH_RETRO_WAKE_SOURCE = "watch-retro";
  * its first step calls for. The instruction that nothing follows the report is
  * as load-bearing as the ordering: one trailing line of sign-off is another
  * text block after it, and the report is intermediate again.
+ *
+ * **The report does not depend on the load succeeding.** `skill-management` is
+ * a selector, not a fixed definition: `loadSkillCatalog` lets a managed or
+ * workspace skill of the same id replace the bundled one, and
+ * `resolveSkillSelector` hands back whichever entry won. So the load can come
+ * back as someone else's skill, or as a refusal, and putting it ahead of the
+ * report is what makes either one land before the user has been told anything.
+ * A refusal is the likelier of the two here: this wake is `clientless`, and an
+ * inline-command load with no human present is denied outright
+ * (`permissions/checker.ts`, `isDynamicSkillLoadInvocation`). The bundled skill
+ * carries no such expansions, so the ordinary path is unaffected, but a shadow
+ * that carries them is denied on arrival.
+ *
+ * Neither outcome is allowed to become the retro. The session was recorded, the
+ * timeline is already in this prompt, and the account of it is the one thing the
+ * user is owed for having pressed stop; a permission error where that account
+ * should be is the same empty thread the `surfaceConversation` guard exists to
+ * prevent, just with prose in it. So the instructions write the report either
+ * way and say the handoff did not happen, rather than reporting on the load.
  */
 const RETRO_INSTRUCTIONS = `Load the \`skill-management\` skill first, before you write anything, and follow it. Do not author or scaffold a skill until the four points that step names are settled: the report below is the alignment its first step calls for.
+
+Write the report below whether or not that load succeeds. If it fails, is refused, or comes back as something other than the skill-management flow, do not report on the load and do not retry it: write the report, and end it with one line saying you could not open the skill-authoring flow, so the user knows the handoff is the part that did not happen.
 
 Then write back to the user in two sections, in this order, both as level-2 headings. That report is the last thing you do this turn, and nothing follows it: no sign-off, no note about what you loaded, no further tool call. Their answers come back as an ordinary reply and the flow picks up from there.
 


### PR DESCRIPTION
## The problem

Ending a **Teach** session from the companion surface produced a retro that the user could not read without unfolding it. The report showed up inside the "Earlier activity" disclosure, sitting next to the reasoning rows in the muted collapsed tone, which is what made it read as thinking.

## Why

Ordering, not classification. The transcript renders an assistant turn as its final prose plus the intermediate work that led there, and collapses that intermediate half into a disclosure a settled turn shows closed. The cut is `finalResponseGroupIndex` in `clients/web/src/domains/chat/transcript/transcript-message-body.tsx`: **everything before the turn's last non-empty text block is intermediate, prose included.**

`RETRO_INSTRUCTIONS` told the model to write the report and *then* load `skill-management`. So the turn came out as

```
thinking → text(the report) → tool_use(skill_load) → text(whatever it says with the skill in hand)
```

and that trailing text became the response, demoting the report to a collapsed row.

## The fix

The skill load moves to the front and the report becomes the last thing in the turn.

This does not jump the flow: `skill-management` Step 1 opens on "Ask before doing anything", so a turn that loads it and then asks is following the skill, and the report's "What I need from you" section *is* the alignment that step calls for. The instruction that nothing follows the report is as load-bearing as the ordering itself, so a sign-off line is refused by name: one more text block after the report puts it back on the wrong side of the same rule.

No client change. The transcript's collapse rule is right for every other turn.

## Testing

- New test locks the ordering (load instructed before the report) and the no-trailing-text rule.
- One existing assertion anchored on the literal `"Write back to the user"`, which the rewrite moved; re-anchored on the instructions' new opening line, keeping what it was actually checking (the retro's own instructions sit outside the untrusted-content fence).
- `bun test src/watch/` — 90 pass, 0 fail. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HT1mZ51g4SokRYSFcfon7S