### PR TITLE
Fix stale Windows installer entrypoint bundles

### DIFF
--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -173,13 +173,9 @@ jobs:
           SENTRY_ALLOW_UPLOAD_FAILURE: "true"
         run: bun run build:runtime
 
-      - name: Build main and preload
-        env:
-          SENTRY_DSN_WINDOWS: ${{ secrets.SENTRY_DSN_WINDOWS }}
-        run: bun run build
-
       - name: Package and sign NSIS installer
         env:
+          SENTRY_DSN_WINDOWS: ${{ secrets.SENTRY_DSN_WINDOWS }}
           WINDOWS_SIGNING_PROVIDER: ${{ vars.WINDOWS_SIGNING_PROVIDER }}
           WINDOWS_SIGNING_TIMESTAMP_URL: ${{ vars.WINDOWS_SIGNING_TIMESTAMP_URL }}
           WINDOWS_SIGNING_PUBLISHER_NAME: ${{ vars.WINDOWS_SIGNING_PUBLISHER_NAME }}

--- a/.github/workflows/windows-package-smoke.yaml
+++ b/.github/workflows/windows-package-smoke.yaml
@@ -67,9 +67,6 @@ jobs:
       - name: Build packaged runtime
         run: bun run build:runtime
 
-      - name: Build main and preload
-        run: bun run build
-
       - name: Package NSIS installer
         run: bunx electron-builder --win --config electron-builder.config.cjs --publish never
 

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -111,13 +111,15 @@ This builds the local `clients/web` source, serves it from Electron's
 ## Packaging
 
 ```bash
-bun run pack        # runtime + native helper + preview handler + electron-vite build + electron-builder --win (NSIS)
+bun run pack        # runtime + native helper + preview handler + electron-builder --win (NSIS)
 bun run pack:debug  # same, with Chrome DevTools enabled in the packaged app
 ```
 
 `pack` builds every bundled resource (`build:runtime`, `build:native-helper`,
 `build:preview-handler`) before `electron-builder`, so the Explorer preview
 handler DLL that `electron-builder.config.cjs` requires is always present.
+The builder rebuilds the Electron main and preload entrypoints immediately
+before collecting app files, including when it is invoked directly.
 
 `build:runtime` bundles the Bun pinned in `.tool-versions`: the host `bun.exe`
 is used when its sha256 matches `scripts/bun-release.ts`, otherwise the

--- a/clients/windows/electron-builder.config.cjs
+++ b/clients/windows/electron-builder.config.cjs
@@ -105,17 +105,23 @@ const resolveSigning = () => {
   }
 };
 
-// Enumerates every packaged executable and DLL (and later the installer)
-// into dist/signing-manifest-<arch>.json for signature verification.
-const enumerateSignableFiles = (args) => {
-  const result = spawnSync("bun", ["scripts/after-pack.ts", ...args], {
+const runBun = (args, label) => {
+  const result = spawnSync("bun", args, {
     cwd: __dirname,
     stdio: "inherit",
   });
   if (result.status !== 0) {
-    throw new Error(`after-pack enumeration failed (exit ${result.status})`);
+    throw new Error(`${label} failed (exit ${result.status})`);
   }
 };
+
+// Enumerates every packaged executable and DLL (and later the installer)
+// into dist/signing-manifest-<arch>.json for signature verification.
+const enumerateSignableFiles = (args) =>
+  runBun(["scripts/after-pack.ts", ...args], "after-pack enumeration");
+
+const buildElectronEntrypoints = () =>
+  runBun(["run", "build"], "Electron build");
 
 /** @type {import("electron-builder").Configuration} */
 module.exports = {
@@ -187,6 +193,7 @@ module.exports = {
       name: "Vellum Bundle",
     },
   ],
+  beforePack: buildElectronEntrypoints,
   afterPack: async (context) => {
     enumerateSignableFiles([
       "--app-out-dir",

--- a/clients/windows/package.json
+++ b/clients/windows/package.json
@@ -23,7 +23,7 @@
     "test:native-helper": "bun scripts/build-native-helper.ts --test",
     "test:preview-handler": "bun scripts/build-preview-handler.ts --test-architecture && bun scripts/build-preview-handler.ts --native-test",
     "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../windows && mkdir -p resources && rm -rf resources/web-dist && cp -R ../web/dist resources/web-dist",
-    "pack": "bun run build:runtime && bun run build:native-helper && bun run build:preview-handler && bun run build && electron-builder --win --config electron-builder.config.cjs --publish never",
+    "pack": "bun run build:runtime && bun run build:native-helper && bun run build:preview-handler && electron-builder --win --config electron-builder.config.cjs --publish never",
     "pack:debug": "VELLUM_ENABLE_CHROME_DEVTOOLS=true bun run pack"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- rebuild the Windows Electron main and preload entrypoints from the electron-builder beforePack hook
- prevent direct electron-builder invocations from packaging stale ignored output
- keep local, smoke, and release packaging on the same build path

## Original prompt

A locally built Windows Setup.exe showed that local mode was unavailable because its Windows providers were not installed after selecting a local assistant. The installer had packaged a stale ignored main-process bundle containing the obsolete fallback, so packaging must always rebuild the Electron entrypoints before collecting files.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->