### PR TITLE
feat(web): model-first profile create behind model-first-profile-create flag

### DIFF
--- a/clients/web/.storybook/viewports.ts
+++ b/clients/web/.storybook/viewports.ts
@@ -18,6 +18,16 @@ export const SB_VIEWPORTS = {
     styles: { width: "390px", height: "844px" },
     type: "mobile" as const,
   },
+  /**
+   * A desktop window too short for what it holds. Height is the whole point:
+   * a dialog that keeps room for an open menu has to give that room back
+   * here, and a story pinned to it shows whether the footer survives.
+   */
+  sbShort: {
+    name: "Desktop (short)",
+    styles: { width: "1280px", height: "500px" },
+    type: "desktop" as const,
+  },
 };
 
 /** The width stories start at. See `preview.tsx` for why it is not pinned. */

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -24,6 +24,14 @@ export interface LlmCatalogModel {
    * no older siblings carries none.
    */
   family?: string;
+  /**
+   * The organisation that made the model, never the one serving it. Set only
+   * where the two differ, which is every model listed first by a provider
+   * that hosts other people's work: Kimi is Moonshot's whoever runs it. A
+   * model listed first by the organisation that made it carries none, and
+   * falls back to that provider's own name.
+   */
+  vendor?: string;
   supportsThinking?: boolean;
   adaptiveThinkingOnly?: boolean;
   longContextPricingThresholdTokens?: number;
@@ -320,6 +328,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "llama3.2",
       displayName: "Llama 3.2",
+      vendor: "meta",
       contextWindowTokens: 128_000,
       defaultContextWindowTokens: 128_000,
       maxOutputTokens: 4_096,
@@ -327,6 +336,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "mistral",
       displayName: "Mistral",
+      vendor: "mistral",
       contextWindowTokens: 32_768,
       defaultContextWindowTokens: 32_768,
       maxOutputTokens: 4_096,
@@ -336,6 +346,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/kimi-k3",
       displayName: "Kimi K3",
+      vendor: "moonshot",
       family: "kimi-k",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
@@ -346,6 +357,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/kimi-k2p6",
       displayName: "Kimi K2.6",
+      vendor: "moonshot",
       family: "kimi-k",
       contextWindowTokens: 262_144,
       defaultContextWindowTokens: 200_000,
@@ -355,7 +367,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/glm-5p2",
       displayName: "GLM 5.2",
-      family: "glm",
+      vendor: "zhipu",
       contextWindowTokens: 1_040_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -366,6 +378,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/minimax-m3",
       displayName: "MiniMax M3",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 524_288,
       defaultContextWindowTokens: 200_000,
@@ -375,6 +388,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/minimax-m2p7",
       displayName: "MiniMax M2.7",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
@@ -383,6 +397,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/deepseek-v4-pro",
       displayName: "DeepSeek V4 Pro",
+      vendor: "deepseek",
       contextWindowTokens: 1_040_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -391,6 +406,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/deepseek-v4-flash-0731",
       displayName: "DeepSeek V4 Flash",
+      vendor: "deepseek",
       contextWindowTokens: 1_040_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -401,6 +417,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "MiniMaxAI/MiniMax-M3",
       displayName: "MiniMax M3",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 524_288,
       defaultContextWindowTokens: 200_000,
@@ -517,6 +534,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "openai/gpt-5.6-sol-pro",
       displayName: "GPT-5.6 Sol Pro",
+      vendor: "openai",
       contextWindowTokens: 1_050_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -535,6 +553,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "openai/gpt-5.6-terra-pro",
       displayName: "GPT-5.6 Terra Pro",
+      vendor: "openai",
       contextWindowTokens: 1_050_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -553,6 +572,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "openai/gpt-5.6-luna-pro",
       displayName: "GPT-5.6 Luna Pro",
+      vendor: "openai",
       contextWindowTokens: 1_050_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -562,6 +582,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "x-ai/grok-4.6",
       displayName: "Grok 4.6",
+      vendor: "xai",
       family: "grok",
       contextWindowTokens: 500_000,
       defaultContextWindowTokens: 200_000,
@@ -572,6 +593,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "x-ai/grok-4.5",
       displayName: "Grok 4.5",
+      vendor: "xai",
       family: "grok",
       contextWindowTokens: 500_000,
       defaultContextWindowTokens: 200_000,
@@ -581,6 +603,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "x-ai/grok-4.3",
       displayName: "Grok 4.3",
+      vendor: "xai",
       family: "grok",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
@@ -590,6 +613,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "x-ai/grok-4.20",
       displayName: "Grok 4.20",
+      vendor: "xai",
       family: "grok",
       contextWindowTokens: 2_000_000,
       defaultContextWindowTokens: 200_000,
@@ -599,6 +623,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "deepseek/deepseek-r1-0528",
       displayName: "DeepSeek R1",
+      vendor: "deepseek",
       contextWindowTokens: 163_840,
       defaultContextWindowTokens: 163_840,
       maxOutputTokens: 32_000,
@@ -607,6 +632,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "deepseek/deepseek-chat-v3-0324",
       displayName: "DeepSeek V3",
+      vendor: "deepseek",
       contextWindowTokens: 163_840,
       defaultContextWindowTokens: 163_840,
       maxOutputTokens: 32_000,
@@ -614,6 +640,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "deepseek/deepseek-v4-pro",
       displayName: "DeepSeek V4 Pro",
+      vendor: "deepseek",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 384_000,
@@ -622,6 +649,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "deepseek/deepseek-v4-flash",
       displayName: "DeepSeek V4 Flash",
+      vendor: "deepseek",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 384_000,
@@ -630,6 +658,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "qwen/qwen3.5-plus-02-15",
       displayName: "Qwen 3.5 Plus",
+      vendor: "alibaba",
       contextWindowTokens: 131_072,
       defaultContextWindowTokens: 131_072,
       maxOutputTokens: 8_192,
@@ -638,6 +667,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "qwen/qwen3.5-397b-a17b",
       displayName: "Qwen 3.5 397B",
+      vendor: "alibaba",
       contextWindowTokens: 131_072,
       defaultContextWindowTokens: 131_072,
       maxOutputTokens: 8_192,
@@ -646,6 +676,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "qwen/qwen3.5-flash-02-23",
       displayName: "Qwen 3.5 Flash",
+      vendor: "alibaba",
       contextWindowTokens: 131_072,
       defaultContextWindowTokens: 131_072,
       maxOutputTokens: 8_192,
@@ -653,6 +684,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "qwen/qwen3-coder-next",
       displayName: "Qwen 3 Coder",
+      vendor: "alibaba",
       contextWindowTokens: 131_072,
       defaultContextWindowTokens: 131_072,
       maxOutputTokens: 8_192,
@@ -660,6 +692,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "moonshotai/kimi-k3",
       displayName: "Kimi K3",
+      vendor: "moonshot",
       family: "kimi-k",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
@@ -670,6 +703,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "moonshotai/kimi-k2.6",
       displayName: "Kimi K2.6",
+      vendor: "moonshot",
       family: "kimi-k",
       contextWindowTokens: 262_144,
       defaultContextWindowTokens: 200_000,
@@ -679,6 +713,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "moonshotai/kimi-k2.5",
       displayName: "Kimi K2.5",
+      vendor: "moonshot",
       family: "kimi-k",
       contextWindowTokens: 256_000,
       defaultContextWindowTokens: 200_000,
@@ -687,6 +722,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m3",
       displayName: "MiniMax M3",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 524_288,
       defaultContextWindowTokens: 200_000,
@@ -696,6 +732,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2.7",
       displayName: "MiniMax M2.7",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
@@ -705,6 +742,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2.5",
       displayName: "MiniMax M2.5",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
@@ -714,6 +752,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2.1",
       displayName: "MiniMax M2.1",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
@@ -723,6 +762,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2",
       displayName: "MiniMax M2",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
@@ -732,6 +772,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2-her",
       displayName: "MiniMax M2-her",
+      vendor: "minimax",
       contextWindowTokens: 65_536,
       defaultContextWindowTokens: 65_536,
       maxOutputTokens: 2_048,
@@ -739,6 +780,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m1",
       displayName: "MiniMax M1",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
@@ -748,6 +790,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-01",
       displayName: "MiniMax-01",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
@@ -756,6 +799,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "z-ai/glm-5.3",
       displayName: "GLM-5.3",
+      vendor: "zhipu",
       family: "glm",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
@@ -765,6 +809,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "z-ai/glm-5.3-flash",
       displayName: "GLM-5.3 Flash",
+      vendor: "zhipu",
       contextWindowTokens: 1_310_720,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -773,6 +818,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "z-ai/glm-5.2",
       displayName: "GLM-5.2",
+      vendor: "zhipu",
       family: "glm",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
@@ -782,6 +828,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "mistralai/mistral-medium-3",
       displayName: "Mistral Medium 3",
+      vendor: "mistral",
       contextWindowTokens: 131_072,
       defaultContextWindowTokens: 131_072,
       maxOutputTokens: 16_000,
@@ -789,6 +836,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "mistralai/mistral-small-2603",
       displayName: "Mistral Small 4",
+      vendor: "mistral",
       contextWindowTokens: 131_072,
       defaultContextWindowTokens: 131_072,
       maxOutputTokens: 16_000,
@@ -796,6 +844,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "meta-llama/llama-4-maverick",
       displayName: "Llama 4 Maverick",
+      vendor: "meta",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 16_000,
@@ -803,6 +852,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "meta-llama/llama-4-scout",
       displayName: "Llama 4 Scout",
+      vendor: "meta",
       contextWindowTokens: 327_680,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 16_000,
@@ -810,6 +860,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "amazon/nova-pro-v1",
       displayName: "Amazon Nova Pro",
+      vendor: "amazon",
       contextWindowTokens: 300_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 5_000,
@@ -906,6 +957,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "xai/grok-4.3",
       displayName: "Grok 4.3",
+      vendor: "xai",
       family: "grok",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
@@ -915,6 +967,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "moonshotai/kimi-k2.6",
       displayName: "Kimi K2.6",
+      vendor: "moonshot",
       family: "kimi-k",
       contextWindowTokens: 262_144,
       defaultContextWindowTokens: 200_000,
@@ -924,6 +977,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "deepseek/deepseek-v4-flash",
       displayName: "DeepSeek V4 Flash",
+      vendor: "deepseek",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 384_000,
@@ -934,6 +988,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "MiniMax-M3",
       displayName: "MiniMax M3",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
@@ -943,6 +998,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "MiniMax-M2.7",
       displayName: "MiniMax M2.7",
+      vendor: "minimax",
       family: "minimax-m",
       contextWindowTokens: 200_000,
       defaultContextWindowTokens: 200_000,
@@ -954,6 +1010,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "deepseek-ai/deepseek-v4-pro",
       displayName: "DeepSeek V4 Pro",
+      vendor: "deepseek",
       contextWindowTokens: 128_000,
       defaultContextWindowTokens: 128_000,
       maxOutputTokens: 8_192,
@@ -966,6 +1023,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "thinkingmachines/inkling",
       displayName: "Inkling",
+      vendor: "thinking-machines",
       contextWindowTokens: 262_144,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 32_768,
@@ -994,6 +1052,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "qwen/qwen3-8b",
       displayName: "Qwen3 8B",
+      vendor: "alibaba",
       contextWindowTokens: 32_768,
       defaultContextWindowTokens: 32_768,
       maxOutputTokens: 32_768,
@@ -1050,6 +1109,36 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   baseten: "Baseten",
   poolside: "Poolside",
 };
+
+/**
+ * Vendor slug to human-readable label, for the organisations that make models
+ * without hosting them. A slug shared with a provider id (`minimax`, `openai`)
+ * names the same organisation in both places, so a picker that groups by
+ * vendor folds the two together rather than drawing the name twice.
+ */
+export const VENDOR_DISPLAY_NAMES: Record<string, string> = {
+  alibaba: "Alibaba",
+  amazon: "Amazon",
+  deepseek: "DeepSeek",
+  meta: "Meta",
+  minimax: "MiniMax",
+  mistral: "Mistral AI",
+  moonshot: "Moonshot AI",
+  openai: "OpenAI",
+  "thinking-machines": "Thinking Machines",
+  xai: "xAI",
+  zhipu: "Z.ai",
+};
+
+/**
+ * The label for a vendor slug, falling back to the provider of the same name
+ * for a first-party organisation the catalog already names.
+ */
+export function vendorDisplayName(vendor: string): string {
+  return (
+    VENDOR_DISPLAY_NAMES[vendor] ?? PROVIDER_DISPLAY_NAMES[vendor] ?? vendor
+  );
+}
 
 /**
  * Whether each provider supports Vellum-managed (`platform`) auth.

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -15,6 +15,15 @@ export interface LlmCatalogModel {
   contextWindowTokens: number;
   defaultContextWindowTokens: number;
   maxOutputTokens: number;
+  /**
+   * The model line this entry belongs to, when the catalog carries more than
+   * one version of it ("claude-opus", "gemini-flash"). Members of a line are
+   * authored newest first, so a picker can offer the newest and fold the rest
+   * away. The slug is the same under every provider that hosts the model,
+   * which is what lets a cross-provider list fold them together; a model with
+   * no older siblings carries none.
+   */
+  family?: string;
   supportsThinking?: boolean;
   adaptiveThinkingOnly?: boolean;
   longContextPricingThresholdTokens?: number;
@@ -37,6 +46,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "claude-opus-5",
       displayName: "Claude Opus 5",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -46,6 +56,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "claude-opus-4-8",
       displayName: "Claude Opus 4.8",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -55,6 +66,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "claude-opus-4-7",
       displayName: "Claude Opus 4.7",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -64,6 +76,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "claude-opus-4-6",
       displayName: "Claude Opus 4.6",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -73,6 +86,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "claude-sonnet-5",
       displayName: "Claude Sonnet 5",
+      family: "claude-sonnet",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -82,6 +96,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "claude-sonnet-4-6",
       displayName: "Claude Sonnet 4.6",
+      family: "claude-sonnet",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 64_000,
@@ -91,6 +106,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "claude-sonnet-4-5-20250929",
       displayName: "Claude Sonnet 4.5",
+      family: "claude-sonnet",
       contextWindowTokens: 200_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 64_000,
@@ -99,6 +115,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "claude-opus-4-5-20251101",
       displayName: "Claude Opus 4.5",
+      family: "claude-opus",
       contextWindowTokens: 200_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 64_000,
@@ -144,6 +161,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gpt-5.5",
       displayName: "GPT-5.5",
+      family: "gpt-5",
       contextWindowTokens: 1_050_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -162,6 +180,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gpt-5.4",
       displayName: "GPT-5.4",
+      family: "gpt-5",
       contextWindowTokens: 1_050_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -171,6 +190,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gpt-5.2",
       displayName: "GPT-5.2",
+      family: "gpt-5",
       contextWindowTokens: 400_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -197,6 +217,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-3.6-flash",
       displayName: "Gemini 3.6 Flash",
+      family: "gemini-flash",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -205,6 +226,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-3.5-flash",
       displayName: "Gemini 3.5 Flash",
+      family: "gemini-flash",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -213,6 +235,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-3.5-flash-lite",
       displayName: "Gemini 3.5 Flash-Lite",
+      family: "gemini-flash-lite",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -221,6 +244,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-3.1-pro-preview",
       displayName: "Gemini 3.1 Pro Preview",
+      family: "gemini-pro",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -230,6 +254,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-3.1-pro-preview-customtools",
       displayName: "Gemini 3.1 Pro Preview (Custom Tools)",
+      family: "gemini-pro",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -239,6 +264,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-3-flash-preview",
       displayName: "Gemini 3 Flash Preview",
+      family: "gemini-flash",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -247,6 +273,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-3.1-flash-lite-preview",
       displayName: "Gemini 3.1 Flash-Lite Preview",
+      family: "gemini-flash-lite",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -255,6 +282,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-3.1-flash-lite",
       displayName: "Gemini 3.1 Flash-Lite",
+      family: "gemini-flash-lite",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -263,6 +291,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-2.5-flash",
       displayName: "Gemini 2.5 Flash",
+      family: "gemini-flash",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -271,6 +300,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-2.5-flash-lite",
       displayName: "Gemini 2.5 Flash Lite",
+      family: "gemini-flash-lite",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -278,6 +308,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "gemini-2.5-pro",
       displayName: "Gemini 2.5 Pro",
+      family: "gemini-pro",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,
@@ -305,6 +336,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/kimi-k3",
       displayName: "Kimi K3",
+      family: "kimi-k",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -314,6 +346,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/kimi-k2p6",
       displayName: "Kimi K2.6",
+      family: "kimi-k",
       contextWindowTokens: 262_144,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 32_768,
@@ -322,6 +355,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/glm-5p2",
       displayName: "GLM 5.2",
+      family: "glm",
       contextWindowTokens: 1_040_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -332,6 +366,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/minimax-m3",
       displayName: "MiniMax M3",
+      family: "minimax-m",
       contextWindowTokens: 524_288,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 512_000,
@@ -340,6 +375,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/minimax-m2p7",
       displayName: "MiniMax M2.7",
+      family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
       maxOutputTokens: 25_000,
@@ -365,6 +401,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "MiniMaxAI/MiniMax-M3",
       displayName: "MiniMax M3",
+      family: "minimax-m",
       contextWindowTokens: 524_288,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 512_000,
@@ -385,6 +422,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-opus-5",
       displayName: "Claude Opus 5",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -394,6 +432,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-opus-4.8",
       displayName: "Claude Opus 4.8",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -403,6 +442,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-opus-4.7",
       displayName: "Claude Opus 4.7",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -412,6 +452,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-opus-4.6",
       displayName: "Claude Opus 4.6",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -421,6 +462,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-sonnet-5",
       displayName: "Claude Sonnet 5",
+      family: "claude-sonnet",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -430,6 +472,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-sonnet-4.6",
       displayName: "Claude Sonnet 4.6",
+      family: "claude-sonnet",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 64_000,
@@ -439,6 +482,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-sonnet-4.5",
       displayName: "Claude Sonnet 4.5",
+      family: "claude-sonnet",
       contextWindowTokens: 200_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 64_000,
@@ -447,6 +491,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-opus-4.5",
       displayName: "Claude Opus 4.5",
+      family: "claude-opus",
       contextWindowTokens: 200_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 64_000,
@@ -517,6 +562,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "x-ai/grok-4.6",
       displayName: "Grok 4.6",
+      family: "grok",
       contextWindowTokens: 500_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 30_000,
@@ -526,6 +572,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "x-ai/grok-4.5",
       displayName: "Grok 4.5",
+      family: "grok",
       contextWindowTokens: 500_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 30_000,
@@ -534,6 +581,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "x-ai/grok-4.3",
       displayName: "Grok 4.3",
+      family: "grok",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 16_000,
@@ -542,6 +590,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "x-ai/grok-4.20",
       displayName: "Grok 4.20",
+      family: "grok",
       contextWindowTokens: 2_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 16_000,
@@ -611,6 +660,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "moonshotai/kimi-k3",
       displayName: "Kimi K3",
+      family: "kimi-k",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -620,6 +670,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "moonshotai/kimi-k2.6",
       displayName: "Kimi K2.6",
+      family: "kimi-k",
       contextWindowTokens: 262_144,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 32_768,
@@ -628,6 +679,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "moonshotai/kimi-k2.5",
       displayName: "Kimi K2.5",
+      family: "kimi-k",
       contextWindowTokens: 256_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 32_768,
@@ -635,6 +687,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m3",
       displayName: "MiniMax M3",
+      family: "minimax-m",
       contextWindowTokens: 524_288,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 512_000,
@@ -643,6 +696,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2.7",
       displayName: "MiniMax M2.7",
+      family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
       maxOutputTokens: 131_072,
@@ -651,6 +705,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2.5",
       displayName: "MiniMax M2.5",
+      family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
       maxOutputTokens: 196_608,
@@ -659,6 +714,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2.1",
       displayName: "MiniMax M2.1",
+      family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
       maxOutputTokens: 196_608,
@@ -667,6 +723,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m2",
       displayName: "MiniMax M2",
+      family: "minimax-m",
       contextWindowTokens: 196_608,
       defaultContextWindowTokens: 196_608,
       maxOutputTokens: 196_608,
@@ -682,6 +739,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-m1",
       displayName: "MiniMax M1",
+      family: "minimax-m",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 40_000,
@@ -690,6 +748,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "minimax/minimax-01",
       displayName: "MiniMax-01",
+      family: "minimax-m",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 1_000_000,
@@ -697,6 +756,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "z-ai/glm-5.3",
       displayName: "GLM-5.3",
+      family: "glm",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -713,6 +773,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "z-ai/glm-5.2",
       displayName: "GLM-5.2",
+      family: "glm",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -768,6 +829,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-opus-5",
       displayName: "Claude Opus 5",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -777,6 +839,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-opus-4.8",
       displayName: "Claude Opus 4.8",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -786,6 +849,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-opus-4.6",
       displayName: "Claude Opus 4.6",
+      family: "claude-opus",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -795,6 +859,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-sonnet-5",
       displayName: "Claude Sonnet 5",
+      family: "claude-sonnet",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -804,6 +869,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "anthropic/claude-sonnet-4.6",
       displayName: "Claude Sonnet 4.6",
+      family: "claude-sonnet",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 64_000,
@@ -821,6 +887,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "openai/gpt-5.5",
       displayName: "GPT-5.5",
+      family: "gpt-5",
       contextWindowTokens: 1_050_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -839,6 +906,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "xai/grok-4.3",
       displayName: "Grok 4.3",
+      family: "grok",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 16_000,
@@ -847,6 +915,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "moonshotai/kimi-k2.6",
       displayName: "Kimi K2.6",
+      family: "kimi-k",
       contextWindowTokens: 262_144,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 32_768,
@@ -865,6 +934,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "MiniMax-M3",
       displayName: "MiniMax M3",
+      family: "minimax-m",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 512_000,
@@ -873,6 +943,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "MiniMax-M2.7",
       displayName: "MiniMax M2.7",
+      family: "minimax-m",
       contextWindowTokens: 200_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 16_384,

--- a/clients/web/src/assistant/llm-model-families.test.ts
+++ b/clients/web/src/assistant/llm-model-families.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Invariants behind `LlmCatalogModel.family`.
+ *
+ * `family` is what lets a cross-provider picker offer the newest member of a
+ * model line and fold its older siblings away, so what the picker leans on is
+ * guarded here rather than discovered as a wrong list.
+ *
+ * The catalog is authored newest first, which is not a fact a test can derive
+ * from a display name. What it can hold is the two things that make "first in
+ * catalog order" mean "newest": the members of a line are ordered the same way
+ * wherever the line appears, and the member that leads each line is the one
+ * pinned below.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { MODELS_BY_PROVIDER } from "@/assistant/llm-model-catalog";
+
+const entries = Object.entries(MODELS_BY_PROVIDER) as [
+  string,
+  readonly { id: string; displayName: string; family?: string }[],
+][];
+
+/** The member that leads each line, and so the one a picker shows. */
+const NEWEST_IN_FAMILY: Record<string, string> = {
+  "claude-opus": "Claude Opus 5",
+  "claude-sonnet": "Claude Sonnet 5",
+  "gpt-5": "GPT-5.5",
+  "gemini-flash": "Gemini 3.6 Flash",
+  "gemini-flash-lite": "Gemini 3.5 Flash-Lite",
+  "gemini-pro": "Gemini 3.1 Pro Preview",
+  grok: "Grok 4.6",
+  "kimi-k": "Kimi K3",
+  "minimax-m": "MiniMax M3",
+  glm: "GLM-5.3",
+};
+
+describe("model families", () => {
+  test("a display name carries the same family under every provider", () => {
+    const seen = new Map<string, string | undefined>();
+    for (const [, models] of entries) {
+      for (const model of models) {
+        if (!seen.has(model.displayName)) {
+          seen.set(model.displayName, model.family);
+          continue;
+        }
+        expect(
+          seen.get(model.displayName),
+          `"${model.displayName}" carries two different families`,
+        ).toBe(model.family);
+      }
+    }
+  });
+
+  test("every declared family has more than one member to fold", () => {
+    const members = new Map<string, Set<string>>();
+    for (const [, models] of entries) {
+      for (const model of models) {
+        if (!model.family) {
+          continue;
+        }
+        const set = members.get(model.family) ?? new Set<string>();
+        set.add(model.displayName);
+        members.set(model.family, set);
+      }
+    }
+    expect(members.size).toBeGreaterThan(0);
+    for (const [family, displayNames] of members) {
+      expect(
+        displayNames.size,
+        `family "${family}" has nothing to fold away`,
+      ).toBeGreaterThan(1);
+    }
+  });
+
+  test("every declared family is pinned to a newest member", () => {
+    const declared = new Set<string>();
+    for (const [, models] of entries) {
+      for (const model of models) {
+        if (model.family) {
+          declared.add(model.family);
+        }
+      }
+    }
+    expect([...declared].sort()).toEqual(Object.keys(NEWEST_IN_FAMILY).sort());
+  });
+
+  test("a family's first member in catalog order is its newest", () => {
+    for (const [providerId, models] of entries) {
+      const leaders = new Map<string, string>();
+      for (const model of models) {
+        if (model.family && !leaders.has(model.family)) {
+          leaders.set(model.family, model.displayName);
+        }
+      }
+      for (const [family, leader] of leaders) {
+        // A provider that hosts only older members leads with one of those,
+        // so the pin is checked against the providers that host the newest.
+        if (!models.some((m) => m.displayName === NEWEST_IN_FAMILY[family])) {
+          continue;
+        }
+        expect(
+          leader,
+          `${providerId} lists family "${family}" out of newest-first order`,
+        ).toBe(NEWEST_IN_FAMILY[family]);
+      }
+    }
+  });
+
+  test("a family's members keep one relative order across providers", () => {
+    const canonicalOrder = new Map<string, string[]>();
+    for (const [providerId, models] of entries) {
+      const perFamily = new Map<string, string[]>();
+      for (const model of models) {
+        if (!model.family) {
+          continue;
+        }
+        perFamily.set(model.family, [
+          ...(perFamily.get(model.family) ?? []),
+          model.displayName,
+        ]);
+      }
+      for (const [family, names] of perFamily) {
+        const canonical = canonicalOrder.get(family);
+        if (!canonical) {
+          canonicalOrder.set(family, names);
+          continue;
+        }
+        // This provider's subset must read as a subsequence of the first
+        // provider's order, plus any member only it hosts. A reshuffle would
+        // make "the newest" depend on which provider serves the model.
+        const shared = canonical.filter((name) => names.includes(name));
+        const only = names.filter((name) => !canonical.includes(name));
+        expect(
+          names,
+          `${providerId} orders family "${family}" differently`,
+        ).toEqual([...shared, ...only]);
+      }
+    }
+  });
+});

--- a/clients/web/src/assistant/llm-model-vendors.test.ts
+++ b/clients/web/src/assistant/llm-model-vendors.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Invariants behind `LlmCatalogModel.vendor`, which is what names a section of
+ * the model picker. Getting it wrong files a model under a gateway rather than
+ * under the organisation that made it, which is the state this field exists to
+ * end: someone looking for Grok looks under xAI, not under whichever router
+ * the catalog happens to list first.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  MODELS_BY_PROVIDER,
+  vendorDisplayName,
+} from "@/assistant/llm-model-catalog";
+
+const entries = Object.entries(MODELS_BY_PROVIDER) as [
+  string,
+  readonly {
+    id: string;
+    displayName: string;
+    family?: string;
+    vendor?: string;
+  }[],
+][];
+
+/**
+ * Providers that list other people's work. Every model one of them lists
+ * first has to name its maker, or the picker files it under the gateway.
+ * MiniMax, Poolside and the first-party labs are absent: they list only what
+ * they made themselves.
+ */
+const AGGREGATOR_PROVIDERS = new Set([
+  "ollama",
+  "fireworks",
+  "together",
+  "openrouter",
+  "vercel-ai-gateway",
+  "atlascloud",
+  "litellm",
+  "opencode",
+  "baseten",
+  "vellum",
+  "openai-compatible",
+]);
+
+/** Vendors the catalog genuinely knows a single model from. */
+const SINGLE_MODEL_VENDORS = new Set(["amazon", "thinking-machines"]);
+
+/** The provider that lists each model first, which is what owns it. */
+const owners = new Map<string, string>();
+for (const [providerId, models] of entries) {
+  for (const model of models) {
+    if (!owners.has(model.displayName)) {
+      owners.set(model.displayName, providerId);
+    }
+  }
+}
+
+function modelNamed(displayName: string) {
+  return entries
+    .flatMap(([, models]) => models)
+    .find((entry) => entry.displayName === displayName);
+}
+
+describe("model vendors", () => {
+  test("a display name carries the same vendor under every provider", () => {
+    const seen = new Map<string, string | undefined>();
+    for (const [, models] of entries) {
+      for (const model of models) {
+        if (!seen.has(model.displayName)) {
+          seen.set(model.displayName, model.vendor);
+          continue;
+        }
+        expect(
+          seen.get(model.displayName),
+          `"${model.displayName}" carries two different vendors`,
+        ).toBe(model.vendor);
+      }
+    }
+  });
+
+  test("a model a gateway lists first names who made it", () => {
+    for (const [displayName, owner] of owners) {
+      if (!AGGREGATOR_PROVIDERS.has(owner)) {
+        continue;
+      }
+      expect(
+        modelNamed(displayName)?.vendor,
+        `"${displayName}" is listed first by ${owner}, which did not make it`,
+      ).toBeTruthy();
+    }
+  });
+
+  test("a model its own maker lists first names no vendor twice", () => {
+    for (const [displayName, owner] of owners) {
+      if (AGGREGATOR_PROVIDERS.has(owner)) {
+        continue;
+      }
+      expect(
+        modelNamed(displayName)?.vendor,
+        `"${displayName}" is listed first by its own maker, ${owner}`,
+      ).toBeUndefined();
+    }
+  });
+
+  test("every vendor slug has a display name", () => {
+    const slugs = new Set<string>();
+    for (const [, models] of entries) {
+      for (const model of models) {
+        if (model.vendor) {
+          slugs.add(model.vendor);
+        }
+      }
+    }
+    expect(slugs.size).toBeGreaterThan(0);
+    for (const slug of slugs) {
+      expect(vendorDisplayName(slug), `"${slug}" has no label`).not.toBe(slug);
+    }
+  });
+
+  test("a vendor is not left naming one model by accident", () => {
+    const byVendor = new Map<string, Set<string>>();
+    for (const [, models] of entries) {
+      for (const model of models) {
+        if (!model.vendor) {
+          continue;
+        }
+        const named = byVendor.get(model.vendor) ?? new Set<string>();
+        named.add(model.displayName);
+        byVendor.set(model.vendor, named);
+      }
+    }
+    for (const [vendor, displayNames] of byVendor) {
+      if (displayNames.size > 1) {
+        continue;
+      }
+      expect(
+        SINGLE_MODEL_VENDORS.has(vendor),
+        `"${vendor}" names one model; a sibling is probably missing it`,
+      ).toBe(true);
+    }
+  });
+
+  test("every member of a model line names the same vendor", () => {
+    const byFamily = new Map<string, Set<string | undefined>>();
+    for (const [, models] of entries) {
+      for (const model of models) {
+        if (!model.family) {
+          continue;
+        }
+        const vendors = byFamily.get(model.family) ?? new Set<string | undefined>();
+        vendors.add(model.vendor);
+        byFamily.set(model.family, vendors);
+      }
+    }
+    for (const [family, vendors] of byFamily) {
+      expect(
+        vendors.size,
+        `family "${family}" spans vendors ${[...vendors].join(", ")}`,
+      ).toBe(1);
+    }
+  });
+});

