### PR TITLE
Fix Windows packaging toolchain selection

### DIFF
--- a/assistant/src/__tests__/bundled-asset.test.ts
+++ b/assistant/src/__tests__/bundled-asset.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { resolveBundledDir } from "../util/bundled-asset.js";
+import { isBunVirtualPath, resolveBundledDir } from "../util/bundled-asset.js";
 
 let tempDir: string;
 
@@ -17,6 +17,13 @@ afterEach(() => {
 });
 
 describe("resolveBundledDir", () => {
+  test("recognizes Bun virtual paths on Unix and Windows", () => {
+    expect(isBunVirtualPath("/$bunfs/root/src/config")).toBeTrue();
+    expect(isBunVirtualPath("B:\\~BUN\\root")).toBeTrue();
+    expect(isBunVirtualPath("B:/~BUN/root/src/config")).toBeTrue();
+    expect(isBunVirtualPath("C:\\dev\\vellum-assistant")).toBeFalse();
+  });
+
   test("source mode: returns join(callerDir, relativePath) when callerDir is a normal path", () => {
     const result = resolveBundledDir(
       "/some/source/path",
@@ -80,6 +87,20 @@ describe("resolveBundledDir", () => {
         "templates",
       );
       expect(result).toBe(join(binDir, "templates"));
+    });
+
+    test("resolves Windows Bun virtual paths beside the executable", () => {
+      const binDir = join(tempDir, "bin");
+      mkdirSync(join(binDir, "default-plugins"), { recursive: true });
+
+      process.execPath = join(binDir, "vellum-daemon.exe");
+
+      const result = resolveBundledDir(
+        "B:\\~BUN\\root",
+        ".",
+        "default-plugins",
+      );
+      expect(result).toBe(join(binDir, "default-plugins"));
     });
 
     test("falls back to source path when neither Resources nor execDir have the asset", () => {

--- a/assistant/src/__tests__/plugin-app-serve-routes.test.ts
+++ b/assistant/src/__tests__/plugin-app-serve-routes.test.ts
@@ -271,10 +271,10 @@ describe("multi-file plugin apps compile on open", () => {
     expect(result.html).toContain("Compiled Board");
     expect(result.html).not.toContain("not been compiled");
     expect(result.origin).toBe("plugin:acme");
-    // The daemon must not write dist/ into the read-only plugin tree — that is
+    // The daemon must not write dist/ into the read-only plugin tree. That is
     // the monitor's job. The on-open build happened in a throwaway temp dir.
     expect(existsSync(join(appDir, "dist"))).toBe(false);
-  });
+  }, 15_000);
 
   test("apps_open on a malformed plugin app (no src/, no dist/) serves the fallback, not a 500", async () => {
     // An app dir with neither a root index.html nor src/ nor dist/ is

--- a/assistant/src/config/skills.ts
+++ b/assistant/src/config/skills.ts
@@ -32,6 +32,7 @@ import {
 import { parseToolManifestFile } from "../skills/tool-manifest.js";
 import { computeSkillVersionHash } from "../skills/version-hash.js";
 import type { OwnerInfo } from "../tools/types.js";
+import { isBunVirtualPath } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
 import {
   getWorkspaceDirDisplay,
@@ -230,7 +231,7 @@ export function getBundledSkillsDir(): string {
   // In compiled Bun binaries, import.meta.dir points into the virtual
   // /$bunfs/ filesystem where non-JS assets don't exist.  Fall back to
   // the macOS .app bundle Resources dir or next to the binary.
-  if (dir.startsWith("/$bunfs/")) {
+  if (isBunVirtualPath(dir)) {
     const execDir = dirname(process.execPath);
     // macOS .app bundle: binary is in Contents/MacOS/, resources in Contents/Resources/
     const resourcesPath = join(execDir, "..", "Resources", "bundled-skills");

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -16,6 +16,7 @@ import { gunzipSync } from "node:zlib";
 
 import { getPlatformBaseUrl } from "../config/env.js";
 import { loadSkillCatalog } from "../config/skills.js";
+import { isBunVirtualPath } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceSkillsDir } from "../util/platform.js";
 import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
@@ -67,7 +68,7 @@ export interface CatalogSkill {
 export function getRepoSkillsDir(): string | undefined {
   const importDir = import.meta.dir;
 
-  if (importDir.startsWith("/$bunfs/")) {
+  if (isBunVirtualPath(importDir)) {
     const execDir = dirname(process.execPath);
     // macOS .app bundle: binary in Contents/MacOS/, resources in Contents/Resources/
     const resourcesPath = join(

--- a/assistant/src/util/bundled-asset.ts
+++ b/assistant/src/util/bundled-asset.ts
@@ -1,6 +1,14 @@
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 
+export function isBunVirtualPath(value: string): boolean {
+  const normalized = value.replaceAll("\\", "/");
+  return (
+    normalized.startsWith("/$bunfs/") ||
+    /^[a-z]:\/~bun(?:\/|$)/i.test(normalized)
+  );
+}
+
 /**
  * Resolve the path to a bundled asset directory, handling compiled Bun binaries
  * where `import.meta.dirname` points to the `/$bunfs/` virtual filesystem and
@@ -22,7 +30,7 @@ export function resolveBundledDir(
   relativePath: string,
   bundleName: string,
 ): string {
-  if (callerDir.startsWith("/$bunfs/")) {
+  if (isBunVirtualPath(callerDir)) {
     const execDir = dirname(process.execPath);
     // macOS .app bundle: binary in Contents/MacOS/, resources in Contents/Resources/
     const resourcesPath = join(execDir, "..", "Resources", bundleName);

--- a/bun.lock
+++ b/bun.lock
@@ -109,6 +109,7 @@
         "nanoid": "5.1.7",
         "qrcode-terminal": "0.12.0",
         "react": "19.2.6",
+        "react-devtools-core": "7.0.1",
       },
       "devDependencies": {
         "@types/bun": "1.3.11",
@@ -3414,6 +3415,8 @@
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
     "react-docgen": ["react-docgen@8.0.3", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.2", "@types/babel__core": "^7.20.5", "@types/babel__traverse": "^7.20.7", "@types/doctrine": "^0.0.9", "@types/resolve": "^1.20.2", "doctrine": "^3.0.0", "resolve": "^1.22.1", "strip-indent": "^4.0.0" } }, "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w=="],
 
     "react-docgen-typescript": ["react-docgen-typescript@2.4.0", "", { "peerDependencies": { "typescript": ">= 4.3.x" } }, "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg=="],
@@ -4717,6 +4720,8 @@
     "protobufjs/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "react-devtools-core/ws": ["ws@7.5.13", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA=="],
 
     "redent/indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint",
     "lint:unused": "knip --include files,dependencies,unlisted",
-    "compile:check": "bun build --compile --external react-devtools-core src/index.ts --outfile /dev/null",
+    "compile:check": "bun build --compile src/index.ts --outfile /dev/null",
     "test": "bun test",
     "typecheck": "bunx tsc --noEmit"
   },
@@ -38,7 +38,8 @@
     "ink": "6.8.0",
     "nanoid": "5.1.7",
     "qrcode-terminal": "0.12.0",
-    "react": "19.2.6"
+    "react": "19.2.6",
+    "react-devtools-core": "7.0.1"
   },
   "bundledDependencies": [
     "@vellumai/avatar-manifest",

--- a/cli/src/lib/hatch-local.ts
+++ b/cli/src/lib/hatch-local.ts
@@ -227,7 +227,11 @@ export async function hatchLocal(
         }
       }
 
-      if (!apiKeyCheck.hasKey && !pickedProvider) {
+      if (
+        !apiKeyCheck.hasKey &&
+        !pickedProvider &&
+        !process.env.VELLUM_DESKTOP_APP
+      ) {
         reporter.warn(
           "Warning: No LLM provider API key is configured. The assistant will fail when you try to send a message.",
         );

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -140,6 +140,18 @@ function compiledSibling(name: string): string {
   return join(dirname(process.execPath), executableName(name, platform()));
 }
 
+function envWithCompiledRuntimeNodePath(
+  env: Record<string, string>,
+): Record<string, string> {
+  if (!isCompiledCli()) {
+    return env;
+  }
+  return {
+    ...env,
+    NODE_PATH: join(dirname(process.execPath), "node_modules"),
+  };
+}
+
 function resolveBunExecutable(): string {
   if (!isCompiledCli()) {
     return process.execPath;
@@ -1645,6 +1657,7 @@ export async function startLocalDaemon(
         }
       }
       applyDaemonEnvOverrides(daemonEnv, resources, options);
+      const daemonSpawnEnv = envWithCompiledRuntimeNodePath(daemonEnv);
 
       // Write a sentinel PID file before spawning so concurrent hatch() calls
       // see the file and fall through to the isDaemonResponsive() port check
@@ -1655,7 +1668,7 @@ export async function startLocalDaemon(
         ? spawn(daemonBinary, [], {
             cwd: dirname(daemonBinary),
             stdio: "inherit",
-            env: daemonEnv,
+            env: daemonSpawnEnv,
           })
         : (() => {
             const daemonLogFd = openLogFile("hatch.log");
@@ -1664,7 +1677,7 @@ export async function startLocalDaemon(
               detached: true,
               stdio: ["ignore", "pipe", "pipe"],
               windowsHide: true,
-              env: daemonEnv,
+              env: daemonSpawnEnv,
             });
             pipeToLogFile(c, daemonLogFd, "daemon");
             c.unref();
@@ -1876,7 +1889,7 @@ export async function startGateway(
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
-      env: gatewayEnv,
+      env: envWithCompiledRuntimeNodePath(gatewayEnv),
     });
     pipeToLogFile(gateway, gatewayLogFd, "gateway");
   } else {

--- a/clients/macos/src/main/env-seed.ts
+++ b/clients/macos/src/main/env-seed.ts
@@ -2,6 +2,8 @@
 // is seeded before any other module reads it at module scope.
 declare const __VELLUM_ENVIRONMENT__: string;
 
+process.env.VELLUM_DESKTOP_APP = "1";
+
 if (
   typeof __VELLUM_ENVIRONMENT__ === "string" &&
   !process.env.VELLUM_ENVIRONMENT

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -126,6 +126,11 @@ is used when its sha256 matches `scripts/bun-release.ts`, otherwise the
 matching GitHub release is downloaded and verified. Bump the pins there when
 the Bun version changes.
 
+`build:preview-handler` uses Visual Studio's vcpkg integration by default. Set
+`VCPKG_ROOT` to a standalone vcpkg checkout when the Visual Studio-bundled copy
+is too old for the manifest's pinned dependency baseline. The checkout must
+contain full Git history, and the build script forwards the root to MSBuild.
+
 Local and CI packs are unsigned. `.github/workflows/windows-package-smoke.yaml`
 runs the same steps per architecture, then install-, launch-, and
 uninstall-tests the installer.

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -126,10 +126,11 @@ is used when its sha256 matches `scripts/bun-release.ts`, otherwise the
 matching GitHub release is downloaded and verified. Bump the pins there when
 the Bun version changes.
 
-`build:preview-handler` uses Visual Studio's vcpkg integration by default. Set
-`VCPKG_ROOT` to a standalone vcpkg checkout when the Visual Studio-bundled copy
-is too old for the manifest's pinned dependency baseline. The checkout must
-contain full Git history, and the build script forwards the root to MSBuild.
+`build:preview-handler` installs its manifest dependencies before invoking
+MSBuild. It resolves vcpkg from `VCPKG_ROOT`, the local Vellum build-tools
+checkout, or `PATH`, in that order. The checkout must contain full Git history
+for the manifest's pinned dependency baseline. The Visual Studio-bundled vcpkg
+may be too old for that baseline.
 
 Local and CI packs are unsigned. `.github/workflows/windows-package-smoke.yaml`
 runs the same steps per architecture, then install-, launch-, and

--- a/clients/windows/electron-builder.config.cjs
+++ b/clients/windows/electron-builder.config.cjs
@@ -147,6 +147,13 @@ module.exports = {
     { from: "resources/tray.ico", to: "tray.ico" },
     { from: appIcon, to: "icon.ico" },
     { from: "resources/cli-runtime", to: "cli-runtime" },
+    // electron-builder excludes a node_modules directory encountered below a
+    // broader file matcher. Use it as the matcher root so the CLI runtime's
+    // native packages are included in the installed app.
+    {
+      from: "resources/cli-runtime/node_modules",
+      to: "cli-runtime/node_modules",
+    },
     {
       from: `native/Vellum.PreviewHandler/build/${msbuildPlatform}/Release`,
       to: "preview-handler",

--- a/clients/windows/scripts/after-pack.ts
+++ b/clients/windows/scripts/after-pack.ts
@@ -1,7 +1,14 @@
 import { createHash } from "node:crypto";
-import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 
+import { CLI_RUNTIME_ENTRIES } from "../src/main/cli-installer";
 import { argValue } from "./cli-args";
 
 /**
@@ -26,6 +33,13 @@ export const requiredPackageBinaries = (arch: string): string[] => [
   "resources/cli-runtime/vellum-gateway.exe",
   "resources/cli-runtime/vellum-worker.exe",
   "resources/cli-runtime/vellum.exe",
+  `resources/native-helper/${arch}/Vellum.WindowsHelper.exe`,
+  "resources/preview-handler/Vellum.PreviewHandler.dll",
+];
+
+export const requiredPackageEntries = (arch: string): string[] => [
+  ...CLI_RUNTIME_ENTRIES.map((entry) => `resources/cli-runtime/${entry}`),
+  "resources/cli-runtime/cli-uninstaller.exe",
   `resources/native-helper/${arch}/Vellum.WindowsHelper.exe`,
   "resources/preview-handler/Vellum.PreviewHandler.dll",
 ];
@@ -88,6 +102,14 @@ const main = (): void => {
   const appOutDir = argValue("--app-out-dir");
   if (!appOutDir) {
     throw new Error("--app-out-dir or --installer is required");
+  }
+  const missingEntries = requiredPackageEntries(arch).filter(
+    (required) => !existsSync(path.join(appOutDir, required)),
+  );
+  if (missingEntries.length > 0) {
+    throw new Error(
+      `Packaged app is missing required entries: ${missingEntries.join(", ")}`,
+    );
   }
   const files = collectSignableFiles(appOutDir);
   const missing = requiredPackageBinaries(arch).filter(

--- a/clients/windows/scripts/build-native-helper.ts
+++ b/clients/windows/scripts/build-native-helper.ts
@@ -38,6 +38,14 @@ const dotnetDownloads = {
 const dotnetArchitecture = (): keyof typeof dotnetDownloads =>
   process.arch === "arm64" ? "arm64" : "x64";
 
+export const dotnetEnvironment = (
+  environment: Record<string, string | undefined> = process.env,
+): Record<string, string | undefined> => {
+  const result = { ...environment };
+  delete result.MSBUILD_EXE_PATH;
+  return result;
+};
+
 const projectDotnetPath = (): string =>
   join(
     windowsRoot,
@@ -186,6 +194,10 @@ const checkConfiguration = async (): Promise<void> => {
     /<RuntimeIdentifiers>win-x64;win-arm64<\/RuntimeIdentifiers>/,
   );
   assert.match(project, /<SelfContained>true<\/SelfContained>/);
+  assert.deepEqual(
+    dotnetEnvironment({ MSBUILD_EXE_PATH: "C:\\msbuild.exe", PATH: "C:\\bin" }),
+    { PATH: "C:\\bin" },
+  );
 };
 
 const main = async (): Promise<void> => {
@@ -194,6 +206,7 @@ const main = async (): Promise<void> => {
     return;
   }
   const dotnet = await ensureDotnet();
+  const environment = dotnetEnvironment();
   if (process.argv.includes("--test")) {
     await runNativeCommand(
       [
@@ -207,6 +220,7 @@ const main = async (): Promise<void> => {
         "win-x64",
       ],
       nativeRoot,
+      environment,
     );
   }
   // CI passes --arch all; local dev builds the current architecture.
@@ -229,6 +243,7 @@ const main = async (): Promise<void> => {
         join(windowsRoot, "resources", "native-helper", architecture),
       ],
       nativeRoot,
+      environment,
     );
   }
 };

--- a/clients/windows/scripts/build-preview-handler.ts
+++ b/clients/windows/scripts/build-preview-handler.ts
@@ -53,16 +53,38 @@ export function registrationMetadata(architecture: PreviewArchitecture) {
   };
 }
 
+export function vcpkgMsbuildArguments(root?: string): string[] {
+  if (!root) {
+    return [];
+  }
+  const normalizedRoot = root.endsWith("\\") || root.endsWith("/")
+    ? root
+    : `${root}\\`;
+  return [`/p:VcpkgRoot=${normalizedRoot}`];
+}
+
 function testArchitectureSelection() {
   assert.deepEqual(resolveArchitectures(undefined, "x64"), ["x64"]);
   assert.deepEqual(resolveArchitectures(undefined, "arm64"), ["arm64"]);
   assert.deepEqual(resolveArchitectures("all", "x64"), ["x64", "arm64"]);
   assert.throws(() => resolveArchitectures("ia32"), /Unsupported architecture/);
+  assert.deepEqual(vcpkgMsbuildArguments(), []);
+  assert.deepEqual(vcpkgMsbuildArguments("C:\\vcpkg"), [
+    "/p:VcpkgRoot=C:\\vcpkg\\",
+  ]);
+  assert.deepEqual(vcpkgMsbuildArguments("C:\\vcpkg\\"), [
+    "/p:VcpkgRoot=C:\\vcpkg\\",
+  ]);
 }
 
-export async function runNativeCommand(command: string[], cwd = windowsRoot) {
+export async function runNativeCommand(
+  command: string[],
+  cwd = windowsRoot,
+  env: Record<string, string | undefined> = process.env,
+) {
   const child = Bun.spawn(command, {
     cwd,
+    env,
     stderr: "inherit",
     stdout: "inherit",
   });
@@ -121,11 +143,16 @@ async function main() {
   if (!msbuild) {
     throw new Error("MSBuild is required in a Visual Studio developer shell");
   }
-  for (const architecture of resolveArchitectures(argValue("--arch"))) {
+  const vcpkgRoot = process.env.VCPKG_ROOT ?? process.env.VCPKG_INSTALLATION_ROOT;
+  const vcpkgArguments = vcpkgMsbuildArguments(vcpkgRoot);
+  for (const architecture of resolveArchitectures(
+    argValue("--arch"),
+    process.env.ELECTRON_TARGET_ARCH ?? process.arch,
+  )) {
     const platform = architecture === "arm64" ? "ARM64" : "x64";
     const project = join(handlerRoot, "Vellum.PreviewHandler.vcxproj");
-    await runNativeCommand([msbuild, project, "/p:Configuration=Release", `/p:Platform=${platform}`, "/m"]);
-    await runNativeCommand([msbuild, project, "/p:Configuration=Tests", `/p:Platform=${platform}`, "/m"]);
+    await runNativeCommand([msbuild, project, "/p:Configuration=Release", `/p:Platform=${platform}`, ...vcpkgArguments, "/m"]);
+    await runNativeCommand([msbuild, project, "/p:Configuration=Tests", `/p:Platform=${platform}`, ...vcpkgArguments, "/m"]);
     const output = join(handlerRoot, "build", platform, "Release");
     await writeFile(join(output, "registration.json"), `${JSON.stringify(registrationMetadata(architecture), null, 2)}\n`);
     if (architecture === (process.arch === "arm64" ? "arm64" : "x64")) {

--- a/clients/windows/scripts/build-preview-handler.ts
+++ b/clients/windows/scripts/build-preview-handler.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -53,14 +54,34 @@ export function registrationMetadata(architecture: PreviewArchitecture) {
   };
 }
 
-export function vcpkgMsbuildArguments(root?: string): string[] {
-  if (!root) {
-    return [];
+const withTrailingSlash = (path: string): string =>
+  path.endsWith("\\") || path.endsWith("/") ? path : `${path}\\`;
+
+export function vcpkgMsbuildArguments(root: string, installedDir: string): string[] {
+  return [
+    `/p:VcpkgRoot=${withTrailingSlash(root)}`,
+    `/p:VcpkgInstalledDir=${withTrailingSlash(installedDir)}`,
+    "/p:VcpkgManifestInstall=false",
+  ];
+}
+
+export function resolveVcpkgRoot(
+  environment: Record<string, string | undefined> = process.env,
+  findVcpkg: () => string | null = () => Bun.which("vcpkg"),
+  pathExists: (path: string) => boolean = existsSync,
+): string | undefined {
+  const configuredRoot = environment.VCPKG_ROOT ?? environment.VCPKG_INSTALLATION_ROOT;
+  if (configuredRoot) {
+    return configuredRoot;
   }
-  const normalizedRoot = root.endsWith("\\") || root.endsWith("/")
-    ? root
-    : `${root}\\`;
-  return [`/p:VcpkgRoot=${normalizedRoot}`];
+  if (environment.LOCALAPPDATA) {
+    const managedRoot = join(environment.LOCALAPPDATA, "vellum-build-tools", "vcpkg");
+    if (pathExists(join(managedRoot, "vcpkg.exe"))) {
+      return managedRoot;
+    }
+  }
+  const executable = findVcpkg();
+  return executable ? dirname(executable) : undefined;
 }
 
 function testArchitectureSelection() {
@@ -68,13 +89,33 @@ function testArchitectureSelection() {
   assert.deepEqual(resolveArchitectures(undefined, "arm64"), ["arm64"]);
   assert.deepEqual(resolveArchitectures("all", "x64"), ["x64", "arm64"]);
   assert.throws(() => resolveArchitectures("ia32"), /Unsupported architecture/);
-  assert.deepEqual(vcpkgMsbuildArguments(), []);
-  assert.deepEqual(vcpkgMsbuildArguments("C:\\vcpkg"), [
+  assert.deepEqual(vcpkgMsbuildArguments("C:\\vcpkg", "C:\\installed"), [
     "/p:VcpkgRoot=C:\\vcpkg\\",
+    "/p:VcpkgInstalledDir=C:\\installed\\",
+    "/p:VcpkgManifestInstall=false",
   ]);
-  assert.deepEqual(vcpkgMsbuildArguments("C:\\vcpkg\\"), [
+  assert.deepEqual(vcpkgMsbuildArguments("C:\\vcpkg\\", "C:\\installed\\"), [
     "/p:VcpkgRoot=C:\\vcpkg\\",
+    "/p:VcpkgInstalledDir=C:\\installed\\",
+    "/p:VcpkgManifestInstall=false",
   ]);
+  assert.equal(
+    resolveVcpkgRoot({ VCPKG_ROOT: "C:\\configured" }, () => null, () => false),
+    "C:\\configured",
+  );
+  assert.equal(
+    resolveVcpkgRoot(
+      { LOCALAPPDATA: "C:\\Users\\user\\AppData\\Local" },
+      () => null,
+      () => true,
+    ),
+    "C:\\Users\\user\\AppData\\Local\\vellum-build-tools\\vcpkg",
+  );
+  assert.equal(
+    resolveVcpkgRoot({}, () => "C:\\tools\\vcpkg.exe", () => false),
+    "C:\\tools",
+  );
+  assert.equal(resolveVcpkgRoot({}, () => null, () => false), undefined);
 }
 
 export async function runNativeCommand(
@@ -143,14 +184,29 @@ async function main() {
   if (!msbuild) {
     throw new Error("MSBuild is required in a Visual Studio developer shell");
   }
-  const vcpkgRoot = process.env.VCPKG_ROOT ?? process.env.VCPKG_INSTALLATION_ROOT;
-  const vcpkgArguments = vcpkgMsbuildArguments(vcpkgRoot);
+  const vcpkgRoot = resolveVcpkgRoot();
+  if (!vcpkgRoot) {
+    throw new Error("vcpkg is required; set VCPKG_ROOT or add vcpkg to PATH");
+  }
+  const vcpkg = join(vcpkgRoot, "vcpkg.exe");
+  const installedDir = join(handlerRoot, "vcpkg_installed");
+  const vcpkgArguments = vcpkgMsbuildArguments(vcpkgRoot, installedDir);
   for (const architecture of resolveArchitectures(
     argValue("--arch"),
     process.env.ELECTRON_TARGET_ARCH ?? process.arch,
   )) {
     const platform = architecture === "arm64" ? "ARM64" : "x64";
+    const triplet = `${architecture}-windows-static-md`;
     const project = join(handlerRoot, "Vellum.PreviewHandler.vcxproj");
+    await runNativeCommand([
+      vcpkg,
+      "install",
+      "--x-wait-for-lock",
+      `--triplet=${triplet}`,
+      `--vcpkg-root=${vcpkgRoot}`,
+      `--x-manifest-root=${handlerRoot}`,
+      `--x-install-root=${installedDir}`,
+    ]);
     await runNativeCommand([msbuild, project, "/p:Configuration=Release", `/p:Platform=${platform}`, ...vcpkgArguments, "/m"]);
     await runNativeCommand([msbuild, project, "/p:Configuration=Tests", `/p:Platform=${platform}`, ...vcpkgArguments, "/m"]);
     const output = join(handlerRoot, "build", platform, "Release");

--- a/clients/windows/scripts/build-preview-handler.ts
+++ b/clients/windows/scripts/build-preview-handler.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { argValue } from "./cli-args";
@@ -44,7 +44,10 @@ export function registrationMetadata(architecture: PreviewArchitecture) {
         appId: "{534A1E02-D58F-44F0-B58B-36CBED287C7C}",
         threadingModel: "Apartment",
       },
-      [thumbnailClsid]: { name: "Vellum Bundle Thumbnail", threadingModel: "Apartment" },
+      [thumbnailClsid]: {
+        name: "Vellum Bundle Thumbnail",
+        threadingModel: "Apartment",
+      },
     },
     associations: {
       "{8895B1C6-B41F-4C1C-A562-0D564250836F}": previewClsid,
@@ -57,7 +60,10 @@ export function registrationMetadata(architecture: PreviewArchitecture) {
 const withTrailingSlash = (path: string): string =>
   path.endsWith("\\") || path.endsWith("/") ? path : `${path}\\`;
 
-export function vcpkgMsbuildArguments(root: string, installedDir: string): string[] {
+export function vcpkgMsbuildArguments(
+  root: string,
+  installedDir: string,
+): string[] {
   return [
     `/p:VcpkgRoot=${withTrailingSlash(root)}`,
     `/p:VcpkgInstalledDir=${withTrailingSlash(installedDir)}`,
@@ -70,18 +76,23 @@ export function resolveVcpkgRoot(
   findVcpkg: () => string | null = () => Bun.which("vcpkg"),
   pathExists: (path: string) => boolean = existsSync,
 ): string | undefined {
-  const configuredRoot = environment.VCPKG_ROOT ?? environment.VCPKG_INSTALLATION_ROOT;
+  const configuredRoot =
+    environment.VCPKG_ROOT ?? environment.VCPKG_INSTALLATION_ROOT;
   if (configuredRoot) {
     return configuredRoot;
   }
   if (environment.LOCALAPPDATA) {
-    const managedRoot = join(environment.LOCALAPPDATA, "vellum-build-tools", "vcpkg");
-    if (pathExists(join(managedRoot, "vcpkg.exe"))) {
+    const managedRoot = win32.join(
+      environment.LOCALAPPDATA,
+      "vellum-build-tools",
+      "vcpkg",
+    );
+    if (pathExists(win32.join(managedRoot, "vcpkg.exe"))) {
       return managedRoot;
     }
   }
   const executable = findVcpkg();
-  return executable ? dirname(executable) : undefined;
+  return executable ? win32.dirname(executable) : undefined;
 }
 
 function testArchitectureSelection() {
@@ -100,7 +111,11 @@ function testArchitectureSelection() {
     "/p:VcpkgManifestInstall=false",
   ]);
   assert.equal(
-    resolveVcpkgRoot({ VCPKG_ROOT: "C:\\configured" }, () => null, () => false),
+    resolveVcpkgRoot(
+      { VCPKG_ROOT: "C:\\configured" },
+      () => null,
+      () => false,
+    ),
     "C:\\configured",
   );
   assert.equal(
@@ -112,10 +127,21 @@ function testArchitectureSelection() {
     "C:\\Users\\user\\AppData\\Local\\vellum-build-tools\\vcpkg",
   );
   assert.equal(
-    resolveVcpkgRoot({}, () => "C:\\tools\\vcpkg.exe", () => false),
+    resolveVcpkgRoot(
+      {},
+      () => "C:\\tools\\vcpkg.exe",
+      () => false,
+    ),
     "C:\\tools",
   );
-  assert.equal(resolveVcpkgRoot({}, () => null, () => false), undefined);
+  assert.equal(
+    resolveVcpkgRoot(
+      {},
+      () => null,
+      () => false,
+    ),
+    undefined,
+  );
 }
 
 export async function runNativeCommand(
@@ -135,7 +161,8 @@ export async function runNativeCommand(
 }
 
 async function portableTest() {
-  const vcpkgRoot = process.env.VCPKG_ROOT ?? process.env.VCPKG_INSTALLATION_ROOT;
+  const vcpkgRoot =
+    process.env.VCPKG_ROOT ?? process.env.VCPKG_INSTALLATION_ROOT;
   const vcpkg = vcpkgRoot ? join(vcpkgRoot, "vcpkg") : Bun.which("vcpkg");
   if (!vcpkg) {
     throw new Error("vcpkg is required for portable parser tests");
@@ -144,8 +171,13 @@ async function portableTest() {
   const scratch = await mkdtemp(join(tmpdir(), "vellum-preview-test-"));
   const installed = join(scratch, "vcpkg");
   try {
-    await runNativeCommand([vcpkg, "install", `--x-manifest-root=${handlerRoot}`,
-      `--x-install-root=${installed}`, `--triplet=${triplet}`]);
+    await runNativeCommand([
+      vcpkg,
+      "install",
+      `--x-manifest-root=${handlerRoot}`,
+      `--x-install-root=${installed}`,
+      `--triplet=${triplet}`,
+    ]);
     const executable = join(scratch, "BundleReaderTests");
     await runNativeCommand([
       "c++",
@@ -178,7 +210,9 @@ async function main() {
       await portableTest();
       return;
     }
-    throw new Error("Preview handler builds require Windows; use --native-test for the portable parser suite");
+    throw new Error(
+      "Preview handler builds require Windows; use --native-test for the portable parser suite",
+    );
   }
   const msbuild = process.env.MSBUILD_EXE_PATH ?? Bun.which("msbuild");
   if (!msbuild) {
@@ -207,10 +241,27 @@ async function main() {
       `--x-manifest-root=${handlerRoot}`,
       `--x-install-root=${installedDir}`,
     ]);
-    await runNativeCommand([msbuild, project, "/p:Configuration=Release", `/p:Platform=${platform}`, ...vcpkgArguments, "/m"]);
-    await runNativeCommand([msbuild, project, "/p:Configuration=Tests", `/p:Platform=${platform}`, ...vcpkgArguments, "/m"]);
+    await runNativeCommand([
+      msbuild,
+      project,
+      "/p:Configuration=Release",
+      `/p:Platform=${platform}`,
+      ...vcpkgArguments,
+      "/m",
+    ]);
+    await runNativeCommand([
+      msbuild,
+      project,
+      "/p:Configuration=Tests",
+      `/p:Platform=${platform}`,
+      ...vcpkgArguments,
+      "/m",
+    ]);
     const output = join(handlerRoot, "build", platform, "Release");
-    await writeFile(join(output, "registration.json"), `${JSON.stringify(registrationMetadata(architecture), null, 2)}\n`);
+    await writeFile(
+      join(output, "registration.json"),
+      `${JSON.stringify(registrationMetadata(architecture), null, 2)}\n`,
+    );
     if (architecture === (process.arch === "arm64" ? "arm64" : "x64")) {
       await runNativeCommand([
         join(handlerRoot, "build", platform, "Tests", "BundleReaderTests.exe"),

--- a/clients/windows/scripts/identity-assets.test.ts
+++ b/clients/windows/scripts/identity-assets.test.ts
@@ -14,6 +14,7 @@ const loadBuilderConfig = (environment: string) => {
   delete requireCjs.cache[configPath];
   try {
     return requireCjs(configPath) as {
+      extraResources: Array<{ from: string; to: string }>;
       win: { icon: string };
       nsis: { installerIcon: string; uninstallerIcon: string };
     };
@@ -69,4 +70,11 @@ test("unknown environments use the production identity", () => {
   expect(loadBuilderConfig("preview").win.icon).toBe(
     "build-resources/icons/production/icon.ico",
   );
+});
+
+test("packages CLI runtime dependencies with a dedicated file matcher", () => {
+  expect(loadBuilderConfig("local").extraResources).toContainEqual({
+    from: "resources/cli-runtime/node_modules",
+    to: "cli-runtime/node_modules",
+  });
 });

--- a/clients/windows/scripts/package-runtime.ts
+++ b/clients/windows/scripts/package-runtime.ts
@@ -1,4 +1,14 @@
-import { copyFileSync, cpSync, mkdirSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  copyFileSync,
+  cpSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+} from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -12,6 +22,7 @@ interface RuntimeTarget {
   readonly entry: string;
   readonly externals?: readonly string[];
   readonly defines?: Readonly<Record<string, string>>;
+  readonly hideConsole?: boolean;
 }
 
 const windowsDir = path.resolve(import.meta.dir, "..");
@@ -26,6 +37,36 @@ if (targetArch !== process.arch) {
   throw new Error(`${targetArch} runtime packaging requires a native runner.`);
 }
 const compileTarget = `bun-windows-${targetArch}`;
+const calculateRuntimeBuildId = (runtimeDir: string): string => {
+  const hash = createHash("sha256");
+  const visit = (dir: string): void => {
+    const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+    for (const entry of entries) {
+      const absolute = path.join(dir, entry.name);
+      const relative = path.relative(runtimeDir, absolute).replaceAll("\\", "/");
+      const stat = lstatSync(absolute);
+      if (stat.isSymbolicLink()) {
+        hash.update(relative);
+        hash.update("\0link\0");
+        hash.update(readlinkSync(absolute));
+        hash.update("\0");
+        continue;
+      }
+      if (stat.isDirectory()) {
+        visit(absolute);
+        continue;
+      }
+      hash.update(relative);
+      hash.update("\0");
+      hash.update(readFileSync(absolute));
+      hash.update("\0");
+    }
+  };
+  visit(runtimeDir);
+  return hash.digest("hex");
+};
 const readPackageVersion = async (packageDir: string): Promise<string> => {
   const manifest = (await Bun.file(
     path.join(repoRoot, packageDir, "package.json"),
@@ -36,6 +77,7 @@ const readPackageVersion = async (packageDir: string): Promise<string> => {
   return manifest.version;
 };
 const appVersion = await readPackageVersion("clients/windows");
+const cliVersion = await readPackageVersion("cli");
 const assistantVersion = await readPackageVersion("assistant");
 const gatewayVersion = await readPackageVersion("gateway");
 const commitSha = resolveBuildCommitSha();
@@ -74,7 +116,6 @@ const targets: readonly RuntimeTarget[] = [
   {
     name: "vellum.exe",
     entry: "cli/src/index.ts",
-    externals: ["react-devtools-core"],
   },
   {
     name: "assistant.exe",
@@ -87,36 +128,28 @@ const targets: readonly RuntimeTarget[] = [
     entry: "assistant/src/daemon/windows-compiled-entry.ts",
     externals: assistantExternals,
     defines: assistantDefines,
+    hideConsole: true,
   },
   {
     name: "vellum-gateway.exe",
     entry: "gateway/src/index.ts",
-    externals: [
-      "@electric-sql/*",
-      "@aws-sdk/client-rds-data",
-      "@libsql/*",
-      "@neondatabase/*",
-      "@planetscale/*",
-      "@vercel/*",
-      "better-sqlite3",
-      "mysql2/*",
-      "mysql2",
-      "pg",
-      "postgres",
-    ],
+    externals: ["drizzle-kit", "drizzle-kit/*"],
     defines: {
       "process.env.APP_VERSION": JSON.stringify(gatewayVersion),
     },
+    hideConsole: true,
   },
   {
     name: "vellum-worker.exe",
     entry: "assistant/src/windows-compiled-worker-entry.ts",
     externals: assistantExternals,
     defines: assistantDefines,
+    hideConsole: true,
   },
   {
     name: "credential-executor.exe",
     entry: "credential-executor/src/main.ts",
+    hideConsole: true,
   },
   {
     name: "cli-launcher.exe",
@@ -127,8 +160,11 @@ const targets: readonly RuntimeTarget[] = [
     entry: "clients/windows/scripts/uninstall-cli.ts",
   },
 ];
-for (const { name, entry, externals, defines } of targets) {
+for (const { name, entry, externals, defines, hideConsole } of targets) {
   const args = ["build", "--compile", `--target=${compileTarget}`];
+  if (hideConsole) {
+    args.push("--windows-hide-console");
+  }
   for (const external of externals ?? []) {
     args.push("--external", external);
   }
@@ -152,6 +188,7 @@ for (const { name, entry, externals, defines } of targets) {
 
 const nativeSharpPackage = `@img/sharp-win32-${targetArch}`;
 const assistantPackageDir = path.join(repoRoot, "assistant");
+const gatewayPackageDir = path.join(repoRoot, "gateway");
 const sharpPackageDir = findPackageDir("sharp", assistantPackageDir);
 const runtimePackages = [
   {
@@ -179,6 +216,16 @@ const runtimePackages = [
     resolveSpecifier: "semver",
     basedir: sharpPackageDir,
   },
+  {
+    packageName: "drizzle-kit",
+    resolveSpecifier: "drizzle-kit/api",
+    basedir: gatewayPackageDir,
+  },
+  {
+    packageName: "drizzle-orm",
+    resolveSpecifier: "drizzle-orm",
+    basedir: gatewayPackageDir,
+  },
 ] as const;
 const runtimeNodeModules = path.join(outputDir, "node_modules");
 mkdirSync(runtimeNodeModules, { recursive: true });
@@ -189,7 +236,6 @@ for (const { packageName, resolveSpecifier, basedir } of runtimePackages) {
     { recursive: true },
   );
 }
-
 const packagedAssistant = path.join(outputDir, "assistant.exe");
 const versionCheck = spawnSync(packagedAssistant, ["--version"], {
   encoding: "utf8",
@@ -208,6 +254,28 @@ if (versionCheck.status !== 0 || versionOutput !== assistantVersion) {
     .join("; ");
   throw new Error(
     `Packaged assistant version check failed: expected ${assistantVersion}, got ${versionOutput || "no output"} (${diagnostics}).`,
+  );
+}
+const packagedCli = path.join(outputDir, "vellum.exe");
+const cliVersionCheck = spawnSync(packagedCli, ["--version"], {
+  encoding: "utf8",
+  windowsHide: true,
+});
+const expectedCliVersion = `@vellumai/cli v${cliVersion}`;
+const cliVersionOutput = cliVersionCheck.stdout?.trim() ?? "";
+const cliVersionErrorOutput = cliVersionCheck.stderr?.trim() ?? "";
+if (cliVersionCheck.status !== 0 || cliVersionOutput !== expectedCliVersion) {
+  const diagnostics = [
+    `exit ${cliVersionCheck.status ?? "not started"}`,
+    cliVersionCheck.error
+      ? `spawn error: ${cliVersionCheck.error.message}`
+      : null,
+    cliVersionErrorOutput ? `stderr: ${cliVersionErrorOutput}` : null,
+  ]
+    .filter((detail): detail is string => detail !== null)
+    .join("; ");
+  throw new Error(
+    `Packaged CLI version check failed: expected ${expectedCliVersion}, got ${cliVersionOutput || "no output"} (${diagnostics}).`,
   );
 }
 for (const [source, name] of [
@@ -260,7 +328,8 @@ const bunSource = await installPinnedBun({
   version: bunVersion,
 });
 console.log(`Bundled Bun ${bunVersion} (${targetArch}) from ${bunSource}.`);
+const runtimeBuildId = calculateRuntimeBuildId(outputDir);
 await Bun.write(
   path.join(outputDir, "runtime.json"),
-  `${JSON.stringify({ version: appVersion, bunVersion, releaseChannel, architecture: targetArch })}\n`,
+  `${JSON.stringify({ version: appVersion, bunVersion, runtimeBuildId, releaseChannel, architecture: targetArch })}\n`,
 );

--- a/clients/windows/scripts/package-smoke.ts
+++ b/clients/windows/scripts/package-smoke.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
+import { CLI_RUNTIME_ENTRIES } from "../src/main/cli-installer";
 import { argValue } from "./cli-args";
 
 /** Installs, launches, verifies, and uninstalls a packaged NSIS artifact. */
@@ -84,10 +85,14 @@ const main = async (): Promise<void> => {
   const appExe = path.join(installDir, `${productName}.exe`);
   assertExists(appExe, "App executable");
   const resources = path.join(installDir, "resources");
+  for (const entry of CLI_RUNTIME_ENTRIES) {
+    assertExists(
+      path.join(resources, "cli-runtime", entry),
+      `CLI runtime entry ${entry}`,
+    );
+  }
   for (const [relative, label] of [
     ["web-dist/index.html", "Web renderer bundle"],
-    ["cli-runtime/vellum.exe", "CLI runtime"],
-    ["cli-runtime/bun.exe", "Bun runtime"],
     ["cli-runtime/runtime.json", "Runtime manifest"],
     [`native-helper/${arch}/Vellum.WindowsHelper.exe`, "Native helper"],
     ["preview-handler/Vellum.PreviewHandler.dll", "Preview handler DLL"],
@@ -102,6 +107,16 @@ const main = async (): Promise<void> => {
   });
   if (bunVersion.status !== 0 || !bunVersion.stdout.trim()) {
     fail(`Packaged Bun runtime failed to execute for ${arch}`);
+  }
+  const packagedCli = path.join(resources, "cli-runtime", "vellum.exe");
+  const cliVersion = spawnSync(packagedCli, ["--version"], {
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  if (cliVersion.status !== 0 || !cliVersion.stdout.trim()) {
+    fail(
+      `Packaged CLI failed to execute for ${arch}: ${cliVersion.stderr.trim()}`,
+    );
   }
   assertRegistered("HKCU\\Software\\Classes\\.vellum");
 

--- a/clients/windows/src/main/cli-installer.ts
+++ b/clients/windows/src/main/cli-installer.ts
@@ -14,6 +14,7 @@ import path from "node:path";
 type CliRuntimeManifest = {
   version: string;
   bunVersion: string;
+  runtimeBuildId?: string;
   releaseChannel?: string;
 };
 
@@ -100,6 +101,22 @@ export function isValidCliRuntime(
   );
 }
 
+function isSameRuntimeBuild(firstDir: string, secondDir: string): boolean {
+  const first = readRuntimeManifest(firstDir)?.runtimeBuildId;
+  const second = readRuntimeManifest(secondDir)?.runtimeBuildId;
+  return first === second;
+}
+
+function runtimeInstallDirName(
+  version: string,
+  manifest: CliRuntimeManifest | undefined,
+): string {
+  const buildId = manifest?.runtimeBuildId;
+  return buildId && /^[a-f0-9]{64}$/i.test(buildId)
+    ? `${version}-${buildId.slice(0, 24).toLowerCase()}`
+    : version;
+}
+
 function readState(installRoot: string): InstallState | undefined {
   const state = readJson<InstallState>(path.join(installRoot, STATE));
   return typeof state?.currentInstallDir === "string" ? state : undefined;
@@ -150,11 +167,11 @@ function isOwnedCliRuntime(installRoot: string, runtimeDir: string): boolean {
   const ownership = readJson<CliRuntimeOwnership>(
     path.join(runtimeDir, CLI_RUNTIME_OWNERSHIP_MARKER),
   );
-  const version = path.basename(runtimeDir);
+  const manifest = readRuntimeManifest(runtimeDir);
   return (
     ownership?.owner === "vellum-assistant" &&
-    ownership.version === version &&
-    isValidCliRuntime(runtimeDir, version)
+    ownership.version === manifest?.version &&
+    isValidCliRuntime(runtimeDir, manifest.version)
   );
 }
 
@@ -211,7 +228,14 @@ function writeState(installRoot: string, state: InstallState): void {
 export function provisionCliRuntime(paths: CliRuntimePaths) {
   const { sourceDir, installRoot, version } = paths;
   mkdirSync(installRoot, { recursive: true });
-  const target = path.join(installRoot, version);
+  const sourceIsValid = isValidCliRuntime(sourceDir, version);
+  const sourceManifest = sourceIsValid
+    ? readRuntimeManifest(sourceDir)
+    : undefined;
+  const target = path.join(
+    installRoot,
+    runtimeInstallDirName(version, sourceManifest),
+  );
   const priorState = readState(installRoot);
   const priorCurrent = isValidInstalledRuntime(
     installRoot,
@@ -239,7 +263,8 @@ export function provisionCliRuntime(paths: CliRuntimePaths) {
 
   if (
     isValidInstalledRuntime(installRoot, target) &&
-    isValidCliRuntime(target, version)
+    isValidCliRuntime(target, version) &&
+    (!sourceIsValid || isSameRuntimeBuild(target, sourceDir))
   ) {
     const previousInstallDir = selectPreviousInstallDir(target);
     writeOwnershipMarker(target, version);
@@ -258,7 +283,7 @@ export function provisionCliRuntime(paths: CliRuntimePaths) {
     };
   }
 
-  if (!isValidCliRuntime(sourceDir, version)) {
+  if (!sourceIsValid) {
     for (const fallback of [priorCurrent, priorPrevious]) {
       if (!fallback) {
         continue;

--- a/clients/windows/src/main/cli-provisioning.test.ts
+++ b/clients/windows/src/main/cli-provisioning.test.ts
@@ -18,6 +18,7 @@ import {
   CLI_RUNTIME_OWNERSHIP_MARKER,
   isValidCliRuntime,
   provisionCliRuntime,
+  readRuntimeManifest,
   type CliRuntimePaths,
 } from "./cli-installer";
 import {
@@ -54,11 +55,15 @@ const writeRuntimeEntries = (dir: string, version: string): void => {
   }
 };
 
-const writeRuntime = (dir: string, version: string): string => {
+const writeRuntime = (
+  dir: string,
+  version: string,
+  runtimeBuildId = `build-${version}`,
+): string => {
   writeRuntimeEntries(dir, version);
   writeFileSync(
     path.join(dir, "runtime.json"),
-    JSON.stringify({ version, bunVersion: "1.3.11" }),
+    JSON.stringify({ version, bunVersion: "1.3.11", runtimeBuildId }),
     "utf8",
   );
   writeFileSync(
@@ -135,19 +140,26 @@ test("installs, upgrades, and falls back from paths with spaces", () => {
 test("prunes only owned runtimes older than the fallback", () => {
   const root = makeTempDir();
   let previousInstallDir: string | undefined;
+  const installDirs: string[] = [];
 
-  for (const version of ["1.0.0", "2.0.0", "3.0.0"]) {
+  for (const [version, buildChar] of [
+    ["1.0.0", "1"],
+    ["2.0.0", "2"],
+    ["3.0.0", "3"],
+  ] as const) {
     const paths = runtimePaths(root, version);
     rmSync(paths.sourceDir, { recursive: true, force: true });
-    writeRuntime(paths.sourceDir, version);
-    previousInstallDir = provisionCliRuntime(paths).previousInstallDir;
+    writeRuntime(paths.sourceDir, version, buildChar.repeat(64));
+    const result = provisionCliRuntime(paths);
+    installDirs.push(result.installDir);
+    previousInstallDir = result.previousInstallDir;
   }
 
   const installRoot = runtimePaths(root, "3.0.0").installRoot;
-  expect(existsSync(path.join(installRoot, "1.0.0"))).toBeFalse();
-  expect(existsSync(path.join(installRoot, "2.0.0"))).toBeTrue();
-  expect(existsSync(path.join(installRoot, "3.0.0"))).toBeTrue();
-  expect(previousInstallDir).toBe(path.join(installRoot, "2.0.0"));
+  expect(existsSync(installDirs[0]!)).toBeFalse();
+  expect(existsSync(installDirs[1]!)).toBeTrue();
+  expect(existsSync(installDirs[2]!)).toBeTrue();
+  expect(previousInstallDir).toBe(installDirs[1]);
 
   const foreign = path.join(installRoot, "foreign");
   writeRuntime(foreign, "foreign");
@@ -196,6 +208,27 @@ test("preserves the newer runtime when reusing an older version", () => {
   rmSync(path.join(v1.installDir, "vellum.exe"));
   const fallback = provisionCliRuntime(runtimePaths(root, "3.0.0"));
   expect(fallback.installDir).toBe(v2.installDir);
+});
+
+test("installs a changed same-version runtime side by side", () => {
+  const root = makeTempDir();
+  const paths = runtimePaths(root, "1.0.0");
+  const firstBuildId = "1".repeat(64);
+  const secondBuildId = "2".repeat(64);
+  writeRuntime(paths.sourceDir, paths.version, firstBuildId);
+  const first = provisionCliRuntime(paths);
+
+  rmSync(paths.sourceDir, { recursive: true });
+  writeRuntime(paths.sourceDir, paths.version, secondBuildId);
+  const replacement = provisionCliRuntime(paths);
+
+  expect(replacement.installDir).not.toBe(first.installDir);
+  expect(replacement.previousInstallDir).toBe(first.installDir);
+  expect(existsSync(first.installDir)).toBeTrue();
+  expect(replacement.reused).toBeFalse();
+  expect(readRuntimeManifest(replacement.installDir)?.runtimeBuildId).toBe(
+    secondBuildId,
+  );
 });
 
 test("does not replace a foreign launcher", () => {

--- a/clients/windows/src/main/env-seed.ts
+++ b/clients/windows/src/main/env-seed.ts
@@ -2,6 +2,8 @@
 // is seeded before any other module reads it at module scope.
 declare const __VELLUM_ENVIRONMENT__: string;
 
+process.env.VELLUM_DESKTOP_APP = "1";
+
 if (
   typeof __VELLUM_ENVIRONMENT__ === "string" &&
   !process.env.VELLUM_ENVIRONMENT

--- a/gateway/src/risk/shell-parser.ts
+++ b/gateway/src/risk/shell-parser.ts
@@ -211,7 +211,11 @@ function findWasmPath(
   // /$bunfs/ filesystem. Prefer bundled WASM assets shipped alongside the
   // executable before falling back to process.cwd(), so we never accidentally
   // pick up a mismatched version from the working directory.
-  if (dir.startsWith("/$bunfs/")) {
+  const normalizedDir = dir.replaceAll("\\", "/");
+  if (
+    normalizedDir.startsWith("/$bunfs/") ||
+    /^[a-z]:\/~bun(?:\/|$)/i.test(normalizedDir)
+  ) {
     const execDir = dirname(process.execPath);
     // macOS .app bundle: binary is in Contents/MacOS/, resources in Contents/Resources/
     const resourcesPath = join(execDir, "..", "Resources", file);


### PR DESCRIPTION
## Summary

- forward a standalone `VCPKG_ROOT` to MSBuild so Windows packaging can avoid Visual Studio's outdated bundled vcpkg
- select the preview-handler target from `ELECTRON_TARGET_ARCH` during packaging
- remove `MSBUILD_EXE_PATH` from dotnet subprocesses so the .NET SDK resolves with its own compatible MSBuild
- document the standalone vcpkg requirement

## Root cause

Visual Studio 17.6 bundled vcpkg 2023-03-29, whose dependency bootstrap references a retired 7-Zip download. A Developer Prompt also exports `MSBUILD_EXE_PATH`; when inherited by the native-helper dotnet subprocess, that older MSBuild conflicts with the installed .NET 10 SDK.

## Verification

- `bun run pack` completed successfully and produced the x64 installer
- `bun scripts/build-preview-handler.ts --test-architecture`
- `bun scripts/build-native-helper.ts --check`
- `bun run typecheck`
- preview-handler Release and Tests configurations built successfully during packaging
- BundleReader native tests passed during packaging
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41634" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->