### PR TITLE
Fix Windows packaged runtime module resolution

### DIFF
--- a/clients/windows/scripts/launch-cli.test.ts
+++ b/clients/windows/scripts/launch-cli.test.ts
@@ -38,6 +38,10 @@ test("forwards CLI arguments to the owned versioned runtime", () => {
 
   expect(launchOwnedCli(launcher, ["ps", "--json"], spawnCli)).toBe(17);
   expect(spawnCli).toHaveBeenCalledWith(target, ["ps", "--json"], {
+    env: {
+      ...process.env,
+      NODE_PATH: path.join(path.dirname(target), "node_modules"),
+    },
     stdio: "inherit",
     windowsHide: false,
   });

--- a/clients/windows/scripts/launch-cli.ts
+++ b/clients/windows/scripts/launch-cli.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
+import { withRuntimeNodePath } from "../src/shared/runtime-environment";
 import { sameWindowsPath } from "../src/shared/windows-path";
 
 interface LauncherOwnership {
@@ -11,7 +12,11 @@ interface LauncherOwnership {
 type SpawnCli = (
   command: string,
   args: string[],
-  options: { stdio: "inherit"; windowsHide: boolean },
+  options: {
+    env: NodeJS.ProcessEnv;
+    stdio: "inherit";
+    windowsHide: boolean;
+  },
 ) => { error?: Error; status: number | null };
 
 export function resolveOwnedCliTarget(execPath: string): string {
@@ -40,7 +45,9 @@ export function launchOwnedCli(
   spawnCli: SpawnCli = (command, commandArgs, options) =>
     spawnSync(command, commandArgs, options),
 ): number {
-  const result = spawnCli(resolveOwnedCliTarget(execPath), args, {
+  const target = resolveOwnedCliTarget(execPath);
+  const result = spawnCli(target, args, {
+    env: withRuntimeNodePath(target),
     stdio: "inherit",
     windowsHide: false,
   });

--- a/clients/windows/scripts/package-runtime.ts
+++ b/clients/windows/scripts/package-runtime.ts
@@ -2,6 +2,7 @@ import { copyFileSync, cpSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
+import { withRuntimeNodePath } from "../src/shared/runtime-environment";
 import { resolveBuildCommitSha } from "./build-metadata";
 import { installPinnedBun } from "./bun-release";
 import { findPackageDir } from "./package-runtime-packages";
@@ -189,17 +190,25 @@ for (const { packageName, resolveSpecifier, basedir } of runtimePackages) {
   );
 }
 
-const versionCheck = spawnSync(
-  path.join(outputDir, "assistant.exe"),
-  ["--version"],
-  { encoding: "utf8", windowsHide: true },
-);
+const packagedAssistant = path.join(outputDir, "assistant.exe");
+const versionCheck = spawnSync(packagedAssistant, ["--version"], {
+  encoding: "utf8",
+  env: withRuntimeNodePath(packagedAssistant),
+  windowsHide: true,
+});
 if (
   versionCheck.status !== 0 ||
   versionCheck.stdout.trim() !== assistantVersion
 ) {
+  const diagnostics = [
+    `exit ${versionCheck.status ?? "not started"}`,
+    versionCheck.error ? `spawn error: ${versionCheck.error.message}` : null,
+    versionCheck.stderr.trim() ? `stderr: ${versionCheck.stderr.trim()}` : null,
+  ]
+    .filter((detail): detail is string => detail !== null)
+    .join("; ");
   throw new Error(
-    `Packaged assistant version check failed: expected ${assistantVersion}, got ${versionCheck.stdout.trim() || "no output"}.`,
+    `Packaged assistant version check failed: expected ${assistantVersion}, got ${versionCheck.stdout.trim() || "no output"} (${diagnostics}).`,
   );
 }
 for (const [source, name] of [

--- a/clients/windows/scripts/package-runtime.ts
+++ b/clients/windows/scripts/package-runtime.ts
@@ -196,19 +196,18 @@ const versionCheck = spawnSync(packagedAssistant, ["--version"], {
   env: withRuntimeNodePath(packagedAssistant),
   windowsHide: true,
 });
-if (
-  versionCheck.status !== 0 ||
-  versionCheck.stdout.trim() !== assistantVersion
-) {
+const versionOutput = versionCheck.stdout?.trim() ?? "";
+const versionErrorOutput = versionCheck.stderr?.trim() ?? "";
+if (versionCheck.status !== 0 || versionOutput !== assistantVersion) {
   const diagnostics = [
     `exit ${versionCheck.status ?? "not started"}`,
     versionCheck.error ? `spawn error: ${versionCheck.error.message}` : null,
-    versionCheck.stderr.trim() ? `stderr: ${versionCheck.stderr.trim()}` : null,
+    versionErrorOutput ? `stderr: ${versionErrorOutput}` : null,
   ]
     .filter((detail): detail is string => detail !== null)
     .join("; ");
   throw new Error(
-    `Packaged assistant version check failed: expected ${assistantVersion}, got ${versionCheck.stdout.trim() || "no output"} (${diagnostics}).`,
+    `Packaged assistant version check failed: expected ${assistantVersion}, got ${versionOutput || "no output"} (${diagnostics}).`,
   );
 }
 for (const [source, name] of [

--- a/clients/windows/src/shared/runtime-environment.ts
+++ b/clients/windows/src/shared/runtime-environment.ts
@@ -1,0 +1,11 @@
+import path from "node:path";
+
+export const withRuntimeNodePath = (
+  runtimeExecutable: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv => {
+  return {
+    ...environment,
+    NODE_PATH: path.join(path.dirname(runtimeExecutable), "node_modules"),
+  };
+};


### PR DESCRIPTION
## Summary

- point the Windows packaging self-check at the versioned runtime node_modules directory
- propagate the same deterministic module path through the installed CLI launcher while preserving the caller working directory
- include exit status, spawn errors, and stderr when the packaged assistant self-check fails

## Original prompt

The Windows installer build compiled assistant.exe successfully, but its version self-check failed when launched from clients/windows because Bun could not resolve the external semver package from its embedded path. The executable worked only when launched from the runtime directory, so the packaging check and installed launcher need to provide the versioned runtime module path explicitly.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->