### PR TITLE
fix(windows): prevent terminal flash during local setup

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -266,6 +266,7 @@ export function ensureLocalRuntime(
     cwd: installDir,
     stdio: "inherit",
     env: envWithBunPath(process.env),
+    windowsHide: true,
   });
 
   if (result.error || result.status !== 0) {
@@ -517,6 +518,7 @@ function ensureBunInstalled(): void {
     execFileSync(resolveBunExecutable(), ["--version"], {
       stdio: "pipe",
       env: envWithBunPath(process.env),
+      windowsHide: true,
     });
     return;
   } catch {
@@ -555,6 +557,7 @@ function ensureBunInstalled(): void {
       stdio: "pipe",
       timeout: 60_000,
       env: installEnv,
+      windowsHide: true,
     });
     console.log("   Bun installed successfully");
   } catch {


### PR DESCRIPTION
## Summary

- hide Bun availability and fallback installation subprocess windows during local assistant setup
- hide the first-time local runtime installation subprocess so onboarding remains inside the app

## Original prompt

While setting up a local assistant on Windows, a terminal window briefly flashes while the app shows “Setting up your assistant.” Keep those setup subprocesses hidden so onboarding does not open a visible terminal.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->