### PR TITLE
fix(web): a failed PDF names the file, and a capped one says so (LUM-3386)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -311,7 +311,19 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     }
 
     if (isPdf && effectiveUrl) {
-      return <PdfPreview url={effectiveUrl} />;
+      return (
+        <PdfPreview
+          url={effectiveUrl}
+          errorFallback={
+            <PreviewMessageCard
+              message={t("attachmentPreviewModal.pdfLoadFailed")}
+              filename={attachment.filename}
+              onDownload={handleDownload}
+              downloadDisabled={!effectiveUrl}
+            />
+          }
+        />
+      );
     }
 
     if (isImage && effectiveUrl && decodeFailedUrl !== effectiveUrl) {
@@ -362,7 +374,9 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
           leftIcon={<Download />}
           onClick={handleDownload}
           disabled={!effectiveUrl}
-          aria-label={t("attachmentPreviewModal.downloadAria", { filename: attachment.filename })}
+          aria-label={t("attachmentPreviewModal.downloadAria", {
+            filename: attachment.filename,
+          })}
           className="mt-4 text-white/70 hover:bg-white/10 hover:text-white max-md:bg-transparent"
           tintColor="currentColor"
         >
@@ -377,7 +391,9 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
       ref={overlayRef}
       role="dialog"
       aria-modal="true"
-      aria-label={t("attachmentPreviewModal.previewAria", { filename: attachment.filename })}
+      aria-label={t("attachmentPreviewModal.previewAria", {
+        filename: attachment.filename,
+      })}
       // Focusable so the overlay can hold keyboard focus for the arrow-key
       // handler; the ring is suppressed since the dialog is the whole screen.
       tabIndex={-1}
@@ -436,7 +452,9 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
             expandOnMobile={false}
             onClick={handleDownload}
             disabled={!effectiveUrl}
-            aria-label={t("attachmentPreviewModal.downloadAria", { filename: attachment.filename })}
+            aria-label={t("attachmentPreviewModal.downloadAria", {
+              filename: attachment.filename,
+            })}
             className="h-11 w-11 rounded-full bg-white/10 text-white/70 hover:bg-white/20 hover:text-white"
             tintColor="currentColor"
           />

--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import type { PDFDocumentProxy } from "pdfjs-dist/legacy/build/pdf.mjs";
 // `?url` emits the package's prebuilt worker as a hashed asset and yields its
 // URL, so the worker is served from our own origin and its version is the
@@ -11,6 +17,8 @@ import PDF_WORKER_URL from "pdfjs-dist/legacy/build/pdf.worker.min.mjs?url";
 
 import { PdfPageSkeleton } from "@/domains/chat/components/chat-attachments/pdf-page-skeleton";
 import { dataUriToUint8Array } from "@/domains/chat/components/chat-attachments/utils";
+import { PreviewTruncationNotice } from "@/domains/chat/components/local-file/preview/preview-truncation-notice";
+import { useTranslation } from "@/i18n";
 
 /**
  * Inline PDF preview rendered via pdfjs-dist canvas. Bypasses Safari/WebKit
@@ -55,14 +63,25 @@ async function loadPdfJs() {
 interface PdfPreviewProps {
   url: string;
   className?: string;
+  /**
+   * Shown when the document cannot be read. The surfaces this renders on
+   * present failure differently (a card over the modal's dark backdrop, a
+   * compact row in the drawer) and each already owns a component that does
+   * it, so the choice, and the wording, belong to the caller.
+   */
+  errorFallback: ReactNode;
 }
 
-export function PdfPreview({ url, className }: PdfPreviewProps) {
+export function PdfPreview({ url, className, errorFallback }: PdfPreviewProps) {
+  const { t } = useTranslation("chat");
   // Spans with block/flex classes rather than divs: the preview also renders
   // inline in chat markdown, where a div inside <p> is invalid HTML.
   const containerRef = useRef<HTMLSpanElement>(null);
   const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null);
   const [numPages, setNumPages] = useState(0);
+  // What the document holds, against `numPages` which is what MAX_PAGES
+  // allows: the gap is what the reader is not being shown.
+  const [totalPages, setTotalPages] = useState(0);
   // Width/height of page 1, stamped onto each canvas as it mounts so the box
   // holds a page's shape before anything is drawn into it: a canvas has no
   // intrinsic size until `renderPage` runs, so the row would otherwise
@@ -72,7 +91,7 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
   // over the real dimensions `renderPage` sets.
   const placeholderAspectRatio = useRef<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
   const canvasRefs = useRef<Map<number, HTMLCanvasElement>>(new Map());
   const renderedPages = useRef<Set<number>>(new Set());
 
@@ -82,9 +101,10 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
 
     async function load() {
       setIsLoading(true);
-      setError(null);
+      setFailed(false);
       setPdf(null);
       setNumPages(0);
+      setTotalPages(0);
       placeholderAspectRatio.current = null;
       renderedPages.current.clear();
 
@@ -124,9 +144,10 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
         placeholderAspectRatio.current = height > 0 ? width / height : null;
         setPdf(doc);
         setNumPages(Math.min(doc.numPages, MAX_PAGES));
+        setTotalPages(doc.numPages);
       } catch {
         if (!cancelled) {
-          setError("Failed to load PDF.");
+          setFailed(true);
         }
       } finally {
         if (!cancelled) {
@@ -259,14 +280,8 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
     );
   }
 
-  if (error) {
-    return (
-      <span className="block w-full max-w-sm rounded-lg border border-white/15 bg-white/[0.08] p-8 text-center">
-        <span className="text-body-medium-lighter block text-white/80">
-          {error}
-        </span>
-      </span>
-    );
+  if (failed) {
+    return errorFallback;
   }
 
   return (
@@ -283,6 +298,11 @@ export function PdfPreview({ url, className }: PdfPreviewProps) {
           style={{ height: "auto" }}
         />
       ))}
+      {totalPages > numPages && (
+        <PreviewTruncationNotice as="span">
+          {t("pdfPreview.pageCapNotice", { count: numPages })}
+        </PreviewTruncationNotice>
+      )}
     </span>
   );
 }

