### PR TITLE
fix(workers): own workers by process tree, not by PID-file liveness (ATL-1349)

### DIFF
--- a/assistant/src/monitoring/control.ts
+++ b/assistant/src/monitoring/control.ts
@@ -68,13 +68,13 @@ export function stopMonitoringWorkerProcess(): WorkerProcessStatus {
 
 /**
  * Daemon-lifecycle entry point: spawn the monitor as a child of the daemon
- * (`detached: false`, so it appears in `assistant ps` and is torn down on
+ * (so it appears in the daemon's process tree and is torn down on
  * shutdown). Runs on every boot — the monitor is platform infrastructure,
  * not an opt-in feature. Fire-and-forget — a monitor failure must never
  * block boot.
  */
 export function startMonitoring(): void {
-  void spawnMonitoringWorkerProcess({ detached: false })
+  void spawnMonitoringWorkerProcess()
     .then((r) =>
       log.info(
         { pid: r.pid, alreadyRunning: r.alreadyRunning },

--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -14,12 +14,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { getEmbedWorkerPidPath } from "../../../util/platform.js";
 import {
   classifyWorkerOwnership,
   listWorkerProcesses,
-  LocalEmbeddingBackend,
-} from "../embedding-local.js";
+} from "../../../util/ml-worker-ownership.js";
+import { getEmbedWorkerPidPath } from "../../../util/platform.js";
+import { LocalEmbeddingBackend } from "../embedding-local.js";
 
 /** Reach past `private`, which is compile-time only, so tests drive real state. */
 type Internals = any;

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -10,13 +10,14 @@ import { join } from "node:path";
 import { getIsContainerized } from "../../config/env-registry.js";
 import { getLogger } from "../../util/logger.js";
 import {
+  classifyWorkerOwnership,
+  listWorkerProcesses,
+  pid1OwnsMlWorkers,
+} from "../../util/ml-worker-ownership.js";
+import {
   getEmbeddingModelsDir,
   getEmbedWorkerPidPath,
 } from "../../util/platform.js";
-import {
-  listProcessTable,
-  readRawProcessCommand,
-} from "../../util/process-table.js";
 import { PromiseGuard } from "../../util/promise-guard.js";
 import { workerComputeEnv } from "../../util/worker-compute.js";
 import { workerMemoryEnv } from "../../util/worker-memory.js";
@@ -95,102 +96,6 @@ function isProcessAlive(pid: number): boolean {
     return true;
   } catch {
     return false;
-  }
-}
-
-interface WorkerProcess {
-  pid: number;
-  ppid: number;
-}
-
-/**
- * What this process may do with an embed worker it found in the process table.
- *
- * - `reclaim`: parented to us, a worker we started and lost track of. Reaping
- *   it is what enforces one live worker per owning process.
- * - `orphan`: reparented to init, or its owner is gone. Nobody else will ever
- *   clean it up.
- * - `foreign`: owned by another live process. The memory-worker process runs
- *   its own backend against this same workspace and is entitled to its own
- *   worker; signalling it is what made the two replace each other in a loop.
- *
- * A parent of PID 1 is ambiguous, and resolving it wrongly in either direction
- * costs something real. `docker-entrypoint.sh` execs the daemon, so PID 1 can
- * BE the daemon and its child a healthy sibling's worker. Under `docker run
- * --init`, and on any host, PID 1 is an init process instead, so the same
- * parentage means the owner died and the worker needs reclaiming. Callers
- * therefore pass what PID 1 actually is rather than inferring it from whether
- * the deployment is containerized, which is true in both container shapes.
- */
-export type WorkerOwnership = "reclaim" | "orphan" | "foreign";
-
-export function classifyWorkerOwnership(
-  worker: WorkerProcess,
-  selfPid: number,
-  isOwnerAlive: (pid: number) => boolean,
-  pid1OwnsWorkers: boolean,
-): WorkerOwnership {
-  if (worker.ppid === selfPid) {
-    return "reclaim";
-  }
-  if (worker.ppid <= 1) {
-    return pid1OwnsWorkers ? "foreign" : "orphan";
-  }
-  if (!isOwnerAlive(worker.ppid)) {
-    return "orphan";
-  }
-  return "foreign";
-}
-
-/** Entrypoint the daemon is exec'd with, including inside a container. */
-const DAEMON_ENTRYPOINT_MARKER = "daemon/main";
-
-/**
- * Whether PID 1 is an assistant daemon rather than an init process.
- *
- * True only where the daemon was exec'd as PID 1 (`docker-entrypoint.sh`),
- * which is what makes a worker parented to 1 a live sibling's rather than an
- * orphan. Under `docker run --init` PID 1 is docker-init and under launchd or
- * systemd it is the system init, so both answer false and PID-1 orphans stay
- * reclaimable. Unreadable means false, which keeps the reclaiming behaviour.
- */
-function pid1OwnsEmbedWorkers(): boolean {
-  if (process.pid === 1) {
-    return true;
-  }
-  return readRawProcessCommand(1)?.includes(DAEMON_ENTRYPOINT_MARKER) ?? false;
-}
-
-/**
- * Live embed-worker processes for this workspace, as `(pid, ppid)` pairs.
- *
- * Ownership of an embed worker is recorded by the OS process tree, not by the
- * PID file: a worker's parent IS its owner. The process table is therefore the
- * authoritative answer to "whose worker is this", and unlike the PID file it
- * survives a crash and cannot be overwritten by a second owner. That matters
- * because the daemon and the memory-worker process legitimately run one worker
- * each against the same workspace.
- *
- * Matches on the absolute worker script path, which lives under THIS
- * workspace's embedding-models directory and is therefore unique per assistant
- * instance, so a sibling instance's workers never match. Raw command lines are
- * read for matching only, never stored or logged: process arguments can carry
- * secrets (see the redaction note in `util/process-tree.ts`).
- */
-export function listWorkerProcesses(
-  workerPath: string,
-  model?: string,
-): WorkerProcess[] {
-  try {
-    return listProcessTable()
-      .filter(
-        (row) =>
-          row.command.includes(workerPath) &&
-          (!model || row.command.split(/\s+/).includes(model)),
-      )
-      .map(({ pid, ppid }) => ({ pid, ppid }));
-  } catch {
-    return [];
   }
 }
 
@@ -874,7 +779,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         worker,
         process.pid,
         isProcessAlive,
-        pid1OwnsEmbedWorkers(),
+        pid1OwnsMlWorkers(),
       );
       if (ownership === "foreign") {
         continue;

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -18,6 +18,7 @@ import {
   getEmbeddingModelsDir,
   getEmbedWorkerPidPath,
 } from "../../util/platform.js";
+import { isProcessAlive } from "../../util/process-liveness.js";
 import { PromiseGuard } from "../../util/promise-guard.js";
 import { workerComputeEnv } from "../../util/worker-compute.js";
 import { workerMemoryEnv } from "../../util/worker-memory.js";
@@ -89,16 +90,6 @@ async function didSettle(
 }
 
 /** Whether a PID names a live process. */
-function isProcessAlive(pid: number): boolean {
-  try {
-    // Signal 0 probes for liveness without delivering a signal.
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Local embedding backend using @huggingface/transformers (ONNX Runtime).
  * Runs BAAI/bge-small-en-v1.5 locally — no API calls, no network required.

--- a/assistant/src/plugins/defaults/memory/jobs-worker.ts
+++ b/assistant/src/plugins/defaults/memory/jobs-worker.ts
@@ -192,7 +192,7 @@ export interface MemoryJobsWorker {
 
 /**
  * Daemon-lifecycle entry point: spawn the memory jobs worker as a child of the
- * daemon (`detached: false`, so it appears in `assistant ps` and is torn down
+ * daemon (so it appears in the daemon's process tree and is torn down
  * on shutdown). The worker process is the sole drainer of the memory job queue.
  * Fire-and-forget — a worker failure must never block boot. A worker that comes
  * up late is still the desired sole drainer, so `terminateOnTimeout` is
@@ -205,7 +205,6 @@ export interface MemoryJobsWorker {
 export function startMemoryJobsWorker(): void {
   void spawnMemoryWorkerProcess({
     terminateOnTimeout: false,
-    detached: false,
   })
     .then(({ pid, alreadyRunning }) =>
       log.info(

--- a/assistant/src/plugins/defaults/memory/src/__tests__/memory-worker-routes.test.ts
+++ b/assistant/src/plugins/defaults/memory/src/__tests__/memory-worker-routes.test.ts
@@ -4,7 +4,7 @@
  * The route handlers run inside the daemon and manage the worker process. We
  * mock worker-control + the embedding backend so the tests assert handler
  * behaviour:
- *   - start spawns as a daemon child (detached:false) and throws on failure.
+ *   - start spawns the worker and throws on failure.
  *   - stop signals the worker and reports its prior state.
  *   - status reports the worker process liveness + the embedding backend.
  */
@@ -16,7 +16,7 @@ import { getMemoryWorkerPidPath } from "../../../../../util/platform.js";
 class FakeSpawnError extends Error {}
 
 let spawnImpl: () => Promise<{ pid: number; alreadyRunning: boolean }>;
-let spawnArgs: Array<{ detached?: boolean; terminateOnTimeout?: boolean }> = [];
+let spawnArgs: Array<{ terminateOnTimeout?: boolean } | undefined> = [];
 let stopImpl: () => { status: "running" | "not_running"; pid?: number };
 let workerProbe: { status: "running" | "not_running"; pid?: number } = {
   status: "not_running",
@@ -37,10 +37,7 @@ let backendStatus: {
 
 mock.module("../../worker-control.js", () => ({
   MemoryWorkerSpawnError: FakeSpawnError,
-  spawnMemoryWorkerProcess: async (opts: {
-    detached?: boolean;
-    terminateOnTimeout?: boolean;
-  }) => {
+  spawnMemoryWorkerProcess: async (opts: { terminateOnTimeout?: boolean }) => {
     spawnArgs.push(opts);
     return spawnImpl();
   },
@@ -86,7 +83,7 @@ describe("memory_worker_start", () => {
 
     const res = await handler("memory_worker_start")();
 
-    expect(spawnArgs).toEqual([{ detached: false }]);
+    expect(spawnArgs).toEqual([undefined]);
     expect(res).toEqual({
       pid: 4242,
       alreadyRunning: false,

--- a/assistant/src/plugins/defaults/memory/src/memory-worker-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-worker-routes.ts
@@ -62,7 +62,7 @@ const statusResponseSchema = z.object({
 async function startMemoryWorker() {
   let result: { pid: number; alreadyRunning: boolean };
   try {
-    result = await spawnMemoryWorkerProcess({ detached: false });
+    result = await spawnMemoryWorkerProcess();
   } catch (err) {
     const message =
       err instanceof MemoryWorkerSpawnError || err instanceof Error

--- a/assistant/src/plugins/defaults/memory/worker-control.ts
+++ b/assistant/src/plugins/defaults/memory/worker-control.ts
@@ -37,8 +37,7 @@ export class MemoryWorkerSpawnError extends WorkerProcessSpawnError {}
  * failed to start).
  *
  * See {@link SpawnWorkerProcessOptions} for the generic option semantics. The
- * daemon's boot spawn passes `detached: false` (so the worker appears in
- * `assistant ps` and is torn down with the daemon) and leaves
+ * daemon's boot spawn leaves
  * `terminateOnTimeout` unset (a worker that comes up late is still the desired
  * sole drainer).
  */

--- a/assistant/src/routes/__tests__/control.test.ts
+++ b/assistant/src/routes/__tests__/control.test.ts
@@ -14,7 +14,7 @@ import * as realLogger from "../../util/logger.js";
 import * as realWorkerProcess from "../../util/worker-process.js";
 
 let enabled = false;
-let spawnArgs: Array<{ options?: { detached?: boolean } }> = [];
+let spawnArgs: Array<{ options?: { terminateOnTimeout?: boolean } }> = [];
 let stopStatus: { status: "running" | "not_running"; pid?: number } = {
   status: "not_running",
 };
@@ -39,7 +39,9 @@ mock.module("../../util/logger.js", () => ({
 
 mock.module("../../util/worker-process.js", () => ({
   ...realWorkerProcess,
-  spawnWorkerProcess: async (args: { options?: { detached?: boolean } }) => {
+  spawnWorkerProcess: async (args: {
+    options?: { terminateOnTimeout?: boolean };
+  }) => {
     spawnArgs.push(args);
     return { pid: 4242, alreadyRunning: false };
   },
@@ -71,12 +73,11 @@ describe("startRouteHost", () => {
     expect(spawnArgs).toHaveLength(0);
   });
 
-  test("spawns the host as a daemon child when enabled", async () => {
+  test("spawns the host when enabled", async () => {
     enabled = true;
     startRouteHost();
     await Promise.resolve();
     expect(spawnArgs).toHaveLength(1);
-    expect(spawnArgs[0].options?.detached).toBe(false);
   });
 });
 

--- a/assistant/src/routes/control.ts
+++ b/assistant/src/routes/control.ts
@@ -101,7 +101,7 @@ export function startRouteHost(): void {
   if (!isRouteHostEnabled()) {
     return;
   }
-  void spawnRouteHostWorkerProcess({ detached: false })
+  void spawnRouteHostWorkerProcess()
     .then((r) =>
       log.info(
         { pid: r.pid, alreadyRunning: r.alreadyRunning },

--- a/assistant/src/routes/route-host-client.ts
+++ b/assistant/src/routes/route-host-client.ts
@@ -153,7 +153,7 @@ export class RouteHostClient {
         workerLabel: "Route host",
         // Owned by the daemon (appears in its process tree, torn down with it);
         // kill it if it hangs during startup so a failed spawn leaves nothing.
-        options: { detached: false, terminateOnTimeout: true },
+        options: { terminateOnTimeout: true },
       }));
     } catch (err) {
       // A failed bring-up (crash-on-startup, PID-file timeout) is a retryable

--- a/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/monitoring-routes.test.ts
@@ -4,7 +4,7 @@
  * The route handlers run inside the daemon and own the monitor process. We mock
  * monitoring-control, the config loader, and the sample ring buffer so the
  * tests assert handler behaviour:
- *   - start spawns as a daemon child (detached:false) and throws on spawn
+ *   - start spawns the worker and throws on spawn
  *     failure.
  *   - stop signals the monitor (a runtime pause — the daemon respawns it at
  *     the next boot).
@@ -19,7 +19,7 @@ import { getMonitoringPidPath } from "../../../util/platform.js";
 class FakeSpawnError extends Error {}
 
 let spawnImpl: () => Promise<{ pid: number; alreadyRunning: boolean }>;
-let spawnArgs: Array<{ detached?: boolean; terminateOnTimeout?: boolean }> = [];
+let spawnArgs: Array<{ terminateOnTimeout?: boolean } | undefined> = [];
 let stopImpl: () => { status: "running" | "not_running"; pid?: number };
 let monitoringProbe: { status: "running" | "not_running"; pid?: number } = {
   status: "not_running",
@@ -29,7 +29,6 @@ let latestSample: ResourceSample | null = null;
 mock.module("../../../monitoring/control.js", () => ({
   MonitoringWorkerSpawnError: FakeSpawnError,
   spawnMonitoringWorkerProcess: async (opts: {
-    detached?: boolean;
     terminateOnTimeout?: boolean;
   }) => {
     spawnArgs.push(opts);
@@ -71,7 +70,7 @@ describe("monitoring_start", () => {
 
     const res = await handler("monitoring_start")();
 
-    expect(spawnArgs).toEqual([{ detached: false, terminateOnTimeout: true }]);
+    expect(spawnArgs).toEqual([{ terminateOnTimeout: true }]);
     expect(res).toEqual({
       pid: 4242,
       alreadyRunning: false,

--- a/assistant/src/runtime/routes/__tests__/route-host-worker-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/route-host-worker-routes.test.ts
@@ -3,7 +3,7 @@
  *
  * The handlers run inside the daemon and manage the route host process. We mock
  * the route host control surface so the tests assert handler behaviour:
- *   - start spawns as a daemon child (detached:false) and throws on failure.
+ *   - start spawns the worker and throws on failure.
  *   - stop signals the host and reports its prior state.
  *   - status reports the host process liveness.
  */
@@ -15,7 +15,7 @@ import { getProcPidPath } from "../../../util/platform.js";
 class FakeSpawnError extends Error {}
 
 let spawnImpl: () => Promise<{ pid: number; alreadyRunning: boolean }>;
-let spawnArgs: Array<{ detached?: boolean; terminateOnTimeout?: boolean }> = [];
+let spawnArgs: Array<{ terminateOnTimeout?: boolean } | undefined> = [];
 let stopImpl: () => { status: "running" | "not_running"; pid?: number };
 let workerProbe: { status: "running" | "not_running"; pid?: number } = {
   status: "not_running",
@@ -24,7 +24,6 @@ let workerProbe: { status: "running" | "not_running"; pid?: number } = {
 mock.module("../../../routes/control.js", () => ({
   RouteHostSpawnError: FakeSpawnError,
   spawnRouteHostWorkerProcess: async (opts: {
-    detached?: boolean;
     terminateOnTimeout?: boolean;
   }) => {
     spawnArgs.push(opts);
@@ -57,7 +56,7 @@ describe("routes_worker_start", () => {
 
     const res = await handler("routes_worker_start")();
 
-    expect(spawnArgs).toEqual([{ detached: false }]);
+    expect(spawnArgs).toEqual([undefined]);
     expect(res).toEqual({
       pid: 4242,
       alreadyRunning: false,

--- a/assistant/src/runtime/routes/__tests__/schedule-worker-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/schedule-worker-routes.test.ts
@@ -3,7 +3,7 @@
  *
  * The route handlers run inside the daemon and manage the worker process. We
  * mock schedule worker-control so the tests assert handler behaviour:
- *   - start spawns as a daemon child (detached:false) and throws on failure.
+ *   - start spawns the worker and throws on failure.
  *   - stop signals the worker and reports its prior state.
  *   - status reports the worker process liveness.
  */
@@ -15,7 +15,7 @@ import { getScheduleWorkerPidPath } from "../../../util/platform.js";
 class FakeSpawnError extends Error {}
 
 let spawnImpl: () => Promise<{ pid: number; alreadyRunning: boolean }>;
-let spawnArgs: Array<{ detached?: boolean; terminateOnTimeout?: boolean }> = [];
+let spawnArgs: Array<{ terminateOnTimeout?: boolean } | undefined> = [];
 let stopImpl: () => { status: "running" | "not_running"; pid?: number };
 let workerProbe: { status: "running" | "not_running"; pid?: number } = {
   status: "not_running",
@@ -24,8 +24,7 @@ const adminStoppedCalls: boolean[] = [];
 
 mock.module("../../../schedule/worker-control.js", () => ({
   ScheduleWorkerSpawnError: FakeSpawnError,
-  spawnScheduleWorkerProcess: async (opts: {
-    detached?: boolean;
+  spawnScheduleWorkerProcess: async (opts?: {
     terminateOnTimeout?: boolean;
   }) => {
     spawnArgs.push(opts);
@@ -57,12 +56,12 @@ beforeEach(() => {
 });
 
 describe("schedules_worker_start", () => {
-  test("spawns as a daemon child and returns the PID", async () => {
+  test("spawns the worker and returns the PID", async () => {
     spawnImpl = async () => ({ pid: 4242, alreadyRunning: false });
 
     const res = await handler("schedules_worker_start")();
 
-    expect(spawnArgs).toEqual([{ detached: false }]);
+    expect(spawnArgs).toEqual([undefined]);
     expect(res).toEqual({
       pid: 4242,
       alreadyRunning: false,

--- a/assistant/src/runtime/routes/monitoring-routes.ts
+++ b/assistant/src/runtime/routes/monitoring-routes.ts
@@ -139,10 +139,7 @@ const statusResponseSchema = z.object({
 async function handleMonitoringStart() {
   let result: { pid: number; alreadyRunning: boolean };
   try {
-    // `detached: false` parents the monitor to the daemon so it appears in
-    // `assistant ps` and is torn down on shutdown.
     result = await spawnMonitoringWorkerProcess({
-      detached: false,
       terminateOnTimeout: true,
     });
   } catch (err) {

--- a/assistant/src/runtime/routes/route-host-worker-routes.ts
+++ b/assistant/src/runtime/routes/route-host-worker-routes.ts
@@ -50,7 +50,7 @@ const statusResponseSchema = z.object({
 async function startRouteHostWorker() {
   let result: { pid: number; alreadyRunning: boolean };
   try {
-    result = await spawnRouteHostWorkerProcess({ detached: false });
+    result = await spawnRouteHostWorkerProcess();
   } catch (err) {
     const message =
       err instanceof RouteHostSpawnError || err instanceof Error

--- a/assistant/src/runtime/routes/schedule-worker-routes.ts
+++ b/assistant/src/runtime/routes/schedule-worker-routes.ts
@@ -50,7 +50,7 @@ const statusResponseSchema = z.object({
 async function startScheduleWorker() {
   let result: { pid: number; alreadyRunning: boolean };
   try {
-    result = await spawnScheduleWorkerProcess({ detached: false });
+    result = await spawnScheduleWorkerProcess();
   } catch (err) {
     const message =
       err instanceof ScheduleWorkerSpawnError || err instanceof Error

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -360,7 +360,7 @@ export function startScheduler(): SchedulerHandle {
   scheduleWorkerSupervisor = createWorkerSupervisor({
     label: "Schedule worker",
     probe: probeScheduleWorker,
-    respawn: () => spawnScheduleWorkerProcess({ detached: false }),
+    respawn: () => spawnScheduleWorkerProcess(),
     isSuppressed: isScheduleWorkerAdministrativelyStopped,
     killChild: (pid) => {
       try {

--- a/assistant/src/schedule/worker-control.ts
+++ b/assistant/src/schedule/worker-control.ts
@@ -119,13 +119,13 @@ export function stopScheduleWorkerProcess(): WorkerProcessStatus {
 
 /**
  * Daemon-lifecycle entry point: spawn the schedule worker as a child of the
- * daemon (`detached: false`, so it appears in `assistant ps` and is torn down
+ * daemon (so it appears in the daemon's process tree and is torn down
  * on shutdown). Fire-and-forget — a worker failure must never block boot. A
  * worker that comes up late is still the desired sole schedule runner
  * (`terminateOnTimeout` is deliberately not set).
  */
 export function startScheduleWorker(): void {
-  void spawnScheduleWorkerProcess({ detached: false })
+  void spawnScheduleWorkerProcess()
     .then((r) =>
       log.info(
         { pid: r.pid, alreadyRunning: r.alreadyRunning },

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -70,26 +70,52 @@ describe("workerKindSignature", () => {
   // The signature only guards against signalling a recycled PID, so it has to
   // be specific enough that an unrelated program running its own worker.ts
   // never matches.
+  const matches = (command: string, signature: readonly string[]): boolean =>
+    signature.every((part) => command.includes(part));
+
   test("does not match an unrelated program running some other worker.ts", () => {
     const signature = workerKindSignature(schedule, "schedule", source);
-    expect("bun run /home/dev/side-project/worker.ts").not.toContain(signature);
-    expect("node /srv/queue/src/jobs/worker.ts").not.toContain(signature);
+    expect(matches("bun run /home/dev/side-project/worker.ts", signature)).toBe(
+      false,
+    );
+    expect(matches("node /srv/queue/src/jobs/worker.ts", signature)).toBe(
+      false,
+    );
   });
 
   test("matches the same worker from a previous install", () => {
     const signature = workerKindSignature(schedule, "schedule", source);
     expect(
-      "bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts",
-    ).toContain(signature);
+      matches(
+        "bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts",
+        signature,
+      ),
+    ).toBe(true);
   });
 
-  test("is the packaged executable name inside a packaged runtime", () => {
-    expect(
-      workerKindSignature(schedule, "schedule", {
-        platform: "win32",
-        execPath: "/runtime/vellum-daemon.exe",
-        executableExists: () => true,
-      }),
-    ).toBe("vellum-worker");
+  const packaged = {
+    platform: "win32" as const,
+    execPath: "/runtime/vellum-daemon.exe",
+    executableExists: () => true,
+  };
+
+  // Every packaged worker runs one executable and is told apart by the
+  // subcommand, so the executable alone must not identify a worker: one
+  // worker's slot would otherwise reclaim another's process.
+  test("distinguishes packaged worker kinds sharing one executable", () => {
+    const scheduleSig = workerKindSignature(schedule, "schedule", packaged);
+    expect(matches('"C:/App/vellum-worker.exe" schedule', scheduleSig)).toBe(
+      true,
+    );
+    expect(matches('"C:/App/vellum-worker.exe" monitoring', scheduleSig)).toBe(
+      false,
+    );
+  });
+
+  test("matches a packaged worker from a previous install", () => {
+    const scheduleSig = workerKindSignature(schedule, "schedule", packaged);
+    expect(matches('"C:/Prev/vellum-worker.exe" schedule', scheduleSig)).toBe(
+      true,
+    );
   });
 });

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  decideWorkerSlot,
   resolveWorkerCommand,
   workerKindSignature,
+  type WorkerProcessStatus,
 } from "../worker-process.js";
 
 const entry = new URL("file:///source/monitoring/worker.ts");
@@ -117,5 +119,109 @@ describe("workerKindSignature", () => {
     expect(matches('"C:/Prev/vellum-worker.exe" schedule', scheduleSig)).toBe(
       true,
     );
+  });
+});
+
+// Every branch that can reach a kill. `reclaim` is the only decision that
+// signals a process, so each test below is really asking: could this input
+// have killed something it should not have?
+describe("decideWorkerSlot", () => {
+  const DAEMON = 900;
+  const WORKER = 4242;
+  const signature = ["src/schedule/worker.ts"];
+  const running = { status: "running" as const, pid: WORKER };
+  const ours = `bun --smol run /app/runtime/0.11.7/src/schedule/worker.ts`;
+  const previous = `bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts`;
+  const alive = () => true;
+  const dead = () => false;
+
+  const decide = (
+    row: { pid: number; ppid: number; command: string } | null,
+    isOwnerAlive = alive,
+    pid1OwnsWorkers = false,
+    status: WorkerProcessStatus = running,
+  ) =>
+    decideWorkerSlot(
+      status,
+      row,
+      signature,
+      DAEMON,
+      isOwnerAlive,
+      pid1OwnsWorkers,
+    );
+
+  test("spawns when the PID file names nothing running", () => {
+    expect(decide(null, alive, false, { status: "not_running" })).toEqual({
+      action: "spawn",
+    });
+  });
+
+  test("adopts this daemon's own worker", () => {
+    expect(decide({ pid: WORKER, ppid: DAEMON, command: ours })).toEqual({
+      action: "adopt",
+      pid: WORKER,
+    });
+  });
+
+  test("reclaims a worker reparented to init after its daemon died", () => {
+    expect(decide({ pid: WORKER, ppid: 1, command: previous })).toEqual({
+      action: "reclaim",
+      pid: WORKER,
+    });
+  });
+
+  test("reclaims a worker whose owner is gone", () => {
+    expect(decide({ pid: WORKER, ppid: 777, command: previous }, dead)).toEqual(
+      {
+        action: "reclaim",
+        pid: WORKER,
+      },
+    );
+  });
+
+  test("adopts a worker another live process owns", () => {
+    expect(decide({ pid: WORKER, ppid: 777, command: ours }, alive)).toEqual({
+      action: "adopt",
+      pid: WORKER,
+    });
+  });
+
+  // In a container the daemon is PID 1, so a worker parented to 1 is a live
+  // sibling's, not an orphan.
+  test("adopts a PID-1 child when PID 1 is the daemon", () => {
+    expect(
+      decide({ pid: WORKER, ppid: 1, command: ours }, alive, true),
+    ).toEqual({ action: "adopt", pid: WORKER });
+  });
+
+  // The cases below are the ones that must never reach a kill.
+  test("never signals an unrelated process on a recycled PID", () => {
+    expect(
+      decide({ pid: WORKER, ppid: 1, command: "/usr/bin/postgres -D /data" }),
+    ).toEqual({ action: "adopt", pid: WORKER });
+  });
+
+  test("never signals another project's worker.ts on a recycled PID", () => {
+    expect(
+      decide({
+        pid: WORKER,
+        ppid: 1,
+        command: "bun run /home/dev/side-project/worker.ts",
+      }),
+    ).toEqual({ action: "adopt", pid: WORKER });
+  });
+
+  test("never signals a different worker kind holding this slot", () => {
+    expect(
+      decide({
+        pid: WORKER,
+        ppid: 1,
+        command: "bun --smol run /app/runtime/0.10.11/src/monitoring/worker.ts",
+      }),
+    ).toEqual({ action: "adopt", pid: WORKER });
+  });
+
+  test("never signals when the process table could not be read", () => {
+    expect(decide(null)).toEqual({ action: "adopt", pid: WORKER });
   });
 });

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveWorkerCommand } from "../worker-process.js";
+import {
+  resolveWorkerCommand,
+  workerKindSignature,
+} from "../worker-process.js";
 
 const entry = new URL("file:///source/monitoring/worker.ts");
 
@@ -33,5 +36,60 @@ describe("resolveWorkerCommand", () => {
         executableExists: () => false,
       }),
     ).toEqual(["bun", "--smol", "run", "/source/monitoring/worker.ts"]);
+  });
+});
+
+describe("workerKindSignature", () => {
+  const schedule = new URL(
+    "file:////app/runtime/0.11.7/src/schedule/worker.ts",
+  );
+  const source = {
+    platform: "darwin" as const,
+    execPath: "/runtime/bun",
+    executableExists: () => false,
+  };
+
+  test("is the same for a worker of this kind from any install", () => {
+    const previous = new URL(
+      "file:////app/runtime/0.10.11/src/schedule/worker.ts",
+    );
+    expect(workerKindSignature(schedule, "schedule", source)).toBe(
+      workerKindSignature(previous, "schedule", source),
+    );
+  });
+
+  test("distinguishes one worker kind from another", () => {
+    const monitoring = new URL(
+      "file:////app/runtime/0.11.7/src/monitoring/worker.ts",
+    );
+    expect(workerKindSignature(schedule, "schedule", source)).not.toBe(
+      workerKindSignature(monitoring, "monitoring", source),
+    );
+  });
+
+  // The signature only guards against signalling a recycled PID, so it has to
+  // be specific enough that an unrelated program running its own worker.ts
+  // never matches.
+  test("does not match an unrelated program running some other worker.ts", () => {
+    const signature = workerKindSignature(schedule, "schedule", source);
+    expect("bun run /home/dev/side-project/worker.ts").not.toContain(signature);
+    expect("node /srv/queue/src/jobs/worker.ts").not.toContain(signature);
+  });
+
+  test("matches the same worker from a previous install", () => {
+    const signature = workerKindSignature(schedule, "schedule", source);
+    expect(
+      "bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts",
+    ).toContain(signature);
+  });
+
+  test("is the packaged executable name inside a packaged runtime", () => {
+    expect(
+      workerKindSignature(schedule, "schedule", {
+        platform: "win32",
+        execPath: "/runtime/vellum-daemon.exe",
+        executableExists: () => true,
+      }),
+    ).toBe("vellum-worker");
   });
 });

--- a/assistant/src/util/ml-worker-ownership.ts
+++ b/assistant/src/util/ml-worker-ownership.ts
@@ -1,0 +1,106 @@
+/**
+ * Process-tree ownership for background worker processes.
+ *
+ * A worker's parent IS its owner. The process table is therefore the
+ * authoritative answer to "whose worker is this": unlike a PID file it
+ * survives a crash, and a second owner cannot overwrite it.
+ *
+ * Nothing here is specific to one worker kind. `listWorkerProcesses` matches
+ * on the absolute worker path the caller passes, and `classifyWorkerOwnership`
+ * takes injected liveness and PID-1 predicates, so any worker whose spawner
+ * knows its own PID can use both.
+ */
+
+import { listProcessTable, readRawProcessCommand } from "./process-table.js";
+
+export interface WorkerProcess {
+  pid: number;
+  ppid: number;
+}
+
+/**
+ * What this process may do with a worker it found in the process table.
+ *
+ * - `reclaim`: parented to us, a worker we started and lost track of. Reaping
+ *   it is what enforces one live worker per owning process.
+ * - `orphan`: reparented to init, or its owner is gone. Nobody else will ever
+ *   clean it up.
+ * - `foreign`: owned by another live process. The memory-worker process runs
+ *   its own backend against this same workspace and is entitled to its own
+ *   worker; signalling it is what made the two replace each other in a loop.
+ *
+ * A parent of PID 1 is ambiguous, and resolving it wrongly in either direction
+ * costs something real. `docker-entrypoint.sh` execs the daemon, so PID 1 can
+ * BE the daemon and its child a healthy sibling's worker. Under `docker run
+ * --init`, and on any host, PID 1 is an init process instead, so the same
+ * parentage means the owner died and the worker needs reclaiming. Callers
+ * therefore pass what PID 1 actually is rather than inferring it from whether
+ * the deployment is containerized, which is true in both container shapes.
+ */
+export type WorkerOwnership = "reclaim" | "orphan" | "foreign";
+
+export function classifyWorkerOwnership(
+  worker: WorkerProcess,
+  selfPid: number,
+  isOwnerAlive: (pid: number) => boolean,
+  pid1OwnsWorkers: boolean,
+): WorkerOwnership {
+  if (worker.ppid === selfPid) {
+    return "reclaim";
+  }
+  if (worker.ppid <= 1) {
+    return pid1OwnsWorkers ? "foreign" : "orphan";
+  }
+  if (!isOwnerAlive(worker.ppid)) {
+    return "orphan";
+  }
+  return "foreign";
+}
+
+/** Entrypoint the daemon is exec'd with, including inside a container. */
+const DAEMON_ENTRYPOINT_MARKER = "daemon/main";
+
+/**
+ * Whether PID 1 is an assistant daemon rather than an init process.
+ *
+ * True only where the daemon was exec'd as PID 1 (`docker-entrypoint.sh`),
+ * which is what makes a worker parented to 1 a live sibling's rather than an
+ * orphan. Under `docker run --init` PID 1 is docker-init and under launchd or
+ * systemd it is the system init, so both answer false and PID-1 orphans stay
+ * reclaimable. Unreadable means false, which keeps the reclaiming behaviour.
+ */
+export function pid1OwnsMlWorkers(): boolean {
+  if (process.pid === 1) {
+    return true;
+  }
+  return readRawProcessCommand(1)?.includes(DAEMON_ENTRYPOINT_MARKER) ?? false;
+}
+
+/**
+ * Live worker processes matching `workerPath`, as `(pid, ppid)` pairs.
+ *
+ * `workerPath` is an absolute path unique to one worker of one install, so a
+ * sibling instance's workers never match. `model`, when given, must appear as
+ * a whole argv token rather than a substring, so a backend for `bge-small`
+ * cannot reclaim a live `bge-small-v2` worker.
+ *
+ * Raw command lines are read for matching only, never stored or logged:
+ * process arguments can carry secrets (see the redaction note in
+ * `util/process-tree.ts`).
+ */
+export function listWorkerProcesses(
+  workerPath: string,
+  model?: string,
+): WorkerProcess[] {
+  try {
+    return listProcessTable()
+      .filter(
+        (row) =>
+          row.command.includes(workerPath) &&
+          (!model || row.command.split(/\s+/).includes(model)),
+      )
+      .map(({ pid, ppid }) => ({ pid, ppid }));
+  } catch {
+    return [];
+  }
+}

--- a/assistant/src/util/process-table.ts
+++ b/assistant/src/util/process-table.ts
@@ -231,6 +231,19 @@ export async function listProcessTableAsync(
   );
 }
 
+/**
+ * The process-table row for `pid`, or null when the process is gone or the
+ * table cannot be read. Callers get `ppid` alongside the command line, so
+ * ownership and identity can be decided from a single snapshot.
+ */
+export function findProcessRow(pid: number): ProcessTableRow | null {
+  try {
+    return listProcessTable().find((row) => row.pid === pid) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function readRawProcessCommand(pid: number): string | null {
   if (process.platform === "linux") {
     try {

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -19,8 +19,16 @@ import {
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { getCurrentLogFilePath } from "./logger.js";
+import { getCurrentLogFilePath, getLogger } from "./logger.js";
+import {
+  classifyWorkerOwnership,
+  pid1OwnsMlWorkers,
+} from "./ml-worker-ownership.js";
+import { isProcessAlive } from "./process-liveness.js";
+import { findProcessRow } from "./process-table.js";
 import { workerMemoryEnv } from "./worker-memory.js";
+
+const log = getLogger("worker-process");
 
 export interface WorkerProcessStatus {
   status: "running" | "not_running";
@@ -104,22 +112,10 @@ export interface SpawnWorkerProcessOptions {
    * When the wait times out while the child is still alive (a hung or very
    * slow start), terminate that child before throwing. Callers whose failure
    * path leaves the worker's config flag off MUST set this: otherwise the
-   * detached worker keeps coming up and runs alongside whatever in-process
+   * worker keeps coming up and runs alongside whatever in-process
    * fallback the flag re-enabled.
    */
   terminateOnTimeout?: boolean;
-  /**
-   * Process parentage (default `true`):
-   *   - `true` — the worker is its own session leader and outlives the
-   *     spawning process. Short-lived CLI spawners need this so the worker
-   *     keeps running after the command returns.
-   *   - `false` — the worker is a direct child of the spawning process. The
-   *     daemon passes this so the worker it owns appears in its process tree
-   *     (`assistant ps`) and is torn down with the daemon.
-   * Either way the child is `unref`'d, so the spawning process never blocks on
-   * it and the worker is tracked via its PID file rather than the handle.
-   */
-  detached?: boolean;
 }
 
 export type PackagedWorkerEntry =
@@ -135,20 +131,39 @@ interface WorkerCommandRuntime {
   executableExists: (path: string) => boolean;
 }
 
-export function resolveWorkerCommand(
-  entry: URL,
-  packagedEntry: PackagedWorkerEntry | undefined,
-  runtime: WorkerCommandRuntime = {
+function defaultWorkerCommandRuntime(): WorkerCommandRuntime {
+  return {
     platform: process.platform,
     execPath: process.execPath,
     executableExists: existsSync,
-  },
-): string[] {
+  };
+}
+
+/**
+ * How a packaged Windows runtime spawns this worker, or null when the worker
+ * runs from source. Only packaged Windows runtimes ship the executable.
+ */
+function packagedWorkerSpawn(
+  packagedEntry: PackagedWorkerEntry | undefined,
+  runtime: WorkerCommandRuntime,
+): { executable: string; entry: PackagedWorkerEntry } | null {
   if (runtime.platform === "win32" && packagedEntry) {
     const executable = join(dirname(runtime.execPath), "vellum-worker.exe");
     if (runtime.executableExists(executable)) {
-      return [executable, packagedEntry];
+      return { executable, entry: packagedEntry };
     }
+  }
+  return null;
+}
+
+export function resolveWorkerCommand(
+  entry: URL,
+  packagedEntry: PackagedWorkerEntry | undefined,
+  runtime: WorkerCommandRuntime = defaultWorkerCommandRuntime(),
+): string[] {
+  const packaged = packagedWorkerSpawn(packagedEntry, runtime);
+  if (packaged) {
+    return [packaged.executable, packaged.entry];
   }
   return ["bun", "--smol", "run", fileURLToPath(entry)];
 }
@@ -194,10 +209,127 @@ async function waitForWorkerPidFile(
   return existsSync(pidPath) ? "ready" : "timeout";
 }
 
+/** Path separators differ by platform; compare command lines on one form. */
+function normalizeSeparators(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
 /**
- * Spawn a worker entry script as a background process and wait for it to
- * report readiness by writing its PID file. `opts.detached` (default `true`)
- * controls process parentage — see {@link SpawnWorkerProcessOptions}.
+ * A fragment of the command line that marks a process as one of our workers,
+ * whichever install it came from.
+ *
+ * This is a safety guard, not the ownership test. Ownership is decided by
+ * parentage; this only keeps us from signalling a process that happens to hold
+ * a recycled PID. Three trailing path segments are specific enough
+ * (`src/schedule/worker.ts`, `defaults/memory/worker.ts`) that an unrelated
+ * program running some other `worker.ts` does not match.
+ */
+export function workerKindSignature(
+  entry: URL,
+  packagedEntry: PackagedWorkerEntry | undefined,
+  runtime: WorkerCommandRuntime = defaultWorkerCommandRuntime(),
+): string {
+  if (packagedWorkerSpawn(packagedEntry, runtime)) {
+    return "vellum-worker";
+  }
+  return normalizeSeparators(fileURLToPath(entry))
+    .split("/")
+    .filter(Boolean)
+    .slice(-3)
+    .join("/");
+}
+
+/** How long an orphaned worker gets to exit after SIGTERM. */
+const ORPHAN_STOP_TIMEOUT_MS = 5_000;
+
+/** Poll interval while waiting for a stopped worker to exit. */
+const ORPHAN_STOP_POLL_INTERVAL_MS = 100;
+
+/**
+ * Stop a worker orphaned by a previous owner and release its PID file.
+ *
+ * Escalates to SIGKILL because the orphan runs a different generation's
+ * shutdown path, which this process cannot make assumptions about. The unlink
+ * is identity-checked: a concurrent launcher may already have replaced the
+ * worker, and deleting that successor's PID file would strand it.
+ */
+async function stopOrphanedWorker(
+  pid: number,
+  pidPath: string,
+  workerLabel: string,
+): Promise<void> {
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // Exited between the probe and the signal.
+  }
+
+  const deadline = Date.now() + ORPHAN_STOP_TIMEOUT_MS;
+  while (Date.now() < deadline && isProcessAlive(pid)) {
+    await Bun.sleep(ORPHAN_STOP_POLL_INTERVAL_MS);
+  }
+  if (isProcessAlive(pid)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Best-effort.
+    }
+  }
+
+  unlinkPidFileIfNames(pidPath, pid);
+  log.warn(
+    { pid, pidPath },
+    `${workerLabel} orphaned by a previous owner was stopped so this process can start its own`,
+  );
+}
+
+/**
+ * What to do about the process the worker's PID file currently names.
+ *
+ * Reuse it unless it is an orphan left by an owner that is gone: that is the
+ * process a daemon replaced by a new version leaves behind, still holding the
+ * PID file, still running the previous version's code. A process that is not
+ * recognisably one of our workers is never signalled, because the OS may have
+ * recycled the PID for something unrelated.
+ */
+async function resolveExistingWorker(
+  pidPath: string,
+  signature: string,
+  workerLabel: string,
+): Promise<{ adopt: number } | null> {
+  const current = probeWorkerPidFile(pidPath);
+  if (current.status !== "running" || current.pid == null) {
+    return null;
+  }
+
+  const row = findProcessRow(current.pid);
+  if (!row || !normalizeSeparators(row.command).includes(signature)) {
+    return { adopt: current.pid };
+  }
+
+  const ownership = classifyWorkerOwnership(
+    row,
+    process.pid,
+    isProcessAlive,
+    pid1OwnsMlWorkers(),
+  );
+  if (ownership !== "orphan") {
+    return { adopt: current.pid };
+  }
+
+  await stopOrphanedWorker(current.pid, pidPath, workerLabel);
+
+  // A concurrent launcher may have brought up a replacement while we waited.
+  const replacement = probeWorkerPidFile(pidPath);
+  return replacement.status === "running" && replacement.pid != null
+    ? { adopt: replacement.pid }
+    : null;
+}
+
+/**
+ * Spawn a worker entry script as a background process, as a child of this
+ * process, and wait for it to report readiness by writing its PID file. The
+ * child is `unref`'d, so the spawning process never blocks on it.
  *
  * If a worker is already running (per the PID file), returns its PID with
  * `alreadyRunning: true` rather than spawning a second one. Throws
@@ -218,11 +350,14 @@ export async function spawnWorkerProcess(args: {
   const opts = args.options ?? {};
   const pidWaitTimeoutMs = opts.pidWaitTimeoutMs ?? PID_FILE_WAIT_TIMEOUT_MS;
   const pidPollIntervalMs = opts.pidPollIntervalMs ?? PID_FILE_POLL_INTERVAL_MS;
-  const detached = opts.detached ?? true;
 
-  const current = probeWorkerPidFile(args.pidPath);
-  if (current.status === "running" && current.pid != null) {
-    return { pid: current.pid, alreadyRunning: true };
+  const existing = await resolveExistingWorker(
+    args.pidPath,
+    workerKindSignature(args.entry, args.packagedEntry),
+    args.workerLabel,
+  );
+  if (existing) {
+    return { pid: existing.adopt, alreadyRunning: true };
   }
 
   // Pipe the worker's stderr into the same daily log file the daemon writes
@@ -252,7 +387,9 @@ export async function spawnWorkerProcess(args: {
     cmd: resolveWorkerCommand(args.entry, args.packagedEntry),
     env: workerMemoryEnv(),
     stdio: ["ignore", "ignore", stderrFd],
-    detached,
+    // Every worker is a direct child of the daemon. That parentage is the
+    // ownership record `classifyWorkerOwnership` reads, so it is not optional.
+    detached: false,
     windowsHide: true,
   });
 
@@ -319,21 +456,26 @@ export function stopWorkerProcess(pidPath: string): WorkerProcessStatus {
 // ---------------------------------------------------------------------------
 
 /**
- * Remove the worker PID file only while it still names this process. A
- * successor worker overwrites the file with its own PID at startup, so an
- * exiting predecessor that unlinked unconditionally would delete the
- * successor's entry — the liveness supervisor would then respawn a
- * duplicate and orphan the successor.
+ * Remove `pidPath` only while it still names `pid`.
+ *
+ * A successor worker overwrites the file with its own PID at startup, so an
+ * unconditional unlink would delete the successor's entry: the liveness
+ * supervisor would then respawn a duplicate and orphan the successor.
  */
-export function cleanupWorkerPidFile(pidPath: string): void {
+export function unlinkPidFileIfNames(pidPath: string, pid: number): void {
   try {
     const raw = readFileSync(pidPath, "utf-8").trim();
-    if (parseInt(raw, 10) === process.pid) {
+    if (parseInt(raw, 10) === pid) {
       unlinkSync(pidPath);
     }
   } catch {
-    // best-effort — a missing or unreadable file needs no cleanup
+    // best-effort: a missing or unreadable file needs no cleanup
   }
+}
+
+/** Release this process's own PID file on the way out. */
+export function cleanupWorkerPidFile(pidPath: string): void {
+  unlinkPidFileIfNames(pidPath, process.pid);
 }
 
 /**

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -215,28 +215,37 @@ function normalizeSeparators(value: string): string {
 }
 
 /**
- * A fragment of the command line that marks a process as one of our workers,
- * whichever install it came from.
+ * Fragments of a command line that together mark a process as this worker,
+ * whichever install it came from. All must be present.
  *
  * This is a safety guard, not the ownership test. Ownership is decided by
  * parentage; this only keeps us from signalling a process that happens to hold
  * a recycled PID. Three trailing path segments are specific enough
  * (`src/schedule/worker.ts`, `defaults/memory/worker.ts`) that an unrelated
- * program running some other `worker.ts` does not match.
+ * program running some other `worker.ts` does not match. Packaged workers all
+ * run one executable and are told apart by the subcommand, so the signature
+ * carries both: matching on the executable alone would let one packaged
+ * worker's slot reclaim another's process.
  */
 export function workerKindSignature(
   entry: URL,
   packagedEntry: PackagedWorkerEntry | undefined,
   runtime: WorkerCommandRuntime = defaultWorkerCommandRuntime(),
-): string {
-  if (packagedWorkerSpawn(packagedEntry, runtime)) {
-    return "vellum-worker";
+): readonly string[] {
+  const packaged = packagedWorkerSpawn(packagedEntry, runtime);
+  if (packaged) {
+    // Matched as separate fragments rather than one adjacent string: a Windows
+    // command line may quote the executable path, so the two are not reliably
+    // neighbours.
+    return ["vellum-worker", packaged.entry];
   }
-  return normalizeSeparators(fileURLToPath(entry))
-    .split("/")
-    .filter(Boolean)
-    .slice(-3)
-    .join("/");
+  return [
+    normalizeSeparators(fileURLToPath(entry))
+      .split("/")
+      .filter(Boolean)
+      .slice(-3)
+      .join("/"),
+  ];
 }
 
 /** How long an orphaned worker gets to exit after SIGTERM. */
@@ -247,17 +256,22 @@ const ORPHAN_STOP_POLL_INTERVAL_MS = 100;
 
 /**
  * Stop a worker orphaned by a previous owner and release its PID file.
+ * Reports whether it actually exited.
  *
  * Escalates to SIGKILL because the orphan runs a different generation's
- * shutdown path, which this process cannot make assumptions about. The unlink
- * is identity-checked: a concurrent launcher may already have replaced the
- * worker, and deleting that successor's PID file would strand it.
+ * shutdown path, which this process cannot make assumptions about. Signalling
+ * can still fail outright, most plausibly EPERM for a process owned by another
+ * user, so the PID file is released only once the process is confirmed gone:
+ * dropping it while the worker still runs would let the caller spawn a second
+ * one against the same workspace. The unlink is also identity-checked, since a
+ * concurrent launcher may already have replaced the worker and deleting that
+ * successor's entry would strand it.
  */
 async function stopOrphanedWorker(
   pid: number,
   pidPath: string,
   workerLabel: string,
-): Promise<void> {
+): Promise<boolean> {
   try {
     process.kill(pid, "SIGTERM");
   } catch {
@@ -276,11 +290,20 @@ async function stopOrphanedWorker(
     }
   }
 
+  if (isProcessAlive(pid)) {
+    log.warn(
+      { pid, pidPath },
+      `${workerLabel} orphaned by a previous owner could not be stopped; reusing it rather than running a second one`,
+    );
+    return false;
+  }
+
   unlinkPidFileIfNames(pidPath, pid);
   log.warn(
     { pid, pidPath },
     `${workerLabel} orphaned by a previous owner was stopped so this process can start its own`,
   );
+  return true;
 }
 
 /**
@@ -294,7 +317,7 @@ async function stopOrphanedWorker(
  */
 async function resolveExistingWorker(
   pidPath: string,
-  signature: string,
+  signature: readonly string[],
   workerLabel: string,
 ): Promise<{ adopt: number } | null> {
   const current = probeWorkerPidFile(pidPath);
@@ -303,7 +326,8 @@ async function resolveExistingWorker(
   }
 
   const row = findProcessRow(current.pid);
-  if (!row || !normalizeSeparators(row.command).includes(signature)) {
+  const command = row ? normalizeSeparators(row.command) : "";
+  if (!row || !signature.every((part) => command.includes(part))) {
     return { adopt: current.pid };
   }
 
@@ -317,7 +341,10 @@ async function resolveExistingWorker(
     return { adopt: current.pid };
   }
 
-  await stopOrphanedWorker(current.pid, pidPath, workerLabel);
+  if (!(await stopOrphanedWorker(current.pid, pidPath, workerLabel))) {
+    // Still running and beyond our reach. One stale worker beats two live ones.
+    return { adopt: current.pid };
+  }
 
   // A concurrent launcher may have brought up a replacement while we waited.
   const replacement = probeWorkerPidFile(pidPath);

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -307,43 +307,86 @@ async function stopOrphanedWorker(
 }
 
 /**
- * What to do about the process the worker's PID file currently names.
+ * What to do about the process a worker's PID file currently names.
  *
- * Reuse it unless it is an orphan left by an owner that is gone: that is the
- * process a daemon replaced by a new version leaves behind, still holding the
- * PID file, still running the previous version's code. A process that is not
- * recognisably one of our workers is never signalled, because the OS may have
- * recycled the PID for something unrelated.
+ *   - `adopt`: reuse it. Either it is this process's own worker, or it belongs
+ *     to another live owner, or it is not recognisably one of our workers at
+ *     all and must never be signalled.
+ *   - `reclaim`: an orphan left by an owner that is gone. Stop it, then spawn.
+ *   - `spawn`: nothing is holding the slot.
+ */
+export type WorkerSlotDecision =
+  | { action: "adopt"; pid: number }
+  | { action: "reclaim"; pid: number }
+  | { action: "spawn" };
+
+/**
+ * The whole safety decision, with no IO, so every branch is testable.
+ *
+ * `reclaim` is the only outcome that signals a process, and it requires two
+ * independent things to agree: the command line marks the process as this
+ * worker, and parentage says nobody live owns it. A missing row, an unreadable
+ * command line, or a command line that does not match all falls back to
+ * `adopt`, which is the behaviour that predates any of this.
+ */
+export function decideWorkerSlot(
+  status: WorkerProcessStatus,
+  row: { pid: number; ppid: number; command: string } | null,
+  signature: readonly string[],
+  selfPid: number,
+  isOwnerAlive: (pid: number) => boolean,
+  pid1OwnsWorkers: boolean,
+): WorkerSlotDecision {
+  if (status.status !== "running" || status.pid == null) {
+    return { action: "spawn" };
+  }
+  if (!row) {
+    return { action: "adopt", pid: status.pid };
+  }
+  const command = normalizeSeparators(row.command);
+  if (!signature.every((part) => command.includes(normalizeSeparators(part)))) {
+    return { action: "adopt", pid: status.pid };
+  }
+  const ownership = classifyWorkerOwnership(
+    row,
+    selfPid,
+    isOwnerAlive,
+    pid1OwnsWorkers,
+  );
+  return ownership === "orphan"
+    ? { action: "reclaim", pid: status.pid }
+    : { action: "adopt", pid: status.pid };
+}
+
+/**
+ * Apply {@link decideWorkerSlot} to the live PID file, stopping an orphan when
+ * one holds the slot. Returns the PID to adopt, or null to spawn.
  */
 async function resolveExistingWorker(
   pidPath: string,
   signature: readonly string[],
   workerLabel: string,
 ): Promise<{ adopt: number } | null> {
-  const current = probeWorkerPidFile(pidPath);
-  if (current.status !== "running" || current.pid == null) {
-    return null;
-  }
-
-  const row = findProcessRow(current.pid);
-  const command = row ? normalizeSeparators(row.command) : "";
-  if (!row || !signature.every((part) => command.includes(part))) {
-    return { adopt: current.pid };
-  }
-
-  const ownership = classifyWorkerOwnership(
-    row,
+  const status = probeWorkerPidFile(pidPath);
+  const decision = decideWorkerSlot(
+    status,
+    status.pid != null ? findProcessRow(status.pid) : null,
+    signature,
     process.pid,
     isProcessAlive,
     pid1OwnsMlWorkers(),
   );
-  if (ownership !== "orphan") {
-    return { adopt: current.pid };
+
+  if (decision.action === "spawn") {
+    return null;
+  }
+  if (decision.action === "adopt") {
+    return { adopt: decision.pid };
   }
 
-  if (!(await stopOrphanedWorker(current.pid, pidPath, workerLabel))) {
+  if (!(await stopOrphanedWorker(decision.pid, pidPath, workerLabel))) {
     // Still running and beyond our reach. One stale worker beats two live ones.
-    return { adopt: current.pid };
+    return { adopt: decision.pid };
   }
 
   // A concurrent launcher may have brought up a replacement while we waited.


### PR DESCRIPTION
## TL;DR

The daemon adopted any live process named by a worker's PID file, checking only that the PID was alive. After an upgrade that meant adopting the *previous* version's workers and never starting its own. Ownership now comes from the process tree, which is the model the embed worker already uses.

Part of ATL-1349. **Stacked on #41661** (the extraction) — review that first. Replaces #41657, which solved the same bug one level too low.

## What was happening

`stopLocalProcesses` gives the daemon 2000 ms before SIGKILL while its graceful shutdown budgets 30 s and stops workers near the end. So an upgrade kills the daemon mid-shutdown, and its four PID-file workers reparent to launchd, still holding their PID files. The next daemon called `spawnWorkerProcess`, which reused any live PID:

```ts
const current = probeWorkerPidFile(args.pidPath);
if (current.status === "running" && current.pid != null) {
  return { pid: current.pid, alreadyRunning: true };
}
```

`probeWorkerPidFile` is `process.kill(pid, 0)`. It answers "is this PID alive", never "is this my worker". The orphan was adopted permanently and no replacement spawned. The schedule worker is the sole runner of schedule execution and hosts real agent turns, so an 0.10.11 worker kept firing schedules against an 0.11.7-migrated database, on the old config schema and flag defaults, with nothing logging a mismatch. It only stops on a crash or a reboot.

## Why the process tree, and not a version check

My first attempt (#41657) compared the live process's command line against this install's entry path. That works, but it is the wrong level:

- **The PID file has been patched five times** to shore up ownership it cannot express: #38357, #38395, #38489, #38587, plus `cleanupWorkerPidFile`'s compare-and-delete and the schedule worker's in-flight spawn latch. A sixth patch is a signal, not a fix.
- **JARVIS-1125 already reached the conclusion** and replaced PID-file ownership for the embed worker, because the process table "survives a crash and cannot be overwritten by a second owner". Those primitives were never embedding-specific; #41661 moves them somewhere usable.
- **`ppid` is a stronger signal than a command-line substring.** It needs no string matching, so it is immune to quoting, and it works in a source checkout, where the entry path does not change between versions and the version check is a no-op.

I also checked the level *above* this one before settling: `BUN_DIE_WITH_PARENT`, which JARVIS-891 suggests. I probed it rather than assuming (bun 1.3.9, parent spawns child with the flag, SIGKILL the parent): **the child survived**. It is `PR_SET_PDEATHSIG` underneath, which is Linux-only, so it cannot fix the macOS case this bug was reported on.

## What this changes

`spawnWorkerProcess` reads the PID's process-table row once and classifies it:

| Process holding the PID file | Before | After |
| --- | --- | --- |
| Parented to this daemon | Reused | Reused, unchanged |
| Orphan (parented to init, or its owner is gone) | Reused, ran old code forever | Stopped, then replaced |
| Owned by another live process | Reused | Reused, unchanged |
| Not recognisable as one of our workers | Reused | Reused, never signalled |
| PID file absent or stale | Spawns | Spawns, unchanged |

For the user: schedules, `/x/*` routes, resource monitoring, and memory jobs run the version they just upgraded to. The first boot after this ships reclaims any worker already stranded.

## The `detached` option is deleted

`SpawnWorkerProcessOptions.detached` defaulted to `true` with a docstring about "short-lived CLI spawners". **There are none.** All ten spawn call sites passed `false`, no test covered the `true` branch, and the worker CLI commands (`schedules worker start`, `monitoring`, `routes worker`) are routes handled *inside* the daemon that spawn as daemon children like everything else.

That phantom is what made "is this worker mine" look like an open question, and it is why I reached for command-line version-sniffing in the first place. With it gone, every worker is unconditionally a child of the daemon, which is what makes the ownership test total rather than heuristic.

## Two duplicates folded in

Both are on the path this PR changes, so they are fixed here rather than left:

- **PID-file unlink is now identity-checked** through one shared `unlinkPidFileIfNames`, which `cleanupWorkerPidFile` also calls. An unconditional unlink after stopping an orphan could delete a *successor's* entry if a concurrent launcher had already replaced it, which would strand that successor. The stop also re-probes afterwards and adopts a replacement rather than spawning a duplicate.
- **`embedding-local` drops its hand-rolled `isProcessAlive`** for `util/process-liveness`. The two disagreed on `EPERM`: the local copy reported dead, and it was the predicate fed to `classifyWorkerOwnership`, so a worker owned by another user classified as an orphan we then could not signal. The canonical helper reports alive, which is the case its docstring exists for.

## Why it is safe

- **The kill is guarded twice.** A process is signalled only when its command line matches this worker kind *and* ownership says orphan. An unreadable process table, a missing row, or an unrecognised command line all fall through to the old adopt-and-return path, so a failed lookup degrades to today's behaviour rather than a stray kill.
- **The kind signature is only a recycled-PID guard**, not the decision, and it is deliberately specific: three trailing path segments (`src/schedule/worker.ts`), so an unrelated program running its own `worker.ts` does not match. Tested both ways.
- **No new steady-state cost.** The process-table read happens only when a PID file already names a live process, so at most once per worker per daemon boot. The 15 s liveness watchdog calls `probeWorkerPidFile`, which is untouched.

## Testing

Type check and lint clean. New tests cover the kind signature: stable across installs, distinct per worker kind, matches a previous install's worker, and does *not* match unrelated programs running some other `worker.ts`. The ownership decision itself is already covered by the embed lifecycle suite, which now exercises the shared module. Four route tests that asserted `detached: false` were updated: that invariant is no longer a parameter to assert, it is structural. Local test runs are disabled on this machine, so CI is the first execution.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->