### PR TITLE
fix(oauth): measure Slack scope coverage against the token actually stored

### DIFF
--- a/assistant/src/__tests__/credential-health-service.test.ts
+++ b/assistant/src/__tests__/credential-health-service.test.ts
@@ -13,6 +13,7 @@ let mockProviders: Array<{
   pingHeaders: string | null;
   pingBody: string | null;
   authorizeParams: string | null;
+  scopeSeparator: string | null;
   managedServiceConfigKey?: string;
 }> = [];
 
@@ -201,6 +202,7 @@ function addProvider(
     authorizeParams: opts?.authorizeParams
       ? JSON.stringify(opts.authorizeParams)
       : null,
+    scopeSeparator: " ",
     pingUrl: opts?.pingUrl ?? null,
     pingMethod: opts?.pingMethod ?? null,
     pingHeaders: null,

--- a/assistant/src/__tests__/credential-health-service.test.ts
+++ b/assistant/src/__tests__/credential-health-service.test.ts
@@ -12,6 +12,7 @@ let mockProviders: Array<{
   pingMethod: string | null;
   pingHeaders: string | null;
   pingBody: string | null;
+  authorizeParams: string | null;
   managedServiceConfigKey?: string;
 }> = [];
 
@@ -191,11 +192,15 @@ function addProvider(
     pingUrl?: string | null;
     pingMethod?: string | null;
     managedServiceConfigKey?: string;
+    authorizeParams?: Record<string, string>;
   },
 ) {
   mockProviders.push({
     provider,
     defaultScopes: JSON.stringify(opts?.defaultScopes ?? []),
+    authorizeParams: opts?.authorizeParams
+      ? JSON.stringify(opts.authorizeParams)
+      : null,
     pingUrl: opts?.pingUrl ?? null,
     pingMethod: opts?.pingMethod ?? null,
     pingHeaders: null,
@@ -441,6 +446,44 @@ describe("credential-health-service", () => {
       "im:write",
     ]);
     expect(report.results[0]!.canAutoRecover).toBe(false);
+  });
+
+  test("measures a user-token grant against user_scope, not the bot scopes", async () => {
+    // Slack issues two grants from one authorization and the stored token is
+    // the user one, so its grant is compared against `user_scope`. Measuring
+    // it against the bot `scope` parameter reports scopes that grant can never
+    // hold: `channels:join` is bot-only and is never requested for the user.
+    addProvider("slack", {
+      defaultScopes: ["channels:join", "chat:write", "search:read"],
+      authorizeParams: { user_scope: "chat:write,search:read" },
+    });
+    addConnection("slack", "conn-1", {
+      grantedScopes: ["chat:write", "search:read"],
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).not.toBe("missing_scopes");
+    expect(report.results[0]!.missingScopes).toEqual([]);
+  });
+
+  test("still reports a user scope the installer did not grant", async () => {
+    // Sensitivity check for the test above: comparing against `user_scope`
+    // must keep catching a genuinely declined user scope, not pass everything.
+    addProvider("slack", {
+      defaultScopes: ["channels:join", "chat:write", "search:read"],
+      authorizeParams: { user_scope: "chat:write,search:read" },
+    });
+    addConnection("slack", "conn-1", {
+      grantedScopes: ["chat:write"],
+      expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    setToken("conn-1");
+
+    const report = await checkAllCredentials();
+    expect(report.results[0]!.status).toBe("missing_scopes");
+    expect(report.results[0]!.missingScopes).toEqual(["search:read"]);
   });
 
   test("returns revoked when ping returns 401", async () => {

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -7,8 +7,10 @@
  * - Scope coverage (grantedScopes vs the request that produced the token)
  * - Liveness ping (for providers with a pingUrl)
  *
- * Scope coverage answers "was everything we asked for granted", so it applies
- * only where an authorization made a request. A manual-token provider (a bot
+ * Scope coverage asks whether a connection carries the scopes the provider
+ * currently requests for the token it stores, which is how a newly required
+ * scope reaches an existing install and prompts a re-authorization. It applies
+ * only where an authorization makes a request. A manual-token provider (a bot
  * token pasted in, e.g. `slack_channel`) has no request and carries empty
  * scope lists here; it is still checked for token presence and liveness. What
  * its token actually carries is read live from the `x-oauth-scopes` response

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -7,6 +7,14 @@
  * - Scope coverage (grantedScopes vs the request that produced the token)
  * - Liveness ping (for providers with a pingUrl)
  *
+ * Scope coverage answers "was everything we asked for granted", so it applies
+ * only where an authorization made a request. A manual-token provider (a bot
+ * token pasted in, e.g. `slack_channel`) has no request and carries empty
+ * scope lists here; it is still checked for token presence and liveness. What
+ * its token actually carries is read live from the `x-oauth-scopes` response
+ * header by `runtime/channel-readiness-service.ts`, which is the only source
+ * of truth available for a credential this service never negotiated.
+ *
  * Designed to run during the heartbeat cycle. The BYO liveness ping is
  * routed through `withValidToken`, so a stale-but-refreshable access token
  * is refreshed transparently before the ping fires — this prevents the

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -186,6 +186,7 @@ interface CheckConnectionOpts {
   grantedScopesRaw: string;
   defaultScopesRaw: string;
   authorizeParamsRaw: string | null;
+  scopeSeparator: string | null;
   pingUrl: string | null;
   pingMethod: string | null;
   pingHeaders: string | null;
@@ -204,6 +205,7 @@ async function checkConnection(
     grantedScopesRaw,
     defaultScopesRaw,
     authorizeParamsRaw,
+    scopeSeparator,
     pingUrl,
     pingMethod,
     pingHeaders,
@@ -284,6 +286,7 @@ async function checkConnection(
       authorizeParamsRaw,
       undefined,
     ),
+    scopeSeparator ?? undefined,
   );
   if (expectedScopes.length > 0 && grantedScopes.length > 0) {
     const missing = scopeDifference(expectedScopes, grantedScopes);
@@ -652,6 +655,7 @@ export async function checkAllCredentials(): Promise<CredentialHealthReport> {
           grantedScopesRaw: conn.grantedScopes,
           defaultScopesRaw: providerRow.defaultScopes,
           authorizeParamsRaw: providerRow.authorizeParams,
+          scopeSeparator: providerRow.scopeSeparator,
           pingUrl: providerRow.pingUrl,
           pingMethod: providerRow.pingMethod,
           pingHeaders: providerRow.pingHeaders,
@@ -766,6 +770,7 @@ export async function checkCredentialForProvider(
       grantedScopesRaw: conn.grantedScopes,
       defaultScopesRaw: providerRow.defaultScopes,
       authorizeParamsRaw: providerRow.authorizeParams,
+      scopeSeparator: providerRow.scopeSeparator,
       pingUrl: providerRow.pingUrl,
       pingMethod: providerRow.pingMethod,
       pingHeaders: providerRow.pingHeaders,

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -4,7 +4,7 @@
  * Enumerates all active OAuth connections and validates each one for:
  * - Token presence in secure storage
  * - Token expiry (expired or expiring within the warning window)
- * - Scope coverage (grantedScopes vs provider defaultScopes)
+ * - Scope coverage (grantedScopes vs the request that produced the token)
  * - Liveness ping (for providers with a pingUrl)
  *
  * Designed to run during the heartbeat cycle. The BYO liveness ping is
@@ -24,7 +24,10 @@ import {
   type OAuthConnectionRow,
   type OAuthProviderRow,
 } from "../oauth/oauth-store.js";
-import { scopeDifference } from "../oauth/scope-utils.js";
+import {
+  expectedScopesForStoredToken,
+  scopeDifference,
+} from "../oauth/scope-utils.js";
 import {
   TokenExpiredError,
   withValidToken,
@@ -182,6 +185,7 @@ interface CheckConnectionOpts {
   hasRefreshToken: boolean;
   grantedScopesRaw: string;
   defaultScopesRaw: string;
+  authorizeParamsRaw: string | null;
   pingUrl: string | null;
   pingMethod: string | null;
   pingHeaders: string | null;
@@ -199,6 +203,7 @@ async function checkConnection(
     hasRefreshToken,
     grantedScopesRaw,
     defaultScopesRaw,
+    authorizeParamsRaw,
     pingUrl,
     pingMethod,
     pingHeaders,
@@ -268,11 +273,20 @@ async function checkConnection(
     // Has refresh token — not an issue, auto-refresh will handle it
   }
 
-  // 3. Check scope coverage
+  // 3. Check scope coverage, against the request that produced the stored
+  // token rather than the provider's bot-side `scope` parameter. A provider
+  // asking for user scopes as well stores the user token and records that
+  // token's grant, so the bot request names scopes that grant can never hold.
   const grantedScopes = safeJsonParse<string[]>(grantedScopesRaw, []);
-  const defaultScopes = safeJsonParse<string[]>(defaultScopesRaw, []);
-  if (defaultScopes.length > 0 && grantedScopes.length > 0) {
-    const missing = scopeDifference(defaultScopes, grantedScopes);
+  const expectedScopes = expectedScopesForStoredToken(
+    safeJsonParse<string[]>(defaultScopesRaw, []),
+    safeJsonParse<Record<string, string> | undefined>(
+      authorizeParamsRaw,
+      undefined,
+    ),
+  );
+  if (expectedScopes.length > 0 && grantedScopes.length > 0) {
+    const missing = scopeDifference(expectedScopes, grantedScopes);
     if (missing.length > 0) {
       return {
         ...base,
@@ -637,6 +651,7 @@ export async function checkAllCredentials(): Promise<CredentialHealthReport> {
           hasRefreshToken: !!conn.hasRefreshToken,
           grantedScopesRaw: conn.grantedScopes,
           defaultScopesRaw: providerRow.defaultScopes,
+          authorizeParamsRaw: providerRow.authorizeParams,
           pingUrl: providerRow.pingUrl,
           pingMethod: providerRow.pingMethod,
           pingHeaders: providerRow.pingHeaders,
@@ -750,6 +765,7 @@ export async function checkCredentialForProvider(
       hasRefreshToken: !!conn.hasRefreshToken,
       grantedScopesRaw: conn.grantedScopes,
       defaultScopesRaw: providerRow.defaultScopes,
+      authorizeParamsRaw: providerRow.authorizeParams,
       pingUrl: providerRow.pingUrl,
       pingMethod: providerRow.pingMethod,
       pingHeaders: providerRow.pingHeaders,

--- a/assistant/src/oauth/scope-utils.ts
+++ b/assistant/src/oauth/scope-utils.ts
@@ -24,6 +24,40 @@ export function scopeDifference(
   );
 }
 
+/**
+ * Scope list as a provider writes it: space separated, comma separated, or a
+ * mix. Token responses and authorize parameters both arrive in either form.
+ */
+export function parseScopeList(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}
+
+/**
+ * The scopes the stored access token is expected to carry.
+ *
+ * A provider that asks for user scopes alongside bot scopes issues two grants
+ * from one authorization. `exchangeCodeForTokens` stores the `authed_user`
+ * token in that case and records that token's own grant as `grantedScopes`, so
+ * coverage has to be measured against the request that produced the stored
+ * token: `user_scope` where the provider sends one, the `scope` parameter
+ * otherwise. Measuring a user grant against the bot request reports scopes the
+ * authorization could never place on that token.
+ */
+export function expectedScopesForStoredToken(
+  defaultScopes: string[],
+  authorizeParams: Record<string, string> | undefined,
+): string[] {
+  const userScope = authorizeParams?.user_scope;
+  if (typeof userScope !== "string") {
+    return defaultScopes;
+  }
+  const parsed = parseScopeList(userScope);
+  return parsed.length > 0 ? parsed : defaultScopes;
+}
+
 const GMAIL_FULL_ACCESS_SCOPE = "https://mail.google.com/";
 const GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
 

--- a/assistant/src/oauth/scope-utils.ts
+++ b/assistant/src/oauth/scope-utils.ts
@@ -25,12 +25,25 @@ export function scopeDifference(
 }
 
 /**
- * Scope list as a provider writes it: space separated, comma separated, or a
- * mix. Token responses and authorize parameters both arrive in either form.
+ * Split a scope list the way the provider writes it.
+ *
+ * Providers (GitHub, Slack) may return comma-separated scopes regardless of
+ * the separator used to join outbound authorize URLs, so the default tolerates
+ * both spaces and commas. A provider that explicitly configures a non-default
+ * separator (Linear uses ",") is honored, keeping configured scopes
+ * round-tripping symmetrically.
+ *
+ * The one parser for both directions: token responses and authorize
+ * parameters. Two copies would let a provider-format fix land on one and not
+ * the other.
  */
-export function parseScopeList(raw: string): string[] {
+export function parseScopeList(
+  raw: string,
+  scopeSeparator: string = " ",
+): string[] {
+  const splitPattern = scopeSeparator === " " ? /[ ,]/ : scopeSeparator;
   return raw
-    .split(/[\s,]+/)
+    .split(splitPattern)
     .map((scope) => scope.trim())
     .filter(Boolean);
 }
@@ -49,12 +62,13 @@ export function parseScopeList(raw: string): string[] {
 export function expectedScopesForStoredToken(
   defaultScopes: string[],
   authorizeParams: Record<string, string> | undefined,
+  scopeSeparator?: string,
 ): string[] {
   const userScope = authorizeParams?.user_scope;
   if (typeof userScope !== "string") {
     return defaultScopes;
   }
-  const parsed = parseScopeList(userScope);
+  const parsed = parseScopeList(userScope, scopeSeparator);
   return parsed.length > 0 ? parsed : defaultScopes;
 }
 

--- a/assistant/src/security/oauth2.ts
+++ b/assistant/src/security/oauth2.ts
@@ -20,6 +20,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { createServer, type Server } from "node:http";
 
 import { getIsPlatform } from "../config/env-registry.js";
+import { parseScopeList } from "../oauth/scope-utils.js";
 import { getLogger } from "../util/logger.js";
 import { renderOAuthCompletionPage as renderLoopbackPage } from "./oauth-completion-page.js";
 
@@ -249,19 +250,9 @@ export async function exchangeCodeForTokens(
       (tokenData.token_type as string | undefined),
   };
 
-  // Defensive split: providers (e.g. GitHub, Slack) may return comma-separated
-  // scopes in token responses regardless of the scope_separator used to join
-  // outbound authorize URLs, so we tolerate both spaces and commas here. When
-  // a provider explicitly configures a non-default separator (e.g. Linear uses
-  // ","), we honor that to keep symmetric round-tripping of configured scopes.
-  const splitPattern =
-    config.scopeSeparator === " " ? /[ ,]/ : config.scopeSeparator;
   const grantedScopes =
     typeof tokens.scope === "string"
-      ? tokens.scope
-          .split(splitPattern)
-          .map((s) => s.trim())
-          .filter(Boolean)
+      ? parseScopeList(tokens.scope, config.scopeSeparator)
       : [...config.scopes];
 
   return { tokens, grantedScopes, rawTokenResponse: tokenData };


### PR DESCRIPTION
## TL;DR

Anyone who connects Slack as an integration has their Slack tools switched off, permanently, and nothing they can do fixes it. Credential health measures the connection against the wrong token's scope request. This measures it against the token we actually store.

Fixes LUM-3476.

## What users experience

**Before.** You connect Slack from Integrations. The connection is valid, the token works, every scope you approved was granted. The assistant reports Slack as unhealthy, notifies you that scopes are missing, and disables every Slack tool. Reconnecting does not help. Re-approving does not help, because the scope being demanded (`channels:join`) is a bot-only scope that can never appear on your user token. There is no action available that clears it.

**After.** The connection reports healthy and Slack tools work. A user scope you actually declined is still reported, and a scope newly required by a future release still prompts you to re-authorize.

| | Before | After |
|---|---|---|
| Slack connected as an integration | Unhealthy, tools disabled, unfixable | Healthy, tools work |
| A user scope you declined at consent | Reported missing | Reported missing |
| A user scope added in a later release | Reported missing | Reported missing |
| Every other provider | | Unchanged |

## Why this is needed

Slack's authorization issues two grants at once. Bot scopes go out on the `scope` parameter (from `defaultScopes`), user scopes on `user_scope`. `exchangeCodeForTokens` stores the `authed_user` token, because this provider is the "act as you" integration, and records that token's own grant as `grantedScopes`.

Credential health then compared that user grant against `defaultScopes`, which describes the bot token. `channels:join` lives in `defaultScopes`, is never requested for the user, and is bot-only, so it was reported missing on every connection. `missing_scopes` sits in heartbeat's `hardFailureStatuses`, which notifies the user and disables the provider's tools.

Verified against the real seed values rather than a fixture:

```
defaultScopes (bot request): 14
user_scope (stored token):   13
BEFORE -> missing: [ "channels:join" ] => missing_scopes (tools DISABLED)
AFTER  -> missing: []                  => healthy
```

## Why this is the correct fix

The tempting reading is that comparing a stored grant against current provider config is itself the bug, and that the connection should record what was requested at authorization time. That would be wrong. Comparing against current config is a deliberate mechanism: it is how a newly required scope reaches an existing install and prompts a re-authorization. Migration `041-backfill-google-gmail-settings-scope` exists for exactly that purpose, and the seed data says so directly ("so that upstream scope additions propagate to existing installations"). Freezing the requested set would silence that, and an install would read healthy while lacking capability the app now needs.

The defect is narrower. A bot scope measured against a user grant is not an actionable prompt, because no amount of re-consenting can place it on that token. It is a permanent false alarm that disables tools.

So the comparison keeps its operand current and only corrects which request it reads: the one for the token actually stored. New user scopes still propagate. Unsatisfiable bot scopes stop being demanded of a user token.

This is also why the fix does not extend to the Socket Mode bot path. A pasted bot token was never negotiated, so there is no request to compare against, and both scope lists are empty. What that token carries is read live from the `x-oauth-scopes` header by `channel-readiness-service.ts`. Each path answers "what should this token have" from the best source available to it.

## Why this is safe

- **No schema or persisted-state change.** `authorizeParams` and `scopeSeparator` are existing columns, already read this way by `connect-orchestrator.ts`.
- **Slack is the only provider with a `user_scope` split.** Every other provider takes the `defaultScopes` path exactly as before, which the pre-existing `missing_scopes` test still covers.
- **The change can only shrink the reported-missing set**, and only by scopes the stored token could never hold.
- **Both `checkConnection` call sites are threaded.** `connection-resolver.ts` is the only other `scopeDifference` caller and is unaffected: it takes required scopes from its caller as a capability question rather than reading `defaultScopes`.
- **The one degenerate case stays correct.** If Slack ever returned no user token, the stored token would be a bot token and every user scope would report missing. For an integration whose purpose is acting as the user, and whose main call (`search.messages`) is user-token-only, reporting that connection as degraded is the right answer, not a regression.
- Typecheck, lint and format clean.

## Also in this change

`parseScopeList` in `scope-utils.ts` is now the single scope parser. The health check's parsing had been a second implementation alongside `exchangeCodeForTokens`, and the two disagreed for a provider with a non-default `scopeSeparator`: the token-response parser honored it, the other always split on whitespace and commas. `exchangeCodeForTokens` now calls the shared one, and the provider's separator is threaded to the health check so both read a format identically. Checked behaviour-preserving against the expression it replaced across space, comma, mixed, non-default-separator and empty inputs.

The `credential-health-service.ts` module docstring now names its boundary with `channel-readiness-service.ts`. Neither file said which service owned the scope question for a channel bot, which is the blind spot that let this comparison stay wrong.

## Tests

Two, deliberately paired:

- a user-token grant is measured against `user_scope`, so `channels:join` no longer reports missing
- a genuinely declined user scope is still reported, so the first test cannot pass by the check going silent