--- a/clients/web/src/domains/chat/components/local-file/preview/file-preview-container.tsx
+++ b/clients/web/src/domains/chat/components/local-file/preview/file-preview-container.tsx
@@ -81,7 +81,7 @@ function previewFor(
     case "text":
       return <TextPreview blob={blob} filename={filename} />;
     case "pdf":
-      return <PdfFilePreview blob={blob} />;
+      return <PdfFilePreview blob={blob} filename={filename} />;
     case "image":
     case "audio":
     case "video":

--- a/clients/web/src/domains/chat/components/local-file/preview/pdf-file-preview.tsx
+++ b/clients/web/src/domains/chat/components/local-file/preview/pdf-file-preview.tsx
@@ -11,13 +11,18 @@ import { type ReactNode } from "react";
 
 import { PdfPageSkeleton } from "@/domains/chat/components/chat-attachments/pdf-page-skeleton";
 import { PdfPreview } from "@/domains/chat/components/chat-attachments/pdf-preview";
+import { PreviewError } from "@/domains/chat/components/local-file/preview/preview-error";
 import { useBlobObjectUrl } from "@/domains/chat/components/local-file/use-local-file-info";
 
 interface PdfFilePreviewProps {
   blob: Blob;
+  filename: string;
 }
 
-export function PdfFilePreview({ blob }: PdfFilePreviewProps): ReactNode {
+export function PdfFilePreview({
+  blob,
+  filename,
+}: PdfFilePreviewProps): ReactNode {
   const url = useBlobObjectUrl(blob, "application/pdf");
 
   // The page shape rather than the prose-line placeholder: this state runs
@@ -33,7 +38,10 @@ export function PdfFilePreview({ blob }: PdfFilePreviewProps): ReactNode {
     // the placeholder overflows a drawer a few hundred pixels wide and then
     // snaps smaller the moment the first canvas replaces it.
     <span className="block w-full [&_[data-slot=skeleton]]:w-full! [&_canvas]:w-full!">
-      <PdfPreview url={url} />
+      <PdfPreview
+        url={url}
+        errorFallback={<PreviewError filename={filename} />}
+      />
     </span>
   );
 }

--- a/clients/web/src/domains/chat/components/local-file/preview/preview-truncation-notice.tsx
+++ b/clients/web/src/domains/chat/components/local-file/preview/preview-truncation-notice.tsx
@@ -5,6 +5,12 @@ import { Typography } from "@vellumai/design-library";
 interface PreviewTruncationNoticeProps {
   /** The already-translated sentence naming how much of the file is shown. */
   children: ReactNode;
+  /**
+   * Root element. A reader that renders inline in chat markdown sits inside
+   * a paragraph, where a nested `p` is invalid and closes its parent early,
+   * so those pass `"span"`. The block class keeps the layout identical.
+   */
+  as?: "p" | "span";
 }
 
 /**
@@ -14,12 +20,13 @@ interface PreviewTruncationNoticeProps {
  */
 export function PreviewTruncationNotice({
   children,
+  as = "p",
 }: PreviewTruncationNoticeProps): ReactNode {
   return (
     <Typography
-      as="p"
+      as={as}
       variant="label-small-default"
-      className="border-t border-[var(--border-element)] pt-2 text-[var(--content-tertiary)]"
+      className="block border-t border-[var(--border-element)] pt-2 text-[var(--content-tertiary)]"
     >
       {children}
     </Typography>

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -124,6 +124,7 @@
     "downloadAria": "Download {filename}",
     "downloadLabel": "Download",
     "nextAttachmentAria": "Next attachment",
+    "pdfLoadFailed": "Couldn't display this PDF",
     "previewAria": "Preview of {filename}",
     "previousAttachmentAria": "Previous attachment"
   },
@@ -1113,6 +1114,9 @@
   },
   "pdfPageSkeleton": {
     "loadingPdf": "Loading PDF"
+  },
+  "pdfPreview": {
+    "pageCapNotice": "{count, plural, one {Showing the first page} other {Showing the first # pages}}"
   },
   "phaseGroupedStepList": {
     "startedAt": "Started at {time}"

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -124,6 +124,7 @@
     "downloadAria": "Descargar {filename}",
     "downloadLabel": "Descargar",
     "nextAttachmentAria": "Adjunto siguiente",
+    "pdfLoadFailed": "No se pudo mostrar este PDF",
     "previewAria": "Vista previa de {filename}",
     "previousAttachmentAria": "Adjunto anterior"
   },
@@ -1113,6 +1114,9 @@
   },
   "pdfPageSkeleton": {
     "loadingPdf": "Cargando PDF"
+  },
+  "pdfPreview": {
+    "pageCapNotice": "{count, plural, one {Mostrando la primera página} other {Mostrando las primeras # páginas}}"
   },
   "phaseGroupedStepList": {
     "startedAt": "Comenzó a las {time}"

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -45,6 +45,9 @@
     "switchTo": "Переключиться на {name}",
     "unnamedAssistant": "Безымянный ассистент"
   },
+  "attachmentPreviewModal": {
+    "pdfLoadFailed": "Не удалось показать этот PDF"
+  },
   "cacheBreakpointMapCard": {
     "description": "Где {count, plural, one {# точка разрыва кэша попала} few {# точки разрыва кэша попали} many {# точек разрыва кэша попали} other {# точки разрыва кэша попали}} в префикс этого запроса и какие сегменты прочитали, а какие создали заново.",
     "estimatedTokens": "≈ {count} токенов",
@@ -580,6 +583,9 @@
   },
   "pdfPageSkeleton": {
     "loadingPdf": "Загрузка PDF"
+  },
+  "pdfPreview": {
+    "pageCapNotice": "{count, plural, one {Показана первая страница} few {Показаны первые # страницы} many {Показаны первые # страниц} other {Показаны первые # страницы}}"
   },
   "pinnedAppColorSwatches": {
     "colors": {


### PR DESCRIPTION
## Summary

- TL;DR: a PDF that fails to load now says which file failed and offers the way on from it, and a document longer than the render cap says so instead of just stopping at page 20. This is the last of LUM-3386.
- The failure fix is a deletion, not an addition. `PdfPreview` was rendering its own bordered box holding the untranslated string "Failed to load PDF." with no filename and no action, using the same white-tint classes as `PreviewMessageCard`, the component the attachment modal already renders for exactly this case ("load failure, file too large, unsupported type", per its own docstring). That box is gone. `PdfPreview` now reports failure through an `errorFallback` prop and each surface supplies the component it already owns: `PreviewMessageCard` over the modal's dark backdrop, `PreviewError` in the drawer, whose navbar carries a persistent download button beside it.
- The cap notice reuses `PreviewTruncationNotice` from #41586 rather than becoming a third copy of that footer, and counts pages through an ICU plural, so Russian gets its "many" form at 20 ("Показаны первые 20 страниц") instead of a form picked for English.

Why this is safe: the render path, the page cap itself, and the loading state are untouched. `errorFallback` is required rather than optional, so no surface can fall back to an unnamed failure, and `errorFallback` is the name `LazyBoundary` already uses for this exact role. Both call sites already held the filename and the download handler; nothing new is threaded through `previewFor` beyond the filename it was already passing to every other reader.

## What changes for the user

| Situation | Before | After |
| --- | --- | --- |
| A PDF fails to load in chat | "Failed to load PDF." in a bare box, in English in every locale | The file is named, with a download button, in the reader's language |
| A PDF fails to load in the drawer | The same bare box | The drawer's own failure row naming the file, beside the navbar's download |
| A 50-page PDF | Stops at page 20 with nothing said, reading as truncated or broken | "Showing the first 20 pages" |
| A PDF under the cap | No notice | No notice |
| Rendering, page cap value, loading state | Unchanged | Unchanged |

## Two things worth a reviewer's eye

The notice component gained an `as` prop. `PdfPreview` builds its tree from spans on purpose, because it also renders inline in chat markdown where a nested `p` is invalid and closes its parent paragraph early. The notice defaults to `p` for the drawer readers, which sit in a div, and the PDF preview passes `span`; a block class keeps the two identical.

"Failed to load PDF." was a third instance of the pattern #41586 fixed: user-facing copy held in a `.ts` value where the JSX-reading lint rule cannot see it. It is worth assuming more of these exist outside the directory that PR swept.

Fixes LUM-3386

## Original prompt

Last of three follow-ups on LUM-3386, after the CDN worker (#41574), the page-shaped loading state (#41577), and the shared-copy cleanup (#41586). The remaining ticket scope was the error state and the page-cap notice. Investigating the error state first turned up that the right fix was to remove a hand-rolled failure box rather than enrich it, since both surfaces already own a failure component and only the PDF path was bypassing them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->