### PR TITLE
fix(oauth): send binary file bodies through oauth request intact

### DIFF
--- a/assistant/src/__tests__/oauth-commands-routes.test.ts
+++ b/assistant/src/__tests__/oauth-commands-routes.test.ts
@@ -717,6 +717,27 @@ describe("POST oauth/request", () => {
     expect(req.body).toEqual({ title: "Sheet" });
   });
 
+  test("decodes a base64 request body into a Buffer", async () => {
+    const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0x00]);
+
+    await getRoute("POST", "oauth/request").handler(
+      makeArgs({
+        body: {
+          provider: "google",
+          url: "https://api.google.com/upload/drive/v3/files",
+          method: "POST",
+          headers: { "Content-Type": "application/pdf" },
+          parsed_data: binary.toString("base64"),
+          body_encoding: "base64",
+        },
+      }),
+    );
+
+    const req = mockResolveRequests[0] as { body: unknown };
+    expect(Buffer.isBuffer(req.body)).toBe(true);
+    expect(Buffer.from(req.body as Uint8Array).equals(binary)).toBe(true);
+  });
+
   test("base64-encodes binary response bodies for the JSON envelope", async () => {
     const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0xff, 0x00]);
     mockResolveResponse = {

--- a/assistant/src/cli/commands/oauth/index.help.ts
+++ b/assistant/src/cli/commands/oauth/index.help.ts
@@ -778,8 +778,10 @@ form for any service other than the provider's default.
 
 The body (-d) is JSON by default. Give a non-JSON Content-Type and the body
 travels to the provider exactly as written, which is what multipart, XML, and
-form-encoded payloads need. Body files (-d @<path>) are read as UTF-8 text, so
-a payload that is not valid UTF-8 cannot be sent this way.
+form-encoded payloads need. Body files (-d @<path>) and stdin (-d @-) are
+read as raw bytes. Valid UTF-8 stays text (or JSON when the Content-Type is
+JSON). Anything else, including PDFs and other binary files, is sent to the
+provider byte for byte.
 
 Note: The Authorization header is set automatically. User-supplied
 -H "Authorization: ..." will be overridden by the OAuth bearer token.
@@ -790,7 +792,8 @@ Examples:
   $ assistant oauth request --provider twitter -X POST -d '{"text":"Hello"}' https://api.x.com/2/tweets
   $ assistant oauth request --provider google https://www.googleapis.com/calendar/v3/calendars/primary/events
   $ assistant oauth request --provider slack -H "Content-Type: application/json" -d '{"channel":"C123"}' /api/chat.postMessage --json
-  $ assistant oauth request --provider google -X POST -H "Content-Type: multipart/related; boundary=b" -d @upload.txt "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart"`,
+  $ assistant oauth request --provider google -X POST -H "Content-Type: multipart/related; boundary=b" -d @upload.txt "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart"
+  $ assistant oauth request --provider google -X POST -H "Content-Type: application/pdf" -d @report.pdf "https://www.googleapis.com/upload/drive/v3/files?uploadType=media"`,
     },
     {
       name: "disconnect",

--- a/assistant/src/cli/commands/oauth/request.test.ts
+++ b/assistant/src/cli/commands/oauth/request.test.ts
@@ -182,6 +182,43 @@ describe("oauth request body encoding", () => {
     );
   });
 
