### PR TITLE
voice: cloud assistants over velay + --say for scripted turns

### DIFF
--- a/cli/src/commands/voice.test.ts
+++ b/cli/src/commands/voice.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import { CliLiveVoiceClient } from "../lib/live-voice/client.js";
+
+import { runSession } from "./voice.js";
+
+/**
+ * Minimal stand-in for the WebSocket the client drives, matching the fake in
+ * `lib/live-voice/client.test.ts`. `runSession` is exercised through a real
+ * `CliLiveVoiceClient` rather than a hand-rolled fake client, because the
+ * client has private fields and cannot be satisfied structurally.
+ */
+class FakeSocket {
+  static readonly OPEN = 1;
+  binaryType = "arraybuffer";
+  readyState = 0;
+  readonly sent: string[] = [];
+  closed = false;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  open(): void {
+    this.readyState = FakeSocket.OPEN;
+    this.onopen?.();
+  }
+
+  deliver(frame: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+}
+
+const READY = {
+  type: "ready",
+  seq: 1,
+  sessionId: "sess_1",
+  conversationId: "conv_1",
+  textInput: true,
+};
+
+describe("runSession --say", () => {
+  test("ends the session after turnDone even with no player (--no-audio)", async () => {
+    const socket = new FakeSocket();
+    const client = new CliLiveVoiceClient({
+      url: "ws://127.0.0.1:7830/v1/live-voice",
+      token: "guardian-token",
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+
+    // player: null is what `--no-audio` passes. Before the fix, `turnDone`'s
+    // `player?.finish().then(...)` short-circuited entirely on a null player,
+    // so `endTurn()` (and therefore `client.end()`) never ran and the session
+    // hung forever with the socket still open. This test hangs on that
+    // regression rather than failing fast, which is exactly the bug: the
+    // suite's own timeout is what would catch it.
+    const sessionDone = runSession({
+      client,
+      player: null,
+      reference: "test-assistant (asst_1)",
+      sayText: "hello",
+    });
+
+    socket.open();
+    socket.deliver(READY);
+    socket.deliver({ type: "tts_done", seq: 2, turnId: "turn_1" });
+
+    await sessionDone;
+
+    expect(socket.closed).toBe(true);
+  });
+});

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -121,7 +121,8 @@ export async function voice(): Promise<void> {
   });
 }
 
-interface SessionDeps {
+/** Exported for tests. Not part of the command's public surface. */
+export interface SessionDeps {
   client: CliLiveVoiceClient;
   player: PcmPlayer | null;
   reference: string;
@@ -144,7 +145,7 @@ interface SessionDeps {
  * failure. The exit code is set on the way out rather than thrown, so a failed
  * session prints one line instead of a stack.
  */
-function runSession({
+export function runSession({
   client,
   player,
   reference,
@@ -380,7 +381,13 @@ function runSession({
       // back at the last byte instead would make Ctrl+C quit the session while
       // the assistant is still talking, and let the next turn start a second
       // player over the top of the first.
-      void player?.finish().then(() => endTurn());
+      //
+      // `player` is null under `--no-audio`, and optional chaining on its own
+      // would short-circuit the whole expression in that case, skipping
+      // `.then()` and leaving `endTurn()` uncalled. `?? Promise.resolve()`
+      // keeps a promise on the left of `.then` either way, so the turn always
+      // ends whether or not there is a player to wait on.
+      void (player?.finish() ?? Promise.resolve()).then(() => endTurn());
     });
 
     client.on("turnCancelled", (turnId) => {

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -36,6 +36,8 @@ ARGUMENTS:
 
 OPTIONS:
     --conversation <id>  Continue an existing conversation instead of starting one
+    --say <message>      Take this one turn, speak the reply, then exit. For
+                         scripts and triggers: no prompt, no terminal needed.
     --no-audio           Print replies without speaking them
     --help               Show this help
 
@@ -51,11 +53,13 @@ DESCRIPTION:
     Ctrl+C interrupts the assistant mid-reply. Ctrl+D, or Ctrl+C when nothing
     is being spoken, ends the session.
 
-    Local and self-hosted assistants only. Vellum cloud assistants authenticate
-    with a session token, which the voice endpoint does not accept.
+    Works with local, self-hosted, and Vellum cloud assistants. A cloud
+    assistant needs a platform login ('vellum login'); the session is
+    authorized per-connection from it.
 
 EXAMPLES:
     vellum voice
+    vellum voice my-assistant --say "i just got back to my desk"
     vellum voice my-assistant
     vellum voice my-assistant --no-audio
     vellum voice --conversation conv_01H8XK3
@@ -73,8 +77,22 @@ export async function voice(): Promise<void> {
   // the daemon accepts any non-empty conversation id, so a swallowed option
   // would open a conversation named after the flag it ate.
   const conversationId = extractValueFlag(args, "conversation");
+  // One turn, then exit. Extracted before the assistant target is parsed so a
+  // multi-word message is never mistaken for a display name.
+  const sayText = extractValueFlag(args, "say");
   const assistantArg = parseAssistantTargetArg(args);
   const audioEnabled = !args.includes("--no-audio");
+
+  if (sayText !== undefined && sayText.trim().length === 0) {
+    console.error("Error: --say needs a message.");
+    process.exit(1);
+  }
+  if (sayText !== undefined && sayText.length > MAX_TEXT_TURN_CHARS) {
+    console.error(
+      `Error: --say is ${sayText.length} characters, limit is ${MAX_TEXT_TURN_CHARS}.`,
+    );
+    process.exit(1);
+  }
 
   let connection;
   try {
@@ -91,16 +109,32 @@ export async function voice(): Promise<void> {
   const client = new CliLiveVoiceClient({
     url: connection.url,
     token: connection.token,
+    tokenTransport: connection.tokenTransport,
     ...(conversationId ? { conversationId } : {}),
   });
 
-  await runSession({ client, player, reference: connection.reference });
+  await runSession({
+    client,
+    player,
+    reference: connection.reference,
+    ...(sayText !== undefined ? { sayText } : {}),
+  });
 }
 
 interface SessionDeps {
   client: CliLiveVoiceClient;
   player: PcmPlayer | null;
   reference: string;
+  /**
+   * Take this one turn and exit, instead of opening a prompt.
+   *
+   * The session ends only once the reply has finished *speaking*, which is why
+   * this cannot be approximated by piping a line into the interactive prompt:
+   * stdin reaches EOF the instant the line is read, readline closes, and the
+   * session is torn down while the turn is still in flight. That race is
+   * winnable on a fast local assistant and reliably lost over velay.
+   */
+  sayText?: string;
 }
 
 /**
@@ -110,7 +144,12 @@ interface SessionDeps {
  * failure. The exit code is set on the way out rather than thrown, so a failed
  * session prints one line instead of a stack.
  */
-function runSession({ client, player, reference }: SessionDeps): Promise<void> {
+function runSession({
+  client,
+  player,
+  reference,
+  sayText,
+}: SessionDeps): Promise<void> {
   return new Promise<void>((resolve) => {
     let rl: Interface | null = null;
     // True from the moment a turn is sent until its reply has been spoken.
@@ -162,6 +201,14 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
         process.stdout.write(chalk.dim(note));
       }
       process.stdout.write("\n");
+      if (sayText !== undefined) {
+        // The reply has been spoken to the end (`turnDone` waits on the
+        // player before calling this), so there is nothing left to stay open
+        // for. Ending here also frees the assistant's single live-voice slot
+        // rather than holding it for a timeout to reclaim.
+        client.end();
+        return;
+      }
       rl?.resume();
       rl?.prompt();
     };
@@ -177,6 +224,29 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
       turnInFlight && (activeTurnId === null || activeTurnId === turnId);
 
     client.on("ready", (frame) => {
+      if (sayText !== undefined) {
+        if (!client.supportsTextInput) {
+          finish(
+            `${reference} does not accept typed turns. Upgrade it with ` +
+              `'vellum upgrade' and try again.`,
+          );
+          client.end();
+          return;
+        }
+        console.log(
+          chalk.dim(`Connected to ${reference}. ${describePlayback(player)}.`),
+        );
+        console.log(`Conversation: ${chalk.dim(frame.conversationId)}\n`);
+        if (!client.sendText(sayText)) {
+          finish("Message not sent, the session is closed.");
+          client.end();
+          return;
+        }
+        turnInFlight = true;
+        activeTurnId = null;
+        return;
+      }
+
       if (!client.supportsTextInput) {
         // The `ready` echo is the only reliable signal. A daemon that predates
         // typed turns answers every `text` frame with `unknown_type`, so

--- a/cli/src/lib/live-voice/client.ts
+++ b/cli/src/lib/live-voice/client.ts
@@ -53,6 +53,13 @@ type EventName = keyof LiveVoiceClientEvents;
 export interface CliLiveVoiceClientOptions {
   readonly url: string;
   readonly token: string;
+  /**
+   * Where the credential goes. `header` is the gateway's `Authorization:
+   * Bearer` (the local and self-hosted path); `query` means the URL already
+   * carries the token velay reads, and no header is sent. Defaults to `header`
+   * so existing callers keep the gateway behaviour.
+   */
+  readonly tokenTransport?: "header" | "query";
   readonly conversationId?: string;
   /** Override the socket factory (tests). */
   readonly webSocketFactory?: (url: string, token: string) => WebSocket;
@@ -118,7 +125,11 @@ export class CliLiveVoiceClient {
     try {
       ws = this.options.webSocketFactory
         ? this.options.webSocketFactory(this.options.url, this.options.token)
-        : openAuthenticatedSocket(this.options.url, this.options.token);
+        : openAuthenticatedSocket(
+            this.options.url,
+            this.options.token,
+            this.options.tokenTransport ?? "header",
+          );
     } catch (err) {
       this.fail(
         err instanceof Error
@@ -340,7 +351,17 @@ export class CliLiveVoiceClient {
  * process listings, shell history, and gateway access logs, and this token is
  * the bound guardian's.
  */
-function openAuthenticatedSocket(url: string, token: string): WebSocket {
+function openAuthenticatedSocket(
+  url: string,
+  token: string,
+  transport: "header" | "query",
+): WebSocket {
+  // velay reads the credential from the query string and no headers at all,
+  // and the URL it was given already carries it. Sending a bearer header there
+  // would authenticate nothing and put a single-use token in a second place.
+  if (transport === "query") {
+    return new WebSocket(url) as WebSocket;
+  }
   return new WebSocket(url, {
     headers: { Authorization: `Bearer ${token}` },
   } as unknown as string[]) as WebSocket;

--- a/cli/src/lib/live-voice/connection.ts
+++ b/cli/src/lib/live-voice/connection.ts
@@ -1,6 +1,10 @@
 /**
  * Resolving the live-voice WebSocket URL and the credential to open it with.
  *
+ * Two transports, chosen by how the assistant is deployed. A cloud assistant
+ * goes through velay with a minted WS token (see `./velay.ts`, which owns that
+ * path end to end). Everything below is the local and self-hosted one.
+ *
  * The endpoint is the **gateway's** `/v1/live-voice`, not the runtime's. That
  * distinction is the whole of the auth story: the runtime's copy demands a
  * gateway service token, which no client can mint, while the gateway's copy
@@ -26,18 +30,36 @@ import {
   formatAssistantReference,
   lookupAssistantByIdentifier,
   resolveTargetAssistant,
+  type AssistantEntry,
 } from "../assistant-config.js";
+import { getPlatformUrl, readPlatformToken } from "../platform-client.js";
 import {
   guardianTokenDueForRenewal,
   loadGuardianToken,
   refreshGuardianToken,
 } from "../guardian-token.js";
+import {
+  buildVelayLiveVoiceUrl,
+  mintVelayWsToken,
+  VelayWsTokenError,
+} from "./velay.js";
+
+/**
+ * Where the credential goes on the upgrade.
+ *
+ * A gateway takes a guardian JWT in an `Authorization` header. velay takes a
+ * minted WS token in the query string and reads no headers, so the two are not
+ * interchangeable: sending the header form to velay authenticates nothing.
+ */
+export type LiveVoiceTokenTransport = "header" | "query";
 
 export interface LiveVoiceConnection {
-  /** `ws(s)://…/v1/live-voice` on the assistant's gateway. */
+  /** `ws(s)://…/v1/live-voice`, on the assistant's gateway or on velay. */
   readonly url: string;
-  /** Guardian access token, sent as `Authorization: Bearer`. */
+  /** Guardian access token, or a minted velay WS token. */
   readonly token: string;
+  /** How {@link token} reaches the server. */
+  readonly tokenTransport: LiveVoiceTokenTransport;
   readonly assistantId: string;
   /** `name (id)` when they differ, else the id, for user-facing output. */
   readonly reference: string;
@@ -65,15 +87,12 @@ export async function resolveLiveVoiceConnection(
     ? resolveNamedAssistant(assistantIdArg)
     : resolveTargetAssistant();
 
-  // Platform-cloud assistants authenticate with a platform session token
-  // (`X-Session-Token`), and the live-voice upgrade accepts only an actor edge
-  // JWT or a velay attestation, neither of which the CLI has for a cloud
-  // instance. Say so plainly rather than opening a socket that 401s.
+  // Platform-cloud assistants are reached the other way round. Their gateway
+  // is behind velay, which authenticates nobody and forwards an attestation
+  // the gateway trusts, so the credential is not the guardian JWT below but a
+  // WS token minted from the platform session the CLI already holds.
   if (entry.cloud === "vellum") {
-    throw new LiveVoiceConnectionError(
-      `${formatAssistantReference(entry)} is a Vellum cloud assistant. ` +
-        "Voice sessions are supported for local and self-hosted assistants only.",
-    );
+    return await resolveCloudConnection(entry);
   }
 
   const baseUrl = (entry.localUrl || entry.runtimeUrl).replace(/\/+$/, "");
@@ -99,6 +118,64 @@ export async function resolveLiveVoiceConnection(
   return {
     url: parsed.toString(),
     token,
+    tokenTransport: "header",
+    assistantId: entry.assistantId,
+    reference: formatAssistantReference(entry),
+  };
+}
+
+/**
+ * Resolve a live-voice connection to a platform-hosted assistant.
+ *
+ * The session token is the CLI's own platform login, not anything specific to
+ * this assistant, so a missing one is a `vellum login` problem rather than an
+ * assistant problem and says so.
+ *
+ * The minted token is deliberately resolved here, at the last moment before
+ * the socket opens, and never cached: it expires in 60 seconds and is consumed
+ * by the upgrade that uses it.
+ */
+async function resolveCloudConnection(
+  entry: AssistantEntry,
+): Promise<LiveVoiceConnection> {
+  const sessionToken = readPlatformToken();
+  if (!sessionToken) {
+    throw new LiveVoiceConnectionError(
+      `${formatAssistantReference(entry)} is a Vellum cloud assistant, which ` +
+        "needs a platform login. Run 'vellum login' and try again.",
+    );
+  }
+
+  // `runtimeUrl` is the platform this entry was hatched against, which is the
+  // one that can mint for it. `getPlatformUrl()` is the fallback for an entry
+  // written before that field was recorded.
+  const platformUrl = (entry.runtimeUrl || getPlatformUrl()).replace(
+    /\/+$/,
+    "",
+  );
+
+  let token: string;
+  try {
+    token = await mintVelayWsToken({
+      platformUrl,
+      assistantId: entry.assistantId,
+      sessionToken,
+    });
+  } catch (err) {
+    if (err instanceof VelayWsTokenError) {
+      throw new LiveVoiceConnectionError(err.message);
+    }
+    throw err;
+  }
+
+  return {
+    url: buildVelayLiveVoiceUrl({
+      platformUrl,
+      assistantId: entry.assistantId,
+      token,
+    }),
+    token,
+    tokenTransport: "query",
     assistantId: entry.assistantId,
     reference: formatAssistantReference(entry),
   };

--- a/cli/src/lib/live-voice/velay.test.ts
+++ b/cli/src/lib/live-voice/velay.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  buildVelayLiveVoiceUrl,
+  velayHostForPlatformUrl,
+  velayWsScheme,
+} from "./velay.js";
+
+const ORIGINAL_VELAY_HOST = process.env.VELLUM_VELAY_HOST;
+
+afterEach(() => {
+  if (ORIGINAL_VELAY_HOST === undefined) {
+    delete process.env.VELLUM_VELAY_HOST;
+  } else {
+    process.env.VELLUM_VELAY_HOST = ORIGINAL_VELAY_HOST;
+  }
+});
+
+describe("velayHostForPlatformUrl", () => {
+  test("maps a platform host onto its environment's velay", () => {
+    delete process.env.VELLUM_VELAY_HOST;
+    expect(velayHostForPlatformUrl("https://platform.vellum.ai")).toBe(
+      "velay.vellum.ai",
+    );
+    expect(velayHostForPlatformUrl("https://dev-platform.vellum.ai")).toBe(
+      "velay-dev.vellum.ai",
+    );
+  });
+
+  test("falls back to production velay for a host outside the convention", () => {
+    delete process.env.VELLUM_VELAY_HOST;
+    // A local platform predicts no velay of its own; guessing one would be
+    // worse than dialing the host that certainly exists.
+    expect(velayHostForPlatformUrl("http://localhost:8000")).toBe(
+      "velay.vellum.ai",
+    );
+    expect(velayHostForPlatformUrl("not a url")).toBe("velay.vellum.ai");
+  });
+
+  test("the env override wins, which is how a local vel up velay is reached", () => {
+    process.env.VELLUM_VELAY_HOST = "localhost:8501";
+    expect(velayHostForPlatformUrl("https://platform.vellum.ai")).toBe(
+      "localhost:8501",
+    );
+  });
+});
+
+describe("velayWsScheme", () => {
+  test("downgrades to ws only for loopback", () => {
+    expect(velayWsScheme("localhost:8501")).toBe("ws");
+    expect(velayWsScheme("127.0.0.1:8501")).toBe("ws");
+    expect(velayWsScheme("velay.vellum.ai")).toBe("wss");
+  });
+});
+
+describe("buildVelayLiveVoiceUrl", () => {
+  test("prefixes the assistant id, which is what selects the tunnel", () => {
+    delete process.env.VELLUM_VELAY_HOST;
+    const url = new URL(
+      buildVelayLiveVoiceUrl({
+        platformUrl: "https://platform.vellum.ai",
+        assistantId: "01a02514-e452-7019-88d5-30828f42cf17",
+        token: "tok_abc",
+      }),
+    );
+
+    expect(url.protocol).toBe("wss:");
+    expect(url.host).toBe("velay.vellum.ai");
+    expect(url.pathname).toBe(
+      "/01a02514-e452-7019-88d5-30828f42cf17/v1/live-voice",
+    );
+    expect(url.searchParams.get("token")).toBe("tok_abc");
+  });
+
+  test("encodes a token rather than letting it break the query", () => {
+    delete process.env.VELLUM_VELAY_HOST;
+    const url = new URL(
+      buildVelayLiveVoiceUrl({
+        platformUrl: "https://platform.vellum.ai",
+        assistantId: "a1",
+        token: "a+b/c=&d",
+      }),
+    );
+    expect(url.searchParams.get("token")).toBe("a+b/c=&d");
+  });
+
+  test("uses ws against a loopback velay so a local stack is reachable", () => {
+    process.env.VELLUM_VELAY_HOST = "localhost:8501";
+    const url = new URL(
+      buildVelayLiveVoiceUrl({
+        platformUrl: "http://localhost:8000",
+        assistantId: "a1",
+        token: "t",
+      }),
+    );
+    expect(url.protocol).toBe("ws:");
+    expect(url.host).toBe("localhost:8501");
+  });
+});

--- a/cli/src/lib/live-voice/velay.ts
+++ b/cli/src/lib/live-voice/velay.ts
@@ -1,0 +1,199 @@
+/**
+ * The cloud leg of a live-voice session: minting a velay WS token and building
+ * the URL it opens.
+ *
+ * A platform-hosted assistant is not reachable the way a local one is. Its
+ * gateway sits behind velay, velay performs no user authentication of its own,
+ * and the gateway upstream accepts only an actor edge JWT or a velay
+ * attestation. The CLI holds neither for a cloud instance: what it has is a
+ * platform session token, which is the wrong credential for the socket but the
+ * right one for the platform.
+ *
+ * So the connection is made in two hops, the same two the web voice room makes
+ * (`clients/web/src/domains/chat/voice/live-voice/connection.ts`):
+ *
+ *  1. POST the platform for a short-lived, org+assistant-scoped WS token.
+ *  2. Open `wss://<velay>/<assistantId>/v1/live-voice?token=<wsToken>`.
+ *
+ * velay consumes the token on the upgrade and injects the authenticated user
+ * and org downstream as `X-Velay-*` headers alongside its bridge proof. The
+ * gateway reads that attestation rather than the query param, and pins it to
+ * the assistant's bound guardian (`requireManagedGuardian`). The token is
+ * therefore an admission ticket for one upgrade, not a session credential.
+ *
+ * Two properties of that ticket shape this module's API. It lives for
+ * `LIVE_VOICE_WS_TOKEN_TTL` (60 seconds) and it is **single-use**: the
+ * validator consumes it atomically, so the same token cannot open a second
+ * socket. Minting is consequently tied to connecting, and a reconnect has to
+ * mint again rather than reuse what resolution returned.
+ */
+
+import { velayHostForPlatformHost } from "@vellumai/service-contracts/ingress";
+
+import { authHeaders } from "../platform-client.js";
+
+/** Production velay, when the platform host implies nothing more specific. */
+const DEFAULT_VELAY_HOST = "velay.vellum.ai";
+
+/** Give up on the mint rather than hang the session behind a stalled platform. */
+const MINT_TIMEOUT_MS = 10_000;
+
+export class VelayWsTokenError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "VelayWsTokenError";
+    this.status = status;
+  }
+}
+
+/**
+ * The velay host serving a given platform base URL.
+ *
+ * `VELLUM_VELAY_HOST` wins when set, which is how a local `vel up` stack is
+ * reached: its velay is a loopback port that no naming convention predicts.
+ * Otherwise the deployment convention maps the platform host onto its sibling
+ * (`platform.vellum.ai` to `velay.vellum.ai`, `dev-platform.vellum.ai` to
+ * `velay-dev.vellum.ai`). A host outside that convention, including localhost,
+ * yields the production default, because guessing a velay for it would be
+ * worse than dialing the one host that certainly exists.
+ */
+export function velayHostForPlatformUrl(platformUrl: string): string {
+  const override = process.env.VELLUM_VELAY_HOST?.trim();
+  if (override) {
+    return override;
+  }
+  try {
+    return (
+      velayHostForPlatformHost(new URL(platformUrl).host) ?? DEFAULT_VELAY_HOST
+    );
+  } catch {
+    return DEFAULT_VELAY_HOST;
+  }
+}
+
+/**
+ * `ws` for a loopback velay, `wss` for everything else.
+ *
+ * The local `vel up` velay is plain HTTP on a loopback port, which a `wss` dial
+ * cannot reach. Mirrors `getVelayWsScheme` in the web client so the two ends of
+ * the transport cannot disagree about which scheme a host takes.
+ */
+export function velayWsScheme(host: string): "ws" | "wss" {
+  let hostname: string;
+  try {
+    ({ hostname } = new URL(`http://${host}`));
+  } catch {
+    return "wss";
+  }
+  return hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname === "::1"
+    ? "ws"
+    : "wss";
+}
+
+/**
+ * Build the velay live-voice URL.
+ *
+ * The `/<assistantId>` prefix is what selects the tunnel: velay strips it to
+ * recover the upstream path, and matches that path against its allowlist and
+ * against the scope recorded for the token. The token rides as `?token=`
+ * because a WebSocket upgrade from a non-browser client still cannot carry a
+ * credential anywhere velay reads except the query string.
+ */
+export function buildVelayLiveVoiceUrl(args: {
+  platformUrl: string;
+  assistantId: string;
+  token: string;
+}): string {
+  const host = velayHostForPlatformUrl(args.platformUrl);
+  const url = new URL(
+    `${velayWsScheme(host)}://${host}/${args.assistantId}/v1/live-voice`,
+  );
+  url.searchParams.set("token", args.token);
+  return url.toString();
+}
+
+interface LiveVoiceTokenResponse {
+  token?: unknown;
+  expiresAt?: unknown;
+}
+
+/**
+ * Mint a single-use velay WS token for one assistant.
+ *
+ * Authenticates with the CLI's stored platform session token. The mint
+ * endpoint pins its authenticators to the user-session ones
+ * (`SessionAuthentication` and `XSessionTokenAuthentication`) and deliberately
+ * excludes API-key auth, so `X-Session-Token` is the CLI's way in and a
+ * `vak_` key is not: a caller holding only an API key cannot mint here, by
+ * design on the platform's side.
+ *
+ * Throws {@link VelayWsTokenError} carrying the HTTP status, so the caller can
+ * tell "sign in again" (401) from "not your assistant" (403) from a platform
+ * that is simply down.
+ */
+export async function mintVelayWsToken(args: {
+  platformUrl: string;
+  assistantId: string;
+  sessionToken: string;
+}): Promise<string> {
+  const url = `${args.platformUrl.replace(/\/+$/, "")}/v1/auth/live-voice-token/`;
+  // `authHeaders` resolves `Vellum-Organization-Id`, which the endpoint needs
+  // to scope the token, and which is cached per token so a session does not
+  // pay for an extra round trip.
+  const headers = await authHeaders(args.sessionToken, args.platformUrl);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ assistantId: args.assistantId }),
+      signal: AbortSignal.timeout(MINT_TIMEOUT_MS),
+    });
+  } catch (err) {
+    throw new VelayWsTokenError(
+      0,
+      `Could not reach the Vellum platform to authorize the voice session: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new VelayWsTokenError(
+      response.status,
+      describeMintFailure(response.status),
+    );
+  }
+
+  const body = (await response.json().catch(() => ({}))) as
+    | LiveVoiceTokenResponse
+    | undefined;
+  const token = typeof body?.token === "string" ? body.token.trim() : "";
+  if (!token) {
+    throw new VelayWsTokenError(
+      response.status,
+      "The Vellum platform returned no voice session token.",
+    );
+  }
+  return token;
+}
+
+/** Turn a mint rejection into something the user can act on. */
+function describeMintFailure(status: number): string {
+  if (status === 401) {
+    return "Not signed in to the Vellum platform. Run 'vellum login' and try again.";
+  }
+  if (status === 403) {
+    return "This account cannot open a voice session on that assistant. Check that it belongs to the organization you are signed in to.";
+  }
+  if (status === 404) {
+    return "The Vellum platform does not offer voice session tokens. It may be running an older release.";
+  }
+  return `The Vellum platform refused to authorize the voice session (HTTP ${status}).`;
+}


### PR DESCRIPTION
## Summary

One coherent change to `vellum voice`, covering **JARVIS-1658** and **JARVIS-1659** together because both rewrite `cli/src/commands/voice.ts` and were built and verified as a unit.

### JARVIS-1658 - cloud assistants over velay

`resolveLiveVoiceConnection` used to refuse `cloud === "vellum"` outright, so no platform-hosted assistant was reachable from `vellum voice` on any machine, laptops included.

The cloud path is now two hops, mirroring what the web voice room does:

1. `POST <platform>/v1/auth/live-voice-token/` with `{assistantId}` returns a **60-second, single-use, org+assistant-scoped token**. It is minted at connect time and **never cached**; a reconnect has to mint again. This matters because the token is an admission ticket for one upgrade, not a session credential - the validator consumes it atomically on the socket upgrade, so a stashed copy is useless the second time.
2. `wss://<velay>/<assistantId>/v1/live-voice?token=<t>`. The `/<assistantId>` prefix is what selects the tunnel: velay strips it to recover the upstream path, consumes the token, and injects `X-Velay-*` headers plus its bridge proof, which the gateway pins to the assistant's bound guardian.

The CLI can mint because that Django view pins `authentication_classes = [SessionAuthentication, XSessionTokenAuthentication]`, so the CLI's stored `X-Session-Token` works with no cookie or CSRF - no new credential type needed.

New file `cli/src/lib/live-voice/velay.ts` owns this leg end to end (host resolution, ws/wss scheme selection, URL building, minting, and error mapping). `resolveLiveVoiceConnection` in `connection.ts` now branches on `entry.cloud === "vellum"` into `resolveCloudConnection`, which mints and returns a `LiveVoiceConnection` with `tokenTransport: "query"` instead of throwing.

**`tokenTransport` on the client** (`cli/src/lib/live-voice/client.ts`): `query` opens a bare socket, because velay reads the token from the URL and no headers at all; `header` keeps the gateway's `Authorization: Bearer`, which is what the local/self-hosted path has always sent. It defaults to `header`, so existing (non-cloud) behavior is unchanged.

### JARVIS-1659 - `--say <message>`

One turn, speak the reply, exit. No prompt, no TTY needed - built for scripts and triggers.

**Why this exists instead of just piping a line into the interactive prompt:** that looks equivalent but isn't. Piping `echo "hi" | vellum voice` reaches EOF the instant the line is read, readline emits `close`, and the existing close handler calls `client.end()` - tearing the session down while the turn may still be in flight. That race is winnable against a fast local assistant (which is why it can look fine in casual testing) and reliably lost over velay, where the extra hop adds enough latency that the reply is essentially never done before stdin closes.

`--say` instead waits for `turnDone` (which itself waits on the player finishing playback) before calling `client.end()`, so the session only closes once the reply has actually finished speaking. This also releases the assistant's single live-voice slot immediately, rather than leaving it held until a timeout reclaims it.

## Verification

- `bunx tsc --noEmit` in `cli/`: clean.
- `bunx eslint` on the four changed/added source files: clean.
- `bun test src/lib/live-voice/` in `cli/`: **34 pass, 0 fail**.
- Verified end-to-end against a **production platform-hosted assistant from a Raspberry Pi** (cloud path, JARVIS-1658), and against a **local velay** (JARVIS-1659, `--say`).

Note: unscoped `bun test` across all of `cli/` has 4 pre-existing failures in `sleep.test.ts` and `flags.test.ts` from local lockfile state, unrelated to this change - not touched here.

## Test plan

- [x] Typecheck, lint, and `src/lib/live-voice/` tests all pass
- [x] Manually verified against a production cloud assistant
- [x] Manually verified `--say` against a local velay

JARVIS-1658
JARVIS-1659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNaqYynH3Qf4dkNpyBhSNX