--- a/clients/web/src/domains/settings/ai/model-first-candidates.test.ts
+++ b/clients/web/src/domains/settings/ai/model-first-candidates.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Rules of the model-first create flow's resolver: which models the list
+ * offers, which routes can serve one, and in what order.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import {
+  customModelProviderCandidates,
+  defaultProviderCandidate,
+  resolveModelFirstOptions,
+  type ModelFirstInput,
+  type ProviderCandidate,
+} from "@/domains/settings/ai/model-first-candidates";
+import type { ProviderConnection } from "@/generated/daemon/types.gen";
+
+function connection(
+  name: string,
+  provider: string,
+  overrides: Record<string, unknown> = {},
+): ProviderConnection {
+  return {
+    name,
+    label: null,
+    provider,
+    auth: { type: "api_key", credential: `credential/${provider}/api_key` },
+    models: null,
+    ...overrides,
+  } as unknown as ProviderConnection;
+}
+
+function input(
+  connections: ProviderConnection[],
+  overrides: Partial<ModelFirstInput> = {},
+): ModelFirstInput {
+  return {
+    connections,
+    developerMode: false,
+    activeAssistantIsSelfHosted: true,
+    labelFor: (provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+    defaultEntryMetaLabel: "Default",
+    ...overrides,
+  };
+}
+
+function optionFor(
+  connections: ProviderConnection[],
+  displayName: string,
+  overrides: Partial<ModelFirstInput> = {},
+) {
+  const option = resolveModelFirstOptions(input(connections, overrides)).find(
+    (candidate) => candidate.displayName === displayName,
+  );
+  if (!option) {
+    throw new Error(`expected an option for "${displayName}"`);
+  }
+  return option;
+}
+
+function providersOf(candidates: readonly ProviderCandidate[]): string[] {
+  return candidates.map((candidate) => candidate.provider);
+}
+
+const VELLUM_CONNECTION = connection("vellum", "vellum", {
+  auth: { type: "platform" },
+});
+
+describe("resolveModelFirstOptions", () => {
+  test("lists each model once across the providers that host it", () => {
+    const options = resolveModelFirstOptions(input([]));
+    const opus = options.filter(
+      (option) => option.displayName === "Claude Opus 4.8",
+    );
+    expect(opus).toHaveLength(1);
+    expect(opus[0].providerCount).toBe(3);
+    expect(opus[0].soleProviderLabel).toBeNull();
+  });
+
+  test("names the single serving provider when only one hosts the model", () => {
+    const option = optionFor([], "Gemini 3.6 Flash");
+    expect(option.providerCount).toBe(1);
+    expect(option.soleProviderLabel).toBe("Google Gemini");
+    expect(providersOf(option.candidates)).toEqual(["gemini"]);
+  });
+
+  test("keeps the per-provider model id on each candidate", () => {
+    const option = optionFor([], "Claude Opus 4.8");
+    const anthropic = option.candidates.find(
+      (candidate) => candidate.provider === "anthropic",
+    );
+    const openrouter = option.candidates.find(
+      (candidate) => candidate.provider === "openrouter",
+    );
+    expect(anthropic?.modelId).toBe("claude-opus-4-8");
+    expect(openrouter?.modelId).toBe("anthropic/claude-opus-4.8");
+  });
+
+  test("orders connected routes ahead of ones needing setup", () => {
+    const option = optionFor(
+      [connection("openrouter-key", "openrouter")],
+      "Claude Opus 4.8",
+    );
+    expect(option.candidates[0].provider).toBe("openrouter");
+    expect(option.candidates[0].connected).toBe(true);
+    expect(
+      option.candidates.slice(1).every((candidate) => !candidate.connected),
+    ).toBe(true);
+  });
+
+  test("annotates what an unconnected route still needs", () => {
+    const keyed = optionFor([], "Claude Opus 4.8").candidates.find(
+      (candidate) => candidate.provider === "anthropic",
+    );
+    expect(keyed?.setup).toBe("api-key");
+
+    const local = optionFor([], "Llama 3.2").candidates.find(
+      (candidate) => candidate.provider === "ollama",
+    );
+    expect(local?.setup).toBe("set-up");
+  });
+
+  test("expands a kind with sibling connections into one row per key", () => {
+    const option = optionFor(
+      [
+        connection("anthropic-work", "anthropic"),
+        connection("anthropic-personal", "anthropic", { label: "Personal" }),
+      ],
+      "Claude Opus 4.8",
+    );
+    const anthropic = option.candidates.filter(
+      (candidate) => candidate.provider === "anthropic",
+    );
+    expect(anthropic.map((candidate) => candidate.value)).toEqual([
+      "anthropic",
+      "anthropic::anthropic-work",
+      "anthropic::anthropic-personal",
+    ]);
+    expect(anthropic[0].meta).toBe("Default");
+    expect(anthropic[0].connectionName).toBe("");
+    expect(anthropic[2].label).toBe("Personal");
+    expect(anthropic[2].connectionName).toBe("anthropic-personal");
+  });
+
+  test("counts provider kinds, not the keys a kind holds", () => {
+    const option = optionFor(
+      [
+        connection("gemini-work", "gemini"),
+        connection("gemini-personal", "gemini"),
+      ],
+      "Gemini 3.6 Flash",
+    );
+    expect(option.candidates).toHaveLength(3);
+    expect(option.providerCount).toBe(1);
+    expect(option.soleProviderLabel).toBe("Google Gemini");
+  });
+
+  test("drops a route the active assistant cannot reach, and with it a model nothing else serves", () => {
+    const platformHosted = resolveModelFirstOptions(
+      input([], { activeAssistantIsSelfHosted: false }),
+    );
+    expect(
+      platformHosted.map((option) => option.displayName),
+    ).not.toContain("Llama 3.2");
+
+    const selfHosted = optionFor([], "Llama 3.2");
+    expect(providersOf(selfHosted.candidates)).toEqual(["ollama"]);
+  });
+
+  test("offers a custom endpoint only for the models its own row lists", () => {
+    const options = resolveModelFirstOptions(
+      input([
+        connection("lm-studio", "openai-compatible", {
+          label: "LM Studio",
+          models: [{ id: "local-mixtral", displayName: "Local Mixtral" }],
+        }),
+      ]),
+    );
+    const custom = options.find(
+      (option) => option.displayName === "Local Mixtral",
+    );
+    expect(custom?.candidates).toHaveLength(1);
+    expect(custom?.candidates[0]).toMatchObject({
+      provider: "openai-compatible",
+      connectionName: "lm-studio",
+      label: "LM Studio",
+      modelId: "local-mixtral",
+      connected: true,
+    });
+    expect(custom?.soleProviderLabel).toBe("LM Studio");
+
+    const opus = options.find(
+      (option) => option.displayName === "Claude Opus 4.8",
+    );
+    expect(providersOf(opus?.candidates ?? [])).not.toContain(
+      "openai-compatible",
+    );
+  });
+
+  test("holds a flagged catalog entry back until developer mode is on", () => {
+    const hidden = resolveModelFirstOptions(
+      input([VELLUM_CONNECTION]),
+    ).map((option) => option.displayName);
+    const shown = resolveModelFirstOptions(
+      input([VELLUM_CONNECTION], { developerMode: true }),
+    ).map((option) => option.displayName);
+    expect(hidden).not.toContain("Qwen3 8B");
+    expect(shown).toContain("Qwen3 8B");
+  });
+
+  test("surfaces the managed route as one entry rather than its upstreams", () => {
+    const option = optionFor([VELLUM_CONNECTION], "Claude Opus 4.8");
+    expect(option.candidates[0]).toMatchObject({
+      provider: "vellum",
+      value: "vellum",
+      meta: "Managed",
+      connected: true,
+      modelId: "claude-opus-4-8",
+    });
+  });
+});
+
+describe("the ChatGPT subscription as a candidate", () => {
+  const CODEX_MODEL = "GPT-5.6 Luna";
+  const NON_CODEX_MODEL = "GPT-5.4 Nano";
+
+  test("is offered for a Codex-eligible model and nothing else", () => {
+    const codex = optionFor([], CODEX_MODEL);
+    expect(providersOf(codex.candidates)).toContain("chatgpt");
+
+    const other = optionFor([], NON_CODEX_MODEL);
+    expect(providersOf(other.candidates)).not.toContain("chatgpt");
+  });
+
+  test("sits next to the API-key route it shares models with", () => {
+    const providers = providersOf(optionFor([], CODEX_MODEL).candidates);
+    expect(providers.indexOf("chatgpt")).toBe(providers.indexOf("openai") + 1);
+  });
+
+  test("is signed into rather than keyed while unconnected", () => {
+    const chatgpt = optionFor([], CODEX_MODEL).candidates.find(
+      (candidate) => candidate.provider === "chatgpt",
+    );
+    expect(chatgpt?.setup).toBe("sign-in");
+    expect(chatgpt?.connected).toBe(false);
+    expect(chatgpt?.label).toBe("ChatGPT Subscription");
+  });
+
+  test("leads and binds no connection once signed in", () => {
+    const option = optionFor(
+      [
+        connection("chatgpt", "chatgpt", {
+          auth: {
+            type: "oauth_subscription",
+            credential: "credential/chatgpt/oauth",
+          },
+        }),
+      ],
+      CODEX_MODEL,
+    );
+    // Identity rows never expand into per-connection entries: dispatch
+    // resolves the canonical subscription row per request.
+    expect(defaultProviderCandidate(option.candidates)).toMatchObject({
+      provider: "chatgpt",
+      value: "chatgpt",
+      connectionName: "",
+      connected: true,
+      modelId: "gpt-5.6-luna",
+    });
+  });
+
+  test("never accepts a model id typed by hand", () => {
+    const candidates = customModelProviderCandidates(input([]), "some-model");
+    expect(providersOf(candidates)).not.toContain("chatgpt");
+  });
+});
+
+describe("defaultProviderCandidate", () => {
+  test("prefers the first connected route", () => {
+    const option = optionFor(
+      [connection("together-key", "together")],
+      "MiniMax M3",
+    );
+    expect(defaultProviderCandidate(option.candidates)).toMatchObject({
+      provider: "together",
+      connected: true,
+      modelId: "MiniMaxAI/MiniMax-M3",
+    });
+  });
+
+  test("falls back to the first route when nothing is connected", () => {
+    const option = optionFor([], "Claude Opus 4.8");
+    expect(defaultProviderCandidate(option.candidates)).toBe(
+      option.candidates[0],
+    );
+  });
+
+  test("is null with no candidates at all", () => {
+    expect(defaultProviderCandidate([])).toBeNull();
+  });
+});
+
+describe("customModelProviderCandidates", () => {
+  test("stamps the typed id on every route", () => {
+    const candidates = customModelProviderCandidates(input([]), "my/model:1");
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(
+      candidates.every((candidate) => candidate.modelId === "my/model:1"),
+    ).toBe(true);
+  });
+
+  test("offers a route whose catalog is empty", () => {
+    const candidates = customModelProviderCandidates(
+      input([
+        connection("lm-studio", "openai-compatible", { label: "LM Studio" }),
+      ]),
+      "local-model",
+    );
+    expect(
+      candidates.some((candidate) => candidate.connectionName === "lm-studio"),
+    ).toBe(true);
+  });
+
+  test("drops routes the active assistant cannot reach", () => {
+    const candidates = customModelProviderCandidates(
+      input([], { activeAssistantIsSelfHosted: false }),
+      "local-model",
+    );
+    expect(providersOf(candidates)).not.toContain("ollama");
+  });
+});

--- a/clients/web/src/domains/settings/ai/model-first-candidates.ts
+++ b/clients/web/src/domains/settings/ai/model-first-candidates.ts
@@ -366,8 +366,7 @@ const VENDOR_KEYS: ReadonlySet<string> = new Set(
  * can already dispatch into first and the rest of the catalog after.
  *
  * Within a section the models keep the owner's catalog order, so the newest
- * of each line leads and {@link collapseSupersededVersions} can fold the rest
- * away.
+ * of each line leads and {@link collapseSectionRows} can fold the rest away.
  */
 export function resolveModelFirstGroups(
   input: ModelFirstInput,
@@ -438,30 +437,41 @@ export function resolveModelFirstGroups(
 }
 
 /**
- * Split a section into the models it shows and the ones it folds away: the
- * first member of each line stays, its older siblings go behind the section's
- * own "show older versions" row. A model with no line always shows, having
- * nothing newer to stand behind.
+ * How many models a section offers before the rest go behind its own "see
+ * more" row. Three is what a section can show without any one of them
+ * turning the list into a wall of a single vendor's work.
  */
-export function collapseSupersededVersions(
+const SECTION_ROW_LIMIT = 3;
+
+/**
+ * Split a section into the models it shows and the ones it folds away.
+ *
+ * Which three show is a question about lines, not about count: each line
+ * collapses to its newest member first, so a section spends its three rows on
+ * three different models rather than on three versions of one. The rest of the
+ * section follows behind its "see more" row, in catalog order, so revealing it
+ * reads as the section carrying on.
+ */
+export function collapseSectionRows(
   options: readonly ModelFirstOption[],
 ): { shown: ModelFirstOption[]; hidden: ModelFirstOption[] } {
-  const shown: ModelFirstOption[] = [];
-  const hidden: ModelFirstOption[] = [];
+  const leads: ModelFirstOption[] = [];
   const led = new Set<string>();
   for (const option of options) {
-    if (option.family === null) {
-      shown.push(option);
-      continue;
+    if (option.family !== null) {
+      if (led.has(option.family)) {
+        continue;
+      }
+      led.add(option.family);
     }
-    if (led.has(option.family)) {
-      hidden.push(option);
-      continue;
-    }
-    led.add(option.family);
-    shown.push(option);
+    leads.push(option);
   }
-  return { shown, hidden };
+  const shown = leads.slice(0, SECTION_ROW_LIMIT);
+  const shownSet = new Set(shown);
+  return {
+    shown,
+    hidden: options.filter((option) => !shownSet.has(option)),
+  };
 }
 
 /**

--- a/clients/web/src/domains/settings/ai/model-first-candidates.ts
+++ b/clients/web/src/domains/settings/ai/model-first-candidates.ts
@@ -22,6 +22,7 @@
 import {
   getVisibleModelsForProvider,
   MODELS_BY_PROVIDER,
+  vendorDisplayName,
   type LlmCatalogModel,
 } from "@/assistant/llm-model-catalog";
 import {
@@ -71,12 +72,16 @@ export interface ModelFirstOption {
   /** Cross-provider identity of the model, and the picker's option value. */
   readonly displayName: string;
   /**
-   * The provider the model is filed under: the first in catalog order that
-   * lists it. For a model several providers host this is the one that made
-   * it available first, which for a first-party model is its vendor and for
-   * an open-weights model is whichever host the catalog lists first.
+   * The provider that lists the model first in catalog order. It decides
+   * where the model sorts, and names its section when no vendor does.
    */
   readonly owner: ConnectionProvider;
+  /**
+   * The organisation that made the model, when that is not the provider
+   * listing it. This is what names the model's section, so Grok is filed
+   * under xAI rather than under whichever gateway happens to serve it.
+   */
+  readonly vendor: string | null;
   /** The model line this belongs to, or null when it has no older siblings. */
   readonly family: string | null;
   /** Every route that can serve it, connected ones first. */
@@ -206,6 +211,7 @@ function selectableKinds(input: ModelFirstInput): CandidateKinds {
 
 interface CatalogEntry {
   readonly owner: ConnectionProvider;
+  readonly vendor: string | null;
   readonly family: string | null;
   /** Position within the owner's own catalog, which is authored newest first. */
   readonly rank: number;
@@ -227,6 +233,7 @@ const CATALOG_INDEX: ReadonlyMap<string, CatalogEntry> = (() => {
       }
       index.set(model.displayName, {
         owner: provider as ConnectionProvider,
+        vendor: model.vendor ?? null,
         family: model.family ?? null,
         rank,
       });
@@ -325,6 +332,7 @@ export function resolveModelFirstOptions(
     return {
       displayName,
       owner: entry?.owner ?? first?.provider ?? OPENAI_COMPATIBLE_PROVIDER,
+      vendor: entry?.vendor ?? null,
       family: entry?.family ?? null,
       candidates,
       providerCount: providerKinds.size,
@@ -334,17 +342,28 @@ export function resolveModelFirstOptions(
 }
 
 export interface ModelFirstGroup {
-  /** The provider the section is named for. */
-  readonly provider: ConnectionProvider;
+  /**
+   * Identity of the section: the vendor slug when the catalog names who made
+   * the models, and the owning provider when it does not. Two providers that
+   * list the same vendor's work share one section under this key.
+   */
+  readonly key: string;
   readonly label: string;
-  /** The section's models, in the owner's own catalog order. */
+  /** The section's models, in catalog order. */
   readonly options: readonly ModelFirstOption[];
 }
 
+/** Every vendor slug the catalog uses, for telling one from a provider id. */
+const VENDOR_KEYS: ReadonlySet<string> = new Set(
+  [...CATALOG_INDEX.values()]
+    .map((entry) => entry.vendor)
+    .filter((vendor): vendor is string => vendor !== null),
+);
+
 /**
  * The model list as sections, which is how a list this long stays readable:
- * one heading per owning provider, the sections the user's own connections
- * reach first and the rest of the catalog after.
+ * one heading per organisation that made the models, the sections the user
+ * can already dispatch into first and the rest of the catalog after.
  *
  * Within a section the models keep the owner's catalog order, so the newest
  * of each line leads and {@link collapseSupersededVersions} can fold the rest
@@ -354,48 +373,68 @@ export function resolveModelFirstGroups(
   input: ModelFirstInput,
 ): ModelFirstGroup[] {
   const options = resolveModelFirstOptions(input);
-  const byOwner = new Map<ConnectionProvider, ModelFirstOption[]>();
+  const byKey = new Map<string, ModelFirstOption[]>();
+  const appearance: string[] = [];
   for (const option of options) {
-    const existing = byOwner.get(option.owner);
+    const key = option.vendor ?? option.owner;
+    const existing = byKey.get(key);
     if (existing) {
       existing.push(option);
       continue;
     }
-    byOwner.set(option.owner, [option]);
+    byKey.set(key, [option]);
+    appearance.push(key);
   }
 
-  const served = providersServedByConnections([...input.connections]);
-  const ordered: ConnectionProvider[] = [];
-  for (const provider of served) {
-    if (byOwner.has(provider) && !ordered.includes(provider)) {
-      ordered.push(provider);
-    }
-  }
-  for (const provider of CATALOG_PROVIDERS) {
-    const owner = provider as ConnectionProvider;
-    if (byOwner.has(owner) && !ordered.includes(owner)) {
-      ordered.push(owner);
-    }
-  }
-  // A section whose owner the catalog does not list at all still gets drawn,
-  // rather than dropping models the picker just offered.
-  for (const owner of byOwner.keys()) {
-    if (!ordered.includes(owner)) {
-      ordered.push(owner);
-    }
+  function ownerIndex(option: ModelFirstOption): number {
+    const index = (CATALOG_PROVIDERS as readonly string[]).indexOf(
+      option.owner,
+    );
+    // A provider the catalog does not list sorts after every one it does.
+    return index < 0 ? CATALOG_PROVIDERS.length : index;
   }
 
-  return ordered.map((provider) => ({
-    provider,
-    label: input.labelFor(provider),
-    options: (byOwner.get(provider) ?? [])
-      .slice()
-      .sort(
-        (a, b) =>
-          (CATALOG_INDEX.get(a.displayName)?.rank ?? 0) -
-          (CATALOG_INDEX.get(b.displayName)?.rank ?? 0),
+  const groups = appearance.map((key) => {
+    const members = byKey.get(key) ?? [];
+    return {
+      key,
+      // The vendor names the section wherever the catalog gives one; the
+      // provider does the rest, and the two share a namespace, so a
+      // first-party vendor resolves to the name the picker already uses.
+      label: VENDOR_KEYS.has(key)
+        ? vendorDisplayName(key)
+        : input.labelFor(key as ConnectionProvider),
+      // A section leads when the user can already dispatch something in it.
+      // That is a question about the models, not their owner: once several
+      // providers merge into one vendor, no single owner answers it.
+      reachable: members.some((option) =>
+        option.candidates.some((candidate) => candidate.connected),
       ),
-  }));
+      rank: Math.min(...members.map(ownerIndex)),
+      options: members
+        .slice()
+        .sort(
+          (a, b) =>
+            ownerIndex(a) - ownerIndex(b) ||
+            (CATALOG_INDEX.get(a.displayName)?.rank ?? 0) -
+              (CATALOG_INDEX.get(b.displayName)?.rank ?? 0),
+        ),
+    };
+  });
+
+  return groups
+    .map((group, index) => ({ group, index }))
+    .sort(
+      (a, b) =>
+        Number(b.group.reachable) - Number(a.group.reachable) ||
+        a.group.rank - b.group.rank ||
+        a.index - b.index,
+    )
+    .map(({ group }) => ({
+      key: group.key,
+      label: group.label,
+      options: group.options,
+    }));
 }
 
 /**

--- a/clients/web/src/domains/settings/ai/model-first-candidates.ts
+++ b/clients/web/src/domains/settings/ai/model-first-candidates.ts
@@ -1,0 +1,323 @@
+/**
+ * Resolver behind the model-first create flow: it turns the model catalog,
+ * the assistant's provider connections, and what the assistant can reach into
+ * the two lists that flow asks for.
+ *
+ * The first list is every model the assistant can use, deduplicated across
+ * providers. `displayName` is the identity key, not `id`: the same model
+ * carries a different id under each provider that hosts it ("Claude Opus 4.8"
+ * is one id on Anthropic and another on OpenRouter) while the label a person
+ * reads is the same, so a picker keyed by id would offer the same model three
+ * times.
+ *
+ * The second list is, for one such model, the routes that can serve it, in
+ * the order the user should consider them: connected routes first, then the
+ * ones that need a key, a setup step, or a sign-in. Each candidate carries
+ * back the per-provider model id, which is what the profile stores.
+ *
+ * Everything here is pure so the rules can be tested without a DOM. Copy is
+ * caller-supplied for the same reason.
+ */
+
+import { getVisibleModelsForProvider } from "@/assistant/llm-model-catalog";
+import {
+  CHATGPT_CONNECTION_PROVIDER,
+  OPENAI_COMPATIBLE_PROVIDER,
+} from "@/domains/settings/ai/constants";
+import {
+  entryPickerValue,
+  expandEndpointEntries,
+  isProviderSelectableForAssistant,
+  parseEntryPickerValue,
+  providersServedByConnections,
+  unconnectedProviders,
+} from "@/domains/settings/ai/provider-availability";
+import { connectionAuthTypeForProvider } from "@/domains/settings/ai/provider-editor-constants";
+import type {
+  ConnectionProvider,
+  ProviderConnection,
+} from "@/generated/daemon/types.gen";
+
+/** What an unconnected candidate needs before it can serve a request. */
+export type CandidateSetup = "api-key" | "set-up" | "sign-in";
+
+export interface ProviderCandidate {
+  /**
+   * Identity of the row, shared with the provider picker's encoding: a bare
+   * provider id means the kind's default entry, `<provider>::<name>` names one
+   * connection among siblings.
+   */
+  readonly value: string;
+  readonly provider: ConnectionProvider;
+  /** The connection this row pins, or `""` for the kind's default entry. */
+  readonly connectionName: string;
+  /** Provider display name, or the connection's own label when it is named. */
+  readonly label: string;
+  /** Right-aligned annotation on the row ("Default", "Managed", "Custom"). */
+  readonly meta?: string;
+  /** The model id this route stores, which differs per provider. */
+  readonly modelId: string;
+  readonly connected: boolean;
+  /** What an unconnected route still needs; `null` once it is connected. */
+  readonly setup: CandidateSetup | null;
+}
+
+export interface ModelFirstOption {
+  /** Cross-provider identity of the model, and the picker's option value. */
+  readonly displayName: string;
+  /** Every route that can serve it, connected ones first. */
+  readonly candidates: readonly ProviderCandidate[];
+  /** Distinct provider kinds among the candidates. */
+  readonly providerCount: number;
+  /** The one route's label, when a single provider kind serves the model. */
+  readonly soleProviderLabel: string | null;
+}
+
+export interface ModelFirstInput {
+  readonly connections: readonly ProviderConnection[];
+  /** Whether feature-flagged catalog entries are visible. */
+  readonly developerMode: boolean;
+  readonly activeAssistantIsSelfHosted: boolean;
+  /** Provider id to display name. */
+  readonly labelFor: (provider: ConnectionProvider) => string;
+  /** Meta on a kind's bare row once it expands into named entries. */
+  readonly defaultEntryMetaLabel: string;
+}
+
+function setupForProvider(provider: ConnectionProvider): CandidateSetup {
+  // The subscription is signed into rather than keyed, and it is not a
+  // connectable kind, so it never reaches the auth-type helper below.
+  if (provider === CHATGPT_CONNECTION_PROVIDER) {
+    return "sign-in";
+  }
+  return connectionAuthTypeForProvider(provider) === "api_key"
+    ? "api-key"
+    : "set-up";
+}
+
+interface CandidateKinds {
+  kinds: ConnectionProvider[];
+  connected: Set<ConnectionProvider>;
+}
+
+/**
+ * Every provider kind the create flow may offer, connected ones first, plus
+ * the set of kinds that are connected.
+ *
+ * The ChatGPT subscription is a routing identity rather than a connectable
+ * kind, so `unconnectedProviders` does not list it. It is added next to the
+ * API-key route it shares its models with, which is where a user comparing
+ * the two ways to reach a GPT model expects to find it.
+ */
+function candidateKinds(
+  connections: readonly ProviderConnection[],
+): CandidateKinds {
+  const mutableConnections = [...connections];
+  const served = providersServedByConnections(mutableConnections);
+  const connected = new Set(served);
+  const pending = unconnectedProviders(mutableConnections);
+  if (!connected.has(CHATGPT_CONNECTION_PROVIDER)) {
+    const openaiIndex = pending.indexOf("openai");
+    if (openaiIndex >= 0) {
+      pending.splice(openaiIndex + 1, 0, CHATGPT_CONNECTION_PROVIDER);
+    } else {
+      pending.push(CHATGPT_CONNECTION_PROVIDER);
+    }
+  }
+  return { kinds: [...served, ...pending], connected };
+}
+
+/** One row of the shared provider-picker encoding. */
+type PickerRow = ReturnType<typeof expandEndpointEntries>[number];
+
+/**
+ * Picker rows for one connected kind, keyed by row value. A kind with a
+ * single connection yields one bare row; a kind with siblings yields its
+ * default row plus one row per named connection.
+ */
+function entryRowsForKind(
+  kind: ConnectionProvider,
+  input: ModelFirstInput,
+): PickerRow[] {
+  return expandEndpointEntries(
+    [kind],
+    [...input.connections],
+    input.labelFor,
+    input.defaultEntryMetaLabel,
+  );
+}
+
+function connectedCandidate(
+  kind: ConnectionProvider,
+  row: PickerRow,
+  modelId: string,
+): ProviderCandidate {
+  return {
+    value: row.value,
+    provider: kind,
+    connectionName: parseEntryPickerValue(row.value)?.connectionName ?? "",
+    label: row.label,
+    meta: row.meta,
+    modelId,
+    connected: true,
+    setup: null,
+  };
+}
+
+function unconnectedCandidate(
+  kind: ConnectionProvider,
+  modelId: string,
+  input: ModelFirstInput,
+): ProviderCandidate {
+  return {
+    value: kind,
+    provider: kind,
+    connectionName: "",
+    label: input.labelFor(kind),
+    modelId,
+    connected: false,
+    setup: setupForProvider(kind),
+  };
+}
+
+function selectableKinds(input: ModelFirstInput): CandidateKinds {
+  const { kinds, connected } = candidateKinds(input.connections);
+  return {
+    kinds: kinds.filter((kind) =>
+      isProviderSelectableForAssistant(kind, input.activeAssistantIsSelfHosted),
+    ),
+    connected,
+  };
+}
+
+/**
+ * Every model the assistant can use, deduplicated by display name, in the
+ * order a person should meet them: the models their connected routes already
+ * serve, then the rest of the catalog.
+ *
+ * A model no reachable route serves is absent rather than disabled. This list
+ * is the flow's first question, and an option that cannot lead anywhere is
+ * not an answer to it.
+ */
+export function resolveModelFirstOptions(
+  input: ModelFirstInput,
+): ModelFirstOption[] {
+  const { kinds, connected } = selectableKinds(input);
+  const byDisplayName = new Map<string, ProviderCandidate[]>();
+  const order: string[] = [];
+
+  function add(displayName: string, candidate: ProviderCandidate): void {
+    const existing = byDisplayName.get(displayName);
+    if (existing) {
+      existing.push(candidate);
+      return;
+    }
+    byDisplayName.set(displayName, [candidate]);
+    order.push(displayName);
+  }
+
+  for (const kind of kinds) {
+    if (kind === OPENAI_COMPATIBLE_PROVIDER) {
+      // A custom endpoint has no catalog: the models it serves are the ones
+      // its own connection row lists, so each endpoint contributes only its
+      // own models and is a candidate only for those.
+      const rows = entryRowsForKind(kind, input);
+      for (const connection of input.connections) {
+        if (connection.provider !== OPENAI_COMPATIBLE_PROVIDER) {
+          continue;
+        }
+        const row = rows.find(
+          (candidateRow) =>
+            candidateRow.value === entryPickerValue(kind, connection.name),
+        );
+        if (!row) {
+          continue;
+        }
+        for (const model of connection.models ?? []) {
+          add(
+            model.displayName ?? model.id,
+            connectedCandidate(kind, row, model.id),
+          );
+        }
+      }
+      continue;
+    }
+
+    const models = getVisibleModelsForProvider(kind, input.developerMode);
+    if (models.length === 0) {
+      continue;
+    }
+    if (!connected.has(kind)) {
+      for (const model of models) {
+        add(model.displayName, unconnectedCandidate(kind, model.id, input));
+      }
+      continue;
+    }
+    const rows = entryRowsForKind(kind, input);
+    for (const model of models) {
+      for (const row of rows) {
+        add(model.displayName, connectedCandidate(kind, row, model.id));
+      }
+    }
+  }
+
+  return order.map((displayName) => {
+    const candidates = byDisplayName.get(displayName) ?? [];
+    const providerKinds = new Set(
+      candidates.map((candidate) => candidate.provider),
+    );
+    const first = candidates[0];
+    const soleProviderLabel =
+      providerKinds.size === 1 && first !== undefined
+        ? candidates.length === 1
+          ? first.label
+          : input.labelFor(first.provider)
+        : null;
+    return {
+      displayName,
+      candidates,
+      providerCount: providerKinds.size,
+      soleProviderLabel,
+    };
+  });
+}
+
+/**
+ * Routes that accept a model id typed by hand, in the same order.
+ *
+ * The ChatGPT subscription is excluded: it validates every id against the
+ * fixed Codex set, so a typed one could never dispatch through it.
+ */
+export function customModelProviderCandidates(
+  input: ModelFirstInput,
+  modelId: string,
+): ProviderCandidate[] {
+  const { kinds, connected } = selectableKinds(input);
+  const candidates: ProviderCandidate[] = [];
+  for (const kind of kinds) {
+    if (kind === CHATGPT_CONNECTION_PROVIDER) {
+      continue;
+    }
+    if (connected.has(kind)) {
+      for (const row of entryRowsForKind(kind, input)) {
+        candidates.push(connectedCandidate(kind, row, modelId));
+      }
+      continue;
+    }
+    candidates.push(unconnectedCandidate(kind, modelId, input));
+  }
+  return candidates;
+}
+
+/**
+ * The candidate a model opens on: the first connected route, so the common
+ * case needs no decision at all. With nothing connected the first route wins
+ * instead, which is the one the flow then offers to connect inline.
+ */
+export function defaultProviderCandidate(
+  candidates: readonly ProviderCandidate[],
+): ProviderCandidate | null {
+  return (
+    candidates.find((candidate) => candidate.connected) ?? candidates[0] ?? null
+  );
+}

--- a/clients/web/src/domains/settings/ai/model-first-candidates.ts
+++ b/clients/web/src/domains/settings/ai/model-first-candidates.ts
@@ -19,12 +19,17 @@
  * caller-supplied for the same reason.
  */
 
-import { getVisibleModelsForProvider } from "@/assistant/llm-model-catalog";
+import {
+  getVisibleModelsForProvider,
+  MODELS_BY_PROVIDER,
+  type LlmCatalogModel,
+} from "@/assistant/llm-model-catalog";
 import {
   CHATGPT_CONNECTION_PROVIDER,
   OPENAI_COMPATIBLE_PROVIDER,
 } from "@/domains/settings/ai/constants";
 import {
+  CATALOG_PROVIDERS,
   entryPickerValue,
   expandEndpointEntries,
   isProviderSelectableForAssistant,
@@ -65,6 +70,15 @@ export interface ProviderCandidate {
 export interface ModelFirstOption {
   /** Cross-provider identity of the model, and the picker's option value. */
   readonly displayName: string;
+  /**
+   * The provider the model is filed under: the first in catalog order that
+   * lists it. For a model several providers host this is the one that made
+   * it available first, which for a first-party model is its vendor and for
+   * an open-weights model is whichever host the catalog lists first.
+   */
+  readonly owner: ConnectionProvider;
+  /** The model line this belongs to, or null when it has no older siblings. */
+  readonly family: string | null;
   /** Every route that can serve it, connected ones first. */
   readonly candidates: readonly ProviderCandidate[];
   /** Distinct provider kinds among the candidates. */
@@ -190,6 +204,37 @@ function selectableKinds(input: ModelFirstInput): CandidateKinds {
   };
 }
 
+interface CatalogEntry {
+  readonly owner: ConnectionProvider;
+  readonly family: string | null;
+  /** Position within the owner's own catalog, which is authored newest first. */
+  readonly rank: number;
+}
+
+/**
+ * Where each model is filed, keyed by the display name that identifies it
+ * across providers. Built from the raw catalog rather than
+ * `getModelsForProvider`, because who lists a model first is a fact about the
+ * catalog and does not move with a feature flag or a routing identity.
+ */
+const CATALOG_INDEX: ReadonlyMap<string, CatalogEntry> = (() => {
+  const index = new Map<string, CatalogEntry>();
+  for (const provider of CATALOG_PROVIDERS) {
+    const models: readonly LlmCatalogModel[] = MODELS_BY_PROVIDER[provider];
+    models.forEach((model, rank) => {
+      if (index.has(model.displayName)) {
+        return;
+      }
+      index.set(model.displayName, {
+        owner: provider as ConnectionProvider,
+        family: model.family ?? null,
+        rank,
+      });
+    });
+  }
+  return index;
+})();
+
 /**
  * Every model the assistant can use, deduplicated by display name, in the
  * order a person should meet them: the models their connected routes already
@@ -273,13 +318,111 @@ export function resolveModelFirstOptions(
           ? first.label
           : input.labelFor(first.provider)
         : null;
+    // A model the static catalog does not know (a custom endpoint's own list)
+    // is filed under the route that serves it, which is the only answer
+    // available and the one the user picked it from.
+    const entry = CATALOG_INDEX.get(displayName);
     return {
       displayName,
+      owner: entry?.owner ?? first?.provider ?? OPENAI_COMPATIBLE_PROVIDER,
+      family: entry?.family ?? null,
       candidates,
       providerCount: providerKinds.size,
       soleProviderLabel,
     };
   });
+}
+
+export interface ModelFirstGroup {
+  /** The provider the section is named for. */
+  readonly provider: ConnectionProvider;
+  readonly label: string;
+  /** The section's models, in the owner's own catalog order. */
+  readonly options: readonly ModelFirstOption[];
+}
+
+/**
+ * The model list as sections, which is how a list this long stays readable:
+ * one heading per owning provider, the sections the user's own connections
+ * reach first and the rest of the catalog after.
+ *
+ * Within a section the models keep the owner's catalog order, so the newest
+ * of each line leads and {@link collapseSupersededVersions} can fold the rest
+ * away.
+ */
+export function resolveModelFirstGroups(
+  input: ModelFirstInput,
+): ModelFirstGroup[] {
+  const options = resolveModelFirstOptions(input);
+  const byOwner = new Map<ConnectionProvider, ModelFirstOption[]>();
+  for (const option of options) {
+    const existing = byOwner.get(option.owner);
+    if (existing) {
+      existing.push(option);
+      continue;
+    }
+    byOwner.set(option.owner, [option]);
+  }
+
+  const served = providersServedByConnections([...input.connections]);
+  const ordered: ConnectionProvider[] = [];
+  for (const provider of served) {
+    if (byOwner.has(provider) && !ordered.includes(provider)) {
+      ordered.push(provider);
+    }
+  }
+  for (const provider of CATALOG_PROVIDERS) {
+    const owner = provider as ConnectionProvider;
+    if (byOwner.has(owner) && !ordered.includes(owner)) {
+      ordered.push(owner);
+    }
+  }
+  // A section whose owner the catalog does not list at all still gets drawn,
+  // rather than dropping models the picker just offered.
+  for (const owner of byOwner.keys()) {
+    if (!ordered.includes(owner)) {
+      ordered.push(owner);
+    }
+  }
+
+  return ordered.map((provider) => ({
+    provider,
+    label: input.labelFor(provider),
+    options: (byOwner.get(provider) ?? [])
+      .slice()
+      .sort(
+        (a, b) =>
+          (CATALOG_INDEX.get(a.displayName)?.rank ?? 0) -
+          (CATALOG_INDEX.get(b.displayName)?.rank ?? 0),
+      ),
+  }));
+}
+
+/**
+ * Split a section into the models it shows and the ones it folds away: the
+ * first member of each line stays, its older siblings go behind the section's
+ * own "show older versions" row. A model with no line always shows, having
+ * nothing newer to stand behind.
+ */
+export function collapseSupersededVersions(
+  options: readonly ModelFirstOption[],
+): { shown: ModelFirstOption[]; hidden: ModelFirstOption[] } {
+  const shown: ModelFirstOption[] = [];
+  const hidden: ModelFirstOption[] = [];
+  const led = new Set<string>();
+  for (const option of options) {
+    if (option.family === null) {
+      shown.push(option);
+      continue;
+    }
+    if (led.has(option.family)) {
+      hidden.push(option);
+      continue;
+    }
+    led.add(option.family);
+    shown.push(option);
+  }
+  return { shown, hidden };
 }
 
 /**

--- a/clients/web/src/domains/settings/ai/model-first-groups.test.ts
+++ b/clients/web/src/domains/settings/ai/model-first-groups.test.ts
@@ -1,0 +1,176 @@
+/**
+ * How the model-first list is shaped before anyone types: one section per
+ * owning provider, and the older members of a model line folded away behind
+ * the newest.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import {
+  collapseSupersededVersions,
+  resolveModelFirstGroups,
+  type ModelFirstInput,
+} from "@/domains/settings/ai/model-first-candidates";
+import type { ProviderConnection } from "@/generated/daemon/types.gen";
+
+function connection(
+  name: string,
+  provider: string,
+  overrides: Record<string, unknown> = {},
+): ProviderConnection {
+  return {
+    name,
+    label: null,
+    provider,
+    auth: { type: "api_key", credential: `credential/${provider}/api_key` },
+    models: null,
+    ...overrides,
+  } as unknown as ProviderConnection;
+}
+
+function input(
+  connections: ProviderConnection[],
+  overrides: Partial<ModelFirstInput> = {},
+): ModelFirstInput {
+  return {
+    connections,
+    developerMode: false,
+    activeAssistantIsSelfHosted: true,
+    labelFor: (provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+    defaultEntryMetaLabel: "Default",
+    ...overrides,
+  };
+}
+
+function groupLabels(connections: ProviderConnection[]): string[] {
+  return resolveModelFirstGroups(input(connections)).map((group) => group.label);
+}
+
+function groupFor(connections: ProviderConnection[], provider: string) {
+  const group = resolveModelFirstGroups(input(connections)).find(
+    (entry) => entry.provider === provider,
+  );
+  if (!group) {
+    throw new Error(`expected a "${provider}" group`);
+  }
+  return group;
+}
+
+function namesOf(connections: ProviderConnection[], provider: string) {
+  return groupFor(connections, provider).options.map(
+    (option) => option.displayName,
+  );
+}
+
+describe("resolveModelFirstGroups", () => {
+  test("files a model under the first provider the catalog lists it", () => {
+    expect(namesOf([], "anthropic")).toContain("Claude Opus 5");
+    // OpenRouter and Vercel host it too, but neither owns it.
+    expect(namesOf([], "openrouter")).not.toContain("Claude Opus 5");
+    // An open-weights model is filed under whichever host the catalog reaches
+    // first, which is a host rather than the lab that trained it.
+    expect(namesOf([], "fireworks")).toContain("Kimi K3");
+  });
+
+  test("leads with the sections the user's own connections reach", () => {
+    expect(groupLabels([connection("openrouter-key", "openrouter")])[0]).toBe(
+      "OpenRouter",
+    );
+    expect(groupLabels([connection("gemini-key", "gemini")])[0]).toBe(
+      "Google Gemini",
+    );
+    // With nothing connected the catalog's own order stands.
+    expect(groupLabels([])[0]).toBe("Anthropic");
+  });
+
+  test("omits a provider that owns no model the assistant can use", () => {
+    // Together hosts MiniMax M3, but Fireworks lists it first and so owns it.
+    expect(groupLabels([connection("together-key", "together")])).not.toContain(
+      "Together AI",
+    );
+    expect(groupLabels([])).toContain("Ollama");
+    expect(
+      resolveModelFirstGroups(
+        input([], { activeAssistantIsSelfHosted: false }),
+      ).map((group) => group.label),
+    ).not.toContain("Ollama");
+  });
+
+  test("keeps a section in its owner's catalog order", () => {
+    expect(namesOf([], "anthropic").slice(0, 3)).toEqual([
+      "Claude Fable 5",
+      "Claude Opus 5",
+      "Claude Opus 4.8",
+    ]);
+  });
+
+  test("carries the family on each option", () => {
+    const byName = new Map(
+      groupFor([], "anthropic").options.map((option) => [
+        option.displayName,
+        option.family,
+      ]),
+    );
+    expect(byName.get("Claude Opus 5")).toBe("claude-opus");
+    expect(byName.get("Claude Opus 4.8")).toBe("claude-opus");
+    expect(byName.get("Claude Fable 5")).toBeNull();
+  });
+
+  test("files a custom endpoint's own models under that endpoint", () => {
+    const custom = resolveModelFirstGroups(
+      input([
+        connection("lm-studio", "openai-compatible", {
+          label: "LM Studio",
+          models: [{ id: "local-mixtral", displayName: "Local Mixtral" }],
+        }),
+      ]),
+    ).find((group) => group.provider === "openai-compatible");
+    expect(custom?.options.map((option) => option.displayName)).toEqual([
+      "Local Mixtral",
+    ]);
+  });
+});
+
+describe("collapseSupersededVersions", () => {
+  function optionsFor(provider: string) {
+    return groupFor([], provider).options;
+  }
+
+  test("shows the newest of each line and folds the rest away", () => {
+    const { shown, hidden } = collapseSupersededVersions(
+      optionsFor("anthropic"),
+    );
+    expect(shown.map((option) => option.displayName)).toEqual([
+      "Claude Fable 5",
+      "Claude Opus 5",
+      "Claude Sonnet 5",
+      "Claude Haiku 4.5",
+    ]);
+    expect(hidden.map((option) => option.displayName)).toEqual([
+      "Claude Opus 4.8",
+      "Claude Opus 4.7",
+      "Claude Opus 4.6",
+      "Claude Sonnet 4.6",
+      "Claude Sonnet 4.5",
+      "Claude Opus 4.5",
+    ]);
+  });
+
+  test("always shows a model with no older siblings", () => {
+    const { shown } = collapseSupersededVersions(optionsFor("gemini"));
+    expect(shown.map((option) => option.displayName)).toEqual([
+      "Gemini 3.6 Flash",
+      "Gemini 3.5 Flash-Lite",
+      "Gemini 3.1 Pro Preview",
+    ]);
+  });
+
+  test("folds nothing when a section holds one member per line", () => {
+    const { shown, hidden } = collapseSupersededVersions(
+      optionsFor("poolside"),
+    );
+    expect(shown).toHaveLength(2);
+    expect(hidden).toHaveLength(0);
+  });
+});

--- a/clients/web/src/domains/settings/ai/model-first-groups.test.ts
+++ b/clients/web/src/domains/settings/ai/model-first-groups.test.ts
@@ -1,14 +1,14 @@
 /**
  * How the model-first list is shaped before anyone types: one section per
- * owning provider, and the older members of a model line folded away behind
- * the newest.
+ * owning provider, three models offered in each, and the rest of the section
+ * folded away behind them.
  */
 
 import { describe, expect, test } from "bun:test";
 
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import {
-  collapseSupersededVersions,
+  collapseSectionRows,
   resolveModelFirstGroups,
   type ModelFirstInput,
 } from "@/domains/settings/ai/model-first-candidates";
@@ -192,21 +192,21 @@ describe("resolveModelFirstGroups", () => {
   });
 });
 
-describe("collapseSupersededVersions", () => {
+describe("collapseSectionRows", () => {
   function optionsFor(provider: string) {
     return groupFor([], provider).options;
   }
 
-  test("shows the newest of each line and folds the rest away", () => {
-    const { shown, hidden } = collapseSupersededVersions(
-      optionsFor("anthropic"),
-    );
+  test("offers three models and folds the rest of the section away", () => {
+    const options = optionsFor("anthropic");
+    const { shown, hidden } = collapseSectionRows(options);
     expect(shown.map((option) => option.displayName)).toEqual([
       "Claude Fable 5",
       "Claude Opus 5",
       "Claude Sonnet 5",
-      "Claude Haiku 4.5",
     ]);
+    // The rest follows in catalog order, so revealing it reads as the section
+    // carrying on rather than as a second list.
     expect(hidden.map((option) => option.displayName)).toEqual([
       "Claude Opus 4.8",
       "Claude Opus 4.7",
@@ -214,22 +214,24 @@ describe("collapseSupersededVersions", () => {
       "Claude Sonnet 4.6",
       "Claude Sonnet 4.5",
       "Claude Opus 4.5",
+      "Claude Haiku 4.5",
     ]);
+    expect(shown.length + hidden.length).toBe(options.length);
   });
 
-  test("always shows a model with no older siblings", () => {
-    const { shown } = collapseSupersededVersions(optionsFor("gemini"));
+  test("spends the three rows on three lines, not three versions of one", () => {
+    // Every OpenAI line's newest member is a 5.6, so the section leads with
+    // those rather than walking down through 5.5 and 5.4.
+    const { shown } = collapseSectionRows(optionsFor("openai"));
     expect(shown.map((option) => option.displayName)).toEqual([
-      "Gemini 3.6 Flash",
-      "Gemini 3.5 Flash-Lite",
-      "Gemini 3.1 Pro Preview",
+      "GPT-5.6 Sol",
+      "GPT-5.6 Terra",
+      "GPT-5.6 Luna",
     ]);
   });
 
-  test("folds nothing when a section holds one member per line", () => {
-    const { shown, hidden } = collapseSupersededVersions(
-      optionsFor("poolside"),
-    );
+  test("folds nothing when a section holds three models or fewer", () => {
+    const { shown, hidden } = collapseSectionRows(optionsFor("poolside"));
     expect(shown).toHaveLength(2);
     expect(hidden).toHaveLength(0);
   });

--- a/clients/web/src/domains/settings/ai/model-first-groups.test.ts
+++ b/clients/web/src/domains/settings/ai/model-first-groups.test.ts
@@ -47,12 +47,12 @@ function groupLabels(connections: ProviderConnection[]): string[] {
   return resolveModelFirstGroups(input(connections)).map((group) => group.label);
 }
 
-function groupFor(connections: ProviderConnection[], provider: string) {
+function groupFor(connections: ProviderConnection[], key: string) {
   const group = resolveModelFirstGroups(input(connections)).find(
-    (entry) => entry.provider === provider,
+    (entry) => entry.key === key,
   );
   if (!group) {
-    throw new Error(`expected a "${provider}" group`);
+    throw new Error(`expected a "${key}" group`);
   }
   return group;
 }
@@ -64,37 +64,82 @@ function namesOf(connections: ProviderConnection[], provider: string) {
 }
 
 describe("resolveModelFirstGroups", () => {
-  test("files a model under the first provider the catalog lists it", () => {
+  test("names a section for the organisation that made the models", () => {
+    // A first-party lab lists its own work, so its own name stands.
+    expect(groupFor([], "anthropic").label).toBe("Anthropic");
     expect(namesOf([], "anthropic")).toContain("Claude Opus 5");
-    // OpenRouter and Vercel host it too, but neither owns it.
-    expect(namesOf([], "openrouter")).not.toContain("Claude Opus 5");
-    // An open-weights model is filed under whichever host the catalog reaches
-    // first, which is a host rather than the lab that trained it.
-    expect(namesOf([], "fireworks")).toContain("Kimi K3");
+    // Kimi is Moonshot's, Grok is xAI's, whichever gateway serves them.
+    expect(groupFor([], "moonshot").label).toBe("Moonshot AI");
+    expect(namesOf([], "moonshot")).toContain("Kimi K3");
+    expect(groupFor([], "xai").label).toBe("xAI");
+    expect(namesOf([], "xai")).toContain("Grok 4.6");
+  });
+
+  test("never names a section for a gateway", () => {
+    const labels = groupLabels([]);
+    for (const gateway of [
+      "Fireworks",
+      "OpenRouter",
+      "Together AI",
+      "Vercel AI Gateway",
+      "Ollama",
+      "Baseten",
+    ]) {
+      expect(labels, `${gateway} still names a section`).not.toContain(gateway);
+    }
+  });
+
+  test("merges the providers that list one vendor's work", () => {
+    // Fireworks lists the newest MiniMax, OpenRouter the older ones, and
+    // MiniMax hosts its own: one section, each model once.
+    const minimax = namesOf([], "minimax");
+    expect(minimax).toContain("MiniMax M3");
+    expect(minimax).toContain("MiniMax-01");
+    expect(minimax.filter((name) => name === "MiniMax M3")).toHaveLength(1);
+    expect(groupLabels([]).filter((label) => label === "MiniMax")).toHaveLength(
+      1,
+    );
+    // A model two providers list still lands in one section, once.
+    expect(namesOf([], "xai").filter((name) => name === "Grok 4.3")).toHaveLength(
+      1,
+    );
+    // And a variant only a gateway lists joins its maker's section.
+    expect(namesOf([], "openai")).toContain("GPT-5.6 Sol Pro");
   });
 
   test("leads with the sections the user's own connections reach", () => {
-    expect(groupLabels([connection("openrouter-key", "openrouter")])[0]).toBe(
-      "OpenRouter",
-    );
     expect(groupLabels([connection("gemini-key", "gemini")])[0]).toBe(
       "Google Gemini",
+    );
+    // Fireworks serves four vendors; the first of them in catalog order leads.
+    expect(groupLabels([connection("fw-key", "fireworks")])[0]).toBe(
+      "Moonshot AI",
     );
     // With nothing connected the catalog's own order stands.
     expect(groupLabels([])[0]).toBe("Anthropic");
   });
 
-  test("omits a provider that owns no model the assistant can use", () => {
-    // Together hosts MiniMax M3, but Fireworks lists it first and so owns it.
-    expect(groupLabels([connection("together-key", "together")])).not.toContain(
-      "Together AI",
+  test("sinks a section the user's connections cannot reach", () => {
+    const labels = groupLabels([connection("openrouter-key", "openrouter")]);
+    // OpenRouter serves Grok and Claude but no Gemini, so Gemini goes below
+    // every section it does serve.
+    expect(labels.indexOf("Google Gemini")).toBeGreaterThan(
+      labels.indexOf("xAI"),
     );
-    expect(groupLabels([])).toContain("Ollama");
+    expect(labels.indexOf("Google Gemini")).toBeGreaterThan(
+      labels.indexOf("Anthropic"),
+    );
+  });
+
+  test("omits a section whose models the assistant cannot use", () => {
+    // Ollama serves Llama 3.2, which only a self-hosted assistant reaches.
+    expect(namesOf([], "meta")).toContain("Llama 3.2");
+    const platformHosted = resolveModelFirstGroups(
+      input([], { activeAssistantIsSelfHosted: false }),
+    ).find((group) => group.key === "meta");
     expect(
-      resolveModelFirstGroups(
-        input([], { activeAssistantIsSelfHosted: false }),
-      ).map((group) => group.label),
-    ).not.toContain("Ollama");
+      platformHosted?.options.map((option) => option.displayName),
+    ).not.toContain("Llama 3.2");
   });
 
   test("keeps a section in its owner's catalog order", () => {
@@ -103,6 +148,21 @@ describe("resolveModelFirstGroups", () => {
       "Claude Opus 5",
       "Claude Opus 4.8",
     ]);
+  });
+
+  test("carries the vendor on each option", () => {
+    const byName = new Map(
+      groupFor([], "xai").options.map((option) => [
+        option.displayName,
+        option.vendor,
+      ]),
+    );
+    expect(byName.get("Grok 4.6")).toBe("xai");
+    expect(
+      groupFor([], "anthropic").options.every(
+        (option) => option.vendor === null,
+      ),
+    ).toBe(true);
   });
 
   test("carries the family on each option", () => {
@@ -125,7 +185,7 @@ describe("resolveModelFirstGroups", () => {
           models: [{ id: "local-mixtral", displayName: "Local Mixtral" }],
         }),
       ]),
-    ).find((group) => group.provider === "openai-compatible");
+    ).find((group) => group.key === "openai-compatible");
     expect(custom?.options.map((option) => option.displayName)).toEqual([
       "Local Mixtral",
     ]);

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -192,9 +192,24 @@ function modelOptionLabels(): string[] {
 function groupHeadings(): string[] {
   return Array.from(
     document.querySelectorAll<HTMLElement>('[data-slot="combobox-group"]'),
-  ).map((group) =>
-    (group.firstElementChild?.textContent ?? "").trim(),
+  ).map((group) => (group.firstElementChild?.textContent ?? "").trim());
+}
+
+/** Row labels inside one section, which is where a label is unambiguous. */
+function sectionRowLabels(heading: string): string[] {
+  const section = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-slot="combobox-group"]'),
+  ).find(
+    (group) => (group.firstElementChild?.textContent ?? "").trim() === heading,
   );
+  if (!section) {
+    throw new Error(
+      `expected a "${heading}" section - saw ${groupHeadings().join(", ")}`,
+    );
+  }
+  return Array.from(
+    section.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map(optionLabel);
 }
 
 /** Type into the model field, which is the list's own search box. */
@@ -418,30 +433,48 @@ describe("the model list", () => {
     );
   });
 
-  test("files models under the provider that owns them, connected first", () => {
+  test("files models under whoever made them, reachable sections first", () => {
     renderCreate([makeConnection("gemini-key", "gemini")]);
     openModelList();
 
     const headings = groupHeadings();
     expect(headings.slice(0, 2)).toEqual(["Google Gemini", "Anthropic"]);
-    // Together hosts models but owns none, so it never becomes a heading.
+    // Grok is xAI's work, whichever gateway happens to serve it, and no
+    // gateway names a section of its own.
+    expect(headings).toContain("xAI");
+    expect(sectionRowLabels("xAI")).toContain("Grok 4.6");
+    expect(headings).not.toContain("OpenRouter");
+    expect(headings).not.toContain("Fireworks");
     expect(headings).not.toContain("Together AI");
+  });
+
+  test("draws one section for a vendor several providers serve", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+    openModelList();
+
+    expect(
+      groupHeadings().filter((heading) => heading === "MiniMax"),
+    ).toHaveLength(1);
+    // Fireworks lists the newest MiniMax and OpenRouter the older ones.
+    expect(sectionRowLabels("MiniMax")).toContain("MiniMax M3");
   });
 
   test("folds older versions behind a row that unfolds the section", () => {
     renderCreate([makeConnection("anthropic-personal")]);
     openModelList();
 
-    expect(modelOptionLabels()).not.toContain("Claude Opus 4.8");
-    expect(modelOptionLabels()).toContain("Claude Opus 5");
-    expect(modelOptionLabels()).toContain("Show older versions (6)");
+    expect(sectionRowLabels("Anthropic")).not.toContain("Claude Opus 4.8");
+    expect(sectionRowLabels("Anthropic")).toContain("Claude Opus 5");
+    expect(sectionRowLabels("Anthropic")).toContain("Show older versions (6)");
 
     clickModelOption("Show older versions (6)");
 
     // The list stays open on the row that was just acted on, and the older
     // versions take the place of the row that stood in for them.
-    expect(modelOptionLabels()).toContain("Claude Opus 4.8");
-    expect(modelOptionLabels()).not.toContain("Show older versions (6)");
+    expect(sectionRowLabels("Anthropic")).toContain("Claude Opus 4.8");
+    expect(sectionRowLabels("Anthropic")).not.toContain(
+      "Show older versions (6)",
+    );
     // Unfolding is not an answer: no model is chosen by it.
     expect(getSaveBtn().disabled).toBe(true);
   });

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -26,6 +26,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
+import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
@@ -96,6 +97,8 @@ const { ProfileEditorModal } = await import(
 // ---------------------------------------------------------------------------
 
 const ASSISTANT_ID = "asst-1";
+
+const initialLifecycleState = useAssistantLifecycleStore.getState();
 
 function makeConnection(
   name: string,
@@ -262,6 +265,49 @@ function getInputByPlaceholder(placeholder: string): HTMLInputElement {
   return input;
 }
 
+function hasInputWithPlaceholder(placeholder: string): boolean {
+  return Array.from(document.querySelectorAll<HTMLInputElement>("input")).some(
+    (el) => el.placeholder === placeholder,
+  );
+}
+
+/** The inline connect form's own Cancel, not the modal footer's. */
+function inlineCancelButton(): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find(
+    (b) =>
+      b.textContent?.trim() === "Cancel" &&
+      b.dataset.testid !== "modal-cancel-btn",
+  );
+  if (!match) {
+    throw new Error("expected the connect form's Cancel button");
+  }
+  return match;
+}
+
+/**
+ * Expand the connect form's own Advanced disclosure. Idempotent, so a form
+ * that survived a route change (the bug this guards) is not toggled shut and
+ * the assertion lands on its stale seed rather than on a missing field.
+ */
+function openCreateFormAdvanced(): void {
+  const toggle = getButton("Advanced");
+  if (toggle.getAttribute("aria-expanded") !== "true") {
+    fireEvent.click(toggle);
+  }
+}
+
+function setupActionButton(): HTMLButtonElement {
+  const match = document.querySelector<HTMLButtonElement>(
+    '[data-testid="candidate-setup-btn"]',
+  );
+  if (!match) {
+    throw new Error("expected a setup action on the provider card");
+  }
+  return match;
+}
+
 function setModelFirstFlag(value: boolean): void {
   useClientFeatureFlagStore.setState({ modelFirstProfileCreate: value });
 }
@@ -281,6 +327,7 @@ afterEach(() => {
   cleanup();
   setModelFirstFlag(false);
   useAssistantIdentityStore.getState().clearIdentity();
+  useAssistantLifecycleStore.setState(initialLifecycleState);
 });
 
 // ---------------------------------------------------------------------------
@@ -465,6 +512,49 @@ describe("a route with no connection yet", () => {
     expect(saveCalls[0].entry.provider_connection).toBe("openrouter-key");
     // The Name still comes from the model's display name, not its raw id.
     expect(saveCalls[0].name).toBe("claude-opus-4-8");
+  });
+
+  test("re-keys the connect form when the lone route changes", () => {
+    // Ollama is a local runtime, so only a self-hosted assistant offers it.
+    useAssistantLifecycleStore.setState({
+      assistantState: { kind: "self_hosted" },
+    });
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Gemini 3.6 Flash");
+    expect(candidateValues()).toEqual(["gemini"]);
+    openCreateFormAdvanced();
+    expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe(
+      "Google Gemini",
+    );
+
+    // The step stays in its lone-route branch, so the form is only remounted
+    // by its key. Without one it would still be creating a Gemini connection
+    // while the card names Ollama, since it seeds itself from props at mount.
+    selectModel("Llama 3.2");
+    expect(candidateValues()).toEqual(["ollama"]);
+    openCreateFormAdvanced();
+    expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe("Ollama");
+    // Ollama authenticates with nothing, so no key is asked for either.
+    expect(hasInputWithPlaceholder("Enter your API key")).toBe(false);
+  });
+
+  test("keeps a lone route reachable after its setup is cancelled", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Gemini 3.6 Flash");
+    expect(hasInputWithPlaceholder("Enter your API key")).toBe(true);
+
+    fireEvent.click(inlineCancelButton());
+
+    // The route stays selected and only its form collapses; the card's own
+    // action is what reopens it, since a lone route has no radio to re-click.
+    expect(candidateValues()).toEqual(["gemini"]);
+    expect(hasInputWithPlaceholder("Enter your API key")).toBe(false);
+    expect(setupActionButton().textContent?.trim()).toBe("Add API key");
+
+    fireEvent.click(setupActionButton());
+    expect(hasInputWithPlaceholder("Enter your API key")).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -232,19 +232,13 @@ function clickModelOption(label: string): void {
   fireEvent.click(option);
 }
 
+/**
+ * Picks a model by name through the query that finds it, which is the one
+ * path that reaches every model: a section offers three and folds the rest.
+ */
 function selectModel(label: string): void {
-  openModelList();
-  const option = Array.from(
-    document.querySelectorAll<HTMLElement>('[role="option"]'),
-  ).find((o) => optionLabel(o) === label);
-  if (!option) {
-    throw new Error(
-      `expected a Model list offering "${label}" - saw ${
-        document.querySelectorAll('[role="option"]').length
-      } rows`,
-    );
-  }
-  fireEvent.click(option);
+  searchModels(label);
+  clickModelOption(label);
 }
 
 function candidateCards(): HTMLElement[] {
@@ -452,38 +446,41 @@ describe("the model list", () => {
     expect(sectionRowLabels("MiniMax")).toContain("MiniMax M3");
   });
 
-  test("folds older versions behind a row that unfolds the section", () => {
+  test("offers three models per section and folds the rest behind See more", () => {
     renderCreate([makeConnection("anthropic-personal")]);
     openModelList();
 
-    expect(sectionRowLabels("Anthropic")).not.toContain("Claude Opus 4.8");
-    expect(sectionRowLabels("Anthropic")).toContain("Claude Opus 5");
-    expect(sectionRowLabels("Anthropic")).toContain("Show older versions (6)");
+    // Three rows and the unfold row, whatever the section holds behind it.
+    expect(sectionRowLabels("Anthropic")).toEqual([
+      "Claude Fable 5",
+      "Claude Opus 5",
+      "Claude Sonnet 5",
+      "See more",
+    ]);
 
-    clickModelOption("Show older versions (6)");
+    clickModelOption("See more");
 
-    // The list stays open on the row that was just acted on, and the older
-    // versions take the place of the row that stood in for them.
+    // The list stays open on the row that was just acted on, and the rest of
+    // the section takes the place of the row that stood in for it.
+    expect(sectionRowLabels("Anthropic")).toContain("Claude Haiku 4.5");
     expect(sectionRowLabels("Anthropic")).toContain("Claude Opus 4.8");
-    expect(sectionRowLabels("Anthropic")).not.toContain(
-      "Show older versions (6)",
-    );
+    expect(sectionRowLabels("Anthropic")).not.toContain("See more");
     // Unfolding is not an answer: no model is chosen by it.
     expect(getSaveBtn().disabled).toBe(true);
   });
 
-  test("a query reaches a folded version and drops the unfold row", () => {
+  test("a query reaches a folded model and drops the unfold row", () => {
     renderCreate([makeConnection("anthropic-personal")]);
 
     searchModels("Opus 4.8");
 
     expect(modelOptionLabels()).toContain("Claude Opus 4.8");
-    expect(modelOptionLabels()).not.toContain("Show older versions (6)");
+    expect(modelOptionLabels()).not.toContain("See more");
     // The headings survive a query, so a match is still placed.
     expect(groupHeadings()).toEqual(["Anthropic"]);
   });
 
-  test("a folded version picked from a query is the model chosen", async () => {
+  test("a folded model picked from a query is the model chosen", async () => {
     const saveCalls = renderCreate([makeConnection("anthropic-personal")]);
 
     searchModels("Opus 4.8");

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -322,19 +322,12 @@ function hasInputWithPlaceholder(placeholder: string): boolean {
   );
 }
 
-/** The inline connect form's own Cancel, not the modal footer's. */
+/**
+ * The inline connect form's own dismiss action. It is named apart from the
+ * dialog's Cancel, which sits right below it and abandons the whole profile.
+ */
 function inlineCancelButton(): HTMLButtonElement {
-  const match = Array.from(
-    document.querySelectorAll<HTMLButtonElement>("button"),
-  ).find(
-    (b) =>
-      b.textContent?.trim() === "Cancel" &&
-      b.dataset.testid !== "modal-cancel-btn",
-  );
-  if (!match) {
-    throw new Error("expected the connect form's Cancel button");
-  }
-  return match;
+  return getButton("Cancel setup");
 }
 
 /**
@@ -661,6 +654,38 @@ describe("a route with no connection yet", () => {
     expect(getInputByPlaceholder("e.g. My Anthropic Key").value).toBe("Ollama");
     // Ollama authenticates with nothing, so no key is asked for either.
     expect(hasInputWithPlaceholder("Enter your API key")).toBe(false);
+  });
+
+  test("puts the tag that asked for a key away while the form is open", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Claude Opus 5");
+    expect(candidateCard("openrouter").textContent).toContain("Add API key");
+
+    pickCandidate("openrouter");
+
+    // The form below the row is already the answer to what the tag asked
+    // for, so the row states the route and nothing else.
+    expect(candidateCard("openrouter").textContent).not.toContain(
+      "Add API key",
+    );
+    // Only that route's tag: the others still say where they stand.
+    expect(candidateCard("anthropic").textContent).toContain("Connected");
+
+    fireEvent.click(inlineCancelButton());
+    expect(candidateCard("openrouter").textContent).toContain("Add API key");
+  });
+
+  test("names its dismiss action apart from the dialog's Cancel", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Gemini 3.6 Flash");
+
+    const dialogCancel = document.querySelector<HTMLButtonElement>(
+      '[data-testid="modal-cancel-btn"]',
+    );
+    expect(dialogCancel?.textContent?.trim()).toBe("Cancel");
+    expect(inlineCancelButton()).not.toBe(dialogCancel);
   });
 
   test("keeps a lone route reachable after its setup is cancelled", () => {

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -181,6 +181,42 @@ function modelRows(): { label: string; meta: string }[] {
   });
 }
 
+/** Row labels of the already-open list, in order. */
+function modelOptionLabels(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map(optionLabel);
+}
+
+/** Section headings on the open list, in order. */
+function groupHeadings(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-slot="combobox-group"]'),
+  ).map((group) =>
+    (group.firstElementChild?.textContent ?? "").trim(),
+  );
+}
+
+/** Type into the model field, which is the list's own search box. */
+function searchModels(query: string): void {
+  openModelList();
+  fireEvent.change(modelField(), { target: { value: query } });
+}
+
+function clickModelOption(label: string): void {
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => optionLabel(o) === label);
+  if (!option) {
+    throw new Error(
+      `expected a Model list offering "${label}" - saw ${
+        document.querySelectorAll('[role="option"]').length
+      } rows`,
+    );
+  }
+  fireEvent.click(option);
+}
+
 function selectModel(label: string): void {
   openModelList();
   const option = Array.from(
@@ -367,7 +403,7 @@ describe("the model list", () => {
     renderCreate([makeConnection("anthropic-personal")]);
 
     const rows = modelRows();
-    const opus = rows.filter((row) => row.label === "Claude Opus 4.8");
+    const opus = rows.filter((row) => row.label === "Claude Opus 5");
     expect(opus).toHaveLength(1);
     expect(opus[0].meta).toBe("3 providers");
 
@@ -380,6 +416,61 @@ describe("the model list", () => {
     expect(modelRows().map((row) => row.label)).toContain(
       "Enter a custom model ID…",
     );
+  });
+
+  test("files models under the provider that owns them, connected first", () => {
+    renderCreate([makeConnection("gemini-key", "gemini")]);
+    openModelList();
+
+    const headings = groupHeadings();
+    expect(headings.slice(0, 2)).toEqual(["Google Gemini", "Anthropic"]);
+    // Together hosts models but owns none, so it never becomes a heading.
+    expect(headings).not.toContain("Together AI");
+  });
+
+  test("folds older versions behind a row that unfolds the section", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+    openModelList();
+
+    expect(modelOptionLabels()).not.toContain("Claude Opus 4.8");
+    expect(modelOptionLabels()).toContain("Claude Opus 5");
+    expect(modelOptionLabels()).toContain("Show older versions (6)");
+
+    clickModelOption("Show older versions (6)");
+
+    // The list stays open on the row that was just acted on, and the older
+    // versions take the place of the row that stood in for them.
+    expect(modelOptionLabels()).toContain("Claude Opus 4.8");
+    expect(modelOptionLabels()).not.toContain("Show older versions (6)");
+    // Unfolding is not an answer: no model is chosen by it.
+    expect(getSaveBtn().disabled).toBe(true);
+  });
+
+  test("a query reaches a folded version and drops the unfold row", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    searchModels("Opus 4.8");
+
+    expect(modelOptionLabels()).toContain("Claude Opus 4.8");
+    expect(modelOptionLabels()).not.toContain("Show older versions (6)");
+    // The headings survive a query, so a match is still placed.
+    expect(groupHeadings()).toEqual(["Anthropic"]);
+  });
+
+  test("a folded version picked from a query is the model chosen", async () => {
+    const saveCalls = renderCreate([makeConnection("anthropic-personal")]);
+
+    searchModels("Opus 4.8");
+    clickModelOption("Claude Opus 4.8");
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.model).toBe("claude-opus-4-8");
   });
 });
 
@@ -413,7 +504,7 @@ describe("the provider step", () => {
       makeConnection("anthropic-personal"),
     ]);
 
-    selectModel("Claude Opus 4.8");
+    selectModel("Claude Opus 5");
 
     expect(candidateValues()).toEqual([
       "anthropic",
@@ -433,7 +524,7 @@ describe("the provider step", () => {
       makeConnection("openrouter-key", "openrouter"),
     ]);
 
-    selectModel("Claude Opus 4.8");
+    selectModel("Claude Opus 5");
     pickCandidate("openrouter");
 
     await waitFor(() => {
@@ -444,7 +535,7 @@ describe("the provider step", () => {
       expect(saveCalls.length).toBe(1);
     });
     expect(saveCalls[0].entry.provider).toBe("openrouter");
-    expect(saveCalls[0].entry.model).toBe("anthropic/claude-opus-4.8");
+    expect(saveCalls[0].entry.model).toBe("anthropic/claude-opus-5");
   });
 
   test("names the key a route with siblings would use", () => {
@@ -453,7 +544,7 @@ describe("the provider step", () => {
       makeConnection("anthropic-personal", "anthropic", { label: "Personal" }),
     ]);
 
-    selectModel("Claude Opus 4.8");
+    selectModel("Claude Opus 5");
 
     expect(candidateValues().slice(0, 3)).toEqual([
       "anthropic",
@@ -470,7 +561,7 @@ describe("a route with no connection yet", () => {
   test("blocks Save and expands its own connect form", async () => {
     renderCreate([makeConnection("anthropic-personal")]);
 
-    selectModel("Claude Opus 4.8");
+    selectModel("Claude Opus 5");
     await waitFor(() => {
       expect(getSaveBtn().disabled).toBe(false);
     });
@@ -492,7 +583,7 @@ describe("a route with no connection yet", () => {
     createdConnection = makeConnection("openrouter-key", "openrouter");
     const saveCalls = renderCreate([makeConnection("anthropic-personal")]);
 
-    selectModel("Claude Opus 4.8");
+    selectModel("Claude Opus 5");
     pickCandidate("openrouter");
 
     fireEvent.change(getInputByPlaceholder("Enter your API key"), {
@@ -508,10 +599,10 @@ describe("a route with no connection yet", () => {
       expect(saveCalls.length).toBe(1);
     });
     expect(saveCalls[0].entry.provider).toBe("openrouter");
-    expect(saveCalls[0].entry.model).toBe("anthropic/claude-opus-4.8");
+    expect(saveCalls[0].entry.model).toBe("anthropic/claude-opus-5");
     expect(saveCalls[0].entry.provider_connection).toBe("openrouter-key");
     // The Name still comes from the model's display name, not its raw id.
-    expect(saveCalls[0].name).toBe("claude-opus-4-8");
+    expect(saveCalls[0].name).toBe("claude-opus-5");
   });
 
   test("re-keys the connect form when the lone route changes", () => {

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -26,6 +26,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
+import { SEARCHABLE_SELECT_MENU_REACH } from "@vellumai/design-library/components/searchable-select";
+
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
 import * as sdkGen from "@/generated/daemon/sdk.gen";
@@ -145,6 +147,17 @@ function renderCreate(
     </Wrapper>,
   );
   return saveCalls;
+}
+
+/** The field stack, which is where the dialog's reserve for the list sits. */
+function fieldStack(): HTMLElement {
+  const stack = document.querySelector<HTMLElement>(
+    '[data-testid="model-first-fields"]',
+  );
+  if (!stack) {
+    throw new Error("expected the model-first field stack");
+  }
+  return stack;
 }
 
 function modelField(): HTMLInputElement {
@@ -494,6 +507,29 @@ describe("the model list", () => {
       expect(saveCalls.length).toBe(1);
     });
     expect(saveCalls[0].entry.model).toBe("claude-opus-4-8");
+  });
+});
+
+describe("the room the dialog keeps for the open list", () => {
+  test("is reserved while the Model field is the whole of it", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    // The list is portaled, so the dialog holds it only because the stack
+    // under the field says how far it reaches.
+    expect(
+      Number.parseInt(fieldStack().style.minHeight, 10),
+    ).toBeGreaterThanOrEqual(SEARCHABLE_SELECT_MENU_REACH);
+  });
+
+  test("is given back once a model answers the question", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Claude Opus 5");
+
+    // The provider step now stands in that room. Anything still reserved
+    // would open as a gap between the flow and the dialog's footer.
+    expect(candidateCards().length).toBeGreaterThan(0);
+    expect(fieldStack().style.minHeight).toBe("");
   });
 });
 

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -1,0 +1,560 @@
+/**
+ * The create flow under `model-first-profile-create`: the model is chosen
+ * first, and the provider question is asked only as far as it needs to be.
+ *
+ * The generated daemon SDK and the credential hooks are mocked the way
+ * `profile-editor-modal.test.tsx` mocks them, so the inline
+ * `ProviderCreateForm` can run its create sequence without network calls. The
+ * ChatGPT connect section is stubbed to a button: its own sign-in flows have
+ * their own tests, and what matters here is that this flow mounts that
+ * section and routes its connection into the editor.
+ *
+ * Coverage:
+ *  - flag off leaves the provider-first flow exactly as it was,
+ *  - one model row per model, annotated with who serves it,
+ *  - a single connected route is stated rather than offered,
+ *  - several routes become cards, connected ones first and pre-selected,
+ *  - an unconnected route blocks Save and expands its own connect form,
+ *  - ChatGPT is a candidate for Codex-eligible models only, and saves the
+ *    same payload the provider-first flow saves,
+ *  - the custom model id escape hatch.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type { ProviderConnection } from "@/generated/daemon/types.gen";
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+let createdConnection: ProviderConnection;
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: () => {}, error: () => {}, warning: () => {} },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  secretsPost: () =>
+    Promise.resolve({ data: undefined, response: { ok: true } }),
+  inferenceProviderconnectionsPost: () =>
+    Promise.resolve({
+      data: createdConnection,
+      response: { ok: true, status: 200 },
+    }),
+}));
+
+mock.module("@/domains/settings/ai/use-stored-credential-presence", () => ({
+  credentialPresenceQueryKey: (
+    assistantId: string,
+    kind: string,
+    name: string,
+  ) => ["credentialPresence", assistantId, kind, name] as const,
+  useStoredCredentialPresence: () => ({
+    hasStoredCredential: false,
+    isLoading: false,
+  }),
+}));
+
+mock.module("@/domains/settings/ai/use-provider-credentials-list", () => ({
+  useProviderCredentialsList: () => ({ credentials: [], isLoading: false }),
+}));
+
+mock.module("@/domains/settings/ai/chatgpt-oauth-section", () => ({
+  ChatgptOAuthSection: ({
+    onConnected,
+  }: {
+    onConnected: (connection: ProviderConnection) => void;
+  }) =>
+    createElement(
+      "button",
+      {
+        type: "button",
+        "data-testid": "chatgpt-connect-stub",
+        onClick: () => onConnected(createdConnection),
+      },
+      "Sign in with ChatGPT",
+    ),
+}));
+
+const { ProfileEditorModal } = await import(
+  "@/domains/settings/ai/profile-editor-modal"
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ASSISTANT_ID = "asst-1";
+
+function makeConnection(
+  name: string,
+  provider = "anthropic",
+  overrides: Record<string, unknown> = {},
+): ProviderConnection {
+  return {
+    name,
+    label: null,
+    provider,
+    auth: { type: "api_key", credential: `credential/${provider}/api_key` },
+    models: null,
+    ...overrides,
+  } as unknown as ProviderConnection;
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, enabled: false } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+type SaveCall = { name: string; entry: Record<string, unknown> };
+
+function renderCreate(
+  connections: ProviderConnection[],
+  saveCalls: SaveCall[] = [],
+) {
+  render(
+    <Wrapper>
+      <ProfileEditorModal
+        isOpen
+        mode="create"
+        existingNames={[]}
+        connections={connections}
+        assistantId={ASSISTANT_ID}
+        onSave={(name, entry) => {
+          saveCalls.push({ name, entry: entry as Record<string, unknown> });
+          return Promise.resolve();
+        }}
+        onCancel={() => {}}
+      />
+    </Wrapper>,
+  );
+  return saveCalls;
+}
+
+function modelField(): HTMLInputElement {
+  const field = document.querySelector<HTMLInputElement>(
+    'input[role="combobox"][aria-label="Model"]',
+  );
+  if (!field) {
+    throw new Error("expected the Model field");
+  }
+  return field;
+}
+
+/** An option row's label, excluding any right-aligned suffix meta. */
+function optionLabel(option: Element): string {
+  return (
+    option.querySelector(".truncate")?.textContent ??
+    option.textContent ??
+    ""
+  ).trim();
+}
+
+function openModelList(): void {
+  fireEvent.focus(modelField());
+}
+
+function modelRows(): { label: string; meta: string }[] {
+  openModelList();
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).map((option) => {
+    const label = optionLabel(option);
+    const full = (option.textContent ?? "").trim();
+    return { label, meta: full.slice(label.length).trim() };
+  });
+}
+
+function selectModel(label: string): void {
+  openModelList();
+  const option = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="option"]'),
+  ).find((o) => optionLabel(o) === label);
+  if (!option) {
+    throw new Error(
+      `expected a Model list offering "${label}" - saw ${
+        document.querySelectorAll('[role="option"]').length
+      } rows`,
+    );
+  }
+  fireEvent.click(option);
+}
+
+function candidateCards(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>('[data-testid="provider-candidate"]'),
+  );
+}
+
+function candidateValues(): string[] {
+  return candidateCards().map((card) => card.dataset.candidate ?? "");
+}
+
+function candidateCard(value: string): HTMLElement {
+  const card = candidateCards().find((c) => c.dataset.candidate === value);
+  if (!card) {
+    throw new Error(
+      `expected a "${value}" candidate - saw ${candidateValues().join(", ")}`,
+    );
+  }
+  return card;
+}
+
+function selectedCandidateValue(): string | null {
+  const checked = candidateCards().find(
+    (card) =>
+      card.querySelector('[role="radio"]')?.getAttribute("aria-checked") ===
+      "true",
+  );
+  return checked?.dataset.candidate ?? null;
+}
+
+function pickCandidate(value: string): void {
+  const radio = candidateCard(value).querySelector<HTMLElement>(
+    '[role="radio"]',
+  );
+  if (!radio) {
+    throw new Error(`expected a radio in the "${value}" candidate`);
+  }
+  fireEvent.click(radio);
+}
+
+function getSaveBtn(): HTMLButtonElement {
+  const btn = document.querySelector<HTMLButtonElement>(
+    '[data-testid="modal-save-btn"]',
+  );
+  if (!btn) {
+    throw new Error("expected a modal-save-btn");
+  }
+  return btn;
+}
+
+function getButton(label: string): HTMLButtonElement {
+  const match = Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((b) => b.textContent?.trim() === label);
+  if (!match) {
+    throw new Error(`expected a "${label}" button`);
+  }
+  return match;
+}
+
+function getInputByPlaceholder(placeholder: string): HTMLInputElement {
+  const input = Array.from(
+    document.querySelectorAll<HTMLInputElement>("input"),
+  ).find((el) => el.placeholder === placeholder);
+  if (!input) {
+    throw new Error(`expected an input with placeholder "${placeholder}"`);
+  }
+  return input;
+}
+
+function setModelFirstFlag(value: boolean): void {
+  useClientFeatureFlagStore.setState({ modelFirstProfileCreate: value });
+}
+
+beforeEach(() => {
+  createdConnection = makeConnection("openai-personal", "openai");
+  setModelFirstFlag(true);
+  // Save awaits the entry-binding version gate, so a hydrated identity keeps
+  // it from waiting out its timeout. The floor is pinned below the gate, which
+  // is the legacy payload the provider-first flow writes on the same daemon.
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("test-asst", "0.10.11", ASSISTANT_ID);
+});
+
+afterEach(() => {
+  cleanup();
+  setModelFirstFlag(false);
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("the flag", () => {
+  test("off leaves the provider-first flow in place", () => {
+    setModelFirstFlag(false);
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    expect(
+      document.querySelector(
+        'button[role="combobox"][aria-labelledby="profile-editor-provider-label"]',
+      ),
+    ).not.toBeNull();
+    expect(candidateCards()).toHaveLength(0);
+    // The provider-first Model field stays disabled until a provider is
+    // chosen, which is the shape of the old flow.
+    expect(modelField().getAttribute("aria-disabled")).not.toBe("true");
+  });
+
+  test("on replaces the provider dropdown with the model list", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    expect(
+      document.querySelector(
+        'button[role="combobox"][aria-labelledby="profile-editor-provider-label"]',
+      ),
+    ).toBeNull();
+    expect(modelField()).not.toBeNull();
+  });
+});
+
+describe("the model list", () => {
+  test("offers each model once, annotated with who serves it", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    const rows = modelRows();
+    const opus = rows.filter((row) => row.label === "Claude Opus 4.8");
+    expect(opus).toHaveLength(1);
+    expect(opus[0].meta).toBe("3 providers");
+
+    const gemini = rows.find((row) => row.label === "Gemini 3.6 Flash");
+    expect(gemini?.meta).toBe("Google Gemini");
+  });
+
+  test("keeps the custom model id escape hatch at the bottom", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+    expect(modelRows().map((row) => row.label)).toContain(
+      "Enter a custom model ID…",
+    );
+  });
+});
+
+describe("the provider step", () => {
+  test("states a single connected route rather than offering it", async () => {
+    const saveCalls = renderCreate([makeConnection("gemini-key", "gemini")]);
+
+    selectModel("Gemini 3.6 Flash");
+
+    expect(candidateValues()).toEqual(["gemini"]);
+    expect(candidateCard("gemini").textContent).toContain("Connected");
+    expect(document.body.textContent).toContain(
+      "Only Google Gemini serves this model.",
+    );
+    expect(document.querySelectorAll('[role="radio"]')).toHaveLength(0);
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.provider).toBe("gemini");
+    expect(saveCalls[0].entry.model).toBe("gemini-3.6-flash");
+  });
+
+  test("puts connected routes first and pre-selects one", () => {
+    renderCreate([
+      makeConnection("openrouter-key", "openrouter"),
+      makeConnection("anthropic-personal"),
+    ]);
+
+    selectModel("Claude Opus 4.8");
+
+    expect(candidateValues()).toEqual([
+      "anthropic",
+      "openrouter",
+      "vercel-ai-gateway",
+    ]);
+    expect(selectedCandidateValue()).toBe("anthropic");
+    expect(candidateCard("anthropic").textContent).toContain("Connected");
+    expect(candidateCard("vercel-ai-gateway").textContent).toContain(
+      "Add API key",
+    );
+  });
+
+  test("switching routes rewrites the model id for the new one", async () => {
+    const saveCalls = renderCreate([
+      makeConnection("anthropic-personal"),
+      makeConnection("openrouter-key", "openrouter"),
+    ]);
+
+    selectModel("Claude Opus 4.8");
+    pickCandidate("openrouter");
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.provider).toBe("openrouter");
+    expect(saveCalls[0].entry.model).toBe("anthropic/claude-opus-4.8");
+  });
+
+  test("names the key a route with siblings would use", () => {
+    renderCreate([
+      makeConnection("anthropic-work"),
+      makeConnection("anthropic-personal", "anthropic", { label: "Personal" }),
+    ]);
+
+    selectModel("Claude Opus 4.8");
+
+    expect(candidateValues().slice(0, 3)).toEqual([
+      "anthropic",
+      "anthropic::anthropic-work",
+      "anthropic::anthropic-personal",
+    ]);
+    expect(candidateCard("anthropic::anthropic-personal").textContent).toContain(
+      "Personal",
+    );
+  });
+});
+
+describe("a route with no connection yet", () => {
+  test("blocks Save and expands its own connect form", async () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Claude Opus 4.8");
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+
+    pickCandidate("openrouter");
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(true);
+    });
+    // The inline create form seeds a Display Name for the chosen provider and
+    // hides its own provider selector, which the outer card already names.
+    expect(getButton("Add")).not.toBeNull();
+    expect(
+      document.querySelector('button[role="combobox"][aria-label="Provider"]'),
+    ).toBeNull();
+  });
+
+  test("connecting it binds the profile and re-applies the model", async () => {
+    createdConnection = makeConnection("openrouter-key", "openrouter");
+    const saveCalls = renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Claude Opus 4.8");
+    pickCandidate("openrouter");
+
+    fireEvent.change(getInputByPlaceholder("Enter your API key"), {
+      target: { value: "sk-test-key" },
+    });
+    fireEvent.click(getButton("Add"));
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.provider).toBe("openrouter");
+    expect(saveCalls[0].entry.model).toBe("anthropic/claude-opus-4.8");
+    expect(saveCalls[0].entry.provider_connection).toBe("openrouter-key");
+    // The Name still comes from the model's display name, not its raw id.
+    expect(saveCalls[0].name).toBe("claude-opus-4-8");
+  });
+});
+
+describe("the ChatGPT subscription", () => {
+  test("is a candidate for a Codex-eligible model and nothing else", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("GPT-5.6 Luna");
+    expect(candidateValues()).toContain("chatgpt");
+    expect(candidateCard("chatgpt").textContent).toContain("Sign in");
+
+    selectModel("GPT-5.4 Nano");
+    expect(candidateValues()).not.toContain("chatgpt");
+  });
+
+  test("expands the shared connect section rather than a create form", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("GPT-5.6 Luna");
+    pickCandidate("chatgpt");
+
+    expect(
+      document.querySelector('[data-testid="chatgpt-connect-stub"]'),
+    ).not.toBeNull();
+  });
+
+  test("leads once signed in and saves the identity payload", async () => {
+    const saveCalls = renderCreate([
+      makeConnection("chatgpt", "chatgpt", {
+        auth: {
+          type: "oauth_subscription",
+          credential: "credential/chatgpt/oauth",
+        },
+      }),
+    ]);
+
+    selectModel("GPT-5.6 Luna");
+    expect(selectedCandidateValue()).toBe("chatgpt");
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.provider).toBe("chatgpt");
+    expect(saveCalls[0].entry.model).toBe("gpt-5.6-luna");
+    expect(saveCalls[0].entry.provider_connection).toBeUndefined();
+  });
+});
+
+describe("the custom model id path", () => {
+  test("saves the typed id through the chosen route", async () => {
+    const saveCalls = renderCreate([makeConnection("openrouter-key", "openrouter")]);
+
+    selectModel("Enter a custom model ID…");
+    fireEvent.change(getInputByPlaceholder("provider/model-id"), {
+      target: { value: "someone/new-model" },
+    });
+    pickCandidate("openrouter");
+
+    await waitFor(() => {
+      expect(getSaveBtn().disabled).toBe(false);
+    });
+    fireEvent.click(getSaveBtn());
+    await waitFor(() => {
+      expect(saveCalls.length).toBe(1);
+    });
+    expect(saveCalls[0].entry.provider).toBe("openrouter");
+    expect(saveCalls[0].entry.model).toBe("someone/new-model");
+  });
+
+  test("never offers the subscription, which only accepts Codex ids", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Enter a custom model ID…");
+    expect(candidateValues()).not.toContain("chatgpt");
+  });
+
+  test("returns to the list without keeping the typed id", () => {
+    renderCreate([makeConnection("anthropic-personal")]);
+
+    selectModel("Enter a custom model ID…");
+    fireEvent.change(getInputByPlaceholder("provider/model-id"), {
+      target: { value: "someone/new-model" },
+    });
+    fireEvent.click(getButton("Choose from list"));
+
+    expect(modelField()).not.toBeNull();
+    expect(getSaveBtn().disabled).toBe(true);
+  });
+});

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -26,7 +26,10 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
 
-import { SEARCHABLE_SELECT_MENU_REACH } from "@vellumai/design-library/components/searchable-select";
+import {
+  SEARCHABLE_SELECT_MENU_MIN_REACH,
+  SEARCHABLE_SELECT_MENU_REACH,
+} from "@vellumai/design-library/components/searchable-select";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
@@ -521,14 +524,27 @@ describe("the room the dialog keeps for the open list", () => {
     ).toBeGreaterThanOrEqual(SEARCHABLE_SELECT_MENU_REACH);
   });
 
-  test("is given back once a model answers the question", () => {
+  test("still stands once a model answers the question", () => {
+    renderCreate([makeConnection("gemini-key", "gemini")]);
+
+    selectModel("Gemini 3.6 Flash");
+
+    // The field outlives the question, so the list can be reopened over
+    // whatever the answer put under it. A sole connected route is the
+    // shortest of those, and giving the room back here is what let a
+    // reopened list cover the dialog's own footer.
+    expect(candidateCards().length).toBe(1);
+    expect(
+      Number.parseInt(fieldStack().style.minHeight, 10),
+    ).toBeGreaterThanOrEqual(SEARCHABLE_SELECT_MENU_MIN_REACH);
+  });
+
+  test("is given back to the custom id, which has no list to open", () => {
     renderCreate([makeConnection("anthropic-personal")]);
 
-    selectModel("Claude Opus 5");
+    openModelList();
+    clickModelOption("Enter a custom model ID…");
 
-    // The provider step now stands in that room. Anything still reserved
-    // would open as a gap between the flow and the dialog's footer.
-    expect(candidateCards().length).toBeGreaterThan(0);
     expect(fieldStack().style.minHeight).toBe("");
   });
 });

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -15,7 +15,7 @@ import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
 import { CHATGPT_CONNECTION_PROVIDER } from "@/domains/settings/ai/constants";
 import {
-  collapseSupersededVersions,
+  collapseSectionRows,
   customModelProviderCandidates,
   defaultProviderCandidate,
   resolveModelFirstGroups,
@@ -38,16 +38,15 @@ import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-st
 const CUSTOM_MODEL_OPTION_VALUE = "__custom-model-id__";
 
 /**
- * Prefix for the row that unfolds one section's older versions. Namespaced the
+ * Prefix for the row that unfolds the rest of one section. Namespaced the
  * same way, and carrying the section it acts on, so picking it is told apart
  * from picking a model.
  */
-const SHOW_OLDER_PREFIX = "__show-older__:";
+const SEE_MORE_PREFIX = "__see-more__:";
 
 /**
- * Where one model row stands in its section's disclosure: the newest of its
- * line, an older one still folded away, or an older one the section's unfold
- * row has revealed.
+ * Where one model row stands in its section's disclosure: one of the rows the
+ * section offers, one still folded away, or one the unfold row has revealed.
  */
 type ModelRowState = "current" | "folded" | "disclosed";
 
@@ -272,9 +271,9 @@ export function ProfileCreateModelFirst({
       openCandidatesFor({ kind: "custom", modelId: "" });
       return;
     }
-    if (value.startsWith(SHOW_OLDER_PREFIX)) {
+    if (value.startsWith(SEE_MORE_PREFIX)) {
       // Acts on the list rather than answering it, so the draft is untouched.
-      const group = value.slice(SHOW_OLDER_PREFIX.length);
+      const group = value.slice(SEE_MORE_PREFIX.length);
       setUnfoldedGroups((previous) =>
         previous.includes(group) ? previous : [...previous, group],
       );
@@ -333,24 +332,22 @@ export function ProfileCreateModelFirst({
       ),
     });
     for (const group of groups) {
-      const { shown, hidden } = collapseSupersededVersions(group.options);
+      const { shown, hidden } = collapseSectionRows(group.options);
       const unfolded = unfoldedGroups.includes(group.key);
       for (const option of shown) {
         rows.push(modelRow(option, group.label, "current"));
       }
       for (const option of hidden) {
         // Folded away while the list is being browsed, but never hidden from
-        // a query: someone who types a version's name means that version.
+        // a query: someone who types a model's name means that model.
         rows.push(
           modelRow(option, group.label, unfolded ? "disclosed" : "folded"),
         );
       }
       if (hidden.length > 0 && !unfolded) {
         rows.push({
-          value: `${SHOW_OLDER_PREFIX}${group.key}`,
-          label: t("profileCreateModelFirst.showOlderVersions", {
-            count: hidden.length,
-          }),
+          value: `${SEE_MORE_PREFIX}${group.key}`,
+          label: t("profileCreateModelFirst.seeMore"),
           group: group.label,
           listAction: true,
         });

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -5,6 +5,7 @@ import { Input } from "@vellumai/design-library/components/input";
 import { Radio, RadioGroup } from "@vellumai/design-library/components/radio";
 import {
   SearchableSelect,
+  SEARCHABLE_SELECT_MENU_REACH,
   type SearchableSelectOption,
 } from "@vellumai/design-library/components/searchable-select";
 import { Tag } from "@vellumai/design-library/components/tag";
@@ -63,10 +64,40 @@ type ModelDraft =
 
 const NO_MODEL: ModelDraft = { kind: "none" };
 
+/** The Model label: one line of `text-body-small-default`, whose leading is 1. */
+const MODEL_LABEL_HEIGHT = 12;
+
+/** The `space-y-1` between the label and the field under it. */
+const MODEL_LABEL_GAP = 4;
+
+/** The field itself, which is an `h-9` input. */
+const MODEL_FIELD_HEIGHT = 36;
+
+/**
+ * Room the Model field and its open list need, measured from the top of the
+ * label to the bottom of a list at its full height.
+ *
+ * The dialog is as tall as what it holds, which before a model is picked is
+ * two lines and a footer. The list is portaled and so is not what it holds:
+ * without this reserve the dialog stays that short and the list opens across
+ * its footer, over the very buttons the flow ends on.
+ */
+const MODEL_LIST_ROOM =
+  MODEL_LABEL_HEIGHT +
+  MODEL_LABEL_GAP +
+  MODEL_FIELD_HEIGHT +
+  SEARCHABLE_SELECT_MENU_REACH;
+
 export interface ProfileCreateModelFirstProps {
   editor: ProfileEditor;
   /** Assistant whose connections the inline connect form writes to. */
   assistantId: string;
+  /**
+   * Whether to keep room under the Model field for its open list. The modal
+   * host is only as tall as its content, so it has to; the settings sidepanel
+   * is already full height and would gain nothing but a gap.
+   */
+  reserveListRoom?: boolean;
 }
 
 /**
@@ -84,6 +115,7 @@ export interface ProfileCreateModelFirstProps {
 export function ProfileCreateModelFirst({
   editor,
   assistantId,
+  reserveListRoom = false,
 }: ProfileCreateModelFirstProps) {
   const { t } = useTranslation("settings");
   const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
@@ -337,8 +369,15 @@ export function ProfileCreateModelFirst({
   const fieldLabelClass =
     "block text-body-small-default text-[var(--content-tertiary)]";
 
+  // Only while the list is the control on screen. A typed model id has no
+  // list to open, so reserving room for one would leave a hole under it.
+  const roomForList = reserveListRoom && draft.kind !== "custom";
+
   return (
-    <div className="space-y-4">
+    <div
+      className="space-y-4"
+      style={roomForList ? { minHeight: MODEL_LIST_ROOM } : undefined}
+    >
       <div className="space-y-1">
         <label className={fieldLabelClass}>
           {t("profileCreateModelFirst.modelLabel")}

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -22,7 +22,7 @@ import { PickerMeta } from "@/domains/settings/ai/provider-picker-availability";
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import type { ProfileEditor } from "@/domains/settings/ai/use-profile-editor";
 import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
-import { useTranslation } from "@/i18n";
+import { useTranslation, type TFunction } from "@/i18n";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 
 /**
@@ -119,6 +119,11 @@ export function ProfileCreateModelFirst({
       : entryPickerValue(editor.provider, editor.providerConnection);
   });
 
+  // The candidate whose connect form is expanded. Separate from the selection
+  // so cancelling the form collapses it without deselecting the route, which
+  // would leave a lone unconnected candidate with nothing left to click.
+  const [setupOpenFor, setSetupOpenFor] = useState<string | null>(null);
+
   const candidates = useMemo<readonly ProviderCandidate[]>(() => {
     if (draft.kind === "catalog") {
       return (
@@ -171,7 +176,10 @@ export function ProfileCreateModelFirst({
       // Nothing can dispatch this route yet. The model stays unset so Save
       // is blocked until the connect form below produces a connection.
       editor.setModel("");
+      setSetupOpenFor(candidate.value);
+      return;
     }
+    setSetupOpenFor(null);
   }
 
   function selectByValue(value: string): void {
@@ -217,7 +225,20 @@ export function ProfileCreateModelFirst({
       selectCandidate(fallback);
       return;
     }
-    setSelectedValue("");
+    // Nothing else can serve this model, so the route stays selected and only
+    // its form collapses. The card's own setup action reopens it.
+    setSetupOpenFor(null);
+  }
+
+  function openSetupFor(value: string): void {
+    const candidate = candidates.find((entry) => entry.value === value);
+    if (!candidate) {
+      return;
+    }
+    if (selectedValue !== candidate.value) {
+      selectCandidate(candidate);
+    }
+    setSetupOpenFor(candidate.value);
   }
 
   const modelOptions = useMemo(
@@ -309,8 +330,14 @@ export function ProfileCreateModelFirst({
           candidates={candidates}
           editor={editor}
           onCancelConnect={handleConnectFormCancel}
+          onOpenSetup={openSetupFor}
           onSelect={selectByValue}
           selectedCandidate={selectedCandidate}
+          setupExpanded={
+            selectedCandidate !== null &&
+            !selectedCandidate.connected &&
+            setupOpenFor === selectedCandidate.value
+          }
         />
       ) : null}
     </div>
@@ -322,8 +349,11 @@ interface ProviderStepProps {
   candidates: readonly ProviderCandidate[];
   editor: ProfileEditor;
   onCancelConnect: () => void;
+  onOpenSetup: (value: string) => void;
   onSelect: (value: string) => void;
   selectedCandidate: ProviderCandidate | null;
+  /** Whether the selected route's connect form is open. */
+  setupExpanded: boolean;
 }
 
 /**
@@ -337,21 +367,43 @@ function ProviderStep({
   candidates,
   editor,
   onCancelConnect,
+  onOpenSetup,
   onSelect,
   selectedCandidate,
+  setupExpanded,
 }: ProviderStepProps) {
   const { t } = useTranslation("settings");
   const soleCandidate = candidates.length === 1 ? candidates[0] : null;
 
+  // Keyed by the route it connects: the create form reads its provider,
+  // label, name, and credential from props once, at mount, so a section
+  // reused across two routes would write the previous one's connection.
   const connectSection =
-    selectedCandidate && !selectedCandidate.connected ? (
+    selectedCandidate && setupExpanded ? (
       <ConnectSection
+        key={selectedCandidate.value}
         assistantId={assistantId}
         candidate={selectedCandidate}
         editor={editor}
         onCancel={onCancelConnect}
       />
     ) : null;
+
+  function setupAction(candidate: ProviderCandidate) {
+    if (candidate.connected || setupExpanded) {
+      return null;
+    }
+    return (
+      <Button
+        variant="link"
+        size="compact"
+        data-testid="candidate-setup-btn"
+        onClick={() => onOpenSetup(candidate.value)}
+      >
+        {candidateSetupLabel(candidate, t)}
+      </Button>
+    );
+  }
 
   return (
     <div className="space-y-1">
@@ -385,6 +437,7 @@ function ProviderStep({
               })}
             </Typography>
           ) : null}
+          {setupAction(soleCandidate)}
           {connectSection}
         </div>
       ) : (
@@ -420,6 +473,7 @@ function ProviderStep({
                   />
                   <CandidateTag candidate={candidate} />
                 </div>
+                {selected ? setupAction(candidate) : null}
                 {selected ? connectSection : null}
               </div>
             );
@@ -440,6 +494,20 @@ function ProviderStep({
   );
 }
 
+/** What an unconnected route still needs, as the tag and the action say it. */
+function candidateSetupLabel(
+  candidate: ProviderCandidate,
+  t: TFunction<"settings">,
+): string {
+  if (candidate.setup === "sign-in") {
+    return t("profileCreateModelFirst.signInTag");
+  }
+  if (candidate.setup === "set-up") {
+    return t("profileCreateModelFirst.setUpTag");
+  }
+  return t("profileCreateModelFirst.addApiKeyTag");
+}
+
 function CandidateTag({ candidate }: { candidate: ProviderCandidate }) {
   const { t } = useTranslation("settings");
   if (candidate.connected) {
@@ -447,13 +515,7 @@ function CandidateTag({ candidate }: { candidate: ProviderCandidate }) {
       <Tag tone="positive">{t("profileCreateModelFirst.connectedTag")}</Tag>
     );
   }
-  const label =
-    candidate.setup === "sign-in"
-      ? t("profileCreateModelFirst.signInTag")
-      : candidate.setup === "set-up"
-        ? t("profileCreateModelFirst.setUpTag")
-        : t("profileCreateModelFirst.addApiKeyTag");
-  return <Tag tone="neutral">{label}</Tag>;
+  return <Tag tone="neutral">{candidateSetupLabel(candidate, t)}</Tag>;
 }
 
 interface ConnectSectionProps {

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -294,7 +294,7 @@ export function ProfileCreateModelFirst({
     });
     for (const group of groups) {
       const { shown, hidden } = collapseSupersededVersions(group.options);
-      const unfolded = unfoldedGroups.includes(group.provider);
+      const unfolded = unfoldedGroups.includes(group.key);
       for (const option of shown) {
         rows.push(modelRow(option, group.label, false));
       }
@@ -305,7 +305,7 @@ export function ProfileCreateModelFirst({
       }
       if (hidden.length > 0 && !unfolded) {
         rows.push({
-          value: `${SHOW_OLDER_PREFIX}${group.provider}`,
+          value: `${SHOW_OLDER_PREFIX}${group.key}`,
           label: t("profileCreateModelFirst.showOlderVersions", {
             count: hidden.length,
           }),

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -366,13 +366,18 @@ export function ProfileCreateModelFirst({
   const fieldLabelClass =
     "block text-body-small-default text-[var(--content-tertiary)]";
 
-  // Only while the list is the control on screen. A typed model id has no
-  // list to open, so reserving room for one would leave a hole under it.
-  const roomForList = reserveListRoom && draft.kind !== "custom";
+  // Only while the Model field is the whole of the dialog. Once a model is
+  // answered, the provider step and the Advanced disclosure stand in the room
+  // the list needs, so holding it open past that point is white space. The
+  // test is the answer, not whether the list happens to be open: reserving on
+  // the open state would grow and shrink the dialog under the user as they
+  // browse it.
+  const roomForList = reserveListRoom && draft.kind === "none";
 
   return (
     <div
       className="space-y-4"
+      data-testid="model-first-fields"
       style={roomForList ? { minHeight: MODEL_LIST_ROOM } : undefined}
     >
       <div className="space-y-1">

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -5,6 +5,7 @@ import { Input } from "@vellumai/design-library/components/input";
 import { Radio, RadioGroup } from "@vellumai/design-library/components/radio";
 import {
   SearchableSelect,
+  SEARCHABLE_SELECT_MENU_MIN_REACH,
   SEARCHABLE_SELECT_MENU_REACH,
   type SearchableSelectOption,
 } from "@vellumai/design-library/components/searchable-select";
@@ -72,31 +73,37 @@ const MODEL_LABEL_GAP = 4;
 /** The field itself, which is an `h-9` input. */
 const MODEL_FIELD_HEIGHT = 36;
 
+/** The Model field with its label, from the top of one to the foot of the other. */
+const MODEL_FIELD_BLOCK =
+  MODEL_LABEL_HEIGHT + MODEL_LABEL_GAP + MODEL_FIELD_HEIGHT;
+
 /**
  * Room the Model field and its open list need, measured from the top of the
  * label to the bottom of a list at its full height.
  *
- * The dialog is as tall as what it holds, which before a model is picked is
- * two lines and a footer. The list is portaled and so is not what it holds:
- * without this reserve the dialog stays that short and the list opens across
- * its footer, over the very buttons the flow ends on.
+ * The dialog is as tall as what it holds, and the list is portaled, so it is
+ * not what it holds. Bounding the list to the dialog body is what keeps it
+ * off the footer; reserving this is what keeps the body from being too short
+ * to hold the list the bound then caps.
  */
-const MODEL_LIST_ROOM =
-  MODEL_LABEL_HEIGHT +
-  MODEL_LABEL_GAP +
-  MODEL_FIELD_HEIGHT +
-  SEARCHABLE_SELECT_MENU_REACH;
+const MODEL_LIST_ROOM = MODEL_FIELD_BLOCK + SEARCHABLE_SELECT_MENU_REACH;
+
+/** The same room for a list at its floor, which is all a picked model spares. */
+const MODEL_LIST_MIN_ROOM =
+  MODEL_FIELD_BLOCK + SEARCHABLE_SELECT_MENU_MIN_REACH;
 
 export interface ProfileCreateModelFirstProps {
   editor: ProfileEditor;
   /** Assistant whose connections the inline connect form writes to. */
   assistantId: string;
   /**
-   * Whether to keep room under the Model field for its open list. The modal
-   * host is only as tall as its content, so it has to; the settings sidepanel
-   * is already full height and would gain nothing but a gap.
+   * Box the open model list is kept inside, and which the field stack then
+   * keeps tall enough to hold it. Pass the scrolling body of a host whose own
+   * actions sit under the field: a dialog, which is only as tall as its
+   * content and whose footer is the next thing below the field. The settings
+   * sidepanel is already full height and passes nothing.
    */
-  reserveListRoom?: boolean;
+  menuBoundary?: Element | null;
 }
 
 /**
@@ -114,7 +121,7 @@ export interface ProfileCreateModelFirstProps {
 export function ProfileCreateModelFirst({
   editor,
   assistantId,
-  reserveListRoom = false,
+  menuBoundary,
 }: ProfileCreateModelFirstProps) {
   const { t } = useTranslation("settings");
   const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
@@ -366,19 +373,28 @@ export function ProfileCreateModelFirst({
   const fieldLabelClass =
     "block text-body-small-default text-[var(--content-tertiary)]";
 
-  // Only while the Model field is the whole of the dialog. Once a model is
-  // answered, the provider step and the Advanced disclosure stand in the room
-  // the list needs, so holding it open past that point is white space. The
-  // test is the answer, not whether the list happens to be open: reserving on
-  // the open state would grow and shrink the dialog under the user as they
-  // browse it.
-  const roomForList = reserveListRoom && draft.kind === "none";
+  // Held for as long as there is a list to open, which is every state but the
+  // custom id, where free text has replaced it. It cannot be held only until
+  // a model is picked: the field outlives the question, and reopening it in a
+  // dialog that had given the room back is what put the list over the footer.
+  // How much is held is the part that changes. While the field is the whole
+  // of the dialog the list gets the height it is meant to be read at; once
+  // the answer stands under it, the room drops to the least the list can be
+  // reopened at, so what the flow gained is not paid for in white space. The
+  // test is never whether the list happens to be open, which would grow and
+  // shrink the dialog under the user as they browse it.
+  const roomForList =
+    !menuBoundary || draft.kind === "custom"
+      ? null
+      : draft.kind === "none"
+        ? MODEL_LIST_ROOM
+        : MODEL_LIST_MIN_ROOM;
 
   return (
     <div
       className="space-y-4"
       data-testid="model-first-fields"
-      style={roomForList ? { minHeight: MODEL_LIST_ROOM } : undefined}
+      style={roomForList === null ? undefined : { minHeight: roomForList }}
     >
       <div className="space-y-1">
         <label className={fieldLabelClass}>
@@ -423,6 +439,7 @@ export function ProfileCreateModelFirst({
             aria-label={t("profileCreateModelFirst.modelAriaLabel")}
             placeholder={t("profileCreateModelFirst.modelPlaceholder")}
             emptyText={t("profileCreateModelFirst.modelNoMatches")}
+            menuBoundary={menuBoundary}
             announceResults={(count) =>
               t("profileCreateModelFirst.modelResultsAnnouncement", { count })
             }

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -44,6 +44,13 @@ const CUSTOM_MODEL_OPTION_VALUE = "__custom-model-id__";
 const SHOW_OLDER_PREFIX = "__show-older__:";
 
 /**
+ * Where one model row stands in its section's disclosure: the newest of its
+ * line, an older one still folded away, or an older one the section's unfold
+ * row has revealed.
+ */
+type ModelRowState = "current" | "folded" | "disclosed";
+
+/**
  * What the user has answered to the flow's first question. A catalog pick is
  * held by display name because that is the identity a model keeps across the
  * providers that host it; the per-provider id follows from the route chosen
@@ -275,12 +282,13 @@ export function ProfileCreateModelFirst({
     const modelRow = (
       option: ModelFirstOption,
       group: string,
-      folded: boolean,
+      state: ModelRowState,
     ): SearchableSelectOption => ({
       value: option.displayName,
       label: option.displayName,
       group,
-      folded,
+      folded: state === "folded",
+      disclosed: state === "disclosed",
       suffix: (
         <PickerMeta
           text={
@@ -296,12 +304,14 @@ export function ProfileCreateModelFirst({
       const { shown, hidden } = collapseSupersededVersions(group.options);
       const unfolded = unfoldedGroups.includes(group.key);
       for (const option of shown) {
-        rows.push(modelRow(option, group.label, false));
+        rows.push(modelRow(option, group.label, "current"));
       }
       for (const option of hidden) {
         // Folded away while the list is being browsed, but never hidden from
         // a query: someone who types a version's name means that version.
-        rows.push(modelRow(option, group.label, !unfolded));
+        rows.push(
+          modelRow(option, group.label, unfolded ? "disclosed" : "folded"),
+        );
       }
       if (hidden.length > 0 && !unfolded) {
         rows.push({
@@ -436,13 +446,17 @@ function ProviderStep({
   // reused across two routes would write the previous one's connection.
   const connectSection =
     selectedCandidate && setupExpanded ? (
-      <ConnectSection
-        key={selectedCandidate.value}
-        assistantId={assistantId}
-        candidate={selectedCandidate}
-        editor={editor}
-        onCancel={onCancelConnect}
-      />
+      // The rule sets the form apart from the row that names the route, so
+      // the form's own actions read as the form's rather than the dialog's.
+      <div className="border-t border-[var(--border-subtle)] pt-3">
+        <ConnectSection
+          key={selectedCandidate.value}
+          assistantId={assistantId}
+          candidate={selectedCandidate}
+          editor={editor}
+          onCancel={onCancelConnect}
+        />
+      </div>
     ) : null;
 
   function setupAction(candidate: ProviderCandidate) {
@@ -461,6 +475,18 @@ function ProviderStep({
     );
   }
 
+  /**
+   * The route's own tag, withheld from the card whose connect form is open:
+   * the form below it is already the answer to what the tag asks for, and
+   * the two on one row read as two ways to do the same thing.
+   */
+  function candidateTag(candidate: ProviderCandidate) {
+    if (setupExpanded && candidate.value === selectedCandidate?.value) {
+      return null;
+    }
+    return <CandidateTag candidate={candidate} />;
+  }
+
   return (
     <div className="space-y-1">
       <span
@@ -472,15 +498,17 @@ function ProviderStep({
 
       {soleCandidate ? (
         <div className="space-y-2">
+          {/* A statement, not a control: nothing here is choosable, so it
+              carries no field border, no chevron and no text cursor. */}
           <div
             data-testid="provider-candidate"
             data-candidate={soleCandidate.value}
-            className="flex min-h-9 items-center justify-between gap-2 rounded-lg border border-[var(--border-element)] px-3 py-2"
+            className="flex min-h-9 cursor-default items-center justify-between gap-2 rounded-lg bg-[var(--surface-sunken)] px-3 py-2"
           >
             <Typography variant="body-medium-lighter" as="span">
               {soleCandidate.label}
             </Typography>
-            <CandidateTag candidate={soleCandidate} />
+            {candidateTag(soleCandidate)}
           </div>
           {soleCandidate.connected ? (
             <Typography
@@ -527,7 +555,7 @@ function ProviderStep({
                       </span>
                     }
                   />
-                  <CandidateTag candidate={candidate} />
+                  {candidateTag(candidate)}
                 </div>
                 {selected ? setupAction(candidate) : null}
                 {selected ? connectSection : null}
@@ -593,6 +621,7 @@ function ConnectSection({
   editor,
   onCancel,
 }: ConnectSectionProps) {
+  const { t } = useTranslation("settings");
   // The subscription is signed into, not created: it has no name, no key, and
   // no endpoint for the create form to collect.
   if (candidate.provider === CHATGPT_CONNECTION_PROVIDER) {
@@ -615,6 +644,9 @@ function ConnectSection({
       hideProviderSelect
       onCreated={editor.handleProviderCreated}
       onCancel={onCancel}
+      // The dialog's own Cancel sits right below this one and abandons the
+      // whole profile; this one only puts the key form away.
+      cancelLabel={t("profileCreateModelFirst.cancelConnect")}
     />
   );
 }

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -3,7 +3,10 @@ import { useEffect, useMemo, useState } from "react";
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 import { Radio, RadioGroup } from "@vellumai/design-library/components/radio";
-import { SearchableSelect } from "@vellumai/design-library/components/searchable-select";
+import {
+  SearchableSelect,
+  type SearchableSelectOption,
+} from "@vellumai/design-library/components/searchable-select";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { Typography } from "@vellumai/design-library/components/typography";
 
@@ -11,10 +14,12 @@ import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
 import { CHATGPT_CONNECTION_PROVIDER } from "@/domains/settings/ai/constants";
 import {
+  collapseSupersededVersions,
   customModelProviderCandidates,
   defaultProviderCandidate,
-  resolveModelFirstOptions,
+  resolveModelFirstGroups,
   type ModelFirstInput,
+  type ModelFirstOption,
   type ProviderCandidate,
 } from "@/domains/settings/ai/model-first-candidates";
 import { entryPickerValue } from "@/domains/settings/ai/provider-availability";
@@ -30,6 +35,13 @@ import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-st
  * never collide with a model's display name.
  */
 const CUSTOM_MODEL_OPTION_VALUE = "__custom-model-id__";
+
+/**
+ * Prefix for the row that unfolds one section's older versions. Namespaced the
+ * same way, and carrying the section it acts on, so picking it is told apart
+ * from picking a model.
+ */
+const SHOW_OLDER_PREFIX = "__show-older__:";
 
 /**
  * What the user has answered to the flow's first question. A catalog pick is
@@ -87,10 +99,19 @@ export function ProfileCreateModelFirst({
     ],
   );
 
-  const options = useMemo(
-    () => resolveModelFirstOptions(resolverInput),
+  const groups = useMemo(
+    () => resolveModelFirstGroups(resolverInput),
     [resolverInput],
   );
+  const options = useMemo(
+    () => groups.flatMap((group) => group.options),
+    [groups],
+  );
+
+  // Sections the user has unfolded. A section stays unfolded for the rest of
+  // the visit: folding it back under them would move the row they were about
+  // to click.
+  const [unfoldedGroups, setUnfoldedGroups] = useState<readonly string[]>([]);
 
   // "Save As New" opens create mode on a profile that already has a provider
   // and a model, so the flow starts on whichever answer that model is: a
@@ -212,6 +233,14 @@ export function ProfileCreateModelFirst({
       openCandidatesFor({ kind: "custom", modelId: "" });
       return;
     }
+    if (value.startsWith(SHOW_OLDER_PREFIX)) {
+      // Acts on the list rather than answering it, so the draft is untouched.
+      const group = value.slice(SHOW_OLDER_PREFIX.length);
+      setUnfoldedGroups((previous) =>
+        previous.includes(group) ? previous : [...previous, group],
+      );
+      return;
+    }
     openCandidatesFor({ kind: "catalog", displayName: value });
   }
 
@@ -241,32 +270,59 @@ export function ProfileCreateModelFirst({
     setSetupOpenFor(candidate.value);
   }
 
-  const modelOptions = useMemo(
-    () => [
-      ...options.map((option) => ({
-        value: option.displayName,
-        label: option.displayName,
-        suffix: (
-          <PickerMeta
-            text={
-              option.soleProviderLabel ??
-              t("profileCreateModelFirst.providerCountMeta", {
-                count: option.providerCount,
-              })
-            }
-          />
-        ),
-      })),
-      {
-        value: CUSTOM_MODEL_OPTION_VALUE,
-        label: t("profileCreateModelFirst.customModelOption"),
-        // The catalog outgrows the menu's height, so the escape hatch is
-        // pinned rather than left at the end of a scroll.
-        sticky: true,
-      },
-    ],
-    [options, t],
-  );
+  const modelOptions = useMemo<SearchableSelectOption[]>(() => {
+    const rows: SearchableSelectOption[] = [];
+    const modelRow = (
+      option: ModelFirstOption,
+      group: string,
+      folded: boolean,
+    ): SearchableSelectOption => ({
+      value: option.displayName,
+      label: option.displayName,
+      group,
+      folded,
+      suffix: (
+        <PickerMeta
+          text={
+            option.soleProviderLabel ??
+            t("profileCreateModelFirst.providerCountMeta", {
+              count: option.providerCount,
+            })
+          }
+        />
+      ),
+    });
+    for (const group of groups) {
+      const { shown, hidden } = collapseSupersededVersions(group.options);
+      const unfolded = unfoldedGroups.includes(group.provider);
+      for (const option of shown) {
+        rows.push(modelRow(option, group.label, false));
+      }
+      for (const option of hidden) {
+        // Folded away while the list is being browsed, but never hidden from
+        // a query: someone who types a version's name means that version.
+        rows.push(modelRow(option, group.label, !unfolded));
+      }
+      if (hidden.length > 0 && !unfolded) {
+        rows.push({
+          value: `${SHOW_OLDER_PREFIX}${group.provider}`,
+          label: t("profileCreateModelFirst.showOlderVersions", {
+            count: hidden.length,
+          }),
+          group: group.label,
+          listAction: true,
+        });
+      }
+    }
+    rows.push({
+      value: CUSTOM_MODEL_OPTION_VALUE,
+      label: t("profileCreateModelFirst.customModelOption"),
+      // The catalog outgrows the menu's height, so the escape hatch is
+      // pinned rather than left at the end of a scroll.
+      sticky: true,
+    });
+    return rows;
+  }, [groups, unfoldedGroups, t]);
 
   const fieldLabelClass =
     "block text-body-small-default text-[var(--content-tertiary)]";

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.tsx
@@ -1,0 +1,502 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@vellumai/design-library/components/button";
+import { Input } from "@vellumai/design-library/components/input";
+import { Radio, RadioGroup } from "@vellumai/design-library/components/radio";
+import { SearchableSelect } from "@vellumai/design-library/components/searchable-select";
+import { Tag } from "@vellumai/design-library/components/tag";
+import { Typography } from "@vellumai/design-library/components/typography";
+
+import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import { ChatgptOAuthSection } from "@/domains/settings/ai/chatgpt-oauth-section";
+import { CHATGPT_CONNECTION_PROVIDER } from "@/domains/settings/ai/constants";
+import {
+  customModelProviderCandidates,
+  defaultProviderCandidate,
+  resolveModelFirstOptions,
+  type ModelFirstInput,
+  type ProviderCandidate,
+} from "@/domains/settings/ai/model-first-candidates";
+import { entryPickerValue } from "@/domains/settings/ai/provider-availability";
+import { PickerMeta } from "@/domains/settings/ai/provider-picker-availability";
+import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
+import type { ProfileEditor } from "@/domains/settings/ai/use-profile-editor";
+import { useActiveAssistantIsSelfHosted } from "@/hooks/use-platform-gate";
+import { useTranslation } from "@/i18n";
+import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
+
+/**
+ * Sentinel for the Model list's sticky escape hatch. Namespaced so it can
+ * never collide with a model's display name.
+ */
+const CUSTOM_MODEL_OPTION_VALUE = "__custom-model-id__";
+
+/**
+ * What the user has answered to the flow's first question. A catalog pick is
+ * held by display name because that is the identity a model keeps across the
+ * providers that host it; the per-provider id follows from the route chosen
+ * next.
+ */
+type ModelDraft =
+  | { readonly kind: "none" }
+  | { readonly kind: "catalog"; readonly displayName: string }
+  | { readonly kind: "custom"; readonly modelId: string };
+
+const NO_MODEL: ModelDraft = { kind: "none" };
+
+export interface ProfileCreateModelFirstProps {
+  editor: ProfileEditor;
+  /** Assistant whose connections the inline connect form writes to. */
+  assistantId: string;
+}
+
+/**
+ * The model-first create flow: pick the model, then the route that serves it.
+ *
+ * The provider question is asked only when there is something to decide. One
+ * candidate that is already connected answers itself and is shown as a fact;
+ * several candidates become radio cards with the connected ones first; a
+ * candidate with no connection yet expands into the connect form it needs, and
+ * nothing is bound to the profile until that form produces a connection.
+ *
+ * It drives the same `useProfileEditor` state the provider-first flow drives,
+ * so a profile saved through either is byte-identical on the wire.
+ */
+export function ProfileCreateModelFirst({
+  editor,
+  assistantId,
+}: ProfileCreateModelFirstProps) {
+  const { t } = useTranslation("settings");
+  const activeAssistantIsSelfHosted = useActiveAssistantIsSelfHosted();
+  const developerMode = useAssistantFeatureFlagStore.use.settingsDeveloperNav();
+  const defaultEntryMetaLabel = t("aiProviderPicker.defaultEntryMeta");
+
+  const resolverInput = useMemo<ModelFirstInput>(
+    () => ({
+      connections: editor.effectiveConnections,
+      developerMode,
+      activeAssistantIsSelfHosted,
+      labelFor: (provider) => PROVIDER_DISPLAY_NAMES[provider] ?? provider,
+      defaultEntryMetaLabel,
+    }),
+    [
+      editor.effectiveConnections,
+      developerMode,
+      activeAssistantIsSelfHosted,
+      defaultEntryMetaLabel,
+    ],
+  );
+
+  const options = useMemo(
+    () => resolveModelFirstOptions(resolverInput),
+    [resolverInput],
+  );
+
+  // "Save As New" opens create mode on a profile that already has a provider
+  // and a model, so the flow starts on whichever answer that model is: a
+  // catalog entry the list offers, or an id only free text can express.
+  const [draft, setDraft] = useState<ModelDraft>(() => {
+    if (editor.model === "") {
+      return NO_MODEL;
+    }
+    const seeded = options.find((option) =>
+      option.candidates.some(
+        (candidate) =>
+          candidate.provider === editor.provider &&
+          candidate.modelId === editor.model,
+      ),
+    );
+    return seeded
+      ? { kind: "catalog", displayName: seeded.displayName }
+      : { kind: "custom", modelId: editor.model };
+  });
+  const [selectedValue, setSelectedValue] = useState(() => {
+    if (editor.provider === "") {
+      return "";
+    }
+    return editor.providerConnection === ""
+      ? editor.provider
+      : entryPickerValue(editor.provider, editor.providerConnection);
+  });
+
+  const candidates = useMemo<readonly ProviderCandidate[]>(() => {
+    if (draft.kind === "catalog") {
+      return (
+        options.find((option) => option.displayName === draft.displayName)
+          ?.candidates ?? []
+      );
+    }
+    if (draft.kind === "custom") {
+      return customModelProviderCandidates(resolverInput, draft.modelId);
+    }
+    return [];
+  }, [draft, options, resolverInput]);
+
+  const selectedCandidate =
+    candidates.find((candidate) => candidate.value === selectedValue) ?? null;
+
+  // The model is written last, once the route that serves it is settled, so
+  // the editor derives the profile's Name from the model's display name under
+  // the provider that will dispatch it. Doing it here rather than in the click
+  // handler is what makes the ordering hold: the handler's view of the editor
+  // predates its own provider change, while this runs after it lands.
+  useEffect(() => {
+    if (!selectedCandidate?.connected) {
+      return;
+    }
+    if (editor.provider !== selectedCandidate.provider) {
+      return;
+    }
+    if (editor.model === selectedCandidate.modelId) {
+      return;
+    }
+    editor.handleModelChange(selectedCandidate.modelId);
+  }, [selectedCandidate, editor]);
+
+  function selectCandidate(candidate: ProviderCandidate): void {
+    setSelectedValue(candidate.value);
+    if (editor.provider !== candidate.provider) {
+      editor.handleProviderChange(candidate.provider);
+      // A named row carries its own binding; the provider change above has
+      // already resolved a lone connection for the bare row.
+      if (candidate.connectionName !== "") {
+        editor.setProviderConnection(candidate.connectionName);
+      }
+    } else {
+      // Re-picking the kind's bare row means "the default entry", so the
+      // explicit binding clears.
+      editor.setProviderConnection(candidate.connectionName);
+    }
+    if (!candidate.connected) {
+      // Nothing can dispatch this route yet. The model stays unset so Save
+      // is blocked until the connect form below produces a connection.
+      editor.setModel("");
+    }
+  }
+
+  function selectByValue(value: string): void {
+    const candidate = candidates.find((entry) => entry.value === value);
+    if (candidate) {
+      selectCandidate(candidate);
+    }
+  }
+
+  function openCandidatesFor(next: ModelDraft): void {
+    setDraft(next);
+    const nextCandidates =
+      next.kind === "catalog"
+        ? (options.find((option) => option.displayName === next.displayName)
+            ?.candidates ?? [])
+        : next.kind === "custom"
+          ? customModelProviderCandidates(resolverInput, next.modelId)
+          : [];
+    const candidate = defaultProviderCandidate(nextCandidates);
+    if (candidate) {
+      selectCandidate(candidate);
+      return;
+    }
+    setSelectedValue("");
+  }
+
+  function handleModelPick(value: string): void {
+    if (value === CUSTOM_MODEL_OPTION_VALUE) {
+      editor.setModel("");
+      openCandidatesFor({ kind: "custom", modelId: "" });
+      return;
+    }
+    openCandidatesFor({ kind: "catalog", displayName: value });
+  }
+
+  function handleCustomModelIdChange(value: string): void {
+    setDraft({ kind: "custom", modelId: value });
+  }
+
+  function handleConnectFormCancel(): void {
+    const fallback = candidates.find((candidate) => candidate.connected);
+    if (fallback) {
+      selectCandidate(fallback);
+      return;
+    }
+    setSelectedValue("");
+  }
+
+  const modelOptions = useMemo(
+    () => [
+      ...options.map((option) => ({
+        value: option.displayName,
+        label: option.displayName,
+        suffix: (
+          <PickerMeta
+            text={
+              option.soleProviderLabel ??
+              t("profileCreateModelFirst.providerCountMeta", {
+                count: option.providerCount,
+              })
+            }
+          />
+        ),
+      })),
+      {
+        value: CUSTOM_MODEL_OPTION_VALUE,
+        label: t("profileCreateModelFirst.customModelOption"),
+        // The catalog outgrows the menu's height, so the escape hatch is
+        // pinned rather than left at the end of a scroll.
+        sticky: true,
+      },
+    ],
+    [options, t],
+  );
+
+  const fieldLabelClass =
+    "block text-body-small-default text-[var(--content-tertiary)]";
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <label className={fieldLabelClass}>
+          {t("profileCreateModelFirst.modelLabel")}
+        </label>
+        {draft.kind === "custom" ? (
+          <>
+            <Input
+              value={draft.modelId}
+              onChange={(event) =>
+                handleCustomModelIdChange(event.target.value)
+              }
+              placeholder={t(
+                "profileCreateModelFirst.customModelPlaceholder",
+              )}
+              aria-label={t("profileCreateModelFirst.customModelAriaLabel")}
+              fullWidth
+              autoFocus
+            />
+            <Button
+              variant="link"
+              size="compact"
+              onClick={() => {
+                editor.setModel("");
+                openCandidatesFor(NO_MODEL);
+              }}
+            >
+              {t("profileCreateModelFirst.chooseFromList")}
+            </Button>
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[var(--content-tertiary)]"
+            >
+              {t("profileCreateModelFirst.customModelHint")}
+            </Typography>
+          </>
+        ) : (
+          <SearchableSelect
+            value={draft.kind === "catalog" ? draft.displayName : ""}
+            onChange={handleModelPick}
+            aria-label={t("profileCreateModelFirst.modelAriaLabel")}
+            placeholder={t("profileCreateModelFirst.modelPlaceholder")}
+            emptyText={t("profileCreateModelFirst.modelNoMatches")}
+            announceResults={(count) =>
+              t("profileCreateModelFirst.modelResultsAnnouncement", { count })
+            }
+            options={modelOptions}
+          />
+        )}
+      </div>
+
+      {draft.kind !== "none" && candidates.length > 0 ? (
+        <ProviderStep
+          assistantId={assistantId}
+          candidates={candidates}
+          editor={editor}
+          onCancelConnect={handleConnectFormCancel}
+          onSelect={selectByValue}
+          selectedCandidate={selectedCandidate}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface ProviderStepProps {
+  assistantId: string;
+  candidates: readonly ProviderCandidate[];
+  editor: ProfileEditor;
+  onCancelConnect: () => void;
+  onSelect: (value: string) => void;
+  selectedCandidate: ProviderCandidate | null;
+}
+
+/**
+ * The flow's second question, which is asked only as far as it needs to be:
+ * a lone connected route is stated rather than offered, and everything else
+ * becomes a card list whose selected card carries its own connect form when
+ * the route it names has no connection yet.
+ */
+function ProviderStep({
+  assistantId,
+  candidates,
+  editor,
+  onCancelConnect,
+  onSelect,
+  selectedCandidate,
+}: ProviderStepProps) {
+  const { t } = useTranslation("settings");
+  const soleCandidate = candidates.length === 1 ? candidates[0] : null;
+
+  const connectSection =
+    selectedCandidate && !selectedCandidate.connected ? (
+      <ConnectSection
+        assistantId={assistantId}
+        candidate={selectedCandidate}
+        editor={editor}
+        onCancel={onCancelConnect}
+      />
+    ) : null;
+
+  return (
+    <div className="space-y-1">
+      <span
+        id="profile-create-provider-label"
+        className="block text-body-small-default text-[var(--content-tertiary)]"
+      >
+        {t("profileCreateModelFirst.providerLabel")}
+      </span>
+
+      {soleCandidate ? (
+        <div className="space-y-2">
+          <div
+            data-testid="provider-candidate"
+            data-candidate={soleCandidate.value}
+            className="flex min-h-9 items-center justify-between gap-2 rounded-lg border border-[var(--border-element)] px-3 py-2"
+          >
+            <Typography variant="body-medium-lighter" as="span">
+              {soleCandidate.label}
+            </Typography>
+            <CandidateTag candidate={soleCandidate} />
+          </div>
+          {soleCandidate.connected ? (
+            <Typography
+              variant="body-small-default"
+              as="p"
+              className="text-[var(--content-tertiary)]"
+            >
+              {t("profileCreateModelFirst.soleProviderHint", {
+                name: soleCandidate.label,
+              })}
+            </Typography>
+          ) : null}
+          {connectSection}
+        </div>
+      ) : (
+        <RadioGroup
+          value={selectedCandidate?.value ?? ""}
+          onValueChange={onSelect}
+          aria-labelledby="profile-create-provider-label"
+        >
+          {candidates.map((candidate) => {
+            const selected = candidate.value === selectedCandidate?.value;
+            return (
+              <div
+                key={candidate.value}
+                data-testid="provider-candidate"
+                data-candidate={candidate.value}
+                className={`space-y-3 rounded-lg border px-3 py-2 ${
+                  selected
+                    ? "border-[var(--border-active)]"
+                    : "border-[var(--border-element)]"
+                }`}
+              >
+                <div className="flex min-h-9 items-center justify-between gap-2">
+                  <Radio
+                    value={candidate.value}
+                    label={
+                      <span className="flex items-center gap-2">
+                        <span>{candidate.label}</span>
+                        {candidate.meta ? (
+                          <PickerMeta text={candidate.meta} />
+                        ) : null}
+                      </span>
+                    }
+                  />
+                  <CandidateTag candidate={candidate} />
+                </div>
+                {selected ? connectSection : null}
+              </div>
+            );
+          })}
+        </RadioGroup>
+      )}
+
+      {editor.newProviderNote ? (
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="text-[var(--content-tertiary)]"
+        >
+          {t("profileEditorFields.newProviderNote")}
+        </Typography>
+      ) : null}
+    </div>
+  );
+}
+
+function CandidateTag({ candidate }: { candidate: ProviderCandidate }) {
+  const { t } = useTranslation("settings");
+  if (candidate.connected) {
+    return (
+      <Tag tone="positive">{t("profileCreateModelFirst.connectedTag")}</Tag>
+    );
+  }
+  const label =
+    candidate.setup === "sign-in"
+      ? t("profileCreateModelFirst.signInTag")
+      : candidate.setup === "set-up"
+        ? t("profileCreateModelFirst.setUpTag")
+        : t("profileCreateModelFirst.addApiKeyTag");
+  return <Tag tone="neutral">{label}</Tag>;
+}
+
+interface ConnectSectionProps {
+  assistantId: string;
+  candidate: ProviderCandidate;
+  editor: ProfileEditor;
+  onCancel: () => void;
+}
+
+/**
+ * The connect flow for a route with no connection yet, inline under the card
+ * that names it. Both branches report the stored connection through the
+ * editor's own `handleProviderCreated`, which is the same path the
+ * provider-first flow's inline create uses.
+ */
+function ConnectSection({
+  assistantId,
+  candidate,
+  editor,
+  onCancel,
+}: ConnectSectionProps) {
+  // The subscription is signed into, not created: it has no name, no key, and
+  // no endpoint for the create form to collect.
+  if (candidate.provider === CHATGPT_CONNECTION_PROVIDER) {
+    return (
+      <ChatgptOAuthSection
+        assistantId={assistantId}
+        onConnected={editor.handleProviderCreated}
+      />
+    );
+  }
+  return (
+    <ProviderCreateForm
+      variant="inline"
+      assistantId={assistantId}
+      existingNames={editor.effectiveConnections.map(
+        (connection) => connection.name,
+      )}
+      connections={editor.effectiveConnections}
+      defaultProviderType={candidate.provider}
+      hideProviderSelect
+      onCreated={editor.handleProviderCreated}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
@@ -421,7 +421,11 @@ export function ProfileEditorFields({
     return (
       <div className="space-y-4">
         {modelFirstCreate ? (
-          <ProfileCreateModelFirst editor={editor} assistantId={assistantId} />
+          <ProfileCreateModelFirst
+            editor={editor}
+            assistantId={assistantId}
+            reserveListRoom={!flat}
+          />
         ) : (
           createProviderSection
         )}

--- a/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
@@ -9,6 +9,7 @@ import { Typography } from "@vellumai/design-library/components/typography";
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import { OPENAI_COMPATIBLE_PROVIDER } from "@/domains/settings/ai/constants";
 import { ProfileAdvancedParams } from "@/domains/settings/ai/profile-advanced-params";
+import { ProfileCreateModelFirst } from "@/domains/settings/ai/profile-create-model-first";
 import { ProfileEditorProviderSection } from "@/domains/settings/ai/profile-editor-provider-section";
 import {
   entryPickerValue,
@@ -23,6 +24,7 @@ import {
 } from "@/domains/settings/ai/provider-picker-availability";
 import { ProviderCreateForm } from "@/domains/settings/ai/provider-create-form";
 import { connectionAuthTypeForProvider } from "@/domains/settings/ai/provider-editor-constants";
+import { useModelFirstProfileCreate } from "@/domains/settings/ai/use-model-first-profile-create-flag";
 import type { ProfileEditor } from "@/domains/settings/ai/use-profile-editor";
 import type {
   ConnectionProvider,
@@ -71,6 +73,7 @@ export function ProfileEditorFields({
 }: ProfileEditorFieldsProps) {
   const { t } = useTranslation("settings");
   const providerAvailability = useProviderPickerAvailability();
+  const modelFirstCreate = useModelFirstProfileCreate();
   const isCreate = editor.effectiveMode === "create";
   const flat = variant === "panel";
 
@@ -412,10 +415,16 @@ export function ProfileEditorFields({
         );
 
     // Create asks two questions: which provider, and which model. Everything
-    // else has an answer the model supplies, so it waits under Advanced.
+    // else has an answer the model supplies, so it waits under Advanced. The
+    // `model-first-profile-create` flag decides the order the two are asked
+    // in; both fill the same editor state.
     return (
       <div className="space-y-4">
-        {createProviderSection}
+        {modelFirstCreate ? (
+          <ProfileCreateModelFirst editor={editor} assistantId={assistantId} />
+        ) : (
+          createProviderSection
+        )}
         {createAdvanced}
         {saveErrorNode}
       </div>

--- a/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-fields.tsx
@@ -50,6 +50,12 @@ export interface ProfileEditorFieldsProps {
    *   is flat and always visible.
    */
   variant: "modal" | "panel";
+  /**
+   * Box the model-first create flow keeps its open list inside, and which it
+   * then keeps tall enough to hold it. The modal host passes its own body;
+   * the sidepanel is already full height and passes nothing.
+   */
+  menuBoundary?: Element | null;
 }
 
 /**
@@ -70,6 +76,7 @@ export function ProfileEditorFields({
   assistantId,
   connections,
   variant,
+  menuBoundary,
 }: ProfileEditorFieldsProps) {
   const { t } = useTranslation("settings");
   const providerAvailability = useProviderPickerAvailability();
@@ -424,7 +431,7 @@ export function ProfileEditorFields({
           <ProfileCreateModelFirst
             editor={editor}
             assistantId={assistantId}
-            reserveListRoom={!flat}
+            menuBoundary={menuBoundary}
           />
         ) : (
           createProviderSection

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
@@ -191,6 +191,23 @@ export const CreateModelFirstListOpen: Story = {
 };
 
 /**
+ * The same open list in a window too short to hold it. The dialog gives back
+ * the room it reserved, the body scrolls instead, and the list caps itself to
+ * what is left, so Cancel and Save stay on screen.
+ */
+export const CreateModelFirstListOpenShort: Story = {
+  args: { mode: "create" },
+  beforeEach: withModelFirstCreate,
+  globals: { viewport: { value: "sbShort", isRotated: false } },
+  play: async () => {
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: "Model" }),
+    );
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeTruthy());
+  },
+};
+
+/**
  * A section with its older versions revealed: the block the unfold row opened
  * is set off by a hairline, and the list stays where the user left it.
  */

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
@@ -184,7 +184,7 @@ export const CreateModelFirstSeveralProviders: Story = {
     const modelField = await screen.findByRole("combobox", { name: "Model" });
     await userEvent.click(modelField);
     await userEvent.click(
-      await screen.findByRole("option", { name: /Claude Opus 4\.8/ }),
+      await screen.findByRole("option", { name: /Claude Opus 5/ }),
     );
     await waitFor(() =>
       expect(screen.getAllByRole("radio").length).toBeGreaterThan(1),

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, screen, userEvent, waitFor } from "storybook/test";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
@@ -171,6 +171,72 @@ export const CreateDuplicateName: Story = {
 export const CreateModelFirst: Story = {
   args: { mode: "create" },
   beforeEach: withModelFirstCreate,
+};
+
+/**
+ * The open model list. Sections are named for whoever made the model, spelled
+ * the way that vendor spells it, and each heading stays pinned while its own
+ * rows scroll under it. The row that unfolds a section's older versions is
+ * drawn as a secondary action, not as one more model.
+ */
+export const CreateModelFirstListOpen: Story = {
+  args: { mode: "create" },
+  beforeEach: withModelFirstCreate,
+  play: async () => {
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: "Model" }),
+    );
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeTruthy());
+  },
+};
+
+/**
+ * A section with its older versions revealed: the block the unfold row opened
+ * is set off by a hairline, and the list stays where the user left it.
+ */
+export const CreateModelFirstOlderVersions: Story = {
+  args: { mode: "create" },
+  beforeEach: withModelFirstCreate,
+  play: async () => {
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: "Model" }),
+    );
+    // Scoped to the section: every section that folds anything offers a row
+    // of the same shape, and several fold the same number.
+    const anthropic = await screen.findByRole("group", { name: "Anthropic" });
+    await userEvent.click(
+      within(anthropic).getByRole("option", { name: /Show older versions/ }),
+    );
+    await waitFor(() =>
+      expect(
+        within(anthropic).getByRole("option", { name: /Claude Opus 4\.8/ }),
+      ).toBeTruthy(),
+    );
+  },
+};
+
+/**
+ * A route with no connection yet. Its card carries the key form, so the tag
+ * that asked for the key steps aside and the form's own dismiss action says
+ * what it dismisses rather than repeating the dialog's Cancel.
+ */
+export const CreateModelFirstConnectForm: Story = {
+  args: { mode: "create" },
+  beforeEach: withModelFirstCreate,
+  play: async () => {
+    await userEvent.click(
+      await screen.findByRole("combobox", { name: "Model" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("option", { name: /Claude Opus 5/ }),
+    );
+    await userEvent.click(
+      await screen.findByRole("radio", { name: /OpenRouter/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Cancel setup" })).toBeTruthy(),
+    );
+  },
 };
 
 /**

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
@@ -3,6 +3,7 @@ import { expect, screen, userEvent, waitFor } from "storybook/test";
 
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
 import type { ProviderConnection } from "@/generated/daemon/types.gen";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 function connection(provider: string): ProviderConnection {
   return {
@@ -21,6 +22,16 @@ const CONNECTIONS: ProviderConnection[] = [
   connection("anthropic"),
   connection("openai"),
 ];
+
+/** Turns the model-first create flow on for one story, and off again after. */
+function withModelFirstCreate() {
+  const previous =
+    useClientFeatureFlagStore.getState().modelFirstProfileCreate === true;
+  useClientFeatureFlagStore.setState({ modelFirstProfileCreate: true });
+  return () => {
+    useClientFeatureFlagStore.setState({ modelFirstProfileCreate: previous });
+  };
+}
 
 const meta: Meta<typeof ProfileEditorModal> = {
   title: "Settings/AI/ProfileEditorModal",
@@ -148,6 +159,55 @@ export const CreateDuplicateName: Story = {
     await userEvent.click(await screen.findByRole("button", { name: "Advanced" }));
     await waitFor(() =>
       expect(screen.getByDisplayValue("Claude Opus 4.8 (2)")).toBeTruthy(),
+    );
+  },
+};
+
+/**
+ * The same create modal under `model-first-profile-create`: it opens on one
+ * list of models rather than a provider dropdown, and asks nothing else until
+ * a model is chosen.
+ */
+export const CreateModelFirst: Story = {
+  args: { mode: "create" },
+  beforeEach: withModelFirstCreate,
+};
+
+/**
+ * A model several connected providers serve. The routes become cards, the
+ * first connected one is already chosen, and the rest carry what they need.
+ */
+export const CreateModelFirstSeveralProviders: Story = {
+  args: { mode: "create" },
+  beforeEach: withModelFirstCreate,
+  play: async () => {
+    const modelField = await screen.findByRole("combobox", { name: "Model" });
+    await userEvent.click(modelField);
+    await userEvent.click(
+      await screen.findByRole("option", { name: /Claude Opus 4\.8/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getAllByRole("radio").length).toBeGreaterThan(1),
+    );
+  },
+};
+
+/**
+ * A model only one connected provider serves. There is nothing to decide, so
+ * the route is stated rather than offered and the flow goes straight to
+ * Advanced.
+ */
+export const CreateModelFirstSingleProvider: Story = {
+  args: { mode: "create", connections: [connection("gemini")] },
+  beforeEach: withModelFirstCreate,
+  play: async () => {
+    const modelField = await screen.findByRole("combobox", { name: "Model" });
+    await userEvent.click(modelField);
+    await userEvent.click(
+      await screen.findByRole("option", { name: /Gemini 3\.6 Flash/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Only Google Gemini serves this model.")).toBeTruthy(),
     );
   },
 };

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
@@ -208,10 +208,10 @@ export const CreateModelFirstListOpenShort: Story = {
 };
 
 /**
- * A section with its older versions revealed: the block the unfold row opened
- * is set off by a hairline, and the list stays where the user left it.
+ * A section with the rest of its models revealed: the block the unfold row
+ * opened is set off by a hairline, and the list stays where the user left it.
  */
-export const CreateModelFirstOlderVersions: Story = {
+export const CreateModelFirstSeeMore: Story = {
   args: { mode: "create" },
   beforeEach: withModelFirstCreate,
   play: async () => {
@@ -219,10 +219,10 @@ export const CreateModelFirstOlderVersions: Story = {
       await screen.findByRole("combobox", { name: "Model" }),
     );
     // Scoped to the section: every section that folds anything offers a row
-    // of the same shape, and several fold the same number.
+    // of the same shape, spelled the same way.
     const anthropic = await screen.findByRole("group", { name: "Anthropic" });
     await userEvent.click(
-      within(anthropic).getByRole("option", { name: /Show older versions/ }),
+      within(anthropic).getByRole("option", { name: "See more" }),
     );
     await waitFor(() =>
       expect(

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.stories.tsx
@@ -191,9 +191,32 @@ export const CreateModelFirstListOpen: Story = {
 };
 
 /**
- * The same open list in a window too short to hold it. The dialog gives back
- * the room it reserved, the body scrolls instead, and the list caps itself to
- * what is left, so Cancel and Save stay on screen.
+ * The list reopened over the answer to its own question. The dialog is at its
+ * shortest here, since one connected route is stated in a line rather than
+ * offered as cards, and the list still opens inside it: bounded by the body,
+ * clear of the footer, and no shorter than it can be read at.
+ */
+export const CreateModelFirstListReopened: Story = {
+  args: { mode: "create", connections: [connection("gemini")] },
+  beforeEach: withModelFirstCreate,
+  play: async () => {
+    const modelField = await screen.findByRole("combobox", { name: "Model" });
+    await userEvent.click(modelField);
+    await userEvent.click(
+      await screen.findByRole("option", { name: /Gemini 3\.6 Flash/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Only Google Gemini serves this model.")).toBeTruthy(),
+    );
+    await userEvent.click(modelField);
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeTruthy());
+  },
+};
+
+/**
+ * The same open list in a window too short to hold it. The dialog stops at
+ * its own ceiling, the body scrolls instead of growing, and the list caps
+ * itself to what is left of the body, so Cancel and Save stay on screen.
  */
 export const CreateModelFirstListOpenShort: Story = {
   args: { mode: "create" },

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { Tag } from "@vellumai/design-library/components/tag";
@@ -105,6 +107,11 @@ function ProfileEditorModalInner({
   onCancel,
 }: ProfileEditorModalInnerProps) {
   const { t } = useTranslation("settings");
+  // The model-first list is portaled, so the dialog holds it by saying where
+  // it ends rather than by where the list is rendered. The body is the box to
+  // name: its bottom edge is the footer's top, so a list kept inside it is a
+  // list kept off Cancel and Save.
+  const [bodyElement, setBodyElement] = useState<HTMLDivElement | null>(null);
   const editor = useProfileEditor({
     mode,
     profileName,
@@ -137,12 +144,13 @@ function ProfileEditorModalInner({
         )}
       </Modal.Header>
 
-      <Modal.Body>
+      <Modal.Body ref={setBodyElement}>
         <ProfileEditorFields
           editor={editor}
           assistantId={assistantId}
           connections={connections}
           variant="modal"
+          menuBoundary={bodyElement}
         />
       </Modal.Body>
 

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -79,6 +79,13 @@ export interface ProviderCreateFormProps {
   hideProviderSelect?: boolean;
   onCreated: (connection: ProviderConnection) => void;
   onCancel: () => void;
+  /**
+   * What the dismiss action says. Give it something more specific than
+   * "Cancel" wherever the form sits inside a dialog that has a Cancel of its
+   * own, so the two are told apart by what they read rather than by which one
+   * is nearer the pointer.
+   */
+  cancelLabel?: ReactNode;
   /** "modal" wraps the form in Modal chrome; "inline" drops it for embedding. */
   variant?: "modal" | "inline";
   /**
@@ -99,6 +106,7 @@ export function ProviderCreateForm({
   hideProviderSelect = false,
   onCreated,
   onCancel,
+  cancelLabel,
   variant = "modal",
   actionsSlot,
 }: ProviderCreateFormProps) {
@@ -609,7 +617,7 @@ export function ProviderCreateForm({
   const footer: ReactNode = (
     <>
       <Button variant="ghost" onClick={onCancel}>
-        {t("providerCreateForm.cancel")}
+        {cancelLabel ?? t("providerCreateForm.cancel")}
       </Button>
       {!isChatgpt && (
         <Button

--- a/clients/web/src/domains/settings/ai/use-model-first-profile-create-flag.ts
+++ b/clients/web/src/domains/settings/ai/use-model-first-profile-create-flag.ts
@@ -1,0 +1,17 @@
+/**
+ * Read seam for the `model-first-profile-create` client flag, which decides
+ * which question the New Model modal asks first: the provider, or the model.
+ */
+
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+/**
+ * No pending state to wait on: the flag defaults off and a `false` read
+ * renders the provider-first flow, which is a working create form on its own,
+ * so the pre-hydration window is never blank. The value is read on every
+ * render rather than latched, because the two flows are alternative ways to
+ * fill the same editor state and neither holds work the other would strand.
+ */
+export function useModelFirstProfileCreate(): boolean {
+  return useClientFeatureFlagStore.use.modelFirstProfileCreate();
+}

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1437,6 +1437,25 @@
     "transient": "Saved, but a test request through this profile could not complete: {detail} This may be temporary.",
     "unknown": "Saved, but a test request through this profile failed: {detail}"
   },
+  "profileCreateModelFirst": {
+    "addApiKeyTag": "Add API key",
+    "chooseFromList": "Choose from list",
+    "connectedTag": "Connected",
+    "customModelAriaLabel": "Custom model ID",
+    "customModelHint": "Enter the exact model identifier your provider expects. It's sent to the connection as-is.",
+    "customModelOption": "Enter a custom model ID…",
+    "customModelPlaceholder": "provider/model-id",
+    "modelAriaLabel": "Model",
+    "modelLabel": "Model",
+    "modelNoMatches": "No matching models",
+    "modelPlaceholder": "Search models…",
+    "modelResultsAnnouncement": "{count, plural, one {# model available} other {# models available}}. Use the up and down arrow keys to move through them, Enter to choose one.",
+    "providerCountMeta": "{count, plural, one {# provider} other {# providers}}",
+    "providerLabel": "Provider",
+    "setUpTag": "Set up",
+    "signInTag": "Sign in",
+    "soleProviderHint": "Only {name} serves this model."
+  },
   "profileDetailPanel": {
     "create": "Create Model",
     "createTitle": "New Model",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1439,6 +1439,7 @@
   },
   "profileCreateModelFirst": {
     "addApiKeyTag": "Add API key",
+    "cancelConnect": "Cancel setup",
     "chooseFromList": "Choose from list",
     "connectedTag": "Connected",
     "customModelAriaLabel": "Custom model ID",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1453,6 +1453,7 @@
     "providerCountMeta": "{count, plural, one {# provider} other {# providers}}",
     "providerLabel": "Provider",
     "setUpTag": "Set up",
+    "showOlderVersions": "{count, plural, one {Show older version (#)} other {Show older versions (#)}}",
     "signInTag": "Sign in",
     "soleProviderHint": "Only {name} serves this model."
   },

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1453,8 +1453,8 @@
     "modelResultsAnnouncement": "{count, plural, one {# model available} other {# models available}}. Use the up and down arrow keys to move through them, Enter to choose one.",
     "providerCountMeta": "{count, plural, one {# provider} other {# providers}}",
     "providerLabel": "Provider",
+    "seeMore": "See more",
     "setUpTag": "Set up",
-    "showOlderVersions": "{count, plural, one {Show older version (#)} other {Show older versions (#)}}",
     "signInTag": "Sign in",
     "soleProviderHint": "Only {name} serves this model."
   },

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1439,6 +1439,7 @@
   },
   "profileCreateModelFirst": {
     "addApiKeyTag": "Añadir clave API",
+    "cancelConnect": "Cancelar configuración",
     "chooseFromList": "Elegir de la lista",
     "connectedTag": "Conectado",
     "customModelAriaLabel": "ID de modelo personalizado",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1437,6 +1437,25 @@
     "transient": "Guardado, pero una solicitud de prueba con este perfil no se pudo completar: {detail} Puede ser temporal.",
     "unknown": "Guardado, pero una solicitud de prueba con este perfil falló: {detail}"
   },
+  "profileCreateModelFirst": {
+    "addApiKeyTag": "Añadir clave API",
+    "chooseFromList": "Elegir de la lista",
+    "connectedTag": "Conectado",
+    "customModelAriaLabel": "ID de modelo personalizado",
+    "customModelHint": "Introduce el identificador exacto del modelo que espera tu proveedor. Se envía a la conexión tal cual.",
+    "customModelOption": "Introduce un ID de modelo personalizado…",
+    "customModelPlaceholder": "proveedor/id-modelo",
+    "modelAriaLabel": "Modelo",
+    "modelLabel": "Modelo",
+    "modelNoMatches": "No hay modelos coincidentes",
+    "modelPlaceholder": "Busca modelos…",
+    "modelResultsAnnouncement": "{count, plural, one {# modelo disponible} other {# modelos disponibles}}. Usa las flechas arriba y abajo para recorrerlos y Intro para elegir uno.",
+    "providerCountMeta": "{count, plural, one {# proveedor} other {# proveedores}}",
+    "providerLabel": "Proveedor",
+    "setUpTag": "Configurar",
+    "signInTag": "Iniciar sesión",
+    "soleProviderHint": "Solo {name} ofrece este modelo."
+  },
   "profileDetailPanel": {
     "create": "Crear modelo",
     "createTitle": "Nuevo modelo",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1453,6 +1453,7 @@
     "providerCountMeta": "{count, plural, one {# proveedor} other {# proveedores}}",
     "providerLabel": "Proveedor",
     "setUpTag": "Configurar",
+    "showOlderVersions": "{count, plural, one {Mostrar versión anterior (#)} other {Mostrar versiones anteriores (#)}}",
     "signInTag": "Iniciar sesión",
     "soleProviderHint": "Solo {name} ofrece este modelo."
   },

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1453,8 +1453,8 @@
     "modelResultsAnnouncement": "{count, plural, one {# modelo disponible} other {# modelos disponibles}}. Usa las flechas arriba y abajo para recorrerlos y Intro para elegir uno.",
     "providerCountMeta": "{count, plural, one {# proveedor} other {# proveedores}}",
     "providerLabel": "Proveedor",
+    "seeMore": "Ver más",
     "setUpTag": "Configurar",
-    "showOlderVersions": "{count, plural, one {Mostrar versión anterior (#)} other {Mostrar versiones anteriores (#)}}",
     "signInTag": "Iniciar sesión",
     "soleProviderHint": "Solo {name} ofrece este modelo."
   },

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1424,6 +1424,25 @@
     "transient": "Сохранено, но тестовый запрос через этот профиль не завершился: {detail} Возможно, это временно.",
     "unknown": "Сохранено, но тестовый запрос через этот профиль не прошёл: {detail}"
   },
+  "profileCreateModelFirst": {
+    "addApiKeyTag": "Добавить API-ключ",
+    "chooseFromList": "Выбрать из списка",
+    "connectedTag": "Подключено",
+    "customModelAriaLabel": "Свой ID модели",
+    "customModelHint": "Точный идентификатор модели, который ждёт провайдер. Он уйдёт в подключение как есть.",
+    "customModelOption": "Ввести свой ID модели…",
+    "customModelPlaceholder": "provider/model-id",
+    "modelAriaLabel": "Модель",
+    "modelLabel": "Модель",
+    "modelNoMatches": "Подходящих моделей нет",
+    "modelPlaceholder": "Поиск моделей…",
+    "modelResultsAnnouncement": "{count, plural, one {# модель доступна} few {# модели доступны} many {# моделей доступно} other {# модели доступно}}. Стрелки вверх и вниз для перехода, Enter для выбора.",
+    "providerCountMeta": "{count, plural, one {# провайдер} few {# провайдера} many {# провайдеров} other {# провайдера}}",
+    "providerLabel": "Провайдер",
+    "setUpTag": "Настроить",
+    "signInTag": "Войти",
+    "soleProviderHint": "Эту модель обслуживает только {name}."
+  },
   "profileDetailPanel": {
     "create": "Создать модель",
     "createTitle": "Новая модель",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1440,6 +1440,7 @@
     "providerCountMeta": "{count, plural, one {# провайдер} few {# провайдера} many {# провайдеров} other {# провайдера}}",
     "providerLabel": "Провайдер",
     "setUpTag": "Настроить",
+    "showOlderVersions": "{count, plural, one {Показать старую версию (#)} few {Показать старые версии (#)} many {Показать старых версий (#)} other {Показать старые версии (#)}}",
     "signInTag": "Войти",
     "soleProviderHint": "Эту модель обслуживает только {name}."
   },

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1426,6 +1426,7 @@
   },
   "profileCreateModelFirst": {
     "addApiKeyTag": "Добавить API-ключ",
+    "cancelConnect": "Отменить настройку",
     "chooseFromList": "Выбрать из списка",
     "connectedTag": "Подключено",
     "customModelAriaLabel": "Свой ID модели",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1440,8 +1440,8 @@
     "modelResultsAnnouncement": "{count, plural, one {# модель доступна} few {# модели доступны} many {# моделей доступно} other {# модели доступно}}. Стрелки вверх и вниз для перехода, Enter для выбора.",
     "providerCountMeta": "{count, plural, one {# провайдер} few {# провайдера} many {# провайдеров} other {# провайдера}}",
     "providerLabel": "Провайдер",
+    "seeMore": "Показать ещё",
     "setUpTag": "Настроить",
-    "showOlderVersions": "{count, plural, one {Показать старую версию (#)} few {Показать старые версии (#)} many {Показать старых версий (#)} other {Показать старые версии (#)}}",
     "signInTag": "Войти",
     "soleProviderHint": "Эту модель обслуживает только {name}."
   },

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -420,6 +420,14 @@
       "label": "ChatGPT Device Code Login",
       "description": "Gates the device-code sign-in as the primary ChatGPT subscription connect flow in the web client. Off: the redirect-and-paste flow is the only flow the connect section shows, with no device code UI and no other-sign-in-options disclosure. On: device code leads, and the redirect-and-paste flow stays reachable behind that disclosure and takes the section over when the assistant has no device-auth route.",
       "defaultEnabled": false
+    },
+    {
+      "id": "model-first-profile-create",
+      "scope": "client",
+      "key": "model-first-profile-create",
+      "label": "Model-First Profile Create",
+      "description": "Reverses the two questions the web client's New Model modal asks when creating an inference profile. Off: the modal asks for a provider first and then offers that provider's models. On: it opens on one searchable list of every catalog model the assistant can reach, deduplicated across providers, and only then asks which provider serves the chosen model. That second question is skipped when a single provider serves it, answered with radio cards when several do, and turned into an inline connect form (API key, setup, or ChatGPT sign-in) when the chosen route has no connection yet. Editing an existing profile is unchanged either way, and both flows persist the same profile shape.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -420,6 +420,14 @@
       "label": "ChatGPT Device Code Login",
       "description": "Gates the device-code sign-in as the primary ChatGPT subscription connect flow in the web client. Off: the redirect-and-paste flow is the only flow the connect section shows, with no device code UI and no other-sign-in-options disclosure. On: device code leads, and the redirect-and-paste flow stays reachable behind that disclosure and takes the section over when the assistant has no device-auth route.",
       "defaultEnabled": false
+    },
+    {
+      "id": "model-first-profile-create",
+      "scope": "client",
+      "key": "model-first-profile-create",
+      "label": "Model-First Profile Create",
+      "description": "Reverses the two questions the web client's New Model modal asks when creating an inference profile. Off: the modal asks for a provider first and then offers that provider's models. On: it opens on one searchable list of every catalog model the assistant can reach, deduplicated across providers, and only then asks which provider serves the chosen model. That second question is skipped when a single provider serves it, answered with radio cards when several do, and turned into an inline connect form (API key, setup, or ChatGPT sign-in) when the chosen route has no connection yet. Editing an existing profile is unchanged either way, and both flows persist the same profile shape.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/packages/design-library/src/components/combobox.test.tsx
+++ b/packages/design-library/src/components/combobox.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Combobox } from "./combobox";
+
+/**
+ * `Combobox.Group`, which is the one part of the combobox that renders
+ * without the root's context. Its keyboard and ARIA contract is driven end to
+ * end by the `Combobox` and `SearchableSelect` stories, which run in a real
+ * browser; what SSR proves is the heading's own wiring and treatment.
+ */
+describe("Combobox.Group", () => {
+  test("names the section it labels", () => {
+    const html = renderToStaticMarkup(
+      <Combobox.Group label="xAI">
+        <span>Grok 4.6</span>
+      </Combobox.Group>,
+    );
+    expect(html).toContain('role="group"');
+    const labelledBy = /aria-labelledby="([^"]+)"/.exec(html)?.[1];
+    expect(labelledBy).toBeTruthy();
+    expect(html).toContain(`id="${labelledBy}"`);
+    expect(html).toContain("xAI");
+  });
+
+  test("leaves the heading's own letters alone", () => {
+    const html = renderToStaticMarkup(
+      <Combobox.Group label="DeepSeek">
+        <span>DeepSeek V4 Pro</span>
+      </Combobox.Group>,
+    );
+    // A vendor's name is spelled the way the vendor spells it. A transform on
+    // the heading would respell every one of them.
+    expect(html).not.toContain("uppercase");
+    expect(html).not.toContain("capitalize");
+  });
+
+  test("pins the heading only where the caller asks for it", () => {
+    const loose = renderToStaticMarkup(
+      <Combobox.Group label="Anthropic">
+        <span>Claude Opus 5</span>
+      </Combobox.Group>,
+    );
+    expect(loose).not.toContain("sticky");
+
+    const pinned = renderToStaticMarkup(
+      <Combobox.Group label="Anthropic" stickyLabel>
+        <span>Claude Opus 5</span>
+      </Combobox.Group>,
+    );
+    // Opaque and above the rows, or the rows scroll straight through it.
+    expect(pinned).toContain("sticky");
+    expect(pinned).toContain("top-0");
+    expect(pinned).toContain("z-10");
+    expect(pinned).toContain("bg-[var(--surface-lift)]");
+  });
+});

--- a/packages/design-library/src/components/combobox.tsx
+++ b/packages/design-library/src/components/combobox.tsx
@@ -430,18 +430,18 @@ function List({ className, children, emptyState, ...rest }: ComboboxListProps) {
     useComboboxContext("List");
 
   // Follow the highlight, and show the current selection when the list opens
-  // with no highlight yet (it may sit far down a long list).
+  // with no highlight yet (it may sit far down a long list). Keyed on the id
+  // rather than on `optionId`, whose identity turns over with the option
+  // array: a list that grows for its own reasons must not drag the scroll
+  // back to a row nobody moved to.
   const target = activeValue ?? (open ? value : null);
+  const targetId = target === null ? undefined : optionId(target);
   useEffect(() => {
-    if (target === null) {
+    if (targetId === undefined) {
       return;
     }
-    const id = optionId(target);
-    if (id === undefined) {
-      return;
-    }
-    document.getElementById(id)?.scrollIntoView?.({ block: "nearest" });
-  }, [target, optionId]);
+    document.getElementById(targetId)?.scrollIntoView?.({ block: "nearest" });
+  }, [targetId]);
 
   if (!open) {
     return null;
@@ -464,12 +464,21 @@ export interface ComboboxGroupProps extends ComponentProps<"div"> {
   /** Heading text, announced as the group's name. */
   label: ReactNode;
   labelClassName?: string;
+  /**
+   * Pin the heading to the top of the scrolling list while its own rows are
+   * still on screen. Worth it once the list is long enough that a section
+   * scrolls past its own heading, which is when a reader loses track of which
+   * section they are in. Off by default: a short list gains nothing from it,
+   * and the opaque backing a pinned heading needs is a visible change.
+   */
+  stickyLabel?: boolean;
 }
 
 /** A labelled section of the list, announced as a group by assistive tech. */
 function Group({
   label,
   labelClassName,
+  stickyLabel = false,
   children,
   ...rest
 }: ComboboxGroupProps) {
@@ -484,8 +493,12 @@ function Group({
       <div
         id={labelId}
         role="presentation"
+        data-slot="combobox-group-label"
         className={cn(
           "px-3 pb-1 pt-2 text-label-small-default text-[var(--content-tertiary)]",
+          // The rows scroll under the heading, so it needs a ground of its
+          // own and a place above them in the stack.
+          stickyLabel && "sticky top-0 z-10 bg-[var(--surface-lift)]",
           labelClassName,
         )}
       >

--- a/packages/design-library/src/components/searchable-select.stories.tsx
+++ b/packages/design-library/src/components/searchable-select.stories.tsx
@@ -22,6 +22,38 @@ const MODELS: SearchableSelectOption[] = [
 ];
 
 /**
+ * The same list disclosed progressively: one section per vendor, the older
+ * version of a line folded away behind the row that unfolds it.
+ */
+const GROUPED_MODELS: SearchableSelectOption[] = [
+  { value: "claude-opus-4-8", label: "Claude Opus 4.8", group: "Anthropic" },
+  { value: "claude-fable-5", label: "Claude Fable 5", group: "Anthropic" },
+  {
+    value: "claude-opus-4-7",
+    label: "Claude Opus 4.7",
+    group: "Anthropic",
+    folded: true,
+  },
+  {
+    value: "claude-opus-4-6",
+    label: "Claude Opus 4.6",
+    group: "Anthropic",
+    folded: true,
+  },
+  {
+    value: "__older-anthropic__",
+    label: "Show older versions (2)",
+    group: "Anthropic",
+    listAction: true,
+  },
+  { value: "gpt-5-6", label: "GPT-5.6", group: "OpenAI" },
+  { value: "gpt-5-6-mini", label: "GPT-5.6 Mini", group: "OpenAI" },
+  { value: "gemini-3-pro", label: "Gemini 3 Pro", group: "Google Gemini" },
+  { value: "gemini-3-flash", label: "Gemini 3 Flash", group: "Google Gemini" },
+  { value: "__custom__", label: "Enter a custom model ID…", sticky: true },
+];
+
+/**
  * A `Select` whose list is filtered by typing. Use it once the option list
  * outgrows what a person can scan in a dropdown; below about a dozen rows,
  * plain `Select` is the simpler control.
@@ -172,5 +204,68 @@ export const NoMatches: Story = {
     await waitFor(() =>
       expect(status(canvasElement)).toContain("0 results are available"),
     );
+  },
+};
+
+/**
+ * Sections and progressive disclosure. Headings come from each row's `group`,
+ * in the order their first row appears; a `folded` row waits for a query or
+ * for the `listAction` row that stands in for it, which is the one row a pick
+ * leaves the list open on.
+ *
+ * The state a `listAction` row toggles belongs to the caller, so this story
+ * owns it locally rather than through args.
+ */
+export const Grouped: Story = {
+  args: { value: "" },
+  parameters: { controls: { disable: true } },
+  render: function RenderGrouped(args) {
+    const [value, setValue] = useState("");
+    const [unfolded, setUnfolded] = useState(false);
+    const options = unfolded
+      ? GROUPED_MODELS.filter((option) => !option.listAction).map((option) =>
+          option.folded ? { ...option, folded: false } : option,
+        )
+      : GROUPED_MODELS;
+    return (
+      <SearchableSelect
+        {...args}
+        options={options}
+        value={value}
+        onChange={(next) => {
+          if (next === "__older-anthropic__") {
+            setUnfolded(true);
+            return;
+          }
+          setValue(next);
+        }}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const field = canvasElement.querySelector<HTMLInputElement>(
+      'input[role="combobox"]',
+    );
+    if (!field) {
+      throw new Error("expected the combobox field");
+    }
+    await userEvent.click(field);
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("option").map((option) => option.textContent),
+      ).not.toContain("Claude Opus 4.7"),
+    );
+
+    await userEvent.click(await screen.findByText("Show older versions (2)"));
+
+    // The list stays open on the row that acted on it, and the folded rows
+    // take the place of the row that stood in for them.
+    await waitFor(() => {
+      const labels = screen
+        .getAllByRole("option")
+        .map((option) => option.textContent);
+      expect(labels).toContain("Claude Opus 4.7");
+      expect(labels).not.toContain("Show older versions (2)");
+    });
   },
 };

--- a/packages/design-library/src/components/searchable-select.stories.tsx
+++ b/packages/design-library/src/components/searchable-select.stories.tsx
@@ -3,7 +3,11 @@ import { useState } from "react";
 import { useArgs } from "storybook/preview-api";
 import { expect, screen, userEvent, waitFor } from "storybook/test";
 
-import { SearchableSelect, type SearchableSelectOption } from "./searchable-select";
+import {
+  SearchableSelect,
+  type SearchableSelectOption,
+  type SearchableSelectProps,
+} from "./searchable-select";
 
 const MODELS: SearchableSelectOption[] = [
   { value: "claude-opus-4-8", label: "Claude Opus 4.8" },
@@ -208,6 +212,57 @@ export const NoMatches: Story = {
 };
 
 /**
+ * Vendors whose names an `uppercase` transform would spell wrong, and enough
+ * of them to make the list scroll past its own headings.
+ */
+const BRAND_MODELS: SearchableSelectOption[] = [
+  { value: "grok-4-6", label: "Grok 4.6", group: "xAI" },
+  { value: "grok-4-6-fast", label: "Grok 4.6 Fast", group: "xAI" },
+  { value: "glm-5-2", label: "GLM 5.2", group: "Z.ai" },
+  { value: "glm-5-2-air", label: "GLM 5.2 Air", group: "Z.ai" },
+  { value: "minimax-m3", label: "MiniMax M3", group: "MiniMax" },
+  { value: "minimax-m2-her", label: "MiniMax M2-her", group: "MiniMax" },
+  { value: "deepseek-v4-pro", label: "DeepSeek V4 Pro", group: "DeepSeek" },
+  { value: "deepseek-v4-flash", label: "DeepSeek V4 Flash", group: "DeepSeek" },
+  { value: "deepseek-r1", label: "DeepSeek R1", group: "DeepSeek" },
+  { value: "kimi-k3", label: "Kimi K3", group: "Moonshot AI" },
+  { value: "kimi-k2-thinking", label: "Kimi K2 Thinking", group: "Moonshot AI" },
+  { value: "llama-4-maverick", label: "Llama 4 Maverick", group: "Meta" },
+  { value: "llama-4-scout", label: "Llama 4 Scout", group: "Meta" },
+  { value: "__custom__", label: "Enter a custom model ID…", sticky: true },
+];
+
+/**
+ * Shared by the two grouped stories. The state a `listAction` row toggles
+ * belongs to the caller, so it is owned here rather than through args, and a
+ * revealed row is marked `disclosed` so the list can set the revealed block
+ * off from what was already there.
+ */
+function RenderGrouped(args: SearchableSelectProps) {
+  const [value, setValue] = useState("");
+  const [unfolded, setUnfolded] = useState(false);
+  const options = unfolded
+    ? GROUPED_MODELS.filter((option) => !option.listAction).map((option) =>
+        option.folded ? { ...option, folded: false, disclosed: true } : option,
+      )
+    : GROUPED_MODELS;
+  return (
+    <SearchableSelect
+      {...args}
+      options={options}
+      value={value}
+      onChange={(next) => {
+        if (next === "__older-anthropic__") {
+          setUnfolded(true);
+          return;
+        }
+        setValue(next);
+      }}
+    />
+  );
+}
+
+/**
  * Sections and progressive disclosure. Headings come from each row's `group`,
  * in the order their first row appears; a `folded` row waits for a query or
  * for the `listAction` row that stands in for it, which is the one row a pick
@@ -219,29 +274,7 @@ export const NoMatches: Story = {
 export const Grouped: Story = {
   args: { value: "" },
   parameters: { controls: { disable: true } },
-  render: function RenderGrouped(args) {
-    const [value, setValue] = useState("");
-    const [unfolded, setUnfolded] = useState(false);
-    const options = unfolded
-      ? GROUPED_MODELS.filter((option) => !option.listAction).map((option) =>
-          option.folded ? { ...option, folded: false } : option,
-        )
-      : GROUPED_MODELS;
-    return (
-      <SearchableSelect
-        {...args}
-        options={options}
-        value={value}
-        onChange={(next) => {
-          if (next === "__older-anthropic__") {
-            setUnfolded(true);
-            return;
-          }
-          setValue(next);
-        }}
-      />
-    );
-  },
+  render: RenderGrouped,
   play: async ({ canvasElement }) => {
     const field = canvasElement.querySelector<HTMLInputElement>(
       'input[role="combobox"]',
@@ -256,7 +289,14 @@ export const Grouped: Story = {
       ).not.toContain("Claude Opus 4.7"),
     );
 
-    await userEvent.click(await screen.findByText("Show older versions (2)"));
+    // The unfold row is an action on the list, not an answer to it: it says
+    // so with `aria-expanded` and is drawn as a secondary action.
+    const unfold = await screen.findByRole("option", {
+      name: "Show older versions (2)",
+    });
+    expect(unfold.getAttribute("aria-expanded")).toBe("false");
+
+    await userEvent.click(unfold);
 
     // The list stays open on the row that acted on it, and the folded rows
     // take the place of the row that stood in for them.
@@ -267,5 +307,55 @@ export const Grouped: Story = {
       expect(labels).toContain("Claude Opus 4.7");
       expect(labels).not.toContain("Show older versions (2)");
     });
+  },
+};
+
+/**
+ * The same list with its older versions already revealed, which is the state
+ * the hairline is for: the block a list action opened is set off from the
+ * rows that were there before it.
+ */
+/**
+ * Headings whose own capitalisation is the point, in a list long enough to
+ * scroll: nothing transforms the letters, and each heading stays pinned to
+ * the top of the list while its own rows are still on screen.
+ */
+export const GroupedStickyHeadings: Story = {
+  args: { value: "", options: BRAND_MODELS },
+  parameters: { controls: { disable: true } },
+  render: function RenderSticky(args) {
+    const [value, setValue] = useState("");
+    return <SearchableSelect {...args} value={value} onChange={setValue} />;
+  },
+  play: async ({ canvasElement }) => {
+    const field = canvasElement.querySelector<HTMLInputElement>(
+      'input[role="combobox"]',
+    );
+    if (!field) {
+      throw new Error("expected the combobox field");
+    }
+    await userEvent.click(field);
+    await waitFor(() =>
+      expect(screen.getByText("xAI").textContent).toBe("xAI"),
+    );
+  },
+};
+
+export const GroupedDisclosed: Story = {
+  args: { value: "" },
+  parameters: { controls: { disable: true } },
+  render: RenderGrouped,
+  play: async ({ canvasElement }) => {
+    const field = canvasElement.querySelector<HTMLInputElement>(
+      'input[role="combobox"]',
+    );
+    if (!field) {
+      throw new Error("expected the combobox field");
+    }
+    await userEvent.click(field);
+    await userEvent.click(await screen.findByText("Show older versions (2)"));
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: /Claude Opus 4\.7/ })).toBeTruthy(),
+    );
   },
 };

--- a/packages/design-library/src/components/searchable-select.tsx
+++ b/packages/design-library/src/components/searchable-select.tsx
@@ -1,7 +1,8 @@
-import { ChevronDown } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 import {
   Fragment,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -47,8 +48,19 @@ export interface SearchableSelectOption {
    * versions"). Picking it reports the value and leaves the list open, and it
    * is offered only while the list is being browsed, since a query has
    * already shown what it would have unfolded.
+   *
+   * It is drawn as a secondary action rather than as a row of the list: a
+   * chevron, quieter text, and `aria-expanded`, so nobody reads it as one
+   * more thing they could choose.
    */
   readonly listAction?: boolean;
+  /**
+   * A row a `listAction` has just revealed. The first one in a section is
+   * drawn under a hairline, so the revealed block reads as an addition to
+   * what was already there rather than as more of it. Ignored while a query
+   * is narrowing the list, which has its own reason for every row it shows.
+   */
+  readonly disclosed?: boolean;
 }
 
 export interface SearchableSelectProps {
@@ -82,6 +94,9 @@ export interface SearchableSelectProps {
 }
 
 const DEFAULT_MENU_MAX_HEIGHT = 280;
+
+/** Breathing room kept between the open list and the edge it collides with. */
+const COLLISION_PADDING = 12;
 
 /**
  * A `Select` whose list is filtered by typing: the trigger is the search
@@ -125,6 +140,7 @@ export function SearchableSelect({
   const reactId = useId();
   const fieldId = id ?? `searchable-select-${reactId}`;
   const anchorRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const [open, setOpen] = useState(false);
   // `null` while the field is showing the current selection rather than a
   // query. Distinct from `""`, which is a query the user has cleared and so
@@ -209,6 +225,18 @@ export function SearchableSelect({
   // commit behaves the same as the pointer one.
   const keepOpenAfterSelect = useRef(false);
 
+  // Where the list was scrolled to when a list action fired. Restored before
+  // paint, so the rows the action reveals grow downward from where the user
+  // was looking instead of sliding the row they just clicked off its line.
+  const heldScrollTop = useRef<number | null>(null);
+  useLayoutEffect(() => {
+    if (heldScrollTop.current === null || !listRef.current) {
+      return;
+    }
+    listRef.current.scrollTop = heldScrollTop.current;
+    heldScrollTop.current = null;
+  }, [options]);
+
   function handleOpenChange(next: boolean) {
     if (next) {
       setOpen(true);
@@ -240,28 +268,71 @@ export function SearchableSelect({
     </p>
   );
 
-  const renderRow = (option: SearchableSelectOption) => (
-    <Combobox.Option
-      key={option.value}
-      value={option.value}
-      className={({ isSelected, isActive }) =>
-        cn(
+  const renderRow = (option: SearchableSelectOption, startsBlock = false) => {
+    if (option.listAction) {
+      return (
+        <Combobox.Option
+          key={option.value}
+          value={option.value}
+          // It expands the section it sits in, and says so: the rows it
+          // reveals are not on screen yet.
+          aria-expanded={false}
+          className={cn(
+            "flex w-full items-center gap-1.5 rounded-md px-3 py-1.5",
+            "text-body-small-default text-[var(--content-tertiary)] transition-colors",
+            "hover:text-[var(--content-secondary)]",
+            "data-[active]:bg-[var(--surface-active)] data-[active]:text-[var(--content-secondary)]",
+          )}
+        >
+          <ChevronDown className="h-3 w-3 shrink-0" aria-hidden />
+          <span className="min-w-0 truncate">{option.label}</span>
+        </Combobox.Option>
+      );
+    }
+    return (
+      <Combobox.Option
+        key={option.value}
+        value={option.value}
+        className={cn(
           "flex w-full items-center gap-2 rounded-md px-3 py-2",
           "text-body-medium-default text-[var(--content-default)] transition-colors",
-          isSelected
-            ? "bg-[var(--surface-active)]"
-            : isActive
-              ? "bg-[var(--surface-hover)]"
-              : "hover:bg-[var(--surface-hover)]",
-        )
-      }
-    >
-      <span className="min-w-0 flex-1 truncate">{option.label}</span>
-      {option.suffix ? (
-        <span className="shrink-0">{option.suffix}</span>
-      ) : null}
-    </Combobox.Option>
-  );
+          "hover:bg-[var(--surface-hover)]",
+          // The keyboard highlight is the stronger fill and the only one:
+          // the selection is marked by its check, so no two rows ever wear
+          // the same tint for different reasons.
+          "data-[active]:bg-[var(--surface-active)]",
+          "aria-selected:text-[var(--content-emphasised)]",
+          startsBlock && "mt-1 border-t border-[var(--border-subtle)] pt-2",
+        )}
+      >
+        <span className="min-w-0 flex-1 truncate">{option.label}</span>
+        {option.suffix ? (
+          <span className="shrink-0">{option.suffix}</span>
+        ) : null}
+        <Check
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 text-[var(--content-default)]",
+            // Held in the layout either way, so a pick does not shuffle the
+            // labels of every row around it.
+            option.value === value ? "visible" : "invisible",
+          )}
+          aria-hidden
+        />
+      </Combobox.Option>
+    );
+  };
+
+  /**
+   * Rows of one section, with a hairline opening the block a list action
+   * revealed. Only the first revealed row carries it, and only while the list
+   * is being browsed.
+   */
+  const renderSectionRows = (rows: readonly SearchableSelectOption[]) => {
+    const firstDisclosed = searching
+      ? -1
+      : rows.findIndex((row) => row.disclosed);
+    return rows.map((row, index) => renderRow(row, index === firstDisclosed));
+  };
 
   return (
     <Field
@@ -280,6 +351,12 @@ export function SearchableSelect({
           keepOpenAfterSelect.current =
             options.find((option) => option.value === next)?.listAction ===
             true;
+          if (keepOpenAfterSelect.current) {
+            // The rows this reveals are inserted where the row that revealed
+            // them stood, and the list must not move under the hand that is
+            // still on it.
+            heldScrollTop.current = listRef.current?.scrollTop ?? null;
+          }
           onChange(next);
           if (!keepOpenAfterSelect.current) {
             close();
@@ -323,8 +400,18 @@ export function SearchableSelect({
           <Popover.Content
             align="start"
             sideOffset={4}
+            // The list's natural home is a dialog body, where an unconstrained
+            // menu runs past the dialog's own edge and buries its actions.
+            // Radix flips it above the field when there is more room there,
+            // and reports what is left as
+            // `--radix-popover-content-available-height`, which the list caps
+            // itself to below.
+            collisionPadding={COLLISION_PADDING}
             data-slot="searchable-select-menu"
-            className="w-[var(--radix-popover-trigger-width)] p-1"
+            // The edge matters where the list floats over a surface its own
+            // colour: without it a menu overlapping a dialog reads as the
+            // dialog's card carrying on, cut off at the wrong place.
+            className="w-[var(--radix-popover-trigger-width)] border border-[var(--border-subtle)] p-1"
             onOpenAutoFocus={(event) => event.preventDefault()}
             onCloseAutoFocus={(event) => event.preventDefault()}
             // Radix measures "outside" against the popover's own DOM, and the
@@ -346,7 +433,10 @@ export function SearchableSelect({
             }}
           >
             <Combobox.List
-              style={{ maxHeight: menuMaxHeight }}
+              ref={listRef}
+              style={{
+                maxHeight: `min(${menuMaxHeight}px, var(--radix-popover-content-available-height, ${menuMaxHeight}px))`,
+              }}
               emptyState={emptyMessage}
             >
               {/* A sticky escape hatch keeps the walkable list non-empty, so
@@ -358,15 +448,21 @@ export function SearchableSelect({
                 : sections.map((section) =>
                     section.group === undefined ? (
                       <Fragment key="ungrouped">
-                        {section.rows.map(renderRow)}
+                        {renderSectionRows(section.rows)}
                       </Fragment>
                     ) : (
                       <Combobox.Group
                         key={section.group}
                         label={section.group}
-                        labelClassName="uppercase tracking-wide"
+                        // Never uppercased: these headings carry names whose
+                        // own capitalisation is the point (xAI, Z.ai,
+                        // DeepSeek), and a transform spells every one of them
+                        // wrong. Size, colour and letter-spacing separate a
+                        // heading from a row without touching its letters.
+                        labelClassName="tracking-wide"
+                        stickyLabel
                       >
-                        {section.rows.map(renderRow)}
+                        {renderSectionRows(section.rows)}
                       </Combobox.Group>
                     ),
                   )}
@@ -376,7 +472,7 @@ export function SearchableSelect({
                   data-slot="searchable-select-pinned"
                   className="sticky bottom-0 z-10 mt-1 border-t border-[var(--border-element)] bg-[var(--surface-lift)] pt-1"
                 >
-                  {stickyOptions.map(renderRow)}
+                  {stickyOptions.map((option) => renderRow(option))}
                 </div>
               ) : null}
             </Combobox.List>

--- a/packages/design-library/src/components/searchable-select.tsx
+++ b/packages/design-library/src/components/searchable-select.tsx
@@ -84,6 +84,18 @@ export interface SearchableSelectProps {
   readonly "aria-labelledby"?: string;
   /** Preferred height cap on the list, in pixels. */
   readonly menuMaxHeight?: number;
+  /**
+   * Element the open list is kept inside, in place of the viewport. Pass the
+   * scrolling box of a host whose own actions sit under the field, such as a
+   * dialog body with a footer below it: the list then caps itself to the room
+   * left in that box, or flips above the field when more of it is there,
+   * instead of opening across the host's edge and over its buttons.
+   *
+   * Opting in is also a promise to keep `SEARCHABLE_SELECT_MENU_MIN_REACH`
+   * of room under the field, since a bounded list never shrinks past the
+   * height it can still be read at.
+   */
+  readonly menuBoundary?: Element | null;
   readonly className?: string;
   /**
    * What the live region says when the number of matches changes. Narrowing
@@ -104,16 +116,49 @@ const MENU_SIDE_OFFSET = 4;
 /** The frame the rows are drawn in: `p-1` on both edges, plus the border. */
 const MENU_FRAME_HEIGHT = 2 * 4 + 2 * 1;
 
+/** One option row: `py-2` around a line of `text-body-medium-default`. */
+const MENU_ROW_HEIGHT = 33;
+
+/** A section heading, which is pinned and so is never scrolled away. */
+const MENU_HEADING_HEIGHT = 22;
+
+/** The pinned block at the foot of the list, with its rule and its margin. */
+const MENU_PINNED_HEIGHT = 42;
+
+/** Rows a bounded list shows before it is quicker to type than to scroll. */
+const MENU_MIN_ROWS = 3;
+
 /**
- * How far a list at the default cap reaches below the field it hangs from:
- * the gap above it, its frame, and the rows themselves.
+ * The shortest list still worth opening: a heading, the pinned row, and three
+ * rows between them. Under that a menu is mostly its own furniture, so a
+ * bounded list takes this much even where its boundary cannot spare it.
+ */
+const MENU_MIN_HEIGHT =
+  MENU_HEADING_HEIGHT + MENU_MIN_ROWS * MENU_ROW_HEIGHT + MENU_PINNED_HEIGHT;
+
+/** Everything a list reaches past its own rows: the gap, the frame, the pad. */
+const MENU_CHROME_HEIGHT =
+  MENU_SIDE_OFFSET + MENU_FRAME_HEIGHT + COLLISION_PADDING;
+
+/**
+ * How far below the field the list reaches at its full height.
  *
  * A host whose own height follows its content, such as a dialog, has no room
- * under the field until it makes some. Reserving this much there is what lets
- * the list open inside the host rather than over whatever sits below it.
+ * under the field until it makes some, and a boundary the host cannot honour
+ * only moves the collision. Reserving this much there is what lets the list
+ * open at the height it is meant to be read at rather than over whatever sits
+ * below it.
  */
 export const SEARCHABLE_SELECT_MENU_REACH =
-  MENU_SIDE_OFFSET + MENU_FRAME_HEIGHT + DEFAULT_MENU_MAX_HEIGHT;
+  MENU_CHROME_HEIGHT + DEFAULT_MENU_MAX_HEIGHT;
+
+/**
+ * The same reach for a list at its floor, for a host that cannot spare the
+ * full one: what it must keep under the field for a bounded list to still be
+ * worth reopening.
+ */
+export const SEARCHABLE_SELECT_MENU_MIN_REACH =
+  MENU_CHROME_HEIGHT + MENU_MIN_HEIGHT;
 
 /**
  * A `Select` whose list is filtered by typing: the trigger is the search
@@ -151,6 +196,7 @@ export function SearchableSelect({
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledBy,
   menuMaxHeight = DEFAULT_MENU_MAX_HEIGHT,
+  menuBoundary,
   className,
   announceResults,
 }: SearchableSelectProps) {
@@ -278,6 +324,15 @@ export function SearchableSelect({
     event.stopPropagation();
     close();
   }
+
+  // The frame is part of what the reported height has to hold, so the rows
+  // get what is left of it; without that the list ends flush against the edge
+  // it was told to stay clear of. Floored where a boundary is set, since a
+  // boundary can leave less room than a list can be read in.
+  const availableHeight = `min(${menuMaxHeight}px, calc(var(--radix-popover-content-available-height, ${menuMaxHeight + MENU_FRAME_HEIGHT}px) - ${MENU_FRAME_HEIGHT}px))`;
+  const menuHeight = menuBoundary
+    ? `max(${MENU_MIN_HEIGHT}px, ${availableHeight})`
+    : availableHeight;
 
   const emptyMessage = (
     <p className="px-3 py-2 text-body-medium-default text-[var(--content-tertiary)]">
@@ -409,6 +464,12 @@ export function SearchableSelect({
                   // to a model name nobody meant to edit.
                   event.currentTarget.select();
                 }}
+                onClick={() => {
+                  // Focus opens the list, and a pick leaves the focus where
+                  // it was. Without this the one gesture that means "show me
+                  // the list again" is the one that does nothing.
+                  setOpen(true);
+                }}
                 onChange={(event) => setQuery(event.target.value)}
                 onKeyDown={handleFieldKeyDown}
               />
@@ -417,13 +478,15 @@ export function SearchableSelect({
           <Popover.Content
             align="start"
             sideOffset={MENU_SIDE_OFFSET}
-            // The list's natural home is a dialog body, where an unconstrained
+            // The list's natural home is a dialog body, where an unbounded
             // menu runs past the dialog's own edge and buries its actions.
-            // Radix flips it above the field when there is more room there,
-            // and reports what is left as
+            // The empty boundary is Radix's own default, the viewport: a
+            // caller that names a box instead has the list flip or shrink to
+            // stay inside it. Either way Radix reports what is left as
             // `--radix-popover-content-available-height`, which the list caps
             // itself to below.
             collisionPadding={COLLISION_PADDING}
+            collisionBoundary={menuBoundary ?? []}
             data-slot="searchable-select-menu"
             // The edge matters where the list floats over a surface its own
             // colour: without it a menu overlapping a dialog reads as the
@@ -451,9 +514,7 @@ export function SearchableSelect({
           >
             <Combobox.List
               ref={listRef}
-              style={{
-                maxHeight: `min(${menuMaxHeight}px, var(--radix-popover-content-available-height, ${menuMaxHeight}px))`,
-              }}
+              style={{ maxHeight: menuHeight }}
               emptyState={emptyMessage}
             >
               {/* A sticky escape hatch keeps the walkable list non-empty, so

--- a/packages/design-library/src/components/searchable-select.tsx
+++ b/packages/design-library/src/components/searchable-select.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown } from "lucide-react";
 import {
+  Fragment,
   useId,
   useMemo,
   useRef,
@@ -27,6 +28,27 @@ export interface SearchableSelectOption {
    * nobody finds.
    */
   readonly sticky?: boolean;
+  /**
+   * Section this row belongs to. Rows carrying the same heading are drawn
+   * together under it, sections in the order their first row appears, and a
+   * section whose rows are all filtered out disappears with them. Leave unset
+   * for a flat list; mixing set and unset headings puts the ungrouped rows in
+   * their own unlabelled section, in the same first-appearance order.
+   */
+  readonly group?: string;
+  /**
+   * Held back from the list until a query asks for it, for a list that
+   * discloses itself progressively (an older version of a model behind the
+   * newest). Typing finds it like any other row.
+   */
+  readonly folded?: boolean;
+  /**
+   * A row that acts on the list rather than answering it ("Show older
+   * versions"). Picking it reports the value and leaves the list open, and it
+   * is offered only while the list is being browsed, since a query has
+   * already shown what it would have unfolded.
+   */
+  readonly listAction?: boolean;
 }
 
 export interface SearchableSelectProps {
@@ -112,27 +134,55 @@ export function SearchableSelect({
   const selectedOption = options.find((option) => option.value === value);
   const trimmedQuery = (query ?? "").trim().toLowerCase();
 
-  const { visibleOptions, stickyOptions } = useMemo(() => {
-    const sticky = options.filter((option) => option.sticky);
-    const matchable = options.filter((option) => !option.sticky);
-    const matches =
-      trimmedQuery === ""
-        ? matchable
-        : matchable.filter(
-            (option) =>
-              option.label.toLowerCase().includes(trimmedQuery) ||
-              option.value.toLowerCase().includes(trimmedQuery),
-          );
-    return { visibleOptions: matches, stickyOptions: sticky };
-  }, [options, trimmedQuery]);
+  const searching = trimmedQuery !== "";
 
-  // What the arrow keys walk, in the order the rows render. The pinned rows
-  // are walkable but they are not matches, so the announced count is the
-  // matches alone: otherwise every count is one too high, and a query that
-  // matched nothing announces the escape hatch as a result.
+  const { sections, visibleOptions, stickyOptions } = useMemo(() => {
+    const offered = options.filter((option) =>
+      option.folded || option.listAction
+        ? Boolean(option.folded) === searching
+        : true,
+    );
+    const sticky = offered.filter((option) => option.sticky);
+    const matchable = offered.filter((option) => !option.sticky);
+    const matches = searching
+      ? matchable.filter(
+          (option) =>
+            option.label.toLowerCase().includes(trimmedQuery) ||
+            option.value.toLowerCase().includes(trimmedQuery),
+        )
+      : matchable;
+    // Sections in the order their first surviving row appears, so a heading
+    // never outlives the rows it names.
+    const byGroup = new Map<string | undefined, SearchableSelectOption[]>();
+    for (const option of matches) {
+      const rows = byGroup.get(option.group);
+      if (rows) {
+        rows.push(option);
+        continue;
+      }
+      byGroup.set(option.group, [option]);
+    }
+    return {
+      sections: [...byGroup.entries()].map(([group, rows]) => ({
+        group,
+        rows,
+      })),
+      visibleOptions: matches,
+      stickyOptions: sticky,
+    };
+  }, [options, trimmedQuery, searching]);
+
+  // What the arrow keys walk, in the order the rows render: sections first,
+  // then the pinned rows. The pinned rows are walkable but they are not
+  // matches, so the announced count is the matches alone: otherwise every
+  // count is one too high, and a query that matched nothing announces the
+  // escape hatch as a result.
   const walkableValues = useMemo(
-    () => [...visibleOptions, ...stickyOptions].map((option) => option.value),
-    [visibleOptions, stickyOptions],
+    () =>
+      [...sections.flatMap((section) => section.rows), ...stickyOptions].map(
+        (option) => option.value,
+      ),
+    [sections, stickyOptions],
   );
 
   const invalid = Boolean(errorText);
@@ -152,9 +202,20 @@ export function SearchableSelect({
     setQuery(null);
   }
 
+  // Set by a pick that acted on the list rather than answering it, and
+  // consumed by the close that the pick itself triggers: `Combobox` closes on
+  // every commit, which for such a row would shut the list the user was still
+  // reading. One flag rather than a per-row click handler, so the keyboard
+  // commit behaves the same as the pointer one.
+  const keepOpenAfterSelect = useRef(false);
+
   function handleOpenChange(next: boolean) {
     if (next) {
       setOpen(true);
+      return;
+    }
+    if (keepOpenAfterSelect.current) {
+      keepOpenAfterSelect.current = false;
       return;
     }
     close();
@@ -216,8 +277,13 @@ export function SearchableSelect({
         options={walkableValues}
         value={value === "" ? null : value}
         onSelect={(next) => {
+          keepOpenAfterSelect.current =
+            options.find((option) => option.value === next)?.listAction ===
+            true;
           onChange(next);
-          close();
+          if (!keepOpenAfterSelect.current) {
+            close();
+          }
         }}
         open={open}
         onOpenChange={handleOpenChange}
@@ -289,7 +355,21 @@ export function SearchableSelect({
                   the pinned row, which is where it belongs anyway. */}
               {visibleOptions.length === 0
                 ? emptyMessage
-                : visibleOptions.map(renderRow)}
+                : sections.map((section) =>
+                    section.group === undefined ? (
+                      <Fragment key="ungrouped">
+                        {section.rows.map(renderRow)}
+                      </Fragment>
+                    ) : (
+                      <Combobox.Group
+                        key={section.group}
+                        label={section.group}
+                        labelClassName="uppercase tracking-wide"
+                      >
+                        {section.rows.map(renderRow)}
+                      </Combobox.Group>
+                    ),
+                  )}
               {stickyOptions.length > 0 ? (
                 <div
                   role="presentation"

--- a/packages/design-library/src/components/searchable-select.tsx
+++ b/packages/design-library/src/components/searchable-select.tsx
@@ -98,6 +98,23 @@ const DEFAULT_MENU_MAX_HEIGHT = 280;
 /** Breathing room kept between the open list and the edge it collides with. */
 const COLLISION_PADDING = 12;
 
+/** The gap the list leaves between itself and the field it hangs from. */
+const MENU_SIDE_OFFSET = 4;
+
+/** The frame the rows are drawn in: `p-1` on both edges, plus the border. */
+const MENU_FRAME_HEIGHT = 2 * 4 + 2 * 1;
+
+/**
+ * How far a list at the default cap reaches below the field it hangs from:
+ * the gap above it, its frame, and the rows themselves.
+ *
+ * A host whose own height follows its content, such as a dialog, has no room
+ * under the field until it makes some. Reserving this much there is what lets
+ * the list open inside the host rather than over whatever sits below it.
+ */
+export const SEARCHABLE_SELECT_MENU_REACH =
+  MENU_SIDE_OFFSET + MENU_FRAME_HEIGHT + DEFAULT_MENU_MAX_HEIGHT;
+
 /**
  * A `Select` whose list is filtered by typing: the trigger is the search
  * field, so the whole interaction is one control and one Tab stop.
@@ -399,7 +416,7 @@ export function SearchableSelect({
           </Popover.Anchor>
           <Popover.Content
             align="start"
-            sideOffset={4}
+            sideOffset={MENU_SIDE_OFFSET}
             // The list's natural home is a dialog body, where an unconstrained
             // menu runs past the dialog's own edge and buries its actions.
             // Radix flips it above the field when there is more room there,


### PR DESCRIPTION
## What

Behind the new client-scope flag `model-first-profile-create` (default off), the New Model modal opened from the chat model picker asks for the **model first**, then the **provider**, and skips the provider question when there is nothing to decide.

- **Model**: one searchable list of every catalog model the assistant can reach, deduplicated across providers by display name. Meta shows the sole provider ("Anthropic") or "N providers". Sticky "Enter a custom model ID" option at the bottom.
- **Provider** (only after a model is picked):
  - exactly one connected route: shown read-only with a Connected tag, no decision;
  - several routes: radio cards, connected first (sibling connections expand to Default + named keys like the legacy picker), default = first connected;
  - selected route not connected: the card expands inline to the existing `ProviderCreateForm` (API key / Set up) or the existing `ChatgptOAuthSection` (Sign in). Save stays blocked until a connection exists.
- Advanced (name, description, params) is unchanged.

Flag off: the legacy provider-first flow is untouched. Edit mode is untouched.

## ChatGPT subscription

- Listed only for Codex-eligible models (derived from `getModelsForProvider("chatgpt")`), never for others.
- Unconnected: tagged "Sign in", expands the existing ChatGPT connect section (respects `chatgpt-device-code-login` as it already does).
- A profile saved via the new flow serializes exactly like the legacy flow (`provider: "chatgpt"`, no bound connection); covered by a test.

## Design

Approved canvas: https://claude.ai/code/artifact/116583f6-faa6-4fea-af1e-88b55c812e92

## Companion

Terraform flag provisioning: vellum-ai/vellum-assistant-platform#10189

## Tests

- `model-first-candidates.test.ts` (22): resolver rules, chatgpt/vellum/openai-compatible/selectability cases.
- `profile-create-model-first.test.tsx` (16): flag off unchanged, sole-route auto select, ordering, inline connect, ChatGPT candidates and payload, custom id path.
- `bunx tsc --noEmit`, `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwXLySiLqPPaJuy3cSipZc
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->