### PR TITLE
test(assistant): drive patch-queue expiry with fake timers

### DIFF
--- a/assistant/src/platform/platform-patch-queue.test.ts
+++ b/assistant/src/platform/platform-patch-queue.test.ts
@@ -3,6 +3,7 @@ import {
   beforeEach,
   describe,
   expect,
+  jest,
   mock,
   setSystemTime,
   test,
@@ -66,14 +67,30 @@ function makeQueue(
   return queue;
 }
 
+const FROZEN_NOW = new Date("2026-01-01T00:00:00.000Z").getTime();
+
+/**
+ * Flush already-queued microtasks. Fake timers stop the clock but not the
+ * promise chain `enqueue` appends onto, so the PATCH work a timer kicks off
+ * lands here.
+ */
 async function settle(): Promise<void> {
-  for (let i = 0; i < 10; i++) {
-    await new Promise((r) => setTimeout(r, 5));
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.resolve();
   }
+}
+
+/** Advance `Date.now()` and the queue's `setTimeout` handles together. */
+async function elapse(ms: number): Promise<void> {
+  setSystemTime(new Date(Date.now() + ms));
+  jest.advanceTimersByTime(ms);
+  await settle();
 }
 
 describe("createPlatformPatchQueue", () => {
   beforeEach(() => {
+    jest.useFakeTimers();
+    setSystemTime(new Date(FROZEN_NOW));
     patches = [];
     builds = 0;
     respond = () => new Response("{}", { status: 200 });
@@ -85,6 +102,8 @@ describe("createPlatformPatchQueue", () => {
     for (const queue of queues) {
       queue.dispose();
     }
+    jest.useRealTimers();
+    setSystemTime();
   });
 
   test("PATCHes once and dedups an unchanged key", async () => {
@@ -203,21 +222,16 @@ describe("createPlatformPatchQueue", () => {
       saveSyncedKey: (synced) => saved.push(synced),
     });
     const start = Date.now();
-    setSystemTime(new Date(start));
-    try {
-      queue.enqueue("a");
-      await settle();
-      setSystemTime(new Date(start + 999));
-      queue.enqueue("a");
-      await settle();
-      setSystemTime(new Date(start + 1000));
-      queue.enqueue("a");
-      await settle();
-      queue.enqueue("a");
-      await settle();
-    } finally {
-      setSystemTime();
-    }
+    queue.enqueue("a");
+    await settle();
+    setSystemTime(new Date(start + 999));
+    queue.enqueue("a");
+    await settle();
+    setSystemTime(new Date(start + 1000));
+    queue.enqueue("a");
+    await settle();
+    queue.enqueue("a");
+    await settle();
 
     expect(patches).toHaveLength(2);
     expect(saved.map((s) => s.syncedAt)).toEqual([start, start + 1000]);
@@ -243,14 +257,12 @@ describe("createPlatformPatchQueue", () => {
     await settle();
     expect(patches).toHaveLength(1);
 
-    await new Promise((r) => setTimeout(r, 300));
-    await settle();
+    await elapse(300);
     expect(patches).toHaveLength(2);
     expect(builds).toBe(2);
 
     queue.dispose();
-    await new Promise((r) => setTimeout(r, 300));
-    await settle();
+    await elapse(300);
     expect(patches).toHaveLength(2);
   });
 
@@ -266,8 +278,7 @@ describe("createPlatformPatchQueue", () => {
     await settle();
     expect(patches).toHaveLength(0);
 
-    await new Promise((r) => setTimeout(r, 300));
-    await settle();
+    await elapse(300);
     expect(patches).toHaveLength(1);
   });
 
@@ -279,12 +290,10 @@ describe("createPlatformPatchQueue", () => {
     expect(patches).toHaveLength(1);
 
     respond = () => new Response("{}", { status: 200 });
-    await new Promise((r) => setTimeout(r, 100));
-    await settle();
+    await elapse(100);
     expect(patches).toHaveLength(2);
 
-    await new Promise((r) => setTimeout(r, 100));
-    await settle();
+    await elapse(100);
     queue.enqueue("a");
     await settle();
     expect(patches).toHaveLength(2);
@@ -301,8 +310,7 @@ describe("createPlatformPatchQueue", () => {
     queue.enqueue("a");
     await settle();
     mockClient = makeClient();
-    await new Promise((r) => setTimeout(r, 100));
-    await settle();
+    await elapse(100);
 
     expect(patches).toHaveLength(1);
   });
@@ -312,14 +320,11 @@ describe("createPlatformPatchQueue", () => {
     respond = () => new Response("nope", { status: 500 });
     queue.enqueue("a");
     await settle();
-    await new Promise((r) => setTimeout(r, 50));
-    await settle();
-    await new Promise((r) => setTimeout(r, 50));
-    await settle();
+    await elapse(50);
+    await elapse(50);
     expect(patches).toHaveLength(3);
 
-    await new Promise((r) => setTimeout(r, 100));
-    await settle();
+    await elapse(100);
     expect(patches).toHaveLength(3);
   });
 
@@ -332,12 +337,10 @@ describe("createPlatformPatchQueue", () => {
     await settle();
     expect(patches.map((p) => p.body.value)).toEqual(["a", "b"]);
 
-    await new Promise((r) => setTimeout(r, 100));
-    await settle();
+    await elapse(100);
     expect(patches.map((p) => p.body.value)).toEqual(["a", "b", "b"]);
 
-    await new Promise((r) => setTimeout(r, 100));
-    await settle();
+    await elapse(100);
     expect(patches).toHaveLength(3);
   });
 
@@ -347,8 +350,7 @@ describe("createPlatformPatchQueue", () => {
     queue.enqueue("a");
     await settle();
     queue.dispose();
-    await new Promise((r) => setTimeout(r, 300));
-    await settle();
+    await elapse(300);
 
     expect(patches).toHaveLength(1);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Dev Release `ci-assistant` failed on `platform-patch-queue.test.ts` ("re-sends at expiry with no enqueue call, and dispose cancels that"): expected 2 patches, received 3.

The expiry and retry cases waited on real `setTimeout` against a 300ms `maxAgeMs`. On a loaded runner the wait can overshoot, the expiry timer fires twice, and the assertion flakes. Neighboring age tests already pin `Date.now()`; this change does the same for the timers.

Approach: fake timers plus a frozen system clock. `elapse(ms)` advances `Date.now()` and the queue's `setTimeout` handles together, then flushes microtasks. Production `platform-patch-queue.ts` is unchanged.

## Test plan

- `cd assistant && bun test src/platform/platform-patch-queue.test.ts` (17/17)
- Re-ran the file five times in a row: all green, ~200-330ms per run (no wall-clock waits)

## CLI verb checklist

No new routes. Test-only change to `assistant/src/platform/platform-patch-queue.test.ts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a029d5-1006-73b1-ada3-172e9fcf7b4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a029d5-1006-73b1-ada3-172e9fcf7b4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

