### PR TITLE
Reactions carry a structured payload on the shared seam

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4198,6 +4198,22 @@ paths:
                     - delete
                     - reaction
                     - button
+                reaction:
+                  type: object
+                  properties:
+                    op:
+                      type: string
+                      enum:
+                        - added
+                        - removed
+                    emoji:
+                      type: string
+                    targetMessageId:
+                      type: string
+                  required:
+                    - op
+                    - emoji
+                    - targetMessageId
                 isEdit:
                   type: boolean
                 callbackQueryId:

--- a/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
+++ b/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
@@ -243,6 +243,7 @@ describe("channel inbound disk pressure gate", () => {
         content: "reaction:thumbsup",
         actorExternalId: "slack-user-1",
         callbackData: "reaction:thumbsup",
+        sourceMetadata: { messageId: "1700000000.1" },
         replyCallbackUrl: "https://gateway.test/deliver/slack",
       }),
     );

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -79,10 +79,7 @@ import { initializeDb } from "../persistence/db-init.js";
 import { linkMessage, recordInbound } from "../persistence/delivery-crud.js";
 import { messages } from "../persistence/schema/conversations.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
-import {
-  isReactionEvent,
-  parseSlackReactionCallbackData,
-} from "../runtime/routes/inbound-stages/reaction-intercept.js";
+import { isReactionEvent } from "../runtime/routes/inbound-stages/reaction-intercept.js";
 import {
   handleChannelInbound,
   seedContactChannel,
@@ -203,69 +200,25 @@ function readPersistedMessages(): Array<{
 // ---------------------------------------------------------------------------
 
 describe("isReactionEvent", () => {
-  test("returns true for reaction added", () => {
-    expect(
-      isReactionEvent({
-        sourceChannel: "slack",
-        callbackData: "reaction:thumbsup",
-      }),
-    ).toBe(true);
+  test("returns true for a stamped reaction kind", () => {
+    expect(isReactionEvent({ eventKind: "reaction" })).toBe(true);
   });
 
-  test("returns true for reaction removed", () => {
-    expect(
-      isReactionEvent({
-        sourceChannel: "slack",
-        callbackData: "reaction_removed:eyes",
-      }),
-    ).toBe(true);
-  });
-
-  test("returns false for non-Slack source", () => {
-    expect(
-      isReactionEvent({
-        sourceChannel: "telegram",
-        callbackData: "reaction:thumbsup",
-      }),
-    ).toBe(false);
+  test("returns true for replayed reaction sentinels, added and removed", () => {
+    expect(isReactionEvent({ callbackData: "reaction:thumbsup" })).toBe(true);
+    expect(isReactionEvent({ callbackData: "reaction_removed:eyes" })).toBe(
+      true,
+    );
   });
 
   test("returns false for non-reaction callback data", () => {
-    expect(
-      isReactionEvent({
-        sourceChannel: "slack",
-        callbackData: "apr:req-1:approve_once",
-      }),
-    ).toBe(false);
+    expect(isReactionEvent({ callbackData: "apr:req-1:approve_once" })).toBe(
+      false,
+    );
   });
 
-  test("returns false when callbackData missing", () => {
-    expect(isReactionEvent({ sourceChannel: "slack" })).toBe(false);
-  });
-});
-
-describe("parseSlackReactionCallbackData", () => {
-  test("parses reaction:<emoji> as added", () => {
-    expect(parseSlackReactionCallbackData("reaction:thumbsup")).toEqual({
-      op: "added",
-      emoji: "thumbsup",
-    });
-  });
-
-  test("parses reaction_removed:<emoji> as removed", () => {
-    expect(parseSlackReactionCallbackData("reaction_removed:eyes")).toEqual({
-      op: "removed",
-      emoji: "eyes",
-    });
-  });
-
-  test("returns null for empty emoji portion", () => {
-    expect(parseSlackReactionCallbackData("reaction:")).toBeNull();
-    expect(parseSlackReactionCallbackData("reaction_removed:")).toBeNull();
-  });
-
-  test("returns null for unrelated callback data", () => {
-    expect(parseSlackReactionCallbackData("apr:req-1:approve")).toBeNull();
+  test("returns false for a plain message", () => {
+    expect(isReactionEvent({})).toBe(false);
   });
 });
 
@@ -356,8 +309,10 @@ describe("Slack reaction event persistence", () => {
     });
     const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
     expect(resp.status).toBe(200);
+    // The payload resolver requires a target message id, so the dispatch
+    // drops the event before the intercept and it never reads as a message.
     expect(((await resp.json()) as Record<string, unknown>).reaction).toBe(
-      "dropped_unknown_target",
+      "dropped_unresolvable_payload",
     );
 
     const rows = readPersistedMessages();

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -80,7 +80,7 @@ import { linkMessage, recordInbound } from "../persistence/delivery-crud.js";
 import { messages } from "../persistence/schema/conversations.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 import {
-  isSlackReactionEvent,
+  isReactionEvent,
   parseSlackReactionCallbackData,
 } from "../runtime/routes/inbound-stages/reaction-intercept.js";
 import {
@@ -202,10 +202,10 @@ function readPersistedMessages(): Array<{
 // Helper unit tests
 // ---------------------------------------------------------------------------
 
-describe("isSlackReactionEvent", () => {
+describe("isReactionEvent", () => {
   test("returns true for reaction added", () => {
     expect(
-      isSlackReactionEvent({
+      isReactionEvent({
         sourceChannel: "slack",
         callbackData: "reaction:thumbsup",
       }),
@@ -214,7 +214,7 @@ describe("isSlackReactionEvent", () => {
 
   test("returns true for reaction removed", () => {
     expect(
-      isSlackReactionEvent({
+      isReactionEvent({
         sourceChannel: "slack",
         callbackData: "reaction_removed:eyes",
       }),
@@ -223,7 +223,7 @@ describe("isSlackReactionEvent", () => {
 
   test("returns false for non-Slack source", () => {
     expect(
-      isSlackReactionEvent({
+      isReactionEvent({
         sourceChannel: "telegram",
         callbackData: "reaction:thumbsup",
       }),
@@ -232,7 +232,7 @@ describe("isSlackReactionEvent", () => {
 
   test("returns false for non-reaction callback data", () => {
     expect(
-      isSlackReactionEvent({
+      isReactionEvent({
         sourceChannel: "slack",
         callbackData: "apr:req-1:approve_once",
       }),
@@ -240,7 +240,7 @@ describe("isSlackReactionEvent", () => {
   });
 
   test("returns false when callbackData missing", () => {
-    expect(isSlackReactionEvent({ sourceChannel: "slack" })).toBe(false);
+    expect(isReactionEvent({ sourceChannel: "slack" })).toBe(false);
   });
 });
 

--- a/assistant/src/__tests__/slack-reaction-approvals.test.ts
+++ b/assistant/src/__tests__/slack-reaction-approvals.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseReactionCallbackData } from "../runtime/routes/channel-route-shared.js";
+import { reactionDecisionForEmoji } from "../runtime/routes/channel-route-shared.js";
 
 // =============================================================================
-// parseReactionCallbackData
+// reactionDecisionForEmoji
 // =============================================================================
 
-describe("parseReactionCallbackData", () => {
+describe("reactionDecisionForEmoji", () => {
   test("maps +1 emoji to approve_once", () => {
-    const result = parseReactionCallbackData("reaction:+1");
+    const result = reactionDecisionForEmoji("+1");
     expect(result).toEqual({
       action: "approve_once",
       source: "slack_reaction",
@@ -16,7 +16,7 @@ describe("parseReactionCallbackData", () => {
   });
 
   test("maps thumbsup emoji to approve_once", () => {
-    const result = parseReactionCallbackData("reaction:thumbsup");
+    const result = reactionDecisionForEmoji("thumbsup");
     expect(result).toEqual({
       action: "approve_once",
       source: "slack_reaction",
@@ -24,7 +24,7 @@ describe("parseReactionCallbackData", () => {
   });
 
   test("maps -1 emoji to reject", () => {
-    const result = parseReactionCallbackData("reaction:-1");
+    const result = reactionDecisionForEmoji("-1");
     expect(result).toEqual({
       action: "reject",
       source: "slack_reaction",
@@ -32,7 +32,7 @@ describe("parseReactionCallbackData", () => {
   });
 
   test("maps thumbsdown emoji to reject", () => {
-    const result = parseReactionCallbackData("reaction:thumbsdown");
+    const result = reactionDecisionForEmoji("thumbsdown");
     expect(result).toEqual({
       action: "reject",
       source: "slack_reaction",
@@ -40,7 +40,7 @@ describe("parseReactionCallbackData", () => {
   });
 
   test("alarm_clock emoji maps to approve_once (legacy compat)", () => {
-    const result = parseReactionCallbackData("reaction:alarm_clock");
+    const result = reactionDecisionForEmoji("alarm_clock");
     expect(result).toEqual({
       action: "approve_once",
       source: "slack_reaction",
@@ -48,7 +48,7 @@ describe("parseReactionCallbackData", () => {
   });
 
   test("white_check_mark emoji maps to approve_once (legacy compat)", () => {
-    const result = parseReactionCallbackData("reaction:white_check_mark");
+    const result = reactionDecisionForEmoji("white_check_mark");
     expect(result).toEqual({
       action: "approve_once",
       source: "slack_reaction",
@@ -56,22 +56,17 @@ describe("parseReactionCallbackData", () => {
   });
 
   test("returns null for unknown emoji", () => {
-    const result = parseReactionCallbackData("reaction:tada");
+    const result = reactionDecisionForEmoji("tada");
     expect(result).toBeNull();
   });
 
-  test("returns null for empty emoji name", () => {
-    const result = parseReactionCallbackData("reaction:");
+  test("returns null for an unmapped emoji", () => {
+    const result = reactionDecisionForEmoji("eyes");
     expect(result).toBeNull();
   });
 
-  test("returns null for non-reaction callback data", () => {
-    const result = parseReactionCallbackData("apr:req-1:approve_once");
-    expect(result).toBeNull();
-  });
-
-  test("returns null for plain text", () => {
-    const result = parseReactionCallbackData("yes");
+  test("returns null for an empty emoji name", () => {
+    const result = reactionDecisionForEmoji("");
     expect(result).toBeNull();
   });
 });

--- a/assistant/src/__tests__/slack-reaction-guardian-approval.test.ts
+++ b/assistant/src/__tests__/slack-reaction-guardian-approval.test.ts
@@ -117,7 +117,11 @@ function reaction(opts: {
       guardianPrincipalId: opts.principal ?? PRINCIPAL,
     },
     conversationId: "guardian-conv",
-    callbackData: `reaction:${opts.emoji}`,
+    reaction: {
+      op: "added" as const,
+      emoji: opts.emoji,
+      targetMessageId: opts.reactedMessageTs ?? "",
+    },
     reactedMessageTs: opts.reactedMessageTs,
     channelDeliveryContext: {
       replyCallbackUrl: "https://gateway.test/deliver",

--- a/assistant/src/runtime/guardian-reply-router.ts
+++ b/assistant/src/runtime/guardian-reply-router.ts
@@ -23,6 +23,7 @@
  * to allow for incremental migration and independent testability.
  */
 
+import type { InboundReactionPayload } from "@vellumai/gateway-client";
 import { isGuardianRequestExpired } from "@vellumai/gateway-client";
 
 import {
@@ -61,7 +62,7 @@ import type {
   ApprovalConversationGenerator,
 } from "./http-types.js";
 import * as pendingInteractions from "./pending-interactions.js";
-import { parseReactionCallbackData } from "./routes/channel-route-shared.js";
+import { reactionDecisionForEmoji } from "./routes/channel-route-shared.js";
 
 const log = getLogger("guardian-reply-router");
 
@@ -106,7 +107,12 @@ export interface GuardianReplyContext {
   /** Callback data from button presses (e.g. `apr:<requestId>:<action>`). */
   callbackData?: string;
   /**
-   * For emoji-reaction decisions (`callbackData` of `reaction:<emoji>`): the
+   * Structured reaction payload when the inbound event is a reaction; the
+   * reaction branch keys on it and reads nothing off callbackData.
+   */
+  reaction?: InboundReactionPayload;
+  /**
+   * For emoji-reaction decisions: the
    * channel-native id (e.g. Slack `ts`) of the message the reaction was
    * attached to. Used to recover the target request from its delivery record.
    */
@@ -368,13 +374,10 @@ export async function routeGuardianReply(
   // even when several cards are pending in the same chat, so — unlike the
   // text/NL paths — no clarification prompt is ever needed. `reaction_removed`
   // never expresses intent and is filtered out before reaching the router.
-  if (
-    callbackData?.startsWith("reaction:") &&
-    !callbackData.startsWith("reaction_removed:")
-  ) {
-    const reaction = parseReactionCallbackData(callbackData);
+  if (ctx.reaction?.op === "added") {
+    const decision = reactionDecisionForEmoji(ctx.reaction.emoji);
     const guardianChatId = channelDeliveryContext?.guardianChatId;
-    if (!reaction || !reactedMessageTs || !guardianChatId) {
+    if (!decision || !reactedMessageTs || !guardianChatId) {
       // Unknown emoji, or missing addressing context — not an actionable
       // approval reaction. Leave it for the caller to persist as a transcript
       // signal (it must not trigger an agent turn).
@@ -393,7 +396,7 @@ export async function routeGuardianReply(
     }
     return applyDecision(
       request.id,
-      reaction.action,
+      decision.action,
       actor,
       undefined,
       channelDeliveryContext,

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -84,13 +84,9 @@ const REACTION_EMOJI_MAP: ReadonlyMap<string, ApprovalAction> = new Map([
  * Parse a `reaction:<emoji_name>` callback data string into an approval
  * decision. Returns null if the emoji is not mapped to any action.
  */
-export function parseReactionCallbackData(
-  data: string,
+export function reactionDecisionForEmoji(
+  emoji: string,
 ): ApprovalDecisionResult | null {
-  if (!data.startsWith("reaction:")) {
-    return null;
-  }
-  const emoji = data.slice("reaction:".length);
   const action = REACTION_EMOJI_MAP.get(emoji);
   if (!action) {
     return null;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -427,7 +427,7 @@ export async function handleChannelInbound({
     return guardianActivationResponse;
   }
 
-  // ── Slack reaction handling ──
+  // ── Reaction handling ──
   // Reactions are passive channel signals — not messages, and not access
   // attempts. Dispatch them to a dedicated interceptor BEFORE the message
   // pipeline (ACL, admission floor, disk-pressure, conversation binding) so a
@@ -437,10 +437,20 @@ export async function handleChannelInbound({
   // transcript signals in the conversation of the reacted message, and routes
   // a guardian's reaction on an approval card through the guardian decision
   // pipeline. Reactions never mint a conversation and never drive an agent
-  // turn.
+  // turn. A family member whose payload does not resolve (no emoji or no
+  // target message id) is dropped as noise here: the kind names the family,
+  // so it must never fall through and be read as a message.
   if (isReactionEvent(body)) {
+    const reaction = resolveInboundReactionPayload(body);
+    if (!reaction) {
+      log.debug(
+        { sourceChannel, conversationExternalId },
+        "Dropping reaction with unresolvable payload",
+      );
+      return { accepted: true, reaction: "dropped_unresolvable_payload" };
+    }
     return handleReactionIntercept({
-      reaction: resolveInboundReactionPayload(body)!,
+      reaction,
       sourceChannel,
       sourceInterface,
       conversationExternalId,

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -6,7 +6,10 @@
  * messages reach this handler.
  */
 import type { SourceMetadata } from "@vellumai/gateway-client";
-import { resolveInboundEventKind } from "@vellumai/gateway-client";
+import {
+  resolveInboundEventKind,
+  resolveInboundReactionPayload,
+} from "@vellumai/gateway-client";
 import {
   ADMISSION_POLICY_DEFAULT,
   type AdmissionPolicy,
@@ -121,8 +124,8 @@ import { handleGuardianActivationIntercept } from "./inbound-stages/guardian-act
 import { handleGuardianReplyIntercept } from "./inbound-stages/guardian-reply-intercept.js";
 import { prepareChannelInboundContent } from "./inbound-stages/inbound-content-prep.js";
 import {
-  handleSlackReactionIntercept,
-  isSlackReactionEvent,
+  handleReactionIntercept,
+  isReactionEvent,
 } from "./inbound-stages/reaction-intercept.js";
 import { runSecretIngressCheck } from "./inbound-stages/secret-ingress-check.js";
 import { tryTranscribeAudioAttachments } from "./inbound-stages/transcribe-audio.js";
@@ -435,9 +438,9 @@ export async function handleChannelInbound({
   // a guardian's reaction on an approval card through the guardian decision
   // pipeline. Reactions never mint a conversation and never drive an agent
   // turn.
-  if (isSlackReactionEvent(body)) {
-    return handleSlackReactionIntercept({
-      callbackData: body.callbackData!,
+  if (isReactionEvent(body)) {
+    return handleReactionIntercept({
+      reaction: resolveInboundReactionPayload(body)!,
       sourceChannel,
       sourceInterface,
       conversationExternalId,
@@ -1187,11 +1190,11 @@ export async function handleChannelInbound({
     // so checking for empty content alone would miss stale callbacks.
     //
     // Reaction events (`reaction:` / `reaction_removed:`) are persisted by
-    // the earlier `isSlackReactionEvent` branch and never reach here; guard
+    // the earlier `isReactionEvent` branch and never reach here; guard
     // explicitly so a future refactor can't let a reaction ts drive a
     // "This approval request has been resolved." edit that would clobber
     // the user's reacted-to message.
-    if (hasCallbackData && !isSlackReactionEvent(body)) {
+    if (hasCallbackData && !isReactionEvent(body)) {
       // Record seen signal even for stale callbacks — the user still interacted
       if (sourceChannel === "telegram" || sourceChannel === "slack") {
         try {

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -9,6 +9,8 @@
  * Extracted from inbound-message-handler.ts to keep the top-level handler
  * focused on orchestration.
  */
+import type { InboundReactionPayload } from "@vellumai/gateway-client";
+
 import {
   listGuardianRequestsOrEmpty,
   listPendingRequestsByDestinationOrEmpty,
@@ -35,6 +37,7 @@ export interface GuardianReplyInterceptParams {
   trimmedContent: string;
   hasCallbackData: boolean;
   callbackData: string | undefined;
+  reaction?: InboundReactionPayload;
   /**
    * For emoji-reaction decisions: the channel-native id (Slack `ts`) of the
    * message the reaction was attached to. Threaded to the router so it can
@@ -81,6 +84,7 @@ export async function handleGuardianReplyIntercept(
     trimmedContent,
     hasCallbackData,
     callbackData,
+    reaction,
     reactedMessageTs,
     rawSenderId,
     canonicalSenderId,
@@ -136,7 +140,7 @@ export async function handleGuardianReplyIntercept(
   // Reactions address one specific request by the reacted card's message id,
   // so they bypass the pending-request list scoping that the text/NL paths
   // need — the router's reaction branch resolves the target directly.
-  const isReaction = callbackData?.startsWith("reaction:") === true;
+  const isReaction = reaction !== undefined;
   let pendingScope: GuardianPendingScope | undefined;
   if (!isReaction) {
     // Hint reads degrade to empty on gateway failure: Slack then blocks the
@@ -178,6 +182,7 @@ export async function handleGuardianReplyIntercept(
     },
     conversationId,
     callbackData,
+    ...(reaction ? { reaction } : {}),
     reactedMessageTs,
     pendingScope,
     approvalConversationGenerator,

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -134,7 +134,7 @@ mock.module("./guardian-reply-intercept.js", () => ({
   },
 }));
 
-import { handleSlackReactionIntercept } from "./reaction-intercept.js";
+import { handleReactionIntercept } from "./reaction-intercept.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -178,7 +178,11 @@ function buildParams(overrides: {
 }) {
   msgCounter++;
   return {
-    callbackData: "reaction:white_check_mark",
+    reaction: {
+      op: "added" as const,
+      emoji: "white_check_mark",
+      targetMessageId: "1700000000.1",
+    },
     sourceChannel: "slack" as const,
     sourceInterface: "slack" as const,
     conversationExternalId: SLACK_CHANNEL_ID,
@@ -226,7 +230,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
   test("guardian verdict routes the reaction into the approval decision pipeline", async () => {
     guardianReplyResponse = { accepted: true, canonicalRouter: "applied" };
 
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: GUARDIAN_USER_ID,
         trustVerdict: GUARDIAN_VERDICT,
@@ -242,7 +246,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
   });
 
   test("contact verdict records the reaction; the decision pipeline self-gate ignores it", async () => {
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: MEMBER_USER_ID,
         trustVerdict: MEMBER_VERDICT,
@@ -266,7 +270,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     storedTarget = null;
     outboundTargetConversationId = "conv-assistant-post";
 
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: MEMBER_USER_ID,
         trustVerdict: MEMBER_VERDICT,
@@ -283,7 +287,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
   test("a reaction on a message that is not stored is dropped without minting", async () => {
     storedTarget = null;
 
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: MEMBER_USER_ID,
         trustVerdict: MEMBER_VERDICT,
@@ -298,7 +302,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
   test("a redelivered reaction never reaches the guardian rail twice", async () => {
     recordedEvent = { eventId: "evt-1", conversationId: "conv-target" };
 
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: GUARDIAN_USER_ID,
         trustVerdict: GUARDIAN_VERDICT,
@@ -319,7 +323,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     storedTarget = null;
     guardianReplyResponse = { accepted: true, canonicalRouter: "applied" };
 
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: GUARDIAN_USER_ID,
         trustVerdict: GUARDIAN_VERDICT,
@@ -331,21 +335,21 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
   });
 
   test("unknown verdict is dropped before any write", async () => {
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({ rawSenderId: "U_STRANGER", trustVerdict: UNKNOWN_VERDICT }),
     );
     expectDropped(result);
   });
 
   test("missing verdict is dropped fail-closed", async () => {
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({ rawSenderId: MEMBER_USER_ID }),
     );
     expectDropped(result);
   });
 
   test("resolutionFailed verdict is dropped fail-closed even with a guardian shape", async () => {
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: GUARDIAN_USER_ID,
         trustVerdict: { ...GUARDIAN_VERDICT, resolutionFailed: true },
@@ -355,7 +359,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
   });
 
   test("memberless guardian verdict is contradictory and dropped fail-closed", async () => {
-    const result = await handleSlackReactionIntercept(
+    const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: GUARDIAN_USER_ID,
         trustVerdict: {
@@ -370,13 +374,13 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
 
   test("classification is verdict-only: no IPC, cache, or local-store reads", async () => {
     guardianReplyResponse = { accepted: true, canonicalRouter: "applied" };
-    await handleSlackReactionIntercept(
+    await handleReactionIntercept(
       buildParams({
         rawSenderId: GUARDIAN_USER_ID,
         trustVerdict: GUARDIAN_VERDICT,
       }),
     );
-    await handleSlackReactionIntercept(
+    await handleReactionIntercept(
       buildParams({
         rawSenderId: MEMBER_USER_ID,
         trustVerdict: MEMBER_VERDICT,

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -23,7 +23,6 @@ import type { SourceMetadata } from "@vellumai/gateway-client";
 import {
   type InboundReactionPayload,
   resolveInboundEventKind,
-  resolveInboundReactionPayload,
 } from "@vellumai/gateway-client";
 
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
@@ -54,54 +53,23 @@ import { handleGuardianReplyIntercept } from "./guardian-reply-intercept.js";
 const log = getLogger("runtime-http");
 
 /**
- * Detect a Slack reaction event by inspecting the inbound payload's
- * `callbackData` prefix. The gateway encodes reactions as a unified
- * `SlackInboundEvent` with `callbackData` of the form `reaction:<emoji>`
- * (added) or `reaction_removed:<emoji>` (removed) — see
- * `gateway/src/slack/normalize.ts`. This helper centralizes that convention
- * so the daemon can route reactions to this dedicated stage instead of the
- * agent-response pipeline.
+ * Whether the inbound payload belongs to the reaction event family, on any
+ * channel. Family membership is the kind alone; whether the payload can be
+ * acted on is `resolveInboundReactionPayload`'s answer, and the dispatch
+ * drops a family member whose payload does not resolve rather than letting
+ * it be reinterpreted as a message.
  */
 export function isReactionEvent(body: {
-  sourceChannel?: string;
   eventKind?: string;
-  reaction?: InboundReactionPayload;
+  isEdit?: boolean;
   callbackData?: string;
-  sourceMetadata?: { messageId?: string };
+  callbackQueryId?: string;
 }): boolean {
-  return (
-    resolveInboundEventKind(body) === "reaction" &&
-    resolveInboundReactionPayload(body) !== null
-  );
-}
-
-/**
- * Parse a reaction `callbackData` string into its op (added/removed) and
- * emoji name. Returns `null` when the input is not a reaction prefix or
- * when the emoji portion is empty.
- */
-export function parseSlackReactionCallbackData(
-  callbackData: string,
-): { op: "added" | "removed"; emoji: string } | null {
-  let op: "added" | "removed";
-  let emoji: string;
-  if (callbackData.startsWith("reaction_removed:")) {
-    op = "removed";
-    emoji = callbackData.slice("reaction_removed:".length);
-  } else if (callbackData.startsWith("reaction:")) {
-    op = "added";
-    emoji = callbackData.slice("reaction:".length);
-  } else {
-    return null;
-  }
-  if (emoji.length === 0) {
-    return null;
-  }
-  return { op, emoji };
+  return resolveInboundEventKind(body) === "reaction";
 }
 
 export interface ReactionInterceptParams {
-  /** The reaction callbackData (`reaction:<emoji>` / `reaction_removed:<emoji>`). */
+  /** The resolved structured payload: op, emoji, and target message id. */
   reaction: InboundReactionPayload;
   sourceChannel: ChannelId;
   sourceInterface: InterfaceId | undefined;

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -20,11 +20,16 @@
  * `unknown` (drop). Reactions never drive an agent turn.
  */
 import type { SourceMetadata } from "@vellumai/gateway-client";
-import { resolveInboundEventKind } from "@vellumai/gateway-client";
+import {
+  type InboundReactionPayload,
+  resolveInboundEventKind,
+  resolveInboundReactionPayload,
+} from "@vellumai/gateway-client";
 
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { getDiskPressureStatus } from "../../../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../../../daemon/disk-pressure-policy.js";
+import type { ProviderMessageMetadata } from "../../../messaging/provider-message-metadata.js";
 import {
   type SlackMessageMetadata,
   writeSlackMetadata,
@@ -57,17 +62,16 @@ const log = getLogger("runtime-http");
  * so the daemon can route reactions to this dedicated stage instead of the
  * agent-response pipeline.
  */
-export function isSlackReactionEvent(body: {
+export function isReactionEvent(body: {
   sourceChannel?: string;
   eventKind?: string;
+  reaction?: InboundReactionPayload;
   callbackData?: string;
+  sourceMetadata?: { messageId?: string };
 }): boolean {
-  // The Slack gate is deliberate, not residue: Slack is the only channel
-  // whose reactions are ingested today, and widening this is a per-channel
-  // decision made with that channel's reaction wire shape, not a fallthrough.
   return (
-    body.sourceChannel === "slack" &&
-    resolveInboundEventKind(body) === "reaction"
+    resolveInboundEventKind(body) === "reaction" &&
+    resolveInboundReactionPayload(body) !== null
   );
 }
 
@@ -98,7 +102,7 @@ export function parseSlackReactionCallbackData(
 
 export interface ReactionInterceptParams {
   /** The reaction callbackData (`reaction:<emoji>` / `reaction_removed:<emoji>`). */
-  callbackData: string;
+  reaction: InboundReactionPayload;
   sourceChannel: ChannelId;
   sourceInterface: InterfaceId | undefined;
   conversationExternalId: string;
@@ -113,15 +117,15 @@ export interface ReactionInterceptParams {
 }
 
 /**
- * Handle a Slack reaction event end to end. Always consumes the event (the
- * caller dispatches here only for `isSlackReactionEvent`), returning the
+ * Handle a reaction event end to end, on any channel. Always consumes the event (the
+ * caller dispatches here only for `isReactionEvent`), returning the
  * response the top-level handler should short-circuit with.
  */
-export async function handleSlackReactionIntercept(
+export async function handleReactionIntercept(
   params: ReactionInterceptParams,
 ): Promise<Record<string, unknown>> {
   const {
-    callbackData,
+    reaction,
     sourceChannel,
     sourceInterface,
     conversationExternalId,
@@ -162,10 +166,7 @@ export async function handleSlackReactionIntercept(
     return { accepted: true, reaction: "dropped_unknown_actor" };
   }
 
-  const reactedMessageTs =
-    typeof sourceMetadata?.messageId === "string"
-      ? sourceMetadata.messageId
-      : undefined;
+  const reactedMessageTs = reaction.targetMessageId;
   // Respect disk-pressure cleanup so reactions don't bypass storage
   // protection. Guardians resolve to `allow-cleanup-mode` (not `block`), so a
   // guardian's approval-by-reaction still flows. Blocked silently and before
@@ -210,12 +211,13 @@ export async function handleSlackReactionIntercept(
   // `reaction_removed:` never does. `handleGuardianReplyIntercept` self-gates
   // on `trustClass === "guardian"`, so a contact's reaction returns no
   // response and falls through to persistence.
-  if (callbackData.startsWith("reaction:") && replyCallbackUrl) {
+  if (reaction.op === "added" && replyCallbackUrl) {
     const reactionIntercept = await handleGuardianReplyIntercept({
       isDuplicate: false,
       trimmedContent: "",
       hasCallbackData: true,
-      callbackData,
+      callbackData: undefined,
+      reaction,
       reactedMessageTs,
       rawSenderId,
       canonicalSenderId,
@@ -272,11 +274,12 @@ export async function handleSlackReactionIntercept(
 
   // Record the reaction as an inline transcript signal.
   try {
-    await persistSlackReactionAsMessage({
+    await persistReactionAsMessage({
       conversationId: result.conversationId,
       conversationExternalId,
       eventId: result.eventId,
-      callbackData,
+      sourceChannel,
+      reaction,
       actorDisplayName,
       reactedMessageTs,
       duplicate: result.duplicate,
@@ -305,11 +308,12 @@ export async function handleSlackReactionIntercept(
  * deduplication and conversation resolution have happened. Duplicate inbound
  * events are skipped here to keep persistence idempotent.
  */
-async function persistSlackReactionAsMessage(params: {
+async function persistReactionAsMessage(params: {
   conversationId: string;
   conversationExternalId: string;
   eventId: string;
-  callbackData: string;
+  sourceChannel: ChannelId;
+  reaction: InboundReactionPayload;
   actorDisplayName?: string;
   reactedMessageTs: string;
   duplicate: boolean;
@@ -317,16 +321,39 @@ async function persistSlackReactionAsMessage(params: {
   if (params.duplicate) {
     return;
   }
+  const parsed = { op: params.reaction.op, emoji: params.reaction.emoji };
 
-  const parsed = parseSlackReactionCallbackData(params.callbackData);
-  if (!parsed) {
-    log.debug(
-      {
-        conversationId: params.conversationId,
-        callbackData: params.callbackData,
+  if (params.sourceChannel !== "slack") {
+    // Slack keeps its own envelope for its renderer; every other channel
+    // writes the neutral shape readProviderMetadata serves to
+    // channel-agnostic readers.
+    const providerMeta: ProviderMessageMetadata = {
+      source: params.sourceChannel,
+      conversationExternalId: params.conversationExternalId,
+      eventKind: "reaction",
+      ...(params.actorDisplayName
+        ? { displayName: params.actorDisplayName }
+        : {}),
+      reaction: {
+        targetMessageId: params.reactedMessageTs,
+        emoji: parsed.emoji,
+        op: parsed.op,
+        ...(params.actorDisplayName
+          ? { actorDisplayName: params.actorDisplayName }
+          : {}),
       },
-      "Skipping reaction persistence: unparseable callbackData",
+    };
+    const persisted = await addMessage(
+      params.conversationId,
+      "user",
+      "[reaction]",
+      {
+        metadata: { providerMeta: JSON.stringify(providerMeta) },
+        skipIndexing: true,
+      },
     );
+    linkMessage(params.eventId, persisted.id);
+    markProcessed(params.eventId);
     return;
   }
 

--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -58,7 +58,7 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
     expect(result!.event.message.reaction?.emoji).toBe("+1");
-    // Transition dual-write for skew-window daemons; see the normalizer.
+    // The sentinel form stays required for mixed-version readers.
     expect(result!.event.message.callbackData).toBe("reaction:+1");
     expect(result!.event.message.reaction?.op).toBe("added");
     expect(result!.event.actor.actorExternalId).toBe("U001");

--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -57,7 +57,8 @@ describe("normalizeSlackReactionAdded", () => {
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
-    expect(result!.event.message.callbackData).toBe("reaction:+1");
+    expect(result!.event.message.reaction?.emoji).toBe("+1");
+    expect(result!.event.message.reaction?.op).toBe("added");
     expect(result!.event.actor.actorExternalId).toBe("U001");
     expect(result!.event.message.conversationExternalId).toBe("C123");
     expect(result!.channel).toBe("C123");
@@ -74,9 +75,8 @@ describe("normalizeSlackReactionAdded", () => {
     const result = normalizeSlackReactionAdded(event, "ev-2", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.callbackData).toBe(
-      "reaction:white_check_mark",
-    );
+    expect(result!.event.message.reaction?.emoji).toBe("white_check_mark");
+    expect(result!.event.message.reaction?.op).toBe("added");
   });
 
   // Self-authored reactions are now filtered upstream in processEventPayload,

--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -58,6 +58,8 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
     expect(result!.event.message.reaction?.emoji).toBe("+1");
+    // Transition dual-write for skew-window daemons; see the normalizer.
+    expect(result!.event.message.callbackData).toBe("reaction:+1");
     expect(result!.event.message.reaction?.op).toBe("added");
     expect(result!.event.actor.actorExternalId).toBe("U001");
     expect(result!.event.message.conversationExternalId).toBe("C123");

--- a/gateway/src/__tests__/slack-socket-mode-group-dm.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-group-dm.test.ts
@@ -274,9 +274,8 @@ describe("LUM-2935: group DM (MPIM) admission", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
-      expect(emitted[0]?.event.message.callbackData).toBe(
-        "reaction:raised_hands",
-      );
+      expect(emitted[0]?.event.message.reaction?.emoji).toBe("raised_hands");
+      expect(emitted[0]?.event.message.reaction?.op).toBe("added");
       expect(emitted[0]?.event.message.conversationExternalId).toBe(MPIM);
     } finally {
       rawDb.close();
@@ -314,7 +313,8 @@ describe("LUM-2935: group DM (MPIM) admission", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(2);
-      expect(emitted[1]?.event.message.callbackData).toBe("reaction:eyes");
+      expect(emitted[1]?.event.message.reaction?.emoji).toBe("eyes");
+      expect(emitted[1]?.event.message.reaction?.op).toBe("added");
     } finally {
       rawDb.close();
     }

--- a/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-outbound-root.test.ts
@@ -957,7 +957,8 @@ describe("LUM-2941: filters widened by an armed root", () => {
       await flushAsyncEventEmission();
 
       expect(emitted).toHaveLength(1);
-      expect(emitted[0]?.event.message.callbackData).toBe("reaction:eyes");
+      expect(emitted[0]?.event.message.reaction?.emoji).toBe("eyes");
+      expect(emitted[0]?.event.message.reaction?.op).toBe("added");
 
       // Same channel, a message the assistant never posted: still dropped.
       deliver(client, ws, "Ev-reaction-other", {

--- a/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
+++ b/gateway/src/__tests__/slack-socket-mode-thread-tracking.test.ts
@@ -2112,7 +2112,8 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       );
       await run();
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.message.callbackData).toBe("reaction:eyes");
+      expect(emitted[0].event.message.reaction?.emoji).toBe("eyes");
+      expect(emitted[0].event.message.reaction?.op).toBe("added");
     } finally {
       rawDb.close();
     }
@@ -2229,7 +2230,8 @@ describe("SlackSocketModeClient event classification admit conditions", () => {
       );
       await run();
       expect(emitted).toHaveLength(1);
-      expect(emitted[0].event.message.callbackData).toBe("reaction:eyes");
+      expect(emitted[0].event.message.reaction?.emoji).toBe("eyes");
+      expect(emitted[0].event.message.reaction?.op).toBe("added");
       expect(emitted[0].routing.assistantId).toBe("ast-actor");
     } finally {
       rawDb.close();

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -1,6 +1,7 @@
 import {
   inboundEventRefersToAnotherMessage,
   type InboundEventKind,
+  type InboundReactionPayload,
   resolveInboundEventKind,
 } from "@vellumai/gateway-client";
 import type { ChannelConversationType } from "@vellumai/gateway-client";
@@ -39,6 +40,8 @@ interface InboundEventBase<C extends InboundChannelId> {
      *  flag and sentinel fields below carry each family's payload and
      *  classify replayed retry payloads that arrive unstamped. */
     eventKind?: InboundEventKind;
+    /** Structured payload when eventKind is "reaction". */
+    reaction?: InboundReactionPayload;
     isEdit?: boolean;
     callbackQueryId?: string;
     callbackData?: string;

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -353,6 +353,7 @@ export async function handleInbound(
         ...(event.message.eventKind
           ? { eventKind: event.message.eventKind }
           : {}),
+        ...(event.message.reaction ? { reaction: event.message.reaction } : {}),
         ...(event.message.isEdit ? { isEdit: true } : {}),
         ...(event.message.callbackQueryId
           ? { callbackQueryId: event.message.callbackQueryId }

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -382,8 +382,9 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result).not.toBeNull();
     expect(result!.event.message.eventKind).toBe("reaction");
     expect(result!.event.sourceChannel).toBe("slack");
-    expect(result!.event.message.callbackData).toBe("reaction:thumbsup");
-    expect(result!.event.message.content).toBe("reaction:thumbsup");
+    expect(result!.event.message.reaction?.emoji).toBe("thumbsup");
+    expect(result!.event.message.reaction?.op).toBe("added");
+    expect(result!.event.message.content).toBe("");
     expect(result!.event.message.conversationExternalId).toBe("C456");
     expect(result!.event.message.externalMessageId).toBe(
       "C456:1234567890.123456:thumbsup:U123",
@@ -435,9 +436,8 @@ describe("normalizeSlackReactionAdded", () => {
     const result = normalizeSlackReactionAdded(event, "evt-6", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.callbackData).toBe(
-      "reaction:white_check_mark",
-    );
+    expect(result!.event.message.reaction?.emoji).toBe("white_check_mark");
+    expect(result!.event.message.reaction?.op).toBe("added");
   });
 
   it("normalizes reactions on a non-bot-thread channel message", () => {
@@ -458,7 +458,8 @@ describe("normalizeSlackReactionAdded", () => {
     const result = normalizeSlackReactionAdded(event, "evt-expand", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.callbackData).toBe("reaction:thumbsup");
+    expect(result!.event.message.reaction?.emoji).toBe("thumbsup");
+    expect(result!.event.message.reaction?.op).toBe("added");
     expect(result!.channel).toBe("C500");
     expect(result!.threadTs).toBe("1700000000.999999");
     expect(result!.routing.assistantId).toBe("ast-1");
@@ -476,10 +477,10 @@ describe("normalizeSlackReactionRemoved", () => {
 
     expect(result).not.toBeNull();
     expect(result!.event.sourceChannel).toBe("slack");
-    expect(result!.event.message.callbackData).toBe(
-      "reaction_removed:thumbsup",
-    );
-    expect(result!.event.message.content).toBe("reaction_removed:thumbsup");
+    expect(result!.event.message.reaction?.emoji).toBe("thumbsup");
+    expect(result!.event.message.reaction?.op).toBe("removed");
+    expect(result!.event.message.content).toBe("");
+    expect(result!.event.message.reaction?.op).toBe("removed");
     expect(result!.event.message.conversationExternalId).toBe("C456");
     expect(result!.event.message.externalMessageId).toBe(
       "C456:1234567890.123456:thumbsup:U123:removed",
@@ -496,9 +497,8 @@ describe("normalizeSlackReactionRemoved", () => {
     const result = normalizeSlackReactionRemoved(event, "evt-r-2", config);
 
     expect(result).not.toBeNull();
-    expect(result!.event.message.callbackData).toBe(
-      "reaction_removed:white_check_mark",
-    );
+    expect(result!.event.message.reaction?.emoji).toBe("white_check_mark");
+    expect(result!.event.message.reaction?.op).toBe("removed");
   });
 
   it("returns null when user is missing", () => {
@@ -572,9 +572,8 @@ describe("normalizeSlackReactionRemoved", () => {
 
     expect(result).not.toBeNull();
     expect(result!.channel).toBe("D789");
-    expect(result!.event.message.callbackData).toBe(
-      "reaction_removed:thumbsup",
-    );
+    expect(result!.event.message.reaction?.emoji).toBe("thumbsup");
+    expect(result!.event.message.reaction?.op).toBe("removed");
     expect(result!.event.message.externalMessageId).toBe(
       "D789:1700000000.000001:thumbsup:U123:removed",
     );

--- a/gateway/src/slack/reaction-normalizer.ts
+++ b/gateway/src/slack/reaction-normalizer.ts
@@ -62,10 +62,10 @@ function normalizeSlackReaction(
           emoji: event.reaction,
           targetMessageId: event.item.ts,
         },
-        // Transition dual-write: a daemon that predates the structured
-        // payload dispatches reactions on the kind and then reads this
-        // string, so a structured-only event would crash it during an
-        // upgrade-skew window. Remove once a release ships both sides.
+        // A daemon that does not yet understand the structured payload
+        // dispatches reactions on the kind and reads this string
+        // unconditionally, so the sentinel form stays required beside the
+        // payload for mixed-version readers.
         callbackData: `${op === "added" ? "reaction" : "reaction_removed"}:${event.reaction}`,
       },
       actor: {

--- a/gateway/src/slack/reaction-normalizer.ts
+++ b/gateway/src/slack/reaction-normalizer.ts
@@ -37,8 +37,6 @@ function normalizeSlackReaction(
   const routing = resolveAssistant(config, channel, event.user);
   if (isRejection(routing)) return null;
 
-  const prefix = op === "added" ? "reaction" : "reaction_removed";
-  const callbackData = `${prefix}:${event.reaction}`;
   // Include reactor user ID to prevent dedup collisions when multiple
   // users react with the same emoji on the same message. Append the op
   // suffix so an add and a subsequent remove of the same emoji by the
@@ -55,10 +53,15 @@ function normalizeSlackReaction(
       receivedAt: new Date().toISOString(),
       message: {
         eventKind: "reaction",
-        content: callbackData,
+        // A reaction has no user-authored text; its payload is structured.
+        content: "",
         conversationExternalId: channel,
         externalMessageId,
-        callbackData,
+        reaction: {
+          op,
+          emoji: event.reaction,
+          targetMessageId: event.item.ts,
+        },
       },
       actor: {
         actorExternalId: event.user,

--- a/gateway/src/slack/reaction-normalizer.ts
+++ b/gateway/src/slack/reaction-normalizer.ts
@@ -62,6 +62,11 @@ function normalizeSlackReaction(
           emoji: event.reaction,
           targetMessageId: event.item.ts,
         },
+        // Transition dual-write: a daemon that predates the structured
+        // payload dispatches reactions on the kind and then reads this
+        // string, so a structured-only event would crash it during an
+        // upgrade-skew window. Remove once a release ships both sides.
+        callbackData: `${op === "added" ? "reaction" : "reaction_removed"}:${event.reaction}`,
       },
       actor: {
         actorExternalId: event.user,

--- a/packages/gateway-client/src/__tests__/inbound-event-kind.test.ts
+++ b/packages/gateway-client/src/__tests__/inbound-event-kind.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from "bun:test";
 import {
   inboundEventRefersToAnotherMessage,
   resolveInboundEventKind,
+  resolveInboundReactionPayload,
 } from "../inbound-event-kind.js";
 
 describe("resolveInboundEventKind", () => {
@@ -78,5 +79,50 @@ describe("inboundEventRefersToAnotherMessage", () => {
     expect(inboundEventRefersToAnotherMessage("delete")).toBe(true);
     expect(inboundEventRefersToAnotherMessage("reaction")).toBe(true);
     expect(inboundEventRefersToAnotherMessage("button")).toBe(true);
+  });
+});
+
+describe("resolveInboundReactionPayload", () => {
+  test("a structured payload wins outright", () => {
+    expect(
+      resolveInboundReactionPayload({
+        eventKind: "reaction",
+        reaction: { op: "removed", emoji: "+1", targetMessageId: "11.22" },
+        callbackData: "reaction:eyes",
+      }),
+    ).toEqual({ op: "removed", emoji: "+1", targetMessageId: "11.22" });
+  });
+
+  test("a replayed payload parses its sentinel and wire target", () => {
+    expect(
+      resolveInboundReactionPayload({
+        callbackData: "reaction:thumbsup",
+        sourceMetadata: { messageId: "33.44" },
+      }),
+    ).toEqual({ op: "added", emoji: "thumbsup", targetMessageId: "33.44" });
+    expect(
+      resolveInboundReactionPayload({
+        callbackData: "reaction_removed:thumbsup",
+        sourceMetadata: { messageId: "33.44" },
+      }),
+    ).toEqual({ op: "removed", emoji: "thumbsup", targetMessageId: "33.44" });
+  });
+
+  test("no emoji or no target is not a reaction payload", () => {
+    expect(
+      resolveInboundReactionPayload({
+        callbackData: "reaction:",
+        sourceMetadata: { messageId: "33.44" },
+      }),
+    ).toBeNull();
+    expect(
+      resolveInboundReactionPayload({ callbackData: "reaction:thumbsup" }),
+    ).toBeNull();
+    expect(
+      resolveInboundReactionPayload({
+        callbackData: "apr:req-1:approve_once",
+        sourceMetadata: { messageId: "33.44" },
+      }),
+    ).toBeNull();
   });
 });

--- a/packages/gateway-client/src/inbound-contract.ts
+++ b/packages/gateway-client/src/inbound-contract.ts
@@ -177,6 +177,15 @@ export const RuntimeInboundPayloadSchema = z.object({
   /** The named event family; absent only on replayed retry payloads,
    *  where resolveInboundEventKind derives it from the legacy fields. */
   eventKind: z.enum(INBOUND_EVENT_KINDS).optional(),
+  /** Structured reaction payload; replayed retry payloads carry the
+   *  callbackData string form resolveInboundReactionPayload reads. */
+  reaction: z
+    .object({
+      op: z.enum(["added", "removed"]),
+      emoji: z.string(),
+      targetMessageId: z.string(),
+    })
+    .optional(),
   isEdit: z.boolean().optional(),
   callbackQueryId: z.string().optional(),
   callbackData: z.string().optional(),

--- a/packages/gateway-client/src/inbound-event-kind.ts
+++ b/packages/gateway-client/src/inbound-event-kind.ts
@@ -73,3 +73,56 @@ export function inboundEventRefersToAnotherMessage(
 ): boolean {
   return kind !== "message";
 }
+
+/** The structured payload of a reaction event. */
+export interface InboundReactionPayload {
+  op: "added" | "removed";
+  /**
+   * The emoji as the channel names it: Slack a colon-name ("+1"), Telegram
+   * and Discord the unicode character, a Discord custom emoji its name.
+   * Decision vocabulary is product policy resolved in the daemon, never
+   * normalized here.
+   */
+  emoji: string;
+  /**
+   * Provider id of the message reacted to, in the same namespace as
+   * `source.messageId`.
+   */
+  targetMessageId: string;
+}
+
+/**
+ * The one reader of a reaction event's payload. A structured `reaction`
+ * field wins; a replayed retry payload persisted before the field carries
+ * the `"reaction:<emoji>"` / `"reaction_removed:<emoji>"` string in
+ * `callbackData` with the target on `sourceMetadata.messageId`, and is
+ * parsed here alone. Returns null when the event is not a reaction or
+ * names no emoji or target.
+ */
+export function resolveInboundReactionPayload(fields: {
+  eventKind?: string;
+  reaction?: InboundReactionPayload;
+  callbackData?: string;
+  sourceMetadata?: { messageId?: string };
+}): InboundReactionPayload | null {
+  if (fields.reaction) {
+    const { op, emoji, targetMessageId } = fields.reaction;
+    return emoji.length > 0 && targetMessageId.length > 0
+      ? { op, emoji, targetMessageId }
+      : null;
+  }
+  const cb = fields.callbackData;
+  const target = fields.sourceMetadata?.messageId;
+  if (cb === undefined || target === undefined || target.length === 0) {
+    return null;
+  }
+  const removed = cb.startsWith("reaction_removed:");
+  const added = !removed && cb.startsWith("reaction:");
+  if (!added && !removed) {
+    return null;
+  }
+  const emoji = cb.slice(cb.indexOf(":") + 1);
+  return emoji.length > 0
+    ? { op: removed ? "removed" : "added", emoji, targetMessageId: target }
+    : null;
+}

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -88,8 +88,12 @@ export {
   inboundEventRefersToAnotherMessage,
   isInboundEventKind,
   resolveInboundEventKind,
+  resolveInboundReactionPayload,
 } from "./inbound-event-kind.js";
-export type { InboundEventKind } from "./inbound-event-kind.js";
+export type {
+  InboundEventKind,
+  InboundReactionPayload,
+} from "./inbound-event-kind.js";
 
 // Plugin admission-denied notice (gateway → plugin) — canned deny copy + envelope
 export {


### PR DESCRIPTION
## TL;DR

PR A of the reactions pair: a reaction's payload becomes structured wire data (`reaction: { op, emoji, targetMessageId }` beside `eventKind: "reaction"`), and the reaction intercept sheds its Slack name gate for the facts it needs. Slack stays the only reaction producer in this PR — exact behavior parity — so that PR B (Telegram and Discord ingest) lands on a seam instead of a sentinel.

## Why this is safe

- **One reader for the legacy encoding**, same discipline as the event kind: `resolveInboundReactionPayload` parses the `"reaction:<emoji>"` strings only for replayed retry payloads; every live consumer reads the structured field. The resolver's matrix is pinned (structured wins, replay parses both directions, empty emoji / missing target / non-reaction strings refuse).
- **The guardian decision chain threads the payload as a first-class field** — the router's reaction branch keys on `op === "added"` and the emoji→action map takes the emoji directly. The `apr:` button path and text/NL paths are untouched.
- **The intercept's gate is now kind-plus-facts** (a resolvable payload), matching the delete stage's shape: nothing changes while Slack is the only producer, and a future channel — plugin included — needs no name added to a list. Its internal trust handling was already channel-agnostic (gateway-stamped verdict, delivery-row addressing).
- **Persistence branches like edits and deletes do**: Slack keeps `slackMeta` for its renderer; any other channel writes the neutral metadata whose reaction sub-schema existed waiting for this writer.
- Every sentinel test pin was converted to a payload pin rather than deleted; the wire's reaction `content` field is now empty (a reaction has no user-authored text), which also means the family-gated verification/invite intercepts have nothing to probe even in replay.
- Verified at the wire before designing: Slack colon-names, Telegram's fixed unicode set and diff-shaped updates, Discord's real-actor reaction dispatches with non-privileged intents — the payload's emoji field deliberately carries each channel's own vocabulary, with decision mapping staying product policy in the daemon.

## Pre-existing bugs fixed here

None fixed; one retired by construction: the reaction sentinel doubled as the event's `content`, so the literal string `"reaction:+1"` was a message body as far as any content-reading code was concerned. The structured payload ends that class.

## What changes for the user

| Before | After |
| --- | --- |
| Nothing user-visible | Same; PR B lights up Telegram and Discord reactions on this seam |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->