### PR TITLE
Discord ingests edits and deletes on the named seam

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4366,6 +4366,8 @@ paths:
                       required:
                         - trustClass
                         - canonicalSenderId
+                    actorUnattributed:
+                      type: boolean
                     emailProvider:
                       type: string
                     emailSubject:

--- a/assistant/src/__tests__/delete-propagation.test.ts
+++ b/assistant/src/__tests__/delete-propagation.test.ts
@@ -1,8 +1,8 @@
 /**
- * Tests for Slack message_deleted propagation into stored messages.
+ * Tests for delete propagation into stored messages.
  *
- * The gateway forwards delete events with `callbackData = "message_deleted"`
- * and `sourceMetadata.messageId` set to the deleted message's ts. The daemon
+ * The gateway forwards delete events with `eventKind: "delete"` and
+ * `sourceMetadata.messageId` set to the deleted message's ts. The daemon
  * marks the corresponding stored row's `slackMeta.deletedAt` while leaving
  * the `content` column untouched (audit retention; the renderer elides based
  * on the deletedAt marker).
@@ -347,6 +347,26 @@ describe("Slack delete propagation", () => {
     const parsed = JSON.parse(row!.metadata!) as Record<string, unknown>;
     const slackMeta = readSlackMetadata(parsed.slackMeta as string);
     expect(slackMeta!.deletedAt).toBeUndefined();
+  });
+
+  test("a never-ingested delete returns without paying the retry window", async () => {
+    // The retry loop exists for one race: an inbound-event row written
+    // before its message link lands. No row at all means nothing can appear
+    // by waiting, and the wait would hold the conversation's serialized
+    // forward lane for every unrelated delete a busy room produces.
+    _setDeleteLookupConfigForTests(2, 500);
+    const started = Date.now();
+    const req = buildSlackDeleteRequest({
+      externalChatId: "C0123CHANNEL",
+      deletedTs: "0000.0000",
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.deleted).toBe(false);
+    // Far under a single 500ms retry delay: the loop short-circuited.
+    expect(Date.now() - started).toBeLessThan(400);
   });
 
   test("delete for row without slackMeta stamps the neutral metadata", async () => {

--- a/assistant/src/__tests__/delete-propagation.test.ts
+++ b/assistant/src/__tests__/delete-propagation.test.ts
@@ -154,6 +154,104 @@ function buildSlackDeleteRequest(opts: {
   });
 }
 
+describe("Discord delete propagation (unattributed)", () => {
+  beforeEach(() => {
+    resetState();
+    _setDeleteLookupConfigForTests(2, 20);
+  });
+
+  test("an unattributed delete applies only to an ingested row, without ACL identity", async () => {
+    // Discord's MESSAGE_DELETE names no actor, so the gateway forwards the
+    // synthetic discord-system id with actorUnattributed stated. No member
+    // exists for that id and no trust verdict rides the event; the delete
+    // still applies, because the original's author cleared the ACL when the
+    // message arrived and the stamp touches only that ingested row.
+    const chatId = "999888777666555444";
+    const originalId = "111222333444555001";
+    const inbound = recordInbound("discord", chatId, originalId, {
+      sourceMessageId: originalId,
+    });
+    const messageId = `msg-${originalId}`;
+    getDb()
+      .insert(messages)
+      .values({
+        id: messageId,
+        conversationId: inbound.conversationId,
+        role: "user",
+        content: "A message someone later deleted",
+        metadata: JSON.stringify({ userMessageChannel: "discord" }),
+        createdAt: Date.now(),
+      })
+      .run();
+    linkMessage(inbound.eventId, messageId);
+
+    const req = new Request("http://localhost:8080/channels/inbound", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gateway-Origin": TEST_BEARER_TOKEN,
+      },
+      body: JSON.stringify({
+        sourceChannel: "discord",
+        interface: "discord",
+        conversationExternalId: chatId,
+        externalMessageId: `${originalId}:delete`,
+        eventKind: "delete",
+        content: "",
+        actorExternalId: "discord-system",
+        sourceMetadata: {
+          messageId: originalId,
+          actorUnattributed: true,
+        },
+      }),
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.deleted).toBe(true);
+
+    const row = getDb()
+      .select()
+      .from(messages)
+      .where(eq(messages.id, messageId))
+      .get();
+    expect(row!.content).toBe("A message someone later deleted");
+    const neutral = readProviderMetadata(row!.metadata);
+    expect(neutral).not.toBeNull();
+    expect(neutral!.source).toBe("discord");
+    expect(neutral!.deletedAt).toBeDefined();
+  });
+
+  test("an unattributed delete for a never-ingested message is a no-op", async () => {
+    const req = new Request("http://localhost:8080/channels/inbound", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gateway-Origin": TEST_BEARER_TOKEN,
+      },
+      body: JSON.stringify({
+        sourceChannel: "discord",
+        interface: "discord",
+        conversationExternalId: "999888777666555444",
+        externalMessageId: "111222333444555002:delete",
+        eventKind: "delete",
+        content: "",
+        actorExternalId: "discord-system",
+        sourceMetadata: {
+          messageId: "111222333444555002",
+          actorUnattributed: true,
+        },
+      }),
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+
+    expect(json.accepted).toBe(true);
+    expect(json.deleted).toBe(false);
+  });
+});
+
 describe("Slack delete propagation", () => {
   beforeEach(() => {
     resetState();

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -481,6 +481,33 @@ export function findMessageBySourceId(
 }
 
 /**
+ * Whether any inbound-event row exists for this source message, linked or
+ * not. Discriminates "never ingested" from "ingested, link still landing":
+ * only the second justifies waiting out the link race, so a delete or edit
+ * for a message the daemon never saw can return immediately instead of
+ * holding its conversation's serialized lane through the retry window.
+ */
+export function hasInboundEventForSource(
+  sourceChannel: string,
+  externalChatId: string,
+  sourceMessageId: string,
+): boolean {
+  const db = getDb();
+  const row = db
+    .select({ id: channelInboundEvents.id })
+    .from(channelInboundEvents)
+    .where(
+      and(
+        eq(channelInboundEvents.sourceChannel, sourceChannel),
+        eq(channelInboundEvents.externalChatId, externalChatId),
+        eq(channelInboundEvents.sourceMessageId, sourceMessageId),
+      ),
+    )
+    .get();
+  return row !== undefined;
+}
+
+/**
  * Reference to the most recent inbound channel event for a conversation:
  * the external chat plus the channel-native message identifiers needed to
  * point back at the triggering message (for Slack, `sourceMessageId` is the

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -88,6 +88,7 @@ import { applyDeterministicTitleIfReplaceable } from "../../persistence/conversa
 import {
   clearPayload,
   findMessageBySourceId,
+  hasInboundEventForSource,
   recordInbound,
 } from "../../persistence/delivery-crud.js";
 import { markProcessed } from "../../persistence/delivery-status.js";
@@ -547,6 +548,20 @@ export async function handleChannelInbound({
         deletedMessageTs,
       );
       if (original) {
+        break;
+      }
+      // The retry window exists for one race: the original's inbound-event
+      // row is written before its message link lands. A source with no row
+      // at all was never ingested, so nothing can appear by waiting, and
+      // waiting would hold this conversation's serialized lane through the
+      // full miss window for every unrelated delete a busy room produces.
+      if (
+        !hasInboundEventForSource(
+          sourceChannel,
+          conversationExternalId,
+          deletedMessageTs,
+        )
+      ) {
         break;
       }
       if (attempt < deleteLookupRetries) {

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -372,11 +372,13 @@ export async function handleChannelInbound({
   const hasCallbackData =
     typeof body.callbackData === "string" && body.callbackData.length > 0;
 
+  // Only a plain message must carry a body: every other family refers to
+  // another message and legitimately arrives empty (a delete has no
+  // content at all).
   if (
     trimmedContent.length === 0 &&
     !hasAttachments &&
-    !isEdit &&
-    !hasCallbackData
+    eventKind === "message"
   ) {
     throw new BadRequestError("content or attachmentIds is required");
   }
@@ -476,7 +478,10 @@ export async function handleChannelInbound({
   // respond to one by minting a verification challenge or creating an access
   // request (LUM-2673). Reaction callbacks never reach this point — the
   // intercept above returns for them.
-  const isCallbackInteraction = hasCallbackData;
+  const isCallbackInteraction =
+    eventKind === "button" ||
+    eventKind === "reaction" ||
+    eventKind === "delete";
 
   // ── Ingress ACL enforcement ──
   const aclResult = await enforceIngressAcl({
@@ -493,26 +498,25 @@ export async function handleChannelInbound({
     assistantId,
     effectiveAdmissionPolicy: effectiveAdmissionPolicyForAcl,
     isCallbackInteraction,
+    // Scoped to deletes: the one family whose wire can name no actor. Any
+    // other kind carrying the flag still faces the full ACL.
+    actorUnattributed:
+      eventKind === "delete" && sourceMetadata?.actorUnattributed === true,
   });
   if (aclResult.earlyResponse) {
     return aclResult.earlyResponse;
   }
   const { resolvedMember } = aclResult;
 
-  // ── Slack delete propagation ──
-  // Slack message_deleted events are forwarded by the gateway with the
-  // sentinel `callbackData = "message_deleted"` and `sourceMetadata.messageId`
-  // set to the original (deleted) message's ts. Short-circuit the rest of
-  // the pipeline: the agent loop should not run for delete notifications,
-  // and routing the event through approval / agent paths would be incorrect.
-  // We mark the stored row as deleted in slackMeta but leave `content`
-  // untouched for audit purposes — rendering elides based on the deletedAt
-  // marker. Gated behind ingress ACL so non-members cannot drive deletes
-  // (matches the edit-intercept policy).
-  // The Slack gate mirrors the reaction intercept's: deletes are ingested
-  // from Slack alone today, and each further channel arrives as its own
-  // decision with its own wire shape.
-  if (sourceChannel === "slack" && eventKind === "delete") {
+  // ── Delete propagation ──
+  // A delete names the original via `sourceMetadata.messageId` and
+  // short-circuits the rest of the pipeline: no agent loop, no approval
+  // routing. The stored row keeps its content for audit; rendering elides on
+  // the deletedAt marker. An attributed delete (the wire names the deleted
+  // message's author, as Slack's does) passed the ingress ACL above; an
+  // unattributed one bypassed it under the ACL's stated contract and applies
+  // only to a row this daemon ingested.
+  if (eventKind === "delete") {
     const deletedMessageTs =
       typeof sourceMetadata?.messageId === "string"
         ? sourceMetadata.messageId
@@ -521,7 +525,7 @@ export async function handleChannelInbound({
     if (!deletedMessageTs) {
       log.debug(
         { conversationExternalId },
-        "Slack message_deleted event missing sourceMetadata.messageId; ignoring",
+        "Delete event missing sourceMetadata.messageId; ignoring",
       );
       return { accepted: true, deleted: false };
     }
@@ -564,7 +568,7 @@ export async function handleChannelInbound({
     if (!original) {
       log.debug(
         { conversationExternalId, deletedMessageTs },
-        "No stored message found for Slack delete after retries; ignoring",
+        "No stored message found for delete after retries; ignoring",
       );
       return { accepted: true, deleted: false };
     }

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -127,6 +127,15 @@ export interface AclEnforcementParams {
    * caller makes the classification explicitly.
    */
   isCallbackInteraction: boolean;
