### PR TITLE
fix(windows): enable sound effects preview

### DIFF
--- a/clients/web/src/domains/settings/pages/sounds-sections.tsx
+++ b/clients/web/src/domains/settings/pages/sounds-sections.tsx
@@ -412,7 +412,7 @@ export function SoundsSections() {
             type="button"
             onClick={previewDefault}
             disabled={!config.globalEnabled}
-            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-white px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] hover:bg-[var(--surface-base)] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-[var(--surface-lift)] dark:hover:bg-[var(--ghost-hover)]"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-white px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] transition-colors hover:bg-[var(--surface-hover)] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-[var(--surface-lift)] dark:hover:bg-[var(--ghost-hover)]"
           >
             <Play className="h-3.5 w-3.5" />
             {t("soundsSections.preview")}

--- a/clients/web/src/domains/settings/pages/sounds-sections.tsx
+++ b/clients/web/src/domains/settings/pages/sounds-sections.tsx
@@ -411,8 +411,7 @@ export function SoundsSections() {
           <button
             type="button"
             onClick={previewDefault}
-            disabled={!config.globalEnabled}
-            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-white px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] hover:bg-[var(--surface-base)] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-[var(--surface-lift)] dark:hover:bg-[var(--ghost-hover)]"
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-white px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] hover:bg-[var(--surface-base)] dark:bg-[var(--surface-lift)] dark:hover:bg-[var(--ghost-hover)]"
           >
             <Play className="h-3.5 w-3.5" />
             {t("soundsSections.preview")}

--- a/clients/web/src/domains/settings/pages/sounds-sections.tsx
+++ b/clients/web/src/domains/settings/pages/sounds-sections.tsx
@@ -411,7 +411,8 @@ export function SoundsSections() {
           <button
             type="button"
             onClick={previewDefault}
-            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-white px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] hover:bg-[var(--surface-base)] dark:bg-[var(--surface-lift)] dark:hover:bg-[var(--ghost-hover)]"
+            disabled={!config.globalEnabled}
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-white px-3 py-1.5 text-body-medium-lighter text-[var(--content-default)] hover:bg-[var(--surface-base)] disabled:cursor-not-allowed disabled:opacity-50 dark:bg-[var(--surface-lift)] dark:hover:bg-[var(--ghost-hover)]"
           >
             <Play className="h-3.5 w-3.5" />
             {t("soundsSections.preview")}

--- a/clients/web/src/lib/sounds/sound-manager.test.ts
+++ b/clients/web/src/lib/sounds/sound-manager.test.ts
@@ -58,7 +58,8 @@ describe("SoundManager", () => {
 
     await manager.previewFallbackBlip();
 
-    expect(FakeAudioContext.lastInstance?.resumed).toBe(true);
-    expect(FakeAudioContext.lastInstance?.started).toBe(true);
+    const context = FakeAudioContext.lastInstance as unknown as FakeAudioContext;
+    expect(context.resumed).toBe(true);
+    expect(context.started).toBe(true);
   });
 });

--- a/clients/web/src/lib/sounds/sound-manager.test.ts
+++ b/clients/web/src/lib/sounds/sound-manager.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, mock, test } from "bun:test";
+
+class FakeAudioContext {
+  static lastInstance: FakeAudioContext | null = null;
+  currentTime = 0;
+  destination = {} as AudioDestinationNode;
+  resumed = false;
+  started = false;
+  state: AudioContextState = "suspended";
+
+  constructor() {
+    FakeAudioContext.lastInstance = this;
+  }
+
+  async resume(): Promise<void> {
+    this.resumed = true;
+    this.state = "running";
+  }
+
+  createOscillator() {
+    return {
+      connect() {},
+      frequency: { setValueAtTime() {} },
+      start: () => {
+        this.started = true;
+      },
+      stop() {},
+      type: "sine" as OscillatorType,
+    };
+  }
+
+  createGain() {
+    return {
+      connect() {},
+      gain: {
+        exponentialRampToValueAtTime() {},
+        linearRampToValueAtTime() {},
+        setValueAtTime() {},
+      },
+    };
+  }
+}
+
+describe("SoundManager", () => {
+  test("plays the default preview without an active sound-effects lifecycle", async () => {
+    mock.module("@/lib/sounds/api", () => ({
+      fetchSoundFile: async () => null,
+    }));
+    FakeAudioContext.lastInstance = null;
+    Object.defineProperty(window, "AudioContext", {
+      configurable: true,
+      value: FakeAudioContext,
+    });
+
+    const { getSoundManager } = await import("@/lib/sounds/sound-manager");
+    const manager = getSoundManager();
+    manager.setFeatureEnabled(false);
+
+    await manager.previewFallbackBlip();
+
+    expect(FakeAudioContext.lastInstance?.resumed).toBe(true);
+    expect(FakeAudioContext.lastInstance?.started).toBe(true);
+  });
+});

