### PR TITLE
fix(web): serve the pdf.js worker from our own bundle (LUM-3386)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
@@ -1,6 +1,14 @@
 import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PDFDocumentProxy } from "pdfjs-dist/legacy/build/pdf.mjs";
+// `?url` emits the package's prebuilt worker as a hashed asset and yields its
+// URL, so the worker is served from our own origin and its version is the
+// `pdfjs-dist` this bundle imports. Not `?worker&url`: the file is already a
+// built worker bundle and needs emitting as-is, not recompiling as a worker
+// entry. A bare `new URL(..., import.meta.url)` does not work here either,
+// since Vite resolves that form for relative paths, not package specifiers.
+// https://vite.dev/guide/assets#explicit-url-imports
+import PDF_WORKER_URL from "pdfjs-dist/legacy/build/pdf.worker.min.mjs?url";
 
 import { dataUriToUint8Array } from "@/domains/chat/components/chat-attachments/utils";
 
@@ -38,7 +46,7 @@ let pdfJsConfigured = false;
 async function loadPdfJs() {
   const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
   if (!pdfJsConfigured) {
-    pdfjs.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.mjs`;
+    pdfjs.GlobalWorkerOptions.workerSrc = PDF_WORKER_URL;
     pdfJsConfigured = true;
   }
   return pdfjs;


### PR DESCRIPTION
## Summary

- TL;DR: the PDF preview's pdf.js worker now ships with the app instead of being fetched from `cdn.jsdelivr.net` on first use. A Vite `?url` import emits the package's prebuilt worker as a hashed asset and yields its URL, so the worker is served from our own origin and its version is by construction the `pdfjs-dist` the bundle imports (previously the URL interpolated `pdfjs.version` into a CDN path, correct only as long as the two stayed in sync).
- This removes a third-party host from the critical path of every session's first PDF preview. A slow, blocked, or offline CDN previously surfaced as the flat "Failed to load PDF." error with no retry, which is a share of the reports behind LUM-3386.

Why this is safe: one call site, one line of behavior change, no API or data-shape change. Verified by an isolated production Vite build against this package: the worker emits as `/assets/pdf.worker.min-<hash>.mjs` at 1,286,284 bytes, byte-identical to `node_modules/pdfjs-dist/legacy/build/pdf.worker.min.mjs`, so it ships verbatim rather than being re-bundled, and the `.mjs` extension is preserved (pdf.js loads it as a module worker). `?url` is deliberate over `?worker&url`, which would recompile an already-built worker; a bare `new URL(..., import.meta.url)` does not work at all here, since Vite resolves that form for relative paths and not package specifiers. Both constraints are recorded at the import so the next reader does not "simplify" it into a broken form, mirroring the existing note on the audio worklet in `pcm-capture.ts`.

## What changes for the user

| Situation | Before | After |
| --- | --- | --- |
| First PDF preview of a session, healthy network | Blocks on a jsdelivr round trip before rendering | Loads from the app's own origin |
| CDN slow, blocked by a network policy, or offline | "Failed to load PDF." with no retry | Renders normally |
| Offline / air-gapped use | PDF previews never work | PDF previews work |
| Worker version vs. bundled pdfjs | Matched only while the interpolated CDN path stayed in sync | Same artifact as the imported package, by construction |
| Rendering, page cap, error copy | Unchanged | Unchanged |

## Deferred, still open on the ticket

LUM-3386 also asks for the preview's presentation work, which is deliberately not in this PR: a page-shaped loading skeleton sized from the first page viewport (today a bare centred spinner), an error state carrying the filename plus download and open-in-workspace actions the way `PreviewUnsupported` does, and a visible note when the 20-page render cap applies. Those are design decisions with their own review surface, and bundling them here would have held a one-line reliability fix behind that discussion. The ticket stays open for them, which is why this says Part of rather than Fixes.

Part of LUM-3386

## Original prompt

Continuing a run through the Activation Hub backlog quick wins, one ticket at a time; this is the third after LUM-3433 and LUM-3396 shipped. LUM-3386's first listed cause is that `pdf-preview.tsx` points `GlobalWorkerOptions.workerSrc` at jsdelivr, putting a third-party fetch in front of every session's first PDF preview and turning any hiccup into a generic failure. The ask was to bundle the worker from the installed package, check for any other `workerSrc` call sites (there is only this one), and explicitly leave the ticket's skeleton/error-state design work alone.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->