### PR TITLE
fix(windows): prevent subprocess terminal flashes

### DIFF
--- a/assistant/src/acp/agent-process.ts
+++ b/assistant/src/acp/agent-process.ts
@@ -92,6 +92,7 @@ export class AcpAgentProcess {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
       env: this.spawnedEnv,
+      windowsHide: true,
     });
 
     const stream = acp.ndJsonStream(

--- a/assistant/src/acp/auto-install.ts
+++ b/assistant/src/acp/auto-install.ts
@@ -86,6 +86,7 @@ function execFileWithTimeout(
         encoding: "utf8",
         cwd: options?.cwd,
         env: options?.env,
+        windowsHide: true,
       },
       (err, stdout) => {
         clearTimeout(timer);

--- a/assistant/src/acp/client-handler.ts
+++ b/assistant/src/acp/client-handler.ts
@@ -380,6 +380,7 @@ export class VellumAcpClientHandler implements Client {
       cwd: params.cwd ?? undefined,
       stdio: ["ignore", "pipe", "pipe"],
       env,
+      windowsHide: true,
     });
 
     const state: TerminalState = {

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -497,6 +497,7 @@ export async function runCompile(
     stdout: "pipe",
     stderr: "pipe",
     env: { ...process.env, NODE_PATH: nodePath },
+    windowsHide: true,
   });
 
   await proc.exited;

--- a/assistant/src/bundler/compiler-tools.ts
+++ b/assistant/src/bundler/compiler-tools.ts
@@ -170,6 +170,7 @@ async function downloadAndExtract(
       cmd: ["tar", "xzf", tmpTar, "-C", targetDir, "--strip-components=1"],
       stdout: "ignore",
       stderr: "pipe",
+      windowsHide: true,
     });
     await proc.exited;
     if (proc.exitCode !== 0) {

--- a/assistant/src/bundler/package-resolver.ts
+++ b/assistant/src/bundler/package-resolver.ts
@@ -124,6 +124,7 @@ async function installPackage(
       cwd: cacheDir,
       stdout: "pipe",
       stderr: "pipe",
+      windowsHide: true,
     });
 
     // Race against timeout

--- a/assistant/src/cli/commands/db/refresh.ts
+++ b/assistant/src/cli/commands/db/refresh.ts
@@ -48,6 +48,7 @@ function findHoldingPids(paths: string[]): number[] {
         encoding: "utf8",
         timeout: 5000,
         stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
       });
       for (const line of output.trim().split("\n")) {
         const pid = parseInt(line, 10);

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -1259,6 +1259,7 @@ export const defaultPostinstallRunner: PostinstallRunner = async ({
     timeout: POSTINSTALL_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
     env: pluginPostinstallEnv(bun),
+    windowsHide: true,
   });
 };
 
@@ -1377,6 +1378,7 @@ export const defaultGitRunner: GitRunner = async (args, opts) => {
     timeout: GIT_TIMEOUT_MS,
     maxBuffer: 64 * 1024 * 1024,
     env: pluginGitEnv(),
+    windowsHide: true,
   });
   return { stdout };
 };

--- a/assistant/src/cli/lib/install-plugin-dependencies.ts
+++ b/assistant/src/cli/lib/install-plugin-dependencies.ts
@@ -319,6 +319,7 @@ export const defaultDependencyInstaller: DependencyInstaller = async ({
     timeout: DEPENDENCY_INSTALL_TIMEOUT_MS,
     maxBuffer: 32 * 1024 * 1024,
     env: dependencyInstallEnv(bun),
+    windowsHide: true,
   });
 };
 

