### PR TITLE
fix(web): compare base media types, decode-check the chip preview, and align the strip only around a tile

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-chip.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-chip.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests for the composer's attachment chip.
+ *
+ * Mounted with `@testing-library/react` (happy-dom, see
+ * `clients/web/test-setup.ts`) against the real design-library `Button` and the
+ * real English catalog.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { AttachmentChip } from "@/domains/chat/components/chat-attachments/attachment-chip";
+
+afterEach(() => {
+  cleanup();
+});
+
+const PREVIEW_URL = "blob:http://localhost:3000/photo";
+
+function renderChip(props: Partial<Parameters<typeof AttachmentChip>[0]> = {}) {
+  const onRemove = mock((_id: string) => {});
+  const onPreviewError = mock(() => {});
+  render(
+    <AttachmentChip
+      id="att-1"
+      filename="photo.jpg"
+      mimeType="image/jpeg"
+      previewUrl={PREVIEW_URL}
+      onRemove={onRemove}
+      onPreviewError={onPreviewError}
+      {...props}
+    />,
+  );
+  return { onRemove, onPreviewError };
+}
+
+describe("AttachmentChip", () => {
+  test("reports a preview the browser cannot decode", () => {
+    const { onPreviewError } = renderChip();
+
+    const image = screen
+      .getByRole("img", { name: "photo.jpg" })
+      .querySelector("img");
+    expect(image?.getAttribute("src")).toBe(PREVIEW_URL);
+
+    fireEvent.error(image as HTMLImageElement);
+    expect(onPreviewError).toHaveBeenCalledTimes(1);
+  });
+
+  test("routes the composer's press guard to the remove control", () => {
+    const pressGuard = mock(() => {});
+    const { onRemove } = renderChip({ pressGuard });
+
+    const remove = screen.getByRole("button", { name: "Remove photo.jpg" });
+    fireEvent.mouseDown(remove);
+    expect(pressGuard).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(remove);
+    expect(onRemove).toHaveBeenCalledWith("att-1");
+  });
+});

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-chip.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-chip.tsx
@@ -30,8 +30,11 @@ interface AttachmentChipProps {
   onRemove: (id: string) => void;
   /** Called when the user clicks an image chip to open a full-screen preview. */
   onPreview?: () => void;
+  /** Called when the browser cannot decode the preview. Lets the owner drop
+   *  the thumbnail for the kind icon. */
+  onPreviewError?: () => void;
   /** The composer's press guard for the remove control. */
-  onRemoveMouseDown?: MouseEventHandler<HTMLElement>;
+  pressGuard?: MouseEventHandler<HTMLElement>;
 }
 
 const ICON_BY_KIND: Record<AttachmentIconKind, ReactNode> = {
@@ -54,7 +57,8 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
   previewUrl,
   onRemove,
   onPreview,
-  onRemoveMouseDown,
+  onPreviewError,
+  pressGuard,
 }) => {
   const { t } = useTranslation("chat");
   const kind = classifyAttachment(mimeType, filename);
@@ -83,14 +87,21 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
       <div
         role={hasPreview ? "img" : undefined}
         aria-label={hasPreview ? filename : undefined}
-        className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-[var(--surface-lift)] bg-cover bg-center text-[var(--content-secondary)]"
-        style={
-          hasPreview && previewUrl
-            ? { backgroundImage: `url(${JSON.stringify(previewUrl)})` }
-            : undefined
-        }
+        className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-[var(--surface-lift)] text-[var(--content-secondary)]"
       >
-        {hasPreview ? null : ICON_BY_KIND[kind]}
+        {hasPreview ? (
+          // A real <img> rather than a CSS background so an undecodable
+          // preview raises `onError` and the owner can fall back to the icon.
+          <img
+            src={previewUrl}
+            alt=""
+            draggable={false}
+            onError={onPreviewError}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          ICON_BY_KIND[kind]
+        )}
       </div>
       <span className="min-w-0 max-w-[156px] truncate text-body-small-default leading-4 text-[var(--content-secondary)]">
         {displayName}
@@ -102,7 +113,7 @@ export const AttachmentChip: FC<AttachmentChipProps> = ({
           size="compact"
           expandOnMobile={false}
           iconOnly={<X />}
-          onMouseDown={onRemoveMouseDown}
+          onMouseDown={pressGuard}
           onClick={(e) => {
             e.stopPropagation();
             onRemove(id);

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-loading-chip.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-loading-chip.tsx
@@ -11,14 +11,14 @@ interface AttachmentLoadingChipProps {
   filename: string;
   onCancel: (localId: string) => void;
   /** The composer's press guard for the cancel control. */
-  onRemoveMouseDown?: MouseEventHandler<HTMLElement>;
+  pressGuard?: MouseEventHandler<HTMLElement>;
 }
 
 export const AttachmentLoadingChip: FC<AttachmentLoadingChipProps> = ({
   localId,
   filename,
   onCancel,
-  onRemoveMouseDown,
+  pressGuard,
 }) => {
   const { t } = useTranslation("chat");
   const displayName = middleTruncate(filename);
@@ -40,7 +40,7 @@ export const AttachmentLoadingChip: FC<AttachmentLoadingChipProps> = ({
         size="compact"
         expandOnMobile={false}
         iconOnly={<X />}
-        onMouseDown={onRemoveMouseDown}
+        onMouseDown={pressGuard}
         onClick={() => onCancel(localId)}
         aria-label={t("attachmentLoadingChip.cancelUploadAria", { filename })}
       />

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -273,11 +273,11 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     return null;
   }
 
-  const mime = attachment.mimeType.toLowerCase();
-  // One classifier picks the media branch, the same one the chip, the tile and
-  // the message square read: a photo delivered as application/octet-stream
-  // previews as an image, and a video named after an image format stays a
-  // video.
+  const mime = attachment.mimeType.split(";")[0]!.trim().toLowerCase();
+  // One classifier picks the media branch, the same one the composer strip,
+  // the chip and the message square read: a photo delivered as
+  // application/octet-stream previews as an image, and a video named after an
+  // image format stays a video.
   const kind = classifyAttachment(attachment.mimeType, attachment.filename);
   const isImage = kind === "image";
   const isVideo = kind === "video";
@@ -286,7 +286,9 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
   // Route by MIME first (text/* and the JSON/JS/XML application types), then
   // fall back to the file extension for uploads that arrive as
   // application/octet-stream. PDF/image/video branches above already win for
-  // their own types.
+  // their own types. Its own test rather than a `kind` check: the inline
+  // preview renders source files too, which `classifyAttachment` splits off
+  // into a separate `code` kind.
   const isText =
     mime.startsWith("text/") ||
     TEXT_PREVIEW_APPLICATION_MIMES.has(mime) ||

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.stories.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.stories.tsx
@@ -20,7 +20,7 @@ import {
   SAMPLE_PREVIEWS,
 } from "@/domains/chat/components/chat-attachments/attachment-fixtures";
 import { AttachmentTile } from "@/domains/chat/components/chat-attachments/attachment-tile";
-import { COMPOSER_MOBILE_RADIUS_CLASS } from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import { COMPOSER_MOBILE_RADIUS_CLASS } from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 
 /** 160x96, so the square crop drops a slice off each end. */
 const LANDSCAPE_PREVIEW = makeSamplePreview(160, 96);

--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-tile.tsx
@@ -3,7 +3,10 @@ import type { MouseEventHandler } from "react";
 
 import { useTranslation } from "@/i18n";
 
-import { Button } from "@vellumai/design-library";
+import { Button, cn } from "@vellumai/design-library";
+
+/** The tile's corner, worn by the box and by the picture it clips. */
+const TILE_RADIUS_CLASS = "rounded-[14px]";
 
 interface AttachmentTileProps {
   id: string;
@@ -43,14 +46,20 @@ export function AttachmentTile({
     <div
       data-slot="attachment-tile"
       title={filename}
-      className="relative size-[100px] shrink-0 rounded-[14px] bg-[var(--surface-base)]"
+      className={cn(
+        "relative size-[100px] shrink-0 bg-[var(--surface-base)]",
+        TILE_RADIUS_CLASS,
+      )}
     >
       {previewUrl !== null ? (
         // The picture is the only thing the tile clips, so the remove control
         // keeps its full press target past the tile's corner.
         <button
           type="button"
-          className="block size-full cursor-pointer overflow-hidden rounded-[14px] outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0"
+          className={cn(
+            "block size-full cursor-pointer overflow-hidden outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0",
+            TILE_RADIUS_CLASS,
+          )}
           aria-label={t("attachmentTile.preview", { filename })}
           onMouseDown={pressGuard}
           onClick={onPreview}
@@ -88,10 +97,7 @@ export function AttachmentTile({
           { filename },
         )}
         onMouseDown={pressGuard}
-        onClick={(event) => {
-          event.stopPropagation();
-          onRemove(id);
-        }}
+        onClick={() => onRemove(id)}
       />
     </div>
   );

--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments-strip.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments-strip.test.tsx
@@ -188,12 +188,11 @@ describe("ChatAttachmentsStrip tiles", () => {
   });
 
   test("keeps the folder row for a path reference", () => {
-    const { container } = renderStrip([pathReference()], { tileImages: true });
+    renderStrip([pathReference()], { tileImages: true });
 
     expect(tiles()).toHaveLength(0);
     expect(screen.getByText("project")).toBeTruthy();
     expect(screen.getByText("/Users/example/project")).toBeTruthy();
-    expect(stripRow(container).className).toContain("items-start");
   });
 
   test("keeps the error chip for a failed image upload", () => {
@@ -212,34 +211,52 @@ describe("ChatAttachmentsStrip tiles", () => {
     expect(onRemove).toHaveBeenCalledWith("local-1");
   });
 
-  test("routes the composer's press guard to the tile's control", () => {
-    const pressGuard = mock(() => {});
-    renderStrip([uploaded()], { tileImages: true, pressGuard });
+  // Every removal control in the strip wears the guard, so a tap on any of
+  // them leaves the textarea focused and the mobile row standing.
+  const PRESS_GUARD_CASES: Array<{
+    what: string;
+    attachment: ChatAttachment;
+    control: string;
+  }> = [
+    { what: "the tile", attachment: uploaded(), control: "Remove photo.jpg" },
+    {
+      what: "a chip",
+      attachment: uploaded({
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+        previewUrl: null,
+      }),
+      control: "Remove report.pdf",
+    },
+    {
+      what: "an uploading chip",
+      attachment: uploading({
+        filename: "report.pdf",
+        mimeType: "application/pdf",
+      }),
+      control: "Cancel upload of report.pdf",
+    },
+    {
+      what: "a path reference",
+      attachment: pathReference(),
+      control: "Remove project",
+    },
+    {
+      what: "a failed upload",
+      attachment: failed(),
+      control: "Remove broken.jpg",
+    },
+  ];
 
-    fireEvent.mouseDown(
-      screen.getByRole("button", { name: "Remove photo.jpg" }),
-    );
-    expect(pressGuard).toHaveBeenCalledTimes(1);
-  });
+  for (const { what, attachment, control } of PRESS_GUARD_CASES) {
+    test(`routes the composer's press guard to ${what}`, () => {
+      const pressGuard = mock(() => {});
+      renderStrip([attachment], { tileImages: true, pressGuard });
 
-  test("routes the composer's press guard to a chip's control", () => {
-    const pressGuard = mock(() => {});
-    renderStrip(
-      [
-        uploaded({
-          filename: "report.pdf",
-          mimeType: "application/pdf",
-          previewUrl: null,
-        }),
-      ],
-      { tileImages: true, pressGuard },
-    );
-
-    fireEvent.mouseDown(
-      screen.getByRole("button", { name: "Remove report.pdf" }),
-    );
-    expect(pressGuard).toHaveBeenCalledTimes(1);
-  });
+      fireEvent.mouseDown(screen.getByRole("button", { name: control }));
+      expect(pressGuard).toHaveBeenCalledTimes(1);
+    });
+  }
 
   test("opens the preview modal from the tile image", () => {
     renderStrip([uploaded()], { tileImages: true });
@@ -290,11 +307,30 @@ describe("ChatAttachmentsStrip chips", () => {
     expect(stripRow(container).className).not.toContain("items-start");
   });
 
+  test("falls back to the kind icon when a chip preview cannot decode", () => {
+    renderStrip([uploaded()]);
+
+    const image = screen.getByRole("img", { name: "photo.jpg" });
+    fireEvent.error(image.querySelector("img") as HTMLImageElement);
+
+    expect(screen.queryByRole("img", { name: "photo.jpg" })).toBeNull();
+    // The chip is still the chip, so the file is still named.
+    expect(screen.getByText("photo.jpg")).toBeTruthy();
+  });
+
   test("opens the row's top inset for a tile row", () => {
     const { container } = renderStrip([uploaded()], { tileImages: true });
 
     expect(stripRow(container).className).toContain("pt-3");
     // A chip beside a 100px tile keeps its own height.
     expect(stripRow(container).className).toContain("items-start");
+  });
+
+  test("keeps the stretch for a mobile row with no tile in it", () => {
+    const { container } = renderStrip([pathReference()], { tileImages: true });
+
+    // The card inset still applies; only the alignment is keyed on a tile.
+    expect(stripRow(container).className).toContain("pt-3");
+    expect(stripRow(container).className).not.toContain("items-start");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/chat-attachments.tsx
@@ -59,44 +59,60 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
   pressGuard,
 }) => {
   const { t } = useTranslation("chat");
+  // A preview the browser could not decode (a TIFF, or a HEIF whose conversion
+  // fell back) would tile as a blank square with no filename, so it drops back
+  // to the chip and its kind icon.
+  const { failedIds, markFailed } = useFailedPreviewIds();
+  // Render from the sanitized list rather than the input, so a URL already
+  // known to be dead reaches neither the strip nor the lightbox.
+  const displayAttachments = useMemo(
+    () =>
+      failedIds.size === 0
+        ? attachments
+        : attachments.map((att) =>
+            att.kind === "uploaded" && failedIds.has(att.localId)
+              ? { ...att, previewUrl: null }
+              : att,
+          ),
+    [attachments, failedIds],
+  );
   // Every finished upload is a gallery sibling, so the lightbox arrows move
   // between the attached photos instead of opening one at a time. Composer
   // previews are inline blob URLs, so the modal needs no assistant to fetch
   // from.
   const uploadedAttachments = useMemo(
     () =>
-      attachments.filter(
+      displayAttachments.filter(
         (att): att is UploadedAttachment => att.kind === "uploaded",
       ),
-    [attachments],
+    [displayAttachments],
   );
   const { openPreview, previewModal } = useAttachmentPreview(
     null,
     uploadedAttachments,
   );
-  // A preview the browser could not decode (a TIFF, or a HEIF whose conversion
-  // fell back) would tile as a blank square with no filename, so it drops back
-  // to the chip.
-  const { failedIds, markFailed } = useFailedPreviewIds();
 
   if (attachments.length === 0) {
     return null;
   }
+
+  // A chip beside a tile keeps its own height rather than stretching to the
+  // tile's. A row with no tile in it is all one height, so it stretches.
+  const hasTile = tileImages && displayAttachments.some(isTiledImage);
 
   return (
     <>
       <div
         className={cn(
           "flex gap-2 overflow-x-auto px-3 pb-1.5 [&::-webkit-scrollbar]:hidden [scrollbar-width:none]",
-          // A tile row sits 12px below the card's top edge, against the 8px a
-          // chip row takes, and a chip beside a tile keeps its own height
-          // rather than stretching to the tile's.
-          tileImages ? "items-start pt-3" : "pt-2",
+          // The card insets its content 12px on mobile, against the 8px a
+          // desktop chip row takes.
+          tileImages ? "pt-3" : "pt-2",
+          hasTile && "items-start",
         )}
       >
-        {attachments.map((att) => {
-          const previewFailed = failedIds.has(att.localId);
-          if (tileImages && !previewFailed && isTiledImage(att)) {
+        {displayAttachments.map((att) => {
+          if (tileImages && isTiledImage(att)) {
             const uploaded = att.kind === "uploaded" ? att : null;
             return (
               <AttachmentTile
@@ -122,7 +138,7 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
                 localId={att.localId}
                 filename={att.filename}
                 onCancel={onRemove}
-                onRemoveMouseDown={pressGuard}
+                pressGuard={pressGuard}
               />
             );
           }
@@ -185,10 +201,11 @@ export const ChatAttachmentsStrip: FC<ChatAttachmentsStripProps> = ({
               id={att.localId}
               filename={att.filename}
               mimeType={att.mimeType}
-              previewUrl={previewFailed ? null : att.previewUrl}
+              previewUrl={att.previewUrl}
               onRemove={onRemove}
               onPreview={() => openPreview(att)}
-              onRemoveMouseDown={pressGuard}
+              onPreviewError={() => markFailed(att.localId)}
+              pressGuard={pressGuard}
             />
           );
         })}

--- a/clients/web/src/domains/chat/components/chat-attachments/use-attachment-preview.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-attachment-preview.tsx
@@ -15,9 +15,9 @@ interface UseAttachmentPreviewResult {
 
 /**
  * Owns the shared full-screen-preview plumbing for the attachment renderers
- * ({@link BubbleAttachments} and {@link MessageAttachments}): the open/close
- * state and the {@link AttachmentPreviewModal} element. Consumers call
- * `openPreview(att)` from an item's click handler and render `previewModal`.
+ * (the message squares and the composer strip): the open/close state and the
+ * {@link AttachmentPreviewModal} element. Consumers call `openPreview(att)`
+ * from an item's click handler and render `previewModal`.
  *
  * When multiple attachments are present, the modal renders prev/next gallery
  * navigation so the user can arrow between sibling images without closing.

--- a/clients/web/src/domains/chat/components/chat-attachments/use-failed-preview-ids.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-failed-preview-ids.ts
@@ -10,8 +10,7 @@ interface UseFailedPreviewIdsResult {
 /**
  * The set of attachment ids whose image preview the browser could not decode (a
  * TIFF, or a HEIF whose conversion fell back), for the surfaces that swap a
- * dead picture for something that still names the file: the composer strip
- * drops to the chip, the message squares drop to their kind icon.
+ * dead picture for something that still names the file.
  *
  * Ids are never reused, and the set is bounded by the attachments one surface
  * shows, so nothing prunes it.

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
@@ -76,6 +76,11 @@ describe("classifyAttachment", () => {
     expect(classifyAttachment("application/octet-stream", "report.pdf")).toBe(
       "pdf",
     );
+    // A dotless name has no extension to fall back to, so the whole name is
+    // not read as one.
+    expect(classifyAttachment("application/octet-stream", "pdf")).not.toBe(
+      "pdf",
+    );
   });
 
   test("keeps a declared type over the filename", () => {
@@ -86,6 +91,15 @@ describe("classifyAttachment", () => {
     // The preview modal routes on this answer, so a text file named after a
     // PDF must not reach the PDF renderer.
     expect(classifyAttachment("text/plain", "notes.pdf")).toBe("text");
-    expect(classifyAttachment("application/json", "data.pdf")).not.toBe("pdf");
+    expect(classifyAttachment("application/json", "data.pdf")).toBe("file");
+    expect(
+      classifyAttachment("application/pdf; charset=binary", "report.pdf"),
+    ).toBe("pdf");
+    expect(
+      classifyAttachment(
+        "application/octet-stream; charset=binary",
+        "photo.jpg",
+      ),
+    ).toBe("image");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.ts
@@ -1,4 +1,7 @@
-import { GENERIC_MIME_TYPES } from "@/domains/chat/utils/mime-sniff";
+import {
+  extensionOf,
+  GENERIC_MIME_TYPES,
+} from "@/domains/chat/utils/mime-sniff";
 
 /**
  * Format a raw byte count into a short human-readable string (e.g. "12 KB", "3.4 MB").
@@ -47,6 +50,11 @@ const IMAGE_EXTENSIONS = new Set([
   "tiff",
 ]);
 
+/** Whether a lowercased filename extension names an image format. */
+function isImageExtension(extension: string): boolean {
+  return IMAGE_EXTENSIONS.has(extension);
+}
+
 /**
  * Whether an attachment is an image, by its type where it has one and by its
  * filename where it does not.
@@ -61,8 +69,7 @@ export function isImageAttachment(file: Pick<File, "name" | "type">): boolean {
   if (file.type.trim().toLowerCase().startsWith("image/")) {
     return true;
   }
-  const extension = file.name.split(".").pop()?.trim().toLowerCase();
-  return extension ? IMAGE_EXTENSIONS.has(extension) : false;
+  return isImageExtension(extensionOf(file.name));
 }
 
 export type AttachmentIconKind =
@@ -79,11 +86,11 @@ export type AttachmentIconKind =
 
 /**
  * Classify an attachment by its MIME type / filename extension so every surface
- * that renders it agrees on what it is. Kept in sync with the macOS
- * `iconForMimeType` helper so the icon surface is consistent across clients.
+ * that renders it agrees on what it is.
  *
- * A declared type wins. Only where the type names nothing does the filename
- * settle whether the file is an image, so a photo picked as
+ * A declared type wins, compared as the base media type so a parameter such as
+ * `; charset=binary` does not hide it. Only where the type names nothing does
+ * the filename settle whether the file is an image, so a photo picked as
  * `application/octet-stream` reads as one while a video named `clip.gif` stays
  * a video.
  */
@@ -91,16 +98,14 @@ export function classifyAttachment(
   mimeType: string,
   filename: string,
 ): AttachmentIconKind {
-  const mime = (mimeType || "").trim().toLowerCase();
-  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  const mime = (mimeType || "").split(";")[0]!.trim().toLowerCase();
+  const ext = extensionOf(filename);
+  const isGenericMime = GENERIC_MIME_TYPES.has(mime);
 
   if (mime.startsWith("image/")) {
     return "image";
   }
-  if (
-    GENERIC_MIME_TYPES.has(mime) &&
-    isImageAttachment({ name: filename, type: mimeType })
-  ) {
+  if (isGenericMime && isImageExtension(ext)) {
     return "image";
   }
   if (mime.startsWith("video/")) {
@@ -109,10 +114,7 @@ export function classifyAttachment(
   if (mime.startsWith("audio/")) {
     return "audio";
   }
-  if (
-    mime === "application/pdf" ||
-    (GENERIC_MIME_TYPES.has(mime) && ext === "pdf")
-  ) {
+  if (mime === "application/pdf" || (isGenericMime && ext === "pdf")) {
     return "pdf";
   }
   if (

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -40,16 +40,14 @@ import {
   useIsCompactComposerWidth,
 } from "@/domains/chat/components/chat-composer/composer-compact";
 import {
+  COMPOSER_MOBILE_RADIUS_CLASS,
+  COMPOSER_RADIUS_CLASS,
   MOBILE_CONTROL_CLASS,
   MOBILE_GHOST_WASH_CLASS,
   MOBILE_GLYPH_CLASS,
   preventPressFocusTransfer,
 } from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
-import {
-  COMPOSER_MOBILE_RADIUS_CLASS,
-  COMPOSER_RADIUS_CLASS,
-  VoiceComposerBar,
-} from "@/domains/chat/components/chat-composer/voice-composer-bar";
+import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-composer-bar";
 import { LiveVoiceButton } from "@/domains/chat/components/live-voice-button";
 import { useSupportsLiveVoice } from "@/lib/backwards-compat/use-supports-live-voice";
 import {
@@ -1032,8 +1030,8 @@ export function ChatComposer({
     : undefined;
 
   // A pill at mobile widths (half the card's 52px collapsed height), the 10px
-  // panel elsewhere, both from the live-voice bar's module: the bar stacks on
-  // this card and has to wear whichever corner it is showing. The banner
+  // panel elsewhere, both shared with the live-voice bar: it stacks on this
+  // card and has to wear whichever corner the card is showing. The banner
   // variants stay literal, since a bottom-only corner is not the same class.
   const cardShapeClass = isMobile
     ? hasBillingBanner

--- a/clients/web/src/domains/chat/components/chat-composer/composer-mobile-chrome.ts
+++ b/clients/web/src/domains/chat/components/chat-composer/composer-mobile-chrome.ts
@@ -1,8 +1,8 @@
 /**
- * The chrome the mobile composer row's controls wear, and the press behaviour
- * every focus-gated control in the mobile composer shares.
+ * The chrome the composer card and its mobile row's controls wear, and the
+ * press behaviour every focus-gated control in the mobile composer shares.
  *
- * Its own module because the controls live outside the composer: the composer
+ * Its own module because the surfaces live outside the composer: the composer
  * assembles the row and passes the switch down, while `VoiceInputButton` and
  * `LiveVoiceButton` paint themselves. Importing the classes back from
  * `chat-composer.tsx` would close a cycle, and re-typing them in each control
@@ -10,6 +10,21 @@
  */
 
 import type { MouseEvent as ReactMouseEvent } from "react";
+
+/**
+ * The chat input's own corner radius, shared with the live-voice bar that
+ * stacks on the card: they sit 8px apart, and two different radii at that
+ * distance read as two unrelated widgets rather than one control area.
+ */
+export const COMPOSER_RADIUS_CLASS = "rounded-[10px]";
+
+/**
+ * The same corner at mobile widths, where the composer card is a 26px pill
+ * (half its 52px collapsed height) rather than the desktop panel. The bar
+ * tracks whichever card it is stacked on, so the two still read as one control
+ * area; a 10px bar over a pill would not.
+ */
+export const COMPOSER_MOBILE_RADIUS_CLASS = "rounded-[26px]";
 
 /**
  * The 40x40 circle the mobile row's controls stand at.

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -32,8 +32,9 @@ mock.module("@/domains/chat/voice/voice-room/voice-mesh-waves", () => ({
   },
 }));
 
-const { COMPOSER_RADIUS_CLASS, VoiceComposerBar } =
+const { VoiceComposerBar } =
   await import("@/domains/chat/components/chat-composer/voice-composer-bar");
+import { COMPOSER_RADIUS_CLASS } from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
 import type { VoiceSurfacePaint } from "@/domains/chat/voice/voice-room/voice-surface-paint";
 import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -69,6 +69,10 @@ import {
   isLiveVoiceMicLive,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  COMPOSER_MOBILE_RADIUS_CLASS,
+  COMPOSER_RADIUS_CLASS,
+} from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 import { VOICE_WAVE_EDGE_FADE_CLASS } from "@/domains/chat/voice/voice-room/voice-listening-waves";
 import {
   MESH_INLINE_TUNING,
@@ -95,23 +99,6 @@ const SILENT_AMPLITUDE = () => 0;
  * beneath it. Touch takes the extra 4px the expanded tap targets want.
  */
 const BAR_HEIGHT_CLASS = "h-10 touch-mobile:h-11";
-
-/**
- * The chat input's own corner radius. Exported so the composer card and this
- * bar can never drift apart: they are stacked with 8px between them, and two
- * different radii at that distance read as two unrelated widgets rather than
- * one control area.
- */
-export const COMPOSER_RADIUS_CLASS = "rounded-[10px]";
-
-/**
- * The same corner at mobile widths, where the composer card is a 26px pill
- * (half its 52px collapsed height) rather than the desktop panel. The bar
- * tracks whichever card it is stacked on, so the two still read as one control
- * area; a 10px bar over a pill would not. Exported for the same reason as its
- * desktop sibling: the card and the bar cannot be allowed to drift.
- */
-export const COMPOSER_MOBILE_RADIUS_CLASS = "rounded-[26px]";
 
 export interface VoiceComposerBarProps {
   state: LiveVoiceSessionState;

--- a/clients/web/src/domains/chat/utils/mime-sniff.ts
+++ b/clients/web/src/domains/chat/utils/mime-sniff.ts
@@ -221,7 +221,14 @@ function normalizeMimeType(raw: string | null): string | null {
   return mime.length > 0 ? mime : null;
 }
 
-function extensionOf(filename: string): string {
+/**
+ * A filename's extension, lowercased, or `""` where it has none.
+ *
+ * Reads only the last path segment, so a directory named `photos.2024` does not
+ * lend its suffix to a dotless file inside it, and a leading dot names a hidden
+ * file rather than an extension.
+ */
+export function extensionOf(filename: string): string {
   const base = filename.slice(filename.lastIndexOf("/") + 1);
   const dot = base.lastIndexOf(".");
   if (dot <= 0) {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review (round 2) for mobile-attachment-tiles.md.

- classifyAttachment compares the base media type (parameters stripped) and shares extensionOf with mime-sniff, so a parameterized PDF or generic-MIME photo classifies the same everywhere and a dotless name never reads as a pdf
- The composer chip renders its preview as a real img with an error fallback, so an undecodable preview drops back to the kind icon on desktop; the composer lightbox never receives a known-dead blob URL
- items-start applies only while a tile is rendered; one pressGuard prop name across tile and chips; tests for every press-guard forward
- Composer radius constants live in composer-mobile-chrome so the tile story no longer imports the voice module graph