### PR TITLE
chore(web): camera-mode polish sweep (a11y, reduced motion, i18n) + device QA checklist

### DIFF
--- a/clients/web/src/domains/chat/voice/camera-shutter.stories.tsx
+++ b/clients/web/src/domains/chat/voice/camera-shutter.stories.tsx
@@ -12,41 +12,20 @@
  * exercised.
  */
 
-import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 // The morph timings and the capture keyframe are hand-written in the app
 // stylesheet, which Storybook's preview.css does not pull in.
 import "@/index.css";
 
 import { CameraShutter } from "./camera-shutter";
-
-/**
- * A frame to read the shutter against: two stops of brightness, because a
- * control that only has to survive mid-grey is not being tested. Story-local
- * sample content standing in for camera video, not app styling.
- */
-const overFakeFeed: Decorator = (Story) => (
-  <div
-    style={{
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      gap: 48,
-      minHeight: 260,
-      padding: "56px 32px",
-      background:
-        "linear-gradient(115deg, #f4efe6 0%, #a9927a 38%, #2c2620 72%, #0b0a09 100%)",
-    }}
-  >
-    <Story />
-  </div>
-);
+import { CameraRowFlipStandIn, overFakeFeed } from "./camera-story-feed";
 
 const meta: Meta<typeof CameraShutter> = {
   title: "Chat/Voice/CameraShutter",
   component: CameraShutter,
   parameters: { layout: "fullscreen" },
-  decorators: [overFakeFeed],
+  decorators: [overFakeFeed({ gap: 48 })],
   args: {
     ariaLabel: "Take photo",
     mode: "photo",
@@ -126,9 +105,12 @@ export const ReducedMotion: Story = {
 export const InTheCameraRow: Story = {
   render: (args) => (
     <div className="relative flex w-[390px] items-center justify-center">
-      <span className="absolute left-11 size-[46px] rounded-full border border-white/20 bg-black/42" />
+      <span
+        aria-hidden
+        className="absolute left-11 size-[46px] rounded-full border border-white/20 bg-black/42"
+      />
       <CameraShutter {...args} />
-      <span className="absolute right-[30px] size-13 rounded-full bg-[rgba(90,74,64,0.75)]" />
+      <CameraRowFlipStandIn />
     </div>
   ),
 };

--- a/clients/web/src/domains/chat/voice/camera-story-feed.tsx
+++ b/clients/web/src/domains/chat/voice/camera-story-feed.tsx
@@ -1,0 +1,81 @@
+/**
+ * The stand-in for the camera feed that every camera story is read against.
+ *
+ * Storybook has no `getUserMedia`, and none of the camera components takes a
+ * stream: each assumes media behind it rather than being handed one, which is
+ * what makes a gradient a complete substitute, and is how the design reference
+ * fakes it too. One module rather than a copy per story file, so a frame that
+ * stops being the honest test case stops being it everywhere at once.
+ *
+ * Story-local sample content standing in for camera video. Nothing here is app
+ * styling, and nothing outside a `.stories.tsx` file imports it.
+ */
+
+import type { Decorator } from "@storybook/react-vite";
+import type { CSSProperties } from "react";
+
+import { CAMERA_WARM } from "./voice-room/camera-mode-paint";
+
+/**
+ * Two stops of brightness in one frame. A control that only has to survive
+ * mid-grey is not being tested, and camera chrome carries no fill it can fall
+ * back on, so the question every story here asks is which frames it survives.
+ */
+export const CAMERA_STORY_FEED =
+  "linear-gradient(115deg, #f4efe6 0%, #a9927a 38%, #2c2620 72%, #0b0a09 100%)";
+
+/**
+ * A dim room lit from the top left: the case the status pill's glass has to
+ * hold up over, where the bright frame above tells you nothing.
+ */
+export const CAMERA_STORY_FEED_DIM =
+  "radial-gradient(120% 90% at 22% 8%, #6d5c4d 0%, #3a3129 42%, #17130f 100%)";
+
+export interface FakeFeedOptions {
+  /** How the story's own cells lay out inside the frame. */
+  direction?: "row" | "column";
+  /** Space between those cells, in pixels. */
+  gap?: number;
+  /** Which frame to read against. Defaults to {@link CAMERA_STORY_FEED}. */
+  background?: string;
+}
+
+/** Puts a story over a stand-in feed. */
+export function overFakeFeed({
+  direction = "row",
+  gap = 32,
+  background = CAMERA_STORY_FEED,
+}: FakeFeedOptions = {}): Decorator {
+  const style: CSSProperties = {
+    display: "flex",
+    flexDirection: direction,
+    alignItems: "center",
+    justifyContent: "center",
+    gap,
+    minHeight: 260,
+    padding: "56px 24px",
+    background,
+  };
+
+  return (Story) => (
+    <div style={style}>
+      <Story />
+    </div>
+  );
+}
+
+/**
+ * Flip, at its place in the shutter row, drawn rather than rendered: the
+ * stories that show the row are about the control in the middle of it, and a
+ * live control off to the side would be a second thing to press. The fill comes
+ * off the same constant the real one reads, so the stand-in cannot drift.
+ */
+export function CameraRowFlipStandIn() {
+  return (
+    <span
+      aria-hidden
+      className="absolute right-[30px] size-13 rounded-full"
+      style={{ background: CAMERA_WARM }}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/CAMERA_MODE_QA.md
+++ b/clients/web/src/domains/chat/voice/voice-room/CAMERA_MODE_QA.md
@@ -80,6 +80,11 @@ the deep-link capture overlay, which shares the shutter and the bottom scrim.
       speaker, camera, end. Every focus ring is a white outline legible over the
       feed, including over a white frame.
 - [ ] Escape minimizes the room from camera mode, and the camera releases.
+- [ ] Locale sweep. Switch the app to Spanish and then to Russian, open the
+      camera, and deny the permission in the browser. The pill, every control
+      name, and the failure message all read in that language. No key names
+      (`cameraError.permissionDenied` and the like) reach the screen, and no
+      English is left over.
 
 ## Design review
 
@@ -116,7 +121,9 @@ camera mode's to fix.
 
 - The Russian catalog lags English by roughly 630 keys across `chat.json`,
   including whole namespaces. The camera surface's own copy is complete in all
-  three locales; the rest is a catalog gap with no camera in it.
+  three locales, failure messages included (`cameraError.*`, `cameraDeepLink.*`,
+  `cameraStatusPill.*`, `liveVoiceStatus.*`, `voiceRoom.*`); the rest is a
+  catalog gap with no camera in it.
 - The shutter uses the native `disabled` attribute while a photo uploads, so a
   keyboard press drops focus to the document body until the round trip finishes.
   The attribute is part of the shared shutter's contract and the deep-link

--- a/clients/web/src/domains/chat/voice/voice-room/CAMERA_MODE_QA.md
+++ b/clients/web/src/domains/chat/voice/voice-room/CAMERA_MODE_QA.md
@@ -1,0 +1,130 @@
+# Camera mode: manual QA
+
+What the suite cannot reach. Every check here needs a real camera, a real screen
+reader, or a real OS setting, so it runs by hand.
+
+Surface under test: the voice room with the viewfinder up (the camera paths of
+`voice-room.tsx`, `camera-status-pill.tsx`, `camera-flash-control.tsx`,
+`camera-shutter.tsx`, and `voice-room-control.tsx` at `surface="camera"`), plus
+the deep-link capture overlay, which shares the shutter and the bottom scrim.
+
+## iPhone
+
+- [ ] The pill clears the notch. Open the camera in the fullscreen room on a
+      notched device and on a Dynamic Island device. The pill sits below the
+      island, on the minimize control's line, and never behind it.
+- [ ] The pill clears the corner control. Give the assistant a name of 40
+      characters or more and open the camera at portrait phone width. The name
+      truncates to an ellipsis, the dot and "Photo" stay whole, and the pill's
+      edge never reaches the minimize control.
+- [ ] The pill clears the grabber. In the mobile sheet, the pill sits below the
+      grabber and the grabber still takes the pull-down.
+- [ ] Flash fires on the rear camera. Cycle off, auto, on, and take a photo in a
+      dark room on each. `on` fires every time, `auto` fires when it is dark,
+      `off` never fires.
+- [ ] Flash is absent on the front camera. Flip to the selfie camera: the
+      control disappears rather than going dead. Flip back and it returns in the
+      mode it was left in.
+- [ ] Flash outlives the call. Set `on`, end the session, start a new one, open
+      the camera. It is still `on`.
+- [ ] Flash does not leak. Set `on` in the room, close the camera, then open the
+      deep-link capture overlay from a chat. Its capture does not fire.
+- [ ] Backgrounding releases the preview. With the viewfinder up, background the
+      app: the status bar's camera indicator goes out. Foreground it: the
+      viewfinder returns, or the room reports the failure. Never a frozen frame.
+- [ ] Minimizing releases the preview. Minimize with the camera up. The
+      indicator goes out and the session keeps running on the composer bar.
+- [ ] VoiceOver says it once. Open the camera and change state. Each change is
+      spoken once, as "Photo. Listening" or "Photo. {name} speaking". Mute the
+      mic mid-turn and the announcement carries "Muted". Nothing says the state
+      a second time.
+- [ ] VoiceOver reaches every control. Swipe through the chrome: minimize,
+      flash, shutter, flip, mic, speaker, camera, end. Each name matches what a
+      press does, and the flash names the state it is in rather than the act.
+- [ ] VoiceOver hears a failure. Deny the camera permission in Settings, then
+      press the camera control. The refusal is spoken, not only drawn.
+- [ ] The capture pulse reads. Take a photo against a bright frame and a dark
+      one. The crimson ring leaves the shutter and is visible on both, and
+      nothing flashes the whole screen.
+- [ ] Fat fingers. Hold the phone one-handed and take five photos in a row. No
+      press lands on flip, on flash, or on end session.
+
+## Android
+
+- [ ] Flipping does not crash. Open on the rear camera, flip to front, flip
+      back, five times over. `setFlashMode` is never called on a camera whose
+      probe came back empty, so a flashless front camera is a control that is
+      gone rather than an app that is.
+- [ ] The control tracks the probe. On a device whose front camera has no flash,
+      the control is present on the rear camera and absent on the front, with no
+      dead state in between.
+- [ ] The native preview shows through. The scrims, the pill, the shutter and
+      the control row all paint over live video, and nothing behind them shows
+      the app's own background.
+- [ ] The scrims reach the native preview. Point at a white wall: the top and
+      bottom bands darken enough to read the pill and the row, and the middle of
+      the frame stays untinted.
+- [ ] TalkBack says it once. Same check as VoiceOver above.
+
+## Desktop web and macOS
+
+- [ ] No flash, anywhere. There is no flash control in the browser or in the
+      desktop app, on any camera.
+- [ ] The pill is present. It renders in the panel variant and the fullscreen
+      variant, top centre, on the minimize control's line.
+- [ ] Reduced motion. Turn on Reduce Motion (macOS: Settings, Accessibility,
+      Display), reload, open the camera. The status dot holds still and fully
+      lit. The shutter's capture pulse still fires and is shorter. The core's
+      morph has no overshoot.
+- [ ] Keyboard walk. Tab from the top of the room: minimize, shutter, flip, mic,
+      speaker, camera, end. Every focus ring is a white outline legible over the
+      feed, including over a white frame.
+- [ ] Escape minimizes the room from camera mode, and the camera releases.
+
+## Design review
+
+Deliberate departures from the handoff. Each needs a yes or a correction before
+the redesign is called shipped.
+
+- [ ] Pill vertical offset. The design puts the pill 82pt from the top. The
+      build aligns it to the corner chrome's own offset, so it shares a line
+      with the minimize control instead of floating on a rhythm of its own.
+      Confirm the shared line, or take the 82.
+- [ ] Control row bottom anchor. The design puts the row 48pt from the bottom.
+      The build keeps the room's existing anchor, shared with the camera-closed
+      room, so the row holds still as the viewfinder opens. Confirm the shared
+      anchor, or accept the row jumping on open.
+- [ ] Speaker mute colour. The design draws the assistant mute red at all times.
+      The build reds it only while it is engaged, matching the mic beside it and
+      keeping red for a control that is doing something to the call. Confirm.
+- [ ] Morph readability. The core animates the `scale` property rather than
+      `transform`, because the utilities that size it set `transform`
+      themselves. Watch it both ways in Storybook (Chat/Voice/CameraShutter,
+      flip the `mode` control) and confirm the overshoot reads as a record
+      button starting rather than a circle being resized.
+- [ ] Desktop fidelity. The chrome is shared, so the crimson accent and the pill
+      apply to the desktop camera view too, minus the OS chrome and the sheet
+      grabber. Confirm that is wanted on desktop.
+- [ ] Minimize in camera mode. The design gives the camera view only the grabber
+      and end session as exits. The build keeps the top-right minimize control,
+      which is the only discoverable exit on desktop. Confirm.
+
+## Known adjacent issues
+
+Found by the polish audit and deliberately left alone, because none of them is
+camera mode's to fix.
+
+- The Russian catalog lags English by roughly 630 keys across `chat.json`,
+  including whole namespaces. The camera surface's own copy is complete in all
+  three locales; the rest is a catalog gap with no camera in it.
+- The shutter uses the native `disabled` attribute while a photo uploads, so a
+  keyboard press drops focus to the document body until the round trip finishes.
+  The attribute is part of the shared shutter's contract and the deep-link
+  overlay relies on it too.
+- The ambient transcript's two `aria-live` regions render over the viewfinder
+  when the captions preference is on. They carry speech rather than session
+  state, so they do not contradict the pill, but nothing stands them down while
+  the camera is up.
+- Every control in the room wraps a `Tooltip` whose content repeats the
+  accessible name, so assistive tech reads the name and then the same words as a
+  description. Room-wide, and older than camera mode.

--- a/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.stories.tsx
@@ -15,6 +15,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 
+import {
+  CameraRowFlipStandIn,
+  overFakeFeed,
+} from "@/domains/chat/voice/camera-story-feed";
 import type { FlashMode } from "@/stores/voice-prefs-store";
 
 import { CameraFlashControl, nextFlashMode } from "./camera-flash-control";
@@ -27,24 +31,6 @@ const LABELS: Record<FlashMode, string> = {
 };
 
 const ORDER: FlashMode[] = ["off", "auto", "on"];
-
-/**
- * A stand-in for the viewfinder. Two stops of brightness in one frame, because
- * a control that only has to survive mid-grey is not being tested.
- */
-function FeedBackdrop({ children }: { children: React.ReactNode }) {
-  return (
-    <div
-      className="flex min-h-[280px] items-center justify-center gap-10 rounded-xl p-10"
-      style={{
-        background:
-          "linear-gradient(115deg, #f4efe6 0%, #a9927a 38%, #2c2620 72%, #0b0a09 100%)",
-      }}
-    >
-      {children}
-    </div>
-  );
-}
 
 /** One state, captioned, so the three can be compared side by side. */
 function StateCell({ mode }: { mode: FlashMode }) {
@@ -64,14 +50,8 @@ function StateCell({ mode }: { mode: FlashMode }) {
 const meta: Meta<typeof CameraFlashControl> = {
   title: "Chat/Voice/Camera Flash Control",
   component: CameraFlashControl,
-  parameters: { layout: "centered" },
-  decorators: [
-    (Story) => (
-      <FeedBackdrop>
-        <Story />
-      </FeedBackdrop>
-    ),
-  ],
+  parameters: { layout: "fullscreen" },
+  decorators: [overFakeFeed({ gap: 40 })],
 };
 
 export default meta;
@@ -134,10 +114,13 @@ export const InTheShutterRow: Story = {
         onClick={() => {}}
         className="absolute left-11"
       />
-      <span className="flex size-[84px] items-center justify-center rounded-full border-[2.5px] border-white">
+      <span
+        aria-hidden
+        className="flex size-[84px] items-center justify-center rounded-full border-[2.5px] border-white"
+      >
         <span className="size-16 rounded-full bg-white" />
       </span>
-      <span className="absolute right-[30px] size-13 rounded-full bg-[rgba(90,74,64,0.75)]" />
+      <CameraRowFlipStandIn />
     </div>
   ),
 };

--- a/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.test.tsx
@@ -120,4 +120,27 @@ describe("CameraFlashControl", () => {
     expect(badge("on")).toBe("");
     expect(badge("off")).toBe("");
   });
+
+  test("the target reaches a thumb even though the circle does not", () => {
+    render(
+      <CameraFlashControl
+        mode="off"
+        ariaLabel="Flash off"
+        autoBadge="A"
+        onClick={() => {}}
+        testId="flash"
+      />,
+    );
+
+    // 46px of visible circle, because a wider one crowds the shutter beside it,
+    // and 4px of invisible margin on every side taking the pressable box to 54.
+    // The platform minimum is 44, and it is the pseudo-element that gets this
+    // control there, so a restyle that drops it breaks the one thing about this
+    // button nobody can see.
+    const className = screen.getByTestId("flash").className;
+    expect(className).toContain("size-[46px]");
+    expect(className).toContain("after:absolute");
+    expect(className).toContain("after:-inset-1");
+    expect(className).toContain("after:content-['']");
+  });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.stories.tsx
@@ -14,40 +14,32 @@
  * "Listening" would be telling them the mic is open.
  */
 
-import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 // The dot's blink is a hand-written keyframe in the app stylesheet, which
 // Storybook's preview.css does not pull in.
 import "@/index.css";
 
-import { CameraStatusPill } from "./camera-status-pill";
+import {
+  CAMERA_STORY_FEED_DIM,
+  overFakeFeed,
+} from "@/domains/chat/voice/camera-story-feed";
 
-/**
- * A frame to read the pill against: a dim room, lit from the top left, which
- * is the case the pill's glass has to survive. Story-local sample content
- * standing in for camera video, not app styling.
- */
-const overFakeFeed: Decorator = (Story) => (
-  <div
-    style={{
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      gap: 16,
-      padding: "56px 24px",
-      background:
-        "radial-gradient(120% 90% at 22% 8%, #6d5c4d 0%, #3a3129 42%, #17130f 100%)",
-    }}
-  >
-    <Story />
-  </div>
-);
+import { CameraStatusPill } from "./camera-status-pill";
 
 const meta: Meta<typeof CameraStatusPill> = {
   title: "Chat/Voice/CameraStatusPill",
   component: CameraStatusPill,
   parameters: { layout: "fullscreen" },
-  decorators: [overFakeFeed],
+  // The dim frame rather than the bright one: what the pill's glass has to
+  // survive is a frame with nothing in it to read against.
+  decorators: [
+    overFakeFeed({
+      direction: "column",
+      gap: 16,
+      background: CAMERA_STORY_FEED_DIM,
+    }),
+  ],
   args: {
     voiceState: "idle",
     statusLabel: "Listening…",

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-camera.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-camera.ts
@@ -29,22 +29,40 @@ import { captureError } from "@/lib/sentry/capture-error";
 
 import { useVoiceCamera, type VoiceCamera } from "./voice-camera";
 
+/** The catalog keys this hook can hand back. See {@link CAMERA_ERROR_KEYS}. */
+export type CameraErrorKey =
+  | "cameraError.permissionDenied"
+  | "cameraError.noDevice"
+  | "cameraError.deviceInUse"
+  | "cameraError.unsupported"
+  | "cameraError.unknown"
+  | "cameraError.captureFailed"
+  | "cameraError.uploadFailed"
+  | "cameraError.notDelivered"
+  | "cameraError.refused"
+  | "cameraError.storeFailed";
+
 /**
- * What the room tells the user when the camera or a photo fails. Short and
- * plain: it is read at a glance, over a live call, by someone holding a phone
- * up at something.
+ * What the room tells the user when the camera or a photo fails, as a catalog
+ * key. Short and plain copy: it is read at a glance, over a live call, by
+ * someone holding a phone up at something.
+ *
+ * Keys rather than sentences because this module is a hook, not a component,
+ * and the room is where a translator's `t` already is. Same reason the status
+ * pill takes the session's word as a key: one decision table, translated once,
+ * at the surface that renders it.
  */
-const CAMERA_ERROR_COPY: Record<string, string> = {
-  "permission-denied": "Camera access is off for Vellum.",
-  "no-device": "No camera found.",
-  "device-in-use": "Another app is using the camera.",
-  unsupported: "This device can't open a camera.",
-  unknown: "Couldn't open the camera.",
-  "capture-failed": "Couldn't take that photo.",
-  "upload-failed": "Couldn't send that photo.",
-  "not-delivered": "Reconnecting. Take that one again.",
-  refused: "Your assistant can't receive photos yet.",
-  "store-failed": "Couldn't add that photo to the conversation.",
+const CAMERA_ERROR_KEYS: Record<string, CameraErrorKey> = {
+  "permission-denied": "cameraError.permissionDenied",
+  "no-device": "cameraError.noDevice",
+  "device-in-use": "cameraError.deviceInUse",
+  unsupported: "cameraError.unsupported",
+  unknown: "cameraError.unknown",
+  "capture-failed": "cameraError.captureFailed",
+  "upload-failed": "cameraError.uploadFailed",
+  "not-delivered": "cameraError.notDelivered",
+  refused: "cameraError.refused",
+  "store-failed": "cameraError.storeFailed",
 };
 
 /**
@@ -79,8 +97,11 @@ export interface VoiceRoomCamera {
    * is behind the room.
    */
   readonly photos: readonly VoiceRoomPhoto[];
-  /** User-facing failure for the camera or the last photo, or null. */
-  readonly errorMessage: string | null;
+  /**
+   * Catalog key for the camera's or the last photo's failure, or null.
+   * Translated by the room, which is where the copy is read.
+   */
+  readonly errorKey: CameraErrorKey | null;
   /** Capture the current frame, upload it, and hand it to the session. */
   readonly shutter: () => Promise<void>;
   /** Open the viewfinder. Call directly from a tap (iOS permission alert). */
@@ -245,14 +266,16 @@ export function useVoiceRoomCamera(
 
   // The camera's own failure wins over a stale photo failure: if the viewfinder
   // is not running, "couldn't send that photo" describes the wrong problem.
-  const errorKey = camera.error ?? sendError;
+  const failure = camera.error ?? sendError;
 
   return {
     camera,
     sending,
     photos,
-    errorMessage: errorKey
-      ? (CAMERA_ERROR_COPY[errorKey] ?? CAMERA_ERROR_COPY.unknown!)
+    // A classification with no copy of its own (`aborted`, which nothing is
+    // meant to show) still says something rather than going silent.
+    errorKey: failure
+      ? (CAMERA_ERROR_KEYS[failure] ?? CAMERA_ERROR_KEYS.unknown!)
       : null,
     shutter,
     open,

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.stories.tsx
@@ -11,38 +11,18 @@
  * live mic never reads as a muted one.
  */
 
-import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { CameraOff, Mic, MicOff, Volume2, VolumeX, X } from "lucide-react";
 
-import { VoiceRoomControl } from "./voice-room-control";
+import { overFakeFeed } from "@/domains/chat/voice/camera-story-feed";
 
-/**
- * A frame to read the controls against: two stops of brightness, because a row
- * that only has to survive mid-grey is not being tested. Story-local sample
- * content standing in for camera video, not app styling.
- */
-const overFakeFeed: Decorator = (Story) => (
-  <div
-    style={{
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      gap: 32,
-      minHeight: 240,
-      padding: "56px 24px",
-      background:
-        "linear-gradient(115deg, #f4efe6 0%, #a9927a 38%, #2c2620 72%, #0b0a09 100%)",
-    }}
-  >
-    <Story />
-  </div>
-);
+import { VoiceRoomControl } from "./voice-room-control";
 
 const meta: Meta<typeof VoiceRoomControl> = {
   title: "Chat/Voice/VoiceRoomControl",
   component: VoiceRoomControl,
   parameters: { layout: "fullscreen" },
-  decorators: [overFakeFeed],
+  decorators: [overFakeFeed({ direction: "column" })],
   args: { surface: "camera", onClick: () => {} },
 };
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.test.tsx
@@ -93,4 +93,16 @@ describe("VoiceRoomControl", () => {
     expect(media.className).toContain("bg-black/45");
     expect(media.className).not.toContain("bg-white");
   });
+
+  test("every control is the same 52px, on every surface", () => {
+    // 52 clears the 44pt a thumb needs on its own, so nothing here depends on
+    // an invisible margin the way the flash control does. Held equal across the
+    // surfaces because the row is the same row whether or not the viewfinder is
+    // up, and a control that resized as the camera opened would move out from
+    // under a thumb already on its way to it.
+    for (const surface of ["room", "media", "camera"] as const) {
+      expect(renderControl({ surface }).className).toContain("size-13");
+      cleanup();
+    }
+  });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -2195,6 +2195,11 @@ describe("VoiceRoom: camera", () => {
     });
 
     expect(announcer().textContent).toMatch(/Camera access is off/);
+    // A sentence, not the key that names it. The hook classifies the failure
+    // and the room translates it, so a key with no catalog entry would reach
+    // the user as "cameraError.permissionDenied" in every language including
+    // this one.
+    expect(announcer().textContent).not.toContain("cameraError.");
     // The visible chip says the same words, so it is decoration by then:
     // announcing both would read the failure twice.
     expect(

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -1955,6 +1955,36 @@ describe("VoiceRoom: camera", () => {
     expect(screen.queryByTestId("voice-room-flash")).toBeNull();
   });
 
+  test("camera mode hands a keyboard the room from the corner down", async () => {
+    stubMediaDevices(async () => fakeStream());
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    // Corner chrome, then the shutter row, then the session row: the order the
+    // eye reads them in, so a keyboard walks the surface top to bottom. Every
+    // control the camera adds is reachable, and none of them lands between the
+    // two mutes. Flash, absent on this path, joins its own row ahead of the
+    // shutter. The pill is not here on purpose: it answers no press.
+    const order = Array.from(
+      document.querySelectorAll<HTMLElement>("button:not([disabled])"),
+    ).map((button) => button.getAttribute("aria-label"));
+
+    expect(order).toEqual([
+      "Minimize voice room",
+      "Take a photo",
+      "Flip camera",
+      "Mute microphone",
+      "Mute assistant",
+      "Close camera",
+      "End voice session",
+    ]);
+  });
+
   test("a failed flip falls back to the camera the user already had", async () => {
     // A phone that cannot hold two captures at once: the first camera opens,
     // the flip's request fails, and reopening the original succeeds.
@@ -2004,7 +2034,9 @@ describe("VoiceRoom: camera", () => {
       });
 
       expect(uploadChatAttachmentSpy).toHaveBeenCalled();
-      expect(screen.queryByText(/Reconnecting/)).not.toBeNull();
+      expect(screen.getByTestId("voice-room-camera-error").textContent).toMatch(
+        /Reconnecting/,
+      );
       // The viewfinder stays up: the user is being asked to take it again.
       expect(viewfinder()).not.toBeNull();
     } finally {
@@ -2092,7 +2124,9 @@ describe("VoiceRoom: camera", () => {
           .getAllByTestId("voice-room-photo")[0]
           ?.getAttribute("data-status"),
       ).toBe("failed");
-      expect(screen.queryByText(/can't receive photos/)).not.toBeNull();
+      expect(screen.getByTestId("voice-room-camera-error").textContent).toMatch(
+        /can't receive photos/,
+      );
     } finally {
       restoreCapture();
     }
@@ -2137,6 +2171,40 @@ describe("VoiceRoom: camera", () => {
     expect(viewfinder()).toBeNull();
     // The denial is named where the user is looking, rather than leaving a
     // control that appears to do nothing.
-    expect(screen.queryByText(/Camera access is off/)).not.toBeNull();
+    expect(screen.getByTestId("voice-room-camera-error").textContent).toMatch(
+      /Camera access is off/,
+    );
+  });
+
+  test("a camera failure is spoken by a region that was already listening", async () => {
+    stubMediaDevices(async () => {
+      throw new DOMException("denied", "NotAllowedError");
+    });
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    // Mounted and silent before anything fails. Assistive tech announces a
+    // change made inside a region it was already watching, so a region that
+    // arrives with the message already in it is announced by nothing reliable.
+    const announcer = () => screen.getByTestId("voice-room-camera-announcer");
+    expect(announcer().textContent).toBe("");
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    expect(announcer().textContent).toMatch(/Camera access is off/);
+    // The visible chip says the same words, so it is decoration by then:
+    // announcing both would read the failure twice.
+    expect(
+      screen.getByTestId("voice-room-camera-error").getAttribute("aria-hidden"),
+    ).toBe("true");
+    // And a camera failure never costs the session its own announcement: the
+    // message stands until the camera is opened or closed again, which folded
+    // into one region would silence every state change for that whole time.
+    expect(screen.getByTestId("voice-room-state-announcer").textContent).toBe(
+      "Listening…",
+    );
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -1041,8 +1041,14 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           }}
         >
           {errorMessage ? (
+            // Visual only. A live region carrying its own first content is
+            // announced unreliably, since assistive tech watches an existing
+            // region for changes rather than a new one for arrival, and this
+            // element mounts with the message already in it. The always-mounted
+            // region at the foot of the room speaks it instead.
             <p
-              role="status"
+              aria-hidden
+              data-testid="voice-room-camera-error"
               className={cn(
                 "rounded-full px-3 py-1 text-xs",
                 // Same reason the controls get a scrim: a failed send reported
@@ -1278,6 +1284,23 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           : muted && state !== "listening"
             ? t("voiceRoom.mutedState", { state: stateLabel })
             : stateLabel}
+      </div>
+
+      {/* The camera's own failures, in words.
+
+          A region of its own rather than a branch of the one above, because the
+          two answer different questions and a failure stands until the camera is
+          opened or closed again: folding it in would silence every state change
+          for as long as the message lasted. Mounted whether or not there is
+          anything to say, since assistive tech announces a change made INSIDE a
+          region it was already watching, not the arrival of a region that comes
+          with its words already in it. */}
+      <div
+        aria-live="polite"
+        className="sr-only"
+        data-testid="voice-room-camera-announcer"
+      >
+        {errorMessage ?? ""}
       </div>
     </motion.div>
   );

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -531,8 +531,12 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   const cameraSupported =
     useSupportsVoiceCamera(assistantId) && isVoiceCameraSupported();
   const viewfinderRef = useRef<HTMLVideoElement | null>(null);
-  const { camera, sending, photos, errorMessage, shutter, open, close } =
+  const { camera, sending, photos, errorKey, shutter, open, close } =
     useVoiceRoomCamera(assistantId, viewfinderRef);
+  // The hook classifies the failure and names it; the room is where a
+  // translator's `t` already is, so the sentence is resolved here. Same split
+  // as the status pill's word below.
+  const errorMessage = errorKey ? t(errorKey) : null;
   const cameraOpen = camera.open;
   // What every control in the room is sitting on. One value passed down rather
   // than a boolean per control, so the row cannot end up half in camera mode.

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -240,6 +240,18 @@
     "shutter": "Take photo",
     "title": "Take a photo"
   },
+  "cameraError": {
+    "captureFailed": "Couldn't take that photo.",
+    "deviceInUse": "Another app is using the camera.",
+    "noDevice": "No camera found.",
+    "notDelivered": "Reconnecting. Take that one again.",
+    "permissionDenied": "Camera access is off for Vellum.",
+    "refused": "Your assistant can't receive photos yet.",
+    "storeFailed": "Couldn't add that photo to the conversation.",
+    "unknown": "Couldn't open the camera.",
+    "unsupported": "This device can't open a camera.",
+    "uploadFailed": "Couldn't send that photo."
+  },
   "cameraStatusPill": {
     "announcePhotoMutedSpeaking": "Photo. Muted. {name} speaking",
     "announcePhotoMutedStatus": "Photo. Muted. {status}",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -240,6 +240,18 @@
     "shutter": "Tomar foto",
     "title": "Tomar una foto"
   },
+  "cameraError": {
+    "captureFailed": "No se pudo tomar esa foto.",
+    "deviceInUse": "Otra aplicación está usando la cámara.",
+    "noDevice": "No se encontró ninguna cámara.",
+    "notDelivered": "Reconectando. Toma esa foto de nuevo.",
+    "permissionDenied": "El acceso a la cámara está desactivado para Vellum.",
+    "refused": "Tu asistente todavía no puede recibir fotos.",
+    "storeFailed": "No se pudo añadir esa foto a la conversación.",
+    "unknown": "No se pudo abrir la cámara.",
+    "unsupported": "Este dispositivo no puede abrir una cámara.",
+    "uploadFailed": "No se pudo enviar esa foto."
+  },
   "cameraStatusPill": {
     "announcePhotoMutedSpeaking": "Foto. Silenciado. {name} está hablando",
     "announcePhotoMutedStatus": "Foto. Silenciado. {status}",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -147,6 +147,18 @@
     "shutter": "Сделать фото",
     "title": "Сделать фото"
   },
+  "cameraError": {
+    "captureFailed": "Не удалось сделать это фото.",
+    "deviceInUse": "Камеру использует другое приложение.",
+    "noDevice": "Камера не найдена.",
+    "notDelivered": "Переподключение. Сделайте это фото ещё раз.",
+    "permissionDenied": "Доступ к камере для Vellum отключён.",
+    "refused": "Ваш ассистент пока не может получать фото.",
+    "storeFailed": "Не удалось добавить это фото в разговор.",
+    "unknown": "Не удалось открыть камеру.",
+    "unsupported": "Это устройство не может открыть камеру.",
+    "uploadFailed": "Не удалось отправить это фото."
+  },
   "cameraStatusPill": {
     "announcePhotoMutedSpeaking": "Фото. Без звука. {name} говорит",
     "announcePhotoMutedStatus": "Фото. Без звука. {status}",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -139,6 +139,14 @@
     "syntheticYield": "Пауза · сжатие не уместило следующий шаг",
     "unrecognizedCall": "Неизвестный вызов"
   },
+  "cameraDeepLink": {
+    "captureFailed": "Не удалось сделать фото. Попробуйте ещё раз.",
+    "close": "Закрыть камеру",
+    "flip": "Сменить камеру",
+    "openFailed": "Не удалось открыть камеру.",
+    "shutter": "Сделать фото",
+    "title": "Сделать фото"
+  },
   "cameraStatusPill": {
     "announcePhotoMutedSpeaking": "Фото. Без звука. {name} говорит",
     "announcePhotoMutedStatus": "Фото. Без звука. {status}",
@@ -730,5 +738,25 @@
   },
   "voiceErrors": {
     "nativeSttNoTranscript": "Нативная диктовка {clientName} не вернула расшифровку. Проверьте нативное распознавание речи в системных настройках и повторите попытку."
+  },
+  "voiceRoom": {
+    "ariaLabel": "Голосовой сеанс",
+    "closeCamera": "Закрыть камеру",
+    "endSessionAria": "Завершить голосовой сеанс",
+    "endSessionTooltip": "Завершить сеанс",
+    "flashAuto": "Автоматическая вспышка",
+    "flashAutoBadge": "А",
+    "flashOff": "Вспышка выключена",
+    "flashOn": "Вспышка включена",
+    "flipCamera": "Сменить камеру",
+    "minimizeAria": "Свернуть голосовую комнату",
+    "minimizeTooltip": "Свернуть (сеанс продолжится)",
+    "muteAssistant": "Отключить звук ассистента",
+    "muteMicrophone": "Отключить микрофон",
+    "mutedState": "Без звука. {state}",
+    "showCamera": "Показать камеру",
+    "takePhoto": "Сделать фото",
+    "unmuteAssistant": "Включить звук ассистента",
+    "unmuteMicrophone": "Включить микрофон"
   }
 }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -477,6 +477,9 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   --camera-shutter-morph-duration: 0.4s;
   --camera-shutter-morph-ease: cubic-bezier(0.34, 1.5, 0.5, 1);
   --camera-shutter-pulse-duration: 500ms;
+  /* The ring takes the duration but not the ease: the morph curve overshoots
+   * past 1, which on a color means interpolating past the target, so only the
+   * core's scale is timed with it. */
   transition: border-color var(--camera-shutter-morph-duration) ease;
 }
 
@@ -496,10 +499,20 @@ html[data-page-transition="pop"]::view-transition-new(root) {
     opacity var(--camera-shutter-morph-duration) ease;
 }
 
+/* The lit frame declares the crimson literal first and then reads the same
+ * color back off `--camera-accent` (published by `camera-mode-paint.ts` and
+ * inherited from the shutter this span sits inside): engines without
+ * color-mix() (Safari/iOS < 16.2, which the iOS shell still targets) drop the
+ * second declaration and keep the literal, and everywhere else the accent stays
+ * single-sourced. Same pattern as the wave accents below. The later frames fade
+ * to nothing, which is a color with no identity to duplicate. */
 @keyframes camera-shutter-pulse {
-  0% { box-shadow: 0 0 0 0 rgba(207, 67, 112, 0.75); }
-  70% { box-shadow: 0 0 0 12px rgba(207, 67, 112, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(207, 67, 112, 0); }
+  0% {
+    box-shadow: 0 0 0 0 rgba(207, 67, 112, 0.75);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--camera-accent) 75%, transparent);
+  }
+  70% { box-shadow: 0 0 0 12px transparent; }
+  100% { box-shadow: 0 0 0 0 transparent; }
 }
 
 .camera-shutter-pulse {


### PR DESCRIPTION
## Summary
- Audits the merged camera-mode surface: single-announcer a11y, focus order and hit areas, reduced-motion coverage, i18n completeness, constant/story consistency
- Fixes what the audits found (details in commits)
- Adds the manual device QA checklist including the accumulated design-review flags

Part of plan: voice-camera-mode-redesign.md (PR 5 of 5)