+  test("reads a binary @file as a Buffer without UTF-8 replacement", async () => {
+    const filePath = join(tempDir, "upload.bin");
+    writeFileSync(filePath, PNG_MAGIC);
+
+    const parsed = readBodyData(`@${filePath}`, {
+      "Content-Type": "application/octet-stream",
+    });
+    expect(Buffer.isBuffer(parsed)).toBe(true);
+    expect(Buffer.from(parsed as Uint8Array).equals(PNG_MAGIC)).toBe(true);
+  });
+
+  test("forwards a binary @file to the route handler as a Buffer", async () => {
+    const filePath = join(tempDir, "report.pdf");
+    writeFileSync(filePath, PNG_MAGIC);
+
+    const { exitCode } = await runRequestCommand([
+      "--provider",
+      "google",
+      "-s",
+      "-X",
+      "POST",
+      "-H",
+      "Content-Type: application/pdf",
+      "-d",
+      `@${filePath}`,
+      "https://www.googleapis.com/upload/drive/v3/files?uploadType=media",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(handleRequestCalls).toHaveLength(1);
+    const call = handleRequestCalls[0] as { body: { parsed_data: unknown } };
+    expect(Buffer.isBuffer(call.body.parsed_data)).toBe(true);
+    expect(
+      Buffer.from(call.body.parsed_data as Uint8Array).equals(PNG_MAGIC),
+    ).toBe(true);
+  });
+
   test("forwards a multipart body to the route handler as a string", async () => {
     const { exitCode } = await runRequestCommand([
       "--provider",

--- a/assistant/src/cli/commands/oauth/request.ts
+++ b/assistant/src/cli/commands/oauth/request.ts
@@ -5,9 +5,10 @@ import type { Command } from "commander";
 import { exitFromIpcResult } from "../../../ipc/cli-client.js";
 import {
   findContentTypeHeader,
+  parseRequestBodyBytes,
   parseRequestBodyData,
 } from "../../../util/oauth-request-body.js";
-import { readStdinSync } from "../../../util/read-stdin.js";
+import { readStdinBytesSync } from "../../../util/read-stdin.js";
 import { subcommand } from "../../lib/cli-command-help.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 
@@ -49,8 +50,8 @@ function parseHeader(raw: string): [string, string] {
  *
  * A non-JSON `Content-Type` keeps the payload as the exact string the caller
  * gave, so multipart, XML, and form-encoded bodies reach the provider
- * unchanged. Files are read as UTF-8 text, so a body that is not valid UTF-8
- * (a raw image, an archive) cannot travel through this flag.
+ * unchanged. Files and stdin are read as raw bytes: valid UTF-8 stays text
+ * (or JSON), and anything else travels as a Buffer.
  */
 export function readBodyData(
   data: string,
@@ -59,12 +60,12 @@ export function readBodyData(
   const contentType = findContentTypeHeader(headers);
 
   if (data === "@-") {
-    return parseRequestBodyData(readStdinSync(), contentType);
+    return parseRequestBodyBytes(readStdinBytesSync(), contentType);
   }
 
   if (data.startsWith("@")) {
     const filePath = data.slice(1);
-    return parseRequestBodyData(readFileSync(filePath, "utf-8"), contentType);
+    return parseRequestBodyBytes(readFileSync(filePath), contentType);
   }
 
   return parseRequestBodyData(data, contentType);
@@ -90,7 +91,7 @@ export function registerRequestCommand(oauth: Command): void {
     )
     .option(
       "-d, --data <data>",
-      "Request body: inline JSON, @filename, or @- for stdin. Sent raw when Content-Type is not JSON",
+      "Request body: inline JSON, @filename, or @- for stdin. Sent raw when Content-Type is not JSON. Files keep their original bytes, including binary",
     )
     .option("-G, --get", "Force GET; body data becomes query params")
     .option("-I, --head", "Send a HEAD request")

--- a/assistant/src/oauth/byo-connection.test.ts
+++ b/assistant/src/oauth/byo-connection.test.ts
@@ -358,6 +358,28 @@ describe("BYOOAuthConnection", () => {
       expect(headers.get("Content-Type")).toBe("application/json");
     });
 
+    test("sends a Buffer body as raw bytes under the caller's Content-Type", async () => {
+      await setupCredential("google");
+      const conn = createConnection();
+      const binary = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe,
+      ]);
+
+      await conn.request({
+        method: "POST",
+        path: "/upload/drive/v3/files",
+        headers: { "Content-Type": "application/pdf" },
+        body: binary,
+      });
+
+      const [, init] = mockFetch.mock.calls[0];
+      const sent = (init as RequestInit).body;
+      expect(Buffer.isBuffer(sent)).toBe(true);
+      expect(Buffer.from(sent as Buffer).equals(binary)).toBe(true);
+      const headers = (init as RequestInit).headers as Headers;
+      expect(headers.get("Content-Type")).toBe("application/pdf");
+    });
+
     test("sends a string body verbatim under the caller's Content-Type", async () => {
       await setupCredential("google");
       const conn = createConnection();

--- a/assistant/src/oauth/byo-connection.ts
+++ b/assistant/src/oauth/byo-connection.ts
@@ -14,7 +14,7 @@ import type {
   OAuthConnectionRequest,
   OAuthConnectionResponse,
 } from "./connection.js";
-import { decodeOAuthResponseBytes } from "./connection.js";
+import { decodeOAuthResponseBytes, isBinaryOAuthBody } from "./connection.js";
 
 const log = getLogger("byo-oauth-connection");
 
@@ -83,15 +83,17 @@ export class BYOOAuthConnection implements OAuthConnection {
 
         // A string body is already in its wire form (multipart, XML,
         // form-encoded, or pre-serialized JSON) and travels verbatim under
-        // the caller's own Content-Type. Objects and arrays are serialized
-        // as JSON and get the JSON Content-Type by default.
+        // the caller's own Content-Type. A Buffer travels as raw bytes.
+        // Objects and arrays are serialized as JSON and get the JSON
+        // Content-Type by default.
         const hasBody = req.body !== undefined && req.body !== null;
+        const binaryBody = isBinaryOAuthBody(req.body) ? req.body : undefined;
         const rawBody = typeof req.body === "string" ? req.body : undefined;
 
         // Use the Headers API for case-insensitive merging. Set defaults
         // first so caller-supplied headers (in any casing) override them.
         const headers = new Headers();
-        if (hasBody && rawBody === undefined) {
+        if (hasBody && rawBody === undefined && binaryBody === undefined) {
           headers.set("Content-Type", "application/json");
         }
         if (req.headers) {
@@ -106,7 +108,11 @@ export class BYOOAuthConnection implements OAuthConnection {
         const resp = await fetch(fullUrl, {
           method: req.method,
           headers,
-          body: hasBody ? (rawBody ?? JSON.stringify(req.body)) : undefined,
+          body: hasBody
+            ? (binaryBody !== undefined
+                ? Buffer.from(binaryBody)
+                : (rawBody ?? JSON.stringify(req.body)))
+            : undefined,
           signal: req.signal
             ? AbortSignal.any([
                 req.signal,

--- a/assistant/src/oauth/connection.ts
+++ b/assistant/src/oauth/connection.ts
@@ -5,8 +5,9 @@ export interface OAuthConnectionRequest {
   headers?: Record<string, string>;
   /**
    * A string is forwarded to the provider verbatim under the caller's own
-   * `Content-Type` (multipart, XML, form-encoded). Anything else is
-   * JSON-serialized and sent as `application/json`.
+   * `Content-Type` (multipart, XML, form-encoded). A Buffer or Uint8Array
+   * is forwarded as raw bytes. Anything else is JSON-serialized and sent
+   * as `application/json`.
    */
   body?: unknown;
   /**

--- a/assistant/src/oauth/platform-connection.test.ts
+++ b/assistant/src/oauth/platform-connection.test.ts
@@ -102,6 +102,41 @@ describe("PlatformOAuthConnection", () => {
     expect(result.body).toEqual(upstreamBody);
   });
 
+  test("encodes a Buffer request body as base64 in the proxy envelope", async () => {
+    const binary = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00,
+    ]);
+
+    const client = makeMockClient(
+      mock(async (_url: string | URL | Request, init?: RequestInit) => {
+        const parsed = JSON.parse(init?.body as string);
+        expect(parsed.request.body).toBe(binary.toString("base64"));
+        expect(parsed.request.body_encoding).toBe("base64");
+        expect(parsed.request.headers["Content-Type"]).toBe("application/pdf");
+
+        return new Response(
+          JSON.stringify({
+            status: 200,
+            headers: { "content-type": "application/json" },
+            body: { id: "file-123" },
+          }),
+          { status: 200 },
+        );
+      }) as unknown as typeof globalThis.fetch,
+    );
+
+    const conn = new PlatformOAuthConnection({
+      ...DEFAULT_OPTIONS,
+      client,
+    });
+    await conn.request({
+      method: "POST",
+      path: "/upload/drive/v3/files",
+      headers: { "Content-Type": "application/pdf" },
+      body: binary,
+    });
+  });
+
   test("decodes base64 binary proxy bodies into a Buffer", async () => {
     const binary = Buffer.from([
       0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00,

--- a/assistant/src/oauth/platform-connection.ts
+++ b/assistant/src/oauth/platform-connection.ts
@@ -7,6 +7,7 @@ import type {
   OAuthConnectionRequest,
   OAuthConnectionResponse,
 } from "./connection.js";
+import { isBinaryOAuthBody } from "./connection.js";
 
 const log = getLogger("platform-oauth-connection");
 const MAX_RETRIES = 3;
@@ -84,20 +85,24 @@ export class PlatformOAuthConnection implements OAuthConnection {
 
     // The envelope carries the caller's headers and body side by side. A
     // string body is placed in the envelope as a string, so the proxy forwards
-    // those bytes verbatim under the caller's Content-Type; an object body
-    // travels as JSON and the proxy serializes it.
-    const body: Record<string, unknown> = {
-      request: {
-        method: req.method,
-        path: req.path,
-        query: req.query ?? {},
-        headers: req.headers ?? {},
-        body: req.body ?? null,
-        ...((req.baseUrl ?? this.baseUrl)
-          ? { base_url: req.baseUrl ?? this.baseUrl }
-          : {}),
-      },
+    // those bytes verbatim under the caller's Content-Type. A Buffer is
+    // base64-encoded so binary uploads survive JSON. An object body travels
+    // as JSON and the proxy serializes it.
+    const request: Record<string, unknown> = {
+      method: req.method,
+      path: req.path,
+      query: req.query ?? {},
+      headers: req.headers ?? {},
+      body: req.body ?? null,
+      ...((req.baseUrl ?? this.baseUrl)
+        ? { base_url: req.baseUrl ?? this.baseUrl }
+        : {}),
     };
+    if (isBinaryOAuthBody(req.body)) {
+      request.body = Buffer.from(req.body).toString("base64");
+      request.body_encoding = "base64";
+    }
+    const body: Record<string, unknown> = { request };
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       const response = await this.client.fetch(proxyPath, {

--- a/assistant/src/runtime/routes/oauth-commands-routes.ts
+++ b/assistant/src/runtime/routes/oauth-commands-routes.ts
@@ -19,7 +19,7 @@ import {
   ServicesSchema,
 } from "../../config/schemas/services.js";
 import type { OAuthConnectionRequest } from "../../oauth/connection.js";
-import { jsonSafeOAuthBody } from "../../oauth/connection.js";
+import { isBinaryOAuthBody, jsonSafeOAuthBody } from "../../oauth/connection.js";
 import {
   resolveOAuthConnection,
   type ResolveOAuthConnectionOptions,
@@ -42,6 +42,7 @@ import { matchHostPattern } from "../../tools/credentials/host-pattern-match.js"
 import { getLogger } from "../../util/logger.js";
 import {
   findContentTypeHeader,
+  parseRequestBodyBytes,
   parseRequestBodyData,
 } from "../../util/oauth-request-body.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
@@ -729,7 +730,8 @@ async function handleToken({ body = {} }: RouteHandlerArgs) {
 /**
  * Resolve a raw `data` string into a request body. A non-JSON Content-Type
  * keeps the payload as the caller's exact string so multipart and other
- * byte-sensitive payloads survive; files are read as UTF-8 text.
+ * byte-sensitive payloads survive. Files are read as raw bytes: valid UTF-8
+ * stays text, and anything else stays a Buffer.
  */
 function readBodyData(data: string, contentType: string | undefined): unknown {
   if (data === "@-") {
@@ -744,7 +746,7 @@ function readBodyData(data: string, contentType: string | undefined): unknown {
 
   if (data.startsWith("@")) {
     const filePath = data.slice(1);
-    return parseRequestBodyData(readFileSync(filePath, "utf-8"), contentType);
+    return parseRequestBodyBytes(readFileSync(filePath), contentType);
   }
 
   return parseRequestBodyData(data, contentType);
@@ -760,6 +762,8 @@ export async function handleRequest({ body = {} }: RouteHandlerArgs) {
     parsed_data?: unknown;
     /** Raw data string (for direct API callers, not the CLI). */
     data?: string;
+    /** When set to base64, `parsed_data` / `data` is a base64 string of raw bytes. */
+    body_encoding?: "base64";
     force_get?: boolean;
     head?: boolean;
     account?: string;
@@ -864,7 +868,15 @@ export async function handleRequest({ body = {} }: RouteHandlerArgs) {
         : undefined;
 
   if (resolvedData !== undefined) {
-    const rawBody = resolvedData;
+    let rawBody = resolvedData;
+    if (b.body_encoding === "base64") {
+      if (typeof rawBody !== "string") {
+        throw new BadRequestError(
+          "body_encoding=base64 requires a string body",
+        );
+      }
+      rawBody = Buffer.from(rawBody, "base64");
+    }
 
     if (b.force_get) {
       if (typeof rawBody === "string") {
@@ -882,7 +894,8 @@ export async function handleRequest({ body = {} }: RouteHandlerArgs) {
       } else if (
         rawBody !== null &&
         typeof rawBody === "object" &&
-        !Array.isArray(rawBody)
+        !Array.isArray(rawBody) &&
+        !isBinaryOAuthBody(rawBody)
       ) {
         for (const [key, value] of Object.entries(
           rawBody as Record<string, unknown>,

--- a/assistant/src/util/oauth-request-body.test.ts
+++ b/assistant/src/util/oauth-request-body.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 
 import {
   findContentTypeHeader,
+  isBinaryOAuthContentType,
   isJsonContentType,
+  parseRequestBodyBytes,
   parseRequestBodyData,
 } from "./oauth-request-body.js";
 
@@ -70,5 +72,62 @@ describe("parseRequestBodyData", () => {
   test("keeps a JSON string scalar in its quoted wire form", () => {
     expect(parseRequestBodyData('"hello"', "application/json")).toBe('"hello"');
     expect(parseRequestBodyData('"hello"', undefined)).toBe('"hello"');
+  });
+});
+
+describe("isBinaryOAuthContentType", () => {
+  test("recognizes PDF, octet-stream, and image types", () => {
+    expect(isBinaryOAuthContentType("application/pdf")).toBe(true);
+    expect(isBinaryOAuthContentType("application/octet-stream")).toBe(true);
+    expect(isBinaryOAuthContentType("image/png; charset=binary")).toBe(true);
+  });
+
+  test("rejects JSON, multipart, and form types", () => {
+    expect(isBinaryOAuthContentType("application/json")).toBe(false);
+    expect(isBinaryOAuthContentType("multipart/related; boundary=b")).toBe(
+      false,
+    );
+    expect(isBinaryOAuthContentType("application/x-www-form-urlencoded")).toBe(
+      false,
+    );
+    expect(isBinaryOAuthContentType(undefined)).toBe(false);
+  });
+});
+
+describe("parseRequestBodyBytes", () => {
+  const png = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe,
+  ]);
+
+  test("keeps invalid UTF-8 as a Buffer", () => {
+    const parsed = parseRequestBodyBytes(png, "multipart/related; boundary=b");
+    expect(Buffer.isBuffer(parsed)).toBe(true);
+    expect(Buffer.from(parsed as Uint8Array).equals(png)).toBe(true);
+  });
+
+  test("keeps a PDF Content-Type as a Buffer even when the bytes are ASCII", () => {
+    const asciiPdf = Buffer.from("%PDF-1.4 simple", "ascii");
+    const parsed = parseRequestBodyBytes(asciiPdf, "application/pdf");
+    expect(Buffer.isBuffer(parsed)).toBe(true);
+    expect(Buffer.from(parsed as Uint8Array).equals(asciiPdf)).toBe(true);
+  });
+
+  test("keeps valid UTF-8 multipart as the exact string", () => {
+    const multipart = "--b\r\nContent-Type: text/csv\r\n\r\na,b\r\n--b--\r\n";
+    expect(
+      parseRequestBodyBytes(
+        Buffer.from(multipart, "utf-8"),
+        "multipart/related; boundary=b",
+      ),
+    ).toBe(multipart);
+  });
+
+  test("parses UTF-8 JSON into an object", () => {
+    expect(
+      parseRequestBodyBytes(
+        Buffer.from('{"name":"Sheet"}', "utf-8"),
+        "application/json",
+      ),
+    ).toEqual({ name: "Sheet" });
   });
 });

--- a/assistant/src/util/oauth-request-body.ts
+++ b/assistant/src/util/oauth-request-body.ts
@@ -1,12 +1,22 @@
 /**
  * Shared helpers for deciding how an outbound OAuth request body is encoded.
  *
- * A body is either structured (an object or array, serialized as JSON) or
- * raw (a string forwarded to the provider byte-for-byte). The Content-Type
- * the caller supplied decides which one a string body is: multipart, XML,
- * form-encoded, and CSV payloads must survive intact, while JSON text is
- * already in its wire form and must not be re-encoded.
+ * A body is structured (an object or array, serialized as JSON), raw text
+ * (a string forwarded to the provider as UTF-8), or raw bytes (a Buffer
+ * forwarded to the provider byte-for-byte). The Content-Type the caller
+ * supplied decides which one a string body is: multipart, XML, form-encoded,
+ * and CSV payloads must survive intact, while JSON text is already in its
+ * wire form and must not be re-encoded. Files that are not valid UTF-8, or
+ * that carry a binary Content-Type, stay as bytes.
  */
+
+const BINARY_MEDIA_TYPES = new Set([
+  "application/octet-stream",
+  "application/pdf",
+  "application/zip",
+  "application/gzip",
+  "application/x-gzip",
+]);
 
 /** True when a Content-Type header names a JSON media type. */
 export function isJsonContentType(
@@ -57,4 +67,45 @@ export function parseRequestBodyData(
   // A JSON string scalar ("hello") would be indistinguishable from a raw
   // body once unquoted, so the original quoted text is kept as the wire form.
   return typeof parsed === "string" ? raw : parsed;
+}
+
+/** True when a Content-Type names a binary media type (PDF, image, zip). */
+export function isBinaryOAuthContentType(
+  contentType: string | undefined | null,
+): boolean {
+  if (!contentType) {
+    return false;
+  }
+  const mediaType = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (
+    mediaType.startsWith("image/") ||
+    mediaType.startsWith("audio/") ||
+    mediaType.startsWith("video/")
+  ) {
+    return true;
+  }
+  return BINARY_MEDIA_TYPES.has(mediaType);
+}
+
+/**
+ * Decide how file or stdin bytes reach the provider.
+ *
+ * Binary Content-Types and payloads that are not valid UTF-8 stay as a
+ * Buffer so the original bytes survive the JSON proxy envelope. Valid UTF-8
+ * follows {@link parseRequestBodyData}.
+ */
+export function parseRequestBodyBytes(
+  raw: Uint8Array,
+  contentType: string | undefined,
+): unknown {
+  if (isBinaryOAuthContentType(contentType)) {
+    return Buffer.from(raw);
+  }
+  let utf8: string;
+  try {
+    utf8 = new TextDecoder("utf-8", { fatal: true }).decode(raw);
+  } catch {
+    return Buffer.from(raw);
+  }
+  return parseRequestBodyData(utf8, contentType);
 }

--- a/assistant/src/util/read-stdin.ts
+++ b/assistant/src/util/read-stdin.ts
@@ -25,3 +25,8 @@ export const STDIN_FD = 0;
 export function readStdinSync(encoding: BufferEncoding = "utf-8"): string {
   return readFileSync(STDIN_FD, encoding);
 }
+
+/** Read all data currently available on stdin as raw bytes. */
+export function readStdinBytesSync(): Buffer {
+  return readFileSync(STDIN_FD);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `assistant oauth request -d @file` read files as UTF-8 text. Invalid bytes became U+FFFD, then the managed Google proxy re-encoded that string.
- Drive media uploads of PDFs were stored as corrupted text (often an Untitled text file).
- `@file` and `@-` now read raw bytes. A binary Content-Type, or a payload that is not valid UTF-8, stays a `Buffer`.
- Managed connections send `body_encoding=base64` in the proxy envelope so the original bytes survive JSON.
- BYO connections send the `Buffer` as the raw `fetch` body.

**Merge order:** merge and deploy the platform companion first: https://github.com/vellum-ai/vellum-assistant-platform/pull/10194. That PR teaches the proxy to decode `body_encoding=base64`. Merging this assistant PR first would upload the ASCII base64 string on current production.

## Prompt / plan
Retention investigation of a managed Google Drive PDF upload. The stop-day standard traces were dropped, but the user's own memory notes and this code path independently confirm the binary-upload corruption.

## Test plan
- `cd assistant && bun test src/util/oauth-request-body.test.ts src/cli/commands/oauth/request.test.ts src/runtime/routes/oauth-commands-routes.test.ts src/oauth/platform-connection.test.ts src/oauth/byo-connection.test.ts` (all passed)
- `cd assistant && bun run typecheck:fast` passed
- Live helper check: a 20-byte PDF-like payload is preserved by `parseRequestBodyBytes` and corrupted by the old UTF-8 `toString` path

## Risk
- Medium. Wrong merge order (assistant before platform) makes managed binary uploads worse until the platform decoder is live.
- Review focus: `parseRequestBodyBytes`, `PlatformOAuthConnection.request` envelope, and the route `body_encoding=base64` decode. Multipart and JSON bodies must stay strings/objects.
- No new IPC route. Existing `assistant oauth request` now forwards bytes.

## CLI verb checklist
No new route. The existing `oauth request` verb is the interface; this change makes `-d @file` binary-safe.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4547af1a-c7d4-4d3a-9482-191a0a675fd1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4547af1a-c7d4-4d3a-9482-191a0a675fd1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

