### PR TITLE
fix(cli): drop ffplay channel flag causing silent live-voice audio

### DIFF
--- a/cli/src/lib/live-voice/pcm-player.ts
+++ b/cli/src/lib/live-voice/pcm-player.ts
@@ -47,6 +47,15 @@ const PLAYERS: readonly PlayerCommand[] = [
   {
     mode: "streaming",
     name: "ffplay",
+    // No channel-count flag. ffplay 7.x rejects `-ac` outright ("Option not
+    // found"), and `-ch_layout` does not exist before 5.1, so either spelling
+    // is broken on some supported machine. The pcm demuxer's `ch_layout`
+    // defaults to mono on every version, which is exactly what these frames
+    // are, so the portable answer is to say nothing and take the default.
+    //
+    // Getting this wrong fails silently: ffplay exits immediately, `adopt()`
+    // settles on that exit like any finished playback, and the session prints
+    // "Speaking via ffplay" while making no sound at all.
     args: (sampleRate) => [
       "-hide_banner",
       "-loglevel",
@@ -57,8 +66,6 @@ const PLAYERS: readonly PlayerCommand[] = [
       "s16le",
       "-ar",
       String(sampleRate),
-      "-ac",
-      "1",
       "-i",
       "pipe:0",
     ],


### PR DESCRIPTION
## Bug

`cli/src/lib/live-voice/pcm-player.ts` invokes `ffplay` with `-ac 1`. ffplay >= 7 rejects that flag outright:

```
Failed to set value '1' for option 'ac': Option not found
```

This makes live-voice CLI audio silent, and it fails **silently**:

1. `resolvePlayer()` only checks whether a binary is on `PATH`. A broken-but-present `ffplay` outranks a working `aplay`, so ffplay is still selected.
2. ffplay exits immediately on the bad flag.
3. `adopt()` treats that immediate exit as normal playback completion.
4. The session still prints "Speaking via ffplay" and no sound is ever made.

Found on a Raspberry Pi 5, Debian 13, ffplay 7.1.4.

## Fix

Pass **no channel-count flag at all**, rather than swapping to the "modern" spelling.

- `-ac` was removed in ffmpeg/ffplay 7.x.
- `-ch_layout` doesn't exist before ffmpeg 5.1.

There is no single flag spelling that works across the range of ffmpeg versions we need to support, so neither `-ac 1` nor `-ch_layout mono` is portable. The pcm demuxer's `ch_layout` option defaults to `mono` on every version, and these frames are already mono, so omitting the flag entirely and taking the default is the portable fix. A comment in the code explains this so a future reader doesn't "fix" it back to one of the broken spellings.

## Out of scope

`resolvePlayer()`'s PATH-only check is the underlying design smell that turned a bad ffplay flag into total silence instead of a visible error (a broken-but-present binary always beats a working fallback, and nothing verifies the chosen player actually produces sound). Not fixing that here to keep this PR to the one-line regression.

JARVIS-1656

## Test plan

- [x] `bunx tsc --noEmit` (from `cli/`) - clean
- [x] `bunx eslint src/lib/live-voice/pcm-player.ts` - clean
- [x] `bun test src/lib/live-voice/` - 27 pass, 0 fail
- [x] Verified on real hardware (Raspberry Pi 5, Debian 13, ffplay 7.1.4) per bug report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNaqYynH3Qf4dkNpyBhSNX