### PR TITLE
Make preview handler vcpkg build self-contained

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -659,6 +659,7 @@
   ],
   "patchedDependencies": {
     "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch",
+    "app-builder-lib@26.8.1": "patches/app-builder-lib@26.8.1.patch",
     "storybook@10.4.0": "patches/storybook@10.4.0.patch",
   },
   "overrides": {

--- a/clients/windows/.gitignore
+++ b/clients/windows/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 out/
 dist/
 build/
+.build-tools/
 resources/web-dist
 resources/native-helper/
 resources/dotnet-sdk/

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -127,11 +127,10 @@ matching GitHub release is downloaded and verified. Bump the pins there when
 the Bun version changes.
 
 `build:preview-handler` installs its manifest dependencies before invoking
-MSBuild. It resolves vcpkg from `VCPKG_ROOT`, the local Vellum build-tools
-checkout, or `PATH`, in that order. The checkout must contain full Git history
-for the manifest's pinned dependency baseline. The Visual Studio-bundled vcpkg
-is too old for that baseline and is ignored when a Developer Prompt exposes it
-through `VCPKG_ROOT` or `PATH`.
+MSBuild. It installs the manifest's pinned vcpkg baseline in the ignored
+`clients/windows/.build-tools` directory and reuses it for future builds. This
+keeps packaging independent of vcpkg copies exposed by Visual Studio,
+environment variables, or `PATH`.
 
 Local and CI packs are unsigned. `.github/workflows/windows-package-smoke.yaml`
 runs the same steps per architecture, then install-, launch-, and

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -130,7 +130,8 @@ the Bun version changes.
 MSBuild. It resolves vcpkg from `VCPKG_ROOT`, the local Vellum build-tools
 checkout, or `PATH`, in that order. The checkout must contain full Git history
 for the manifest's pinned dependency baseline. The Visual Studio-bundled vcpkg
-may be too old for that baseline.
+is too old for that baseline and is ignored when a Developer Prompt exposes it
+through `VCPKG_ROOT` or `PATH`.
 
 Local and CI packs are unsigned. `.github/workflows/windows-package-smoke.yaml`
 runs the same steps per architecture, then install-, launch-, and

--- a/clients/windows/electron-builder.config.cjs
+++ b/clients/windows/electron-builder.config.cjs
@@ -127,6 +127,9 @@ const buildElectronEntrypoints = () =>
 module.exports = {
   appId,
   productName,
+  toolsets: {
+    winCodeSign: "1.1.0",
+  },
   publish: {
     provider: "generic",
     url: `https://storage.googleapis.com/vellum-ai-${bucketEnv}-releases/win-electron/${targetArch}/`,

--- a/clients/windows/native/Vellum.PreviewHandler/Vellum.PreviewHandler.vcxproj
+++ b/clients/windows/native/Vellum.PreviewHandler/Vellum.PreviewHandler.vcxproj
@@ -30,7 +30,14 @@
     <TargetName Condition="'$(Configuration)'=='Tests'">BundleReaderTests</TargetName>
     <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static-md</VcpkgTriplet>
     <VcpkgTriplet Condition="'$(Platform)'=='ARM64'">arm64-windows-static-md</VcpkgTriplet>
+    <VcpkgInstalledDir Condition="'$(VcpkgInstalledDir)'==''">$(MSBuildThisFileDirectory)vcpkg_installed\</VcpkgInstalledDir>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <Link>
+      <AdditionalLibraryDirectories>$(VcpkgInstalledDir)$(VcpkgTriplet)\lib;$(VcpkgInstalledDir)$(VcpkgTriplet)\lib\manual-link;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>zs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -39,7 +46,7 @@
       <SDLCheck>true</SDLCheck>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);$(VcpkgInstalledDir)$(VcpkgTriplet)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link Condition="'$(Configuration)'=='Release'">
       <AdditionalDependencies>windowscodecs.lib;shlwapi.lib;ole32.lib;gdi32.lib;user32.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -58,8 +65,5 @@
     <ClInclude Include="BundleReader.h" />
     <ClInclude Include="ComServer.h" />
   </ItemGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)'=='Tests'">
-    <!-- zlib comes from the vcpkg MSBuild autolink wildcard. -->
-  </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/clients/windows/scripts/build-preview-handler.ts
+++ b/clients/windows/scripts/build-preview-handler.ts
@@ -92,9 +92,13 @@ export function resolveVcpkgRoot(
   if (configuredRoot && !isVisualStudioBundledVcpkgRoot(configuredRoot)) {
     return configuredRoot;
   }
-  if (environment.LOCALAPPDATA) {
+  const userProfile = environment.USERPROFILE ?? environment.HOME;
+  const localAppData =
+    environment.LOCALAPPDATA ??
+    (userProfile ? win32.join(userProfile, "AppData", "Local") : undefined);
+  if (localAppData) {
     const managedRoot = win32.join(
-      environment.LOCALAPPDATA,
+      localAppData,
       "vellum-build-tools",
       "vcpkg",
     );
@@ -147,6 +151,18 @@ function testArchitectureSelection() {
     resolveVcpkgRoot(
       {
         LOCALAPPDATA: "C:\\Users\\user\\AppData\\Local",
+        VCPKG_ROOT:
+          "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg\\",
+      },
+      () => null,
+      () => true,
+    ),
+    "C:\\Users\\user\\AppData\\Local\\vellum-build-tools\\vcpkg",
+  );
+  assert.equal(
+    resolveVcpkgRoot(
+      {
+        USERPROFILE: "C:\\Users\\user",
         VCPKG_ROOT:
           "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg\\",
       },

--- a/clients/windows/scripts/build-preview-handler.ts
+++ b/clients/windows/scripts/build-preview-handler.ts
@@ -72,7 +72,10 @@ export function vcpkgMsbuildArguments(
 }
 
 export function isVisualStudioBundledVcpkgRoot(root: string): boolean {
-  const normalized = win32.normalize(root).toLowerCase();
+  const normalized = win32
+    .normalize(root)
+    .replace(/[\\/]+$/, "")
+    .toLowerCase();
   return (
     normalized.includes("\\microsoft visual studio\\") &&
     normalized.endsWith("\\vc\\vcpkg")
@@ -145,7 +148,7 @@ function testArchitectureSelection() {
       {
         LOCALAPPDATA: "C:\\Users\\user\\AppData\\Local",
         VCPKG_ROOT:
-          "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg",
+          "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg\\",
       },
       () => null,
       () => true,

--- a/clients/windows/scripts/build-preview-handler.ts
+++ b/clients/windows/scripts/build-preview-handler.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve, win32 } from "node:path";
+import { dirname, join, resolve, sep, win32 } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { argValue } from "./cli-args";
@@ -13,6 +13,9 @@ const windowsRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const nativeRoot = join(windowsRoot, "native");
 const handlerRoot = join(nativeRoot, "Vellum.PreviewHandler");
 const fixtureRoot = join(nativeRoot, "fixtures", "vellum-bundle-contract");
+const managedBuildToolsRoot = join(windowsRoot, ".build-tools");
+const vcpkgManifest = join(handlerRoot, "vcpkg.json");
+const vcpkgRepository = "https://github.com/microsoft/vcpkg.git";
 const previewClsid = "{5888DF89-8AD1-4D76-87C4-548A79E8C2E5}";
 const thumbnailClsid = "{C90464A7-6608-44C9-8983-2EA82F10E454}";
 
@@ -71,49 +74,103 @@ export function vcpkgMsbuildArguments(
   ];
 }
 
-export function isVisualStudioBundledVcpkgRoot(root: string): boolean {
-  const normalized = win32
-    .normalize(root)
-    .replace(/[\\/]+$/, "")
-    .toLowerCase();
-  return (
-    normalized.includes("\\microsoft visual studio\\") &&
-    normalized.endsWith("\\vc\\vcpkg")
-  );
+async function readVcpkgBaseline(): Promise<string> {
+  const manifest = (await Bun.file(vcpkgManifest).json()) as {
+    "builtin-baseline"?: unknown;
+  };
+  const baseline = manifest["builtin-baseline"];
+  if (typeof baseline !== "string" || !/^[0-9a-f]{40}$/.test(baseline)) {
+    throw new Error("vcpkg.json must contain a 40-character builtin-baseline");
+  }
+  return baseline;
 }
 
-export function resolveVcpkgRoot(
-  environment: Record<string, string | undefined> = process.env,
-  findVcpkg: () => string | null = () => Bun.which("vcpkg"),
-  pathExists: (path: string) => boolean = existsSync,
-): string | undefined {
-  const configuredRoot =
-    environment.VCPKG_ROOT ?? environment.VCPKG_INSTALLATION_ROOT;
-  if (configuredRoot && !isVisualStudioBundledVcpkgRoot(configuredRoot)) {
-    return configuredRoot;
+async function bootstrapManagedVcpkg(
+  buildToolsRoot: string,
+  baseline: string,
+): Promise<string> {
+  const checkoutsRoot = join(buildToolsRoot, "vcpkg");
+  const targetRoot = join(checkoutsRoot, baseline);
+  const targetExecutable = join(targetRoot, "vcpkg.exe");
+  if (existsSync(targetExecutable)) {
+    return targetRoot;
   }
-  const userProfile = environment.USERPROFILE ?? environment.HOME;
-  const localAppData =
-    environment.LOCALAPPDATA ??
-    (userProfile ? win32.join(userProfile, "AppData", "Local") : undefined);
-  if (localAppData) {
-    const managedRoot = win32.join(
-      localAppData,
-      "vellum-build-tools",
-      "vcpkg",
+
+  const git = Bun.which("git");
+  if (!git) {
+    throw new Error("Git is required to install the Windows vcpkg build tool");
+  }
+
+  await mkdir(checkoutsRoot, { recursive: true });
+  const resolvedToolsRoot = resolve(buildToolsRoot);
+  const resolvedTargetRoot = resolve(targetRoot);
+  if (!resolvedTargetRoot.startsWith(`${resolvedToolsRoot}${sep}`)) {
+    throw new Error("Refusing to initialize vcpkg outside the build-tools root");
+  }
+  await rm(targetRoot, { recursive: true, force: true });
+  await mkdir(targetRoot, { recursive: true });
+  try {
+    console.log(
+      `[preview-handler] Installing pinned vcpkg ${baseline.slice(0, 12)}...`,
     );
-    if (pathExists(win32.join(managedRoot, "vcpkg.exe"))) {
-      return managedRoot;
+    await runNativeCommand([git, "-C", targetRoot, "init"]);
+    await runNativeCommand([
+      git,
+      "-C",
+      targetRoot,
+      "config",
+      "core.longpaths",
+      "true",
+    ]);
+    await runNativeCommand([
+      git,
+      "-C",
+      targetRoot,
+      "remote",
+      "add",
+      "origin",
+      vcpkgRepository,
+    ]);
+    await runNativeCommand([
+      git,
+      "-C",
+      targetRoot,
+      "fetch",
+      "--depth=1",
+      "origin",
+      baseline,
+    ]);
+    await runNativeCommand([
+      git,
+      "-C",
+      targetRoot,
+      "checkout",
+      "--detach",
+      "FETCH_HEAD",
+    ]);
+    const systemRoot = process.env.SystemRoot ?? "C:\\Windows";
+    const commandShell =
+      process.env.ComSpec ?? win32.join(systemRoot, "System32", "cmd.exe");
+    const bootstrap = join(targetRoot, "bootstrap-vcpkg.bat");
+    await runNativeCommand(
+      [commandShell, "/d", "/c", "call", bootstrap, "-disableMetrics"],
+      targetRoot,
+    );
+    if (!existsSync(targetExecutable)) {
+      throw new Error("vcpkg bootstrap completed without creating vcpkg.exe");
     }
+    return targetRoot;
+  } catch (error) {
+    await rm(targetRoot, { recursive: true, force: true });
+    throw error;
   }
-  const executable = findVcpkg();
-  if (!executable) {
-    return undefined;
-  }
-  const executableRoot = win32.dirname(executable);
-  return isVisualStudioBundledVcpkgRoot(executableRoot)
-    ? undefined
-    : executableRoot;
+}
+
+async function ensureVcpkgRoot(): Promise<string> {
+  return bootstrapManagedVcpkg(
+    managedBuildToolsRoot,
+    await readVcpkgBaseline(),
+  );
 }
 
 function testArchitectureSelection() {
@@ -131,71 +188,6 @@ function testArchitectureSelection() {
     "/p:VcpkgInstalledDir=C:\\installed\\",
     "/p:VcpkgManifestInstall=false",
   ]);
-  assert.equal(
-    resolveVcpkgRoot(
-      { VCPKG_ROOT: "C:\\configured" },
-      () => null,
-      () => false,
-    ),
-    "C:\\configured",
-  );
-  assert.equal(
-    resolveVcpkgRoot(
-      { LOCALAPPDATA: "C:\\Users\\user\\AppData\\Local" },
-      () => null,
-      () => true,
-    ),
-    "C:\\Users\\user\\AppData\\Local\\vellum-build-tools\\vcpkg",
-  );
-  assert.equal(
-    resolveVcpkgRoot(
-      {
-        LOCALAPPDATA: "C:\\Users\\user\\AppData\\Local",
-        VCPKG_ROOT:
-          "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg\\",
-      },
-      () => null,
-      () => true,
-    ),
-    "C:\\Users\\user\\AppData\\Local\\vellum-build-tools\\vcpkg",
-  );
-  assert.equal(
-    resolveVcpkgRoot(
-      {
-        USERPROFILE: "C:\\Users\\user",
-        VCPKG_ROOT:
-          "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg\\",
-      },
-      () => null,
-      () => true,
-    ),
-    "C:\\Users\\user\\AppData\\Local\\vellum-build-tools\\vcpkg",
-  );
-  assert.equal(
-    resolveVcpkgRoot(
-      {},
-      () => "C:\\tools\\vcpkg.exe",
-      () => false,
-    ),
-    "C:\\tools",
-  );
-  assert.equal(
-    resolveVcpkgRoot(
-      {},
-      () =>
-        "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg\\vcpkg.exe",
-      () => false,
-    ),
-    undefined,
-  );
-  assert.equal(
-    resolveVcpkgRoot(
-      {},
-      () => null,
-      () => false,
-    ),
-    undefined,
-  );
 }
 
 export async function runNativeCommand(
@@ -272,11 +264,9 @@ async function main() {
   if (!msbuild) {
     throw new Error("MSBuild is required in a Visual Studio developer shell");
   }
-  const vcpkgRoot = resolveVcpkgRoot();
-  if (!vcpkgRoot) {
-    throw new Error("vcpkg is required; set VCPKG_ROOT or add vcpkg to PATH");
-  }
+  const vcpkgRoot = await ensureVcpkgRoot();
   const vcpkg = join(vcpkgRoot, "vcpkg.exe");
+  console.log(`[preview-handler] Using vcpkg: ${vcpkg}`);
   const installedDir = join(handlerRoot, "vcpkg_installed");
   const vcpkgArguments = vcpkgMsbuildArguments(vcpkgRoot, installedDir);
   for (const architecture of resolveArchitectures(

--- a/clients/windows/scripts/build-preview-handler.ts
+++ b/clients/windows/scripts/build-preview-handler.ts
@@ -71,6 +71,14 @@ export function vcpkgMsbuildArguments(
   ];
 }
 
+export function isVisualStudioBundledVcpkgRoot(root: string): boolean {
+  const normalized = win32.normalize(root).toLowerCase();
+  return (
+    normalized.includes("\\microsoft visual studio\\") &&
+    normalized.endsWith("\\vc\\vcpkg")
+  );
+}
+
 export function resolveVcpkgRoot(
   environment: Record<string, string | undefined> = process.env,
   findVcpkg: () => string | null = () => Bun.which("vcpkg"),
@@ -78,7 +86,7 @@ export function resolveVcpkgRoot(
 ): string | undefined {
   const configuredRoot =
     environment.VCPKG_ROOT ?? environment.VCPKG_INSTALLATION_ROOT;
-  if (configuredRoot) {
+  if (configuredRoot && !isVisualStudioBundledVcpkgRoot(configuredRoot)) {
     return configuredRoot;
   }
   if (environment.LOCALAPPDATA) {
@@ -92,7 +100,13 @@ export function resolveVcpkgRoot(
     }
   }
   const executable = findVcpkg();
-  return executable ? win32.dirname(executable) : undefined;
+  if (!executable) {
+    return undefined;
+  }
+  const executableRoot = win32.dirname(executable);
+  return isVisualStudioBundledVcpkgRoot(executableRoot)
+    ? undefined
+    : executableRoot;
 }
 
 function testArchitectureSelection() {
@@ -128,11 +142,32 @@ function testArchitectureSelection() {
   );
   assert.equal(
     resolveVcpkgRoot(
+      {
+        LOCALAPPDATA: "C:\\Users\\user\\AppData\\Local",
+        VCPKG_ROOT:
+          "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg",
+      },
+      () => null,
+      () => true,
+    ),
+    "C:\\Users\\user\\AppData\\Local\\vellum-build-tools\\vcpkg",
+  );
+  assert.equal(
+    resolveVcpkgRoot(
       {},
       () => "C:\\tools\\vcpkg.exe",
       () => false,
     ),
     "C:\\tools",
+  );
+  assert.equal(
+    resolveVcpkgRoot(
+      {},
+      () =>
+        "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\vcpkg\\vcpkg.exe",
+      () => false,
+    ),
+    undefined,
   );
   assert.equal(
     resolveVcpkgRoot(

--- a/clients/windows/scripts/build-preview-handler.ts
+++ b/clients/windows/scripts/build-preview-handler.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve, sep, win32 } from "node:path";
@@ -70,6 +70,7 @@ export function vcpkgMsbuildArguments(
   return [
     `/p:VcpkgRoot=${withTrailingSlash(root)}`,
     `/p:VcpkgInstalledDir=${withTrailingSlash(installedDir)}`,
+    "/p:VcpkgEnabled=false",
     "/p:VcpkgManifestInstall=false",
   ];
 }
@@ -181,13 +182,24 @@ function testArchitectureSelection() {
   assert.deepEqual(vcpkgMsbuildArguments("C:\\vcpkg", "C:\\installed"), [
     "/p:VcpkgRoot=C:\\vcpkg\\",
     "/p:VcpkgInstalledDir=C:\\installed\\",
+    "/p:VcpkgEnabled=false",
     "/p:VcpkgManifestInstall=false",
   ]);
   assert.deepEqual(vcpkgMsbuildArguments("C:\\vcpkg\\", "C:\\installed\\"), [
     "/p:VcpkgRoot=C:\\vcpkg\\",
     "/p:VcpkgInstalledDir=C:\\installed\\",
+    "/p:VcpkgEnabled=false",
     "/p:VcpkgManifestInstall=false",
   ]);
+  const project = readFileSync(
+    join(handlerRoot, "Vellum.PreviewHandler.vcxproj"),
+    "utf8",
+  );
+  assert.match(
+    project,
+    /\$\(VcpkgInstalledDir\)\$\(VcpkgTriplet\)\\include/,
+  );
+  assert.match(project, /<AdditionalDependencies>zs\.lib;/);
 }
 
 export async function runNativeCommand(

--- a/clients/windows/scripts/identity-assets.test.ts
+++ b/clients/windows/scripts/identity-assets.test.ts
@@ -17,6 +17,7 @@ const loadBuilderConfig = (environment: string) => {
       extraResources: Array<{ from: string; to: string }>;
       win: { icon: string };
       nsis: { installerIcon: string; uninstallerIcon: string };
+      toolsets: { winCodeSign: string };
     };
   } finally {
     if (previous === undefined) {
@@ -77,4 +78,8 @@ test("packages CLI runtime dependencies with a dedicated file matcher", () => {
     from: "resources/cli-runtime/node_modules",
     to: "cli-runtime/node_modules",
   });
+});
+
+test("uses the modular Windows code-signing toolset", () => {
+  expect(loadBuilderConfig("local").toolsets.winCodeSign).toBe("1.1.0");
 });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "path-to-regexp": "8.4.2"
   },
   "patchedDependencies": {
+    "app-builder-lib@26.8.1": "patches/app-builder-lib@26.8.1.patch",
     "storybook@10.4.0": "patches/storybook@10.4.0.patch",
     "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch"
   }

--- a/patches/app-builder-lib@26.8.1.patch
+++ b/patches/app-builder-lib@26.8.1.patch
@@ -1,0 +1,17 @@
+diff --git a/out/winPackager.js b/out/winPackager.js
+--- a/out/winPackager.js
++++ b/out/winPackager.js
+@@ -181,7 +181,12 @@ class WinPackager extends platformPackager_1.PlatformPackager {
+         }
+         const timer = (0, timer_1.time)("wine&sign");
+         // rcedit crashed of executed using wine, resourcehacker works
+-        if (process.platform === "win32" || process.platform === "darwin") {
++        if (process.platform === "win32") {
++            const vendor = await (0, windows_1.getRceditBundle)((_c = this.config.toolsets) === null || _c === void 0 ? void 0 : _c.winCodeSign);
++            const executable = arch === builder_util_1.Arch.ia32 ? vendor.x86 : vendor.x64;
++            await (0, builder_util_1.exec)(executable, args);
++        }
++        else if (process.platform === "darwin") {
+             await (0, builder_util_1.executeAppBuilder)(["rcedit", "--args", JSON.stringify(args)], undefined /* child-process */, {}, 3 /* retry three times */);
+         }
+         else if (this.info.framework.name === "electron") {


### PR DESCRIPTION
## Summary

- bootstrap the manifest-pinned vcpkg checkout under the Windows build-tools directory
- install preview-handler dependencies explicitly before MSBuild
- pass the exact installation root and triplet into the project
- consume the vcpkg include and library directories directly from the project
- link the static zlib library explicitly and disable global vcpkg MSBuild integration
- add regression assertions for the direct dependency configuration

## Root cause

Dependency installation could succeed while compilation still failed because the project received vcpkg include and library paths only when global MSBuild integration happened to be imported. Developer Prompt, ordinary PowerShell, local machines, and CI could therefore install identical packages but compile with different paths.

## Verification

- complete `VELLUM_ENVIRONMENT=dev` `bun run pack` exited successfully
- produced `dist/Vellum Dev-Setup-0.0.1-x64.exe` (1,397,902,730 bytes)
- preview-handler Release build passed with zero warnings and errors
- preview-handler Tests build passed with zero warnings and errors
- BundleReader native tests passed
- Windows TypeScript type-check passed