### PR TITLE
fix(web): keep a declared MIME type over a .pdf filename

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
@@ -83,5 +83,9 @@ describe("classifyAttachment", () => {
     // preview modal picks its branch from this answer.
     expect(classifyAttachment("video/mp4", "clip.gif")).toBe("video");
     expect(classifyAttachment("text/plain", "diagram.svg")).toBe("text");
+    // The preview modal routes on this answer, so a text file named after a
+    // PDF must not reach the PDF renderer.
+    expect(classifyAttachment("text/plain", "notes.pdf")).toBe("text");
+    expect(classifyAttachment("application/json", "data.pdf")).not.toBe("pdf");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.ts
@@ -109,7 +109,10 @@ export function classifyAttachment(
   if (mime.startsWith("audio/")) {
     return "audio";
   }
-  if (mime === "application/pdf" || ext === "pdf") {
+  if (
+    mime === "application/pdf" ||
+    (GENERIC_MIME_TYPES.has(mime) && ext === "pdf")
+  ) {
     return "pdf";
   }
   if (


### PR DESCRIPTION
## Summary
Addresses the Codex P2 on #41588.

classifyAttachment returned `pdf` for any file whose name ends in `.pdf`, whatever its MIME type. Now that the preview modal routes on that answer, a `text/plain` or `application/json` file named `notes.pdf` reached PdfPreview instead of TextPreview.

The extension fallback for pdf is now restricted to generic and empty MIME types, matching the rule the image fallback already follows: a declared type wins, and the filename only settles what nothing else names.

## Test
- `bun run test:ci` on utils, the preview modal, the composer strip and the text preview
- `bun run typecheck`