### PR TITLE
fix(web): give the PDF preview a page-shaped loading state (LUM-3386)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-page-skeleton.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-page-skeleton.tsx
@@ -20,11 +20,19 @@ interface PdfPageSkeletonProps {
    * canvases moves nothing.
    */
   aspectRatio?: number;
+  /**
+   * Width constraint, which the caller owns because the same placeholder
+   * stands in for pages at very different sizes: the chat column and the
+   * fullscreen modal cap a viewport-relative width, while the document
+   * drawer is a few hundred pixels wide and its pages fill it.
+   */
+  className?: string;
 }
 
 /** Page-shaped placeholder for a PDF that is being fetched and parsed. */
 export function PdfPageSkeleton({
   aspectRatio,
+  className,
 }: PdfPageSkeletonProps): ReactNode {
   const { t } = useTranslation("chat");
   return (
@@ -32,7 +40,7 @@ export function PdfPageSkeleton({
       as="span"
       role="status"
       aria-label={t("pdfPageSkeleton.loadingPdf")}
-      className="block w-[90vw] max-w-[800px] rounded"
+      className={`block rounded ${className ?? "w-full"}`}
       style={{ aspectRatio: aspectRatio ?? DEFAULT_PAGE_ASPECT_RATIO }}
     />
   );

--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-page-skeleton.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-page-skeleton.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
+
+import { useTranslation } from "@/i18n";
+
+/**
+ * Width/height of a US Letter page, used until the document reports its own.
+ * A placeholder is drawn before `getDocument` resolves, which is the only
+ * point the real page dimensions become available, so some ratio has to be
+ * assumed: the two common paper sizes (Letter 0.77, A4 0.71) are close enough
+ * that either reserves nearly the right space for the other.
+ */
+const DEFAULT_PAGE_ASPECT_RATIO = 8.5 / 11;
+
+interface PdfPageSkeletonProps {
+  /**
+   * Width/height of the document's first page when known. The placeholder
+   * holds the shape the rendered page will occupy, so the transition to
+   * canvases moves nothing.
+   */
+  aspectRatio?: number;
+}
+
+/** Page-shaped placeholder for a PDF that is being fetched and parsed. */
+export function PdfPageSkeleton({
+  aspectRatio,
+}: PdfPageSkeletonProps): ReactNode {
+  const { t } = useTranslation("chat");
+  return (
+    <Skeleton
+      as="span"
+      role="status"
+      aria-label={t("pdfPageSkeleton.loadingPdf")}
+      className="block w-[90vw] max-w-[800px] rounded"
+      style={{ aspectRatio: aspectRatio ?? DEFAULT_PAGE_ASPECT_RATIO }}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
@@ -104,17 +104,25 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
           void doc.destroy();
           return;
         }
-        // Hand the proxy to state before reading a page: from here the
-        // cleanup effect owns destroying it, so a page read that throws
-        // releases the worker instead of stranding it.
-        setPdf(doc);
-
-        const firstPage = await doc.getPage(1);
+        // The proxy stays this function's to release until it is handed to
+        // state: the cleanup effect only destroys what it sees replaced or
+        // unmounted, so a document abandoned here would hold its worker for
+        // as long as the error state is on screen.
+        let firstPage;
+        try {
+          firstPage = await doc.getPage(1);
+        } catch (pageError) {
+          void doc.destroy();
+          throw pageError;
+        }
         if (cancelled) {
+          void doc.destroy();
           return;
         }
+
         const { width, height } = firstPage.getViewport({ scale: 1 });
         placeholderAspectRatio.current = height > 0 ? width / height : null;
+        setPdf(doc);
         setNumPages(Math.min(doc.numPages, MAX_PAGES));
       } catch {
         if (!cancelled) {

--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
@@ -1,4 +1,3 @@
-import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { PDFDocumentProxy } from "pdfjs-dist/legacy/build/pdf.mjs";
 // `?url` emits the package's prebuilt worker as a hashed asset and yields its
@@ -10,6 +9,7 @@ import type { PDFDocumentProxy } from "pdfjs-dist/legacy/build/pdf.mjs";
 // https://vite.dev/guide/assets#explicit-url-imports
 import PDF_WORKER_URL from "pdfjs-dist/legacy/build/pdf.worker.min.mjs?url";
 
+import { PdfPageSkeleton } from "@/domains/chat/components/chat-attachments/pdf-page-skeleton";
 import { dataUriToUint8Array } from "@/domains/chat/components/chat-attachments/utils";
 
 /**
@@ -63,6 +63,11 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
   const containerRef = useRef<HTMLSpanElement>(null);
   const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null);
   const [numPages, setNumPages] = useState(0);
+  // Width/height of page 1, applied to every canvas so the boxes hold their
+  // page's shape from the moment they mount. A canvas has no intrinsic size
+  // until `renderPage` draws into it, so without this the row collapses to
+  // the 2:1 default and the transcript reflows again as each page arrives.
+  const [pageAspectRatio, setPageAspectRatio] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const canvasRefs = useRef<Map<number, HTMLCanvasElement>>(new Map());
@@ -77,6 +82,7 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
       setError(null);
       setPdf(null);
       setNumPages(0);
+      setPageAspectRatio(null);
       renderedPages.current.clear();
 
       try {
@@ -95,6 +101,13 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
           void doc.destroy();
           return;
         }
+        const firstPage = await doc.getPage(1);
+        if (cancelled) {
+          void doc.destroy();
+          return;
+        }
+        const { width, height } = firstPage.getViewport({ scale: 1 });
+        setPageAspectRatio(height > 0 ? width / height : null);
         setPdf(doc);
         setNumPages(Math.min(doc.numPages, MAX_PAGES));
       } catch {
@@ -206,8 +219,8 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
 
   if (isLoading) {
     return (
-      <span className="flex items-center justify-center py-24">
-        <Loader2 className="h-8 w-8 animate-spin text-white/70" />
+      <span className="flex justify-center">
+        <PdfPageSkeleton />
       </span>
     );
   }
@@ -233,7 +246,12 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
           ref={setCanvasRef(i + 1)}
           data-page={i + 1}
           className="w-[90vw] max-w-[800px]"
-          style={{ height: "auto" }}
+          style={{
+            height: "auto",
+            ...(pageAspectRatio === null
+              ? {}
+              : { aspectRatio: pageAspectRatio }),
+          }}
         />
       ))}
     </span>

--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
@@ -104,14 +104,17 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
           void doc.destroy();
           return;
         }
+        // Hand the proxy to state before reading a page: from here the
+        // cleanup effect owns destroying it, so a page read that throws
+        // releases the worker instead of stranding it.
+        setPdf(doc);
+
         const firstPage = await doc.getPage(1);
         if (cancelled) {
-          void doc.destroy();
           return;
         }
         const { width, height } = firstPage.getViewport({ scale: 1 });
         placeholderAspectRatio.current = height > 0 ? width / height : null;
-        setPdf(doc);
         setNumPages(Math.min(doc.numPages, MAX_PAGES));
       } catch {
         if (!cancelled) {
@@ -219,7 +222,15 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
     (pageNum: number) => (el: HTMLCanvasElement | null) => {
       if (el) {
         canvasRefs.current.set(pageNum, el);
-        if (placeholderAspectRatio.current !== null) {
+        // Only ever a stand-in for an empty box. This callback's identity
+        // changes every render, so React detaches and reattaches the ref on
+        // a canvas that has already been drawn into, and re-stamping the
+        // placeholder there would stretch it back to page 1's shape with no
+        // second `renderPage` coming to clear it.
+        if (
+          placeholderAspectRatio.current !== null &&
+          !renderedPages.current.has(pageNum)
+        ) {
           el.style.aspectRatio = String(placeholderAspectRatio.current);
         }
       } else {

--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
@@ -63,11 +63,14 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
   const containerRef = useRef<HTMLSpanElement>(null);
   const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null);
   const [numPages, setNumPages] = useState(0);
-  // Width/height of page 1, applied to every canvas so the boxes hold their
-  // page's shape from the moment they mount. A canvas has no intrinsic size
-  // until `renderPage` draws into it, so without this the row collapses to
-  // the 2:1 default and the transcript reflows again as each page arrives.
-  const [pageAspectRatio, setPageAspectRatio] = useState<number | null>(null);
+  // Width/height of page 1, stamped onto each canvas as it mounts so the box
+  // holds a page's shape before anything is drawn into it: a canvas has no
+  // intrinsic size until `renderPage` runs, so the row would otherwise
+  // collapse to the 2:1 default and reflow again as each page arrives. Held
+  // in a ref, not state, because only the imperative mount/render pair reads
+  // it: React never owns `aspectRatio`, so it cannot re-apply the placeholder
+  // over the real dimensions `renderPage` sets.
+  const placeholderAspectRatio = useRef<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const canvasRefs = useRef<Map<number, HTMLCanvasElement>>(new Map());
@@ -82,7 +85,7 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
       setError(null);
       setPdf(null);
       setNumPages(0);
-      setPageAspectRatio(null);
+      placeholderAspectRatio.current = null;
       renderedPages.current.clear();
 
       try {
@@ -107,7 +110,7 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
           return;
         }
         const { width, height } = firstPage.getViewport({ scale: 1 });
-        setPageAspectRatio(height > 0 ? width / height : null);
+        placeholderAspectRatio.current = height > 0 ? width / height : null;
         setPdf(doc);
         setNumPages(Math.min(doc.numPages, MAX_PAGES));
       } catch {
@@ -170,6 +173,12 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
 
         canvas.width = viewport.width;
         canvas.height = viewport.height;
+        // The placeholder ratio is page 1's, a stand-in for a box with
+        // nothing in it yet. This page now carries its own dimensions, so
+        // drop the override and let them drive the height: a document mixing
+        // portrait and landscape pages would otherwise stretch every page
+        // after the first into page 1's shape.
+        canvas.style.aspectRatio = "";
 
         await page.render({ canvas, viewport }).promise;
       } catch {
@@ -210,6 +219,9 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
     (pageNum: number) => (el: HTMLCanvasElement | null) => {
       if (el) {
         canvasRefs.current.set(pageNum, el);
+        if (placeholderAspectRatio.current !== null) {
+          el.style.aspectRatio = String(placeholderAspectRatio.current);
+        }
       } else {
         canvasRefs.current.delete(pageNum);
       }
@@ -220,7 +232,10 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
   if (isLoading) {
     return (
       <span className="flex justify-center">
-        <PdfPageSkeleton />
+        {/* Matches the canvases' own width cap, so the placeholder occupies
+            the box the pages will. Callers that size pages differently (the
+            drawer) override it the same way they override the canvases. */}
+        <PdfPageSkeleton className="w-[90vw] max-w-[800px]" />
       </span>
     );
   }
@@ -246,12 +261,7 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
           ref={setCanvasRef(i + 1)}
           data-page={i + 1}
           className="w-[90vw] max-w-[800px]"
-          style={{
-            height: "auto",
-            ...(pageAspectRatio === null
-              ? {}
-              : { aspectRatio: pageAspectRatio }),
-          }}
+          style={{ height: "auto" }}
         />
       ))}
     </span>

