### PR TITLE
feat(desktop): wire quick-input tray right-click menu item

### DIFF
--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -19,7 +19,10 @@ import {
   planPlatformForward,
 } from "@vellumai/electron-desktop/platform-forward";
 import { installPopoutWindows } from "@vellumai/electron-desktop/popout-window";
-import { installQuickInput } from "@vellumai/electron-desktop/quick-input-window";
+import {
+  installQuickInput,
+  toggleQuickInput,
+} from "@vellumai/electron-desktop/quick-input-window";
 import { planAppProtocolAssetRequest } from "@vellumai/electron-utils/app-protocol";
 import {
   pairedGatewayTargetsFromLockfile,
@@ -480,6 +483,7 @@ app
       toggleMainWindow: toggleMainWindowVisibility,
       ensureMainWindow: ensureMainWindowVisible,
       openAbout: openAboutWindow,
+      toggleQuickInput,
     });
     installNativeAuth();
     installMainWindow();

--- a/clients/windows/src/main/tray.test.ts
+++ b/clients/windows/src/main/tray.test.ts
@@ -63,6 +63,9 @@ mock.module("./main-window", () => ({
   ensureVisible: () => undefined,
   toggleVisibility: () => undefined,
 }));
+mock.module("@vellumai/electron-desktop/quick-input-window", () => ({
+  toggleQuickInput: () => undefined,
+}));
 
 const { installWindowsTray } = await import("./tray");
 const { installFeatureFlagsIpc, isFeatureEnabled } =

--- a/clients/windows/src/main/tray.ts
+++ b/clients/windows/src/main/tray.ts
@@ -6,6 +6,7 @@ import { openAboutWindow } from "@vellumai/electron-desktop/about";
 import { acceleratorOption } from "@vellumai/electron-desktop/commands";
 import { getWatchedLockfile } from "@vellumai/electron-desktop/lockfile-watcher";
 import { configureStatusIconFallback } from "@vellumai/electron-desktop/status-icon";
+import { toggleQuickInput } from "@vellumai/electron-desktop/quick-input-window";
 import {
   configureTrayModel,
   installTray,
@@ -96,5 +97,6 @@ export const installWindowsTray = (
     ensureMainWindow: async () => ensureVisible(),
     openAbout: openAboutWindow,
     toggleMainWindow: toggleVisibility,
+    toggleQuickInput,
   });
 };

--- a/packages/electron-desktop/src/commands.ts
+++ b/packages/electron-desktop/src/commands.ts
@@ -156,6 +156,22 @@ export const acceleratorOption = (
 };
 
 /**
+ * Resolve the accelerator for a global shortcut key (quickInput,
+ * globalHotkey, toggleVoice…), preferring the user override from
+ * `settings.hotkeys.<key>` over the compiled default. Returns a
+ * menu/tray template fragment with no `accelerator` key when the binding
+ * is disabled or has no default — matching the contract of `acceleratorOption`
+ * so callers never pass an empty string to `Menu.buildFromTemplate`.
+ */
+export const resolveGlobalAcceleratorOption = (
+  key: string,
+): { accelerator?: string } => {
+  const accelerator =
+    readHotkeyOverride(key) ?? GLOBAL_SHORTCUT_DEFAULTS[key] ?? "";
+  return accelerator ? { accelerator } : {};
+};
+
+/**
  * Send a command to whichever BrowserWindow currently has focus, falling
  * back to the first window if none is focused (which happens when a menu
  * item is clicked from the menu bar while the app is in the background but

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -19,6 +19,7 @@ import {
 } from "@vellumai/ipc-contract";
 
 import { onAvatarChange } from "./avatar";
+import { GLOBAL_SHORTCUT_DEFAULTS } from "./commands";
 import { getName, onNameChange } from "./identity";
 import {
   getStatus,
@@ -133,6 +134,11 @@ export interface TrayHandlers {
    * Open (or focus the existing) About window.
    */
   openAbout(): void;
