### PR TITLE
feat(companion): smaller options steps and an artwork baseline for the pill

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -4,7 +4,8 @@ import {
   COMPANION_BASE_AVATAR_BOX,
   COMPANION_BASE_MAX_PILL_WIDTH,
   COMPANION_SIZES,
-  COMPANION_SIZE_BOXES,
+  companionBoxFor,
+  companionCardSideFor,
   companionNearEdgeFor,
   companionScaleFor,
   type CompanionSize,
@@ -289,10 +290,12 @@ const BIG_CREATURE = geometryFor("huge", "small");
 const BIG_OPTIONS = geometryFor("small", "huge");
 
 /**
- * The part of the base reach the geometry does not publish: the pill's widest.
- * Bound to the contract for the cases that are about it rather than the sum.
+ * The part of the base reach the geometry does not publish: the pill's widest,
+ * at the options size {@link GEOMETRY} is drawn in. Bound to the contract for
+ * the cases that are about it rather than the sum.
  */
-const MAX_PILL_WIDTH = COMPANION_BASE_MAX_PILL_WIDTH;
+const MAX_PILL_WIDTH =
+  COMPANION_BASE_MAX_PILL_WIDTH * companionScaleFor(GEOMETRY.optionsBox);
 
 /**
  * The growth direction is the only rule in the companion window worth testing
@@ -348,11 +351,17 @@ describe("growthFor", () => {
   /**
    * The room is measured from the avatar's centre while the pill starts at the
    * avatar's edge, so the half box is the difference between fitting and
-   * clipping. 340pt on the right clears the gap and the widest body and still
-   * cuts the controls off.
+   * clipping. Room enough for the gap and the widest body still cuts the
+   * controls off.
    */
   test("flips when only the avatar's half box is missing on the right", () => {
-    expect(growthFor(DISPLAY.width - 340, DISPLAY, GEOMETRY)).toBe("left");
+    expect(
+      growthFor(
+        DISPLAY.width - (NEEDED - GEOMETRY.avatarBox / 2),
+        DISPLAY,
+        GEOMETRY,
+      ),
+    ).toBe("left");
   });
 
   test("measures against the display's own origin, not the screen's", () => {
@@ -648,11 +657,11 @@ describe("geometryFor", () => {
       CompanionSize,
       { maxReach: number; canvasWidth: number; canvasHeight: number }
     > = {
-      small: { maxReach: 350, canvasWidth: 748, canvasHeight: 338 },
-      medium: { maxReach: 525, canvasWidth: 1122, canvasHeight: 507 },
-      large: { maxReach: 700, canvasWidth: 1496, canvasHeight: 676 },
-      huge: { maxReach: 875, canvasWidth: 1870, canvasHeight: 845 },
-      ridiculous: { maxReach: 1750, canvasWidth: 3740, canvasHeight: 1690 },
+      small: { maxReach: 261, canvasWidth: 570, canvasHeight: 267 },
+      medium: { maxReach: 361, canvasWidth: 794, canvasHeight: 374 },
+      large: { maxReach: 536, canvasWidth: 1168, canvasHeight: 547 },
+      huge: { maxReach: 711, canvasWidth: 1542, canvasHeight: 720 },
+      ridiculous: { maxReach: 930, canvasWidth: 2100, canvasHeight: 1035 },
     };
     for (const size of COMPANION_SIZES) {
       const { maxReach, canvasWidth, canvasHeight } = geometryFor(size, size);
@@ -668,7 +677,7 @@ describe("geometryFor", () => {
   test("takes the creature's box from the avatar axis alone", () => {
     for (const options of COMPANION_SIZES) {
       expect(geometryFor("large", options).avatarBox).toBe(
-        COMPANION_SIZE_BOXES.large,
+        companionBoxFor("avatar", "large"),
       );
     }
   });
@@ -680,30 +689,48 @@ describe("geometryFor", () => {
   test("takes the pill's box from the options axis alone", () => {
     for (const avatar of COMPANION_SIZES) {
       expect(geometryFor(avatar, "large").optionsBox).toBe(
-        COMPANION_SIZE_BOXES.large,
+        companionBoxFor("options", "large"),
       );
     }
   });
 
   /**
-   * The two-box distances are the one-box ones wherever there is only one size,
-   * which is what makes the second axis a widening rather than a second
-   * geometry to keep in step.
+   * The two sides of the avatar at each step, as the numbers they come to.
+   *
+   * Not one scale times the authored pair: a name is a creature and a pill a
+   * notch apart, so the two sides move at different rates and each step is its
+   * own canvas. The authored pair is stated first, since each of these is that
+   * one layout scaled.
    */
-  test("reduces to the single-scale canvas when the axes agree", () => {
-    // The two sides at the base size, which the whole layout is authored
-    // around: the creature and its shadow below, the card's height above.
+  test("states both sides of the avatar at every named step", () => {
+    // The pill's bottom sits 14 under the avatar's centre, so its top stands
+    // 30 over it where the creature's box reaches only 22, and the card rises
+    // its whole height off that same line. Both sides then take the pad.
     expect(
       companionNearEdgeFor(
         COMPANION_BASE_AVATAR_BOX,
         COMPANION_BASE_AVATAR_BOX,
       ),
-    ).toBe(46);
+    ).toBe(54);
+    expect(
+      companionCardSideFor(
+        COMPANION_BASE_AVATAR_BOX,
+        COMPANION_BASE_AVATAR_BOX,
+      ),
+    ).toBe(300);
+    const sides: Record<
+      CompanionSize,
+      { riseAbove: number; dropBelow: number }
+    > = {
+      small: { riseAbove: 221, dropBelow: 46 },
+      medium: { riseAbove: 305, dropBelow: 69 },
+      large: { riseAbove: 455, dropBelow: 92 },
+      huge: { riseAbove: 605, dropBelow: 115 },
+      ridiculous: { riseAbove: 805, dropBelow: 230 },
+    };
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size, size);
-      const scale = companionScaleFor(geometry.avatarBox);
-      expect(geometry.dropBelow).toBe(46 * scale);
-      expect(geometry.riseAbove).toBe(292 * scale);
+      const { riseAbove, dropBelow } = geometryFor(size, size);
+      expect({ riseAbove, dropBelow }).toEqual(sides[size]);
     }
   });
 
@@ -717,14 +744,21 @@ describe("geometryFor", () => {
 
   /**
    * The canvas is a window size, and a window cannot be a fraction of a point.
-   * The offsets are not rounded, because they are arithmetic on the way to a
-   * position that is.
+   * The two offsets are whole points too, and the width is even: the avatar
+   * sits on the canvas's centre line and on the line between the offsets, so a
+   * fraction anywhere here stands the creature on a half point that a resize
+   * cannot land back on. The options axis is where this bites, since its
+   * smaller steps are not whole multiples of the box the layout is authored at.
    */
   test("gives every size a whole-point canvas", () => {
     for (const size of COMPANION_SIZES) {
       const geometry = geometryFor(size, size);
       expect(Number.isInteger(geometry.canvasWidth)).toBe(true);
       expect(Number.isInteger(geometry.canvasHeight)).toBe(true);
+      expect(Number.isInteger(geometry.riseAbove)).toBe(true);
+      expect(Number.isInteger(geometry.dropBelow)).toBe(true);
+      expect(Number.isInteger(geometry.maxReach)).toBe(true);
+      expect(geometry.canvasWidth % 2).toBe(0);
     }
   });
 
@@ -774,31 +808,32 @@ describe("geometryFor with the two axes apart", () => {
    *
    * The width is where the gap rule shows: the gap is breathing room, so the
    * smaller of the two boxes decides how much of it there is, and the creature
-   * below takes the base gap rather than the chasm its own scale would ask for,
-   * which would put its reach at 401. The two heights are the two sides of the
-   * avatar: the near edge clears the creature's bottom and the pill's top
-   * alike, and the far edge clears the card growing either way.
+   * below takes its small pill's gap rather than the chasm its own scale would
+   * ask for, which would put its reach at 315. The two heights are the two
+   * sides of the avatar: the near edge clears the creature's box and the pill's
+   * top alike, and the far edge clears the card growing either way.
    */
   test("holds the pill, the card and the creature at each mix", () => {
-    // An enormous creature's half box, the base gap, and a base-width pill.
+    // An enormous creature's half box, the gap its small pill earns, and that
+    // pill at its widest.
     expect(BIG_CREATURE).toEqual({
       avatarBox: 110,
-      optionsBox: 44,
-      maxReach: 383,
-      canvasWidth: 886,
-      riseAbove: 361,
+      optionsBox: 32,
+      maxReach: 294,
+      canvasWidth: 708,
+      riseAbove: 274,
       dropBelow: 115,
-      canvasHeight: 476,
+      canvasHeight: 389,
     });
-    // A base half box, the same gap, and a pill two and a half times as wide.
+    // A base half box, the base gap, and a pill twice as wide.
     expect(BIG_OPTIONS).toEqual({
       avatarBox: 44,
-      optionsBox: 110,
-      maxReach: 824,
-      canvasWidth: 1768,
-      riseAbove: 763,
-      dropBelow: 148,
-      canvasHeight: 911,
+      optionsBox: 88,
+      maxReach: 666,
+      canvasWidth: 1428,
+      riseAbove: 614,
+      dropBelow: 122,
+      canvasHeight: 736,
     });
   });
 
@@ -821,8 +856,13 @@ describe("geometryFor with the two axes apart", () => {
    * display gets there.
    */
   test("still grows the designed way where neither side can hold the pill", () => {
+    const enormousOptions = geometryFor("small", "ridiculous");
     expect(
-      growthFor(DISPLAY.width - BIG_OPTIONS.maxReach + 1, DISPLAY, BIG_OPTIONS),
+      growthFor(
+        DISPLAY.width - enormousOptions.maxReach + 1,
+        DISPLAY,
+        enormousOptions,
+      ),
     ).toBe("right");
   });
 });

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -15,7 +15,7 @@ import {
   COMPANION_BASE_MAX_PILL_WIDTH,
   COMPANION_INTRO_ACTIONS,
   COMPANION_INTRO_BEATS,
-  COMPANION_SIZE_BOXES,
+  companionBoxFor,
   companionCardSideFor,
   companionGapFor,
   companionNearEdgeFor,
@@ -160,12 +160,22 @@ export interface CompanionGeometry {
    * back past it, and the shadow.
    */
   dropBelow: number;
-  /** The pill's far edge at its widest, measured from the avatar's centre. */
+  /**
+   * The pill's far edge at its widest, measured from the avatar's centre.
+   *
+   * Whole points, as every number here is: the window is placed and sized in
+   * them, and the avatar stands on the line between the two offsets and on the
+   * canvas's own centre line.
+   */
   maxReach: number;
 }
 
 /**
  * The canvas for a pair of named sizes.
+ *
+ * Each name goes through its own axis's table ({@link companionBoxFor}), so the
+ * same name on both axes is a creature and a pill a notch apart rather than two
+ * boxes of one size.
  *
  * The asymmetry between {@link CompanionGeometry.riseAbove} and `dropBelow` is
  * the point of the shape. Sizing both sides for the card, which is what pinning
@@ -185,8 +195,8 @@ export const geometryFor = (
   avatar: CompanionSize,
   options: CompanionSize,
 ): CompanionGeometry => {
-  const avatarBox = COMPANION_SIZE_BOXES[avatar];
-  const optionsBox = COMPANION_SIZE_BOXES[options];
+  const avatarBox = companionBoxFor("avatar", avatar);
+  const optionsBox = companionBoxFor("options", options);
   const pad = companionPadFor(avatarBox, optionsBox);
   const gap = companionGapFor(avatarBox, optionsBox);
   const maxPillWidth =
@@ -195,20 +205,34 @@ export const geometryFor = (
   // gap, so the reach is the avatar's half box, the gap, and the widest pill.
   // The canvas has to hold it in whichever direction main later picks, so it is
   // sized for both sides, and `growthFor` picks that direction by the same
-  // number.
-  const maxReach = avatarBox / 2 + gap + maxPillWidth;
+  // number. Whole points like everything else published here: the options
+  // sizes below the authored box are not whole multiples of it, and a reach
+  // carrying a repeating fraction is a canvas edge that lands between points.
+  const maxReach = Math.round(avatarBox / 2 + gap + maxPillWidth);
   // Both distances come from the contract, which is where the renderer reads
   // them too: main places the window by them and the renderer anchors the
   // surface by them, so a second copy of either is the avatar drawn somewhere
   // main did not put it. Each already answers for both card directions, which
   // is what lets a flip move the canvas rather than resize it.
-  const riseAbove = companionCardSideFor(avatarBox, optionsBox);
   const dropBelow = companionNearEdgeFor(avatarBox, optionsBox);
+  const canvasHeight = Math.round(
+    companionCardSideFor(avatarBox, optionsBox) + dropBelow,
+  );
+  // The near edge is taken exactly as the contract states it and the card's
+  // side absorbs the rounding, because the renderer names the card's edge with
+  // `100%` and steps back from it by that near edge. Rounding the other way
+  // round would leave main placing the window by one line and the renderer
+  // drawing the creature on another, and a card side is a ceiling with slack in
+  // it where a near edge is the line itself.
+  const riseAbove = canvasHeight - dropBelow;
   return {
     avatarBox,
     optionsBox,
-    canvasWidth: Math.round(maxReach * 2 + pad * 2),
-    canvasHeight: Math.round(riseAbove + dropBelow),
+    // Twice a whole half rather than a whole total. The renderer puts the
+    // avatar on the canvas's centre line, so an odd width would stand the
+    // creature on a half point and a resize would not land back on it.
+    canvasWidth: Math.round(maxReach + pad) * 2,
+    canvasHeight,
     riseAbove,
     dropBelow,
     maxReach,

--- a/clients/web/src/components/companion-intro.test.tsx
+++ b/clients/web/src/components/companion-intro.test.tsx
@@ -30,15 +30,16 @@ const offCanvasBottom = (top: string): number => {
  * Where the introduction's card lands beside the surface it is describing.
  *
  * Every beat but the first holds the pill open, so the card and the pill are on
- * screen together, and the pill is bottom-flush with the creature rather than
- * centred on it. A card that only cleared the creature would be drawn over the
- * controls it is captioning wherever the pill is the taller of the two.
+ * screen together, and the pill stands on the creature's visible bottom rather
+ * than being centred on it. A card that only cleared the creature would be
+ * drawn over the controls it is captioning wherever the pill is the taller of
+ * the two.
  */
 describe("the companion introduction's clearance", () => {
   /**
    * A small creature under a large pill, which is the pair that separates the
-   * two rules: the creature reaches 22 points above its centre and the pill
-   * 88, so a step off the creature alone lands the card inside the pill.
+   * two rules: the creature's box reaches 22 points above its centre and the
+   * pill 96, so a step off the creature alone lands the card inside the pill.
    */
   test("clears a pill that stands taller than the creature", () => {
     const { container: surface } = render(
@@ -88,8 +89,9 @@ describe("the companion introduction's clearance", () => {
       />,
     );
 
-    // The step down for 44 under 110 is the creature's half box plus the gap,
-    // 22 + 12 points, over the 2.5 scale the options box leaves the canvas at.
+    // The step down for 44 under 110 is the creature's own box below the
+    // baseline, so its half box plus the gap: 22 + 12 points, over the 2.5
+    // scale the options box leaves the canvas at.
     expect(cardOf(container).style.transform).toBe("translateY(13.6px)");
   });
 });

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -193,8 +193,8 @@ export function CompanionIntro({
     companionLayoutFor(avatarBox, optionsBox);
   // Clears whichever of the creature and the pill reaches further on this side,
   // and then the gap. Stepping off the creature alone would put the card inside
-  // a pill taller than it, since the pill is bottom-flush with the avatar
-  // rather than centred on it and every beat but `meet` holds it open.
+  // a pill taller than it, since the pill stands on the creature's baseline
+  // rather than being centred on it and every beat but `meet` holds it open.
   const stepOff = inUnits(introStepOff(cardGrowth));
 
   // Hung off the avatar's own edge, which is the point the host positioned this

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -25,6 +25,9 @@ describe("companionLayoutFor", () => {
     expect(layout.scale).toBe(1);
     expect(layout.avatarRel).toBe(1);
     expect(layout.avatarHalf).toBe(22);
+    // The artwork is 28 inside that 44 box, so it stops 14 short of the
+    // centre where the box runs 22.
+    expect(layout.baseline).toBe(14);
     expect(layout.gap).toBe(12);
     expect(layout.inUnits(34)).toBe(34);
   });
@@ -45,6 +48,7 @@ describe("companionLayoutFor", () => {
     expect(layout.scale).toBe(2.5);
     expect(layout.avatarRel).toBe(0.4);
     expect(layout.avatarHalf).toBe(22);
+    expect(layout.baseline).toBe(14);
     expect(layout.gap).toBe(12);
     expect(`${layout.inUnits(34)}`).toBe("13.6");
     expect(`${layout.inUnits(148)}`).toBe("59.2");
@@ -65,6 +69,8 @@ describe("companionLayoutFor", () => {
     expect(layout.scale).toBe(1);
     expect(layout.avatarRel).toBe(2.5);
     expect(layout.avatarHalf).toBe(55);
+    // The baseline scales with the creature the same way its box does.
+    expect(layout.baseline).toBe(35);
     expect(layout.gap).toBe(12);
     expect(layout.inUnits(67)).toBe(67);
   });
@@ -76,10 +82,10 @@ describe("companionLayoutFor", () => {
    */
   test("names a line from the canvas edge the avatar is near", () => {
     const layout = companionLayoutFor(44, 44);
-    expect(layout.lineAt("up", 0)).toBe("calc(100% - 46px)");
-    expect(layout.lineAt("up", 22)).toBe("calc(100% - 24px)");
-    expect(layout.lineAt("down", 0)).toBe("46px");
-    expect(layout.lineAt("down", 22)).toBe("68px");
+    expect(layout.lineAt("up", 0)).toBe("calc(100% - 54px)");
+    expect(layout.lineAt("up", 22)).toBe("calc(100% - 32px)");
+    expect(layout.lineAt("down", 0)).toBe("54px");
+    expect(layout.lineAt("down", 22)).toBe("76px");
   });
 
   /** A flip anchors the other edge and moves nothing else. */
@@ -99,33 +105,40 @@ describe("companionLayoutFor", () => {
 /**
  * How far the introduction's card starts from the avatar's centre.
  *
- * Its own distance rather than the pill's, because the pill is bottom-flush
- * with the creature rather than centred on it. Every beat but the first holds
- * the pill open, so a card that only cleared the creature would be drawn over
- * the thing it is describing.
+ * Its own distance rather than the pill's, because the pill stands on the
+ * creature's baseline rather than being centred on it. Every beat but the first
+ * holds the pill open, so a card that only cleared the creature would be drawn
+ * over the thing it is describing.
  */
 describe("the introduction's step off the creature", () => {
-  test("clears the creature itself when the two boxes agree", () => {
+  /**
+   * Even at the authored pair the pill is the taller thing upward: its bottom
+   * is 14 above the centre and it is a whole box tall, so its top stands 30 up
+   * where the creature's box reaches 22. Downward that baseline is inside the
+   * creature's box, so the creature is what has to be cleared.
+   */
+  test("clears whichever reaches further when the two boxes agree", () => {
     const layout = companionLayoutFor(44, 44);
-    expect(layout.introStepOff("up")).toBe(34);
+    expect(layout.introStepOff("up")).toBe(42);
     expect(layout.introStepOff("down")).toBe(34);
   });
 
   /**
-   * A small creature under a large pill: bottom-flush puts the pill's top 88
-   * points above the avatar's centre where the creature reaches only 22, so
-   * the card has to start past the pill.
+   * A small creature under a large pill: standing on the baseline puts the
+   * pill's top 96 points above the avatar's centre where the creature reaches
+   * only 22, so the card has to start past the pill.
    */
   test("clears a pill that stands taller than the creature", () => {
     const layout = companionLayoutFor(44, 110);
-    const pillTop = 110 - 22;
+    const pillTop = 110 - 14;
     expect(layout.introStepOff("up")).toBe(pillTop + 12);
     expect(layout.introStepOff("up")).toBeGreaterThan(pillTop);
   });
 
   /**
-   * Downward there is nothing to clear but the creature: the pill's bottom
-   * edge *is* the creature's bottom edge, whichever of the two is larger.
+   * Downward there is nothing to clear but the creature: the pill's bottom edge
+   * is the creature's baseline, which sits inside the creature's own box
+   * whatever the pill's size.
    */
   test("takes the creature's own bottom growing downward", () => {
     expect(companionLayoutFor(44, 110).introStepOff("down")).toBe(34);

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -1,4 +1,5 @@
 import {
+  companionBaselineFor,
   companionGapFor,
   companionNearEdgeFor,
   companionScaleFor,
@@ -138,6 +139,15 @@ export interface CompanionLayout {
   avatarRel: number;
   /** Half the creature's box, which is what everything beside it steps off from. */
   avatarHalf: number;
+  /**
+   * How far below the creature's centre its artwork stops, which is the line
+   * the pill's bottom sits on.
+   *
+   * Shorter than {@link CompanionLayout.avatarHalf}: the box runs past the
+   * drawing to hold the glow and the bob's slack, and it is the drawing the eye
+   * lines the pill up with.
+   */
+  baseline: number;
   /** The room the creature keeps from anything drawn beside it. */
   gap: number;
   /** The one conversion into the units the layout is stated in. */
@@ -164,9 +174,9 @@ export interface CompanionLayout {
   /**
    * How far past the avatar's centre the introduction's card starts, in points.
    *
-   * Its own distance rather than the pill's, because the pill is bottom-flush
-   * with the creature rather than centred on it: a card stepped off the
-   * creature alone lands inside a pill that stands taller than the creature.
+   * Its own distance rather than the pill's, because the pill stands on the
+   * creature's baseline rather than being centred on it: a card stepped off the
+   * creature alone lands inside a pill that reaches past the creature's box.
    */
   introStepOff: (cardGrowth: CompanionCardGrowth) => number;
 }
@@ -187,19 +197,22 @@ export function companionLayoutFor(
 ): CompanionLayout {
   const scale = companionScaleFor(optionsBox);
   const avatarHalf = avatarBox / 2;
+  const baseline = companionBaselineFor(avatarBox);
   const gap = companionGapFor(avatarBox, optionsBox);
   const nearEdge = companionNearEdgeFor(avatarBox, optionsBox);
   const inUnits = (points: number): number => points / scale;
-  // What is drawn beside the creature, measured from the creature's centre.
-  // The pill is bottom-flush with the avatar, so downward the two stop on the
-  // same line and upward the pill reaches a whole options box back past it,
-  // which stands above a creature smaller than the pill.
-  const reachUp = Math.max(avatarHalf, optionsBox - avatarHalf);
-  const reachDown = avatarHalf;
+  // One rule read on each side: whichever of the creature's box and the pill
+  // reaches further from the centre. The pill's bottom is the creature's
+  // baseline, so downward it reaches that baseline and upward it reaches a
+  // whole options box back past it, and the creature's own half box is what
+  // stands there when the creature is the larger.
+  const reachUp = Math.max(avatarHalf, optionsBox - baseline);
+  const reachDown = Math.max(avatarHalf, baseline);
   return {
     scale,
     avatarRel: avatarBox / optionsBox,
     avatarHalf,
+    baseline,
     gap,
     inUnits,
     lineAt: (cardGrowth, offset) =>

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -23,9 +23,10 @@ import { composeSvg } from "@/utils/avatar-svg-compositor";
 import {
   COMPANION_BASE_AVATAR_BOX,
   COMPANION_INTRO_BEATS,
-  COMPANION_SIZE_BOXES,
   COMPANION_SIZES,
+  companionBoxFor,
   type CompanionIntroBeat,
+  type CompanionSizeAxis,
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
 
@@ -85,16 +86,19 @@ const BACKDROPS = {
 type Backdrop = keyof typeof BACKDROPS;
 
 /**
- * The five named steps, as the boxes the surface actually takes.
+ * The five named steps for one axis, as the boxes the surface actually takes.
  *
  * The controls offer the names and hand over the numbers, because the names are
  * what a user picks from a menu and the boxes are what the surface is drawn in.
- * Both axes read from the same set: one vocabulary, two answers.
+ * Per axis rather than shared, because the same name is a different box on each
+ * one: one vocabulary, two tables.
  */
-const SIZE_OPTIONS = COMPANION_SIZES.map((size) => COMPANION_SIZE_BOXES[size]);
-const SIZE_LABELS: Record<number, string> = Object.fromEntries(
-  COMPANION_SIZES.map((size) => [COMPANION_SIZE_BOXES[size], size]),
-);
+const sizeOptionsFor = (axis: CompanionSizeAxis): number[] =>
+  COMPANION_SIZES.map((size) => companionBoxFor(axis, size));
+const sizeLabelsFor = (axis: CompanionSizeAxis): Record<number, string> =>
+  Object.fromEntries(
+    COMPANION_SIZES.map((size) => [companionBoxFor(axis, size), size]),
+  );
 
 type StoryArgs = React.ComponentProps<typeof CompanionSurface> & {
   backdrop: Backdrop;
@@ -134,13 +138,13 @@ const meta: Meta<StoryArgs> = {
     },
     avatarBox: {
       name: "avatarSize",
-      control: { type: "select", labels: SIZE_LABELS },
-      options: SIZE_OPTIONS,
+      control: { type: "select", labels: sizeLabelsFor("avatar") },
+      options: sizeOptionsFor("avatar"),
     },
     optionsBox: {
       name: "optionsSize",
-      control: { type: "select", labels: SIZE_LABELS },
-      options: SIZE_OPTIONS,
+      control: { type: "select", labels: sizeLabelsFor("options") },
+      options: sizeOptionsFor("options"),
     },
     accentHex: { control: "color" },
     watching: { control: "boolean" },
@@ -261,17 +265,17 @@ export const TypingWhileWorking: Story = {
  * size axes exist for.
  *
  * The pill, the card and the gap follow the options size and the creature
- * follows the avatar size, so the controls here sit at the size the layout is
- * authored at while the creature runs well past them. The two still share a
- * bottom line and that gap: the pill's avatar-facing edge is the creature's own
- * visual edge plus the gap, which is the distance the host sizes the window by.
+ * follows the avatar size, so the controls here sit well short of the creature
+ * beside them. The pill's bottom still sits on the creature's visible bottom,
+ * and its avatar-facing edge is the creature's own visual edge plus the gap,
+ * which is the distance the host sizes the window by.
  */
 export const BigAvatarSmallOptions: Story = {
   args: {
     phase: "hover",
     hovered: true,
-    avatarBox: COMPANION_SIZE_BOXES.huge,
-    optionsBox: COMPANION_SIZE_BOXES.small,
+    avatarBox: companionBoxFor("avatar", "huge"),
+    optionsBox: companionBoxFor("options", "small"),
   },
 };
 
@@ -280,16 +284,17 @@ export const BigAvatarSmallOptions: Story = {
  *
  * The surface scales its own box by the options size and the creature carries
  * the difference back down, so the pill and every control on it grow and the
- * creature does not. The gap is the smaller of the two objects' clearance
- * rather than the larger one's, so a small creature beside an enormous pill is
- * not separated from it by a chasm.
+ * creature does not. The pill still stands on the creature's visible bottom and
+ * so reaches well above its head. The gap is the smaller of the two objects'
+ * clearance rather than the larger one's, so a small creature beside an
+ * enormous pill is not separated from it by a chasm.
  */
 export const SmallAvatarBigOptions: Story = {
   args: {
     phase: "hover",
     hovered: true,
-    avatarBox: COMPANION_SIZE_BOXES.small,
-    optionsBox: COMPANION_SIZE_BOXES.huge,
+    avatarBox: companionBoxFor("avatar", "small"),
+    optionsBox: companionBoxFor("options", "huge"),
   },
 };
 
@@ -303,8 +308,8 @@ export const SmallAvatarBigOptions: Story = {
 export const RestingBigAvatarSmallOptions: Story = {
   args: {
     phase: "resting",
-    avatarBox: COMPANION_SIZE_BOXES.huge,
-    optionsBox: COMPANION_SIZE_BOXES.small,
+    avatarBox: companionBoxFor("avatar", "huge"),
+    optionsBox: companionBoxFor("options", "small"),
   },
 };
 
@@ -312,8 +317,8 @@ export const RestingBigAvatarSmallOptions: Story = {
 export const RestingSmallAvatarBigOptions: Story = {
   args: {
     phase: "resting",
-    avatarBox: COMPANION_SIZE_BOXES.small,
-    optionsBox: COMPANION_SIZE_BOXES.huge,
+    avatarBox: companionBoxFor("avatar", "small"),
+    optionsBox: companionBoxFor("options", "huge"),
   },
 };
 
@@ -603,17 +608,18 @@ export const AgainstTheRightEdge: Story = {
  * The flip with the two sizes pulling against each other, which is where a
  * mirrored anchor is easiest to get wrong.
  *
- * The pill is pinned by its right edge a gap off a creature more than twice its
- * height, and the two still share a bottom line. The creature holds the same
- * spot it holds growing rightward: what a flip moves is the pill.
+ * The pill is pinned by its right edge a gap off a creature several times its
+ * height, and its bottom still sits on the creature's visible bottom. The
+ * creature holds the same spot it holds growing rightward: what a flip moves is
+ * the pill.
  */
 export const BigAvatarAgainstTheRightEdge: Story = {
   args: {
     phase: "hover",
     hovered: true,
     growth: "left",
-    avatarBox: COMPANION_SIZE_BOXES.huge,
-    optionsBox: COMPANION_SIZE_BOXES.small,
+    avatarBox: companionBoxFor("avatar", "huge"),
+    optionsBox: companionBoxFor("options", "small"),
   },
   decorators: [againstTheRightEdge],
 };

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -464,14 +464,16 @@ describe("the companion surface's anchor in the canvas", () => {
   });
 
   /**
-   * The avatar's bottom line is the fixed point. The pill's bottom sits on it,
-   * which at this size puts the pill's own centre on the avatar's centre too,
-   * and the mascot never moves whichever way the pill or the card grows.
+   * The creature's visible bottom is the fixed point. The pill's bottom sits on
+   * it rather than on the avatar's box, which runs a further 8 points down to
+   * hold the glow, and the mascot never moves whichever way the pill or the
+   * card grows.
    */
-  test("sits the pill's bottom on the avatar's bottom", () => {
+  test("sits the pill's bottom on the creature's visible bottom", () => {
     const { container } = render(<CompanionSurface phase="hover" />);
-    // 46 from the canvas edge to the avatar's centre, 22 further to its bottom.
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
+    // 54 from the canvas edge to the avatar's centre, 14 further to the bottom
+    // of the 28pt artwork inside its 44pt box.
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 40px)");
     expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
@@ -480,15 +482,15 @@ describe("the companion surface's anchor in the canvas", () => {
    * down, so the row's bottom is the avatar's bottom either way and the card
    * hangs off it in whichever direction the host picked.
    */
-  test("hangs the card off the avatar's line when it grows up", () => {
+  test("hangs the card off the creature's line when it grows up", () => {
     const { container } = render(<CompanionSurface phase="typing" />);
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 40px)");
     expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   /**
    * The whole column against the other edge: the avatar sits on the canvas's
-   * top line, the pill keeps its bottom on the avatar's, and the card falls
+   * top line, the pill keeps its bottom on the creature's, and the card falls
    * away from the row instead of hanging off it. The column reverses for the
    * reason the row does when the pill grows left: the row holding the avatar's
    * line has to end up against the avatar, and the conversation stacks away
@@ -498,7 +500,7 @@ describe("the companion surface's anchor in the canvas", () => {
     const { container: resting } = render(
       <CompanionSurface phase="resting" cardGrowth="down" />,
     );
-    expect(avatarOf(resting).style.top).toBe("46px");
+    expect(avatarOf(resting).style.top).toBe("54px");
 
     const { container: hover } = render(
       <CompanionSurface phase="hover" cardGrowth="down" />,
@@ -544,7 +546,7 @@ describe("the companion surface's anchor in the canvas", () => {
     for (const phase of PHASES) {
       const { container } = render(<CompanionSurface phase={phase} />);
       expect(avatarOf(container).style.left).toBe("50%");
-      expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+      expect(avatarOf(container).style.top).toBe("calc(100% - 54px)");
       expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
       cleanup();
     }
@@ -625,9 +627,9 @@ describe("the companion surface at two sizes", () => {
 
   /**
    * 55 to a huge creature's edge, then the gap the smaller of the two earns.
-   * Bottom-flush with it as well: the near edge is 115 at this pair and the
-   * creature's bottom is 55 in from its centre, so the pill's bottom lands 60
-   * from the canvas edge.
+   * On its visible bottom as well: the near edge is 115 at this pair and the
+   * artwork stops 35 in from the centre, so the pill's bottom lands 80 from the
+   * canvas edge.
    */
   test("steps the pill off a larger creature's edge and onto its bottom", () => {
     const { container } = render(
@@ -635,22 +637,22 @@ describe("the companion surface at two sizes", () => {
     );
     expect(surfaceOf(container).style.left).toBe("calc(50% + 67px)");
     expect(avatarOf(container).style.top).toBe("calc(100% - 115px)");
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 60px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 80px)");
     expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   /**
    * The same rules the other way round, read in the pill's own units: 22 points
    * to the creature's edge and 12 of gap, at a scale of two and a half, and the
-   * pill's bottom on the creature's own bottom as before.
+   * pill's bottom on the creature's visible bottom the same way.
    */
   test("steps it off a smaller creature and onto its bottom too", () => {
     const { container } = render(
       <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
     );
     expect(surfaceOf(container).style.left).toBe("calc(50% + 13.6px)");
-    expect(avatarOf(container).style.top).toBe("calc(100% - 59.2px)");
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 50.4px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 62.4px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 56.8px)");
     expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
@@ -676,12 +678,12 @@ describe("the companion surface at two sizes", () => {
       />,
     );
     expect(avatarOf(container).style.top).toBe("115px");
-    expect(surfaceOf(container).style.top).toBe("170px");
+    expect(surfaceOf(container).style.top).toBe("150px");
   });
 
   /**
    * The card growing downward starts on its composer row's top line, which is
-   * one options box above the creature's bottom whatever the creature's size.
+   * one options box above the creature's baseline whatever the creature's size.
    */
   test("drops the card from the composer row's own line", () => {
     const { container } = render(
@@ -726,7 +728,7 @@ describe("the companion surface at two sizes", () => {
       <CompanionSurface phase="resting" avatarBox={110} optionsBox={110} />,
     );
     expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
-    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 54px)");
   });
 });
 

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -23,6 +23,7 @@ import type {
 
 import {
   COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_AVATAR_IMAGE,
   COMPANION_BASE_MAX_PILL_WIDTH,
 } from "@vellumai/ipc-contract";
 import type {
@@ -192,8 +193,12 @@ const WATCHING_RING_ACCENT = "#ff9f45";
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
  * every side. Both the still and the composed creature draw at this size, so
  * nothing moves when one replaces the other.
+ *
+ * From the contract because the pill lines up with the creature's visible
+ * bottom: `companionBaselineFor` answers half of this, and the two processes
+ * cannot be left holding different readings of where the creature stops.
  */
-const AVATAR_IMAGE = 28;
+const AVATAR_IMAGE = COMPANION_BASE_AVATAR_IMAGE;
 
 /**
  * The clearance every round thing inside the pill keeps from its edge.
@@ -707,7 +712,7 @@ export function CompanionSurface({
   // The distances everything below is placed by, in points, and the one
   // conversion into the units this layout is stated in. Shared with
   // `CompanionIntro`, whose card hangs off the same creature.
-  const { scale, avatarRel, avatarHalf, gap, lineAt, edgeAt } =
+  const { scale, avatarRel, avatarHalf, baseline, gap, lineAt, edgeAt } =
     companionLayoutFor(avatarBox, optionsBox);
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
@@ -724,28 +729,25 @@ export function CompanionSurface({
   const placement = edgeAt(growth, avatarHalf + gap);
 
   // The card growing downward draws its composer row first, so the row starts
-  // on the avatar's top line and the card falls away from it; everything else
-  // hangs upward off the avatar's bottom line.
+  // one options box above the creature's baseline and the card falls away from
+  // it; everything else hangs upward off that baseline.
   const dropsFromTheRow = typing && cardGrowth === "down";
 
   const style: CSSProperties = {
     width,
     ...placement,
-    // **Bottom-flush with the avatar.** The pill's bottom edge sits on the
-    // avatar's, and the card keeps that line: its composer row is the column's
-    // last child growing up and its first growing down, so the row's bottom is
-    // the avatar's bottom either way and the mascot does not move when Type is
-    // pressed. The line is the avatar's *box*, not the artwork inside it, which
-    // is inset by an `INNER_GAP` on every side and so stops short of it. Which
-    // way the card stacks is the host's call: parked by the Dock a card growing
-    // down would grow off the bottom of the screen, and at the top of the
-    // display a card growing up has nowhere to be (see
+    // **On the creature's visible bottom.** The pill's bottom edge sits on the
+    // bottom of the artwork, and the card keeps that line: its composer row is
+    // the column's last child growing up and its first growing down, so the
+    // row's bottom is that line either way and the mascot does not move when
+    // Type is pressed. The line is the artwork, not the avatar's *box*, which
+    // runs an `INNER_GAP` further down to hold the glow and the bob's slack.
+    // Which way the card stacks is the host's call: parked by the Dock a card
+    // growing down would grow off the bottom of the screen, and at the top of
+    // the display a card growing up has nowhere to be (see
     // `CompanionSurfaceCardGrowth`). The row is one options box tall, so a card
     // growing downward starts exactly that far above the line.
-    top: lineAt(
-      cardGrowth,
-      dropsFromTheRow ? avatarHalf - optionsBox : avatarHalf,
-    ),
+    top: lineAt(cardGrowth, dropsFromTheRow ? baseline - optionsBox : baseline),
     transform: dropsFromTheRow ? "none" : "translateY(-100%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -739,11 +739,13 @@ export type CompanionCardGrowth = (typeof COMPANION_CARD_GROWTHS)[number];
  * state. A continuous scale would be a layout nobody had ever looked at; five
  * steps are five layouts, each checkable in Storybook.
  *
- * `medium` is the default. `small` is the size the surface's layout is authored
- * at, which every other step scales from. `ridiculous` is the joke at the end
- * of the scale, and it is a real step rather than a gag drawn some other way:
- * every length on the surface is stated in `small`, so the largest step costs
- * one number here and is drawn by the same code as the other four.
+ * `medium` is the default. Every length on the surface is stated at 44 points
+ * and scaled from there, and which named step that is depends on the axis: it
+ * is `small` on the avatar's table and `medium` on the options' (see
+ * {@link COMPANION_OPTIONS_SIZE_BOXES}). `ridiculous` is the joke at the end of
+ * the scale, and it is a real step rather than a gag drawn some other way: the
+ * largest step costs one number per table and is drawn by the same code as the
+ * other four.
  */
 export const COMPANION_SIZES = [
   "small",
@@ -756,7 +758,7 @@ export const COMPANION_SIZES = [
 export type CompanionSize = (typeof COMPANION_SIZES)[number];
 
 /** The avatar's box in points, per named size. The scale is this over `small`. */
-export const COMPANION_SIZE_BOXES: Record<CompanionSize, number> = {
+export const COMPANION_AVATAR_SIZE_BOXES: Record<CompanionSize, number> = {
   small: 44,
   medium: 66,
   large: 88,
@@ -767,6 +769,29 @@ export const COMPANION_SIZE_BOXES: Record<CompanionSize, number> = {
   // display is too short for it, so the oversize step lands on paths the other
   // four already take near an edge.
   ridiculous: 220,
+};
+
+/**
+ * The options pill's box in points, per named size.
+ *
+ * One notch below the creature's table at every step, because a control strip
+ * and a mascot are not read at the same size: the creature is a character on
+ * the desktop and wants to be seen, and the pill is a row of controls that
+ * wants to be reachable. The same name on both axes should leave the pill
+ * comfortably shorter than the creature holding it out.
+ *
+ * The pill is authored at 44 and {@link companionScaleFor} still divides by
+ * {@link COMPANION_BASE_AVATAR_BOX}, so these are scales of that one layout:
+ * `small` is that layout at 32/44 and `medium` is it at 1:1. Nothing here is a
+ * second set of dimensions, which is what keeps the five steps five drawings of
+ * the same surface.
+ */
+export const COMPANION_OPTIONS_SIZE_BOXES: Record<CompanionSize, number> = {
+  small: 32,
+  medium: 44,
+  large: 66,
+  huge: 88,
+  ridiculous: 110,
 };
 
 /**
@@ -786,8 +811,9 @@ export const DEFAULT_COMPANION_SIZE: CompanionSize = "medium";
  * The two things on the surface a user sizes, sized separately.
  *
  * An avatar big enough to read from across the room does not mean a pill that
- * wide, and both axes take the same five steps ({@link COMPANION_SIZES}), so
- * there is one vocabulary and two answers rather than two scales to learn.
+ * wide, and both axes take the same five names ({@link COMPANION_SIZES}), so
+ * there is one vocabulary and two answers rather than two scales to learn. Each
+ * axis reads its own table, since the same name means a different box on each.
  * `avatar` sizes the creature, its glow and its bob; `options` sizes the pill,
  * the typing card, the call's body and the introduction's card.
  */
@@ -796,14 +822,39 @@ export const COMPANION_SIZE_AXES = ["avatar", "options"] as const;
 export type CompanionSizeAxis = (typeof COMPANION_SIZE_AXES)[number];
 
 /**
+ * The box one axis draws a named size at.
+ *
+ * The one place a name becomes a number, so nothing downstream has to remember
+ * which of the two tables its axis reads. Names are what the menus offer and
+ * what the store keeps; boxes are what the geometry is done in.
+ */
+export const companionBoxFor = (
+  axis: CompanionSizeAxis,
+  size: CompanionSize,
+): number =>
+  axis === "avatar"
+    ? COMPANION_AVATAR_SIZE_BOXES[size]
+    : COMPANION_OPTIONS_SIZE_BOXES[size];
+
+/**
  * The avatar's box the companion's layout is authored at, and the size every
  * other length in that layout is stated in.
  *
- * The scale is the box in {@link COMPANION_SIZE_BOXES} over this one. The
- * renderer draws at this size and scales the whole surface by that factor, so
- * the two processes never hold two sets of dimensions.
+ * The scale is the box in either size table over this one. The renderer draws
+ * at this size and scales the whole surface by that factor, so the two
+ * processes never hold two sets of dimensions.
  */
-export const COMPANION_BASE_AVATAR_BOX = COMPANION_SIZE_BOXES.small;
+export const COMPANION_BASE_AVATAR_BOX = COMPANION_AVATAR_SIZE_BOXES.small;
+
+/**
+ * The creature's artwork inside that box, which is inset on every side.
+ *
+ * The visible creature rather than the box around it. The box is bigger than
+ * the drawing so the glow has somewhere to fall off into and the bob has
+ * somewhere to rise into, and `CompanionSurface` draws both the still and the
+ * composed avatar at this size so nothing moves when one replaces the other.
+ */
+export const COMPANION_BASE_AVATAR_IMAGE = 28;
 
 /**
  * Room the pill's shadow and the avatar's glow paint outside their own boxes,
@@ -863,6 +914,19 @@ export const companionScaleFor = (box: number): number =>
   box / COMPANION_BASE_AVATAR_BOX;
 
 /**
+ * How far below the avatar's centre the pill's bottom sits, for a given avatar
+ * box.
+ *
+ * The creature's visible bottom rather than its box's. The box runs past the
+ * artwork on every side to hold the glow and the bob's slack, so a pill lined
+ * up with the box reads as sitting below the creature rather than beside it.
+ * The bob lifts the creature off this line and returns to it, which is what
+ * makes the line the thing the eye keeps coming back to.
+ */
+export const companionBaselineFor = (avatarBox: number): number =>
+  (COMPANION_BASE_AVATAR_IMAGE / 2) * companionScaleFor(avatarBox);
+
+/**
  * That gap for a given pair of boxes.
  *
  * Scaled by the smaller of the two, because the gap is breathing room and the
@@ -910,13 +974,14 @@ export const companionPadFor = (
  * somewhere other than where main believes it is.
  *
  * What has to clear that edge depends on which way the card grows, because the
- * pill's bottom edge is the avatar's: growing up, the near side holds the
- * avatar's own half box and nothing else; growing down, the pill stands on that
- * line and reaches a whole options box back past it, which pokes above a
- * smaller creature. The larger of the two is taken so the answer is the same
- * either way, since a flip moves the canvas rather than resizing it, and a near
- * edge that changed with the direction would shift the avatar by the
- * difference.
+ * pill stands on the creature's baseline ({@link companionBaselineFor}) rather
+ * than on its box: growing up, the near side holds the avatar's own half box,
+ * which runs below that line and is where the glow paints; growing down, the
+ * pill stands on the baseline and reaches a whole options box back past it,
+ * which pokes above a smaller creature. The larger of the two is taken so the
+ * answer is the same either way, since a flip moves the canvas rather than
+ * resizing it, and a near edge that changed with the direction would shift the
+ * avatar by the difference.
  *
  * The far edge is {@link companionCardSideFor}, which the renderer never has to
  * state: `100%` names the canvas there, and main sizes it.
@@ -925,7 +990,7 @@ export const companionNearEdgeFor = (
   avatarBox: number,
   optionsBox: number,
 ): number =>
-  Math.max(avatarBox / 2, optionsBox - avatarBox / 2) +
+  Math.max(avatarBox / 2, optionsBox - companionBaselineFor(avatarBox)) +
   companionPadFor(avatarBox, optionsBox);
 
 /**
@@ -933,10 +998,10 @@ export const companionNearEdgeFor = (
  * into, for a given pair of boxes.
  *
  * The far half of {@link companionNearEdgeFor}, taken over both growths for the
- * same reason. Growing up, the card stands on the avatar's bottom line and
- * rises its whole height from there; growing down, its composer row holds that
- * line and the rest of the card falls away below it. The avatar's own half box
- * is the floor under both, for a creature taller than the card beside it.
+ * same reason. Growing up, the card stands on the creature's baseline and rises
+ * its whole height from there; growing down, its composer row holds that line
+ * and the rest of the card falls away below it. The avatar's own half box is
+ * the floor under both, for a creature taller than the card beside it.
  *
  * Only main consumes this: the renderer names that edge with `100%` and lets
  * main size the canvas. It lives here to sit beside the constants it reads.
@@ -946,11 +1011,12 @@ export const companionCardSideFor = (
   optionsBox: number,
 ): number => {
   const scale = companionScaleFor(optionsBox);
+  const baseline = companionBaselineFor(avatarBox);
   return (
     Math.max(
-      COMPANION_BASE_CARD_HEIGHT * scale - avatarBox / 2,
+      COMPANION_BASE_CARD_HEIGHT * scale - baseline,
       (COMPANION_BASE_CARD_HEIGHT - COMPANION_BASE_AVATAR_BOX) * scale +
-        avatarBox / 2,
+        baseline,
       avatarBox / 2,
     ) + companionPadFor(avatarBox, optionsBox)
   );
@@ -1146,8 +1212,8 @@ export interface CompanionSurfaceState {
    * The avatar's box in points, which is the creature's whole scale.
    *
    * Numbers rather than the named sizes, because a name is a lookup both sides
-   * would then have to hold the same copy of. See {@link COMPANION_SIZE_BOXES},
-   * and {@link COMPANION_SIZE_AXES} for why there are two of them.
+   * would then have to hold the same copy of. See {@link companionBoxFor}, and
+   * {@link COMPANION_SIZE_AXES} for why there are two of them.
    */
   avatarBox: number;
   /**


### PR DESCRIPTION
## Summary
- The options axis gets its own step table (32/44/66/88/110): small is a 32pt pill with ~20pt controls; the avatar table is unchanged
- The pill's bottom sits on the creature's visible bottom (artwork), not its box; near-edge, card-side and intro clearances follow from one contract baseline helper
- Storybook size controls map each axis through its own table

Follow-up to #41564.