### PR TITLE
fix(windows): reflect global screen recording consent

### DIFF
--- a/clients/windows/native/Vellum.WindowsHelper.Tests/TextInsertionTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/TextInsertionTests.cs
@@ -74,6 +74,9 @@ public static class TextInsertionTests
         Assert(PermissionService.MapConsent("Allow", "Deny") == "denied");
         Assert(PermissionService.MapConsent("Deny", "Allow") == "denied");
         Assert(PermissionService.MapConsent(null, null) == "unknown");
+        Assert(PermissionService.MapGlobalConsent("Allow") == "granted");
+        Assert(PermissionService.MapGlobalConsent("Deny") == "denied");
+        Assert(PermissionService.MapGlobalConsent(null) == "unknown");
         Assert(PermissionService.MapOnlineSpeech(1) == "granted");
         Assert(PermissionService.MapOnlineSpeech(0) == "denied");
         Assert(PermissionService.MapOnlineSpeech(null) == "not-determined");

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/PermissionService.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/PermissionService.cs
@@ -77,18 +77,7 @@ public sealed class PermissionService : IRpcModule, INativeCapability
         return "unknown";
     }
 
-    public static string MapGlobalConsent(object? value)
-    {
-        if (IsDenyConsent(value))
-        {
-            return "denied";
-        }
-        if (IsAllowConsent(value))
-        {
-            return "granted";
-        }
-        return "unknown";
-    }
+    public static string MapGlobalConsent(object? value) => MapConsent(value, null);
 
     public static string MapOnlineSpeech(object? hasAccepted) => hasAccepted switch
     {

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/PermissionService.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/PermissionService.cs
@@ -48,7 +48,7 @@ public sealed class PermissionService : IRpcModule, INativeCapability
     public object QueryState() => new
     {
         microphone = ReadConsent(MicrophoneConsentPath),
-        screen = ReadConsent(ScreenConsentPath),
+        screen = ReadGlobalConsent(ScreenConsentPath),
         speechRecognition = MapOnlineSpeech(
             _readCurrentUserValue(OnlineSpeechPath, "HasAccepted")),
         notifications = MapToastEnabled(
@@ -59,6 +59,9 @@ public sealed class PermissionService : IRpcModule, INativeCapability
         _readCurrentUserValue(path, "Value"),
         _readCurrentUserValue($@"{path}\NonPackaged", "Value"));
 
+    private string ReadGlobalConsent(string path) =>
+        MapGlobalConsent(_readCurrentUserValue(path, "Value"));
+
     // Desktop apps are gated by the global capability consent plus the
     // non-packaged app consent; a deny on either wins.
     public static string MapConsent(object? global, object? nonPackaged)
@@ -68,6 +71,19 @@ public sealed class PermissionService : IRpcModule, INativeCapability
             return "denied";
         }
         if (IsAllowConsent(global) && (nonPackaged is null || IsAllowConsent(nonPackaged)))
+        {
+            return "granted";
+        }
+        return "unknown";
+    }
+
+    public static string MapGlobalConsent(object? value)
+    {
+        if (IsDenyConsent(value))
+        {
+            return "denied";
+        }
+        if (IsAllowConsent(value))
         {
             return "granted";
         }


### PR DESCRIPTION
## Summary

- Report screen recording status from the Windows global graphics-capture consent.
- Keep per-app consent handling for microphone and cover the global mapping.

## Original prompt

Fix the Windows client so the Assistant Permissions and Privacy screen shows Screen Recording as enabled when the Windows all-apps screen recording setting is enabled. The native permissions bridge should reflect the setting represented by that toggle.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->