### PR TITLE
feat(web): restyle the ask-question card against its Figma spec

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/composer-compact.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/composer-compact.tsx
@@ -1,11 +1,6 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  type ReactNode,
-  type RefObject,
-} from "react";
+import { createContext, useContext, type ReactNode } from "react";
+
+import { COMPACT_WIDTH_PX, useIsCompactWidth } from "@/hooks/use-compact-width";
 
 /**
  * Composer card width (px) below which the action row can no longer hold the
@@ -13,10 +8,10 @@ import {
  * other and the two labels render on top of one another. Below this the pair
  * collapses into a single hamburger menu holding both sections.
  *
- * Measured against the card, not the viewport: the composer also narrows when
- * the sidebar opens or the window is split, and the collision follows the card.
+ * This is the tightest surface in the chat column, so it is what sets the
+ * column's shared threshold.
  */
-export const COMPOSER_COMPACT_WIDTH_PX = 520;
+export const COMPOSER_COMPACT_WIDTH_PX = COMPACT_WIDTH_PX;
 
 const ComposerCompactContext = createContext(false);
 
@@ -45,27 +40,6 @@ export function ComposerCompactProvider({
 
 /**
  * Track whether `ref`'s element is narrower than
- * {@link COMPOSER_COMPACT_WIDTH_PX}, via `ResizeObserver` so it follows
- * sidebar toggles and window resizes, not just the initial layout.
+ * {@link COMPOSER_COMPACT_WIDTH_PX}.
  */
-export function useIsCompactComposerWidth(
-  ref: RefObject<HTMLElement | null>,
-): boolean {
-  const [compact, setCompact] = useState(false);
-
-  useEffect(() => {
-    const el = ref.current;
-    if (!el || typeof ResizeObserver === "undefined") {
-      return;
-    }
-    const measure = () => {
-      setCompact(el.getBoundingClientRect().width < COMPOSER_COMPACT_WIDTH_PX);
-    };
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [ref]);
-
-  return compact;
-}
+export const useIsCompactComposerWidth = useIsCompactWidth;

--- a/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
@@ -608,6 +608,22 @@ describe("QuestionPromptCard width", () => {
     expect(headerLayout()).toBe("inline");
   });
 
+  test("only a card that can be dragged takes selection away from a thumb", () => {
+    setPointer(true);
+    renderCard();
+
+    // Narrow, the gesture competes with a long-press, so selection stands down.
+    const header = document.querySelector<HTMLElement>("[data-header]")!;
+    expect(header.className).toContain("select-none");
+
+    setCardWidth(ROOMY_PX);
+
+    // Roomy the card holds still, so a long-press on the question is free.
+    expect(
+      document.querySelector<HTMLElement>("[data-header]")!.className,
+    ).not.toContain("select-none");
+  });
+
   test("the header reflows without remounting what it sits above", () => {
     renderCard();
     const before = collapsibleRegion();

--- a/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
@@ -1,11 +1,14 @@
 /**
- * Tests for the `QuestionPromptCard` minimized state (LUM-3390).
+ * Tests for the `QuestionPromptCard` collapse (LUM-3390) and the width that
+ * decides whether it is offered at all.
  *
- * The card sits between the transcript and the composer, so at full height it
- * covers the message it is asking about. Minimizing has to put the options out
+ * The card sits between the transcript and the composer, so on a narrow card it
+ * covers the message it is asking about. Collapsing has to put the options out
  * of reach as well as out of sight: a collapsed row still answers a click and
  * still takes a hotkey unless something says otherwise, and either would submit
- * an answer the user never saw.
+ * an answer the user never saw. A card wide enough to sit beside the transcript
+ * has nothing to collapse for and offers no control to do it with, which makes
+ * "wide and collapsed" a state the card must never reach.
  *
  * The gesture itself is covered in `use-question-card-minimize.test.ts`; these
  * cover what the card does with it.
@@ -70,16 +73,85 @@ function setPointer(coarse: boolean): void {
   });
 }
 
+/**
+ * happy-dom ships a `ResizeObserver` whose methods do nothing, and no layout
+ * engine behind `getBoundingClientRect`, so a card here measures zero and reads
+ * as narrow. That is the useful default: the roomy layout is the one that needs
+ * room proven. Width changes are driven by holding the observer's own callback
+ * and calling it, rather than by remounting the card, because the collapse
+ * state lives in `useState` and a remount would reset it and pass the
+ * auto-expand assertions for the wrong reason.
+ */
+interface StubbedObserver {
+  callback: ResizeObserverCallback;
+  targets: Set<Element>;
+}
+
+const resizeObservers = new Set<StubbedObserver>();
+let originalResizeObserver: typeof ResizeObserver;
+
+function installResizeObserver(): void {
+  originalResizeObserver = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class {
+    private entry: StubbedObserver;
+    constructor(callback: ResizeObserverCallback) {
+      this.entry = { callback, targets: new Set() };
+      resizeObservers.add(this.entry);
+    }
+    observe(target: Element) {
+      this.entry.targets.add(target);
+    }
+    unobserve(target: Element) {
+      this.entry.targets.delete(target);
+    }
+    disconnect() {
+      resizeObservers.delete(this.entry);
+    }
+  } as unknown as typeof ResizeObserver;
+}
+
+/**
+ * Report `px` as every observed element's inline size. Other components in the
+ * tree build their own observers, so each is notified about its own target
+ * rather than whichever was constructed last.
+ */
+function setCardWidth(px: number): void {
+  act(() => {
+    for (const observer of resizeObservers) {
+      for (const target of observer.targets) {
+        observer.callback(
+          [
+            {
+              target,
+              borderBoxSize: [{ inlineSize: px, blockSize: 0 }],
+            } as unknown as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver,
+        );
+      }
+    }
+  });
+}
+
+/** Comfortably past the release band, so a narrow card becomes roomy. */
+const ROOMY_PX = 800;
+/** Comfortably below the threshold, so a roomy card becomes narrow again. */
+const CRAMPED_PX = 380;
+
 beforeEach(() => {
   pointerIsCoarse = false;
   mediaListeners.clear();
   installMatchMedia();
+  resizeObservers.clear();
+  installResizeObserver();
 });
 
 afterEach(() => {
   cleanup();
   pointerIsCoarse = false;
   mediaListeners.clear();
+  resizeObservers.clear();
+  globalThis.ResizeObserver = originalResizeObserver;
 });
 
 function renderCard(
@@ -101,10 +173,9 @@ function renderCard(
 }
 
 /**
- * Whichever control currently carries the collapse state. Expanded that is the
- * header chevron; minimized it is the summary itself, which is named by its own
- * contents rather than a label, so `aria-expanded` is what identifies it in
- * both states.
+ * The collapse chevron, which a narrow card carries in both states and a roomy
+ * card carries in neither. `aria-expanded` is what identifies it, since its
+ * label changes with the direction it points.
  */
 function toggleButton(): HTMLElement {
   const control = document.querySelector<HTMLElement>("[aria-expanded]");
@@ -114,10 +185,13 @@ function toggleButton(): HTMLElement {
   return control;
 }
 
+function queryToggleButton(): HTMLElement | null {
+  return document.querySelector<HTMLElement>("[aria-expanded]");
+}
+
 /**
  * The text a screen reader would reach, which is not the same as the text in
- * the DOM: both halves of the header crossfade stay mounted at zero height, and
- * so does the whole collapsed body.
+ * the DOM: the collapsed body stays mounted at zero height.
  */
 function accessibleText(root: Element): string {
   const out: string[] = [];
@@ -179,54 +253,55 @@ function swipeDown(): void {
   fireEvent.touchEnd(surface, { changedTouches: at(300) });
 }
 
-function collapsibleRegion(): HTMLElement {
-  const id = toggleButton().getAttribute("aria-controls");
-  expect(id).toBeTruthy();
-  const region = document.getElementById(id!);
-  expect(region).not.toBeNull();
-  return region!;
+/** How the header is arranged: a meta row of its own, or one line with it. */
+function headerLayout(): string | null {
+  return (
+    document.querySelector<HTMLElement>("[data-header]")?.dataset.header ?? null
+  );
 }
 
-describe("QuestionPromptCard minimize", () => {
-  test("renders expanded, with the minimize control open", () => {
+/** The region the chevron collapses, addressed without going through it. */
+function collapsibleRegion(): HTMLElement {
+  const el = document.querySelector<HTMLElement>(
+    '[data-slot="question-card-body"]',
+  );
+  if (!el) {
+    throw new Error("the card rendered no collapsible body");
+  }
+  return el;
+}
+
+describe("QuestionPromptCard collapse", () => {
+  test("renders expanded, with the collapse control open", () => {
     renderCard();
 
     expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
     expect(toggleButton().getAttribute("aria-label")).toBe("Minimize question");
+    expect(toggleButton().getAttribute("aria-controls")).toBe(
+      collapsibleRegion().id,
+    );
     expect(
       screen.getByText("Pick the most useful starting point."),
     ).toBeDefined();
     expect(collapsibleRegion().hasAttribute("inert")).toBe(false);
   });
 
-  test("the minimize button collapses the body and swaps in a summary", () => {
-    renderCard();
+  test("the chevron collapses the body and leaves the header standing", () => {
+    const { container } = renderCard();
 
     fireEvent.click(toggleButton());
 
     expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
-    // The question itself stays: it is what the summary row is a summary of.
-    expect(
-      screen.getByText("What should we build first for MarkOne?"),
-    ).toBeDefined();
-    expect(screen.getByText(/4 options/)).toBeDefined();
-  });
-
-  test("the summary line is announced only once the body it stands in for is gone", () => {
-    const { container } = renderCard();
-
-    expect(accessibleText(container)).not.toContain("4 options");
+    // Both header lines survive the collapse: they are what a collapsed card
+    // is, rather than a stand-in for it.
+    expect(accessibleText(container)).toContain(
+      "What should we build first for MarkOne?",
+    );
     expect(accessibleText(container)).toContain(
       "Pick the most useful starting point.",
     );
-
-    fireEvent.click(toggleButton());
-
-    expect(accessibleText(container)).toContain("4 options");
-    expect(accessibleText(container)).not.toContain(
-      "Pick the most useful starting point.",
-    );
-    // The options go with it: a row read out here is one the user cannot see.
+    // The options go with the body: a row read out here is one the user
+    // cannot see.
     expect(accessibleText(container)).not.toContain("Choose the ideal clients");
   });
 
@@ -238,12 +313,14 @@ describe("QuestionPromptCard minimize", () => {
     expect(collapsibleRegion().hasAttribute("inert")).toBe(true);
   });
 
-  test("tapping a minimized card's header reopens it", () => {
+  test("tapping a collapsed card's header reopens it", () => {
     renderCard();
 
     fireEvent.click(toggleButton());
     expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
 
+    // The whole header is the target, so a thumb has more than the chevron to
+    // land on.
     fireEvent.click(
       screen.getByText("What should we build first for MarkOne?"),
     );
@@ -251,7 +328,7 @@ describe("QuestionPromptCard minimize", () => {
     expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
   });
 
-  test("tapping an expanded card's header does not minimize it", () => {
+  test("tapping an expanded card's header does not collapse it", () => {
     renderCard();
 
     fireEvent.click(
@@ -261,7 +338,7 @@ describe("QuestionPromptCard minimize", () => {
     expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
   });
 
-  test("option hotkeys stop answering once the card is minimized", () => {
+  test("option hotkeys stop answering once the card is collapsed", () => {
     const submitted: QuestionResponseEntry[][] = [];
     renderCard({ onSubmitAll: (r) => submitted.push(r) });
 
@@ -277,125 +354,123 @@ describe("QuestionPromptCard minimize", () => {
     expect(submitted).toHaveLength(1);
   });
 
-  test("Escape still closes a minimized card", () => {
+  test("Escape closes the card in every state it has", () => {
     let closed = 0;
     renderCard({ onClose: () => (closed += 1) });
 
     fireEvent.click(toggleButton());
     fireEvent.keyDown(window, { key: "Escape" });
-
     expect(closed).toBe(1);
+
+    fireEvent.click(toggleButton());
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(closed).toBe(2);
+
+    // Roomy, where it is the only way out the card offers at all.
+    setCardWidth(ROOMY_PX);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(closed).toBe(3);
   });
 
-  test("the pager leaves with the rows it pages between", () => {
+  test("the pager stays behind when the rows it pages between leave", () => {
     renderCard({ entries: [ENTRY, { ...ENTRY, id: "q2" }] });
-
-    expect(
-      screen.queryByRole("button", { name: "Next question" }),
-    ).not.toBeNull();
 
     fireEvent.click(toggleButton());
 
-    expect(screen.queryByRole("button", { name: "Next question" })).toBeNull();
+    // Paging a collapsed card changes the question its header shows, which is
+    // the one thing still on screen to change.
+    expect(
+      screen.queryByRole("button", { name: "Next question" }),
+    ).not.toBeNull();
   });
 
-  test("a batch announces its position rather than drawing it", () => {
-    // The pager offers movement without saying where from, and the header has
-    // a wrapped question to fit on a phone. The count is carried by a status
-    // line a reader hears and a screen does not show.
+  test("a batch draws its position and announces every change to it", () => {
     renderCard({ entries: [ENTRY, { ...ENTRY, id: "q2" }] });
 
     const status = screen.getByRole("status");
     expect(status.textContent).toBe("1 of 2");
-    expect(status.className).toContain("sr-only");
+    // Drawn, not hidden from sight and read only to a screen reader.
+    expect(status.className).not.toContain("sr-only");
 
     fireEvent.click(screen.getByRole("button", { name: "Next question" }));
 
-    // A live region, so paging is heard rather than only reachable.
+    // A live region, so paging is heard rather than only seen.
     expect(screen.getByRole("status").textContent).toBe("2 of 2");
   });
 
-  test("a minimized batch has no position to report", () => {
+  test("a collapsed batch still reports its position", () => {
     renderCard({ entries: [ENTRY, { ...ENTRY, id: "q2" }] });
 
     fireEvent.click(toggleButton());
 
-    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByRole("status").textContent).toBe("1 of 2");
   });
 
-  test("a single question announces no position at all", () => {
+  test("a single question reports no position at all", () => {
     renderCard();
 
     expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Next question" })).toBeNull();
   });
 
-  test("a minimized card keeps no chevron of its own", () => {
-    const { container } = renderCard({ onClose: () => {} });
+  test("a collapsed card keeps one chevron, turned the other way", () => {
+    renderCard();
 
     fireEvent.click(toggleButton());
 
+    expect(toggleButton().tagName).toBe("BUTTON");
+    expect(toggleButton().getAttribute("aria-label")).toBe("Reopen question");
     expect(
-      Array.from(container.querySelectorAll("button")).filter((button) => {
+      Array.from(document.querySelectorAll("button")).filter((button) => {
         const label = button.getAttribute("aria-label");
         return label === "Minimize question" || label === "Reopen question";
       }),
-    ).toHaveLength(0);
-    // What reopens the card is the summary itself, not a second chevron
-    // pointing the other way.
-    expect(toggleButton().tagName).not.toBe("BUTTON");
+    ).toHaveLength(1);
   });
 
-  test("a minimized card is announced as the question it stands for", () => {
-    renderCard();
+  test("the chevron says which question it reopens", () => {
+    const { container } = renderCard();
 
     fireEvent.click(toggleButton());
 
-    // Descendants of a `role="button"` are flattened into its accessible name,
-    // so an `aria-label` here would trade the question and the option count for
-    // a generic phrase and a reader would lose both. Name-from-content is what
-    // keeps them, and it is the whole reason the label is absent.
-    expect(
-      screen.getByRole("button", {
-        name: /What should we build first for MarkOne\?.*4 options/,
-      }),
-    ).toBeDefined();
+    // Its own label says what the press does. The question is header content
+    // rather than part of that name, so a reader landing on the control would
+    // otherwise have no idea which question it stands for.
+    const describedBy = toggleButton().getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const description = container.ownerDocument.getElementById(describedBy!);
+    expect(description?.textContent).toBe(
+      "What should we build first for MarkOne?",
+    );
   });
 
-  test("the keyboard reopens a minimized card", () => {
+  test("the chevron is a real button, so the browser owns its keystrokes", () => {
     renderCard();
+
+    // `fireEvent.keyDown` does not synthesize the activation click a browser
+    // gives a real button, so the guarantee worth pinning here is that this is
+    // one, rather than an element that has to hand-roll Enter and Space.
+    expect(toggleButton().tagName).toBe("BUTTON");
 
     fireEvent.click(toggleButton());
     expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
-
-    // The summary is a `role="button"` div, so it handles the keystrokes a
-    // real button would have taken care of on its own.
-    fireEvent.keyDown(toggleButton(), { key: "Enter" });
-
-    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
-
-    fireEvent.click(toggleButton());
-    fireEvent.keyDown(toggleButton(), { key: " " });
-
-    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
   });
 
-  test("focus follows the control that replaces the one it was on", () => {
+  test("the chevron keeps focus across a collapse and back", () => {
     renderCard();
 
-    const chevron = toggleButton();
-    chevron.focus();
-    fireEvent.click(chevron);
-
-    // The chevron has just unmounted. Left alone, focus would land on the
-    // document body and the next Tab would restart from the top of the page.
+    toggleButton().focus();
     expect(document.activeElement).toBe(toggleButton());
 
-    fireEvent.keyDown(toggleButton(), { key: "Enter" });
+    fireEvent.click(toggleButton());
 
-    // And back: the summary keeps the DOM node but loses its role and tab
-    // stop, so focus has to move to the chevron that took over from it.
+    // One button across both states, so the DOM keeps focus on it rather than
+    // dropping to the body and restarting the next Tab from the top of the
+    // page.
     expect(document.activeElement).toBe(toggleButton());
-    expect(toggleButton().tagName).toBe("BUTTON");
+
+    fireEvent.click(toggleButton());
+    expect(document.activeElement).toBe(toggleButton());
   });
 
   test("mounting does not pull focus into the card", () => {
@@ -418,21 +493,6 @@ describe("QuestionPromptCard minimize", () => {
     expect(document.activeElement).not.toBe(toggleButton());
   });
 
-  test("a swipe carries focus when it is the focused control being retired", () => {
-    // The hybrid keyboard-and-touch case: focus has been tabbed onto the
-    // chevron, and a thumb then swipes the card shut underneath it. The
-    // chevron unmounts, so focus has to land on what replaced it.
-    setPointer(true);
-    renderCard();
-    toggleButton().focus();
-    expect(document.activeElement).toBe(toggleButton());
-
-    swipeDown();
-
-    expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
-    expect(document.activeElement).toBe(toggleButton());
-  });
-
   test("the hotkey badges follow the pointer changing under a mounted card", () => {
     // The pointer read is subscribed rather than sampled once, so a convertible
     // folding into tablet mode reaches a card that is already on screen.
@@ -447,5 +507,117 @@ describe("QuestionPromptCard minimize", () => {
 
     setPointer(false);
     expect(hotkeyBadges(container)).not.toHaveLength(0);
+  });
+});
+
+describe("QuestionPromptCard width", () => {
+  test("a roomy card offers no collapse, beside a pager that stays", () => {
+    // Batched, so the cluster the chevron sits in is on screen either way and
+    // the chevron leaving is the chevron's own doing.
+    renderCard({ entries: [ENTRY, { ...ENTRY, id: "q2" }] });
+    expect(queryToggleButton()).not.toBeNull();
+
+    setCardWidth(ROOMY_PX);
+
+    expect(queryToggleButton()).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Next question" }),
+    ).not.toBeNull();
+    expect(collapsibleRegion().hasAttribute("inert")).toBe(false);
+  });
+
+  test("a roomy single question carries no header controls at all", () => {
+    renderCard();
+    expect(queryToggleButton()).not.toBeNull();
+
+    setCardWidth(ROOMY_PX);
+
+    expect(queryToggleButton()).toBeNull();
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Previous question" }),
+    ).toBeNull();
+  });
+
+  test("a card collapsed while narrow opens once it has the room", () => {
+    const { container } = renderCard();
+
+    fireEvent.click(toggleButton());
+    expect(collapsibleRegion().hasAttribute("inert")).toBe(true);
+
+    setCardWidth(ROOMY_PX);
+
+    // Nothing left to reopen it with, so it cannot stay shut.
+    expect(collapsibleRegion().hasAttribute("inert")).toBe(false);
+    expect(accessibleText(container)).toContain("Choose the ideal clients");
+  });
+
+  test("a card held open by its width does not spring shut when the room goes", () => {
+    renderCard();
+
+    fireEvent.click(toggleButton());
+    setCardWidth(ROOMY_PX);
+    setCardWidth(CRAMPED_PX);
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
+    expect(collapsibleRegion().hasAttribute("inert")).toBe(false);
+  });
+
+  test("a swipe cannot collapse a roomy card", () => {
+    setPointer(true);
+    renderCard();
+    setCardWidth(ROOMY_PX);
+
+    swipeDown();
+
+    expect(queryToggleButton()).toBeNull();
+    expect(collapsibleRegion().hasAttribute("inert")).toBe(false);
+  });
+
+  test("a roomy card leaves vertical panning to the browser", () => {
+    renderCard();
+    // A narrow card claims the axis it drags on, or the browser can cancel the
+    // touch stream mid-gesture and the collapse commits nothing.
+    expect(dragSurface().className).toContain("touch-action");
+
+    setCardWidth(ROOMY_PX);
+
+    // Roomy it drags on no axis, so holding the declaration would only stop a
+    // finger that wanted to scroll the transcript.
+    expect(dragSurface().className).not.toContain("touch-action");
+  });
+
+  test("a lone chevron rides on the question's line rather than a row of its own", () => {
+    // With no pager to carry, a meta row would be a whole line holding one
+    // 24px control, pushing the question down for nothing.
+    renderCard();
+    expect(headerLayout()).toBe("inline");
+
+    fireEvent.click(toggleButton());
+    expect(headerLayout()).toBe("inline");
+  });
+
+  test("a pager earns the meta row it sits on", () => {
+    renderCard({ entries: [ENTRY, { ...ENTRY, id: "q2" }] });
+
+    expect(headerLayout()).toBe("stacked");
+
+    // Until the card is roomy enough to put the whole cluster beside the
+    // question.
+    setCardWidth(ROOMY_PX);
+    expect(headerLayout()).toBe("inline");
+  });
+
+  test("the header reflows without remounting what it sits above", () => {
+    renderCard();
+    const before = collapsibleRegion();
+
+    setCardWidth(ROOMY_PX);
+    setCardWidth(CRAMPED_PX);
+
+    // The collapse eases on `grid-template-rows`, which a freshly mounted node
+    // has no previous value to interpolate from. A reflow that remounted this
+    // one would make the next collapse jump instead of run.
+    expect(collapsibleRegion()).toBe(before);
   });
 });

--- a/clients/web/src/domains/chat/components/question-prompt-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.stories.tsx
@@ -2,18 +2,21 @@
  * The pending `ask_question` card, the prompt that docks above the composer
  * while the assistant is waiting on an answer.
  *
- * The card is pure props, so these stories drive it directly. What they are
- * for is the minimized state (LUM-3390): it is a live interaction, and the
- * chevron, the swipe and the tap all land on the same transition, so it wants
- * to be played with rather than screenshotted. Open a story, use the chevron
- * in the header, and on a touch target drag the card down or flick it back up.
+ * The card measures itself, so width is the axis these stories are organised
+ * around, and the decorator is what varies. A roomy card puts the question
+ * beside the pager on one line and offers no collapse at all; a narrow one
+ * stacks the pager above the question and carries a chevron to put the options
+ * away. The `Narrow*` stories are the cramped end, which is where the card is
+ * measured against the mock.
  *
- * The `Minimized*` stories start there instead, since that state is where the
- * card is measured against the mock. They are set to the phone viewport, which
- * is where the card is at its most cramped and where the collapse earns its
- * keep. Note that a desktop browser reports a fine pointer at any width, so the
- * numeric hotkey badges stay on; open the story in a device-emulated frame, or
- * on a real phone, to see the card without them.
+ * The collapse is a live interaction, and the chevron, the swipe and the header
+ * tap all land on the same transition, so it wants to be played with rather
+ * than screenshotted. Open a `Narrow` story, use the chevron, and on a touch
+ * target drag the card down or flick it back up.
+ *
+ * A desktop browser reports a fine pointer at any width, so the numeric hotkey
+ * badges stay on; open a story in a device-emulated frame, or on a real phone,
+ * to see the card without them.
  */
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
@@ -45,9 +48,8 @@ const CADENCE: QuestionEntry = {
 };
 
 /**
- * A question long enough to run past the one line the minimized header keeps,
- * which is the shape the collapse actually ships in: the card docks above the
- * composer with the question truncated to whatever the row has left.
+ * A question long enough to run past the two lines a collapsed header keeps,
+ * which is what bounds the height of a card docked above the composer.
  */
 const LONG: QuestionEntry = {
   id: "q3",
@@ -85,38 +87,76 @@ const meta: Meta<typeof QuestionPromptCard> = {
 export default meta;
 type Story = StoryObj<typeof QuestionPromptCard>;
 
-/** The default: expanded, one question, four options and the free-text row. */
-export const Expanded: Story = {
+/**
+ * The width a chat column reaches when the sidebar is closed, which is where
+ * the card gets its one-line header.
+ */
+const roomy: Story["decorators"] = [
+  (Story) => (
+    <div className="w-[600px] max-w-full">
+      <Story />
+    </div>
+  ),
+];
+
+/**
+ * A phone, or a desktop column squeezed by the sidebar. Both put the card in
+ * the same layout, which is the point of measuring the card rather than the
+ * window.
+ */
+const narrow: Story["decorators"] = [
+  (Story) => (
+    <div className="w-[386px] max-w-full">
+      <Story />
+    </div>
+  ),
+];
+
+/** The default: roomy, one question, four options and the free-text row. */
+export const Roomy: Story = {
   args: { entries: [MARKONE] },
+  decorators: roomy,
 };
 
 /**
- * A batch. The pager shares the trailing cluster with the minimize chevron, and
- * both leave when the card minimizes, since each of them acts on rows that are
- * on screen. Which question you are on is announced to a screen reader and not
- * drawn: a sighted reader has the options changing under them to say it.
+ * A batch with room. The count sits inline with the pager on the same line as
+ * the question, and the card offers no way to collapse: it is beside the
+ * transcript rather than on top of it.
  */
-export const Batched: Story = {
+export const RoomyBatched: Story = {
   args: { entries: [MARKONE, CADENCE] },
+  decorators: roomy,
 };
 
-/** A question with no description, so the header is a single line to begin with. */
+/** A question with no description, so the header is a single line either way. */
 export const NoDescription: Story = {
   args: { entries: [CADENCE] },
+  decorators: roomy,
 };
 
-/** Mid-submit: every control is disabled, but the card still minimizes. */
+/** Mid-submit: every control is disabled, but the card still collapses. */
 export const Submitting: Story = {
   args: { entries: [MARKONE], isSubmitting: true },
+  decorators: narrow,
 };
 
-/** No `onClose`, so the card renders without its X and Escape does nothing. */
-export const NotDismissible: Story = {
-  args: { entries: [MARKONE], onClose: undefined },
+/**
+ * The narrow header: the count and the chevrons take a line of their own above
+ * the question, and the chevron on the end puts the options away.
+ */
+export const Narrow: Story = {
+  args: { entries: [MARKONE] },
+  decorators: narrow,
 };
 
-/** Lands the story in the minimized state, which is otherwise a click away. */
-const minimizeCard: Story["play"] = async ({ canvasElement }) => {
+/** A narrow batch, where the pager earns the line it sits on. */
+export const NarrowBatched: Story = {
+  args: { entries: [MARKONE, CADENCE] },
+  decorators: narrow,
+};
+
+/** Lands the story collapsed, which is otherwise a click away. */
+const collapseCard: Story["play"] = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.click(
     await canvas.findByRole("button", { name: "Minimize question" }),
@@ -124,34 +164,25 @@ const minimizeCard: Story["play"] = async ({ canvasElement }) => {
 };
 
 /**
- * The minimized card, at the width it docks above the composer on a phone. The
- * question truncates to one line, the option count and the way back stand in
- * for the body, and the only control left is the X: the chevron leaves with the
- * rows it collapsed, and the summary itself is what reopens the card. Click it,
- * or tab to it and press Enter.
+ * The collapsed card, at the width it docks above the composer on a phone. The
+ * header stays whole (question, description, count and pager) and everything
+ * under it goes. The chevron turns over to point back up. Click it, tab to it
+ * and press Enter, or tap anywhere on the header.
  */
-export const Minimized: Story = {
+export const Collapsed: Story = {
   args: { entries: [LONG] },
+  decorators: narrow,
   globals: { viewport: { value: "sbMobile" } },
-  play: minimizeCard,
+  play: collapseCard,
 };
 
 /**
- * A minimized batch, which is a plain one-line row: no pager, since there are
- * no options on screen to page between, and no position to report.
+ * A collapsed batch, which still pages: the chevrons act on the question the
+ * header is showing, and the count follows them.
  */
-export const MinimizedBatched: Story = {
+export const CollapsedBatched: Story = {
   args: { entries: [MARKONE, CADENCE] },
+  decorators: narrow,
   globals: { viewport: { value: "sbMobile" } },
-  play: minimizeCard,
-};
-
-/**
- * The expanded card at phone width, to compare the two against each other: the
- * pager and the one chevron sit in the trailing cluster, and both go away
- * together on the way down.
- */
-export const BatchedOnAPhone: Story = {
-  args: { entries: [MARKONE, CADENCE] },
-  globals: { viewport: { value: "sbMobile" } },
+  play: collapseCard,
 };

--- a/clients/web/src/domains/chat/components/question-prompt-card.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.test.tsx
@@ -11,7 +11,7 @@ describe("QuestionPromptCard — single entry", () => {
     () => {},
   );
   test.todo(
-    "hides the pagination counter for a single entry but still renders disabled chevrons + X",
+    "renders neither a counter nor a pager for a single entry",
     () => {},
   );
   test.todo(
@@ -63,12 +63,7 @@ describe("QuestionPromptCard — single entry", () => {
   test.todo("`s` hotkey auto-submits a skip on single-entry batches", () => {});
 });
 
-describe("QuestionPromptCard — close (X) button", () => {
-  test.todo(
-    "does not render the close button when onClose is omitted",
-    () => {},
-  );
-  test.todo("fires onClose on click without invoking onSubmitAll", () => {});
+describe("QuestionPromptCard: dismissal", () => {
   test.todo(
     "Escape closes the card when no text is typed and onClose is supplied",
     () => {},
@@ -81,10 +76,8 @@ describe("QuestionPromptCard — close (X) button", () => {
     "Escape with typed text clears the input WITHOUT firing onClose",
     () => {},
   );
-  test.todo(
-    "disables the close button while a response is submitting",
-    () => {},
-  );
+  test.todo("Escape does nothing when onClose is omitted", () => {});
+  test.todo("Escape is inert while a response is submitting", () => {});
 });
 
 describe("QuestionPromptCard — paginated batch", () => {

--- a/clients/web/src/domains/chat/components/question-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.tsx
@@ -376,9 +376,11 @@ export function QuestionPromptBody({
           // beside a narrow one, where the question can wrap to several lines,
           // it belongs level with the first of them.
           !stackedHeader && (isCompact ? "items-start" : "items-center"),
-          // Only where a drag can start: elsewhere this would take away the
-          // ability to select the question text and give nothing back.
-          isTouch && "select-none",
+          // Only where a drag can actually start, which is the same pair of
+          // conditions the gesture and `touch-action` read. A roomy card holds
+          // still under a thumb, so suppressing selection there would cost a
+          // long-press on the question and give nothing back.
+          isTouch && isCompact && "select-none",
         )}
       >
         {hasMetaCluster && (

--- a/clients/web/src/domains/chat/components/question-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.tsx
@@ -4,12 +4,12 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  ChevronUp,
   Pencil,
-  X,
 } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
-  type TouchEvent as ReactTouchEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useId,
@@ -18,12 +18,9 @@ import {
 } from "react";
 
 import type { QuestionResponseEntry } from "@/domains/chat/api/event-types";
-import {
-  expandedChromeOpacity,
-  minimizedChromeOpacity,
-  useQuestionCardMinimize,
-} from "@/domains/chat/hooks/use-question-card-minimize";
+import { useQuestionCardMinimize } from "@/domains/chat/hooks/use-question-card-minimize";
 import { useTranslation } from "@/i18n";
+import { useIsCompactWidth } from "@/hooks/use-compact-width";
 import { useOptionHotkeys } from "@/hooks/use-option-hotkeys";
 import type { QuestionEntry } from "@/types/interaction-ui-types";
 import { usePointerCoarse } from "@/utils/pointer";
@@ -43,38 +40,43 @@ export interface QuestionPromptCardProps {
   /** True while the final batched POST is in flight. */
   isSubmitting: boolean;
   /**
-   * Fires once when the user clicks Done (multi-entry batch) or
-   * auto-submits the single-entry batch. Responses are ordered to match
+   * Fires once when every entry has an answer. Responses are ordered to match
    * `entries[]` so the daemon can pair them back to its questions.
    */
   onSubmitAll: (responses: QuestionResponseEntry[]) => void;
   /**
-   * Optional escape hatch. When provided, an X button renders top-right and
-   * calls this handler on click. The owner posts `{ kind: "close" }` to the
-   * daemon and clears local state — there is no composer free-text intercept
-   * fallback in the batched UI.
+   * Optional escape hatch, reached by Escape. The owner posts
+   * `{ kind: "close" }` to the daemon and clears local state.
    */
   onClose?: () => void;
 }
 
 /**
  * Paginated question prompt — one entry visible at a time, with chevrons to
- * page through, an inline Skip / Send footer, and a global Done button that
- * fires the batched POST. Local draft state survives navigation so the user
- * can revise prior answers freely.
+ * page through and an inline Skip / Send footer. Local draft state survives
+ * navigation so the user can revise prior answers freely.
  *
- * Layout, hotkey, and behavior contract is documented in
- * `.private/plans/ask-question-batched-ui.md` (PR 2).
+ * The card owns its own padding: the bottom inset has to sit above the
+ * collapsing rows rather than below them, or minimizing would leave the
+ * expanded card's floor behind as dead space under the header.
  */
 export function QuestionPromptCard(props: QuestionPromptCardProps) {
-  // The card owns its own padding: the bottom inset has to sit above the
-  // collapsing rows rather than below them, or minimizing would leave the
-  // expanded card's floor behind as dead space under the summary line.
+  const cardRef = useRef<HTMLDivElement>(null);
+  const isCompact = useIsCompactWidth(cardRef);
+
   return (
-    <Card.Root noPadding>
-      <QuestionPromptBody {...props} />
+    <Card.Root noPadding ref={cardRef}>
+      <QuestionPromptBody {...props} isCompact={isCompact} />
     </Card.Root>
   );
+}
+
+interface QuestionPromptBodyProps extends QuestionPromptCardProps {
+  /**
+   * Whether the card is too narrow for the roomy header. Owned by
+   * `QuestionPromptCard`, which measures the card itself.
+   */
+  isCompact: boolean;
 }
 
 /**
@@ -87,28 +89,34 @@ export function QuestionPromptCard(props: QuestionPromptCardProps) {
  * (touch) devices — the pencil icon stays since it's iconography, not a
  * hotkey hint.
  *
+ * ## Header
+ *
+ * The question and its description sit beside the pager on a roomy card and
+ * above it on a narrow one, from one tree of elements that only changes
+ * classes. Swapping the elements themselves would remount the collapsing rows
+ * below, and `grid-template-rows` has no previous value to ease from after a
+ * fresh mount, so the collapse would jump.
+ *
  * ## Minimized state
  *
  * At full height the card covers the assistant message the question is about,
- * which on a phone is most of what is left of the transcript (LUM-3390). The
- * header stays put and everything below it collapses to nothing, leaving the
- * question and an option count docked above the composer. Three ways through
- * it, all driving the same state: the header's chevron minimizes, a vertical
- * swipe anywhere on the card goes either way, and a minimized card reopens
- * from its own header. The swipe carries no grabber of its own, so it is a
- * shortcut for whoever finds it rather than the advertised way through; the
- * chevron and the summary are what the card actually offers.
+ * which on a narrow card is most of what is left of the transcript (LUM-3390).
+ * The header stays put and everything below it collapses to nothing. Three ways
+ * through it, all driving the same state: the header's chevron, a vertical
+ * swipe anywhere on the card, and a tap on a collapsed card's header. The swipe
+ * carries no grabber of its own, so it is a shortcut for whoever finds it
+ * rather than the advertised way through.
  *
- * `useQuestionCardMinimize` reduces all of that to one `progress` value, which
- * every moving part below reads. Mid-drag it tracks the finger; at rest it is
- * the state and CSS eases between the two.
+ * A roomy card sits beside the transcript rather than on top of it, so it
+ * carries no collapse chevron and `useQuestionCardMinimize` holds it open.
  */
 export function QuestionPromptBody({
   entries,
   isSubmitting,
   onSubmitAll,
   onClose,
-}: QuestionPromptCardProps) {
+  isCompact,
+}: QuestionPromptBodyProps) {
   const { t } = useTranslation("chat");
 
   // Defensive: schema requires ≥1 entry, but real-world streams can deliver
@@ -128,76 +136,10 @@ export function QuestionPromptBody({
   );
   const inputRef = useRef<HTMLInputElement>(null);
   const collapsibleId = useId();
+  const questionId = useId();
 
-  const minimize = useQuestionCardMinimize();
-  const { expand, isMinimized, progress, dragAttr, toggle } = minimize;
-
-  // The two halves of the collapse control. Only one is ever on screen: the
-  // chevron while expanded, the summary while minimized.
-  const summaryRef = useRef<HTMLDivElement>(null);
-  const chevronRef = useRef<HTMLButtonElement>(null);
-  // Whether the control that is about to be retired is the one holding focus.
-  // Crossing the state unmounts the chevron and strips the summary of its role
-  // and tab stop, so a keyboard user would be left on the document body with
-  // the next Tab restarting from the top of the page.
-  //
-  // Sampled up front rather than read in the effect below, which runs after the
-  // commit that already removed the chevron and sent focus to the body. And a
-  // sample rather than a flag saying "a control was activated", because the
-  // swipe crosses the same state without going through either control: a thumb
-  // that was not holding focus must not drag it out of wherever the user left
-  // it, and one that was must not lose it.
-  const controlHadFocusRef = useRef(false);
-
-  const sampleControlFocus = useCallback(() => {
-    const control = isMinimized ? summaryRef.current : chevronRef.current;
-    controlHadFocusRef.current =
-      control !== null && document.activeElement === control;
-  }, [isMinimized]);
-
-  const handleMinimize = useCallback(() => {
-    sampleControlFocus();
-    toggle();
-  }, [sampleControlFocus, toggle]);
-
-  const handleReopen = useCallback(() => {
-    sampleControlFocus();
-    expand();
-  }, [sampleControlFocus, expand]);
-
-  // The third way across, and the only one that does not run through a control.
-  // Sampling on touch-start is early enough for any of them: the engine cannot
-  // commit before the finger has moved.
-  const { onTouchStart } = minimize.dragHandlers;
-  const handleCardTouchStart = useCallback(
-    (event: ReactTouchEvent) => {
-      sampleControlFocus();
-      onTouchStart(event);
-    },
-    [sampleControlFocus, onTouchStart],
-  );
-
-  // `role="button"` buys the summary the click, not the keystrokes a real
-  // button would have handled for free.
-  const handleReopenKeyDown = useCallback(
-    (event: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault();
-        handleReopen();
-      }
-    },
-    [handleReopen],
-  );
-
-  useEffect(() => {
-    if (!controlHadFocusRef.current) {
-      return;
-    }
-    controlHadFocusRef.current = false;
-    // The counterpart, which this same commit has just put on screen.
-    const replacement = isMinimized ? summaryRef.current : chevronRef.current;
-    replacement?.focus();
-  }, [isMinimized]);
+  const minimize = useQuestionCardMinimize({ canMinimize: isCompact });
+  const { isMinimized, progress, dragAttr, toggle } = minimize;
 
   const isBatched = entries.length > 1;
   const currentEntry = entries[currentIndex];
@@ -321,21 +263,20 @@ export function QuestionPromptBody({
   }, [canGoNext]);
 
   useOptionHotkeys(
-    // A minimized card has no rows on screen, so the option, free-text, skip
-    // and pagination hotkeys would act invisibly: zero options means no digit
-    // resolves to one, and the free-text digit lands on a no-op. Escape is the
-    // exception and stays wired in both states, because it is the keyboard's
-    // way out of the card and the X beside it is the only other one.
+    // A minimized card has no rows on screen, so the option, free-text and skip
+    // hotkeys would act invisibly: zero options means no digit resolves to one,
+    // and the free-text digit lands on a no-op. Escape is the exception and
+    // stays wired in both states, because it is the only way out of the card.
     isMinimized ? 0 : (currentEntry?.options.length ?? 0),
     handleSelectByIndex,
     isMinimized ? NOOP : handleFocusFreeText,
     !isSubmitting && currentEntry !== undefined,
     {
-      onPrev: isBatched && !isMinimized ? handlePrev : undefined,
-      onNext: isBatched && !isMinimized ? handleNext : undefined,
-      // Only register `s` when in a batched UX *and* skipping is meaningful
-      // for the current row. The legacy single-question card had no `s`
-      // hotkey at all — preserve that parity by gating on `isBatched`. The
+      // Paging stays live while collapsed, matching the chevrons beside the
+      // count, which do too. The header text is what changes under either one.
+      onPrev: isBatched ? handlePrev : undefined,
+      onNext: isBatched ? handleNext : undefined,
+      // Only register `s` when skipping is meaningful for the current row. The
       // `hasFreeText` gate is a UX safety net (`recordResponse` itself also
       // guards `hasFreeText`).
       onSkip: !hasFreeText && !isMinimized ? handleSkip : undefined,
@@ -400,9 +341,11 @@ export function QuestionPromptBody({
       ? currentDraft.optionId
       : null;
   const isSkipped = currentDraft?.kind === "skip";
-
-  const expandedOpacity = expandedChromeOpacity(progress);
-  const minimizedOpacity = minimizedChromeOpacity(progress);
+  const hasMetaCluster = isBatched || isCompact;
+  // The meta row only earns a line of its own when the pager is on it. A
+  // collapse chevron by itself fits at the end of the question's own line, and
+  // taking a whole row for it would push the question down for nothing.
+  const stackedHeader = isCompact && isBatched;
 
   return (
     <div
@@ -410,180 +353,142 @@ export function QuestionPromptBody({
       // card drags on. Without it a downward swipe can be claimed as native
       // viewport or ancestor panning, and the touch stream is cancelled before
       // `touchend`: the card would follow the finger and then snap back with
-      // nothing committed. Zoom and horizontal panning are left alone, since
-      // neither is a gesture the card wants.
+      // nothing committed. A roomy card drags on no axis at all, so it leaves
+      // the declaration off rather than blocking a finger that only wants to
+      // scroll the transcript.
       data-slot="question-card-surface"
-      className="relative flex flex-col p-4 [touch-action:pan-x_pinch-zoom]"
-      onTouchStart={handleCardTouchStart}
+      className={cn(
+        "relative flex flex-col p-3",
+        isCompact && "[touch-action:pan-x_pinch-zoom]",
+      )}
+      onTouchStart={minimize.dragHandlers.onTouchStart}
       onTouchMove={minimize.dragHandlers.onTouchMove}
       onTouchEnd={minimize.dragHandlers.onTouchEnd}
       onTouchCancel={minimize.dragHandlers.onTouchCancel}
       onClickCapture={minimize.dragHandlers.onClickCapture}
     >
       <div
+        data-header={stackedHeader ? "stacked" : "inline"}
         className={cn(
-          "flex items-start gap-2",
+          "flex flex-col gap-4 py-1",
+          !stackedHeader && "flex-row gap-2",
+          // Beside a roomy card's two lines the cluster reads best centred;
+          // beside a narrow one, where the question can wrap to several lines,
+          // it belongs level with the first of them.
+          !stackedHeader && (isCompact ? "items-start" : "items-center"),
           // Only where a drag can start: elsewhere this would take away the
           // ability to select the question text and give nothing back.
           isTouch && "select-none",
         )}
       >
+        {hasMetaCluster && (
+          <div
+            className={cn(
+              "flex shrink-0 items-center gap-4",
+              stackedHeader ? "w-full justify-between" : "order-2 justify-end",
+            )}
+          >
+            {isBatched && (
+              // Drawn is not announced: a reader who activates Next and stays
+              // on the button sees none of the options changing underneath, so
+              // the same node that shows the count also reports it.
+              <Typography
+                variant="body-medium-default"
+                as="span"
+                role="status"
+                className="text-[color:var(--content-tertiary)]"
+              >
+                {t("questionPromptCard.position", {
+                  current: currentIndex + 1,
+                  total: entries.length,
+                })}
+              </Typography>
+            )}
+            <div className="flex items-center gap-2">
+              {isBatched && (
+                <>
+                  <Button
+                    variant="ghost"
+                    size="compact"
+                    iconOnly={<ChevronLeft />}
+                    onClick={handlePrev}
+                    disabled={!canGoPrev || isSubmitting}
+                    aria-label={t("questionPromptCard.previousQuestionAria")}
+                  />
+                  <Button
+                    variant="ghost"
+                    size="compact"
+                    iconOnly={<ChevronRight />}
+                    onClick={handleNext}
+                    disabled={!canGoNext || isSubmitting}
+                    aria-label={t("questionPromptCard.nextQuestionAria")}
+                  />
+                </>
+              )}
+              {isCompact && (
+                // One button across both states rather than one per state: the
+                // browser keeps focus on an element that stays mounted, which
+                // is the whole of what a collapse owes a keyboard user here.
+                // Its label says what the press does; `aria-describedby` adds
+                // which question it does it to, since the question text is
+                // header content rather than part of the name.
+                <Button
+                  variant="ghost"
+                  size="compact"
+                  iconOnly={isMinimized ? <ChevronUp /> : <ChevronDown />}
+                  onClick={toggle}
+                  aria-expanded={!isMinimized}
+                  aria-controls={collapsibleId}
+                  aria-describedby={questionId}
+                  aria-label={
+                    isMinimized
+                      ? t("questionPromptCard.expandAria")
+                      : t("questionPromptCard.minimizeAria")
+                  }
+                />
+              )}
+            </div>
+          </div>
+        )}
+
         <div
-          ref={summaryRef}
           className={cn(
-            "flex min-w-0 flex-1 flex-col",
+            "flex min-w-0 flex-col gap-1",
+            !stackedHeader && "order-1 flex-1",
             isMinimized && "cursor-pointer",
           )}
-          // A minimized card carries no chevron of its own, so the summary is
-          // what reopens it, by tap and by keyboard alike. Left off while
-          // expanded, so the header's own buttons aren't shadowed by a handler
-          // that would undo them on the way up.
-          //
-          // Deliberately not `Button`, and deliberately unlabelled:
-          //
-          // - A real button would have to swap in at the state flip, and
-          //   changing the element type at this position remounts everything
-          //   under it. The two crossfading rows below are in there, and they
-          //   ease on `grid-template-rows`, which a fresh mount has no previous
-          //   value to interpolate from. The collapse would jump instead of
-          //   running.
-          // - A button's accessible name comes from its contents, and here the
-          //   contents are exactly what a reader should hear in place of the
-          //   body: the question, and the count of options behind it. An
-          //   `aria-label` would replace both with a generic phrase, since
-          //   descendants of `role="button"` are flattened into the name.
-          role={isMinimized ? "button" : undefined}
-          tabIndex={isMinimized ? 0 : undefined}
-          aria-expanded={isMinimized ? false : undefined}
-          aria-controls={isMinimized ? collapsibleId : undefined}
-          onClick={isMinimized ? handleReopen : undefined}
-          onKeyDown={isMinimized ? handleReopenKeyDown : undefined}
+          // A collapsed card's whole header reopens it, so a thumb has more
+          // than the chevron to land on. Deliberately not a control: the
+          // chevron beside it already carries the role, the name and the tab
+          // stop, and a second one would only shadow it.
+          onClick={isMinimized ? toggle : undefined}
         >
           <Typography
-            variant="body-medium-default"
+            id={questionId}
+            variant="body-large-default"
             as="div"
             className={cn(
-              "text-[color:var(--content-default)]",
-              isMinimized && "truncate",
+              "text-[color:var(--content-emphasised)]",
+              isMinimized && "line-clamp-2",
             )}
           >
             {currentEntry.question}
           </Typography>
           {currentEntry.description && (
-            <div
-              className="question-card-motion grid"
-              style={{ gridTemplateRows: `${progress}fr` }}
-              data-dragging={dragAttr}
-              // Collapsed to nothing is invisible, not absent. Without this the
-              // description is still read out under a minimized card, and the
-              // summary line below it under an expanded one.
-              aria-hidden={isMinimized || undefined}
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[color:var(--content-tertiary)]"
             >
-              <div className="min-h-0 overflow-hidden">
-                <Typography
-                  variant="body-small-default"
-                  as="p"
-                  className="question-card-motion pt-1 text-[color:var(--content-tertiary)]"
-                  style={{ opacity: expandedOpacity }}
-                  data-dragging={dragAttr}
-                >
-                  {currentEntry.description}
-                </Typography>
-              </div>
-            </div>
-          )}
-          <div
-            className="question-card-motion grid"
-            style={{ gridTemplateRows: `${1 - progress}fr` }}
-            data-dragging={dragAttr}
-            aria-hidden={!isMinimized || undefined}
-          >
-            <div className="min-h-0 overflow-hidden">
-              <Typography
-                variant="body-small-default"
-                as="p"
-                className="question-card-motion pt-1 text-[color:var(--content-tertiary)]"
-                style={{ opacity: minimizedOpacity }}
-                data-dragging={dragAttr}
-              >
-                {t("questionPromptCard.minimizedSummary", {
-                  count: currentEntry.options.length,
-                })}
-              </Typography>
-            </div>
-          </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          {!isMinimized && (
-            // Everything in here belongs to rows that are on screen: the pager
-            // pages between them, the chevron puts them away, and the status
-            // line says which of them you are on. So they leave with the rows,
-            // fading out over the first half of the collapse and unmounting
-            // once the state commits, by which point they are already
-            // invisible. The chevron points down and stays there: reopening is
-            // the minimized header's job, and a second control rotated the
-            // other way would only duplicate it.
-            <div
-              className="question-card-motion flex items-center gap-1"
-              style={{ opacity: expandedOpacity }}
-              data-dragging={dragAttr}
-            >
-              {isBatched && (
-                // The pager offers movement without saying where from. A
-                // sighted reader takes that from the options changing under
-                // them, which is nothing a reader paging by button can see, so
-                // the count is announced rather than drawn.
-                <span role="status" className="sr-only">
-                  {t("questionPromptCard.position", {
-                    current: currentIndex + 1,
-                    total: entries.length,
-                  })}
-                </span>
-              )}
-              <Button
-                variant="ghost"
-                size="compact"
-                iconOnly={<ChevronLeft />}
-                onClick={handlePrev}
-                disabled={!canGoPrev || isSubmitting}
-                aria-label={t("questionPromptCard.previousQuestionAria")}
-              />
-              <Button
-                variant="ghost"
-                size="compact"
-                iconOnly={<ChevronRight />}
-                onClick={handleNext}
-                disabled={!canGoNext || isSubmitting}
-                aria-label={t("questionPromptCard.nextQuestionAria")}
-              />
-              <Button
-                ref={chevronRef}
-                variant="ghost"
-                size="compact"
-                iconOnly={<ChevronDown />}
-                onClick={handleMinimize}
-                aria-expanded
-                aria-controls={collapsibleId}
-                aria-label={t("questionPromptCard.minimizeAria")}
-              />
-            </div>
-          )}
-          {onClose && (
-            <Button
-              variant="ghost"
-              size="compact"
-              iconOnly={<X />}
-              onClick={onClose}
-              disabled={isSubmitting}
-              aria-label={t("questionPromptCard.closeQuestionAria")}
-              className="-mr-1"
-            />
+              {currentEntry.description}
+            </Typography>
           )}
         </div>
       </div>
 
       <div
         id={collapsibleId}
+        data-slot="question-card-body"
         className="question-card-motion grid"
         style={{ gridTemplateRows: `${progress}fr` }}
         data-dragging={dragAttr}
@@ -592,7 +497,8 @@ export function QuestionPromptBody({
         inert={isMinimized}
       >
         <div className="min-h-0 overflow-hidden">
-          <div className="mt-3 flex flex-col gap-1.5">
+          <div className="mt-2 h-px w-full bg-[var(--border-hover)]" />
+          <div className="mt-2 flex flex-col gap-1">
             {currentEntry.options.map((option, index) => {
               const badgeNumber = index + 1;
               const isSelected = selectedOptionId === option.id;
@@ -603,7 +509,7 @@ export function QuestionPromptBody({
                   fullWidth
                   disabled={isSubmitting || hasFreeText}
                   onClick={() => handleOptionClick(option.id)}
-                  className="h-auto justify-start whitespace-normal px-3 py-2 text-left"
+                  className="h-auto justify-start whitespace-normal p-1.5 text-left"
                   aria-label={t("questionPromptCard.optionAria", {
                     number: badgeNumber,
                     label: option.label,
@@ -621,16 +527,14 @@ export function QuestionPromptBody({
             })}
 
             <div
-              className={`flex items-center gap-2 rounded-md px-3 py-2 transition-colors ${
-                hasFreeText ? "bg-[var(--surface-base)]" : ""
-              }`}
+              className={cn(
+                "flex items-center gap-3 rounded-md p-1.5 transition-colors",
+                hasFreeText && "bg-[var(--surface-base)]",
+              )}
             >
-              <span
-                aria-hidden="true"
-                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)] text-[color:var(--content-secondary)]"
-              >
+              <RowGlyph>
                 <Pencil className="h-3.5 w-3.5" />
-              </span>
+              </RowGlyph>
               <input
                 ref={inputRef}
                 type="text"
@@ -674,7 +578,7 @@ export function QuestionPromptBody({
               <Typography
                 variant="body-small-default"
                 as="p"
-                className="px-3 text-[color:var(--content-tertiary)]"
+                className="px-1.5 text-[color:var(--content-tertiary)]"
               >
                 {t("questionPromptCard.skippedHint")}
               </Typography>
@@ -683,6 +587,22 @@ export function QuestionPromptBody({
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * The square that leads a row: a hotkey digit on an option, a pencil on the
+ * free-text line. Decorative in both cases: the row's own label carries the
+ * meaning.
+ */
+function RowGlyph({ children }: { children: ReactNode }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="text-body-small-default flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)] text-[color:var(--content-secondary)]"
+    >
+      {children}
+    </span>
   );
 }
 
@@ -709,15 +629,8 @@ function QuestionRowContents({
   showCheck,
 }: QuestionRowContentsProps) {
   return (
-    <span className="flex w-full min-w-0 items-start gap-2">
-      {showBadge && (
-        <span
-          aria-hidden="true"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)] text-label-small-default text-[color:var(--content-secondary)]"
-        >
-          {badgeNumber}
-        </span>
-      )}
+    <span className="flex w-full min-w-0 items-center gap-3">
+      {showBadge && <RowGlyph>{badgeNumber}</RowGlyph>}
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
         <Typography
           variant="body-medium-default"
@@ -739,7 +652,7 @@ function QuestionRowContents({
       {showCheck && (
         <Check
           aria-hidden="true"
-          className="mt-1 h-3.5 w-3.5 shrink-0 text-[var(--primary-base)]"
+          className="h-3.5 w-3.5 shrink-0 text-[var(--primary-base)]"
         />
       )}
     </span>

--- a/clients/web/src/domains/chat/hooks/use-question-card-minimize.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-question-card-minimize.test.ts
@@ -18,8 +18,6 @@ import {
   MINIMIZE_COMMIT_PX,
   MINIMIZE_TRAVEL_PX,
   collapseProgress,
-  expandedChromeOpacity,
-  minimizedChromeOpacity,
   useQuestionCardMinimize,
 } from "@/domains/chat/hooks/use-question-card-minimize";
 
@@ -102,53 +100,39 @@ describe("collapseProgress", () => {
   });
 });
 
-describe("chrome opacities", () => {
-  test("the two crossfades never overlap", () => {
-    for (const progress of [0, 0.25, 0.5, 0.75, 1]) {
-      const both =
-        expandedChromeOpacity(progress) > 0 &&
-        minimizedChromeOpacity(progress) > 0;
-      expect(both).toBe(false);
-    }
-  });
-
-  test("each is fully opaque at its own resting state", () => {
-    expect(expandedChromeOpacity(1)).toBe(1);
-    expect(expandedChromeOpacity(0)).toBe(0);
-    expect(minimizedChromeOpacity(0)).toBe(1);
-    expect(minimizedChromeOpacity(1)).toBe(0);
-  });
-});
-
 // ---------------------------------------------------------------------------
 // State and gesture
 // ---------------------------------------------------------------------------
 
 describe("useQuestionCardMinimize", () => {
   test("starts expanded", () => {
-    const { result } = renderHook(() => useQuestionCardMinimize());
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: true }),
+    );
 
     expect(result.current.isMinimized).toBe(false);
     expect(result.current.progress).toBe(1);
     expect(result.current.dragAttr).toBeUndefined();
   });
 
-  test("toggle flips the state and expand only ever opens", () => {
-    const { result } = renderHook(() => useQuestionCardMinimize());
+  test("toggle flips the state", () => {
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: true }),
+    );
 
     act(() => result.current.toggle());
     expect(result.current.isMinimized).toBe(true);
     expect(result.current.progress).toBe(0);
 
-    act(() => result.current.expand());
+    act(() => result.current.toggle());
     expect(result.current.isMinimized).toBe(false);
-
-    act(() => result.current.expand());
-    expect(result.current.isMinimized).toBe(false);
+    expect(result.current.progress).toBe(1);
   });
 
   test("a downward drag tracks the finger before it commits", () => {
-    const { result } = renderHook(() => useQuestionCardMinimize());
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: true }),
+    );
     const half = MINIMIZE_TRAVEL_PX / 2;
 
     act(() => {
@@ -168,7 +152,9 @@ describe("useQuestionCardMinimize", () => {
   });
 
   test("releasing past the commit distance minimizes", () => {
-    const { result } = renderHook(() => useQuestionCardMinimize());
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: true }),
+    );
     const travel = MINIMIZE_COMMIT_PX + 10;
 
     act(() => {
@@ -189,7 +175,9 @@ describe("useQuestionCardMinimize", () => {
   });
 
   test("releasing short of the commit distance springs back", () => {
-    const { result } = renderHook(() => useQuestionCardMinimize());
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: true }),
+    );
     const travel = MINIMIZE_COMMIT_PX - 10;
 
     act(() => {
@@ -209,7 +197,9 @@ describe("useQuestionCardMinimize", () => {
   });
 
   test("an upward drag past the commit distance expands a minimized card", () => {
-    const { result } = renderHook(() => useQuestionCardMinimize());
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: true }),
+    );
     const travel = MINIMIZE_COMMIT_PX + 10;
 
     act(() => result.current.toggle());
@@ -230,7 +220,9 @@ describe("useQuestionCardMinimize", () => {
   });
 
   test("the click a drag leaves behind is swallowed, and only that one", () => {
-    const { result } = renderHook(() => useQuestionCardMinimize());
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: true }),
+    );
     let stopped = 0;
     const click = () =>
       ({
@@ -260,8 +252,86 @@ describe("useQuestionCardMinimize", () => {
     expect(stopped).toBe(1);
   });
 
+  test("a card with no room to collapse into holds open, and stays open", () => {
+    const { result, rerender } = renderHook(
+      ({ canMinimize }) => useQuestionCardMinimize({ canMinimize }),
+      { initialProps: { canMinimize: true } },
+    );
+
+    act(() => result.current.toggle());
+    expect(result.current.isMinimized).toBe(true);
+
+    rerender({ canMinimize: false });
+    expect(result.current.isMinimized).toBe(false);
+    expect(result.current.progress).toBe(1);
+
+    // The request went with the room, so the card does not spring shut the
+    // moment the room comes back.
+    rerender({ canMinimize: true });
+    expect(result.current.isMinimized).toBe(false);
+  });
+
+  test("a card with no room to collapse into never arms the gesture", () => {
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: false }),
+    );
+    const travel = MINIMIZE_COMMIT_PX + 10;
+
+    act(() => {
+      result.current.dragHandlers.onTouchStart(
+        touchEvent("touchstart", [finger(START_Y)]),
+      );
+      result.current.dragHandlers.onTouchMove(
+        touchEvent("touchmove", [finger(START_Y + travel)]),
+      );
+      result.current.dragHandlers.onTouchEnd(
+        touchEvent("touchend", [], [finger(START_Y + travel)]),
+      );
+    });
+
+    expect(result.current.isDragging).toBe(false);
+    expect(result.current.isMinimized).toBe(false);
+  });
+
+  test("a gesture that outlives the room it armed in commits nothing", () => {
+    const { result, rerender } = renderHook(
+      ({ canMinimize }) => useQuestionCardMinimize({ canMinimize }),
+      { initialProps: { canMinimize: true } },
+    );
+    const travel = MINIMIZE_COMMIT_PX + 10;
+
+    act(() => {
+      result.current.dragHandlers.onTouchStart(
+        touchEvent("touchstart", [finger(START_Y)]),
+      );
+      result.current.dragHandlers.onTouchMove(
+        touchEvent("touchmove", [finger(START_Y + travel)]),
+      );
+    });
+
+    // The card widens mid-drag, as a rotation does. The engine only consults
+    // `enabled` when a gesture arms, so this one still reaches the release.
+    rerender({ canMinimize: false });
+
+    act(() => {
+      result.current.dragHandlers.onTouchEnd(
+        touchEvent("touchend", [], [finger(START_Y + travel)]),
+      );
+    });
+
+    expect(result.current.isMinimized).toBe(false);
+
+    // The release must leave nothing behind either: a request recorded here
+    // would spring the card shut the next time it narrows, with nothing on
+    // screen having asked for it.
+    rerender({ canMinimize: true });
+    expect(result.current.isMinimized).toBe(false);
+  });
+
   test("a tap that never moves leaves the following click alone", () => {
-    const { result } = renderHook(() => useQuestionCardMinimize());
+    const { result } = renderHook(() =>
+      useQuestionCardMinimize({ canMinimize: true }),
+    );
     let stopped = 0;
     const click = () =>
       ({

--- a/clients/web/src/domains/chat/hooks/use-question-card-minimize.ts
+++ b/clients/web/src/domains/chat/hooks/use-question-card-minimize.ts
@@ -4,18 +4,22 @@
  *
  * The card sits between the transcript and the composer, so at full height it
  * covers the assistant message the question is about (LUM-3390). Minimizing
- * leaves a one-line stand-in and hands the message back, and the state is
- * per-prompt: `QuestionPromptSlot` keys the card by `requestId`, so a new
- * question always arrives expanded.
+ * hands that message back, and the state is per-prompt: `QuestionPromptSlot`
+ * keys the card by `requestId`, so a new question always arrives expanded.
  *
  * Motion is expressed as a single `progress` in `[0, 1]`, 1 expanded and 0
  * minimized, that every animated part of the card reads. At rest it is the
  * state itself and CSS eases between the two; during a drag it tracks the
  * finger directly and the card's transitions are dropped, so the card follows
  * the gesture rather than lagging behind it.
+ *
+ * A card wide enough to sit beside the transcript rather than on top of it has
+ * nothing to minimize for, and carries no control to reopen from. `canMinimize`
+ * is what says so, and this hook owns every consequence of it, because the
+ * control and the gesture that substitutes for it have to agree.
  */
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   MouseEvent as ReactMouseEvent,
   TouchEvent as ReactTouchEvent,
@@ -55,31 +59,20 @@ export function collapseProgress(
   return clamp01(resting - dragOffset / MINIMIZE_TRAVEL_PX);
 }
 
-/**
- * Opacity for chrome that belongs to the expanded card (the description, the
- * pager). Gone by the halfway point so it has cleared out before the summary
- * line it shares the header with fades in.
- */
-export function expandedChromeOpacity(progress: number): number {
-  return clamp01(progress * 2 - 1);
-}
-
-/**
- * Opacity for the one-line summary that stands in for the collapsed body. The
- * mirror of {@link expandedChromeOpacity}: the two never overlap, so the header
- * reads as one line swapping for another rather than as two lines dissolving
- * through each other.
- */
-export function minimizedChromeOpacity(progress: number): number {
-  return clamp01(1 - progress * 2);
-}
-
 export interface QuestionCardDragHandlers {
   onTouchStart: (event: ReactTouchEvent) => void;
   onTouchMove: (event: ReactTouchEvent) => void;
   onTouchEnd: (event: ReactTouchEvent) => void;
   onTouchCancel: () => void;
   onClickCapture: (event: ReactMouseEvent) => void;
+}
+
+export interface UseQuestionCardMinimizeOptions {
+  /**
+   * Whether the card is narrow enough to be worth collapsing. False disarms the
+   * gesture and holds the card open.
+   */
+  canMinimize: boolean;
 }
 
 export interface UseQuestionCardMinimizeResult {
@@ -91,16 +84,16 @@ export interface UseQuestionCardMinimizeResult {
   isDragging: boolean;
   /** `data-dragging` value for every element the drag animates. */
   dragAttr: "true" | undefined;
-  /** Flips the state. Backs the header's minimize / reopen button. */
+  /** Flips the state. Backs the header's collapse chevron. */
   toggle: () => void;
-  /** Reopens a minimized card. Backs the header's tap target. */
-  expand: () => void;
   /** Touch handlers for the card's drag surface. */
   dragHandlers: QuestionCardDragHandlers;
 }
 
-export function useQuestionCardMinimize(): UseQuestionCardMinimizeResult {
-  const [isMinimized, setIsMinimized] = useState(false);
+export function useQuestionCardMinimize({
+  canMinimize,
+}: UseQuestionCardMinimizeOptions): UseQuestionCardMinimizeResult {
+  const [minimizeRequested, setMinimizeRequested] = useState(false);
 
   // A tap that ends a drag must not also toggle. `touchend` runs before the
   // synthetic `click`, so the flag is raised while the drag resolves and
@@ -108,7 +101,7 @@ export function useQuestionCardMinimize(): UseQuestionCardMinimizeResult {
   const draggedRef = useRef(false);
 
   const swipe = useSwipeEngine({
-    enabled: true,
+    enabled: canMinimize,
     axis: "vertical",
     commitThresholdPx: MINIMIZE_COMMIT_PX,
     // The card follows the finger one-to-one for its whole travel. The engine's
@@ -120,10 +113,28 @@ export function useQuestionCardMinimize(): UseQuestionCardMinimizeResult {
       draggedRef.current = true;
     },
     onCommit: (delta) => {
+      // The engine only consults `enabled` when a gesture arms, so a drag that
+      // started while the card was narrow still lands here after a rotation
+      // widens it. Committing then would leave a card collapsed with no
+      // chevron to reopen it.
+      if (!canMinimize) {
+        return;
+      }
       haptic.light();
-      setIsMinimized(delta > 0);
+      setMinimizeRequested(delta > 0);
     },
   });
+
+  // Dropping the request rather than only overriding it below: a card held open
+  // by its width must not spring shut again the moment the width comes back,
+  // with nothing on screen having asked for it.
+  useEffect(() => {
+    if (!canMinimize) {
+      setMinimizeRequested(false);
+    }
+  }, [canMinimize]);
+
+  const isMinimized = minimizeRequested && canMinimize;
 
   const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel } = swipe;
 
@@ -136,13 +147,7 @@ export function useQuestionCardMinimize(): UseQuestionCardMinimizeResult {
   );
 
   const toggle = useCallback(() => {
-    setIsMinimized((minimized) => !minimized);
-  }, []);
-
-  // Drag suppression lives in `onClickCapture` below, which stops the click
-  // before it reaches any handler, so this one is free to be unconditional.
-  const expand = useCallback(() => {
-    setIsMinimized(false);
+    setMinimizeRequested((minimized) => !minimized);
   }, []);
 
   /**
@@ -178,7 +183,6 @@ export function useQuestionCardMinimize(): UseQuestionCardMinimizeResult {
     isDragging: swipe.isDragging,
     dragAttr: swipe.isDragging ? "true" : undefined,
     toggle,
-    expand,
     dragHandlers,
   };
 }

--- a/clients/web/src/hooks/use-compact-width.test.ts
+++ b/clients/web/src/hooks/use-compact-width.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for `useIsCompactWidth`.
+ *
+ * Two things carry weight here. The release band, because the sidebar rail
+ * settles on a spring that overshoots its target, so a threshold read straight
+ * would flip the layout twice for one toggle. And the render count, because
+ * this hook usually watches a surface whose height animates, and a hook that
+ * re-rendered on every notification would re-render its consumer on every frame
+ * of that animation.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+import { COMPACT_WIDTH_PX, useIsCompactWidth } from "@/hooks/use-compact-width";
+
+interface StubbedObserver {
+  callback: ResizeObserverCallback;
+  targets: Set<Element>;
+}
+
+const observers = new Set<StubbedObserver>();
+let originalResizeObserver: typeof ResizeObserver;
+
+beforeEach(() => {
+  observers.clear();
+  originalResizeObserver = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class {
+    private entry: StubbedObserver;
+    constructor(callback: ResizeObserverCallback) {
+      this.entry = { callback, targets: new Set() };
+      observers.add(this.entry);
+    }
+    observe(target: Element) {
+      this.entry.targets.add(target);
+    }
+    unobserve(target: Element) {
+      this.entry.targets.delete(target);
+    }
+    disconnect() {
+      observers.delete(this.entry);
+    }
+  } as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  observers.clear();
+  globalThis.ResizeObserver = originalResizeObserver;
+  document.body.replaceChildren();
+});
+
+/**
+ * happy-dom has no layout engine, so the box a real browser would measure has
+ * to be stubbed onto the element.
+ */
+function elementOfWidth(width: number): HTMLElement {
+  const el = document.createElement("div");
+  el.getBoundingClientRect = () => ({ width }) as DOMRect;
+  document.body.appendChild(el);
+  return el;
+}
+
+function resizeTo(width: number): void {
+  act(() => {
+    for (const observer of observers) {
+      for (const target of observer.targets) {
+        observer.callback(
+          [
+            {
+              target,
+              borderBoxSize: [{ inlineSize: width, blockSize: 0 }],
+            } as unknown as ResizeObserverEntry,
+          ],
+          {} as ResizeObserver,
+        );
+      }
+    }
+  });
+}
+
+function mount(initialWidth: number) {
+  const el = elementOfWidth(initialWidth);
+  const ref = { current: el };
+  let renders = 0;
+  const view = renderHook(() => {
+    renders += 1;
+    return useIsCompactWidth(ref);
+  });
+  return { ...view, renderCount: () => renders };
+}
+
+describe("useIsCompactWidth", () => {
+  test("an element that has not been laid out counts as compact", () => {
+    // The roomy layout is the one that has to prove it has room.
+    const { result } = mount(0);
+
+    expect(result.current).toBe(true);
+  });
+
+  test("a roomy element reads roomy from the first render", () => {
+    // Measured in a layout effect, so the first paint is already right rather
+    // than flashing the compact layout and correcting.
+    const { result, renderCount } = mount(COMPACT_WIDTH_PX * 2);
+
+    expect(result.current).toBe(false);
+    expect(renderCount()).toBe(2);
+  });
+
+  test("narrowing past the threshold turns compact on", () => {
+    const { result } = mount(COMPACT_WIDTH_PX * 2);
+
+    resizeTo(COMPACT_WIDTH_PX - 1);
+
+    expect(result.current).toBe(true);
+  });
+
+  test("leaving the compact layout costs more width than entering it did", () => {
+    const { result } = mount(0);
+    expect(result.current).toBe(true);
+
+    // Past the threshold but still inside the release band, which is where a
+    // spring's overshoot lands. Reading the threshold straight here would flip
+    // the layout out and back for a single sidebar toggle.
+    resizeTo(COMPACT_WIDTH_PX + 1);
+    expect(result.current).toBe(true);
+
+    resizeTo(COMPACT_WIDTH_PX + 100);
+    expect(result.current).toBe(false);
+
+    // Coming back the other way the threshold itself is the line, so nothing
+    // is ever drawn in a box too small for it.
+    resizeTo(COMPACT_WIDTH_PX + 1);
+    expect(result.current).toBe(false);
+    resizeTo(COMPACT_WIDTH_PX - 1);
+    expect(result.current).toBe(true);
+  });
+
+  test("notifications that do not cross the line do not accumulate renders", () => {
+    const { renderCount } = mount(COMPACT_WIDTH_PX * 2);
+    const before = renderCount();
+
+    // What a collapsing card sends on every frame it changes height. React
+    // re-renders once before it bails out on an unchanged state, so the
+    // guarantee is that the cost stops there rather than tracking the
+    // notifications.
+    for (let i = 0; i < 20; i++) {
+      resizeTo(COMPACT_WIDTH_PX * 2);
+    }
+
+    expect(renderCount() - before).toBeLessThanOrEqual(1);
+  });
+});

--- a/clients/web/src/hooks/use-compact-width.ts
+++ b/clients/web/src/hooks/use-compact-width.ts
@@ -1,0 +1,74 @@
+/**
+ * Whether a chat-column surface has room for its roomy layout, measured against
+ * the surface itself rather than the viewport.
+ *
+ * Everything stacked in `ChatColumn` (the composer, the question card, the
+ * connect card) is the same width and narrows together when the sidebar opens
+ * or the window is split, so they share one threshold. A viewport query would
+ * miss all of that, and a CSS container query cannot hand the boolean to the
+ * behavior that reads it: which controls mount, whether a gesture arms, and
+ * whether a surface is inert. See `docs/PLATFORM_ADAPTATION.md`.
+ */
+
+import { useLayoutEffect, useState, type RefObject } from "react";
+
+/**
+ * Width (px) below which a chat-column surface drops to its compact layout.
+ * Set by the composer's action row, which is the tightest of them: below this
+ * its labelled access and model-profile triggers overlap.
+ */
+export const COMPACT_WIDTH_PX = 520;
+
+/**
+ * Extra width a compact surface must regain before it expands again.
+ *
+ * The sidebar rail animates on `cubic-bezier(0.34, 1.56, 0.64, 1)`, which
+ * overshoots its target by roughly 10% before settling. The chat column takes
+ * the complement, so one sidebar toggle can carry a surface across the
+ * threshold, back, and across again. This band is wider than that overshoot, so
+ * the layout settles once. It only ever holds a surface in the compact layout
+ * for longer, never the reverse, so nothing collides while it waits.
+ */
+const COMPACT_WIDTH_RELEASE_PX = 24;
+
+/**
+ * True while `ref`'s element is narrower than {@link COMPACT_WIDTH_PX}.
+ *
+ * An element that has not been laid out reports a zero box, which counts as
+ * compact: the roomy layout is the one that needs room proven.
+ */
+export function useIsCompactWidth(ref: RefObject<HTMLElement | null>): boolean {
+  const [compact, setCompact] = useState(true);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+
+    const apply = (width: number) => {
+      setCompact(
+        (wasCompact) =>
+          width <
+          COMPACT_WIDTH_PX + (wasCompact ? COMPACT_WIDTH_RELEASE_PX : 0),
+      );
+    };
+
+    // Before paint, so the first frame is already the right layout.
+    apply(el.getBoundingClientRect().width);
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const inlineSize = entries[0]?.borderBoxSize?.[0]?.inlineSize;
+      // Reading the entry keeps a collapse animation, which notifies on every
+      // frame it changes height, from forcing a measurement per frame.
+      apply(inlineSize ?? el.getBoundingClientRect().width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return compact;
+}

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1203,9 +1203,8 @@
     "submitFailed": "Failed to submit response. Please try again."
   },
   "questionPromptCard": {
-    "closeQuestionAria": "Close question",
+    "expandAria": "Reopen question",
     "minimizeAria": "Minimize question",
-    "minimizedSummary": "{count, plural, one {# option} other {# options}} · Tap to reopen",
     "nextQuestionAria": "Next question",
     "optionAria": "Option {number}: {label}",
     "previousQuestionAria": "Previous question",
@@ -1216,7 +1215,7 @@
     "skipped": "Skipped",
     "skippedHint": "Skipped - pick an option to override",
     "typeDifferentAnswerAria": "Type a different answer",
-    "typeSomethingElsePlaceholder": "Type something else"
+    "typeSomethingElsePlaceholder": "Something else"
   },
   "queuedMessagesDrawer": {
     "cancelAll": "Cancel all",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1203,9 +1203,8 @@
     "submitFailed": "No se pudo enviar tu respuesta. Inténtalo de nuevo."
   },
   "questionPromptCard": {
-    "closeQuestionAria": "Cerrar pregunta",
+    "expandAria": "Reabrir pregunta",
     "minimizeAria": "Minimizar pregunta",
-    "minimizedSummary": "{count, plural, one {# opción} other {# opciones}} · Toca para reabrir",
     "nextQuestionAria": "Pregunta siguiente",
     "optionAria": "Opción {number}: {label}",
     "previousQuestionAria": "Pregunta anterior",
@@ -1216,7 +1215,7 @@
     "skipped": "Omitida",
     "skippedHint": "Omitida: elige una opción para anular",
     "typeDifferentAnswerAria": "Escribe una respuesta diferente",
-    "typeSomethingElsePlaceholder": "Escribe algo más"
+    "typeSomethingElsePlaceholder": "Algo más"
   },
   "queuedMessagesDrawer": {
     "cancelAll": "Cancelar todos",


### PR DESCRIPTION
Redesigns the pending `ask_question` card against three new Figma frames: a
[roomy card](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=8237-86620),
a [narrow one](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=8237-86734),
and the [collapsed state](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=8246-168281).

## What changes

The card gets two header layouts, keyed off **its own width** rather than the
viewport, because it also narrows on a desktop when the sidebar is open or the
window is split. Roomy: the question sits beside the count and pager on one
line, and there is no collapse control at all. Narrow: the meta row takes a
line of its own above the question, with a chevron on the end.

A meta row holding nothing but that chevron rides inline instead, since one
24px control does not earn a whole line.

The collapse simplifies. A collapsed card keeps its entire header, question and
description included, so only the divider and the rows below it move. That is
one collapsing region instead of three, and one persistent button in place of
two half-controls, which lets the focus-transfer apparatus go: the browser
keeps focus on an element that stays mounted.

## Two things reviewers should weigh

**The X is gone, per the mocks, which removes touch dismissal entirely.** There
is no Escape key on a phone, so a touch user can no longer send
`{ kind: "close" }` at all. They can Skip every entry, which auto-submits, but
that is `{ kind: "skip" }` per question, a signal the daemon can distinguish. On
an N-entry batch, dismissal costs N taps instead of one. This was raised and
decided deliberately rather than falling out of the mock.

**This touches the composer.** The composer's width measurement moves to a
shared hook so the two surfaces cannot disagree about how much room they have
(they are siblings in `ChatColumn` and are always the same width). `ChatComposer`
therefore inherits a 24px release band and a `useLayoutEffect` initial measure.
The band is one-directional: it only holds the compact layout longer, never
renders labelled triggers in a box too small for them.

## Notes

- No wire changes. Skip and free-text already existed end to end.
- Layout is JS-measured rather than a CSS container query, because the boolean
  has to reach the chevron's mount, the swipe's `enabled`, `inert`, hotkey
  gating and `touch-action`. See `docs/PLATFORM_ADAPTATION.md` on not mirroring
  a CSS threshold in JS.
- The visible position count returns, on the node that also announces it via
  `role="status"`. The chevron takes `aria-describedby` to the question so a
  reader landing on it hears which question it reopens.
- `questionPromptCard.closeQuestionAria` and `minimizedSummary` are removed from
  both catalogs; `catalogs.test.ts` fails on orphaned keys.

## Verification

- Measured in Storybook against all three frames: roomy 600px single-row,
  narrow 386px two-row, collapsed 386x90 with `grid-template-rows: 0fr` and
  `inert`. Every colour, size and radius resolves to the mock's token.
- Every new guard was mutation-tested. Reverting the latch reset, the `onCommit`
  bail, the conditional `touch-action`, the `canMinimize` wiring, the chevron's
  width gate, or the inline-header rule each fails a specific test. Two guards
  were vacuous on the first pass and were rewritten.
- `test:ci` 1110/1111. The one failure is the pre-existing
  `daily-reset-time.test.ts` ICU `GMT` vs `GMT+0`, untouched by this branch.

## Still outstanding

Device QA on a real phone, carried from #41417 / #41485 / #41518: the swipe
against the iOS keyboard, and the chevron tap target. A collapsed card's whole
header is a tap target, so the chevron is not the only way back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)