### PR TITLE
fix(cli): resolve upgrade target assistants by unique display name

### DIFF
--- a/cli/src/__tests__/upgrade-local.test.ts
+++ b/cli/src/__tests__/upgrade-local.test.ts
@@ -33,6 +33,8 @@ const realUpgradeLifecycle = { ...upgradeLifecycle };
 
 const findAssistantByNameMock =
   mock<typeof assistantConfig.findAssistantByName>();
+const lookupAssistantByIdentifierMock =
+  mock<typeof assistantConfig.lookupAssistantByIdentifier>();
 const getActiveAssistantMock = mock<typeof assistantConfig.getActiveAssistant>(
   () => "local-assistant",
 );
@@ -46,6 +48,7 @@ const saveAssistantEntryMock = mock<typeof assistantConfig.saveAssistantEntry>(
 mock.module("../lib/assistant-config", () => ({
   ...realAssistantConfig,
   findAssistantByName: findAssistantByNameMock,
+  lookupAssistantByIdentifier: lookupAssistantByIdentifierMock,
   getActiveAssistant: getActiveAssistantMock,
   loadAllAssistants: loadAllAssistantsMock,
   saveAssistantEntry: saveAssistantEntryMock,
@@ -228,6 +231,8 @@ beforeEach(() => {
   const entry = makeLocalEntry();
   findAssistantByNameMock.mockReset();
   findAssistantByNameMock.mockReturnValue(entry);
+  lookupAssistantByIdentifierMock.mockReset();
+  lookupAssistantByIdentifierMock.mockReturnValue({ status: "found", entry });
   getActiveAssistantMock.mockReset();
   getActiveAssistantMock.mockReturnValue("local-assistant");
   loadAllAssistantsMock.mockReset();
@@ -444,5 +449,118 @@ describe("vellum upgrade local", () => {
     expect(startLocalDaemonMock).not.toHaveBeenCalled();
     expect(startGatewayMock).not.toHaveBeenCalled();
     expect(consoleLogSpy.mock.calls.flat().join("\n")).toContain("Already on");
+  });
+});
+
+// Mirrors the precedence documented in `cli/AGENTS.md` § "Assistant targeting
+// convention": exact assistant ID wins over a display-name match; a unique
+// display-name match resolves to its assistant; an ambiguous display name is
+// an error listing the matching IDs. These tests exercise `vellum upgrade`'s
+// wiring against that precedence rather than re-testing the precedence logic
+// itself (covered directly in `assistant-config.test.ts`).
+function lookupByFixture(
+  fixture: AssistantEntry[],
+): typeof assistantConfig.lookupAssistantByIdentifier {
+  return (identifier: string) => {
+    const exactId = fixture.find((e) => e.assistantId === identifier);
+    if (exactId) {
+      return { status: "found", entry: exactId };
+    }
+    const nameMatches = fixture.filter((e) => e.name === identifier);
+    if (nameMatches.length === 1) {
+      return { status: "found", entry: nameMatches[0] };
+    }
+    if (nameMatches.length > 1) {
+      return { status: "ambiguous", matches: nameMatches };
+    }
+    return { status: "not_found" };
+  };
+}
+
+describe("vellum upgrade assistant targeting", () => {
+  function makeQuillEntry(
+    overrides: Partial<AssistantEntry> = {},
+  ): AssistantEntry {
+    return {
+      ...makeLocalEntry(),
+      assistantId: "quill-uuid",
+      name: "Quill",
+      ...overrides,
+    };
+  }
+
+  test("resolves a unique display-name match to its assistant", async () => {
+    const quill = makeQuillEntry();
+    process.argv = [
+      "bun",
+      "vellum",
+      "upgrade",
+      "Quill",
+      "--version",
+      cliPkg.version ? `v${cliPkg.version}` : "v0.8.12",
+    ];
+    lookupAssistantByIdentifierMock.mockImplementation(
+      lookupByFixture([quill]),
+    );
+
+    await upgrade();
+
+    expect(lookupAssistantByIdentifierMock).toHaveBeenCalledWith("Quill");
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(stopLocalProcessesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceDir: quill.resources!.instanceDir }),
+    );
+  });
+
+  test("an exact assistant-ID match wins over a same-string display-name match", async () => {
+    // A second assistant happens to be *named* the first assistant's ID —
+    // the ID lookup must still win.
+    const target = makeQuillEntry({ assistantId: "quill-uuid" });
+    const decoy = makeQuillEntry({
+      assistantId: "decoy-uuid",
+      name: "quill-uuid",
+    });
+    process.argv = [
+      "bun",
+      "vellum",
+      "upgrade",
+      "quill-uuid",
+      "--version",
+      cliPkg.version ? `v${cliPkg.version}` : "v0.8.12",
+    ];
+    lookupAssistantByIdentifierMock.mockImplementation(
+      lookupByFixture([target, decoy]),
+    );
+
+    await upgrade();
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(stopLocalProcessesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ instanceDir: target.resources!.instanceDir }),
+    );
+  });
+
+  test("an ambiguous display name fails and lists the matching IDs", async () => {
+    const first = makeQuillEntry({ assistantId: "quill-uuid-1" });
+    const second = makeQuillEntry({ assistantId: "quill-uuid-2" });
+    process.argv = [
+      "bun",
+      "vellum",
+      "upgrade",
+      "Quill",
+      "--version",
+      cliPkg.version ? `v${cliPkg.version}` : "v0.8.12",
+    ];
+    lookupAssistantByIdentifierMock.mockImplementation(
+      lookupByFixture([first, second]),
+    );
+
+    await expect(upgrade()).rejects.toThrow("process.exit(1)");
+
+    expect(stopLocalProcessesMock).not.toHaveBeenCalled();
+    const errText = consoleErrorSpy.mock.calls.flat().join("\n");
+    expect(errText).toContain("Multiple assistants match 'Quill'");
+    expect(errText).toContain("quill-uuid-1");
+    expect(errText).toContain("quill-uuid-2");
   });
 });

