### PR TITLE
fix(inbox-management): pin scheduled runs to cost-optimized

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -465,7 +465,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-23T23:40:56.000Z"
+      "updatedAt": "2026-08-28T15:07:47.000Z"
     },
     {
       "id": "influencer",
@@ -1408,7 +1408,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants on Windows",
-      "updatedAt": "2026-08-27T22:43:52.000Z"
+      "updatedAt": "2026-08-27T23:10:01.000Z"
     }
   ]
 }

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -104,7 +104,10 @@ Create a recurring schedule via `schedule_create`:
 - Default: `0 */3 * * 1-5` (every 3 hours on weekdays)
 - Message: `"Load the inbox-management skill and run the inbox management pipeline."`
 - Mode: `execute`
+- Pin `inference_profile: "cost-optimized"` so runs use the cheap utility profile, not the chat model
 - Set `reuse_conversation: true` for context accumulation across runs
+
+If an inbox-management schedule already exists, pin `cost-optimized` on it with `schedule_update` instead of creating a second schedule.
 
 Confirm cadence with user. Overnight: urgent-scan only.
 

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -107,7 +107,7 @@ Create a recurring schedule via `schedule_create`:
 - Pin `inference_profile: "cost-optimized"` so runs use the cheap utility profile, not the chat model
 - Set `reuse_conversation: true` for context accumulation across runs
 
-If an inbox-management schedule already exists, pin `cost-optimized` on it with `schedule_update` instead of creating a second schedule.
+If an inbox-management schedule already exists, pin `cost-optimized` on it with `schedule_update` instead of creating a second schedule. The pipeline also re-pins on every run, so already-enabled jobs pick this up without repeating setup.
 
 Confirm cadence with user. Overnight: urgent-scan only.
 
@@ -125,7 +125,20 @@ Confirm the user wants drafts generated. Some prefer flag-only forever.
 
 Each step is silent unless something qualifies for interrupt. Run these in order.
 
-### Step 0: Missed-run check & resume
+### Step 0: Pin cheap profile, then missed-run check & resume
+
+**Pin `cost-optimized` if needed.** This run may already be on the chat model. Before the rest of the pipeline, re-pin the inbox-management schedule so later fires stay cheap. Idempotent: no-op when already pinned or no matching schedule exists.
+
+```sh
+assistant schedules list --json | jq -r '
+  .schedules[]
+  | select(.message == "Load the inbox-management skill and run the inbox management pipeline.")
+  | select(.inferenceProfile != "cost-optimized")
+  | .id
+' | while read -r id; do
+  [ -n "$id" ] && assistant schedules update "$id" --profile cost-optimized
+done
+```
 
 **Resume interrupted runs first.** Before starting a new pipeline pass, check `bun run scripts/gmail-runs.ts list`. If the most recent run has `status: "interrupted"`, resume it via `bun run scripts/gmail-archive.ts archive --resume "<run-id>"` before proceeding. Also run `bun run scripts/gmail-runs.ts prune` to clean up logs older than 30 days.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Inbox-management schedules were inheriting the chat model (`balanced` / `mainAgent`). On a high-frequency pipeline that is a silent credit burner: Dan's every-2-hour inbox job spent `$13.83` of a `$25` pack on `glm-5p2` in 36 hours.

The schedule skill already supports pinning `inference_profile` so a recurring job stays on a chosen model. This change:

1. Pins `cost-optimized` on create (and on `schedule_update` if the job already exists).
2. Re-pins at the start of every scheduled pipeline run. Already-enabled jobs never re-enter setup, so the create-time instruction alone would not reach them. The pipeline check is idempotent (match the stock pipeline message, skip when already pinned).
3. Regenerates `skills/catalog.json` `updatedAt` so the catalog check stays green.

## Test plan

- [x] `node scripts/skills/lint-skill-spec.mjs inbox-management`
- [x] `node scripts/skills/lint-skill-imports.mjs inbox-management`
- [x] `node scripts/skills/check-catalog.mjs`
- Instruction-only change. Existing installs pick this up the next successful pipeline run.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8ec2cc1-4f51-4bfa-a4aa-87f6252e1ef2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8ec2cc1-4f51-4bfa-a4aa-87f6252e1ef2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

