### PR TITLE
refactor(workers): move worker process-tree ownership to a shared module (ATL-1349)

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -14,12 +14,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { getEmbedWorkerPidPath } from "../../../util/platform.js";
 import {
   classifyWorkerOwnership,
   listWorkerProcesses,
-  LocalEmbeddingBackend,
-} from "../embedding-local.js";
+} from "../../../util/ml-worker-ownership.js";
+import { getEmbedWorkerPidPath } from "../../../util/platform.js";
+import { LocalEmbeddingBackend } from "../embedding-local.js";
 
 /** Reach past `private`, which is compile-time only, so tests drive real state. */
 type Internals = any;

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -10,13 +10,14 @@ import { join } from "node:path";
 import { getIsContainerized } from "../../config/env-registry.js";
 import { getLogger } from "../../util/logger.js";
 import {
+  classifyWorkerOwnership,
+  listWorkerProcesses,
+  pid1OwnsMlWorkers,
+} from "../../util/ml-worker-ownership.js";
+import {
   getEmbeddingModelsDir,
   getEmbedWorkerPidPath,
 } from "../../util/platform.js";
-import {
-  listProcessTable,
-  readRawProcessCommand,
-} from "../../util/process-table.js";
 import { PromiseGuard } from "../../util/promise-guard.js";
 import { workerComputeEnv } from "../../util/worker-compute.js";
 import { workerMemoryEnv } from "../../util/worker-memory.js";
@@ -95,102 +96,6 @@ function isProcessAlive(pid: number): boolean {
     return true;
   } catch {
     return false;
-  }
-}
-
-interface WorkerProcess {
-  pid: number;
-  ppid: number;
-}
-
-/**
- * What this process may do with an embed worker it found in the process table.
- *
- * - `reclaim`: parented to us, a worker we started and lost track of. Reaping
- *   it is what enforces one live worker per owning process.
- * - `orphan`: reparented to init, or its owner is gone. Nobody else will ever
- *   clean it up.
- * - `foreign`: owned by another live process. The memory-worker process runs
- *   its own backend against this same workspace and is entitled to its own
- *   worker; signalling it is what made the two replace each other in a loop.
- *
- * A parent of PID 1 is ambiguous, and resolving it wrongly in either direction
- * costs something real. `docker-entrypoint.sh` execs the daemon, so PID 1 can
- * BE the daemon and its child a healthy sibling's worker. Under `docker run
- * --init`, and on any host, PID 1 is an init process instead, so the same
- * parentage means the owner died and the worker needs reclaiming. Callers
- * therefore pass what PID 1 actually is rather than inferring it from whether
- * the deployment is containerized, which is true in both container shapes.
- */
-export type WorkerOwnership = "reclaim" | "orphan" | "foreign";
-
-export function classifyWorkerOwnership(
-  worker: WorkerProcess,
-  selfPid: number,
-  isOwnerAlive: (pid: number) => boolean,
-  pid1OwnsWorkers: boolean,
-): WorkerOwnership {
-  if (worker.ppid === selfPid) {
-    return "reclaim";
-  }
-  if (worker.ppid <= 1) {
-    return pid1OwnsWorkers ? "foreign" : "orphan";
-  }
-  if (!isOwnerAlive(worker.ppid)) {
-    return "orphan";
-  }
-  return "foreign";
-}
-
-/** Entrypoint the daemon is exec'd with, including inside a container. */
-const DAEMON_ENTRYPOINT_MARKER = "daemon/main";
-
-/**
- * Whether PID 1 is an assistant daemon rather than an init process.
- *
- * True only where the daemon was exec'd as PID 1 (`docker-entrypoint.sh`),
- * which is what makes a worker parented to 1 a live sibling's rather than an
- * orphan. Under `docker run --init` PID 1 is docker-init and under launchd or
- * systemd it is the system init, so both answer false and PID-1 orphans stay
- * reclaimable. Unreadable means false, which keeps the reclaiming behaviour.
- */
-function pid1OwnsEmbedWorkers(): boolean {
-  if (process.pid === 1) {
-    return true;
-  }
-  return readRawProcessCommand(1)?.includes(DAEMON_ENTRYPOINT_MARKER) ?? false;
-}
-
-/**
- * Live embed-worker processes for this workspace, as `(pid, ppid)` pairs.
- *
- * Ownership of an embed worker is recorded by the OS process tree, not by the
- * PID file: a worker's parent IS its owner. The process table is therefore the
- * authoritative answer to "whose worker is this", and unlike the PID file it
- * survives a crash and cannot be overwritten by a second owner. That matters
- * because the daemon and the memory-worker process legitimately run one worker
- * each against the same workspace.
- *
- * Matches on the absolute worker script path, which lives under THIS
- * workspace's embedding-models directory and is therefore unique per assistant
- * instance, so a sibling instance's workers never match. Raw command lines are
- * read for matching only, never stored or logged: process arguments can carry
- * secrets (see the redaction note in `util/process-tree.ts`).
- */
-export function listWorkerProcesses(
-  workerPath: string,
-  model?: string,
-): WorkerProcess[] {
-  try {
-    return listProcessTable()
-      .filter(
-        (row) =>
-          row.command.includes(workerPath) &&
-          (!model || row.command.split(/\s+/).includes(model)),
-      )
-      .map(({ pid, ppid }) => ({ pid, ppid }));
-  } catch {
-    return [];
   }
 }
 
