### PR TITLE
fix(cli): stop truncating the WAL checkpoint on every upgrade (ATL-1349)

### DIFF
--- a/cli/src/__tests__/clean.test.ts
+++ b/cli/src/__tests__/clean.test.ts
@@ -31,6 +31,7 @@ beforeAll(() => {
     detectOrphanedProcesses: detectOrphansMock,
   }));
   mock.module("../lib/process.js", () => ({
+    ...realProcess,
     stopProcess: stopProcessMock,
   }));
 });

--- a/cli/src/__tests__/retire-local.test.ts
+++ b/cli/src/__tests__/retire-local.test.ts
@@ -33,14 +33,22 @@ const realNginxIngress = { ...(await import("../lib/nginx-ingress.js")) };
 const realRetireArchive = { ...(await import("../lib/retire-archive.js")) };
 
 const stopProcessByPidFileMock = mock(
-  async (_pidFile: string, _label: string): Promise<boolean> => true,
+  async (
+    _pidFile: string,
+    _label: string,
+    _extraCleanupFiles?: string[],
+    _timeoutMs?: number,
+  ): Promise<boolean> => true,
 );
+
+const { DAEMON_STOP_TIMEOUT_MS } = realProcess;
 const stopOrphanedDaemonProcessesMock = mock(
   async (_excludePids?: ReadonlySet<string>): Promise<boolean> => false,
 );
 const stopIngressNginxMock = mock(async (): Promise<boolean> => false);
 
 mock.module("../lib/process.js", () => ({
+  ...realProcess,
   stopProcessByPidFile: stopProcessByPidFileMock,
   stopOrphanedDaemonProcesses: stopOrphanedDaemonProcessesMock,
 }));
