### PR TITLE
fix(browser): give the Chrome Web Store install URL on the path that fails

### DIFF
--- a/assistant/src/__tests__/headless-browser-mode.test.ts
+++ b/assistant/src/__tests__/headless-browser-mode.test.ts
@@ -148,6 +148,7 @@ import {
   formatModeSelectionFailure,
   parseBrowserMode,
 } from "../tools/browser/browser-execution.js";
+import { CHROME_WEB_STORE_INSTALL_URL } from "../tools/browser/browser-status-constants.js";
 import type { ToolContext } from "../tools/types.js";
 
 // Restore all module mocks after this file completes so they don't
@@ -305,6 +306,7 @@ describe("formatModeSelectionFailure", () => {
     );
     expect(formatted).toContain("Remediation:");
     expect(formatted).toContain("extension is installed and enabled");
+    expect(formatted).toContain(CHROME_WEB_STORE_INSTALL_URL);
   });
 
   test("renders cdp-inspect transport_error with remediation", () => {
@@ -330,6 +332,29 @@ describe("formatModeSelectionFailure", () => {
     expect(formatted).toContain("Discovery code: unreachable");
     expect(formatted).toContain("Remediation:");
     expect(formatted).toContain("--remote-debugging-port");
+  });
+
+  test("includes the Chrome Web Store install URL for host-bridge failures", () => {
+    const diagnostics: AttemptDiagnostic[] = [
+      {
+        candidateKind: "host-bridge",
+        inclusionReason: "auto candidate",
+        stage: "send",
+        errorCode: "transport_error",
+        errorMessage: "desktop client could not reach Chrome",
+      },
+    ];
+
+    const error = new CdpError(
+      "transport_error",
+      "Host bridge unreachable",
+      { attemptDiagnostics: diagnostics },
+    );
+
+    const formatted = formatModeSelectionFailure("auto", error);
+
+    expect(formatted).toContain("Remediation:");
+    expect(formatted).toContain(CHROME_WEB_STORE_INSTALL_URL);
   });
 });
 
@@ -398,6 +423,7 @@ describe("browser_mode wiring through tool execution", () => {
     );
     expect(result.content).toContain("Remediation:");
     expect(result.content).toContain("extension is installed and enabled");
+    expect(result.content).toContain(CHROME_WEB_STORE_INSTALL_URL);
     // Factory should not have been called for CDP
     expect(cdpSendCalls).toEqual([]);
   });
