### PR TITLE
fix(web): close the deferred chooser-avatar follow-ups from #41549

### DIFF
--- a/clients/web/src/assistant/api.ts
+++ b/clients/web/src/assistant/api.ts
@@ -642,27 +642,41 @@ export type ListAssistantsResult =
   | { ok: true; status: number; data: Assistant[] }
   | { ok: false; status: number; error: Record<string, unknown> };
 
+const ASSISTANTS_PAGE_SIZE = 100;
+/** Bounds a runaway `next` chain; 2000 assistants is far past any real org. */
+const ASSISTANTS_MAX_PAGES = 20;
+
+/** Every page, so an org past one page size lists (and looks up) all of its assistants. */
 export async function listAssistants(): Promise<ListAssistantsResult> {
-  const { data, error, response } = await assistantsList({
-    query: { hosting: "all" },
-    throwOnError: false,
-  });
+  const results: Assistant[] = [];
+  let status = 200;
+  for (let page = 0; page < ASSISTANTS_MAX_PAGES; page++) {
+    const { data, error, response } = await assistantsList({
+      query: {
+        hosting: "all",
+        limit: ASSISTANTS_PAGE_SIZE,
+        offset: results.length,
+      },
+      throwOnError: false,
+    });
 
-  assertHasResponse(response, error, "Failed to list assistants.");
+    assertHasResponse(response, error, "Failed to list assistants.");
 
-  if (response.ok) {
-    return {
-      ok: true,
-      status: response.status,
-      data: data?.results ?? [],
-    };
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        error: toErrorObject(error, response),
+      };
+    }
+    status = response.status;
+    const pageResults = data?.results ?? [];
+    results.push(...pageResults);
+    if (!data?.next || pageResults.length === 0) {
+      break;
+    }
   }
-
-  return {
-    ok: false,
-    status: response.status,
-    error: toErrorObject(error, response),
-  };
+  return { ok: true, status, data: results };
 }
 
 export type ActivateResult =

--- a/clients/web/src/assistant/api.ts
+++ b/clients/web/src/assistant/api.ts
@@ -673,10 +673,16 @@ export async function listAssistants(): Promise<ListAssistantsResult> {
     const pageResults = data?.results ?? [];
     results.push(...pageResults);
     if (!data?.next || pageResults.length === 0) {
-      break;
+      return { ok: true, status, data: results };
     }
   }
-  return { ok: true, status, data: results };
+  // A partial list must not read as authoritative: local mode mirrors it
+  // into the lockfile, dropping whatever it omits.
+  return {
+    ok: false,
+    status,
+    error: { detail: "Assistant list exceeded the page cap." },
+  };
 }
 
 export type ActivateResult =

--- a/clients/web/src/assistant/list-assistants.test.ts
+++ b/clients/web/src/assistant/list-assistants.test.ts
@@ -88,6 +88,15 @@ describe("listAssistants", () => {
     expect(assistantsList).toHaveBeenCalledTimes(2);
   });
 