@@ -151,6 +159,26 @@ describe("retireLocal — CES sibling stop", () => {
       ([, label]) => label === "gateway",
     );
     expect(gatewayStopCall).toBeDefined();
+  });
+
+  // The daemon stops its own worker processes (schedule, route host, resource
+  // monitor, memory jobs) near the end of a long shutdown sequence. The 2s
+  // default in stopProcess would SIGKILL it first, stranding those workers as
+  // orphans that outlive the runtime that spawned them.
+  test("gives the daemon its full stop budget, not the default grace", async () => {
+    const entry = makeEntry("test-assistant");
+    await retireLocal("test-assistant", entry, {
+      progress: () => {},
+      log: () => {},
+      warn: () => {},
+      error: () => {},
+    });
+
+    const daemonStopCall = stopProcessByPidFileMock.mock.calls.find(
+      ([, label]) => label === "daemon",
+    );
+    expect(daemonStopCall?.[3]).toBe(DAEMON_STOP_TIMEOUT_MS);
+    expect(DAEMON_STOP_TIMEOUT_MS).toBeGreaterThan(60_000);
   });
 
   test("CES stop is a no-op when ces.pid is absent", async () => {

--- a/cli/src/__tests__/retire-local.test.ts
+++ b/cli/src/__tests__/retire-local.test.ts
@@ -178,7 +178,10 @@ describe("retireLocal — CES sibling stop", () => {
       ([, label]) => label === "daemon",
     );
     expect(daemonStopCall?.[3]).toBe(DAEMON_STOP_TIMEOUT_MS);
-    expect(DAEMON_STOP_TIMEOUT_MS).toBeGreaterThan(60_000);
+    // The budget is only meaningful if it outlasts the daemon's own 30s
+    // force-exit, which is what it is derived from. Anything at or below that
+    // kills the daemon before it can fold the WAL and hand off on its way out.
+    expect(DAEMON_STOP_TIMEOUT_MS).toBeGreaterThan(30_000);
   });
 
   test("CES stop is a no-op when ces.pid is absent", async () => {

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -223,14 +223,15 @@ describe("sleep command", () => {
     }
 
     expect(stopProcessByPidFileMock).toHaveBeenCalledTimes(3);
-    // The assistant stop passes a generous 120s grace so the daemon's WAL
-    // checkpoint completes before any SIGKILL (default 2s would truncate it).
+    // The assistant stop passes the daemon's own shutdown budget plus a margin,
+    // so its WAL checkpoint completes before any SIGKILL (the default 2s grace
+    // would truncate it).
     expect(stopProcessByPidFileMock).toHaveBeenNthCalledWith(
       1,
       join(assistantRootDir, "workspace", "vellum.pid"),
       "assistant",
       undefined,
-      120_000,
+      45_000,
     );
     expect(stopProcessByPidFileMock).toHaveBeenNthCalledWith(
       2,

--- a/cli/src/__tests__/sleep.test.ts
+++ b/cli/src/__tests__/sleep.test.ts
@@ -26,6 +26,7 @@ const isProcessAliveMock = mock((): { alive: boolean; pid: number | null } => ({
 const realProcess = { ...(await import("../lib/process.js")) };
 
 mock.module("../lib/process.js", () => ({
+  ...realProcess,
   isProcessAlive: isProcessAliveMock,
   stopProcessByPidFile: stopProcessByPidFileMock,
 }));

--- a/cli/src/__tests__/teleport.test.ts
+++ b/cli/src/__tests__/teleport.test.ts
@@ -325,6 +325,7 @@ mock.module("../lib/docker.js", () => ({
 const stopProcessByPidFileMock = mock(async () => true);
 
 mock.module("../lib/process.js", () => ({
+  ...realProcess,
   stopProcessByPidFile: stopProcessByPidFileMock,
 }));
 

--- a/cli/src/commands/sleep.ts
+++ b/cli/src/commands/sleep.ts
@@ -17,7 +17,11 @@ import {
   stopContainerTunnelEdge,
   stopIngressNginx,
 } from "../lib/nginx-ingress.js";
-import { isProcessAlive, stopProcessByPidFile } from "../lib/process";
+import {
+  DAEMON_STOP_TIMEOUT_MS,
+  isProcessAlive,
+  stopProcessByPidFile,
+} from "../lib/process";
 import { resolveFreshBearerToken } from "./client.js";
 
 const ACTIVE_CALL_LEASES_FILE = "active-call-leases.json";
@@ -208,18 +212,11 @@ export async function sleep(): Promise<void> {
     }
   }
 
-  // Stop assistant — use a generous timeout. On SIGTERM the daemon runs a
-  // WAL checkpoint before exiting, which can take several seconds on a
-  // multi-GB database. The default 2s grace in stopProcess() would SIGKILL a
-  // healthy daemon mid-checkpoint, forcing a costly multi-minute WAL recovery
-  // on the next start. The timeout is only a SIGKILL ceiling — stopProcess
-  // returns as soon as the process exits, so this adds no delay in the common
-  // case and only applies when the daemon is genuinely wedged.
   const assistantStopped = await stopProcessByPidFile(
     assistantPidFile,
     "assistant",
     undefined,
-    120_000,
+    DAEMON_STOP_TIMEOUT_MS,
   );
   if (!assistantStopped) {
     console.log("Assistant is not running.");

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -47,7 +47,10 @@ import {
 import { hatchLocal } from "../lib/hatch-local.js";
 import { retireLocal } from "../lib/retire-local.js";
 import { validateAssistantName } from "../lib/retire-archive.js";
-import { stopProcessByPidFile } from "../lib/process.js";
+import {
+  DAEMON_STOP_TIMEOUT_MS,
+  stopProcessByPidFile,
+} from "../lib/process.js";
 import {
   fetchAssistantIngressUrl,
   fetchCurrentVersion,
@@ -1497,6 +1500,8 @@ export async function teleport(): Promise<void> {
       await stopProcessByPidFile(
         getDaemonPidPath(fromEntry.resources),
         "assistant",
+        undefined,
+        DAEMON_STOP_TIMEOUT_MS,
       );
       await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);
     }

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -17,6 +17,7 @@ import {
   waitForDaemonMigrationsReady,
 } from "../lib/http-client.js";
 import {
+  DAEMON_STOP_TIMEOUT_MS,
   isProcessAlive,
   resolveProcessState,
   stopProcessByPidFile,
@@ -149,7 +150,12 @@ export async function wake(): Promise<void> {
       console.log(
         `Assistant running (pid ${daemonState.pid}) — restarting in watch mode...`,
       );
-      const stopped = await stopProcessByPidFile(pidFile, "assistant");
+      const stopped = await stopProcessByPidFile(
+        pidFile,
+        "assistant",
+        undefined,
+        DAEMON_STOP_TIMEOUT_MS,
+      );
       if (!stopped && isProcessAlive(pidFile).alive) {
         daemonRunning = true;
         daemonUnready = true;

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -44,6 +44,7 @@ import {
 } from "./http-client.js";
 import { stopIngressNginx } from "./nginx-ingress.js";
 import {
+  DAEMON_STOP_TIMEOUT_MS,
   type ProcessState,
   executableName,
   isProcessAlive,
@@ -1982,7 +1983,12 @@ export async function stopLocalProcesses(
     ? join(resources.instanceDir, ".vellum")
     : join(homedir(), ".vellum");
   const daemonPidFile = getDaemonPidPath(resources);
-  await stopProcessByPidFile(daemonPidFile, "daemon");
+  await stopProcessByPidFile(
+    daemonPidFile,
+    "daemon",
+    undefined,
+    DAEMON_STOP_TIMEOUT_MS,
+  );
 
   const gatewayPidFile = join(vellumDir, "gateway.pid");
   await stopProcessByPidFile(gatewayPidFile, "gateway", undefined, 7000);

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -1740,8 +1740,17 @@ export async function startLocalDaemon(
           console.log(
             "   Bundled assistant not healthy after 60s, falling back to source assistant...",
           );
-          // Kill the bundled daemon to avoid two processes competing for the same port
-          await stopProcessByPidFile(pidFile, "bundled daemon");
+          // Kill the bundled daemon to avoid two processes competing for the
+          // same port. It gets the full stop budget like any other daemon:
+          // failing the health probe does not mean it has nothing to flush, and
+          // a daemon still working through a long DB migration is exactly the
+          // one whose WAL checkpoint must not be interrupted.
+          await stopProcessByPidFile(
+            pidFile,
+            "bundled daemon",
+            undefined,
+            DAEMON_STOP_TIMEOUT_MS,
+          );
           daemonSpawn = watch
             ? await startDaemonWatchFromSource(
                 assistantIndex,

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -281,18 +281,11 @@ export async function resolveProcessState(
 /**
  * SIGKILL ceiling for stopping the assistant daemon.
  *
- * The daemon's graceful shutdown fires plugin shutdown hooks, commits the
- * workspace, flushes telemetry, SIGTERMs the worker processes it owns
- * (schedule, route host, resource monitor, memory jobs), and folds the SQLite
- * WAL back into the database. Those steps run near the end of the sequence, so
- * a short grace period kills the daemon before it reaches them: the workers
- * reparent to init and keep running on that runtime version, and an
- * interrupted checkpoint costs a multi-minute WAL recovery on the next start.
- *
- * A ceiling, not a delay. `stopProcess` returns as soon as the process exits,
- * so this only applies to a daemon that is genuinely wedged.
+ * Defined in `@vellumai/local-mode` because the host wrappers that spawn these
+ * commands derive their own timeouts from it: a wrapper that expires first
+ * kills the CLI before this ceiling is ever reached.
  */
-export const DAEMON_STOP_TIMEOUT_MS = 120_000;
+export { DAEMON_STOP_TIMEOUT_MS } from "@vellumai/local-mode";
 
 /**
  * Stop a process by PID: SIGTERM, wait up to `timeoutMs`, then SIGKILL if still alive.

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -279,6 +279,22 @@ export async function resolveProcessState(
 }
 
 /**
+ * SIGKILL ceiling for stopping the assistant daemon.
+ *
+ * The daemon's graceful shutdown fires plugin shutdown hooks, commits the
+ * workspace, flushes telemetry, SIGTERMs the worker processes it owns
+ * (schedule, route host, resource monitor, memory jobs), and folds the SQLite
+ * WAL back into the database. Those steps run near the end of the sequence, so
+ * a short grace period kills the daemon before it reaches them: the workers
+ * reparent to init and keep running on that runtime version, and an
+ * interrupted checkpoint costs a multi-minute WAL recovery on the next start.
+ *
+ * A ceiling, not a delay. `stopProcess` returns as soon as the process exits,
+ * so this only applies to a daemon that is genuinely wedged.
+ */
+export const DAEMON_STOP_TIMEOUT_MS = 120_000;
+
+/**
  * Stop a process by PID: SIGTERM, wait up to `timeoutMs`, then SIGKILL if still alive.
  * Returns true if the process was stopped, false if it wasn't alive or
  * termination failed.

--- a/cli/src/lib/retire-local.ts
+++ b/cli/src/lib/retire-local.ts
@@ -12,6 +12,7 @@ import type { AssistantEntry } from "./assistant-config.js";
 import { stopIngressNginx } from "./nginx-ingress.js";
 import { getKnownPidsFromAssistants } from "./orphan-detection.js";
 import {
+  DAEMON_STOP_TIMEOUT_MS,
   stopOrphanedDaemonProcesses,
   stopProcessByPidFile,
 } from "./process.js";
@@ -119,7 +120,12 @@ export async function retireLocal(
   }
 
   const daemonPidFile = getDaemonPidPath(resources);
-  const daemonStopped = await stopProcessByPidFile(daemonPidFile, "daemon");
+  const daemonStopped = await stopProcessByPidFile(
+    daemonPidFile,
+    "daemon",
+    undefined,
+    DAEMON_STOP_TIMEOUT_MS,
+  );
 
   // Stop gateway via PID file — use a longer timeout because the gateway has a
   // drain window (5s) before it exits.
@@ -137,10 +143,10 @@ export async function retireLocal(
     reporter.log("credential-executor stopped.");
   }
 
-  // Stop Qdrant — the daemon's graceful shutdown tries to stop it via
-  // qdrantManager.stop(), but if the daemon was SIGKILL'd (after 2s timeout)
-  // Qdrant may still be running as an orphan. Check both the current PID file
-  // location and the legacy location.
+  // Stop Qdrant. The daemon's graceful shutdown tries to stop it via
+  // qdrantManager.stop(), but a daemon that never completes that shutdown
+  // (crash, OOM kill, or the SIGKILL ceiling above) leaves Qdrant running as
+  // an orphan. Check both the current PID file location and the legacy one.
   const qdrantPidFile = join(
     vellumDir,
     "workspace",

--- a/packages/local-mode/src/hatch.ts
+++ b/packages/local-mode/src/hatch.ts
@@ -1,8 +1,12 @@
 import { spawn } from "node:child_process";
 
+import {
+  DAEMON_STOP_TIMEOUT_MS,
+  HOST_WRAPPER_LONG_HEADROOM_MS,
+} from "./lifecycle-budgets";
 import type { CliInvocation } from "./util";
 
-const HATCH_TIMEOUT_MS = 120_000;
+const HATCH_TIMEOUT_MS = DAEMON_STOP_TIMEOUT_MS + HOST_WRAPPER_LONG_HEADROOM_MS;
 // Docker hatches pull images and wait up to 5 min for container readiness.
 const DOCKER_HATCH_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -85,7 +89,11 @@ export function runHatch(
     });
 
     child.on("error", (err) => {
-      finish({ ok: false, status: 500, error: `Failed to spawn CLI: ${err.message}` });
+      finish({
+        ok: false,
+        status: 500,
+        error: `Failed to spawn CLI: ${err.message}`,
+      });
     });
   });
 }

--- a/packages/local-mode/src/hatch.ts
+++ b/packages/local-mode/src/hatch.ts
@@ -1,12 +1,19 @@
 import { spawn } from "node:child_process";
 
 import {
+  DAEMON_READINESS_WINDOW_MS,
   DAEMON_STOP_TIMEOUT_MS,
   HOST_WRAPPER_LONG_HEADROOM_MS,
 } from "./lifecycle-budgets";
 import type { CliInvocation } from "./util";
 
-const HATCH_TIMEOUT_MS = DAEMON_STOP_TIMEOUT_MS + HOST_WRAPPER_LONG_HEADROOM_MS;
+// A hatch whose daemon comes up but never becomes ready spends the readiness
+// window first, then rolls back through the full daemon stop, so the wrapper
+// has to cover both plus the gateway and CES cleanup that follows.
+const HATCH_TIMEOUT_MS =
+  DAEMON_READINESS_WINDOW_MS +
+  DAEMON_STOP_TIMEOUT_MS +
+  HOST_WRAPPER_LONG_HEADROOM_MS;
 // Docker hatches pull images and wait up to 5 min for container readiness.
 const DOCKER_HATCH_TIMEOUT_MS = 10 * 60 * 1000;
 

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -18,6 +18,11 @@ export {
 } from "./util";
 export type { CliInvocation } from "./util";
 export {
+  DAEMON_STOP_TIMEOUT_MS,
+  HOST_WRAPPER_HEADROOM_MS,
+  HOST_WRAPPER_LONG_HEADROOM_MS,
+} from "./lifecycle-budgets";
+export {
   resolveLocalConfigFromEnv,
   resolveLockfilePaths,
   resolveConfigDir,

--- a/packages/local-mode/src/lifecycle-budgets.ts
+++ b/packages/local-mode/src/lifecycle-budgets.ts
@@ -35,3 +35,13 @@ export const HOST_WRAPPER_HEADROOM_MS = 30_000;
 
 /** Headroom for commands that also archive or provision after stopping. */
 export const HOST_WRAPPER_LONG_HEADROOM_MS = 60_000;
+
+/**
+ * How long the CLI polls a freshly started daemon for readiness before giving
+ * up on it.
+ *
+ * A command that starts a daemon spends this before it can even discover it
+ * needs to stop one, so its wrapper budget has to cover the wait and the stop
+ * that may follow it, not just the stop.
+ */
+export const DAEMON_READINESS_WINDOW_MS = 60_000;

--- a/packages/local-mode/src/lifecycle-budgets.ts
+++ b/packages/local-mode/src/lifecycle-budgets.ts
@@ -13,18 +13,18 @@
 /**
  * SIGKILL ceiling for stopping the assistant daemon.
  *
- * The daemon's graceful shutdown fires plugin shutdown hooks, commits the
- * workspace, flushes telemetry, SIGTERMs the worker processes it owns
- * (schedule, route host, resource monitor, memory jobs), and folds the SQLite
- * WAL back into the database. Those steps run near the end of the sequence, so
- * a short grace period kills the daemon before it reaches them: the workers
- * reparent to init and keep running on that runtime version, and an
- * interrupted checkpoint costs a multi-minute WAL recovery on the next start.
+ * Derived from the daemon's own budget rather than guessed. Its shutdown arms
+ * a 30s force-exit timer; when that fires it hands the SQLite WAL fold to a
+ * detached subprocess that outlives `process.exit` and then exits. So a daemon
+ * whose event loop still runs is gone within 30s with its WAL folded, and a
+ * daemon whose event loop is blocked never fires that timer at all, which no
+ * amount of extra waiting changes. Waiting past the daemon's own ceiling plus
+ * a margin therefore buys nothing and only delays the SIGKILL.
  *
  * A ceiling, not a delay. The CLI returns as soon as the process exits, so
  * this only applies to a daemon that is genuinely wedged.
  */
-export const DAEMON_STOP_TIMEOUT_MS = 120_000;
+export const DAEMON_STOP_TIMEOUT_MS = 45_000;
 
 /**
  * Headroom a host wrapper allows on top of {@link DAEMON_STOP_TIMEOUT_MS} for

--- a/packages/local-mode/src/lifecycle-budgets.ts
+++ b/packages/local-mode/src/lifecycle-budgets.ts
@@ -1,0 +1,37 @@
+/**
+ * Timeouts shared between the CLI's lifecycle commands and the host wrappers
+ * that spawn them.
+ *
+ * A host wrapper kills the CLI subprocess when its own timeout expires, so
+ * every wrapper timeout must sit above the budget of the command it runs.
+ * Otherwise a slow-but-succeeding command is killed partway and misreported as
+ * a failure, and the SIGKILL ceiling it was waiting on is never reached.
+ * Deriving the wrapper timeouts from the same constant keeps the two from
+ * drifting apart.
+ */
+
+/**
+ * SIGKILL ceiling for stopping the assistant daemon.
+ *
+ * The daemon's graceful shutdown fires plugin shutdown hooks, commits the
+ * workspace, flushes telemetry, SIGTERMs the worker processes it owns
+ * (schedule, route host, resource monitor, memory jobs), and folds the SQLite
+ * WAL back into the database. Those steps run near the end of the sequence, so
+ * a short grace period kills the daemon before it reaches them: the workers
+ * reparent to init and keep running on that runtime version, and an
+ * interrupted checkpoint costs a multi-minute WAL recovery on the next start.
+ *
+ * A ceiling, not a delay. The CLI returns as soon as the process exits, so
+ * this only applies to a daemon that is genuinely wedged.
+ */
+export const DAEMON_STOP_TIMEOUT_MS = 120_000;
+
+/**
+ * Headroom a host wrapper allows on top of {@link DAEMON_STOP_TIMEOUT_MS} for
+ * the rest of a command: the gateway's drain window, the CES and Qdrant stops,
+ * and any archiving or bring-up the command does around them.
+ */
+export const HOST_WRAPPER_HEADROOM_MS = 30_000;
+
+/** Headroom for commands that also archive or provision after stopping. */
+export const HOST_WRAPPER_LONG_HEADROOM_MS = 60_000;

--- a/packages/local-mode/src/retire.ts
+++ b/packages/local-mode/src/retire.ts
@@ -56,7 +56,7 @@ export function runRetire(
       finish({
         ok: false,
         status: 500,
-        error: "Retire timed out after 60 seconds",
+        error: `Retire timed out after ${RETIRE_TIMEOUT_MS / 1000} seconds`,
       });
     }, RETIRE_TIMEOUT_MS);
 

--- a/packages/local-mode/src/retire.ts
+++ b/packages/local-mode/src/retire.ts
@@ -1,11 +1,17 @@
 import { spawn } from "node:child_process";
 
+import {
+  DAEMON_STOP_TIMEOUT_MS,
+  HOST_WRAPPER_LONG_HEADROOM_MS,
+} from "./lifecycle-budgets";
 import type { CliInvocation } from "./util";
 
-const RETIRE_TIMEOUT_MS = 60_000;
+const RETIRE_TIMEOUT_MS =
+  DAEMON_STOP_TIMEOUT_MS + HOST_WRAPPER_LONG_HEADROOM_MS;
 
 export type RetireResult =
-  { ok: true } | { ok: false; status: number; error: string };
+  | { ok: true }
+  | { ok: false; status: number; error: string };
 
 export interface RetireOptions {
   platformToken?: string;

--- a/packages/local-mode/src/sleep.ts
+++ b/packages/local-mode/src/sleep.ts
@@ -1,12 +1,12 @@
 import { spawn } from "node:child_process";
 
+import {
+  DAEMON_STOP_TIMEOUT_MS,
+  HOST_WRAPPER_HEADROOM_MS,
+} from "./lifecycle-budgets";
 import type { CliInvocation } from "./util";
 
-// The CLI's `sleep` command uses a 120s SIGKILL ceiling for the assistant
-// daemon (WAL checkpoint can be slow on large databases) plus 7s for the
-// gateway drain window. The wrapper timeout must sit above that total so a
-// slow-but-succeeding sleep isn't killed and misreported as a timeout.
-const SLEEP_TIMEOUT_MS = 150_000;
+const SLEEP_TIMEOUT_MS = DAEMON_STOP_TIMEOUT_MS + HOST_WRAPPER_HEADROOM_MS;
 
 export type SleepResult =
   | { ok: true }


### PR DESCRIPTION
## TL;DR

- **The bug:** Upgrading gives the daemon **2 seconds** before SIGKILL. Folding the SQLite WAL is the *last* step of its shutdown, and its own safety net hangs off a 30s timer SIGKILL never lets fire. So **every upgrade skips the WAL fold**, and the next boot pays a recovery that grows with database size (multi-minute on large DBs), looking like a hung assistant.
- **The fix:** One shared stop budget, **45s**, applied at all six daemon-stop sites, with the `packages/local-mode` wrapper timeouts derived from it so a wrapper can never expire before the command it runs.
- **Why 45s:** Derived, not picked. The daemon force-exits itself at 30s (folding the WAL via a detached subprocess on the way out). A live daemon is gone within 30s; a hard-blocked one never benefits from more waiting. 45s = that ceiling + 50% margin.
- **Why it is safe:** It is a *ceiling*, not a wait - a healthy daemon still stops in under a second, unchanged. A wedged daemon takes 45s instead of 2s. `sleep` actually gets **faster** (its hand-picked 120s drops to 45s).
- **Why this shape is right:** The budget nesting (wrapper > CLI stop > daemon force-exit) existed implicitly and was written nowhere, which is how retire's 60s wrapper drifted below the stop it waits on. It is now one constant plus derivations, with a test asserting the relationship instead of a magic number.
- **Reviewers:** Sidd - this replaces your 120s from #34836; Noa - the local-mode wrapper timeouts are now derived. Independent of the other ATL-1349 PRs.
## Why this is needed

`stopProcess` defaults to a 2000 ms SIGTERM grace, and `stopLocalProcesses` (the upgrade path) took that default. The daemon's shutdown fires plugin hooks, commits the workspace, flushes enrichment and telemetry, drains the HTTP server, stops its workers, and only then runs:

```ts
await runAsyncSqlite("PRAGMA wal_checkpoint(TRUNCATE)", "shutdown:wal-checkpoint-truncate");
```

Two seconds does not get near it. And the daemon's own safety net does not help: `spawnDetachedWalCheckpoint()` hangs off its **30 second force-exit timer**, which never fires, because SIGKILL cannot be caught. So the fold is simply skipped, every time, with nothing to notice it.

The comment on that code says what the cost is: the next boot opens a large WAL instead of a small one and pays "a multi-minute recovery". That lands on exactly the people least able to absorb it, the ones with the biggest databases.

**Six call sites stop the daemon, and they had four different behaviours.** `sleep` was the only one with a real value, 120000 ms, kept by hand in a comment. Nothing propagated it, and nothing checked it against the daemon's own ceiling:

| Call site | Before | After |
| --- | --- | --- |
| `sleep` | 120000 ms | `DAEMON_STOP_TIMEOUT_MS` |
| `stopLocalProcesses` (upgrade, hatch rollback) | 2000 ms default | `DAEMON_STOP_TIMEOUT_MS` |
| `retireLocal` | 2000 ms default | `DAEMON_STOP_TIMEOUT_MS` |
| `teleport` | 2000 ms default | `DAEMON_STOP_TIMEOUT_MS` |
| `wake` watch-mode restart | 2000 ms default | `DAEMON_STOP_TIMEOUT_MS` |
| bundled-daemon fallback | 2000 ms default | `DAEMON_STOP_TIMEOUT_MS` |

The bundled-daemon fallback is included deliberately. Failing a health probe does not mean a daemon has nothing to flush, and one still working through a long DB migration is exactly the one whose checkpoint must not be cut short.

**A second, smaller reason:** the same kill strands the daemon's worker processes, which it SIGTERMs just before the WAL fold. #41668 reclaims those on the next boot regardless, so this is not the load-bearing justification. What it adds is that the workers get told to drain instead of being killed mid-turn. The better fix for that is reordering the shutdown so workers are signalled first, which is noted on ATL-1349 and is not this PR.

## What the user experienced before

Every upgrade left the WAL unfolded, so the next start paid a recovery that grows with database size. On a multi-GB database that is minutes of an assistant that appears to hang on startup, with no indication why, after every single update.

Separately, in-flight scheduled work was killed rather than drained, and the background workers survived into the next version (which is ATL-1349's headline, fixed by #41668).

## What the user experiences after

Upgrades fold the WAL, so the next boot opens a small one and starts promptly. Scheduled work in flight gets a chance to finish rather than being killed at two seconds.

**The cost, plainly:** a genuinely *wedged* daemon now takes 45 seconds to be force-killed instead of 2. A healthy daemon is unaffected, because `stopProcess` polls at 100 ms and returns the moment the process exits.

45 seconds is derived rather than chosen. The daemon arms a **30 second force-exit timer**, and when it fires it hands the WAL fold to a detached subprocess that outlives `process.exit`. So a daemon whose event loop still runs is gone within 30 seconds with its WAL folded, and one whose loop is blocked never fires that timer at all, which waiting longer does not change. Past that ceiling plus a margin the extra wait buys nothing and only delays the SIGKILL someone is waiting on.

That also makes `sleep` **faster** than before: it has used 120 seconds since June, chosen before this was a shared constant and without accounting for the daemon's own ceiling. The wrappers follow it down: sleep 150s to 75s, retire 180s to 105s, hatch 240s to 165s.

## The host wrapper changes are a consequence of this, not a separate fix

Being explicit, because it reads like extra value and is not. A host wrapper in `packages/local-mode` kills the CLI subprocess when its own timeout expires, so every wrapper must outlast the command it runs. At the old 2 second stop they all did. Raising the stop is what broke two of them:

| Wrapper | Before | After |
| --- | --- | --- |
| `SLEEP_TIMEOUT_MS` | 150000, hand-maintained | 75000, derived |
| `RETIRE_TIMEOUT_MS` | 60000, fine at a 2s stop, below a longer one | 105000, derived |
| `HATCH_TIMEOUT_MS` | 120000, no room for a rollback stop | 165000, derived |

So the budget moves into `@vellumai/local-mode`, which both the CLI and the wrappers can see, and each wrapper is `DAEMON_STOP_TIMEOUT_MS + headroom`. Without this the change would ship a regression where retiring from the desktop app reports a timeout while the CLI is still archiving.

## Why it is safe

- **A ceiling, not a wait.** Nothing sleeps for the timeout; it bounds how long a non-exiting process is tolerated before SIGKILL. In the common case the daemon exits in well under a second and nothing is different.
- **`sleep` gets faster, not slower.** Its 120000 ms daemon stop drops to 45000 ms, and its wrapper from 150000 to 75000. Its existing test asserting the stop value is updated to the derived one.
- **The enclosing budget has room.** The upgrade flow allows 20 minutes.
- **PID-reuse and liveness guards are untouched.** `stopProcessByPidFile` still verifies the PID belongs to a vellum process before signalling.

## Why this shape

Raising the literals where they hurt is how the drift happened: `sleep` picked a generous value, wrote the reasoning in a comment, and nothing carried it anywhere else or checked it against what the daemon actually does. Deriving the budget from the daemon's force-exit, and each wrapper from the budget, makes both "a wrapper must outlast its command" and "the CLI must outlast the daemon's own ceiling" structural rather than things a future change has to remember.

## Test-mock fix included

Four test files partially mocked `lib/process` without spreading the real module, so a new export resolved to `undefined` inside the module under test and the timeout would have silently become the default. They now spread the real module, matching what `wake.test.ts` already did. Pre-existing trap; any future export from that module would have hit it.

## Not in scope

The CLI spells the daemon readiness deadline as a `60000` literal at several sites in `lib/local.ts`, and `DAEMON_READINESS_WINDOW_MS` mirrors that rather than sourcing it. Threading one constant through those sites means touching several timeouts that share the value but are not all the same thing. Noted on ATL-1349, along with the shutdown-reordering fix that would supersede this PR's worker-related motivation.

## Testing

Type check and lint clean across `cli/` and `packages/local-mode`, CI green. Added a regression test that `retireLocal` passes the budget rather than the default, with a floor asserting the derivation itself: the budget must outlast the daemon's 30s force-exit, so the test cannot be satisfied by shrinking the constant back toward the old grace and does not need editing when the value is tuned. Local test runs are disabled on this machine, so CI is the first execution.

