### PR TITLE
feat(web): add the 100px composer attachment tile

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for the mobile composer's attachment tile.
+ *
+ * Mounted with `@testing-library/react` (happy-dom, see
+ * `clients/web/test-setup.ts`), against the real design-library `Button` and
+ * the real English catalog, so the accessible names asserted here are the ones
+ * a screen reader gets.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { AttachmentTile } from "@/domains/chat/components/chat-attachments/attachment-tile";
+
+afterEach(() => {
+  cleanup();
+});
+
+const PREVIEW_URL = "blob:http://localhost:3000/photo";
+
+function renderTile(props: Partial<Parameters<typeof AttachmentTile>[0]> = {}) {
+  const onRemove = mock((_id: string) => {});
+  const onPreview = mock(() => {});
+  render(
+    <AttachmentTile
+      id="att-1"
+      filename="photo.jpg"
+      previewUrl={PREVIEW_URL}
+      onRemove={onRemove}
+      onPreview={onPreview}
+      {...props}
+    />,
+  );
+  return { onRemove, onPreview };
+}
+
+describe("AttachmentTile", () => {
+  test("shows the uploaded image and no caption", () => {
+    const { onRemove, onPreview } = renderTile();
+
+    const preview = screen.getByRole("button", { name: "Preview photo.jpg" });
+    const image = preview.querySelector("img");
+    expect(image?.getAttribute("src")).toBe(PREVIEW_URL);
+
+    fireEvent.click(preview);
+    expect(onPreview).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove photo.jpg" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledWith("att-1");
+
+    // The filename reaches the user through the tooltip and the accessible
+    // names only. The tile carries no caption.
+    expect(screen.queryByText("photo.jpg")).toBeNull();
+  });
+
+  test("shows a spinner face while the upload is in flight", () => {
+    const { onRemove } = renderTile({ previewUrl: null, uploading: true });
+
+    expect(document.querySelector("img")).toBeNull();
+    expect(
+      screen.getByRole("img", { name: "Uploading photo.jpg" }),
+    ).toBeTruthy();
+
+    // The control cancels the upload rather than removing a finished
+    // attachment, and says so.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Cancel upload of photo.jpg" }),
+    );
+    expect(onRemove).toHaveBeenCalledWith("att-1");
+  });
+
+  test("disables the image when there is nothing to open", () => {
+    renderTile({ onPreview: undefined });
+
+    const preview = screen.getByRole("button", { name: "Preview photo.jpg" });
+    expect(preview.hasAttribute("disabled")).toBe(true);
+  });
+
+  test("routes the composer's press guard to the remove control only", () => {
+    const onRemoveMouseDown = mock(() => {});
+    renderTile({ onRemoveMouseDown });
+
+    // The guard cancels the mousedown so a tap on the X does not blur the
+    // textarea and collapse the mobile row.
+    fireEvent.mouseDown(
+      screen.getByRole("button", { name: "Remove photo.jpg" }),
+    );
+    expect(onRemoveMouseDown).toHaveBeenCalledTimes(1);
+
+    fireEvent.mouseDown(
+      screen.getByRole("button", { name: "Preview photo.jpg" }),
+    );
+    expect(onRemoveMouseDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.tsx
@@ -1,0 +1,95 @@
+import { Loader2, X } from "lucide-react";
+import type { MouseEventHandler } from "react";
+
+import { useTranslation } from "@/i18n";
+
+import { Button } from "@vellumai/design-library";
+
+/**
+ * The remove control's 12px glyph. `Button` reads a glyph size override on its
+ * icon wrapper, not from a `[&_svg]:size-*` on the button box.
+ */
+const REMOVE_GLYPH_CLASS = "size-3 [&_svg]:size-3";
+
+interface AttachmentTileProps {
+  id: string;
+  filename: string;
+  /** Decoded image URL. `null` while the upload is still in flight. */
+  previewUrl: string | null;
+  /** Spinner face, and the control reads "cancel" instead of "remove". */
+  uploading?: boolean;
+  onRemove: (id: string) => void;
+  /** Opens the full-screen preview. Only honoured once `previewUrl` is set. */
+  onPreview?: () => void;
+  /** The composer's press guard for the remove control. */
+  onRemoveMouseDown?: MouseEventHandler<HTMLElement>;
+}
+
+/**
+ * The mobile composer's attached image: a square thumbnail with a remove
+ * control and no caption. The filename lives only in the tooltip and the
+ * accessible names.
+ */
+export function AttachmentTile({
+  id,
+  filename,
+  previewUrl,
+  uploading = false,
+  onRemove,
+  onPreview,
+  onRemoveMouseDown,
+}: AttachmentTileProps) {
+  const { t } = useTranslation("chat");
+
+  return (
+    <div
+      data-slot="attachment-tile"
+      title={filename}
+      className="relative size-[100px] shrink-0 overflow-hidden rounded-[14px] bg-[var(--surface-base)]"
+    >
+      {previewUrl !== null ? (
+        <button
+          type="button"
+          className="block size-full cursor-pointer"
+          aria-label={t("attachmentTile.preview", { filename })}
+          onClick={onPreview}
+          disabled={onPreview == null}
+        >
+          <img
+            src={previewUrl}
+            alt=""
+            draggable={false}
+            className="size-full object-cover"
+          />
+        </button>
+      ) : (
+        <div
+          role="img"
+          aria-label={t("attachmentTile.uploading", { filename })}
+          className="flex size-full items-center justify-center text-[var(--content-tertiary)]"
+        >
+          <Loader2 className="size-4 animate-spin" />
+        </div>
+      )}
+      <Button
+        variant="ghost"
+        size="compact"
+        iconOnly={<X />}
+        expandOnMobile={false}
+        // The `before:` pseudo-element widens the press target past the 24px
+        // visual without moving it.
+        className="absolute right-1.5 top-1.5 rounded-full bg-[var(--surface-lift)] [--vbtn-fg:var(--content-default)] before:absolute before:-inset-2 before:content-['']"
+        iconOnlyGlyphClassName={REMOVE_GLYPH_CLASS}
+        aria-label={t(
+          uploading ? "attachmentTile.cancelUpload" : "attachmentTile.remove",
+          { filename },
+        )}
+        onMouseDown={onRemoveMouseDown}
+        onClick={(event) => {
+          event.stopPropagation();
+          onRemove(id);
+        }}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -127,6 +127,12 @@
     "previewAria": "Preview of {filename}",
     "previousAttachmentAria": "Previous attachment"
   },
+  "attachmentTile": {
+    "cancelUpload": "Cancel upload of {filename}",
+    "preview": "Preview {filename}",
+    "remove": "Remove {filename}",
+    "uploading": "Uploading {filename}"
+  },
   "backgroundTaskDetailPanel": {
     "closeDetail": "Close task detail",
     "command": "Command",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -127,6 +127,12 @@
     "previewAria": "Vista previa de {filename}",
     "previousAttachmentAria": "Adjunto anterior"
   },
+  "attachmentTile": {
+    "cancelUpload": "Cancelar la subida de {filename}",
+    "preview": "Vista previa de {filename}",
+    "remove": "Quitar {filename}",
+    "uploading": "Subiendo {filename}"
+  },
   "backgroundTaskDetailPanel": {
     "closeDetail": "Cerrar detalle de la tarea",
     "command": "Comando",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -45,6 +45,12 @@
     "switchTo": "Переключиться на {name}",
     "unnamedAssistant": "Безымянный ассистент"
   },
+  "attachmentTile": {
+    "cancelUpload": "Отменить загрузку {filename}",
+    "preview": "Предпросмотр {filename}",
+    "remove": "Удалить {filename}",
+    "uploading": "Загрузка {filename}"
+  },
   "cacheBreakpointMapCard": {
     "description": "Где {count, plural, one {# точка разрыва кэша попала} few {# точки разрыва кэша попали} many {# точек разрыва кэша попали} other {# точки разрыва кэша попали}} в префикс этого запроса и какие сегменты прочитали, а какие создали заново.",
     "estimatedTokens": "≈ {count} токенов",


### PR DESCRIPTION
## Summary
- Add `AttachmentTile`, the 100x100 image tile with a circular remove control for the mobile composer (no consumer yet)
- Translated aria labels in en and es; the i18n lint ratchet already covers all of `src/`, so no eslint config change was needed

Part of plan: mobile-attachment-tiles.md (PR 1 of 3)