### PR TITLE
fix(web): one image classifier, shared failed-preview hook, and a hardened composer tile

### DIFF
--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -92,8 +92,9 @@ const STRUCTURAL_PROPS = new Set([
   "testId",
   "to",
   "type",
-  // Layout-only className wrappers (`w-32 shrink-0`) read as copy to
+  // Layout-only className props (`w-32 shrink-0`) read as copy to
   // `looksLikeCopy` because of spaces, but they are never user-facing text.
+  "iconOnlyGlyphClassName",
   "wrapperClassName",
 ]);
 

--- a/clients/web/eslint-rules/no-untranslated-strings.test.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.test.mjs
@@ -51,6 +51,11 @@ ruleTester.run("no-untranslated-strings", noUntranslatedStrings, {
       code: `const C = () => <div className="flex gap-2" data-slot="row" id="root" />;`,
     },
     {
+      name: "the design library's own className props are not copy",
+      filename: COMPONENT,
+      code: `const C = () => <Button iconOnlyGlyphClassName="size-3 [&_svg]:size-3" wrapperClassName="w-32 shrink-0" />;`,
+    },
+    {
       name: "JSX text with no letters",
       filename: COMPONENT,
       code: `const C = () => <span>{value} / {other} &middot; 42</span>;`,

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-chip.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-chip.tsx
@@ -10,7 +10,7 @@ import {
   FileVideo,
   X,
 } from "lucide-react";
-import type { FC, ReactNode } from "react";
+import type { FC, MouseEventHandler, ReactNode } from "react";
 
 import { useTranslation } from "@/i18n";
 
@@ -27,11 +27,11 @@ interface AttachmentChipProps {
   filename: string;
   mimeType: string;
   previewUrl: string | null;
-  /** When omitted, the chip renders in read-only mode (no remove button).
-   *  This lets the same chip be reused inside sent user message bubbles. */
-  onRemove?: (id: string) => void;
+  onRemove: (id: string) => void;
   /** Called when the user clicks an image chip to open a full-screen preview. */
   onPreview?: () => void;
+  /** The composer's press guard for the remove control. */
+  onRemoveMouseDown?: MouseEventHandler<HTMLElement>;
 }
 
 const ICON_BY_KIND: Record<AttachmentIconKind, ReactNode> = {
@@ -54,6 +54,7 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
   previewUrl,
   onRemove,
   onPreview,
+  onRemoveMouseDown,
 }) => {
   const { t } = useTranslation("chat");
   const kind = classifyAttachment(mimeType, filename);
@@ -94,22 +95,21 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
       <span className="min-w-0 max-w-[156px] truncate text-body-small-default leading-4 text-[var(--content-secondary)]">
         {displayName}
       </span>
-      {onRemove ? (
-        <div className="flex shrink-0 items-center gap-2">
-          <div className="h-8 w-px shrink-0 bg-[var(--border-disabled)]" />
-          <Button
-            variant="ghost"
-            size="compact"
-            expandOnMobile={false}
-            iconOnly={<X />}
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove(id);
-            }}
-            aria-label={t("attachmentChip.removeAria", { filename })}
-          />
-        </div>
-      ) : null}
+      <div className="flex shrink-0 items-center gap-2">
+        <div className="h-8 w-px shrink-0 bg-[var(--border-disabled)]" />
+        <Button
+          variant="ghost"
+          size="compact"
+          expandOnMobile={false}
+          iconOnly={<X />}
+          onMouseDown={onRemoveMouseDown}
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove(id);
+          }}
+          aria-label={t("attachmentChip.removeAria", { filename })}
+        />
+      </div>
     </div>
   );
 };

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-fixtures.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-fixtures.ts
@@ -22,6 +22,27 @@ export const SAMPLE_PREVIEWS: string[] = [
 ];
 
 /**
+ * A non-square preview: three bands along the long edge. Dropped into a square
+ * tile, `object-cover` eats most of the outer two, which is the crop a tile
+ * story is there to show.
+ */
+export function makeSamplePreview(width: number, height: number): string {
+  const landscape = width > height;
+  const band = (landscape ? width : height) / 3;
+  const bands = [0, 1, 2]
+    .map((index) => {
+      const fill = `hsl(196 58% ${34 + index * 16}%)`;
+      const offset = index * band;
+      return landscape
+        ? `<rect x="${offset}" y="0" width="${band}" height="${height}" fill="${fill}"/>`
+        : `<rect x="0" y="${offset}" width="${width}" height="${band}" fill="${fill}"/>`;
+    })
+    .join("");
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">${bands}</svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/**
  * A display attachment with sensible PNG defaults. Pass `overrides` for the
  * fields a test actually cares about.
  */

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-loading-chip.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-loading-chip.tsx
@@ -1,5 +1,5 @@
 import { Loader2, X } from "lucide-react";
-import type { FC } from "react";
+import type { FC, MouseEventHandler } from "react";
 
 import { Button } from "@vellumai/design-library";
 
@@ -10,12 +10,15 @@ interface AttachmentLoadingChipProps {
   localId: string;
   filename: string;
   onCancel: (localId: string) => void;
+  /** The composer's press guard for the cancel control. */
+  onRemoveMouseDown?: MouseEventHandler<HTMLElement>;
 }
 
 export const AttachmentLoadingChip: FC<AttachmentLoadingChipProps> = ({
   localId,
   filename,
   onCancel,
+  onRemoveMouseDown,
 }) => {
   const { t } = useTranslation("chat");
   const displayName = middleTruncate(filename);
@@ -37,6 +40,7 @@ export const AttachmentLoadingChip: FC<AttachmentLoadingChipProps> = ({
         size="compact"
         expandOnMobile={false}
         iconOnly={<X />}
+        onMouseDown={onRemoveMouseDown}
         onClick={() => onCancel(localId)}
         aria-label={t("attachmentLoadingChip.cancelUploadAria", { filename })}
       />

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -18,8 +18,8 @@ import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-previ
 import { PreviewMessageCard } from "@/domains/chat/components/chat-attachments/preview-message-card";
 import { TextPreview } from "@/domains/chat/components/chat-attachments/text-preview";
 import {
+  classifyAttachment,
   formatAttachmentSize,
-  isImageAttachment,
 } from "@/domains/chat/components/chat-attachments/utils";
 import { useGallerySwipe } from "@/domains/chat/components/chat-attachments/use-gallery-swipe";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
@@ -274,18 +274,14 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
   }
 
   const mime = attachment.mimeType.toLowerCase();
-  const isImage = isImageAttachment({
-    name: attachment.filename,
-    type: attachment.mimeType,
-  });
-  const isVideo = mime.startsWith("video/");
-  // Some uploads come through with a generic application/octet-stream MIME;
-  // fall back to the filename extension so a real PDF still gets the inline
-  // preview branch.
-  const isPdf =
-    mime === "application/pdf" ||
-    (mime === "application/octet-stream" &&
-      attachment.filename.toLowerCase().endsWith(".pdf"));
+  // One classifier picks the media branch, the same one the chip, the tile and
+  // the message square read: a photo delivered as application/octet-stream
+  // previews as an image, and a video named after an image format stays a
+  // video.
+  const kind = classifyAttachment(attachment.mimeType, attachment.filename);
+  const isImage = kind === "image";
+  const isVideo = kind === "video";
+  const isPdf = kind === "pdf";
   const extension = getExtension(attachment.filename);
   // Route by MIME first (text/* and the JSON/JS/XML application types), then
   // fall back to the file extension for uploads that arrive as

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.stories.tsx
@@ -13,35 +13,19 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ReactNode } from "react";
 import { fn } from "storybook/test";
 
-import { SAMPLE_PREVIEWS } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
-import { AttachmentTile } from "@/domains/chat/components/chat-attachments/attachment-tile";
+import { cn } from "@vellumai/design-library";
 
-/**
- * A non-square preview: three bands along the long edge with a dot centred on
- * the middle one. Dropped into the square tile, `object-cover` eats most of
- * the outer two bands, which is the crop these stories are here to show.
- */
-function bandedPreview(width: number, height: number, hue: number): string {
-  const landscape = width > height;
-  const band = (landscape ? width : height) / 3;
-  const bands = [0, 1, 2]
-    .map((index) => {
-      const fill = `hsl(${hue + index * 18} 58% ${34 + index * 16}%)`;
-      const offset = index * band;
-      return landscape
-        ? `<rect x="${offset}" y="0" width="${band}" height="${height}" fill="${fill}"/>`
-        : `<rect x="0" y="${offset}" width="${width}" height="${band}" fill="${fill}"/>`;
-    })
-    .join("");
-  const dot = `<circle cx="${width / 2}" cy="${height / 2}" r="${Math.min(width, height) / 5}" fill="#ffffff" fill-opacity="0.85"/>`;
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">${bands}${dot}</svg>`;
-  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
-}
+import {
+  makeSamplePreview,
+  SAMPLE_PREVIEWS,
+} from "@/domains/chat/components/chat-attachments/attachment-fixtures";
+import { AttachmentTile } from "@/domains/chat/components/chat-attachments/attachment-tile";
+import { COMPOSER_MOBILE_RADIUS_CLASS } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 
 /** 160x96, so the square crop drops a slice off each end. */
-const LANDSCAPE_PREVIEW = bandedPreview(160, 96, 196);
+const LANDSCAPE_PREVIEW = makeSamplePreview(160, 96);
 /** 96x160, so the square crop drops a slice off the top and the bottom. */
-const PORTRAIT_PREVIEW = bandedPreview(96, 160, 24);
+const PORTRAIT_PREVIEW = makeSamplePreview(96, 160);
 
 /**
  * Four attached photos, enough to overflow the card's tile row. The first two
@@ -73,7 +57,12 @@ const meta: Meta<typeof AttachmentTile> = {
   title: "Chat/AttachmentTile",
   component: AttachmentTile,
   parameters: { layout: "centered" },
-  args: { ...PHOTOS[0]!, onRemove: fn(), onPreview: fn() },
+  args: {
+    ...PHOTOS[0]!,
+    onRemove: fn(),
+    onPreview: fn(),
+    onPreviewError: fn(),
+  },
 };
 export default meta;
 
@@ -90,7 +79,7 @@ export const Image: Story = {};
  * the strip does not jump when the image lands.
  */
 export const Uploading: Story = {
-  args: { uploading: true, previewUrl: null },
+  args: { previewUrl: null },
 };
 
 /**
@@ -103,7 +92,12 @@ export const InCard: Story = {
   parameters: { layout: "fullscreen" },
   render: (args) => (
     <PhonePage>
-      <div className="flex w-full flex-col gap-3 rounded-[26px] bg-[var(--surface-lift)] pb-1.5 pl-3 pr-1.5 pt-3">
+      <div
+        className={cn(
+          "flex w-full flex-col gap-3 bg-[var(--surface-lift)] pb-1.5 pl-3 pr-1.5 pt-3",
+          COMPOSER_MOBILE_RADIUS_CLASS,
+        )}
+      >
         <div className="flex gap-2">
           {PHOTOS.slice(0, 2).map((photo) => (
             <AttachmentTile key={photo.id} {...args} {...photo} />

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.test.tsx
@@ -21,6 +21,7 @@ const PREVIEW_URL = "blob:http://localhost:3000/photo";
 function renderTile(props: Partial<Parameters<typeof AttachmentTile>[0]> = {}) {
   const onRemove = mock((_id: string) => {});
   const onPreview = mock(() => {});
+  const onPreviewError = mock(() => {});
   render(
     <AttachmentTile
       id="att-1"
@@ -28,10 +29,11 @@ function renderTile(props: Partial<Parameters<typeof AttachmentTile>[0]> = {}) {
       previewUrl={PREVIEW_URL}
       onRemove={onRemove}
       onPreview={onPreview}
+      onPreviewError={onPreviewError}
       {...props}
     />,
   );
-  return { onRemove, onPreview };
+  return { onRemove, onPreview, onPreviewError };
 }
 
 describe("AttachmentTile", () => {
@@ -55,7 +57,7 @@ describe("AttachmentTile", () => {
   });
 
   test("shows a spinner face while the upload is in flight", () => {
-    const { onRemove } = renderTile({ previewUrl: null, uploading: true });
+    const { onRemove } = renderTile({ previewUrl: null });
 
     expect(document.querySelector("img")).toBeNull();
     expect(
@@ -71,8 +73,7 @@ describe("AttachmentTile", () => {
   });
 
   test("reports a preview the browser cannot decode", () => {
-    const onPreviewError = mock(() => {});
-    renderTile({ onPreviewError });
+    const { onPreviewError } = renderTile();
 
     const image = screen
       .getByRole("button", { name: "Preview photo.jpg" })
@@ -83,27 +84,20 @@ describe("AttachmentTile", () => {
     expect(onPreviewError).toHaveBeenCalledTimes(1);
   });
 
-  test("disables the image when there is nothing to open", () => {
-    renderTile({ onPreview: undefined });
+  test("routes the composer's press guard to both controls", () => {
+    const pressGuard = mock(() => {});
+    renderTile({ pressGuard });
 
-    const preview = screen.getByRole("button", { name: "Preview photo.jpg" });
-    expect(preview.hasAttribute("disabled")).toBe(true);
-  });
-
-  test("routes the composer's press guard to the remove control only", () => {
-    const onRemoveMouseDown = mock(() => {});
-    renderTile({ onRemoveMouseDown });
-
-    // The guard cancels the mousedown so a tap on the X does not blur the
-    // textarea and collapse the mobile row.
+    // The guard cancels the mousedown so a tap on the tile does not blur the
+    // textarea and collapse the mobile row out from under the finger.
     fireEvent.mouseDown(
       screen.getByRole("button", { name: "Remove photo.jpg" }),
     );
-    expect(onRemoveMouseDown).toHaveBeenCalledTimes(1);
+    expect(pressGuard).toHaveBeenCalledTimes(1);
 
     fireEvent.mouseDown(
       screen.getByRole("button", { name: "Preview photo.jpg" }),
     );
-    expect(onRemoveMouseDown).toHaveBeenCalledTimes(1);
+    expect(pressGuard).toHaveBeenCalledTimes(2);
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.tsx
@@ -5,27 +5,22 @@ import { useTranslation } from "@/i18n";
 
 import { Button } from "@vellumai/design-library";
 
-/**
- * The remove control's 12px glyph. `Button` reads a glyph size override on its
- * icon wrapper, not from a `[&_svg]:size-*` on the button box.
- */
-const REMOVE_GLYPH_CLASS = "size-3 [&_svg]:size-3";
-
 interface AttachmentTileProps {
   id: string;
   filename: string;
-  /** Decoded image URL. `null` while the upload is still in flight. */
+  /** Decoded image URL. `null` while the upload is still in flight, which is
+   *  what puts the tile on its spinner face. */
   previewUrl: string | null;
-  /** Spinner face, and the control reads "cancel" instead of "remove". */
-  uploading?: boolean;
   onRemove: (id: string) => void;
-  /** Opens the full-screen preview. Only honoured once `previewUrl` is set. */
-  onPreview?: () => void;
+  /** Opens the full-screen preview. */
+  onPreview: () => void;
   /** Called when the browser cannot decode the preview. Lets the owner drop
    *  the tile for a chip, which still names the file. */
-  onPreviewError?: () => void;
-  /** The composer's press guard for the remove control. */
-  onRemoveMouseDown?: MouseEventHandler<HTMLElement>;
+  onPreviewError: () => void;
+  /** The composer's press guard. It rides both controls: a press anywhere on
+   *  the tile would otherwise blur the textarea, collapsing the row before the
+   *  click lands. */
+  pressGuard?: MouseEventHandler<HTMLElement>;
 }
 
 /**
@@ -37,11 +32,10 @@ export function AttachmentTile({
   id,
   filename,
   previewUrl,
-  uploading = false,
   onRemove,
   onPreview,
   onPreviewError,
-  onRemoveMouseDown,
+  pressGuard,
 }: AttachmentTileProps) {
   const { t } = useTranslation("chat");
 
@@ -49,15 +43,17 @@ export function AttachmentTile({
     <div
       data-slot="attachment-tile"
       title={filename}
-      className="relative size-[100px] shrink-0 overflow-hidden rounded-[14px] bg-[var(--surface-base)]"
+      className="relative size-[100px] shrink-0 rounded-[14px] bg-[var(--surface-base)]"
     >
       {previewUrl !== null ? (
+        // The picture is the only thing the tile clips, so the remove control
+        // keeps its full press target past the tile's corner.
         <button
           type="button"
-          className="block size-full cursor-pointer"
+          className="block size-full cursor-pointer overflow-hidden rounded-[14px] outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0"
           aria-label={t("attachmentTile.preview", { filename })}
+          onMouseDown={pressGuard}
           onClick={onPreview}
-          disabled={onPreview == null}
         >
           <img
             src={previewUrl}
@@ -84,12 +80,14 @@ export function AttachmentTile({
         // The `before:` pseudo-element widens the press target past the 24px
         // visual without moving it.
         className="absolute right-1.5 top-1.5 rounded-full bg-[var(--surface-lift)] [--vbtn-fg:var(--content-default)] before:absolute before:-inset-2 before:content-['']"
-        iconOnlyGlyphClassName={REMOVE_GLYPH_CLASS}
+        iconOnlyGlyphClassName="size-3 [&_svg]:size-3"
         aria-label={t(
-          uploading ? "attachmentTile.cancelUpload" : "attachmentTile.remove",
+          previewUrl === null
+            ? "attachmentTile.cancelUpload"
+            : "attachmentTile.remove",
           { filename },
         )}
-        onMouseDown={onRemoveMouseDown}
+        onMouseDown={pressGuard}
         onClick={(event) => {
           event.stopPropagation();
           onRemove(id);

--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments-strip.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments-strip.test.tsx
@@ -17,6 +17,7 @@ import { ChatAttachmentsStrip } from "@/domains/chat/components/chat-attachments
 import type {
   ChatAttachment,
   FailedAttachmentUpload,
+  PathReferenceAttachment,
   PendingAttachmentUpload,
   UploadedAttachment,
 } from "@/domains/chat/composer-store";
@@ -26,6 +27,7 @@ afterEach(() => {
 });
 
 const PREVIEW_URL = "data:image/png;base64,AAAA";
+const SECOND_PREVIEW_URL = "data:image/png;base64,BBBB";
 
 function uploaded(
   overrides: Partial<UploadedAttachment> = {},
@@ -65,6 +67,18 @@ function failed(
     mimeType: "image/jpeg",
     sizeBytes: 512,
     error: "Upload failed",
+    ...overrides,
+  };
+}
+
+function pathReference(
+  overrides: Partial<PathReferenceAttachment> = {},
+): PathReferenceAttachment {
+  return {
+    kind: "path-reference",
+    localId: "local-4",
+    filename: "project",
+    path: "/Users/example/project",
     ...overrides,
   };
 }
@@ -173,6 +187,15 @@ describe("ChatAttachmentsStrip tiles", () => {
     expect(screen.getByText("photo.jpg")).toBeTruthy();
   });
 
+  test("keeps the folder row for a path reference", () => {
+    const { container } = renderStrip([pathReference()], { tileImages: true });
+
+    expect(tiles()).toHaveLength(0);
+    expect(screen.getByText("project")).toBeTruthy();
+    expect(screen.getByText("/Users/example/project")).toBeTruthy();
+    expect(stripRow(container).className).toContain("items-start");
+  });
+
   test("keeps the error chip for a failed image upload", () => {
     renderStrip([failed()], { tileImages: true });
 
@@ -199,6 +222,25 @@ describe("ChatAttachmentsStrip tiles", () => {
     expect(pressGuard).toHaveBeenCalledTimes(1);
   });
 
+  test("routes the composer's press guard to a chip's control", () => {
+    const pressGuard = mock(() => {});
+    renderStrip(
+      [
+        uploaded({
+          filename: "report.pdf",
+          mimeType: "application/pdf",
+          previewUrl: null,
+        }),
+      ],
+      { tileImages: true, pressGuard },
+    );
+
+    fireEvent.mouseDown(
+      screen.getByRole("button", { name: "Remove report.pdf" }),
+    );
+    expect(pressGuard).toHaveBeenCalledTimes(1);
+  });
+
   test("opens the preview modal from the tile image", () => {
     renderStrip([uploaded()], { tileImages: true });
 
@@ -211,6 +253,29 @@ describe("ChatAttachmentsStrip tiles", () => {
       PREVIEW_URL,
     );
   });
+
+  test("moves between the attached photos inside the lightbox", () => {
+    renderStrip(
+      [
+        uploaded(),
+        uploaded({
+          localId: "local-5",
+          id: "att-2",
+          filename: "second.jpg",
+          previewUrl: SECOND_PREVIEW_URL,
+        }),
+      ],
+      { tileImages: true },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Preview photo.jpg" }));
+    expect(screen.getByAltText("photo.jpg")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next attachment" }));
+    expect(screen.getByAltText("second.jpg").getAttribute("src")).toBe(
+      SECOND_PREVIEW_URL,
+    );
+  });
 });
 
 describe("ChatAttachmentsStrip chips", () => {
@@ -221,11 +286,15 @@ describe("ChatAttachmentsStrip chips", () => {
     expect(screen.getByText("photo.jpg")).toBeTruthy();
     expect(screen.getByText("shot.png")).toBeTruthy();
     expect(stripRow(container).className).toContain("pt-2");
+    // Desktop rows are all one height, so nothing overrides the stretch.
+    expect(stripRow(container).className).not.toContain("items-start");
   });
 
   test("opens the row's top inset for a tile row", () => {
     const { container } = renderStrip([uploaded()], { tileImages: true });
 
     expect(stripRow(container).className).toContain("pt-3");
+    // A chip beside a 100px tile keeps its own height.
+    expect(stripRow(container).className).toContain("items-start");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
@@ -1,22 +1,22 @@
 import { AlertCircle, Folder, Paperclip, X } from "lucide-react";
 import type { FC, MouseEventHandler } from "react";
-import { useCallback, useState } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "@/i18n";
 
 import { Button, cn } from "@vellumai/design-library";
 
 import { AttachmentChip } from "@/domains/chat/components/chat-attachments/attachment-chip";
 import { AttachmentLoadingChip } from "@/domains/chat/components/chat-attachments/attachment-loading-chip";
-import { AttachmentPreviewModal } from "@/domains/chat/components/chat-attachments/attachment-preview-modal";
 import { AttachmentTile } from "@/domains/chat/components/chat-attachments/attachment-tile";
 import { useAttachmentFilePicker } from "@/domains/chat/components/chat-attachments/use-attachment-file-picker";
+import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import { useFailedPreviewIds } from "@/domains/chat/components/chat-attachments/use-failed-preview-ids";
 import type {
   ChatAttachment,
-  PendingAttachmentUpload,
   UploadedAttachment,
 } from "@/domains/chat/composer-store";
 import {
-  isImageAttachment,
+  classifyAttachment,
   middleTruncate,
 } from "@/domains/chat/components/chat-attachments/utils";
 
@@ -29,7 +29,7 @@ interface ChatAttachmentsStripProps {
    * attachment on its own.
    */
   tileImages?: boolean;
-  /** The composer's press guard for the tile's remove control. */
+  /** The composer's press guard, worn by every control the strip renders. */
   pressGuard?: MouseEventHandler<HTMLElement>;
 }
 
@@ -38,16 +38,14 @@ interface ChatAttachmentsStripProps {
  * still uploading or already carries a decodable preview. Anything else keeps
  * the chip, which is the only place its filename or its error shows.
  */
-function isTiledImage(
-  att: ChatAttachment,
-): att is PendingAttachmentUpload | UploadedAttachment {
+function isTiledImage(att: ChatAttachment): boolean {
   if (att.kind !== "uploading" && att.kind !== "uploaded") {
     return false;
   }
   if (att.kind === "uploaded" && att.previewUrl === null) {
     return false;
   }
-  return isImageAttachment({ name: att.filename, type: att.mimeType });
+  return classifyAttachment(att.mimeType, att.filename) === "image";
 }
 
 /**
@@ -61,20 +59,25 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
   pressGuard,
 }) => {
   const { t } = useTranslation("chat");
-  const [previewAttachment, setPreviewAttachment] =
-    useState<UploadedAttachment | null>(null);
-  const handleClosePreview = useCallback(() => setPreviewAttachment(null), []);
-  // Local ids whose preview the browser could not decode (a TIFF, or a HEIF
-  // whose conversion fell back). Their tile would be a blank square with no
-  // filename, so they drop back to the chip.
-  const [failedPreviewIds, setFailedPreviewIds] = useState<ReadonlySet<string>>(
-    new Set(),
+  // Every finished upload is a gallery sibling, so the lightbox arrows move
+  // between the attached photos instead of opening one at a time. Composer
+  // previews are inline blob URLs, so the modal needs no assistant to fetch
+  // from.
+  const uploadedAttachments = useMemo(
+    () =>
+      attachments.filter(
+        (att): att is UploadedAttachment => att.kind === "uploaded",
+      ),
+    [attachments],
   );
-  const markPreviewFailed = useCallback((localId: string) => {
-    setFailedPreviewIds((prev) =>
-      prev.has(localId) ? prev : new Set(prev).add(localId),
-    );
-  }, []);
+  const { openPreview, previewModal } = useAttachmentPreview(
+    null,
+    uploadedAttachments,
+  );
+  // A preview the browser could not decode (a TIFF, or a HEIF whose conversion
+  // fell back) would tile as a blank square with no filename, so it drops back
+  // to the chip.
+  const { failedIds, markFailed } = useFailedPreviewIds();
 
   if (attachments.length === 0) {
     return null;
@@ -86,12 +89,13 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
         className={cn(
           "flex gap-2 overflow-x-auto px-3 pb-1.5 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]",
           // A tile row sits 12px below the card's top edge, against the 8px a
-          // chip row takes.
-          tileImages ? "pt-3" : "pt-2",
+          // chip row takes, and a chip beside a tile keeps its own height
+          // rather than stretching to the tile's.
+          tileImages ? "items-start pt-3" : "pt-2",
         )}
       >
         {attachments.map((att) => {
-          const previewFailed = failedPreviewIds.has(att.localId);
+          const previewFailed = failedIds.has(att.localId);
           if (tileImages && !previewFailed && isTiledImage(att)) {
             const uploaded = att.kind === "uploaded" ? att : null;
             return (
@@ -100,15 +104,14 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
                 id={att.localId}
                 filename={att.filename}
                 previewUrl={uploaded?.previewUrl ?? null}
-                uploading={att.kind === "uploading"}
                 onRemove={onRemove}
-                onPreview={
-                  uploaded ? () => setPreviewAttachment(uploaded) : undefined
-                }
-                onPreviewError={
-                  uploaded ? () => markPreviewFailed(att.localId) : undefined
-                }
-                onRemoveMouseDown={pressGuard}
+                onPreview={() => {
+                  if (uploaded) {
+                    openPreview(uploaded);
+                  }
+                }}
+                onPreviewError={() => markFailed(att.localId)}
+                pressGuard={pressGuard}
               />
             );
           }
@@ -119,6 +122,7 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
                 localId={att.localId}
                 filename={att.filename}
                 onCancel={onRemove}
+                onRemoveMouseDown={pressGuard}
               />
             );
           }
@@ -143,6 +147,7 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
                   size="compact"
                   expandOnMobile={false}
                   iconOnly={<X />}
+                  onMouseDown={pressGuard}
                   onClick={() => onRemove(att.localId)}
                   aria-label={t("chatAttachments.removeAria", { filename: att.filename })}
                 />
@@ -163,6 +168,7 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
                 <Button
                   variant="ghost"
                   size="compact"
+                  onMouseDown={pressGuard}
                   onClick={() => onRemove(att.localId)}
                   aria-label={t("chatAttachments.removeAria", { filename: att.filename })}
                   className="ml-0.5 underline"
@@ -181,18 +187,13 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
               mimeType={att.mimeType}
               previewUrl={previewFailed ? null : att.previewUrl}
               onRemove={onRemove}
-              onPreview={() => setPreviewAttachment(att)}
+              onPreview={() => openPreview(att)}
+              onRemoveMouseDown={pressGuard}
             />
           );
         })}
       </div>
-      {previewAttachment && (
-        <AttachmentPreviewModal
-          open
-          onClose={handleClosePreview}
-          attachment={previewAttachment}
-        />
-      )}
+      {previewModal}
     </>
   );
 };

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-squares.tsx
@@ -18,7 +18,7 @@
  * and place `renderSquare(att, index)` inside whatever container they need.
  */
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import type { ReactNode } from "react";
 
 import type { DisplayAttachment } from "@/domains/chat/types/types";
@@ -26,6 +26,7 @@ import type { DisplayAttachment } from "@/domains/chat/types/types";
 import { downloadAttachment } from "@/domains/chat/components/chat-attachments/download-attachment";
 import { MessageAttachmentSquare } from "@/domains/chat/components/chat-attachments/message-attachment-square";
 import { useAttachmentPreview } from "@/domains/chat/components/chat-attachments/use-attachment-preview";
+import { useFailedPreviewIds } from "@/domains/chat/components/chat-attachments/use-failed-preview-ids";
 
 interface UseAttachmentSquaresOptions {
   attachments: DisplayAttachment[];
@@ -56,21 +57,16 @@ export function useAttachmentSquares({
   attachments,
   assistantId,
 }: UseAttachmentSquaresOptions): UseAttachmentSquaresResult {
-  const [failedImageIds, setFailedImageIds] = useState<ReadonlySet<string>>(
-    new Set(),
-  );
-  const markImageFailed = useCallback((id: string) => {
-    setFailedImageIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
-  }, []);
+  const { failedIds, markFailed: markImageFailed } = useFailedPreviewIds();
 
   const displayAttachments = useMemo(
     () =>
-      failedImageIds.size === 0
+      failedIds.size === 0
         ? attachments
         : attachments.map((att) =>
-            failedImageIds.has(att.id) ? { ...att, previewUrl: null } : att,
+            failedIds.has(att.id) ? { ...att, previewUrl: null } : att,
           ),
-    [attachments, failedImageIds],
+    [attachments, failedIds],
   );
 
   const { openPreview, previewModal } = useAttachmentPreview(

--- a/clients/web/src/domains/chat/components/chat-attachments/use-failed-preview-ids.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-failed-preview-ids.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from "react";
+
+interface UseFailedPreviewIdsResult {
+  /** Ids whose preview the browser could not decode. */
+  failedIds: ReadonlySet<string>;
+  /** Records an id whose preview failed to decode. */
+  markFailed: (id: string) => void;
+}
+
+/**
+ * The set of attachment ids whose image preview the browser could not decode (a
+ * TIFF, or a HEIF whose conversion fell back), for the surfaces that swap a
+ * dead picture for something that still names the file: the composer strip
+ * drops to the chip, the message squares drop to their kind icon.
+ *
+ * Ids are never reused, and the set is bounded by the attachments one surface
+ * shows, so nothing prunes it.
+ */
+export function useFailedPreviewIds(): UseFailedPreviewIdsResult {
+  const [failedIds, setFailedIds] = useState<ReadonlySet<string>>(new Set());
+  const markFailed = useCallback((id: string) => {
+    setFailedIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+  }, []);
+
+  return { failedIds, markFailed };
+}

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
@@ -1,5 +1,6 @@
 /**
- * The image test the vision gate reads.
+ * The image test the vision gate reads, and the classifier every attachment
+ * surface renders from.
  *
  * Files arriving from a native picker carry whatever type their provider
  * published, which on Android may be nothing at all, so a filter reading the
@@ -8,7 +9,10 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { isImageAttachment } from "@/domains/chat/components/chat-attachments/utils";
+import {
+  classifyAttachment,
+  isImageAttachment,
+} from "@/domains/chat/components/chat-attachments/utils";
 
 describe("isImageAttachment", () => {
   test("reads a type that names an image", () => {
@@ -55,5 +59,29 @@ describe("isImageAttachment", () => {
     );
     expect(isImageAttachment({ name: "noextension", type: "" })).toBe(false);
     expect(isImageAttachment({ name: "archive.zip", type: "" })).toBe(false);
+  });
+});
+
+describe("classifyAttachment", () => {
+  test("reads the declared type", () => {
+    expect(classifyAttachment("image/jpeg", "photo.jpg")).toBe("image");
+    expect(classifyAttachment("application/pdf", "report.pdf")).toBe("pdf");
+  });
+
+  test("falls back to the filename under a type that names nothing", () => {
+    expect(classifyAttachment("application/octet-stream", "photo.jpg")).toBe(
+      "image",
+    );
+    expect(classifyAttachment("", "photo.HEIC")).toBe("image");
+    expect(classifyAttachment("application/octet-stream", "report.pdf")).toBe(
+      "pdf",
+    );
+  });
+
+  test("keeps a declared type over the filename", () => {
+    // A video the user named after an image format is still a video, and the
+    // preview modal picks its branch from this answer.
+    expect(classifyAttachment("video/mp4", "clip.gif")).toBe("video");
+    expect(classifyAttachment("text/plain", "diagram.svg")).toBe("text");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.ts
@@ -1,3 +1,5 @@
+import { GENERIC_MIME_TYPES } from "@/domains/chat/utils/mime-sniff";
+
 /**
  * Format a raw byte count into a short human-readable string (e.g. "12 KB", "3.4 MB").
  *
@@ -76,18 +78,29 @@ export type AttachmentIconKind =
   | "file";
 
 /**
- * Classify an attachment by its MIME type / filename extension so the chip can
- * render an appropriate icon. Kept in sync with the macOS `iconForMimeType`
- * helper so the icon surface is consistent across clients.
+ * Classify an attachment by its MIME type / filename extension so every surface
+ * that renders it agrees on what it is. Kept in sync with the macOS
+ * `iconForMimeType` helper so the icon surface is consistent across clients.
+ *
+ * A declared type wins. Only where the type names nothing does the filename
+ * settle whether the file is an image, so a photo picked as
+ * `application/octet-stream` reads as one while a video named `clip.gif` stays
+ * a video.
  */
 export function classifyAttachment(
   mimeType: string,
   filename: string,
 ): AttachmentIconKind {
-  const mime = (mimeType || "").toLowerCase();
+  const mime = (mimeType || "").trim().toLowerCase();
   const ext = filename.split(".").pop()?.toLowerCase() ?? "";
 
   if (mime.startsWith("image/")) {
+    return "image";
+  }
+  if (
+    GENERIC_MIME_TYPES.has(mime) &&
+    isImageAttachment({ name: filename, type: mimeType })
+  ) {
     return "image";
   }
   if (mime.startsWith("video/")) {

--- a/clients/web/src/domains/chat/utils/mime-sniff.ts
+++ b/clients/web/src/domains/chat/utils/mime-sniff.ts
@@ -43,8 +43,12 @@ const OOXML_MIME_TYPES: Record<string, string> = {
   xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 };
 
-/** Server types that name no format and must not shadow the extension map. */
-const GENERIC_MIME_TYPES = new Set([
+/**
+ * Types that name no format, so they must not shadow what the filename or the
+ * bytes say. An empty type is the same claim made by saying nothing.
+ */
+export const GENERIC_MIME_TYPES = new Set([
+  "",
   "application/octet-stream",
   "binary/octet-stream",
 ]);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for mobile-attachment-tiles.md.

- classifyAttachment applies the image-extension fallback for generic MIME types, so the tile, chip, square and preview modal agree; the modal derives image/video/pdf from that one classifier
- useFailedPreviewIds is shared by the composer strip and useAttachmentSquares
- AttachmentTile: press guard on both controls, clip only the picture so the remove target is a full 40px, keyboard focus ring, no separate uploading prop
- Strip: items-start for mixed rows, press guard on every removal control, gallery navigation in the composer lightbox
- Stories use COMPOSER_MOBILE_RADIUS_CLASS and a shared makeSamplePreview fixture
- The generic-MIME set moves to one exported constant in mime-sniff.ts, which already held a copy
- no-untranslated-strings treats iconOnlyGlyphClassName as structural, like wrapperClassName, so the tile can pass the glyph size inline