### PR TITLE
Discord ingests component button presses

### DIFF
--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -16,7 +16,7 @@ describe("parseCallbackData", () => {
     expect(result).not.toBeNull();
     expect(result!.action).toBe(expectedAction);
     expect(result!.requestId).toBe("req-123");
-    expect(result!.source).toBe("telegram_button");
+    expect(result!.source).toBe("button");
   });
 
   test.each<[string, string]>([
@@ -33,12 +33,19 @@ describe("parseCallbackData", () => {
     },
   );
 
-  test("parses slack source channel", () => {
-    const result = parseCallbackData("apr:req-789:approve_once", "slack");
-    expect(result).not.toBeNull();
-    expect(result!.action).toBe("approve_once");
-    expect(result!.requestId).toBe("req-789");
-    expect(result!.source).toBe("slack_button");
+  test("every channel's button press attributes as the button modality", () => {
+    for (const channel of ["slack", "telegram", "whatsapp", "discord"]) {
+      const result = parseCallbackData("apr:req-789:approve_once", channel);
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("approve_once");
+      expect(result!.requestId).toBe("req-789");
+      expect(result!.source).toBe("button");
+    }
+  });
+
+  test("an in-app surface press attributes as vellum_surface", () => {
+    const result = parseCallbackData("apr:req-789:approve_once", "vellum");
+    expect(result!.source).toBe("vellum_surface");
   });
 
   test("returns null for unknown action", () => {

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -241,7 +241,7 @@ describe("handleChannelDecision", () => {
     const mockConv = conversationMocks.get("conv-1") as Conversation;
     const decision: ApprovalDecisionResult = {
       action: "reject",
-      source: "telegram_button",
+      source: "button",
     };
 
     const result = handleChannelDecision("conv-1", decision);
@@ -261,7 +261,7 @@ describe("handleChannelDecision", () => {
     const newerMock = conversationMocks.get("conv-1") as Conversation;
     const decision: ApprovalDecisionResult = {
       action: "approve_once",
-      source: "telegram_button",
+      source: "button",
       requestId: "req-newer",
     };
 
@@ -280,7 +280,7 @@ describe("handleChannelDecision", () => {
     registerPendingConfirmation("req-1", "conv-1", "shell");
     const decision: ApprovalDecisionResult = {
       action: "approve_once",
-      source: "telegram_button",
+      source: "button",
       requestId: "req-missing",
     };
 

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -160,11 +160,14 @@ export interface ChannelApprovalPrompt {
 // Decision result (daemon-internal)
 // ---------------------------------------------------------------------------
 
-/** How the user communicated their decision. */
+/**
+ * How the user communicated their decision: the modality, never the channel.
+ * A channel-prefixed value here would misattribute the next channel that
+ * joins (every channel's buttons ride the same `apr:` callback), and no
+ * consumer reads a channel off this field.
+ */
 export type ApprovalDecisionSource =
-  | "telegram_button"
-  | "whatsapp_button"
-  | "slack_button"
+  | "button"
   | "reaction"
   | "vellum_surface"
   | "plain_text";

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -52,13 +52,9 @@ export function parseCallbackData(
     return null;
   }
   const source =
-    sourceChannel === "whatsapp"
-      ? ("whatsapp_button" as const)
-      : sourceChannel === "slack"
-        ? ("slack_button" as const)
-        : sourceChannel === "vellum"
-          ? ("vellum_surface" as const)
-          : ("telegram_button" as const);
+    sourceChannel === "vellum"
+      ? ("vellum_surface" as const)
+      : ("button" as const);
   return { action, source, requestId };
 }
 

--- a/gateway/src/discord/forward.test.ts
+++ b/gateway/src/discord/forward.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Logger } from "pino";
+
+import "../__tests__/test-preload.js";
+
+const seededContacts: Array<{
+  externalUserId: string;
+  externalChatId?: string;
+}> = [];
+const forwarded: Array<Record<string, unknown>> = [];
+
+const actualContactHelpers = await import("../verification/contact-helpers.js");
+mock.module("../verification/contact-helpers.js", () => ({
+  ...actualContactHelpers,
+  upsertContactChannel: async (params: {
+    externalUserId: string;
+    externalChatId?: string;
+  }) => {
+    seededContacts.push(params);
+  },
+}));
+
+const actualHandleInbound = await import("../handlers/handle-inbound.js");
+mock.module("../handlers/handle-inbound.js", () => ({
+  ...actualHandleInbound,
+  handleInbound: async (_config: unknown, event: Record<string, unknown>) => {
+    forwarded.push(event);
+    return { forwarded: true, rejected: false };
+  },
+}));
+
+const { createDiscordInboundEventHandler } = await import("./forward.js");
+const { createConversationTaskQueue } =
+  await import("../channels/conversation-queue.js");
+import type { DiscordInboundEvent } from "../channels/inbound-event.js";
+import type { GatewayConfig } from "../config.js";
+
+const noopLog = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+} as unknown as Logger;
+
+function makeHandler() {
+  return createDiscordInboundEventHandler({
+    config: {
+      gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    } as GatewayConfig,
+    log: noopLog,
+    notifyRecordActivity: () => {},
+    forwardQueue: createConversationTaskQueue(),
+  });
+}
+
+function discordEvent(overrides: {
+  eventKind: "message" | "edit" | "delete" | "reaction" | "button";
+  actorUnattributed?: boolean;
+  chatType?: string;
+}): DiscordInboundEvent {
+  return {
+    version: "v1",
+    sourceChannel: "discord",
+    receivedAt: new Date().toISOString(),
+    message: {
+      eventKind: overrides.eventKind,
+      content: overrides.eventKind === "message" ? "<@bot-1> hi" : "",
+      conversationExternalId: "channel-1",
+      externalMessageId: `msg-${overrides.eventKind}`,
+    },
+    actor: {
+      actorExternalId: overrides.actorUnattributed
+        ? "discord-system"
+        : "user-1",
+    },
+    source: {
+      updateId: "u-1",
+      messageId: "msg-1",
+      chatType: overrides.chatType ?? "channel",
+      isDirectMessage: overrides.chatType === "dm",
+      ...(overrides.actorUnattributed ? { actorUnattributed: true } : {}),
+    },
+    raw: {},
+  };
+}
+
+/** Let the enqueued forward closure run to completion. */
+async function drain(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("contact seeding gate", () => {
+  beforeEach(() => {
+    seededContacts.length = 0;
+    forwarded.length = 0;
+  });
+
+  test("admitted user-authored kinds seed a contact and forward", async () => {
+    const handler = makeHandler();
+    handler(discordEvent({ eventKind: "message" }));
+    handler(discordEvent({ eventKind: "edit" }));
+    await drain();
+
+    expect(seededContacts).toHaveLength(2);
+    expect(forwarded).toHaveLength(2);
+  });
+
+  test("ungated kinds never seed: a stranger's reaction, press, or delete mints no contact", async () => {
+    // These kinds ride with no admission gate in front of them, so a seed
+    // here would create a contact record the trust resolver later reads as
+    // an existing unverified contact. They still forward; the daemon's own
+    // gates decide what they touch.
+    const handler = makeHandler();
+    handler(discordEvent({ eventKind: "reaction" }));
+    handler(discordEvent({ eventKind: "button" }));
+    handler(discordEvent({ eventKind: "delete", actorUnattributed: true }));
+    await drain();
+
+    expect(seededContacts).toHaveLength(0);
+    expect(forwarded).toHaveLength(3);
+  });
+
+  test("only a DM records the chat as the contact's delivery address", async () => {
+    const handler = makeHandler();
+    handler(discordEvent({ eventKind: "message", chatType: "dm" }));
+    handler(discordEvent({ eventKind: "message" }));
+    await drain();
+
+    expect(seededContacts[0]?.externalChatId).toBe("channel-1");
+    expect(seededContacts[1]?.externalChatId).toBeUndefined();
+  });
+});

--- a/gateway/src/discord/forward.ts
+++ b/gateway/src/discord/forward.ts
@@ -30,16 +30,16 @@ export function createDiscordInboundEventHandler(options: {
 
     // A guild channel is a room the actor is standing in, not their private
     // delivery address. Recording it as externalChatId would post private
-    // notices in public, so only DMs carry that field. An unattributed
-    // event's actor is a synthetic system id, not a person: seeding a
-    // contact from it would mint a ghost and, on a DM, bind that ghost to a
-    // real conversation. Reactions never seed either: they ride ungated
-    // (no admission gate stands before them), so seeding here would mint a
-    // contact record for any stranger who reacts in a visible channel, and
-    // the daemon's intercept then reads that record as an existing contact.
+    // notices in public, so only DMs carry that field. Only the two
+    // admission-gated, user-authored kinds seed a contact: every other kind
+    // (reactions, button presses, unattributed deletes) rides ungated, and
+    // seeding from one would mint a contact record for any stranger who
+    // touches a visible channel, which the trust resolver then reads as an
+    // existing unverified contact.
+    const eventKind = event.message.eventKind;
     if (
       !event.source.actorUnattributed &&
-      event.message.eventKind !== "reaction"
+      (eventKind === "message" || eventKind === "edit")
     ) {
       void upsertContactChannel({
         sourceChannel: "discord",

--- a/gateway/src/discord/gateway-socket.test.ts
+++ b/gateway/src/discord/gateway-socket.test.ts
@@ -529,6 +529,101 @@ describe("reaction dispatch", () => {
   });
 });
 
+describe("interaction dispatch", () => {
+  const buttonPress = (overrides: Record<string, unknown> = {}) => ({
+    op: 0,
+    t: "INTERACTION_CREATE",
+    s: 4,
+    d: {
+      id: "inter-1",
+      token: "inter-token-1",
+      type: 3,
+      channel_id: "dm-channel-1",
+      data: { custom_id: "apr:req-1:approve_once", component_type: 2 },
+      message: { id: "card-msg-1" },
+      user: { id: "user-1", username: "alice", global_name: "Alice" },
+      ...overrides,
+    },
+  });
+
+  test("a button press acks deferred-update and forwards a button event", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(buttonPress());
+    await Promise.resolve();
+
+    const ack = h.fetchCalls.find((c) => c.url.includes("/interactions/"));
+    expect(ack?.url).toBe(
+      "https://discord.com/api/v10/interactions/inter-1/inter-token-1/callback",
+    );
+
+    expect(h.events).toHaveLength(1);
+    const event = h.events[0];
+    expect(event.message.eventKind).toBe("button");
+    expect(event.message.callbackData).toBe("apr:req-1:approve_once");
+    expect(event.message.content).toBe("apr:req-1:approve_once");
+    expect(event.message.conversationExternalId).toBe("dm-channel-1");
+    expect(event.source.messageId).toBe("card-msg-1");
+    expect(event.actor.actorExternalId).toBe("user-1");
+    expect(event.source.isDirectMessage).toBe(true);
+  });
+
+  test("a guild press names its actor from member.user", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(
+      buttonPress({
+        guild_id: "guild-1",
+        user: undefined,
+        member: { user: { id: "user-2", username: "bob" } },
+      }),
+    );
+
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0].actor.actorExternalId).toBe("user-2");
+    expect(h.events[0].source.isDirectMessage).toBe(false);
+  });
+
+  test("non-component interaction types are neither acked nor forwarded", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    // An application command (type 2) has no consumer here.
+    ws.message(buttonPress({ type: 2 }));
+    await Promise.resolve();
+
+    expect(h.events).toHaveLength(0);
+    expect(
+      h.fetchCalls.filter((c) => c.url.includes("/interactions/")),
+    ).toHaveLength(0);
+  });
+
+  test("a select-menu press is not consumed", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(
+      buttonPress({
+        data: { custom_id: "pick", component_type: 3, values: ["a"] },
+      }),
+    );
+
+    expect(h.events).toHaveLength(0);
+  });
+
+  test("a bot actor drops at normalization but the ack still lands", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(
+      buttonPress({ user: { id: "other-bot", username: "x", bot: true } }),
+    );
+    await Promise.resolve();
+
+    expect(h.events).toHaveLength(0);
+    expect(
+      h.fetchCalls.filter((c) => c.url.includes("/interactions/")),
+    ).toHaveLength(1);
+  });
+});
+
 describe("shutdown", () => {
   test("stop closes with 1000 and schedules nothing", async () => {
     const h = harness();

--- a/gateway/src/discord/gateway-socket.ts
+++ b/gateway/src/discord/gateway-socket.ts
@@ -53,11 +53,16 @@ import {
   DiscordMessageCreateSchema,
   DiscordReadySchema,
   DiscordThreadListSchema,
+  DISCORD_COMPONENT_TYPE_BUTTON,
+  DISCORD_INTERACTION_CALLBACK_DEFERRED_UPDATE,
+  DISCORD_INTERACTION_TYPE_MESSAGE_COMPONENT,
+  DiscordInteractionSchema,
   DiscordMessageDeleteSchema,
   DiscordMessageReactionSchema,
   DiscordThreadSchema,
 } from "./message-schemas.js";
 import {
+  normalizeDiscordInteraction,
   normalizeDiscordMessage,
   normalizeDiscordMessageDelete,
   normalizeDiscordMessageReaction,
@@ -673,6 +678,9 @@ export class DiscordGatewayClient {
       case "MESSAGE_REACTION_REMOVE":
         this.handleMessageReaction(data, "removed");
         return;
+      case "INTERACTION_CREATE":
+        this.handleInteractionCreate(data);
+        return;
       default:
         return;
     }
@@ -781,6 +789,87 @@ export class DiscordGatewayClient {
       "Discord delete forwarded",
     );
     this.onEvent(normalized, new Map());
+  }
+
+  private handleInteractionCreate(data: unknown): void {
+    const parsed = DiscordInteractionSchema.safeParse(data);
+    if (!parsed.success) {
+      log.warn("Dropping malformed INTERACTION_CREATE");
+      return;
+    }
+    const interaction = parsed.data;
+    // Only component button presses are consumed; commands, selects and
+    // modals have no consumer, and an unhandled interaction type must not be
+    // acked into a state the user reads as accepted.
+    if (
+      interaction.type !== DISCORD_INTERACTION_TYPE_MESSAGE_COMPONENT ||
+      interaction.data?.component_type !== DISCORD_COMPONENT_TYPE_BUTTON
+    ) {
+      return;
+    }
+    if (!interaction.id || !interaction.token) {
+      log.warn("Dropping INTERACTION_CREATE without id or token");
+      return;
+    }
+    // ACK inside Discord's 3-second deadline, before any forwarding work.
+    // DeferredMessageUpdate leaves the card untouched; the daemon's decision
+    // flow rewrites it through the notification adapter's update path, the
+    // same shape as Telegram's answerCallbackQuery-then-edit.
+    void this.acknowledgeInteraction(interaction.id, interaction.token);
+    const parentChannelId = interaction.channel_id
+      ? this.threadParents.parentOf(interaction.channel_id)
+      : undefined;
+    const normalized = normalizeDiscordInteraction(interaction, {
+      ...(parentChannelId !== undefined ? { parentChannelId } : {}),
+      raw: (data ?? {}) as Record<string, unknown>,
+    });
+    if (!normalized) {
+      log.debug(
+        { interactionId: interaction.id },
+        "Discord interaction dropped by normalization",
+      );
+      return;
+    }
+    log.info(
+      {
+        interactionId: interaction.id,
+        conversationExternalId: normalized.message.conversationExternalId,
+      },
+      "Discord button press forwarded",
+    );
+    this.onEvent(normalized, new Map());
+  }
+
+  /**
+   * POST the deferred-update ack for a component press. The interaction
+   * token in the URL authorizes the call; no bot header is needed. Failure
+   * is logged and swallowed: the press still forwards, and the only cost is
+   * Discord showing the guardian an interaction-failed notice.
+   */
+  private async acknowledgeInteraction(
+    interactionId: string,
+    token: string,
+  ): Promise<void> {
+    try {
+      const response = await this.fetchFn(
+        `${DISCORD_API_BASE_URL}/interactions/${interactionId}/${token}/callback`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            type: DISCORD_INTERACTION_CALLBACK_DEFERRED_UPDATE,
+          }),
+        },
+      );
+      if (!response.ok) {
+        log.warn(
+          { interactionId, status: response.status },
+          "Discord interaction ack failed",
+        );
+      }
+    } catch (err) {
+      log.warn({ err, interactionId }, "Discord interaction ack failed");
+    }
   }
 
   private handleMessageReaction(data: unknown, op: "added" | "removed"): void {

--- a/gateway/src/discord/message-schemas.ts
+++ b/gateway/src/discord/message-schemas.ts
@@ -20,6 +20,7 @@
  */
 
 import type {
+  APIMessageComponentButtonInteraction,
   APIThreadChannel,
   GatewayHelloData,
   GatewayMessageCreateDispatchData,
@@ -92,6 +93,21 @@ export const DiscordThreadListSchema = z.object({
 /** THREAD_CREATE / THREAD_UPDATE / THREAD_DELETE data: one channel object. */
 export const DiscordThreadSchema = DiscordChannelSchema;
 
+/**
+ * A user object, as carried by message authors and interaction actors. The
+ * `bot` indicator fails CLOSED, unlike the tolerant fields around it: absent
+ * stays `undefined` (Discord omits it for humans), but a present-and-malformed
+ * value collapses to `true`, because this is the classifier standing between
+ * ingestion and a bot feedback loop, and collapsing to `undefined` would read
+ * as human.
+ */
+const DiscordUserSchema = z.object({
+  id: idString(),
+  username: optionalString(),
+  global_name: z.string().nullable().optional().catch(undefined),
+  bot: z.boolean().optional().catch(true),
+});
+
 /** MESSAGE_CREATE dispatch data — the fields admission and normalization read. */
 export const DiscordMessageCreateSchema = z.object({
   id: idString(),
@@ -117,22 +133,7 @@ export const DiscordMessageCreateSchema = z.object({
    * successive edits of one message are never swallowed as duplicates.
    */
   edited_timestamp: z.string().nullable().optional().catch(undefined),
-  author: z
-    .object({
-      id: idString(),
-      username: optionalString(),
-      global_name: z.string().nullable().optional().catch(undefined),
-      /**
-       * Bot indicator — fails CLOSED, unlike the tolerant fields around it.
-       * Absent stays `undefined` (Discord omits it for humans), but a
-       * present-and-malformed value collapses to `true`: this is the one
-       * classifier standing between the admission gate and a bot reply loop,
-       * and collapsing to `undefined` would read as human.
-       */
-      bot: z.boolean().optional().catch(true),
-    })
-    .optional()
-    .catch(undefined),
+  author: DiscordUserSchema.optional().catch(undefined),
   /**
    * Present on webhook-delivered messages, whose author is not a real user.
    * Fails closed like `author.bot`: a malformed value collapses to a sentinel
@@ -201,6 +202,45 @@ export const DiscordMessageReactionSchema = z.object({
 export type DiscordMessageReaction = z.infer<
   typeof DiscordMessageReactionSchema
 >;
+
+/** InteractionType.MessageComponent: a component press, the one type consumed. */
+export const DISCORD_INTERACTION_TYPE_MESSAGE_COMPONENT = 3;
+/** ComponentType.Button within a component interaction's data. */
+export const DISCORD_COMPONENT_TYPE_BUTTON = 2;
+/** InteractionResponseType.DeferredMessageUpdate: ACK without a loading state. */
+export const DISCORD_INTERACTION_CALLBACK_DEFERRED_UPDATE = 6;
+
+/**
+ * INTERACTION_CREATE data: the fields the component-button path reads.
+ * Interactions ride the Gateway by default and need no intent bit; an
+ * Interactions Endpoint URL configured in the developer portal would divert
+ * them to HTTP and silence this dispatch, so the app must not configure one.
+ * The actor arrives as `user` in a DM and as `member.user` in a guild. The
+ * guild sentinel matches the create schema's reasoning.
+ */
+export const DiscordInteractionSchema = z.object({
+  id: idString(),
+  /** Authorizes the callback ack; it rides in the URL, not a header. */
+  token: idString(),
+  type: optionalNumber(),
+  channel_id: optionalString(),
+  guild_id: z.string().optional().catch("malformed-guild-id"),
+  data: z
+    .object({
+      custom_id: idString(),
+      component_type: optionalNumber(),
+    })
+    .optional()
+    .catch(undefined),
+  /** The message the pressed component is attached to (the card). */
+  message: z.object({ id: idString() }).optional().catch(undefined),
+  member: z
+    .object({ user: DiscordUserSchema.optional().catch(undefined) })
+    .optional()
+    .catch(undefined),
+  user: DiscordUserSchema.optional().catch(undefined),
+});
+export type DiscordInteraction = z.infer<typeof DiscordInteractionSchema>;
 
 // ---------------------------------------------------------------------------
 // Compile-time cross-check against the official Discord API types.
@@ -293,6 +333,30 @@ type _DiscordApiCrossChecks = [
     ModeledKeysAreOfficial<
       NonNullable<DiscordMessageReaction["emoji"]>,
       GatewayMessageReactionRemoveDispatchData["emoji"]
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      DiscordInteraction,
+      APIMessageComponentButtonInteraction
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      NonNullable<DiscordInteraction["data"]>,
+      APIMessageComponentButtonInteraction["data"]
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      NonNullable<DiscordInteraction["member"]>,
+      NonNullable<APIMessageComponentButtonInteraction["member"]>
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      NonNullable<DiscordInteraction["user"]>,
+      NonNullable<APIMessageComponentButtonInteraction["user"]>
     >
   >,
   Expect<

--- a/gateway/src/discord/normalize.test.ts
+++ b/gateway/src/discord/normalize.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from "bun:test";
 
 import { admitDiscordMessage } from "./admit.js";
 import {
+  DiscordInteractionSchema,
   DiscordMessageCreateSchema,
   DiscordMessageDeleteSchema,
   DiscordMessageReactionSchema,
 } from "./message-schemas.js";
 import {
+  normalizeDiscordInteraction,
   normalizeDiscordMessage,
   normalizeDiscordMessageDelete,
   normalizeDiscordMessageReaction,
@@ -613,6 +615,90 @@ describe("normalizeDiscordMessageReaction", () => {
         emoji: { id: null, name: "\u{1F44D}" },
       }),
       { op: "added", parentChannelId: "channel-1", raw: {} },
+    );
+
+    expect(event!.message.conversationExternalId).toBe("channel-1");
+    expect(event!.source.threadId).toBe("thread-1");
+  });
+});
+describe("normalizeDiscordInteraction", () => {
+  function parseInteraction(payload: Record<string, unknown>) {
+    const parsed = DiscordInteractionSchema.safeParse(payload);
+    if (!parsed.success) {
+      throw new Error("schema unexpectedly rejected payload");
+    }
+    return parsed.data;
+  }
+
+  const base = (overrides: Record<string, unknown> = {}) => ({
+    id: "inter-1",
+    token: "inter-token-1",
+    type: 3,
+    channel_id: "dm-channel-1",
+    data: { custom_id: "apr:req-1:approve_once", component_type: 2 },
+    message: { id: "card-msg-1" },
+    user: { id: "user-1", username: "alice", global_name: "Alice" },
+    ...overrides,
+  });
+
+  test("a DM button press takes the button family with the card's id", () => {
+    const event = normalizeDiscordInteraction(parseInteraction(base()), {
+      raw: {},
+    });
+
+    expect(event).not.toBeNull();
+    expect(event!.message.eventKind).toBe("button");
+    expect(event!.message.callbackData).toBe("apr:req-1:approve_once");
+    expect(event!.message.content).toBe("apr:req-1:approve_once");
+    expect(event!.message.externalMessageId).toBe("inter-1");
+    expect(event!.source.messageId).toBe("card-msg-1");
+    expect(event!.actor.actorExternalId).toBe("user-1");
+    expect(event!.actor.displayName).toBe("Alice");
+    expect(event!.source.isDirectMessage).toBe(true);
+    expect(event!.source.conversationType).toBe("dm");
+  });
+
+  test("a guild press names its actor from member.user and proves no DM", () => {
+    const event = normalizeDiscordInteraction(
+      parseInteraction(
+        base({
+          guild_id: "guild-1",
+          user: undefined,
+          member: { user: { id: "user-2", username: "bob" } },
+        }),
+      ),
+      { raw: {} },
+    );
+
+    expect(event!.actor.actorExternalId).toBe("user-2");
+    expect(event!.source.isDirectMessage).toBe(false);
+    expect(event!.source.conversationType).toBeUndefined();
+  });
+
+  test("a bot actor cannot press a real button and drops", () => {
+    const event = normalizeDiscordInteraction(
+      parseInteraction(
+        base({ user: { id: "bot-x", username: "x", bot: true } }),
+      ),
+      { raw: {} },
+    );
+
+    expect(event).toBeNull();
+  });
+
+  test("an interaction naming no actor drops", () => {
+    const event = normalizeDiscordInteraction(
+      parseInteraction(base({ user: undefined })),
+      { raw: {} },
+    );
+
+    expect(event).toBeNull();
+  });
+
+  test("a thread press addresses the parent conversation", () => {
+    const event = normalizeDiscordInteraction(
+      parseInteraction(base({ channel_id: "thread-1", guild_id: "guild-1" })),
+      { parentChannelId: "channel-1", raw: {} },
     );
 
     expect(event!.message.conversationExternalId).toBe("channel-1");

--- a/gateway/src/discord/normalize.ts
+++ b/gateway/src/discord/normalize.ts
@@ -17,6 +17,7 @@ import type { DiscordInboundEvent } from "../channels/inbound-event.js";
 import type { AdmissionCandidate } from "./admit.js";
 import { extractDiscordAttachments } from "./attachments.js";
 import type {
+  DiscordInteraction,
   DiscordMessageCreate,
   DiscordMessageDelete,
   DiscordMessageReaction,
@@ -129,6 +130,66 @@ export function normalizeDiscordMessage(
  * author cleared the ACL when the message arrived; nothing here asserts who
  * deleted it.
  */
+/**
+ * Normalize a component-button INTERACTION_CREATE into the button event
+ * family, the same shape a Telegram callback query takes: `callbackData`
+ * carries the component's `custom_id` (`apr:<requestId>:<action>` on an
+ * approval card) and `source.messageId` names the card the press landed on.
+ * The actor is `user` in a DM and `member.user` in a guild; an interaction
+ * whose actor cannot be named, or whose actor is a bot, cannot be routed
+ * and drops.
+ */
+export function normalizeDiscordInteraction(
+  interaction: DiscordInteraction,
+  options: {
+    parentChannelId?: string;
+    raw: Record<string, unknown>;
+  },
+): DiscordInboundEvent | null {
+  const actor = interaction.user ?? interaction.member?.user;
+  const customId = interaction.data?.custom_id;
+  if (
+    !interaction.id ||
+    !interaction.channel_id ||
+    !customId ||
+    !actor?.id ||
+    actor.bot === true
+  ) {
+    return null;
+  }
+  const inThread = options.parentChannelId !== undefined;
+  const isDirectMessage = interaction.guild_id === undefined;
+  return {
+    version: "v1",
+    sourceChannel: "discord",
+    receivedAt: new Date().toISOString(),
+    message: {
+      eventKind: "button",
+      content: customId,
+      conversationExternalId: options.parentChannelId ?? interaction.channel_id,
+      externalMessageId: interaction.id,
+      callbackData: customId,
+    },
+    actor: {
+      actorExternalId: actor.id,
+      ...(actor.username !== undefined ? { username: actor.username } : {}),
+      ...(typeof actor.global_name === "string"
+        ? { displayName: actor.global_name }
+        : {}),
+      ...(actor.bot !== undefined ? { isBot: actor.bot } : {}),
+    },
+    source: {
+      updateId: interaction.id,
+      messageId: interaction.message?.id,
+      chatType: isDirectMessage ? "dm" : "channel",
+      isDirectMessage,
+      ...(isDirectMessage ? { conversationType: "dm" as const } : {}),
+      ...(inThread ? { threadId: interaction.channel_id } : {}),
+    },
+    raw: options.raw,
+  };
+}
+
 export function normalizeDiscordMessageReaction(
   reaction: DiscordMessageReaction,
   options: {


### PR DESCRIPTION
# Discord ingests component button presses

Part of LUM-3356 (channel parity), the last stage-1 ingest gap. First of two PRs: this one teaches the gateway to consume `INTERACTION_CREATE`; the follow-up upgrades the Discord notification adapter to render approval cards with real component buttons (the adapter's docstring has always promised buttons as "a rendering upgrade, not a new decision path").

## TL;DR

The Discord gateway client now consumes component button presses: it acks each press with `DeferredMessageUpdate` inside Discord's 3-second deadline and forwards it as a button event, the same event family a Telegram callback query takes. The `custom_id` rides as `callbackData` (the shared `apr:<requestId>:<action>` convention) and the card's message id rides on the source, so the daemon's existing guardian decision pipeline consumes Discord presses with zero new daemon branches.

This PR is inert in production until the adapter renders buttons: today's Discord approval cards are plain text with typed-command instructions, so no component interactions exist to arrive. Landing ingest first means a button never ships whose press goes nowhere.

## What changes for the user

| Before | After |
| --- | --- |
| Nothing (no Discord messages carry components yet) | Nothing yet; with the follow-up adapter PR, tapping Approve/Reject on a Discord approval card applies the decision |

## Wire facts (verified against Discord docs and discord-api-types)

- Interactions ride the Gateway by default with **no intent bit**; configuring an Interactions Endpoint URL in the developer portal would divert them to HTTP and silence the dispatch. The schema docstring records that constraint.
- An interaction must be acknowledged within **3 seconds**; `DeferredMessageUpdate` (type 6) acks a component press without a loading state and leaves the card untouched. The daemon's existing cross-surface withdrawal machinery (#41526) rewrites the card when the request resolves, so ack-then-edit mirrors Telegram's `answerCallbackQuery`-then-edit shape.
- The callback URL (`POST /interactions/{id}/{token}/callback`) is authorized by the interaction token itself; ack failure is logged and swallowed (the press still forwards; the only cost is Discord's interaction-failed notice).
- Only `InteractionType.MessageComponent` + `ComponentType.Button` is consumed. Commands, selects, and modals have no consumer, and an unhandled type must not be acked into a state the user reads as accepted.
- The actor is `user` in a DM and `member.user` in a guild; bot actors drop at normalization (fail-closed `bot` catch, shared with message authors via the extracted `DiscordUserSchema`).

## Cleanup in passing

- `ApprovalDecisionSource` collapses `telegram_button` / `whatsapp_button` / `slack_button` to one `"button"` modality value. The field has no production readers (write-only), and the channel-prefixed ladder defaulted every unknown channel to `telegram_button`, so a Discord press would have been recorded as a Telegram button. Same cleanup family as the `slack_reaction` → `reaction` rename that merged in #41592. `vellum_surface` and `plain_text` stay: they name modalities, not channels.
- The message-author user object is extracted as a shared `DiscordUserSchema` instead of being duplicated for the interaction actor.

## Why this is safe

- No production Discord message carries components yet, so the new dispatch path cannot fire until the adapter PR lands; and if it somehow did, the daemon's existing button handling validates the embedded request id and guardian identity before any decision applies.
- Compile-time cross-checks pin the interaction schema (and its data/member/user subsets) against `APIMessageComponentButtonInteraction`.
- Enum values (interaction type 3, component type 2, callback type 6) are pinned as named constants sourced from the official types.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->