+  /**
+   * The platform named no actor for this event (the id is a channel's
+   * synthetic system identity). There is no identity claim to enforce, so
+   * the ACL neither resolves a member nor denies: the family stage that
+   * consumes such an event applies it only to rows whose author cleared
+   * this ACL when the original message arrived. Callers set this ONLY for
+   * event kinds that cannot start an agent turn.
+   */
+  actorUnattributed?: boolean;
 }
 
 /**
@@ -205,6 +214,10 @@ export async function enforceIngressAcl(
     effectiveAdmissionPolicy,
     isCallbackInteraction,
   } = params;
+
+  if (params.actorUnattributed) {
+    return { resolvedMember: null };
+  }
 
   let validatedBootstrapSession: VerificationSessionWire | undefined;
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -116,9 +116,9 @@ export interface AclEnforcementParams {
    */
   effectiveAdmissionPolicy?: AdmissionPolicy;
   /**
-   * True when the inbound event is an interaction callback (e.g. a Slack
-   * Block Kit button press or a message_deleted sentinel) rather than a
-   * message the sender composed. Callbacks are decision attempts / lifecycle
+   * True when the inbound event is an interaction callback (a button
+   * press, a reaction, a delete: any kind that is not a composed message
+   * or an edit of one). Callbacks are decision attempts / lifecycle
    * events, not access attempts: a denied callback must never mint a
    * verification challenge or create an access request — a stale button
    * press from an unrecognized sender would otherwise spawn a fresh

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -314,7 +314,7 @@ describe("Slack inbound mention rendering", () => {
 
     expect(result).not.toBeNull();
     expect(result!.event.message.content).toBe("@vex @leo edited");
-    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.eventKind).toBe("edit");
     expect(result!.event.message.externalMessageId).toBe("evt-edit-render");
     expect(result!.event.source.messageId).toBe("1700000000.000100");
     expect(result!.event.actor.actorExternalId).toBe("U_USER123");
@@ -346,7 +346,7 @@ describe("normalizeSlackMessageEdit", () => {
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
-    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.eventKind).toBe("edit");
     expect(result!.event.message.content).toBe("edited hello world");
   });
 
@@ -483,7 +483,7 @@ describe("normalizeSlackMessageEdit", () => {
     const result = normalizeSlackMessageEdit(event, "evt-108", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.eventKind).toBe("edit");
   });
 
   test("resolves an unrouted non-DM edit to the local assistant", () => {
@@ -609,7 +609,7 @@ describe("normalizeSlackMessageEdit", () => {
     expect(result!.event.message.content).toContain(
       "can you take another look",
     );
-    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.eventKind).toBe("edit");
   });
 
   test("forwards rich-text-only edit when text is identical but edited.ts changes", () => {
@@ -634,7 +634,7 @@ describe("normalizeSlackMessageEdit", () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.eventKind).toBe("edit");
   });
 
   test("forwards edit when previous_message is missing (cannot prove no-op)", () => {
@@ -644,6 +644,6 @@ describe("normalizeSlackMessageEdit", () => {
 
     const result = normalizeSlackMessageEdit(event, "evt-no-prev", config);
     expect(result).not.toBeNull();
-    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.eventKind).toBe("edit");
   });
 });

--- a/gateway/src/__tests__/slack-normalize.test.ts
+++ b/gateway/src/__tests__/slack-normalize.test.ts
@@ -339,7 +339,7 @@ function makeMessageChangedEvent(
 }
 
 describe("normalizeSlackMessageEdit", () => {
-  test("normalizes message_changed event with isEdit: true", () => {
+  test("normalizes message_changed event as an edit", () => {
     const config = makeConfig();
     const event = makeMessageChangedEvent();
     const result = normalizeSlackMessageEdit(event, "evt-100", config);

--- a/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
@@ -887,7 +887,7 @@ describe("LUM-2941: the assistant's own bot_message echoes", () => {
       });
       await flushAsyncEventEmission();
       expect(emitted).toHaveLength(1);
-      expect(emitted[0]?.event.message.callbackData).toBe("message_deleted");
+      expect(emitted[0]?.event.message.eventKind).toBe("delete");
     } finally {
       rawDb.close();
     }
@@ -997,7 +997,7 @@ describe("LUM-2941: filters widened by an armed root", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
-      expect(emitted[0]?.event.message.isEdit).toBe(true);
+      expect(emitted[0]?.event.message.eventKind).toBe("edit");
 
       deliver(client, ws, "Ev-edit-other", {
         type: "message",
@@ -1042,7 +1042,7 @@ describe("LUM-2941: filters widened by an armed root", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
-      expect(emitted[0]?.event.message.callbackData).toBe("message_deleted");
+      expect(emitted[0]?.event.message.eventKind).toBe("delete");
 
       deliver(client, ws, "Ev-del-other", {
         type: "message",

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -1580,7 +1580,7 @@ describe("SlackSocketModeClient thread tracking", () => {
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-dm-edit");
-      expect(emitted[0].event.message.isEdit).toBe(true);
+      expect(emitted[0].event.message.eventKind).toBe("edit");
     } finally {
       rawDb.close();
     }
@@ -1620,7 +1620,7 @@ describe("SlackSocketModeClient thread tracking", () => {
 
       expect(emitted).toHaveLength(1);
       expect(emitted[0].event.source.updateId).toBe("Ev-dm-delete");
-      expect(emitted[0].event.message.callbackData).toBe("message_deleted");
+      expect(emitted[0].event.message.eventKind).toBe("delete");
     } finally {
       rawDb.close();
     }
@@ -2155,7 +2155,7 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       );
       await run();
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.message.isEdit).toBe(true);
+      expect(emitted[0].event.message.eventKind).toBe("edit");
     } finally {
       rawDb.close();
     }
@@ -2186,7 +2186,7 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       );
       await run();
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.message.callbackData).toBe("message_deleted");
+      expect(emitted[0].event.message.eventKind).toBe("delete");
     } finally {
       rawDb.close();
     }
@@ -2269,7 +2269,7 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       );
       await run();
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.message.isEdit).toBe(true);
+      expect(emitted[0].event.message.eventKind).toBe("edit");
       expect(emitted[0].routing.assistantId).toBe("ast-actor");
     } finally {
       rawDb.close();
@@ -2306,7 +2306,7 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       );
       await run();
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.message.callbackData).toBe("message_deleted");
+      expect(emitted[0].event.message.eventKind).toBe("delete");
       expect(emitted[0].routing.assistantId).toBe("ast-actor");
     } finally {
       rawDb.close();

--- a/gateway/src/__tests__/telegram-normalize.test.ts
+++ b/gateway/src/__tests__/telegram-normalize.test.ts
@@ -229,7 +229,7 @@ describe("normalizeTelegramUpdate", () => {
     };
     const result = normalizeTelegramUpdate(payload);
     expect(result).not.toBeNull();
-    expect(result!.message.isEdit).toBe(true);
+    expect(result!.message.eventKind).toBe("edit");
     expect(result!.message.content).toBe("Hello bot (edited)");
     expect(result!.message.conversationExternalId).toBe("99001");
     expect(result!.message.externalMessageId).toBe("200");
@@ -280,7 +280,7 @@ describe("normalizeTelegramUpdate", () => {
     };
     const result = normalizeTelegramUpdate(payload);
     expect(result).not.toBeNull();
-    expect(result!.message.isEdit).toBe(true);
+    expect(result!.message.eventKind).toBe("edit");
     expect(result!.message.content).toBe("Updated caption");
     expect(result!.message.attachments).toHaveLength(1);
   });

--- a/gateway/src/__tests__/telegram-normalize.test.ts
+++ b/gateway/src/__tests__/telegram-normalize.test.ts
@@ -212,7 +212,7 @@ describe("normalizeTelegramUpdate", () => {
     expect(normalizeTelegramUpdate(payload)).toBeNull();
   });
 
-  test("normalizes an edited_message update with isEdit flag", () => {
+  test("normalizes an edited_message update as an edit", () => {
     const payload = {
       update_id: 200,
       edited_message: {
@@ -260,7 +260,7 @@ describe("normalizeTelegramUpdate", () => {
     expect(result!.message.content).toBe("Original");
   });
 
-  test("sets isEdit for edited_message with photo", () => {
+  test("classifies an edited_message with photo as an edit", () => {
     const payload = {
       update_id: 400,
       edited_message: {

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -91,6 +91,15 @@ interface InboundEventBase<C extends InboundChannelId> {
      */
     isDirectMessage?: boolean;
     /**
+     * True when the platform names no actor for this event: the synthetic
+     * actorExternalId identifies the channel's system, not a person, so
+     * nothing downstream may treat it as an identity claim. A delete on a
+     * platform whose dispatch carries no author is the canonical case; the
+     * daemon then applies the event only to rows it ingested, whose author
+     * cleared the ACL on arrival.
+     */
+    actorUnattributed?: boolean;
+    /**
      * Thread/conversation-group identifier, when the source channel carries one
      * (e.g. Slack `thread_ts`). Channel-agnostic name so other channels (email
      * `In-Reply-To`, etc.) can reuse the field later.

--- a/gateway/src/discord/forward.ts
+++ b/gateway/src/discord/forward.ts
@@ -30,16 +30,21 @@ export function createDiscordInboundEventHandler(options: {
 
     // A guild channel is a room the actor is standing in, not their private
     // delivery address. Recording it as externalChatId would post private
-    // notices in public, so only DMs carry that field.
-    void upsertContactChannel({
-      sourceChannel: "discord",
-      externalUserId: event.actor.actorExternalId,
-      ...(event.source.chatType === "dm"
-        ? { externalChatId: event.message.conversationExternalId }
-        : {}),
-      displayName: event.actor.displayName,
-      username: event.actor.username,
-    }).catch(() => {});
+    // notices in public, so only DMs carry that field. An unattributed
+    // event's actor is a synthetic system id, not a person: seeding a
+    // contact from it would mint a ghost and, on a DM, bind that ghost to a
+    // real conversation.
+    if (!event.source.actorUnattributed) {
+      void upsertContactChannel({
+        sourceChannel: "discord",
+        externalUserId: event.actor.actorExternalId,
+        ...(event.source.chatType === "dm"
+          ? { externalChatId: event.message.conversationExternalId }
+          : {}),
+        displayName: event.actor.displayName,
+        username: event.actor.username,
+      }).catch(() => {});
+    }
 
     // The event's conversation address is the parent channel for threaded
     // messages, and a Discord thread is itself a channel. Include the thread

--- a/gateway/src/discord/gateway-socket.ts
+++ b/gateway/src/discord/gateway-socket.ts
@@ -683,10 +683,16 @@ export class DiscordGatewayClient {
     const message = parsed.data;
     // Embed resolution and other non-user revisions dispatch MESSAGE_UPDATE
     // with no edited_timestamp; nothing the user said changed, so there is
-    // nothing to rewrite. Without MESSAGE_CONTENT the content of a
-    // non-exempt guild edit also arrives empty; rewriting a stored row to
-    // empty would destroy text over an intent gap, so those drop too.
-    if (message.edited_timestamp == null || message.content.length === 0) {
+    // nothing to rewrite. Guild content is additionally ambiguous when
+    // empty: without MESSAGE_CONTENT a non-exempt guild edit arrives with
+    // its text hidden, and rewriting a stored row to empty would destroy
+    // text over an intent gap. A DM is inside the content exemption, so an
+    // empty DM revision is a real clearing (an attachment message whose
+    // caption was removed) and propagates.
+    if (
+      message.edited_timestamp == null ||
+      (message.guild_id !== undefined && message.content.length === 0)
+    ) {
       log.debug(
         { messageId: message.id },
         "Dropping MESSAGE_UPDATE with no user revision",

--- a/gateway/src/discord/gateway-socket.ts
+++ b/gateway/src/discord/gateway-socket.ts
@@ -53,9 +53,14 @@ import {
   DiscordMessageCreateSchema,
   DiscordReadySchema,
   DiscordThreadListSchema,
+  DiscordMessageDeleteSchema,
   DiscordThreadSchema,
 } from "./message-schemas.js";
-import { normalizeDiscordMessage, toAdmissionCandidate } from "./normalize.js";
+import {
+  normalizeDiscordMessage,
+  normalizeDiscordMessageDelete,
+  toAdmissionCandidate,
+} from "./normalize.js";
 import { DiscordSessionState } from "./session-state.js";
 import { ThreadParentCache } from "./thread-parents.js";
 
@@ -654,9 +659,114 @@ export class DiscordGatewayClient {
       case "MESSAGE_CREATE":
         this.handleMessageCreate(data);
         return;
+      case "MESSAGE_UPDATE":
+        this.handleMessageUpdate(data);
+        return;
+      case "MESSAGE_DELETE":
+        this.handleMessageDelete(data);
+        return;
       default:
         return;
     }
+  }
+
+  private handleMessageUpdate(data: unknown): void {
+    if (!this.botUserId) {
+      log.warn("Dropping MESSAGE_UPDATE: bot identity not yet resolved");
+      return;
+    }
+    const parsed = DiscordMessageCreateSchema.safeParse(data);
+    if (!parsed.success) {
+      log.warn("Dropping malformed MESSAGE_UPDATE");
+      return;
+    }
+    const message = parsed.data;
+    // Embed resolution and other non-user revisions dispatch MESSAGE_UPDATE
+    // with no edited_timestamp; nothing the user said changed, so there is
+    // nothing to rewrite. Without MESSAGE_CONTENT the content of a
+    // non-exempt guild edit also arrives empty; rewriting a stored row to
+    // empty would destroy text over an intent gap, so those drop too.
+    if (message.edited_timestamp == null || message.content.length === 0) {
+      log.debug(
+        { messageId: message.id },
+        "Dropping MESSAGE_UPDATE with no user revision",
+      );
+      return;
+    }
+    const parentChannelId = this.threadParents.parentOf(message.channel_id);
+    const candidate = toAdmissionCandidate(message, parentChannelId);
+    if (!candidate) {
+      log.warn("Dropping MESSAGE_UPDATE with no author identity");
+      return;
+    }
+    const legacyAllowedChannelIds = this.readLegacyAllowedChannelIds?.();
+    const verdict = admitDiscordMessage(candidate, {
+      botUserId: this.botUserId,
+      ...(legacyAllowedChannelIds !== undefined
+        ? { legacyAllowedChannelIds }
+        : {}),
+    });
+    if (!verdict.admitted) {
+      log.debug(
+        { reason: verdict.reason, channelId: message.channel_id },
+        "Discord edit dropped by admission gate",
+      );
+      return;
+    }
+    const normalized = normalizeDiscordMessage(message, {
+      ...(parentChannelId !== undefined ? { parentChannelId } : {}),
+      raw: (data ?? {}) as Record<string, unknown>,
+      edit: { revision: message.edited_timestamp },
+    });
+    if (!normalized) {
+      log.warn(
+        { messageId: message.id },
+        "Discord edit dropped by normalization",
+      );
+      return;
+    }
+    log.info(
+      {
+        messageId: message.id,
+        conversationExternalId: normalized.message.conversationExternalId,
+      },
+      "Discord edit admitted",
+    );
+    this.onEvent(normalized, new Map());
+  }
+
+  private handleMessageDelete(data: unknown): void {
+    const parsed = DiscordMessageDeleteSchema.safeParse(data);
+    if (!parsed.success) {
+      log.warn("Dropping malformed MESSAGE_DELETE");
+      return;
+    }
+    const del = parsed.data;
+    // No admission gate: the dispatch names no author to gate on, and the
+    // daemon applies an unattributed delete only to a row it ingested, so a
+    // delete for anything the admission gate kept out is a no-op there. The
+    // event still rides the full forward path, where the kill switch and
+    // per-family stages apply.
+    const parentChannelId = this.threadParents.parentOf(del.channel_id);
+    const normalized = normalizeDiscordMessageDelete(del, {
+      ...(parentChannelId !== undefined ? { parentChannelId } : {}),
+      raw: (data ?? {}) as Record<string, unknown>,
+    });
+    if (!normalized) {
+      log.warn(
+        { messageId: del.id },
+        "Discord delete dropped by normalization",
+      );
+      return;
+    }
+    log.info(
+      {
+        messageId: del.id,
+        conversationExternalId: normalized.message.conversationExternalId,
+      },
+      "Discord delete forwarded",
+    );
+    this.onEvent(normalized, new Map());
   }
 
   private handleMessageCreate(data: unknown): void {

--- a/gateway/src/discord/message-schemas.ts
+++ b/gateway/src/discord/message-schemas.ts
@@ -23,6 +23,8 @@ import type {
   APIThreadChannel,
   GatewayHelloData,
   GatewayMessageCreateDispatchData,
+  GatewayMessageDeleteDispatchData,
+  GatewayMessageUpdateDispatchData,
   GatewayReadyDispatchData,
   GatewayReceivePayload,
 } from "discord-api-types/v10";
@@ -106,6 +108,13 @@ export const DiscordMessageCreateSchema = z.object({
   guild_id: z.string().optional().catch("malformed-guild-id"),
   /** Empty (not absent) on non-exempt messages without MESSAGE_CONTENT. */
   content: z.string().catch(""),
