### PR TITLE
fix(dictation): never send a cleanup rewrite that lost the user's words

### DIFF
--- a/assistant/src/runtime/routes/__tests__/dictation-cleanup-guard.test.ts
+++ b/assistant/src/runtime/routes/__tests__/dictation-cleanup-guard.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The dictation cleanup pass rewrites what the user actually said, so the
+ * rewrite only becomes the payload when it is plausibly the same utterance.
+ *
+ * LUM-3432: a rewrite cut short by a `max_tokens` stop, or one that dropped
+ * most of the transcript, used to be inserted verbatim -- the user sent a
+ * fragment of a request they had spoken in full, with no indication anything
+ * was missing.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  computeMaxTokens,
+  resolveCleanedDictation,
+} from "../diagnostics-routes.js";
+
+const SPOKEN =
+  "Hello Quill can you generate a list of 20 open HR coordinator or HR " +
+  "related roles that are remote and pay about 50 to 60 K per year";
+
+describe("resolveCleanedDictation", () => {
+  test("accepts an ordinary cleanup", () => {
+    const cleaned =
+      "Hello Quill, can you generate a list of 20 open HR coordinator or HR " +
+      "related roles that are remote and pay about 50 to 60K per year?";
+    expect(resolveCleanedDictation(SPOKEN, cleaned, "end_turn")).toEqual({
+      text: cleaned,
+      rejected: null,
+    });
+  });
+
+  test("trims surrounding whitespace off an accepted cleanup", () => {
+    const { text } = resolveCleanedDictation(
+      "so um I think we should ship the thing on Tuesday you know",
+      "  I think we should ship the thing on Tuesday.  ",
+      "end_turn",
+    );
+    expect(text).toBe("I think we should ship the thing on Tuesday.");
+  });
+
+  test("rejects a rewrite cut off by max_tokens and keeps the raw words", () => {
+    expect(
+      resolveCleanedDictation(
+        SPOKEN,
+        "Hello Quill, can you create a list",
+        "max_tokens",
+      ),
+    ).toEqual({ text: SPOKEN, rejected: "truncated" });
+  });
+
+  test("rejects a max_tokens rewrite even when it kept most of the words", () => {
+    const nearlyComplete = SPOKEN.slice(0, SPOKEN.length - 4);
+    const { rejected } = resolveCleanedDictation(
+      SPOKEN,
+      nearlyComplete,
+      "max_tokens",
+    );
+    expect(rejected).toBe("truncated");
+  });
+
+  test("rejects a summary that dropped most of the transcript", () => {
+    expect(
+      resolveCleanedDictation(SPOKEN, "Can you create a list?", "end_turn"),
+    ).toEqual({ text: SPOKEN, rejected: "too-short" });
+  });
+
+  test("short utterances are exempt from the length ratio", () => {
+    // Filler removal legitimately guts a short phrase, so the ratio would
+    // reject a correct cleanup here.
+    expect(
+      resolveCleanedDictation("um yeah okay so", "Okay.", "end_turn"),
+    ).toEqual({ text: "Okay.", rejected: null });
+  });
+
+  test("an empty rewrite falls back to raw without flagging a rejection", () => {
+    // The model returned nothing usable; there is no rewrite to distrust.
+    expect(resolveCleanedDictation(SPOKEN, "   ", "end_turn")).toEqual({
+      text: SPOKEN,
+      rejected: null,
+    });
+  });
+});
+
+describe("computeMaxTokens", () => {
+  test("budgets room for the transcript, reasoning, and JSON scaffolding", () => {
+    // The tool call carries the whole transcript back in `text`, so a budget
+    // at or near the input's own token count is what let a rewrite get cut
+    // mid-argument.
+    const estimatedInputTokens = Math.ceil(SPOKEN.length / 3);
+    expect(computeMaxTokens(SPOKEN.length)).toBeGreaterThan(
+      estimatedInputTokens * 2,
+    );
+  });
+
+  test("holds a floor for very short transcripts", () => {
+    expect(computeMaxTokens(5)).toBe(512);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/dictation-cleanup-guard.test.ts
+++ b/assistant/src/runtime/routes/__tests__/dictation-cleanup-guard.test.ts
@@ -1,11 +1,7 @@
 /**
- * The dictation cleanup pass rewrites what the user actually said, so the
- * rewrite only becomes the payload when it is plausibly the same utterance.
- *
- * LUM-3432: a rewrite cut short by a `max_tokens` stop, or one that dropped
- * most of the transcript, used to be inserted verbatim -- the user sent a
- * fragment of a request they had spoken in full, with no indication anything
- * was missing.
+ * The dictation cleanup pass rewrites what the user actually said, so a
+ * rewrite the provider cut off at the token cap must never become the
+ * payload: the raw transcript is sent instead.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -59,18 +55,31 @@ describe("resolveCleanedDictation", () => {
     expect(rejected).toBe("truncated");
   });
 
-  test("rejects a summary that dropped most of the transcript", () => {
-    expect(
-      resolveCleanedDictation(SPOKEN, "Can you create a list?", "end_turn"),
-    ).toEqual({ text: SPOKEN, rejected: "too-short" });
+  test("rejects the token-cap stop under every provider's name for it", () => {
+    for (const stopReason of ["length", "max_output_tokens", "MAX_TOKENS "]) {
+      expect(
+        resolveCleanedDictation(SPOKEN, "Hello Quill, can you", stopReason)
+          .rejected,
+      ).toBe("truncated");
+    }
   });
 
-  test("short utterances are exempt from the length ratio", () => {
-    // Filler removal legitimately guts a short phrase, so the ratio would
-    // reject a correct cleanup here.
+  test("a missing stop reason is not treated as a truncation", () => {
+    const cleaned = "Hello Quill, can you generate a list?";
+    expect(resolveCleanedDictation(SPOKEN, cleaned, undefined)).toEqual({
+      text: cleaned,
+      rejected: null,
+    });
+  });
+
+  test("a much shorter rewrite is the model's call, not a rejection", () => {
+    // The prompt asks for fillers and vague phrasing to go, so a concise
+    // rewrite of a rambling utterance is a correct cleanup.
+    const spoken =
+      "um you know I just kind of wanted to say like thank you so much you know";
     expect(
-      resolveCleanedDictation("um yeah okay so", "Okay.", "end_turn"),
-    ).toEqual({ text: "Okay.", rejected: null });
+      resolveCleanedDictation(spoken, "Thank you so much.", "end_turn"),
+    ).toEqual({ text: "Thank you so much.", rejected: null });
   });
 
   test("an empty rewrite falls back to raw without flagging a rejection", () => {
@@ -84,9 +93,8 @@ describe("resolveCleanedDictation", () => {
 
 describe("computeMaxTokens", () => {
   test("budgets room for the transcript, reasoning, and JSON scaffolding", () => {
-    // The tool call carries the whole transcript back in `text`, so a budget
-    // at or near the input's own token count is what let a rewrite get cut
-    // mid-argument.
+    // The tool call carries the whole transcript back in `text`, so the
+    // budget has to clear the input's own token count with room to spare.
     const estimatedInputTokens = Math.ceil(SPOKEN.length / 3);
     expect(computeMaxTokens(SPOKEN.length)).toBeGreaterThan(
       estimatedInputTokens * 2,

--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -22,6 +22,7 @@ import {
   getConfiguredProvider,
   userMessage,
 } from "../../providers/provider-send-message.js";
+import { isMaxTokensStopReason } from "../../providers/stop-reasons.js";
 import { getLogger } from "../../util/logger.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { BadRequestError } from "./errors.js";
@@ -178,60 +179,40 @@ function buildCommandPrompt(body: DictationBody, stylePrompt?: string): string {
 
 export function computeMaxTokens(inputLength: number): number {
   const estimatedInputTokens = Math.ceil(inputLength / 3);
-  // The cleanup tool call has to carry the whole transcript back in its `text`
+  // The cleanup tool call carries the whole transcript back in its `text`
   // argument, plus a `reasoning` string and the JSON scaffolding around both,
-  // so the budget has to cover well more than the input. The old
-  // `estimatedInputTokens + 128` left roughly 128 tokens for reasoning and
-  // scaffolding combined, and a `max_tokens` stop cuts the tool JSON mid-`text`
-  // -- which used to be accepted verbatim as the cleaned text (LUM-3432).
-  // `max_tokens` is a ceiling rather than a target, so raising it costs no
-  // latency on a call that stops well short of it.
+  // so the budget has to cover well more than the input alone. `max_tokens` is
+  // a ceiling rather than a target: a call that stops short of it costs no
+  // extra latency.
   return Math.max(512, estimatedInputTokens * 2 + 256);
 }
 
-/**
- * Smallest transcript the length-ratio check below applies to. Short
- * utterances legitimately shrink a long way once fillers go ("um yeah okay
- * so" -> "Okay"), so the ratio is noise below this length.
- */
-const CLEANUP_RATIO_MIN_LENGTH = 40;
-
-/**
- * How much of the spoken transcript the cleanup pass is allowed to drop.
- * Cleanup removes fillers and tightens phrasing, so some shrink is expected;
- * losing more than this is a truncated tool call or a summary, not a cleanup.
- */
-const CLEANUP_MIN_LENGTH_RATIO = 0.6;
-
-export type CleanupRejection = "truncated" | "too-short";
+export type CleanupRejection = "truncated";
 
 /**
  * Decide whether the cleanup model's rewrite is safe to use as the payload.
  *
- * The rewrite replaces what the user actually said, so it only wins when it
- * is plausibly the same utterance. A `max_tokens` stop means the tool JSON
- * was cut mid-argument, and a rewrite that lost most of the transcript is a
- * summary; both used to be inserted verbatim, silently sending a fragment of
- * a request the user had spoken in full (LUM-3432). In either case the raw
- * transcript is the safer payload: unpolished beats wrong.
+ * The rewrite replaces what the user actually said. A token-cap stop means the
+ * tool JSON was cut mid-argument, so however complete the `text` argument
+ * happens to look, it is a fragment; the raw transcript is the safer payload
+ * then. Unpolished beats wrong.
+ *
+ * Whether a shorter rewrite still preserved the meaning is the model's call
+ * (the prompt asks it to drop fillers and tighten phrasing), so there is no
+ * length check here: a deterministic ratio cannot tell a concise cleanup from
+ * a summary.
  */
 export function resolveCleanedDictation(
   raw: string,
   cleaned: string,
-  stopReason: string,
+  stopReason: string | null | undefined,
 ): { text: string; rejected: CleanupRejection | null } {
   const trimmed = cleaned.trim();
   if (!trimmed) {
     return { text: raw, rejected: null };
   }
-  if (stopReason === "max_tokens") {
+  if (isMaxTokensStopReason(stopReason)) {
     return { text: raw, rejected: "truncated" };
-  }
-  if (
-    raw.length >= CLEANUP_RATIO_MIN_LENGTH &&
-    trimmed.length < raw.length * CLEANUP_MIN_LENGTH_RATIO
-  ) {
-    return { text: raw, rejected: "too-short" };
   }
   return { text: trimmed, rejected: null };
 }

--- a/assistant/src/runtime/routes/diagnostics-routes.ts
+++ b/assistant/src/runtime/routes/diagnostics-routes.ts
@@ -176,9 +176,64 @@ function buildCommandPrompt(body: DictationBody, stylePrompt?: string): string {
   return sections.join("\n");
 }
 
-function computeMaxTokens(inputLength: number): number {
+export function computeMaxTokens(inputLength: number): number {
   const estimatedInputTokens = Math.ceil(inputLength / 3);
-  return Math.max(256, estimatedInputTokens + 128);
+  // The cleanup tool call has to carry the whole transcript back in its `text`
+  // argument, plus a `reasoning` string and the JSON scaffolding around both,
+  // so the budget has to cover well more than the input. The old
+  // `estimatedInputTokens + 128` left roughly 128 tokens for reasoning and
+  // scaffolding combined, and a `max_tokens` stop cuts the tool JSON mid-`text`
+  // -- which used to be accepted verbatim as the cleaned text (LUM-3432).
+  // `max_tokens` is a ceiling rather than a target, so raising it costs no
+  // latency on a call that stops well short of it.
+  return Math.max(512, estimatedInputTokens * 2 + 256);
+}
+
+/**
+ * Smallest transcript the length-ratio check below applies to. Short
+ * utterances legitimately shrink a long way once fillers go ("um yeah okay
+ * so" -> "Okay"), so the ratio is noise below this length.
+ */
+const CLEANUP_RATIO_MIN_LENGTH = 40;
+
+/**
+ * How much of the spoken transcript the cleanup pass is allowed to drop.
+ * Cleanup removes fillers and tightens phrasing, so some shrink is expected;
+ * losing more than this is a truncated tool call or a summary, not a cleanup.
+ */
+const CLEANUP_MIN_LENGTH_RATIO = 0.6;
+
+export type CleanupRejection = "truncated" | "too-short";
+
+/**
+ * Decide whether the cleanup model's rewrite is safe to use as the payload.
+ *
+ * The rewrite replaces what the user actually said, so it only wins when it
+ * is plausibly the same utterance. A `max_tokens` stop means the tool JSON
+ * was cut mid-argument, and a rewrite that lost most of the transcript is a
+ * summary; both used to be inserted verbatim, silently sending a fragment of
+ * a request the user had spoken in full (LUM-3432). In either case the raw
+ * transcript is the safer payload: unpolished beats wrong.
+ */
+export function resolveCleanedDictation(
+  raw: string,
+  cleaned: string,
+  stopReason: string,
+): { text: string; rejected: CleanupRejection | null } {
+  const trimmed = cleaned.trim();
+  if (!trimmed) {
+    return { text: raw, rejected: null };
+  }
+  if (stopReason === "max_tokens") {
+    return { text: raw, rejected: "truncated" };
+  }
+  if (
+    raw.length >= CLEANUP_RATIO_MIN_LENGTH &&
+    trimmed.length < raw.length * CLEANUP_MIN_LENGTH_RATIO
+  ) {
+    return { text: raw, rejected: "too-short" };
+  }
+  return { text: trimmed, rejected: null };
 }
 
 interface DictationResult {
@@ -329,7 +384,23 @@ async function handleDictation(body: DictationBody): Promise<DictationResult> {
             ...profileMeta,
           };
         }
-        const cleanedText = input.text?.trim() || transcription;
+        const { text: cleanedText, rejected } = resolveCleanedDictation(
+          transcription,
+          input.text ?? "",
+          response.stopReason,
+        );
+        if (rejected) {
+          // Lengths only -- transcript content must never be logged.
+          log.warn(
+            {
+              rejected,
+              stopReason: response.stopReason,
+              rawChars: transcription.length,
+              cleanedChars: input.text?.trim().length ?? 0,
+            },
+            "Dictation cleanup rejected, using raw transcription",
+          );
+        }
         const normalizedText = applyDictionary(cleanedText, profile.dictionary);
         return {
           text: normalizedText,


### PR DESCRIPTION
Part of the LUM-3432 RCA. One of two independent fixes; the composer-side one (Send finishes dictation before it sends) is #41631.

## The problem

`handleVoiceTranscript` posts the raw transcript to `/v1/dictation` and, when the daemon classifies the utterance as dictation, **replaces the user's words with the model's rewrite**. The daemon accepted whatever came back:

```ts
const cleanedText = input.text?.trim() || transcription;
```

No stop-reason check. A token-cap stop cuts the tool JSON mid-`text`, and the partial string was then taken as the finished cleanup. `computeMaxTokens` made this reachable:

```ts
return Math.max(256, estimatedInputTokens + 128);
```

The tool call has to carry the whole transcript back in `text`, plus a `reasoning` string, plus the JSON scaffolding around both. Budgeting `input + 128` leaves roughly 128 tokens for reasoning and scaffolding combined, which gets thin fast as the dictation grows. The result is a truncated request in the composer with nothing to indicate words went missing.

## The fix

`resolveCleanedDictation(raw, cleaned, stopReason)` keeps the raw transcript when the call stopped at the token cap. The check goes through the provider layer's `isMaxTokensStopReason()`, so OpenAI's `length` and `max_output_tokens` are caught alongside `max_tokens`; the guard works whatever provider the `interactionClassifier` profile resolves to.

Rejections log at `warn` with lengths only, never transcript content, so this is greppable in the field alongside the existing `dictation: finalize …Chars=` line on the client.

Separately, the token budget goes to `max(512, input * 2 + 256)` so the truncation stops happening in the first place. `max_tokens` is a ceiling rather than a target, so a call that stops well short of it costs no extra latency.

### Why there is no length check

An earlier revision also rejected a rewrite that dropped more than 40% of a long transcript. That is gone. The prompt explicitly asks the model to remove fillers and vague phrasing, so a rambling "um you know I just kind of wanted to say like thank you so much you know" correctly becomes "Thank you so much.", and a character ratio would have thrown that away for the raw text. Whether a shorter rewrite preserved the meaning is a judgement the model is already making; a deterministic threshold cannot tell a concise cleanup from a summary, and the root AGENTS.md rule is to leave that kind of call to the model. The token-cap stop is the mechanical failure we can detect for certain, so that is the one guard.

The principle: unpolished beats wrong. The user can fix punctuation. They cannot fix words that were never inserted.

## Tests

`assistant/src/runtime/routes/__tests__/dictation-cleanup-guard.test.ts` covers the accept path, the token-cap rejection under every provider's stop-reason spelling, a missing stop reason, the concise-rewrite accept, the empty-rewrite fallback, and the token budget floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwAQPbuB5cqbcNzePwf3VW
