### PR TITLE
fix: camera-mode self-review round 2

### DIFF
--- a/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
+++ b/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
@@ -43,10 +43,12 @@ struct VoiceSessionAttributes: ActivityAttributes {
 
         /// User-facing activity copy, passed through from the web side.
         ///
-        /// `LIVE_VOICE_STATE_LABELS` and `liveVoiceSurfaceLabel` (including its
+        /// `LIVE_VOICE_STATE_KEYS` and `liveVoiceSurfaceLabelKey` (including its
         /// `reconnecting` → "Reconnecting…" case and its silent-`speaking` →
-        /// "Thinking…" remap) in `live-voice-store.ts` are the single source of
-        /// this copy — it is the same call the voice room makes. **The native
+        /// "Thinking…" remap) in `live-voice-store.ts`, resolved through the
+        /// web's own catalog, are the single source of this copy: it is the
+        /// same call the voice room makes, so the label arrives in the language
+        /// the app is in. **The native
         /// side must never invent its own phase wording** — the shell ships on
         /// App Store cadence while
         /// that copy deploys continuously, so a native `switch` over `phase`

--- a/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
+++ b/clients/ios/App/VoiceActivity/VoiceSessionIslandViews.swift
@@ -19,9 +19,10 @@ import UIKit
 //
 // 1. **No native phase copy.** Every string describing the *session* is either
 //    `ContentState.label` or `VoiceSessionAttributes.assistantName`, both
-//    passed through from the web side. `LIVE_VOICE_STATE_LABELS` /
-//    `liveVoiceSurfaceLabel` in `live-voice-store.ts` own the wording — this
-//    shell ships on App Store cadence while that copy deploys continuously,
+//    passed through from the web side. `LIVE_VOICE_STATE_KEYS` /
+//    `liveVoiceSurfaceLabelKey` in `live-voice-store.ts`, resolved through the
+//    web's own catalog, own the wording: this shell ships on App Store cadence
+//    while that copy deploys continuously,
 //    so a native `switch` over `phase` would fossilize old strings. Tight
 //    slots truncate the passed label; they never substitute a shorter native
 //    one.
@@ -526,8 +527,8 @@ struct VoiceApprovalControls: View {
 /// Always one line with a tail ellipsis. The web side decides how long the
 /// string is, so the tight slots shorten what they were given instead of
 /// substituting a native string of their own. Every phase that reaches an
-/// activity has a non-empty label (`LIVE_VOICE_STATE_LABELS` maps only the
-/// phases with no activity to `""`), and the plugin rejects an empty
+/// activity has a non-empty label (`LIVE_VOICE_STATE_KEYS` keys only the
+/// phases with no activity to nothing), and the plugin rejects an empty
 /// `assistantName`, so there is no empty-string case to special-case.
 struct VoiceSessionText: View {
     let text: String

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -106,22 +106,26 @@ the island UI would still have to handle.
 
 ### Why label copy comes from the web
 
-`ContentState.label` is a string passed through from
-`liveVoiceSurfaceLabel(state, reconnecting, assistantAudioActive)` — the *same
-call the voice room makes*, so the island reads exactly what the room reads. The
+`ContentState.label` is a string the web resolves out of its own catalog, keyed
+by `liveVoiceSurfaceLabelKey(state, reconnecting, assistantAudioActive, muted)`:
+the *same call the voice room makes*, so the island reads exactly what the room
+reads, in the language the app is in. The
 native side never switches on `phase` to produce wording — not in the expanded
 island, not in the compact slots, not on the Lock Screen. Three reasons, in order
 of importance:
 
-1. **Cadence.** `LIVE_VOICE_STATE_LABELS` deploys continuously; this shell ships
+1. **Cadence.** `LIVE_VOICE_STATE_KEYS` and the catalog behind it deploy
+   continuously; this shell ships
    on App Store review. A native `switch` would fossilize whatever wording was
    current at submission and drift silently from the room the user is looking at.
 2. **Two relabel rules, neither derivable from `phase` alone.**
-   `liveVoiceSurfaceLabel` maps `connecting` + `reconnecting` to "Reconnecting…",
+   `liveVoiceSurfaceLabelKey` maps `connecting` + `reconnecting` to "Reconnecting…",
    and a `speaking` with no audio actually playing to "Thinking…" — `speaking`
    stays set across a mid-turn tool run (JARVIS-1279). Reproducing either
    natively means shipping more state across the bridge and duplicating the rule.
-3. **Localization.** The web layer already owns user-facing copy.
+3. **Localization.** The web layer owns user-facing copy, and the label crosses
+   the bridge already translated, so the island follows the app language with no
+   catalog on this side.
 
 Wherever the label *is* rendered it is only ever truncated (`.lineLimit(1)` +
 `.truncationMode(.tail)` in `VoiceSessionText`), never swapped for a shorter

--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -5,10 +5,13 @@ reader, or a real OS setting, so it runs by hand.
 
 Surface under test: the voice room with the viewfinder up, under
 `src/domains/chat/voice/voice-room/` (the camera paths of `voice-room.tsx`,
-`camera-status-pill.tsx`, `camera-flash-control.tsx`, `camera-shutter.tsx`, and
-`voice-room-control.tsx` at `surface="camera"`), plus the deep-link capture
-overlay in `src/domains/chat/components/chat-attachments/`, which shares the
-shutter and the bottom scrim.
+`camera-status-pill.tsx`, `camera-flash-control.tsx`, and
+`voice-room-control.tsx` at `surface="camera"`). Two things it runs on live
+outside that directory and are in scope with it: the shutter at
+`src/domains/chat/voice/camera-shutter.tsx`, which the room shares with the
+deep-link capture overlay, and that overlay itself in
+`src/domains/chat/components/chat-attachments/`, which also shares the bottom
+scrim.
 
 ## iPhone
 
@@ -126,11 +129,12 @@ the redesign is called shipped.
       resting state also carries `backdrop-blur-sm`, which the handoff draws as
       a flat fill. Confirm the glyph sits as a sibling of the icons beside it,
       and that the blur is wanted over a busy frame.
-- [ ] Localized session words on the minimized surfaces. The composer's voice
-      bar and the title-bar session pill read the session's state through the
-      catalog rather than the store's English map, so they follow the app
-      language the way the room already did. Sweep them in Spanish and Russian
-      alongside the room.
+- [ ] Localized session words on the surfaces outside the room. The composer's
+      voice bar, the title-bar session pill, the iOS Dynamic Island and the
+      macOS companion panel all read the session's state through the catalog,
+      so they follow the app language the way the room does. Sweep them in
+      Spanish and Russian alongside the room, the island backgrounded so a
+      server-composed push is what lands.
 
 ## Known adjacent issues
 

--- a/clients/web/src/domains/chat/voice/camera-story-feed.tsx
+++ b/clients/web/src/domains/chat/voice/camera-story-feed.tsx
@@ -145,7 +145,7 @@ export function CameraRowScene({
         {...ROW_FLASH}
         {...flash}
         onClick={() => {}}
-        className="absolute left-[33px]"
+        className="absolute left-11"
       />
       <CameraShutter {...shutter} />
       <CameraRowFlipStandIn />

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
@@ -62,6 +62,7 @@ mock.module("@/lib/sentry/capture-error", () => ({
 
 const { registerLiveActivityPushToken } =
   await import("@/domains/chat/voice/live-voice/live-activity-push-registration");
+const { changeLocale } = await import("@/i18n");
 
 beforeEach(() => {
   lastUpsertArg = null;
@@ -127,6 +128,24 @@ describe("registerLiveActivityPushToken content state", () => {
     await registerLiveActivityPushToken({ ...REGISTRATION, muted: false });
 
     expect(lastUpsertArg?.body.labels.listening).toBe("Listening…");
+  });
+
+  /**
+   * The table is the platform's whole vocabulary, so one built in English puts
+   * the island back into English on the first push after iOS suspends this web
+   * layer, which is the only state the island is ever seen in.
+   */
+  test("registers the table in the language the app is in", async () => {
+    await changeLocale("es");
+    try {
+      await registerLiveActivityPushToken(REGISTRATION);
+
+      expect(lastUpsertArg?.body.labels.listening).toBe("Escuchando…");
+      expect(lastUpsertArg?.body.labels.thinking).toBe("Pensando…");
+    } finally {
+      // Process-global, so leaving it set would fail every later assertion.
+      await changeLocale("en");
+    }
   });
 
   // The stored row is what every background push composes from, so a slow

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -18,13 +18,16 @@
  * arrives.
  *
  * **The lexicon travels with the token.** Phase wording belongs to the web
- * layer — `liveVoiceSurfaceLabel` is the same call the voice room makes, and
- * the native side deliberately owns none of it because the shell ships on App
- * Store cadence while this bundle deploys continuously. A server composing its
- * own strings would reintroduce exactly that drift one layer further out, so
- * registration hands over a phase→label map and the platform only ever looks a
- * phase up in it. The accent and mute state travel the same way and for the
- * same underlying reason. See {@link LiveActivityRegistration}.
+ * layer: `liveVoiceSurfaceLabelKey` is the same call the voice room makes and
+ * the catalog behind it is the same one, and the native side deliberately owns
+ * none of it because the shell ships on App Store cadence while this bundle
+ * deploys continuously. A server composing its own strings would reintroduce
+ * exactly that drift one layer further out, so registration hands over a
+ * phase to label map and the platform only ever looks a phase up in it. The map
+ * is built in the language the app is in, which is what makes a
+ * server-composed push read the way the room did. The accent and mute state
+ * travel the same way and for the same underlying reason. See
+ * {@link LiveActivityRegistration}.
  *
  * Best-effort throughout, like everything else that touches the island: a
  * failure here costs a background update, never a voice session.
@@ -36,21 +39,28 @@ import {
 } from "@/generated/api/sdk.gen";
 import {
   isLiveVoiceSessionActive,
-  LIVE_VOICE_STATE_LABELS,
-  liveVoiceSurfaceLabel,
+  LIVE_VOICE_STATE_KEYS,
+  liveVoiceSurfaceLabelKey,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { fixedT } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 import { resolveSignedApnsEnvironment } from "@/runtime/apns-environment";
 import { createStorageAccessor } from "@/utils/typed-storage";
 
 /**
- * Every phase an activity can be pushed into, paired with its wording.
+ * Every phase an activity can be pushed into, paired with its wording in the
+ * app's current language.
  *
- * Derived from the label table rather than restated, so a phase added to the
+ * Derived from the key table rather than restated, so a phase added to the
  * session cannot quietly ship without server-side copy. `idle` and `failed` are
  * filtered out for the same reason they have no `ContentState.Phase` case:
  * neither has an activity to address.
+ *
+ * The non-reactive `t`, because this is plain module code on the registration
+ * path rather than a render. The map is a snapshot of the language the
+ * registration was made in, and the caller re-registers whenever the content
+ * the platform composes from moves.
  *
  * `muted` is baked into the table rather than left at its steady state. The
  * platform composes pushes by looking a phase up in this map, so a table built
@@ -63,15 +73,17 @@ import { createStorageAccessor } from "@/utils/typed-storage";
  * cannot observe them.
  */
 function phaseLabels(muted: boolean): Record<string, string> {
+  const t = fixedT("chat");
   const labels: Record<string, string> = {};
   const phases = (
-    Object.keys(LIVE_VOICE_STATE_LABELS) as LiveVoiceSessionState[]
+    Object.keys(LIVE_VOICE_STATE_KEYS) as LiveVoiceSessionState[]
   ).filter(isLiveVoiceSessionActive);
   for (const phase of phases) {
-    // Read through the same helper the room and the mirror use rather than the
+    // Keyed through the same helper the room and the mirror use rather than the
     // raw table, so a server-pushed label is the string the user would have
     // seen locally, including the relabel rules.
-    labels[phase] = liveVoiceSurfaceLabel(phase, false, true, muted);
+    const key = liveVoiceSurfaceLabelKey(phase, false, true, muted);
+    labels[phase] = key ? t(key) : "";
   }
   return labels;
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -16,8 +16,7 @@ import {
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
-  LIVE_VOICE_STATE_LABELS,
-  liveVoiceSurfaceLabel,
+  LIVE_VOICE_STATE_KEYS,
   liveVoiceSurfaceLabelKey,
   minimizeVoiceRoom,
   releaseLiveVoiceTurn,
@@ -214,53 +213,66 @@ describe("useLiveVoiceStore — room minimize", () => {
   });
 });
 
-describe("LIVE_VOICE_STATE_LABELS", () => {
+/**
+ * What a surface renders for a session in English: the key the resolver
+ * returns, read out of the catalog every surface reads it out of.
+ */
+function surfaceLabel(
+  state: LiveVoiceSessionState,
+  reconnecting: boolean,
+  assistantAudioActive: boolean,
+  muted: boolean,
+): string {
+  const key = liveVoiceSurfaceLabelKey(
+    state,
+    reconnecting,
+    assistantAudioActive,
+    muted,
+  );
+  if (!key) {
+    return "";
+  }
+  const slot = key.replace("liveVoiceStatus.", "");
+  return enChat.liveVoiceStatus[slot as keyof typeof enChat.liveVoiceStatus];
+}
+
+describe("LIVE_VOICE_STATE_KEYS", () => {
   /**
-   * `toVoiceAvatarVisual` collapses `transcribing` into `thinking`, so a label
-   * of its own put two different words for one phase on screen at once: the
+   * `toVoiceAvatarVisual` collapses `transcribing` into `thinking`, so a key of
+   * its own put two different words for one phase on screen at once: the
    * avatar and eyes caption reading thinking, the label reading transcribing.
    */
   test("gives transcribing no wording of its own", () => {
-    expect(LIVE_VOICE_STATE_LABELS.transcribing).toBe(
-      LIVE_VOICE_STATE_LABELS.thinking,
+    expect(LIVE_VOICE_STATE_KEYS.transcribing).toBe(
+      LIVE_VOICE_STATE_KEYS.thinking,
     );
   });
 
-  /** The collapse is the label's, not the phase's: the state still exists. */
+  /** The collapse is the wording's, not the phase's: the state still exists. */
   test("keeps transcribing a distinct session state", () => {
     expect(toVoiceAvatarVisual("transcribing", false)).toBe(
       toVoiceAvatarVisual("thinking", false),
     );
-    expect(liveVoiceSurfaceLabel("transcribing", false, true, false)).toBe(
-      "Thinking…",
-    );
+    expect(surfaceLabel("transcribing", false, true, false)).toBe("Thinking…");
   });
 });
 
-describe("liveVoiceSurfaceLabel", () => {
+describe("liveVoiceSurfaceLabelKey", () => {
   test("a speaking phase with no audio playing reads as thinking", () => {
     // `speaking` stays set across a mid-turn tool run (the ack was spoken and
     // the assistant is now silent) so every surface says "Thinking…".
-    expect(liveVoiceSurfaceLabel("speaking", false, false, false)).toBe(
-      "Thinking…",
-    );
-    expect(liveVoiceSurfaceLabel("speaking", false, true, false)).toBe(
-      "Speaking…",
-    );
+    expect(surfaceLabel("speaking", false, false, false)).toBe("Thinking…");
+    expect(surfaceLabel("speaking", false, true, false)).toBe("Speaking…");
   });
 
   test("carries the reconnecting relabel through unchanged", () => {
-    expect(liveVoiceSurfaceLabel("connecting", true, false, false)).toBe(
+    expect(surfaceLabel("connecting", true, false, false)).toBe(
       "Reconnecting…",
     );
-    expect(liveVoiceSurfaceLabel("listening", false, false, false)).toBe(
-      "Listening…",
-    );
+    expect(surfaceLabel("listening", false, false, false)).toBe("Listening…");
     // Only `connecting` reads the signal: a retry that has already reconnected
     // far enough to listen is listening.
-    expect(liveVoiceSurfaceLabel("listening", true, false, false)).toBe(
-      "Listening…",
-    );
+    expect(surfaceLabel("listening", true, false, false)).toBe("Listening…");
   });
 
   /**
@@ -268,16 +280,12 @@ describe("liveVoiceSurfaceLabel", () => {
    * surface claims to be listening beside a mute button that says it is not.
    */
   test("a muted listening phase reads as muted", () => {
-    expect(liveVoiceSurfaceLabel("listening", false, false, true)).toBe(
-      "Muted",
-    );
+    expect(surfaceLabel("listening", false, false, true)).toBe("Muted");
   });
 
   /** A state rather than an activity, so no ellipsis where the phases have one. */
   test("says muted without an ellipsis", () => {
-    expect(liveVoiceSurfaceLabel("listening", false, false, true)).not.toContain(
-      "\u2026",
-    );
+    expect(surfaceLabel("listening", false, false, true)).not.toContain("…");
   });
 
   /**
@@ -285,15 +293,9 @@ describe("liveVoiceSurfaceLabel", () => {
    * speaking, so relabelling those would trade one false statement for another.
    */
   test("leaves the assistant's own phases alone while muted", () => {
-    expect(liveVoiceSurfaceLabel("thinking", false, false, true)).toBe(
-      "Thinking…",
-    );
-    expect(liveVoiceSurfaceLabel("speaking", false, true, true)).toBe(
-      "Speaking…",
-    );
-    expect(liveVoiceSurfaceLabel("transcribing", false, false, true)).toBe(
-      "Thinking…",
-    );
+    expect(surfaceLabel("thinking", false, false, true)).toBe("Thinking…");
+    expect(surfaceLabel("speaking", false, true, true)).toBe("Speaking…");
+    expect(surfaceLabel("transcribing", false, false, true)).toBe("Thinking…");
   });
 
   /**
@@ -301,20 +303,15 @@ describe("liveVoiceSurfaceLabel", () => {
    * session that is not currently connected at all.
    */
   test("does not hide a reconnect behind the mute", () => {
-    expect(liveVoiceSurfaceLabel("connecting", true, false, true)).toBe(
-      "Reconnecting…",
-    );
+    expect(surfaceLabel("connecting", true, false, true)).toBe("Reconnecting…");
   });
-});
 
-describe("liveVoiceSurfaceLabelKey", () => {
   /**
-   * The key and the English label are the same decision, so a surface that
-   * translates the key cannot say a different thing from the surfaces that read
-   * the label. The catalog is the other half of that: a key whose English copy
-   * had drifted would translate into a word the room never shows.
+   * The key table is the only source of session wording, so a key naming a
+   * message the catalog does not carry leaves every surface rendering the key
+   * itself, the island and the macOS companion included.
    */
-  test("keys the copy the English label reads out", () => {
+  test("keys copy the catalog actually carries", () => {
     const cases: [LiveVoiceSessionState, boolean, boolean, boolean][] = [
       ["connecting", false, false, false],
       ["connecting", true, false, false],
@@ -328,12 +325,10 @@ describe("liveVoiceSurfaceLabelKey", () => {
     ];
 
     for (const [state, reconnecting, audio, muted] of cases) {
-      const key = liveVoiceSurfaceLabelKey(state, reconnecting, audio, muted);
-      expect(key).not.toBeNull();
-      const slot = key!.replace("liveVoiceStatus.", "");
-      expect(liveVoiceSurfaceLabel(state, reconnecting, audio, muted)).toBe(
-        enChat.liveVoiceStatus[slot as keyof typeof enChat.liveVoiceStatus],
-      );
+      expect(
+        liveVoiceSurfaceLabelKey(state, reconnecting, audio, muted),
+      ).not.toBeNull();
+      expect(surfaceLabel(state, reconnecting, audio, muted)).toBeTruthy();
     }
   });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -43,7 +43,7 @@ import { createSelectors } from "@/utils/create-selectors";
  *   turn-boundary `ptt_release` frame in manual mode. Distinct from `thinking`
  *   because it stamps end-of-speech latency and gates the
  *   `utterance_discarded` return to `listening`, though the two share a label
- *   (see {@link LIVE_VOICE_STATE_LABELS}).
+ *   (see {@link LIVE_VOICE_STATE_KEYS}).
  * - `thinking` — server is generating the assistant response.
  * - `speaking` — TTS audio is queued/playing.
  * - `ending` — graceful teardown in progress.
@@ -85,8 +85,13 @@ export type LiveVoiceStatusKey =
  * unique to `transcribing` puts two words for one phase on screen at once,
  * across a window that is usually under a second and that offers the user
  * nothing to act on.
+ *
+ * A phase and its wording are paired here and nowhere else. The wording itself
+ * is `liveVoiceStatus` in the `chat` catalog, and every surface resolves the
+ * key through it, so each of them says the same thing in the reader's own
+ * language.
  */
-const LIVE_VOICE_STATE_KEYS: Record<
+export const LIVE_VOICE_STATE_KEYS: Record<
   LiveVoiceSessionState,
   LiveVoiceStatusKey | null
 > = {
@@ -99,39 +104,6 @@ const LIVE_VOICE_STATE_KEYS: Record<
   ending: "liveVoiceStatus.ending",
   failed: null,
 };
-
-/**
- * English copy per key, mirroring `liveVoiceStatus` in the `chat` catalog. What
- * the surfaces reading a label rather than a key resolve to, the iOS Live
- * Activity registration among them: it hands its wording to native code, which
- * has no translator in reach.
- */
-const LIVE_VOICE_STATUS_ENGLISH: Record<LiveVoiceStatusKey, string> = {
-  "liveVoiceStatus.connecting": "Connecting…",
-  "liveVoiceStatus.reconnecting": "Reconnecting…",
-  "liveVoiceStatus.listening": "Listening…",
-  "liveVoiceStatus.thinking": "Thinking…",
-  "liveVoiceStatus.speaking": "Speaking…",
-  "liveVoiceStatus.ending": "Ending…",
-  "liveVoiceStatus.muted": "Muted",
-};
-
-/**
- * English activity label per session state, for the native surfaces with no
- * translator in reach: the iOS Live Activity's push registration reads it, and
- * enumerates it to cover every phase. Derived from
- * {@link LIVE_VOICE_STATE_KEYS}, which is the only place a phase and its
- * wording are paired.
- *
- * The assertion restates the shape `Object.entries` widens to `string`.
- */
-export const LIVE_VOICE_STATE_LABELS: Record<LiveVoiceSessionState, string> =
-  Object.fromEntries(
-    Object.entries(LIVE_VOICE_STATE_KEYS).map(([state, key]) => [
-      state,
-      key ? LIVE_VOICE_STATUS_ENGLISH[key] : "",
-    ]),
-  ) as Record<LiveVoiceSessionState, string>;
 
 /**
  * The catalog key a *surface* shows for a session: the phase's own key plus the
@@ -147,8 +119,8 @@ export const LIVE_VOICE_STATE_LABELS: Record<LiveVoiceSessionState, string> =
  * then went silent while a tool runs. Announcing "Speaking…" while nothing is
  * audible is wrong for the room's caption, wrong for its screen-reader
  * announcement, and wrong for the Dynamic Island (JARVIS-1279). Every surface
- * that renders session activity resolves this, the voice room and the iOS Live
- * Activity mirror, so the island always reads exactly what the room reads.
+ * that renders session activity calls this, the room and the out-of-app
+ * mirrors alike, so the island always reads exactly what the room reads.
  *
  * `listening` is the same problem through the microphone: the session holds
  * that phase while the mic is muted, so the surface claims to be listening
@@ -175,30 +147,6 @@ export function liveVoiceSurfaceLabelKey(
     return "liveVoiceStatus.thinking";
   }
   return LIVE_VOICE_STATE_KEYS[state];
-}
-
-/**
- * English copy for {@link liveVoiceSurfaceLabelKey}, for the surfaces that
- * cannot reach a translator: the iOS Live Activity mirror and the push
- * registration that hands its wording to native code. Empty for the phases that
- * carry no word.
- *
- * Every surface rendered by this app reads the key instead, so a Spanish or
- * Russian reader gets the session's state in their own language.
- */
-export function liveVoiceSurfaceLabel(
-  state: LiveVoiceSessionState,
-  reconnecting: boolean,
-  assistantAudioActive: boolean,
-  muted: boolean,
-): string {
-  const key = liveVoiceSurfaceLabelKey(
-    state,
-    reconnecting,
-    assistantAudioActive,
-    muted,
-  );
-  return key ? LIVE_VOICE_STATUS_ENGLISH[key] : "";
 }
 
 /**
@@ -475,7 +423,7 @@ export interface LiveVoiceState {
   /**
    * Latency measurements for the last turn, `null` until a turn is measured.
    * Debug surface only — per the minimal-treatment note on
-   * {@link LIVE_VOICE_STATE_LABELS}, no surface renders this: the controller
+   * {@link LIVE_VOICE_STATE_KEYS}, no surface renders this: the controller
    * logs one `console.debug("[live-voice] turn latency", …)` line per
    * completed turn and this field waits for a future debug panel.
    */

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -155,6 +155,7 @@ const { useAssistantIdentityStore } =
   await import("@/stores/assistant-identity-store");
 const { BUNDLED_COMPONENTS } =
   await import("@/utils/avatar-bundled-components");
+const { changeLocale } = await import("@/i18n");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -234,9 +235,12 @@ beforeEach(() => {
   emitPushToken = null;
 });
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
   useLiveVoiceStore.getState().reset();
+  // The locale is process-global, so a test that switches it would leave every
+  // later suite in this file asserting Spanish copy.
+  await changeLocale("en");
 });
 
 // ---------------------------------------------------------------------------
@@ -536,6 +540,25 @@ describe("updating the activity", () => {
     );
     expect(lastUpdatePayload()?.label).toBe("Thinking…");
   });
+
+  // The island and the macOS companion render the label the mirror hands them
+  // verbatim, so a label resolved in English would leave both reading a
+  // language the app is not in. Nothing in the session moves on a switch, so
+  // the mirror has to re-read it itself.
+  test("follows the active locale", async () => {
+    renderMirror();
+    await setPhase("listening");
+    expect(lastStartPayload()?.label).toBe("Listening…");
+
+    await act(async () => {
+      await changeLocale("es");
+    });
+
+    expect(lastUpdatePayload()?.label).toBe("Escuchando…");
+
+    // The phase behind it is untouched: only the wording moved.
+    expect(lastUpdatePayload()?.phase).toBe("listening");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -762,9 +785,9 @@ describe("registering the activity for server-driven updates", () => {
     });
 
     expect(registerLiveActivityPushToken).toHaveBeenCalledTimes(1);
-    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject(
-      { conversationId: "conv-9" },
-    );
+    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject({
+      conversationId: "conv-9",
+    });
   });
 
   // iOS reissues tokens mid-activity and each value invalidates the last, so a
@@ -781,9 +804,9 @@ describe("registering the activity for server-driven updates", () => {
     await emitToken("token-def");
 
     expect(registerLiveActivityPushToken).toHaveBeenCalledTimes(2);
-    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject(
-      { token: "token-def" },
-    );
+    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject({
+      token: "token-def",
+    });
   });
 
   // The platform composes every push from the registration, so a mute the

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -43,17 +43,23 @@
  * is never read: it changes per animation frame and would exhaust the budget
  * within a second. `activityLabel` is read and is safe to: the daemon emits it
  * only on a change it wants surfaced, a few times per turn at most.
+ *
+ * The active locale is the one input that is not the session's. The phase label
+ * is catalog copy, so a language switch changes what both surfaces should read
+ * while nothing in the store moves, and the mirror re-reads the session itself
+ * on one.
  */
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import {
   isLiveVoiceSessionActive,
-  liveVoiceSurfaceLabel,
+  liveVoiceSurfaceLabelKey,
   subscribeSettledLiveVoiceState,
   useLiveVoiceStore,
   type LiveVoiceState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useTranslation, type TFunction } from "@/i18n";
 import { getRenderedAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import { getIslandAvatarSource } from "@/hooks/use-island-avatar-source";
 import {
@@ -88,22 +94,26 @@ import { assistantDisplayName } from "@/utils/assistant-display-name";
  */
 function toActivityContent(
   session: LiveVoiceState,
+  t: TFunction<"chat">,
 ): VoiceLiveActivityContent | null {
   if (!isLiveVoiceSessionActive(session.state)) {
     return null;
   }
+  const labelKey = liveVoiceSurfaceLabelKey(
+    session.state,
+    session.reconnecting,
+    session.assistantAudioActive,
+    session.muted,
+  );
   return {
     phase: session.state,
-    // The room's label, verbatim: the same `liveVoiceSurfaceLabel` call the
-    // room makes, including its "Reconnecting…" relabel, its
-    // silent-`speaking` to "Thinking…" remap, and its muted-`listening` to
-    // "Muted" remap, so the island never has wording of its own to drift from.
-    label: liveVoiceSurfaceLabel(
-      session.state,
-      session.reconnecting,
-      session.assistantAudioActive,
-      session.muted,
-    ),
+    // The room's label: the same `liveVoiceSurfaceLabelKey` call the room
+    // makes, resolved through the same catalog, including its "Reconnecting…"
+    // relabel, its silent-`speaking` to "Thinking…" remap, and its
+    // muted-`listening` to "Muted" remap. The island and the desktop panel
+    // therefore have no wording of their own to drift from, and they read in
+    // whatever language the app is in.
+    label: labelKey ? t(labelKey) : "",
     // The accent the avatar (and therefore the voice room) renders. `""` for
     // an avatar with no color to match: the native side canonicalizes
     // unparseable input to its neutral gray. An avatar still loading when the
@@ -210,6 +220,21 @@ function sameContent(
 }
 
 export function useLiveActivityMirror(): void {
+  const { t } = useTranslation("chat");
+  /**
+   * The translator the effect below resolves the phase label with.
+   *
+   * Held in a ref rather than closed over, because the effect runs once for the
+   * mirror's whole lifetime: making it depend on `t` would tear the mirror down
+   * on a language switch, and its cleanup ends the activity.
+   */
+  const translate = useRef(t);
+  /**
+   * Re-runs the mirror against the session as it stands, or `null` before the
+   * effect has mounted and after it has torn down.
+   */
+  const resync = useRef<(() => void) | null>(null);
+
   useEffect(() => {
     /**
      * The last payload handed to the bridge, or `null` when no activity has
@@ -281,7 +306,7 @@ export function useLiveActivityMirror(): void {
     };
 
     const sync = (session: LiveVoiceState): void => {
-      const content = toActivityContent(session);
+      const content = toActivityContent(session, translate.current);
 
       if (content === null) {
         if (pushed === null) {
@@ -340,6 +365,7 @@ export function useLiveActivityMirror(): void {
     // plugin holds at most one activity, so a redundant `start` updates the
     // running one rather than stacking a second island.
     sync(useLiveVoiceStore.getState());
+    resync.current = () => sync(useLiveVoiceStore.getState());
     const unsubscribe = subscribeSettledLiveVoiceState(sync);
     // Subscribed for the mirror's whole lifetime rather than per activity: the
     // token can arrive before the next settled state does, and a listener
@@ -348,7 +374,7 @@ export function useLiveActivityMirror(): void {
       ({ token }) => {
         pushToken = token;
         const session = useLiveVoiceStore.getState();
-        const content = toActivityContent(session);
+        const content = toActivityContent(session, translate.current);
         // A token for a session that has already ended registers nothing: the
         // activity it addresses is on its way out, and the `end` path has
         // already dropped the registration.
@@ -359,6 +385,7 @@ export function useLiveActivityMirror(): void {
     );
 
     return () => {
+      resync.current = null;
       unsubscribe();
       unsubscribeToken();
       // A surface that outlives its mirror sits on the Lock Screen, or floats
@@ -373,4 +400,13 @@ export function useLiveActivityMirror(): void {
       }
     };
   }, []);
+
+  // The phase label is catalog copy, so switching language mid-call changes
+  // what both surfaces should read while nothing in the session moves. Nothing
+  // would push it otherwise, and the island a user is looking at would stay in
+  // the language they just left.
+  useEffect(() => {
+    translate.current = t;
+    resync.current?.();
+  }, [t]);
 }

--- a/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.test.tsx
@@ -17,16 +17,33 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, render, screen } from "@testing-library/react";
 
-import { liveVoiceSurfaceLabel } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { liveVoiceSurfaceLabelKey } from "@/domains/chat/voice/live-voice/live-voice-store";
 import {
   CameraStatusPill,
   useCameraStatusAnnouncement,
   type CameraStatusAnnouncement,
 } from "@/domains/chat/voice/voice-room/camera-status-pill";
+import { fixedT } from "@/i18n";
 
 afterEach(() => {
   cleanup();
 });
+
+/** The session's own surface label, resolved the way every surface resolves it. */
+function surfaceLabel(
+  state: Parameters<typeof liveVoiceSurfaceLabelKey>[0],
+  reconnecting: boolean,
+  assistantAudioActive: boolean,
+  muted: boolean,
+): string {
+  const key = liveVoiceSurfaceLabelKey(
+    state,
+    reconnecting,
+    assistantAudioActive,
+    muted,
+  );
+  return key ? fixedT("chat")(key) : "";
+}
 
 const pill = () => screen.getByTestId("camera-status-pill");
 const dot = () => screen.getByTestId("camera-status-dot");
@@ -175,7 +192,7 @@ describe("CameraStatusPill", () => {
     render(
       <CameraStatusPill
         voiceState="idle"
-        statusLabel={liveVoiceSurfaceLabel("connecting", true, false, false)}
+        statusLabel={surfaceLabel("connecting", true, false, false)}
         assistantName="Luna"
       />,
     );

--- a/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.tsx
@@ -66,10 +66,28 @@ const MODE_WORD_KEYS = {
   live: "cameraStatusPill.live",
 } as const;
 
-/** The sentence the mode's word opens, with the session's state inside it. */
+/**
+ * The whole sentence the room speaks, per mode and per state.
+ *
+ * Four messages a mode rather than one with a translated fragment pushed into
+ * it. "Muted" and the assistant's name belong inside the sentence a translator
+ * is writing, so the mute can move where the language puts it and the name can
+ * take whatever the verb agrees with. A nested `t()` would fix both at English
+ * word order. See `docs/I18N.md`.
+ */
 const MODE_ANNOUNCE_KEYS = {
-  photo: "cameraStatusPill.announcePhoto",
-  live: "cameraStatusPill.announceLive",
+  photo: {
+    status: "cameraStatusPill.announcePhoto",
+    mutedStatus: "cameraStatusPill.announcePhotoMuted",
+    speaking: "cameraStatusPill.announcePhotoSpeaking",
+    mutedSpeaking: "cameraStatusPill.announcePhotoMutedSpeaking",
+  },
+  live: {
+    status: "cameraStatusPill.announceLive",
+    mutedStatus: "cameraStatusPill.announceLiveMuted",
+    speaking: "cameraStatusPill.announceLiveSpeaking",
+    mutedSpeaking: "cameraStatusPill.announceLiveMutedSpeaking",
+  },
 } as const;
 
 /** The pill's fill per mode. See `camera-mode-paint.ts` for the values. */
@@ -120,16 +138,16 @@ function useAssistantWord(assistantName: string | null | undefined): string {
  * the session back and this returns the empty string rather than unmounting a
  * region assistive tech is watching.
  *
- * Composed rather than looked up in a key grid: the mode's word opens the
- * sentence, the session's state closes it, and mute wraps the state with the
- * room's own `voiceRoom.mutedState` pattern. A grid would need a key per mode
- * per mute per speaker, and every mode added would double it.
+ * One message per state rather than a sentence assembled here: the mode, the
+ * mute and the speaker pick the key, and the sentence behind it is whole. What
+ * still interpolates is the one part no catalog can hold, the session's own
+ * status word or the assistant's name.
  *
- * The mute wrap is what the visible row does not carry. The session relabels
+ * Saying the mute is what the visible row does not do. The session relabels
  * only `listening` for a muted mic, so "Thinking…" on its own tells a
  * screen-reader user the assistant is working without telling them it cannot
- * hear them. The one phase the session does relabel is skipped, since wrapping
- * that reads "Muted. Muted".
+ * hear them. The one phase the session does relabel takes the plain sentence,
+ * since the muted one over it reads "Muted. Muted".
  */
 export function useCameraStatusAnnouncement(
   status: CameraStatusAnnouncement | null,
@@ -142,21 +160,20 @@ export function useCameraStatusAnnouncement(
   }
 
   const { mode = "photo", voiceState, statusLabel, muted } = status;
-  const mutedWord = t("liveVoiceStatus.muted");
-  const spoken =
-    voiceState === "assistant"
-      ? t("cameraStatusPill.speakingState", { name })
-      : statusLabel || (muted ? mutedWord : "");
+  const keys = MODE_ANNOUNCE_KEYS[mode];
 
-  if (!spoken) {
-    return t(MODE_WORD_KEYS[mode]);
+  if (voiceState === "assistant") {
+    return t(muted ? keys.mutedSpeaking : keys.speaking, { name });
   }
 
-  const state =
-    muted && spoken !== mutedWord
-      ? t("voiceRoom.mutedState", { state: spoken })
-      : spoken;
-  return t(MODE_ANNOUNCE_KEYS[mode], { status: state });
+  const mutedWord = t("liveVoiceStatus.muted");
+  const state = statusLabel || (muted ? mutedWord : "");
+  if (!state) {
+    return t(MODE_WORD_KEYS[mode]);
+  }
+  return t(muted && state !== mutedWord ? keys.mutedStatus : keys.status, {
+    status: state,
+  });
 }
 
 export function CameraStatusPill({

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.test.tsx
@@ -440,6 +440,35 @@ describe("useVoiceCamera: two flips at once", () => {
     expect(facing()).toBe("environment");
     expect(flipSpy).toHaveBeenCalledTimes(2);
   });
+
+  test("holds its claim through its own fallback reacquisition", async () => {
+    // On Capacitor with the native preview refused, the flip takes the web
+    // branch, and `acquire` releases the capture to request the replacement.
+    // That release is the running flip's own, so it must leave the claim
+    // standing: `sourceRef` reads `native-pending` across the await, and a
+    // second tap that got past both guards would start a competing flip.
+    startSpy.mockImplementation(async () => false);
+    const getUserMedia = mock(async () => fakeStream());
+    stubMediaDevices(getUserMedia);
+
+    render(<Probe />);
+    await press("open");
+    expect(facing()).toBe("environment");
+
+    const slowStart = deferredCall<boolean>();
+    startSpy.mockImplementation(slowStart.answer);
+    await press("flip");
+
+    // Lands while the first flip is still inside `acquire`.
+    await press("flip");
+    expect(startSpy).toHaveBeenCalledTimes(2);
+
+    await settle(() => slowStart.resolve(false));
+
+    expect(facing()).toBe("user");
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(getUserMedia).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("useVoiceCamera: a flip the bridge never answers", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
@@ -274,9 +274,9 @@ export function useVoiceCamera(
   const flashProbeEpochRef = useRef(0);
   // The flip that is running, as its own identity, or null for none. See
   // `flipCamera`: two of them overlapping spin the hardware twice and agree on
-  // the wrong answer. An identity rather than a flag because releasing the
-  // camera drops the claim (see `stopCapture`), and a flip that resumes after
-  // that must not drop the claim of the flip that replaced it.
+  // the wrong answer. An identity rather than a flag because an external
+  // release drops the claim (see `releaseCamera`), and a flip that resumes
+  // after that must not drop the claim of the flip that replaced it.
   const flipInFlightRef = useRef<object | null>(null);
   // True while a flash-capable camera is running with a mode other than off,
   // which is exactly when the plugin has state of ours to hand back. Cleared
@@ -291,17 +291,19 @@ export function useVoiceCamera(
     useState<string[]>(NO_FLASH_MODES);
   const flashMode = useVoicePrefsStore.use.flashMode();
 
+  /**
+   * Tear the running capture down.
+   *
+   * Every path that stops the hardware goes through here, including the flip's
+   * own reacquisition, so it deliberately says nothing about the flip claim:
+   * that belongs to {@link releaseCamera}, which is the external half.
+   */
   const stopCapture = useCallback(() => {
     // Cancels any acquire still in flight, so its stream is stopped on arrival
     // rather than installed behind this release, and any flash probe still in
     // flight, whose camera is the one going away here.
     acquireEpochRef.current++;
     flashProbeEpochRef.current++;
-    // A flip still running belongs to the camera this releases, so its claim
-    // goes with it. Nothing else clears the claim of a bridge call that never
-    // comes back, and a flip left marked in flight is a flip button that never
-    // works again, across a close and a reopen included.
-    flipInFlightRef.current = null;
     const source = sourceRef.current;
     sourceRef.current = null;
     if (source === "native-pending" || source === "native") {
@@ -326,6 +328,24 @@ export function useVoiceCamera(
       videoRef.current.srcObject = null;
     }
   }, [videoRef]);
+
+  /**
+   * Give the camera up on someone else's say-so: the user closing the
+   * viewfinder, or the component going away.
+   *
+   * This is the only thing that abandons a running flip's claim, and it has to
+   * be. Nothing else clears the claim of a bridge call that never comes back,
+   * so a flip left marked in flight is a flip button that never works again,
+   * across a close and a reopen included. A flip's *own* reacquisition calls
+   * `stopCapture` directly instead: on the fallback path the flip releases the
+   * capture to request the other camera, and dropping its claim there would
+   * leave the guard open for a second tap to start a competing flip while the
+   * first one is still mid-await.
+   */
+  const releaseCamera = useCallback(() => {
+    flipInFlightRef.current = null;
+    stopCapture();
+  }, [stopCapture]);
 
   /**
    * Ask the camera that is running what it can do with its flash.
@@ -507,12 +527,12 @@ export function useVoiceCamera(
   }, [facing, start]);
 
   const closeCamera = useCallback(() => {
-    stopCapture();
+    releaseCamera();
     setOpen(false);
     setNative(false);
     setError(null);
     setSupportedFlashModes(NO_FLASH_MODES);
-  }, [stopCapture]);
+  }, [releaseCamera]);
 
   /**
    * Switch cameras, keeping the viewfinder up.
@@ -536,6 +556,12 @@ export function useVoiceCamera(
    * which is a viewfinder mirrored the wrong way and every later flip working
    * from a facing the camera does not have. Dropping the second tap is also
    * what the user meant by it.
+   *
+   * The claim survives this flip's own reacquisition. On the fallback path
+   * `acquire` releases the capture before requesting the replacement, and
+   * `sourceRef` reads `native-pending` across that await, so a claim dropped
+   * there would leave both guards open for a second tap. Only `releaseCamera`
+   * abandons a claim, which is why `acquire` calls `stopCapture` directly.
    */
   const flipCamera = useCallback(async () => {
     if (!sourceRef.current || flipInFlightRef.current) {
@@ -652,7 +678,7 @@ export function useVoiceCamera(
   // The capture outlives React's own teardown of the element, so releasing
   // the hardware has to be explicit. Without this the camera light stays on
   // after the room closes.
-  useEffect(() => stopCapture, [stopCapture]);
+  useEffect(() => releaseCamera, [releaseCamera]);
 
   // The `<video>` renders on the same commit that flips `open`, so a stream
   // acquired in `start()` has no element to attach to yet. This runs after

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -505,8 +505,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   //
   // Taken as a catalog key and resolved here, once, for every surface in the
   // room that shows it: the connect caption, the state announcer, and the
-  // camera's status pill. Deriving it twice (a key for one, English for the
-  // other) is what lets the two drift.
+  // camera's status pill. The out-of-app mirrors take the same key and resolve
+  // it through the same catalog, so one table decides the wording and every
+  // surface reads it in the language the app is in.
   const stateLabelKey = liveVoiceSurfaceLabelKey(
     state,
     reconnecting,
@@ -1159,11 +1160,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
                     ariaLabel={t(FLASH_LABEL_KEYS[flashMode])}
                     autoBadge={t("voiceRoom.flashAutoBadge")}
                     onClick={() => setFlashMode(nextFlashMode(flashMode))}
-                    // Centred 56px from its edge, the same distance flip sits
-                    // from the other: the two flank the shutter symmetrically,
-                    // and the 46px control needs the smaller offset to get
-                    // there than flip's 52px one does.
-                    className="absolute left-[33px]"
+                    // The design's own offset. It is not flip's on the other
+                    // side: the design places the two flanks independently, so
+                    // matching them to each other is a departure from it.
+                    className="absolute left-11"
                     testId="voice-room-flash"
                   />
                 </Tooltip>

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -254,10 +254,15 @@
   },
   "cameraStatusPill": {
     "announceLive": "Live. {status}",
+    "announceLiveMuted": "Live. Muted. {status}",
+    "announceLiveMutedSpeaking": "Live. Muted. {name} speaking",
+    "announceLiveSpeaking": "Live. {name} speaking",
     "announcePhoto": "Photo. {status}",
+    "announcePhotoMuted": "Photo. Muted. {status}",
+    "announcePhotoMutedSpeaking": "Photo. Muted. {name} speaking",
+    "announcePhotoSpeaking": "Photo. {name} speaking",
     "live": "Live",
     "photo": "Photo",
-    "speakingState": "{name} speaking",
     "yourAssistant": "Your assistant"
   },
   "cardSurface": {

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -254,10 +254,15 @@
   },
   "cameraStatusPill": {
     "announceLive": "En vivo. {status}",
+    "announceLiveMuted": "En vivo. Silenciado. {status}",
+    "announceLiveMutedSpeaking": "En vivo. Silenciado. {name} está hablando",
+    "announceLiveSpeaking": "En vivo. {name} está hablando",
     "announcePhoto": "Foto. {status}",
+    "announcePhotoMuted": "Foto. Silenciado. {status}",
+    "announcePhotoMutedSpeaking": "Foto. Silenciado. {name} está hablando",
+    "announcePhotoSpeaking": "Foto. {name} está hablando",
     "live": "En vivo",
     "photo": "Foto",
-    "speakingState": "{name} está hablando",
     "yourAssistant": "Tu asistente"
   },
   "cardSurface": {

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -161,10 +161,15 @@
   },
   "cameraStatusPill": {
     "announceLive": "Прямой эфир. {status}",
+    "announceLiveMuted": "Прямой эфир. Без звука. {status}",
+    "announceLiveMutedSpeaking": "Прямой эфир. Без звука. {name} говорит",
+    "announceLiveSpeaking": "Прямой эфир. {name} говорит",
     "announcePhoto": "Фото. {status}",
+    "announcePhotoMuted": "Фото. Без звука. {status}",
+    "announcePhotoMutedSpeaking": "Фото. Без звука. {name} говорит",
+    "announcePhotoSpeaking": "Фото. {name} говорит",
     "live": "Прямой эфир",
     "photo": "Фото",
-    "speakingState": "{name} говорит",
     "yourAssistant": "Ваш ассистент"
   },
   "channelReferenceChip": {

--- a/clients/web/src/runtime/native-live-activity.ts
+++ b/clients/web/src/runtime/native-live-activity.ts
@@ -51,10 +51,10 @@ export interface VoiceLiveActivityContent {
    */
   phase: ActiveLiveVoiceSessionState;
   /**
-   * User-facing activity copy. Pass
-   * `liveVoiceSurfaceLabel(state, reconnecting, assistantAudioActive, muted)` so the
-   * island shows exactly what the voice room shows; the native side
-   * deliberately owns no phase wording of its own.
+   * User-facing activity copy. Pass the `chat` catalog's message for
+   * `liveVoiceSurfaceLabelKey(state, reconnecting, assistantAudioActive,
+   * muted)` so the island shows exactly what the voice room shows, in the same
+   * language; the native side deliberately owns no phase wording of its own.
    */
   label: string;
   /** Avatar accent as `#RRGGBB`. Unparseable values fall back to a neutral gray natively. */

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -408,9 +408,10 @@ export type VoiceActivityPhase = (typeof VOICE_ACTIVITY_PHASES)[number];
 export interface VoiceActivityContent {
   phase: VoiceActivityPhase;
   /**
-   * User-facing phase copy, passed through from the web layer verbatim
-   * (`liveVoiceSurfaceLabel`), so the surface shows exactly what the voice room
-   * shows. Main and the surface own no phase wording of their own. The wording
+   * User-facing phase copy, passed through from the web layer verbatim: the
+   * web resolves `liveVoiceSurfaceLabelKey` through its own catalog, so the
+   * surface shows exactly what the voice room shows, in the language the app is
+   * in. Main and the surface own no phase wording of their own. The wording
    * deploys continuously with the web bundle while the shell ships on release
    * cadence, so a `switch` over `phase` on this side would fossilize.
    */


### PR DESCRIPTION
## Summary
Round-2 fixes: restores the design's exact flash offset, localizes the Live Activity mirror and push labels (iOS island and macOS companion follow the app language), preserves the flip claim through internal fallback reacquisition, returns camera announcements to whole-sentence catalog messages, corrects a QA doc path.

Part of plan: voice-camera-mode-redesign.md (self-review fixes)