### PR TITLE
chore(plugins): bump imessage marketplace pin to 01701eb

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -219,7 +219,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/imessage",
-        "ref": "069a8375e2a6ed069550866114a653218864bc91"
+        "ref": "01701eb1be4074f99371af90fc4340fdd1674efb"
       },
       "description": "iMessage and SMS channel for the Vellum assistant, backed by a Photon line.",
       "category": "productivity",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Repin the curated iMessage plugin to the latest `vellum-ai/imessage` `main` commit so catalog installs pick up webhook reply delivery and Comms as a selectable provider.

## Summary

- Bump `plugins/marketplace.json` `imessage.source.ref` from `069a8375e2a6ed069550866114a653218864bc91` to `01701eb1be4074f99371af90fc4340fdd1674efb`.
- That SHA is current `main` on [`vellum-ai/imessage`](https://github.com/vellum-ai/imessage): [offer Comms as a selectable iMessage provider (#50)](https://github.com/vellum-ai/imessage/pull/50).
- The previous pin was the "Coming soon" Comms gate. This pin also includes Linq as a selectable provider, webhook reply targeting so assistant answers go back out as iMessage, setup/verify of the guardian iMessage handle, and floor-deny notices.

This is a pin-only change. Catalog metadata (name, description, category, homepage, license, icon) is unchanged.

## Test plan

- Manifest JSON parses; `imessage.source.ref` is a full 40-hex SHA.
- Confirmed `01701eb1be4074f99371af90fc4340fdd1674efb` is `origin/main` on `vellum-ai/imessage`.
- After merge, `assistant plugins install imessage` (or upgrade of an existing install) should resolve this pin.

## Risk

Low. Catalog pin only. Existing installs stay on the old SHA until a user upgrades.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27c6a680-a343-44ed-ae79-a2fa51ae8a90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27c6a680-a343-44ed-ae79-a2fa51ae8a90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

