### PR TITLE
refactor(web): derive the PDF page total from the document proxy

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/pdf-preview.tsx
@@ -79,9 +79,6 @@ export function PdfPreview({ url, className, errorFallback }: PdfPreviewProps) {
   const containerRef = useRef<HTMLSpanElement>(null);
   const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null);
   const [numPages, setNumPages] = useState(0);
-  // What the document holds, against `numPages` which is what MAX_PAGES
-  // allows: the gap is what the reader is not being shown.
-  const [totalPages, setTotalPages] = useState(0);
   // Width/height of page 1, stamped onto each canvas as it mounts so the box
   // holds a page's shape before anything is drawn into it: a canvas has no
   // intrinsic size until `renderPage` runs, so the row would otherwise
@@ -104,7 +101,6 @@ export function PdfPreview({ url, className, errorFallback }: PdfPreviewProps) {
       setFailed(false);
       setPdf(null);
       setNumPages(0);
-      setTotalPages(0);
       placeholderAspectRatio.current = null;
       renderedPages.current.clear();
 
@@ -144,7 +140,6 @@ export function PdfPreview({ url, className, errorFallback }: PdfPreviewProps) {
         placeholderAspectRatio.current = height > 0 ? width / height : null;
         setPdf(doc);
         setNumPages(Math.min(doc.numPages, MAX_PAGES));
-        setTotalPages(doc.numPages);
       } catch {
         if (!cancelled) {
           setFailed(true);
@@ -298,7 +293,9 @@ export function PdfPreview({ url, className, errorFallback }: PdfPreviewProps) {
           style={{ height: "auto" }}
         />
       ))}
-      {totalPages > numPages && (
+      {/* `numPages` is what MAX_PAGES allows; the proxy knows what the
+          document actually holds, and the gap is what is not being shown. */}
+      {pdf !== null && pdf.numPages > numPages && (
         <PreviewTruncationNotice as="span">
           {t("pdfPreview.pageCapNotice", { count: numPages })}
         </PreviewTruncationNotice>


### PR DESCRIPTION
## Summary

- TL;DR: the PDF preview's page-cap notice reads the document's page count from the document proxy it already holds, instead of copying that number into a second piece of state. Three lines lighter, one `useState` and one setter fewer, no behavior change.
- `totalPages` was only ever `doc.numPages` for the same `doc` that `pdf` already holds, so it was state duplicating state. The notice now derives it (`pdf !== null && pdf.numPages > numPages`), which is the same condition with nothing to keep in sync.

Why this is safe: `pdf` and the old `totalPages` were assigned from the same proxy on the same line pair and reset together, so the derived value equals the stored one at every point in the lifecycle. Purely internal: the notice renders under exactly the conditions it did before.

## Origin

Found by the `/simplify` pass over #41589 while that PR was in review. It merged before the pass finished, so this lands as a follow-up rather than a fixup commit. Redundant state is the first thing that pass looks for, and this is a textbook instance: a cached value that could be derived.

Part of LUM-3386
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->