--- a/assistant/src/cli/lib/merge-plugin-tree.ts
+++ b/assistant/src/cli/lib/merge-plugin-tree.ts
@@ -205,6 +205,7 @@ async function threeWayMergeFile(
         encoding: "buffer",
         timeout: MERGE_TIMEOUT_MS,
         maxBuffer: 64 * 1024 * 1024,
+        windowsHide: true,
       });
       return { content: stdout, conflicted: false, binaryConflicted: false };
     } catch (err) {

--- a/assistant/src/cli/lib/publish-plugin.ts
+++ b/assistant/src/cli/lib/publish-plugin.ts
@@ -199,7 +199,10 @@ export function validatePluginForPublish(dir: string): PublishValidation {
 // ---------------------------------------------------------------------------
 
 async function runGit(dir: string, args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("git", args, { cwd: dir });
+  const { stdout } = await execFileAsync("git", args, {
+    cwd: dir,
+    windowsHide: true,
+  });
   return stdout.trim();
 }
 

--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -126,6 +126,7 @@ function isVellumDaemonProcess(pid: number): boolean {
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     }).trim();
     // The daemon is spawned as `bun run <path>/main.ts` — look for bun
     // running our daemon entry point.

--- a/assistant/src/daemon/install-assistant-command.ts
+++ b/assistant/src/daemon/install-assistant-command.ts
@@ -262,6 +262,7 @@ function commandResolvesElsewhere(
     const resolved = execFileSync("/usr/bin/which", [commandName], {
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     }).trim();
     return resolved !== "" && !candidatePaths.has(resolved);
   } catch {

--- a/assistant/src/daemon/video-thumbnail.ts
+++ b/assistant/src/daemon/video-thumbnail.ts
@@ -35,7 +35,7 @@ async function extractThumbnail(inputPath: string): Promise<string | null> {
         "5",
         outputPath,
       ],
-      { stderr: "pipe" },
+      { stderr: "pipe", windowsHide: true },
     );
 
     let timer: ReturnType<typeof setTimeout>;

--- a/assistant/src/monitoring/page-cache.ts
+++ b/assistant/src/monitoring/page-cache.ts
@@ -143,7 +143,11 @@ export async function readFileResidency(
     const { stdout } = await execFileAsync(
       "fincore",
       ["--bytes", "--json", ...paths],
-      { timeout: 10_000, maxBuffer: 4 * 1024 * 1024 },
+      {
+        timeout: 10_000,
+        maxBuffer: 4 * 1024 * 1024,
+        windowsHide: true,
+      },
     );
     return parseFincoreJson(stdout);
   } catch {

--- a/assistant/src/outbound-proxy/certs.ts
+++ b/assistant/src/outbound-proxy/certs.ts
@@ -49,6 +49,7 @@ export async function ensureLocalCA(dataDir: string): Promise<void> {
   const keyProc = Bun.spawn(["openssl", "genrsa", "-out", keyPath, "2048"], {
     stdout: "pipe",
     stderr: "pipe",
+    windowsHide: true,
   });
   const keyExit = await keyProc.exited;
   if (keyExit !== 0) {
@@ -76,7 +77,7 @@ export async function ensureLocalCA(dataDir: string): Promise<void> {
       "-addext",
       "keyUsage=critical,keyCertSign,cRLSign",
     ],
-    { stdout: "pipe", stderr: "pipe" },
+    { stdout: "pipe", stderr: "pipe", windowsHide: true },
   );
   const certExit = await certProc.exited;
   if (certExit !== 0) {
@@ -144,7 +145,7 @@ export async function issueLeafCert(
   // Generate leaf key
   const keyProc = Bun.spawn(
     ["openssl", "genrsa", "-out", leafKeyPath, "2048"],
-    { stdout: "pipe", stderr: "pipe" },
+    { stdout: "pipe", stderr: "pipe", windowsHide: true },
   );
   const keyExit = await keyProc.exited;
   if (keyExit !== 0) {
@@ -166,7 +167,7 @@ export async function issueLeafCert(
       "-subj",
       `/CN=${hostname}`,
     ],
-    { stdout: "pipe", stderr: "pipe" },
+    { stdout: "pipe", stderr: "pipe", windowsHide: true },
   );
   const csrExit = await csrProc.exited;
   if (csrExit !== 0) {
@@ -198,7 +199,7 @@ export async function issueLeafCert(
       "-extfile",
       extPath,
     ],
-    { stdout: "pipe", stderr: "pipe" },
+    { stdout: "pipe", stderr: "pipe", windowsHide: true },
   );
   const signExit = await signProc.exited;
   if (signExit !== 0) {

--- a/assistant/src/persistence/embeddings/qdrant-manager.ts
+++ b/assistant/src/persistence/embeddings/qdrant-manager.ts
@@ -286,6 +286,7 @@ export class QdrantManager {
           cmd: ["tar", "xzf", tmpTar, "-C", binDir, release.binaryName],
           stdout: "ignore",
           stderr: "pipe",
+          windowsHide: true,
         });
         await proc.exited;
         if (proc.exitCode !== 0) {

--- a/assistant/src/runtime/routes/archive-utils.ts
+++ b/assistant/src/runtime/routes/archive-utils.ts
@@ -25,7 +25,12 @@ export async function createTarGz(
     const { stdout } = await execFileAsync(
       "tar",
       ["czf", "-", "-C", staging, "."],
-      { maxBuffer: maxBytes, timeout: 30_000, encoding: "buffer" },
+      {
+        maxBuffer: maxBytes,
+        timeout: 30_000,
+        encoding: "buffer",
+        windowsHide: true,
+      },
     );
     const buf = Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout);
     return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);

--- a/assistant/src/runtime/routes/debug-bash-routes.ts
+++ b/assistant/src/runtime/routes/debug-bash-routes.ts
@@ -97,6 +97,7 @@ function handleDebugBash({ body }: RouteHandlerArgs): Promise<DebugBashResult> {
       stdio: ["ignore", "pipe", "pipe"],
       detached: true,
       env: buildSanitizedEnv(),
+      windowsHide: true,
     });
 
     const timer = setTimeout(() => {

--- a/assistant/src/schedule/run-script.ts
+++ b/assistant/src/schedule/run-script.ts
@@ -66,6 +66,7 @@ export async function runScript(
     detached: true,
     stdout: "pipe",
     stderr: "pipe",
+    windowsHide: true,
     env: {
       ...buildSanitizedEnv(),
       // __SCHEDULE_ID lets a saved command find its own dir; __SCHEDULE_RUN_ID

--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -421,6 +421,7 @@ export async function installSkillDependenciesIfPresent(
       cwd: skillDir,
       stdio: "inherit",
       env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+      windowsHide: true,
     });
     child.on("error", reject);
     child.on("close", (code) => {

--- a/assistant/src/skills/clawhub.ts
+++ b/assistant/src/skills/clawhub.ts
@@ -195,6 +195,7 @@ async function runClawhub(
     env: { ...process.env, CLAWHUB_DISABLE_TELEMETRY: "1" },
     stdout: "pipe",
     stderr: "pipe",
+    windowsHide: true,
   });
 
   let timer: ReturnType<typeof setTimeout>;

--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -125,6 +125,7 @@ export async function runInlineCommand(
         cwd: workingDir,
         env,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/assistant/src/tools/browser/browser-manager.ts
+++ b/assistant/src/tools/browser/browser-manager.ts
@@ -268,6 +268,7 @@ class BrowserManager {
             {
               stdout: "pipe",
               stderr: "pipe",
+              windowsHide: true,
             },
           );
           const timeoutMs = 300_000;

--- a/assistant/src/tools/browser/runtime-check.ts
+++ b/assistant/src/tools/browser/runtime-check.ts
@@ -104,6 +104,7 @@ export async function importPlaywright(): Promise<typeof import("playwright")> {
       cwd: externalDir,
       stdout: "pipe",
       stderr: "pipe",
+      windowsHide: true,
     });
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
@@ -168,6 +169,7 @@ export async function ensureChromiumHeadlessShell(
         stdout: "pipe",
         stderr: "pipe",
         cwd: externalPwExists ? externalDir : undefined,
+        windowsHide: true,
       },
     );
     const timeoutMs = 120_000;

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -472,6 +472,7 @@ export const hostShellTool = {
         env: hostEnv,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
+        windowsHide: true,
       });
 
       const stdoutChunks: Buffer[] = [];
@@ -659,6 +660,7 @@ export const hostShellTool = {
         env: hostEnv,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
+        windowsHide: true,
       });
 
       const killTree = () => terminateProcessTree(child);

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -161,6 +161,7 @@ function spawnRunner(
       env,
       stdio: ["ignore", "pipe", "pipe"],
       detached: true,
+      windowsHide: true,
     });
 
     const timer = setTimeout(() => {

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -327,6 +327,7 @@ export const shellTool = {
         env,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
+        windowsHide: true,
       });
 
       const killTree = buildKillTree(child, {
@@ -548,6 +549,7 @@ export const shellTool = {
         env,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
+        windowsHide: true,
       });
 
       const killTree = buildKillTree(child, {

--- a/assistant/src/util/bun-runtime.ts
+++ b/assistant/src/util/bun-runtime.ts
@@ -165,6 +165,7 @@ async function downloadBun(installDir: string): Promise<string> {
         : ["unzip", "-o", tmpZip, "-d", installDir],
       stdout: "ignore",
       stderr: "pipe",
+      windowsHide: true,
     });
     await proc.exited;
     if (proc.exitCode !== 0) {

--- a/assistant/src/util/disk-usage.ts
+++ b/assistant/src/util/disk-usage.ts
@@ -30,6 +30,7 @@ async function getDirectorySizeBytes(paths: string[]): Promise<number | null> {
     }
     const { stdout } = await execFileAsync("du", ["-sb", ...existing], {
       timeout: 30_000,
+      windowsHide: true,
     });
     let total = 0;
     for (const line of stdout.trim().split("\n")) {

--- a/assistant/src/util/file-use.ts
+++ b/assistant/src/util/file-use.ts
@@ -48,7 +48,10 @@ type ExecFileRunner = (
 ) => Promise<ExecFileResult>;
 
 const runExecFile: ExecFileRunner = async (command, args, options) => {
-  const { stdout } = await execFileAsync(command, args, options);
+  const { stdout } = await execFileAsync(command, args, {
+    ...options,
+    windowsHide: true,
+  });
   return { stdout };
 };
 

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -260,6 +260,7 @@ async function runSips(
       stdout: "ignore",
       stderr: "ignore",
       timeout: 15_000,
+      windowsHide: true,
     });
     await proc.exited;
     if (proc.exitCode !== 0) {

--- a/assistant/src/util/process-table.ts
+++ b/assistant/src/util/process-table.ts
@@ -157,6 +157,7 @@ function runProcessTableCommand(
     cmd: command,
     stdout: "pipe",
     stderr: "ignore",
+    windowsHide: true,
   });
   if (result.exitCode !== 0) {
     throw new Error(
@@ -173,6 +174,7 @@ async function runProcessTableCommandAsync(
   const { stdout } = await execFileAsync(command[0], command.slice(1), {
     encoding: "utf8",
     maxBuffer: 8 * 1024 * 1024,
+    windowsHide: true,
   });
   return parser(stdout);
 }

--- a/assistant/src/util/spawn.ts
+++ b/assistant/src/util/spawn.ts
@@ -29,6 +29,7 @@ export function spawnWithTimeout(
     const proc = Bun.spawn(cmd, {
       stdout: "pipe",
       stderr: "pipe",
+      windowsHide: true,
       env: {
         ...process.env,
         PATH: [

--- a/assistant/src/workspace/git-service.ts
+++ b/assistant/src/workspace/git-service.ts
@@ -1804,6 +1804,7 @@ export class WorkspaceGitService {
         timeout: timeoutMs,
         env: { ...cleanGitEnv(this.workspaceDir), ...options?.env },
         signal: options?.signal,
+        windowsHide: true,
       });
       return { stdout, stderr };
     } catch (err) {

--- a/assistant/src/workspace/migrations/010-app-dir-rename.ts
+++ b/assistant/src/workspace/migrations/010-app-dir-rename.ts
@@ -242,6 +242,7 @@ export const appDirRenameMigration: WorkspaceMigration = {
             cwd: appsDir,
             stdio: "ignore",
             timeout: 10_000,
+            windowsHide: true,
           },
         );
       }

--- a/cli/src/adapters/openclaw-http-server.ts
+++ b/cli/src/adapters/openclaw-http-server.ts
@@ -51,11 +51,13 @@ const server = http.createServer(async (req, res) => {
         encoding: "utf-8",
         timeout: 120000,
         env: npmEnv,
+        windowsHide: true,
       });
       const child = spawn("vellum-openclaw-adapter", [], {
         detached: true,
         stdio: "ignore",
         env: npmEnv,
+        windowsHide: true,
       });
       child.unref();
       const responseBody = JSON.stringify({
@@ -91,6 +93,7 @@ const server = http.createServer(async (req, res) => {
         encoding: "utf-8",
         timeout: 10000,
         env: execEnv,
+        windowsHide: true,
       });
       const health = JSON.parse(output.trim()) as Record<string, unknown>;
       const result: Record<string, unknown> = {
@@ -108,6 +111,7 @@ const server = http.createServer(async (req, res) => {
             encoding: "utf-8",
             timeout: 10000,
             env: execEnv,
+            windowsHide: true,
           });
           result.message = `${result.message}\n\nGateway Status:\n${gatewayOutput.trim()}`;
         } catch (gatewayErr) {
@@ -138,6 +142,7 @@ const server = http.createServer(async (req, res) => {
             encoding: "utf-8",
             timeout: 10000,
             env: execEnv,
+            windowsHide: true,
           });
           result.message = `${result.message}\n\nGateway Status:\n${gatewayOutput.trim()}`;
         } catch (gatewayErr) {

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1479,6 +1479,7 @@ async function runViteDevServer(
   const child = spawn("bun", ["run", "dev"], {
     cwd: webSourceDir,
     stdio: "inherit",
+    windowsHide: true,
     env: {
       ...process.env,
       ...flagEnvVars,

--- a/cli/src/commands/exec.ts
+++ b/cli/src/commands/exec.ts
@@ -156,7 +156,10 @@ export async function exec(): Promise<void> {
   const cloud = entry.cloud;
 
   if (cloud === "local") {
-    const child = spawn(command[0], command.slice(1), { stdio: "inherit" });
+    const child = spawn(command[0], command.slice(1), {
+      stdio: "inherit",
+      windowsHide: true,
+    });
     await new Promise<void>((resolve) => {
       child.on("close", (code) => {
         process.exitCode = code ?? 0;
@@ -187,7 +190,10 @@ export async function exec(): Promise<void> {
       ? ["exec", "-it", container, ...command]
       : ["exec", container, ...command];
 
-    const child = spawn("docker", dockerArgs, { stdio: "inherit" });
+    const child = spawn("docker", dockerArgs, {
+      stdio: "inherit",
+      windowsHide: true,
+    });
     await new Promise<void>((resolve, reject) => {
       child.on("close", (code) => {
         if (code === 0) resolve();

--- a/cli/src/commands/logs.ts
+++ b/cli/src/commands/logs.ts
@@ -329,7 +329,10 @@ async function showDockerLogs(
     // Single container — stream directly to stdout/stderr
     const target = targets[0];
     const args = buildDockerArgs(target.containerName);
-    const child = spawn("docker", args, { stdio: "inherit" });
+    const child = spawn("docker", args, {
+      stdio: "inherit",
+      windowsHide: true,
+    });
 
     await new Promise<void>((resolve, reject) => {
       child.on("close", (code) => {
@@ -356,6 +359,7 @@ async function showDockerLogs(
       const args = buildDockerArgs(target.containerName);
       const child = spawn("docker", args, {
         stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
       });
 
       const prefix = `[${target.name}] `;
@@ -466,7 +470,10 @@ async function showGcpLogs(
 
   if (opts.follow) {
     // For follow mode, stream output directly to terminal
-    const child = spawn("gcloud", args, { stdio: "inherit" });
+    const child = spawn("gcloud", args, {
+      stdio: "inherit",
+      windowsHide: true,
+    });
     await new Promise<void>((resolve, reject) => {
       child.on("close", (code) => {
         if (code !== 0 && code !== null) {
@@ -503,6 +510,7 @@ async function showCustomLogs(
   if (opts.follow) {
     const child = spawn("ssh", [...SSH_OPTS, sshTarget, remoteCmd], {
       stdio: "inherit",
+      windowsHide: true,
     });
     await new Promise<void>((resolve, reject) => {
       child.on("close", (code) => {
@@ -544,6 +552,7 @@ async function showAwsLogs(
   if (opts.follow) {
     const child = spawn("ssh", [...SSH_OPTS, sshTarget, remoteCmd], {
       stdio: "inherit",
+      windowsHide: true,
     });
     await new Promise<void>((resolve, reject) => {
       child.on("close", (code) => {

--- a/cli/src/commands/ssh.ts
+++ b/cli/src/commands/ssh.ts
@@ -73,7 +73,7 @@ export async function ssh(): Promise<void> {
     child = spawn(
       "docker",
       ["exec", "-it", res.assistantContainer, "/bin/sh"],
-      { stdio: "inherit" },
+      { stdio: "inherit", windowsHide: true },
     );
   } else if (cloud === "gcp") {
     const project = entry.project;
@@ -94,7 +94,7 @@ export async function ssh(): Promise<void> {
     child = spawn(
       "gcloud",
       ["compute", "ssh", sshTarget, `--project=${project}`, `--zone=${zone}`],
-      { stdio: "inherit" },
+      { stdio: "inherit", windowsHide: true },
     );
   } else if (cloud === "vellum") {
     const token = readPlatformToken();
@@ -117,7 +117,10 @@ export async function ssh(): Promise<void> {
 
     console.log(`🔗 Connecting to ${entry.assistantId} via ssh...\n`);
 
-    child = spawn("ssh", [...SSH_OPTS, sshTarget], { stdio: "inherit" });
+    child = spawn("ssh", [...SSH_OPTS, sshTarget], {
+      stdio: "inherit",
+      windowsHide: true,
+    });
   } else {
     console.error(`Error: Unknown cloud type '${cloud}'.`);
     process.exit(1);

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -1527,7 +1527,7 @@ async function resolveLatestAndMaybeSelfUpdate(
     const installResult = spawnSync(
       "bun",
       ["install", "-g", `vellum@${stripVersionPrefix(latestTag)}`],
-      { stdio: "inherit" },
+      { stdio: "inherit", windowsHide: true },
     );
     if (installResult.error || installResult.status !== 0) {
       const detail =
@@ -1551,6 +1551,7 @@ async function resolveLatestAndMaybeSelfUpdate(
     console.log(`🚀 Re-running upgrade with updated CLI...\n`);
     const reexecResult = spawnSync("vellum", reexecArgs, {
       stdio: "inherit",
+      windowsHide: true,
     });
     process.exit(reexecResult.status ?? 1);
   }

--- a/cli/src/lib/cloudflare-tunnel.ts
+++ b/cli/src/lib/cloudflare-tunnel.ts
@@ -24,6 +24,7 @@ export function getCloudflareTunnelVersion(): string | null {
       encoding: "utf-8",
       timeout: 5_000,
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     });
     return output.trim();
   } catch {
@@ -41,7 +42,7 @@ export function startCloudflareTunnelProcess(targetPort: number): ChildProcess {
     "cloudflared",
     ["tunnel", "--url", `http://localhost:${targetPort}`, "--no-autoupdate"],
     // Keep stdio as pipes so we can parse the URL from output.
-    { stdio: ["ignore", "pipe", "pipe"] },
+    { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
   );
 }
 

--- a/cli/src/lib/detached-process.ts
+++ b/cli/src/lib/detached-process.ts
@@ -50,6 +50,7 @@ export async function relaunchDetached(
   const child = spawn(process.execPath, spawnArgs, {
     detached: true,
     stdio: ["ignore", fd, fd],
+    windowsHide: true,
   });
   if (typeof fd === "number") {
     closeSync(fd);

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -77,7 +77,7 @@ function getMacOSPlatformUUID(): string | null {
   try {
     const output = execSync(
       "ioreg -rd1 -c IOPlatformExpertDevice | awk '/IOPlatformUUID/{print $3}'",
-      { encoding: "utf-8", timeout: 5000 },
+      { encoding: "utf-8", timeout: 5000, windowsHide: true },
     ).trim();
     const uuid = output.replace(/"/g, "");
     return uuid.length > 0 ? uuid : null;
@@ -316,7 +316,9 @@ function isUnreachableGatewayError(error: unknown): boolean {
   );
 }
 
-function classifyRefreshThrownError(error: unknown): GuardianTokenRefreshResult {
+function classifyRefreshThrownError(
+  error: unknown,
+): GuardianTokenRefreshResult {
   if (isTimeoutLikeError(error)) {
     return {
       ok: false,

--- a/cli/src/lib/live-voice/pcm-player.ts
+++ b/cli/src/lib/live-voice/pcm-player.ts
@@ -124,7 +124,11 @@ export function isOnPath(command: string): boolean {
       ? ["where", [command]]
       : ["/bin/sh", ["-c", `command -v ${command}`]];
   try {
-    execFileSync(probe, args, { stdio: "ignore", timeout: 2000 });
+    execFileSync(probe, args, {
+      stdio: "ignore",
+      timeout: 2000,
+      windowsHide: true,
+    });
     return true;
   } catch {
     return false;
@@ -268,6 +272,7 @@ export class PcmPlayer {
     }
     const child = spawn(this.player.name, this.player.args(sampleRate), {
       stdio: ["pipe", "ignore", "ignore"],
+      windowsHide: true,
     });
     this.adopt(child);
     this.activeSampleRate = sampleRate;
@@ -297,6 +302,7 @@ export class PcmPlayer {
     this.adopt(
       spawn(this.player.name, this.player.args(sampleRate, filePath), {
         stdio: "ignore",
+        windowsHide: true,
       }),
     );
   }

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -835,6 +835,7 @@ async function startDaemonFromSource(
     ? spawn(bunPath, ["run", daemonMainPath], {
         stdio: "inherit",
         env: spawnEnv,
+        windowsHide: true,
       })
     : (() => {
         const daemonLogFd = openLogFile("hatch.log");
@@ -1173,7 +1174,12 @@ function findPidListeningOnPort(port: number): number | undefined {
     const output = execFileSync(
       "lsof",
       ["-iTCP:" + port, "-sTCP:LISTEN", "-t"],
-      { encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"] },
+      {
+        encoding: "utf-8",
+        timeout: 3000,
+        stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
+      },
     ).trim();
     // lsof -t may return multiple PIDs (one per line); take the first.
     const pid = parseInt(output.split("\n")[0], 10);
@@ -1659,6 +1665,7 @@ export async function startLocalDaemon(
             cwd: dirname(daemonBinary),
             stdio: "inherit",
             env: daemonEnv,
+            windowsHide: true,
           })
         : (() => {
             const daemonLogFd = openLogFile("hatch.log");
@@ -1939,6 +1946,7 @@ function isNgrokProcess(pid: number): boolean {
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     }).trim();
     return /ngrok/.test(output);
   } catch {

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -415,6 +415,7 @@ export function getNginxVersion(): string | null {
   const result = spawnSync(nginxBin(), ["-v"], {
     encoding: "utf-8",
     timeout: 5_000,
+    windowsHide: true,
   });
   if (result.error || result.status !== 0) return null;
   const output = `${result.stderr || ""}${result.stdout || ""}`.trim();
@@ -464,6 +465,7 @@ function isIngressNginxProcess(pid: number, paths: IngressPaths): boolean {
         encoding: "utf-8",
         timeout: 3000,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       },
     ).trim();
     return (
@@ -604,7 +606,7 @@ export function startIngressNginx(opts: {
   const child = spawn(
     nginxBin(),
     ["-p", paths.dir, "-c", paths.confPath, "-g", "daemon off;"],
-    { detached: true, stdio: ["ignore", fd, fd] },
+    { detached: true, stdio: ["ignore", fd, fd], windowsHide: true },
   );
   closeSync(fd);
 

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -36,6 +36,7 @@ export function getNgrokVersion(): string | null {
       encoding: "utf-8",
       timeout: 5_000,
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     });
     return output.trim();
   } catch {
@@ -152,6 +153,7 @@ export function startNgrokProcess(
   const child = spawn("ngrok", args, {
     detached: true,
     stdio,
+    windowsHide: true,
   });
 
   // The child process inherits a duplicate of the fd via dup2, so the

--- a/cli/src/lib/open-browser.ts
+++ b/cli/src/lib/open-browser.ts
@@ -12,7 +12,11 @@ export function openBrowser(url: string): void {
     platform === "win32"
       ? ["/c", "start", '""', url.replace(/&/g, "^&")]
       : [url];
-  const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+  const child = spawn(cmd, args, {
+    stdio: "ignore",
+    detached: true,
+    windowsHide: true,
+  });
   child.on("error", () => {
     // Silently ignore — the user can still copy the URL from the console.
   });

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -118,6 +118,7 @@ export function isVellumProcess(
       encoding: "utf-8",
       timeout: 3000,
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     }).trim();
     return isVellumCommandLine(output);
   } catch {
@@ -446,6 +447,7 @@ export async function stopOrphanedDaemonProcesses(
       encoding: "utf-8",
       timeout: 5000,
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     });
   } catch {
     return false;

--- a/cli/src/lib/retire-local.ts
+++ b/cli/src/lib/retire-local.ts
@@ -211,6 +211,7 @@ export async function retireLocal(
   const child = spawn(archiveCommand.command, archiveCommand.args, {
     stdio: "ignore",
     detached: true,
+    windowsHide: true,
     ...(archiveCommand.env
       ? { env: { ...process.env, ...archiveCommand.env } }
       : {}),

--- a/cli/src/lib/step-runner.ts
+++ b/cli/src/lib/step-runner.ts
@@ -42,6 +42,7 @@ export function exec(
     const child = spawn(command, args, {
       cwd: options.cwd,
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let stdout = "";
@@ -82,6 +83,7 @@ export function execWithStdin(
     const child = spawn(command, args, {
       cwd: options.cwd,
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let stdout = "";
@@ -116,6 +118,7 @@ export function execOutput(
     const child = spawn(command, args, {
       cwd: options.cwd,
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let settled = false;

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -88,6 +88,7 @@ function realFindBinary(): string | null {
       encoding: "utf-8",
       timeout: 5_000,
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     });
     if (!res.error && res.status === 0) {
       return candidate;
@@ -97,7 +98,11 @@ function realFindBinary(): string | null {
 }
 
 function realRun(bin: string, args: string[]): TailscaleCommandResult {
-  const res = spawnSync(bin, args, { encoding: "utf-8", timeout: 15_000 });
+  const res = spawnSync(bin, args, {
+    encoding: "utf-8",
+    timeout: 15_000,
+    windowsHide: true,
+  });
   if (res.error) {
     throw res.error;
   }

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -74,6 +74,7 @@ export async function captureUpgradeFailureLogs(
           {
             encoding: "utf8",
             maxBuffer: 10 * 1024 * 1024, // 10 MB
+            windowsHide: true,
           },
         );
         const output = [result.stdout, result.stderr].filter(Boolean).join("");

--- a/credential-executor/src/http/log-export-routes.ts
+++ b/credential-executor/src/http/log-export-routes.ts
@@ -177,6 +177,7 @@ export async function handleLogExportRoute(
     const proc = spawnSync("tar", ["czf", "-", "-C", staging, "."], {
       maxBuffer: MAX_LOG_BYTES * 2, // allow headroom for tar overhead
       timeout: 30_000,
+      windowsHide: true,
     });
 
     if (proc.status !== 0) {

--- a/gateway/src/http/routes/log-export.ts
+++ b/gateway/src/http/routes/log-export.ts
@@ -145,7 +145,7 @@ export function createLogExportHandler(config: GatewayConfig) {
       const archivePath = `${stagingDir}.tar.gz`;
       const tarProc = Bun.spawn(
         ["/usr/bin/tar", "czf", archivePath, "-C", stagingDir, "."],
-        { stdout: "pipe", stderr: "pipe" },
+        { stdout: "pipe", stderr: "pipe", windowsHide: true },
       );
       const tarExit = await tarProc.exited;
       if (tarExit !== 0) {
@@ -381,7 +381,7 @@ async function collectDaemonExport(
 
   const extractProc = Bun.spawn(
     ["/usr/bin/tar", "xzf", tarGzPath, "-C", destDir],
-    { stdout: "pipe", stderr: "pipe" },
+    { stdout: "pipe", stderr: "pipe", windowsHide: true },
   );
   const extractExit = await extractProc.exited;
   if (extractExit !== 0) {
@@ -451,7 +451,7 @@ async function collectCesExport(
 
   const extractProc = Bun.spawn(
     ["/usr/bin/tar", "xzf", tarGzPath, "-C", destDir],
-    { stdout: "pipe", stderr: "pipe" },
+    { stdout: "pipe", stderr: "pipe", windowsHide: true },
   );
   const extractExit = await extractProc.exited;
   if (extractExit !== 0) {

--- a/packages/electron-desktop/src/preload-externals.ts
+++ b/packages/electron-desktop/src/preload-externals.ts
@@ -32,6 +32,7 @@ export const buildPreloadAndScanExternals = async (
     cwd: clientRoot,
     stdout: "pipe",
     stderr: "pipe",
+    windowsHide: true,
   });
   if ((await proc.exited) !== 0) {
     const stderr = await new Response(proc.stderr).text();


### PR DESCRIPTION
## Summary

- hide subprocess windows launched during assistant onboarding, including shell, skill, Git, Bun, and plugin installation work
- apply the same hidden-window behavior across other packaged background runtimes, lifecycle helpers, browser/runtime downloads, ACP agents, scheduled commands, media helpers, tunnels, upgrades, and log exports
- preserve intentionally interactive CLI output while preventing separate console windows from being created on Windows

## Original prompt

After local assistant setup completes on Windows, many terminal windows open during the remaining onboarding flow. The earlier setup fix only covered CLI setup subprocesses. This follow-up started with onboarding and was expanded at the user’s request into a repo-wide audit of production subprocess launch sites that can run under packaged or background processes.