### PR TITLE
fix(design-library): copy clean HTML and markdown from rendered markdown

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -356,6 +356,9 @@
     "gateway": {
       "name": "@vellumai/vellum-gateway",
       "version": "0.11.6",
+      "bin": {
+        "gateway": "./src/cli/index.ts",
+      },
       "dependencies": {
         "@vellumai/assistant-client": "workspace:*",
         "@vellumai/ces-client": "workspace:*",
@@ -455,6 +458,7 @@
         "@vitest/runner": "4.1.6",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
+        "happy-dom": "20.10.2",
         "katex": "0.16.47",
         "lucide-react": "1.16.0",
         "playwright": "1.60.0",
@@ -3892,7 +3896,7 @@
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -4520,6 +4524,8 @@
 
     "cheerio/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
+    "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -4629,8 +4635,6 @@
     "googleapis-common/google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
 
     "happy-dom/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
-
-    "happy-dom/whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "iconv-corefoundation/cli-truncate": ["cli-truncate@2.1.0", "", { "dependencies": { "slice-ansi": "^3.0.0", "string-width": "^4.2.0" } }, "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg=="],
 

--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -243,6 +243,11 @@ export function inferProviderFromModel(model: string): string | undefined {
   if (model.startsWith("poolside/")) {
     return "poolside";
   }
+  if (model === "qwen/qwen3-8b") {
+    // The only qwen/* ID the Vellum hosted provider carries; the rest are
+    // OpenRouter's.
+    return "vellum";
+  }
   if (model.includes("/")) {
     return "openrouter";
   }

--- a/packages/design-library/package.json
+++ b/packages/design-library/package.json
@@ -87,6 +87,7 @@
     "@vitest/runner": "4.1.6",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "happy-dom": "20.10.2",
     "katex": "0.16.47",
     "lucide-react": "1.16.0",
     "playwright": "1.60.0",

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -65,6 +65,7 @@ function CopyButton({
       onClick={onClick}
       title={copied ? "Copied!" : "Copy"}
       data-reveal=""
+      data-copy-control=""
       className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-md bg-stone-200/80 text-[var(--content-tertiary)] hover:bg-stone-300 hover:text-[var(--content-secondary)] dark:bg-moss-600/80 dark:hover:bg-moss-500 dark:hover:text-stone-200"
     >
       <div className="relative h-3.5 w-3.5">

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -2,6 +2,7 @@ import { Check, Copy } from "lucide-react";
 import {
   type AnchorHTMLAttributes,
   Children,
+  type ClipboardEvent,
   isValidElement,
   type ReactNode,
   useCallback,
@@ -20,6 +21,10 @@ import type { Components } from "react-markdown";
 import "katex/dist/katex.min.css";
 
 import { cn } from "../utils/cn";
+import {
+  buildSelectionClipboardPayload,
+  isSelectionWithin,
+} from "../utils/selection-clipboard";
 
 const MAX_CODE_BLOCK_HEIGHT = 400;
 
@@ -127,7 +132,10 @@ function CodeBlockWrapper({ children }: { children: ReactNode }) {
       className="relative mb-2 overflow-hidden rounded-md bg-stone-100 last:mb-0 dark:bg-moss-800"
     >
       {language && (
-        <div className="flex items-center justify-between px-3 pt-2">
+        <div
+          data-code-block-header=""
+          className="flex items-center justify-between px-3 pt-2"
+        >
           {/* typography: off-scale — monospace language label */}
           {}
           <span className="font-mono text-xs font-medium uppercase text-[var(--content-tertiary)]">
@@ -899,6 +907,32 @@ function remarkPreserveOrderedListNumbers() {
   };
 }
 
+/**
+ * Replace the browser's `copy` payload for a selection that lies entirely
+ * within the rendered markdown. The browser's own HTML flavor inlines
+ * computed background colors (grey shading when pasted into Outlook) and its
+ * plain-text flavor is a flat dump with a blank line after every block. The
+ * replacement is semantic HTML plus markdown. See
+ * `buildSelectionClipboardPayload`.
+ *
+ * A selection that reaches outside the message is left to the browser.
+ */
+function handleSelectionCopy(event: ClipboardEvent<HTMLDivElement>) {
+  const root = event.currentTarget;
+  const selection = root.ownerDocument.defaultView?.getSelection();
+  if (
+    !selection ||
+    !event.clipboardData ||
+    !isSelectionWithin(selection, root)
+  ) {
+    return;
+  }
+  const payload = buildSelectionClipboardPayload(selection, root.ownerDocument);
+  event.clipboardData.setData("text/html", payload.html);
+  event.clipboardData.setData("text/plain", payload.text);
+  event.preventDefault();
+}
+
 export interface MarkdownMessageProps {
   content: string;
   className?: string;
@@ -994,6 +1028,7 @@ export function MarkdownMessage({
     <div
       data-slot="markdown-message"
       className={cn("text-chat text-[var(--content-default)]", className)}
+      onCopy={handleSelectionCopy}
     >
       <ReactMarkdown
         remarkPlugins={[

--- a/packages/design-library/src/utils/selection-clipboard.test.ts
+++ b/packages/design-library/src/utils/selection-clipboard.test.ts
@@ -1,0 +1,243 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+
+import {
+  buildSelectionClipboardPayload,
+  isSelectionWithin,
+} from "./selection-clipboard";
+
+const window = new Window();
+const document = window.document as unknown as Document;
+
+afterAll(() => {
+  void window.close();
+});
+
+/**
+ * Render `html` into a fresh root, select `target` (a CSS selector, default
+ * the whole root), and return the root plus the live selection.
+ */
+function selectIn(html: string, target?: string) {
+  const root = document.createElement("div");
+  root.innerHTML = html;
+  document.body.appendChild(root);
+  const selection = document.getSelection();
+  if (!selection) {
+    throw new Error("no selection");
+  }
+  selection.removeAllRanges();
+  const range = document.createRange();
+  range.selectNodeContents(
+    target ? (root.querySelector(target) ?? root) : root,
+  );
+  selection.addRange(range);
+  return { root, selection };
+}
+
+function payloadFor(html: string, target?: string) {
+  const { selection } = selectIn(html, target);
+  return buildSelectionClipboardPayload(selection, document);
+}
+
+describe("html flavor", () => {
+  test("keeps semantic tags and drops classes, styles, and data attributes", () => {
+    const { html } = payloadFor(
+      '<p class="mb-3" data-x="1" style="background: grey"><strong class="font-bold">Hi</strong> <a class="link" href="https://example.com" target="_blank" rel="noopener">there</a></p>',
+    );
+    expect(html).toBe(
+      '<p><strong>Hi</strong> <a href="https://example.com">there</a></p>',
+    );
+  });
+
+  test("strips the code block header row and its grey wrapper", () => {
+    const { html } = payloadFor(
+      '<div class="bg-stone-100"><div data-code-block-header=""><span>sql</span><button>Copy</button></div><pre class="p-3" style="max-height: 400px"><code class="language-sql">SELECT 1</code></pre></div>',
+    );
+    expect(html).not.toContain("<button");
+    expect(html).not.toContain("class=");
+    expect(html).not.toContain("style=");
+    expect(html).not.toContain("sql</span>");
+    expect(html).toContain("<pre><code>SELECT 1</code></pre>");
+  });
+
+  test("keeps ordered list start, pinned item ordinals, and image src/alt", () => {
+    const { html } = payloadFor(
+      '<ol start="3" class="list"><li value="4">a</li></ol><img src="x.png" alt="pic" class="w-4">',
+    );
+    expect(html).toBe(
+      '<ol start="3"><li value="4">a</li></ol><img src="x.png" alt="pic">',
+    );
+  });
+
+  test("drops aria-hidden KaTeX duplicates", () => {
+    const { html } = payloadFor(
+      '<p><span class="katex"><span class="katex-mathml">x</span><span class="katex-html" aria-hidden="true">x</span></span></p>',
+    );
+    expect(html).not.toContain("aria-hidden");
+    expect(html).toBe("<p><span><span>x</span></span></p>");
+  });
+});
+
+describe("markdown flavor", () => {
+  test("separates paragraphs by one blank line and list items by one newline", () => {
+    const { text } = payloadFor(
+      "<p>First.</p><p>Second.</p><ul><li>one</li><li>two</li></ul><p>Third.</p>",
+    );
+    expect(text).toBe("First.\n\nSecond.\n\n- one\n- two\n\nThird.");
+  });
+
+  test("renders headings with their level's hashes", () => {
+    const { text } = payloadFor(
+      "<h1>One</h1><p>body</p><h3>Three</h3><h6>Six</h6>",
+    );
+    expect(text).toBe("# One\n\nbody\n\n### Three\n\n###### Six");
+  });
+
+  test("renders bold, italic, strikethrough, links, and inline code", () => {
+    const { text } = payloadFor(
+      '<p><strong>bold</strong> and <em>italic</em> and <del>gone</del>, a <a href="https://example.com">link</a>, and <code class="rounded">useState()</code>.</p>',
+    );
+    expect(text).toBe(
+      "**bold** and _italic_ and ~~gone~~, a [link](https://example.com), and `useState()`.",
+    );
+  });
+
+  test("keeps emphasis markers tight against their content", () => {
+    const { text } = payloadFor("<p>a <strong> bold </strong>b</p>");
+    expect(text).toBe("a **bold** b");
+  });
+
+  test("leaves an autolink unwrapped", () => {
+    const { text } = payloadFor(
+      '<p><a href="https://example.com">https://example.com</a></p>',
+    );
+    expect(text).toBe("https://example.com");
+  });
+
+  test("grows the inline code delimiter past backticks in the content", () => {
+    const { text } = payloadFor("<p><code>a ` b</code></p>");
+    expect(text).toBe("``a ` b``");
+  });
+
+  test("renders images as markdown", () => {
+    const { text } = payloadFor('<p><img src="x.png" alt="a cat"></p>');
+    expect(text).toBe("![a cat](x.png)");
+  });
+
+  test("numbers ordered lists from their start and honors pinned ordinals", () => {
+    const { text } = payloadFor(
+      '<ol start="4"><li>four</li><li>five</li><li value="9">nine</li></ol>',
+    );
+    expect(text).toBe("4. four\n5. five\n9. nine");
+  });
+
+  test("indents a nested list under its parent item", () => {
+    const { text } = payloadFor(
+      "<ul><li>one<ul><li>nested</li><li>also nested</li></ul></li><li>two</li></ul>",
+    );
+    expect(text).toBe("- one\n  - nested\n  - also nested\n- two");
+  });
+
+  test("indents a list nested under an ordered item by the marker width", () => {
+    const { text } = payloadFor(
+      "<ol><li>first<ul><li>nested</li></ul></li></ol>",
+    );
+    expect(text).toBe("1. first\n   - nested");
+  });
+
+  test("prefixes every line of a blockquote, blank lines included", () => {
+    const { text } = payloadFor(
+      "<blockquote><div><p>First para.</p><p>Second para.</p></div></blockquote>",
+    );
+    expect(text).toBe("> First para.\n>\n> Second para.");
+  });
+
+  test("renders a code block as a fence with its language and indentation", () => {
+    const { text } = payloadFor(
+      '<p>Run:</p><div data-code-block-header=""><span>ts</span><button>Copy</button></div><pre><code class="block font-mono language-ts">function f() {\n  return 1;\n}\n</code></pre>',
+    );
+    expect(text).toBe("Run:\n\n```ts\nfunction f() {\n  return 1;\n}\n```");
+  });
+
+  test("grows the fence past a backtick run inside the code", () => {
+    const { text } = payloadFor("<pre><code>const fence = ```;</code></pre>");
+    expect(text).toBe("````\nconst fence = ```;\n````");
+  });
+
+  test("renders tables as GFM pipes with a separator row", () => {
+    const { text } = payloadFor(
+      "<table><thead><tr><th>A</th><th>B</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>",
+    );
+    expect(text).toBe("| A | B |\n| --- | --- |\n| 1 | 2 |");
+  });
+
+  test("escapes pipes inside table cells", () => {
+    const { text } = payloadFor(
+      "<table><tr><th>Op</th></tr><tr><td><code>a | b</code></td></tr></table>",
+    );
+    expect(text).toBe("| Op |\n| --- |\n| `a \\| b` |");
+  });
+
+  test("renders a horizontal rule", () => {
+    const { text } = payloadFor("<p>above</p><hr><p>below</p>");
+    expect(text).toBe("above\n\n---\n\nbelow");
+  });
+
+  test("tolerates react-markdown's newline text nodes between blocks", () => {
+    const { text } = payloadFor(
+      "<p>Hello,</p>\n<p>Thanks for reaching out.</p>\n<p>Best,<br>Alice</p>",
+    );
+    expect(text).toBe("Hello,\n\nThanks for reaching out.\n\nBest,\nAlice");
+  });
+
+  test("collapses whitespace in prose", () => {
+    const { text } = payloadFor("<p>a  b\n   c</p>");
+    expect(text).toBe("a b c");
+  });
+
+  test("skips the copy button and aria-hidden KaTeX duplicates", () => {
+    const { text } = payloadFor(
+      '<p><span class="katex"><span class="katex-mathml">x</span><span class="katex-html" aria-hidden="true">x</span></span><button>Copy</button></p>',
+    );
+    expect(text).toBe("x");
+  });
+
+  test("a partial selection within a paragraph copies only the selected text", () => {
+    const { root, selection } = selectIn("<p>Hello wide world</p>");
+    const textNode = root.querySelector("p")?.firstChild;
+    if (!textNode) {
+      throw new Error("no text node");
+    }
+    selection.removeAllRanges();
+    const range = document.createRange();
+    range.setStart(textNode, 6);
+    range.setEnd(textNode, 10);
+    selection.addRange(range);
+    const payload = buildSelectionClipboardPayload(selection, document);
+    expect(payload.text).toBe("wide");
+    expect(payload.html).toBe("wide");
+  });
+});
+
+describe("isSelectionWithin", () => {
+  test("is true when the whole selection is inside the container", () => {
+    const { root, selection } = selectIn("<p>a</p><p>b</p>", "p:last-child");
+    expect(isSelectionWithin(selection, root)).toBe(true);
+  });
+
+  test("is false for a collapsed selection", () => {
+    const { root, selection } = selectIn("<p>a</p>");
+    selection.collapseToStart();
+    expect(isSelectionWithin(selection, root)).toBe(false);
+  });
+
+  test("is false when the selection reaches outside the container", () => {
+    const { root, selection } = selectIn("<p>a</p>");
+    const outside = document.createElement("p");
+    outside.textContent = "outside";
+    document.body.appendChild(outside);
+    const range = selection.getRangeAt(0);
+    range.setEnd(outside.firstChild as Node, 3);
+    expect(isSelectionWithin(selection, root)).toBe(false);
+  });
+});

--- a/packages/design-library/src/utils/selection-clipboard.test.ts
+++ b/packages/design-library/src/utils/selection-clipboard.test.ts
@@ -69,6 +69,14 @@ describe("html flavor", () => {
     );
   });
 
+  test("keeps a task list checkbox a checkbox", () => {
+    const { html } = payloadFor(
+      '<ul><li class="task"><input type="checkbox" disabled="" checked=""> done</li></ul>',
+    );
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain("checked");
+  });
+
   test("drops aria-hidden KaTeX duplicates", () => {
     const { html } = payloadFor(
       '<p><span class="katex"><span class="katex-mathml">x</span><span class="katex-html" aria-hidden="true">x</span></span></p>',
@@ -105,6 +113,20 @@ describe("markdown flavor", () => {
   test("keeps emphasis markers tight against their content", () => {
     const { text } = payloadFor("<p>a <strong> bold </strong>b</p>");
     expect(text).toBe("a **bold** b");
+  });
+
+  test("switches the marker for emphasis nested in the same emphasis", () => {
+    const { text } = payloadFor(
+      "<p><em>italic <em>inner</em> tail</em> and <strong>bold <strong>inner</strong></strong></p>",
+    );
+    expect(text).toBe("_italic *inner* tail_ and **bold __inner__**");
+  });
+
+  test("renders task list items as GFM checkboxes", () => {
+    const { text } = payloadFor(
+      '<ul><li><input type="checkbox" disabled=""> open task</li><li><input type="checkbox" disabled="" checked=""> done task</li></ul>',
+    );
+    expect(text).toBe("- [ ] open task\n- [x] done task");
   });
 
   test("leaves an autolink unwrapped", () => {

--- a/packages/design-library/src/utils/selection-clipboard.test.ts
+++ b/packages/design-library/src/utils/selection-clipboard.test.ts
@@ -49,9 +49,17 @@ describe("html flavor", () => {
     );
   });
 
+  test("keeps the content of a button that is not a copy control", () => {
+    const { html, text } = payloadFor(
+      '<p>Open <button type="button" class="chip"><code>src/app.ts</code></button> now.</p>',
+    );
+    expect(html).toBe("<p>Open <code>src/app.ts</code> now.</p>");
+    expect(text).toBe("Open `src/app.ts` now.");
+  });
+
   test("strips the code block header row and its grey wrapper", () => {
     const { html } = payloadFor(
-      '<div class="bg-stone-100"><div data-code-block-header=""><span>sql</span><button>Copy</button></div><pre class="p-3" style="max-height: 400px"><code class="language-sql">SELECT 1</code></pre></div>',
+      '<div class="bg-stone-100"><div data-code-block-header=""><span>sql</span><button data-copy-control="">Copy</button></div><pre class="p-3" style="max-height: 400px"><code class="language-sql">SELECT 1</code></pre></div>',
     );
     expect(html).not.toContain("<button");
     expect(html).not.toContain("class=");
@@ -153,6 +161,13 @@ describe("markdown flavor", () => {
     expect(text).toBe("4. four\n5. five\n9. nine");
   });
 
+  test("continues numbering from a pinned ordinal, not from the list start", () => {
+    const { text } = payloadFor(
+      '<ol><li>one</li><li>two</li><li value="4">four</li><li>five</li></ol>',
+    );
+    expect(text).toBe("1. one\n2. two\n4. four\n5. five");
+  });
+
   test("indents a nested list under its parent item", () => {
     const { text } = payloadFor(
       "<ul><li>one<ul><li>nested</li><li>also nested</li></ul></li><li>two</li></ul>",
@@ -176,7 +191,7 @@ describe("markdown flavor", () => {
 
   test("renders a code block as a fence with its language and indentation", () => {
     const { text } = payloadFor(
-      '<p>Run:</p><div data-code-block-header=""><span>ts</span><button>Copy</button></div><pre><code class="block font-mono language-ts">function f() {\n  return 1;\n}\n</code></pre>',
+      '<p>Run:</p><div data-code-block-header=""><span>ts</span><button data-copy-control="">Copy</button></div><pre><code class="block font-mono language-ts">function f() {\n  return 1;\n}\n</code></pre>',
     );
     expect(text).toBe("Run:\n\n```ts\nfunction f() {\n  return 1;\n}\n```");
   });
@@ -219,7 +234,7 @@ describe("markdown flavor", () => {
 
   test("skips the copy button and aria-hidden KaTeX duplicates", () => {
     const { text } = payloadFor(
-      '<p><span class="katex"><span class="katex-mathml">x</span><span class="katex-html" aria-hidden="true">x</span></span><button>Copy</button></p>',
+      '<p><span class="katex"><span class="katex-mathml">x</span><span class="katex-html" aria-hidden="true">x</span></span><button data-copy-control="">Copy</button></p>',
     );
     expect(text).toBe("x");
   });

--- a/packages/design-library/src/utils/selection-clipboard.ts
+++ b/packages/design-library/src/utils/selection-clipboard.ts
@@ -31,15 +31,19 @@ const KEPT_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
 };
 
 /**
- * Elements that never carry copyable content: interactive chrome (the code
- * block copy button and the header row it sits in, whose language label the
+ * Elements that never carry copyable content: marked chrome (the code block
+ * copy control and the header row it sits in, whose language label the
  * markdown fence already states) and presentational duplicates (KaTeX renders
  * both a visual `aria-hidden` layer and an accessible MathML layer for one
  * formula; copying both would repeat the formula).
+ *
+ * Matching is by marker, not by tag: a consumer can render real content inside
+ * a `<button>` (a workspace path that opens a file, a previewable image), and
+ * dropping every button would silently omit it from the copy.
  */
 function isChrome(element: Element): boolean {
   return (
-    element.tagName === "BUTTON" ||
+    element.hasAttribute("data-copy-control") ||
     element.hasAttribute("data-code-block-header") ||
     element.getAttribute("aria-hidden") === "true"
   );
@@ -51,6 +55,23 @@ function pruneChrome(root: ParentNode): void {
     if (isChrome(element)) {
       element.remove();
     }
+  }
+}
+
+/**
+ * Replace the buttons that survived pruning with their own children. Their
+ * content is real, but `<button>` means nothing in a pasted document.
+ */
+function unwrapButtons(root: ParentNode): void {
+  for (const button of Array.from(root.querySelectorAll("button"))) {
+    const parent = button.parentNode;
+    if (!parent) {
+      continue;
+    }
+    while (button.firstChild) {
+      parent.insertBefore(button.firstChild, button);
+    }
+    parent.removeChild(button);
   }
 }
 
@@ -221,23 +242,28 @@ function renderList(list: Element): string {
   const items = Array.from(list.children).filter(
     (child) => child.tagName === "LI",
   );
+  let next = Number.isNaN(start) ? 1 : start;
   return items
-    .map((item, index) => {
-      const marker = ordered
-        ? `${itemNumber(item, Number.isNaN(start) ? 1 : start, index)}. `
-        : "- ";
-      return renderListItem(item, marker);
+    .map((item) => {
+      if (!ordered) {
+        return renderListItem(item, "- ");
+      }
+      const number = itemNumber(item, next);
+      next = number + 1;
+      return renderListItem(item, `${number}. `);
     })
     .join("\n");
 }
 
 /**
  * A list item's own ordinal when the renderer pinned one via `value`,
- * otherwise its position counted from the list's `start`.
+ * otherwise the count carried from the item above it. Counting from the
+ * running position rather than the list's `start` keeps the items after a
+ * pinned jump in sequence with the jump.
  */
-function itemNumber(item: Element, start: number, index: number): number {
+function itemNumber(item: Element, next: number): number {
   const pinned = Number.parseInt(item.getAttribute("value") ?? "", 10);
-  return Number.isNaN(pinned) ? start + index : pinned;
+  return Number.isNaN(pinned) ? next : pinned;
 }
 
 /**
@@ -492,6 +518,7 @@ function cloneSelection(
     container.appendChild(selection.getRangeAt(i).cloneContents());
   }
   pruneChrome(container);
+  unwrapButtons(container);
   return container;
 }
 

--- a/packages/design-library/src/utils/selection-clipboard.ts
+++ b/packages/design-library/src/utils/selection-clipboard.ts
@@ -22,6 +22,8 @@
 const KEPT_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
   a: ["href"],
   img: ["src", "alt"],
+  // A task list checkbox reads as a text field without its type.
+  input: ["type", "checked", "disabled"],
   ol: ["start"],
   li: ["value"],
   td: ["colspan", "rowspan"],
@@ -239,11 +241,29 @@ function itemNumber(item: Element, start: number, index: number): number {
 }
 
 /**
+ * The GFM task box for an item whose renderer emitted a checkbox, so a copied
+ * checklist pastes back as a checklist.
+ */
+function taskBox(item: Element): string {
+  const checkbox = Array.from(item.children).find(
+    (child) =>
+      child.tagName === "INPUT" && child.getAttribute("type") === "checkbox",
+  );
+  if (!checkbox) {
+    return "";
+  }
+  const checked =
+    (checkbox as HTMLInputElement).checked || checkbox.hasAttribute("checked");
+  return checked ? "[x] " : "[ ] ";
+}
+
+/**
  * Render one list item: the marker opens the first line and every following
  * line is indented to the marker's width, which is what makes a nested list
  * nest.
  */
 function renderListItem(item: Element, marker: string): string {
+  const opener = `${marker}${taskBox(item)}`;
   const blocks = renderBlocks(item);
   let body = "";
   blocks.forEach((block, index) => {
@@ -258,7 +278,7 @@ function renderListItem(item: Element, marker: string): string {
     .split("\n")
     .map((line, index) => {
       if (index === 0) {
-        return `${marker}${line}`;
+        return `${opener}${line}`;
       }
       return line === "" ? "" : `${indent}${line}`;
     })
@@ -330,7 +350,21 @@ function renderCell(cell: Element): string {
   return renderOneLine(cell).replace(/\|/g, "\\|");
 }
 
-function renderInline(node: Node): string {
+/**
+ * Emphasis already open around a node. Nesting the same marker twice is
+ * ambiguous in markdown, so the inner one switches to the other spelling.
+ */
+interface EmphasisContext {
+  em: boolean;
+  strong: boolean;
+}
+
+const NO_EMPHASIS: EmphasisContext = { em: false, strong: false };
+
+function renderInline(
+  node: Node,
+  context: EmphasisContext = NO_EMPHASIS,
+): string {
   if (node.nodeType === node.TEXT_NODE) {
     return (node.textContent ?? "").replace(/\s+/g, " ");
   }
@@ -344,18 +378,24 @@ function renderInline(node: Node): string {
   if (tag === "IMG") {
     return `![${node.getAttribute("alt") ?? ""}](${node.getAttribute("src") ?? ""})`;
   }
-  const inner = renderInlineChildren(node);
+  if (tag === "STRONG" || tag === "B") {
+    const inner = renderInlineChildren(node, { ...context, strong: true });
+    return inner.trim() === ""
+      ? inner
+      : wrapEmphasis(inner, context.strong ? "__" : "**");
+  }
+  if (tag === "EM" || tag === "I") {
+    const inner = renderInlineChildren(node, { ...context, em: true });
+    return inner.trim() === ""
+      ? inner
+      : wrapEmphasis(inner, context.em ? "*" : "_");
+  }
+  const inner = renderInlineChildren(node, context);
   if (tag === "CODE") {
     return wrapCode(inner);
   }
   if (inner.trim() === "") {
     return inner;
-  }
-  if (tag === "STRONG" || tag === "B") {
-    return wrapEmphasis(inner, "**");
-  }
-  if (tag === "EM" || tag === "I") {
-    return wrapEmphasis(inner, "_");
   }
   if (tag === "DEL" || tag === "S" || tag === "STRIKE") {
     return wrapEmphasis(inner, "~~");
@@ -366,8 +406,13 @@ function renderInline(node: Node): string {
   return inner;
 }
 
-function renderInlineChildren(element: Element): string {
-  return Array.from(element.childNodes).map(renderInline).join("");
+function renderInlineChildren(
+  element: Element,
+  context: EmphasisContext = NO_EMPHASIS,
+): string {
+  return Array.from(element.childNodes)
+    .map((child) => renderInline(child, context))
+    .join("");
 }
 
 /** Split off the whitespace around `text`, which markers may not enclose. */

--- a/packages/design-library/src/utils/selection-clipboard.ts
+++ b/packages/design-library/src/utils/selection-clipboard.ts
@@ -1,0 +1,469 @@
+/**
+ * Clipboard payloads for a text selection inside rendered markdown.
+ *
+ * The browser's own `copy` serialization has two problems for prose that is
+ * pasted elsewhere:
+ *
+ * - Its `text/html` flavor inlines the *computed* styles of every selected
+ *   node and its ancestors, background colors included. A code block or
+ *   blockquote therefore pastes into Outlook (Word engine) with grey shading.
+ * - Its `text/plain` flavor is a flat text dump: block structure becomes a
+ *   blank line after every block, list items included, and every marker,
+ *   fence, and emphasis the rendered message showed is gone.
+ *
+ * Both payloads here are built from a clone of the selected DOM instead. The
+ * HTML flavor keeps only semantic tags and the handful of attributes that
+ * carry meaning. The plain flavor is markdown, so a paste into a
+ * markdown-aware box (the composer, Slack, GitHub, Notion) round-trips the
+ * formatting the reader selected.
+ */
+
+/** Attributes that carry meaning outside our stylesheet, per tag. */
+const KEPT_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
+  a: ["href"],
+  img: ["src", "alt"],
+  ol: ["start"],
+  li: ["value"],
+  td: ["colspan", "rowspan"],
+  th: ["colspan", "rowspan"],
+};
+
+/**
+ * Elements that never carry copyable content: interactive chrome (the code
+ * block copy button and the header row it sits in, whose language label the
+ * markdown fence already states) and presentational duplicates (KaTeX renders
+ * both a visual `aria-hidden` layer and an accessible MathML layer for one
+ * formula; copying both would repeat the formula).
+ */
+function isChrome(element: Element): boolean {
+  return (
+    element.tagName === "BUTTON" ||
+    element.hasAttribute("data-code-block-header") ||
+    element.getAttribute("aria-hidden") === "true"
+  );
+}
+
+/** Drop every chrome element from a cloned fragment. */
+function pruneChrome(root: ParentNode): void {
+  for (const element of Array.from(root.querySelectorAll("*"))) {
+    if (isChrome(element)) {
+      element.remove();
+    }
+  }
+}
+
+/**
+ * Strip a cloned fragment down to semantic markup: every attribute outside
+ * `KEPT_ATTRIBUTES` is dropped, so no class, inline style, or data attribute
+ * survives.
+ */
+function stripAttributes(root: ParentNode): void {
+  for (const element of Array.from(root.querySelectorAll("*"))) {
+    const kept = KEPT_ATTRIBUTES[element.tagName.toLowerCase()] ?? [];
+    for (const name of Array.from(element.getAttributeNames())) {
+      if (!kept.includes(name)) {
+        element.removeAttribute(name);
+      }
+    }
+  }
+}
+
+const HEADING_LEVELS: Readonly<Record<string, number>> = {
+  H1: 1,
+  H2: 2,
+  H3: 3,
+  H4: 4,
+  H5: 5,
+  H6: 6,
+};
+
+/**
+ * Tags that open their own block. Anything else is inline and joins the run
+ * of text around it.
+ */
+const BLOCK_TAGS: ReadonlySet<string> = new Set([
+  "ARTICLE",
+  "ASIDE",
+  "BLOCKQUOTE",
+  "DIV",
+  "FIGURE",
+  "FOOTER",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "HEADER",
+  "HR",
+  "LI",
+  "MAIN",
+  "OL",
+  "P",
+  "PRE",
+  "SECTION",
+  "TABLE",
+  "TR",
+  "UL",
+]);
+
+interface MarkdownBlock {
+  /** Tag that produced the block, so joiners can keep nested lists tight. */
+  tag: string;
+  text: string;
+}
+
+function isElement(node: Node): node is Element {
+  return node.nodeType === node.ELEMENT_NODE;
+}
+
+/**
+ * Render the children of `node` as a list of markdown blocks. Runs of inline
+ * content between block children collapse into a paragraph block; whitespace
+ * that only separates block tags in the source collapses away entirely.
+ */
+function renderBlocks(node: Node): MarkdownBlock[] {
+  const blocks: MarkdownBlock[] = [];
+  let inline = "";
+
+  const flushInline = () => {
+    // Markers pushed outside their own padding can leave a doubled space
+    // where the surrounding text already ended in one.
+    const text = inline
+      .replace(/[ \t]{2,}/g, " ")
+      .replace(/[ \t]+$/gm, "")
+      .trim();
+    if (text !== "") {
+      blocks.push({ tag: "P", text });
+    }
+    inline = "";
+  };
+
+  for (const child of Array.from(node.childNodes)) {
+    if (isElement(child) && BLOCK_TAGS.has(child.tagName)) {
+      flushInline();
+      const text = renderBlock(child);
+      if (text !== "") {
+        blocks.push({ tag: child.tagName, text });
+      }
+      continue;
+    }
+    inline += renderInline(child);
+  }
+  flushInline();
+
+  return blocks;
+}
+
+/** Join blocks the way markdown separates them: one blank line between. */
+function joinBlocks(blocks: MarkdownBlock[]): string {
+  return blocks.map((block) => block.text).join("\n\n");
+}
+
+/** Render the children of `node` as one markdown string. */
+function renderContainer(node: Node): string {
+  return joinBlocks(renderBlocks(node));
+}
+
+/** Render the children of `node` as a single line, for headings and cells. */
+function renderOneLine(node: Node): string {
+  return renderContainer(node)
+    .replace(/\s*\n\s*/g, " ")
+    .trim();
+}
+
+function renderBlock(element: Element): string {
+  const tag = element.tagName;
+  if (tag === "HR") {
+    return "---";
+  }
+  if (tag === "PRE") {
+    return renderFencedCode(element);
+  }
+  if (tag === "TABLE") {
+    return renderTable(element);
+  }
+  if (tag === "TR") {
+    return renderTableRow(cellsOf(element));
+  }
+  if (tag === "UL" || tag === "OL") {
+    return renderList(element);
+  }
+  if (tag === "LI") {
+    // A list item cloned without its list, as happens when a selection starts
+    // mid-list, still reads as one.
+    return renderListItem(element, "- ");
+  }
+  if (tag === "BLOCKQUOTE") {
+    return quoteLines(renderContainer(element));
+  }
+  const level = HEADING_LEVELS[tag];
+  if (level !== undefined) {
+    const heading = renderOneLine(element);
+    return heading === "" ? "" : `${"#".repeat(level)} ${heading}`;
+  }
+  return renderContainer(element);
+}
+
+/** Prefix every line of a blockquote's content, blank lines included. */
+function quoteLines(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line === "" ? ">" : `> ${line}`))
+    .join("\n");
+}
+
+function renderList(list: Element): string {
+  const ordered = list.tagName === "OL";
+  const start = Number.parseInt(list.getAttribute("start") ?? "1", 10);
+  const items = Array.from(list.children).filter(
+    (child) => child.tagName === "LI",
+  );
+  return items
+    .map((item, index) => {
+      const marker = ordered
+        ? `${itemNumber(item, Number.isNaN(start) ? 1 : start, index)}. `
+        : "- ";
+      return renderListItem(item, marker);
+    })
+    .join("\n");
+}
+
+/**
+ * A list item's own ordinal when the renderer pinned one via `value`,
+ * otherwise its position counted from the list's `start`.
+ */
+function itemNumber(item: Element, start: number, index: number): number {
+  const pinned = Number.parseInt(item.getAttribute("value") ?? "", 10);
+  return Number.isNaN(pinned) ? start + index : pinned;
+}
+
+/**
+ * Render one list item: the marker opens the first line and every following
+ * line is indented to the marker's width, which is what makes a nested list
+ * nest.
+ */
+function renderListItem(item: Element, marker: string): string {
+  const blocks = renderBlocks(item);
+  let body = "";
+  blocks.forEach((block, index) => {
+    if (index > 0) {
+      // A nested list belongs to the item above it, so it stays tight.
+      body += block.tag === "UL" || block.tag === "OL" ? "\n" : "\n\n";
+    }
+    body += block.text;
+  });
+  const indent = " ".repeat(marker.length);
+  return body
+    .split("\n")
+    .map((line, index) => {
+      if (index === 0) {
+        return `${marker}${line}`;
+      }
+      return line === "" ? "" : `${indent}${line}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Render a code block as a fence. The language comes from the
+ * `language-<name>` class react-markdown puts on the inner `<code>`, and the
+ * fence grows past any backtick run in the body so the block cannot be closed
+ * early.
+ */
+function renderFencedCode(pre: Element): string {
+  const code = pre.querySelector("code");
+  const language = code ? codeLanguage(code) : "";
+  const body = ((code ?? pre).textContent ?? "").replace(/\n+$/, "");
+  const fence = "`".repeat(Math.max(3, longestBacktickRun(body) + 1));
+  return `${fence}${language}\n${body}\n${fence}`;
+}
+
+function codeLanguage(code: Element): string {
+  const match = /(?:^|\s)language-([\w+#.-]+)/.exec(
+    code.getAttribute("class") ?? "",
+  );
+  return match ? match[1] : "";
+}
+
+function longestBacktickRun(text: string): number {
+  let longest = 0;
+  for (const run of text.matchAll(/`+/g)) {
+    longest = Math.max(longest, run[0].length);
+  }
+  return longest;
+}
+
+function cellsOf(row: Element): Element[] {
+  return Array.from(row.children).filter(
+    (child) => child.tagName === "TD" || child.tagName === "TH",
+  );
+}
+
+/** Render a table as GFM pipes, with a separator row under the header. */
+function renderTable(table: Element): string {
+  const rows = Array.from(table.querySelectorAll("tr")).map(cellsOf);
+  if (rows.length === 0) {
+    return "";
+  }
+  const width = Math.max(...rows.map((cells) => cells.length));
+  const lines = [
+    renderTableRow(rows[0], width),
+    `| ${Array.from({ length: width }, () => "---").join(" | ")} |`,
+  ];
+  for (const cells of rows.slice(1)) {
+    lines.push(renderTableRow(cells, width));
+  }
+  return lines.join("\n");
+}
+
+function renderTableRow(cells: Element[], width = cells.length): string {
+  const rendered = Array.from(
+    { length: Math.max(width, cells.length) },
+    (_, index) => (cells[index] ? renderCell(cells[index]) : ""),
+  );
+  return `| ${rendered.join(" | ")} |`;
+}
+
+/** A cell is one line, and its pipes are escaped so they stay content. */
+function renderCell(cell: Element): string {
+  return renderOneLine(cell).replace(/\|/g, "\\|");
+}
+
+function renderInline(node: Node): string {
+  if (node.nodeType === node.TEXT_NODE) {
+    return (node.textContent ?? "").replace(/\s+/g, " ");
+  }
+  if (!isElement(node)) {
+    return "";
+  }
+  const tag = node.tagName;
+  if (tag === "BR") {
+    return "\n";
+  }
+  if (tag === "IMG") {
+    return `![${node.getAttribute("alt") ?? ""}](${node.getAttribute("src") ?? ""})`;
+  }
+  const inner = renderInlineChildren(node);
+  if (tag === "CODE") {
+    return wrapCode(inner);
+  }
+  if (inner.trim() === "") {
+    return inner;
+  }
+  if (tag === "STRONG" || tag === "B") {
+    return wrapEmphasis(inner, "**");
+  }
+  if (tag === "EM" || tag === "I") {
+    return wrapEmphasis(inner, "_");
+  }
+  if (tag === "DEL" || tag === "S" || tag === "STRIKE") {
+    return wrapEmphasis(inner, "~~");
+  }
+  if (tag === "A") {
+    return renderLink(node, inner);
+  }
+  return inner;
+}
+
+function renderInlineChildren(element: Element): string {
+  return Array.from(element.childNodes).map(renderInline).join("");
+}
+
+/** Split off the whitespace around `text`, which markers may not enclose. */
+function splitPadding(text: string): [string, string, string] {
+  const match = /^(\s*)([\s\S]*?)(\s*)$/.exec(text);
+  if (!match) {
+    return ["", text, ""];
+  }
+  return [match[1], match[2], match[3]];
+}
+
+function wrapEmphasis(text: string, marker: string): string {
+  const [lead, core, trail] = splitPadding(text);
+  return `${lead}${marker}${core}${marker}${trail}`;
+}
+
+/**
+ * Wrap an inline code span. The delimiter grows past any backtick run in the
+ * content, and a content edge that is itself a backtick gets a space so the
+ * delimiter stays distinguishable.
+ */
+function wrapCode(text: string): string {
+  const [lead, core, trail] = splitPadding(text);
+  if (core === "") {
+    return text;
+  }
+  const delimiter = "`".repeat(longestBacktickRun(core) + 1);
+  const pad = core.startsWith("`") || core.endsWith("`") ? " " : "";
+  return `${lead}${delimiter}${pad}${core}${pad}${delimiter}${trail}`;
+}
+
+/** An anchor whose text is its own href is an autolink and needs no wrapper. */
+function renderLink(anchor: Element, text: string): string {
+  const href = anchor.getAttribute("href") ?? "";
+  const [lead, core, trail] = splitPadding(text);
+  if (href === "" || href === core) {
+    return text;
+  }
+  return `${lead}[${core}](${href})${trail}`;
+}
+
+export interface SelectionClipboardPayload {
+  html: string;
+  text: string;
+}
+
+/**
+ * True when every end of `selection` lies inside `container`. A selection
+ * that reaches outside is left to the browser, since building a payload from
+ * only the inside part would silently drop the rest.
+ */
+export function isSelectionWithin(
+  selection: Selection,
+  container: Node,
+): boolean {
+  if (selection.rangeCount === 0 || selection.isCollapsed) {
+    return false;
+  }
+  for (let i = 0; i < selection.rangeCount; i++) {
+    const range = selection.getRangeAt(i);
+    if (
+      !container.contains(range.startContainer) ||
+      !container.contains(range.endContainer)
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function cloneSelection(
+  selection: Selection,
+  ownerDocument: Document,
+): HTMLElement {
+  const container = ownerDocument.createElement("div");
+  for (let i = 0; i < selection.rangeCount; i++) {
+    container.appendChild(selection.getRangeAt(i).cloneContents());
+  }
+  pruneChrome(container);
+  return container;
+}
+
+/**
+ * Build clean `text/html` and markdown `text/plain` payloads for `selection`.
+ * Each flavor gets its own clone, since markdown reads the class names that
+ * the HTML flavor strips. The live DOM is untouched.
+ */
+export function buildSelectionClipboardPayload(
+  selection: Selection,
+  ownerDocument: Document,
+): SelectionClipboardPayload {
+  const htmlRoot = cloneSelection(selection, ownerDocument);
+  stripAttributes(htmlRoot);
+  const markdownRoot = cloneSelection(selection, ownerDocument);
+  return {
+    html: htmlRoot.innerHTML,
+    text: renderContainer(markdownRoot).trim(),
+  };
+}


### PR DESCRIPTION
## Summary

Two user-reported symptoms when drag-selecting assistant text in the web chat and pressing Cmd/Ctrl+C:

- Pasting into Outlook gave the text a grey background.
- Pasting into the chat composer gave extra blank lines between every block, list items included.

Root cause is Chromium's own copy serialization, not our markup. Its `text/html` flavor inlines the *computed* style of every selected node and its ancestors, so the code-block and blockquote wrappers carry their background-color into Word's HTML importer. Its `text/plain` flavor is a flat dump that puts a blank line after every block element and drops every marker the reader could see.

The per-block Copy buttons were never affected: they write `pre.textContent` straight to the clipboard.

## Before / after

Real user path in Storybook (`MarkdownMessage / KitchenSink`): drag-select the whole message, Cmd+C, paste into a contenteditable rich editor (Outlook-like) and into a plain textarea (chat composer).

| Before (`main`) | After (this branch) |
| --- | --- |
| ![copy-paste-before](https://github.com/user-attachments/assets/6b5821e1-d41b-4d33-8bd5-e8150b975060) | ![copy-paste-after](https://github.com/user-attachments/assets/1ab2dfac-c97d-49f6-9a4f-06e3558f464b) |
| Grey band behind every block in the rich pane, and the code block's Copy button comes along. The textarea gets a flat dump: no heading or list markers, no fence, a stray `ts` label on its own line. | No grey anywhere. Headings, lists, the task checklist, table, and code survive as structure in the rich pane; the textarea gets clean markdown. |

## Approach

`MarkdownMessage`'s root handles `onCopy` for a selection that lies entirely inside it and writes both flavors itself, built from a clone of the selected ranges so the live DOM is untouched. A selection that reaches outside the message falls through to the browser, since a payload built from only the inside part would silently drop the rest.

- **`text/html`**: semantic tags plus the attributes that carry meaning (`href`, `src`, `alt`, `start`, `value`, `type`/`checked`/`disabled` on a task checkbox, `colspan`, `rowspan`). No class, no inline style, no data attribute, so nothing can supply a background.
- **`text/plain`**: markdown. Headings, bold/italic/strikethrough, links (autolinks stay bare), inline code with a delimiter that grows past backticks in the content, fenced code blocks carrying their language and indentation, blockquotes, nested lists indented to the parent marker's width, GFM task boxes and tables with escaped pipes, and rules. Markdown-aware paste targets (the composer, Slack, GitHub, Notion) therefore round-trip the formatting; a truly plain destination shows the markers literally, the same trade-off ChatGPT and Claude.ai make. Emphasis nested inside the same kind switches spelling (`*` inside `_`, `__` inside `**`) so it stays unambiguous.
- Copy buttons, the code-block header row (whose language label the fence already states), and `aria-hidden` KaTeX duplicates are dropped from both flavors.

## Test plan

- `bun test src/utils/selection-clipboard.test.ts src/components/markdown-message.test.tsx` in `packages/design-library`: 84 pass. Unit tests cover headings, nested and ordered lists with pinned ordinals, task lists, a two-paragraph blockquote, emphasis (including nested) / link / inline code, a fenced block with language and indentation, tables with escaped pipes, rules, and the attribute stripping.
- `bunx tsc --noEmit` clean in `packages/design-library`, `clients/web`, and `cli`; Prettier and ESLint clean.
- Storybook in Chrome: dispatched a real `copy` event over a full-message selection on the `Default`, `QuoteWithInlineCode`, `LongCodeBlock`, and `KitchenSink` stories and read both flavors back. HTML has no `class=`, `style=`, `background`, `<button>`, or `aria-hidden`; plain text has no triple newlines, and the code block copies as a fence with its language and indentation intact. A selection extended to a node outside the message is confirmed not intercepted.
- End-to-end user path, main vs this branch, shown in the before/after table above: real mouse selection, real Cmd+C, real Cmd+V into a contenteditable rich editor and a plain textarea. That pass is what caught the task-checkbox and nested-emphasis defects, now fixed.
- Outlook itself was not exercised. The claim it fixes rests on the absence of any background declaration in the HTML payload.

## Unrelated commit riding along

`fix(cli): infer the Vellum hosted provider for qwen/qwen3-8b` fixes a guard that is already red on `main`: #41567 added `qwen/qwen3-8b` under the Vellum hosted provider, which the CLI's `inferProviderFromModel` heuristic answered as `openrouter`. The CLI check only runs on PRs that touch the root lockfile, so this branch (which adds a `happy-dom` devDependency) is the one that surfaces it. Happy to split it out if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