+  /**
+   * Set on MESSAGE_UPDATE dispatches; null on a MESSAGE_CREATE and on
+   * update dispatches that carry no user revision (embed resolution). Each
+   * revision's timestamp makes the edit's dedup id unique per revision, so
+   * successive edits of one message are never swallowed as duplicates.
+   */
+  edited_timestamp: z.string().nullable().optional().catch(undefined),
   author: z
     .object({
       id: idString(),
@@ -151,6 +160,18 @@ export const DiscordMessageCreateSchema = z.object({
     .catch(undefined),
 });
 export type DiscordMessageCreate = z.infer<typeof DiscordMessageCreateSchema>;
+
+/**
+ * MESSAGE_DELETE carries three fields and nothing else: no author, no
+ * content, no mentions. The guild sentinel matches the create schema's
+ * reasoning: absence means DM, so a malformed value must not read as one.
+ */
+export const DiscordMessageDeleteSchema = z.object({
+  id: idString(),
+  channel_id: idString(),
+  guild_id: z.string().optional().catch("malformed-guild-id"),
+});
+export type DiscordMessageDelete = z.infer<typeof DiscordMessageDeleteSchema>;
 
 // ---------------------------------------------------------------------------
 // Compile-time cross-check against the official Discord API types.
@@ -205,6 +226,18 @@ type _DiscordApiCrossChecks = [
     ModeledKeysAreOfficial<
       z.infer<typeof DiscordMessageCreateSchema>,
       GatewayMessageCreateDispatchData
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      z.infer<typeof DiscordMessageCreateSchema>,
+      GatewayMessageUpdateDispatchData
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      z.infer<typeof DiscordMessageDeleteSchema>,
+      GatewayMessageDeleteDispatchData
     >
   >,
   Expect<

--- a/gateway/src/discord/normalize.test.ts
+++ b/gateway/src/discord/normalize.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
 import { admitDiscordMessage } from "./admit.js";
-import { DiscordMessageCreateSchema } from "./message-schemas.js";
-import { normalizeDiscordMessage, toAdmissionCandidate } from "./normalize.js";
+import {
+  DiscordMessageCreateSchema,
+  DiscordMessageDeleteSchema,
+} from "./message-schemas.js";
+import {
+  normalizeDiscordMessage,
+  normalizeDiscordMessageDelete,
+  toAdmissionCandidate,
+} from "./normalize.js";
 import "../__tests__/test-preload.js";
 
 /** A well-formed guild MESSAGE_CREATE payload, as Discord sends it. */
@@ -406,5 +413,72 @@ describe("normalizeDiscordMessage", () => {
     expect(normalizeDiscordMessage(noChannel, { raw: {} })).toBeNull();
     const noAuthor = parse(messagePayload({ author: undefined }));
     expect(normalizeDiscordMessage(noAuthor, { raw: {} })).toBeNull();
+  });
+});
+
+describe("normalizeDiscordMessage: edits", () => {
+  test("an edit names its family and revision without carrying media", () => {
+    const message = parse(
+      messagePayload({
+        edited_timestamp: "2026-08-27T10:00:00.000000+00:00",
+        attachments: [{ id: "att-1", filename: "photo.png" }],
+      }),
+    );
+    const event = normalizeDiscordMessage(message, {
+      raw: {},
+      edit: { revision: message.edited_timestamp! },
+    });
+
+    expect(event).not.toBeNull();
+    expect(event!.message.eventKind).toBe("edit");
+    // The dedup id is unique per revision so successive edits of one message
+    // never swallow each other; the source id keeps naming the message the
+    // edit rewrites.
+    expect(event!.message.externalMessageId).toBe(
+      "msg-1:edit:2026-08-27T10:00:00.000000+00:00",
+    );
+    expect(event!.source.messageId).toBe("msg-1");
+    // An edit refers to another message and ingests no media of its own.
+    expect(event!.message.attachments).toBeUndefined();
+  });
+});
+
+describe("normalizeDiscordMessageDelete", () => {
+  test("a delete states its family and its unattributed actor", () => {
+    const parsed = DiscordMessageDeleteSchema.safeParse({
+      id: "msg-9",
+      channel_id: "channel-1",
+      guild_id: "guild-1",
+    });
+    expect(parsed.success).toBe(true);
+    const event = normalizeDiscordMessageDelete(
+      parsed.success ? parsed.data : (undefined as never),
+      { raw: {} },
+    );
+
+    expect(event).not.toBeNull();
+    expect(event!.message.eventKind).toBe("delete");
+    expect(event!.message.externalMessageId).toBe("msg-9:delete");
+    expect(event!.source.messageId).toBe("msg-9");
+    // The wire names no actor: the synthetic id is not an identity claim,
+    // and the flag is what lets the daemon treat it that way.
+    expect(event!.actor.actorExternalId).toBe("discord-system");
+    expect(event!.source.actorUnattributed).toBe(true);
+    expect(event!.source.isDirectMessage).toBe(false);
+  });
+
+  test("a DM delete proves its lane by guild absence", () => {
+    const parsed = DiscordMessageDeleteSchema.safeParse({
+      id: "msg-10",
+      channel_id: "dm-channel-1",
+    });
+    expect(parsed.success).toBe(true);
+    const event = normalizeDiscordMessageDelete(
+      parsed.success ? parsed.data : (undefined as never),
+      { raw: {} },
+    );
+
+    expect(event!.source.isDirectMessage).toBe(true);
+    expect(event!.source.conversationType).toBe("dm");
   });
 });

--- a/gateway/src/discord/normalize.ts
+++ b/gateway/src/discord/normalize.ts
@@ -16,7 +16,10 @@
 import type { DiscordInboundEvent } from "../channels/inbound-event.js";
 import type { AdmissionCandidate } from "./admit.js";
 import { extractDiscordAttachments } from "./attachments.js";
-import type { DiscordMessageCreate } from "./message-schemas.js";
+import type {
+  DiscordMessageCreate,
+  DiscordMessageDelete,
+} from "./message-schemas.js";
 
 /**
  * Build the admission gate's input from a parsed message. `parentChannelId`
@@ -56,6 +59,12 @@ export function normalizeDiscordMessage(
     parentChannelId?: string;
     /** The original dispatch `d` payload, preserved verbatim. */
     raw: Record<string, unknown>;
+    /**
+     * Set for a MESSAGE_UPDATE. The revision id joins the event's dedup id
+     * so successive edits of one message never swallow each other, while
+     * `source.messageId` keeps naming the message the edit rewrites.
+     */
+    edit?: { revision: string };
   },
 ): DiscordInboundEvent | null {
   const authorId = message.author?.id;
@@ -74,11 +83,13 @@ export function normalizeDiscordMessage(
     sourceChannel: "discord",
     receivedAt: new Date().toISOString(),
     message: {
-      eventKind: "message",
+      eventKind: options.edit ? "edit" : "message",
       content: message.content,
       conversationExternalId: options.parentChannelId ?? message.channel_id,
-      externalMessageId: message.id,
-      ...(attachments.length > 0 ? { attachments } : {}),
+      externalMessageId: options.edit
+        ? `${message.id}:edit:${options.edit.revision}`
+        : message.id,
+      ...(attachments.length > 0 && !options.edit ? { attachments } : {}),
     },
     actor: {
       actorExternalId: authorId,
@@ -104,6 +115,52 @@ export function normalizeDiscordMessage(
       isDirectMessage,
       ...(isDirectMessage ? { conversationType: "dm" as const } : {}),
       ...(inThread ? { threadId: message.channel_id } : {}),
+    },
+    raw: options.raw,
+  };
+}
+
+/**
+ * Normalize a MESSAGE_DELETE. The wire names no actor: the dispatch carries
+ * only the message, channel and optional guild ids, so the actor is the
+ * synthetic `discord-system` and `actorUnattributed` states the fact. The
+ * daemon applies an unattributed delete only to a row it ingested, whose
+ * author cleared the ACL when the message arrived; nothing here asserts who
+ * deleted it.
+ */
+export function normalizeDiscordMessageDelete(
+  del: DiscordMessageDelete,
+  options: {
+    parentChannelId?: string;
+    raw: Record<string, unknown>;
+  },
+): DiscordInboundEvent | null {
+  if (!del.id || !del.channel_id) {
+    return null;
+  }
+  const inThread = options.parentChannelId !== undefined;
+  const isDirectMessage = del.guild_id === undefined;
+  return {
+    version: "v1",
+    sourceChannel: "discord",
+    receivedAt: new Date().toISOString(),
+    message: {
+      eventKind: "delete",
+      content: "",
+      conversationExternalId: options.parentChannelId ?? del.channel_id,
+      externalMessageId: `${del.id}:delete`,
+    },
+    actor: {
+      actorExternalId: "discord-system",
+    },
+    source: {
+      updateId: del.id,
+      messageId: del.id,
+      chatType: isDirectMessage ? "dm" : "channel",
+      isDirectMessage,
+      actorUnattributed: true,
+      ...(isDirectMessage ? { conversationType: "dm" as const } : {}),
+      ...(inThread ? { threadId: del.channel_id } : {}),
     },
     raw: options.raw,
   };

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -4,6 +4,7 @@ import {
   makeUnauthenticatedSenderVerdict,
   type SourceMetadata,
   type TrustVerdict,
+  resolveInboundEventKind,
 } from "@vellumai/gateway-client";
 import type { GatewayConfig } from "../config.js";
 import { ContactStore } from "../db/contact-store.js";
@@ -181,20 +182,29 @@ export async function admitInbound(
 
   const displayName = event.actor.displayName || event.actor.username;
 
+  // Only user-authored text can carry a verification code or an invite:
+  // reactions, button presses and deletes are not utterances, and running
+  // the text intercepts over their payloads reads sentinel strings as
+  // messages.
+  const eventKind = resolveInboundEventKind(event.message);
+  const carriesUserText = eventKind === "message" || eventKind === "edit";
+
   // ── Text verification intercept ──
   // Must run before forwardToRuntime so the assistant never sees
   // verification code messages. Both success and failure short-circuit.
-  const verificationResult = await tryTextVerificationIntercept({
-    sourceChannel: event.sourceChannel,
-    messageContent: event.message.content,
-    actorExternalUserId: event.actor.actorExternalId,
-    actorChatId: event.message.conversationExternalId,
-    isDirectMessage: event.source.isDirectMessage,
-    actorDisplayName: event.actor.displayName,
-    actorUsername: event.actor.username,
-    replyCallbackUrl: options?.replyCallbackUrl,
-    assistantId: routing.assistantId,
-  });
+  const verificationResult = carriesUserText
+    ? await tryTextVerificationIntercept({
+        sourceChannel: event.sourceChannel,
+        messageContent: event.message.content,
+        actorExternalUserId: event.actor.actorExternalId,
+        actorChatId: event.message.conversationExternalId,
+        isDirectMessage: event.source.isDirectMessage,
+        actorDisplayName: event.actor.displayName,
+        actorUsername: event.actor.username,
+        replyCallbackUrl: options?.replyCallbackUrl,
+        assistantId: routing.assistantId,
+      })
+    : ({ intercepted: false } as const);
 
   if (verificationResult.intercepted) {
     log.info(
@@ -272,7 +282,7 @@ export async function admitInbound(
   // them. A code that matches no invite falls through as a normal message.
   // Unauthenticated senders never redeem: a spoofable address must not mint
   // a membership binding it may not own.
-  if (options?.senderAuthenticated !== false) {
+  if (carriesUserText && options?.senderAuthenticated !== false) {
     const inviteResult = await tryInviteRedemptionIntercept({
       sourceChannel: event.sourceChannel,
       messageContent: event.message.content,
@@ -356,6 +366,9 @@ export async function handleInbound(
         sourceMetadata: {
           updateId: event.source.updateId,
           messageId: event.source.messageId,
+          ...(event.source.actorUnattributed
+            ? { actorUnattributed: true }
+            : {}),
           chatType: event.source.chatType,
           conversationType: event.source.conversationType,
           ...(event.source.threadId ? { threadId: event.source.threadId } : {}),
@@ -415,7 +428,14 @@ export async function handleInbound(
     // Fire-and-forget so write failures here cannot leak as unhandled
     // rejections.
     if (!response.denied) {
-      void touchContactChannelStats(event, response.duplicate).catch(() => {});
+      // A delete is not an interaction by the person: its actor may be a
+      // synthetic system id, and bumping presence stats for one would
+      // record activity nobody performed.
+      if (resolveInboundEventKind(event.message) !== "delete") {
+        void touchContactChannelStats(event, response.duplicate).catch(
+          () => {},
+        );
+      }
     }
 
     return { forwarded: true, rejected: false, runtimeResponse: response };

--- a/gateway/src/slack/message-change-normalizer.ts
+++ b/gateway/src/slack/message-change-normalizer.ts
@@ -72,7 +72,6 @@ export function normalizeSlackMessageEdit(
         content,
         conversationExternalId: channel,
         externalMessageId,
-        isEdit: true,
       },
       actor: {
         actorExternalId: edited.user,
@@ -155,8 +154,6 @@ export function normalizeSlackMessageDelete(
         conversationExternalId: channel,
         // Unique per delete event to avoid dedup collisions
         externalMessageId: eventId,
-        // Sentinel value that classifies unstamped replayed retry payloads
-        callbackData: "message_deleted",
       },
       actor: {
         actorExternalId: actorId,

--- a/gateway/src/slack/message-change-normalizer.ts
+++ b/gateway/src/slack/message-change-normalizer.ts
@@ -14,7 +14,7 @@ import { resolveAssistant, isRejection } from "../routing/resolve-assistant.js";
 
 /**
  * Normalize a Slack `message_changed` event into the gateway's canonical
- * inbound event shape with `isEdit: true`.
+ * inbound event shape with `eventKind: "edit"`.
  *
  * The edited content lives in `event.message` (not `event.previous_message`).
  * Uses `event.message.ts` as `source.messageId` so the runtime can correlate
@@ -108,10 +108,10 @@ export function normalizeSlackMessageEdit(
  *
  * The deleted message's `ts` arrives as `event.deleted_ts` and the prior
  * content (including any `thread_ts`) lives in `event.previous_message`.
- * The daemon detects deletes via the `message_deleted` sentinel placed in
- * `callbackData` and uses `source.messageId` (= `deleted_ts`) to look up
- * the stored row. `message.content` is intentionally empty — the daemon
- * just marks the row deleted and does not re-process content.
+ * The daemon routes deletes on `eventKind: "delete"` and uses
+ * `source.messageId` (= `deleted_ts`) to look up the stored row.
+ * `message.content` is intentionally empty — the daemon just marks the row
+ * deleted and does not re-process content.
  *
  * Each delete event gets a unique `externalMessageId` (= eventId) so the
  * dedup pipeline does not collide if Slack re-delivers the event.

--- a/gateway/src/slack/message-change-normalizer.ts
+++ b/gateway/src/slack/message-change-normalizer.ts
@@ -110,7 +110,7 @@ export function normalizeSlackMessageEdit(
  * content (including any `thread_ts`) lives in `event.previous_message`.
  * The daemon routes deletes on `eventKind: "delete"` and uses
  * `source.messageId` (= `deleted_ts`) to look up the stored row.
- * `message.content` is intentionally empty — the daemon just marks the row
+ * `message.content` is intentionally empty: the daemon just marks the row
  * deleted and does not re-process content.
  *
  * Each delete event gets a unique `externalMessageId` (= eventId) so the

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -1407,7 +1407,7 @@ describe("normalizeSlackMessageEdit", () => {
 
     expect(result).not.toBeNull();
     expect(result!.event.message.eventKind).toBe("edit");
-    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.eventKind).toBe("edit");
     expect(result!.event.message.conversationExternalId).toBe("C456");
     expect(result!.event.actor.actorExternalId).toBe("U123");
     expect(result!.event.source.chatType).toBe("channel");
@@ -1568,7 +1568,7 @@ describe("normalizeSlackMessageDelete", () => {
     expect(result).not.toBeNull();
     expect(result!.event.message.eventKind).toBe("delete");
     expect(result!.event.sourceChannel).toBe("slack");
-    expect(result!.event.message.callbackData).toBe("message_deleted");
+    expect(result!.event.message.eventKind).toBe("delete");
     expect(result!.event.message.content).toBe("");
     expect(result!.event.message.externalMessageId).toBe("evt-del-dm");
     expect(result!.event.message.conversationExternalId).toBe("D789");
@@ -1588,7 +1588,7 @@ describe("normalizeSlackMessageDelete", () => {
     const result = normalizeSlackMessageDelete(event, "evt-del-ch", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.callbackData).toBe("message_deleted");
+    expect(result!.event.message.eventKind).toBe("delete");
     expect(result!.event.message.content).toBe("");
     expect(result!.event.message.externalMessageId).toBe("evt-del-ch");
     // source.messageId carries the original deleted message's ts
@@ -1787,7 +1787,7 @@ describe("message edit/delete tolerant validation", () => {
 
     expect(result).not.toBeNull();
     expect(result!.event.message.content).toBe("");
-    expect(result!.event.message.isEdit).toBe(true);
+    expect(result!.event.message.eventKind).toBe("edit");
   });
 
   it("preserves unknown extra keys verbatim in an edit's raw", () => {

--- a/gateway/src/telegram/normalize.test.ts
+++ b/gateway/src/telegram/normalize.test.ts
@@ -107,7 +107,7 @@ describe("normalizeTelegramUpdate: event kinds", () => {
 
     expect(result).not.toBeNull();
     expect(result!.message.eventKind).toBe("edit");
-    expect(result!.message.isEdit).toBe(true);
+    expect(result!.message.eventKind).toBe("edit");
   });
 
   it("classifies a plain message as a message", () => {

--- a/gateway/src/telegram/normalize.ts
+++ b/gateway/src/telegram/normalize.ts
@@ -326,7 +326,6 @@ export function normalizeTelegramUpdate(
       conversationExternalId: String(message.chat.id),
       externalMessageId: String(updateId),
       ...(attachments.length > 0 ? { attachments } : {}),
-      ...(isEdit ? { isEdit: true } : {}),
     },
     actor: {
       actorExternalId,

--- a/packages/gateway-client/src/inbound-contract.ts
+++ b/packages/gateway-client/src/inbound-contract.ts
@@ -139,6 +139,11 @@ export const SourceMetadataSchema = z
      * "not provided", never as a decision.
      */
     trustVerdict: TrustVerdictSchema.optional(),
+    /**
+     * The platform named no actor for this event; the actor id is the
+     * channel's synthetic system identity, never an identity claim.
+     */
+    actorUnattributed: z.boolean().optional(),
 
     // Email-specific fields
     /**


### PR DESCRIPTION
## TL;DR

PR 3 of the stack, the payoff: Discord ingests edits and deletes. The intents have always delivered `MESSAGE_UPDATE` and `MESSAGE_DELETE`; the dispatch switch silently dropped both. Edits now rewrite the stored row in place with the same semantics Slack and Telegram settled (never re-triggering a reply), and deletions mark the row while keeping its content for audit. Built to the North-Star shape: the delete stage gates on the kind plus the facts it needs, not channel names — a plugin channel stating `eventKind: delete` with a message id now works with zero Vellum-side code.

## Why this is safe

- **Edits ride the existing admission gate** (mention-scoped in guilds, free in DMs — the exemption that guarantees their content is real), drop non-user revisions (embed resolution has no `edited_timestamp`) and content-hidden guild edits rather than rewriting a stored row to empty, and dedup per revision (`id:edit:<edited_timestamp>`) so successive edits never swallow each other — the same uniqueness discipline Slack's edit events use.
- **Deletes carry the only shape their wire has**: three ids, no author. The wire states `actorUnattributed`; the ACL honors that fact by neither resolving nor denying (scoped at the call site to deletes only, so no other kind can ride the bypass), because the applying stage touches only rows whose author cleared that same ACL when the original arrived. Slack's attributed deletes keep their pinned ACL path bit-for-bit — the non-member-rejection test still passes unchanged.
- **The kind finishes replacing the sentinels**: callback-interaction classification and the body-required check key on `eventKind`; verification and invite intercepts run only on user-authored text; producers shed the now-redundant `isEdit` and `"message_deleted"` stamps (replayed pre-kind payloads still classify via the pinned derivation contract). Both new Discord dispatch shapes are compile-time cross-checked against `discord-api-types`.
- Coverage: Discord normalizer tests pin the edit's per-revision dedup id and media-free shape, and the delete's unattributed statement on both lanes; daemon end-to-end tests drive an unattributed delete through the real handler (applies to an ingested row, no-ops on a never-ingested one); every legacy-field test pin was converted to a kind pin rather than deleted.

## Pre-existing bugs fixed here

1. **Reactions, button presses and deletes ran through the text-verification and invite intercepts** as if their payloads were utterances — a sentinel string could be probed as a verification code. Now only user-authored text reaches those intercepts.
2. **Deletes bumped contact presence/interaction stats** with no person behind the event. They no longer do.

## What changes for the user

| Before | After |
| --- | --- |
| Editing a message you sent to the assistant on Discord changed nothing | The stored message updates in place, with the edit marked in the neutral metadata |
| Deleting a message you sent on Discord left it in the assistant's history as if nothing happened | The row is marked deleted (content kept for audit; the model-facing transcript can elide it) |
| Slack/Telegram edit and delete behavior | Unchanged, now under kind-keyed gates with their tests converted, not removed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->