### PR TITLE
Drop the obscure-credits read from usePlanUsageBalance

### DIFF
--- a/clients/web/src/domains/settings/billing/usage-balance-panel.stories.tsx
+++ b/clients/web/src/domains/settings/billing/usage-balance-panel.stories.tsx
@@ -1,10 +1,9 @@
 /**
- * The Usage Balance reading that the `obscure-credits` flag puts where the
- * current plan's price row used to sit: how much of the usage credit the
- * account was granted is already used, and, once the wallet behind it is
- * empty too, a strip offering to top it up. The reading itself turns
- * negative as soon as the granted credit is used up, whatever the wallet
- * holds.
+ * The Usage Balance reading that sits in place of the current plan's price
+ * row: how much of the usage credit the account was granted is already used,
+ * and, once the wallet behind it is empty too, a strip offering to top it up.
+ * The reading itself turns negative as soon as the granted credit is used up,
+ * whatever the wallet holds.
  *
  * Pure props, so every reading below is a fixture rather than a live usage
  * read. `PlanTile` mounts it as a footer; `Settings/Billing/PlanTile` carries

--- a/clients/web/src/domains/settings/billing/usage-balance-panel.tsx
+++ b/clients/web/src/domains/settings/billing/usage-balance-panel.tsx
@@ -20,9 +20,8 @@ export interface UsageBalancePanelProps {
 }
 
 /**
- * The current-plan tile's footer while `obscure-credits` is on, in place of the
- * price row: how much of the usage credit the account was granted it has
- * already used.
+ * The current-plan tile's footer, in place of the price row: how much of the
+ * usage credit the account was granted it has already used.
  */
 export function UsageBalancePanel({
   ratio,

--- a/clients/web/src/hooks/use-plan-usage-balance.test.tsx
+++ b/clients/web/src/hooks/use-plan-usage-balance.test.tsx
@@ -3,30 +3,18 @@
  *
  * The hook reads entirely off the billing summary's usage-grant figures, so
  * there is no endpoint to drive: every case seeds the two figures and the
- * subscription directly. The hook only speaks when the `obscure-credits` flag
- * is on and the figures support an honest reading, with one deliberate
- * exception: a Pro sub whose unexpired grants total nothing reads as a fully
- * spent bar rather than no bar at all. `usageGrantRatio` is the pure half
- * that resolves the ratio.
+ * subscription directly. The hook only speaks when the figures support an
+ * honest reading, with one deliberate exception: a Pro sub whose unexpired
+ * grants total nothing reads as a fully spent bar rather than no bar at all.
+ * `usageGrantRatio` is the pure half that resolves the ratio.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { act, renderHook } from "@testing-library/react";
+import { describe, expect, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
 
 import type { SubscriptionResponse } from "@/generated/api/types.gen";
 
-const { useClientFeatureFlagStore } =
-  await import("@/stores/client-feature-flag-store");
-const { usePlanUsageBalance, usageGrantRatio } =
-  await import("./use-plan-usage-balance");
-
-function setObscureCredits(value: boolean): void {
-  act(() => {
-    useClientFeatureFlagStore
-      .getState()
-      .setFlags({ obscureCredits: value }, null);
-  });
-}
+import { usageGrantRatio, usePlanUsageBalance } from "./use-plan-usage-balance";
 
 function proSubscription(
   over: Partial<SubscriptionResponse> = {},
@@ -64,14 +52,6 @@ function renderBalance(args: {
 }) {
   return renderHook(() => usePlanUsageBalance(args));
 }
-
-beforeEach(() => {
-  setObscureCredits(true);
-});
-
-afterEach(() => {
-  setObscureCredits(false);
-});
 
 describe("usePlanUsageBalance on a Pro sub", () => {
   test("reads the used share of the grants", () => {
@@ -126,17 +106,6 @@ describe("usePlanUsageBalance on a Pro sub", () => {
     });
 
     expect(result.current?.ratio).toBe(1);
-  });
-
-  test("stays silent while the flag is off", () => {
-    setObscureCredits(false);
-    const { result } = renderBalance({
-      subscription: proSubscription(),
-      totalUsageBalance: "25.00",
-      availableUsageBalance: "15.00",
-    });
-
-    expect(result.current).toBeNull();
   });
 
   test("stays silent when the platform reports no grant figures", () => {
@@ -208,17 +177,6 @@ describe("usePlanUsageBalance on a free plan", () => {
       subscription: freeSubscription(),
       totalUsageBalance: "0.00",
       availableUsageBalance: "0.00",
-    });
-
-    expect(result.current).toBeNull();
-  });
-
-  test("stays silent while the flag is off", () => {
-    setObscureCredits(false);
-    const { result } = renderBalance({
-      subscription: freeSubscription(),
-      totalUsageBalance: "5.00",
-      availableUsageBalance: "1.60",
     });
 
     expect(result.current).toBeNull();

--- a/clients/web/src/hooks/use-plan-usage-balance.ts
+++ b/clients/web/src/hooks/use-plan-usage-balance.ts
@@ -1,5 +1,5 @@
 /**
- * The Usage Balance reading behind the `obscure-credits` flag.
+ * The current plan's Usage Balance reading.
  *
  * Every plan reads straight off the billing summary's usage-grant figures:
  * how much of the credit the org was granted (initial credit and Pro bundle
@@ -22,7 +22,6 @@
  */
 
 import type { SubscriptionResponse } from "@/generated/api/types.gen";
-import { useObscureCredits } from "@/hooks/use-obscure-credits-flag";
 import { parseUsd } from "@/lib/billing/parse-usd";
 
 export interface PlanUsageBalance {
@@ -76,11 +75,6 @@ export function usePlanUsageBalance(
     availableUsageBalance = null,
     totalUsageBalance = null,
   } = args;
-  const obscureCredits = useObscureCredits();
-
-  if (!obscureCredits) {
-    return null;
-  }
 
   const total = parseUsd(totalUsageBalance);
   const ratio = usageGrantRatio(total, parseUsd(availableUsageBalance));


### PR DESCRIPTION
## Summary

- `usePlanUsageBalance` no longer reads `useObscureCredits()`; the reading now depends only on the usage-grant figures and the subscription plan, and the module docstring describes the hook rather than the flag.
- Dropped the two flag-OFF test cases and the flag setup helper; every remaining case asserts the reading directly, and the now-unneeded dynamic import became a static one.
- Prose-only docstring updates on `usage-balance-panel.tsx` and its stories file. No behavior change ships here: `plan-card.tsx` and `use-preferences-usage.ts` keep their own flag gates until the sibling PRs land.

Part of plan: remove-obscure-credits-flag.md (PR 1 of 6)