### PR TITLE
fix(web): share baseMimeType and trim the extension in extensionOf

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/attachment-preview-modal.tsx
@@ -22,6 +22,7 @@ import {
   formatAttachmentSize,
 } from "@/domains/chat/components/chat-attachments/utils";
 import { useGallerySwipe } from "@/domains/chat/components/chat-attachments/use-gallery-swipe";
+import { baseMimeType } from "@/domains/chat/utils/mime-sniff";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
 import type { DisplayAttachment } from "@/types/attachment-types";
 import { useTranslation } from "@/i18n";
@@ -273,7 +274,7 @@ export const AttachmentPreviewModal: FC<AttachmentPreviewModalProps> = ({
     return null;
   }
 
-  const mime = attachment.mimeType.split(";")[0]!.trim().toLowerCase();
+  const mime = baseMimeType(attachment.mimeType);
   // One classifier picks the media branch, the same one the composer strip,
   // the chip and the message square read: a photo delivered as
   // application/octet-stream previews as an image, and a video named after an

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.test.ts
@@ -73,6 +73,7 @@ describe("classifyAttachment", () => {
       "image",
     );
     expect(classifyAttachment("", "photo.HEIC")).toBe("image");
+    expect(classifyAttachment("", "photo.jpg ")).toBe("image");
     expect(classifyAttachment("application/octet-stream", "report.pdf")).toBe(
       "pdf",
     );

--- a/clients/web/src/domains/chat/components/chat-attachments/utils.ts
+++ b/clients/web/src/domains/chat/components/chat-attachments/utils.ts
@@ -1,4 +1,5 @@
 import {
+  baseMimeType,
   extensionOf,
   GENERIC_MIME_TYPES,
 } from "@/domains/chat/utils/mime-sniff";
@@ -98,7 +99,7 @@ export function classifyAttachment(
   mimeType: string,
   filename: string,
 ): AttachmentIconKind {
-  const mime = (mimeType || "").split(";")[0]!.trim().toLowerCase();
+  const mime = baseMimeType(mimeType || "");
   const ext = extensionOf(filename);
   const isGenericMime = GENERIC_MIME_TYPES.has(mime);
 

--- a/clients/web/src/domains/chat/utils/mime-sniff.test.ts
+++ b/clients/web/src/domains/chat/utils/mime-sniff.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  baseMimeType,
+  extensionOf,
   type LocalFileKind,
   resolveLocalFileType,
   sniffMimeType,
@@ -318,5 +320,25 @@ describe("resolveLocalFileType: OOXML packages under their zip signature", () =>
         filename: "notes.md",
       }),
     ).toEqual({ mime: "application/zip", kind: "file" });
+  });
+});
+
+describe("baseMimeType", () => {
+  test("drops parameters and normalizes case and whitespace", () => {
+    expect(baseMimeType("application/pdf; charset=binary")).toBe(
+      "application/pdf",
+    );
+    expect(baseMimeType(" Image/JPEG ")).toBe("image/jpeg");
+    expect(baseMimeType("")).toBe("");
+  });
+});
+
+describe("extensionOf", () => {
+  test("reads the last segment's suffix, lowercased and trimmed", () => {
+    expect(extensionOf("photo.JPG")).toBe("jpg");
+    expect(extensionOf("photo.jpg ")).toBe("jpg");
+    expect(extensionOf("photos.2024/report")).toBe("");
+    expect(extensionOf(".hidden")).toBe("");
+    expect(extensionOf("pdf")).toBe("");
   });
 });

--- a/clients/web/src/domains/chat/utils/mime-sniff.ts
+++ b/clients/web/src/domains/chat/utils/mime-sniff.ts
@@ -213,11 +213,16 @@ export async function sniffBlobMimeType(blob: Blob): Promise<string | null> {
   return sniffMimeType(new Uint8Array(head));
 }
 
+/** A media type without its parameters, lowercased: `image/jpeg; q=0.8` reads as `image/jpeg`. */
+export function baseMimeType(raw: string): string {
+  return raw.split(";")[0]!.trim().toLowerCase();
+}
+
 function normalizeMimeType(raw: string | null): string | null {
   if (!raw) {
     return null;
   }
-  const mime = raw.split(";")[0]!.trim().toLowerCase();
+  const mime = baseMimeType(raw);
   return mime.length > 0 ? mime : null;
 }
 
@@ -234,7 +239,10 @@ export function extensionOf(filename: string): string {
   if (dot <= 0) {
     return "";
   }
-  return base.slice(dot + 1).toLowerCase();
+  return base
+    .slice(dot + 1)
+    .trim()
+    .toLowerCase();
 }
 
 function kindForMimeType(mime: string | null): LocalFileKind {


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review (round 3) for mobile-attachment-tiles.md.

- `baseMimeType` is exported from `mime-sniff.ts` and used by `classifyAttachment` and the preview modal, so the base-media-type parse exists once
- `extensionOf` trims the extension again, restoring image classification for a provider-supplied name like `photo.jpg ` and keeping it in step with the resize gate
- Tests for both helpers