--- a/cli/src/__tests__/upgrade-local.test.ts
+++ b/cli/src/__tests__/upgrade-local.test.ts
@@ -452,31 +452,15 @@ describe("vellum upgrade local", () => {
   });
 });
 
-// Mirrors the precedence documented in `cli/AGENTS.md` § "Assistant targeting
-// convention": exact assistant ID wins over a display-name match; a unique
-// display-name match resolves to its assistant; an ambiguous display name is
-// an error listing the matching IDs. These tests exercise `vellum upgrade`'s
-// wiring against that precedence rather than re-testing the precedence logic
-// itself (covered directly in `assistant-config.test.ts`).
-function lookupByFixture(
-  fixture: AssistantEntry[],
-): typeof assistantConfig.lookupAssistantByIdentifier {
-  return (identifier: string) => {
-    const exactId = fixture.find((e) => e.assistantId === identifier);
-    if (exactId) {
-      return { status: "found", entry: exactId };
-    }
-    const nameMatches = fixture.filter((e) => e.name === identifier);
-    if (nameMatches.length === 1) {
-      return { status: "found", entry: nameMatches[0] };
-    }
-    if (nameMatches.length > 1) {
-      return { status: "ambiguous", matches: nameMatches };
-    }
-    return { status: "not_found" };
-  };
-}
-
+// `cli/AGENTS.md` § "Assistant targeting convention": exact assistant ID
+// matches win over display-name matches; a unique display-name match
+// resolves to its assistant; an ambiguous display name is an error listing
+// the matching IDs. That precedence lives in, and is tested directly against,
+// `lookupAssistantByIdentifier` (see assistant-config.test.ts). These tests
+// only check `vellum upgrade`'s wiring: each one stubs the exact result
+// (found/ambiguous) the shared helper would return for a given argument, and
+// asserts the command acts on it correctly, without reimplementing the
+// lookup rules themselves.
 describe("vellum upgrade assistant targeting", () => {
   function makeQuillEntry(
     overrides: Partial<AssistantEntry> = {},
@@ -489,19 +473,24 @@ describe("vellum upgrade assistant targeting", () => {
     };
   }
 
-  test("resolves a unique display-name match to its assistant", async () => {
-    const quill = makeQuillEntry();
-    process.argv = [
+  function argvFor(...positional: string[]): string[] {
+    return [
       "bun",
       "vellum",
       "upgrade",
-      "Quill",
+      ...positional,
       "--version",
       cliPkg.version ? `v${cliPkg.version}` : "v0.8.12",
     ];
-    lookupAssistantByIdentifierMock.mockImplementation(
-      lookupByFixture([quill]),
-    );
+  }
+
+  test("resolves a unique display-name match to its assistant", async () => {
+    const quill = makeQuillEntry();
+    process.argv = argvFor("Quill");
+    lookupAssistantByIdentifierMock.mockReturnValue({
+      status: "found",
+      entry: quill,
+    });
 
     await upgrade();
 
@@ -512,28 +501,42 @@ describe("vellum upgrade assistant targeting", () => {
     );
   });
 
-  test("an exact assistant-ID match wins over a same-string display-name match", async () => {
-    // A second assistant happens to be *named* the first assistant's ID —
-    // the ID lookup must still win.
-    const target = makeQuillEntry({ assistantId: "quill-uuid" });
-    const decoy = makeQuillEntry({
-      assistantId: "decoy-uuid",
-      name: "quill-uuid",
+  test("resolves a multi-word display-name argument, unsplit by --version", async () => {
+    const multiWord = makeQuillEntry({ name: "My Assistant" });
+    process.argv = argvFor("My", "Assistant");
+    lookupAssistantByIdentifierMock.mockReturnValue({
+      status: "found",
+      entry: multiWord,
     });
-    process.argv = [
-      "bun",
-      "vellum",
-      "upgrade",
-      "quill-uuid",
-      "--version",
-      cliPkg.version ? `v${cliPkg.version}` : "v0.8.12",
-    ];
-    lookupAssistantByIdentifierMock.mockImplementation(
-      lookupByFixture([target, decoy]),
-    );
 
     await upgrade();
 
+    expect(lookupAssistantByIdentifierMock).toHaveBeenCalledWith(
+      "My Assistant",
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(stopLocalProcessesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instanceDir: multiWord.resources!.instanceDir,
+      }),
+    );
+  });
+
+  test("an exact assistant-ID argument resolves via the shared helper's found result", async () => {
+    // `lookupAssistantByIdentifier` owns ID-wins-over-name precedence
+    // (covered in assistant-config.test.ts); this only checks that
+    // `vellum upgrade` passes the raw argument through unmodified and acts
+    // on whatever entry the shared helper resolves.
+    const target = makeQuillEntry({ assistantId: "quill-uuid" });
+    process.argv = argvFor("quill-uuid");
+    lookupAssistantByIdentifierMock.mockReturnValue({
+      status: "found",
+      entry: target,
+    });
+
+    await upgrade();
+
+    expect(lookupAssistantByIdentifierMock).toHaveBeenCalledWith("quill-uuid");
     expect(exitSpy).not.toHaveBeenCalled();
     expect(stopLocalProcessesMock).toHaveBeenCalledWith(
       expect.objectContaining({ instanceDir: target.resources!.instanceDir }),
@@ -541,19 +544,14 @@ describe("vellum upgrade assistant targeting", () => {
   });
 
   test("an ambiguous display name fails and lists the matching IDs", async () => {
-    const first = makeQuillEntry({ assistantId: "quill-uuid-1" });
-    const second = makeQuillEntry({ assistantId: "quill-uuid-2" });
-    process.argv = [
-      "bun",
-      "vellum",
-      "upgrade",
-      "Quill",
-      "--version",
-      cliPkg.version ? `v${cliPkg.version}` : "v0.8.12",
-    ];
-    lookupAssistantByIdentifierMock.mockImplementation(
-      lookupByFixture([first, second]),
-    );
+    process.argv = argvFor("Quill");
+    lookupAssistantByIdentifierMock.mockReturnValue({
+      status: "ambiguous",
+      matches: [
+        makeQuillEntry({ assistantId: "quill-uuid-1" }),
+        makeQuillEntry({ assistantId: "quill-uuid-2" }),
+      ],
+    });
 
     await expect(upgrade()).rejects.toThrow("process.exit(1)");
 

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -44,6 +44,7 @@ import {
   restoreBackup,
 } from "../lib/backup-ops.js";
 import { emitCliError, categorizeUpgradeError } from "../lib/cli-error.js";
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import { exec } from "../lib/step-runner.js";
 import {
   broadcastUpgradeEvent,
@@ -91,9 +92,14 @@ interface UpgradeArgs {
   force: boolean;
 }
 
+// Flags that consume the following argv token as a value, rather than a
+// boolean switch. Passed to `parseAssistantTargetArg` so an unquoted
+// multi-word display name is not truncated at a flag's value.
+const UPGRADE_FLAGS_WITH_VALUES = ["--version"];
+
 function parseArgs(): UpgradeArgs {
   const args = process.argv.slice(3);
-  let name: string | null = null;
+  const name = parseAssistantTargetArg(args, UPGRADE_FLAGS_WITH_VALUES) ?? null;
   let version: string | null = null;
   let latest = false;
   let prepare = false;
@@ -168,7 +174,8 @@ function parseArgs(): UpgradeArgs {
     } else if (arg === "--force") {
       force = true;
     } else if (!arg.startsWith("-")) {
-      name = arg;
+      // Positional token, part of a possibly multi-word display name.
+      // Collected up front via `parseAssistantTargetArg` above.
     } else {
       console.error(`Error: Unknown option '${arg}'.`);
       emitCliError("UNKNOWN", `Unknown option '${arg}'`);

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -6,8 +6,10 @@ import cliPkg from "../../package.json";
 
 import {
   findAssistantByName,
+  formatAssistantLookupError,
   getActiveAssistant,
   loadAllAssistants,
+  lookupAssistantByIdentifier,
   saveAssistantEntry,
   type AssistantEntry,
 } from "../lib/assistant-config";
@@ -202,22 +204,22 @@ function parseArgs(): UpgradeArgs {
 
 /**
  * Resolve which assistant to target for the upgrade command. Priority:
- * 1. Explicit name argument
+ * 1. Explicit name argument (exact assistant ID wins over a display-name
+ *    match; a unique display-name match resolves; an ambiguous display
+ *    name is an error listing the matching IDs)
  * 2. Active assistant set via `vellum use`
  * 3. Sole assistant (when exactly one exists)
  */
 function resolveTargetAssistant(nameArg: string | null): AssistantEntry {
   if (nameArg) {
-    const entry = findAssistantByName(nameArg);
-    if (!entry) {
-      console.error(`No assistant found with name '${nameArg}'.`);
-      emitCliError(
-        "ASSISTANT_NOT_FOUND",
-        `No assistant found with name '${nameArg}'.`,
-      );
+    const result = lookupAssistantByIdentifier(nameArg);
+    if (result.status !== "found") {
+      const msg = formatAssistantLookupError(nameArg, result);
+      console.error(msg);
+      emitCliError("ASSISTANT_NOT_FOUND", msg);
       process.exit(1);
     }
-    return entry;
+    return result.entry;
   }
 
   const active = getActiveAssistant();


### PR DESCRIPTION
## JARVIS-1657: `vellum upgrade <display-name>` fails to resolve an assistant by its display name

### Repro

```
$ vellum upgrade Quill --version 0.11.6-dev.202608271738.c4a1b33
No assistant found with name 'Quill'.
CLI_ERROR:{"error":"ASSISTANT_NOT_FOUND","message":"No assistant found with name 'Quill'."}
```

`vellum ps` lists the assistant under exactly that display name (`Quill`, a platform-hosted assistant with `cloud: vellum`). The same command with the assistant's UUID works fine.

### Root cause

`upgrade.ts` has its own local `resolveTargetAssistant()` that resolved the explicit name argument with `findAssistantByName()`. Despite the name, that function only matches the literal `assistantId` field:

```ts
export function findAssistantByName(name: string): AssistantEntry | null {
  return readAssistants().find((entry) => entry.assistantId === name) ?? null;
}
```

It never looks at an assistant's display name, so any display-name argument (unique or not) always fails with `ASSISTANT_NOT_FOUND`. This is a hand-rolled lookup that bypasses the shared `lookupAssistantByIdentifier()` helper. `cli/AGENTS.md` § "Assistant targeting convention":

> Exact assistant ID matches must win over display-name matches. Unique display-name matches may resolve to the matching assistant ID, but ambiguous display names must fail with an error that lists the matching IDs.

`resolveTargetAssistant()` in `upgrade.ts` is the single resolution point feeding every upgrade topology (`local`, `docker`, `vellum` cloud), so this bug affected `vellum upgrade` regardless of where the assistant is hosted — including the reported cloud-assistant case.

### Fix

Swap `findAssistantByName()` for the shared `lookupAssistantByIdentifier()` (plus `formatAssistantLookupError()` for the error message) in the explicit-name branch of `resolveTargetAssistant()`, matching the reference usage in `cli/src/lib/live-voice/connection.ts`:

- Exact assistant ID still wins outright.
- A unique display-name match now resolves to that assistant.
- An ambiguous display name still fails, now listing the matching IDs (previously the plain `findAssistantByName` failure mode gave no such detail — it just always said "not found").

The exact-ID re-read further down the file (re-reading rollback state saved mid-upgrade via `findAssistantByName(entry.assistantId)`) is untouched — that one already does a correct exact-ID lookup, not a display-name one.

### Tests

Extended `cli/src/__tests__/upgrade-local.test.ts` with a new `vellum upgrade assistant targeting` describe block covering:

- resolving a unique display-name match to its assistant
- an exact assistant-ID match winning over a same-string display-name match on a different assistant
- an ambiguous display name failing and listing the matching IDs

(The `lookupAssistantByIdentifier` precedence itself — ID-wins-over-name / unique-name-resolves / ambiguous-name-errors — is already covered directly in `assistant-config.test.ts`; these new tests exercise `upgrade.ts`'s wiring against that precedence.)

### Verification (from `cli/`)

- `bunx tsc --noEmit` — clean
- `bunx eslint src/commands/upgrade.ts src/__tests__/upgrade-local.test.ts` — clean
- `bun test src/__tests__/upgrade-local.test.ts` — 9 pass, 0 fail

Note: `bun test` across the whole `cli/` package has 4 pre-existing failures in `sleep.test.ts` and `flags.test.ts` caused by local lockfile/cross-environment state on this machine — confirmed unrelated by reproducing them on unmodified `main` before making any change here.

JARVIS-1657
