### PR TITLE
fix(web): keep the 100% reading beside the extra-usage-credits line

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
@@ -238,8 +238,9 @@ export const MidCycle: Story = {
 
 /**
  * The grants used up with credits still in the wallet behind them. The
- * percentage steps aside and the amber extra-credits line takes the bar's
- * place, and no strip appears: the next turn still has something to draw on.
+ * percentage keeps its neutral color while the amber extra-credits line takes
+ * the bar's place, and no strip appears: the next turn still has something to
+ * draw on.
  */
 export const SpentBundle: Story = {
   name: "Spent bundle, extra credits",

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
@@ -243,7 +243,7 @@ describe("PreferencesUsagePanel", () => {
 
     const panel = await findByTestId("preferences-usage");
     expect(getByText("Now using extra usage credits")).toBeTruthy();
-    expect(panel.textContent).not.toContain("100% used");
+    expect(panel.textContent).toContain("100% used");
     expect(queryByText("Add credits to continue.")).toBeNull();
     expect(queryByTestId("preferences-usage-add-credits")).toBeNull();
   });
@@ -308,11 +308,11 @@ describe("PreferencesUsagePanel", () => {
     const panel = await findByTestId("preferences-usage");
     // Amber, not red: nothing has gone wrong yet, the wallet behind the
     // grants still has something to draw on, so the line names it while the
-    // percentage, the bar, and the strip all stay away.
+    // bar and the strip stay away and the percentage keeps its neutral color.
     expect(getByText("Now using extra usage credits").className).toContain(
       "--system-mid-strong",
     );
-    expect(panel.textContent).not.toContain("100% used");
+    expect(getByText("100% used").className).toContain("--content-secondary");
     expect(panel.querySelector('[data-slot="progress-bar-fill"]')).toBeNull();
     expect(queryByText("Add credits to continue.")).toBeNull();
     expect(queryByTestId("preferences-usage-add-credits")).toBeNull();

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.tsx
@@ -38,10 +38,10 @@ export function PreferencesUsagePanel({
 
   const title = t("preferencesUsagePanel.title");
   const pct = Math.round(usage.ratio * 100);
-  // Used-up grants with credit still behind them are not an alarm: the next
-  // turn draws on extra usage credits, and the amber line below says so in
-  // the bar's place. An empty wallet keeps the red reading whether or not
-  // the BYOK-aware `exhausted` raises the strip below.
+  // Used-up grants with credit still behind them are not an alarm: the
+  // percentage keeps its neutral color and the amber line below names the
+  // extra usage credits in the bar's place. An empty wallet keeps the red
+  // reading whether or not the BYOK-aware `exhausted` raises the strip below.
   const { spent, exhausted, usingExtraCredits } = usage;
 
   return (
@@ -56,19 +56,17 @@ export function PreferencesUsagePanel({
             {title}
           </Typography>
           <div className="flex shrink-0 items-center gap-1.5">
-            {usingExtraCredits ? null : (
-              <Typography
-                as="span"
-                variant="body-small-default"
-                className={
-                  spent
-                    ? "whitespace-nowrap text-[var(--system-negative-strong)]"
-                    : "whitespace-nowrap text-[var(--content-secondary)]"
-                }
-              >
-                {t("preferencesUsagePanel.pctUsed", { pct })}
-              </Typography>
-            )}
+            <Typography
+              as="span"
+              variant="body-small-default"
+              className={
+                spent && !usingExtraCredits
+                  ? "whitespace-nowrap text-[var(--system-negative-strong)]"
+                  : "whitespace-nowrap text-[var(--content-secondary)]"
+              }
+            >
+              {t("preferencesUsagePanel.pctUsed", { pct })}
+            </Typography>
             <Button
               variant="ghost"
               size="compact"


### PR DESCRIPTION
## Summary
- The preferences usage panel shows the "100% used" percentage again in the extra-usage-credits state. It renders in the neutral secondary color rather than red, since the amber line below already names the state; red stays reserved for the spent states with nothing to draw on.
- The progress bar stays replaced by the "Now using extra usage credits" line, and the exhausted and BYOK states are unchanged.
- Updated the panel tests and the Storybook docstring to match.

## Original prompt
Yesterday's change (#41487) made the preferences menu's usage card drop both the "100% used" percentage and the progress bar once a user has spent 100% of their usage grants with credits still behind them, showing a "Now using extra usage credits" line in the bar's place. The user wants the "100% used" text restored in that state while the bar stays hidden.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->