### PR TITLE
Fix Electron post-login cloud assistant routing

### DIFF
--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -184,9 +184,22 @@ describe("resolveNativePostAuthDestination", () => {
 
 describe("startAuthFlow on Electron", () => {
   const windowWithBridge = window as { vellum?: unknown };
+  const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
+
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: { href: "app://vellum.ai/assistant/welcome" },
+    });
+  });
 
   afterEach(() => {
     delete windowWithBridge.vellum;
+    useResolvedAssistantsStore.setState({ assistants: [] });
+    if (originalLocation) {
+      Object.defineProperty(window, "location", originalLocation);
+    }
   });
 
   test("a bridge without auth.startOAuth rejects instead of falling into the loopback flow", async () => {
@@ -214,6 +227,44 @@ describe("startAuthFlow on Electron", () => {
 
     expect(startOAuth).toHaveBeenCalledTimes(1);
     expect(startOAuth).toHaveBeenCalledWith({ intent: "login" });
+  });
+
+  test("refreshes the account before choosing the post-login destination", async () => {
+    const startOAuth = mock(() =>
+      Promise.resolve({ sessionToken: "session-token" }),
+    );
+    windowWithBridge.vellum = { platform: "electron", auth: { startOAuth } };
+    const { useAuthStore } = await import("@/stores/auth-store");
+    const originalRefreshSession = useAuthStore.getState().refreshSession;
+    const refreshSession = mock(async () => {
+      useResolvedAssistantsStore.setState({
+        assistants: [
+          {
+            id: "asst-1",
+            hatchedAt: new Date(
+              Date.now() - ONBOARDED_HATCH_AGE_MS,
+            ).toISOString(),
+            isLocal: false,
+            isPlatformHosted: true,
+            isPaired: false,
+          },
+        ],
+      });
+      return true;
+    });
+    useAuthStore.setState({ refreshSession });
+
+    try {
+      await startAuthFlow("workos", "/account/provider/callback", {
+        returnTo: routes.onboarding.hosting,
+        intent: "login",
+      });
+    } finally {
+      useAuthStore.setState({ refreshSession: originalRefreshSession });
+    }
+
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+    expect(window.location.href).toBe(routes.assistant);
   });
 });
 

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -46,6 +46,12 @@ mock.module("@/lib/auth/allauth-client", () => ({
   getSession: async () => ({ ok: true, data: { user: { id: "user-1" } } }),
 }));
 
+const refreshSession = mock(async () => true);
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: { getState: () => ({ refreshSession }) },
+  whenPlatformSessionSettled: async () => {},
+}));
+
 const {
   clearStaleNativeCheckoutStash,
   resolveNativePostAuthDestination,
@@ -234,9 +240,7 @@ describe("startAuthFlow on Electron", () => {
       Promise.resolve({ sessionToken: "session-token" }),
     );
     windowWithBridge.vellum = { platform: "electron", auth: { startOAuth } };
-    const { useAuthStore } = await import("@/stores/auth-store");
-    const originalRefreshSession = useAuthStore.getState().refreshSession;
-    const refreshSession = mock(async () => {
+    refreshSession.mockImplementationOnce(async () => {
       useResolvedAssistantsStore.setState({
         assistants: [
           {
@@ -252,16 +256,11 @@ describe("startAuthFlow on Electron", () => {
       });
       return true;
     });
-    useAuthStore.setState({ refreshSession });
 
-    try {
-      await startAuthFlow("workos", "/account/provider/callback", {
-        returnTo: routes.onboarding.hosting,
-        intent: "login",
-      });
-    } finally {
-      useAuthStore.setState({ refreshSession: originalRefreshSession });
-    }
+    await startAuthFlow("workos", "/account/provider/callback", {
+      returnTo: routes.onboarding.hosting,
+      intent: "login",
+    });
 
     expect(refreshSession).toHaveBeenCalledTimes(1);
     expect(window.location.href).toBe(routes.assistant);

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -239,7 +239,11 @@ describe("startAuthFlow on Electron", () => {
     const startOAuth = mock(() =>
       Promise.resolve({ sessionToken: "session-token" }),
     );
-    windowWithBridge.vellum = { platform: "electron", auth: { startOAuth } };
+    windowWithBridge.vellum = {
+      platform: "electron",
+      auth: { startOAuth },
+      menu: { setPlatformSession: async () => {} },
+    };
     refreshSession.mockImplementationOnce(async () => {
       useResolvedAssistantsStore.setState({
         assistants: [

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -311,9 +311,9 @@ export function getSessionTokenFromCookies(): string | null {
  * Post-auth destination for the native (Capacitor/Electron) flows. Delegates
  * the signup checkout-stash + destination decision to the shared
  * `resolveSignupCheckoutDestination`. A first-run signup routes through
- * consent (privacy) first. An already-onboarded assistant skips privacy and
- * research. A login keeps its `returnTo` unless that target is the first-run
- * funnel and the assistant is already onboarded.
+ * consent (privacy) first. An already-onboarded assistant skips hosting,
+ * privacy, and research. A login keeps its `returnTo` unless that target is
+ * the first-run funnel and the assistant is already onboarded.
  */
 export function resolveNativePostAuthDestination(
   intent: string | undefined,
@@ -348,6 +348,7 @@ function isFirstRunOnboardingReturnTo(
   }
   const pathname = returnTo.split(/[?#]/)[0] ?? returnTo;
   return (
+    pathname === routes.onboarding.hosting ||
     pathname === routes.onboarding.privacy ||
     pathname === routes.onboarding.research
   );

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -462,6 +462,13 @@ export async function startAuthFlow(
       });
       if (result?.sessionToken) {
         primeElectronSessionToken(result.sessionToken);
+        // Reconcile the account before choosing where login lands. Keep this
+        // dynamic because auth-store imports this module.
+        const { useAuthStore, whenPlatformSessionSettled } = await import(
+          "@/stores/auth-store"
+        );
+        await useAuthStore.getState().refreshSession();
+        await whenPlatformSessionSettled();
         await setMenuPlatformSession(true);
         const destination = sanitizeReturnTo(
           resolveNativePostAuthDestination(options.intent, options.returnTo),


### PR DESCRIPTION
## Summary

- refresh the authenticated Electron session before resolving the post-login destination
- wait for platform assistant reconciliation so existing cloud assistants do not leave fresh installs on a locked hosting card
- add regression coverage for an installed desktop client logging into an established account

## Original prompt

Investigate the locally built Windows Setup.exe initial login flow, where OAuth returned to the app but the Vellum Cloud option remained grayed out. Ship the fix through the standard isolated-worktree PR workflow.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->