### PR TITLE
feat(oauth): gate the monday.com integration behind a feature flag

### DIFF
--- a/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
+++ b/assistant/src/__tests__/oauth-connect-orchestrator.test.ts
@@ -133,6 +133,7 @@ mock.module("../inbound/public-ingress-urls.js", () => ({
 // ---------------------------------------------------------------------------
 
 import { orchestrateOAuthConnect } from "../oauth/connect-orchestrator.js";
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
 import { setConfig } from "./helpers/set-config.js";
 
 /** Seed `ingress.publicBaseUrl` in the real workspace config. */
@@ -219,6 +220,7 @@ beforeEach(() => {
   setPublicBaseUrl("");
   mockIdentityResult = "user@example.com";
   mockProviderStore = {};
+  setOverridesForTesting({});
 
   mockPrepareResult = {
     authorizeUrl: "https://provider.example.com/authorize?prepared",
@@ -803,5 +805,98 @@ describe("orchestrateOAuthConnect — transport selection", () => {
       };
       expect(capturedConfig.scopeSeparator).toBe(" ");
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature-flag gating
+// ---------------------------------------------------------------------------
+
+/**
+ * A provider whose seed entry declares a `featureFlag` is only connectable
+ * while that flag is enabled. The orchestrator is the shared choke point for
+ * every connect path (runtime routes, gateway, CLI, credential vault tool),
+ * so the gate lives here rather than in each entry point.
+ */
+describe("orchestrateOAuthConnect — feature-flag gating", () => {
+  const GATED_PROVIDER = makeProviderRow({
+    provider: "gated",
+    displayLabel: "Gated",
+    loopbackPort: 17399,
+    featureFlag: "gated-provider-flag",
+  });
+
+  test("refuses to connect a gated provider when its flag is disabled", async () => {
+    mockProviderStore["gated"] = GATED_PROVIDER;
+    setOverridesForTesting({ "gated-provider-flag": false });
+
+    const result = await orchestrateOAuthConnect({
+      service: "gated",
+      clientId: "client-id",
+      isInteractive: false,
+      callbackTransport: "loopback",
+    });
+
+    expect(result.success).toBe(false);
+    // No authorization flow may be started for a gated provider.
+    expect(lastPrepareArgs).toBeNull();
+    expect(lastStartArgs).toBeNull();
+  });
+
+  test("gated provider is indistinguishable from an unregistered one", async () => {
+    mockProviderStore["gated"] = GATED_PROVIDER;
+    setOverridesForTesting({ "gated-provider-flag": false });
+
+    const gated = await orchestrateOAuthConnect({
+      service: "gated",
+      clientId: "client-id",
+      isInteractive: false,
+      callbackTransport: "loopback",
+    });
+    const absent = await orchestrateOAuthConnect({
+      service: "not-a-provider",
+      clientId: "client-id",
+      isInteractive: false,
+      callbackTransport: "loopback",
+    });
+
+    expect(gated.success).toBe(false);
+    expect(absent.success).toBe(false);
+    if (gated.success || absent.success) {
+      return;
+    }
+    // Identical wording so the gate does not leak that the provider exists.
+    expect(gated.error).toBe(absent.error.replace("not-a-provider", "gated"));
+  });
+
+  test("connects a gated provider once its flag is enabled", async () => {
+    mockProviderStore["gated"] = GATED_PROVIDER;
+    setOverridesForTesting({ "gated-provider-flag": true });
+
+    const result = await orchestrateOAuthConnect({
+      service: "gated",
+      clientId: "client-id",
+      isInteractive: false,
+      callbackTransport: "loopback",
+    });
+
+    expect(result.success).toBe(true);
+    expect(lastPrepareArgs).not.toBeNull();
+  });
+
+  test("leaves ungated providers connectable", async () => {
+    mockProviderStore["google"] = GOOGLE_PROVIDER;
+    setOverridesForTesting({});
+
+    const result = await orchestrateOAuthConnect({
+      service: "google",
+      clientId: "client-id",
+      isInteractive: false,
+      callbackTransport: "loopback",
+    });
+
+    expect(GOOGLE_PROVIDER.featureFlag).toBeNull();
+    expect(result.success).toBe(true);
+    expect(lastPrepareArgs).not.toBeNull();
   });
 });

--- a/assistant/src/oauth/connect-orchestrator.ts
+++ b/assistant/src/oauth/connect-orchestrator.ts
@@ -19,6 +19,7 @@
  * - Running identity verifiers
  */
 
+import { loadConfig } from "../config/loader.js";
 import { emitPostConnectNudge } from "../home/post-connect-feed.js";
 import { invalidateAssistantSuggestedPromptsCache } from "../home/suggested-prompts-cache.js";
 import type { TokenEndpointAuthMethod } from "../security/oauth2.js";
@@ -27,6 +28,7 @@ import { getLogger } from "../util/logger.js";
 import type { OAuthConnectResult } from "./connect-types.js";
 import { verifyIdentity } from "./identity-verifier.js";
 import { getProvider } from "./oauth-store.js";
+import { isProviderVisible } from "./provider-visibility.js";
 import { storeOAuth2Tokens } from "./token-persistence.js";
 
 const log = getLogger("oauth-connect-orchestrator");
@@ -123,6 +125,20 @@ export async function orchestrateOAuthConnect(
   // Read provider config from the DB
   const providerRow = getProvider(options.service);
   if (!providerRow) {
+    return {
+      success: false,
+      error: `No OAuth provider registered for "${options.service}". Ensure the provider is seeded in the database.`,
+      safeError: true,
+    };
+  }
+
+  // A provider gated behind a disabled feature flag is not connectable. This
+  // is the choke point every connect path funnels through (runtime routes,
+  // gateway, CLI, credential vault tool), so enforcing here covers all of
+  // them rather than relying on each entry point to check. The error matches
+  // the not-found case above so a gated provider is indistinguishable from an
+  // absent one, mirroring the provider routes.
+  if (!isProviderVisible(providerRow, loadConfig())) {
     return {
       success: false,
       error: `No OAuth provider registered for "${options.service}". Ensure the provider is seeded in the database.`,

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -807,6 +807,7 @@ export const PROVIDER_SEED_DATA: Record<
     identityHeaders: { "Content-Type": "application/json" },
     identityBody: { query: "{ me { id name email } }" },
     identityResponsePaths: ["data.me.name", "data.me.email"],
+    featureFlag: "monday-oauth",
   },
 
   eventbrite: {

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -404,6 +404,14 @@
       "label": "Channel Conversation Sidecar",
       "description": "Renders a conversation bound to an external channel (Slack, Telegram, Discord, phone, email, and any other channel adapter) as two lanes in web chat: Vellum stays the primary full-width lane, and the canonical external-channel transcript moves into the existing read-only right drawer, opened from a channel-thread control in the chat header. Rows the client can attribute to the external channel are drawn once, in the drawer, instead of being blended into the Vellum lane. The drawer offers an Open in <channel> secondary action and a per-message Reference in Vellum action that stages one quoted reference above the Vellum composer. The Vellum composer stays the only input; nothing about delivery, routing, or permissions changes. Off leaves the header deep-link pill and the blended transcript unchanged.",
       "defaultEnabled": false
+    },
+    {
+      "id": "monday-oauth",
+      "scope": "assistant",
+      "key": "monday-oauth",
+      "label": "monday.com Integration",
+      "description": "Gates the seeded monday.com OAuth provider. When off, the provider is hidden from GET /v1/oauth/providers, its get-by-id route, and the connect/update routes, so it cannot be listed or connected from the CLI, gateway, or web integrations list. The row is still seeded into oauth_providers on startup; only its visibility changes.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -404,6 +404,14 @@
       "label": "Channel Conversation Sidecar",
       "description": "Renders a conversation bound to an external channel (Slack, Telegram, Discord, phone, email, and any other channel adapter) as two lanes in web chat: Vellum stays the primary full-width lane, and the canonical external-channel transcript moves into the existing read-only right drawer, opened from a channel-thread control in the chat header. Rows the client can attribute to the external channel are drawn once, in the drawer, instead of being blended into the Vellum lane. The drawer offers an Open in <channel> secondary action and a per-message Reference in Vellum action that stages one quoted reference above the Vellum composer. The Vellum composer stays the only input; nothing about delivery, routing, or permissions changes. Off leaves the header deep-link pill and the blended transcript unchanged.",
       "defaultEnabled": false
+    },
+    {
+      "id": "monday-oauth",
+      "scope": "assistant",
+      "key": "monday-oauth",
+      "label": "monday.com Integration",
+      "description": "Gates the seeded monday.com OAuth provider. When off, the provider is hidden from GET /v1/oauth/providers, its get-by-id route, and the connect/update routes, so it cannot be listed or connected from the CLI, gateway, or web integrations list. The row is still seeded into oauth_providers on startup; only its visibility changes.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## What

Puts the seeded monday.com OAuth provider behind a new `monday-oauth` feature flag (assistant scope, `defaultEnabled: false`), so it can be rolled out deliberately instead of appearing the moment the row is seeded.

Also closes a gap in the gating mechanism itself, found in review — see commit 2.

## Why

The provider shipped visible to everyone. Gating it lets us control exposure without reverting the seed data.

## How

**Commit 1 — gate the provider**

- `featureFlag: "monday-oauth"` on the `monday` entry in `PROVIDER_SEED_DATA`.
- Flag registered in `meta/feature-flags/feature-flag-registry.json`. Assistant scope is required — `provider-visibility.ts` resolves through `isAssistantFeatureFlagEnabled`.
- Bundled copies regenerated with `bun run meta/sync-bundled-copies.ts`. Only the web copy is tracked; the assistant and gateway copies are gitignored.

The flag name matches the provider's existing `managedServiceConfigKey`, per step 6 of `assistant/src/oauth/AGENTS.md`.

**Commit 2 — enforce the gate in the connect path**

This is the first production use of the `featureFlag` field on `PROVIDER_SEED_DATA`, and it surfaced that the gate was incomplete. `isProviderVisible` was only consulted by the provider routes (list, get-by-id, update, delete). The connect path resolves providers with a bare `getProvider()` existence check — `oauth_apps_upsert`, `oauth_apps_connect_post`, and `orchestrateOAuthConnect` alike. A `settings.write` caller, including the CLI (which reaches `oauth_apps_upsert` directly), could create an app for a gated provider and run the authorization flow with the flag off.

The check now lives in `orchestrateOAuthConnect`, the shared choke point every connect path funnels through, so one check covers runtime routes, gateway, CLI, and the credential vault tool instead of three that can drift. The refusal reuses the not-found wording so a gated provider is indistinguishable from an absent one, matching how the provider routes already collapse both cases.

## Effect

With the flag off, monday is absent from `GET /v1/oauth/providers` (so it's not in the web integrations list or `providers list`) **and** cannot be connected through any path. The row is still seeded into `oauth_providers` on startup; only visibility changes, so **enabling the flag later needs no backfill**.

## Verification

New regression tests in `oauth-connect-orchestrator.test.ts`: a disabled flag refuses the connect and starts no authorization flow, the error is indistinguishable from an unregistered provider, enabling the flag restores the connect, and ungated providers are unaffected. **Verified these fail without the fix** (2 of 4 fail on the unpatched orchestrator).

For the seed change I also ran a temporary test against the real seed path (removed before commit) confirming the row seeds with the flag attached, is hidden by the registry default, visible when enabled, and that `monday` is the only provider filtered out — no effect on the other 22.

`tsc --noEmit` clean. Pre-commit hooks (secrets, generic-examples, Prettier, ESLint, typecheck) green on both commits. The oauth suites pass file-by-file.

Note: running several oauth suites together produces pre-existing failures — 4 in `byo-connection.test.ts`, plus a `getOAuthCallbackUrl` mock collision between `oauth-connect-orchestrator.test.ts` and the routes suites. Both reproduce on an unmodified tree (confirmed by stashing this branch's changes and re-running the identical batches). Cross-file mock pollution on main, not touched here.

## Follow-up

The flag still needs creating via Terraform in `vellum-assistant-platform` (step 3 of `meta/feature-flags/AGENTS.md`). Until it lands there, installs fall back to the registry default of `false` — the safe direction, and the reason this ordering is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)