### PR TITLE
fix(composer): make Send finish dictation instead of racing it

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer-utils.ts
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer-utils.ts
@@ -17,6 +17,13 @@ export interface ComposerKeyDownPolicy {
    * disagree about what counts as content.
    */
   hasStagedContext?: boolean;
+  /**
+   * Whether a dictation session is recording or transcribing. Words already
+   * spoken are content the composer does not hold yet, so Enter has to reach
+   * `onSubmit` (which finishes dictation before it sends) rather than being
+   * swallowed as "nothing to send".
+   */
+  dictationInFlight?: boolean;
   sendDisabled: boolean;
   attachmentsUploadingCount: number;
   cmdEnterMode: boolean;
@@ -69,7 +76,8 @@ export function shouldSubmitOnEnter(
   const hasContent =
     Boolean(policy.input.trim()) ||
     policy.canSendAttachments ||
-    Boolean(policy.hasStagedContext);
+    Boolean(policy.hasStagedContext) ||
+    Boolean(policy.dictationInFlight);
   if (
     hasContent &&
     !policy.sendDisabled &&

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -475,6 +475,51 @@ describe("shouldSubmitOnEnter — guards still preventDefault but skip submit", 
   });
 });
 
+describe("shouldSubmitOnEnter — dictation in flight", () => {
+  const DICTATING_POLICY = {
+    input: "",
+    canSendAttachments: false,
+    dictationInFlight: true,
+    sendDisabled: false,
+    attachmentsUploadingCount: 0,
+    cmdEnterMode: false,
+  };
+
+  test("Enter with an empty draft submits while dictating", () => {
+    // Words already spoken are content the composer does not hold yet, so
+    // Enter has to reach onSubmit, which finishes dictation before it sends
+    // (LUM-3432).
+    expect(shouldSubmitOnEnter(ENTER, false, DICTATING_POLICY)).toBe("submit");
+  });
+
+  test("Enter with an empty draft and no dictation still prevents", () => {
+    expect(
+      shouldSubmitOnEnter(ENTER, false, {
+        ...DICTATING_POLICY,
+        dictationInFlight: false,
+      }),
+    ).toBe("prevent");
+  });
+
+  test("dictation does not override sendDisabled", () => {
+    expect(
+      shouldSubmitOnEnter(ENTER, false, {
+        ...DICTATING_POLICY,
+        sendDisabled: true,
+      }),
+    ).toBe("prevent");
+  });
+
+  test("dictation does not override an uploading attachment", () => {
+    expect(
+      shouldSubmitOnEnter(ENTER, false, {
+        ...DICTATING_POLICY,
+        attachmentsUploadingCount: 1,
+      }),
+    ).toBe("prevent");
+  });
+});
+
 describe("shouldSubmitOnEnter — non-Enter keys", () => {
   test("Space is ignored (key !== 'Enter')", () => {
     expect(
@@ -2945,10 +2990,27 @@ describe("ChatComposer — live-voice integration", () => {
     // WHEN the composer renders
     const { queryByLabelText } = renderVoiceComposer();
 
-    // THEN the send slot (which holds the voice-mode entry point while idle) is
-    // hidden entirely during dictation, so no second mic/voice session can open
-    // alongside the recorder — mutual exclusion by absence.
+    // THEN the voice-mode entry point is gone from the send slot: dictation
+    // counts as something to send, so the send arrow takes the slot and no
+    // second mic/voice session can open alongside the recorder.
     expect(queryByLabelText("Start voice mode")).toBeNull();
+  });
+
+  test("dictation keeps a live send button so Send can finish the session", () => {
+    // GIVEN dictation is in flight with an empty draft. The send arrow used
+    // to be hidden for the whole session, which left no gesture for ending
+    // dictation and sending in one move (LUM-3432).
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoicePhase = "processing";
+
+    // WHEN the composer renders
+    const { getByLabelText } = renderVoiceComposer();
+
+    // THEN the send arrow is mounted and pressable, even with nothing in the
+    // draft: the words the user spoke are the payload, and `submitMessage`
+    // waits for them before it reads the composer.
+    const send = getByLabelText("Send message") as HTMLButtonElement;
+    expect(send.disabled).toBe(false);
   });
 
   test("electron dictation uses the system overlay instead of the inline composer preview", () => {
@@ -2961,8 +3023,8 @@ describe("ChatComposer — live-voice integration", () => {
     const { queryByLabelText } = renderVoiceComposer();
 
     // THEN the shared top-center dictation overlay owns the visual treatment,
-    // so the composer-specific preview is absent; and the send slot (voice-mode
-    // entry point) stays hidden during dictation — mutual exclusion by absence.
+    // so the composer-specific preview is absent; and the voice-mode entry
+    // point has given the send slot up to the send arrow for the session.
     expect(queryByLabelText("Transcribing")).toBeNull();
     expect(queryByLabelText("Start voice mode")).toBeNull();
   });

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -185,11 +185,13 @@ mock.module("@/domains/chat/voice/voice-room/voice-first-run-card", () => ({
 // `.use.phase()` and `.use.setAudioLevel()` selectors are consumed by the
 // composer.
 let mockVoicePhase = "idle";
+let mockVoiceHold = false;
 const setAudioLevelSpy = mock((_level: number) => undefined);
 mock.module("@/domains/chat/voice/voice-recording-store", () => ({
   useVoiceRecordingStore: {
     use: {
       phase: () => mockVoicePhase,
+      hold: () => mockVoiceHold,
       setAudioLevel: () => setAudioLevelSpy,
     },
   },
@@ -328,6 +330,7 @@ function resetLiveVoiceMocks() {
   mockNativePickersAvailable = false;
   mockIsNativePlatform = false;
   mockVoicePhase = "idle";
+  mockVoiceHold = false;
   mockPreflightVerdict = { status: "ready" };
   preflightSpy.mockClear();
   navigateSpy.mockClear();
@@ -3011,6 +3014,23 @@ describe("ChatComposer — live-voice integration", () => {
     // waits for them before it reads the composer.
     const send = getByLabelText("Send message") as HTMLButtonElement;
     expect(send.disabled).toBe(false);
+  });
+
+  test("a held key's dictation into another app does not light Send", () => {
+    // GIVEN the bridge's hidden recorder is running a hold. The store is
+    // window-global, so this composer sees the phase, but the session is
+    // not its content and its target cannot stop that recorder.
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockVoicePhase = "recording";
+    mockVoiceHold = true;
+
+    // WHEN the composer renders with an empty draft
+    const { queryByLabelText } = renderVoiceComposer();
+
+    // THEN there is nothing to send: the slot holds the voice-mode entry
+    // point exactly as it does with no microphone open at all.
+    expect(queryByLabelText("Send message")).toBeNull();
+    expect(queryByLabelText("Start voice mode")).not.toBeNull();
   });
 
   test("electron dictation uses the system overlay instead of the inline composer preview", () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -824,6 +824,16 @@ export function ChatComposer({
   // Send) for the whole turn.
   const interruptOnSend = useInterruptOnSend();
   const busyRowActive = isAssistantBusy && !interruptOnSend;
+  // Words already spoken are content the composer does not hold yet, so a
+  // live dictation session makes the send slot pressable on its own: Send
+  // there means "finish, then send", and `useComposerSubmit` awaits the
+  // transcript before it reads the draft (LUM-3432). Without this the send
+  // arrow stays disabled -- or cedes the slot to voice mode -- for the whole
+  // of an empty-composer dictation, which is most of them. Deliberately not
+  // folded into `canSendMessageContent`: the busy row's stop/send swap below
+  // is about a draft that is ready to queue right now, and a session still
+  // being spoken is not that.
+  const canSendOrFinishDictation = canSendMessageContent || isVoiceActive;
   // The busy row holds exactly one control, and stop is the default: it is the
   // only escape from a turn already running. Send takes the slot only where it
   // is strictly better, which is where the keyboard cannot submit AND pressing
@@ -858,7 +868,7 @@ export function ChatComposer({
     showVoiceInput &&
     Boolean(assistantId) &&
     supportsLiveVoice &&
-    !canSendMessageContent &&
+    !canSendOrFinishDictation &&
     !isLiveVoiceActive;
 
   // Mobile lifts the access and profile triggers out of the action row into a
@@ -1169,13 +1179,19 @@ export function ChatComposer({
   ) : null;
 
   const sendBlocked =
-    sendDisabled || attachmentsUploadingCount > 0 || !canSendMessageContent;
+    sendDisabled || attachmentsUploadingCount > 0 || !canSendOrFinishDictation;
 
-  // macOS parity: the send button is hidden during recording and while
-  // transcription is being processed. Only the voice button (mic / stop /
-  // spinner) is shown. Otherwise the send slot holds voice mode until there is
-  // something to send, at which point the send arrow takes over.
-  const sendSlot = isVoiceActive ? null : showVoiceModeInSendSlot ? (
+  // The send arrow stays through a dictation session, where pressing it means
+  // "finish, then send": `useComposerSubmit` ends the session and waits for
+  // the transcript before it reads the draft (LUM-3432). It used to be hidden
+  // for the whole session (macOS parity), which left the mic button as the
+  // only control on the row and no gesture at all for ending dictation and
+  // sending in one move -- while Enter stayed live and sent whatever stale
+  // draft was in the box. The two controls now divide the job: the mic stops
+  // and leaves the words in the composer, the arrow stops and sends them.
+  // Otherwise the slot holds voice mode until there is something to send, at
+  // which point the send arrow takes over.
+  const sendSlot = showVoiceModeInSendSlot ? (
     // Session entry point: once a session starts here the slot gives way to
     // the send arrow and the bar above the card owns stopping. Disabled while
     // dictation is active or a live-voice session already runs elsewhere, so a
@@ -1196,7 +1212,7 @@ export function ChatComposer({
       onMouseDown={rowPressGuard}
       disabled={sendBlocked}
       title={
-        sendDisabled || !canSendMessageContent
+        sendDisabled || !canSendOrFinishDictation
           ? t("chatComposer.typeToSend")
           : attachmentsUploadingCount > 0
             ? t("chatComposer.uploadingAttachments")
@@ -1492,6 +1508,7 @@ export function ChatComposer({
               attachmentsUploadingCount,
               cmdEnterMode,
               hasStagedContext,
+              dictationInFlight: isVoiceActive,
             },
           );
           if (decision === "ignore") {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -384,6 +384,13 @@ export function ChatComposer({
   const voicePhase = useVoiceRecordingStore.use.phase();
   const isVoiceActive =
     voicePhase === "recording" || voicePhase === "processing";
+  // The recording store is window-global and shared with the bridge's hidden
+  // recorder, which a held voice key drives into whatever app is in front.
+  // That session is flagged `hold` as it starts, and it is not this
+  // composer's content: its words land at a cursor elsewhere, and its
+  // recorder is not the one the composer's target can stop.
+  const voiceHold = useVoiceRecordingStore.use.hold();
+  const ownsDictation = isVoiceActive && !voiceHold;
   // Holds the MediaStream opened by VoiceInputButton so we can reuse it for
   // amplitude analysis rather than opening a second getUserMedia request.
   const [voiceStream, setVoiceStream] = useState<MediaStream | null>(null);
@@ -824,16 +831,16 @@ export function ChatComposer({
   // Send) for the whole turn.
   const interruptOnSend = useInterruptOnSend();
   const busyRowActive = isAssistantBusy && !interruptOnSend;
-  // Words already spoken are content the composer does not hold yet, so a
-  // live dictation session makes the send slot pressable on its own: Send
-  // there means "finish, then send", and `useComposerSubmit` awaits the
-  // transcript before it reads the draft (LUM-3432). Without this the send
-  // arrow stays disabled -- or cedes the slot to voice mode -- for the whole
-  // of an empty-composer dictation, which is most of them. Deliberately not
-  // folded into `canSendMessageContent`: the busy row's stop/send swap below
-  // is about a draft that is ready to queue right now, and a session still
-  // being spoken is not that.
-  const canSendOrFinishDictation = canSendMessageContent || isVoiceActive;
+  // Words already spoken are content the composer does not hold yet, so the
+  // composer's own dictation session makes the send slot pressable on its
+  // own: Send there means "finish, then send", and `useComposerSubmit`
+  // awaits the transcript before it reads the draft (LUM-3432). Without this
+  // the send arrow stays disabled, or cedes the slot to voice mode, for the
+  // whole of an empty-composer dictation, which is most of them.
+  // Deliberately not folded into `canSendMessageContent`: the busy row's
+  // stop/send swap below is about a draft that is ready to queue right now,
+  // and a session still being spoken is not that.
+  const canSendOrFinishDictation = canSendMessageContent || ownsDictation;
   // The busy row holds exactly one control, and stop is the default: it is the
   // only escape from a turn already running. Send takes the slot only where it
   // is strictly better, which is where the keyboard cannot submit AND pressing
@@ -1508,7 +1515,7 @@ export function ChatComposer({
               attachmentsUploadingCount,
               cmdEnterMode,
               hasStagedContext,
-              dictationInFlight: isVoiceActive,
+              dictationInFlight: ownsDictation,
             },
           );
           if (decision === "ignore") {

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
@@ -450,6 +450,26 @@ describe("useComposerSubmit during dictation", () => {
     expect(sendMessage.mock.calls[0]?.[0]).toBe("typed by hand");
   });
 
+  test("a held key's dictation elsewhere does not hold up an ordinary send", async () => {
+    // The bridge's hidden recorder is running a hold into another app. The
+    // composer's draft is unrelated to it and goes out at once.
+    useComposerStore.getState().setInput("typed while a hold runs");
+    let stopped = false;
+    useVoiceRecordingStore.getState().startRecording({ hold: true });
+    unregisterVoiceTarget = registerPushToTalkTarget({
+      start: () => {},
+      stop: () => {
+        stopped = true;
+      },
+    });
+
+    const { result, sendMessage } = renderSubmit();
+    await submit(result);
+
+    expect(stopped).toBe(false);
+    expect(sendMessage.mock.calls[0]?.[0]).toBe("typed while a hold runs");
+  });
+
   test("a thread switch during the wait cancels the send and keeps the words", async () => {
     // The composer is shared across threads: the transcript lands in whatever
     // thread is active once it arrives, while the send that was pressed still

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
@@ -2,9 +2,12 @@
  * Tests for `useComposerSubmit`: the optional `beforeSend` gate (a blocking
  * gate must cancel the send losslessly, with draft, attachments, staged
  * quotes, and the staged channel reference untouched, while a passing or
- * omitted gate leaves the submit path unchanged) and the staged channel
+ * omitted gate leaves the submit path unchanged), the staged channel
  * reference's send behavior (sendable alone, leads mixed content, clears on
- * send). Uses the real composer, quote-reply, and channel-reference stores,
+ * send), and the mid-dictation send path (LUM-3432: a send pressed while
+ * words are still being spoken finishes dictation and sends the finished
+ * transcript, never the draft that was sitting there). Uses the real
+ * composer, quote-reply, channel-reference, and voice-recording stores,
  * reset between tests. The token below is a synthetic value invented for
  * these tests.
  */
@@ -20,6 +23,9 @@ import {
 } from "@/domains/chat/composer-store";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import type { DisplayAttachment } from "@/domains/chat/types/types";
+import { registerPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
+import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
+
 import {
   useComposerSubmit,
   type UseComposerSubmitParams,
@@ -61,11 +67,14 @@ function renderSubmit(overrides: Partial<UseComposerSubmitParams> = {}) {
     activeConversationId: "conv-1",
     ...overrides,
   };
-  const { result } = renderHook(
+  const { result, rerender } = renderHook(
     (props: UseComposerSubmitParams) => useComposerSubmit(props),
     { initialProps: baseParams },
   );
-  return { result, sendMessage };
+  const rerenderWith = (next: Partial<UseComposerSubmitParams>) => {
+    rerender({ ...baseParams, ...next });
+  };
+  return { result, sendMessage, rerenderWith };
 }
 
 async function submit(result: {
@@ -86,6 +95,8 @@ const stagedChannelReference: ChannelReference = {
   isTruncated: false,
 };
 
+let unregisterVoiceTarget: (() => void) | null = null;
+
 beforeEach(() => {
   useComposerStore.getState().setInput("");
   useComposerStore.getState().resetAttachments();
@@ -95,6 +106,9 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  unregisterVoiceTarget?.();
+  unregisterVoiceTarget = null;
+  useVoiceRecordingStore.getState().reset();
 });
 
 describe("useComposerSubmit beforeSend gate", () => {
@@ -330,5 +344,159 @@ describe("useComposerSubmit delivery order", () => {
       "doomed",
       "still goes",
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mid-dictation send (LUM-3432)
+// ---------------------------------------------------------------------------
+
+/**
+ * Stands in for `VoiceInputButton`: stopping ends capture, then the
+ * transcript lands in the composer and only after that does the session
+ * finalize. Passing `transcript: null` models a session that ended without
+ * producing any text.
+ */
+function recordingWithTranscript(transcript: string | null): void {
+  const voice = useVoiceRecordingStore.getState();
+  voice.startRecording();
+  unregisterVoiceTarget = registerPushToTalkTarget({
+    start: () => {},
+    stop: () => {
+      useVoiceRecordingStore.getState().stopRecording();
+      setTimeout(() => {
+        if (transcript === null) {
+          useVoiceRecordingStore.getState().fail("audio-capture");
+          return;
+        }
+        useComposerStore
+          .getState()
+          .setInput((current) =>
+            current ? `${current} ${transcript}` : transcript,
+          );
+        useVoiceRecordingStore.getState().finalize();
+      }, 0);
+    },
+  });
+}
+
+describe("useComposerSubmit during dictation", () => {
+  test("sends the finished transcript, not the draft that was on screen", async () => {
+    useComposerStore.getState().setInput("");
+    recordingWithTranscript("the whole request, spoken in full");
+
+    const { result, sendMessage } = renderSubmit();
+    await submit(result);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[0]).toBe(
+      "the whole request, spoken in full",
+    );
+  });
+
+  test("a stale fragment in the composer never goes out on its own", async () => {
+    // The reported failure: an earlier session left a fragment behind, the
+    // user re-dictated, and Send shipped the fragment mid-utterance.
+    useComposerStore.getState().setInput("can you create a list");
+    recordingWithTranscript("with all the constraints that mattered");
+
+    const { result, sendMessage } = renderSubmit();
+    await submit(result);
+
+    expect(sendMessage.mock.calls[0]?.[0]).toBe(
+      "can you create a list with all the constraints that mattered",
+    );
+  });
+
+  test("cancels the send and keeps the draft when no transcript survives", async () => {
+    useComposerStore.getState().setInput("older draft");
+    recordingWithTranscript(null);
+
+    const { result, sendMessage } = renderSubmit();
+    await submit(result);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(useComposerStore.getState().input).toBe("older draft");
+  });
+
+  test("an explicit override is its own payload and does not wait", async () => {
+    // Starter prompts and the secret guard's re-send carry their own text,
+    // so they must not be held behind an unrelated dictation session.
+    useComposerStore.getState().setInput("");
+    let stopped = false;
+    useVoiceRecordingStore.getState().startRecording();
+    unregisterVoiceTarget = registerPushToTalkTarget({
+      start: () => {},
+      stop: () => {
+        stopped = true;
+      },
+    });
+
+    const { result, sendMessage } = renderSubmit();
+    await act(async () => {
+      await result.current.submitMessage("a starter prompt");
+    });
+
+    expect(stopped).toBe(false);
+    expect(sendMessage.mock.calls[0]?.[0]).toBe("a starter prompt");
+  });
+
+  test("leaves an ordinary send untouched when nothing is recording", async () => {
+    useComposerStore.getState().setInput("typed by hand");
+
+    const { result, sendMessage } = renderSubmit();
+    await submit(result);
+
+    expect(sendMessage.mock.calls[0]?.[0]).toBe("typed by hand");
+  });
+
+  test("a thread switch during the wait cancels the send and keeps the words", async () => {
+    // The composer is shared across threads: the transcript lands in whatever
+    // thread is active once it arrives, while the send that was pressed still
+    // belongs to the thread it was pressed in. Neither thread should get it.
+    useComposerStore.getState().setInput("");
+    recordingWithTranscript("spoken into the first thread");
+
+    const { result, sendMessage, rerenderWith } = renderSubmit();
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.submitMessage();
+    });
+    act(() => {
+      rerenderWith({ activeConversationId: "conv-2" });
+    });
+    await act(async () => {
+      await pending;
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(useComposerStore.getState().input).toBe(
+      "spoken into the first thread",
+    );
+  });
+
+  test("a prompt that blocks sending during the wait wins over the press", async () => {
+    // A confirmation or secret prompt flips `sendDisabled` while the
+    // transcript is still on its way; the send pressed before it existed
+    // must not slip past the gate it would have hit a moment later.
+    useComposerStore.getState().setInput("");
+    recordingWithTranscript("said while a prompt arrived");
+
+    const { result, sendMessage, rerenderWith } = renderSubmit();
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.submitMessage();
+    });
+    act(() => {
+      rerenderWith({ sendDisabled: true });
+    });
+    await act(async () => {
+      await pending;
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(useComposerStore.getState().input).toBe(
+      "said while a prompt arrived",
+    );
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.test.tsx
@@ -495,6 +495,44 @@ describe("useComposerSubmit during dictation", () => {
     );
   });
 
+  test("an edit cancelled during the wait cancels the send and never undoes", async () => {
+    // Escape is live again once the recording reaches processing, so the user
+    // can back out of the edit while the transcript is still on its way. The
+    // send pressed inside that edit must not go on to undo the original
+    // message and deliver the transcript in its place.
+    useComposerStore.getState().setInput("");
+    recordingWithTranscript("a rewrite the user backed out of");
+    const cancelEditing = mock(() => {});
+
+    const { result, sendMessage, rerenderWith } = renderSubmit({
+      isEditing: true,
+      editingMessageId: "msg-1",
+      canUndoEdit: true,
+      cancelEditing,
+    });
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.submitMessage();
+    });
+    act(() => {
+      rerenderWith({
+        isEditing: false,
+        editingMessageId: null,
+        canUndoEdit: true,
+        cancelEditing,
+      });
+    });
+    await act(async () => {
+      await pending;
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(cancelEditing).not.toHaveBeenCalled();
+    expect(useComposerStore.getState().input).toBe(
+      "a rewrite the user backed out of",
+    );
+  });
+
   test("a prompt that blocks sending during the wait wins over the press", async () => {
     // A confirmation or secret prompt flips `sendDisabled` while the
     // transcript is still on its way; the send pressed before it existed

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.ts
@@ -116,17 +116,23 @@ export function useComposerSubmit({
    */
   const sendChainRef = useRef<Promise<void>>(Promise.resolve());
   /**
-   * Live copies of the two values a mid-dictation send has to re-read after
-   * it has waited: `submitMessage` awaits the transcript for up to several
-   * seconds, and the closure it started in remembers the conversation and
-   * the blocking state as they were at the press, not as they are now.
+   * Live copies of the values a mid-dictation send has to re-read after it
+   * has waited: `submitMessage` awaits the transcript for up to several
+   * seconds, and the closure it started in remembers the conversation, the
+   * blocking state and the edit in progress as they were at the press, not
+   * as they are now. The edit is tracked by the message it targets, null
+   * when nothing is being edited, so a cancelled or swapped edit reads as a
+   * change.
    */
   const activeConversationIdRef = useRef(activeConversationId);
   const sendDisabledRef = useRef(sendDisabled);
+  const editingTarget = isEditing ? editingMessageId : null;
+  const editingTargetRef = useRef(editingTarget);
   useEffect(() => {
     activeConversationIdRef.current = activeConversationId;
     sendDisabledRef.current = sendDisabled;
-  }, [activeConversationId, sendDisabled]);
+    editingTargetRef.current = editingTarget;
+  }, [activeConversationId, sendDisabled, editingTarget]);
 
   // --- Focus effect -------------------------------------------------------
   useEffect(() => {
@@ -151,6 +157,7 @@ export function useComposerSubmit({
       // does not wait.
       if (inputOverride === undefined) {
         const conversationAtPress = activeConversationIdRef.current;
+        const editingAtPress = editingTargetRef.current;
         const outcome = await finishActiveDictation();
         if (outcome === "no-transcript") {
           // The spoken words did not survive. The draft sitting in the
@@ -165,10 +172,15 @@ export function useComposerSubmit({
         // thread's draft and deliver it to another. A confirmation or secret
         // prompt arriving during the wait flips `sendDisabled` for the same
         // reason, and the prompt gate must win over a send pressed before it
-        // existed. Either way the words stay in the draft for the user.
+        // existed. An edit cancelled during the wait (Escape is live again
+        // once the recording has moved to processing) would otherwise still
+        // be undone and re-sent by this closure, which remembers the edit as
+        // it stood at the press. Either way the words stay in the draft for
+        // the user.
         if (
           activeConversationIdRef.current !== conversationAtPress ||
-          sendDisabledRef.current
+          sendDisabledRef.current ||
+          editingTargetRef.current !== editingAtPress
         ) {
           return;
         }

--- a/clients/web/src/domains/chat/hooks/use-composer-submit.ts
+++ b/clients/web/src/domains/chat/hooks/use-composer-submit.ts
@@ -34,6 +34,7 @@ import {
   useQuoteReplyStore,
   type StagedQuote,
 } from "@/domains/chat/quote-reply-store";
+import { finishActiveDictation } from "@/domains/chat/voice/finish-dictation";
 import { conversationsByIdUndoPost } from "@/generated/daemon/sdk.gen";
 import { haptic } from "@/utils/haptics";
 import { isPointerCoarse } from "@/utils/pointer";
@@ -114,6 +115,18 @@ export function useComposerSubmit({
    * were made. See where it is advanced in `submitMessage`.
    */
   const sendChainRef = useRef<Promise<void>>(Promise.resolve());
+  /**
+   * Live copies of the two values a mid-dictation send has to re-read after
+   * it has waited: `submitMessage` awaits the transcript for up to several
+   * seconds, and the closure it started in remembers the conversation and
+   * the blocking state as they were at the press, not as they are now.
+   */
+  const activeConversationIdRef = useRef(activeConversationId);
+  const sendDisabledRef = useRef(sendDisabled);
+  useEffect(() => {
+    activeConversationIdRef.current = activeConversationId;
+    sendDisabledRef.current = sendDisabled;
+  }, [activeConversationId, sendDisabled]);
 
   // --- Focus effect -------------------------------------------------------
   useEffect(() => {
@@ -126,6 +139,40 @@ export function useComposerSubmit({
   // --- Submit logic -------------------------------------------------------
   const submitMessage = useCallback(
     async (inputOverride?: string, opts?: { bypassSecretCheck?: boolean }) => {
+      if (sendDisabled) {
+        return;
+      }
+      // A send pressed mid-dictation means "finish, then send". Waiting for
+      // the transcript to land is what keeps the payload equal to what the
+      // user can read: the live partial is not in the draft yet, so sending
+      // first would drop everything spoken since the draft was last written
+      // (LUM-3432). An explicit override is its own payload (a starter
+      // prompt, the secret guard's re-send) and never the live draft, so it
+      // does not wait.
+      if (inputOverride === undefined) {
+        const conversationAtPress = activeConversationIdRef.current;
+        const outcome = await finishActiveDictation();
+        if (outcome === "no-transcript") {
+          // The spoken words did not survive. The draft sitting in the
+          // composer is not what the user asked to send, so leave it intact
+          // rather than sending it in their place.
+          return;
+        }
+        // The wait is long enough for the world to move. The composer is not
+        // keyed by conversation, so a thread switch during it lands the
+        // transcript in the new thread's draft while this closure still
+        // holds the old thread's `sendMessage`: sending now would clear one
+        // thread's draft and deliver it to another. A confirmation or secret
+        // prompt arriving during the wait flips `sendDisabled` for the same
+        // reason, and the prompt gate must win over a send pressed before it
+        // existed. Either way the words stay in the draft for the user.
+        if (
+          activeConversationIdRef.current !== conversationAtPress ||
+          sendDisabledRef.current
+        ) {
+          return;
+        }
+      }
       const input = useComposerStore.getState().input;
       const chatAttachments = useComposerStore.getState().attachments;
       const uploadingCount = selectUploadingCount(chatAttachments);
@@ -135,9 +182,6 @@ export function useComposerSubmit({
       const stagedQuotes = useQuoteReplyStore.getState().stagedQuotes;
       const channelReference = useChannelReferenceStore.getState().reference;
       const trimmed = (inputOverride ?? input).trim();
-      if (sendDisabled) {
-        return;
-      }
       // A staged channel reference is content in its own right: "look at this
       // message" is a complete instruction, so it makes an otherwise empty
       // composer sendable exactly as a staged quote does.

--- a/clients/web/src/domains/chat/voice/finish-dictation.test.ts
+++ b/clients/web/src/domains/chat/voice/finish-dictation.test.ts
@@ -1,0 +1,104 @@
+/**
+ * `finishActiveDictation` is what makes Send mean "finish, then send" while
+ * dictation is live (LUM-3432). It has to stop the session, wait for the
+ * transcript to reach the composer, and tell the caller whether any words
+ * actually arrived. Uses the real recording store, reset between tests.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { finishActiveDictation } from "@/domains/chat/voice/finish-dictation";
+import { registerPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
+import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
+
+const store = useVoiceRecordingStore;
+
+/** Registers a stop handler and returns its unregister for cleanup. */
+function withTarget(stop: () => void): () => void {
+  return registerPushToTalkTarget({ start: () => {}, stop });
+}
+
+let unregister: (() => void) | null = null;
+
+afterEach(() => {
+  unregister?.();
+  unregister = null;
+  store.getState().reset();
+});
+
+describe("finishActiveDictation", () => {
+  test("does nothing when no session is in flight", async () => {
+    let stopped = false;
+    unregister = withTarget(() => {
+      stopped = true;
+    });
+
+    expect(await finishActiveDictation()).toBe("none");
+    expect(stopped).toBe(false);
+  });
+
+  test("stops a live session and reports the transcript delivered", async () => {
+    store.getState().startRecording();
+    unregister = withTarget(() => {
+      store.getState().stopRecording();
+      // The button writes the transcript into the composer and only then
+      // finalizes, so `done` is the signal that the draft holds the words.
+      setTimeout(() => store.getState().finalize(), 0);
+    });
+
+    expect(await finishActiveDictation(1000)).toBe("delivered");
+  });
+
+  test("settles even when the stop finalizes synchronously", async () => {
+    store.getState().startRecording();
+    unregister = withTarget(() => {
+      store.getState().stopRecording();
+      store.getState().finalize();
+    });
+
+    expect(await finishActiveDictation(1000)).toBe("delivered");
+  });
+
+  test("reports no transcript when the session fails", async () => {
+    store.getState().startRecording();
+    unregister = withTarget(() => {
+      store.getState().stopRecording();
+      setTimeout(() => store.getState().fail("audio-capture"), 0);
+    });
+
+    expect(await finishActiveDictation(1000)).toBe("no-transcript");
+  });
+
+  test("reports no transcript when the session ends with nothing to insert", async () => {
+    store.getState().startRecording();
+    unregister = withTarget(() => {
+      store.getState().stopRecording();
+      // The empty/cancelled paths reset straight back to idle.
+      setTimeout(() => store.getState().reset(), 0);
+    });
+
+    expect(await finishActiveDictation(1000)).toBe("no-transcript");
+  });
+
+  test("gives up rather than guessing when the stop never lands", async () => {
+    store.getState().startRecording();
+    // A stop pressed on an instance that owns no recorder is a no-op, so the
+    // phase never moves.
+    unregister = withTarget(() => {});
+
+    expect(await finishActiveDictation(20)).toBe("no-transcript");
+  });
+
+  test("waits out a session already transcribing without stopping it again", async () => {
+    store.getState().startRecording();
+    store.getState().stopRecording();
+    let stopped = false;
+    unregister = withTarget(() => {
+      stopped = true;
+    });
+    setTimeout(() => store.getState().finalize(), 0);
+
+    expect(await finishActiveDictation(1000)).toBe("delivered");
+    expect(stopped).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/voice/finish-dictation.test.ts
+++ b/clients/web/src/domains/chat/voice/finish-dictation.test.ts
@@ -46,7 +46,7 @@ describe("finishActiveDictation", () => {
       setTimeout(() => store.getState().finalize(), 0);
     });
 
-    expect(await finishActiveDictation(1000)).toBe("delivered");
+    expect(await finishActiveDictation()).toBe("delivered");
   });
 
   test("settles even when the stop finalizes synchronously", async () => {
@@ -56,7 +56,7 @@ describe("finishActiveDictation", () => {
       store.getState().finalize();
     });
 
-    expect(await finishActiveDictation(1000)).toBe("delivered");
+    expect(await finishActiveDictation()).toBe("delivered");
   });
 
   test("reports no transcript when the session fails", async () => {
@@ -66,7 +66,7 @@ describe("finishActiveDictation", () => {
       setTimeout(() => store.getState().fail("audio-capture"), 0);
     });
 
-    expect(await finishActiveDictation(1000)).toBe("no-transcript");
+    expect(await finishActiveDictation()).toBe("no-transcript");
   });
 
   test("reports no transcript when the session ends with nothing to insert", async () => {
@@ -77,16 +77,35 @@ describe("finishActiveDictation", () => {
       setTimeout(() => store.getState().reset(), 0);
     });
 
-    expect(await finishActiveDictation(1000)).toBe("no-transcript");
+    expect(await finishActiveDictation()).toBe("no-transcript");
   });
 
-  test("gives up rather than guessing when the stop never lands", async () => {
-    store.getState().startRecording();
-    // A stop pressed on an instance that owns no recorder is a no-op, so the
-    // phase never moves.
-    unregister = withTarget(() => {});
+  test("leaves a held key's session alone: it is not the composer's", async () => {
+    // The bridge's hidden recorder runs every hold, into another app. The
+    // composer's target cannot stop that recorder, and its words are not
+    // this composer's content, so the send goes out as if no mic were open.
+    store.getState().startRecording({ hold: true });
+    let stopped = false;
+    unregister = withTarget(() => {
+      stopped = true;
+    });
 
-    expect(await finishActiveDictation(20)).toBe("no-transcript");
+    expect(await finishActiveDictation()).toBe("none");
+    expect(stopped).toBe(false);
+    expect(store.getState().phase).toBe("recording");
+  });
+
+  test("waits out a slow transcription rather than dropping it on a clock", async () => {
+    store.getState().startRecording();
+    unregister = withTarget(() => {
+      store.getState().stopRecording();
+      // Longer than any fixed ceiling a test would tolerate is not the
+      // point; the point is that nothing but the button's own finalize
+      // settles the wait.
+      setTimeout(() => store.getState().finalize(), 60);
+    });
+
+    expect(await finishActiveDictation()).toBe("delivered");
   });
 
   test("waits out a session already transcribing without stopping it again", async () => {
@@ -98,7 +117,7 @@ describe("finishActiveDictation", () => {
     });
     setTimeout(() => store.getState().finalize(), 0);
 
-    expect(await finishActiveDictation(1000)).toBe("delivered");
+    expect(await finishActiveDictation()).toBe("delivered");
     expect(stopped).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/voice/finish-dictation.ts
+++ b/clients/web/src/domains/chat/voice/finish-dictation.ts
@@ -1,0 +1,102 @@
+/**
+ * Ends an in-flight dictation session and waits for its transcript to land
+ * in the composer, so a send can never outrun the words the user is watching
+ * themselves say.
+ *
+ * Dictation shows two texts at once: the committed draft in the textarea and
+ * the live partial underneath it. Only the draft is the payload, and nothing
+ * on screen says so, so pressing Send mid-utterance used to send whatever the
+ * textarea happened to hold and drop everything spoken since (LUM-3432).
+ * Awaiting this first makes Send mean "finish, then send", which is the
+ * gesture people already reach for at the end of dictating.
+ *
+ * The transcript is written to the composer by `onTranscript` *before*
+ * `finalize()` moves the store to `done`, so a `done` phase is the signal
+ * that the words are in the draft and the send can read them.
+ */
+
+import { getPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
+import {
+  useVoiceRecordingStore,
+  type VoiceRecordingPhase,
+} from "@/domains/chat/voice/voice-recording-store";
+
+/**
+ * Ceiling on the wait. Generous, because the batch STT round trip owns most
+ * of the `processing` phase; hitting it means the session is wedged rather
+ * than slow, and the caller drops the send instead of guessing at a payload.
+ */
+const FINALIZE_TIMEOUT_MS = 10_000;
+
+export type DictationFinishOutcome =
+  /** Nothing was recording or transcribing; the caller can proceed as normal. */
+  | "none"
+  /** A session finished and put its transcript in the composer. */
+  | "delivered"
+  /** A session ended without producing text (error, silence, or a wedged stop). */
+  | "no-transcript";
+
+function isInFlight(phase: VoiceRecordingPhase): boolean {
+  return phase === "recording" || phase === "processing";
+}
+
+/**
+ * Stop any live dictation and resolve once it has reached a terminal phase.
+ *
+ * Callers should proceed only on `"none"` or `"delivered"`. A
+ * `"no-transcript"` result means the user pressed Send while speaking and
+ * the words did not survive: sending the draft that happens to be sitting
+ * there would send something they did not ask for, and the draft is left
+ * untouched so they can simply try again.
+ */
+export async function finishActiveDictation(
+  timeoutMs: number = FINALIZE_TIMEOUT_MS,
+): Promise<DictationFinishOutcome> {
+  const store = useVoiceRecordingStore;
+  if (!isInFlight(store.getState().phase)) {
+    return "none";
+  }
+
+  if (store.getState().phase === "recording") {
+    // The composer's own `VoiceInputButton` registers itself as the target,
+    // so this is the instance that owns the recorder in the flow that
+    // matters. A press that lands on an instance owning no recorder is a
+    // no-op and falls through to the timeout below.
+    getPushToTalkTarget()?.stop();
+  }
+
+  const terminalPhase = await new Promise<VoiceRecordingPhase | null>(
+    (resolve) => {
+      let unsubscribe: (() => void) | null = null;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const settle = (phase: VoiceRecordingPhase | null) => {
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        unsubscribe?.();
+        unsubscribe = null;
+        resolve(phase);
+      };
+
+      unsubscribe = store.subscribe((state) => {
+        if (!isInFlight(state.phase)) {
+          settle(state.phase);
+        }
+      });
+      timer = setTimeout(() => {
+        console.warn("dictation: finalize timed out, send dropped");
+        settle(null);
+      }, timeoutMs);
+
+      // `stop()` above can drive the session all the way to a terminal phase
+      // before the subscription exists.
+      const current = store.getState().phase;
+      if (!isInFlight(current)) {
+        settle(current);
+      }
+    },
+  );
+
+  return terminalPhase === "done" ? "delivered" : "no-transcript";
+}

--- a/clients/web/src/domains/chat/voice/finish-dictation.ts
+++ b/clients/web/src/domains/chat/voice/finish-dictation.ts
@@ -21,13 +21,6 @@ import {
   type VoiceRecordingPhase,
 } from "@/domains/chat/voice/voice-recording-store";
 
-/**
- * Ceiling on the wait. Generous, because the batch STT round trip owns most
- * of the `processing` phase; hitting it means the session is wedged rather
- * than slow, and the caller drops the send instead of guessing at a payload.
- */
-const FINALIZE_TIMEOUT_MS = 10_000;
-
 export type DictationFinishOutcome =
   /** Nothing was recording or transcribing; the caller can proceed as normal. */
   | "none"
@@ -41,62 +34,75 @@ function isInFlight(phase: VoiceRecordingPhase): boolean {
 }
 
 /**
- * Stop any live dictation and resolve once it has reached a terminal phase.
+ * Whether the session in the window-global store is the composer's own. The
+ * store is shared with the bridge's hidden recorder, which a held voice key
+ * always drives (its words are aimed at a cursor in another app), and every
+ * session that recorder opens is flagged `hold` as it starts. What is left
+ * once holds are excluded is a press that resolved to the registered target,
+ * which on a chat route is the composer's microphone.
+ */
+function isComposerSession(state: {
+  phase: VoiceRecordingPhase;
+  hold: boolean;
+}): boolean {
+  return isInFlight(state.phase) && !state.hold;
+}
+
+/**
+ * Stop the composer's live dictation, if any, and resolve once it has
+ * reached a terminal phase.
  *
  * Callers should proceed only on `"none"` or `"delivered"`. A
  * `"no-transcript"` result means the user pressed Send while speaking and
  * the words did not survive: sending the draft that happens to be sitting
  * there would send something they did not ask for, and the draft is left
  * untouched so they can simply try again.
+ *
+ * A session the composer does not own (a held key dictating into another
+ * app) is `"none"`: it is not content for this composer, and the send goes
+ * out with the draft exactly as it would with no microphone open.
+ *
+ * The wait has no ceiling of its own. Every exit from `processing` is made
+ * by the recording button (finalize, fail, or reset, whatever the batch STT
+ * round trip does), and a composer session in `recording` leaves it through
+ * the stop issued here on the target that owns the recorder. A slow
+ * transcription is still a transcription on its way to the draft, so the
+ * send waits for it rather than dropping it on a clock.
  */
-export async function finishActiveDictation(
-  timeoutMs: number = FINALIZE_TIMEOUT_MS,
-): Promise<DictationFinishOutcome> {
+export async function finishActiveDictation(): Promise<DictationFinishOutcome> {
   const store = useVoiceRecordingStore;
-  if (!isInFlight(store.getState().phase)) {
+  if (!isComposerSession(store.getState())) {
     return "none";
   }
 
   if (store.getState().phase === "recording") {
     // The composer's own `VoiceInputButton` registers itself as the target,
-    // so this is the instance that owns the recorder in the flow that
-    // matters. A press that lands on an instance owning no recorder is a
-    // no-op and falls through to the timeout below.
+    // so this is the instance that owns the recorder for a session that is
+    // not a hold.
     getPushToTalkTarget()?.stop();
   }
 
-  const terminalPhase = await new Promise<VoiceRecordingPhase | null>(
-    (resolve) => {
-      let unsubscribe: (() => void) | null = null;
-      let timer: ReturnType<typeof setTimeout> | null = null;
-      const settle = (phase: VoiceRecordingPhase | null) => {
-        if (timer !== null) {
-          clearTimeout(timer);
-          timer = null;
-        }
-        unsubscribe?.();
-        unsubscribe = null;
-        resolve(phase);
-      };
+  const terminalPhase = await new Promise<VoiceRecordingPhase>((resolve) => {
+    let unsubscribe: (() => void) | null = null;
+    const settle = (phase: VoiceRecordingPhase) => {
+      unsubscribe?.();
+      unsubscribe = null;
+      resolve(phase);
+    };
 
-      unsubscribe = store.subscribe((state) => {
-        if (!isInFlight(state.phase)) {
-          settle(state.phase);
-        }
-      });
-      timer = setTimeout(() => {
-        console.warn("dictation: finalize timed out, send dropped");
-        settle(null);
-      }, timeoutMs);
-
-      // `stop()` above can drive the session all the way to a terminal phase
-      // before the subscription exists.
-      const current = store.getState().phase;
-      if (!isInFlight(current)) {
-        settle(current);
+    unsubscribe = store.subscribe((state) => {
+      if (!isInFlight(state.phase)) {
+        settle(state.phase);
       }
-    },
-  );
+    });
+
+    // `stop()` above can drive the session all the way to a terminal phase
+    // before the subscription exists.
+    const current = store.getState().phase;
+    if (!isInFlight(current)) {
+      settle(current);
+    }
+  });
 
   return terminalPhase === "done" ? "delivered" : "no-transcript";
 }


### PR DESCRIPTION
Part of the LUM-3432 RCA. One of two independent fixes; the daemon-side one (never accept a cleanup rewrite that lost the user's words) is #41629.

## The problem

Dictation puts two texts on screen at once:

- the **committed draft** in the textarea, in normal weight
- the **live partial** underneath it, in 11px italics (and `truncate`, so even that is ellipsized)

Only the draft is the payload, and nothing on screen says so. Send was never gated on the recording phase:

```ts
const sendBlocked =
  sendDisabled || attachmentsUploadingCount > 0 || !canSendMessageContent;
```

No `voicePhase` term, and the Enter policy answered the same way. So a send pressed mid-utterance shipped whatever the textarea happened to hold and dropped everything spoken since. That is how a user sent `can you create a list` while the line under it read back the full request they had just spoken -- 20 roles, HR coordinator, remote, 50-60K -- none of which reached the assistant.

## The fix

`finishActiveDictation()` stops the live session, waits for the transcript to reach the composer, and reports whether any words arrived. `submitMessage` awaits it before it reads the draft, so **Send now means "finish, then send"** -- the gesture people already reach for at the end of dictating.

The wait keys on the recording store's own terminal phases. `onTranscript` writes the transcript into the composer *before* `finalize()` moves the store to `done`, so `done` is a reliable signal that the words are in the draft.

A session that ends without producing text (`error`, silence, or a stop that never lands) cancels the send and leaves the draft untouched. The user pressed Send in the middle of speaking, meaning "send what I'm saying"; if that did not survive, sending some other draft in its place is not what they asked for, and they lose nothing by pressing again.

An explicit `inputOverride` -- a starter prompt, the secret guard's re-send -- carries its own payload and never waits on an unrelated session.

**The wait is long enough for the world to move**, so two values are re-read from live refs after it rather than trusted from the closure the press started in:

- the **active conversation**: the composer is shared across threads, so a switch mid-wait lands the transcript in the new thread's draft while the closure still holds the old thread's `sendMessage`. The send is cancelled and the words stay in the draft.
- **`sendDisabled`**: a confirmation or secret prompt arriving mid-wait must win over a send pressed before it existed. Same outcome.

Attachment upload state was already read from the store after the wait.

**Only the composer's own session counts.** The recording store is window-global and shared with the bridge's hidden recorder, which a held voice key drives into whatever app is in front. Every such session is flagged `hold` as it starts, so "in flight and not a hold" is the composer's session: only that one lights Send, opens the Enter policy, or makes the send wait. A foreign hold leaves Send exactly as it is with no microphone open.

**The wait has no fixed ceiling.** Every exit from `processing` is made by the recording button (finalize, fail, or reset around the STT round trip), and a composer session in `recording` leaves through the stop issued on the owning target. Batch STT has no client deadline and the server allows it minutes, so a clock here would cut off transcriptions still on their way to the draft.

## Two gates had to open for this to be reachable

**Enter was swallowed.** The Enter policy counted an empty draft as nothing to send, so during an empty-composer dictation (most of them) Enter did nothing -- and whenever a stale fragment *was* sitting there, it sent that instead. `dictationInFlight` joins `hasContent`, keeping the Enter policy and the send button answering "is there something to send" from the same state, which the surrounding code explicitly cares about.

**The send arrow was hidden outright** for the whole session (`isVoiceActive ? null : …`, macOS parity), leaving the mic button as the row's only control and no pointer gesture at all for ending dictation and sending in one move. It stays now, and the two controls divide the job cleanly:

- **mic (stop square)** -- stop, leave the words in the composer
- **send arrow** -- stop, and send them

Deliberately scoped: `canSendOrFinishDictation` is a separate flag rather than folded into `canSendMessageContent`, so the busy row's stop/send swap keeps its existing behavior. That swap is about a draft ready to queue right now, and a session still being spoken is not that.

## What this does not fix

The underlying design flaw -- two texts on screen, only one of which is the payload -- is still there. The real fix is streaming the interim into the textarea itself so there is only ever one text, which is a follow-up. This PR makes the current arrangement safe: the payload can no longer be text the user cannot see.

## Tests

- `finish-dictation.test.ts` -- terminal-phase resolution, the synchronous-stop race, failure and empty sessions, a foreign hold left alone, and a slow finalize waited out
- `use-composer-submit.test.tsx` -- sends the finished transcript rather than the on-screen draft, the reported stale-fragment case, the cancel-and-keep-draft path, override passthrough, and the two post-wait cancels (thread switch, prompt arriving) Also: an edit cancelled during the wait cancels the send and skips the undo.
- `chat-composer.test.tsx` -- the Enter policy while dictating (and that it does not override `sendDisabled` or an uploading attachment), plus a live send button during the composer's own session and none during a foreign hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FwAQPbuB5cqbcNzePwf3VW