### PR TITLE
fix(voice): stop the session greeting counting as a user turn

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -390,6 +390,7 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
     );
     expect(fake.lastPersistOpts()?.metadata).toEqual({
       voiceSessionTurn: true,
+      scripted: true,
       hidden: true,
       messageKind: VOICE_ESCALATION_CONTINUATION_MESSAGE_KIND,
     });
@@ -404,8 +405,11 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
 
     await startVoiceTurn(makeTurnOptions()); // content: CALL_OPENING_MARKER
 
+    // Visible AND scripted: the opener is shown, but the assistant wrote it,
+    // so it is not the user taking a turn.
     expect(fake.lastPersistOpts()?.metadata).toEqual({
       voiceSessionTurn: true,
+      scripted: true,
     });
   });
 
@@ -425,6 +429,7 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
     // analytics already read.
     expect(fake.lastPersistOpts()?.metadata).toEqual({
       voiceSessionTurn: true,
+      scripted: true,
       client: {
         voice: true,
         voice_session_id: "session-123",
@@ -444,8 +449,39 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
 
     expect(fake.lastPersistOpts()?.metadata).toEqual({
       voiceSessionTurn: true,
+      scripted: true,
       client: { voice: true, voice_session_id: "session-123" },
     });
+  });
+
+  test("a turn the user really spoke is left unmarked, not marked false", async () => {
+    // Absent means UNKNOWN and falls through to the legacy classifier, which
+    // is the safe answer here. Stamping `false` would assert this turn was
+    // typed by the user, and a wrong `false` is trusted downstream.
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what is on my calendar",
+    });
+
+    expect(fake.lastPersistOpts()?.metadata).not.toHaveProperty("scripted");
+  });
+
+  test("scripted is not derived from hidden", async () => {
+    // The two answer different questions, and the opener is the case that
+    // separates them: shown to the user, written by the assistant. Deriving
+    // one from the other lets every visible-but-scripted turn count as
+    // activation, which is the largest single source of funnel inflation.
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn(makeTurnOptions()); // content: CALL_OPENING_MARKER
+
+    const metadata = fake.lastPersistOpts()?.metadata;
+    expect(metadata?.scripted).toBe(true);
+    expect(metadata).not.toHaveProperty("hidden");
   });
 
   test("a phone turn carries no client bag", async () => {
@@ -501,6 +537,7 @@ describe("startVoiceTurn hiddenSyntheticPrompt", () => {
     expect(fake.lastPersistOpts()?.content).toBe(SYNTHETIC_CONTENT);
     expect(fake.lastPersistOpts()?.metadata).toEqual({
       voiceSessionTurn: true,
+      scripted: true,
       hidden: true,
     });
     expect(echoes).toHaveLength(0);

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1031,6 +1031,19 @@ export async function startVoiceTurn(
         // Durable "this turn came from an open voice session" marker; see
         // `isVoiceSessionUserMessage` for why the channel fields cannot carry it.
         voiceSessionTurn: true,
+        // Auto-sent on the user's behalf rather than spoken or typed by them,
+        // so activation metrics exclude it (see the `scripted` contract on the
+        // send route). Keyed off the synthetic set, NOT off
+        // `isHiddenSyntheticPrompt`: the two answer different questions, and
+        // deriving one from the other is what lets a visible-but-scripted turn
+        // through. `hidden` decides whether a human sees the row; `scripted`
+        // decides whether it counts as the user taking a turn.
+        //
+        // Only ever `true` here. A genuine voice turn is left absent rather
+        // than stamped `false`, because absent means UNKNOWN and falls through
+        // to the legacy classifier, while a wrong `false` is trusted
+        // downstream.
+        ...(isSyntheticVoicePrompt ? { scripted: true } : {}),
         ...(isHiddenSyntheticPrompt ? { hidden: true } : {}),
         ...(isEscalationContinuation
           ? { messageKind: VOICE_ESCALATION_CONTINUATION_MESSAGE_KIND }

--- a/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
@@ -157,6 +157,70 @@ describe("live-voice session telemetry", () => {
     });
   });
 
+  /**
+   * Run one typed turn against a session with a real turn starter, then close.
+   *
+   * `readySession` wires none, so `handleTextTurn` returns before dispatching
+   * and every silence assertion against it passes for the wrong reason.
+   */
+  async function endAfterTypedTurn(frame: {
+    text: string;
+    hidden?: boolean;
+  }): Promise<void> {
+    let started = false;
+    const session = new LiveVoiceSession(createContext(), {
+      resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+      resolveCredentialReadiness: mock(
+        async (): Promise<LiveVoiceCredentialReadiness> => ({
+          status: "ready",
+        }),
+      ),
+      startVoiceTurn: mock(async () => {
+        started = true;
+        return { turnId: "bridge-turn-1", abort: mock() };
+      }),
+      emitMetrics: false,
+    });
+    await session.start();
+    await session.handleClientFrame({ type: "text", ...frame });
+    for (let attempt = 0; attempt < 40 && !started; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    if (!started) {
+      throw new Error("the typed turn never reached the bridge");
+    }
+    await session.close("client_end");
+  }
+
+  test("the greeting that opens a session does not spend its silence reason", async () => {
+    // The classification answers "did anything come from the person?". A
+    // session that greets and hears nothing back is silent, and counting the
+    // greeting would retire the taxonomy for every greeted session.
+    await endAfterTypedTurn({
+      text: "this message is sent automatically",
+      hidden: true,
+    });
+
+    expect(recordLiveVoiceSessionEnded).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      screen: "ended_client_end:silent_no_audio",
+      outcome: "completed",
+    });
+  });
+
+  test("a turn the user really took clears the silence reason", async () => {
+    // The other half, and what keeps the test above honest: the same path with
+    // an ordinary typed turn is the person taking a turn, so the session is
+    // not silent and carries no classification at all.
+    await endAfterTypedTurn({ text: "typed by hand" });
+
+    expect(recordLiveVoiceSessionEnded).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      screen: "ended_client_end",
+      outcome: "completed",
+    });
+  });
+
   test("a dropped socket ends as completed, not failed", async () => {
     const session = readySession();
     await session.start();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -4953,7 +4953,17 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // silent" onto a session that has turns, a contradictory row. Setting it
       // before can at worst leave a silent session unexplained, which is a gap
       // rather than a false statement.
-      this.dispatchedTurn = true;
+      //
+      // A synthetic prompt does not count. The silence classification answers
+      // "did anything come from the person?", and the session opening by
+      // greeting them is the session talking to itself. Counting it would
+      // retire the whole taxonomy for every greeted session: `no_speech`,
+      // `text_only` and `no_turn` become unreachable, and `no_audio` survives
+      // only where capture failed early enough to withhold the greeting. That
+      // is the one rate the funnel has for "voice didn't work for me".
+      if (!activeTurn.hiddenPrompt) {
+        this.dispatchedTurn = true;
+      }
       const handle = await this.startVoiceTurn({
         conversationId: this.conversationId,
         voiceSessionId: this.context.sessionId,


### PR DESCRIPTION
Follow-up to #41515. The greeting a voice session opens with is written by the assistant, but the telemetry counted it as the person taking a turn. That broke two metrics in different ways.

## Silent-session rate

`dispatchedTurn` decides whether an ended session carries a silence classification, and the greeting was setting it. For a greeted session that made `no_speech`, `text_only` and `no_turn` unreachable, leaving only `no_ready` and the slice of `no_audio` where capture failed early enough to withhold the greeting.

`telemetry/live-voice-funnel.ts` calls this rate "the closest thing the telemetry has to a 'voice didn't work for me' rate". The case it most wants to see — someone opens voice and never speaks — was precisely the case it stopped being able to see.

A synthetic prompt no longer sets the flag.

## Activation

The greeting persisted with a `voice_session_id` but no `scripted` marker, so it read as a genuine user turn. The send route's own `scripted` contract names "hidden kickoff greetings" among the turns it exists for. Synthetic voice prompts now stamp it.

## Why `scripted` is not keyed off `hidden`

It is keyed off the synthetic set instead. The two answer different questions: `hidden` decides whether a human sees the row, `scripted` decides whether it counts as the user taking a turn. The **call opener is the case that separates them** — visible and scripted at once — and deriving one from the other is what lets every visible-but-scripted turn through, which ANT-10 found to be the single largest source of funnel inflation.

A consequence worth naming: this also fixes the call opener and the verification prompt, which were miscounted the same way. I had previously flagged those as a separate pre-existing gap and deliberately changed course, because scoping to `hidden` would have encoded the exact bug the ANT-10 write-up warns about.

Only ever stamped `true`. A turn the user really spoke is left **absent** rather than `false`: absent means UNKNOWN and falls through to the legacy classifier, while a wrong `false` is trusted downstream.

## Verification

Both fixes are covered by tests confirmed to fail without them, checked by reverting each in isolation:

- revert the `scripted` stamp → **6 bridge tests fail**
- revert the `dispatchedTurn` gate → the greeting's silence test fails, while its user-took-a-turn counterpart keeps passing

That second pair matters. My first attempt at those tests was **vacuous**: the telemetry file's default harness wires no `startVoiceTurn`, so a typed turn returns before dispatching and the assertion passed for the wrong reason. They now run against a session with a real turn starter, and the paired user-took-a-turn case is what keeps them honest.

Green: 503 live-voice, 337 calls, typecheck and lint clean.

⚠️ **Pre-existing on `main`, untouched here:** 17 failures in `src/telemetry` (config-setting stores, memory corpus sizing, usage reporter, watchdog events), byte-identical before and after this change. Nothing voice-related, but worth knowing main is red there independently of this PR.

## Not fixed here

The continuation-announcement turn (`CONTINUATION_DELIVERY_CONTENT`) is also machine-authored and still leaves `scripted` absent. It sits outside the synthetic set and reaching it cleanly needs either an import cycle or a new turn option, so it stays as-is: unknown today, unknown after this change, no regression either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LA2LWfMZvVh2yEnemuuNvD