### PR TITLE
test(assistant): drop mocks for a module that no longer exists

### DIFF
--- a/assistant/src/__tests__/approval-cascade.test.ts
+++ b/assistant/src/__tests__/approval-cascade.test.ts
@@ -95,19 +95,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   linkAttachmentToMessage: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/compaction-events.test.ts
+++ b/assistant/src/__tests__/compaction-events.test.ts
@@ -123,18 +123,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   linkAttachmentToMessage: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 // Per-test compaction result — set before calling forceCompact().
 let mockCompactResult: ContextWindowResult = {
   messages: [],

--- a/assistant/src/__tests__/conversation-abort-tool-results.test.ts
+++ b/assistant/src/__tests__/conversation-abort-tool-results.test.ts
@@ -83,19 +83,6 @@ mock.module("../persistence/conversation-queries.js", () => ({
   listConversations: () => [],
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -165,18 +165,6 @@ mock.module("../persistence/conversation-disk-view.js", () => ({
   rebuildConversationDiskViewFromDbState: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../apps/app-store.js", () => ({
   getApp: () => null,
   listAppFiles: () => [],

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -263,19 +263,6 @@ afterAll(() => {
   );
 });
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../apps/app-store.js", () => ({
   getApp: () => null,
   listAppFiles: () => [],

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -421,19 +421,6 @@ mock.module("../persistence/conversation-disk-view.js", () => ({
     rebuildConversationDiskViewFromDbStateMock,
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../apps/app-store.js", () => ({
   getApp: () => null,
   listAppFiles: () => [],

--- a/assistant/src/__tests__/conversation-confirmation-signals.test.ts
+++ b/assistant/src/__tests__/conversation-confirmation-signals.test.ts
@@ -86,19 +86,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   linkAttachmentToMessage: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/conversation-process-callsite.test.ts
+++ b/assistant/src/__tests__/conversation-process-callsite.test.ts
@@ -134,18 +134,6 @@ mock.module("../persistence/conversation-queries.js", () => ({
   listConversations: () => [],
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 // Mock AgentLoop to capture the callSite argument that runAgentLoopImpl passes
 // via the options object (see assistant/src/agent/loop.ts → AgentLoopConstructorOptions).
 mock.module("../agent/loop.js", () => ({

--- a/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
+++ b/assistant/src/__tests__/conversation-provider-retry-repair.test.ts
@@ -73,19 +73,6 @@ mock.module("../memory/archive-store.js", () => ({
   insertCompactionEpisode: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -217,19 +217,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   setAttachmentThumbnail: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/conversation-slash-queue.test.ts
+++ b/assistant/src/__tests__/conversation-slash-queue.test.ts
@@ -71,19 +71,6 @@ mock.module("../persistence/conversation-queries.js", () => ({
   listConversations: () => [],
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/conversation-slash-unknown.test.ts
+++ b/assistant/src/__tests__/conversation-slash-unknown.test.ts
@@ -70,19 +70,6 @@ mock.module("../persistence/conversation-queries.js", () => ({
   listConversations: () => [],
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/conversation-speed-override.test.ts
+++ b/assistant/src/__tests__/conversation-speed-override.test.ts
@@ -111,18 +111,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   linkAttachmentToMessage: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/conversation-store-ephemeral.test.ts
+++ b/assistant/src/__tests__/conversation-store-ephemeral.test.ts
@@ -96,18 +96,6 @@ mock.module("../persistence/conversation-queries.js", () => ({
   listConversations: () => [],
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../agent/loop.js", () => ({
   AgentLoop: class {
     constructor() {}

--- a/assistant/src/__tests__/conversation-wait-for-idle.test.ts
+++ b/assistant/src/__tests__/conversation-wait-for-idle.test.ts
@@ -99,18 +99,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   linkAttachmentToMessage: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    injectedText: "",
-    semanticHits: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../plugins/defaults/compaction/window-manager.js", () => ({
   ContextWindowManager: class {
     estimateInputTokens() {

--- a/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-cache-state.test.ts
@@ -81,11 +81,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   linkAttachmentToMessage: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => null,
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../memory/query-builder.js", () => ({
   buildMemoryQuery: () => "",
 }));

--- a/assistant/src/__tests__/conversation-workspace-injection.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-injection.test.ts
@@ -86,23 +86,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   uploadAttachment: () => ({ id: "att-1" }),
   linkAttachmentToMessage: () => {},
 }));
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    reason: null,
-    provider: "mock",
-    model: "mock",
-    injectedText: "",
-    semanticHits: 0,
-    mergedCount: 0,
-    selectedCount: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-    topCandidates: [],
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
 mock.module("../memory/query-builder.js", () => ({
   buildMemoryQuery: () => "",
 }));

--- a/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
+++ b/assistant/src/__tests__/conversation-workspace-tool-tracking.test.ts
@@ -83,23 +83,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   uploadAttachment: () => ({ id: "att-1" }),
   linkAttachmentToMessage: () => {},
 }));
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    reason: null,
-    provider: "mock",
-    model: "mock",
-    injectedText: "",
-    semanticHits: 0,
-    mergedCount: 0,
-    selectedCount: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-    topCandidates: [],
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
 mock.module("../memory/query-builder.js", () => ({
   buildMemoryQuery: () => "",
 }));

--- a/assistant/src/__tests__/processing-flag-persist-failure.test.ts
+++ b/assistant/src/__tests__/processing-flag-persist-failure.test.ts
@@ -97,11 +97,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   linkAttachmentToMessage: () => {},
 }));
 
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => null,
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
-
 mock.module("../memory/query-builder.js", () => ({
   buildMemoryQuery: () => "",
 }));

--- a/assistant/src/__tests__/prompt-cache-cross-turn-stability.test.ts
+++ b/assistant/src/__tests__/prompt-cache-cross-turn-stability.test.ts
@@ -165,23 +165,6 @@ mock.module("../persistence/attachments-store.js", () => ({
   uploadAttachment: () => ({ id: "att-1" }),
   linkAttachmentToMessage: () => {},
 }));
-mock.module("../memory/retriever.js", () => ({
-  buildMemoryRecall: async () => ({
-    enabled: false,
-    degraded: false,
-    reason: null,
-    provider: "mock",
-    model: "mock",
-    injectedText: "",
-    semanticHits: 0,
-    mergedCount: 0,
-    selectedCount: 0,
-    injectedTokens: 0,
-    latencyMs: 0,
-    topCandidates: [],
-  }),
-  injectMemoryRecallAsUserBlock: (msgs: Message[]) => msgs,
-}));
 mock.module("../memory/query-builder.js", () => ({
   buildMemoryQuery: () => "",
 }));


### PR DESCRIPTION
## Summary

- TL;DR: 20 assistant test files mocked `../memory/retriever.js`, a module that no longer exists, stubbing `buildMemoryRecall` and `injectMemoryRecallAsUserBlock`, functions that no longer exist either. 250 lines of deletion, no behavior change.
- These are inert, not load-bearing. That was the thing worth checking before deleting: a mock that stops working is usually worse than one that never existed, because the suite quietly starts doing the real thing. Here there is no real thing left to do.

Why this is safe, in the order I checked it:

1. **The module is gone.** `assistant/src/memory/` has no tracked files; the memory implementation lives under `assistant/src/plugins/defaults/memory/`, and no `retriever.ts` exists anywhere in the tree.
2. **Both stubbed functions are gone.** `buildMemoryRecall` appeared in exactly 20 places, every one of them these mocks, with zero production references. `injectMemoryRecallAsUserBlock`'s only remaining mention is a comment in `conversation-graph-memory.ts` describing "the same pattern as old injectMemoryRecallAsUserBlock", which is history, not a call site.
3. **So nothing changes about what these suites touch.** The usual risk with deleting a stub is that a suite was being kept away from something expensive (embeddings, Qdrant) and now reaches for it. That needs a live import path to reach through, and there is none: no production code imports the module or calls either function.
4. **Nothing was orphaned.** `eslint` over `assistant/src/__tests__` is clean, so no import was left unused by the removal (the `Message` type these blocks referenced is used elsewhere in each file).

Local `bun test` is blocked by a hook in this repo, so CI is the verifier for the suites themselves. The diff is deletion-only, which keeps that risk about as low as it goes.

## Origin

Found while auditing documentation citations (#41599): `assistant/docs/error-handling.md` cited `MemoryRecallResult` in `memory/retriever.ts` as a live example of the result-object pattern. Fixing the doc raised the question of what else still pointed at that module, and the answer was these 20 files. The doc fix shipped separately because it should not wait on a 20-file test change, and this should not have ridden along inside a docs PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41614" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->