### PR TITLE
fix: camera-mode self-review round 3

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -59,8 +59,9 @@ import { createStorageAccessor } from "@/utils/typed-storage";
  *
  * The non-reactive `t`, because this is plain module code on the registration
  * path rather than a render. The map is a snapshot of the language the
- * registration was made in, and the caller re-registers whenever the content
- * the platform composes from moves.
+ * registration was made in, and the caller re-registers whenever anything the
+ * platform composes from moves, the active locale included: a language switch
+ * moves nothing in the session, so the caller keys on it directly.
  *
  * `muted` is baked into the table rather than left at its steady state. The
  * platform composes pushes by looking a phase up in this map, so a table built

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -155,7 +155,7 @@ const { useAssistantIdentityStore } =
   await import("@/stores/assistant-identity-store");
 const { BUNDLED_COMPONENTS } =
   await import("@/utils/avatar-bundled-components");
-const { changeLocale } = await import("@/i18n");
+const { changeLocale, currentLocale } = await import("@/i18n");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -228,6 +228,7 @@ beforeEach(() => {
   endVoiceLiveActivity.mockImplementation(async () => {});
   subscribeVoiceLiveActivityPushToken.mockClear();
   registerLiveActivityPushToken.mockClear();
+  registerLiveActivityPushToken.mockImplementation(async () => {});
   unregisterLiveActivityPushToken.mockClear();
   startVoiceActivity.mockClear();
   updateVoiceActivity.mockClear();
@@ -828,6 +829,41 @@ describe("registering the activity for server-driven updates", () => {
     expect(registerLiveActivityPushToken).toHaveBeenCalledTimes(1);
     expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject({
       muted: true,
+    });
+  });
+
+  // The platform words every background push by looking a phase up in the
+  // label table the registration carried, so a language switch the registration
+  // never heard about leaves the island reading the language the user just
+  // left. Nothing in the session moves on a switch, which is why the mirror has
+  // to key on the locale itself. The table is built inside the upsert from the
+  // language active when the call is made (pinned by
+  // `live-activity-push-registration.test.ts`), so the locale recorded here is
+  // the language the platform ends up holding.
+  test("re-registers in the new language when the app's language changes", async () => {
+    const localesRegisteredIn: string[] = [];
+    registerLiveActivityPushToken.mockImplementation(async () => {
+      localesRegisteredIn.push(currentLocale());
+    });
+    renderMirror();
+    await settled(() => {
+      useLiveVoiceStore.getState().setSessionContext("assistant-1", "conv-1");
+      useLiveVoiceStore.getState().setState("listening");
+    });
+    await emitToken("token-abc");
+    registerLiveActivityPushToken.mockClear();
+    localesRegisteredIn.length = 0;
+
+    await act(async () => {
+      await changeLocale("es");
+    });
+
+    expect(registerLiveActivityPushToken).toHaveBeenCalledTimes(1);
+    expect(localesRegisteredIn).toEqual(["es"]);
+    // Only the wording moved: the activity it addresses is the same one.
+    expect(registerLiveActivityPushToken.mock.calls.at(-1)?.[0]).toMatchObject({
+      token: "token-abc",
+      conversationId: "conv-1",
     });
   });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -59,7 +59,7 @@ import {
   useLiveVoiceStore,
   type LiveVoiceState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { useTranslation, type TFunction } from "@/i18n";
+import { currentLocale, useTranslation, type TFunction } from "@/i18n";
 import { getRenderedAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import { getIslandAvatarSource } from "@/hooks/use-island-avatar-source";
 import {
@@ -258,7 +258,7 @@ export function useLiveActivityMirror(): void {
     let pushToken: string | null = null;
     /**
      * What was last registered with the platform, as `token:assistant:
-     * conversation:accent:muted`.
+     * conversation:accent:muted:locale`.
      *
      * Every part matters and none is stable: the token rotates; a session
      * started from a draft has no conversation id until the server's `ready`
@@ -266,6 +266,10 @@ export function useLiveActivityMirror(): void {
      * leave the activity addressable by nothing; and the accent and mute state
      * are content the platform composes its pushes from, so a stale
      * registration would push the island back to whatever they were at start.
+     * The locale is in the key for that last reason too: the registration
+     * carries a phase to label table, so a language switch (which moves nothing
+     * in the session) has to re-upsert one built in the new language, or every
+     * background push after it reads in the language the user just left.
      * Comparing the whole tuple re-registers when any part moves and stays
      * quiet when none does.
      */
@@ -291,7 +295,10 @@ export function useLiveActivityMirror(): void {
         return;
       }
       const { accentHex, muted } = content;
-      const key = `${pushToken}:${assistantId}:${conversationId}:${accentHex}:${String(muted)}`;
+      // Read here rather than closed over: the resync a language switch fires
+      // runs through this same path, and reading fresh is what lets it see the
+      // locale that switch landed on.
+      const key = `${pushToken}:${assistantId}:${conversationId}:${accentHex}:${String(muted)}:${currentLocale()}`;
       if (key === registeredKey) {
         return;
       }
@@ -404,7 +411,9 @@ export function useLiveActivityMirror(): void {
   // The phase label is catalog copy, so switching language mid-call changes
   // what both surfaces should read while nothing in the session moves. Nothing
   // would push it otherwise, and the island a user is looking at would stay in
-  // the language they just left.
+  // the language they just left. The same resync re-upserts the push
+  // registration, which carries the table every server-composed push is worded
+  // from.
   useEffect(() => {
     translate.current = t;
     resync.current?.();

--- a/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.tsx
@@ -140,8 +140,9 @@ function useAssistantWord(assistantName: string | null | undefined): string {
  *
  * One message per state rather than a sentence assembled here: the mode, the
  * mute and the speaker pick the key, and the sentence behind it is whole. What
- * still interpolates is the one part no catalog can hold, the session's own
- * status word or the assistant's name.
+ * still interpolates is what this sentence does not decide: the session's
+ * status word, which the room resolves from this same catalog, or the
+ * assistant's name.
  *
  * Saying the mute is what the visible row does not do. The session relabels
  * only `listening` for a muted mic, so "Thinking…" on its own tells a


### PR DESCRIPTION
## Summary
The push-registration dedupe key includes the active locale so a mid-session language switch re-upserts the server-composed island label table; corrects one announcement docstring.

Part of plan: voice-camera-mode-redesign.md (self-review fixes)