### PR TITLE
Fix login in locally packaged Windows installers

### DIFF
--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -111,8 +111,9 @@ This builds the local `clients/web` source, serves it from Electron's
 ## Packaging
 
 ```bash
-bun run pack        # runtime + native helper + preview handler + electron-builder --win (NSIS)
-bun run pack:debug  # same, with Chrome DevTools enabled in the packaged app
+bun run pack                     # dev installer for testing on another machine
+bun run pack --environment local # local-platform installer
+bun run pack:debug               # dev installer with Chrome DevTools enabled
 ```
 
 `pack` builds every bundled resource (`build:runtime`, `build:native-helper`,
@@ -120,6 +121,10 @@ bun run pack:debug  # same, with Chrome DevTools enabled in the packaged app
 handler DLL that `electron-builder.config.cjs` requires is always present.
 The builder rebuilds the Electron main and preload entrypoints immediately
 before collecting app files, including when it is invoked directly.
+
+The default `dev` environment keeps an installed test build connected to the
+deployed dev platform, including its login endpoint. Pass `--environment local`
+only when a platform server is available at `localhost:8000`.
 
 `build:runtime` bundles the Bun pinned in `.tool-versions`: the host `bun.exe`
 is used when its sha256 matches `scripts/bun-release.ts`, otherwise the

--- a/clients/windows/package.json
+++ b/clients/windows/package.json
@@ -23,8 +23,8 @@
     "test:native-helper": "bun scripts/build-native-helper.ts --test",
     "test:preview-handler": "bun scripts/build-preview-handler.ts --test-architecture && bun scripts/build-preview-handler.ts --native-test",
     "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../windows && mkdir -p resources && rm -rf resources/web-dist && cp -R ../web/dist resources/web-dist",
-    "pack": "bun run build:runtime && bun run build:native-helper && bun run build:preview-handler && electron-builder --win --config electron-builder.config.cjs --publish never",
-    "pack:debug": "VELLUM_ENABLE_CHROME_DEVTOOLS=true bun run pack"
+    "pack": "bun scripts/pack.ts",
+    "pack:debug": "bun scripts/pack.ts --debug"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/clients/windows/scripts/pack.ts
+++ b/clients/windows/scripts/pack.ts
@@ -1,0 +1,69 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { argValue } from "./cli-args";
+
+const usage = `Usage: bun run pack [flags]
+
+Build and package the Windows app for the target architecture.
+
+Flags:
+  --environment, --env <name>  Set VELLUM_ENVIRONMENT (default: dev)
+  --debug                      Enable Chrome DevTools in the packaged app
+  --help, -h                   Show this help`;
+
+if (process.argv.includes("--help") || process.argv.includes("-h")) {
+  console.log(usage);
+  process.exit(0);
+}
+
+const environmentArgument =
+  argValue("--environment") ?? argValue("--env");
+const hasEnvironmentArgument = process.argv.some(
+  (argument) =>
+    argument === "--environment" ||
+    argument.startsWith("--environment=") ||
+    argument === "--env" ||
+    argument.startsWith("--env="),
+);
+if (
+  hasEnvironmentArgument &&
+  (!environmentArgument || environmentArgument.startsWith("-"))
+) {
+  console.error("--environment requires a value");
+  process.exit(1);
+}
+const environment =
+  environmentArgument?.trim() ||
+  process.env.VELLUM_ENVIRONMENT?.trim() ||
+  "dev";
+const debug = process.argv.includes("--debug");
+const env = {
+  ...process.env,
+  VELLUM_ENVIRONMENT: environment,
+  ...(debug ? { VELLUM_ENABLE_CHROME_DEVTOOLS: "true" } : {}),
+};
+
+const runBun = (args: string[]): void => {
+  const result = spawnSync(process.execPath, args, {
+    cwd: path.resolve(import.meta.dir, ".."),
+    env,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+};
+
+runBun(["run", "build:runtime"]);
+runBun(["run", "build:native-helper"]);
+runBun(["run", "build:preview-handler"]);
+runBun([
+  "x",
+  "electron-builder",
+  "--win",
+  "--config",
+  "electron-builder.config.cjs",
+  "--publish",
+  "never",
+]);


### PR DESCRIPTION
## Summary

- Route the Windows pack command through one environment-aware runner.
- Default local installer testing to the deployed dev platform so login can fetch auth configuration before opening the browser.
- Preserve explicit local-platform and packaged DevTools options and document both.

## Original prompt

The installed Windows x64 build produced by the local pack command did not open a browser when Log In was clicked. The packaged build needs a working login flow when installed on a native test machine that is not running the platform backend locally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->