--- a/clients/web/src/lib/sounds/sound-manager.ts
+++ b/clients/web/src/lib/sounds/sound-manager.ts
@@ -75,18 +75,18 @@ class SoundManager {
     const pool = eventConfig.sounds.filter(validateSoundFilename);
 
     if (pool.length === 0) {
-      this.playFallbackBlip(volume);
+      void this.playFallbackBlip(volume);
       return;
     }
 
     const filename = pool[Math.floor(Math.random() * pool.length)];
     if (!filename) {
-      this.playFallbackBlip(volume);
+      void this.playFallbackBlip(volume);
       return;
     }
     const ok = await this.playFile(filename, volume);
     if (!ok) {
-      this.playFallbackBlip(volume);
+      await this.playFallbackBlip(volume);
     }
   }
 
@@ -97,16 +97,13 @@ class SoundManager {
     const volume = clampVolume(volumeOverride ?? this.config?.volume ?? 0.7);
     const ok = await this.playFile(filename, volume);
     if (!ok) {
-      this.playFallbackBlip(volume);
+      await this.playFallbackBlip(volume);
     }
   }
 
   async previewFallbackBlip(volumeOverride?: number): Promise<void> {
-    if (!this.featureEnabled) {
-      return;
-    }
     const volume = clampVolume(volumeOverride ?? this.config?.volume ?? 0.7);
-    this.playFallbackBlip(volume);
+    await this.playFallbackBlip(volume);
   }
 
   clearCache(): void {
@@ -169,7 +166,7 @@ class SoundManager {
     return promise;
   }
 
-  private playFallbackBlip(volume: number): void {
+  private async playFallbackBlip(volume: number): Promise<void> {
     if (typeof window === "undefined") {
       return;
     }
@@ -186,7 +183,7 @@ class SoundManager {
       }
       const ctx = this.audioContext;
       if (ctx.state === "suspended") {
-        void ctx.resume();
+        await ctx.resume();
       }
 
       const oscillator = ctx.createOscillator();

--- a/clients/web/src/lib/sounds/sound-manager.ts
+++ b/clients/web/src/lib/sounds/sound-manager.ts
@@ -102,6 +102,9 @@ class SoundManager {
   }
 
   async previewFallbackBlip(volumeOverride?: number): Promise<void> {
+    if (!this.featureEnabled) {
+      return;
+    }
     const volume = clampVolume(volumeOverride ?? this.config?.volume ?? 0.7);
     this.playFallbackBlip(volume);
   }

--- a/clients/web/src/lib/sounds/sound-manager.ts
+++ b/clients/web/src/lib/sounds/sound-manager.ts
@@ -102,9 +102,6 @@ class SoundManager {
   }
 
   async previewFallbackBlip(volumeOverride?: number): Promise<void> {
-    if (!this.featureEnabled) {
-      return;
-    }
     const volume = clampVolume(volumeOverride ?? this.config?.volume ?? 0.7);
     this.playFallbackBlip(volume);
   }


### PR DESCRIPTION
## Summary
- Let the default sound preview play without an active assistant lifecycle state.
- Resume Chromium Web Audio before scheduling the preview blip.
- Make Preview visibly interactive with pointer and hover feedback.

## Original prompt
Fix the sound-effects Preview button on Windows. Although sound effects were enabled, the Preview control appeared unavailable and clicking it did not play the default blip. The settings preview must work independently of background sound-effect lifecycle state.