### PR TITLE
spike(voice): a capture gate for live vision

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.test.ts
@@ -12,8 +12,9 @@
  * below changes gain and offset and NOTHING else, which is the only way to show
  * that invariance is a property of the gate rather than a property of the clip.
  *
- * What these tests do NOT establish is any absolute threshold value. See
- * `assistant/docs/live-vision-frame-gate-spike.md`.
+ * What these tests do NOT establish is any absolute threshold value. The
+ * calibration notes live in the description of the PR that introduced this
+ * module (#41659).
  */
 
 import { describe, expect, test } from "bun:test";
@@ -403,22 +404,31 @@ describe("frame gate keep policy", () => {
     const gate = createFrameGate(TEST_OPTIONS);
     gate.reset(0);
 
-    // Every frame is a different scene, which is the busy-street case: the
-    // novelty threshold provides no protection at all here, and only the floor
-    // stops the flood. This is the assertion that bounds the feature's cost.
+    // The busy-street case: a new scene every other frame, each held for one
+    // repeat so a settled, wildly novel frame arrives about every 66 ms. That
+    // asks for far more keeps than the floor's one per 100 ms, and the settle
+    // check cannot be what limits them, so only the floor stands between this
+    // and a flood. This is the assertion that bounds the feature's cost.
+    const frames = 300;
+    const frameGapMs = 33;
     let keeps = 0;
     let time = 0;
-    for (let step = 0; step < 100; step++) {
-      // 10 s of frames at 100 ms, well inside `motionMaxAgeMs` so the settle
-      // check is live and rejecting too.
-      if (gate.offer(scene({ seed: 100 + step }), time).keep) {
+    for (let step = 0; step < frames; step++) {
+      if (gate.offer(scene({ seed: 100 + Math.floor(step / 2) }), time).keep) {
         keeps += 1;
       }
-      time += 100;
+      time += frameGapMs;
     }
-    // 10 s at a 100 ms floor cannot exceed 101 keeps in principle; what matters
-    // is that it lands near the floor's rate rather than near the frame rate.
-    expect(keeps).toBeLessThanOrEqual(10_000 / TEST_OPTIONS.minIntervalMs + 1);
+    // Offered ~150 settled novel frames; the floor admits at most one per
+    // `minIntervalMs`. The upper bound sits far below both the offered frame
+    // count and the eligible-keep count, so removing or breaking the
+    // rate-floor rung fails this assertion rather than slipping past it. The
+    // lower bound proves the gate is keeping near the floor's rate instead of
+    // going silent.
+    const elapsedMs = frames * frameGapMs;
+    const floorBound = Math.floor(elapsedMs / TEST_OPTIONS.minIntervalMs) + 1;
+    expect(keeps).toBeLessThanOrEqual(floorBound);
+    expect(keeps).toBeGreaterThanOrEqual(Math.floor(floorBound / 2));
   });
 });
 
@@ -435,5 +445,24 @@ describe("frame gate reset", () => {
     const afterFlip = gate.offer(scene({ seed: 120 }), 1_000);
     expect(afterFlip.reason).toBe("first");
     expect(afterFlip.novelty).toBeNull();
+  });
+
+  test("a reset does not open a gap in the rate floor", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    expect(gate.offer(scene({ seed: 16 }), 0).keep).toBe(true);
+
+    // A flip right on the heels of a keep. The baseline is rightly gone, but
+    // the keep was already paid for, so the next keep still waits out the
+    // floor: otherwise flipping back and forth doubles the keep rate.
+    gate.reset(20);
+    const tooSoon = gate.offer(scene({ seed: 160 }), 50);
+    expect(tooSoon.keep).toBe(false);
+    expect(tooSoon.reason).toBe("rate-floor");
+
+    const afterFloor = gate.offer(scene({ seed: 160 }), 150);
+    expect(afterFloor.keep).toBe(true);
+    expect(afterFloor.reason).toBe("first");
+    expect(afterFloor.novelty).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.test.ts
@@ -1,0 +1,439 @@
+/**
+ * Tests for the live-vision frame gate.
+ *
+ * These are the spike's answer to the first risk: does a 16x16 normalized
+ * difference actually separate "the view changed" from the three things that
+ * move pixels without meaning anything on a handheld phone, namely exposure
+ * drift, sensor noise, and hand shake.
+ *
+ * The frames are synthetic on purpose. Real footage tunes the thresholds, but
+ * it cannot prove the state machine, because a recorded clip cannot be replayed
+ * with one variable changed at a time. A generated scene can: the exposure test
+ * below changes gain and offset and NOTHING else, which is the only way to show
+ * that invariance is a property of the gate rather than a property of the clip.
+ *
+ * What these tests do NOT establish is any absolute threshold value. See
+ * `assistant/docs/live-vision-frame-gate-spike.md`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  createFrameGate,
+  DEFAULT_FRAME_GATE_OPTIONS,
+  FRAME_GRID_CELLS,
+  FRAME_GRID_SIZE,
+  type FrameGateOptions,
+  type FrameGrid,
+} from "./voice-frame-gate";
+
+/**
+ * Short intervals so a test can span several keeps in a readable number of
+ * frames. The thresholds are the real defaults: the timing is what is being
+ * made convenient, not the decision.
+ */
+const TEST_OPTIONS: FrameGateOptions = {
+  ...DEFAULT_FRAME_GATE_OPTIONS,
+  // Pinned rather than inherited. These tests cover the mechanism, and the
+  // shipped tuning moves as real footage accumulates: coupling the two makes a
+  // threshold change look like a broken state machine.
+  noveltyThreshold: 0.35,
+  minIntervalMs: 100,
+  maxIntervalMs: 1_000,
+  settleGraceMs: 200,
+  warmupMs: 0,
+};
+
+/**
+ * Score bounds the metric must satisfy for ANY workable threshold to exist.
+ *
+ * Both are calibrated against the real clip, not invented: nine seconds of
+ * deliberately holding a phone still peaked at 0.0925 novelty, and genuinely
+ * distinct views scored 0.97 to 1.12. These constants bracket that gap with
+ * margin. If a change to the metric pushes a nuisance case above the ceiling
+ * or a real change below the floor, no single threshold divides them any more
+ * and the approach itself is in trouble, which is what these assert.
+ */
+const NUISANCE_CEILING = 0.15;
+const SIGNAL_FLOOR = 0.3;
+
+/** Deterministic RNG, so a threshold assertion cannot flake. */
+function makeRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function clampLuma(value: number): number {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+/**
+ * A synthetic scene with real spatial structure.
+ *
+ * Structure matters: a grid of uniform random values has no correlation
+ * between neighbours, so every comparison against it looks like a scene change
+ * and the tests would pass for the wrong reason. This has edges and gradients,
+ * which is what a downscaled photograph looks like.
+ *
+ * `panX` slides the sampling window horizontally, which is how a pan is
+ * simulated without needing a larger source image.
+ */
+function scene({
+  seed,
+  panX = 0,
+}: {
+  seed: number;
+  panX?: number;
+}): FrameGrid {
+  const grid = new Uint8Array(FRAME_GRID_CELLS);
+  for (let y = 0; y < FRAME_GRID_SIZE; y++) {
+    for (let x = 0; x < FRAME_GRID_SIZE; x++) {
+      const sx = x + panX;
+      const value =
+        128 +
+        60 * Math.sin((sx + seed * 7) * 0.4) +
+        40 * Math.cos((y + seed * 3) * 0.6) +
+        30 * Math.sin((sx * y + seed * 11) * 0.11);
+      grid[y * FRAME_GRID_SIZE + x] = clampLuma(value);
+    }
+  }
+  return grid;
+}
+
+/** Apply a gain and offset, as auto-exposure and auto-white-balance do. */
+function exposed(
+  grid: FrameGrid,
+  { gain, offset }: { gain: number; offset: number },
+): FrameGrid {
+  const out = new Uint8Array(FRAME_GRID_CELLS);
+  for (let i = 0; i < FRAME_GRID_CELLS; i++) {
+    out[i] = clampLuma(grid[i]! * gain + offset);
+  }
+  return out;
+}
+
+/** Add zero-mean sensor noise of the given amplitude in luma units. */
+function noisy(
+  grid: FrameGrid,
+  amplitude: number,
+  random: () => number,
+): FrameGrid {
+  const out = new Uint8Array(FRAME_GRID_CELLS);
+  for (let i = 0; i < FRAME_GRID_CELLS; i++) {
+    out[i] = clampLuma(grid[i]! + (random() * 2 - 1) * amplitude);
+  }
+  return out;
+}
+
+/** A hand over the lens: near-uniform and dark, with a little noise. */
+function occluded(random: () => number): FrameGrid {
+  const out = new Uint8Array(FRAME_GRID_CELLS);
+  for (let i = 0; i < FRAME_GRID_CELLS; i++) {
+    out[i] = clampLuma(38 + (random() * 2 - 1) * 4);
+  }
+  return out;
+}
+
+/** A blank wall: bright, near-uniform, nothing to photograph. */
+function flatWall(random: () => number): FrameGrid {
+  const out = new Uint8Array(FRAME_GRID_CELLS);
+  for (let i = 0; i < FRAME_GRID_CELLS; i++) {
+    out[i] = clampLuma(180 + (random() * 2 - 1) * 3);
+  }
+  return out;
+}
+
+/** Novelty of `candidate` against a gate whose last keep was `baseline`. */
+function noveltyBetween(baseline: FrameGrid, candidate: FrameGrid): number {
+  const gate = createFrameGate(TEST_OPTIONS);
+  gate.reset(0);
+  gate.offer(baseline, 0);
+  // Far enough apart that the settle check is skipped, so the reported novelty
+  // is not shadowed by a "moving" decision.
+  const decision = gate.offer(candidate, 10_000);
+  return decision.novelty ?? Number.NaN;
+}
+
+describe("createFrameGate", () => {
+  test("rejects a grid of the wrong size", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    expect(() => gate.offer(new Uint8Array(64), 0)).toThrow(
+      /expects 256 cells, received 64/,
+    );
+  });
+
+  test("keeps the first settled frame after the camera opens", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    const decision = gate.offer(scene({ seed: 1 }), 0);
+    expect(decision.keep).toBe(true);
+    expect(decision.reason).toBe("first");
+    // Nothing to compare against yet, so both scores are honestly absent
+    // rather than reported as zero.
+    expect(decision.motion).toBeNull();
+    expect(decision.novelty).toBeNull();
+  });
+
+  test("skips frames inside the post-open warmup", () => {
+    const gate = createFrameGate({ ...TEST_OPTIONS, warmupMs: 600 });
+    gate.reset(0);
+    expect(gate.offer(scene({ seed: 1 }), 0).reason).toBe("warmup");
+    expect(gate.offer(scene({ seed: 1 }), 599).reason).toBe("warmup");
+    // The first frame past the window becomes the baseline, so a badly exposed
+    // opening frame is never what the assistant sees first.
+    expect(gate.offer(scene({ seed: 1 }), 600).keep).toBe(true);
+  });
+});
+
+describe("frame gate invariance", () => {
+  /**
+   * The headline invariant. A phone re-exposing is the single most common
+   * whole-frame pixel change there is, and a gate that fires on it would send
+   * a photo every time a cloud moved.
+   */
+  test("an exposure change alone is not novelty", () => {
+    const base = scene({ seed: 2 });
+    const brighter = exposed(base, { gain: 1.15, offset: 22 });
+    const darker = exposed(base, { gain: 0.85, offset: -18 });
+
+    expect(noveltyBetween(base, brighter)).toBeLessThan(NUISANCE_CEILING);
+    expect(noveltyBetween(base, darker)).toBeLessThan(
+      NUISANCE_CEILING,
+    );
+  });
+
+  test("sensor noise alone is not novelty", () => {
+    const random = makeRandom(7);
+    const base = scene({ seed: 3 });
+    const sameViewAgain = noisy(base, 6, random);
+
+    expect(noveltyBetween(base, sameViewAgain)).toBeLessThan(NUISANCE_CEILING);
+  });
+
+  test("a different scene is novelty, by a wide margin", () => {
+    const base = scene({ seed: 4 });
+    const different = scene({ seed: 40 });
+    const cutScore = noveltyBetween(base, different);
+
+    expect(cutScore).toBeGreaterThan(SIGNAL_FLOOR);
+    // The separation is what makes the threshold tunable at all: if a scene cut
+    // and an exposure change landed near each other, no single number would
+    // divide them and the whole approach would be wrong. Measured separation on
+    // these fixtures is roughly 10x; asserted at 5x because the exact ratio is
+    // a property of the chosen seeds, and a test that sits a few percent from
+    // failing is a flake waiting for someone to add a fixture.
+    const exposureScore = noveltyBetween(
+      base,
+      exposed(base, { gain: 1.15, offset: 22 }),
+    );
+    expect(cutScore).toBeGreaterThan(exposureScore * 5);
+  });
+
+  /**
+   * The limitation, pinned so it is a known property rather than a surprise in
+   * the field. Clipping destroys information instead of rescaling it, so no
+   * normalization recovers it and the frame genuinely does look different.
+   */
+  test("a clipping exposure swing defeats invariance, by design", () => {
+    const base = scene({ seed: 2 });
+    const blownOut = exposed(base, { gain: 1.5, offset: 40 });
+    expect(noveltyBetween(base, blownOut)).toBeGreaterThan(
+      noveltyBetween(base, exposed(base, { gain: 1.15, offset: 22 })) * 3,
+    );
+  });
+});
+
+describe("frame gate featureless rejection", () => {
+  /**
+   * Both of these exist because of a measured failure, not a predicted one.
+   * Two frames of the same blank wall scored 0.33 against each other, just
+   * under the 0.35 keep threshold, because normalization divides a featureless
+   * frame by its own sensor noise. Rejecting on absolute detail is the fix, and
+   * it is the right behaviour independently: nobody wants a photo of a wall.
+   */
+  test("skips a hand over the lens instead of sending it", () => {
+    const random = makeRandom(11);
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    gate.offer(scene({ seed: 5 }), 0);
+
+    const decision = gate.offer(occluded(random), 10_000);
+    expect(decision.keep).toBe(false);
+    expect(decision.reason).toBe("featureless");
+    expect(decision.detail).toBeLessThan(TEST_OPTIONS.minDetail);
+  });
+
+  test("never makes a blank wall the baseline", () => {
+    const random = makeRandom(13);
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+
+    // A camera opening while face-down on a table. Keeping this frame would
+    // both send a useless photo and poison every comparison after it.
+    const decision = gate.offer(flatWall(random), 0);
+    expect(decision.reason).toBe("featureless");
+
+    // Lifting the phone off the table reads as movement, because it is: the
+    // rejected frame is still the motion reference even though it was never
+    // kept. One settled frame later the gate takes its first keep, which is
+    // what proves the wall never became a baseline.
+    expect(gate.offer(scene({ seed: 14 }), 100).reason).toBe("moving");
+    const settled = gate.offer(scene({ seed: 14 }), 133);
+    expect(settled.reason).toBe("first");
+    expect(settled.novelty).toBeNull();
+  });
+
+  test("a real scene clears the detail floor with room to spare", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    // Guards the fixtures as much as the gate: if the synthetic scenes drifted
+    // below the floor, every other test here would pass for the wrong reason.
+    expect(gate.offer(scene({ seed: 15 }), 0).detail).toBeGreaterThan(
+      TEST_OPTIONS.minDetail * 3,
+    );
+  });
+});
+
+describe("frame gate settle behaviour", () => {
+  test("skips a moving view rather than keeping a smeared frame", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    gate.offer(scene({ seed: 6 }), 0);
+
+    // Frames 33 ms apart, panning fast. Inside `motionMaxAgeMs`, so motion is
+    // real evidence.
+    let time = 33;
+    let sawMoving = false;
+    for (let step = 1; step <= 12; step++) {
+      const decision = gate.offer(scene({ seed: 6, panX: step * 2 }), time);
+      if (decision.reason === "moving") {
+        sawMoving = true;
+      }
+      time += 33;
+    }
+    expect(sawMoving).toBe(true);
+  });
+
+  test("reports no motion when frames arrive too far apart to judge", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    gate.offer(scene({ seed: 7 }), 0);
+
+    // One sample per second is the naive interval design. A low difference here
+    // would mean the scene is static, not that the camera is steady, so the
+    // gate declines to call it motion at all.
+    const decision = gate.offer(scene({ seed: 7, panX: 6 }), 1_000);
+    expect(decision.motion).toBeNull();
+    expect(decision.reason).not.toBe("moving");
+  });
+
+  test("keeps a moving frame once the settle grace expires", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    gate.offer(scene({ seed: 8 }), 0);
+
+    // A camera that never settles, as in someone's hand while they walk. The
+    // failure this guards against is silence that looks exactly like the
+    // feature being broken.
+    let time = 33;
+    let keptWhileMoving = false;
+    while (time < 2_000) {
+      const decision = gate.offer(
+        scene({ seed: 8, panX: Math.round(time / 20) }),
+        time,
+      );
+      if (decision.keep && (decision.motion ?? 0) >= TEST_OPTIONS.settleThreshold) {
+        keptWhileMoving = true;
+        break;
+      }
+      time += 33;
+    }
+    expect(keptWhileMoving).toBe(true);
+  });
+});
+
+describe("frame gate keep policy", () => {
+  test("a slow pan is eventually kept, because novelty accumulates", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    gate.offer(scene({ seed: 9 }), 0);
+
+    // This is the case that a previous-frame comparison cannot catch: each
+    // frame is nearly identical to the one before it, so a consecutive-frame
+    // gate would capture nothing while the view changed completely.
+    let time = 200;
+    let kept = false;
+    for (let step = 1; step <= 60; step++) {
+      // A quarter cell per frame: below any sane settle threshold.
+      const decision = gate.offer(
+        scene({ seed: 9, panX: step * 0.25 }),
+        time,
+      );
+      if (decision.keep) {
+        kept = true;
+        expect(decision.reason).toBe("novel");
+        break;
+      }
+      time += 200;
+    }
+    expect(kept).toBe(true);
+  });
+
+  test("refreshes a completely static view on the heartbeat", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    const still = scene({ seed: 10 });
+    gate.offer(still, 0);
+
+    // Nothing changes at all, so novelty never fires. Without a heartbeat the
+    // assistant's picture of the room would be frozen at whatever it saw first.
+    expect(gate.offer(still, 500).reason).toBe("unchanged");
+    const beat = gate.offer(still, 1_000);
+    expect(beat.keep).toBe(true);
+    expect(beat.reason).toBe("heartbeat");
+  });
+
+  test("the rate floor bounds the keep rate on a saturating view", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+
+    // Every frame is a different scene, which is the busy-street case: the
+    // novelty threshold provides no protection at all here, and only the floor
+    // stops the flood. This is the assertion that bounds the feature's cost.
+    let keeps = 0;
+    let time = 0;
+    for (let step = 0; step < 100; step++) {
+      // 10 s of frames at 100 ms, well inside `motionMaxAgeMs` so the settle
+      // check is live and rejecting too.
+      if (gate.offer(scene({ seed: 100 + step }), time).keep) {
+        keeps += 1;
+      }
+      time += 100;
+    }
+    // 10 s at a 100 ms floor cannot exceed 101 keeps in principle; what matters
+    // is that it lands near the floor's rate rather than near the frame rate.
+    expect(keeps).toBeLessThanOrEqual(10_000 / TEST_OPTIONS.minIntervalMs + 1);
+  });
+});
+
+describe("frame gate reset", () => {
+  test("a flip invalidates the baseline instead of reporting a scene change", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    gate.offer(scene({ seed: 12 }), 0);
+
+    // The front camera is mirrored and points somewhere else, so every score
+    // against the rear camera's baseline would be meaningless. After a reset
+    // the next frame is a first keep, not a novelty keep.
+    gate.reset(1_000);
+    const afterFlip = gate.offer(scene({ seed: 120 }), 1_000);
+    expect(afterFlip.reason).toBe("first");
+    expect(afterFlip.novelty).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.test.ts
@@ -465,4 +465,30 @@ describe("frame gate reset", () => {
     expect(afterFloor.reason).toBe("first");
     expect(afterFloor.novelty).toBeNull();
   });
+
+  test("the settle grace after a reset waits out the retained rate floor", () => {
+    const gate = createFrameGate(TEST_OPTIONS);
+    gate.reset(0);
+    expect(gate.offer(scene({ seed: 18 }), 0).keep).toBe(true);
+
+    // A flip right after a keep, with the camera still moving. A keep becomes
+    // possible only when the retained floor expires at 100 ms, so the settle
+    // check owns the full grace from there and the earliest forced keep lands
+    // at 300 ms. Anchoring the grace at the first post-reset offer instead
+    // would force a smeared keep the moment the floor opens.
+    gate.reset(10);
+    let firstKeepAtMs: number | null = null;
+    for (let step = 0; step < 12; step++) {
+      const time = 20 + step * 33;
+      const decision = gate.offer(scene({ seed: 18, panX: step * 2 }), time);
+      if (decision.keep) {
+        firstKeepAtMs = time;
+        break;
+      }
+    }
+    expect(firstKeepAtMs).not.toBeNull();
+    expect(firstKeepAtMs!).toBeGreaterThanOrEqual(
+      TEST_OPTIONS.minIntervalMs + TEST_OPTIONS.settleGraceMs,
+    );
+  });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.ts
@@ -248,8 +248,11 @@ export interface FrameGate {
    */
   offer(grid: FrameGrid, nowMs: number): FrameGateDecision;
   /**
-   * Drop all history: no last-kept baseline, no previous frame, and a fresh
-   * warmup window starting at `nowMs`.
+   * Drop all comparison history: no last-kept baseline, no previous frame,
+   * and a fresh warmup window starting at `nowMs`. The one survivor is the
+   * rate floor's clock: a keep made just before the reset still counts
+   * against {@link FrameGateOptions.minIntervalMs}, because the floor bounds
+   * cost and a reset does not refund the frame already sent.
    *
    * Call this when the camera opens, and on anything else that invalidates
    * comparison against earlier frames. A camera flip is the important one: the
@@ -326,7 +329,9 @@ export function createFrameGate(
   let hasPrevious = false;
   let hasKept = false;
   let previousAtMs = 0;
-  let keptAtMs = 0;
+  // When the last keep happened. Survives reset() on purpose: the rate floor
+  // is the feature's cost bound, and a camera flip must not open a gap in it.
+  let keptAtMs = Number.NEGATIVE_INFINITY;
   let warmupUntilMs = Number.NEGATIVE_INFINITY;
   // The first offer that got past warmup, which is the moment the very first
   // keep became possible. Only consulted before that first keep: afterwards
@@ -415,6 +420,12 @@ export function createFrameGate(
       const forced = nowMs - eligibleSinceMs >= options.settleGraceMs;
 
       if (!hasKept) {
+        // The baseline is gone after a reset, but the floor's clock is not: a
+        // first keep is still a keep, and it pays the same minimum gap as any
+        // other, so a flip right after a keep cannot raise the keep rate.
+        if (nowMs - keptAtMs < options.minIntervalMs) {
+          return skipFrame(nowMs, "rate-floor", motion, novelty);
+        }
         if (moving && !forced) {
           return skipFrame(nowMs, "moving", motion, novelty);
         }
@@ -441,7 +452,9 @@ export function createFrameGate(
       hasPrevious = false;
       hasKept = false;
       previousAtMs = 0;
-      keptAtMs = 0;
+      // `keptAtMs` is deliberately not cleared: comparison history is invalid
+      // after a reset, but the cost of the last keep is already paid and the
+      // rate floor still counts it.
       warmupUntilMs = nowMs + options.warmupMs;
       firstEligibleAtMs = null;
     },

--- a/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.ts
@@ -1,0 +1,449 @@
+/**
+ * The live-vision frame gate: decides which viewfinder frames are worth
+ * keeping, so an interval capture can run without flooding the conversation.
+ *
+ * ## What this is not
+ *
+ * It is not an image differ. It never sees an image. It sees a tiny grid of
+ * luma samples and a timestamp, and answers keep or skip. Everything expensive
+ * (encoding a JPEG, crossing the Capacitor bridge, uploading, persisting an
+ * inline history image) happens only on a keep, which is the entire point: a
+ * gate that has to encode a frame before rejecting it has not saved anything.
+ *
+ * Two samplers feed it the same {@link FrameGrid}. On the web path a `<video>`
+ * is drawn to a small canvas; on iOS the native preview's existing
+ * `AVCaptureVideoDataOutput` buffer is strided down in Swift. Keeping the
+ * decision here rather than in each sampler is what lets the thresholds be
+ * tuned in a browser and shipped to a phone unchanged.
+ *
+ * ## The two scores
+ *
+ * Both come from the same grid, which is why the gate needs only one per
+ * frame:
+ *
+ * - `motion` compares the frame to the one immediately before it. It answers
+ *   "is the camera settled right now". On a handheld phone this doubles as the
+ *   blur check: a frame captured while the view is moving is a smeared frame,
+ *   and settled and sharp are the same condition.
+ * - `novelty` compares the frame to the last frame actually KEPT. It answers
+ *   "is this worth sending".
+ *
+ * Comparing against the last kept frame rather than the previous frame is the
+ * detail that makes a slow pan work. Frame to frame a slow pan never exceeds
+ * any sane threshold, so a gate keyed on consecutive frames captures nothing
+ * while the scene changes completely.
+ *
+ * ## Why the grid is normalized
+ *
+ * A phone's auto-exposure and auto-white-balance drift constantly, and a raw
+ * pixel delta fires on a cloud crossing the sun. Each grid is z-scored (mean
+ * subtracted, divided by its own standard deviation) before comparison, which
+ * makes both scores invariant to global brightness and gain. The standard
+ * deviation is floored, because a genuinely flat view (a phone pointed at a
+ * white wall) has almost none, and dividing by it would amplify sensor noise
+ * into a scene change. A frame with too little structure to normalize safely
+ * is rejected outright: see {@link FrameGateOptions.minDetail}.
+ *
+ * Downscaling to {@link FRAME_GRID_SIZE} squared is itself the low-pass filter
+ * that removes sensor noise and sub-pixel hand shake, so no separate blur or
+ * denoise step is needed.
+ *
+ * ## The one case normalization cannot save
+ *
+ * Exposure invariance holds only while the sensor is not clipping. A hard
+ * swing that blows out highlights or crushes shadows destroys information
+ * rather than rescaling it, and no normalization recovers what was clipped.
+ * Pointing a phone from a dim room at a bright window will therefore score as
+ * a real change. That is a limitation to know about, not a bug to fix here:
+ * the frame genuinely does look different, and the model would probably rather
+ * see it than not.
+ */
+
+/**
+ * Width and height of the comparison grid, in cells.
+ *
+ * 16 is chosen to be large enough that a change confined to one part of the
+ * frame still moves the score, and small enough that the whole grid is 256
+ * bytes: cheap to compute on a video callback thread and negligible to send
+ * across the Capacitor bridge every frame.
+ */
+export const FRAME_GRID_SIZE = 16;
+
+/** Number of cells in a {@link FrameGrid}. */
+export const FRAME_GRID_CELLS = FRAME_GRID_SIZE * FRAME_GRID_SIZE;
+
+/**
+ * One frame reduced to grayscale luma, row-major, 0-255.
+ *
+ * A `Uint8Array` rather than floats because this is the wire format: the iOS
+ * sampler produces exactly these bytes from the pixel buffer, and widening
+ * them would triple the bridge payload for no precision that survives the
+ * downscale.
+ */
+export type FrameGrid = Uint8Array;
+
+/** Why the gate kept or skipped a frame. Surfaced for the tuning readout. */
+export type FrameGateReason =
+  /** Nothing has been kept yet, and the view has settled. */
+  | "first"
+  /** Enough changed against the last kept frame. */
+  | "novel"
+  /** Nothing changed, but the last keep is old enough to refresh. */
+  | "heartbeat"
+  /** Still inside the post-open warmup, where exposure has not converged. */
+  | "warmup"
+  /** A keep happened too recently. */
+  | "rate-floor"
+  /** The view is moving, so this frame is likely smeared. */
+  | "moving"
+  /** The view has almost no structure: a blank wall, or a hand over the lens. */
+  | "featureless"
+  /** Settled, recent enough, and materially the same as the last keep. */
+  | "unchanged";
+
+export interface FrameGateDecision {
+  readonly keep: boolean;
+  readonly reason: FrameGateReason;
+  /**
+   * Difference from the previous frame, or null when there was no previous
+   * frame close enough in time for the number to mean anything. See
+   * {@link FrameGateOptions.motionMaxAgeMs}.
+   */
+  readonly motion: number | null;
+  /** Difference from the last kept frame, or null when nothing is kept yet. */
+  readonly novelty: number | null;
+  /**
+   * How much spatial structure this frame has, as the standard deviation of
+   * its luma in 0-255 units, before normalization. A photographic scene runs
+   * in the tens; a blank wall or a palm over the lens is low single digits.
+   */
+  readonly detail: number;
+}
+
+export interface FrameGateOptions {
+  /**
+   * Novelty at or above which a settled frame is kept.
+   *
+   * In z-scored mean-absolute-difference units, so roughly: 0 is an identical
+   * view, small values are the same scene from a slightly different angle, and
+   * large ones are a different subject. Empirical, and the one number the
+   * tuning rig exists to find.
+   */
+  readonly noveltyThreshold: number;
+  /**
+   * Motion at or above which the view counts as still moving. Measured in the
+   * same units as novelty, but across a much shorter interval, so it is a much
+   * smaller number.
+   */
+  readonly settleThreshold: number;
+  /**
+   * Shortest gap between two keeps. This, not the novelty threshold, is what
+   * bounds the cost of the feature: pointed at a busy street every frame is
+   * genuinely novel, and only a floor stops that from becoming a flood.
+   */
+  readonly minIntervalMs: number;
+  /**
+   * Longest gap between two keeps while the view is settled. Refreshes the
+   * model's picture of a static scene, and is why a motionless camera does not
+   * go silent forever.
+   */
+  readonly maxIntervalMs: number;
+  /**
+   * How long to wait for a settled frame before keeping a moving one anyway.
+   *
+   * Without this a camera in the hand of someone walking never settles and so
+   * never sends, which is the one failure mode that looks exactly like the
+   * feature being broken. A slightly smeared frame beats nothing at all.
+   */
+  readonly settleGraceMs: number;
+  /**
+   * Frames to ignore after {@link FrameGate.reset}, in milliseconds.
+   *
+   * A camera that has just started delivers badly exposed frames while
+   * auto-exposure and white balance converge. On iOS these are visibly green
+   * or black. Keeping one as the first thing the assistant sees is worse than
+   * waiting.
+   */
+  readonly warmupMs: number;
+  /**
+   * Luma standard deviation below which a frame is treated as featureless and
+   * never kept.
+   *
+   * Discovered by measurement rather than designed in. Normalization divides
+   * by a frame's own deviation, so two frames of the same blank wall are two
+   * fields of amplified sensor noise, and they score as a scene change against
+   * each other. Flooring the divisor (see {@link MIN_GRID_DEVIATION}) bounds
+   * that but does not remove it.
+   *
+   * Rejecting the frame outright is the better answer for a second reason that
+   * has nothing to do with the arithmetic: a photograph of a blank wall or of
+   * the user's palm is worthless to send. The case where the gate cannot tell
+   * whether anything changed is the same case where nobody wants the picture.
+   */
+  readonly minDetail: number;
+  /**
+   * Maximum age of the previous frame for {@link FrameGateDecision.motion} to
+   * be meaningful.
+   *
+   * Motion means "the view moved between two adjacent frames". At video rate
+   * the gap is tens of milliseconds and the number is a real settle signal. If
+   * frames arrive a second apart, a low value means the scene is static, not
+   * that the camera is steady, and applying the settle check to it would
+   * reject on the wrong evidence. Past this age the check is skipped and
+   * `motion` is reported as null.
+   */
+  readonly motionMaxAgeMs: number;
+}
+
+/**
+ * Calibrated against two handheld clips: one mostly moving, one fixed on a
+ * subject while hands work on it. Not a shipped configuration, since two clips
+ * are enough to rule values out but not to pin one.
+ *
+ * What the clips established:
+ *
+ * - Holding the phone still peaked at 0.0925 novelty on one clip and 0.039 on
+ *   the other, against real auto-exposure and real sensor noise. The threshold
+ *   sits an order of magnitude above that floor.
+ * - Genuinely distinct views score around 1.0. The same subject from a
+ *   slightly different angle scores 0.35 to 0.60, so a 0.35 threshold kept one
+ *   storage box five times in a row.
+ * - `noveltyThreshold` also controls SHARPNESS, which is not obvious. A lower
+ *   threshold fires earlier, just as a scene settles into its new view. A
+ *   higher one waits for more accumulated difference, by which point the
+ *   camera is often moving again. At 0.8 both clips produced a keep above the
+ *   settle threshold; at 0.6 neither produced any, while capturing more
+ *   distinct subjects. Sharper photos from a lower bar.
+ * - 0.6 costs roughly three near-duplicate frames out of nine on the moving
+ *   clip. Both marginal keeps landed exactly on the threshold, which is what a
+ *   well-placed bar looks like rather than a badly placed one.
+ * - The rate floor, not the threshold, bounds the keep rate on moving footage:
+ *   sweeping the threshold across the low range changes nothing there, because
+ *   the floor gates every keep first. The threshold earns its keep on a fixed
+ *   camera, where 30% of frames are turned away as unchanged.
+ *
+ * Which is why `minIntervalMs` is the other number to argue about. Images
+ * persist inline in conversation history and are re-sent on every turn, so at
+ * this floor a ten-minute call is on the order of a hundred images re-sent
+ * repeatedly. Retention has to be solved alongside this regardless of tuning.
+ */
+export const DEFAULT_FRAME_GATE_OPTIONS: FrameGateOptions = {
+  noveltyThreshold: 0.6,
+  settleThreshold: 0.08,
+  minIntervalMs: 5_000,
+  maxIntervalMs: 30_000,
+  settleGraceMs: 5_000,
+  warmupMs: 600,
+  minDetail: 8,
+  motionMaxAgeMs: 120,
+};
+
+export interface FrameGate {
+  /**
+   * Offer one frame. `grid` is read synchronously and never retained, so a
+   * caller may reuse a single scratch buffer for every frame.
+   *
+   * `nowMs` is a monotonic reading in milliseconds. The gate never reads a
+   * clock itself, which is what makes it testable without faking time.
+   */
+  offer(grid: FrameGrid, nowMs: number): FrameGateDecision;
+  /**
+   * Drop all history: no last-kept baseline, no previous frame, and a fresh
+   * warmup window starting at `nowMs`.
+   *
+   * Call this when the camera opens, and on anything else that invalidates
+   * comparison against earlier frames. A camera flip is the important one: the
+   * front camera is mirrored and points somewhere else entirely, so every
+   * score against a rear-camera baseline is meaningless.
+   */
+  reset(nowMs: number): void;
+}
+
+/**
+ * Floor for a grid's standard deviation, in luma units, before it is used as a
+ * normalizing divisor.
+ *
+ * A featureless view (a wall, a ceiling, a hand over the lens) has almost no
+ * spatial variation, and what remains is sensor noise. Dividing by that would
+ * scale noise up to the magnitude of real structure and make two frames of the
+ * same blank wall look like a scene change.
+ */
+const MIN_GRID_DEVIATION = 6;
+
+/**
+ * Z-score `grid` into `out`: subtract the mean, divide by the deviation.
+ *
+ * This is what makes both scores invariant to exposure. Two frames of the same
+ * scene at different brightness have the same normalized form.
+ *
+ * Returns the frame's UNFLOORED luma deviation, which is the detail measure
+ * the featureless check reads. The floor applies to the divisor only.
+ */
+function normalizeGrid(grid: FrameGrid, out: Float32Array): number {
+  let sum = 0;
+  for (let i = 0; i < FRAME_GRID_CELLS; i++) {
+    sum += grid[i]!;
+  }
+  const mean = sum / FRAME_GRID_CELLS;
+
+  let variance = 0;
+  for (let i = 0; i < FRAME_GRID_CELLS; i++) {
+    const delta = grid[i]! - mean;
+    variance += delta * delta;
+  }
+  const detail = Math.sqrt(variance / FRAME_GRID_CELLS);
+  const divisor = Math.max(detail, MIN_GRID_DEVIATION);
+
+  for (let i = 0; i < FRAME_GRID_CELLS; i++) {
+    out[i] = (grid[i]! - mean) / divisor;
+  }
+  return detail;
+}
+
+/** Mean absolute difference between two normalized grids. */
+function meanAbsoluteDifference(a: Float32Array, b: Float32Array): number {
+  let total = 0;
+  for (let i = 0; i < FRAME_GRID_CELLS; i++) {
+    total += Math.abs(a[i]! - b[i]!);
+  }
+  return total / FRAME_GRID_CELLS;
+}
+
+/**
+ * Create a gate.
+ *
+ * Allocation-free after construction: three fixed grids and no per-frame
+ * garbage, so this can run on every frame of a video callback without
+ * producing collection pressure during a live call.
+ */
+export function createFrameGate(
+  options: FrameGateOptions = DEFAULT_FRAME_GATE_OPTIONS,
+): FrameGate {
+  const current = new Float32Array(FRAME_GRID_CELLS);
+  const previous = new Float32Array(FRAME_GRID_CELLS);
+  const kept = new Float32Array(FRAME_GRID_CELLS);
+
+  let hasPrevious = false;
+  let hasKept = false;
+  let previousAtMs = 0;
+  let keptAtMs = 0;
+  let warmupUntilMs = Number.NEGATIVE_INFINITY;
+  // The first offer that got past warmup, which is the moment the very first
+  // keep became possible. Only consulted before that first keep: afterwards
+  // eligibility is governed by `minIntervalMs` instead.
+  let firstEligibleAtMs: number | null = null;
+
+  // Detail of the frame being decided right now. Held here rather than passed
+  // through every helper: it is a property of `current`, which the helpers
+  // already read from.
+  let detail = 0;
+
+  function rememberPrevious(nowMs: number): void {
+    previous.set(current);
+    hasPrevious = true;
+    previousAtMs = nowMs;
+  }
+
+  function keepFrame(
+    nowMs: number,
+    reason: FrameGateReason,
+    motion: number | null,
+    novelty: number | null,
+  ): FrameGateDecision {
+    kept.set(current);
+    hasKept = true;
+    keptAtMs = nowMs;
+    rememberPrevious(nowMs);
+    return { keep: true, reason, motion, novelty, detail };
+  }
+
+  function skipFrame(
+    nowMs: number,
+    reason: FrameGateReason,
+    motion: number | null,
+    novelty: number | null,
+  ): FrameGateDecision {
+    rememberPrevious(nowMs);
+    return { keep: false, reason, motion, novelty, detail };
+  }
+
+  return {
+    offer(grid: FrameGrid, nowMs: number): FrameGateDecision {
+      if (grid.length !== FRAME_GRID_CELLS) {
+        throw new Error(
+          `frame gate expects ${FRAME_GRID_CELLS} cells, received ${grid.length}`,
+        );
+      }
+
+      detail = normalizeGrid(grid, current);
+
+      // Motion is only trustworthy against a frame that arrived recently. See
+      // `motionMaxAgeMs`: at one sample per second a small difference means
+      // the scene is static, which is not the question being asked.
+      const motion =
+        hasPrevious && nowMs - previousAtMs <= options.motionMaxAgeMs
+          ? meanAbsoluteDifference(current, previous)
+          : null;
+      const novelty = hasKept ? meanAbsoluteDifference(current, kept) : null;
+
+      // Warmup is checked before everything else, including the first keep:
+      // the frames it covers are the badly exposed ones, and the whole reason
+      // to wait is to avoid making one of them the baseline.
+      if (nowMs < warmupUntilMs) {
+        return skipFrame(nowMs, "warmup", motion, novelty);
+      }
+
+      // Ahead of every keep path, including the first: a blank wall must not
+      // become the baseline that everything afterwards is compared against.
+      if (detail < options.minDetail) {
+        return skipFrame(nowMs, "featureless", motion, novelty);
+      }
+
+      if (firstEligibleAtMs === null) {
+        firstEligibleAtMs = nowMs;
+      }
+      const moving = motion !== null && motion >= options.settleThreshold;
+      // The settle grace runs from the moment a keep became POSSIBLE, not from
+      // the last frame offered. After a keep that is the end of the rate floor:
+      // measuring from the first frame after a keep would spend the whole grace
+      // inside the floor, and the settle check would never apply again.
+      const eligibleSinceMs = hasKept
+        ? keptAtMs + options.minIntervalMs
+        : firstEligibleAtMs;
+      // Past the grace window a moving frame is kept anyway rather than
+      // letting a walking user's camera go silent indefinitely.
+      const forced = nowMs - eligibleSinceMs >= options.settleGraceMs;
+
+      if (!hasKept) {
+        if (moving && !forced) {
+          return skipFrame(nowMs, "moving", motion, novelty);
+        }
+        return keepFrame(nowMs, "first", motion, novelty);
+      }
+
+      const sinceKeep = nowMs - keptAtMs;
+      if (sinceKeep < options.minIntervalMs) {
+        return skipFrame(nowMs, "rate-floor", motion, novelty);
+      }
+      if (moving && !forced) {
+        return skipFrame(nowMs, "moving", motion, novelty);
+      }
+      if (sinceKeep >= options.maxIntervalMs) {
+        return keepFrame(nowMs, "heartbeat", motion, novelty);
+      }
+      if (novelty !== null && novelty >= options.noveltyThreshold) {
+        return keepFrame(nowMs, "novel", motion, novelty);
+      }
+      return skipFrame(nowMs, "unchanged", motion, novelty);
+    },
+
+    reset(nowMs: number): void {
+      hasPrevious = false;
+      hasKept = false;
+      previousAtMs = 0;
+      keptAtMs = 0;
+      warmupUntilMs = nowMs + options.warmupMs;
+      firstEligibleAtMs = null;
+    },
+  };
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-frame-gate.ts
@@ -409,12 +409,15 @@ export function createFrameGate(
       }
       const moving = motion !== null && motion >= options.settleThreshold;
       // The settle grace runs from the moment a keep became POSSIBLE, not from
-      // the last frame offered. After a keep that is the end of the rate floor:
-      // measuring from the first frame after a keep would spend the whole grace
-      // inside the floor, and the settle check would never apply again.
-      const eligibleSinceMs = hasKept
-        ? keptAtMs + options.minIntervalMs
-        : firstEligibleAtMs;
+      // the last frame offered: measuring from any earlier point would spend
+      // the grace inside the rate floor, and the settle check would never
+      // apply again. A keep becomes possible at the later of the first
+      // post-warmup offer and the end of the floor, including the floor a
+      // reset retains from a keep made just before it.
+      const eligibleSinceMs = Math.max(
+        firstEligibleAtMs,
+        keptAtMs + options.minIntervalMs,
+      );
       // Past the grace window a moving frame is kept anyway rather than
       // letting a walking user's camera go silent indefinitely.
       const forced = nowMs - eligibleSinceMs >= options.settleGraceMs;


### PR DESCRIPTION
Spike for live vision: the assistant takes photos on its own during a voice
call, at an interval, and this decides which ones are worth keeping.

**Nothing imports this yet.** One module and its tests. Merging it parks the
work somewhere durable and gives the sampler work a contract to build against.

## The problem it solves

Auto-capture at 1Hz is easy. Auto-capture that does not flood the conversation
is the hard part, and the cost is not the camera. Images persist inline in
conversation history and are re-sent on **every turn** (JARVIS-1534: an 11.7MB
request that was 99.3% base64, driving median LLM call duration to 8.8s against
a ~800ms baseline). Every photo kept is paid for repeatedly, for the rest of the
call.

So the gate exists to keep the count low and the quality high, and it has to do
that before anything expensive happens.

## Mechanics

Each frame is reduced to a **16x16 grid of luma samples, 256 bytes**. Both
scores come from that one grid, which is what makes it cheap enough to run on
every frame:

- **`motion`** compares the frame to the one immediately before it. It answers
  "is the camera settled right now". On a handheld phone this doubles as the
  blur check, because settled and sharp are the same condition.
- **`novelty`** compares the frame to the last frame **actually kept**. It
  answers "is this worth sending".

Comparing against the last *kept* frame rather than the previous frame is the
detail that makes a slow pan work. Frame to frame, a slow pan never exceeds any
sane threshold, so a gate keyed on consecutive frames captures nothing while the
view changes completely.

Each grid is **z-scored** before comparison (mean subtracted, divided by its own
standard deviation), which makes both scores invariant to brightness and gain. A
phone re-exposing is the most common whole-frame pixel change there is, and a
raw delta fires on a cloud crossing the sun.

The decision is an ordered ladder, and every rejection names which rung stopped
it:

```
1. warmed up?           -> skip: warmup       (exposure has not converged)
2. enough detail?       -> skip: featureless  (blank wall, hand over lens)
3. nothing kept yet?    -> KEEP: first
4. long enough gap?     -> skip: rate-floor
5. camera settled?      -> skip: moving       (frame would be smeared)
6. overdue?             -> KEEP: heartbeat
7. different enough?    -> KEEP: novel
8. otherwise            -> skip: unchanged
```

The module is **pure and platform-free**: it takes a grid and a timestamp and
returns keep/skip. No camera, no DOM, and it never reads a clock. That is the
whole point of the shape, because it means one tested decision engine serves
every platform and the thresholds transfer unchanged.

**Cost: 0.70 microseconds per frame** measured in JS over 1674 real frames, or
about 0.002% of one core at 30fps. Native will be faster. The gate is not where
the money goes.

## What the measurements changed

Calibrated against two real handheld clips (a moving room sweep and a fixed
workbench session), not against intuition. Several defaults come from results
that contradicted the obvious guess, which is the main reason this was worth
spiking rather than just writing:

- **The rate floor is the binding control, not the novelty threshold.** On
  moving footage, sweeping novelty across its whole low range changed the keep
  count *not at all*, because the floor gated every keep first. The threshold
  earns its keep on a fixed camera, where 30% of frames are turned away as
  unchanged. So `minIntervalMs` is the number to argue about, and it should be
  set from what conversation history can afford to carry.

- **A lower novelty threshold produces sharper photos.** Genuinely
  counter-intuitive. The threshold decides *when* the gate fires, and timing
  decides sharpness: a lower bar fires as a scene settles into its new view, a
  higher one waits for more accumulated difference by which point the camera is
  moving again. At 0.8 each clip produced a keep above the settle threshold; at
  0.6 neither did, while capturing *more* distinct subjects. Novelty and settle
  are not independent knobs.

- **Two frames of the same blank wall scored 0.33 against each other**, near the
  keep threshold, because normalization divides a featureless frame by its own
  sensor noise. Fixed by rejecting on absolute detail. That is also the right
  behaviour on its own terms: nobody wants a photo of a wall.

- **Holding still peaked at 0.09 and 0.04 novelty** on the two clips, against
  real auto-exposure and real sensor noise. The threshold sits an order of
  magnitude above the nuisance floor, which is the number that decides whether
  the feature floods.

- **Clipping exposure is the one confound that defeats normalization** (~0.34).
  Blown-out detail is destroyed rather than rescaled. Neither clip contains a
  hard exposure swing, so this is still measured only against synthetic frames.

## Running it on devices

The gate is platform-free. **Only the sampler differs**, and its only job is to
produce 256 bytes per frame. Everything below is about where those bytes come
from.

### iOS

**The frames are already flowing and we are already paying for them.**
`CameraController.prepare` calls `configureDataOutput()` unconditionally, which
attaches an `AVCaptureVideoDataOutput` (32BGRA, `alwaysDiscardsLateVideoFrames`)
delegating to a background queue. Every frame at sensor rate already arrives in
`captureOutput` today and is thrown away:

```swift
guard let completion = sampleBufferCaptureCompletionBlock else { return }
```

So the sampler is arithmetic added to a callback that already runs. No new
capture plumbing, and **nothing changes about the capture session graph**, which
matters because the live call is holding an `AVAudioSession` and renegotiating
it is how this codebase has broken echo cancellation before.

**Do not reach for `captureSample`.** It looks like the cheap API and is not: it
grabs the next frame from the data output, then runs a full-resolution
`CGContext.makeImage()`, a JPEG encode, a base64 encode, and a JSON string
across the Capacitor bridge. With `enableHighResolution: true` that is multiple
megabytes **per tick**, on a phone already holding a voice call. It also carries
three defects that a once-per-shutter-press call never exposes but a 1Hz loop
will hit constantly:

- the completion block is written on `.main` and read on the data-output queue
  with no synchronization
- two error paths call the completion and return **without** clearing it, so the
  next frame fires it again and double-resolves the Capacitor call
- a second call while one is pending overwrites the first's completion, so the
  first promise never settles

The right shape is to **extract the grid in Swift and ship 256 bytes** over the
bridge, encoding a real frame only on a keep. That is a patch to the vendored
plugin rather than a first-party one, because `CameraController` owns the
`setSampleBufferDelegate` and only one object can hold it. The patch channel
already exists and already carries four changes.

**Verification is the real constraint here, not the code.** The Simulator has no
camera, and device builds go through TestFlight, so there is no fast local loop
for any of this. That is the argument for keeping the web sampler alive as a
tuning rig rather than treating it as throwaway.

### Android

A per-frame path exists and is already in use: legacy
`android.hardware.Camera.PreviewCallback` / `onPreviewFrame`, in
`CameraActivity.takeSnapshot`. Structurally the same one-shot latch as iOS, just
an older API.

**The pixels are cheaper here than on iOS.** The plugin never calls
`setPreviewFormat` anywhere, so frames arrive in the legacy default, **NV21** —
and in NV21 the luma plane is simply the first `width * height` bytes of the
buffer. A luma sampler on Android is `bytes[i]`, with no colour conversion at
all. iOS asks for `kCVPixelFormatType_32BGRA` and has to do RGB-to-luma maths
per sample.

**And as on iOS, `captureSample` is the wrong door for a different reason.** It
is not a photo capture, it does read the live preview, but everything expensive
happens *after* the raw buffer is already in hand: `rotateNV21` is a per-pixel
Java loop allocating a second full-size buffer and it runs for any non-zero
display rotation (so, portrait, so, always), then a full JPEG encode, then
base64, then a bridge marshal. A sampler skips all four.

Four frictions that are genuinely worse than iOS, and worth costing before
committing:

- **The frame callback runs on the main thread.** `Camera.open()` is called
  from `onResume`, and the legacy API delivers frames on the thread that opened
  the camera. iOS already has a dedicated `DispatchQueue` for this. On Android
  we would need our own `HandlerThread` or the sampler lands on the UI thread
  during a live call.
- **`setPreviewCallback` has exactly one slot.** `takeSnapshot` installs its own
  and then clears it in a `finally`, which would silently tear down a
  continuously-installed sampler. Needs multiplexing, or the shutter path has to
  restore it.
- **No buffer reuse.** Plain `setPreviewCallback` allocates a fresh `byte[]` per
  frame, which is GC churn at 30fps. `setPreviewCallbackWithBuffer` plus
  `addCallbackBuffer` is the fix, and it is new code.
- **Preview size is chosen to fit the view**, not to be cheap to sample, so we
  subsample the Y plane with a stride rather than requesting a small size.

The plugin is also on `android.hardware.Camera` and `android.app.Fragment`, both
deprecated. Anything built here inherits that, which is an argument for keeping
the Android sampler as small as it can possibly be.

**Shape I would recommend:** a first-party plugin under
`clients/android/app/.../ai/vellum/assistant/`, following the existing
`VoiceAudioSessionPlugin` pattern (14 first-party plugins already there, with a
unit-test convention alongside), plus a minimal addition to the existing
camera-preview patch to expose a frame listener. `CameraActivity` keeps `mCamera`
private, so some patch is unavoidable, but it can stay small and the patch
channel into this exact Java file already works.

### Desktop and web

`drawImage(video, 0, 0, 16, 16)` onto one reused offscreen canvas, then
`getImageData`. Sub-millisecond, no per-frame allocation. This is the easy path
because a `<video>` element genuinely exists.

Worth keeping even though mobile ships first: it is the **tuning rig**. Every
threshold in this module was found by running real footage through it and
looking at contact sheets, and that loop is minutes in a browser versus a
TestFlight cycle on device.

### What is shared, and what is not

Shared across all three: this module, the thresholds, and the tests. A threshold
change is a one-line edit that lands everywhere at once, which is why the tests
are deliberately decoupled from the shipped tuning values.

Not shared: the sampler, which is small and platform-specific by nature.

### Sequencing, given mobile ships first

The two mobile samplers are comparable in size, and neither is large. The thing
that differs is the feedback loop: iOS has no local verification at all
(Simulator has no camera, device builds go via TestFlight), while Android can at
least be exercised on a connected device.

So the order I would suggest is: keep the web sampler as the tuning rig, build
**Android first** because you can actually watch it work while writing it, then
port to iOS once the sampler's shape is settled and the only open question is
Swift specifics. That inverts the usual iOS-first habit, but it puts the slow
loop last, when there is least left to discover.

The alternative is to build both against the contract in this PR and accept one
TestFlight round trip on iOS to shake out the grid extraction. Also fine, and
faster in wall-clock if both are worked in parallel.

## The one thing to get right in the sampler

**It must area-average, not point-sample.** Measured: naive stride-sampling
inflates still-frame motion **6x** (0.0029 to 0.0176) against a settle threshold
of 0.08. That eats three quarters of the settle margin and quietly degrades the
blur check.

The right way to get it is to let the camera hardware scaler deliver a smaller
buffer rather than summing two million pixels per frame in software. This is
cheap if it is designed in and expensive to retrofit, so it is worth deciding
before either sampler is written.

## Not done

- **No sampler exists yet.** This is the decision engine only.
- **Retention.** The gate reduces the count; it does not stop images being
  re-sent every turn. That is JARVIS-1534, and it needs to land alongside this
  or the feature is expensive regardless of tuning. A fix is implemented and
  under review separately.
- **Thresholds are n=2.** Two clips, both deliberately shot. Enough to rule
  values out, not to pin them.
- **No subject awareness.** The gate captures *views*, not subjects. Measured:
  cheap statistics cannot close this. Motion-compensated differencing works
  (halves apparent change during camera movement) but does not discriminate, and
  a dog scored *lower* than a blank wall. Salience is semantic and is not in a
  luma grid. On-device Vision or ML Kit is the only real option, and it is not
  needed for a first cut: the user pausing on something is the subject signal,
  and the gate already reads it.

## Seeing it work

There is an interactive scope showing every frame of both clips against the real
logic, with the thresholds live: https://claude.ai/code/artifact/75dcc7e4-8eff-4825-9d04-0896bbabd47f
(private until Alex shares it from the page's share menu)

Scrub the timeline, watch which rung rejects each frame, and move the sliders to
see the contact sheet change. The clearest thing in it: switch between the two
clips at fixed settings and watch which control is doing the work change
completely.


---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1aLsv8F1aYKFuBdjfTfWC
