### PR TITLE
fix(chrome-extension): show empty picker when no assistants exist

### DIFF
--- a/clients/chrome-extension/background/__tests__/extension-environment.test.ts
+++ b/clients/chrome-extension/background/__tests__/extension-environment.test.ts
@@ -169,14 +169,14 @@ describe('createFirstAssistantUrl', () => {
   ];
 
   for (const { env, webBaseUrl } of cases) {
-    test(`${env} opens the web chooser on ${webBaseUrl}`, () => {
+    test(`${env} opens the hatching entry on ${webBaseUrl}`, () => {
       expect(createFirstAssistantUrl(env)).toBe(
         `${webBaseUrl}${CREATE_ASSISTANT_WEB_PATH}`,
       );
     });
   }
 
-  test('points at the select-assistant route so a signed-in user can hatch', () => {
-    expect(CREATE_ASSISTANT_WEB_PATH).toBe('/assistant/select-assistant');
+  test('points at the platform hatching route, not the local-only chooser create action', () => {
+    expect(CREATE_ASSISTANT_WEB_PATH).toBe('/assistant/onboarding/hatching');
   });
 });

--- a/clients/chrome-extension/background/__tests__/extension-environment.test.ts
+++ b/clients/chrome-extension/background/__tests__/extension-environment.test.ts
@@ -16,6 +16,8 @@ import {
   parseExtensionEnvironment,
   resolveBuildDefaultEnvironment,
   cloudUrlsForEnvironment,
+  createFirstAssistantUrl,
+  CREATE_ASSISTANT_WEB_PATH,
   type ExtensionEnvironment,
 } from '../extension-environment.js';
 
@@ -155,5 +157,26 @@ describe('cloudUrlsForEnvironment', () => {
     const fromProd = cloudUrlsForEnvironment('production');
     expect(fromProd.apiBaseUrl).toBe('https://platform.vellum.ai');
     expect(fromProd.webBaseUrl).toBe('https://www.vellum.ai');
+  });
+});
+
+describe('createFirstAssistantUrl', () => {
+  const cases: Array<{ env: ExtensionEnvironment; webBaseUrl: string }> = [
+    { env: 'production', webBaseUrl: 'https://www.vellum.ai' },
+    { env: 'staging', webBaseUrl: 'https://staging-assistant.vellum.ai' },
+    { env: 'dev', webBaseUrl: 'https://dev-assistant.vellum.ai' },
+    { env: 'local', webBaseUrl: 'http://localhost:3000' },
+  ];
+
+  for (const { env, webBaseUrl } of cases) {
+    test(`${env} opens the web chooser on ${webBaseUrl}`, () => {
+      expect(createFirstAssistantUrl(env)).toBe(
+        `${webBaseUrl}${CREATE_ASSISTANT_WEB_PATH}`,
+      );
+    });
+  }
+
+  test('points at the select-assistant route so a signed-in user can hatch', () => {
+    expect(CREATE_ASSISTANT_WEB_PATH).toBe('/assistant/select-assistant');
   });
 });

--- a/clients/chrome-extension/background/extension-environment.ts
+++ b/clients/chrome-extension/background/extension-environment.ts
@@ -132,3 +132,14 @@ export function cloudUrlsForEnvironment(env: ExtensionEnvironment): CloudUrls {
       };
   }
 }
+
+/**
+ * Web-app path for creating the first cloud assistant. The extension cannot
+ * hatch; this is the chooser, which already has "Create a new assistant".
+ */
+export const CREATE_ASSISTANT_WEB_PATH = '/assistant/select-assistant';
+
+/** Environment-specific URL that opens the web app's assistant chooser. */
+export function createFirstAssistantUrl(env: ExtensionEnvironment): string {
+  return `${cloudUrlsForEnvironment(env).webBaseUrl}${CREATE_ASSISTANT_WEB_PATH}`;
+}

--- a/clients/chrome-extension/background/extension-environment.ts
+++ b/clients/chrome-extension/background/extension-environment.ts
@@ -134,12 +134,13 @@ export function cloudUrlsForEnvironment(env: ExtensionEnvironment): CloudUrls {
 }
 
 /**
- * Web-app path for creating the first cloud assistant. The extension cannot
- * hatch; this is the chooser, which already has "Create a new assistant".
+ * Web-app path for creating the first cloud assistant. Platform users hatch
+ * here. The hatching route gate sends unconsented users through privacy first.
+ * The chooser is not used: its create action is local-client only.
  */
-export const CREATE_ASSISTANT_WEB_PATH = '/assistant/select-assistant';
+export const CREATE_ASSISTANT_WEB_PATH = '/assistant/onboarding/hatching';
 
