### PR TITLE
fix: camera-mode self-review round 1 (hook + voice state)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -17,7 +17,6 @@ import {
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
   LIVE_VOICE_STATE_LABELS,
-  liveVoiceStateLabel,
   liveVoiceSurfaceLabel,
   liveVoiceSurfaceLabelKey,
   minimizeVoiceRoom,
@@ -215,15 +214,6 @@ describe("useLiveVoiceStore — room minimize", () => {
   });
 });
 
-describe("liveVoiceStateLabel", () => {
-  test("relabels only the connecting phase while reconnecting", () => {
-    expect(liveVoiceStateLabel("connecting", true)).toBe("Reconnecting…");
-    expect(liveVoiceStateLabel("connecting", false)).toBe("Connecting…");
-    // reconnecting is ignored for every other phase.
-    expect(liveVoiceStateLabel("listening", true)).toBe("Listening…");
-  });
-});
-
 describe("LIVE_VOICE_STATE_LABELS", () => {
   /**
    * `toVoiceAvatarVisual` collapses `transcribing` into `thinking`, so a label
@@ -241,7 +231,9 @@ describe("LIVE_VOICE_STATE_LABELS", () => {
     expect(toVoiceAvatarVisual("transcribing", false)).toBe(
       toVoiceAvatarVisual("thinking", false),
     );
-    expect(liveVoiceStateLabel("transcribing", false)).toBe("Thinking…");
+    expect(liveVoiceSurfaceLabel("transcribing", false, true, false)).toBe(
+      "Thinking…",
+    );
   });
 });
 
@@ -262,6 +254,11 @@ describe("liveVoiceSurfaceLabel", () => {
       "Reconnecting…",
     );
     expect(liveVoiceSurfaceLabel("listening", false, false, false)).toBe(
+      "Listening…",
+    );
+    // Only `connecting` reads the signal: a retry that has already reconnected
+    // far enough to listen is listening.
+    expect(liveVoiceSurfaceLabel("listening", true, false, false)).toBe(
       "Listening…",
     );
   });
@@ -598,6 +595,28 @@ describe("isLiveVoiceMicLive", () => {
     for (const state of micOff) {
       expect(isLiveVoiceMicLive(state)).toBe(false);
     }
+  });
+});
+
+describe("useLiveVoiceStore: utteranceOpen", () => {
+  test("closed until the server VAD opens an utterance", () => {
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(false);
+    useLiveVoiceStore.getState().setUtteranceOpen(true);
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(true);
+  });
+
+  test("closes again when the utterance ends or is discarded", () => {
+    useLiveVoiceStore.getState().setUtteranceOpen(true);
+    useLiveVoiceStore.getState().setUtteranceOpen(false);
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(false);
+  });
+
+  test("reset closes it with the rest of the session", () => {
+    // Session-scoped: an utterance open when the session ends must not read as
+    // the user talking into the next one.
+    useLiveVoiceStore.getState().setUtteranceOpen(true);
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -133,28 +133,14 @@ export const LIVE_VOICE_STATE_LABELS: Record<LiveVoiceSessionState, string> =
   ) as Record<LiveVoiceSessionState, string>;
 
 /**
- * User-facing activity label for a session, factoring in the orthogonal
- * `reconnecting` signal. Drives the room's aria-live label. During a retry of a
- * dropped connection the base `connecting` phase relabels to "Reconnecting…" so
- * surfaces distinguish it from the initial connect (the JARVIS-1255 gap);
- * `reconnecting` is ignored for every other phase.
- *
- * The lower layer for callers with no audio or mute signal to consult: an
- * audible assistant and an open mic leave the other two remaps in
- * {@link liveVoiceSurfaceLabelKey} unfired, so what comes back is the phase's
- * own word.
- */
-export function liveVoiceStateLabel(
-  state: LiveVoiceSessionState,
-  reconnecting: boolean,
-): string {
-  return liveVoiceSurfaceLabel(state, reconnecting, true, false);
-}
-
-/**
  * The catalog key a *surface* shows for a session: the phase's own key plus the
  * remaps that keep the word true of what is actually happening. Keys exist so
  * surfaces can localize without forking the decision table.
+ *
+ * `connecting` relabels to "Reconnecting…" while the controller is retrying a
+ * dropped connection, so a surface distinguishes a retry from the initial
+ * connect (the JARVIS-1255 gap). `reconnecting` is ignored for every other
+ * phase.
  *
  * `speaking` stays set across a mid-turn tool run: the assistant spoke an ack,
  * then went silent while a tool runs. Announcing "Speaking…" while nothing is
@@ -425,6 +411,15 @@ export interface LiveVoiceState {
    * make, however it was made.
    */
   pendingApprovalRequestId: string | null;
+  /**
+   * Whether the server VAD is holding an utterance open: set on
+   * `speech_started`, cleared on `utterance_end` / `utterance_discarded`. The
+   * session's own answer to "is the user talking right now", published because
+   * a surface renders that boundary directly (the camera-mode status pill's
+   * dot). Only hands-free sessions have one; a manual session leaves it false.
+   * Session-scoped, so `reset()` clears it with everything else.
+   */
+  utteranceOpen: boolean;
   /** In-flight partial transcript of the user's current utterance. */
   partialTranscript: string;
   /** Last finalized user transcript. */
@@ -567,6 +562,8 @@ export interface LiveVoiceActions {
   setFirstRunCardOpen: (open: boolean) => void;
   /** Publish or clear the pre-open "configure voice" notice. */
   setConfigNotice: (notice: string | null) => void;
+  /** Record whether the server VAD is holding an utterance open. */
+  setUtteranceOpen: (utteranceOpen: boolean) => void;
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   /** Append a delta to the accumulated assistant transcript. */
@@ -714,6 +711,7 @@ const INITIAL_SESSION_STATE: Omit<LiveVoiceState, "starter"> = {
   photoRejectedSeq: 0,
   photoRejectedReason: null,
   controls: null,
+  utteranceOpen: false,
   partialTranscript: "",
   finalTranscript: "",
   assistantTranscript: "",
@@ -761,6 +759,7 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setStarter: (starter) => set({ starter }),
   setFirstRunCardOpen: (firstRunCardOpen) => set({ firstRunCardOpen }),
   setConfigNotice: (configNotice) => set({ configNotice }),
+  setUtteranceOpen: (utteranceOpen) => set({ utteranceOpen }),
   setPartialTranscript: (partialTranscript) => set({ partialTranscript }),
   setFinalTranscript: (finalTranscript) => set({ finalTranscript }),
   appendAssistantTranscript: (delta) =>

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -1529,6 +1529,72 @@ describe("utterance_discarded", () => {
   });
 });
 
+/**
+ * The VAD boundary the controller publishes. Session-local until a surface
+ * needed it: the camera-mode status pill renders it as "the user is talking",
+ * so the boundary the session acts on and the one the dot draws are one fact.
+ */
+describe("published utterance boundary", () => {
+  test("opens on speech_started and closes on utterance_end", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(false);
+
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq: 2 });
+    });
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(true);
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 3,
+        reason: "silence",
+      });
+    });
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(false);
+  });
+
+  test("closes on an utterance the server discarded", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq: 2 });
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 3,
+      });
+    });
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(false);
+  });
+
+  test("stays closed for a manual session, which has no server VAD", async () => {
+    const h = renderController();
+    await startListening(h);
+
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq: 2 });
+    });
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(false);
+  });
+
+  test("does not survive the session that opened it", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq: 2 });
+    });
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(true);
+
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+    expect(useLiveVoiceStore.getState().utteranceOpen).toBe(false);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Turn latency (server metrics frame + client-heard measurement)
 // ---------------------------------------------------------------------------

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -879,10 +879,12 @@ export function useLiveVoice(
           // next utterance. Speech resuming inside a HELD utterance (semantic
           // endpointing suppressed the boundary) re-fires speech_started for
           // the same utterance — its finalized transcript prefix must stay.
+          const s = useLiveVoiceStore.getState();
           if (!session.utteranceOpen) {
-            useLiveVoiceStore.getState().clearUserTranscripts();
+            s.clearUserTranscripts();
           }
           session.utteranceOpen = true;
+          s.setUtteranceOpen(true);
           flushPlaybackToListening(session);
         }),
         client.on("utteranceEnd", () => {
@@ -890,27 +892,30 @@ export function useLiveVoice(
             return;
           }
           session.utteranceOpen = false;
+          const s = useLiveVoiceStore.getState();
+          s.setUtteranceOpen(false);
           // End of user speech: stamp the client-heard latency start; the
           // response's first tts_audio consumes it (see
           // beginAssistantAudioIfNeeded). Manual mode stamps at the
           // ptt_release send instead (see releasePushToTalk).
           session.speechEndedAtMs = performance.now();
           // Server VAD closed the utterance; its transcription is finishing.
-          useLiveVoiceStore.getState().setState("transcribing");
+          s.setState("transcribing");
         }),
         client.on("utteranceDiscarded", () => {
           if (!live() || !session.handsFree) {
             return;
           }
           session.utteranceOpen = false;
-          // The discarded utterance never becomes a turn — drop its
+          const s = useLiveVoiceStore.getState();
+          s.setUtteranceOpen(false);
+          // The discarded utterance never becomes a turn: drop its
           // end-of-speech stamp so it can't pair with a later turn's audio.
           session.speechEndedAtMs = null;
           // The closed utterance had no usable speech (noise/cough); return
           // to listening. A discarded utterance never reaches `thinking`
           // (empty finals stay in `transcribing`), so any other state belongs
           // to a newer turn and is left alone.
-          const s = useLiveVoiceStore.getState();
           if (s.state === "transcribing") {
             s.setState("listening");
           }

--- a/clients/web/src/domains/chat/voice/voice-room/use-camera-voice-state.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-camera-voice-state.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The camera pill's dot reports the session's own signals, so every case here
+ * is about the dot refusing to claim a voice the session does not have.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useCameraVoiceState } from "@/domains/chat/voice/voice-room/use-camera-voice-state";
+
+beforeEach(() => {
+  useLiveVoiceStore.getState().reset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/** The room's call: phase, whether assistant audio is flowing, camera open. */
+function render(
+  state: Parameters<typeof useCameraVoiceState>[0],
+  assistantAudioActive: boolean,
+  enabled: boolean,
+) {
+  return renderHook(() =>
+    useCameraVoiceState(state, assistantAudioActive, enabled),
+  );
+}
+
+describe("useCameraVoiceState", () => {
+  test("is idle while listening to a room nobody is speaking into", () => {
+    // The point of reading the VAD rather than the microphone: a fan, a car,
+    // a television are all amplitude, and none of them is the user's turn.
+    useLiveVoiceStore.getState().setInputAmplitude(0.9);
+    const { result } = render("listening", false, true);
+
+    expect(result.current).toBe("idle");
+  });
+
+  test("reports the user exactly while the server VAD holds an utterance", () => {
+    const { result } = render("listening", false, true);
+    expect(result.current).toBe("idle");
+
+    act(() => {
+      useLiveVoiceStore.getState().setUtteranceOpen(true);
+    });
+    expect(result.current).toBe("user");
+
+    act(() => {
+      useLiveVoiceStore.getState().setUtteranceOpen(false);
+    });
+    expect(result.current).toBe("idle");
+  });
+
+  test("says nothing about the user while the camera is closed", () => {
+    useLiveVoiceStore.getState().setUtteranceOpen(true);
+    const { result } = render("listening", false, false);
+
+    expect(result.current).toBe("idle");
+  });
+
+  test("says nothing about the user while the mic is muted", () => {
+    // Muting streams silence rather than closing the socket, so an utterance
+    // caught mid-word stays open until the VAD's silence window expires. The
+    // pill's own word reads "Muted" for that whole window.
+    useLiveVoiceStore.getState().setUtteranceOpen(true);
+    useLiveVoiceStore.getState().setMuted(true);
+    const { result } = render("listening", false, true);
+
+    expect(result.current).toBe("idle");
+  });
+
+  test("reports the assistant only while its audio is actually flowing", () => {
+    // `speaking` stays set across a mid-turn tool run, which is silence.
+    expect(render("speaking", false, true).result.current).toBe("idle");
+    cleanup();
+    expect(render("speaking", true, true).result.current).toBe("assistant");
+  });
+
+  test("gives the assistant the dot when both have a claim on it", () => {
+    useLiveVoiceStore.getState().setUtteranceOpen(true);
+    const { result } = render("speaking", true, true);
+
+    expect(result.current).toBe("assistant");
+  });
+
+  test("is idle in every phase with no voice in it", () => {
+    useLiveVoiceStore.getState().setUtteranceOpen(true);
+    for (const state of ["connecting", "transcribing", "thinking"] as const) {
+      const { result } = render(state, true, true);
+      expect(result.current).toBe("idle");
+      cleanup();
+    }
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/use-camera-voice-state.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-camera-voice-state.ts
@@ -1,24 +1,22 @@
 /**
  * Who is talking, for the camera-mode status pill's dot.
  *
- * The assistant half is exact: the session's `speaking` phase gated on audio
- * actually flowing, the same pairing `toVoiceAvatarVisual` uses so the dot and
- * the room's other cast never disagree about whether a turn is audible.
+ * Both halves are the session's own signals, so the dot never claims a voice
+ * the session does not have. The assistant half is the `speaking` phase gated
+ * on audio actually flowing, the same pairing `toVoiceAvatarVisual` uses so the
+ * dot and the room's other cast never disagree about whether a turn is audible.
+ * The user half is the server VAD's utterance boundary, published by the
+ * controller as the store's `utteranceOpen`: the same signal that decides when
+ * the user's turn ends.
  *
- * The user half has no exact signal to read. The session's own VAD boundaries
- * (`speech_started` / `utterance_end`) stay inside `use-live-voice.ts` as a
- * ref, so nothing is published for a surface to read, and thresholding the
- * amplitude is the closest stand-in. It is polled on a coarse interval rather
- * than per frame, and the boolean only moves when the thresholded value
- * crosses: a dot that blinks on a 1.5s CSS keyframe needs to know *whether* a
- * voice is active, not how loud it is, and driving a decorative loop through
- * React state is exactly what CONVENTIONS.md (LUM-2859) forbids.
+ * The mute check is not redundant with it. Muting streams silence rather than
+ * closing the socket, so an utterance the user was mid-way through stays open
+ * until the VAD's silence window expires, and for that window the dot would say
+ * the user is talking beside a label that reads "Muted".
  */
 
-import { useEffect, useState } from "react";
-
 import {
-  getLiveVoiceInputAmplitude,
+  useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
@@ -30,42 +28,20 @@ import {
  */
 export type CameraVoiceState = "idle" | "user" | "assistant";
 
-/**
- * Mic amplitude (the store's smoothed [0, 1] value) above which the dot counts
- * the user as talking. The session's own barge-in threshold, which is the
- * louder of the two levels `use-live-voice.ts` works in and therefore the one
- * that survives a 250ms sample without blinking at room noise.
- */
-const USER_SPEAKING_AMPLITUDE = 0.05;
-
-/** Sample spacing. Four samples a second is a dot, not a waveform. */
-const POLL_MS = 250;
-
 export function useCameraVoiceState(
   state: LiveVoiceSessionState,
   assistantAudioActive: boolean,
-  /** False while the camera is closed: nothing renders the dot, so don't poll. */
+  /** False while the camera is closed: nothing renders the dot. */
   enabled: boolean,
 ): CameraVoiceState {
-  const listening = enabled && state === "listening";
-  const [userSpeaking, setUserSpeaking] = useState(false);
-
-  useEffect(() => {
-    if (!listening) {
-      setUserSpeaking(false);
-      return;
-    }
-    const id = window.setInterval(() => {
-      const speaking = getLiveVoiceInputAmplitude() >= USER_SPEAKING_AMPLITUDE;
-      // Same value in means the same value out, which React bails out on, so a
-      // steady voice (or a steady silence) costs no renders at all.
-      setUserSpeaking((was) => (was === speaking ? was : speaking));
-    }, POLL_MS);
-    return () => window.clearInterval(id);
-  }, [listening]);
+  const utteranceOpen = useLiveVoiceStore.use.utteranceOpen();
+  const muted = useLiveVoiceStore.use.muted();
 
   if (state === "speaking" && assistantAudioActive) {
     return "assistant";
   }
-  return listening && userSpeaking ? "user" : "idle";
+  if (enabled && state === "listening" && utteranceOpen && !muted) {
+    return "user";
+  }
+  return "idle";
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.test-helper.ts
@@ -1,0 +1,67 @@
+/**
+ * The `navigator.mediaDevices` stubbing the camera suites share.
+ *
+ * Both the hook's own tests (`voice-camera.test.tsx`) and the room's
+ * acquisition tests (`voice-room.test.tsx`) have to present a camera to
+ * `useVoiceCamera`, take it away again, and hand back a stream that survives
+ * happy-dom's `srcObject` instance check. One copy, so a fix to the stand-in
+ * stream reaches both.
+ */
+
+/** What a stubbed `mediaDevices` answers `getUserMedia` with. */
+export type FakeGetUserMedia = (
+  constraints?: MediaStreamConstraints,
+) => Promise<unknown>;
+
+const originalMediaDevices = Object.getOwnPropertyDescriptor(
+  navigator,
+  "mediaDevices",
+);
+
+/**
+ * Present a camera to the code under test. Pass the `getUserMedia` on its own,
+ * or the whole `mediaDevices` object when a test needs to shape the rest of it;
+ * `null` / `undefined` removes the API entirely, which is the "this device has
+ * no camera" case.
+ */
+export function stubMediaDevices(
+  mediaDevices:
+    FakeGetUserMedia | { getUserMedia: FakeGetUserMedia } | null | undefined,
+): void {
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value:
+      typeof mediaDevices === "function"
+        ? { getUserMedia: mediaDevices }
+        : (mediaDevices ?? undefined),
+  });
+}
+
+/** Put `navigator.mediaDevices` back the way the suite found it. */
+export function restoreMediaDevices(): void {
+  if (originalMediaDevices) {
+    Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
+    return;
+  }
+  stubMediaDevices(null);
+}
+
+/**
+ * A real `MediaStream`, because happy-dom's `HTMLMediaElement.srcObject` setter
+ * enforces the same instance check the browser does and a duck-typed stand-in
+ * throws where a real camera would not. happy-dom's implementation has no
+ * `getTracks()` or `getVideoTracks()`, which release and the negotiated-track
+ * log need, so those two are filled in.
+ */
+export function fakeStream(
+  getSettings?: () => MediaTrackSettings,
+): MediaStream {
+  const stream = new MediaStream();
+  Object.defineProperties(stream, {
+    getTracks: { value: () => [] },
+    getVideoTracks: {
+      value: () => (getSettings ? [{ getSettings }] : []),
+    },
+  });
+  return stream;
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.test.tsx
@@ -14,6 +14,12 @@ import { useRef } from "react";
 
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 
+import {
+  fakeStream,
+  restoreMediaDevices,
+  stubMediaDevices,
+} from "./voice-camera.test-helper";
+
 // Replaced rather than spread over the real module: platform detection reaches
 // the generated auth SDK through `native-auth`, and the hook under test wants
 // exactly one thing from it.
@@ -96,18 +102,6 @@ async function openNativeCamera() {
   await waitFor(() => expect(getFlashModesSpy).toHaveBeenCalled());
 }
 
-const originalMediaDevices = Object.getOwnPropertyDescriptor(
-  navigator,
-  "mediaDevices",
-);
-
-function stubMediaDevices(value: unknown) {
-  Object.defineProperty(navigator, "mediaDevices", {
-    configurable: true,
-    value,
-  });
-}
-
 beforeEach(() => {
   nativeMobile = true;
   startSpy.mockClear();
@@ -123,11 +117,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  if (originalMediaDevices) {
-    Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
-  } else {
-    stubMediaDevices(undefined);
-  }
+  restoreMediaDevices();
 });
 
 describe("useVoiceCamera: which cameras get a flash control", () => {
@@ -172,7 +162,7 @@ describe("useVoiceCamera: which cameras get a flash control", () => {
 
   test("offers nothing on the browser fallback path", async () => {
     nativeMobile = false;
-    stubMediaDevices({ getUserMedia: async () => fakeStream() });
+    stubMediaDevices(async () => fakeStream());
 
     render(<Probe />);
     await press("open");
@@ -198,7 +188,7 @@ describe("useVoiceCamera: which cameras get a flash control", () => {
     // Both flash calls reach for the capture device the preview owns. Asking
     // before there is one is the case iOS answers by force-unwrapping.
     startSpy.mockImplementation(async () => false);
-    stubMediaDevices(undefined);
+    stubMediaDevices(null);
 
     render(<Probe />);
     await press("open");
@@ -452,6 +442,86 @@ describe("useVoiceCamera: two flips at once", () => {
   });
 });
 
+describe("useVoiceCamera: a flip the bridge never answers", () => {
+  test("comes back after a close and a reopen", async () => {
+    // Nothing times out a bridge call, so a hand-back that never settles used
+    // to hold the flip guard for the life of the hook: the button stopped
+    // working, and closing the camera and raising it again did not bring it
+    // back.
+    useVoicePrefsStore.setState({ flashMode: "on" });
+    await openNativeCamera();
+    await waitFor(() => expect(setFlashModeSpy).toHaveBeenCalledWith("on"));
+
+    const neverAnswers = deferredCall<boolean>();
+    setFlashModeSpy.mockImplementation(neverAnswers.answer);
+    await press("flip");
+    expect(flipSpy).not.toHaveBeenCalled();
+
+    setFlashModeSpy.mockImplementation(async () => true);
+    await press("close");
+    await press("open");
+    await waitFor(() => expect(flashAvailable()).toBe(true));
+
+    await press("flip");
+
+    expect(flipSpy).toHaveBeenCalledTimes(1);
+    expect(facing()).toBe("user");
+  });
+
+  test("does not release the flip that replaced it when it finally answers", async () => {
+    // The other side of the recovery: the abandoned flip still runs its own
+    // exit, and by then the claim it took belongs to a flip that is mid-flight.
+    // Clearing it there would put two flips on the hardware at once, which is
+    // the case the guard exists for.
+    useVoicePrefsStore.setState({ flashMode: "on" });
+    await openNativeCamera();
+    await waitFor(() => expect(setFlashModeSpy).toHaveBeenCalledWith("on"));
+
+    const abandoned = deferredCall<boolean>();
+    setFlashModeSpy.mockImplementation(abandoned.answer);
+    await press("flip");
+
+    setFlashModeSpy.mockImplementation(async () => true);
+    await press("close");
+    await press("open");
+    await waitFor(() => expect(flashAvailable()).toBe(true));
+
+    const replacement = deferredCall<boolean>();
+    setFlashModeSpy.mockImplementation(replacement.answer);
+    await press("flip");
+
+    await settle(() => abandoned.resolve(true));
+
+    // The replacement is still handing its own flash back, so this tap is the
+    // second flip its guard is there to drop.
+    await press("flip");
+    expect(flipSpy).not.toHaveBeenCalled();
+
+    await settle(() => replacement.resolve(true));
+
+    expect(flipSpy).toHaveBeenCalledTimes(1);
+    expect(facing()).toBe("user");
+  });
+
+  test("does not hold the next flip behind its capability probe", async () => {
+    // The probe decides one button and the flip epoch already makes a late
+    // answer safe, so waiting on it would let a slow probe do exactly what the
+    // hung hand-back above does.
+    await openNativeCamera();
+    await waitFor(() => expect(flashAvailable()).toBe(true));
+
+    const slowProbe = deferredCall<string[]>();
+    getFlashModesSpy.mockImplementation(slowProbe.answer);
+    await press("flip");
+    expect(facing()).toBe("user");
+
+    await press("flip");
+
+    expect(flipSpy).toHaveBeenCalledTimes(2);
+    expect(facing()).toBe("environment");
+  });
+});
+
 /** A bridge call the test decides the timing of, not the microtask queue. */
 function deferredCall<T>() {
   let resolve: (value: T) => void = () => {};
@@ -470,18 +540,4 @@ async function settle(release: () => void) {
     release();
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
-}
-
-/**
- * A real `MediaStream`, because happy-dom's `srcObject` setter enforces the
- * same instance check the browser does, with the two methods release needs
- * filled in.
- */
-function fakeStream() {
-  const stream = new MediaStream();
-  Object.defineProperties(stream, {
-    getTracks: { value: () => [] },
-    getVideoTracks: { value: () => [] },
-  });
-  return stream;
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
@@ -272,9 +272,12 @@ export function useVoiceCamera(
   // the capture, so the acquire epoch alone would let a probe of the outgoing
   // camera answer for the one that replaced it.
   const flashProbeEpochRef = useRef(0);
-  // True from the first line of a flip to the last. See `flipCamera`: two of
-  // them overlapping spin the hardware twice and agree on the wrong answer.
-  const flipInFlightRef = useRef(false);
+  // The flip that is running, as its own identity, or null for none. See
+  // `flipCamera`: two of them overlapping spin the hardware twice and agree on
+  // the wrong answer. An identity rather than a flag because releasing the
+  // camera drops the claim (see `stopCapture`), and a flip that resumes after
+  // that must not drop the claim of the flip that replaced it.
+  const flipInFlightRef = useRef<object | null>(null);
   // True while a flash-capable camera is running with a mode other than off,
   // which is exactly when the plugin has state of ours to hand back. Cleared
   // rather than re-derived, so a camera that turned out to have no flash is
@@ -294,6 +297,11 @@ export function useVoiceCamera(
     // flight, whose camera is the one going away here.
     acquireEpochRef.current++;
     flashProbeEpochRef.current++;
+    // A flip still running belongs to the camera this releases, so its claim
+    // goes with it. Nothing else clears the claim of a bridge call that never
+    // comes back, and a flip left marked in flight is a flip button that never
+    // works again, across a close and a reopen included.
+    flipInFlightRef.current = null;
     const source = sourceRef.current;
     sourceRef.current = null;
     if (source === "native-pending" || source === "native") {
@@ -533,7 +541,8 @@ export function useVoiceCamera(
     if (!sourceRef.current || flipInFlightRef.current) {
       return;
     }
-    flipInFlightRef.current = true;
+    const claim = {};
+    flipInFlightRef.current = claim;
     try {
       // Before anything else, and before the flip itself: from here on the
       // camera any outstanding probe asked about is not the one that will be
@@ -571,8 +580,11 @@ export function useVoiceCamera(
           setFacing(next);
         }
         // Re-probed whether or not the flip took: on a failure the old camera
-        // is still running and its capabilities were just cleared.
-        await probeFlash();
+        // is still running and its capabilities were just cleared. Not awaited,
+        // so the flip is available again the moment the flip itself settles;
+        // the probe epoch is what makes a late answer safe, and the next flip
+        // bumps it before anything else.
+        void probeFlash();
         return;
       }
 
@@ -588,10 +600,11 @@ export function useVoiceCamera(
         setOpen(false);
       }
     } finally {
-      // Unconditional, and the only place this is cleared: a release or a
-      // close landing mid-flip takes one of the bail-outs above, and a flip
-      // left marked in flight would be a flip button that never works again.
-      flipInFlightRef.current = false;
+      // This flip's own claim only. A release landing mid-flip already dropped
+      // it, and the claim standing now may belong to the flip that came after.
+      if (flipInFlightRef.current === claim) {
+        flipInFlightRef.current = null;
+      }
     }
   }, [acquire, facing, probeFlash]);
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -47,6 +47,11 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  fakeStream,
+  restoreMediaDevices,
+  stubMediaDevices,
+} from "@/domains/chat/voice/voice-room/voice-camera.test-helper";
 import { MIN_VERSION as NONINTERACTIVE_VOICE_MIN_VERSION } from "@/lib/backwards-compat/use-supports-noninteractive-voice-turns";
 import { MIN_VERSION as CAMERA_MIN_VERSION } from "@/lib/backwards-compat/use-supports-voice-camera";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
@@ -1487,38 +1492,6 @@ describe("VoiceRoom — no push-to-talk / manual-release affordance (hands-free)
  * inside the room rather than behind the system camera.
  */
 describe("VoiceRoom: camera", () => {
-  const originalMediaDevices = Object.getOwnPropertyDescriptor(
-    navigator,
-    "mediaDevices",
-  );
-
-  /** Present a camera to the room; `null` removes the API entirely. */
-  function stubMediaDevices(
-    getUserMedia:
-      ((constraints?: MediaStreamConstraints) => Promise<unknown>) | null,
-  ) {
-    Object.defineProperty(navigator, "mediaDevices", {
-      configurable: true,
-      value: getUserMedia ? { getUserMedia } : undefined,
-    });
-  }
-
-  // A real `MediaStream`, because happy-dom's `HTMLMediaElement.srcObject`
-  // setter enforces the same instance check the browser does and a duck-typed
-  // stand-in throws where a real camera would not, but happy-dom's
-  // implementation has no `getTracks()`, which release needs, so that one
-  // method is filled in.
-  function fakeStream(getSettings?: () => MediaTrackSettings) {
-    const stream = new MediaStream();
-    Object.defineProperties(stream, {
-      getTracks: { value: () => [] },
-      getVideoTracks: {
-        value: () => (getSettings ? [{ getSettings }] : []),
-      },
-    });
-    return stream;
-  }
-
   /**
    * Make the shutter able to produce a frame.
    *
@@ -1580,11 +1553,7 @@ describe("VoiceRoom: camera", () => {
   const viewfinder = () => screen.queryByTestId("voice-room-viewfinder");
 
   afterEach(() => {
-    if (originalMediaDevices) {
-      Object.defineProperty(navigator, "mediaDevices", originalMediaDevices);
-    } else {
-      stubMediaDevices(null);
-    }
+    restoreMediaDevices();
   });
 
   test("offers no camera when the assistant version is unknown", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -544,9 +544,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
     ? "camera"
     : "room";
 
-  // Camera mode's own status readout. Gated on the camera so the user-speaking
-  // poll inside the hook only runs while something renders its dot, and the
-  // name is resolved the way the first-run card resolves it.
+  // Camera mode's own status readout. Gated on the camera so the user half is
+  // only reported while something renders its dot, and the name is resolved the
+  // way the first-run card resolves it.
   const cameraVoiceState = useCameraVoiceState(
     state,
     assistantAudioActive,


### PR DESCRIPTION
## Summary
Fixes gaps from the plan self-review: publishes the session's real VAD boundary for the camera pill dot (plan decision D2 as recommended), makes flip recover from a hung bridge call, deletes a dead label wrapper, dedupes camera test scaffolding.

Part of plan: voice-camera-mode-redesign.md (self-review fixes)