--- a/clients/web/src/domains/chat/components/local-file/preview/file-preview-container.tsx
+++ b/clients/web/src/domains/chat/components/local-file/preview/file-preview-container.tsx
@@ -25,6 +25,7 @@ import {
   localFileKindFromFilename,
 } from "@/domains/chat/components/local-file/local-file-icon";
 import { previewByteCapFor } from "@/domains/chat/components/local-file/local-file-limits";
+import { PdfPageSkeleton } from "@/domains/chat/components/chat-attachments/pdf-page-skeleton";
 import { PreviewSkeleton } from "@/domains/chat/components/local-file/preview/preview-skeleton";
 import { PreviewUnsupported } from "@/domains/chat/components/local-file/preview/preview-unsupported";
 import {
@@ -161,6 +162,14 @@ export function FilePreviewContainer({
   // the panel must not wrap it in a second scroller.
   let showsCsvGrid = false;
 
+  // One placeholder for every stage before a reader takes over (fetching the
+  // bytes, then resolving the reader's chunk), shaped like what is coming:
+  // a PDF resolves into a page, and swapping prose lines for a page shape
+  // partway through is the jump this placeholder exists to avoid. The other
+  // readers render prose-like content, which is what `PreviewSkeleton` draws.
+  const loadingPlaceholder =
+    previewKind === "pdf" ? <PdfPageSkeleton /> : <PreviewSkeleton />;
+
   let body: ReactNode;
   if (isUnsupported) {
     body = (
@@ -217,11 +226,11 @@ export function FilePreviewContainer({
       </div>
     );
   } else if (probe.status === "loading" || isPending || blob === undefined) {
-    body = <PreviewSkeleton />;
+    body = loadingPlaceholder;
   } else {
     showsCsvGrid = previewKind === "csv";
     body = (
-      <LazyBoundary fallback={<PreviewSkeleton />}>
+      <LazyBoundary fallback={loadingPlaceholder}>
         {previewFor(previewKind, blob, documentName)}
       </LazyBoundary>
     );

--- a/clients/web/src/domains/chat/components/local-file/preview/pdf-file-preview.tsx
+++ b/clients/web/src/domains/chat/components/local-file/preview/pdf-file-preview.tsx
@@ -28,9 +28,11 @@ export function PdfFilePreview({ blob }: PdfFilePreviewProps): ReactNode {
   }
 
   return (
-    // PdfPreview sizes its canvases for the fullscreen modal (90vw); pin them
-    // to the drawer's width instead.
-    <span className="block w-full [&_canvas]:w-full!">
+    // PdfPreview sizes its canvases and its loading placeholder for the
+    // fullscreen modal (90vw); pin both to the drawer's width instead, or
+    // the placeholder overflows a drawer a few hundred pixels wide and then
+    // snaps smaller the moment the first canvas replaces it.
+    <span className="block w-full [&_[data-slot=skeleton]]:w-full! [&_canvas]:w-full!">
       <PdfPreview url={url} />
     </span>
   );

--- a/clients/web/src/domains/chat/components/local-file/preview/pdf-file-preview.tsx
+++ b/clients/web/src/domains/chat/components/local-file/preview/pdf-file-preview.tsx
@@ -9,8 +9,8 @@
 
 import { type ReactNode } from "react";
 
+import { PdfPageSkeleton } from "@/domains/chat/components/chat-attachments/pdf-page-skeleton";
 import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-preview";
-import { PreviewSkeleton } from "@/domains/chat/components/local-file/preview/preview-skeleton";
 import { useBlobObjectUrl } from "@/domains/chat/components/local-file/use-local-file-info";
 
 interface PdfFilePreviewProps {
@@ -20,8 +20,11 @@ interface PdfFilePreviewProps {
 export function PdfFilePreview({ blob }: PdfFilePreviewProps): ReactNode {
   const url = useBlobObjectUrl(blob, "application/pdf");
 
+  // The page shape rather than the prose-line placeholder: this state runs
+  // straight into `PdfPreview`'s own loading state, so a different shape here
+  // would have the drawer swap placeholders on the way to the same document.
   if (url === null) {
-    return <PreviewSkeleton />;
+    return <PdfPageSkeleton />;
   }
 
   return (

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1111,6 +1111,9 @@
   "pageTabs": {
     "formStepsAria": "Form steps"
   },
+  "pdfPageSkeleton": {
+    "loadingPdf": "Loading PDF"
+  },
   "phaseGroupedStepList": {
     "startedAt": "Started at {time}"
   },

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1111,6 +1111,9 @@
   "pageTabs": {
     "formStepsAria": "Pasos del formulario"
   },
+  "pdfPageSkeleton": {
+    "loadingPdf": "Cargando PDF"
+  },
   "phaseGroupedStepList": {
     "startedAt": "Comenzó a las {time}"
   },

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -578,6 +578,9 @@
     "usageSubtitle": "Счётчики токенов и вызовов, нормализованные маршрутом ассистента.",
     "usageTitle": "Использование"
   },
+  "pdfPageSkeleton": {
+    "loadingPdf": "Загрузка PDF"
+  },
   "pinnedAppColorSwatches": {
     "colors": {
       "green": "Зелёный",


### PR DESCRIPTION
## Summary

- TL;DR: opening a PDF now reserves the shape of the page it is about to show, instead of a spinner floating in a 200px band. `PdfPreview` renders a page-shaped `Skeleton` while the document loads, and once the document resolves, page 1's real viewport ratio is pinned onto every canvas so the boxes hold their page's shape from the moment they mount.
- The second, quieter half of the jump is the canvases themselves. A canvas has no intrinsic size until something is drawn into it, so the freshly mounted row collapsed to the 2:1 default and the transcript reflowed again as each page finished rendering. Carrying the measured aspect ratio onto the canvas closes that.
- The drawer stops changing its mind about the placeholder shape. `PdfFilePreview` showed the prose-line `PreviewSkeleton` while it built an object URL and then handed off to `PdfPreview`, which showed a spinner: two different placeholders back to back for one file. Both are now the page shape.

Why this is safe: presentation only, in the loading path. No change to fetching, parsing, rendering, the page cap, or the error path. `PreviewSkeleton` keeps its five other callers (csv, markdown, media, text, and the container) and is untouched. The new component composes the existing design-library `Skeleton` and follows that primitive's documented contract for standalone use (`role="status"` plus a label), so no design-library change was needed.

## What changes for the user

| Moment | Before | After |
| --- | --- | --- |
| PDF opening in chat | Spinner centred in an empty 200px band | A page-shaped placeholder the size of the page that is coming |
| Document resolves, pages still rendering | Canvases collapse to a 2:1 strip, content reflows per page | Canvases already hold each page's shape; nothing moves |
| PDF opening in the document drawer | Prose-line placeholder, then a spinner | One page shape throughout |
| Rendering, 20-page cap, failure copy | Unchanged | Unchanged |

## A note on the default ratio

The placeholder has to be drawn before `getDocument` resolves, which is the only moment real page dimensions become available, so the first frame has to assume a ratio. It assumes US Letter. The two common paper sizes (Letter 0.77, A4 0.71) are close enough that either reserves nearly the right space for the other, and the moment the document resolves the measured ratio takes over. Worth knowing this is an assumption rather than a measurement, since the ticket's wording ("sized from the first page viewport") reads as though the dimensions are available up front.

## Known remaining seam, deliberately not in this PR

The drawer runs two generic placeholder stages ahead of the two this PR fixes: `FilePreviewContainer` shows `PreviewSkeleton` while it fetches the bytes, and again as the `LazyBoundary` fallback while the preview chunk loads. Those are kind-agnostic and shared by all five preview types, so making them page-shaped for PDFs means teaching the container which kind it is about to render, and then answering the same question for csv (a grid?) and markdown (prose, which is what it already draws). That is a design decision for the whole preview family rather than a PDF fix, and it is worth doing as its own change.

Part of LUM-3386

## Original prompt

Continuing the Activation Hub quick-win run, this is the first of three follow-ups on LUM-3386 after its CDN half shipped in #41574. The ask was to check whether the remaining work sits at the right seam before writing anything, which turned up that there is only one PDF renderer (the drawer delegates to it), so the loading fix lands in one place and covers both surfaces. This PR takes the loading state; the error state and the page-cap note follow separately, after a small cleanup to make the shared preview components translatable.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->