### PR TITLE
fix(voice): clear a canceled start's survivor when its replacement fails

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.test.tsx
@@ -12,7 +12,14 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { useRef } from "react";
 
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 
 import {
   fakeStream,
@@ -60,6 +67,8 @@ function Probe({ flash = true }: { flash?: boolean }) {
       </span>
       <span data-testid="facing">{camera.facing}</span>
       <span data-testid="flipping">{camera.flipping ? "yes" : "no"}</span>
+      <span data-testid="open-state">{camera.open ? "yes" : "no"}</span>
+      <span data-testid="native-state">{camera.native ? "yes" : "no"}</span>
       <button
         type="button"
         data-testid="open"
@@ -98,6 +107,20 @@ async function press(testId: string) {
   });
 }
 
+/**
+ * The same press, and the same read, scoped to one of two probes on screen at
+ * once. The bare helpers above go through `screen`, which spans the whole
+ * document and so finds both copies of a test id.
+ */
+async function pressIn(container: HTMLElement, testId: string) {
+  await act(async () => {
+    within(container).getByTestId(testId).click();
+  });
+}
+
+const readIn = (container: HTMLElement, testId: string) =>
+  within(container).getByTestId(testId).textContent;
+
 /** Render the probe and open a native camera, settling the capability probe. */
 async function openNativeCamera() {
   render(<Probe />);
@@ -110,6 +133,7 @@ beforeEach(() => {
   startSpy.mockClear();
   startSpy.mockImplementation(async () => true);
   stopSpy.mockClear();
+  stopSpy.mockImplementation(async () => {});
   flipSpy.mockClear();
   flipSpy.mockImplementation(async () => true);
   getFlashModesSpy.mockClear();
@@ -668,6 +692,37 @@ describe("useVoiceCamera: an open superseded while the bridge starts it", () => 
     expect(stopSpy).toHaveBeenCalledTimes(2);
   });
 
+  test("waits for the survivor's release before asking the browser", async () => {
+    // The same failure, on a shell that has `getUserMedia` to fall back to.
+    // The device the fallback is about to ask for is the one the survivor is
+    // still holding, and a request that overlaps the release comes back
+    // `NotReadableError`, which closes the viewfinder it was opening.
+    const getUserMedia = mock(async () => fakeStream());
+    stubMediaDevices(getUserMedia);
+
+    const firstStart = deferredCall<boolean>();
+    startSpy.mockImplementation(firstStart.answer);
+    render(<Probe />);
+    await press("open");
+    await press("close");
+
+    const secondStart = deferredCall<boolean>();
+    startSpy.mockImplementation(secondStart.answer);
+    await press("open");
+    await settle(() => firstStart.resolve(true));
+
+    const release = deferredCall<undefined>();
+    stopSpy.mockImplementation(release.answer);
+    await settle(() => secondStart.resolve(false));
+
+    expect(stopSpy).toHaveBeenCalledTimes(2);
+    expect(getUserMedia).not.toHaveBeenCalled();
+
+    await settle(() => release.resolve(undefined));
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
   test("stops the camera nothing owns when only a close follows", async () => {
     // The other half of the discipline: with no reopen behind it, the
     // superseded start is the last owner standing, and the stop it posts
@@ -682,6 +737,31 @@ describe("useVoiceCamera: an open superseded while the bridge starts it", () => 
     await settle(() => slowStart.resolve(true));
 
     expect(stopSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useVoiceCamera: a start the plugin refuses", () => {
+  test("leaves a preview another surface is showing alone", async () => {
+    // Both plugin implementations refuse a start while a preview is running,
+    // so a second surface raising its camera over a live one fails by design.
+    // That failure raised nothing and owns nothing: the hardware it collided
+    // with is the viewfinder the first surface is still reporting open, and a
+    // stop posted for it would be the room's camera going dark because the
+    // composer's overlay asked for one.
+    stubMediaDevices(null);
+    const owner = render(<Probe />);
+    await pressIn(owner.container, "open");
+    await waitFor(() => expect(getFlashModesSpy).toHaveBeenCalled());
+    expect(readIn(owner.container, "open-state")).toBe("yes");
+    stopSpy.mockClear();
+
+    startSpy.mockImplementation(async () => false);
+    const intruder = render(<Probe />);
+    await pressIn(intruder.container, "open");
+
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(readIn(owner.container, "open-state")).toBe("yes");
+    expect(readIn(owner.container, "native-state")).toBe("yes");
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.test.tsx
@@ -645,6 +645,29 @@ describe("useVoiceCamera: an open superseded while the bridge starts it", () => 
     await waitFor(() => expect(flashAvailable()).toBe(true));
   });
 
+  test("a failed replacement start still clears a canceled start's survivor", async () => {
+    // Start A resolves after a close and a reopen, and defers its cleanup to
+    // the reopen's pending start B. When B then fails, B is the newest call
+    // and posts the stop that clears whatever A left running; nothing else
+    // owns a native source that would.
+    const firstStart = deferredCall<boolean>();
+    startSpy.mockImplementation(firstStart.answer);
+    render(<Probe />);
+    await press("open");
+    await press("close");
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+
+    const secondStart = deferredCall<boolean>();
+    startSpy.mockImplementation(secondStart.answer);
+    await press("open");
+
+    await settle(() => firstStart.resolve(true));
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+
+    await settle(() => secondStart.resolve(false));
+    expect(stopSpy).toHaveBeenCalledTimes(2);
+  });
+
   test("stops the camera nothing owns when only a close follows", async () => {
     // The other half of the discipline: with no reopen behind it, the
     // superseded start is the last owner standing, and the stop it posts

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
@@ -127,10 +127,7 @@ const NO_FLASH_MODES: string[] = [];
 
 /**
  * The newest native start or stop any instance of this hook posted to the
- * bridge. A start that fails while it is the newest call posts a stop, both
- * to correct the ledger and to clear any preview a canceled earlier start
- * left running when it deferred cleanup to the calls behind it.
- * Module-scoped because the native preview is one plugin instance
+ * bridge. Module-scoped because the native preview is one plugin instance
  * shared across hook instances (the room and the capture overlay), so a stale
  * start deciding whether its cleanup is safe cannot consult its own refs: the
  * newest call can belong to an instance it has never seen. When the newest
@@ -140,15 +137,36 @@ const NO_FLASH_MODES: string[] = [];
 let lastNativePreviewCall: "start" | "stop" = "stop";
 
 /**
- * Counts the calls the ledger describes, so a failed start can tell whether
- * it is still the newest one before it downgrades the ledger: when a newer
- * call sits behind it on the bridge, the ledger is that call's to describe.
+ * Counts the calls the ledger describes, so a failed start can tell whether it
+ * is still the newest one before it clears up after an orphaned preview: when
+ * a newer call sits behind it on the bridge, that cleanup is the newer call's.
  */
 let nativePreviewCallSeq = 0;
+
+/**
+ * Whether a preview is running that no hook instance owns.
+ *
+ * Set by a canceled start that resolved into live hardware while another start
+ * sat behind it on the bridge. A stop posted from there would land after that
+ * start and tear down the preview it is installing, so the canceled start
+ * leaves the hardware to whichever call ends up holding it, and this is the
+ * note it leaves behind.
+ *
+ * Cleared by every stop {@link recordNativePreviewCall} takes, which covers
+ * both a release tearing its own capture down and the failed start that posts
+ * a stop deliberately to collect the orphan: either one is posted after the
+ * orphan's own start resolved, so it is the call that finally lands on that
+ * hardware. Cleared as well by a start that succeeds, which both plugins
+ * refuse while a preview is running and so proves there is none left over.
+ */
+let nativePreviewOrphaned = false;
 
 /** Record a native start or stop posted to the bridge, returning its seq. */
 function recordNativePreviewCall(call: "start" | "stop"): number {
   lastNativePreviewCall = call;
+  if (call === "stop") {
+    nativePreviewOrphaned = false;
+  }
   return ++nativePreviewCallSeq;
 }
 
@@ -457,14 +475,22 @@ export function useVoiceCamera(
           // newest call on the bridge is another start, in this instance or
           // any other, the opposite holds: that start sits behind this one on
           // the bridge, and an unscoped stop posted now lands after it,
-          // tearing down the very preview it is installing.
+          // tearing down the very preview it is installing. The hardware this
+          // start raised is then nobody's until that call settles, which is
+          // what `nativePreviewOrphaned` records.
           if (started && lastNativePreviewCall === "stop") {
             await stopNativeVoiceCamera();
+          } else if (started) {
+            nativePreviewOrphaned = true;
           }
           return "aborted";
         }
         if (started) {
           sourceRef.current = "native";
+          // A start the plugin accepted is a start it did not refuse as
+          // "camera already started", so nothing was running in front of it
+          // and no earlier start left a preview behind.
+          nativePreviewOrphaned = false;
           setNative(true);
           setFacing(nextFacing);
           // Not awaited: the viewfinder is already live and the flash control
@@ -474,15 +500,24 @@ export function useVoiceCamera(
           return null;
         }
         sourceRef.current = null;
-        // A failed start raises nothing itself, but an earlier canceled
-        // start may have resolved while this one was pending and deferred
-        // its cleanup here, trusting the newest call to own the hardware.
-        // While this failure is still the ledger's newest call, it posts the
-        // stop that clears any such survivor; on a bare failure the stop
-        // lands on stopped hardware and does nothing.
-        if (nativeCallSeq === nativePreviewCallSeq) {
+        // A failed start raises nothing itself, so the only hardware it has
+        // any claim on is a preview an earlier canceled start deferred to it.
+        // While this failure is still the newest call on the bridge it is the
+        // one holding that deferral, and the stop it posts is what collects
+        // it. Without an orphan there is nothing to collect: the preview this
+        // start collided with belongs to a viewfinder somewhere else that is
+        // reporting itself open, and stopping it would close that surface's
+        // camera out from under it.
+        if (nativeCallSeq === nativePreviewCallSeq && nativePreviewOrphaned) {
           recordNativePreviewCall("stop");
-          void stopNativeVoiceCamera();
+          // Awaited, so the fallback below asks for a device the native side
+          // has finished releasing. A `getUserMedia` racing that release comes
+          // back `NotReadableError`, which closes the replacement viewfinder
+          // instead of opening it.
+          await stopNativeVoiceCamera();
+          if (epoch !== acquireEpochRef.current) {
+            return "aborted";
+          }
         }
       }
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-camera.ts
@@ -127,8 +127,10 @@ const NO_FLASH_MODES: string[] = [];
 
 /**
  * The newest native start or stop any instance of this hook posted to the
- * bridge, corrected to "stop" when a start reports failure with nothing newer
- * behind it. Module-scoped because the native preview is one plugin instance
+ * bridge. A start that fails while it is the newest call posts a stop, both
+ * to correct the ledger and to clear any preview a canceled earlier start
+ * left running when it deferred cleanup to the calls behind it.
+ * Module-scoped because the native preview is one plugin instance
  * shared across hook instances (the room and the capture overlay), so a stale
  * start deciding whether its cleanup is safe cannot consult its own refs: the
  * newest call can belong to an instance it has never seen. When the newest
@@ -472,11 +474,15 @@ export function useVoiceCamera(
           return null;
         }
         sourceRef.current = null;
-        // A failed start raises nothing, so while it is still the ledger's
-        // newest call it stops reading as a live preview a stale sibling
-        // must spare.
+        // A failed start raises nothing itself, but an earlier canceled
+        // start may have resolved while this one was pending and deferred
+        // its cleanup here, trusting the newest call to own the hardware.
+        // While this failure is still the ledger's newest call, it posts the
+        // stop that clears any such survivor; on a bare failure the stop
+        // lands on stopped hardware and does nothing.
         if (nativeCallSeq === nativePreviewCallSeq) {
-          lastNativePreviewCall = "stop";
+          recordNativePreviewCall("stop");
+          void stopNativeVoiceCamera();
         }
       }
 


### PR DESCRIPTION
## Summary
- A canceled native camera start that resolves while a newer start is pending defers its cleanup to the calls behind it. When that newer start fails, nothing stopped the preview the canceled start left running (live camera hidden behind an opaque web view, unreachable from close). The failed start, while it is the ledger's newest call, now posts the survivor-clearing stop; on a bare failure the stop lands on stopped hardware and does nothing.
- Regression test covers the close, reopen, stale-success, replacement-failure interleaving.

Follow-up to #41636: this addresses the last open Codex thread there, which arrived after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)