### PR TITLE
feat(web): show attached images as 100px tiles in the mobile composer

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.test.tsx
@@ -72,6 +72,19 @@ describe("AttachmentPreviewModal content loading", () => {
     expect(attachmentsByIdContentGet).not.toHaveBeenCalled();
   });
 
+  test("renders a generic-MIME image by its extension", () => {
+    renderModal({
+      ...ATTACHMENT,
+      filename: "photo.jpg",
+      mimeType: "application/octet-stream",
+      previewUrl: "data:image/png;base64,AAAA",
+    });
+
+    expect(screen.getByAltText("photo.jpg").getAttribute("src")).toBe(
+      "data:image/png;base64,AAAA",
+    );
+  });
+
   test("shows a clear message for rehydrated attachments and never fetches", () => {
     renderModal({ ...ATTACHMENT, id: "rehydrated:abc" });
 

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -17,7 +17,10 @@ import { Button, Typography } from "@vellumai/design-library";
 import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-preview";
 import { PreviewMessageCard } from "@/domains/chat/components/chat-attachments/preview-message-card";
 import { TextPreview } from "@/domains/chat/components/chat-attachments/text-preview";
-import { formatAttachmentSize } from "@/domains/chat/components/chat-attachments/utils";
+import {
+  formatAttachmentSize,
+  isImageAttachment,
+} from "@/domains/chat/components/chat-attachments/utils";
 import { useGallerySwipe } from "@/domains/chat/components/chat-attachments/use-gallery-swipe";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
 import type { DisplayAttachment } from "@/types/attachment-types";
@@ -271,7 +274,10 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
   }
 
   const mime = attachment.mimeType.toLowerCase();
-  const isImage = mime.startsWith("image/");
+  const isImage = isImageAttachment({
+    name: attachment.filename,
+    type: attachment.mimeType,
+  });
   const isVideo = mime.startsWith("video/");
   // Some uploads come through with a generic application/octet-stream MIME;
   // fall back to the filename extension so a real PDF still gets the inline

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.test.tsx
@@ -70,6 +70,19 @@ describe("AttachmentTile", () => {
     expect(onRemove).toHaveBeenCalledWith("att-1");
   });
 
+  test("reports a preview the browser cannot decode", () => {
+    const onPreviewError = mock(() => {});
+    renderTile({ onPreviewError });
+
+    const image = screen
+      .getByRole("button", { name: "Preview photo.jpg" })
+      .querySelector("img");
+    expect(image).toBeTruthy();
+
+    fireEvent.error(image as HTMLImageElement);
+    expect(onPreviewError).toHaveBeenCalledTimes(1);
+  });
+
   test("disables the image when there is nothing to open", () => {
     renderTile({ onPreview: undefined });
 

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.tsx
@@ -21,6 +21,9 @@ interface AttachmentTileProps {
   onRemove: (id: string) => void;
   /** Opens the full-screen preview. Only honoured once `previewUrl` is set. */
   onPreview?: () => void;
+  /** Called when the browser cannot decode the preview. Lets the owner drop
+   *  the tile for a chip, which still names the file. */
+  onPreviewError?: () => void;
   /** The composer's press guard for the remove control. */
   onRemoveMouseDown?: MouseEventHandler<HTMLElement>;
 }
@@ -37,6 +40,7 @@ export function AttachmentTile({
   uploading = false,
   onRemove,
   onPreview,
+  onPreviewError,
   onRemoveMouseDown,
 }: AttachmentTileProps) {
   const { t } = useTranslation("chat");
@@ -59,6 +63,7 @@ export function AttachmentTile({
             src={previewUrl}
             alt=""
             draggable={false}
+            onError={onPreviewError}
             className="size-full object-cover"
           />
         </button>

--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments-strip.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments-strip.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for the composer's attachment strip: which attachments the mobile
+ * composer shows as tiles, which keep the chip there, and that desktop keeps
+ * the chip for all of them.
+ *
+ * Mounted with `@testing-library/react` (happy-dom, see
+ * `clients/web/test-setup.ts`) against the real chips, the real tile and the
+ * real preview modal, so what is asserted is the strip's actual dispatch
+ * rather than a stub's.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { ChatAttachmentsStrip } from "@/domains/chat/components/chat-attachments/chat-attachments";
+import type {
+  ChatAttachment,
+  FailedAttachmentUpload,
+  PendingAttachmentUpload,
+  UploadedAttachment,
+} from "@/domains/chat/composer-store";
+
+afterEach(() => {
+  cleanup();
+});
+
+const PREVIEW_URL = "data:image/png;base64,AAAA";
+
+function uploaded(
+  overrides: Partial<UploadedAttachment> = {},
+): UploadedAttachment {
+  return {
+    kind: "uploaded",
+    localId: "local-1",
+    id: "att-1",
+    filename: "photo.jpg",
+    mimeType: "image/jpeg",
+    sizeBytes: 1_024,
+    previewUrl: PREVIEW_URL,
+    ...overrides,
+  };
+}
+
+function uploading(
+  overrides: Partial<PendingAttachmentUpload> = {},
+): PendingAttachmentUpload {
+  return {
+    kind: "uploading",
+    localId: "local-2",
+    filename: "shot.png",
+    mimeType: "image/png",
+    sizeBytes: 2_048,
+    ...overrides,
+  };
+}
+
+function failed(
+  overrides: Partial<FailedAttachmentUpload> = {},
+): FailedAttachmentUpload {
+  return {
+    kind: "failed",
+    localId: "local-3",
+    filename: "broken.jpg",
+    mimeType: "image/jpeg",
+    sizeBytes: 512,
+    error: "Upload failed",
+    ...overrides,
+  };
+}
+
+function renderStrip(
+  attachments: ChatAttachment[],
+  props: Partial<Parameters<typeof ChatAttachmentsStrip>[0]> = {},
+) {
+  const onRemove = mock((_localId: string) => {});
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const result = render(
+    <QueryClientProvider client={client}>
+      <ChatAttachmentsStrip
+        attachments={attachments}
+        onRemove={onRemove}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+  return { ...result, onRemove };
+}
+
+/** The scrolling row itself, which is the strip's first rendered element. */
+function stripRow(container: HTMLElement): HTMLElement {
+  return container.firstElementChild as HTMLElement;
+}
+
+function tiles(): Element[] {
+  return Array.from(document.querySelectorAll('[data-slot="attachment-tile"]'));
+}
+
+describe("ChatAttachmentsStrip tiles", () => {
+  test("shows an uploaded image as a tile with no caption", () => {
+    renderStrip([uploaded()], { tileImages: true });
+
+    expect(tiles()).toHaveLength(1);
+    expect(
+      screen.getByRole("button", { name: "Preview photo.jpg" }),
+    ).toBeTruthy();
+    // The chip is what carries a filename; the tile identifies the attachment
+    // by the picture alone.
+    expect(screen.queryByText("photo.jpg")).toBeNull();
+  });
+
+  test("shows an image still uploading as a spinner tile", () => {
+    renderStrip([uploading()], { tileImages: true });
+
+    expect(tiles()).toHaveLength(1);
+    expect(
+      screen.getByRole("img", { name: "Uploading shot.png" }),
+    ).toBeTruthy();
+    expect(screen.queryByText("shot.png")).toBeNull();
+  });
+
+  test("keeps the chip for a non-image attachment", () => {
+    renderStrip(
+      [
+        uploaded({
+          filename: "report.pdf",
+          mimeType: "application/pdf",
+          previewUrl: null,
+        }),
+      ],
+      { tileImages: true },
+    );
+
+    expect(tiles()).toHaveLength(0);
+    expect(screen.getByText("report.pdf")).toBeTruthy();
+  });
+
+  test("keeps the chip for an image with no decodable preview", () => {
+    renderStrip([uploaded({ previewUrl: null })], { tileImages: true });
+
+    expect(tiles()).toHaveLength(0);
+    expect(screen.getByText("photo.jpg")).toBeTruthy();
+  });
+
+  test("keeps the error chip for a failed image upload", () => {
+    renderStrip([failed()], { tileImages: true });
+
+    expect(tiles()).toHaveLength(0);
+    expect(screen.getByText("broken.jpg")).toBeTruthy();
+    expect(screen.getByText("Dismiss")).toBeTruthy();
+  });
+
+  test("removes the attachment the tile's control names", () => {
+    const { onRemove } = renderStrip([uploaded()], { tileImages: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove photo.jpg" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onRemove).toHaveBeenCalledWith("local-1");
+  });
+
+  test("routes the composer's press guard to the tile's control", () => {
+    const pressGuard = mock(() => {});
+    renderStrip([uploaded()], { tileImages: true, pressGuard });
+
+    fireEvent.mouseDown(
+      screen.getByRole("button", { name: "Remove photo.jpg" }),
+    );
+    expect(pressGuard).toHaveBeenCalledTimes(1);
+  });
+
+  test("opens the preview modal from the tile image", () => {
+    renderStrip([uploaded()], { tileImages: true });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview photo.jpg" }));
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByAltText("photo.jpg").getAttribute("src")).toBe(
+      PREVIEW_URL,
+    );
+  });
+});
+
+describe("ChatAttachmentsStrip chips", () => {
+  test("keeps the chip for every attachment without the tile opt-in", () => {
+    const { container } = renderStrip([uploaded(), uploading()]);
+
+    expect(tiles()).toHaveLength(0);
+    expect(screen.getByText("photo.jpg")).toBeTruthy();
+    expect(screen.getByText("shot.png")).toBeTruthy();
+    expect(stripRow(container).className).toContain("pt-2");
+  });
+
+  test("opens the row's top inset for a tile row", () => {
+    const { container } = renderStrip([uploaded()], { tileImages: true });
+
+    expect(stripRow(container).className).toContain("pt-3");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments-strip.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments-strip.test.tsx
@@ -121,6 +121,23 @@ describe("ChatAttachmentsStrip tiles", () => {
     expect(screen.queryByText("shot.png")).toBeNull();
   });
 
+  test("shows an image whose type is a generic blob as a tile", () => {
+    renderStrip(
+      [
+        uploading({
+          filename: "photo.jpg",
+          mimeType: "application/octet-stream",
+        }),
+      ],
+      { tileImages: true },
+    );
+
+    expect(tiles()).toHaveLength(1);
+    expect(
+      screen.getByRole("img", { name: "Uploading photo.jpg" }),
+    ).toBeTruthy();
+  });
+
   test("keeps the chip for a non-image attachment", () => {
     renderStrip(
       [
@@ -139,6 +156,18 @@ describe("ChatAttachmentsStrip tiles", () => {
 
   test("keeps the chip for an image with no decodable preview", () => {
     renderStrip([uploaded({ previewUrl: null })], { tileImages: true });
+
+    expect(tiles()).toHaveLength(0);
+    expect(screen.getByText("photo.jpg")).toBeTruthy();
+  });
+
+  test("falls back to the chip when the tile preview cannot decode", () => {
+    renderStrip([uploaded()], { tileImages: true });
+
+    const image = document.querySelector('[data-slot="attachment-tile"] img');
+    expect(image).toBeTruthy();
+
+    fireEvent.error(image as HTMLImageElement);
 
     expect(tiles()).toHaveLength(0);
     expect(screen.getByText("photo.jpg")).toBeTruthy();

--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
@@ -1,23 +1,53 @@
 import { AlertCircle, Folder, Paperclip, X } from "lucide-react";
-import type { FC } from "react";
+import type { FC, MouseEventHandler } from "react";
 import { useCallback, useState } from "react";
 import { useTranslation } from "@/i18n";
 
-import { Button } from "@vellumai/design-library";
+import { Button, cn } from "@vellumai/design-library";
 
 import { AttachmentChip } from "@/domains/chat/components/chat-attachments/attachment-chip";
 import { AttachmentLoadingChip } from "@/domains/chat/components/chat-attachments/attachment-loading-chip";
 import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
+import { AttachmentTile } from "@/domains/chat/components/chat-attachments/attachment-tile";
 import { useAttachmentFilePicker } from "@/domains/chat/components/chat-attachments/use-attachment-file-picker";
 import type {
   ChatAttachment,
+  PendingAttachmentUpload,
   UploadedAttachment,
 } from "@/domains/chat/composer-store";
-import { middleTruncate } from "@/domains/chat/components/chat-attachments/utils";
+import {
+  classifyAttachment,
+  middleTruncate,
+} from "@/domains/chat/components/chat-attachments/utils";
 
 interface ChatAttachmentsStripProps {
   attachments: ChatAttachment[];
   onRemove: (localId: string) => void;
+  /**
+   * Render images as square tiles instead of chips. The tile drops the
+   * filename, so it only suits a surface where the picture identifies the
+   * attachment on its own.
+   */
+  tileImages?: boolean;
+  /** The composer's press guard for the tile's remove control. */
+  pressGuard?: MouseEventHandler<HTMLElement>;
+}
+
+/**
+ * Whether the strip shows this attachment as a tile: an image that is either
+ * still uploading or already carries a decodable preview. Anything else keeps
+ * the chip, which is the only place its filename or its error shows.
+ */
+function isTiledImage(
+  att: ChatAttachment,
+): att is PendingAttachmentUpload | UploadedAttachment {
+  if (att.kind !== "uploading" && att.kind !== "uploaded") {
+    return false;
+  }
+  if (att.kind === "uploaded" && att.previewUrl === null) {
+    return false;
+  }
+  return classifyAttachment(att.mimeType, att.filename) === "image";
 }
 
 /**
@@ -27,6 +57,8 @@ interface ChatAttachmentsStripProps {
 export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
   attachments,
   onRemove,
+  tileImages = false,
+  pressGuard,
 }) => {
   const { t } = useTranslation("chat");
   const [previewAttachment, setPreviewAttachment] =
@@ -39,8 +71,32 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
 
   return (
     <>
-      <div className="flex gap-2 overflow-x-auto px-3 pb-1.5 pt-2 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
+      <div
+        className={cn(
+          "flex gap-2 overflow-x-auto px-3 pb-1.5 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]",
+          // A tile row sits 12px below the card's top edge, against the 8px a
+          // chip row takes.
+          tileImages ? "pt-3" : "pt-2",
+        )}
+      >
         {attachments.map((att) => {
+          if (tileImages && isTiledImage(att)) {
+            const uploaded = att.kind === "uploaded" ? att : null;
+            return (
+              <AttachmentTile
+                key={att.localId}
+                id={att.localId}
+                filename={att.filename}
+                previewUrl={uploaded?.previewUrl ?? null}
+                uploading={att.kind === "uploading"}
+                onRemove={onRemove}
+                onPreview={
+                  uploaded ? () => setPreviewAttachment(uploaded) : undefined
+                }
+                onRemoveMouseDown={pressGuard}
+              />
+            );
+          }
           if (att.kind === "uploading") {
             return (
               <AttachmentLoadingChip

--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
@@ -16,7 +16,7 @@ import type {
   UploadedAttachment,
 } from "@/domains/chat/composer-store";
 import {
-  classifyAttachment,
+  isImageAttachment,
   middleTruncate,
 } from "@/domains/chat/components/chat-attachments/utils";
 
@@ -47,7 +47,7 @@ function isTiledImage(
   if (att.kind === "uploaded" && att.previewUrl === null) {
     return false;
   }
-  return classifyAttachment(att.mimeType, att.filename) === "image";
+  return isImageAttachment({ name: att.filename, type: att.mimeType });
 }
 
 /**
@@ -64,6 +64,17 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
   const [previewAttachment, setPreviewAttachment] =
     useState<UploadedAttachment | null>(null);
   const handleClosePreview = useCallback(() => setPreviewAttachment(null), []);
+  // Local ids whose preview the browser could not decode (a TIFF, or a HEIF
+  // whose conversion fell back). Their tile would be a blank square with no
+  // filename, so they drop back to the chip.
+  const [failedPreviewIds, setFailedPreviewIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+  const markPreviewFailed = useCallback((localId: string) => {
+    setFailedPreviewIds((prev) =>
+      prev.has(localId) ? prev : new Set(prev).add(localId),
+    );
+  }, []);
 
   if (attachments.length === 0) {
     return null;
@@ -80,7 +91,8 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
         )}
       >
         {attachments.map((att) => {
-          if (tileImages && isTiledImage(att)) {
+          const previewFailed = failedPreviewIds.has(att.localId);
+          if (tileImages && !previewFailed && isTiledImage(att)) {
             const uploaded = att.kind === "uploaded" ? att : null;
             return (
               <AttachmentTile
@@ -92,6 +104,9 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
                 onRemove={onRemove}
                 onPreview={
                   uploaded ? () => setPreviewAttachment(uploaded) : undefined
+                }
+                onPreviewError={
+                  uploaded ? () => markPreviewFailed(att.localId) : undefined
                 }
                 onRemoveMouseDown={pressGuard}
               />
@@ -164,7 +179,7 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
               id={att.localId}
               filename={att.filename}
               mimeType={att.mimeType}
-              previewUrl={att.previewUrl}
+              previewUrl={previewFailed ? null : att.previewUrl}
               onRemove={onRemove}
               onPreview={() => setPreviewAttachment(att)}
             />

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -1668,6 +1668,8 @@ export function ChatComposer({
                   <ChatAttachmentsStrip
                     attachments={attachments}
                     onRemove={removeAttachment}
+                    tileImages={isMobile}
+                    pressGuard={rowPressGuard}
                   />
                   {isMobile ? (
                     <>


### PR DESCRIPTION
## Summary
- The composer strip renders image attachments as `AttachmentTile` on mobile (uploading and uploaded), keeping the chip for files, failures and path references, and for everything on desktop
- The composer passes `tileImages={isMobile}` and its press guard so tapping the remove control does not blur the draft
- New strip test covering the tile/chip dispatch and the desktop regression guard

Part of plan: mobile-attachment-tiles.md (PR 2 of 3)