+  test("a chain still open at the page cap fails rather than truncating", async () => {
+    for (let i = 0; i < 20; i++) {
+      pages.push(ok([`a${i}`], "…?more"));
+    }
+    const result = await listAssistants();
+    expect(result.ok).toBe(false);
+    expect(assistantsList).toHaveBeenCalledTimes(20);
+  });
+
   test("a failed later page fails the whole list", async () => {
     pages.push(ok(["a"], "…?offset=1"), {
       error: { detail: "nope" },

--- a/clients/web/src/assistant/list-assistants.test.ts
+++ b/clients/web/src/assistant/list-assistants.test.ts
@@ -1,0 +1,102 @@
+/**
+ * `listAssistants` follows the platform's `next` chain so an org past one
+ * page size lists every assistant; the chooser and the avatar lookup both
+ * read this wrapper.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type ListCall = {
+  query?: { hosting?: string; limit?: number; offset?: number };
+};
+type Page = {
+  data?: { results: { id: string }[]; next: string | null };
+  error?: unknown;
+  response: { ok: boolean; status: number };
+};
+
+const pages: Page[] = [];
+const assistantsList = mock(async (_opts: ListCall): Promise<Page> => {
+  const page = pages.shift();
+  if (!page) {
+    throw new Error("unexpected extra page request");
+  }
+  return page;
+});
+
+const noop = mock(async () => ({
+  data: undefined,
+  error: undefined,
+  response: { ok: true, status: 200 },
+}));
+mock.module("@/generated/api/sdk.gen", () => ({
+  assistantsActivateCreate: noop,
+  assistantsBackupsCreate: noop,
+  assistantsBackupsRestoreCreate: noop,
+  assistantsBackupsRetrieve: noop,
+  assistantsHatchCreate: noop,
+  assistantsList,
+  assistantsRestartDetailCreate: noop,
+  assistantsRetireDetailDestroy: noop,
+  assistantsRetireDestroy: noop,
+  assistantsRetrieve: noop,
+}));
+
+const { listAssistants } = await import("./api");
+
+const ok = (ids: string[], next: string | null): Page => ({
+  data: { results: ids.map((id) => ({ id })), next },
+  response: { ok: true, status: 200 },
+});
+
+beforeEach(() => {
+  pages.length = 0;
+  assistantsList.mockClear();
+});
+
+describe("listAssistants", () => {
+  test("a single page is returned as-is", async () => {
+    pages.push(ok(["a", "b"], null));
+    const result = await listAssistants();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.map((a) => a.id)).toEqual(["a", "b"]);
+    }
+    expect(assistantsList).toHaveBeenCalledTimes(1);
+    expect(assistantsList.mock.calls[0]?.[0].query).toEqual({
+      hosting: "all",
+      limit: 100,
+      offset: 0,
+    });
+  });
+
+  test("follows next with an offset until the chain ends", async () => {
+    pages.push(ok(["a", "b"], "…?offset=2"), ok(["c"], null));
+    const result = await listAssistants();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.map((a) => a.id)).toEqual(["a", "b", "c"]);
+    }
+    expect(assistantsList).toHaveBeenCalledTimes(2);
+    expect(assistantsList.mock.calls[1]?.[0].query?.offset).toBe(2);
+  });
+
+  test("an empty page ends the chain even when next is set", async () => {
+    pages.push(ok(["a"], "…?offset=1"), ok([], "…?offset=1"));
+    const result = await listAssistants();
+    expect(result.ok && result.data.length).toBe(1);
+    expect(assistantsList).toHaveBeenCalledTimes(2);
+  });
+
+  test("a failed later page fails the whole list", async () => {
+    pages.push(ok(["a"], "…?offset=1"), {
+      error: { detail: "nope" },
+      response: { ok: false, status: 500 },
+    });
+    const result = await listAssistants();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(500);
+    }
+  });
+});

--- a/clients/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/clients/web/src/hooks/use-assistant-avatar.test.tsx
@@ -208,6 +208,36 @@ describe("useAssistantAvatar", () => {
       expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
     });
 
+    test("a read issued for the active assistant persists even if the user switched before it landed", async () => {
+      let resolveState: (state: AvatarState) => void = () => {};
+      fetchAvatarState.mockImplementationOnce(
+        () =>
+          new Promise<AvatarState>((resolve) => {
+            resolveState = resolve;
+          }),
+      );
+      const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+      });
+
+      useResolvedAssistantsStore.getState().setActiveAssistantId("asst-2");
+      resolveState(characterState);
+
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledWith(
+          "asst-1",
+          { kind: "character", traits },
+          expect.any(Number),
+        );
+      });
+    });
+
     test("a superseded legacy read that finishes last persists nothing and drops its blob", async () => {
       let resolveOld: (result: AvatarFileResult<string>) => void = () => {};
       const oldImage = new Promise<AvatarFileResult<string>>((resolve) => {

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -233,6 +233,12 @@ export function useAssistantAvatar(
       // last it must neither overwrite the last-seen entry nor revoke the
       // URL the newer query renders, so it drops its own blob instead.
       const generation = fetchGenerations.claim(id);
+      // Decided at request time: the transport is pinned to whichever
+      // assistant is active when the request goes out, so a read that was
+      // issued for the active assistant is its avatar even if the user has
+      // switched away by the time it lands (a reconnect sweep, say).
+      const isActiveRead =
+        id === useResolvedAssistantsStore.getState().activeAssistantId;
       const [components, { state, traits, imageUrl }] = await Promise.all([
         fetchCharacterComponents(id),
         supportsManifest
@@ -260,7 +266,7 @@ export function useAssistantAvatar(
       // what the chooser falls back to once this assistant is unreachable.
       // Only the active assistant's read is trusted here: a sibling behind a
       // transport that ignores the id would cache the wrong avatar.
-      if (id === useResolvedAssistantsStore.getState().activeAssistantId) {
+      if (isActiveRead) {
         void persistLastSeenAvatar(client, id, { traits, imageUrl });
       }
 

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -46,13 +46,9 @@ import {
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
-import { suppressPlatformAvatarUrl } from "@/hooks/use-platform-avatar-urls";
+import { supersedePlatformAvatar } from "@/hooks/use-platform-avatar-urls";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { SYNC_TAGS } from "@/lib/sync/types";
-import {
-  resolvePlatformAssistantId,
-  useResolvedAssistantsStore,
-} from "@/stores/resolved-assistants-store";
 
 /**
  * A reconnect can flap: error, reopen, error, reopen. Collapse a burst into
@@ -250,11 +246,7 @@ export function useAssistantResourceSync(
  * have changed there.
  */
 function onAvatarChanged(queryClient: QueryClient, assistantId: string): void {
-  useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
-  suppressPlatformAvatarUrl(
-    queryClient,
-    resolvePlatformAssistantId(assistantId),
-  );
+  supersedePlatformAvatar(queryClient, assistantId);
   invalidateAvatarQueries(queryClient, assistantId);
 }
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -176,6 +176,7 @@ const { chooserRowAvatarCacheQueryKey, persistLastSeenAvatar } =
   await import("@/lib/persist-last-seen-avatar");
 const { platformAvatarUrlsQueryKey } =
   await import("@/hooks/use-platform-avatar-urls");
+const { resetAvatarSupersedeForTests } = await import("@/lib/avatar-supersede");
 
 /** Past the window a bare avatar stays fresh for. */
 const A_MINUTE_LATER = 61_000;
@@ -273,6 +274,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   setSystemTime();
+  resetAvatarSupersedeForTests();
   revokeObjectURL.mockClear();
   useResolvedAssistantsStore.getState().setActiveAssistantId(null);
   useResolvedAssistantsStore.setState({ assistants: [] });

--- a/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
+++ b/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
@@ -14,6 +14,7 @@ import {
   describe,
   expect,
   mock,
+  setSystemTime,
   spyOn,
   test,
 } from "bun:test";
@@ -42,6 +43,13 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
 }));
 
+const resolvePairedAssistantPlatformId = mock(
+  async (_id: string): Promise<string | null> => null,
+);
+mock.module("@/lib/paired-platform-identity", () => ({
+  resolvePairedAssistantPlatformId,
+}));
+
 const listAssistants = mock(
   async (): Promise<AssistantApi.ListAssistantsResult> => ({
     ok: true,
@@ -58,10 +66,12 @@ const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 const {
   platformAvatarUrlsQueryKey,
-  resetPlatformAvatarUrlSuppressionsForTests,
+  supersedePlatformAvatar,
   suppressPlatformAvatarUrl,
   usePlatformAvatarUrls,
 } = await import("@/hooks/use-platform-avatar-urls");
+const { AVATAR_SUPERSEDE_WINDOW_MS, resetAvatarSupersedeForTests } =
+  await import("@/lib/avatar-supersede");
 
 const initialAuthState = useAuthStore.getState();
 
@@ -106,7 +116,8 @@ beforeEach(() => {
   remoteGatewayMode = false;
   gatewayAuthEnabled = false;
   orgReady = true;
-  resetPlatformAvatarUrlSuppressionsForTests();
+  resetAvatarSupersedeForTests();
+  resolvePairedAssistantPlatformId.mockClear();
   signIn();
   listAssistants.mockResolvedValue({
     ok: true,
@@ -121,6 +132,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  setSystemTime();
   listAssistants.mockReset();
   useAuthStore.setState(initialAuthState, true);
 });
@@ -319,7 +331,7 @@ describe("suppressPlatformAvatarUrl", () => {
     ).toBe("success");
   });
 
-  test("a list started after suppression carries the id again", async () => {
+  test("a list started inside the window still omits the id; one after it carries it again", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -338,10 +350,79 @@ describe("suppressPlatformAvatarUrl", () => {
     await act(() =>
       queryClient.refetchQueries({ queryKey: ["platformAvatarUrls"] }),
     );
-
     expect(listAssistants).toHaveBeenCalledTimes(2);
+    await settle();
+    expect(result.current.has("a")).toBe(false);
+
+    setSystemTime(new Date(Date.now() + AVATAR_SUPERSEDE_WINDOW_MS));
+    await act(() =>
+      queryClient.refetchQueries({ queryKey: ["platformAvatarUrls"] }),
+    );
+    expect(listAssistants).toHaveBeenCalledTimes(3);
     await waitFor(() => {
       expect(result.current.get("a")).toBe(WITH_AVATAR);
     });
+  });
+});
+
+describe("supersedePlatformAvatar", () => {
+  const PAIRED_UUID = "11111111-2222-4333-8444-555555555555";
+
+  test("a paired row without a persisted UUID is suppressed under the UUID the daemon answers", async () => {
+    resolvePairedAssistantPlatformId.mockResolvedValueOnce(PAIRED_UUID);
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "paired-slug",
+          isLocal: false,
+          isPlatformHosted: false,
+          isPaired: true,
+          cloud: "paired",
+        },
+      ],
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const key = platformAvatarUrlsQueryKey("user-1", null);
+    queryClient.setQueryData(key, new Map([[PAIRED_UUID, WITH_AVATAR]]));
+
+    act(() => supersedePlatformAvatar(queryClient, "paired-slug"));
+
+    await waitFor(() => {
+      expect(resolvePairedAssistantPlatformId).toHaveBeenCalledWith(
+        "paired-slug",
+      );
+    });
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<Map<string, string>>(key)?.has(PAIRED_UUID),
+      ).toBe(false);
+    });
+  });
+
+  test("a row with a known platform id never asks the paired daemon", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "paired-slug",
+          isLocal: false,
+          isPlatformHosted: false,
+          isPaired: true,
+          cloud: "paired",
+          platformAssistantId: PAIRED_UUID,
+        },
+      ],
+    });
+    const queryClient = new QueryClient();
+    const key = platformAvatarUrlsQueryKey("user-1", null);
+    queryClient.setQueryData(key, new Map([[PAIRED_UUID, WITH_AVATAR]]));
+
+    supersedePlatformAvatar(queryClient, "paired-slug");
+
+    expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
+    expect(
+      queryClient.getQueryData<Map<string, string>>(key)?.has(PAIRED_UUID),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
+++ b/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
@@ -206,6 +206,26 @@ describe("usePlatformAvatarUrls", () => {
     expect(result.current.size).toBe(0);
   });
 
+  test("a failed poll keeps the last good map", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    listAssistants.mockRejectedValueOnce(new Error("offline"));
+    await act(() =>
+      queryClient.refetchQueries({ queryKey: ["platformAvatarUrls"] }),
+    );
+    expect(listAssistants).toHaveBeenCalledTimes(2);
+    await settle();
+    expect(result.current.get("a")).toBe(WITH_AVATAR);
+  });
+
   test("one list call serves every consumer in a stale window", async () => {
     const wrapper = createWrapper();
     const { result } = renderHook(

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -3,9 +3,17 @@ import { type QueryClient, useQuery } from "@tanstack/react-query";
 import { listAssistants } from "@/assistant/api";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
+import {
+  isAvatarSuperseded,
+  markAvatarSuperseded,
+} from "@/lib/avatar-supersede";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
 import { useRequestOrganizationId } from "@/stores/organization-store";
+import {
+  resolvePlatformAssistantId,
+  useResolvedAssistantsStore,
+} from "@/stores/resolved-assistants-store";
 
 export type PlatformAvatarUrls = ReadonlyMap<string, string>;
 
@@ -28,32 +36,18 @@ export function platformAvatarUrlsQueryKey(
 const PLATFORM_AVATAR_URLS_KEY_PREFIX = ["platformAvatarUrls"] as const;
 
 /**
- * Per-id tombstones stamped with the fetch generation current at suppression.
- * A list fetch that started at or before the stamp omits the id when it
- * lands; one that started after it is fresher than the suppression and
- * carries the id again, clearing the tombstone.
- */
-const suppressedPlatformIds = new Map<string, number>();
-let fetchGeneration = 0;
-
-export function resetPlatformAvatarUrlSuppressionsForTests(): void {
-  suppressedPlatformIds.clear();
-  fetchGeneration = 0;
-}
-
-/**
- * Drops one platform id from every cached map without refetching. Mirrors
- * the store's `clearAvatarUrl`: live evidence outranks a URL observed
- * earlier, and the platform copy lags the daemon's async sync, so an
- * immediate refetch would only re-serve the stale URL. The next stale-window
- * refetch restores it. A list in flight keeps its siblings and lands without
- * this id (see the tombstones above); nothing is cancelled.
+ * Drops one platform id from every cached map without refetching and marks
+ * it superseded (see `avatar-supersede`): live evidence outranks a URL
+ * observed earlier, and the platform copy lags the daemon's async sync, so
+ * an immediate refetch would only re-serve the stale URL. A list in flight
+ * keeps its siblings and lands without this id; nothing is cancelled. The
+ * first refetch after the window restores it.
  */
 export function suppressPlatformAvatarUrl(
   queryClient: QueryClient,
   platformAssistantId: string,
 ): void {
-  suppressedPlatformIds.set(platformAssistantId, fetchGeneration);
+  markAvatarSuperseded(platformAssistantId);
   queryClient.setQueriesData<PlatformAvatarUrls>(
     { queryKey: PLATFORM_AVATAR_URLS_KEY_PREFIX },
     (urls) => {
@@ -68,6 +62,36 @@ export function suppressPlatformAvatarUrl(
 }
 
 /**
+ * Everything a fresher local avatar read outranks for `assistantId`: the
+ * row's synced `avatarUrl` and its platform lookup entry. A paired row keyed
+ * by its local slug is also suppressed under its platform UUID once the
+ * paired daemon answers, since that is the key the list carries.
+ */
+export function supersedePlatformAvatar(
+  queryClient: QueryClient,
+  assistantId: string,
+): void {
+  const store = useResolvedAssistantsStore.getState();
+  store.clearAvatarUrl(assistantId);
+  suppressPlatformAvatarUrl(
+    queryClient,
+    resolvePlatformAssistantId(assistantId),
+  );
+  const row = store.assistants.find((a) => a.id === assistantId);
+  if (row?.isPaired && !row.platformAssistantId) {
+    // Dynamic: the resolver reaches the auth store, which reaches this
+    // module through the avatar hooks.
+    void import("@/lib/paired-platform-identity")
+      .then((m) => m.resolvePairedAssistantPlatformId(assistantId))
+      .then((platformId) => {
+        if (platformId) {
+          suppressPlatformAvatarUrl(queryClient, platformId);
+        }
+      });
+  }
+}
+
+/**
  * Modes where the resolved store is lockfile-driven, so its rows never carry
  * `avatarUrl` and the platform list is only reachable through a side query.
  * Gateway auth has no platform list at all.
@@ -78,7 +102,6 @@ export function isLockfileDrivenStore(): boolean {
 
 /** Never throws: a chooser row falls back to its other sources, not an error. */
 async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
-  const startGeneration = ++fetchGeneration;
   try {
     const result = await listAssistants();
     if (!result.ok) {
@@ -86,10 +109,7 @@ async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
     }
     const urls = new Map<string, string>();
     for (const assistant of result.data) {
-      if (
-        assistant.avatar_url &&
-        !isSuppressed(assistant.id, startGeneration)
-      ) {
+      if (assistant.avatar_url && !isAvatarSuperseded(assistant.id)) {
         urls.set(assistant.id, assistant.avatar_url);
       }
     }
@@ -97,19 +117,6 @@ async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
   } catch {
     return EMPTY_AVATAR_URLS;
   }
-}
-
-/** Suppressed during or after this fetch; an older tombstone is stale and dropped. */
-function isSuppressed(platformAssistantId: string, startGeneration: number) {
-  const suppressedAt = suppressedPlatformIds.get(platformAssistantId);
-  if (suppressedAt === undefined) {
-    return false;
-  }
-  if (suppressedAt >= startGeneration) {
-    return true;
-  }
-  suppressedPlatformIds.delete(platformAssistantId);
-  return false;
 }
 
 /**
@@ -131,6 +138,11 @@ export function usePlatformAvatarUrls(): PlatformAvatarUrls {
     queryFn: fetchPlatformAvatarUrls,
     enabled: hasPlatformSession && isOrgReady && isLockfileDrivenStore(),
     staleTime: PLATFORM_AVATAR_URLS_STALE_TIME_MS,
+    // staleTime alone never refetches a chooser that stays mounted, and a
+    // sibling's change on another client sends no event here; poll while
+    // the window is in the foreground.
+    refetchInterval: PLATFORM_AVATAR_URLS_STALE_TIME_MS,
+    refetchIntervalInBackground: false,
     retry: false,
   });
   return query.data ?? EMPTY_AVATAR_URLS;

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -100,23 +100,23 @@ export function isLockfileDrivenStore(): boolean {
   return (isLocalClient() || isRemoteGatewayMode()) && !isGatewayAuthEnabled();
 }
 
-/** Never throws: a chooser row falls back to its other sources, not an error. */
+/**
+ * Throws on failure so React Query keeps the last good map through a failed
+ * poll; with no prior data the hook reads that as an empty map, and a
+ * chooser row falls back to its other sources, never an error.
+ */
 async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
-  try {
-    const result = await listAssistants();
-    if (!result.ok) {
-      return EMPTY_AVATAR_URLS;
-    }
-    const urls = new Map<string, string>();
-    for (const assistant of result.data) {
-      if (assistant.avatar_url && !isAvatarSuperseded(assistant.id)) {
-        urls.set(assistant.id, assistant.avatar_url);
-      }
-    }
-    return urls;
-  } catch {
-    return EMPTY_AVATAR_URLS;
+  const result = await listAssistants();
+  if (!result.ok) {
+    throw new Error(`Failed to list assistants (${result.status})`);
   }
+  const urls = new Map<string, string>();
+  for (const assistant of result.data) {
+    if (assistant.avatar_url && !isAvatarSuperseded(assistant.id)) {
+      urls.set(assistant.id, assistant.avatar_url);
+    }
+  }
+  return urls;
 }
 
 /**

--- a/clients/web/src/lib/avatar-supersede.test.ts
+++ b/clients/web/src/lib/avatar-supersede.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
+
+import {
+  AVATAR_SUPERSEDE_WINDOW_MS,
+  isAvatarSuperseded,
+  markAvatarSuperseded,
+  resetAvatarSupersedeForTests,
+} from "./avatar-supersede";
+
+afterEach(() => {
+  setSystemTime();
+  resetAvatarSupersedeForTests();
+});
+
+describe("avatar supersede window", () => {
+  test("an unmarked id is not superseded", () => {
+    expect(isAvatarSuperseded("a")).toBe(false);
+  });
+
+  test("a mark holds for the window and expires after it", () => {
+    markAvatarSuperseded("a");
+    expect(isAvatarSuperseded("a")).toBe(true);
+    setSystemTime(new Date(Date.now() + AVATAR_SUPERSEDE_WINDOW_MS - 1));
+    expect(isAvatarSuperseded("a")).toBe(true);
+    setSystemTime(new Date(Date.now() + 1));
+    expect(isAvatarSuperseded("a")).toBe(false);
+  });
+
+  test("a later mark restarts the window", () => {
+    markAvatarSuperseded("a");
+    setSystemTime(new Date(Date.now() + AVATAR_SUPERSEDE_WINDOW_MS - 1));
+    markAvatarSuperseded("a");
+    setSystemTime(new Date(Date.now() + AVATAR_SUPERSEDE_WINDOW_MS - 1));
+    expect(isAvatarSuperseded("a")).toBe(true);
+  });
+});

--- a/clients/web/src/lib/avatar-supersede.ts
+++ b/clients/web/src/lib/avatar-supersede.ts
@@ -1,0 +1,31 @@
+/**
+ * Platform ids whose synced avatar was just outranked by fresher local
+ * evidence, stamped with when. The daemon syncs the change to the platform
+ * asynchronously and the platform's read path can lag behind the write, so
+ * any list that lands inside the window may still carry the old URL; it is
+ * dropped for that id. After the window the platform copy is trusted again.
+ */
+export const AVATAR_SUPERSEDE_WINDOW_MS = 60_000;
+
+const supersededAt = new Map<string, number>();
+
+export function markAvatarSuperseded(platformAssistantId: string): void {
+  supersededAt.set(platformAssistantId, Date.now());
+}
+
+/** Inside the window; an expired mark is dropped on the way out. */
+export function isAvatarSuperseded(platformAssistantId: string): boolean {
+  const at = supersededAt.get(platformAssistantId);
+  if (at === undefined) {
+    return false;
+  }
+  if (Date.now() - at < AVATAR_SUPERSEDE_WINDOW_MS) {
+    return true;
+  }
+  supersededAt.delete(platformAssistantId);
+  return false;
+}
+
+export function resetAvatarSupersedeForTests(): void {
+  supersededAt.clear();
+}

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -1,15 +1,11 @@
 import type { QueryClient } from "@tanstack/react-query";
 
-import { suppressPlatformAvatarUrl } from "@/hooks/use-platform-avatar-urls";
+import { supersedePlatformAvatar } from "@/hooks/use-platform-avatar-urls";
 import {
   deleteLastSeenAvatar,
   lastSeenAvatarGenerations,
   writeLastSeenAvatar,
 } from "@/lib/avatar-last-seen-cache";
-import {
-  resolvePlatformAssistantId,
-  useResolvedAssistantsStore,
-} from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
 
 /** The chooser's query over the last-seen cache; invalidated after every persist. */
@@ -59,11 +55,7 @@ export async function persistLastSeenAvatar(
     // A blob that cannot be read back is simply not cached.
     return;
   }
-  useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
-  suppressPlatformAvatarUrl(
-    queryClient,
-    resolvePlatformAssistantId(assistantId),
-  );
+  supersedePlatformAvatar(queryClient, assistantId);
   void queryClient.invalidateQueries({
     queryKey: chooserRowAvatarCacheQueryKey(assistantId),
   });

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  setSystemTime,
+} from "bun:test";
 
 import {
   assistantsValidForOrg,
@@ -6,6 +13,11 @@ import {
   type ResolvedAssistant,
 } from "@/stores/resolved-assistants-store";
 import { SELECTED_ASSISTANT_STORAGE_KEY } from "@/assistant/selected-assistant-storage";
+import {
+  AVATAR_SUPERSEDE_WINDOW_MS,
+  markAvatarSuperseded,
+  resetAvatarSupersedeForTests,
+} from "@/lib/avatar-supersede";
 import { useLockfileStore } from "@/stores/lockfile-store";
 import type { Lockfile, LockfileAssistant } from "@/runtime/local-mode-host";
 
@@ -396,6 +408,41 @@ describe("setFromApi connectability", () => {
     expect(
       useResolvedAssistantsStore.getState().assistants[0].avatarUrl,
     ).toBeUndefined();
+  });
+
+  describe("inside the supersede window", () => {
+    afterEach(() => {
+      setSystemTime();
+      resetAvatarSupersedeForTests();
+    });
+
+    it("setFromApi and upsertFromApi keep a superseded row's avatarUrl null until the window passes", () => {
+      markAvatarSuperseded("asst-a");
+      const entries = [
+        apiEntry({ id: "asst-a", avatar_url: "https://cdn.example/old.png" }),
+        apiEntry({ id: "asst-b", avatar_url: "https://cdn.example/b.png" }),
+      ];
+      useResolvedAssistantsStore.getState().setFromApi(entries);
+      let byId = new Map(
+        useResolvedAssistantsStore.getState().assistants.map((a) => [a.id, a]),
+      );
+      expect(byId.get("asst-a")?.avatarUrl).toBeNull();
+      expect(byId.get("asst-b")?.avatarUrl).toBe("https://cdn.example/b.png");
+
+      useResolvedAssistantsStore.getState().upsertFromApi(entries[0]);
+      expect(
+        useResolvedAssistantsStore
+          .getState()
+          .assistants.find((a) => a.id === "asst-a")?.avatarUrl,
+      ).toBeNull();
+
+      setSystemTime(new Date(Date.now() + AVATAR_SUPERSEDE_WINDOW_MS));
+      useResolvedAssistantsStore.getState().setFromApi(entries);
+      byId = new Map(
+        useResolvedAssistantsStore.getState().assistants.map((a) => [a.id, a]),
+      );
+      expect(byId.get("asst-a")?.avatarUrl).toBe("https://cdn.example/old.png");
+    });
   });
 
   it("clearAvatarUrl nulls one row's avatarUrl and leaves the rest", () => {

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -26,6 +26,7 @@
 import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
+import { isAvatarSuperseded } from "@/lib/avatar-supersede";
 import {
   isLocalClient,
   isLocalAssistant,
@@ -69,6 +70,15 @@ export interface ResolvedAssistant {
   /** Platform UUID for a locally hatched entry whose `id` is the instance
    *  name; only the lockfile carries it. API rows are already keyed by UUID. */
   platformAssistantId?: string;
+}
+
+/**
+ * A list that lands inside the supersede window may still carry the URL a
+ * local read just outranked; keep the row on its live/cache sources until
+ * the platform copy can have caught up.
+ */
+function apiAvatarUrl(a: Assistant): string | null | undefined {
+  return isAvatarSuperseded(a.id) ? null : a.avatar_url;
 }
 
 /** The id the platform knows `a` by: the lockfile's registration for a local instance, else `a.id`. */
@@ -216,7 +226,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               runtimeUrl: lockfileFields.runtimeUrl,
               platformAssistantId: lockfileFields.platformAssistantId,
               ingressUrl: a.ingress_url,
-              avatarUrl: a.avatar_url,
+              avatarUrl: apiAvatarUrl(a),
               currentReleaseVersion: a.current_release_version,
               releaseChannel: a.release_channel,
               isActiveLockfileAssistant:
@@ -241,7 +251,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           name: assistant.name,
           hatchedAt: assistant.created,
           ingressUrl: assistant.ingress_url,
-          avatarUrl: assistant.avatar_url,
+          avatarUrl: apiAvatarUrl(assistant),
           currentReleaseVersion: assistant.current_release_version,
           releaseChannel: assistant.release_channel,
           ...classifyApiEntry(


### PR DESCRIPTION
## Summary

Closes out the six items deferred in #41549's body.

- **Time-windowed supersede (replaces the fetch-generation tombstones).** New `lib/avatar-supersede.ts` marks a platform id when fresher local evidence outranks its synced URL; any list that lands inside the 60 s window drops that id, whichever fetch it came from. This closes the generation-0 edge in the lookup and, because `setFromApi` / `upsertFromApi` now consult the same mark, the pure-cloud replication-lag reload race as well. After the window the platform copy is trusted again.
- **`supersedePlatformAvatar(queryClient, assistantId)`** is now the single entry point for "a local read outranks the platform copy" (used by `persistLastSeenAvatar` and the `avatar_updated` handler). For a paired row that has not persisted its UUID yet it also resolves the UUID through the paired daemon and suppresses under that key, so the lookup entry is no longer suppressed by the local slug only.
- **Switch-during-reconnect race:** `useAssistantAvatar` decides "is this the active assistant's read" when the request goes out, not when it lands, so a reconnect-sweep refetch that resolves after the user switches away still feeds the last-seen cache.
- **Foreground polling:** `usePlatformAvatarUrls` gets `refetchInterval` (60 s, foreground only) matching the host-avatar query, so a chooser that stays mounted picks up a sibling's change on another client.
- **Pagination:** `listAssistants()` follows the platform's `next` chain (page size 100, capped at 20 pages) so both the chooser list and the avatar lookup see every assistant in an org past one page.

## Original prompt

After the read side of the chooser avatar arc (#41549, plan PRs 9 and 10 plus two fix PRs) merged to main, its body carried six Codex P2s that had been deferred past the review-cycle limit: two replication-lag races that could restore a stale `avatar_url`, a tombstone generation edge, a missing foreground refetch on the platform list query, paired-row suppression keyed by the local slug before the UUID resolves, and `listAssistants()` reading only the first page. The ask was to address all of them now that the feature branch is on main.