@@ -585,6 +611,7 @@ describe("browser_mode wiring through tool execution", () => {
     expect(result.content).toContain("Reason: Host browser not reachable");
     expect(result.content).toContain("Remediation:");
     expect(result.content).toContain("extension is installed and enabled");
+    expect(result.content).toContain(CHROME_WEB_STORE_INSTALL_URL);
   });
 
   test("pinned extension with timeout transport error surfaces failover diagnostics in snapshot", async () => {

--- a/assistant/src/cli/commands/__tests__/browser.test.ts
+++ b/assistant/src/cli/commands/__tests__/browser.test.ts
@@ -67,7 +67,9 @@ mock.module("../../../util/logger.js", () => ({
 // Import module under test (after mocks)
 // ---------------------------------------------------------------------------
 
-const { registerBrowserCommand } = await import("../browser.js");
+const { formatBrowserStatusLines, registerBrowserCommand } = await import(
+  "../browser.js"
+);
 
 // ---------------------------------------------------------------------------
 // Test helper
@@ -530,6 +532,66 @@ describe("--json output", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.ok).toBe(false);
     expect(parsed.error).toBe("Error: Element not found");
+  });
+});
+
+describe("formatBrowserStatusLines", () => {
+  test("prints userActions including the Chrome Web Store install URL", () => {
+    const installUrl =
+      "https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne";
+    const lines = formatBrowserStatusLines(
+      JSON.stringify({
+        requestedMode: "auto",
+        recommendedMode: "cdp-inspect",
+        stickyConversationMode: null,
+        modes: [
+          {
+            mode: "extension",
+            available: false,
+            autoCandidate: true,
+            summary:
+              "Extension mode is unavailable: no Chrome Extension is connected.",
+            userActions: [
+              `Install the Vellum Assistant Chrome extension from the Chrome Web Store: ${installUrl}`,
+              "Open the extension and pair with your assistant.",
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(lines).not.toBeNull();
+    const rendered = lines!.join("\n");
+    expect(rendered).toContain("Requested mode: auto");
+    expect(rendered).toContain("✗ extension (auto-candidate)");
+    expect(rendered).toContain(installUrl);
+    expect(rendered).toContain("Open the extension and pair with your assistant.");
+  });
+
+  test("omits userActions when the mode is ready", () => {
+    const lines = formatBrowserStatusLines(
+      JSON.stringify({
+        requestedMode: "extension",
+        recommendedMode: "extension",
+        stickyConversationMode: null,
+        modes: [
+          {
+            mode: "extension",
+            available: true,
+            autoCandidate: true,
+            summary: "Extension mode is ready.",
+            userActions: [],
+          },
+        ],
+      }),
+    );
+
+    expect(lines).not.toBeNull();
+    expect(lines!.some((line) => line.trim().startsWith("- "))).toBe(false);
+  });
+
+  test("returns null for non-JSON status content", () => {
+    expect(formatBrowserStatusLines("not json")).toBeNull();
   });
 });
 

--- a/assistant/src/cli/commands/browser.ts
+++ b/assistant/src/cli/commands/browser.ts
@@ -262,6 +262,7 @@ interface StatusModeEntry {
   available: boolean;
   autoCandidate: boolean;
   summary: string;
+  userActions?: string[];
 }
 
 interface StatusPayload {
@@ -271,31 +272,50 @@ interface StatusPayload {
   modes: StatusModeEntry[];
 }
 
-function formatBrowserStatus(content: string): void {
+/** Render `assistant browser status` JSON as human-readable lines. */
+export function formatBrowserStatusLines(content: string): string[] | null {
   let data: StatusPayload;
   try {
     data = JSON.parse(content);
   } catch {
-    log.info(content);
-    return;
+    return null;
   }
 
-  log.info(`Requested mode: ${data.requestedMode}`);
+  const lines: string[] = [];
+  lines.push(`Requested mode: ${data.requestedMode}`);
   if (data.recommendedMode) {
-    log.info(`Recommended:    ${data.recommendedMode}`);
+    lines.push(`Recommended:    ${data.recommendedMode}`);
   }
   if (data.stickyConversationMode) {
-    log.info(`Sticky mode:    ${data.stickyConversationMode}`);
+    lines.push(`Sticky mode:    ${data.stickyConversationMode}`);
   }
-  log.info("");
+  lines.push("");
 
   const modes = data.modes ?? [];
   for (const mode of modes) {
     const icon = mode.available ? "✓" : "✗";
     const auto = mode.autoCandidate ? " (auto-candidate)" : "";
-    log.info(`  ${icon} ${mode.mode}${auto}`);
-    log.info(`    ${mode.summary}`);
-    log.info("");
+    lines.push(`  ${icon} ${mode.mode}${auto}`);
+    lines.push(`    ${mode.summary}`);
+    for (const action of mode.userActions ?? []) {
+      if (!action) {
+        continue;
+      }
+      lines.push(`    - ${action}`);
+    }
+    lines.push("");
+  }
+  return lines;
+}
+
+function formatBrowserStatus(content: string): void {
+  const lines = formatBrowserStatusLines(content);
+  if (lines == null) {
+    log.info(content);
+    return;
+  }
+  for (const line of lines) {
+    log.info(line);
   }
 }
 

--- a/assistant/src/tools/browser/__tests__/browser-status.test.ts
+++ b/assistant/src/tools/browser/__tests__/browser-status.test.ts
@@ -5,6 +5,7 @@ import type { ToolContext } from "../../types.js";
 import {
   BROWSER_STATUS_INPUT_FIELD,
   BROWSER_STATUS_MODE,
+  CHROME_WEB_STORE_INSTALL_URL,
 } from "../browser-status-constants.js";
 import { CdpError } from "../cdp-client/errors.js";
 
@@ -214,6 +215,9 @@ describe("executeBrowserStatus", () => {
     expect(extension.summary).toContain("no Chrome Extension is connected");
     expect(extension.verified).toBe("preflight");
     expect(extension.details.transport).toBe("extension-ws");
+    expect(extension.userActions.join("\n")).toContain(
+      CHROME_WEB_STORE_INSTALL_URL,
+    );
   });
 
   test("probe failure diagnostics include remediation actions", async () => {
@@ -237,6 +241,9 @@ describe("executeBrowserStatus", () => {
     expect(extension).toBeDefined();
     expect(extension.available).toBe(false);
     expect(extension.summary).toContain("probe failed");
+    expect(extension.userActions.join("\n")).toContain(
+      CHROME_WEB_STORE_INSTALL_URL,
+    );
   });
 
   test("recommendation order follows auto candidate precedence with available extension", async () => {

--- a/assistant/src/tools/browser/browser-execution.ts
+++ b/assistant/src/tools/browser/browser-execution.ts
@@ -39,6 +39,8 @@ import {
   BROWSER_STATUS_MODES,
   type BrowserStatusMode,
   CDP_INSPECT_STATUS_DISCOVERY_CODE,
+  CHROME_EXTENSION_INSTALL_HINT,
+  CHROME_WEB_STORE_INSTALL_URL,
   EXTENSION_STATUS_ERROR_MARKER,
 } from "./browser-status-constants.js";
 import {
@@ -296,6 +298,7 @@ export function parseBrowserMode(
 const REMEDIATION_HINTS: Record<string, string[]> = {
   // Extension backend
   "extension:transport_error": [
+    CHROME_EXTENSION_INSTALL_HINT,
     "Ensure the Vellum browser extension is installed and enabled, or that the macOS desktop client is running for host browser proxy mode.",
     "For extension mode: check that the extension WebSocket connection is active (extension popup → status).",
     "For macOS host browser proxy: verify the desktop client is running and has an active SSE connection to the assistant.",
@@ -335,11 +338,11 @@ const REMEDIATION_HINTS: Record<string, string[]> = {
     "Ensure Chrome on the user's machine is on version 146 or higher (chrome://settings/help).",
     'Ensure "Allow remote debugging for this browser instance" is toggled on at chrome://inspect/#remote-debugging.',
     "Verify the desktop client is running and has an active SSE connection to the assistant.",
-    "Installing the Vellum Chrome extension is the preferred path and avoids the debug-port requirement.",
+    `Installing the Vellum Chrome extension is the preferred path and avoids the debug-port requirement: ${CHROME_WEB_STORE_INSTALL_URL}`,
   ],
   "host-bridge:transport_error": [
     "The desktop client could not reach Chrome's remote-debugging endpoint on the user's machine.",
-    "Ensure Chrome is running with remote debugging enabled, or install the Vellum Chrome extension (preferred).",
+    `Ensure Chrome is running with remote debugging enabled, or install the Vellum Chrome extension (preferred): ${CHROME_WEB_STORE_INSTALL_URL}`,
     "Verify the desktop client is running and connected.",
   ],
   // Local/Playwright backend
@@ -2487,7 +2490,7 @@ function modeTradeoffs(mode: StatusCheckMode): string[] {
 
 function extensionSetupActions(): string[] {
   return [
-    "Install the Vellum Assistant Chrome extension from the Chrome Web Store: https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne",
+    CHROME_EXTENSION_INSTALL_HINT,
     "Open the extension and pair with your assistant.",
   ];
 }

--- a/assistant/src/tools/browser/browser-status-constants.ts
+++ b/assistant/src/tools/browser/browser-status-constants.ts
@@ -26,6 +26,13 @@ export const EXTENSION_STATUS_ERROR_MARKER = {
   HTTP_401: "401",
 } as const;
 
+/** Chrome Web Store listing for the Vellum Assistant browser extension. */
+export const CHROME_WEB_STORE_INSTALL_URL =
+  "https://chromewebstore.google.com/detail/vellum-assistant-browser/hphbdmpffeigpcdjkckleobjmhhokpne";
+
+/** User-facing install step for status userActions and command-failure hints. */
+export const CHROME_EXTENSION_INSTALL_HINT = `Install the Vellum Assistant Chrome extension from the Chrome Web Store: ${CHROME_WEB_STORE_INSTALL_URL}`;
+
 export const CDP_INSPECT_STATUS_DISCOVERY_CODE = {
   NO_TARGETS: DEVTOOLS_DISCOVERY_CODE.NO_TARGETS,
   INVALID_RESPONSE: DEVTOOLS_DISCOVERY_CODE.INVALID_RESPONSE,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Closes JARVIS-1577. When Chrome access fails, the assistant should hand the user the Chrome Web Store install link. The link already existed in status `userActions` and the browser skill, but not on the path a user actually hits.

- Command failures (`formatModeSelectionFailure` / `REMEDIATION_HINTS`) mentioned the extension without a URL.
- `assistant browser status` typed `StatusModeEntry` without `userActions` and silently dropped the install link.

## Summary
- Share one Chrome Web Store install hint (`CHROME_EXTENSION_INSTALL_HINT`) used by status `userActions` and command-failure remediation.
- Include that URL on extension and host-bridge failure hints.
- Print `userActions` from the CLI status formatter so `assistant browser status` shows the install link.

## Test plan
- `cd assistant && bun test src/__tests__/headless-browser-mode.test.ts src/tools/browser/__tests__/browser-status.test.ts src/cli/commands/__tests__/browser.test.ts`
- Result: 76 pass, 0 fail
- Assert command-failure text and status `userActions` contain the Chrome Web Store URL
- Assert `formatBrowserStatusLines` prints `userActions`

## Risk
Low. Additive copy on existing error and status surfaces. No schema, migration, or feature-flag changes.

## CLI verb checklist
No new routes. This only formats an existing status payload field the daemon already returns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e3fc7d4-4234-4746-936a-1587e14a6e34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e3fc7d4-4234-4746-936a-1587e14a6e34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

