### PR TITLE
feat(web): camera-mode shutter geometry, capture pulse, and control-row treatment

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/camera-capture-overlay.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/camera-capture-overlay.test.tsx
@@ -253,6 +253,17 @@ describe("CameraCaptureOverlay", () => {
     expect(shutter().hasAttribute("disabled")).toBe(true);
   });
 
+  test("the shutter's band is darkened, since the shutter carries no fill", () => {
+    renderOverlay();
+
+    // A white ring around a white core is invisible against a bright wall
+    // unless something behind it gives way. Inert, because it lies over the
+    // controls it exists to make readable.
+    const scrim = screen.getByTestId("camera-deep-link-scrim");
+    expect(scrim.className).toContain("pointer-events-none");
+    expect(scrim.getAttribute("style")).toContain("gradient");
+  });
+
   test("an acquisition failure closes the surface rather than stranding it", () => {
     cameraError = "permission-denied";
 

--- a/clients/web/src/domains/chat/components/chat-attachments/camera-capture-overlay.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/camera-capture-overlay.tsx
@@ -63,6 +63,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { CameraShutter } from "@/domains/chat/voice/camera-shutter";
+import { CAMERA_SCRIM_BOTTOM } from "@/domains/chat/voice/voice-room/camera-mode-paint";
 import { useVoiceCamera } from "@/domains/chat/voice/voice-room/voice-camera";
 import { VoiceRoomControl } from "@/domains/chat/voice/voice-room/voice-room-control";
 import {
@@ -243,6 +244,21 @@ export function CameraCaptureOverlay({
           />
         )}
 
+        {/* Legibility scrim for the band the shutter sits in.
+
+            The shutter carries no fill of its own: it is a white ring around a
+            white core, which is invisible against a bright wall unless
+            something behind it gives way. The room darkens the same band for
+            the same reason, and shares the gradient so the two surfaces cannot
+            drift. Inert, since it lies over the controls, and it covers only
+            the bottom band so the part the user is aiming stays untouched. */}
+        <div
+          aria-hidden
+          data-testid="camera-deep-link-scrim"
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-[38%]"
+          style={{ background: CAMERA_SCRIM_BOTTOM }}
+        />
+
         {/* First tabbable control in the box, so one Tab off the dialog is the
             way out of here. */}
         <div
@@ -252,7 +268,7 @@ export function CameraCaptureOverlay({
           <VoiceRoomControl
             label={t("cameraDeepLink.close")}
             onClick={close}
-            overMedia
+            surface="media"
             data-testid="camera-deep-link-close"
           >
             <X className="size-5" />
@@ -275,7 +291,7 @@ export function CameraCaptureOverlay({
             <VoiceRoomControl
               label={t("cameraDeepLink.flip")}
               onClick={() => void flipCamera()}
-              overMedia
+              surface="media"
               data-testid="camera-deep-link-flip"
             >
               <SwitchCamera className="size-5" />

--- a/clients/web/src/domains/chat/voice/camera-shutter.stories.tsx
+++ b/clients/web/src/domains/chat/voice/camera-shutter.stories.tsx
@@ -1,0 +1,134 @@
+/**
+ * The shutter, judged where it ships: over a camera feed.
+ *
+ * Storybook has no `getUserMedia`, and the shutter never reads a stream anyway,
+ * so a gradient stands in for the feed exactly as the design reference does.
+ * The gradient runs from near-white to near-black in one frame on purpose: the
+ * shutter carries no fill of its own any more, and the only interesting
+ * question about a white ring is which frames it survives.
+ *
+ * `Live` is the one state the app cannot reach. Capture is photo-only until
+ * frame streaming ships; the state is part of this component's contract, and
+ * this is where it is exercised.
+ */
+
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+
+// The morph timings and the capture keyframe are hand-written in the app
+// stylesheet, which Storybook's preview.css does not pull in.
+import "@/index.css";
+
+import { CameraShutter } from "./camera-shutter";
+
+/**
+ * A frame to read the shutter against: two stops of brightness, because a
+ * control that only has to survive mid-grey is not being tested. Story-local
+ * sample content standing in for camera video, not app styling.
+ */
+const overFakeFeed: Decorator = (Story) => (
+  <div
+    style={{
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 48,
+      minHeight: 260,
+      padding: "56px 32px",
+      background:
+        "linear-gradient(115deg, #f4efe6 0%, #a9927a 38%, #2c2620 72%, #0b0a09 100%)",
+    }}
+  >
+    <Story />
+  </div>
+);
+
+const meta: Meta<typeof CameraShutter> = {
+  title: "Chat/Voice/CameraShutter",
+  component: CameraShutter,
+  parameters: { layout: "fullscreen" },
+  decorators: [overFakeFeed],
+  args: {
+    ariaLabel: "Take photo",
+    mode: "photo",
+    onClick: () => {},
+  },
+  argTypes: {
+    mode: {
+      options: ["photo", "live"],
+      control: { type: "inline-radio" },
+      description:
+        "The sampling policy the press acts on. Live is unreachable in the app.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CameraShutter>;
+
+/**
+ * Rest. White ring, white core, nothing behind it: legibility over a bright
+ * frame is the surface's bottom scrim's job, and a dark backing here dulled
+ * the one control meant to be the brightest thing on the screen.
+ *
+ * Press it. The crimson ring leaving the shutter is the capture feedback, and
+ * it is deliberately not a full-screen white flash: this fires mid sentence,
+ * and a strobing screen is hostile at the moment the user is still talking.
+ */
+export const Photo: Story = {};
+
+/**
+ * The frame is going. The core dips while the ring holds its size, so the
+ * target under the user's thumb does not move between one shot and the next,
+ * and the press is refused until the last one lands.
+ */
+export const Sending: Story = {
+  args: { capturing: true, disabled: true },
+};
+
+/**
+ * Streaming. The core shrinks past its target and settles back, which is the
+ * record-button language every camera on the platform already uses: a crimson
+ * dot that says "running, tap to stop" rather than "tap to take one".
+ *
+ * Not reachable in the app. Flip the `mode` control to watch the morph both
+ * ways, which is the part the overshoot exists for.
+ */
+export const Live: Story = {
+  args: { mode: "live", ariaLabel: "Stop live" },
+};
+
+/**
+ * The same two states under reduced motion, forced here through the class the
+ * component applies from `useReducedMotion`. The overshoot is gone, the morph
+ * is a linear 200ms, and the capture pulse stays: it is feedback rather than
+ * decoration, and without it a press on an unchanged viewfinder is
+ * indistinguishable from a dead button. Press either one.
+ */
+export const ReducedMotion: Story = {
+  render: (args) => (
+    <>
+      <CameraShutter {...args} className="camera-shutter-calm" />
+      <CameraShutter
+        {...args}
+        mode="live"
+        ariaLabel="Stop live"
+        className="camera-shutter-calm"
+      />
+    </>
+  ),
+};
+
+/**
+ * Where it actually sits: centred, with flash to the left and flip to the
+ * right, neither of them reachable by a thumb aimed at the middle. The two
+ * flanking marks are story-local stand-ins at the design's offsets.
+ */
+export const InTheCameraRow: Story = {
+  render: (args) => (
+    <div className="relative flex w-[390px] items-center justify-center">
+      <span className="absolute left-11 size-[46px] rounded-full border border-white/20 bg-black/42" />
+      <CameraShutter {...args} />
+      <span className="absolute right-[30px] size-13 rounded-full bg-[rgba(90,74,64,0.75)]" />
+    </div>
+  ),
+};

--- a/clients/web/src/domains/chat/voice/camera-shutter.stories.tsx
+++ b/clients/web/src/domains/chat/voice/camera-shutter.stories.tsx
@@ -4,12 +4,12 @@
  * Storybook has no `getUserMedia`, and the shutter never reads a stream anyway,
  * so a gradient stands in for the feed exactly as the design reference does.
  * The gradient runs from near-white to near-black in one frame on purpose: the
- * shutter carries no fill of its own any more, and the only interesting
- * question about a white ring is which frames it survives.
+ * shutter carries no fill of its own, and the only interesting question about a
+ * white ring is which frames it survives.
  *
- * `Live` is the one state the app cannot reach. Capture is photo-only until
- * frame streaming ships; the state is part of this component's contract, and
- * this is where it is exercised.
+ * `Live` is the one state the app cannot reach, since the capture path is
+ * photo-only. It is part of this component's contract, and this is where it is
+ * exercised.
  */
 
 import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";

--- a/clients/web/src/domains/chat/voice/camera-shutter.test.tsx
+++ b/clients/web/src/domains/chat/voice/camera-shutter.test.tsx
@@ -5,7 +5,7 @@
  * Load-bearing contracts: the design's outer geometry (an 84px ring measured
  * border-in, around a 64px core), which is what makes the shutter the one
  * target on the surface a thumb finds without looking; both capture modes,
- * including the live one the app cannot reach yet; the capture pulse, which is
+ * including the live one the app does not reach; the capture pulse, which is
  * the ONLY thing that distinguishes a taken photo from a dead button, since a
  * viewfinder looks identical either side of a press; and the button surviving a
  * `Tooltip` wrapper, which reaches it through Radix's `asChild` slot rather
@@ -62,10 +62,10 @@ describe("CameraShutter", () => {
     expect(core().className).toContain("bg-white");
     expect(core().className).toContain("scale-100");
 
-    // Unreachable in the app today (the capture path is photo-only), and part
-    // of the component's contract regardless: the core shrinking to a crimson
-    // dot is the record-button language, and it ships with the component
-    // rather than being re-derived when streaming lands.
+    // Unreachable in the app (the capture path is photo-only), and part of the
+    // component's contract regardless: the core shrinking to a crimson dot is
+    // the record-button language, and it belongs to the component rather than
+    // to whichever caller reaches it first.
     rerender(
       <CameraShutter
         onClick={noop}
@@ -110,7 +110,7 @@ describe("CameraShutter", () => {
 
     fireEvent.click(shutter());
     // The ring morphing back to white already reports what happened. A capture
-    // pulse would report a frame that was never taken.
+    // pulse would report a frame nobody took.
     expect(pulse()).toBeNull();
   });
 

--- a/clients/web/src/domains/chat/voice/camera-shutter.test.tsx
+++ b/clients/web/src/domains/chat/voice/camera-shutter.test.tsx
@@ -2,45 +2,125 @@
  * Tests for `CameraShutter`, the control the voice room and the deep-link
  * capture overlay share.
  *
- * Load-bearing contracts: the dark fill and dark outer hairline that keep the
- * white ring legible against a frame of any brightness (the voice room pins
- * both classes in its own suite); `capturing` shrinking the inner disc while
- * `disabled` dims the ring, since the two are separate axes at the overlay's
- * call site; and the button surviving a `Tooltip` wrapper, which reaches it
- * through Radix's `asChild` slot rather than rendering its own element.
+ * Load-bearing contracts: the design's outer geometry (an 84px ring measured
+ * border-in, around a 64px core), which is what makes the shutter the one
+ * target on the surface a thumb finds without looking; both capture modes,
+ * including the live one the app cannot reach yet; the capture pulse, which is
+ * the ONLY thing that distinguishes a taken photo from a dead button, since a
+ * viewfinder looks identical either side of a press; and the button surviving a
+ * `Tooltip` wrapper, which reaches it through Radix's `asChild` slot rather
+ * than rendering its own element.
  */
 
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { Tooltip } from "@vellumai/design-library";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as motionReact from "motion/react";
 
-import { CameraShutter } from "@/domains/chat/voice/camera-shutter";
+// `useReducedMotion` reads a cached media-query singleton, so a per-test
+// `matchMedia` stub can't flip it. Override just that export and drive it
+// through this toggle instead.
+let reducedMotion = false;
+mock.module("motion/react", () => ({
+  ...motionReact,
+  useReducedMotion: () => reducedMotion,
+}));
+
+const { CameraShutter } = await import("@/domains/chat/voice/camera-shutter");
 
 afterEach(() => {
   cleanup();
+  reducedMotion = false;
 });
 
 const noop = () => {};
 
+const shutter = () => screen.getByTestId("s");
+const core = () => screen.getByTestId("camera-shutter-core");
+const pulse = () => screen.queryByTestId("camera-shutter-pulse");
+
 describe("CameraShutter", () => {
-  test("wears the dark fill and hairline that separate it from the video", () => {
+  test("wears the design's outer geometry, ring measured border-in", () => {
     render(<CameraShutter onClick={noop} ariaLabel="Take photo" testId="s" />);
 
-    const button = screen.getByTestId("s");
-    expect(button.className).toContain("bg-black/30");
-    expect(button.className).toContain("shadow-");
-    expect(button.className).toContain("border-white");
+    // 84 is the OUTER measure: the 2.5px ring eats into it rather than adding
+    // to it, so the gap between ring and core is the design's 7.5px.
+    expect(shutter().className).toContain("size-[84px]");
+    expect(shutter().className).toContain("border-[2.5px]");
+    expect(shutter().className).toContain("box-border");
+    expect(core().className).toContain("size-16");
   });
 
-  test("capturing shrinks the disc and disabled dims the ring, separately", () => {
-    const { container, rerender } = render(
+  test("photo is white at rest; live is crimson and shrunk", () => {
+    const { rerender } = render(
       <CameraShutter onClick={noop} ariaLabel="Take photo" testId="s" />,
     );
 
-    const disc = () => container.querySelector("span") as HTMLElement;
-    expect(disc().className).toContain("size-11");
-    expect(screen.getByTestId("s").className).not.toContain("opacity-60");
+    expect(shutter().getAttribute("data-mode")).toBe("photo");
+    expect(shutter().className).toContain("border-white");
+    expect(core().className).toContain("bg-white");
+    expect(core().className).toContain("scale-100");
+
+    // Unreachable in the app today (the capture path is photo-only), and part
+    // of the component's contract regardless: the core shrinking to a crimson
+    // dot is the record-button language, and it ships with the component
+    // rather than being re-derived when streaming lands.
+    rerender(
+      <CameraShutter
+        onClick={noop}
+        ariaLabel="Stop live"
+        testId="s"
+        mode="live"
+      />,
+    );
+    expect(shutter().getAttribute("data-mode")).toBe("live");
+    expect(shutter().className).toContain("border-[var(--camera-accent)]");
+    expect(core().className).toContain("bg-[var(--camera-accent)]");
+    expect(core().className).toContain("scale-[0.58]");
+  });
+
+  test("a photo press fires the ring pulse, and fires it again per press", () => {
+    render(<CameraShutter onClick={noop} ariaLabel="Take photo" testId="s" />);
+
+    // Nothing at rest: the keyframe starts from a shadow the ring does not
+    // otherwise have, so mounting it would announce a photo nobody took.
+    expect(pulse()).toBeNull();
+
+    fireEvent.click(shutter());
+    const first = pulse();
+    expect(first).not.toBeNull();
+    expect(first!.className).toContain("camera-shutter-pulse");
+
+    // A remount, not a reused node: a CSS animation cannot be replayed by
+    // leaving the element in place, and these presses come as fast as a thumb.
+    fireEvent.click(shutter());
+    expect(pulse()).not.toBe(first);
+  });
+
+  test("live's press stops the stream and does not pulse", () => {
+    render(
+      <CameraShutter
+        onClick={noop}
+        ariaLabel="Stop live"
+        testId="s"
+        mode="live"
+      />,
+    );
+
+    fireEvent.click(shutter());
+    // The ring morphing back to white already reports what happened. A capture
+    // pulse would report a frame that was never taken.
+    expect(pulse()).toBeNull();
+  });
+
+  test("capturing dips the core and disabled dims the ring, separately", () => {
+    const { rerender } = render(
+      <CameraShutter onClick={noop} ariaLabel="Take photo" testId="s" />,
+    );
+
+    expect(core().className).not.toContain("opacity-70");
+    expect(shutter().className).not.toContain("opacity-60");
 
     // The overlay disables the shutter before the viewfinder is ready, with
     // nothing being captured yet.
@@ -52,8 +132,8 @@ describe("CameraShutter", () => {
         disabled
       />,
     );
-    expect(disc().className).toContain("size-11");
-    expect(screen.getByTestId("s").className).toContain("opacity-60");
+    expect(core().className).not.toContain("opacity-70");
+    expect(shutter().className).toContain("opacity-60");
 
     rerender(
       <CameraShutter
@@ -64,7 +144,21 @@ describe("CameraShutter", () => {
         disabled
       />,
     );
-    expect(disc().className).toContain("size-6");
+    // The ring holds its size while the frame goes: the target under the
+    // user's thumb must not move between one shot and the next.
+    expect(core().className).toContain("opacity-70");
+    expect(core().className).toContain("size-16");
+  });
+
+  test("reduced motion retimes the morph without dropping the pulse", () => {
+    reducedMotion = true;
+    render(<CameraShutter onClick={noop} ariaLabel="Take photo" testId="s" />);
+
+    // The calm class swaps the overshoot for a linear 200ms and shortens the
+    // pulse. It does not remove the pulse: that is feedback, not decoration.
+    expect(shutter().className).toContain("camera-shutter-calm");
+    fireEvent.click(shutter());
+    expect(pulse()).not.toBeNull();
   });
 
   test("still takes the press when a Tooltip wraps it", () => {
@@ -81,7 +175,7 @@ describe("CameraShutter", () => {
       </Tooltip>,
     );
 
-    const button = screen.getByTestId("s");
+    const button = shutter();
     expect(button.getAttribute("aria-label")).toBe("Take photo");
 
     fireEvent.click(button);

--- a/clients/web/src/domains/chat/voice/camera-shutter.tsx
+++ b/clients/web/src/domains/chat/voice/camera-shutter.tsx
@@ -7,17 +7,15 @@
  * consistent. A ring around a core, at the size the platform's own camera uses,
  * so it is the one thing on the surface nobody has to be taught.
  *
- * White, with no fill of its own. Legibility over a bright frame is the scrim's
- * job now, not the button's: both surfaces darken the band the shutter sits in,
- * so a dark backing here would be a second answer to a question already
- * answered, and it dulled the one control that is supposed to be the brightest
- * thing on the screen.
+ * White, with no fill of its own. Both surfaces darken the band the shutter
+ * sits in, so legibility over a bright frame is the scrim's job rather than the
+ * button's: a dark backing here answers a question already answered, and dulls
+ * the one control that is supposed to be the brightest thing on the screen.
  *
  * `mode` is the sampling policy the press acts on. `live` is built and
- * exercised by the stories and the suite but is not reachable in the app: the
- * capture path is photo-only until frame streaming ships, and the state is part
- * of this component's contract rather than something a future caller should
- * have to re-derive.
+ * exercised by the stories and the suite but is not reachable in the app, where
+ * the capture path is photo-only. It belongs to this component's contract
+ * rather than to whichever caller reaches it first.
  *
  * Presentational, with one exception. The caller owns what a press does, what
  * counts as busy, and the label, so nothing here reaches for a store or the
@@ -78,8 +76,8 @@ export function CameraShutter({
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     // Live's press stops the stream, which the ring's own morph back to white
-    // already reports. A capture pulse there would announce a frame that was
-    // never taken.
+    // already reports. A capture pulse there would announce a frame nobody
+    // took.
     if (!live) {
       setPulses((count) => count + 1);
     }

--- a/clients/web/src/domains/chat/voice/camera-shutter.tsx
+++ b/clients/web/src/domains/chat/voice/camera-shutter.tsx
@@ -4,20 +4,39 @@
  *
  * One component rather than two copies because the two are the same control
  * doing the same job, and the look is load-bearing in a way that has to stay
- * consistent. Video is the only thing a shutter is ever seen against, and the
- * frame can be any brightness, so white alone is not enough: a white ring on a
- * white wall is as invisible as a dark one on a dark shirt. The white sits on a
- * dark fill and a dark outer hairline, so one edge or the other separates it
- * from the video at both extremes.
+ * consistent. A ring around a core, at the size the platform's own camera uses,
+ * so it is the one thing on the surface nobody has to be taught.
  *
- * Presentational only. The caller owns what a press does, what counts as busy,
- * and the label, so nothing here reaches for a store or the camera. Leftover
- * props land on the button, which is what lets a `Tooltip` wrap it.
+ * White, with no fill of its own. Legibility over a bright frame is the scrim's
+ * job now, not the button's: both surfaces darken the band the shutter sits in,
+ * so a dark backing here would be a second answer to a question already
+ * answered, and it dulled the one control that is supposed to be the brightest
+ * thing on the screen.
+ *
+ * `mode` is the sampling policy the press acts on. `live` is built and
+ * exercised by the stories and the suite but is not reachable in the app: the
+ * capture path is photo-only until frame streaming ships, and the state is part
+ * of this component's contract rather than something a future caller should
+ * have to re-derive.
+ *
+ * Presentational, with one exception. The caller owns what a press does, what
+ * counts as busy, and the label, so nothing here reaches for a store or the
+ * camera. The press FEEDBACK is the component's, because that is the part no
+ * caller can see: a photo leaves the viewfinder unchanged, so without the pulse
+ * a successful capture and a dead button look identical. Leftover props land on
+ * the button, which is what lets a `Tooltip` wrap it.
  */
 
-import type { ComponentProps } from "react";
+import type { ComponentProps, MouseEvent } from "react";
+import { useState } from "react";
 
 import { cn } from "@vellumai/design-library";
+import { useReducedMotion } from "motion/react";
+
+import { cameraModeStyle } from "@/domains/chat/voice/voice-room/camera-mode-paint";
+
+/** Which sampling policy the press acts on. See the module docstring. */
+export type CameraShutterMode = "photo" | "live";
 
 export interface CameraShutterProps extends Omit<
   ComponentProps<"button">,
@@ -26,9 +45,14 @@ export interface CameraShutterProps extends Omit<
   /** Accessible name. The two surfaces phrase the shot differently. */
   ariaLabel: string;
   /**
-   * The frame is being captured or uploaded. Shrinks the inner disc: the
-   * shutter's own press animation doubling as the progress signal, so nothing
-   * else has to appear over the viewfinder.
+   * `photo` takes one frame per press; `live` is streaming, and the press
+   * stops it. Photo is the resting state, so it is the default.
+   */
+  mode?: CameraShutterMode;
+  /**
+   * The frame is being captured or uploaded. Dips the core, which is the whole
+   * signal: the ring holds its size so the target under the user's thumb never
+   * moves between one shot and the next.
    */
   capturing?: boolean;
   testId?: string;
@@ -36,31 +60,76 @@ export interface CameraShutterProps extends Omit<
 
 export function CameraShutter({
   ariaLabel,
+  mode = "photo",
   capturing = false,
   disabled = false,
   testId,
   className,
+  onClick,
+  style,
   ...buttonProps
 }: CameraShutterProps) {
+  const reduce = useReducedMotion();
+  // Bumped per press so the pulse remounts and its keyframe restarts. A CSS
+  // animation cannot be replayed by toggling a class within one frame, and the
+  // presses this has to answer come as fast as a thumb can tap.
+  const [pulses, setPulses] = useState(0);
+  const live = mode === "live";
+
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    // Live's press stops the stream, which the ring's own morph back to white
+    // already reports. A capture pulse there would announce a frame that was
+    // never taken.
+    if (!live) {
+      setPulses((count) => count + 1);
+    }
+    onClick?.(event);
+  };
+
   return (
     <button
       type="button"
       disabled={disabled}
       aria-label={ariaLabel}
       data-testid={testId}
+      data-mode={mode}
+      onClick={handleClick}
+      style={{ ...cameraModeStyle(), ...style }}
       className={cn(
-        "flex size-16 items-center justify-center rounded-full border-4 transition",
-        "border-white bg-black/30 shadow-[0_0_0_1.5px_rgba(0,0,0,0.4)]",
+        // Border-box: the design's 84 is the outer measure, ring included, so
+        // the core's gap inside it is what the border eats into.
+        "camera-shutter relative box-border flex size-[84px] items-center justify-center rounded-full border-[2.5px]",
         "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white",
-        disabled ? "opacity-60" : "hover:bg-black/45",
+        live ? "border-[var(--camera-accent)]" : "border-white",
+        disabled ? "opacity-60" : "hover:opacity-90",
+        reduce && "camera-shutter-calm",
         className,
       )}
       {...buttonProps}
     >
+      {/* Nothing to render until the first press: the keyframe starts from a
+          shadow the ring does not otherwise have, so mounting it at rest would
+          fire a capture pulse for a photo nobody took.
+
+          Inset out to the ring's OUTER edge, so the pulse leaves the shutter's
+          own circle rather than starting 2.5px inside it. */}
+      {pulses > 0 ? (
+        <span
+          key={pulses}
+          aria-hidden
+          data-testid="camera-shutter-pulse"
+          className="camera-shutter-pulse pointer-events-none absolute -inset-[2.5px] rounded-full"
+        />
+      ) : null}
+
       <span
+        data-testid="camera-shutter-core"
         className={cn(
-          "rounded-full bg-white transition-all",
-          capturing ? "size-6" : "size-11",
+          "camera-shutter-core size-16 rounded-full",
+          live
+            ? "scale-[0.58] bg-[var(--camera-accent)]"
+            : "scale-100 bg-white",
+          capturing && "opacity-70",
         )}
       />
     </button>

--- a/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.stories.tsx
@@ -126,16 +126,18 @@ function CycleScene() {
  */
 export const InTheShutterRow: Story = {
   render: () => (
-    <div className="relative flex w-[340px] items-center justify-center">
+    <div className="relative flex w-[390px] items-center justify-center">
       <CameraFlashControl
         mode="auto"
         ariaLabel={LABELS.auto}
         autoBadge="A"
         onClick={() => {}}
-        className="absolute left-8"
+        className="absolute left-11"
       />
-      <span className="size-16 rounded-full border-4 border-white bg-black/30 shadow-[0_0_0_1.5px_rgba(0,0,0,0.4)]" />
-      <span className="absolute right-8 size-12 rounded-full border border-white/25 bg-black/45 backdrop-blur-sm" />
+      <span className="flex size-[84px] items-center justify-center rounded-full border-[2.5px] border-white">
+        <span className="size-16 rounded-full bg-white" />
+      </span>
+      <span className="absolute right-[30px] size-13 rounded-full bg-[rgba(90,74,64,0.75)]" />
     </div>
   ),
 };

--- a/clients/web/src/domains/chat/voice/voice-room/camera-mode-paint.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-mode-paint.ts
@@ -63,9 +63,8 @@ export const CAMERA_DESTRUCTIVE = "#e8453f";
 
 /**
  * Legibility scrims for the top and bottom bands of the feed, where all the
- * camera chrome lives. Only those two bands: the design explicitly dropped the
- * screen-edge tint, so the middle of the frame (the part the user is actually
- * aiming at) stays untouched.
+ * camera chrome lives. Only those two bands carry a tint, so the middle of the
+ * frame (the part the user is actually aiming at) stays untouched.
  */
 export const CAMERA_SCRIM_TOP = "linear-gradient(rgba(0,0,0,.42), transparent)";
 export const CAMERA_SCRIM_BOTTOM =

--- a/clients/web/src/domains/chat/voice/voice-room/camera-mode-paint.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-mode-paint.ts
@@ -1,6 +1,7 @@
 /**
- * The paint camera mode wears: the accent pair its chrome is toned with, and
- * the two scrims that keep that chrome legible over the feed.
+ * The paint camera mode wears: the accents its chrome is toned with, the fills
+ * its control row is told apart by, and the two scrims that keep both legible
+ * over the feed.
  *
  * Fixed values rather than theme tokens, deliberately. What sits behind this
  * chrome is an arbitrary live camera image, not a surface the app painted, so
@@ -34,6 +35,33 @@ export const CAMERA_ACCENT = "#cf4370";
 export const CAMERA_ACCENT_SOFT = "#ffd9e4";
 
 /**
+ * The warm brown the camera's own controls are filled with: flip beside the
+ * shutter, and the toggle that closes the viewfinder.
+ *
+ * A third hue in a row that otherwise has only two, and that is the point. The
+ * row already spends white on "the session is live" and red on "this changes
+ * the call", so a control that does neither cannot borrow either without
+ * saying something untrue. Warm rather than more glass because over a feed a
+ * translucent black button is the one that vanishes into a dark frame.
+ *
+ * The stronger of the pair goes to a toggle that is engaged: the camera control
+ * is held down for as long as the viewfinder is up, and sits a shade heavier
+ * than the resting controls beside it.
+ */
+export const CAMERA_WARM = "rgba(90,74,64,.75)";
+export const CAMERA_WARM_STRONG = "rgba(90,74,64,.8)";
+
+/**
+ * The red a control acting on the call wears over the feed: the mutes while
+ * engaged, and end-session always.
+ *
+ * Solid, not the translucent red the room's other surfaces use. The chrome here
+ * sits on arbitrary video, and a 55%-opacity red over a red jumper is a button
+ * with no edges; the whole row is filled for the same reason.
+ */
+export const CAMERA_DESTRUCTIVE = "#e8453f";
+
+/**
  * Legibility scrims for the top and bottom bands of the feed, where all the
  * camera chrome lives. Only those two bands: the design explicitly dropped the
  * screen-edge tint, so the middle of the frame (the part the user is actually
@@ -51,5 +79,8 @@ export function cameraModeStyle(): CSSProperties {
   return {
     "--camera-accent": CAMERA_ACCENT,
     "--camera-accent-soft": CAMERA_ACCENT_SOFT,
+    "--camera-warm": CAMERA_WARM,
+    "--camera-warm-strong": CAMERA_WARM_STRONG,
+    "--camera-destructive": CAMERA_DESTRUCTIVE,
   } as CSSProperties;
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.stories.tsx
@@ -1,0 +1,145 @@
+/**
+ * The room's circular controls in camera mode, over a stand-in for the feed.
+ *
+ * Camera mode only. The other two surfaces tone themselves from the assistant's
+ * avatar through the `--room-*` contract, which is the room's to publish and
+ * has no meaning outside it; the camera palette is fixed, published by the
+ * control itself, and therefore the one that can be read honestly here.
+ *
+ * The row is the point rather than any single control: the read to check is
+ * that white, warm and red separate at arm's length, and in particular that a
+ * live mic never reads as a muted one.
+ */
+
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import { CameraOff, Mic, MicOff, Volume2, VolumeX, X } from "lucide-react";
+
+import { VoiceRoomControl } from "./voice-room-control";
+
+/**
+ * A frame to read the controls against: two stops of brightness, because a row
+ * that only has to survive mid-grey is not being tested. Story-local sample
+ * content standing in for camera video, not app styling.
+ */
+const overFakeFeed: Decorator = (Story) => (
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      gap: 32,
+      minHeight: 240,
+      padding: "56px 24px",
+      background:
+        "linear-gradient(115deg, #f4efe6 0%, #a9927a 38%, #2c2620 72%, #0b0a09 100%)",
+    }}
+  >
+    <Story />
+  </div>
+);
+
+const meta: Meta<typeof VoiceRoomControl> = {
+  title: "Chat/Voice/VoiceRoomControl",
+  component: VoiceRoomControl,
+  parameters: { layout: "fullscreen" },
+  decorators: [overFakeFeed],
+  args: { surface: "camera", onClick: () => {} },
+};
+
+export default meta;
+type Story = StoryObj<typeof VoiceRoomControl>;
+
+/** One control with the word for what it is, so the five can be compared. */
+function ToneCell({
+  caption,
+  children,
+}: {
+  caption: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3">
+      {children}
+      <span className="font-mono text-[11px] text-white/70">{caption}</span>
+    </div>
+  );
+}
+
+/**
+ * The five states the row can be in, captioned.
+ *
+ * The mic is the correction this palette exists for. Camera mode used to
+ * replace the room's face with a viewfinder and leave "is she still listening"
+ * answered by an absence of red; a live mic is now solid white with a dark
+ * glyph, and red is kept for the mic that is genuinely off.
+ */
+export const CameraTones: Story = {
+  render: (args) => (
+    <div className="flex items-start gap-6">
+      <ToneCell caption="mic live">
+        <VoiceRoomControl {...args} tone="live" label="Mute microphone">
+          <Mic className="size-5" />
+        </VoiceRoomControl>
+      </ToneCell>
+      <ToneCell caption="mic muted">
+        <VoiceRoomControl
+          {...args}
+          tone="destructive"
+          pressed
+          label="Unmute microphone"
+        >
+          <MicOff className="size-5" />
+        </VoiceRoomControl>
+      </ToneCell>
+      <ToneCell caption="speaker muted">
+        <VoiceRoomControl
+          {...args}
+          tone="destructive"
+          pressed
+          label="Unmute assistant"
+        >
+          <VolumeX className="size-5" />
+        </VoiceRoomControl>
+      </ToneCell>
+      <ToneCell caption="camera (engaged)">
+        <VoiceRoomControl {...args} pressed label="Close camera">
+          <CameraOff className="size-5" />
+        </VoiceRoomControl>
+      </ToneCell>
+      <ToneCell caption="end">
+        <VoiceRoomControl
+          {...args}
+          tone="destructive"
+          label="End voice session"
+        >
+          <X className="size-5" strokeWidth={2.5} />
+        </VoiceRoomControl>
+      </ToneCell>
+    </div>
+  ),
+};
+
+/**
+ * The row as it ships, at its own 16px gap: mute the mic, mute the assistant,
+ * close the camera, end the session. Four 52px circles, the same four whether
+ * or not the viewfinder is up, so nothing resizes under a reaching thumb when
+ * the camera opens.
+ */
+export const CameraRow: Story = {
+  render: (args) => (
+    <div className="flex items-center justify-center gap-4">
+      <VoiceRoomControl {...args} tone="live" label="Mute microphone">
+        <Mic className="size-5" />
+      </VoiceRoomControl>
+      <VoiceRoomControl {...args} label="Mute assistant">
+        <Volume2 className="size-5" />
+      </VoiceRoomControl>
+      <VoiceRoomControl {...args} pressed label="Close camera">
+        <CameraOff className="size-5" />
+      </VoiceRoomControl>
+      <VoiceRoomControl {...args} tone="destructive" label="End voice session">
+        <X className="size-5" strokeWidth={2.5} />
+      </VoiceRoomControl>
+    </div>
+  ),
+};

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.stories.tsx
@@ -68,10 +68,10 @@ function ToneCell({
 /**
  * The five states the row can be in, captioned.
  *
- * The mic is the correction this palette exists for. Camera mode used to
- * replace the room's face with a viewfinder and leave "is she still listening"
- * answered by an absence of red; a live mic is now solid white with a dark
- * glyph, and red is kept for the mic that is genuinely off.
+ * The mic is the one to read first. A viewfinder covers the room's face, so a
+ * live mic goes solid white with a dark glyph rather than leaving "is she still
+ * listening" to an absence of red; red belongs to the mic that is genuinely
+ * off.
  */
 export const CameraTones: Story = {
   render: (args) => (

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.test.tsx
@@ -3,9 +3,9 @@
  *
  * Load-bearing contracts: the three surfaces, since a control that reads the
  * wrong one is invisible rather than merely wrong; the `live` tone, whose whole
- * job is to exist only where the room's own look has been replaced by a
- * viewfinder; and the corner's exemption from the camera fills, which is what
- * keeps the bottom row reading as one set of related acts.
+ * job is to exist only where a viewfinder covers the room's own look; and the
+ * corner's exemption from the camera fills, which is what keeps the bottom row
+ * reading as one set of related acts.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for `VoiceRoomControl`, every circular icon control in the room.
+ *
+ * Load-bearing contracts: the three surfaces, since a control that reads the
+ * wrong one is invisible rather than merely wrong; the `live` tone, whose whole
+ * job is to exist only where the room's own look has been replaced by a
+ * viewfinder; and the corner's exemption from the camera fills, which is what
+ * keeps the bottom row reading as one set of related acts.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render, screen } from "@testing-library/react";
+
+import {
+  VoiceRoomControl,
+  type VoiceRoomControlProps,
+} from "@/domains/chat/voice/voice-room/voice-room-control";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderControl(props: Partial<VoiceRoomControlProps> = {}) {
+  render(
+    <VoiceRoomControl
+      label="Mute microphone"
+      onClick={() => {}}
+      data-testid="c"
+      {...props}
+    >
+      <span />
+    </VoiceRoomControl>,
+  );
+  return screen.getByTestId("c");
+}
+
+describe("VoiceRoomControl", () => {
+  test("camera mode fills every tone, and tells them apart by what they do", () => {
+    // White for the control that says the session is live, warm for the ones
+    // that are about the camera rather than the call, red for the one act that
+    // cannot be undone.
+    expect(
+      renderControl({ surface: "camera", tone: "live" }).className,
+    ).toContain("bg-white");
+    cleanup();
+    expect(renderControl({ surface: "camera" }).className).toContain(
+      "bg-[var(--camera-warm)]",
+    );
+    cleanup();
+    expect(
+      renderControl({ surface: "camera", tone: "destructive" }).className,
+    ).toContain("bg-[var(--camera-destructive)]");
+  });
+
+  test("an engaged toggle sits a shade heavier than its resting peers", () => {
+    // The camera control is held down for the whole time the viewfinder is up;
+    // flip, beside it, toggles nothing.
+    expect(
+      renderControl({ surface: "camera", pressed: true }).className,
+    ).toContain("bg-[var(--camera-warm-strong)]");
+  });
+
+  test("the camera fills are published as vars by the control itself", () => {
+    // Nothing above this in the tree is guaranteed to carry the contract: the
+    // deep-link overlay mounts these controls outside the room entirely.
+    const style = renderControl({ surface: "camera" }).getAttribute("style");
+    expect(style).toContain("--camera-warm");
+    expect(style).toContain("--camera-destructive");
+  });
+
+  test("corner chrome keeps the glass treatment in camera mode", () => {
+    // A filled circle in the corner would join the bottom row's set of related
+    // acts, which the minimize control is not part of.
+    const bare = renderControl({ surface: "camera", bare: true });
+    expect(bare.className).toContain("bg-black/45");
+    expect(bare.className).not.toContain("camera-warm");
+  });
+
+  test("the live tone is the neutral one anywhere but camera mode", () => {
+    // Off the viewfinder the room's own look answers "is she listening", so a
+    // solid white circle would be an answer to a question already answered,
+    // and it would be the loudest thing in a room built around an avatar.
+    const room = renderControl({ tone: "live" });
+    expect(room.className).toContain("border-[var(--room-border)]");
+    expect(room.className).not.toContain("bg-white");
+    cleanup();
+
+    // The deep-link capture overlay is over video without being in camera
+    // mode: it has no `--camera-*` contract, and its two controls are chrome
+    // on a modal rather than a session row.
+    const media = renderControl({ tone: "live", surface: "media" });
+    expect(media.className).toContain("bg-black/45");
+    expect(media.className).not.toContain("bg-white");
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
@@ -3,13 +3,12 @@
  * the camera toggle, flip camera, end session.
  *
  * The treatment varies along three axes, so it lives in one place rather than
- * being assembled per call site: neutral vs destructive toning, bordered vs
- * bare, and whether the viewfinder is open behind the control. A scrim that
- * every call site has to remember is one that reaches most of the row and
- * misses a control.
+ * being assembled per call site: the toning, bordered vs bare, and what is
+ * behind the control. A scrim that every call site has to remember is one that
+ * reaches most of the row and misses a control.
  *
  * The element is a bare `<button>`, not the design library's `Button`. These
- * are 48px circles; `Button`'s sizes stop at `h-8` with `rounded-md` on every
+ * are 52px circles; `Button`'s sizes stop at `h-8` with `rounded-md` on every
  * one of them, and it carries `active:scale-[0.97]` plus a theme-token focus
  * ring. The room paints itself an arbitrary avatar color, so theme tokens are
  * as likely to be invisible on it as legible, which is what the `--room-*`
@@ -25,8 +24,11 @@
 import { Tooltip, cn } from "@vellumai/design-library";
 import type { ReactNode } from "react";
 
+import { cameraModeStyle } from "./camera-mode-paint";
+
 /**
- * The treatment for a control sitting over the open viewfinder.
+ * The treatment for a control sitting over video: the deep-link capture
+ * overlay's two, and the room's corner chrome once the viewfinder is up.
  *
  * Every other treatment here is derived from the assistant's avatar tone,
  * which is the correct reference right up until the camera opens: the feed
@@ -43,6 +45,35 @@ const OVER_MEDIA_NEUTRAL_CLASS =
   "border-white/25 bg-black/45 text-white backdrop-blur-sm hover:bg-black/60 hover:text-white focus-visible:outline-white";
 
 /**
+ * Camera mode's palette for the room's own row: every control filled, and told
+ * apart by what it does rather than by an outline.
+ *
+ * Glass is the wrong instrument once the whole surface is a viewfinder. The
+ * row then sits on the busiest background the app ever paints, and five
+ * translucent circles over it read as one smear; the design fills them
+ * instead, and spends color on the only distinction that matters at arm's
+ * length: what will happen if you hit the wrong one.
+ *
+ * Hover dips the whole control rather than moving to a fourth fill. Each of
+ * these is the design's exact value, and a hover color invented beside it
+ * would be a color no table names.
+ */
+const CAMERA_LIVE_CLASS =
+  "border-transparent bg-white text-neutral-900 hover:opacity-90 focus-visible:outline-white";
+const CAMERA_NEUTRAL_CLASS =
+  "border-transparent bg-[var(--camera-warm)] text-white hover:opacity-90 focus-visible:outline-white";
+const CAMERA_ENGAGED_CLASS =
+  "border-transparent bg-[var(--camera-warm-strong)] text-white hover:opacity-90 focus-visible:outline-white";
+const CAMERA_DESTRUCTIVE_CLASS =
+  "border-transparent bg-[var(--camera-destructive)] text-white hover:opacity-90 focus-visible:outline-white";
+
+/** What is behind the control. See {@link VoiceRoomControlProps.surface}. */
+export type VoiceRoomControlSurface = "room" | "media" | "camera";
+
+/** How the control is toned. See {@link VoiceRoomControlProps.tone}. */
+export type VoiceRoomControlTone = "neutral" | "destructive" | "live";
+
+/**
  * The red worn by a control that is doing something to the call: the two mutes
  * while engaged, and end-session always.
  *
@@ -55,13 +86,56 @@ const OVER_MEDIA_NEUTRAL_CLASS =
  * the glyph goes white because a red-on-red icon is the first thing to
  * disappear.
  */
-function destructiveClass(overMedia: boolean, isLight: boolean): string {
-  if (overMedia) {
+function destructiveClass(
+  surface: VoiceRoomControlSurface,
+  isLight: boolean,
+): string {
+  if (surface === "camera") {
+    return CAMERA_DESTRUCTIVE_CLASS;
+  }
+  if (surface === "media") {
     return "border-red-200/40 bg-red-600/55 text-white backdrop-blur-sm hover:bg-red-600/70 focus-visible:outline-white";
   }
   return isLight
     ? "border-red-700/50 bg-red-600/15 text-red-800 hover:bg-red-600/25"
     : "border-red-400/50 bg-red-500/20 text-red-300 hover:bg-red-500/30";
+}
+
+/** The whole treatment: three tones across three surfaces, resolved in one place. */
+function treatmentClass({
+  tone,
+  surface,
+  isLight,
+  bare,
+  pressed,
+}: {
+  tone: VoiceRoomControlTone;
+  surface: VoiceRoomControlSurface;
+  isLight: boolean;
+  bare: boolean;
+  pressed: boolean;
+}): string {
+  if (tone === "destructive") {
+    return destructiveClass(surface, isLight);
+  }
+  // Corner chrome keeps the glass treatment even in camera mode. The warm
+  // fills are how the bottom row reads as one set of related acts, and a
+  // filled circle in the corner would join a set it is not in.
+  if (surface === "camera" && !bare) {
+    if (tone === "live") {
+      return CAMERA_LIVE_CLASS;
+    }
+    // An engaged toggle sits a shade heavier than the resting controls beside
+    // it: the camera control is held down for as long as the viewfinder is up,
+    // and flip, which toggles nothing, takes the lighter warm.
+    return pressed ? CAMERA_ENGAGED_CLASS : CAMERA_NEUTRAL_CLASS;
+  }
+  return cn(
+    bare
+      ? "text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]"
+      : "border-[var(--room-border)] text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]",
+    surface !== "room" && OVER_MEDIA_NEUTRAL_CLASS,
+  );
 }
 
 export interface VoiceRoomControlProps {
@@ -79,11 +153,21 @@ export interface VoiceRoomControlProps {
   children: ReactNode;
   /**
    * `destructive` for a control acting ON the call: a mute while engaged, and
-   * end-session always. Defaults to the neutral toning.
+   * end-session always. `live` for the one that shows the session is running,
+   * which in camera mode is filled solid white: an un-slashed mic on glass is
+   * the single thing the redesign corrected, because a viewfinder that
+   * replaced the room's face left "is she still listening" answered by an
+   * absence of red. Off the camera surface `live` IS the neutral toning, since
+   * the room's own look already answers that. Defaults to neutral.
    */
-  tone?: "neutral" | "destructive";
-  /** True while the viewfinder is open behind this control. */
-  overMedia?: boolean;
+  tone?: VoiceRoomControlTone;
+  /**
+   * What is behind the control: the room's own look, arbitrary video (the
+   * deep-link capture overlay), or the room in camera mode, which paints its
+   * whole chrome from the `--camera-*` contract. One axis rather than a
+   * boolean per surface, since a control is only ever on one of them.
+   */
+  surface?: VoiceRoomControlSurface;
   /** The room's look is a light avatar color, so reds need the darker pick. */
   isLight?: boolean;
   /**
@@ -104,7 +188,7 @@ export function VoiceRoomControl({
   onClick,
   children,
   tone = "neutral",
-  overMedia = false,
+  surface = "room",
   isLight = false,
   bare = false,
   pressed,
@@ -121,18 +205,21 @@ export function VoiceRoomControl({
         aria-pressed={pressed}
         disabled={disabled}
         data-testid={testId}
+        style={surface === "camera" ? cameraModeStyle() : undefined}
         className={cn(
-          "flex size-12 items-center justify-center rounded-full transition",
+          // 52px, in every state. The row is the same one whether or not the
+          // viewfinder is up, and a control that resized as the camera opened
+          // would move under a thumb already on its way to it.
+          "flex size-13 items-center justify-center rounded-full transition",
           "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--room-fg-muted)]",
           !bare && "border",
-          tone === "destructive"
-            ? destructiveClass(overMedia, isLight)
-            : cn(
-                bare
-                  ? "text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]"
-                  : "border-[var(--room-border)] text-[var(--room-fg-muted)] hover:bg-[var(--room-wash)] hover:text-[var(--room-fg)]",
-                overMedia && OVER_MEDIA_NEUTRAL_CLASS,
-              ),
+          treatmentClass({
+            tone,
+            surface,
+            isLight,
+            bare,
+            pressed: Boolean(pressed),
+          }),
           className,
         )}
       >

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
@@ -154,11 +154,11 @@ export interface VoiceRoomControlProps {
   /**
    * `destructive` for a control acting ON the call: a mute while engaged, and
    * end-session always. `live` for the one that shows the session is running,
-   * which in camera mode is filled solid white: an un-slashed mic on glass is
-   * the single thing the redesign corrected, because a viewfinder that
-   * replaced the room's face left "is she still listening" answered by an
-   * absence of red. Off the camera surface `live` IS the neutral toning, since
-   * the room's own look already answers that. Defaults to neutral.
+   * which in camera mode is filled solid white: a viewfinder covers the room's
+   * face, so nothing else on screen answers "is she still listening", and an
+   * un-slashed mic on glass leaves that answer to an absence of red. Off the
+   * camera surface `live` IS the neutral toning, since the room's own look
+   * answers it. Defaults to neutral.
    */
   tone?: VoiceRoomControlTone;
   /**

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-layout.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-layout.ts
@@ -13,7 +13,7 @@
  * Zones are inset past the room's corner controls — the gear/✕ cluster above,
  * the mute/stop cluster below — so text never collides with them. The `rem`
  * floor in each anchor is what guarantees that clearance (the controls are a
- * fixed 3rem tall at a 1.25rem inset); the percentage takes over on taller
+ * fixed 3.25rem tall at a 1.25rem inset); the percentage takes over on taller
  * viewports, where hugging a fixed offset off the edge would strand the text
  * far below the eyes. Both are safe-area aware per docs/CAPACITOR.md — the
  * `var()` is set by `capacitor-plugin-safe-area` on Capacitor iOS, `env()`

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -435,6 +435,9 @@ const endButton = () =>
 /** The corner chevron: dismisses the room, leaves the call running. */
 const minimizeButton = () =>
   screen.queryByRole("button", { name: "Minimize voice room" });
+/** The row's mic, named for the act it offers, so this is the LIVE one. */
+const micButton = () =>
+  screen.queryByRole("button", { name: "Mute microphone" });
 
 describe("VoiceRoom — visibility", () => {
   test("renders nothing when no session is active", () => {
@@ -1828,7 +1831,7 @@ describe("VoiceRoom: camera", () => {
     expect(pill().textContent).toContain("Reconnecting…");
   });
 
-  test("the controls take a scrim once they sit over the feed", async () => {
+  test("the controls take camera mode's own fills once they sit over the feed", async () => {
     stubMediaDevices(async () => fakeStream());
     seedCameraCapableAssistant();
     startOwnedSession("listening");
@@ -1836,37 +1839,104 @@ describe("VoiceRoom: camera", () => {
 
     // Closed: the room's own flat color is behind them, and the controls wear
     // the tone-derived hairline treatment.
-    expect(cameraToggle()!.className).not.toContain("bg-black");
+    expect(cameraToggle()!.className).not.toContain("camera-warm");
+    expect(micButton()!.className).not.toContain("bg-white");
 
     await act(async () => {
       fireEvent.click(cameraToggle()!);
     });
 
-    // Open: the background is now arbitrary camera video, where a border-only
-    // control disappears against dark clothing. Every control on the surface
-    // has to carry its own fill, the end button included.
-    const scrimmed = [
-      "Close camera",
-      "Mute microphone",
-      "Mute assistant",
-      "Flip camera",
-      "Minimize voice room",
-    ];
-    for (const name of scrimmed) {
+    // Open: the background is arbitrary camera video, where a border-only
+    // control disappears against dark clothing and five translucent circles
+    // read as one smear. Every control is filled, and color carries the only
+    // distinction that matters at arm's length: what happens if you hit the
+    // wrong one.
+    //
+    // The mic is the correction the redesign exists for. With the room's face
+    // replaced by a viewfinder, this button is the only thing left saying the
+    // session can still hear you, so a live mic goes solid white with a dark
+    // glyph rather than sitting on the same glass as its neighbours. It used
+    // to wear the same `bg-black/45` scrim as everything else.
+    const mic = micButton()!;
+    expect(mic.className).toContain("bg-white");
+    expect(mic.className).toContain("text-neutral-900");
+
+    // The camera's own controls take the warm fill: a third hue, because the
+    // row already spends white on "the session is live" and red on "this
+    // changes the call", and these do neither. The engaged toggle (the camera
+    // control, held down for as long as the viewfinder is up) sits a shade
+    // heavier than the resting controls beside it.
+    expect(cameraToggle()!.className).toContain(
+      "bg-[var(--camera-warm-strong)]",
+    );
+    for (const name of ["Mute assistant", "Flip camera"]) {
       expect(screen.getByRole("button", { name }).className).toContain(
-        "bg-black/45",
+        "bg-[var(--camera-warm)]",
       );
     }
-    const end = screen.getByRole("button", { name: "End voice session" });
-    expect(end.className).toContain("bg-red-600/55");
+    // The vars the fills name are published by the control itself, so a
+    // renamed constant surfaces here rather than as a transparent button.
+    expect(cameraToggle()!.getAttribute("style")).toContain("--camera-warm");
 
-    // The shutter is white so it reads on a dark frame, which leaves it
-    // invisible on a bright one unless it carries a dark backing of its own.
-    // It is the only control on the surface with no neutral scrim to fall
-    // back on, so it is asserted separately rather than in the loop above.
+    // Solid red, not the translucent red the room's other surfaces use: a
+    // 55%-opacity red over a red jumper is a button with no edges.
+    const end = screen.getByRole("button", { name: "End voice session" });
+    expect(end.className).toContain("bg-[var(--camera-destructive)]");
+
+    // Corner chrome keeps the glass treatment. The warm fills are how the
+    // bottom row reads as one set of related acts, and a filled circle in the
+    // corner would join a set it is not in.
+    expect(minimizeButton()!.className).toContain("bg-black/45");
+
+    // The shutter carries no fill at all any more. Legibility over a bright
+    // frame is the bottom scrim's job now, and a dark backing here was a
+    // second answer to that question that dulled the one control meant to be
+    // the brightest thing on the screen.
     const shutter = screen.getByTestId("voice-room-shutter");
-    expect(shutter.className).toContain("bg-black/30");
-    expect(shutter.className).toContain("shadow-");
+    expect(shutter.className).toContain("border-white");
+    expect(shutter.className).toContain("size-[84px]");
+    expect(shutter.className).not.toContain("bg-black");
+  });
+
+  test("a muted mic drops the white fill for the destructive red", async () => {
+    stubMediaDevices(async () => fakeStream());
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+    await act(async () => {
+      useLiveVoiceStore.setState({ muted: true });
+    });
+
+    // The white fill says "the session can hear you", so it cannot survive the
+    // mic being switched off. Muted is the one state where the red slashed
+    // treatment is honest.
+    const mic = screen.getByRole("button", { name: "Unmute microphone" });
+    expect(mic.className).toContain("bg-[var(--camera-destructive)]");
+    expect(mic.className).not.toContain("bg-white");
+  });
+
+  test("the row is one size whether or not the viewfinder is up", async () => {
+    stubMediaDevices(async () => fakeStream());
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    // 52px in both states. A control that resized as the camera opened would
+    // move out from under a thumb already on its way to it.
+    expect(micButton()!.className).toContain("size-13");
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    expect(micButton()!.className).toContain("size-13");
+    expect(
+      screen.getByRole("button", { name: "Flip camera" }).className,
+    ).toContain("size-13");
   });
 
   test("offers no flash control on the browser fallback path", async () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -1852,11 +1852,10 @@ describe("VoiceRoom: camera", () => {
     // distinction that matters at arm's length: what happens if you hit the
     // wrong one.
     //
-    // The mic is the correction the redesign exists for. With the room's face
-    // replaced by a viewfinder, this button is the only thing left saying the
-    // session can still hear you, so a live mic goes solid white with a dark
-    // glyph rather than sitting on the same glass as its neighbours. It used
-    // to wear the same `bg-black/45` scrim as everything else.
+    // With a viewfinder over the room's face, the mic is the only thing on
+    // screen saying the session can still hear you, so a live one goes solid
+    // white with a dark glyph rather than sitting on the same glass as its
+    // neighbours, where the answer would be an absence of red.
     const mic = micButton()!;
     expect(mic.className).toContain("bg-white");
     expect(mic.className).toContain("text-neutral-900");
@@ -1888,10 +1887,10 @@ describe("VoiceRoom: camera", () => {
     // corner would join a set it is not in.
     expect(minimizeButton()!.className).toContain("bg-black/45");
 
-    // The shutter carries no fill at all any more. Legibility over a bright
-    // frame is the bottom scrim's job now, and a dark backing here was a
-    // second answer to that question that dulled the one control meant to be
-    // the brightest thing on the screen.
+    // The shutter carries no fill at all. Legibility over a bright frame is
+    // the bottom scrim's job, and a dark backing here answers a question
+    // already answered while dulling the one control meant to be the
+    // brightest thing on the screen.
     const shutter = screen.getByTestId("voice-room-shutter");
     expect(shutter.className).toContain("border-white");
     expect(shutter.className).toContain("size-[84px]");

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -185,7 +185,10 @@ import { useCustomAvatarFieldHex } from "./use-custom-avatar-field";
 // minimize, the two mutes, the camera toggle, flip camera and end session. See
 // that module for the toning, and for why the design library's `Button` is not
 // the element here.
-import { VoiceRoomControl } from "./voice-room-control";
+import {
+  VoiceRoomControl,
+  type VoiceRoomControlSurface,
+} from "./voice-room-control";
 import {
   VoiceRoomColorLook,
   VoiceRoomVoiceBands,
@@ -208,11 +211,11 @@ const CORNER_GAP = "1.25rem";
  * top-right minimize control and grows in both directions from there. A
  * configured assistant name is arbitrarily long, so without this the pill runs
  * under that control and off a phone-width room. Each side gives up the corner
- * chrome's own offset, the control's 3rem box, and a gap so the two never
+ * chrome's own offset, the control's 3.25rem box, and a gap so the two never
  * touch; a percentage resolves against the room, which is what the pill has to
  * fit inside.
  */
-const CAMERA_PILL_MAX_WIDTH = `calc(100% - 2 * (max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 3.5rem))`;
+const CAMERA_PILL_MAX_WIDTH = `calc(100% - 2 * (max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 3.75rem))`;
 
 /**
  * The flash button's accessible name, per state.
@@ -531,6 +534,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const { camera, sending, photos, errorMessage, shutter, open, close } =
     useVoiceRoomCamera(assistantId, viewfinderRef);
   const cameraOpen = camera.open;
+  // What every control in the room is sitting on. One value passed down rather
+  // than a boolean per control, so the row cannot end up half in camera mode.
+  const controlSurface: VoiceRoomControlSurface = cameraOpen
+    ? "camera"
+    : "room";
 
   // Camera mode's own status readout. Gated on the camera so the user-speaking
   // poll inside the hook only runs while something renders its dot, and the
@@ -927,7 +935,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           tooltip={t("voiceRoom.minimizeTooltip")}
           onClick={minimizeVoiceRoom}
           bare
-          overMedia={cameraOpen}
+          surface={controlSurface}
         >
           <ChevronDown className="size-5" />
         </VoiceRoomControl>
@@ -1023,8 +1031,14 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         <div
           data-testid="voice-room-camera-controls"
           className="absolute inset-x-0 z-10 flex flex-col items-center gap-3"
+          // The session row's own offset, plus its 52px height, plus the 46px
+          // the design leaves between the two. The shutter grew to 84px, so the
+          // clearance had to be recomputed from the row's top edge rather than
+          // left at a constant that happened to work at 64: the thing you press
+          // often has to stay off the thing that hangs up, and it is the GAP
+          // that guarantees that, not the number.
           style={{
-            bottom: `calc(5.5rem + max(${CORNER_GAP}, ${SAFE_AREA_BOTTOM}))`,
+            bottom: `calc(6.125rem + max(${CORNER_GAP}, ${SAFE_AREA_BOTTOM}))`,
           }}
         >
           {errorMessage ? (
@@ -1114,15 +1128,17 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                     ariaLabel={t(FLASH_LABEL_KEYS[flashMode])}
                     autoBadge={t("voiceRoom.flashAutoBadge")}
                     onClick={() => setFlashMode(nextFlashMode(flashMode))}
-                    className="absolute left-8"
+                    className="absolute left-11"
                     testId="voice-room-flash"
                   />
                 </Tooltip>
               ) : null}
 
-              {/* The one control with no `overMedia` branch: the shutter
-                  exists only while the viewfinder does, so it is never seen
-                  against anything but video. */}
+              {/* The one control with no surface branch: the shutter exists
+                  only while the viewfinder does, so it is never seen against
+                  anything but video. Photo is the only mode the capture path
+                  can reach; the shutter's live state waits on frame
+                  streaming. */}
               <Tooltip content={t("voiceRoom.takePhoto")}>
                 <CameraShutter
                   onClick={() => void shutter()}
@@ -1136,8 +1152,8 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
               <VoiceRoomControl
                 label={t("voiceRoom.flipCamera")}
                 onClick={() => void camera.flipCamera()}
-                overMedia={cameraOpen}
-                className="absolute right-8"
+                surface={controlSurface}
+                className="absolute right-[30px]"
               >
                 <SwitchCamera className="size-5" />
               </VoiceRoomControl>
@@ -1161,9 +1177,14 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           }
           onClick={() => setLiveVoiceMuted(!muted)}
           pressed={muted}
-          tone={muted ? "destructive" : "neutral"}
+          // The one control the camera mode redesign exists to correct. With
+          // the viewfinder up, the room's face is gone and this button is the
+          // only thing left saying the session can still hear you, so while it
+          // is live it goes solid white rather than sitting on the same glass
+          // as the controls around it.
+          tone={muted ? "destructive" : "live"}
           isLight={tone?.isLight}
-          overMedia={cameraOpen}
+          surface={controlSurface}
         >
           {muted ? <MicOff className="size-5" /> : <Mic className="size-5" />}
         </VoiceRoomControl>
@@ -1178,7 +1199,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           pressed={outputMuted}
           tone={outputMuted ? "destructive" : "neutral"}
           isLight={tone?.isLight}
-          overMedia={cameraOpen}
+          surface={controlSurface}
         >
           {outputMuted ? (
             <VolumeX className="size-5" />
@@ -1216,7 +1237,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             }
             onClick={() => (cameraOpen ? close() : void open())}
             pressed={cameraOpen}
-            overMedia={cameraOpen}
+            surface={controlSurface}
             data-testid="voice-room-camera-toggle"
           >
             {cameraOpen ? (
@@ -1233,7 +1254,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           onClick={endLiveVoiceSession}
           tone="destructive"
           isLight={tone?.isLight}
-          overMedia={cameraOpen}
+          surface={controlSurface}
         >
           <X className="size-5" strokeWidth={2.5} />
         </VoiceRoomControl>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -1032,11 +1032,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           data-testid="voice-room-camera-controls"
           className="absolute inset-x-0 z-10 flex flex-col items-center gap-3"
           // The session row's own offset, plus its 52px height, plus the 46px
-          // the design leaves between the two. The shutter grew to 84px, so the
-          // clearance had to be recomputed from the row's top edge rather than
-          // left at a constant that happened to work at 64: the thing you press
-          // often has to stay off the thing that hangs up, and it is the GAP
-          // that guarantees that, not the number.
+          // the design leaves between the two. Composed from the row's top edge
+          // rather than written as one constant: the thing you press often has
+          // to stay off the thing that hangs up, and it is the GAP that
+          // guarantees that, not the number.
           style={{
             bottom: `calc(6.125rem + max(${CORNER_GAP}, ${SAFE_AREA_BOTTOM}))`,
           }}
@@ -1137,8 +1136,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
               {/* The one control with no surface branch: the shutter exists
                   only while the viewfinder does, so it is never seen against
                   anything but video. Photo is the only mode the capture path
-                  can reach; the shutter's live state waits on frame
-                  streaming. */}
+                  reaches. */}
               <Tooltip content={t("voiceRoom.takePhoto")}>
                 <CameraShutter
                   onClick={() => void shutter()}
@@ -1177,11 +1175,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           }
           onClick={() => setLiveVoiceMuted(!muted)}
           pressed={muted}
-          // The one control the camera mode redesign exists to correct. With
-          // the viewfinder up, the room's face is gone and this button is the
-          // only thing left saying the session can still hear you, so while it
-          // is live it goes solid white rather than sitting on the same glass
-          // as the controls around it.
+          // With the viewfinder up, the room's face is covered and this button
+          // is the only thing on screen saying the session can still hear you.
+          // A live mic therefore goes solid white rather than sitting on the
+          // same glass as the controls around it, where the answer would be an
+          // absence of red.
           tone={muted ? "destructive" : "live"}
           isLight={tone?.isLight}
           surface={controlSurface}

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -469,10 +469,10 @@ html[data-page-transition="pop"]::view-transition-new(root) {
  * Reduced motion retimes rather than removes. The pulse is feedback, not
  * decoration: a press on a shutter whose viewfinder does not change is
  * otherwise indistinguishable from a dead button, so it stays and shortens.
- * The overshoot is the part that is movement for its own sake, and it goes.
- * `.camera-shutter-calm` is what the component applies from `useReducedMotion`
- * (which is also what its tests can read); the media query is defense-in-depth
- * for any caller that renders the markup without it. */
+ * The overshoot is the part that is movement for its own sake, so that is what
+ * it drops. `.camera-shutter-calm` is what the component applies from
+ * `useReducedMotion` (which is also what its tests can read); the media query
+ * is defense-in-depth for any caller that renders the markup without it. */
 .camera-shutter {
   --camera-shutter-morph-duration: 0.4s;
   --camera-shutter-morph-ease: cubic-bezier(0.34, 1.5, 0.5, 1);

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -456,6 +456,64 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   }
 }
 
+/* Camera shutter: the ring and core the voice room's viewfinder and the
+ * deep-link capture overlay share.
+ *
+ * Three timings, one contract, so a caller cannot half-adopt it. The core's
+ * morph overshoots on purpose: shrinking past its target and settling back is
+ * what makes the photo-to-live change read as a record button starting rather
+ * than a circle being resized. The capture pulse is a ring of crimson leaving
+ * the shutter, and deliberately NOT a full-screen white flash, which strobes
+ * the frame in the middle of a conversation the user is still holding.
+ *
+ * Reduced motion retimes rather than removes. The pulse is feedback, not
+ * decoration: a press on a shutter whose viewfinder does not change is
+ * otherwise indistinguishable from a dead button, so it stays and shortens.
+ * The overshoot is the part that is movement for its own sake, and it goes.
+ * `.camera-shutter-calm` is what the component applies from `useReducedMotion`
+ * (which is also what its tests can read); the media query is defense-in-depth
+ * for any caller that renders the markup without it. */
+.camera-shutter {
+  --camera-shutter-morph-duration: 0.4s;
+  --camera-shutter-morph-ease: cubic-bezier(0.34, 1.5, 0.5, 1);
+  --camera-shutter-pulse-duration: 500ms;
+  transition: border-color var(--camera-shutter-morph-duration) ease;
+}
+
+.camera-shutter-calm {
+  --camera-shutter-morph-duration: 0.2s;
+  --camera-shutter-morph-ease: linear;
+  --camera-shutter-pulse-duration: 250ms;
+}
+
+/* `scale` rather than `transform`: the utilities the core is sized with set the
+ * independent transform property, so a transition on `transform` would time
+ * nothing at all. */
+.camera-shutter-core {
+  transition:
+    scale var(--camera-shutter-morph-duration) var(--camera-shutter-morph-ease),
+    background-color var(--camera-shutter-morph-duration) ease,
+    opacity var(--camera-shutter-morph-duration) ease;
+}
+
+@keyframes camera-shutter-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(207, 67, 112, 0.75); }
+  70% { box-shadow: 0 0 0 12px rgba(207, 67, 112, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(207, 67, 112, 0); }
+}
+
+.camera-shutter-pulse {
+  animation: camera-shutter-pulse var(--camera-shutter-pulse-duration) ease-out 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .camera-shutter {
+    --camera-shutter-morph-duration: 0.2s;
+    --camera-shutter-morph-ease: linear;
+    --camera-shutter-pulse-duration: 250ms;
+  }
+}
+
 /* Deep-link message highlight — a one-shot background flash applied when the
  * transcript scrolls to a message (e.g. opening a saved bookmark). Fades from
  * the active-surface tint back to transparent over 2s. */


### PR DESCRIPTION
## Summary
- Shared shutter gets the design geometry (84pt ring, overshoot morph, crimson live state) and a capture pulse instead of a screen flash
- Camera-mode control treatment: solid-white live mic, destructive red speaker/end, warm camera/flip; uniform 52px controls
- Bottom-third re-anchored to the design offsets; pinned test assertions rewritten with rationale

## Deliberate deviations from the design table

- **The session control row stays at `max(1.25rem, safe-area-bottom)` rather than moving to 48pt.** That row is shared with the camera-closed room, so moving it would restyle a look this PR is meant to leave alone, and moving it only when the camera opens would jump the row out from under a reaching thumb, which is the same reason the 52px bump is applied in both states. On the notched phone the design was measured against, the existing rule already resolves to 34pt. Everything above the row is anchored FROM it, so the shutter still sits exactly 140pt above the row's bottom edge, which is the design's 188 minus its 48: the bottom third's internal proportions are the design's even though its floor is the room's.
- **The shutter clearance is recomputed, not kept.** `calc(5.5rem + max(...))` became `calc(6.125rem + max(...))`: the row's 52px height plus the 46px the design leaves between the two. The old constant happened to clear a 64px shutter; the 84px one needs the gap stated rather than inherited.
- **The speaker takes the destructive red only while it is engaged.** The design's table paints it `#e8453f` unconditionally, but the correction this whole design exists for is that a red control reads as "off". Painting an un-muted speaker red recreates that exact bug on the button next to the mic, so unmuted it takes the row's warm fill and muted it goes red. Same rule for the mic: white while live, red while muted.
- **Ink is `text-neutral-900` (#171717) rather than `#1a1a1a`**, matching the flash control that shipped in PR 3 with the same dark-glyph-on-white treatment. One ink across the camera chrome beats two that differ by three units.
- **The deep-link capture overlay gained the room's bottom scrim.** The shutter lost its dark backing (the design has no fill behind the ring), and the room's scrim is what takes over that job. The overlay had no scrim, so its shutter would have been a white ring with nothing to read against on a bright frame; it now shares `CAMERA_SCRIM_BOTTOM`.

## Notes

- The shutter's `live` state is built, exercised by Storybook and the suite, and unreachable in the app: neither call site passes `mode`, and the capture path stays photo-only until frame streaming lands.
- New stories: `camera-shutter.stories.tsx` (photo, sending, live, reduced-motion, in-row) and `voice-room-control.stories.tsx` (camera tones, camera row), both over a gradient standing in for the feed.
- `VoiceRoomControl`'s `overMedia` boolean became a three-valued `surface` (`room` / `media` / `camera`), since a control is only ever on one of them and camera mode needed a third treatment rather than a second boolean.

Part of plan: voice-camera-mode-redesign.md (PR 4 of 5)


Review note: the ink deviation recorded above was reverted during self-review; #41625 replaced text-neutral-900 with CAMERA_INK = #1a1a1a (the design value) across the camera chrome.
