### PR TITLE
Discord approval cards render component buttons

### DIFF
--- a/assistant/src/__tests__/channel-approval.test.ts
+++ b/assistant/src/__tests__/channel-approval.test.ts
@@ -16,7 +16,7 @@ describe("parseCallbackData", () => {
     expect(result).not.toBeNull();
     expect(result!.action).toBe(expectedAction);
     expect(result!.requestId).toBe("req-123");
-    expect(result!.source).toBe("telegram_button");
+    expect(result!.source).toBe("button");
   });
 
   test.each<[string, string]>([
@@ -33,12 +33,19 @@ describe("parseCallbackData", () => {
     },
   );
 
-  test("parses slack source channel", () => {
-    const result = parseCallbackData("apr:req-789:approve_once", "slack");
-    expect(result).not.toBeNull();
-    expect(result!.action).toBe("approve_once");
-    expect(result!.requestId).toBe("req-789");
-    expect(result!.source).toBe("slack_button");
+  test("every channel's button press attributes as the button modality", () => {
+    for (const channel of ["slack", "telegram", "whatsapp", "discord"]) {
+      const result = parseCallbackData("apr:req-789:approve_once", channel);
+      expect(result).not.toBeNull();
+      expect(result!.action).toBe("approve_once");
+      expect(result!.requestId).toBe("req-789");
+      expect(result!.source).toBe("button");
+    }
+  });
+
+  test("an in-app surface press attributes as vellum_surface", () => {
+    const result = parseCallbackData("apr:req-789:approve_once", "vellum");
+    expect(result!.source).toBe("vellum_surface");
   });
 
   test("returns null for unknown action", () => {

--- a/assistant/src/__tests__/channel-approvals.test.ts
+++ b/assistant/src/__tests__/channel-approvals.test.ts
@@ -241,7 +241,7 @@ describe("handleChannelDecision", () => {
     const mockConv = conversationMocks.get("conv-1") as Conversation;
     const decision: ApprovalDecisionResult = {
       action: "reject",
-      source: "telegram_button",
+      source: "button",
     };
 
     const result = handleChannelDecision("conv-1", decision);
@@ -261,7 +261,7 @@ describe("handleChannelDecision", () => {
     const newerMock = conversationMocks.get("conv-1") as Conversation;
     const decision: ApprovalDecisionResult = {
       action: "approve_once",
-      source: "telegram_button",
+      source: "button",
       requestId: "req-newer",
     };
 
@@ -280,7 +280,7 @@ describe("handleChannelDecision", () => {
     registerPendingConfirmation("req-1", "conv-1", "shell");
     const decision: ApprovalDecisionResult = {
       action: "approve_once",
-      source: "telegram_button",
+      source: "button",
       requestId: "req-missing",
     };
 

--- a/assistant/src/__tests__/notification-discord-adapter.test.ts
+++ b/assistant/src/__tests__/notification-discord-adapter.test.ts
@@ -10,7 +10,11 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const dmOpens: string[] = [];
-const sendCalls: Array<{ channelId: string; text: string }> = [];
+const sendCalls: Array<{
+  channelId: string;
+  text: string;
+  approval?: { requestId: string } | undefined;
+}> = [];
 const editCalls: Array<{ channelId: string; messageId: string; text: string }> =
   [];
 
@@ -22,8 +26,15 @@ mock.module("../messaging/providers/discord/api.js", () => ({
 }));
 
 mock.module("../messaging/providers/discord/send.js", () => ({
-  sendDiscordReply: async (target: { channelId: string }, text: string) => {
-    sendCalls.push({ channelId: target.channelId, text });
+  sendDiscordReply: async (
+    target: { channelId: string },
+    text: string,
+    approval?: { requestId: string },
+  ) => {
+    if (approval && failRichSends) {
+      throw new Error("simulated component rejection");
+    }
+    sendCalls.push({ channelId: target.channelId, text, approval });
     return { lastMessageId: String(2000 + sendCalls.length) };
   },
   editDiscordMessage: async (
@@ -68,10 +79,13 @@ function makeDestination(
   };
 }
 
+let failRichSends = false;
+
 beforeEach(() => {
   dmOpens.length = 0;
   sendCalls.length = 0;
   editCalls.length = 0;
+  failRichSends = false;
 });
 
 describe("DiscordAdapter.send", () => {
@@ -87,7 +101,7 @@ describe("DiscordAdapter.send", () => {
     expect(sendCalls[0].text).toContain("Your task finished.");
   });
 
-  test("approval notifications carry the typed-command instructions", async () => {
+  test("approval notifications deliver with component buttons", async () => {
     const adapter = new DiscordAdapter();
     const result = await adapter.send(
       makePayload({
@@ -102,6 +116,28 @@ describe("DiscordAdapter.send", () => {
 
     expect(result.success).toBe(true);
     expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0].approval?.requestId).toBe("req-1");
+    // The rich card carries no typed-command tail; buttons are the controls.
+    expect(sendCalls[0].text).not.toContain("Reply");
+  });
+
+  test("a failed rich delivery falls back to the typed-command card", async () => {
+    failRichSends = true;
+    const adapter = new DiscordAdapter();
+    const result = await adapter.send(
+      makePayload({
+        approvalContext: {
+          requestId: "req-1",
+          actions: [{ id: "approve_once", label: "Approve once" }],
+          plainTextFallback: 'Reply "approve" or "reject" to decide.',
+        },
+      }),
+      makeDestination(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0].approval).toBeUndefined();
     expect(sendCalls[0].text).toContain(
       'Reply "approve" or "reject" to decide.',
     );

--- a/assistant/src/__tests__/notification-discord-adapter.test.ts
+++ b/assistant/src/__tests__/notification-discord-adapter.test.ts
@@ -25,14 +25,23 @@ mock.module("../messaging/providers/discord/api.js", () => ({
   },
 }));
 
+const actualSend = await import("../messaging/providers/discord/send.js");
 mock.module("../messaging/providers/discord/send.js", () => ({
+  DiscordPartialSendError: actualSend.DiscordPartialSendError,
   sendDiscordReply: async (
     target: { channelId: string },
     text: string,
     approval?: { requestId: string },
   ) => {
     if (approval && failRichSends) {
-      throw new Error("simulated component rejection");
+      throw failRichSends === "partial"
+        ? new actualSend.DiscordPartialSendError(
+            new Error("final chunk rejected"),
+            2,
+            "tail of the card",
+            "1500",
+          )
+        : new Error("simulated component rejection");
     }
     sendCalls.push({ channelId: target.channelId, text, approval });
     return { lastMessageId: String(2000 + sendCalls.length) };
@@ -79,7 +88,7 @@ function makeDestination(
   };
 }
 
-let failRichSends = false;
+let failRichSends: boolean | "partial" = false;
 
 beforeEach(() => {
   dmOpens.length = 0;
@@ -119,6 +128,29 @@ describe("DiscordAdapter.send", () => {
     expect(sendCalls[0].approval?.requestId).toBe("req-1");
     // The rich card carries no typed-command tail; buttons are the controls.
     expect(sendCalls[0].text).not.toContain("Reply");
+  });
+
+  test("a mid-card failure completes the card instead of replaying it", async () => {
+    failRichSends = "partial";
+    const adapter = new DiscordAdapter();
+    const result = await adapter.send(
+      makePayload({
+        approvalContext: {
+          requestId: "req-1",
+          actions: [{ id: "approve_once", label: "Approve once" }],
+          plainTextFallback: 'Reply "approve" or "reject" to decide.',
+        },
+      }),
+      makeDestination(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(sendCalls).toHaveLength(1);
+    // Only the undelivered remainder goes out, with the typed instructions;
+    // the delivered chunks are never sent twice.
+    expect(sendCalls[0].approval).toBeUndefined();
+    expect(sendCalls[0].text).toContain("tail of the card");
+    expect(sendCalls[0].text).toContain('Reply "approve" or "reject"');
   });
 
   test("a failed rich delivery falls back to the typed-command card", async () => {

--- a/assistant/src/__tests__/notification-discord-adapter.test.ts
+++ b/assistant/src/__tests__/notification-discord-adapter.test.ts
@@ -18,7 +18,11 @@ const sendCalls: Array<{
 const editCalls: Array<{ channelId: string; messageId: string; text: string }> =
   [];
 
+// Spread the actual module: the real send.js is imported below for its
+// error class and transitively needs api.js's other named exports.
+const actualApi = await import("../messaging/providers/discord/api.js");
 mock.module("../messaging/providers/discord/api.js", () => ({
+  ...actualApi,
   openDiscordDmChannel: async (userId: string) => {
     dmOpens.push(userId);
     return `dm-for-${userId}`;

--- a/assistant/src/messaging/providers/discord/send.test.ts
+++ b/assistant/src/messaging/providers/discord/send.test.ts
@@ -30,8 +30,12 @@ mock.module("../../../util/logger.js", () => ({
   getLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
 }));
 
-const { sendDiscordReply, sendDiscordAttachments, editDiscordMessage } =
-  await import("./send.js");
+const {
+  sendDiscordReply,
+  sendDiscordAttachments,
+  editDiscordMessage,
+  DiscordPartialSendError,
+} = await import("./send.js");
 
 const originalFetch = globalThis.fetch;
 
@@ -187,6 +191,60 @@ describe("sendDiscordReply", () => {
     const row = JSON.parse(calls[0].body as string).components[0];
     expect(row.components[0].style).toBe(2);
     expect(row.components[1].style).toBe(2);
+  });
+
+  test("a failure after the first chunk names the undelivered remainder", async () => {
+    const long = Array.from({ length: 400 }, (_, i) => `line ${i}`).join("\n");
+    let posts = 0;
+    globalThis.fetch = (async (url: string | URL, init?: RequestInit) => {
+      posts += 1;
+      calls.push({
+        url: String(url),
+        method: init?.method ?? "GET",
+        headers: {},
+        body: init?.body,
+      });
+      if (posts > 1) {
+        return new Response(JSON.stringify({ message: "rejected" }), {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify({ id: "msg-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    let thrown: unknown;
+    try {
+      await sendDiscordReply({ channelId: "C1" }, long);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(DiscordPartialSendError);
+    const partial = thrown as InstanceType<typeof DiscordPartialSendError>;
+    expect(partial.chunksSent).toBe(1);
+    expect(partial.lastMessageId).toBe("msg-1");
+    // The delivered prefix plus the named remainder reassemble the text, so
+    // a caller completing the card sends no line twice and drops none.
+    const delivered = JSON.parse(calls[0].body as string).content;
+    expect(`${delivered}\n${partial.remainingText}`).toBe(long);
+  });
+
+  test("a failure on the first chunk propagates plainly, so full fallback is safe", async () => {
+    stubFetch(400, { message: "rejected" });
+
+    let thrown: unknown;
+    try {
+      await sendDiscordReply({ channelId: "C1" }, "short card");
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).not.toBeInstanceOf(DiscordPartialSendError);
   });
 
   test("a custom_id past Discord's cap throws instead of sending a dead button", async () => {

--- a/assistant/src/messaging/providers/discord/send.test.ts
+++ b/assistant/src/messaging/providers/discord/send.test.ts
@@ -123,6 +123,82 @@ describe("sendDiscordReply", () => {
     await sendDiscordReply({ channelId: "C1" }, "   ");
     expect(calls).toHaveLength(0);
   });
+
+  test("an approval card carries its buttons on the shared apr: convention", async () => {
+    await sendDiscordReply({ channelId: "C1" }, "Approve?", {
+      requestId: "req-1",
+      actions: [
+        { id: "approve_once", label: "Approve once" },
+        { id: "reject", label: "Reject" },
+      ],
+      plainTextFallback: "reply approve or reject",
+    });
+
+    const body = JSON.parse(calls[0].body as string);
+    expect(body.components).toEqual([
+      {
+        type: 1,
+        components: [
+          {
+            type: 2,
+            style: 1,
+            label: "Approve once",
+            custom_id: "apr:req-1:approve_once",
+          },
+          {
+            type: 2,
+            style: 4,
+            label: "Reject",
+            custom_id: "apr:req-1:reject",
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("buttons ride only the final chunk of a long card", async () => {
+    const long = Array.from({ length: 400 }, (_, i) => `line ${i}`).join("\n");
+    await sendDiscordReply({ channelId: "C1" }, long, {
+      requestId: "req-1",
+      actions: [{ id: "approve_once", label: "Approve once" }],
+      plainTextFallback: "reply approve",
+    });
+
+    expect(calls.length).toBeGreaterThan(1);
+    const withComponents = calls.filter(
+      (c) => JSON.parse(c.body as string).components !== undefined,
+    );
+    // The final chunk's id is the one the delivery row records, so the
+    // message a press arrives on is the message the row can find.
+    expect(withComponents).toHaveLength(1);
+    expect(calls.indexOf(withComponents[0])).toBe(calls.length - 1);
+  });
+
+  test("an action's own emphasis outranks positional styling", async () => {
+    await sendDiscordReply({ channelId: "C1" }, "Meet?", {
+      requestId: "req-1",
+      actions: [
+        { id: "accept", label: "Accept", emphasis: "secondary" },
+        { id: "later", label: "Later" },
+      ],
+      plainTextFallback: "reply accept or later",
+    });
+
+    const row = JSON.parse(calls[0].body as string).components[0];
+    expect(row.components[0].style).toBe(2);
+    expect(row.components[1].style).toBe(2);
+  });
+
+  test("a custom_id past Discord's cap throws instead of sending a dead button", async () => {
+    await expect(
+      sendDiscordReply({ channelId: "C1" }, "Approve?", {
+        requestId: "r".repeat(120),
+        actions: [{ id: "approve_once", label: "Approve once" }],
+        plainTextFallback: "reply approve",
+      }),
+    ).rejects.toThrow("100-character limit");
+    expect(calls).toHaveLength(0);
+  });
 });
 
 describe("sendDiscordAttachments", () => {
@@ -182,6 +258,12 @@ describe("sendDiscordAttachments", () => {
 describe("editDiscordMessage", () => {
   const bodyOf = (index = 0): Record<string, unknown> =>
     JSON.parse(String(calls[index]?.body)) as Record<string, unknown>;
+
+  test("an edit always strips components, so a settled card keeps no live buttons", async () => {
+    await editDiscordMessage({ channelId: "C1" }, "m1", "Approved");
+    const body = JSON.parse(calls[0].body as string);
+    expect(body.components).toEqual([]);
+  });
 
   test("patches the message rather than posting a new one", async () => {
     await editDiscordMessage({ channelId: "C1" }, "M9", "revised");

--- a/assistant/src/messaging/providers/discord/send.ts
+++ b/assistant/src/messaging/providers/discord/send.ts
@@ -142,6 +142,38 @@ function messagesRoute(target: DiscordSendTarget): string {
   return `/channels/${encodeURIComponent(target.channelId)}/messages`;
 }
 
+/**
+ * A multi-chunk send that failed after at least one chunk was posted. The
+ * already-delivered chunks cannot be unsent, so a caller with a fallback
+ * must not replay the whole text; the undelivered remainder is what is
+ * still owed to the reader.
+ */
+export class DiscordPartialSendError extends Error {
+  readonly chunksSent: number;
+  readonly remainingText: string;
+  readonly lastMessageId?: string;
+
+  constructor(
+    cause: unknown,
+    chunksSent: number,
+    remainingText: string,
+    lastMessageId?: string,
+  ) {
+    super(
+      `Discord send failed after ${chunksSent} chunk(s): ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+      { cause },
+    );
+    this.name = "DiscordPartialSendError";
+    this.chunksSent = chunksSent;
+    this.remainingText = remainingText;
+    if (lastMessageId !== undefined) {
+      this.lastMessageId = lastMessageId;
+    }
+  }
+}
+
 /** Outcome of a Discord reply send. */
 export interface DiscordSendResult {
   /**
@@ -227,18 +259,33 @@ export async function sendDiscordReply(
 
   let lastMessageId: string | undefined;
   for (const [index, chunk] of chunks.entries()) {
-    const sent = await callDiscordApi<DiscordMessage>(
-      "POST",
-      messagesRoute(target),
-      {
-        content: chunk,
-        allowed_mentions: DISCORD_ALLOWED_MENTIONS,
-        ...(components.length > 0 && index === chunks.length - 1
-          ? { components }
-          : {}),
-      },
-    );
-    lastMessageId = typeof sent?.id === "string" ? sent.id : undefined;
+    try {
+      const sent = await callDiscordApi<DiscordMessage>(
+        "POST",
+        messagesRoute(target),
+        {
+          content: chunk,
+          allowed_mentions: DISCORD_ALLOWED_MENTIONS,
+          ...(components.length > 0 && index === chunks.length - 1
+            ? { components }
+            : {}),
+        },
+      );
+      lastMessageId = typeof sent?.id === "string" ? sent.id : undefined;
+    } catch (err) {
+      // Nothing posted yet propagates plainly; a caller may retry or fall
+      // back with the full text. Past the first chunk the delivered prefix
+      // cannot be unsent, so the error names what is still owed.
+      if (index === 0) {
+        throw err;
+      }
+      throw new DiscordPartialSendError(
+        err,
+        index,
+        chunks.slice(index).join("\n"),
+        lastMessageId,
+      );
+    }
   }
 
   log.debug(

--- a/assistant/src/messaging/providers/discord/send.ts
+++ b/assistant/src/messaging/providers/discord/send.ts
@@ -5,6 +5,8 @@
  * attachments, by calling the Discord REST API directly via ./api.ts.
  */
 
+import type { ApprovalUIMetadata } from "@vellumai/gateway-client";
+
 import { getAttachmentContent } from "../../../persistence/attachments-store.js";
 import type { RuntimeAttachmentMetadata } from "../../../runtime/http-types.js";
 import { getLogger } from "../../../util/logger.js";
@@ -41,6 +43,90 @@ const DISCORD_ALLOWED_MENTIONS = { parse: ["users"] } as const;
  * through the same failure notice as any other attachment error.
  */
 const DISCORD_MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024;
+
+// Component wire values, from Discord's message-components table.
+const DISCORD_COMPONENT_ACTION_ROW = 1;
+const DISCORD_COMPONENT_BUTTON = 2;
+const DISCORD_BUTTON_STYLE_PRIMARY = 1;
+const DISCORD_BUTTON_STYLE_SECONDARY = 2;
+const DISCORD_BUTTON_STYLE_DANGER = 4;
+/** Discord caps a component `custom_id` at 100 characters. */
+const DISCORD_MAX_CUSTOM_ID_CHARS = 100;
+/** Discord caps a button label at 80 characters. */
+const DISCORD_MAX_BUTTON_LABEL_CHARS = 80;
+/** Discord caps an action row at five buttons. */
+const DISCORD_MAX_BUTTONS_PER_ROW = 5;
+
+interface DiscordButtonComponent {
+  type: typeof DISCORD_COMPONENT_BUTTON;
+  style: number;
+  label: string;
+  custom_id: string;
+}
+
+interface DiscordActionRow {
+  type: typeof DISCORD_COMPONENT_ACTION_ROW;
+  components: DiscordButtonComponent[];
+}
+
+/** Translate a surface-agnostic emphasis into Discord's button style value. */
+function discordStyleForEmphasis(
+  emphasis: "primary" | "secondary" | "destructive",
+): number {
+  switch (emphasis) {
+    case "primary":
+      return DISCORD_BUTTON_STYLE_PRIMARY;
+    case "destructive":
+      return DISCORD_BUTTON_STYLE_DANGER;
+    case "secondary":
+      return DISCORD_BUTTON_STYLE_SECONDARY;
+  }
+}
+
+/**
+ * Build the action rows for an approval card. Each button's `custom_id` is
+ * the shared `apr:<requestId>:<action>` callback convention, which the
+ * gateway forwards verbatim as the button event's `callbackData`. Styling
+ * mirrors the Slack card: an action's own `emphasis` wins, otherwise the
+ * first action is primary and `reject` is danger. Discord requires a style
+ * on every button, so the remainder are explicitly secondary.
+ *
+ * Throws when a `custom_id` would exceed Discord's cap: the caller falls
+ * back to the plain-text card rather than sending a button that could not
+ * round-trip its request id.
+ */
+function buildDiscordApprovalComponents(
+  approval: ApprovalUIMetadata,
+): DiscordActionRow[] {
+  const buttons = approval.actions.map((action, index) => {
+    const customId = `apr:${approval.requestId}:${action.id}`;
+    if (customId.length > DISCORD_MAX_CUSTOM_ID_CHARS) {
+      throw new Error(
+        `custom_id for action "${action.id}" is ${customId.length} characters, exceeding Discord's ${DISCORD_MAX_CUSTOM_ID_CHARS}-character limit`,
+      );
+    }
+    return {
+      type: DISCORD_COMPONENT_BUTTON,
+      style: action.emphasis
+        ? discordStyleForEmphasis(action.emphasis)
+        : action.id === "reject"
+          ? DISCORD_BUTTON_STYLE_DANGER
+          : index === 0
+            ? DISCORD_BUTTON_STYLE_PRIMARY
+            : DISCORD_BUTTON_STYLE_SECONDARY,
+      label: action.label.slice(0, DISCORD_MAX_BUTTON_LABEL_CHARS),
+      custom_id: customId,
+    } satisfies DiscordButtonComponent;
+  });
+  const rows: DiscordActionRow[] = [];
+  for (let i = 0; i < buttons.length; i += DISCORD_MAX_BUTTONS_PER_ROW) {
+    rows.push({
+      type: DISCORD_COMPONENT_ACTION_ROW,
+      components: buttons.slice(i, i + DISCORD_MAX_BUTTONS_PER_ROW),
+    });
+  }
+  return rows;
+}
 
 /** Send target for one Discord delivery. */
 export interface DiscordSendTarget {
@@ -108,6 +194,11 @@ export async function editDiscordMessage(
     {
       content: options?.emphasis === "muted" ? mutedText(text) : text,
       allowed_mentions: DISCORD_ALLOWED_MENTIONS,
+      // A PATCH that omits `components` keeps whatever the message carries,
+      // and every edit through this path states a final text: a card that
+      // has been answered or withdrawn must not keep live buttons. Always
+      // stripping makes that an invariant rather than a caller's chore.
+      components: [],
     },
   );
   log.debug(
@@ -123,20 +214,28 @@ export async function editDiscordMessage(
 export async function sendDiscordReply(
   target: DiscordSendTarget,
   text: string,
+  approval?: ApprovalUIMetadata,
 ): Promise<DiscordSendResult> {
   const chunks = renderDiscordMessages(text);
   if (chunks.length === 0) {
     return {};
   }
 
+  // Buttons ride the final chunk: its id is the one recorded on the delivery
+  // row, so the message a press arrives on is the message the row can find.
+  const components = approval ? buildDiscordApprovalComponents(approval) : [];
+
   let lastMessageId: string | undefined;
-  for (const chunk of chunks) {
+  for (const [index, chunk] of chunks.entries()) {
     const sent = await callDiscordApi<DiscordMessage>(
       "POST",
       messagesRoute(target),
       {
         content: chunk,
         allowed_mentions: DISCORD_ALLOWED_MENTIONS,
+        ...(components.length > 0 && index === chunks.length - 1
+          ? { components }
+          : {}),
       },
     );
     lastMessageId = typeof sent?.id === "string" ? sent.id : undefined;

--- a/assistant/src/notifications/adapters/discord.ts
+++ b/assistant/src/notifications/adapters/discord.ts
@@ -16,6 +16,7 @@
 
 import { openDiscordDmChannel } from "../../messaging/providers/discord/api.js";
 import {
+  DiscordPartialSendError,
   editDiscordMessage,
   sendDiscordReply,
 } from "../../messaging/providers/discord/send.js";
@@ -76,6 +77,26 @@ export class DiscordAdapter implements ChannelAdapter {
           // (reactions, button presses, in-place withdrawal).
           return { success: true, messageId: sent.lastMessageId };
         } catch (richErr) {
+          if (richErr instanceof DiscordPartialSendError) {
+            // The leading chunks are delivered and cannot be unsent, so a
+            // full plain-text fallback would duplicate them. Complete the
+            // card instead: the undelivered remainder plus the typed-command
+            // instructions, whose message becomes the card's address.
+            log.warn(
+              {
+                err: richErr,
+                sourceEventName: payload.sourceEventName,
+                guardianUserId,
+                chunksSent: richErr.chunksSent,
+              },
+              "Rich Discord delivery failed mid-card, completing in plain text",
+            );
+            const completion = await sendDiscordReply(
+              { channelId },
+              appendPlainTextFallback(richErr.remainingText, approval),
+            );
+            return { success: true, messageId: completion.lastMessageId };
+          }
           log.warn(
             {
               err: richErr,

--- a/assistant/src/notifications/adapters/discord.ts
+++ b/assistant/src/notifications/adapters/discord.ts
@@ -8,10 +8,10 @@
  * (cached per user) and a room id on the binding can never become a delivery
  * target. That is Slack's D-prefix DM gate, achieved by construction.
  *
- * Approval notifications carry the typed-command instructions instead of
- * component buttons: nothing ingests INTERACTION_CREATE yet, and a button
- * whose press goes nowhere is a dead control. When interaction ingest lands,
- * buttons arrive here as a rendering upgrade, not a new decision path.
+ * Approval notifications render component buttons whose presses the gateway
+ * ingests as button events on the shared `apr:` callback convention; a
+ * rendering failure falls back to the plain-text card with typed-command
+ * instructions, so a card is always actionable one way or the other.
  */
 
 import { openDiscordDmChannel } from "../../messaging/providers/discord/api.js";
@@ -53,14 +53,46 @@ export class DiscordAdapter implements ChannelAdapter {
       };
     }
 
-    const text = appendPlainTextFallback(
-      resolveMessageText(payload),
-      payload.approvalContext,
-    );
+    const messageText = resolveMessageText(payload);
+    const approval = payload.approvalContext;
 
     try {
       const channelId = await openDiscordDmChannel(guardianUserId);
-      const sent = await sendDiscordReply({ channelId }, text);
+
+      if (approval) {
+        // Attempt rich delivery with component buttons; on failure, fall
+        // back to the plain-text card below.
+        try {
+          const sent = await sendDiscordReply(
+            { channelId },
+            messageText,
+            approval,
+          );
+          log.info(
+            { sourceEventName: payload.sourceEventName, guardianUserId },
+            "Discord approval notification delivered with buttons",
+          );
+          // The message id lets the delivery row address the card later
+          // (reactions, button presses, in-place withdrawal).
+          return { success: true, messageId: sent.lastMessageId };
+        } catch (richErr) {
+          log.warn(
+            {
+              err: richErr,
+              sourceEventName: payload.sourceEventName,
+              guardianUserId,
+            },
+            "Rich Discord delivery failed, falling back to plain text",
+          );
+        }
+      }
+
+      // When falling back from rich delivery, append the plain-text
+      // instructions so the guardian still knows how to approve/reject.
+      const sent = await sendDiscordReply(
+        { channelId },
+        appendPlainTextFallback(messageText, approval),
+      );
 
       log.info(
         { sourceEventName: payload.sourceEventName, guardianUserId },

--- a/assistant/src/runtime/channel-approval-types.ts
+++ b/assistant/src/runtime/channel-approval-types.ts
@@ -160,11 +160,14 @@ export interface ChannelApprovalPrompt {
 // Decision result (daemon-internal)
 // ---------------------------------------------------------------------------
 
-/** How the user communicated their decision. */
+/**
+ * How the user communicated their decision: the modality, never the channel.
+ * A channel-prefixed value here would misattribute the next channel that
+ * joins (every channel's buttons ride the same `apr:` callback), and no
+ * consumer reads a channel off this field.
+ */
 export type ApprovalDecisionSource =
-  | "telegram_button"
-  | "whatsapp_button"
-  | "slack_button"
+  | "button"
   | "reaction"
   | "vellum_surface"
   | "plain_text";

--- a/assistant/src/runtime/routes/channel-route-shared.ts
+++ b/assistant/src/runtime/routes/channel-route-shared.ts
@@ -52,13 +52,9 @@ export function parseCallbackData(
     return null;
   }
   const source =
-    sourceChannel === "whatsapp"
-      ? ("whatsapp_button" as const)
-      : sourceChannel === "slack"
-        ? ("slack_button" as const)
-        : sourceChannel === "vellum"
-          ? ("vellum_surface" as const)
-          : ("telegram_button" as const);
+    sourceChannel === "vellum"
+      ? ("vellum_surface" as const)
+      : ("button" as const);
   return { action, source, requestId };
 }
 

--- a/gateway/src/discord/gateway-socket.test.ts
+++ b/gateway/src/discord/gateway-socket.test.ts
@@ -529,6 +529,101 @@ describe("reaction dispatch", () => {
   });
 });
 
+describe("interaction dispatch", () => {
+  const buttonPress = (overrides: Record<string, unknown> = {}) => ({
+    op: 0,
+    t: "INTERACTION_CREATE",
+    s: 4,
+    d: {
+      id: "inter-1",
+      token: "inter-token-1",
+      type: 3,
+      channel_id: "dm-channel-1",
+      data: { custom_id: "apr:req-1:approve_once", component_type: 2 },
+      message: { id: "card-msg-1" },
+      user: { id: "user-1", username: "alice", global_name: "Alice" },
+      ...overrides,
+    },
+  });
+
+  test("a button press acks deferred-update and forwards a button event", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(buttonPress());
+    await Promise.resolve();
+
+    const ack = h.fetchCalls.find((c) => c.url.includes("/interactions/"));
+    expect(ack?.url).toBe(
+      "https://discord.com/api/v10/interactions/inter-1/inter-token-1/callback",
+    );
+
+    expect(h.events).toHaveLength(1);
+    const event = h.events[0];
+    expect(event.message.eventKind).toBe("button");
+    expect(event.message.callbackData).toBe("apr:req-1:approve_once");
+    expect(event.message.content).toBe("apr:req-1:approve_once");
+    expect(event.message.conversationExternalId).toBe("dm-channel-1");
+    expect(event.source.messageId).toBe("card-msg-1");
+    expect(event.actor.actorExternalId).toBe("user-1");
+    expect(event.source.isDirectMessage).toBe(true);
+  });
+
+  test("a guild press names its actor from member.user", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(
+      buttonPress({
+        guild_id: "guild-1",
+        user: undefined,
+        member: { user: { id: "user-2", username: "bob" } },
+      }),
+    );
+
+    expect(h.events).toHaveLength(1);
+    expect(h.events[0].actor.actorExternalId).toBe("user-2");
+    expect(h.events[0].source.isDirectMessage).toBe(false);
+  });
+
+  test("non-component interaction types are neither acked nor forwarded", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    // An application command (type 2) has no consumer here.
+    ws.message(buttonPress({ type: 2 }));
+    await Promise.resolve();
+
+    expect(h.events).toHaveLength(0);
+    expect(
+      h.fetchCalls.filter((c) => c.url.includes("/interactions/")),
+    ).toHaveLength(0);
+  });
+
+  test("a select-menu press is not consumed", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(
+      buttonPress({
+        data: { custom_id: "pick", component_type: 3, values: ["a"] },
+      }),
+    );
+
+    expect(h.events).toHaveLength(0);
+  });
+
+  test("a bot actor drops at normalization but the ack still lands", async () => {
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(
+      buttonPress({ user: { id: "other-bot", username: "x", bot: true } }),
+    );
+    await Promise.resolve();
+
+    expect(h.events).toHaveLength(0);
+    expect(
+      h.fetchCalls.filter((c) => c.url.includes("/interactions/")),
+    ).toHaveLength(1);
+  });
+});
+
 describe("shutdown", () => {
   test("stop closes with 1000 and schedules nothing", async () => {
     const h = harness();

--- a/gateway/src/discord/gateway-socket.ts
+++ b/gateway/src/discord/gateway-socket.ts
@@ -53,11 +53,16 @@ import {
   DiscordMessageCreateSchema,
   DiscordReadySchema,
   DiscordThreadListSchema,
+  DISCORD_COMPONENT_TYPE_BUTTON,
+  DISCORD_INTERACTION_CALLBACK_DEFERRED_UPDATE,
+  DISCORD_INTERACTION_TYPE_MESSAGE_COMPONENT,
+  DiscordInteractionSchema,
   DiscordMessageDeleteSchema,
   DiscordMessageReactionSchema,
   DiscordThreadSchema,
 } from "./message-schemas.js";
 import {
+  normalizeDiscordInteraction,
   normalizeDiscordMessage,
   normalizeDiscordMessageDelete,
   normalizeDiscordMessageReaction,
@@ -673,6 +678,9 @@ export class DiscordGatewayClient {
       case "MESSAGE_REACTION_REMOVE":
         this.handleMessageReaction(data, "removed");
         return;
+      case "INTERACTION_CREATE":
+        this.handleInteractionCreate(data);
+        return;
       default:
         return;
     }
@@ -781,6 +789,87 @@ export class DiscordGatewayClient {
       "Discord delete forwarded",
     );
     this.onEvent(normalized, new Map());
+  }
+
+  private handleInteractionCreate(data: unknown): void {
+    const parsed = DiscordInteractionSchema.safeParse(data);
+    if (!parsed.success) {
+      log.warn("Dropping malformed INTERACTION_CREATE");
+      return;
+    }
+    const interaction = parsed.data;
+    // Only component button presses are consumed; commands, selects and
+    // modals have no consumer, and an unhandled interaction type must not be
+    // acked into a state the user reads as accepted.
+    if (
+      interaction.type !== DISCORD_INTERACTION_TYPE_MESSAGE_COMPONENT ||
+      interaction.data?.component_type !== DISCORD_COMPONENT_TYPE_BUTTON
+    ) {
+      return;
+    }
+    if (!interaction.id || !interaction.token) {
+      log.warn("Dropping INTERACTION_CREATE without id or token");
+      return;
+    }
+    // ACK inside Discord's 3-second deadline, before any forwarding work.
+    // DeferredMessageUpdate leaves the card untouched; the daemon's decision
+    // flow rewrites it through the notification adapter's update path, the
+    // same shape as Telegram's answerCallbackQuery-then-edit.
+    void this.acknowledgeInteraction(interaction.id, interaction.token);
+    const parentChannelId = interaction.channel_id
+      ? this.threadParents.parentOf(interaction.channel_id)
+      : undefined;
+    const normalized = normalizeDiscordInteraction(interaction, {
+      ...(parentChannelId !== undefined ? { parentChannelId } : {}),
+      raw: (data ?? {}) as Record<string, unknown>,
+    });
+    if (!normalized) {
+      log.debug(
+        { interactionId: interaction.id },
+        "Discord interaction dropped by normalization",
+      );
+      return;
+    }
+    log.info(
+      {
+        interactionId: interaction.id,
+        conversationExternalId: normalized.message.conversationExternalId,
+      },
+      "Discord button press forwarded",
+    );
+    this.onEvent(normalized, new Map());
+  }
+
+  /**
+   * POST the deferred-update ack for a component press. The interaction
+   * token in the URL authorizes the call; no bot header is needed. Failure
+   * is logged and swallowed: the press still forwards, and the only cost is
+   * Discord showing the guardian an interaction-failed notice.
+   */
+  private async acknowledgeInteraction(
+    interactionId: string,
+    token: string,
+  ): Promise<void> {
+    try {
+      const response = await this.fetchFn(
+        `${DISCORD_API_BASE_URL}/interactions/${interactionId}/${token}/callback`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            type: DISCORD_INTERACTION_CALLBACK_DEFERRED_UPDATE,
+          }),
+        },
+      );
+      if (!response.ok) {
+        log.warn(
+          { interactionId, status: response.status },
+          "Discord interaction ack failed",
+        );
+      }
+    } catch (err) {
+      log.warn({ err, interactionId }, "Discord interaction ack failed");
+    }
   }
 
   private handleMessageReaction(data: unknown, op: "added" | "removed"): void {

--- a/gateway/src/discord/message-schemas.ts
+++ b/gateway/src/discord/message-schemas.ts
@@ -20,6 +20,7 @@
  */
 
 import type {
+  APIMessageComponentButtonInteraction,
   APIThreadChannel,
   GatewayHelloData,
   GatewayMessageCreateDispatchData,
@@ -92,6 +93,21 @@ export const DiscordThreadListSchema = z.object({
 /** THREAD_CREATE / THREAD_UPDATE / THREAD_DELETE data: one channel object. */
 export const DiscordThreadSchema = DiscordChannelSchema;
 
+/**
+ * A user object, as carried by message authors and interaction actors. The
+ * `bot` indicator fails CLOSED, unlike the tolerant fields around it: absent
+ * stays `undefined` (Discord omits it for humans), but a present-and-malformed
+ * value collapses to `true`, because this is the classifier standing between
+ * ingestion and a bot feedback loop, and collapsing to `undefined` would read
+ * as human.
+ */
+const DiscordUserSchema = z.object({
+  id: idString(),
+  username: optionalString(),
+  global_name: z.string().nullable().optional().catch(undefined),
+  bot: z.boolean().optional().catch(true),
+});
+
 /** MESSAGE_CREATE dispatch data — the fields admission and normalization read. */
 export const DiscordMessageCreateSchema = z.object({
   id: idString(),
@@ -117,22 +133,7 @@ export const DiscordMessageCreateSchema = z.object({
    * successive edits of one message are never swallowed as duplicates.
    */
   edited_timestamp: z.string().nullable().optional().catch(undefined),
-  author: z
-    .object({
-      id: idString(),
-      username: optionalString(),
-      global_name: z.string().nullable().optional().catch(undefined),
-      /**
-       * Bot indicator — fails CLOSED, unlike the tolerant fields around it.
-       * Absent stays `undefined` (Discord omits it for humans), but a
-       * present-and-malformed value collapses to `true`: this is the one
-       * classifier standing between the admission gate and a bot reply loop,
-       * and collapsing to `undefined` would read as human.
-       */
-      bot: z.boolean().optional().catch(true),
-    })
-    .optional()
-    .catch(undefined),
+  author: DiscordUserSchema.optional().catch(undefined),
   /**
    * Present on webhook-delivered messages, whose author is not a real user.
    * Fails closed like `author.bot`: a malformed value collapses to a sentinel
@@ -201,6 +202,45 @@ export const DiscordMessageReactionSchema = z.object({
 export type DiscordMessageReaction = z.infer<
   typeof DiscordMessageReactionSchema
 >;
+
+/** InteractionType.MessageComponent: a component press, the one type consumed. */
+export const DISCORD_INTERACTION_TYPE_MESSAGE_COMPONENT = 3;
+/** ComponentType.Button within a component interaction's data. */
+export const DISCORD_COMPONENT_TYPE_BUTTON = 2;
+/** InteractionResponseType.DeferredMessageUpdate: ACK without a loading state. */
+export const DISCORD_INTERACTION_CALLBACK_DEFERRED_UPDATE = 6;
+
+/**
+ * INTERACTION_CREATE data: the fields the component-button path reads.
+ * Interactions ride the Gateway by default and need no intent bit; an
+ * Interactions Endpoint URL configured in the developer portal would divert
+ * them to HTTP and silence this dispatch, so the app must not configure one.
+ * The actor arrives as `user` in a DM and as `member.user` in a guild. The
+ * guild sentinel matches the create schema's reasoning.
+ */
+export const DiscordInteractionSchema = z.object({
+  id: idString(),
+  /** Authorizes the callback ack; it rides in the URL, not a header. */
+  token: idString(),
+  type: optionalNumber(),
+  channel_id: optionalString(),
+  guild_id: z.string().optional().catch("malformed-guild-id"),
+  data: z
+    .object({
+      custom_id: idString(),
+      component_type: optionalNumber(),
+    })
+    .optional()
+    .catch(undefined),
+  /** The message the pressed component is attached to (the card). */
+  message: z.object({ id: idString() }).optional().catch(undefined),
+  member: z
+    .object({ user: DiscordUserSchema.optional().catch(undefined) })
+    .optional()
+    .catch(undefined),
+  user: DiscordUserSchema.optional().catch(undefined),
+});
+export type DiscordInteraction = z.infer<typeof DiscordInteractionSchema>;
 
 // ---------------------------------------------------------------------------
 // Compile-time cross-check against the official Discord API types.
@@ -293,6 +333,30 @@ type _DiscordApiCrossChecks = [
     ModeledKeysAreOfficial<
       NonNullable<DiscordMessageReaction["emoji"]>,
       GatewayMessageReactionRemoveDispatchData["emoji"]
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      DiscordInteraction,
+      APIMessageComponentButtonInteraction
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      NonNullable<DiscordInteraction["data"]>,
+      APIMessageComponentButtonInteraction["data"]
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      NonNullable<DiscordInteraction["member"]>,
+      NonNullable<APIMessageComponentButtonInteraction["member"]>
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      NonNullable<DiscordInteraction["user"]>,
+      NonNullable<APIMessageComponentButtonInteraction["user"]>
     >
   >,
   Expect<

--- a/gateway/src/discord/normalize.test.ts
+++ b/gateway/src/discord/normalize.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from "bun:test";
 
 import { admitDiscordMessage } from "./admit.js";
 import {
+  DiscordInteractionSchema,
   DiscordMessageCreateSchema,
   DiscordMessageDeleteSchema,
   DiscordMessageReactionSchema,
 } from "./message-schemas.js";
 import {
+  normalizeDiscordInteraction,
   normalizeDiscordMessage,
   normalizeDiscordMessageDelete,
   normalizeDiscordMessageReaction,
@@ -613,6 +615,90 @@ describe("normalizeDiscordMessageReaction", () => {
         emoji: { id: null, name: "\u{1F44D}" },
       }),
       { op: "added", parentChannelId: "channel-1", raw: {} },
+    );
+
+    expect(event!.message.conversationExternalId).toBe("channel-1");
+    expect(event!.source.threadId).toBe("thread-1");
+  });
+});
+describe("normalizeDiscordInteraction", () => {
+  function parseInteraction(payload: Record<string, unknown>) {
+    const parsed = DiscordInteractionSchema.safeParse(payload);
+    if (!parsed.success) {
+      throw new Error("schema unexpectedly rejected payload");
+    }
+    return parsed.data;
+  }
+
+  const base = (overrides: Record<string, unknown> = {}) => ({
+    id: "inter-1",
+    token: "inter-token-1",
+    type: 3,
+    channel_id: "dm-channel-1",
+    data: { custom_id: "apr:req-1:approve_once", component_type: 2 },
+    message: { id: "card-msg-1" },
+    user: { id: "user-1", username: "alice", global_name: "Alice" },
+    ...overrides,
+  });
+
+  test("a DM button press takes the button family with the card's id", () => {
+    const event = normalizeDiscordInteraction(parseInteraction(base()), {
+      raw: {},
+    });
+
+    expect(event).not.toBeNull();
+    expect(event!.message.eventKind).toBe("button");
+    expect(event!.message.callbackData).toBe("apr:req-1:approve_once");
+    expect(event!.message.content).toBe("apr:req-1:approve_once");
+    expect(event!.message.externalMessageId).toBe("inter-1");
+    expect(event!.source.messageId).toBe("card-msg-1");
+    expect(event!.actor.actorExternalId).toBe("user-1");
+    expect(event!.actor.displayName).toBe("Alice");
+    expect(event!.source.isDirectMessage).toBe(true);
+    expect(event!.source.conversationType).toBe("dm");
+  });
+
+  test("a guild press names its actor from member.user and proves no DM", () => {
+    const event = normalizeDiscordInteraction(
+      parseInteraction(
+        base({
+          guild_id: "guild-1",
+          user: undefined,
+          member: { user: { id: "user-2", username: "bob" } },
+        }),
+      ),
+      { raw: {} },
+    );
+
+    expect(event!.actor.actorExternalId).toBe("user-2");
+    expect(event!.source.isDirectMessage).toBe(false);
+    expect(event!.source.conversationType).toBeUndefined();
+  });
+
+  test("a bot actor cannot press a real button and drops", () => {
+    const event = normalizeDiscordInteraction(
+      parseInteraction(
+        base({ user: { id: "bot-x", username: "x", bot: true } }),
+      ),
+      { raw: {} },
+    );
+
+    expect(event).toBeNull();
+  });
+
+  test("an interaction naming no actor drops", () => {
+    const event = normalizeDiscordInteraction(
+      parseInteraction(base({ user: undefined })),
+      { raw: {} },
+    );
+
+    expect(event).toBeNull();
+  });
+
+  test("a thread press addresses the parent conversation", () => {
+    const event = normalizeDiscordInteraction(
+      parseInteraction(base({ channel_id: "thread-1", guild_id: "guild-1" })),
+      { parentChannelId: "channel-1", raw: {} },
     );
 
     expect(event!.message.conversationExternalId).toBe("channel-1");

--- a/gateway/src/discord/normalize.ts
+++ b/gateway/src/discord/normalize.ts
@@ -17,6 +17,7 @@ import type { DiscordInboundEvent } from "../channels/inbound-event.js";
 import type { AdmissionCandidate } from "./admit.js";
 import { extractDiscordAttachments } from "./attachments.js";
 import type {
+  DiscordInteraction,
   DiscordMessageCreate,
   DiscordMessageDelete,
   DiscordMessageReaction,
@@ -129,6 +130,66 @@ export function normalizeDiscordMessage(
  * author cleared the ACL when the message arrived; nothing here asserts who
  * deleted it.
  */
+/**
+ * Normalize a component-button INTERACTION_CREATE into the button event
+ * family, the same shape a Telegram callback query takes: `callbackData`
+ * carries the component's `custom_id` (`apr:<requestId>:<action>` on an
+ * approval card) and `source.messageId` names the card the press landed on.
+ * The actor is `user` in a DM and `member.user` in a guild; an interaction
+ * whose actor cannot be named, or whose actor is a bot, cannot be routed
+ * and drops.
+ */
+export function normalizeDiscordInteraction(
+  interaction: DiscordInteraction,
+  options: {
+    parentChannelId?: string;
+    raw: Record<string, unknown>;
+  },
+): DiscordInboundEvent | null {
+  const actor = interaction.user ?? interaction.member?.user;
+  const customId = interaction.data?.custom_id;
+  if (
+    !interaction.id ||
+    !interaction.channel_id ||
+    !customId ||
+    !actor?.id ||
+    actor.bot === true
+  ) {
+    return null;
+  }
+  const inThread = options.parentChannelId !== undefined;
+  const isDirectMessage = interaction.guild_id === undefined;
+  return {
+    version: "v1",
+    sourceChannel: "discord",
+    receivedAt: new Date().toISOString(),
+    message: {
+      eventKind: "button",
+      content: customId,
+      conversationExternalId: options.parentChannelId ?? interaction.channel_id,
+      externalMessageId: interaction.id,
+      callbackData: customId,
+    },
+    actor: {
+      actorExternalId: actor.id,
+      ...(actor.username !== undefined ? { username: actor.username } : {}),
+      ...(typeof actor.global_name === "string"
+        ? { displayName: actor.global_name }
+        : {}),
+      ...(actor.bot !== undefined ? { isBot: actor.bot } : {}),
+    },
+    source: {
+      updateId: interaction.id,
+      messageId: interaction.message?.id,
+      chatType: isDirectMessage ? "dm" : "channel",
+      isDirectMessage,
+      ...(isDirectMessage ? { conversationType: "dm" as const } : {}),
+      ...(inThread ? { threadId: interaction.channel_id } : {}),
+    },
+    raw: options.raw,
+  };
+}
+
 export function normalizeDiscordMessageReaction(
   reaction: DiscordMessageReaction,
   options: {


### PR DESCRIPTION
# Discord approval cards render component buttons

Part of LUM-3356 (channel parity). Second of two PRs, stacked on #41615 (gateway ingest of component presses); merge that first so a rendered button always has a consumer.

## TL;DR

A guardian's Discord approval card now carries real Approve/Reject buttons instead of typed-command instructions. Tapping one lands as a button event on the shared `apr:<requestId>:<action>` convention (ingested by #41615) and flows through the same guardian decision pipeline as Slack, Telegram, and web. A rendering failure falls back to the plain-text card, so a card is always actionable one way or the other.

## What changes for the user

| Before | After |
| --- | --- |
| Discord approval cards said "Reply approve or reject to decide" | Discord approval cards show tappable Approve/Reject buttons (approve styled primary, reject styled danger, matching the Slack card) |
| A resolved card's instructions just changed text | A resolved or withdrawn card also loses its buttons: every edit strips components, so a settled card never keeps live controls |

## Design notes

- **Buttons ride the card's final chunk.** The final chunk's message id is what the delivery row records, so the message a press arrives on is exactly the message the row can find (the same alignment the reaction path uses).
- **Styling policy is shared, not re-invented.** An action's own `emphasis` wins; without one, first-is-primary and reject-is-danger, mirroring `buildCardActions` in the Slack adapter. Discord requires a style on every button, so the remainder are explicitly secondary.
- **Wire caps guarded.** A `custom_id` past Discord's 100-character cap throws before anything sends (falling back to the plain-text card) rather than shipping a button that could not round-trip its request id; labels truncate at Discord's 80-character cap.
- **Component stripping is an invariant, not a caller's chore.** Discord's PATCH keeps whatever `components` the message carries when the field is omitted (the same trap as Telegram's `editMessageText` keeping the inline keyboard), so `editDiscordMessage` always sends `components: []`: every caller of that path states final text (withdrawal, adapter update, transport edit).

## Why this is safe

- Stacked on #41615: presses are acked within Discord's deadline and consumed by the daemon's existing button pipeline, which validates the embedded request id and guardian identity before any decision applies.
- The fallback path is the exact card shipped today; the rich path only adds components to a message the adapter already sends.
- Cross-surface withdrawal (#41526) plus the unconditional component strip means a decided request leaves no pressable buttons anywhere.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41616" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->