### PR TITLE
fix(companion): keep the drag when a flick carries the pointer off the canvas

### DIFF
--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -227,7 +227,7 @@ export function CompanionIntro({
       // The card is not a drag handle. Everything else on this surface is, and
       // a press that both read a sentence and flung the pill across the desktop
       // would be the one interaction here nobody could undo.
-      onMouseDown={(event) => {
+      onPointerDown={(event) => {
         event.stopPropagation();
       }}
     >

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -5,7 +5,7 @@ import {
   render,
   waitFor,
 } from "@testing-library/react";
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 import type { CompanionSurfaceState } from "@vellumai/ipc-contract";
 
@@ -44,6 +44,7 @@ const resetState = () => {
   STATE.watchEnabled = true;
   STATE.intro = null;
   STATE.assistantName = "Ziggy";
+  STATE.turns = [];
   delete STATE.character;
 };
 
@@ -412,7 +413,12 @@ describe("dragging the companion surface", () => {
       const canvas = canvasOf(container);
 
       fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
-      fireEvent.mouseDown(pinned[half], { screenX: 500, screenY: 500 });
+      fireEvent.pointerDown(pinned[half], {
+        button: 0,
+        pointerId: 1,
+        screenX: 500,
+        screenY: 500,
+      });
       fireEvent.mouseMove(canvas, {
         clientX: 120,
         clientY: 120,
@@ -438,7 +444,12 @@ describe("dragging the companion surface", () => {
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
-    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
     fireEvent.mouseMove(canvas, {
       clientX: 120,
       clientY: 120,
@@ -468,7 +479,12 @@ describe("dragging the companion surface", () => {
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
     expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
-    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
     fireEvent.mouseMove(canvas, {
       clientX: 120,
       clientY: 120,
@@ -497,7 +513,12 @@ describe("dragging the companion surface", () => {
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
-    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
     fireEvent.mouseMove(canvas, {
       clientX: 120,
       clientY: 120,
@@ -517,11 +538,224 @@ describe("dragging the companion surface", () => {
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
-    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
     fireEvent.mouseUp(canvas);
     fireEvent.click(avatar);
 
     expect(activateMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * The window is moved a message at a time, so it trails the hand, and a flick
+   * outruns it far enough to carry the pointer past the canvas edge, which sits
+   * a pad's width off the creature on the side the card does not grow into.
+   * Handing the desktop back there would drop the grab under a button that is
+   * still down.
+   */
+  test("keeps the drag alive when the pointer leaves the canvas mid-press", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const { pill } = await pinSurface(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 520,
+      screenY: 500,
+      buttons: 1,
+    });
+    expect(moveByMock.mock.calls).toEqual([[20, 0]]);
+    moveByMock.mockClear();
+    setInteractiveMock.mockClear();
+
+    fireEvent.mouseLeave(canvas);
+
+    expect(setInteractiveMock).not.toHaveBeenCalledWith(false);
+    expect(moveByMock).not.toHaveBeenCalled();
+
+    // Still the same grab, so the next frame moves the window by its own travel
+    // rather than starting over from wherever the pointer reappeared.
+    fireEvent.mouseMove(canvas, {
+      clientX: 900,
+      clientY: 900,
+      screenX: 560,
+      screenY: 530,
+      buttons: 1,
+    });
+
+    expect(moveByMock.mock.calls).toEqual([[40, 30]]);
+  });
+
+  test("takes pointer capture on a left press and not on a right-click", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const { pill } = await pinSurface(container);
+    const canvas = canvasOf(container);
+    const capture = spyOn(pill, "setPointerCapture").mockImplementation(
+      () => undefined,
+    );
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 7,
+      screenX: 500,
+      screenY: 500,
+    });
+
+    expect(capture.mock.calls).toEqual([[7]]);
+
+    // A right-press opens the menu, which takes the pointer for as long as it
+    // is up. Capturing it here would hold a grab nothing ever releases.
+    fireEvent.pointerDown(pill, {
+      button: 2,
+      pointerId: 8,
+      screenX: 500,
+      screenY: 500,
+    });
+
+    expect(capture.mock.calls).toEqual([[7]]);
+  });
+
+  test("still hands the desktop back on a leave that follows the release", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const { pill } = await pinSurface(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 540,
+      screenY: 500,
+      buttons: 1,
+    });
+    fireEvent.mouseUp(canvas);
+    fireEvent.mouseLeave(canvas);
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
+  });
+
+  /**
+   * Capture retargets the click to whatever holds it, so a press that armed the
+   * drag from a control is a click that control never sees. The surface's own
+   * controls stop the press, but the card draws the assistant's markdown and
+   * the copy affordance on a code block belongs to the design library.
+   */
+  test("a press on a control the card's markdown draws is not a grab", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const { pill } = await pinSurface(container);
+    const canvas = canvasOf(container);
+    const capture = spyOn(pill, "setPointerCapture").mockImplementation(
+      () => undefined,
+    );
+
+    // The turns are drawn on the card Type opens, and only once the exchange on
+    // it is this composer's own: send a message, then let the reply arrive the
+    // way main pushes it.
+    const type = Array.from(pill.querySelectorAll("button")).find(
+      (button) => button.getAttribute("aria-label") === "Type",
+    );
+    fireEvent.click(type as HTMLElement);
+    const field = await waitFor(() => {
+      const found = container.querySelector("input");
+      if (!found) {
+        throw new Error("Expected the composer field to render");
+      }
+      return found;
+    });
+    fireEvent.change(field, { target: { value: "hello" } });
+    fireEvent.keyDown(field, { key: "Enter" });
+    STATE.turns = [
+      { role: "assistant", text: "Try this:\n\n```ts\nconst a = 1;\n```" },
+    ];
+    pushState();
+
+    const copy = await waitFor(() => {
+      const found = pill.querySelector<HTMLElement>("[data-copy-control]");
+      if (!found) {
+        throw new Error("Expected the code block's copy control to render");
+      }
+      return found;
+    });
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.pointerDown(copy, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 540,
+      screenY: 520,
+      buttons: 1,
+    });
+
+    expect(capture).not.toHaveBeenCalled();
+    expect(moveByMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The host can take the pointer away mid-drag, which releases the capture and
+   * sends no `mouseup` after it. Nothing else reports that press: the leave
+   * defers to a live drag, so the cancel is the only thing left to end it.
+   */
+  test("ends the drag when the host takes the pointer away", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    const { pill } = await pinSurface(container);
+    const canvas = canvasOf(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    fireEvent.pointerDown(pill, {
+      button: 0,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
+    fireEvent.mouseMove(canvas, {
+      clientX: 120,
+      clientY: 120,
+      screenX: 520,
+      screenY: 500,
+      buttons: 1,
+    });
+    expect(moveByMock.mock.calls).toEqual([[20, 0]]);
+    moveByMock.mockClear();
+
+    fireEvent.pointerCancel(canvas);
+    fireEvent.mouseLeave(canvas);
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
+
+    fireEvent.mouseMove(canvas, {
+      clientX: 900,
+      clientY: 900,
+      screenX: 560,
+      screenY: 530,
+      buttons: 1,
+    });
+
+    expect(moveByMock).not.toHaveBeenCalled();
   });
 });
 
@@ -1012,7 +1246,12 @@ describe("the companion's own menu", () => {
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
     // button 2 is the right button; the drag arms only on the left.
-    fireEvent.mouseDown(pill, { button: 2, screenX: 500, screenY: 500 });
+    fireEvent.pointerDown(pill, {
+      button: 2,
+      pointerId: 1,
+      screenX: 500,
+      screenY: 500,
+    });
     fireEvent.mouseMove(canvas, {
       clientX: 120,
       clientY: 120,

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -717,10 +717,11 @@ describe("dragging the companion surface", () => {
 
   /**
    * The host can take the pointer away mid-drag, which releases the capture and
-   * sends no `mouseup` after it. Nothing else reports that press: the leave
-   * defers to a live drag, so the cancel is the only thing left to end it.
+   * sends no `mouseup` after it. Nothing else reports that press: a leave that
+   * came while the drag was live deferred to it and does not come again, so
+   * the cancel has to end the drag and hand the desktop back by itself.
    */
-  test("ends the drag when the host takes the pointer away", async () => {
+  test("ends the drag and gives the desktop back when the host takes the pointer away", async () => {
     const { container } = render(<CompanionSurfacePage />);
     const { pill } = await pinSurface(container);
     const canvas = canvasOf(container);
@@ -741,9 +742,14 @@ describe("dragging the companion surface", () => {
     });
     expect(moveByMock.mock.calls).toEqual([[20, 0]]);
     moveByMock.mockClear();
+    setInteractiveMock.mockClear();
+
+    // The pointer is off the canvas with the button down, so the leave defers
+    // to the drag and the window stays clickable for it.
+    fireEvent.mouseLeave(canvas);
+    expect(setInteractiveMock).not.toHaveBeenCalledWith(false);
 
     fireEvent.pointerCancel(canvas);
-    fireEvent.mouseLeave(canvas);
 
     expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
 

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -446,8 +446,8 @@ export function CompanionSurfacePage() {
       }}
       onPointerCancel={() => {
         // The capture goes with the pointer when the host takes it, so nothing
-        // more reports this press. The leave no longer ends a drag, so this has
-        // to.
+        // more reports this press, and the leave defers to a live drag. This is
+        // what ends one the host took away.
         dragRef.current = null;
       }}
       onMouseLeave={() => {

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -446,9 +446,12 @@ export function CompanionSurfacePage() {
       }}
       onPointerCancel={() => {
         // The capture goes with the pointer when the host takes it, so nothing
-        // more reports this press, and the leave defers to a live drag. This is
-        // what ends one the host took away.
+        // more reports this press, and a leave that deferred to the drag may
+        // never arrive. Give the desktop back the way a leave does; a pointer
+        // still on the pill re-arms it on its next move.
         dragRef.current = null;
+        setHovered(false);
+        setInteractive(false);
       }}
       onMouseLeave={() => {
         // A leave is not a release. A drag can carry the pointer off the canvas

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -333,11 +333,9 @@ export function CompanionSurfacePage() {
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
     // **A drag whose release this window never saw ends here.**
     //
-    // The drag is ended by `mouseup` or by the pointer leaving the canvas, and
-    // both are events this window has to receive. Neither arrives when the
-    // button comes up over another app: the canvas is a bounded rectangle, a
-    // fast drag outruns a window that is moved a message at a time, and the
-    // release then lands somewhere this page is not.
+    // The drag is ended by `mouseup`, which the capture the press takes
+    // delivers wherever the button comes up. The host can still break that
+    // capture, and the release then lands somewhere this page is not.
     //
     // Left alone that press never ends. Every later move is read as a drag
     // frame, so the surface follows a pointer with no button held and the first
@@ -446,10 +444,21 @@ export function CompanionSurfacePage() {
       onMouseUp={() => {
         dragRef.current = null;
       }}
-      onMouseLeave={() => {
-        // The pointer left the canvas entirely, which mouse-move cannot report.
-        // A drag ends here too: the button came up somewhere we cannot see.
+      onPointerCancel={() => {
+        // The capture goes with the pointer when the host takes it, so nothing
+        // more reports this press. The leave no longer ends a drag, so this has
+        // to.
         dragRef.current = null;
+      }}
+      onMouseLeave={() => {
+        // A leave is not a release. A drag can carry the pointer off the canvas
+        // and back, and handing the desktop back mid-press would put the window
+        // click-through under a button that is still down. Only a release ends
+        // the drag, seen as `mouseup` or as a move with no button held.
+        if (dragRef.current !== null) {
+          return;
+        }
+        // The pointer left the canvas entirely, which mouse-move cannot report.
         setHovered(false);
         setInteractive(false);
       }}
@@ -554,13 +563,33 @@ export function CompanionSurfacePage() {
         }
         rootRef={pillRef}
         avatarRef={avatarRef}
-        onSurfaceMouseDown={(event) => {
+        onSurfacePointerDown={(event) => {
           // A right-click is a menu, not a grab. Left alone it would arm the
           // drag and then never be released by a `mouseup` this window sees,
-          // because the menu takes the pointer for as long as it is open.
+          // because the menu takes the pointer for as long as it is open. It
+          // must not take the capture below either, for the same reason.
           if (event.button !== 0) {
             return;
           }
+          // A press on a control is not a grab, and here it must not even arm
+          // one: capture retargets the click to whatever holds it, so a press
+          // that took capture from a control is a click that control never
+          // sees. The surface's own controls stop the press themselves; the
+          // card's replies are markdown, and the affordances the design library
+          // draws inside them cannot.
+          if (
+            (event.target as Element).closest(
+              "button, a, input, textarea, select, [contenteditable='true']",
+            ) !== null
+          ) {
+            return;
+          }
+          // The window is moved a message at a time, so it trails the hand and
+          // a quick drag carries the pointer off the canvas. Capture keeps the
+          // moves and the release coming here regardless of what the pointer is
+          // over, and holds the canvas's `mouseleave` back until the button is
+          // up.
+          event.currentTarget.setPointerCapture(event.pointerId);
           dragRef.current = { x: event.screenX, y: event.screenY };
           pressOriginRef.current = { x: event.screenX, y: event.screenY };
           draggedRef.current = false;

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -17,6 +17,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type {
   CSSProperties,
   MouseEvent as ReactMouseEvent,
+  PointerEvent as ReactPointerEvent,
   ReactNode,
   Ref,
 } from "react";
@@ -388,7 +389,7 @@ export interface CompanionSurfaceProps {
    * from reaching it. The gap between the two is not a handle: there is nothing
    * drawn in it to grab.
    */
-  onSurfaceMouseDown?: (event: ReactMouseEvent<HTMLDivElement>) => void;
+  onSurfacePointerDown?: (event: ReactPointerEvent<HTMLDivElement>) => void;
   /**
    * Open the surface's own menu, which a right-click on the avatar or the pill
    * asks for.
@@ -634,7 +635,7 @@ export function CompanionSurface({
   cardGrowth = "up",
   rootRef,
   avatarRef,
-  onSurfaceMouseDown,
+  onSurfacePointerDown,
   onSurfaceContextMenu,
   spotlight,
   onTalk,
@@ -856,7 +857,7 @@ export function CompanionSurface({
               `flex h-11 items-center rounded-full ${growth === "left" ? "justify-end" : ""}`
         }`}
         style={style}
-        onMouseDown={onSurfaceMouseDown}
+        onPointerDown={onSurfacePointerDown}
         onContextMenu={onSurfaceContextMenu}
         ref={rootRef}
       >
@@ -961,7 +962,7 @@ export function CompanionSurface({
           }`,
         }}
         elementRef={avatarRef}
-        onMouseDown={onSurfaceMouseDown}
+        onPointerDown={onSurfacePointerDown}
         onContextMenu={onSurfaceContextMenu}
         onClick={onAvatarClick}
       />
@@ -1010,7 +1011,7 @@ function CompanionLink({
         }
       }}
       // A press on a link is not a grab, the way a press on a control is not.
-      onMouseDown={(event) => {
+      onPointerDown={(event) => {
         event.stopPropagation();
       }}
     >
@@ -1188,7 +1189,7 @@ function Composer({
         }}
         // A press in the field is not a drag, and the field wants the caret
         // that press would otherwise be stolen from.
-        onMouseDown={(event) => {
+        onPointerDown={(event) => {
           event.stopPropagation();
         }}
         className="min-w-0 flex-1 bg-transparent text-[12px] text-white/85 select-text placeholder:text-white/40 focus:outline-none"
@@ -1214,7 +1215,7 @@ function Composer({
             : t("companionSurface.send")
         }
         onClick={message === "" ? onCancel : send}
-        onMouseDown={(event) => {
+        onPointerDown={(event) => {
           event.stopPropagation();
         }}
         className="grid size-7 shrink-0 place-items-center rounded-full bg-white/10 text-white/85 transition-colors hover:bg-white/20"
@@ -1258,7 +1259,7 @@ function Avatar({
   edge,
   style,
   elementRef,
-  onMouseDown,
+  onPointerDown,
   onContextMenu,
   onClick,
 }: {
@@ -1271,7 +1272,7 @@ function Avatar({
   edge?: ReactNode;
   style?: CSSProperties;
   elementRef?: Ref<HTMLDivElement>;
-  onMouseDown?: (event: ReactMouseEvent<HTMLDivElement>) => void;
+  onPointerDown?: (event: ReactPointerEvent<HTMLDivElement>) => void;
   onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onClick?: () => void;
 }) {
@@ -1289,7 +1290,7 @@ function Avatar({
       className="absolute grid size-11 cursor-grab place-items-center active:cursor-grabbing"
       style={style}
       ref={elementRef}
-      onMouseDown={onMouseDown}
+      onPointerDown={onPointerDown}
       onContextMenu={onContextMenu}
       onClick={onClick}
     >
@@ -1787,7 +1788,7 @@ function PillButton({
       onClick={onClick}
       // A press on a control is not the start of a drag. Without this the
       // surface would move under a click meant to activate something on it.
-      onMouseDown={(event) => {
+      onPointerDown={(event) => {
         event.stopPropagation();
       }}
       className={`group flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] transition-colors hover:bg-white/15 ${


### PR DESCRIPTION
## Summary

Flicking the macOS companion quickly drops the drag: the surface stops following and cannot be dragged again until the button is released and the avatar re-grabbed.

**Why.** The drag is renderer-driven: every `mousemove` sends a delta to main over IPC, so the window trails the cursor by at least a frame. A fast flick carries the cursor outside the transparent canvas (the avatar sits about a pad's width from the canvas edge on the side the card does not grow into). Blink then fires `mouseleave` on the page's root `<div>` with the button still held and retargets later `mousemove`/`mouseup` to `<html>`, which the root's handlers never see. The root's `onMouseLeave` dropped the drag and called `setInteractive(false)` mid-press, so main put the window back to click-through under a button that was still down. #40832 fixed the aftermath of a lost release (`buttons === 0`), not the drop itself.

**Fix.** The press arms on `pointerdown` and takes `setPointerCapture(pointerId)` on the pressed element (pill root or avatar). With capture, the root keeps receiving out-of-viewport moves and the release wherever it happens, and `mouseleave` is deferred until after the release with no button held, so the existing handlers stay right. Verified in Chromium through a CDP harness (same input path as native).

- `onSurfaceMouseDown` is now `onSurfacePointerDown`; the "a press on a control is not a grab" `stopPropagation` guards move from `onMouseDown` to `onPointerDown` with it (pill buttons, composer field, send, links, intro card).
- Capture retargets `click` to whatever holds it, so a press that landed on a control (`button, a, input, textarea, select, [contenteditable]`) neither captures nor arms a drag. This covers controls the design library draws inside card replies, such as the code-block Copy button, which have no guard of their own.
- `onMouseLeave` returns early while a drag is live; only a release ends a drag (`mouseup`, a move with `buttons === 0`, or `pointercancel`, which now clears it too).

## Tests

`companion-surface-page.test.tsx`: the six existing presses use `pointerDown`; five new tests pin that a drag survives a mid-press leave, that capture is taken on a left press and not a right-click, that a press on a markdown-drawn control neither captures nor arms, that `pointercancel` ends the drag and hands the desktop back, and that a leave following a release still hands it back.

## QA on a device

- [ ] Flick the companion fast downward (card growing up) and upward near the top of the display: it keeps following.
- [ ] Release over another app: the window goes click-through (clicks behind the canvas land on the app).
- [ ] Press the avatar without moving: Vellum comes forward. Drag it and release: it does not.
- [ ] Right-click the avatar: the size menu opens, no drag arms.
- [ ] Open Type, get a reply with a fenced code block, hover it and press Copy: it copies.
- [ ] Talk / Type / Teach, the composer field and Send still work under the pointer.

Residual, not in this PR: the window still trails the cursor by a frame on fast flicks. Removing that would mean a main-driven drag that polls `screen.getCursorScreenPoint()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
