### PR TITLE
fix: camera-mode self-review round 1 (stories + test slop)

### DIFF
--- a/clients/web/src/domains/chat/voice/camera-shutter.stories.tsx
+++ b/clients/web/src/domains/chat/voice/camera-shutter.stories.tsx
@@ -19,7 +19,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import "@/index.css";
 
 import { CameraShutter } from "./camera-shutter";
-import { CameraRowFlipStandIn, overFakeFeed } from "./camera-story-feed";
+import { CameraRowScene, overFakeFeed } from "./camera-story-feed";
 
 const meta: Meta<typeof CameraShutter> = {
   title: "Chat/Voice/CameraShutter",
@@ -98,19 +98,11 @@ export const ReducedMotion: Story = {
 };
 
 /**
- * Where it actually sits: centred, with flash to the left and flip to the
- * right, neither of them reachable by a thumb aimed at the middle. The two
- * flanking marks are story-local stand-ins at the design's offsets.
+ * Where it actually sits: centred, with the real flash control to the left and
+ * flip to the right, neither of them reachable by a thumb aimed at the middle.
+ * The `mode` control still drives the shutter here, so the morph can be watched
+ * with the row's weight around it.
  */
 export const InTheCameraRow: Story = {
-  render: (args) => (
-    <div className="relative flex w-[390px] items-center justify-center">
-      <span
-        aria-hidden
-        className="absolute left-11 size-[46px] rounded-full border border-white/20 bg-black/42"
-      />
-      <CameraShutter {...args} />
-      <CameraRowFlipStandIn />
-    </div>
-  ),
+  render: (args) => <CameraRowScene shutter={args} />,
 };

--- a/clients/web/src/domains/chat/voice/camera-story-feed.tsx
+++ b/clients/web/src/domains/chat/voice/camera-story-feed.tsx
@@ -1,19 +1,26 @@
 /**
- * The stand-in for the camera feed that every camera story is read against.
+ * The scenery every camera story is read against: the stand-in for the feed,
+ * the captioned cell, and the control row the shutter and flash both sit in.
  *
  * Storybook has no `getUserMedia`, and none of the camera components takes a
  * stream: each assumes media behind it rather than being handed one, which is
  * what makes a gradient a complete substitute, and is how the design reference
  * fakes it too. One module rather than a copy per story file, so a frame that
- * stops being the honest test case stops being it everywhere at once.
+ * stops being the honest test case stops being it everywhere at once, and so
+ * the row's offsets are stated once outside the app.
  *
  * Story-local sample content standing in for camera video. Nothing here is app
  * styling, and nothing outside a `.stories.tsx` file imports it.
  */
 
 import type { Decorator } from "@storybook/react-vite";
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
+import { CameraShutter, type CameraShutterProps } from "./camera-shutter";
+import {
+  CameraFlashControl,
+  type CameraFlashControlProps,
+} from "./voice-room/camera-flash-control";
 import { CAMERA_WARM } from "./voice-room/camera-mode-paint";
 
 /**
@@ -64,18 +71,84 @@ export function overFakeFeed({
   );
 }
 
+/** One control with the word for what it is, so a set can be read side by side. */
+export function ToneCell({
+  caption,
+  children,
+}: {
+  caption: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-3">
+      {children}
+      <span className="font-mono text-[11px] text-white/70">{caption}</span>
+    </div>
+  );
+}
+
 /**
  * Flip, at its place in the shutter row, drawn rather than rendered: the
- * stories that show the row are about the control in the middle of it, and a
- * live control off to the side would be a second thing to press. The fill comes
- * off the same constant the real one reads, so the stand-in cannot drift.
+ * stories that show the row are about the two controls that change how the
+ * next photo comes out, and a live control off to the side would be a third
+ * thing to press. The fill comes off the same constant the real one reads, so
+ * the stand-in cannot drift.
  */
-export function CameraRowFlipStandIn() {
+function CameraRowFlipStandIn() {
   return (
     <span
       aria-hidden
       className="absolute right-[30px] size-13 rounded-full"
       style={{ background: CAMERA_WARM }}
     />
+  );
+}
+
+const ROW_SHUTTER: CameraShutterProps = {
+  ariaLabel: "Take photo",
+  onClick: () => {},
+};
+
+const ROW_FLASH: Pick<
+  CameraFlashControlProps,
+  "mode" | "ariaLabel" | "autoBadge"
+> = {
+  mode: "auto",
+  ariaLabel: "Flash auto",
+  autoBadge: "A",
+};
+
+export interface CameraRowSceneProps {
+  /** The shutter in the middle. Defaults to a photo shutter at rest. */
+  shutter?: CameraShutterProps;
+  /** The flash control to its left. Defaults to auto, the state with the badge. */
+  flash?: Pick<CameraFlashControlProps, "mode" | "ariaLabel">;
+}
+
+/**
+ * The row as it ships, at a phone's width: flash on the left, flip on the
+ * right, shutter between them, neither flank reachable by a thumb aimed at the
+ * middle.
+ *
+ * The shutter and the flash are the real components, since both are
+ * presentational and read nothing from a store, so a story about either one in
+ * place is a story about the pair. The offsets are the design's, stated here
+ * rather than in each story file.
+ */
+export function CameraRowScene({
+  shutter = ROW_SHUTTER,
+  flash,
+}: CameraRowSceneProps) {
+  return (
+    <div className="relative flex w-[390px] items-center justify-center">
+      <CameraFlashControl
+        {...ROW_FLASH}
+        {...flash}
+        onClick={() => {}}
+        className="absolute left-[33px]"
+      />
+      <CameraShutter {...shutter} />
+      <CameraRowFlipStandIn />
+    </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.stories.tsx
@@ -16,8 +16,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 
 import {
-  CameraRowFlipStandIn,
+  CameraRowScene,
   overFakeFeed,
+  ToneCell,
 } from "@/domains/chat/voice/camera-story-feed";
 import type { FlashMode } from "@/stores/voice-prefs-store";
 
@@ -31,21 +32,6 @@ const LABELS: Record<FlashMode, string> = {
 };
 
 const ORDER: FlashMode[] = ["off", "auto", "on"];
-
-/** One state, captioned, so the three can be compared side by side. */
-function StateCell({ mode }: { mode: FlashMode }) {
-  return (
-    <div className="flex flex-col items-center gap-3">
-      <CameraFlashControl
-        mode={mode}
-        ariaLabel={LABELS[mode]}
-        autoBadge="A"
-        onClick={() => {}}
-      />
-      <span className="font-mono text-[11px] text-white/70">{mode}</span>
-    </div>
-  );
-}
 
 const meta: Meta<typeof CameraFlashControl> = {
   title: "Chat/Voice/Camera Flash Control",
@@ -67,7 +53,14 @@ export const States: Story = {
   render: () => (
     <>
       {ORDER.map((mode) => (
-        <StateCell key={mode} mode={mode} />
+        <ToneCell key={mode} caption={mode}>
+          <CameraFlashControl
+            mode={mode}
+            ariaLabel={LABELS[mode]}
+            autoBadge="A"
+            onClick={() => {}}
+          />
+        </ToneCell>
       ))}
     </>
   ),
@@ -85,15 +78,14 @@ export const Cycle: Story = {
 function CycleScene() {
   const [mode, setMode] = useState<FlashMode>("off");
   return (
-    <div className="flex flex-col items-center gap-3">
+    <ToneCell caption={mode}>
       <CameraFlashControl
         mode={mode}
         ariaLabel={LABELS[mode]}
         autoBadge="A"
         onClick={() => setMode(nextFlashMode(mode))}
       />
-      <span className="font-mono text-[11px] text-white/70">{mode}</span>
-    </div>
+    </ToneCell>
   );
 }
 
@@ -106,21 +98,6 @@ function CycleScene() {
  */
 export const InTheShutterRow: Story = {
   render: () => (
-    <div className="relative flex w-[390px] items-center justify-center">
-      <CameraFlashControl
-        mode="auto"
-        ariaLabel={LABELS.auto}
-        autoBadge="A"
-        onClick={() => {}}
-        className="absolute left-11"
-      />
-      <span
-        aria-hidden
-        className="flex size-[84px] items-center justify-center rounded-full border-[2.5px] border-white"
-      >
-        <span className="size-16 rounded-full bg-white" />
-      </span>
-      <CameraRowFlipStandIn />
-    </div>
+    <CameraRowScene flash={{ mode: "auto", ariaLabel: LABELS.auto }} />
   ),
 };

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.stories.tsx
@@ -14,7 +14,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { CameraOff, Mic, MicOff, Volume2, VolumeX, X } from "lucide-react";
 
-import { overFakeFeed } from "@/domains/chat/voice/camera-story-feed";
+import { overFakeFeed, ToneCell } from "@/domains/chat/voice/camera-story-feed";
 
 import { VoiceRoomControl } from "./voice-room-control";
 
@@ -28,22 +28,6 @@ const meta: Meta<typeof VoiceRoomControl> = {
 
 export default meta;
 type Story = StoryObj<typeof VoiceRoomControl>;
-
-/** One control with the word for what it is, so the five can be compared. */
-function ToneCell({
-  caption,
-  children,
-}: {
-  caption: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="flex flex-col items-center gap-3">
-      {children}
-      <span className="font-mono text-[11px] text-white/70">{caption}</span>
-    </div>
-  );
-}
 
 /**
  * The five states the row can be in, captioned.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.test.tsx
@@ -1,11 +1,16 @@
 /**
  * Tests for `VoiceRoomControl`, every circular icon control in the room.
  *
- * Load-bearing contracts: the three surfaces, since a control that reads the
- * wrong one is invisible rather than merely wrong; the `live` tone, whose whole
- * job is to exist only where a viewfinder covers the room's own look; and the
- * corner's exemption from the camera fills, which is what keeps the bottom row
- * reading as one set of related acts.
+ * Only what a real room render cannot reach. The camera fills and the shared
+ * 52px size are proved in `voice-room.test.tsx`, against the room's own
+ * controls with the viewfinder genuinely open; asserting them again here
+ * against a bare harness proves one branch twice and leaves two places to fix
+ * when the palette moves.
+ *
+ * What is left is the paint contract the control publishes for itself, since
+ * the deep-link overlay mounts these outside the room entirely, and the `live`
+ * tone off camera mode, where the `media` surface is one the room never
+ * renders at all.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -36,45 +41,12 @@ function renderControl(props: Partial<VoiceRoomControlProps> = {}) {
 }
 
 describe("VoiceRoomControl", () => {
-  test("camera mode fills every tone, and tells them apart by what they do", () => {
-    // White for the control that says the session is live, warm for the ones
-    // that are about the camera rather than the call, red for the one act that
-    // cannot be undone.
-    expect(
-      renderControl({ surface: "camera", tone: "live" }).className,
-    ).toContain("bg-white");
-    cleanup();
-    expect(renderControl({ surface: "camera" }).className).toContain(
-      "bg-[var(--camera-warm)]",
-    );
-    cleanup();
-    expect(
-      renderControl({ surface: "camera", tone: "destructive" }).className,
-    ).toContain("bg-[var(--camera-destructive)]");
-  });
-
-  test("an engaged toggle sits a shade heavier than its resting peers", () => {
-    // The camera control is held down for the whole time the viewfinder is up;
-    // flip, beside it, toggles nothing.
-    expect(
-      renderControl({ surface: "camera", pressed: true }).className,
-    ).toContain("bg-[var(--camera-warm-strong)]");
-  });
-
   test("the camera fills are published as vars by the control itself", () => {
     // Nothing above this in the tree is guaranteed to carry the contract: the
     // deep-link overlay mounts these controls outside the room entirely.
     const style = renderControl({ surface: "camera" }).getAttribute("style");
     expect(style).toContain("--camera-warm");
     expect(style).toContain("--camera-destructive");
-  });
-
-  test("corner chrome keeps the glass treatment in camera mode", () => {
-    // A filled circle in the corner would join the bottom row's set of related
-    // acts, which the minimize control is not part of.
-    const bare = renderControl({ surface: "camera", bare: true });
-    expect(bare.className).toContain("bg-black/45");
-    expect(bare.className).not.toContain("camera-warm");
   });
 
   test("the live tone is the neutral one anywhere but camera mode", () => {
@@ -92,17 +64,5 @@ describe("VoiceRoomControl", () => {
     const media = renderControl({ tone: "live", surface: "media" });
     expect(media.className).toContain("bg-black/45");
     expect(media.className).not.toContain("bg-white");
-  });
-
-  test("every control is the same 52px, on every surface", () => {
-    // 52 clears the 44pt a thumb needs on its own, so nothing here depends on
-    // an invisible margin the way the flash control does. Held equal across the
-    // surfaces because the row is the same row whether or not the viewfinder is
-    // up, and a control that resized as the camera opened would move out from
-    // under a thumb already on its way to it.
-    for (const surface of ["room", "media", "camera"] as const) {
-      expect(renderControl({ surface }).className).toContain("size-13");
-      cleanup();
-    }
   });
 });


### PR DESCRIPTION
## Summary
Self-review fixes: row stories compose the real sibling components via a shared scene, the captioned story cell lives once in camera-story-feed, and voice-room-control tests keep only what the room render cannot cover.

Part of plan: voice-camera-mode-redesign.md (self-review fixes)