-/** Environment-specific URL that opens the web app's assistant chooser. */
+/** Environment-specific URL that opens the web app's hatching entry. */
 export function createFirstAssistantUrl(env: ExtensionEnvironment): string {
   return `${cloudUrlsForEnvironment(env).webBaseUrl}${CREATE_ASSISTANT_WEB_PATH}`;
 }

--- a/clients/chrome-extension/background/worker.ts
+++ b/clients/chrome-extension/background/worker.ts
@@ -26,6 +26,7 @@
 import {
   type ExtensionEnvironment,
   cloudUrlsForEnvironment,
+  createFirstAssistantUrl,
   parseExtensionEnvironment,
   resolveBuildDefaultEnvironment,
 } from "./extension-environment.js";
@@ -1480,6 +1481,20 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponseFn) => {
       const env = await getEffectiveEnvironment();
       const assistants = await fetchAssistants(env);
       sendResponseFn({ ok: true, assistants });
+    })().catch((err) =>
+      sendResponseFn({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return true; // async
+  }
+
+  if (message.type === "open-create-assistant") {
+    (async () => {
+      const env = await getEffectiveEnvironment();
+      await chrome.tabs.create({ url: createFirstAssistantUrl(env) });
+      sendResponseFn({ ok: true });
     })().catch((err) =>
       sendResponseFn({
         ok: false,

--- a/clients/chrome-extension/popup/App.tsx
+++ b/clients/chrome-extension/popup/App.tsx
@@ -23,6 +23,7 @@ export function App() {
   const [signInError, setSignInError] = useState<string | null>(null);
   const [assistantsError, setAssistantsError] = useState<string | null>(null);
   const [cloudEmail, setCloudEmail] = useState<string | undefined>(undefined);
+  const [refreshingAssistants, setRefreshingAssistants] = useState(false);
   const modeRef = useRef(mode);
   modeRef.current = mode;
 
@@ -143,8 +144,11 @@ export function App() {
         setScreen({ name: 'main' });
         sendMessage({ type: 'connect' });
       } else if (assistants.length === 0) {
-        setScreen({ name: 'main' });
-        sendMessage({ type: 'connect' });
+        setScreen({
+          name: 'picker',
+          assistants: [],
+          email: response.session?.email,
+        });
       } else if (assistants.length === 1) {
         const a = assistants[0]!;
         sendMessage({
@@ -168,6 +172,56 @@ export function App() {
     setAssistantsError(null);
     handleSignIn();
   }, [handleSignIn]);
+
+  const handleRefreshAssistants = useCallback(() => {
+    if (refreshingAssistants) {
+      return;
+    }
+    setRefreshingAssistants(true);
+    sendMessage<{
+      ok: boolean;
+      assistants?: CloudAssistant[];
+      error?: string;
+    }>({ type: 'list-assistants' })
+      .then((response) => {
+        if (modeRef.current !== 'cloud') {
+          return;
+        }
+        if (!response?.ok) {
+          setScreen({
+            name: 'picker',
+            assistants: [],
+            email: cloudEmail,
+            error: response?.error ?? 'Unable to load assistants',
+          });
+          return;
+        }
+        const assistants = response.assistants ?? [];
+        if (assistants.length === 1) {
+          const a = assistants[0]!;
+          sendMessage({
+            type: 'select-assistant',
+            assistantId: a.id,
+            assistantName: a.name,
+          });
+          setScreen({ name: 'main' });
+          sendMessage({ type: 'connect' });
+          return;
+        }
+        setScreen({
+          name: 'picker',
+          assistants,
+          email: cloudEmail,
+        });
+      })
+      .finally(() => {
+        setRefreshingAssistants(false);
+      });
+  }, [cloudEmail, refreshingAssistants]);
+
+  const handleCreateAssistant = useCallback(() => {
+    sendMessage({ type: 'open-create-assistant' });
+  }, []);
 
   const handleSelfHosted = useCallback(() => {
     setMode('self-hosted');
@@ -255,8 +309,12 @@ export function App() {
               <PickerScreen
                 assistants={screen.assistants}
                 email={screen.email}
+                error={screen.error}
+                refreshing={refreshingAssistants}
                 onSelect={handleSelectAssistant}
                 onBack={handleBackToWelcome}
+                onRetry={handleRefreshAssistants}
+                onCreateAssistant={handleCreateAssistant}
               />
             );
           case 'main':

--- a/clients/chrome-extension/popup/AppContext.tsx
+++ b/clients/chrome-extension/popup/AppContext.tsx
@@ -7,7 +7,7 @@ import type { ConnectionHealthDetail, ConnectionHealthState } from './popup-stat
 
 export type Screen =
   | { name: 'welcome' }
-  | { name: 'picker'; assistants: CloudAssistant[]; email?: string }
+  | { name: 'picker'; assistants: CloudAssistant[]; email?: string; error?: string }
   | { name: 'main' }
   | { name: 'activity' }
   | { name: 'detail'; operation: OperationEntry }

--- a/clients/chrome-extension/popup/screens/PickerScreen.test.tsx
+++ b/clients/chrome-extension/popup/screens/PickerScreen.test.tsx
@@ -1,21 +1,26 @@
 import { describe, expect, test } from 'bun:test';
+import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { PickerScreen } from './PickerScreen.js';
+import { PickerScreen, type PickerScreenProps } from './PickerScreen.js';
+
+function renderPicker(overrides: Partial<PickerScreenProps> = {}): string {
+  return renderToStaticMarkup(
+    createElement(PickerScreen, {
+      assistants: [],
+      onSelect: () => {},
+      onBack: () => {},
+      onCreateAssistant: () => {},
+      ...overrides,
+    }),
+  );
+}
 
 describe('PickerScreen', () => {
   test('renders an empty state that sends the user to create an assistant', () => {
-    const html = renderToStaticMarkup(
-      <PickerScreen
-        assistants={[]}
-        onSelect={() => {}}
-        onBack={() => {}}
-        onRetry={() => {}}
-        onCreateAssistant={() => {}}
-      />,
-    );
+    const html = renderPicker({ onRetry: () => {} });
 
-    expect(html).toContain("You don't have an assistant yet");
+    expect(html).toContain('You don&#x27;t have an assistant yet');
     expect(html).toContain('Create an assistant');
     expect(html).toContain('Refresh');
     expect(html).not.toContain('Loading assistants');
@@ -23,35 +28,24 @@ describe('PickerScreen', () => {
   });
 
   test('lists assistants when the catalog is populated', () => {
-    const html = renderToStaticMarkup(
-      <PickerScreen
-        assistants={[{ id: 'asst-123', name: 'Alice' }]}
-        onSelect={() => {}}
-        onBack={() => {}}
-        onCreateAssistant={() => {}}
-      />,
-    );
+    const html = renderPicker({
+      assistants: [{ id: 'asst-123', name: 'Alice' }],
+    });
 
     expect(html).toContain('Alice');
     expect(html).toContain('Select which assistant to connect to this browser.');
-    expect(html).not.toContain("You don't have an assistant yet");
+    expect(html).not.toContain('You don&#x27;t have an assistant yet');
     expect(html).not.toContain('Create an assistant');
   });
 
   test('shows a load error instead of the empty state', () => {
-    const html = renderToStaticMarkup(
-      <PickerScreen
-        assistants={[]}
-        error="Failed to fetch assistants (403): forbidden"
-        onSelect={() => {}}
-        onBack={() => {}}
-        onRetry={() => {}}
-        onCreateAssistant={() => {}}
-      />,
-    );
+    const html = renderPicker({
+      error: 'Failed to fetch assistants (403): forbidden',
+      onRetry: () => {},
+    });
 
     expect(html).toContain('Unable to load assistants');
     expect(html).toContain('Failed to fetch assistants (403): forbidden');
-    expect(html).not.toContain("You don't have an assistant yet");
+    expect(html).not.toContain('You don&#x27;t have an assistant yet');
   });
 });

--- a/clients/chrome-extension/popup/screens/PickerScreen.test.tsx
+++ b/clients/chrome-extension/popup/screens/PickerScreen.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { PickerScreen } from './PickerScreen.js';
+
+describe('PickerScreen', () => {
+  test('renders an empty state that sends the user to create an assistant', () => {
+    const html = renderToStaticMarkup(
+      <PickerScreen
+        assistants={[]}
+        onSelect={() => {}}
+        onBack={() => {}}
+        onRetry={() => {}}
+        onCreateAssistant={() => {}}
+      />,
+    );
+
+    expect(html).toContain("You don't have an assistant yet");
+    expect(html).toContain('Create an assistant');
+    expect(html).toContain('Refresh');
+    expect(html).not.toContain('Loading assistants');
+    expect(html).not.toContain('Select which assistant to connect');
+  });
+
+  test('lists assistants when the catalog is populated', () => {
+    const html = renderToStaticMarkup(
+      <PickerScreen
+        assistants={[{ id: 'asst-123', name: 'Alice' }]}
+        onSelect={() => {}}
+        onBack={() => {}}
+        onCreateAssistant={() => {}}
+      />,
+    );
+
+    expect(html).toContain('Alice');
+    expect(html).toContain('Select which assistant to connect to this browser.');
+    expect(html).not.toContain("You don't have an assistant yet");
+    expect(html).not.toContain('Create an assistant');
+  });
+
+  test('shows a load error instead of the empty state', () => {
+    const html = renderToStaticMarkup(
+      <PickerScreen
+        assistants={[]}
+        error="Failed to fetch assistants (403): forbidden"
+        onSelect={() => {}}
+        onBack={() => {}}
+        onRetry={() => {}}
+        onCreateAssistant={() => {}}
+      />,
+    );
+
+    expect(html).toContain('Unable to load assistants');
+    expect(html).toContain('Failed to fetch assistants (403): forbidden');
+    expect(html).not.toContain("You don't have an assistant yet");
+  });
+});

--- a/clients/chrome-extension/popup/screens/PickerScreen.tsx
+++ b/clients/chrome-extension/popup/screens/PickerScreen.tsx
@@ -4,9 +4,11 @@ export interface PickerScreenProps {
   assistants: CloudAssistant[];
   email?: string;
   error?: string;
+  refreshing?: boolean;
   onSelect: (id: string, name: string) => void;
   onBack: () => void;
   onRetry?: () => void;
+  onCreateAssistant: () => void;
 }
 
 export function PickerScreen({
@@ -14,9 +16,11 @@ export function PickerScreen({
   onSelect,
   onBack,
   error,
+  refreshing,
   onRetry,
+  onCreateAssistant,
 }: PickerScreenProps) {
-  const loading = assistants.length === 0 && !error;
+  const isEmpty = assistants.length === 0 && !error;
 
   return (
     <div>
@@ -45,9 +49,11 @@ export function PickerScreen({
         <h1 className="text-lg font-semibold text-fg">Choose an Assistant</h1>
       </header>
 
-      <p className="text-sm text-fg-muted mb-4">
-        Select which assistant to connect to this browser.
-      </p>
+      {!isEmpty && !error && (
+        <p className="text-sm text-fg-muted mb-4">
+          Select which assistant to connect to this browser.
+        </p>
+      )}
 
       {error && (
         <div className="rounded-lg bg-danger-soft p-3 mb-4" role="alert">
@@ -59,18 +65,41 @@ export function PickerScreen({
             <button
               type="button"
               onClick={onRetry}
-              className="mt-2 text-xs px-3 py-1.5 rounded bg-surface-alt text-fg border-none cursor-pointer hover:bg-edge-hover transition-colors"
+              disabled={refreshing}
+              className="mt-2 text-xs px-3 py-1.5 rounded bg-surface-alt text-fg border-none cursor-pointer hover:bg-edge-hover transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
             >
-              Retry
+              {refreshing ? 'Refreshing...' : 'Retry'}
             </button>
           )}
         </div>
       )}
 
-      {loading && (
-        <p className="text-xs text-fg-subtle text-center py-5">
-          Loading assistants...
-        </p>
+      {isEmpty && (
+        <div className="flex flex-col items-center text-center px-2 pt-5 pb-2">
+          <p className="text-sm font-medium text-fg mb-1.5">
+            You don't have an assistant yet
+          </p>
+          <p className="text-xs text-fg-muted mb-4">
+            Create one in the Vellum app, then come back here to connect it.
+          </p>
+          <button
+            type="button"
+            onClick={onCreateAssistant}
+            className="bg-fg text-bg rounded-lg px-4 py-2.5 text-sm font-medium w-full max-w-[240px] hover:opacity-90 transition-opacity cursor-pointer"
+          >
+            Create an assistant
+          </button>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              disabled={refreshing}
+              className="mt-2 bg-transparent text-fg-muted border border-edge rounded-lg px-4 py-2.5 text-sm w-full max-w-[240px] hover:border-edge-hover hover:text-fg transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {refreshing ? 'Refreshing...' : 'Refresh'}
+            </button>
+          )}
+        </div>
       )}
 
       {assistants.length > 0 && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

A signed-in Chrome extension user with no hatched assistant landed on **Choose an Assistant** and saw nothing. The picker treated an empty catalog as "Loading assistants..." forever. Sign-in with zero assistants also skipped the picker and tried to connect, which immediately failed with "Sign in and select an assistant to connect."

This change:

- Renders a real empty state on the picker: copy plus **Create an assistant**
- Opens the environment-matched platform hatching entry (`/assistant/onboarding/hatching`) so they can create one. The chooser is not used here: its create action is local-client only.
- Routes a zero-assistant cloud sign-in to the picker instead of the main screen
- Adds **Refresh** so they can reload the catalog after creating one

## Test plan

- [x] `cd clients/chrome-extension && bun test background/__tests__/extension-environment.test.ts`
- [x] `cd clients/chrome-extension && bun test popup/screens/PickerScreen.test.tsx`
- [x] `cd clients/chrome-extension && bunx tsc --noEmit`

## Risk

Low. Cloud users who already have one or more assistants keep the existing auto-select / picker list paths. The empty state only appears when `/v1/assistants/` returns an empty list. The create button lands on the hatching route, whose gate still sends unconsented users through privacy first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eab10933-bd4e-4b22-96d3-f313d7c6781c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eab10933-bd4e-4b22-96d3-f313d7c6781c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