@@ -874,7 +779,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         worker,
         process.pid,
         isProcessAlive,
-        pid1OwnsEmbedWorkers(),
+        pid1OwnsMlWorkers(),
       );
       if (ownership === "foreign") {
         continue;

--- a/assistant/src/util/ml-worker-ownership.ts
+++ b/assistant/src/util/ml-worker-ownership.ts
@@ -1,0 +1,106 @@
+/**
+ * Process-tree ownership for background worker processes.
+ *
+ * A worker's parent IS its owner. The process table is therefore the
+ * authoritative answer to "whose worker is this": unlike a PID file it
+ * survives a crash, and a second owner cannot overwrite it.
+ *
+ * Nothing here is specific to one worker kind. `listWorkerProcesses` matches
+ * on the absolute worker path the caller passes, and `classifyWorkerOwnership`
+ * takes injected liveness and PID-1 predicates, so any worker whose spawner
+ * knows its own PID can use both.
+ */
+
+import { listProcessTable, readRawProcessCommand } from "./process-table.js";
+
+export interface WorkerProcess {
+  pid: number;
+  ppid: number;
+}
+
+/**
+ * What this process may do with a worker it found in the process table.
+ *
+ * - `reclaim`: parented to us, a worker we started and lost track of. Reaping
+ *   it is what enforces one live worker per owning process.
+ * - `orphan`: reparented to init, or its owner is gone. Nobody else will ever
+ *   clean it up.
+ * - `foreign`: owned by another live process. The memory-worker process runs
+ *   its own backend against this same workspace and is entitled to its own
+ *   worker; signalling it is what made the two replace each other in a loop.
+ *
+ * A parent of PID 1 is ambiguous, and resolving it wrongly in either direction
+ * costs something real. `docker-entrypoint.sh` execs the daemon, so PID 1 can
+ * BE the daemon and its child a healthy sibling's worker. Under `docker run
+ * --init`, and on any host, PID 1 is an init process instead, so the same
+ * parentage means the owner died and the worker needs reclaiming. Callers
+ * therefore pass what PID 1 actually is rather than inferring it from whether
+ * the deployment is containerized, which is true in both container shapes.
+ */
+export type WorkerOwnership = "reclaim" | "orphan" | "foreign";
+
+export function classifyWorkerOwnership(
+  worker: WorkerProcess,
+  selfPid: number,
+  isOwnerAlive: (pid: number) => boolean,
+  pid1OwnsWorkers: boolean,
+): WorkerOwnership {
+  if (worker.ppid === selfPid) {
+    return "reclaim";
+  }
+  if (worker.ppid <= 1) {
+    return pid1OwnsWorkers ? "foreign" : "orphan";
+  }
+  if (!isOwnerAlive(worker.ppid)) {
+    return "orphan";
+  }
+  return "foreign";
+}
+
+/** Entrypoint the daemon is exec'd with, including inside a container. */
+const DAEMON_ENTRYPOINT_MARKER = "daemon/main";
+
+/**
+ * Whether PID 1 is an assistant daemon rather than an init process.
+ *
+ * True only where the daemon was exec'd as PID 1 (`docker-entrypoint.sh`),
+ * which is what makes a worker parented to 1 a live sibling's rather than an
+ * orphan. Under `docker run --init` PID 1 is docker-init and under launchd or
+ * systemd it is the system init, so both answer false and PID-1 orphans stay
+ * reclaimable. Unreadable means false, which keeps the reclaiming behaviour.
+ */
+export function pid1OwnsMlWorkers(): boolean {
+  if (process.pid === 1) {
+    return true;
+  }
+  return readRawProcessCommand(1)?.includes(DAEMON_ENTRYPOINT_MARKER) ?? false;
+}
+
+/**
+ * Live worker processes matching `workerPath`, as `(pid, ppid)` pairs.
+ *
+ * `workerPath` is an absolute path unique to one worker of one install, so a
+ * sibling instance's workers never match. `model`, when given, must appear as
+ * a whole argv token rather than a substring, so a backend for `bge-small`
+ * cannot reclaim a live `bge-small-v2` worker.
+ *
+ * Raw command lines are read for matching only, never stored or logged:
+ * process arguments can carry secrets (see the redaction note in
+ * `util/process-tree.ts`).
+ */
+export function listWorkerProcesses(
+  workerPath: string,
+  model?: string,
+): WorkerProcess[] {
+  try {
+    return listProcessTable()
+      .filter(
+        (row) =>
+          row.command.includes(workerPath) &&
+          (!model || row.command.split(/\s+/).includes(model)),
+      )
+      .map(({ pid, ppid }) => ({ pid, ppid }));
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## TL;DR

Pure move, no behaviour change. The worker process-tree ownership primitives live in `embedding-local.ts` even though nothing in them is about embeddings. This moves them to `util/ml-worker-ownership.ts` so other workers can use them.

Part of ATL-1349, and the enabling step for JARVIS-891.

## Why

`classifyWorkerOwnership` answers "whose worker is this" from the OS process tree: a worker's parent IS its owner. That was written for the embed worker (JARVIS-1125) after PID-file ownership proved unreliable, and its own docstring says why the process table is better:

> unlike the PID file it survives a crash and cannot be overwritten by a second owner

But it is generic on both axes that matter. `listWorkerProcesses` matches on whatever absolute worker path the caller passes, and `classifyWorkerOwnership` takes injected liveness and PID-1 predicates. The only thing tying either to embeddings was the file it happened to live in.

The consequence of that accident: the embed worker has a real ownership model, and the four PID-file workers (schedule, route host, resource monitor, memory jobs) have none. They ask "is this PID alive", which cannot distinguish their own worker from one a previous daemon left behind. That is ATL-1349, and the follow-up PR fixes it on top of this module.

## What moved

`WorkerProcess`, `WorkerOwnership`, `classifyWorkerOwnership`, `listWorkerProcesses`, and the PID-1 daemon probe. The probe is renamed `pid1OwnsMlWorkers`: it asks what PID 1 is, which is a question about the daemon, not about embeddings.

`embedding-local.ts` imports all of them and keeps its call sites untouched.

## Why it is safe

The three moved function bodies are **byte-identical** to their previous versions. I verified this mechanically rather than by eye, diffing each body at `HEAD` against the new module:

```
--- export function classifyWorkerOwnership
  IDENTICAL
--- export function listWorkerProcesses
  IDENTICAL
--- pid1 predicate (renamed, body must match)
  IDENTICAL
```

The embed lifecycle tests are unchanged apart from their import path, so they exercise the moved code as-is. Docstrings were generalised to describe the new home (they said "embed worker" where the code says "worker"); the logic they describe did not change.

## A note for anyone who remembers the earlier attempt

There is an older unmerged commit that did this same extraction (`62ff74b6fe`, from the JARVIS-891 branch). **Do not cherry-pick it.** It predates #41079, which moved `listWorkerProcesses` onto the shared `listProcessTable` helper and added Windows process inspection. That commit still carries its own bespoke `/proc` and `ps` enumerators, so applying it would reintroduce ~60 lines of duplicate enumeration and regress Windows support. This PR redoes the extraction against current `main` instead, which is why it is smaller.

## Not in scope

`embedding-local.ts` has a local `isProcessAlive` that duplicates `util/process-liveness.ts`, but the two differ on `EPERM` (the local one reports dead, the shared one reports alive). Reconciling them is a behaviour change, not a move, so it stays out of this PR.

`listWorkerProcesses` swallows a process-table read failure and returns `[]`, which reads as "we own nothing" and silently disables reclaim. Worth logging, but again not a pure move.

## Testing

Type check and lint clean. Local test runs are disabled on this machine, so CI is the first execution of the embed lifecycle suite against the moved code.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->