+  /**
+   * Toggle the Quick Input popover panel. Optional — only wired on builds
+   * where the quick-input feature flag can be enabled (Electron desktop).
+   */
+  toggleQuickInput?(): void;
 }
 
 /**
@@ -176,6 +182,15 @@ const isMultiAssistantEnabled = (): boolean => {
  */
 const isDeveloperMenuEnabled = (): boolean => {
   return getRuntime().featureEnabled("developer-menu-items");
+};
+
+/**
+ * Whether the quick-input feature flag is currently enabled.
+ * Checked at menu-build time so toggling the flag takes effect on the next
+ * right-click without requiring an app restart.
+ */
+const isQuickInputEnabled = (): boolean => {
+  return getRuntime().featureEnabled("quick-input");
 };
 
 const buildTrayMenu = (
@@ -303,6 +318,18 @@ const buildTrayMenu = (
         trayRuntime.dispatch({ kind: "newConversation" });
       },
     },
+    // Quick Input: a floating panel the user can type into without switching
+    // to the main window. Gated by the quick-input feature flag; the handler
+    // is optional so this block safely compiles on builds that don't wire it.
+    ...(isQuickInputEnabled() && handlers.toggleQuickInput
+      ? [
+          {
+            label: "Quick Input",
+            accelerator: GLOBAL_SHORTCUT_DEFAULTS.quickInput,
+            click: handlers.toggleQuickInput,
+          },
+        ]
+      : []),
     {
       label: "Current Conversation",
       icon: trayRuntime.icon("conversation"),

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -135,8 +135,8 @@ export interface TrayHandlers {
    */
   openAbout(): void;
   /**
-   * Toggle the Quick Input popover panel. Optional — only wired on builds
-   * where the quick-input feature flag can be enabled (Electron desktop).
+   * Toggle the Quick Input popover panel. Optional — only wired on Electron
+   * desktop builds that configure the quick-input window.
    */
   toggleQuickInput?(): void;
 }
@@ -182,15 +182,6 @@ const isMultiAssistantEnabled = (): boolean => {
  */
 const isDeveloperMenuEnabled = (): boolean => {
   return getRuntime().featureEnabled("developer-menu-items");
-};
-
-/**
- * Whether the quick-input feature flag is currently enabled.
- * Checked at menu-build time so toggling the flag takes effect on the next
- * right-click without requiring an app restart.
- */
-const isQuickInputEnabled = (): boolean => {
-  return getRuntime().featureEnabled("quick-input");
 };
 
 const buildTrayMenu = (
@@ -318,10 +309,9 @@ const buildTrayMenu = (
         trayRuntime.dispatch({ kind: "newConversation" });
       },
     },
-    // Quick Input: a floating panel the user can type into without switching
-    // to the main window. Gated by the quick-input feature flag; the handler
-    // is optional so this block safely compiles on builds that don't wire it.
-    ...(isQuickInputEnabled() && handlers.toggleQuickInput
+    // Quick Input: floating panel to send a message without switching windows.
+    // Present whenever the handler is wired (Electron desktop builds).
+    ...(handlers.toggleQuickInput
       ? [
           {
             label: "Quick Input",

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -19,7 +19,7 @@ import {
 } from "@vellumai/ipc-contract";
 
 import { onAvatarChange } from "./avatar";
-import { GLOBAL_SHORTCUT_DEFAULTS } from "./commands";
+import { resolveGlobalAcceleratorOption } from "./commands";
 import { getName, onNameChange } from "./identity";
 import {
   getStatus,
@@ -325,7 +325,7 @@ const buildTrayMenu = (
       ? [
           {
             label: "Quick Input",
-            accelerator: GLOBAL_SHORTCUT_DEFAULTS.quickInput,
+            ...resolveGlobalAcceleratorOption("quickInput"),
             click: handlers.toggleQuickInput,
           },
         ]


### PR DESCRIPTION
Add a "Quick Input" item to the tray right-click menu, gated on the `quick-input` feature flag. When enabled, clicking it toggles the floating Quick Input panel the same way the global Cmd+Shift+/ shortcut does.

- Add `toggleQuickInput?` to `TrayHandlers` and `isQuickInputEnabled()` helper in `tray-model.ts`
- Pass `toggleQuickInput` from the `quick-input-window` module in both the macOS and Windows `installTray` call sites
- Mock `quick-input-window` in the Windows tray test to avoid pulling in Electron's `screen` API which isn't available in the test env

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
