### PR TITLE
Add Grok 4.6, GLM-5.3, and GLM-5.3 Flash to the OpenRouter catalog

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1375,6 +1375,32 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       // false; the `cacheReadPer1mTokens` rates below only apply if OpenRouter
       // starts reporting cached tokens in usage.
       {
+        id: "x-ai/grok-4.6",
+        displayName: "Grok 4.6",
+        contextWindowTokens: 500000,
+        // xAI publishes no completion cap; 30K is the tracker-reported
+        // single-response limit used for sibling Grok 4.x catalog rows.
+        maxOutputTokens: 30000,
+        supportsThinking: true,
+        supportsCaching: false,
+        supportsVision: true,
+        supportsToolUse: true,
+        longContextPricingThresholdTokens: 200000,
+        pricing: {
+          inputPer1mTokens: 2,
+          outputPer1mTokens: 6,
+          cacheReadPer1mTokens: 0.5,
+          tiers: [
+            {
+              inputTokenThreshold: 200000,
+              inputPer1mTokens: 4,
+              outputPer1mTokens: 12,
+              cacheReadPer1mTokens: 1,
+            },
+          ],
+        },
+      },
+      {
         id: "x-ai/grok-4.5",
         displayName: "Grok 4.5",
         contextWindowTokens: 500000,
@@ -1697,6 +1723,36 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: { inputPer1mTokens: 0.2, outputPer1mTokens: 1.1 },
       },
       // Z.ai
+      {
+        id: "z-ai/glm-5.3",
+        displayName: "GLM-5.3",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: false,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 1.4,
+          outputPer1mTokens: 4.4,
+          cacheReadPer1mTokens: 0.26,
+        },
+      },
+      {
+        id: "z-ai/glm-5.3-flash",
+        displayName: "GLM-5.3 Flash",
+        contextWindowTokens: 1310720,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 0.075,
+          outputPer1mTokens: 0.25,
+          cacheReadPer1mTokens: 0.015,
+        },
+      },
       {
         id: "z-ai/glm-5.2",
         displayName: "GLM-5.2",

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -513,6 +513,15 @@ export const MODELS_BY_PROVIDER = {
       longContextPricingThresholdTokens: 272_000,
     },
     {
+      id: "x-ai/grok-4.6",
+      displayName: "Grok 4.6",
+      contextWindowTokens: 500_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 30_000,
+      supportsThinking: true,
+      longContextPricingThresholdTokens: 200_000,
+    },
+    {
       id: "x-ai/grok-4.5",
       displayName: "Grok 4.5",
       contextWindowTokens: 500_000,
@@ -682,6 +691,22 @@ export const MODELS_BY_PROVIDER = {
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 1_000_000,
+    },
+    {
+      id: "z-ai/glm-5.3",
+      displayName: "GLM-5.3",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+    },
+    {
+      id: "z-ai/glm-5.3-flash",
+      displayName: "GLM-5.3 Flash",
+      contextWindowTokens: 1_310_720,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
     },
     {
       id: "z-ai/glm-5.2",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1252,6 +1252,32 @@
           }
         },
         {
+          "id": "x-ai/grok-4.6",
+          "displayName": "Grok 4.6",
+          "contextWindowTokens": 500000,
+          "maxOutputTokens": 30000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": false,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 2,
+            "outputPer1mTokens": 6,
+            "cacheReadPer1mTokens": 0.5,
+            "tiers": [
+              {
+                "inputTokenThreshold": 200000,
+                "inputPer1mTokens": 4,
+                "outputPer1mTokens": 12,
+                "cacheReadPer1mTokens": 1
+              }
+            ]
+          }
+        },
+        {
           "id": "x-ai/grok-4.5",
           "displayName": "Grok 4.5",
           "contextWindowTokens": 500000,
@@ -1618,6 +1644,40 @@
           "pricing": {
             "inputPer1mTokens": 0.2,
             "outputPer1mTokens": 1.1
+          }
+        },
+        {
+          "id": "z-ai/glm-5.3",
+          "displayName": "GLM-5.3",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.4,
+            "outputPer1mTokens": 4.4,
+            "cacheReadPer1mTokens": 0.26
+          }
+        },
+        {
+          "id": "z-ai/glm-5.3-flash",
+          "displayName": "GLM-5.3 Flash",
+          "contextWindowTokens": 1310720,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.075,
+            "outputPer1mTokens": 0.25,
+            "cacheReadPer1mTokens": 0.015
           }
         },
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the three new OpenRouter models to the hardcoded catalog so they appear in the settings picker:

- `x-ai/grok-4.6` (Grok 4.6)
- `z-ai/glm-5.3` (GLM-5.3)
- `z-ai/glm-5.3-flash` (GLM-5.3 Flash)

Pricing, context windows, and capability flags are taken from OpenRouter (`GET /api/v1/models`). Grok 4.6 includes the 200k long-context pricing tier. The default OpenRouter model stays `x-ai/grok-4.20`.

This is the catalog-only PR so these models can ship without waiting on custom-id lookup.

## Test plan

- [x] `cd assistant && bun test src/__tests__/llm-catalog-parity.test.ts`
- [x] `cd clients/web && bun test src/assistant/llm-model-catalog.test.ts`

## Follow-up

Custom OpenRouter model IDs (picker vs text input, public lookup, no new schema) stay in #41537.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d75a72c-12d7-430a-9a9d-2549c4189571?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d75a72c-12d7-430a-9a9d-2549c4189571&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

