### PR TITLE
fix: camera-mode self-review round 1 (room, pill, i18n, css)

### DIFF
--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -3,10 +3,12 @@
 What the suite cannot reach. Every check here needs a real camera, a real screen
 reader, or a real OS setting, so it runs by hand.
 
-Surface under test: the voice room with the viewfinder up (the camera paths of
-`voice-room.tsx`, `camera-status-pill.tsx`, `camera-flash-control.tsx`,
-`camera-shutter.tsx`, and `voice-room-control.tsx` at `surface="camera"`), plus
-the deep-link capture overlay, which shares the shutter and the bottom scrim.
+Surface under test: the voice room with the viewfinder up, under
+`src/domains/chat/voice/voice-room/` (the camera paths of `voice-room.tsx`,
+`camera-status-pill.tsx`, `camera-flash-control.tsx`, `camera-shutter.tsx`, and
+`voice-room-control.tsx` at `surface="camera"`), plus the deep-link capture
+overlay in `src/domains/chat/components/chat-attachments/`, which shares the
+shutter and the bottom scrim.
 
 ## iPhone
 
@@ -113,6 +115,22 @@ the redesign is called shipped.
 - [ ] Minimize in camera mode. The design gives the camera view only the grabber
       and end session as exits. The build keeps the top-right minimize control,
       which is the only discoverable exit on desktop. Confirm.
+- [ ] Capture feedback reaches the deep-link overlay too. The shutter is shared,
+      so dimming the core while a frame uploads restyles the overlay's shutter
+      as well as the room's, and it is an opacity dip rather than the core
+      shrinking. Take a photo from the overlay and confirm the dip reads as
+      "working" there, or ask for a treatment that is the room's alone.
+- [ ] Flash glyph and blur. The bolt is bespoke (lucide has no slashed one and
+      none that carries a badge) and snapped to lucide in three ways: the
+      24-unit viewBox, the 2-unit stroke, and the 20px it renders at. Its
+      resting state also carries `backdrop-blur-sm`, which the handoff draws as
+      a flat fill. Confirm the glyph sits as a sibling of the icons beside it,
+      and that the blur is wanted over a busy frame.
+- [ ] Localized session words on the minimized surfaces. The composer's voice
+      bar and the title-bar session pill read the session's state through the
+      catalog rather than the store's English map, so they follow the app
+      language the way the room already did. Sweep them in Spanish and Russian
+      alongside the room.
 
 ## Known adjacent issues
 

--- a/clients/web/src/domains/chat/components/chat-attachments/camera-capture-overlay.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/camera-capture-overlay.tsx
@@ -251,11 +251,14 @@ export function CameraCaptureOverlay({
             something behind it gives way. The room darkens the same band for
             the same reason, and shares the gradient so the two surfaces cannot
             drift. Inert, since it lies over the controls, and it covers only
-            the bottom band so the part the user is aiming stays untouched. */}
+            the bottom band so the part the user is aiming stays untouched.
+
+            The floor is the room's too: 38% of a short window stops above the
+            shutter, leaving the control it exists for sitting on bare frame. */}
         <div
           aria-hidden
           data-testid="camera-deep-link-scrim"
-          className="pointer-events-none absolute inset-x-0 bottom-0 h-[38%]"
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-[max(38%,15rem)]"
           style={{ background: CAMERA_SCRIM_BOTTOM }}
         />
 

--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.tsx
@@ -65,8 +65,8 @@ import { Mic, MicOff, Volume2, VolumeX, X } from "lucide-react";
 import { Button, cn } from "@vellumai/design-library";
 
 import {
-  LIVE_VOICE_STATE_LABELS,
   isLiveVoiceMicLive,
+  liveVoiceSurfaceLabelKey,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { VOICE_WAVE_EDGE_FADE_CLASS } from "@/domains/chat/voice/voice-room/voice-listening-waves";
@@ -190,6 +190,12 @@ export function VoiceComposerBar({
   const mutedInk = {
     "--vbtn-fg": voiceSurfaceMutedInk(paint),
   } as CSSProperties;
+  // The session's own word, taken as a catalog key so the live region reads in
+  // the user's language. The bar is handed a phase and a mute flag and nothing
+  // else, so the reconnect and assistant-audio remaps are handed the values
+  // that leave them unfired. Mute keeps the branch at the region below: this
+  // bar says "Muted" in every phase, not only the one the session relabels.
+  const stateKey = liveVoiceSurfaceLabelKey(state, false, true, false);
   return (
     <div
       role="group"
@@ -268,7 +274,7 @@ export function VoiceComposerBar({
         <div className="relative min-w-0 flex-1" />
       )}
       <span aria-live="polite" className="sr-only">
-        {muted ? t("voiceComposerBar.muted") : LIVE_VOICE_STATE_LABELS[state]}
+        {muted ? t("voiceComposerBar.muted") : stateKey ? t(stateKey) : ""}
       </span>
 
       <div className="relative flex shrink-0 items-center gap-1">

--- a/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
+++ b/clients/web/src/domains/chat/components/voice-session-pill-host.tsx
@@ -81,12 +81,12 @@ import {
 } from "@/domains/chat/components/voice-session-pill";
 import { useComposerOnScreen } from "@/domains/chat/hooks/use-composer-on-screen";
 import {
-  LIVE_VOICE_STATE_LABELS,
   dismissLiveVoiceFailure,
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   getLiveVoiceOutputAmplitude,
   isLiveVoiceSessionActive,
+  liveVoiceSurfaceLabelKey,
   setLiveVoiceMuted,
   setLiveVoiceOutputMuted,
   useLiveVoiceStore,
@@ -139,6 +139,15 @@ export function VoiceSessionPillHost({
   const muted = useLiveVoiceStore.use.muted();
   const outputMuted = useLiveVoiceStore.use.outputMuted();
 
+  // The session's own word, taken as a catalog key so the pill reads in the
+  // user's language. This host observes neither the reconnect flag nor whether
+  // assistant audio is flowing, so those two remaps are handed the values that
+  // leave them unfired and what comes back is the phase's own word. Mute keeps
+  // the branch below rather than being passed in: the pill says "Muted" in
+  // every phase, not only the one the session relabels for it.
+  const stateKey = liveVoiceSurfaceLabelKey(state, false, true, false);
+  const stateLabel = stateKey ? t(stateKey) : "";
+
   const navigate = useNavigate();
 
   // Both flags come from the shared hook above:
@@ -181,7 +190,7 @@ export function VoiceSessionPillHost({
   } else if (visible) {
     content = (
       <VoiceSessionPill
-        primaryLabel={muted ? t("voiceSessionPillHost.muted") : LIVE_VOICE_STATE_LABELS[state]}
+        primaryLabel={muted ? t("voiceSessionPillHost.muted") : stateLabel}
         state={state}
         getAmplitude={getLiveVoiceInputAmplitude}
         getOutputAmplitude={getLiveVoiceOutputAmplitude}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -117,10 +117,11 @@ const LIVE_VOICE_STATUS_ENGLISH: Record<LiveVoiceStatusKey, string> = {
 };
 
 /**
- * English activity label per session state, shared by every surface that shows
- * session activity (the composer's voice bar and the title-bar session pill),
- * so the two always agree. Derived from {@link LIVE_VOICE_STATE_KEYS}, which is
- * the only place a phase and its wording are paired.
+ * English activity label per session state, for the native surfaces with no
+ * translator in reach: the iOS Live Activity's push registration reads it, and
+ * enumerates it to cover every phase. Derived from
+ * {@link LIVE_VOICE_STATE_KEYS}, which is the only place a phase and its
+ * wording are paired.
  *
  * The assertion restates the shape `Object.entries` widens to `string`.
  */
@@ -191,9 +192,13 @@ export function liveVoiceSurfaceLabelKey(
 }
 
 /**
- * English copy for {@link liveVoiceSurfaceLabelKey}, for the surfaces that read
- * the label itself: the room's caption and the iOS Live Activity mirror. Empty
- * for the phases that carry no word.
+ * English copy for {@link liveVoiceSurfaceLabelKey}, for the surfaces that
+ * cannot reach a translator: the iOS Live Activity mirror and the push
+ * registration that hands its wording to native code. Empty for the phases that
+ * carry no word.
+ *
+ * Every surface rendered by this app reads the key instead, so a Spanish or
+ * Russian reader gets the session's state in their own language.
  */
 export function liveVoiceSurfaceLabel(
   state: LiveVoiceSessionState,

--- a/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-flash-control.tsx
@@ -12,8 +12,10 @@
  * outlines, and auto adds the badge that says which of the two it is.
  *
  * A bespoke glyph rather than a lucide icon: the set has a bolt, but not a
- * slashed one, and not one that carries a badge. It is drawn at lucide's own
- * 24-unit grid and stroke so it reads as a sibling of the icons beside it.
+ * slashed one, and not one that carries a badge. It snaps to lucide in all
+ * three of the things that make an icon read as one of a set: the 24-unit
+ * viewBox it is drawn on, the 2-unit stroke it is drawn with, and the 20px it
+ * renders at, which is the size every other glyph in the control row takes.
  *
  * Presentational only. The caller owns the mode, what a press does, and the
  * accessible name. Leftover props land on the button, which is what lets a
@@ -25,6 +27,8 @@ import type { ComponentProps } from "react";
 import { cn } from "@vellumai/design-library";
 
 import type { FlashMode } from "@/stores/voice-prefs-store";
+
+import { CAMERA_FLASH_GLASS_CLASS, cameraModeStyle } from "./camera-mode-paint";
 
 /** The order a press moves through. Off is the resting state, so it closes the loop. */
 const FLASH_CYCLE: Record<FlashMode, FlashMode> = {
@@ -70,6 +74,10 @@ export function CameraFlashControl({
       aria-label={ariaLabel}
       data-testid={testId}
       data-flash-mode={mode}
+      // The control sits in the shutter's row rather than in the room's own,
+      // which is the element that publishes the camera contract, so it carries
+      // the vars its armed ink reads.
+      style={cameraModeStyle()}
       className={cn(
         // Border-box with a border in every state, transparent when the state
         // has no visible one, so the three states measure identically and the
@@ -84,8 +92,8 @@ export function CameraFlashControl({
         // around it uses them: what sits behind this is arbitrary camera
         // video, so there is no surface for a token to describe.
         armed
-          ? "border-transparent bg-white/92 text-neutral-900"
-          : "border-white/20 bg-black/42 text-white backdrop-blur-sm",
+          ? "border-transparent bg-white/92 text-[var(--camera-ink)]"
+          : CAMERA_FLASH_GLASS_CLASS,
         className,
       )}
       {...buttonProps}
@@ -108,7 +116,7 @@ export function CameraFlashControl({
       {mode === "auto" ? (
         <span
           aria-hidden
-          className="absolute right-2.5 bottom-2 text-[8px] leading-none font-bold"
+          className="absolute right-1.5 bottom-[5px] text-[8px] leading-none font-bold"
         >
           {autoBadge}
         </span>

--- a/clients/web/src/domains/chat/voice/voice-room/camera-mode-paint.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-mode-paint.ts
@@ -17,6 +17,12 @@
  * scope is the camera, and nothing outside it should be able to reach them. The
  * scrims are plain background values, since a gradient layer has nothing to
  * hand down.
+ *
+ * The glass treatments ship as class strings for the same reason the colors
+ * ship as vars: the design gives three different pieces of chrome three
+ * different fills, and a literal written at each call site is a fill that
+ * drifts the first time one of them is retuned. Each value lives here once and
+ * every consumer names it.
  */
 
 import type { CSSProperties } from "react";
@@ -33,6 +39,22 @@ export const CAMERA_ACCENT = "#cf4370";
  * over video, so the status dot takes this instead while the assistant speaks.
  */
 export const CAMERA_ACCENT_SOFT = "#ffd9e4";
+
+/**
+ * The crimson at the weight a whole surface can be filled with: the capture
+ * accent at 90%, so a status mark painted in it still lets a little of the
+ * frame through and reads as chrome over video rather than a sticker on it.
+ * Published as `--camera-accent-fill`.
+ */
+export const CAMERA_ACCENT_FILL = "rgba(207,67,112,.9)";
+
+/**
+ * The ink a glyph takes on a fill bright enough to lose a white one: the mic
+ * while the session is live, and the flash while it is armed. Near-black rather
+ * than pure, matching the weight the rest of the room's dark text carries.
+ * Published as `--camera-ink`.
+ */
+export const CAMERA_INK = "#1a1a1a";
 
 /**
  * The warm brown the camera's own controls are filled with: flip beside the
@@ -71,6 +93,41 @@ export const CAMERA_SCRIM_BOTTOM =
   "linear-gradient(transparent, rgba(0,0,0,.46))";
 
 /**
+ * The status pill's glass: the design's own fill and hairline, under the blur
+ * that keeps it honest over a bright frame. Its own values rather than the
+ * over-media glass below, because the pill is a readout rather than a target
+ * and sits lighter than the controls it shares a screen with.
+ */
+export const CAMERA_PILL_GLASS_CLASS =
+  "border-[0.5px] border-[rgba(255,255,255,0.18)] bg-[rgba(0,0,0,0.34)] text-[rgba(255,255,255,0.88)] backdrop-blur-[8px]";
+
+/**
+ * The same pill while the camera is streaming rather than sampling: filled with
+ * the capture accent, so "this is going out live" is legible as a change in
+ * color from across the screen. The border firms up and the text goes to pure
+ * white, since a crimson fill takes more contrast than the glass does.
+ */
+export const CAMERA_PILL_LIVE_CLASS =
+  "border-[0.5px] border-[rgba(255,255,255,0.25)] bg-[var(--camera-accent-fill)] text-white backdrop-blur-[8px]";
+
+/**
+ * The flash control at rest, which the design draws heavier than the pill and
+ * behind a firmer hairline: it is a target rather than a readout, and it has to
+ * hold an edge beside the near-white it cycles into.
+ */
+export const CAMERA_FLASH_GLASS_CLASS =
+  "border-white/20 bg-black/42 text-white backdrop-blur-sm";
+
+/**
+ * The scrim any mark sitting directly on live video takes: the room's corner
+ * chrome once the viewfinder is up, the deep-link overlay's controls, and the
+ * camera's own failure message. The blur is what keeps it readable over a busy
+ * frame without pushing the fill toward opaque.
+ */
+export const CAMERA_MEDIA_GLASS_CLASS =
+  "bg-black/45 text-white backdrop-blur-sm";
+
+/**
  * The `--camera-*` vars as an inline style, for the element that owns a piece
  * of camera chrome. Mirrors the `voiceSurfaceStyle` pattern next door.
  */
@@ -78,6 +135,8 @@ export function cameraModeStyle(): CSSProperties {
   return {
     "--camera-accent": CAMERA_ACCENT,
     "--camera-accent-soft": CAMERA_ACCENT_SOFT,
+    "--camera-accent-fill": CAMERA_ACCENT_FILL,
+    "--camera-ink": CAMERA_INK,
     "--camera-warm": CAMERA_WARM,
     "--camera-warm-strong": CAMERA_WARM_STRONG,
     "--camera-destructive": CAMERA_DESTRUCTIVE,

--- a/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.stories.tsx
@@ -12,6 +12,10 @@
  * session's whole surface label (`liveVoiceSurfaceLabelKey`), and Connecting,
  * Reconnecting, Thinking and Ending are states a user can sit in while a fixed
  * "Listening" would be telling them the mic is open.
+ *
+ * Both modes are here even though the app only ever opens the photo one: Live
+ * is the design's second treatment, and a variant with no story is a treatment
+ * nobody can look at.
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
@@ -41,11 +45,18 @@ const meta: Meta<typeof CameraStatusPill> = {
     }),
   ],
   args: {
+    mode: "photo",
     voiceState: "idle",
     statusLabel: "Listening…",
     assistantName: "Luna",
   },
   argTypes: {
+    mode: {
+      options: ["photo", "live"],
+      control: { type: "inline-radio" },
+      description:
+        "What the camera is doing. Photo is glass; Live fills with the capture accent.",
+    },
     voiceState: {
       options: ["idle", "user", "assistant"],
       control: { type: "inline-radio" },
@@ -129,9 +140,18 @@ export const LongAssistantName: Story = {
   },
 };
 
-/** Every combination the pill can be in, stacked. */
+/**
+ * Streaming rather than sampling. Filled with the capture accent, because "this
+ * is going out continuously" is the one thing about the surface that has to be
+ * legible without reading. Not reachable from the app yet: the room opens the
+ * photo mode only.
+ */
+export const Live: Story = { args: { mode: "live" } };
+
+/** Every combination the pill can be in, stacked, in both modes. */
 export const StateMatrix: Story = {
   argTypes: {
+    mode: { table: { disable: true } },
     voiceState: { table: { disable: true } },
     statusLabel: { table: { disable: true } },
   },
@@ -148,6 +168,27 @@ export const StateMatrix: Story = {
       />
       <CameraStatusPill {...args} voiceState="idle" statusLabel="Muted" />
       <CameraStatusPill {...args} voiceState="idle" statusLabel="Ending…" />
+      {/* The live fill against the same frame, at the three states the mode is
+          worth comparing in: nobody talking, the user talking, and the
+          assistant answering. */}
+      <CameraStatusPill
+        {...args}
+        mode="live"
+        voiceState="idle"
+        statusLabel="Listening…"
+      />
+      <CameraStatusPill
+        {...args}
+        mode="live"
+        voiceState="user"
+        statusLabel="Listening…"
+      />
+      <CameraStatusPill
+        {...args}
+        mode="live"
+        voiceState="assistant"
+        statusLabel="Speaking…"
+      />
     </>
   ),
 };

--- a/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.test.tsx
@@ -1,13 +1,16 @@
 /**
  * Tests for `CameraStatusPill`, the readout at the top of the room while the
- * camera is open.
+ * camera is open, and for `useCameraStatusAnnouncement`, the sentence the room
+ * speaks in its place.
  *
  * Load-bearing contracts: the dot's three voice states (which one blinks, and
  * that the assistant's takes the rose accent rather than white); that the word
  * is the session's own surface label for every phase, with the assistant's name
- * the only substitution; and the announcement, which is a written sentence
- * rather than the visible fragments, so a screen reader hears "Photo. Luna
- * speaking" instead of the pill's separator dot.
+ * the only substitution; that the pill announces nothing itself, since a live
+ * region arriving with its words already in it is announced by nothing
+ * reliable; and the composed sentence, which is written prose rather than the
+ * visible fragments, so a screen reader hears "Photo. Luna speaking" instead of
+ * the pill's separator dot.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -15,7 +18,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
 
 import { liveVoiceSurfaceLabel } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { CameraStatusPill } from "@/domains/chat/voice/voice-room/camera-status-pill";
+import {
+  CameraStatusPill,
+  useCameraStatusAnnouncement,
+  type CameraStatusAnnouncement,
+} from "@/domains/chat/voice/voice-room/camera-status-pill";
 
 afterEach(() => {
   cleanup();
@@ -23,8 +30,21 @@ afterEach(() => {
 
 const pill = () => screen.getByTestId("camera-status-pill");
 const dot = () => screen.getByTestId("camera-status-dot");
-/** What a screen reader is handed: the sr-only sentence, not the fragments. */
-const announcement = () => pill().querySelector(".sr-only")?.textContent ?? "";
+
+/** The room's side of the split: the sentence, with no pill around it. */
+function Announcer({ status }: { status: CameraStatusAnnouncement | null }) {
+  return (
+    <span data-testid="announcement">
+      {useCameraStatusAnnouncement(status)}
+    </span>
+  );
+}
+
+function announce(status: CameraStatusAnnouncement | null): string {
+  cleanup();
+  render(<Announcer status={status} />);
+  return screen.getByTestId("announcement").textContent ?? "";
+}
 
 describe("CameraStatusPill", () => {
   test("idle holds the dot still and repeats the session's own word", () => {
@@ -39,7 +59,6 @@ describe("CameraStatusPill", () => {
     expect(dot().className).toContain("bg-white/50");
     expect(dot().className).not.toContain("camera-status-blink");
     expect(pill().textContent).toContain("Listening…");
-    expect(announcement()).toBe("Photo. Listening…");
   });
 
   test("a talking user blinks a white dot beside the same word", () => {
@@ -53,9 +72,6 @@ describe("CameraStatusPill", () => {
 
     expect(dot().className).toContain("bg-white");
     expect(dot().className).toContain("camera-status-blink");
-    // The word answers "can she hear me", which is unchanged by the user
-    // talking; the dot is what says a voice is live.
-    expect(announcement()).toBe("Photo. Listening…");
   });
 
   test("the assistant takes the rose accent and its own name", () => {
@@ -73,7 +89,6 @@ describe("CameraStatusPill", () => {
     // The name is the whole substitution: it says what "Speaking…" would, plus
     // whose voice it is.
     expect(pill().textContent).not.toContain("Speaking…");
-    expect(announcement()).toBe("Photo. Luna speaking");
   });
 
   test("an unresolved assistant falls back rather than naming nobody", () => {
@@ -88,7 +103,6 @@ describe("CameraStatusPill", () => {
     // Translated copy, not the English fallback in `assistantDisplayName`: the
     // name lands inside a sentence this catalog owns.
     expect(pill().textContent).toContain("Your assistant");
-    expect(announcement()).toBe("Photo. Your assistant speaking");
   });
 
   test("a blank name falls back the same way a missing one does", () => {
@@ -103,65 +117,6 @@ describe("CameraStatusPill", () => {
     expect(pill().textContent).toContain("Your assistant");
   });
 
-  test("a muted mic reaches the announcement in a phase that never says so", () => {
-    render(
-      <CameraStatusPill
-        voiceState="idle"
-        statusLabel="Thinking…"
-        assistantName="Luna"
-        muted
-      />,
-    );
-
-    // The session does not relabel its own phases for mute, and the pill is the
-    // only announcer while the viewfinder is up, so "Thinking…" alone would
-    // leave a screen-reader user unaware the mic is off.
-    expect(announcement()).toBe("Photo. Muted. Thinking…");
-    // The design's row carries the status word only.
-    expect(screen.getByTestId("camera-status-word").textContent).toBe(
-      "Thinking…",
-    );
-  });
-
-  test("a muted mic reaches the announcement while the assistant talks", () => {
-    render(
-      <CameraStatusPill
-        voiceState="assistant"
-        statusLabel="Speaking…"
-        assistantName="Luna"
-        muted
-      />,
-    );
-
-    expect(announcement()).toBe("Photo. Muted. Luna speaking");
-  });
-
-  test("does not say muted twice when the word already says it", () => {
-    render(
-      <CameraStatusPill
-        voiceState="idle"
-        statusLabel="Muted"
-        assistantName="Luna"
-        muted
-      />,
-    );
-
-    expect(announcement()).toBe("Photo. Muted");
-  });
-
-  test("an unmuted phase announces exactly what it did", () => {
-    render(
-      <CameraStatusPill
-        voiceState="idle"
-        statusLabel="Thinking…"
-        assistantName="Luna"
-        muted={false}
-      />,
-    );
-
-    expect(announcement()).toBe("Photo. Thinking…");
-  });
-
   test("a muted mic replaces the listening word, in both channels", () => {
     render(
       <CameraStatusPill
@@ -173,7 +128,6 @@ describe("CameraStatusPill", () => {
 
     expect(pill().textContent).toContain("Muted");
     expect(pill().textContent).not.toContain("Listening");
-    expect(announcement()).toBe("Photo. Muted");
   });
 
   test("a connecting session says so instead of claiming to listen", () => {
@@ -188,7 +142,6 @@ describe("CameraStatusPill", () => {
     expect(pill().textContent).toContain("Connecting…");
     expect(pill().textContent).not.toContain("Listening");
     expect(dot().className).not.toContain("camera-status-blink");
-    expect(announcement()).toBe("Photo. Connecting…");
   });
 
   test("a thinking session says so instead of claiming to listen", () => {
@@ -202,7 +155,6 @@ describe("CameraStatusPill", () => {
 
     expect(pill().textContent).toContain("Thinking…");
     expect(pill().textContent).not.toContain("Listening");
-    expect(announcement()).toBe("Photo. Thinking…");
   });
 
   test("an ending session says so instead of claiming to listen", () => {
@@ -215,7 +167,6 @@ describe("CameraStatusPill", () => {
     );
 
     expect(pill().textContent).toContain("Ending…");
-    expect(announcement()).toBe("Photo. Ending…");
   });
 
   test("the words are the session's surface label, not a second copy of it", () => {
@@ -243,12 +194,11 @@ describe("CameraStatusPill", () => {
       />,
     );
 
-    expect(pill().textContent).toBe("PhotoPhoto");
+    expect(pill().textContent).toBe("Photo");
     expect(pill().textContent).not.toContain("·");
-    expect(announcement()).toBe("Photo");
   });
 
-  test("announces as a polite status, with the visible fragments hidden", () => {
+  test("announces nothing itself, and hides its fragments", () => {
     render(
       <CameraStatusPill
         voiceState="idle"
@@ -257,8 +207,12 @@ describe("CameraStatusPill", () => {
       />,
     );
 
-    expect(pill().getAttribute("role")).toBe("status");
-    expect(pill().getAttribute("aria-live")).toBe("polite");
+    // A live region mounting with its first sentence already inside it is
+    // announced unreliably, so the room owns the one that is always there and
+    // this stays a drawing.
+    expect(pill().getAttribute("role")).toBeNull();
+    expect(pill().getAttribute("aria-live")).toBeNull();
+    expect(pill().querySelector(".sr-only")).toBeNull();
     // Reading the row itself would announce the separator and drop the verb.
     const row = pill().querySelector("[aria-hidden]");
     expect(row).not.toBeNull();
@@ -303,7 +257,194 @@ describe("CameraStatusPill", () => {
     expect(pill().querySelector("[aria-hidden]")?.className).toContain(
       "min-w-0",
     );
-    // Clipping is CSS, so the name stays whole in the announcement.
-    expect(announcement()).toBe(`Photo. ${long} speaking`);
+  });
+
+  test("photo is the mode it wears when the room names none", () => {
+    render(
+      <CameraStatusPill
+        voiceState="idle"
+        statusLabel="Listening…"
+        assistantName="Luna"
+      />,
+    );
+
+    expect(pill().dataset.cameraMode).toBe("photo");
+    // Glass, so the frame reads through a mark that is only sampling it.
+    expect(pill().className).toContain("bg-[rgba(0,0,0,0.34)]");
+    expect(pill().className).toContain("backdrop-blur-[8px]");
+  });
+
+  test("live fills with the capture accent and says so", () => {
+    render(
+      <CameraStatusPill
+        mode="live"
+        voiceState="idle"
+        statusLabel="Listening…"
+        assistantName="Luna"
+      />,
+    );
+
+    expect(pill().dataset.cameraMode).toBe("live");
+    expect(pill().textContent).toContain("Live");
+    expect(pill().textContent).not.toContain("Photo");
+    // Filled rather than glass: "this is going out continuously" has to be
+    // legible without reading.
+    expect(pill().className).toContain("bg-[var(--camera-accent-fill)]");
+    expect(pill().className).toContain("border-[rgba(255,255,255,0.25)]");
+    expect(pill().className).toContain("text-white");
+    // The accent the fill names is published by the pill itself, so a renamed
+    // constant surfaces here rather than as a transparent chip.
+    expect(pill().getAttribute("style")).toContain("--camera-accent-fill");
+  });
+});
+
+describe("useCameraStatusAnnouncement", () => {
+  test("says nothing at all while the camera is closed", () => {
+    // The empty string rather than an unmounted region: assistive tech
+    // announces a change made inside a region it was already watching.
+    expect(announce(null)).toBe("");
+  });
+
+  test("leads with the mode and closes with the session's own word", () => {
+    expect(
+      announce({
+        voiceState: "idle",
+        statusLabel: "Listening…",
+        assistantName: "Luna",
+      }),
+    ).toBe("Photo. Listening…");
+  });
+
+  test("a talking user changes the dot, not the sentence", () => {
+    // The word answers "can she hear me", which is unchanged by the user
+    // talking; the dot is what says a voice is live.
+    expect(
+      announce({
+        voiceState: "user",
+        statusLabel: "Listening…",
+        assistantName: "Luna",
+      }),
+    ).toBe("Photo. Listening…");
+  });
+
+  test("names the assistant while it is the one talking", () => {
+    expect(
+      announce({
+        voiceState: "assistant",
+        statusLabel: "Speaking…",
+        assistantName: "Luna",
+      }),
+    ).toBe("Photo. Luna speaking");
+  });
+
+  test("an unresolved assistant falls back rather than naming nobody", () => {
+    expect(
+      announce({
+        voiceState: "assistant",
+        statusLabel: "Speaking…",
+        assistantName: null,
+      }),
+    ).toBe("Photo. Your assistant speaking");
+  });
+
+  test("a muted mic reaches the sentence in a phase that never says so", () => {
+    // The session does not relabel its own phases for mute, and this is the
+    // room's only announcement while the viewfinder is up, so "Thinking…"
+    // alone would leave a screen-reader user unaware the mic is off.
+    expect(
+      announce({
+        voiceState: "idle",
+        statusLabel: "Thinking…",
+        assistantName: "Luna",
+        muted: true,
+      }),
+    ).toBe("Photo. Muted. Thinking…");
+  });
+
+  test("a muted mic reaches the sentence while the assistant talks", () => {
+    expect(
+      announce({
+        voiceState: "assistant",
+        statusLabel: "Speaking…",
+        assistantName: "Luna",
+        muted: true,
+      }),
+    ).toBe("Photo. Muted. Luna speaking");
+  });
+
+  test("does not say muted twice when the word already says it", () => {
+    expect(
+      announce({
+        voiceState: "idle",
+        statusLabel: "Muted",
+        assistantName: "Luna",
+        muted: true,
+      }),
+    ).toBe("Photo. Muted");
+  });
+
+  test("an unmuted phase announces exactly what it did", () => {
+    expect(
+      announce({
+        voiceState: "idle",
+        statusLabel: "Thinking…",
+        assistantName: "Luna",
+        muted: false,
+      }),
+    ).toBe("Photo. Thinking…");
+  });
+
+  test("a muted mic with no phase word left still says the mic is off", () => {
+    expect(
+      announce({
+        voiceState: "idle",
+        statusLabel: "",
+        assistantName: "Luna",
+        muted: true,
+      }),
+    ).toBe("Photo. Muted");
+  });
+
+  test("a phase with no label leaves the mode word standing alone", () => {
+    expect(
+      announce({
+        voiceState: "idle",
+        statusLabel: "",
+        assistantName: "Luna",
+      }),
+    ).toBe("Photo");
+  });
+
+  test("a long name stays whole, since a screen reader has no width", () => {
+    const long =
+      "Marguerite Vandersteen of the Northern Reaches, Third of Her Name";
+
+    expect(
+      announce({
+        voiceState: "assistant",
+        statusLabel: "Speaking…",
+        assistantName: long,
+      }),
+    ).toBe(`Photo. ${long} speaking`);
+  });
+
+  test("the live mode opens the same sentence with its own word", () => {
+    expect(
+      announce({
+        mode: "live",
+        voiceState: "idle",
+        statusLabel: "Listening…",
+        assistantName: "Luna",
+      }),
+    ).toBe("Live. Listening…");
+    expect(
+      announce({
+        mode: "live",
+        voiceState: "assistant",
+        statusLabel: "Speaking…",
+        assistantName: "Luna",
+        muted: true,
+      }),
+    ).toBe("Live. Muted. Luna speaking");
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.tsx
@@ -18,13 +18,17 @@
  * while it is audibly talking: it says everything "Speaking…" would, plus
  * whose voice it is.
  *
- * Photo is the only mode it renders, and it answers no press, so it is a status
- * region rather than a button.
+ * Two modes, told apart by fill as well as by word. Photo is glass, so the
+ * frame reads through the mark that is only sampling it; Live is filled with
+ * the capture accent, because "this is going out continuously" is the one thing
+ * about the surface that has to be legible without reading.
  *
- * The announcement carries one thing the visible row does not: a muted mic, in
- * every phase rather than only the one the session relabels for it. The pill is
- * the room's sole announcer while the viewfinder is up, so a phase word on its
- * own would leave a screen-reader user unaware the mic is off.
+ * It answers no press, so it is a plain region rather than a button, and it
+ * announces nothing: a live region that mounts with its first sentence already
+ * inside it is announced unreliably, since assistive tech watches an existing
+ * region for changes rather than a new one for arrival. The room owns one
+ * always-mounted region and fills it from {@link useCameraStatusAnnouncement},
+ * which is the same sentence this pill would have spoken.
  *
  * A configured assistant name is arbitrarily long, so the name is the one part
  * that gives way: it truncates to an ellipsis inside whatever width the room
@@ -41,10 +45,42 @@ import { useReducedMotion } from "motion/react";
 
 import { useTranslation } from "@/i18n";
 
-import { cameraModeStyle } from "./camera-mode-paint";
+import {
+  CAMERA_PILL_GLASS_CLASS,
+  CAMERA_PILL_LIVE_CLASS,
+  cameraModeStyle,
+} from "./camera-mode-paint";
 import type { CameraVoiceState } from "./use-camera-voice-state";
 
+/**
+ * What the camera is doing: sampling single frames, or streaming. Only `photo`
+ * is reachable from the app today; `live` is the mode the design ships the pill
+ * for, and the variant exists so the treatment lands with the surface rather
+ * than after it.
+ */
+export type CameraMode = "photo" | "live";
+
+/** The mode's own word, which leads the pill and the announcement alike. */
+const MODE_WORD_KEYS = {
+  photo: "cameraStatusPill.photo",
+  live: "cameraStatusPill.live",
+} as const;
+
+/** The sentence the mode's word opens, with the session's state inside it. */
+const MODE_ANNOUNCE_KEYS = {
+  photo: "cameraStatusPill.announcePhoto",
+  live: "cameraStatusPill.announceLive",
+} as const;
+
+/** The pill's fill per mode. See `camera-mode-paint.ts` for the values. */
+const MODE_CONTAINER_CLASSES = {
+  photo: CAMERA_PILL_GLASS_CLASS,
+  live: CAMERA_PILL_LIVE_CLASS,
+} as const;
+
 export interface CameraStatusPillProps {
+  /** What the camera is doing. Defaults to `photo`. */
+  mode?: CameraMode;
   /** Whose voice is active. See `use-camera-voice-state.ts`. */
   voiceState: CameraVoiceState;
   /**
@@ -59,57 +95,87 @@ export interface CameraStatusPillProps {
   statusLabel: string;
   /** The session assistant's name, spoken when it is the one talking. */
   assistantName?: string | null;
-  /**
-   * Whether the mic is muted. Read by the announcement alone: the visible row
-   * carries whatever word the session's own label gives it, so nothing here
-   * takes a second decision about mute that could drift from that one.
-   */
+}
+
+/**
+ * Everything the spoken sentence needs, which is the pill's own props plus the
+ * mic. Mute is announced and not drawn: the visible row carries whatever word
+ * the session's label gives it, so nothing takes a second decision about mute
+ * that could drift from that one.
+ */
+export interface CameraStatusAnnouncement extends CameraStatusPillProps {
+  /** Whether the mic is muted. */
   muted?: boolean;
 }
 
+/** The name the pill speaks, with a fallback rather than naming nobody. */
+function useAssistantWord(assistantName: string | null | undefined): string {
+  const { t } = useTranslation("chat");
+  return assistantName?.trim() || t("cameraStatusPill.yourAssistant");
+}
+
+/**
+ * The one sentence camera mode says, for the room's always-mounted live region.
+ * `null` while the camera is closed, where the room's own state announcer takes
+ * the session back and this returns the empty string rather than unmounting a
+ * region assistive tech is watching.
+ *
+ * Composed rather than looked up in a key grid: the mode's word opens the
+ * sentence, the session's state closes it, and mute wraps the state with the
+ * room's own `voiceRoom.mutedState` pattern. A grid would need a key per mode
+ * per mute per speaker, and every mode added would double it.
+ *
+ * The mute wrap is what the visible row does not carry. The session relabels
+ * only `listening` for a muted mic, so "Thinking…" on its own tells a
+ * screen-reader user the assistant is working without telling them it cannot
+ * hear them. The one phase the session does relabel is skipped, since wrapping
+ * that reads "Muted. Muted".
+ */
+export function useCameraStatusAnnouncement(
+  status: CameraStatusAnnouncement | null,
+): string {
+  const { t } = useTranslation("chat");
+  const name = useAssistantWord(status?.assistantName);
+
+  if (!status) {
+    return "";
+  }
+
+  const { mode = "photo", voiceState, statusLabel, muted } = status;
+  const mutedWord = t("liveVoiceStatus.muted");
+  const spoken =
+    voiceState === "assistant"
+      ? t("cameraStatusPill.speakingState", { name })
+      : statusLabel || (muted ? mutedWord : "");
+
+  if (!spoken) {
+    return t(MODE_WORD_KEYS[mode]);
+  }
+
+  const state =
+    muted && spoken !== mutedWord
+      ? t("voiceRoom.mutedState", { state: spoken })
+      : spoken;
+  return t(MODE_ANNOUNCE_KEYS[mode], { status: state });
+}
+
 export function CameraStatusPill({
+  mode = "photo",
   voiceState,
   statusLabel,
   assistantName,
-  muted,
 }: CameraStatusPillProps) {
   const { t } = useTranslation("chat");
   const reduce = useReducedMotion();
 
-  const name = assistantName?.trim() || t("cameraStatusPill.yourAssistant");
+  const name = useAssistantWord(assistantName);
   const speaking = voiceState === "assistant";
   const voiceWord = speaking ? name : statusLabel;
 
-  // The pill is the only announcer while the viewfinder is up, so a muted mic
-  // has to reach the announcement in the phases the session does not relabel
-  // for it: "Thinking…" alone tells a screen-reader user the assistant is
-  // working without telling them it cannot hear them. `listening` is the one
-  // phase the session does relabel, and prefixing that reads "Muted. Muted".
-  const mutedWord = t("liveVoiceStatus.muted");
-  const announcedWord = voiceWord || (muted ? mutedWord : "");
-  const prefixMuted = Boolean(muted) && announcedWord !== mutedWord;
-
-  const announcement = speaking
-    ? t(
-        prefixMuted
-          ? "cameraStatusPill.announcePhotoMutedSpeaking"
-          : "cameraStatusPill.announcePhotoSpeaking",
-        { name },
-      )
-    : announcedWord
-      ? t(
-          prefixMuted
-            ? "cameraStatusPill.announcePhotoMutedStatus"
-            : "cameraStatusPill.announcePhotoStatus",
-          { status: announcedWord },
-        )
-      : t("cameraStatusPill.photo");
-
   return (
     <div
-      role="status"
-      aria-live="polite"
       data-testid="camera-status-pill"
+      data-camera-mode={mode}
       style={cameraModeStyle()}
       className={cn(
         // A floor width, so the word swapping between the session's phases and
@@ -118,21 +184,19 @@ export function CameraStatusPill({
         // it knows what corner chrome the pill has to keep clear of.
         "inline-flex min-w-[9rem] max-w-full items-center justify-center",
         "rounded-full",
-        "border-[0.5px] border-[rgba(255,255,255,0.18)] bg-[rgba(0,0,0,0.34)]",
+        "px-3 py-[5px]",
+        "text-label-medium-default",
         // Blur rather than a heavier fill: the frame behind can be any
         // brightness, and an opaque chip over a viewfinder reads as a hole.
-        "px-3 py-[5px] backdrop-blur-[8px]",
-        "text-label-medium-default text-[rgba(255,255,255,0.88)]",
+        MODE_CONTAINER_CLASSES[mode],
         // The token's 11px at the design's 600. Rebinding the weight var beats
         // a `font-semibold` beside it: both set `font-weight`, and which one
         // wins is Tailwind's utility ordering rather than the order written.
         "[--text-label-medium-default-weight:600]",
       )}
     >
-      {/* The visible row is a set of fragments, so it is hidden from assistive
-          tech and this sentence is announced in its place. */}
-      <span className="sr-only">{announcement}</span>
-
+      {/* A set of fragments rather than a sentence, so it is hidden from
+          assistive tech; the room's live region speaks the sentence. */}
       <span
         aria-hidden
         className="inline-flex min-w-0 items-center gap-[7px] whitespace-nowrap"
@@ -150,7 +214,7 @@ export function CameraStatusPill({
             voiceState !== "idle" && !reduce && "camera-status-blink",
           )}
         />
-        <span className="flex-none">{t("cameraStatusPill.photo")}</span>
+        <span className="flex-none">{t(MODE_WORD_KEYS[mode])}</span>
         {voiceWord ? (
           <>
             <span className="flex-none opacity-45">·</span>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
@@ -24,7 +24,7 @@
 import { Tooltip, cn } from "@vellumai/design-library";
 import type { ReactNode } from "react";
 
-import { cameraModeStyle } from "./camera-mode-paint";
+import { CAMERA_MEDIA_GLASS_CLASS, cameraModeStyle } from "./camera-mode-paint";
 
 /**
  * The treatment for a control sitting over video: the deep-link capture
@@ -38,11 +38,14 @@ import { cameraModeStyle } from "./camera-mode-paint";
  *
  * Fixed colors rather than tone-derived ones, deliberately. What sits behind
  * these is arbitrary camera video, not a color the room picked, so there is
- * nothing to derive from. The blur is what keeps the scrim honest over a busy
- * frame without having to push the fill toward opaque.
+ * nothing to derive from. The scrim itself is `camera-mode-paint.ts`'s, shared
+ * with the camera's failure message; only the hairline and the hover belong to
+ * a control.
  */
-const OVER_MEDIA_NEUTRAL_CLASS =
-  "border-white/25 bg-black/45 text-white backdrop-blur-sm hover:bg-black/60 hover:text-white focus-visible:outline-white";
+const OVER_MEDIA_NEUTRAL_CLASS = cn(
+  CAMERA_MEDIA_GLASS_CLASS,
+  "border-white/25 hover:bg-black/60 hover:text-white focus-visible:outline-white",
+);
 
 /**
  * Camera mode's palette for the room's own row: every control filled, and told
@@ -59,7 +62,7 @@ const OVER_MEDIA_NEUTRAL_CLASS =
  * would be a color no table names.
  */
 const CAMERA_LIVE_CLASS =
-  "border-transparent bg-white text-neutral-900 hover:opacity-90 focus-visible:outline-white";
+  "border-transparent bg-white text-[var(--camera-ink)] hover:opacity-90 focus-visible:outline-white";
 const CAMERA_NEUTRAL_CLASS =
   "border-transparent bg-[var(--camera-warm)] text-white hover:opacity-90 focus-visible:outline-white";
 const CAMERA_ENGAGED_CLASS =

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-layout.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-layout.ts
@@ -12,13 +12,14 @@
  *
  * Zones are inset past the room's corner controls — the gear/✕ cluster above,
  * the mute/stop cluster below — so text never collides with them. The `rem`
- * floor in each anchor is what guarantees that clearance (the controls are a
- * fixed 3.25rem tall at a 1.25rem inset); the percentage takes over on taller
- * viewports, where hugging a fixed offset off the edge would strand the text
- * far below the eyes. Both are safe-area aware per docs/CAPACITOR.md — the
- * `var()` is set by `capacitor-plugin-safe-area` on Capacitor iOS, `env()`
- * covers standard browsers with `viewport-fit=cover`, and `0px` covers desktop
- * / non-notch devices.
+ * floor in each anchor is what guarantees that clearance: the controls are a
+ * fixed 3.25rem tall at a 1.25rem inset, which reaches 4.5rem, so the floor
+ * sits a quarter of a rem past that rather than tangent to it. The percentage
+ * takes over on taller viewports, where hugging a fixed offset off the edge
+ * would strand the text far below the eyes. Both are safe-area aware per
+ * docs/CAPACITOR.md: the `var()` is set by `capacitor-plugin-safe-area` on
+ * Capacitor iOS, `env()` covers standard browsers with `viewport-fit=cover`,
+ * and `0px` covers desktop / non-notch devices.
  *
  * Percentages (not `vh`) resolve against the room box, so the zones size
  * correctly both in the app — where the room is a `fixed inset-0` overlay — and
@@ -35,7 +36,7 @@ export const SAFE_AREA_RIGHT =
   "var(--safe-area-inset-right, env(safe-area-inset-right, 0px))";
 
 /** Top edge of the upper (user) zone — clears the top-right gear/✕ cluster. */
-export const VOICE_ROOM_UPPER_ZONE_TOP = `calc(max(4.5rem, 11%) + ${SAFE_AREA_TOP})`;
+export const VOICE_ROOM_UPPER_ZONE_TOP = `calc(max(4.75rem, 11%) + ${SAFE_AREA_TOP})`;
 /** Height of the upper zone. Content is bottom-anchored inside it, so a longer
  *  utterance grows upward and its oldest lines dissolve into the fade. */
 export const VOICE_ROOM_UPPER_ZONE_HEIGHT = "18%";
@@ -46,7 +47,7 @@ export const VOICE_ROOM_UPPER_ZONE_HEIGHT = "18%";
  * baseline, so turning live captions on replaces the status word roughly in
  * place rather than moving the room's text to a different region.
  */
-export const VOICE_ROOM_LOWER_ZONE_BOTTOM = `calc(max(4.5rem, 14%) + ${SAFE_AREA_BOTTOM})`;
+export const VOICE_ROOM_LOWER_ZONE_BOTTOM = `calc(max(4.75rem, 14%) + ${SAFE_AREA_BOTTOM})`;
 /** Ceiling on the lower zone. Content is bottom-anchored, so a long response
  *  keeps its newest words on the baseline and fades out the top. */
 export const VOICE_ROOM_LOWER_ZONE_MAX_HEIGHT = "28%";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -1755,7 +1755,7 @@ describe("VoiceRoom: camera", () => {
     expect(screen.queryByTestId("voice-room-scrim-bottom")).toBeNull();
   });
 
-  test("the pill is the only announcer of voice state while the camera is open", async () => {
+  test("one region announces the voice state, camera open or closed", async () => {
     stubMediaDevices(async () => fakeStream());
     seedCameraCapableAssistant();
     startOwnedSession("listening");
@@ -1770,15 +1770,16 @@ describe("VoiceRoom: camera", () => {
       fireEvent.click(cameraToggle()!);
     });
 
-    // Open: the pill says it with the mode attached, and the old region stands
-    // down, so a screen reader hears the state once rather than twice.
-    expect(announcer().textContent).toBe("");
-    expect(screen.getByTestId("camera-status-pill").textContent).toContain(
-      "Photo. Listening…",
-    );
+    // Open: the same region takes the mode word, rather than a second region
+    // arriving with its words already in it, which assistive tech would not
+    // reliably announce. The pill draws the state and says nothing.
+    expect(announcer().textContent).toBe("Photo. Listening…");
+    const pill = screen.getByTestId("camera-status-pill");
+    expect(pill.getAttribute("aria-live")).toBeNull();
+    expect(pill.querySelector(".sr-only")).toBeNull();
   });
 
-  test("the pill keeps the muted prefix the standing-down region carried", async () => {
+  test("the announcement keeps the muted prefix once the camera is open", async () => {
     stubMediaDevices(async () => fakeStream());
     seedCameraCapableAssistant();
     startOwnedSession("listening");
@@ -1796,12 +1797,10 @@ describe("VoiceRoom: camera", () => {
       fireEvent.click(cameraToggle()!);
     });
 
-    // Open: the region stands down, so the pill has to carry the mic's state or
-    // it is lost for the rest of the phase.
-    expect(announcer().textContent).toBe("");
-    expect(screen.getByTestId("camera-status-pill").textContent).toContain(
-      "Photo. Muted. Thinking…",
-    );
+    // Open: the mode leads and the prefix survives, since the visible row
+    // carries only the phase word and the mic's state would otherwise be lost
+    // for the rest of it.
+    expect(announcer().textContent).toBe("Photo. Muted. Thinking…");
   });
 
   test("the pill carries the session's own label, not a fixed listening word", async () => {
@@ -1858,7 +1857,7 @@ describe("VoiceRoom: camera", () => {
     // neighbours, where the answer would be an absence of red.
     const mic = micButton()!;
     expect(mic.className).toContain("bg-white");
-    expect(mic.className).toContain("text-neutral-900");
+    expect(mic.className).toContain("text-[var(--camera-ink)]");
 
     // The camera's own controls take the warm fill: a third hue, because the
     // row already spends white on "the session is live" and red on "this

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -135,7 +135,6 @@ import {
   endLiveVoiceSession,
   getLiveVoiceInputAmplitude,
   getLiveVoiceOutputAmplitude,
-  liveVoiceSurfaceLabel,
   liveVoiceSurfaceLabelKey,
   minimizeVoiceRoom,
   setLiveVoiceMuted,
@@ -154,8 +153,15 @@ import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
 import { toneForBg } from "@/utils/avatar-tone";
 
 import { CameraFlashControl, nextFlashMode } from "./camera-flash-control";
-import { CAMERA_SCRIM_BOTTOM, CAMERA_SCRIM_TOP } from "./camera-mode-paint";
-import { CameraStatusPill } from "./camera-status-pill";
+import {
+  CAMERA_MEDIA_GLASS_CLASS,
+  CAMERA_SCRIM_BOTTOM,
+  CAMERA_SCRIM_TOP,
+} from "./camera-mode-paint";
+import {
+  CameraStatusPill,
+  useCameraStatusAnnouncement,
+} from "./camera-status-pill";
 import { useActiveConnectSurface } from "./use-active-connect-surface";
 import { useCameraVoiceState } from "./use-camera-voice-state";
 import { useChatHeaderBottom } from "./use-chat-header-bottom";
@@ -496,12 +502,18 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // muted `listening` reads as "Muted", so they are not told it is hearing them
   // while the mic is off. Shared with the iOS Live Activity mirror and the
   // macOS companion, which show this exact string.
-  const stateLabel = liveVoiceSurfaceLabel(
+  //
+  // Taken as a catalog key and resolved here, once, for every surface in the
+  // room that shows it: the connect caption, the state announcer, and the
+  // camera's status pill. Deriving it twice (a key for one, English for the
+  // other) is what lets the two drift.
+  const stateLabelKey = liveVoiceSurfaceLabelKey(
     state,
     reconnecting,
     assistantAudioActive,
     muted,
   );
+  const stateLabel = stateLabelKey ? t(stateLabelKey) : "";
 
   // The state caption (e.g. "Listening…") shows only while the assistant
   // transcript is hidden. Nothing in the room toggles that any more: the
@@ -552,17 +564,24 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
     assistantAudioActive,
     cameraOpen,
   );
-  // The same decision as `stateLabel`, taken as a catalog key so the pill's
-  // word reaches a Spanish or Russian reader in their own language.
-  const cameraStatusKey = liveVoiceSurfaceLabelKey(
-    state,
-    reconnecting,
-    assistantAudioActive,
-    muted,
-  );
   const assistantName = useResolvedAssistantsStore.use
     .assistants()
     .find((a) => a.id === assistantId)?.name;
+  // The one sentence camera mode says. Composed here rather than inside the
+  // pill so the room's own always-mounted region speaks it: a live region that
+  // arrives with its first sentence already in it is announced by nothing
+  // reliable. Null while the camera is closed, where the region below carries
+  // the session's plain label instead.
+  const cameraAnnouncement = useCameraStatusAnnouncement(
+    cameraOpen
+      ? {
+          voiceState: cameraVoiceState,
+          statusLabel: stateLabel,
+          assistantName,
+          muted,
+        }
+      : null,
+  );
 
   // The flash. A preference rather than a session setting, because the reason
   // someone turns it on (a dark room, a phone that under-exposes) outlives the
@@ -813,10 +832,14 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
             className="pointer-events-none absolute inset-x-0 top-0 z-[3] h-[22%]"
             style={{ background: CAMERA_SCRIM_TOP }}
           />
+          {/* The floor is what carries the scrim past the shutter in a short
+              room: 38% of a 500px panel stops above it, leaving the one control
+              meant to be the brightest thing on screen sitting on bare frame.
+              15rem clears the shutter's own row and the control row under it. */}
           <div
             aria-hidden
             data-testid="voice-room-scrim-bottom"
-            className="pointer-events-none absolute inset-x-0 bottom-0 z-[3] h-[38%]"
+            className="pointer-events-none absolute inset-x-0 bottom-0 z-[3] h-[max(38%,15rem)]"
             style={{ background: CAMERA_SCRIM_BOTTOM }}
           />
         </>
@@ -896,9 +919,8 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         >
           <CameraStatusPill
             voiceState={cameraVoiceState}
-            statusLabel={cameraStatusKey ? t(cameraStatusKey) : ""}
+            statusLabel={stateLabel}
             assistantName={assistantName}
-            muted={muted}
           />
         </div>
       ) : null}
@@ -1060,7 +1082,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                 // read. Camera-closed (a denied permission, the case where the
                 // viewfinder never came up) keeps the room's own treatment.
                 cameraOpen
-                  ? "bg-black/45 text-white backdrop-blur-sm"
+                  ? CAMERA_MEDIA_GLASS_CLASS
                   : "bg-[var(--room-wash)] text-[var(--room-fg)]",
               )}
             >
@@ -1137,7 +1159,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                     ariaLabel={t(FLASH_LABEL_KEYS[flashMode])}
                     autoBadge={t("voiceRoom.flashAutoBadge")}
                     onClick={() => setFlashMode(nextFlashMode(flashMode))}
-                    className="absolute left-11"
+                    // Centred 56px from its edge, the same distance flip sits
+                    // from the other: the two flank the shutter symmetrically,
+                    // and the 46px control needs the smaller offset to get
+                    // there than flip's 52px one does.
+                    className="absolute left-[33px]"
                     testId="voice-room-flash"
                   />
                 </Tooltip>
@@ -1269,22 +1295,28 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       </div>
 
       {/* Screen readers get session-state changes here; the avatar is the
-          visual channel, so this stays off-screen. */}
+          visual channel, so this stays off-screen.
+
+          One region across both looks, rather than a second one appearing with
+          the viewfinder. Assistive tech announces a change made INSIDE a region
+          it was already watching, not the arrival of a region that comes with
+          its words already in it, so the camera's sentence is written into this
+          one and the pill above stays a drawing. */}
       <div
         aria-live="polite"
         className="sr-only"
         data-testid="voice-room-state-announcer"
       >
-        {/* The status pill is the announcer while the camera is open, and it
-            says the same label with the mode attached, so this region stands
-            down rather than reading the state twice. It takes the mute prefix
-            below with it, on the same rule.
+        {/* With the camera open the sentence leads with the mode word and
+            carries the mute prefix itself (see `useCameraStatusAnnouncement`),
+            so the room says the state once rather than twice.
 
-            A muted `listening` already reads as "Muted", so prefixing it again
-            would announce "Muted. Muted". The assistant's own phases still
-            need the prefix: "Thinking…" alone would not say the mic is off. */}
+            Closed, a muted `listening` already reads as "Muted", so prefixing
+            it again would announce "Muted. Muted". The assistant's own phases
+            still need the prefix: "Thinking…" alone would not say the mic is
+            off. */}
         {cameraOpen
-          ? ""
+          ? cameraAnnouncement
           : muted && state !== "listening"
             ? t("voiceRoom.mutedState", { state: stateLabel })
             : stateLabel}

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -253,11 +253,11 @@
     "uploadFailed": "Couldn't send that photo."
   },
   "cameraStatusPill": {
-    "announcePhotoMutedSpeaking": "Photo. Muted. {name} speaking",
-    "announcePhotoMutedStatus": "Photo. Muted. {status}",
-    "announcePhotoSpeaking": "Photo. {name} speaking",
-    "announcePhotoStatus": "Photo. {status}",
+    "announceLive": "Live. {status}",
+    "announcePhoto": "Photo. {status}",
+    "live": "Live",
     "photo": "Photo",
+    "speakingState": "{name} speaking",
     "yourAssistant": "Your assistant"
   },
   "cardSurface": {

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -253,11 +253,11 @@
     "uploadFailed": "No se pudo enviar esa foto."
   },
   "cameraStatusPill": {
-    "announcePhotoMutedSpeaking": "Foto. Silenciado. {name} está hablando",
-    "announcePhotoMutedStatus": "Foto. Silenciado. {status}",
-    "announcePhotoSpeaking": "Foto. {name} está hablando",
-    "announcePhotoStatus": "Foto. {status}",
+    "announceLive": "En vivo. {status}",
+    "announcePhoto": "Foto. {status}",
+    "live": "En vivo",
     "photo": "Foto",
+    "speakingState": "{name} está hablando",
     "yourAssistant": "Tu asistente"
   },
   "cardSurface": {

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -160,11 +160,11 @@
     "uploadFailed": "Не удалось отправить это фото."
   },
   "cameraStatusPill": {
-    "announcePhotoMutedSpeaking": "Фото. Без звука. {name} говорит",
-    "announcePhotoMutedStatus": "Фото. Без звука. {status}",
-    "announcePhotoSpeaking": "Фото. {name} говорит",
-    "announcePhotoStatus": "Фото. {status}",
+    "announceLive": "Прямой эфир. {status}",
+    "announcePhoto": "Фото. {status}",
+    "live": "Прямой эфир",
     "photo": "Фото",
+    "speakingState": "{name} говорит",
     "yourAssistant": "Ваш ассистент"
   },
   "channelReferenceChip": {

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -437,12 +437,15 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 /* Camera-mode status dot: the 5px mark in the voice room's status pill,
  * breathing while a voice is live (the user talking, or the assistant
  * answering). Long on, short dip: a hard on/off blink at this size reads as a
- * fault light over a camera feed. The component also holds it static via
- * useReducedMotion; the media query is defense-in-depth for callers that
- * don't, and pins the dot lit rather than mid-dip. */
+ * fault light over a camera feed. The loop closes on the lit value it opens
+ * with, so every repeat fades back up rather than snapping from the dip to full
+ * at the boundary. The component also holds it static via useReducedMotion; the
+ * media query is defense-in-depth for callers that don't, and pins the dot lit
+ * rather than mid-dip. */
 @keyframes camera-status-blink {
-  0%, 60% { opacity: 1; }
-  80%, 100% { opacity: 0.25; }
+  0%, 55% { opacity: 1; }
+  75% { opacity: 0.25; }
+  100% { opacity: 1; }
 }
 
 .camera-status-blink {


### PR DESCRIPTION
## Summary
Fixes self-review gaps: reliable always-mounted announcer, the pill's plan-required Live variant, composed announcements, localized label surfaces (room caption, session pill, composer bar), consolidated glass/ink constants, flash and layout fidelity nudges, closed blink loop, scrim floor, QA doc moved to docs/.

Part of plan: voice-camera-mode-redesign.md (self-review fixes)