### PR TITLE
fix(workers): own workers by process tree, not by PID-file liveness (ATL-1349)

### DIFF
--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -19,6 +19,8 @@ import {
   classifyWorkerOwnership,
   listWorkerProcesses,
 } from "../../../util/worker-ownership.js";
+import { ORPHAN_STOP_TIMEOUT_MS } from "../../../util/worker-process.js";
+import { EMBEDDING_SHUTDOWN_BUDGET_MS } from "../embedding-backend.js";
 import { LocalEmbeddingBackend } from "../embedding-local.js";
 
 /** Reach past `private`, which is compile-time only, so tests drive real state. */
@@ -752,4 +754,15 @@ describe("model matching", () => {
       listWorkerProcesses(scriptPath, "foo/bar-small-v2").map((w) => w.pid),
     ).toEqual([proc.pid]);
   });
+});
+
+// The daemon's orphan reclaim SIGTERMs a stale memory worker and waits
+// ORPHAN_STOP_TIMEOUT_MS before SIGKILL. That worker's shutdown reaps the ONNX
+// subprocess it owns, bounded at EMBEDDING_SHUTDOWN_BUDGET_MS + 1s. If the
+// reclaim ceiling does not outlast the reap, reclaiming kills the worker
+// mid-reap and strands the subprocess, which is the JARVIS-1125 failure.
+test("orphan reclaim outlasts the embedding reap it must not truncate", () => {
+  expect(ORPHAN_STOP_TIMEOUT_MS).toBeGreaterThan(
+    EMBEDDING_SHUTDOWN_BUDGET_MS + 1_000,
+  );
 });

--- a/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
+++ b/assistant/src/persistence/embeddings/__tests__/embedding-local-lifecycle.test.ts
@@ -14,11 +14,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import { getEmbedWorkerPidPath } from "../../../util/platform.js";
 import {
   classifyWorkerOwnership,
   listWorkerProcesses,
-} from "../../../util/ml-worker-ownership.js";
-import { getEmbedWorkerPidPath } from "../../../util/platform.js";
+} from "../../../util/worker-ownership.js";
 import { LocalEmbeddingBackend } from "../embedding-local.js";
 
 /** Reach past `private`, which is compile-time only, so tests drive real state. */

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -10,17 +10,17 @@ import { join } from "node:path";
 import { getIsContainerized } from "../../config/env-registry.js";
 import { getLogger } from "../../util/logger.js";
 import {
-  classifyWorkerOwnership,
-  listWorkerProcesses,
-  pid1OwnsMlWorkers,
-} from "../../util/ml-worker-ownership.js";
-import {
   getEmbeddingModelsDir,
   getEmbedWorkerPidPath,
 } from "../../util/platform.js";
 import { PromiseGuard } from "../../util/promise-guard.js";
 import { workerComputeEnv } from "../../util/worker-compute.js";
 import { workerMemoryEnv } from "../../util/worker-memory.js";
+import {
+  classifyWorkerOwnership,
+  listWorkerProcesses,
+  pid1OwnsWorkers,
+} from "../../util/worker-ownership.js";
 import { EmbeddingRuntimeManager } from "./embedding-runtime-manager.js";
 import {
   type EmbeddingBackend,
@@ -779,7 +779,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
         worker,
         process.pid,
         isProcessAlive,
-        pid1OwnsMlWorkers(),
+        pid1OwnsWorkers(),
       );
       if (ownership === "foreign") {
         continue;

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { EMBEDDING_SHUTDOWN_BUDGET_MS } from "../../persistence/embeddings/embedding-backend.js";
 import {
   decideWorkerSlot,
-  ORPHAN_STOP_TIMEOUT_MS,
   resolveWorkerCommand,
   workerKindSignature,
   type WorkerProcessStatus,
@@ -235,17 +233,5 @@ describe("decideWorkerSlot", () => {
 
   test("never signals when the process table could not be read", () => {
     expect(decide(null)).toEqual({ action: "adopt", pid: WORKER });
-  });
-});
-
-// The orphan stop must outlast the longest shutdown a worker can legitimately
-// run, or reclaiming one strands whatever that shutdown was collecting. The
-// memory worker's embedding reap is currently the longest; if that budget
-// grows, this fails rather than silently cutting the reap short.
-describe("ORPHAN_STOP_TIMEOUT_MS", () => {
-  test("outlasts the memory worker's embedding reap", () => {
-    expect(ORPHAN_STOP_TIMEOUT_MS).toBeGreaterThan(
-      EMBEDDING_SHUTDOWN_BUDGET_MS + 1_000,
-    );
   });
 });

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  classifyOrphanAfterWait,
   decideWorkerSlot,
-  escalationAuthorised,
   resolveWorkerCommand,
   workerKindSignature,
   type WorkerProcessStatus,
@@ -239,36 +239,44 @@ describe("decideWorkerSlot", () => {
 
 // Escalation happens after an awaited SIGTERM grace, so the PID alone cannot
 // carry identity across it: the orphan may exit mid-wait and the OS may hand
-// its PID to a stranger. SIGKILL is authorised only while the command line
-// still reads as this worker.
-describe("escalationAuthorised", () => {
+// its PID to a stranger, or the process table may simply fail to answer.
+// Only a positive re-match escalates, and only a proven "gone" releases the
+// slot; a live PID whose identity cannot be read resolves to reuse, because
+// releasing it would spawn a second worker next to a live one.
+describe("classifyOrphanAfterWait", () => {
   const signature = ["src/schedule/worker.ts"];
+  const ours = "bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts";
+
+  test("dead PID: gone, slot may be released", () => {
+    expect(classifyOrphanAfterWait(false, null, signature)).toBe("gone");
+    expect(classifyOrphanAfterWait(false, ours, signature)).toBe("gone");
+  });
 
   test("still this worker: escalation proceeds", () => {
+    expect(classifyOrphanAfterWait(true, ours, signature)).toBe("orphan");
+  });
+
+  test("PID reused by a stranger: orphan exited, never SIGKILL", () => {
     expect(
-      escalationAuthorised(
-        "bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts",
-        signature,
-      ),
-    ).toBe(true);
-  });
-
-  test("orphan exited and PID reused by a stranger: never SIGKILL", () => {
-    expect(escalationAuthorised("/usr/bin/postgres -D /data", signature)).toBe(
-      false,
-    );
-  });
-
-  test("orphan exited, PID unclaimed: reads as gone", () => {
-    expect(escalationAuthorised(null, signature)).toBe(false);
+      classifyOrphanAfterWait(true, "/usr/bin/postgres -D /data", signature),
+    ).toBe("gone");
   });
 
   test("PID reused by a different worker kind: never SIGKILL", () => {
     expect(
-      escalationAuthorised(
+      classifyOrphanAfterWait(
+        true,
         "bun --smol run /app/runtime/0.10.11/src/monitoring/worker.ts",
         signature,
       ),
-    ).toBe(false);
+    ).toBe("gone");
+  });
+
+  // The fail-safe vex pinned: a live PID with an unreadable command line is
+  // neither killable nor releasable.
+  test("alive but command unreadable: identity-unreadable, reuse the slot", () => {
+    expect(classifyOrphanAfterWait(true, null, signature)).toBe(
+      "identity-unreadable",
+    );
   });
 });

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -64,7 +64,7 @@ describe("workerKindSignature", () => {
     const monitoring = new URL(
       "file:////app/runtime/0.11.7/src/monitoring/worker.ts",
     );
-    expect(workerKindSignature(schedule, "schedule", source)).not.toBe(
+    expect(workerKindSignature(schedule, "schedule", source)).not.toEqual(
       workerKindSignature(monitoring, "monitoring", source),
     );
   });

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import { EMBEDDING_SHUTDOWN_BUDGET_MS } from "../../persistence/embeddings/embedding-backend.js";
 import {
   decideWorkerSlot,
+  ORPHAN_STOP_TIMEOUT_MS,
   resolveWorkerCommand,
   workerKindSignature,
   type WorkerProcessStatus,
@@ -233,5 +235,17 @@ describe("decideWorkerSlot", () => {
 
   test("never signals when the process table could not be read", () => {
     expect(decide(null)).toEqual({ action: "adopt", pid: WORKER });
+  });
+});
+
+// The orphan stop must outlast the longest shutdown a worker can legitimately
+// run, or reclaiming one strands whatever that shutdown was collecting. The
+// memory worker's embedding reap is currently the longest; if that budget
+// grows, this fails rather than silently cutting the reap short.
+describe("ORPHAN_STOP_TIMEOUT_MS", () => {
+  test("outlasts the memory worker's embedding reap", () => {
+    expect(ORPHAN_STOP_TIMEOUT_MS).toBeGreaterThan(
+      EMBEDDING_SHUTDOWN_BUDGET_MS + 1_000,
+    );
   });
 });

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -179,11 +179,21 @@ describe("decideWorkerSlot", () => {
     );
   });
 
-  test("adopts a worker another live process owns", () => {
+  // `isOwnerAlive` is "is the owner a daemon", not "does that PID exist". These
+  // workers have exactly one legitimate owner, so a recycled owner PID must not
+  // keep a stranded worker looking owned.
+  test("adopts a worker a live daemon owns", () => {
     expect(decide({ pid: WORKER, ppid: 777, command: ours }, alive)).toEqual({
       action: "adopt",
       pid: WORKER,
     });
+  });
+
+  test("reclaims a worker whose owner PID was recycled to a non-daemon", () => {
+    const ownerIsNotADaemon = () => false;
+    expect(
+      decide({ pid: WORKER, ppid: 777, command: previous }, ownerIsNotADaemon),
+    ).toEqual({ action: "reclaim", pid: WORKER });
   });
 
   // In a container the daemon is PID 1, so a worker parented to 1 is a live

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -147,7 +147,7 @@ describe("decideWorkerSlot", () => {
       signature,
       DAEMON,
       isOwnerAlive,
-      () => pid1OwnsWorkers,
+      pid1OwnsWorkers,
     );
 
   test("spawns when the PID file names nothing running", () => {

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   decideWorkerSlot,
+  escalationAuthorised,
   resolveWorkerCommand,
   workerKindSignature,
   type WorkerProcessStatus,
@@ -233,5 +234,41 @@ describe("decideWorkerSlot", () => {
 
   test("never signals when the process table could not be read", () => {
     expect(decide(null)).toEqual({ action: "adopt", pid: WORKER });
+  });
+});
+
+// Escalation happens after an awaited SIGTERM grace, so the PID alone cannot
+// carry identity across it: the orphan may exit mid-wait and the OS may hand
+// its PID to a stranger. SIGKILL is authorised only while the command line
+// still reads as this worker.
+describe("escalationAuthorised", () => {
+  const signature = ["src/schedule/worker.ts"];
+
+  test("still this worker: escalation proceeds", () => {
+    expect(
+      escalationAuthorised(
+        "bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts",
+        signature,
+      ),
+    ).toBe(true);
+  });
+
+  test("orphan exited and PID reused by a stranger: never SIGKILL", () => {
+    expect(escalationAuthorised("/usr/bin/postgres -D /data", signature)).toBe(
+      false,
+    );
+  });
+
+  test("orphan exited, PID unclaimed: reads as gone", () => {
+    expect(escalationAuthorised(null, signature)).toBe(false);
+  });
+
+  test("PID reused by a different worker kind: never SIGKILL", () => {
+    expect(
+      escalationAuthorised(
+        "bun --smol run /app/runtime/0.10.11/src/monitoring/worker.ts",
+        signature,
+      ),
+    ).toBe(false);
   });
 });

--- a/assistant/src/util/__tests__/worker-process-command.test.ts
+++ b/assistant/src/util/__tests__/worker-process-command.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveWorkerCommand } from "../worker-process.js";
+import {
+  decideWorkerSlot,
+  resolveWorkerCommand,
+  workerKindSignature,
+  type WorkerProcessStatus,
+} from "../worker-process.js";
 
 const entry = new URL("file:///source/monitoring/worker.ts");
 
@@ -33,5 +38,190 @@ describe("resolveWorkerCommand", () => {
         executableExists: () => false,
       }),
     ).toEqual(["bun", "--smol", "run", "/source/monitoring/worker.ts"]);
+  });
+});
+
+describe("workerKindSignature", () => {
+  const schedule = new URL(
+    "file:////app/runtime/0.11.7/src/schedule/worker.ts",
+  );
+  const source = {
+    platform: "darwin" as const,
+    execPath: "/runtime/bun",
+    executableExists: () => false,
+  };
+
+  test("is the same for a worker of this kind from any install", () => {
+    const previous = new URL(
+      "file:////app/runtime/0.10.11/src/schedule/worker.ts",
+    );
+    expect(workerKindSignature(schedule, "schedule", source)).toEqual(
+      workerKindSignature(previous, "schedule", source),
+    );
+  });
+
+  test("distinguishes one worker kind from another", () => {
+    const monitoring = new URL(
+      "file:////app/runtime/0.11.7/src/monitoring/worker.ts",
+    );
+    expect(workerKindSignature(schedule, "schedule", source)).not.toBe(
+      workerKindSignature(monitoring, "monitoring", source),
+    );
+  });
+
+  // The signature only guards against signalling a recycled PID, so it has to
+  // be specific enough that an unrelated program running its own worker.ts
+  // never matches.
+  const matches = (command: string, signature: readonly string[]): boolean =>
+    signature.every((part) => command.includes(part));
+
+  test("does not match an unrelated program running some other worker.ts", () => {
+    const signature = workerKindSignature(schedule, "schedule", source);
+    expect(matches("bun run /home/dev/side-project/worker.ts", signature)).toBe(
+      false,
+    );
+    expect(matches("node /srv/queue/src/jobs/worker.ts", signature)).toBe(
+      false,
+    );
+  });
+
+  test("matches the same worker from a previous install", () => {
+    const signature = workerKindSignature(schedule, "schedule", source);
+    expect(
+      matches(
+        "bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts",
+        signature,
+      ),
+    ).toBe(true);
+  });
+
+  const packaged = {
+    platform: "win32" as const,
+    execPath: "/runtime/vellum-daemon.exe",
+    executableExists: () => true,
+  };
+
+  // Every packaged worker runs one executable and is told apart by the
+  // subcommand, so the executable alone must not identify a worker: one
+  // worker's slot would otherwise reclaim another's process.
+  test("distinguishes packaged worker kinds sharing one executable", () => {
+    const scheduleSig = workerKindSignature(schedule, "schedule", packaged);
+    expect(matches('"C:/App/vellum-worker.exe" schedule', scheduleSig)).toBe(
+      true,
+    );
+    expect(matches('"C:/App/vellum-worker.exe" monitoring', scheduleSig)).toBe(
+      false,
+    );
+  });
+
+  test("matches a packaged worker from a previous install", () => {
+    const scheduleSig = workerKindSignature(schedule, "schedule", packaged);
+    expect(matches('"C:/Prev/vellum-worker.exe" schedule', scheduleSig)).toBe(
+      true,
+    );
+  });
+});
+
+// Every branch that can reach a kill. `reclaim` is the only decision that
+// signals a process, so each test below is really asking: could this input
+// have killed something it should not have?
+describe("decideWorkerSlot", () => {
+  const DAEMON = 900;
+  const WORKER = 4242;
+  const signature = ["src/schedule/worker.ts"];
+  const running = { status: "running" as const, pid: WORKER };
+  const ours = `bun --smol run /app/runtime/0.11.7/src/schedule/worker.ts`;
+  const previous = `bun --smol run /app/runtime/0.10.11/src/schedule/worker.ts`;
+  const alive = () => true;
+  const dead = () => false;
+
+  const decide = (
+    row: { pid: number; ppid: number; command: string } | null,
+    isOwnerAlive = alive,
+    pid1OwnsWorkers = false,
+    status: WorkerProcessStatus = running,
+  ) =>
+    decideWorkerSlot(
+      status,
+      row,
+      signature,
+      DAEMON,
+      isOwnerAlive,
+      () => pid1OwnsWorkers,
+    );
+
+  test("spawns when the PID file names nothing running", () => {
+    expect(decide(null, alive, false, { status: "not_running" })).toEqual({
+      action: "spawn",
+    });
+  });
+
+  test("adopts this daemon's own worker", () => {
+    expect(decide({ pid: WORKER, ppid: DAEMON, command: ours })).toEqual({
+      action: "adopt",
+      pid: WORKER,
+    });
+  });
+
+  test("reclaims a worker reparented to init after its daemon died", () => {
+    expect(decide({ pid: WORKER, ppid: 1, command: previous })).toEqual({
+      action: "reclaim",
+      pid: WORKER,
+    });
+  });
+
+  test("reclaims a worker whose owner is gone", () => {
+    expect(decide({ pid: WORKER, ppid: 777, command: previous }, dead)).toEqual(
+      {
+        action: "reclaim",
+        pid: WORKER,
+      },
+    );
+  });
+
+  test("adopts a worker another live process owns", () => {
+    expect(decide({ pid: WORKER, ppid: 777, command: ours }, alive)).toEqual({
+      action: "adopt",
+      pid: WORKER,
+    });
+  });
+
+  // In a container the daemon is PID 1, so a worker parented to 1 is a live
+  // sibling's, not an orphan.
+  test("adopts a PID-1 child when PID 1 is the daemon", () => {
+    expect(
+      decide({ pid: WORKER, ppid: 1, command: ours }, alive, true),
+    ).toEqual({ action: "adopt", pid: WORKER });
+  });
+
+  // The cases below are the ones that must never reach a kill.
+  test("never signals an unrelated process on a recycled PID", () => {
+    expect(
+      decide({ pid: WORKER, ppid: 1, command: "/usr/bin/postgres -D /data" }),
+    ).toEqual({ action: "adopt", pid: WORKER });
+  });
+
+  test("never signals another project's worker.ts on a recycled PID", () => {
+    expect(
+      decide({
+        pid: WORKER,
+        ppid: 1,
+        command: "bun run /home/dev/side-project/worker.ts",
+      }),
+    ).toEqual({ action: "adopt", pid: WORKER });
+  });
+
+  test("never signals a different worker kind holding this slot", () => {
+    expect(
+      decide({
+        pid: WORKER,
+        ppid: 1,
+        command: "bun --smol run /app/runtime/0.10.11/src/monitoring/worker.ts",
+      }),
+    ).toEqual({ action: "adopt", pid: WORKER });
+  });
+
+  test("never signals when the process table could not be read", () => {
+    expect(decide(null)).toEqual({ action: "adopt", pid: WORKER });
   });
 });

--- a/assistant/src/util/process-table.ts
+++ b/assistant/src/util/process-table.ts
@@ -236,7 +236,7 @@ export async function listProcessTableAsync(
  * table cannot be read. Callers get `ppid` alongside the command line, so
  * ownership and identity can be decided from a single snapshot.
  */
-export function findProcessRow(pid: number): ProcessTableRow | null {
+function findProcessRow(pid: number): ProcessTableRow | null {
   try {
     return listProcessTable().find((row) => row.pid === pid) ?? null;
   } catch {

--- a/assistant/src/util/process-table.ts
+++ b/assistant/src/util/process-table.ts
@@ -231,6 +231,19 @@ export async function listProcessTableAsync(
   );
 }
 
+/**
+ * The process-table row for `pid`, or null when the process is gone or the
+ * table cannot be read. Callers get `ppid` alongside the command line, so
+ * ownership and identity can be decided from a single snapshot.
+ */
+export function findProcessRow(pid: number): ProcessTableRow | null {
+  try {
+    return listProcessTable().find((row) => row.pid === pid) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function readRawProcessCommand(pid: number): string | null {
   if (process.platform === "linux") {
     try {
@@ -243,9 +256,5 @@ export function readRawProcessCommand(pid: number): string | null {
     }
   }
 
-  try {
-    return listProcessTable().find((row) => row.pid === pid)?.command ?? null;
-  } catch {
-    return null;
-  }
+  return findProcessRow(pid)?.command ?? null;
 }

--- a/assistant/src/util/worker-ownership.ts
+++ b/assistant/src/util/worker-ownership.ts
@@ -69,7 +69,7 @@ const DAEMON_ENTRYPOINT_MARKER = "daemon/main";
  * systemd it is the system init, so both answer false and PID-1 orphans stay
  * reclaimable. Unreadable means false, which keeps the reclaiming behaviour.
  */
-export function pid1OwnsMlWorkers(): boolean {
+export function pid1OwnsWorkers(): boolean {
   if (process.pid === 1) {
     return true;
   }

--- a/assistant/src/util/worker-ownership.ts
+++ b/assistant/src/util/worker-ownership.ts
@@ -64,15 +64,14 @@ export function classifyWorkerOwnership(
 const DAEMON_PROCESS_PATTERN = /vellum-daemon|[\\/]daemon[\\/]main/;
 
 /**
- * Whether `pid` is a live assistant daemon.
+ * Whether a command line belongs to an assistant daemon.
  *
  * For a worker with exactly one legitimate owner, "is the owner alive" is not
  * the same question as "does some process still hold that PID". The OS recycles
  * PIDs, and a recycled owner PID would otherwise leave a stranded worker
  * looking owned, and therefore untouchable, indefinitely.
  */
-export function isDaemonProcess(pid: number): boolean {
-  const command = readRawProcessCommand(pid);
+export function isDaemonCommand(command: string | null): boolean {
   return command != null && DAEMON_PROCESS_PATTERN.test(command);
 }
 
@@ -84,9 +83,17 @@ export function isDaemonProcess(pid: number): boolean {
  * orphan. Under `docker run --init` PID 1 is docker-init and under launchd or
  * systemd it is the system init, so both answer false and PID-1 orphans stay
  * reclaimable. Unreadable means false, which keeps the reclaiming behaviour.
+ *
+ * Callers that already hold a process-table snapshot pass PID 1's command line
+ * so this does not read the table a second time.
  */
-export function pid1OwnsWorkers(): boolean {
-  return process.pid === 1 || isDaemonProcess(1);
+export function pid1OwnsWorkers(pid1Command?: string | null): boolean {
+  if (process.pid === 1) {
+    return true;
+  }
+  return isDaemonCommand(
+    pid1Command === undefined ? readRawProcessCommand(1) : pid1Command,
+  );
 }
 
 /**

--- a/assistant/src/util/worker-ownership.ts
+++ b/assistant/src/util/worker-ownership.ts
@@ -57,8 +57,24 @@ export function classifyWorkerOwnership(
   return "foreign";
 }
 
-/** Entrypoint the daemon is exec'd with, including inside a container. */
-const DAEMON_ENTRYPOINT_MARKER = "daemon/main";
+/**
+ * Command lines that identify an assistant daemon, running from source
+ * (`.../daemon/main.ts`) or as the packaged binary.
+ */
+const DAEMON_PROCESS_PATTERN = /vellum-daemon|[\\/]daemon[\\/]main/;
+
+/**
+ * Whether `pid` is a live assistant daemon.
+ *
+ * For a worker with exactly one legitimate owner, "is the owner alive" is not
+ * the same question as "does some process still hold that PID". The OS recycles
+ * PIDs, and a recycled owner PID would otherwise leave a stranded worker
+ * looking owned, and therefore untouchable, indefinitely.
+ */
+export function isDaemonProcess(pid: number): boolean {
+  const command = readRawProcessCommand(pid);
+  return command != null && DAEMON_PROCESS_PATTERN.test(command);
+}
 
 /**
  * Whether PID 1 is an assistant daemon rather than an init process.
@@ -70,10 +86,7 @@ const DAEMON_ENTRYPOINT_MARKER = "daemon/main";
  * reclaimable. Unreadable means false, which keeps the reclaiming behaviour.
  */
 export function pid1OwnsWorkers(): boolean {
-  if (process.pid === 1) {
-    return true;
-  }
-  return readRawProcessCommand(1)?.includes(DAEMON_ENTRYPOINT_MARKER) ?? false;
+  return process.pid === 1 || isDaemonProcess(1);
 }
 
 /**

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -21,11 +21,11 @@ import { fileURLToPath } from "node:url";
 
 import { getCurrentLogFilePath, getLogger } from "./logger.js";
 import { isProcessAlive } from "./process-liveness.js";
-import { findProcessRow, type ProcessTableRow } from "./process-table.js";
+import { listProcessTable, type ProcessTableRow } from "./process-table.js";
 import { workerMemoryEnv } from "./worker-memory.js";
 import {
   classifyWorkerOwnership,
-  isDaemonProcess,
+  isDaemonCommand,
   pid1OwnsWorkers,
 } from "./worker-ownership.js";
 
@@ -367,7 +367,7 @@ export function decideWorkerSlot(
   signature: readonly string[],
   selfPid: number,
   isOwnerAlive: (pid: number) => boolean,
-  pid1OwnsWorkers: () => boolean,
+  pid1OwnsWorkers: boolean,
 ): WorkerSlotDecision {
   if (status.status !== "running" || status.pid == null) {
     return { action: "spawn" };
@@ -383,7 +383,7 @@ export function decideWorkerSlot(
     row,
     selfPid,
     isOwnerAlive,
-    pid1OwnsWorkers(),
+    pid1OwnsWorkers,
   );
   return ownership === "orphan"
     ? { action: "reclaim", pid: status.pid }
@@ -401,13 +401,29 @@ function inspectWorkerSlot(
   signature: readonly string[],
 ): WorkerSlotDecision {
   const status = probeWorkerPidFile(pidPath);
+  if (status.status !== "running" || status.pid == null) {
+    return { action: "spawn" };
+  }
+
+  // The worker's row, its owner's identity, and what PID 1 is all come from
+  // one snapshot. Reading the table is a subprocess on most platforms, so
+  // asking three separate times would be three of them per worker.
+  let table: readonly ProcessTableRow[];
+  try {
+    table = listProcessTable();
+  } catch {
+    table = [];
+  }
+  const commandOf = (pid: number): string | null =>
+    table.find((row) => row.pid === pid)?.command ?? null;
+
   return decideWorkerSlot(
     status,
-    status.pid != null ? findProcessRow(status.pid) : null,
+    table.find((row) => row.pid === status.pid) ?? null,
     signature,
     process.pid,
-    isDaemonProcess,
-    pid1OwnsWorkers,
+    (pid) => isDaemonCommand(commandOf(pid)),
+    pid1OwnsWorkers(commandOf(1)),
   );
 }
 

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -21,7 +21,11 @@ import { fileURLToPath } from "node:url";
 
 import { getCurrentLogFilePath, getLogger } from "./logger.js";
 import { isProcessAlive } from "./process-liveness.js";
-import { listProcessTable, type ProcessTableRow } from "./process-table.js";
+import {
+  listProcessTable,
+  type ProcessTableRow,
+  readRawProcessCommand,
+} from "./process-table.js";
 import { workerMemoryEnv } from "./worker-memory.js";
 import {
   classifyWorkerOwnership,
@@ -273,6 +277,25 @@ export function workerKindSignature(
 }
 
 /**
+ * Whether a command line still authorises escalating against a PID we
+ * classified as the orphan before an awaited gap. The OS reuses PIDs, so
+ * liveness alone cannot carry identity across a wait: a null or unrecognised
+ * command means the orphan exited and the PID may now belong to a stranger,
+ * which must read as "gone", never as a target.
+ */
+export function escalationAuthorised(
+  command: string | null,
+  signature: readonly string[],
+): boolean {
+  return command != null && matchesSignature(command, signature);
+}
+
+/** Re-read identity for `pid` from the live process table. */
+function stillThisWorker(pid: number, signature: readonly string[]): boolean {
+  return escalationAuthorised(readRawProcessCommand(pid), signature);
+}
+
+/**
  * How long an orphaned worker gets to exit after SIGTERM.
  *
  * Derived from the longest shutdown any worker can legitimately take, not
@@ -318,6 +341,7 @@ async function stopOrphanedWorker(
   pid: number,
   pidPath: string,
   workerLabel: string,
+  signature: readonly string[],
 ): Promise<boolean> {
   try {
     process.kill(pid, "SIGTERM");
@@ -326,7 +350,11 @@ async function stopOrphanedWorker(
   }
 
   await waitForExit(pid, ORPHAN_STOP_TIMEOUT_MS);
-  if (isProcessAlive(pid)) {
+  // Identity is re-proven after every awaited gap, not carried by the PID:
+  // the orphan may have exited during the wait and the OS may have handed its
+  // PID to a stranger. A PID that no longer reads as this worker is treated
+  // as exited, whatever now holds it.
+  if (isProcessAlive(pid) && stillThisWorker(pid, signature)) {
     try {
       process.kill(pid, "SIGKILL");
     } catch {
@@ -335,7 +363,7 @@ async function stopOrphanedWorker(
     await waitForExit(pid, ORPHAN_KILL_CONFIRM_MS);
   }
 
-  if (isProcessAlive(pid)) {
+  if (isProcessAlive(pid) && stillThisWorker(pid, signature)) {
     log.warn(
       { pid, pidPath },
       `${workerLabel} orphaned by a previous owner could not be stopped; reusing it rather than running a second one`,
@@ -462,8 +490,9 @@ async function reclaimWorkerSlot(
   pid: number,
   pidPath: string,
   workerLabel: string,
+  signature: readonly string[],
 ): Promise<number | null> {
-  if (!(await stopOrphanedWorker(pid, pidPath, workerLabel))) {
+  if (!(await stopOrphanedWorker(pid, pidPath, workerLabel, signature))) {
     // Still running and beyond our reach. One stale worker beats two live ones.
     return pid;
   }
@@ -499,10 +528,8 @@ export async function spawnWorkerProcess(args: {
   const pidPollIntervalMs = opts.pidPollIntervalMs ?? PID_FILE_POLL_INTERVAL_MS;
   const detached = opts.detached ?? true;
 
-  const decision = inspectWorkerSlot(
-    args.pidPath,
-    workerKindSignature(args.entry, args.packagedEntry),
-  );
+  const signature = workerKindSignature(args.entry, args.packagedEntry);
+  const decision = inspectWorkerSlot(args.pidPath, signature);
   if (decision.action === "adopt") {
     return { pid: decision.pid, alreadyRunning: true };
   }
@@ -511,6 +538,7 @@ export async function spawnWorkerProcess(args: {
       decision.pid,
       args.pidPath,
       args.workerLabel,
+      signature,
     );
     if (adopted != null) {
       return { pid: adopted, alreadyRunning: true };

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -267,6 +267,21 @@ const ORPHAN_STOP_TIMEOUT_MS = 5_000;
 const ORPHAN_STOP_POLL_INTERVAL_MS = 100;
 
 /**
+ * How long to wait for a SIGKILLed worker to actually disappear. Signal
+ * delivery and reaping are asynchronous, so a liveness probe taken straight
+ * after the kill can still see a process that is on its way out.
+ */
+const ORPHAN_KILL_CONFIRM_MS = 1_000;
+
+/** Poll until `pid` is gone or `timeoutMs` elapses. */
+async function waitForExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && isProcessAlive(pid)) {
+    await Bun.sleep(ORPHAN_STOP_POLL_INTERVAL_MS);
+  }
+}
+
+/**
  * Stop a worker orphaned by a previous owner and release its PID file.
  * Reports whether it actually exited.
  *
@@ -290,16 +305,14 @@ async function stopOrphanedWorker(
     // Exited between the probe and the signal.
   }
 
-  const deadline = Date.now() + ORPHAN_STOP_TIMEOUT_MS;
-  while (Date.now() < deadline && isProcessAlive(pid)) {
-    await Bun.sleep(ORPHAN_STOP_POLL_INTERVAL_MS);
-  }
+  await waitForExit(pid, ORPHAN_STOP_TIMEOUT_MS);
   if (isProcessAlive(pid)) {
     try {
       process.kill(pid, "SIGKILL");
     } catch {
       // Best-effort.
     }
+    await waitForExit(pid, ORPHAN_KILL_CONFIRM_MS);
   }
 
   if (isProcessAlive(pid)) {

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -20,13 +20,13 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { getCurrentLogFilePath, getLogger } from "./logger.js";
-import {
-  classifyWorkerOwnership,
-  pid1OwnsMlWorkers as pid1OwnsWorkers,
-} from "./ml-worker-ownership.js";
 import { isProcessAlive } from "./process-liveness.js";
 import { findProcessRow, type ProcessTableRow } from "./process-table.js";
 import { workerMemoryEnv } from "./worker-memory.js";
+import {
+  classifyWorkerOwnership,
+  pid1OwnsWorkers,
+} from "./worker-ownership.js";
 
 const log = getLogger("worker-process");
 

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -25,6 +25,7 @@ import { findProcessRow, type ProcessTableRow } from "./process-table.js";
 import { workerMemoryEnv } from "./worker-memory.js";
 import {
   classifyWorkerOwnership,
+  isDaemonProcess,
   pid1OwnsWorkers,
 } from "./worker-ownership.js";
 
@@ -350,9 +351,15 @@ export type WorkerSlotDecision =
  *
  * `reclaim` is the only outcome that signals a process, and it requires two
  * independent things to agree: the command line marks the process as this
- * worker, and parentage says nobody live owns it. A missing row, an unreadable
+ * worker, and parentage says no daemon owns it. A missing row, an unreadable
  * command line, and a command line that does not match all fall back to
  * `adopt`, so an uncertain answer never costs a process its life.
+ *
+ * `isOwnerAlive` is the caller's definition of a legitimate owner. These
+ * workers have exactly one, the daemon, so passing a plain liveness probe
+ * would let a recycled owner PID keep a stranded worker looking owned forever.
+ * The embed worker passes a liveness probe instead, because two processes may
+ * each legitimately run one of its workers.
  */
 export function decideWorkerSlot(
   status: WorkerProcessStatus,
@@ -399,7 +406,7 @@ function inspectWorkerSlot(
     status.pid != null ? findProcessRow(status.pid) : null,
     signature,
     process.pid,
-    isProcessAlive,
+    isDaemonProcess,
     pid1OwnsWorkers,
   );
 }

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -19,8 +19,16 @@ import {
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { getCurrentLogFilePath } from "./logger.js";
+import { getCurrentLogFilePath, getLogger } from "./logger.js";
+import {
+  classifyWorkerOwnership,
+  pid1OwnsMlWorkers as pid1OwnsWorkers,
+} from "./ml-worker-ownership.js";
+import { isProcessAlive } from "./process-liveness.js";
+import { findProcessRow, type ProcessTableRow } from "./process-table.js";
 import { workerMemoryEnv } from "./worker-memory.js";
+
+const log = getLogger("worker-process");
 
 export interface WorkerProcessStatus {
   status: "running" | "not_running";
@@ -135,20 +143,39 @@ interface WorkerCommandRuntime {
   executableExists: (path: string) => boolean;
 }
 
-export function resolveWorkerCommand(
-  entry: URL,
-  packagedEntry: PackagedWorkerEntry | undefined,
-  runtime: WorkerCommandRuntime = {
+function defaultWorkerCommandRuntime(): WorkerCommandRuntime {
+  return {
     platform: process.platform,
     execPath: process.execPath,
     executableExists: existsSync,
-  },
-): string[] {
+  };
+}
+
+/**
+ * How a packaged Windows runtime spawns this worker, or null when the worker
+ * runs from source. Only packaged Windows runtimes ship the executable.
+ */
+function packagedWorkerSpawn(
+  packagedEntry: PackagedWorkerEntry | undefined,
+  runtime: WorkerCommandRuntime,
+): { executable: string; entry: PackagedWorkerEntry } | null {
   if (runtime.platform === "win32" && packagedEntry) {
     const executable = join(dirname(runtime.execPath), "vellum-worker.exe");
     if (runtime.executableExists(executable)) {
-      return [executable, packagedEntry];
+      return { executable, entry: packagedEntry };
     }
+  }
+  return null;
+}
+
+export function resolveWorkerCommand(
+  entry: URL,
+  packagedEntry: PackagedWorkerEntry | undefined,
+  runtime: WorkerCommandRuntime = defaultWorkerCommandRuntime(),
+): string[] {
+  const packaged = packagedWorkerSpawn(packagedEntry, runtime);
+  if (packaged) {
+    return [packaged.executable, packaged.entry];
   }
   return ["bun", "--smol", "run", fileURLToPath(entry)];
 }
@@ -194,10 +221,200 @@ async function waitForWorkerPidFile(
   return existsSync(pidPath) ? "ready" : "timeout";
 }
 
+/** Path separators differ by platform; compare command lines on one form. */
+function normalizeSeparators(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+/**
+ * Fragments of a command line that together mark a process as this worker,
+ * whichever install it came from. All must be present.
+ *
+ * This is a safety guard, not the ownership test. Ownership is decided by
+ * parentage; this only keeps us from signalling a process that happens to hold
+ * a recycled PID. Three trailing path segments are specific enough
+ * (`src/schedule/worker.ts`, `defaults/memory/worker.ts`) that an unrelated
+ * program running some other `worker.ts` does not match. Packaged workers all
+ * run one executable and are told apart by the subcommand, so the signature
+ * carries both: matching on the executable alone would let one packaged
+ * worker's slot reclaim another's process.
+ */
+export function workerKindSignature(
+  entry: URL,
+  packagedEntry: PackagedWorkerEntry | undefined,
+  runtime: WorkerCommandRuntime = defaultWorkerCommandRuntime(),
+): readonly string[] {
+  const packaged = packagedWorkerSpawn(packagedEntry, runtime);
+  if (packaged) {
+    // Matched as separate fragments rather than one adjacent string: a Windows
+    // command line may quote the executable path, so the two are not reliably
+    // neighbours.
+    return ["vellum-worker", packaged.entry];
+  }
+  return [
+    normalizeSeparators(fileURLToPath(entry))
+      .split("/")
+      .filter(Boolean)
+      .slice(-3)
+      .join("/"),
+  ];
+}
+
+/** How long an orphaned worker gets to exit after SIGTERM. */
+const ORPHAN_STOP_TIMEOUT_MS = 5_000;
+
+/** Poll interval while waiting for a stopped worker to exit. */
+const ORPHAN_STOP_POLL_INTERVAL_MS = 100;
+
+/**
+ * Stop a worker orphaned by a previous owner and release its PID file.
+ * Reports whether it actually exited.
+ *
+ * Escalates to SIGKILL because the orphan runs a different generation's
+ * shutdown path, which this process cannot make assumptions about. Signalling
+ * can still fail outright, most plausibly EPERM for a process owned by another
+ * user, so the PID file is released only once the process is confirmed gone:
+ * dropping it while the worker still runs would let the caller spawn a second
+ * one against the same workspace. The unlink is also identity-checked, since a
+ * concurrent launcher may already have replaced the worker and deleting that
+ * successor's entry would strand it.
+ */
+async function stopOrphanedWorker(
+  pid: number,
+  pidPath: string,
+  workerLabel: string,
+): Promise<boolean> {
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // Exited between the probe and the signal.
+  }
+
+  const deadline = Date.now() + ORPHAN_STOP_TIMEOUT_MS;
+  while (Date.now() < deadline && isProcessAlive(pid)) {
+    await Bun.sleep(ORPHAN_STOP_POLL_INTERVAL_MS);
+  }
+  if (isProcessAlive(pid)) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Best-effort.
+    }
+  }
+
+  if (isProcessAlive(pid)) {
+    log.warn(
+      { pid, pidPath },
+      `${workerLabel} orphaned by a previous owner could not be stopped; reusing it rather than running a second one`,
+    );
+    return false;
+  }
+
+  unlinkPidFileIfNames(pidPath, pid);
+  log.warn(
+    { pid, pidPath },
+    `${workerLabel} orphaned by a previous owner was stopped so this process can start its own`,
+  );
+  return true;
+}
+
+/**
+ * What to do about the process a worker's PID file currently names.
+ *
+ *   - `adopt`: reuse it. Either it is this process's own worker, or it belongs
+ *     to another live owner, or it is not recognisably one of our workers at
+ *     all and must never be signalled.
+ *   - `reclaim`: an orphan left by an owner that is gone. Stop it, then spawn.
+ *   - `spawn`: nothing is holding the slot.
+ */
+export type WorkerSlotDecision =
+  | { action: "adopt"; pid: number }
+  | { action: "reclaim"; pid: number }
+  | { action: "spawn" };
+
+/**
+ * The whole safety decision, with no IO, so every branch is testable.
+ *
+ * `reclaim` is the only outcome that signals a process, and it requires two
+ * independent things to agree: the command line marks the process as this
+ * worker, and parentage says nobody live owns it. A missing row, an unreadable
+ * command line, and a command line that does not match all fall back to
+ * `adopt`, so an uncertain answer never costs a process its life.
+ */
+export function decideWorkerSlot(
+  status: WorkerProcessStatus,
+  row: Pick<ProcessTableRow, "pid" | "ppid" | "command"> | null,
+  signature: readonly string[],
+  selfPid: number,
+  isOwnerAlive: (pid: number) => boolean,
+  pid1OwnsWorkers: () => boolean,
+): WorkerSlotDecision {
+  if (status.status !== "running" || status.pid == null) {
+    return { action: "spawn" };
+  }
+  if (!row) {
+    return { action: "adopt", pid: status.pid };
+  }
+  const command = normalizeSeparators(row.command);
+  if (!signature.every((part) => command.includes(normalizeSeparators(part)))) {
+    return { action: "adopt", pid: status.pid };
+  }
+  const ownership = classifyWorkerOwnership(
+    row,
+    selfPid,
+    isOwnerAlive,
+    pid1OwnsWorkers(),
+  );
+  return ownership === "orphan"
+    ? { action: "reclaim", pid: status.pid }
+    : { action: "adopt", pid: status.pid };
+}
+
+/**
+ * The slot decision for the worker at `pidPath`, made without yielding.
+ *
+ * Callers spawn inside their own synchronous prefix, so this stays sync: an
+ * `await` here would let a caller's next tick run before the child exists.
+ */
+function inspectWorkerSlot(
+  pidPath: string,
+  signature: readonly string[],
+): WorkerSlotDecision {
+  const status = probeWorkerPidFile(pidPath);
+  return decideWorkerSlot(
+    status,
+    status.pid != null ? findProcessRow(status.pid) : null,
+    signature,
+    process.pid,
+    isProcessAlive,
+    pid1OwnsWorkers,
+  );
+}
+
+/**
+ * Stop the orphan holding the slot, then report a PID to adopt instead of
+ * spawning: either the orphan itself when it could not be stopped, or a
+ * replacement a concurrent launcher brought up while we waited.
+ */
+async function reclaimWorkerSlot(
+  pid: number,
+  pidPath: string,
+  workerLabel: string,
+): Promise<number | null> {
+  if (!(await stopOrphanedWorker(pid, pidPath, workerLabel))) {
+    // Still running and beyond our reach. One stale worker beats two live ones.
+    return pid;
+  }
+  const replacement = probeWorkerPidFile(pidPath);
+  return replacement.status === "running" && replacement.pid != null
+    ? replacement.pid
+    : null;
+}
+
 /**
  * Spawn a worker entry script as a background process and wait for it to
  * report readiness by writing its PID file. `opts.detached` (default `true`)
- * controls process parentage — see {@link SpawnWorkerProcessOptions}.
+ * controls process parentage, see {@link SpawnWorkerProcessOptions}.
  *
  * If a worker is already running (per the PID file), returns its PID with
  * `alreadyRunning: true` rather than spawning a second one. Throws
@@ -220,9 +437,22 @@ export async function spawnWorkerProcess(args: {
   const pidPollIntervalMs = opts.pidPollIntervalMs ?? PID_FILE_POLL_INTERVAL_MS;
   const detached = opts.detached ?? true;
 
-  const current = probeWorkerPidFile(args.pidPath);
-  if (current.status === "running" && current.pid != null) {
-    return { pid: current.pid, alreadyRunning: true };
+  const decision = inspectWorkerSlot(
+    args.pidPath,
+    workerKindSignature(args.entry, args.packagedEntry),
+  );
+  if (decision.action === "adopt") {
+    return { pid: decision.pid, alreadyRunning: true };
+  }
+  if (decision.action === "reclaim") {
+    const adopted = await reclaimWorkerSlot(
+      decision.pid,
+      args.pidPath,
+      args.workerLabel,
+    );
+    if (adopted != null) {
+      return { pid: adopted, alreadyRunning: true };
+    }
   }
 
   // Pipe the worker's stderr into the same daily log file the daemon writes
@@ -319,21 +549,26 @@ export function stopWorkerProcess(pidPath: string): WorkerProcessStatus {
 // ---------------------------------------------------------------------------
 
 /**
- * Remove the worker PID file only while it still names this process. A
- * successor worker overwrites the file with its own PID at startup, so an
- * exiting predecessor that unlinked unconditionally would delete the
- * successor's entry — the liveness supervisor would then respawn a
- * duplicate and orphan the successor.
+ * Remove `pidPath` only while it still names `pid`.
+ *
+ * A successor worker overwrites the file with its own PID at startup, so an
+ * unconditional unlink would delete the successor's entry: the liveness
+ * supervisor would then respawn a duplicate and orphan the successor.
  */
-export function cleanupWorkerPidFile(pidPath: string): void {
+export function unlinkPidFileIfNames(pidPath: string, pid: number): void {
   try {
     const raw = readFileSync(pidPath, "utf-8").trim();
-    if (parseInt(raw, 10) === process.pid) {
+    if (parseInt(raw, 10) === pid) {
       unlinkSync(pidPath);
     }
   } catch {
-    // best-effort — a missing or unreadable file needs no cleanup
+    // best-effort: a missing or unreadable file needs no cleanup
   }
+}
+
+/** Release this process's own PID file on the way out. */
+export function cleanupWorkerPidFile(pidPath: string): void {
+  unlinkPidFileIfNames(pidPath, process.pid);
 }
 
 /**

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -272,8 +272,16 @@ export function workerKindSignature(
   ];
 }
 
-/** How long an orphaned worker gets to exit after SIGTERM. */
-const ORPHAN_STOP_TIMEOUT_MS = 5_000;
+/**
+ * How long an orphaned worker gets to exit after SIGTERM.
+ *
+ * Derived from the longest shutdown any worker can legitimately take, not
+ * picked. The memory worker reaps the ONNX embedding subprocess it owns before
+ * exiting and bounds that at `EMBEDDING_SHUTDOWN_BUDGET_MS + 1s`, so a shorter
+ * ceiling here would SIGKILL it mid-reap and strand the very subprocess that
+ * reap exists to collect. A test asserts this stays above that bound.
+ */
+export const ORPHAN_STOP_TIMEOUT_MS = 15_000;
 
 /** Poll interval while waiting for a stopped worker to exit. */
 const ORPHAN_STOP_POLL_INTERVAL_MS = 100;

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -277,22 +277,42 @@ export function workerKindSignature(
 }
 
 /**
- * Whether a command line still authorises escalating against a PID we
- * classified as the orphan before an awaited gap. The OS reuses PIDs, so
- * liveness alone cannot carry identity across a wait: a null or unrecognised
- * command means the orphan exited and the PID may now belong to a stranger,
- * which must read as "gone", never as a target.
+ * What became of the orphan after an awaited gap, from liveness plus a fresh
+ * command-line read.
+ *
+ *   - `gone`: the PID is dead, or alive under a command line that is not this
+ *     worker (the orphan exited and the OS recycled its PID). The slot may be
+ *     released.
+ *   - `orphan`: still alive and still reads as this worker. Escalation may
+ *     proceed.
+ *   - `identity-unreadable`: alive, but the command line could not be read, so
+ *     "still the orphan" and "recycled PID" cannot be told apart. Uncertainty
+ *     must resolve to reuse: no signal, and the slot must NOT be released, or
+ *     a second worker would be spawned next to a live one.
  */
-export function escalationAuthorised(
+export type OrphanFate = "gone" | "orphan" | "identity-unreadable";
+
+export function classifyOrphanAfterWait(
+  alive: boolean,
   command: string | null,
   signature: readonly string[],
-): boolean {
-  return command != null && matchesSignature(command, signature);
+): OrphanFate {
+  if (!alive) {
+    return "gone";
+  }
+  if (command == null) {
+    return "identity-unreadable";
+  }
+  return matchesSignature(command, signature) ? "orphan" : "gone";
 }
 
-/** Re-read identity for `pid` from the live process table. */
-function stillThisWorker(pid: number, signature: readonly string[]): boolean {
-  return escalationAuthorised(readRawProcessCommand(pid), signature);
+/** Re-read the orphan's fate for `pid` from the live process table. */
+function orphanFate(pid: number, signature: readonly string[]): OrphanFate {
+  return classifyOrphanAfterWait(
+    isProcessAlive(pid),
+    readRawProcessCommand(pid),
+    signature,
+  );
 }
 
 /**
@@ -352,21 +372,25 @@ async function stopOrphanedWorker(
   await waitForExit(pid, ORPHAN_STOP_TIMEOUT_MS);
   // Identity is re-proven after every awaited gap, not carried by the PID:
   // the orphan may have exited during the wait and the OS may have handed its
-  // PID to a stranger. A PID that no longer reads as this worker is treated
-  // as exited, whatever now holds it.
-  if (isProcessAlive(pid) && stillThisWorker(pid, signature)) {
+  // PID to a stranger. Only a positive re-match escalates, and only a proven
+  // "gone" releases the slot.
+  let fate = orphanFate(pid, signature);
+  if (fate === "orphan") {
     try {
       process.kill(pid, "SIGKILL");
     } catch {
       // Best-effort.
     }
     await waitForExit(pid, ORPHAN_KILL_CONFIRM_MS);
+    fate = orphanFate(pid, signature);
   }
 
-  if (isProcessAlive(pid) && stillThisWorker(pid, signature)) {
+  if (fate !== "gone") {
     log.warn(
-      { pid, pidPath },
-      `${workerLabel} orphaned by a previous owner could not be stopped; reusing it rather than running a second one`,
+      { pid, pidPath, fate },
+      fate === "orphan"
+        ? `${workerLabel} orphaned by a previous owner could not be stopped; reusing it rather than running a second one`
+        : `${workerLabel} is still live but its identity could not be re-read; reusing it rather than risking a duplicate`,
     );
     return false;
   }

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -227,6 +227,17 @@ function normalizeSeparators(value: string): string {
   return value.replaceAll("\\", "/");
 }
 
+/** Whether a command line carries every fragment that marks this worker. */
+function matchesSignature(
+  command: string,
+  signature: readonly string[],
+): boolean {
+  const normalized = normalizeSeparators(command);
+  return signature.every((part) =>
+    normalized.includes(normalizeSeparators(part)),
+  );
+}
+
 /**
  * Fragments of a command line that together mark a process as this worker,
  * whichever install it came from. All must be present.
@@ -375,8 +386,7 @@ export function decideWorkerSlot(
   if (!row) {
     return { action: "adopt", pid: status.pid };
   }
-  const command = normalizeSeparators(row.command);
-  if (!signature.every((part) => command.includes(normalizeSeparators(part)))) {
+  if (!matchesSignature(row.command, signature)) {
     return { action: "adopt", pid: status.pid };
   }
   const ownership = classifyWorkerOwnership(
@@ -417,9 +427,17 @@ function inspectWorkerSlot(
   const commandOf = (pid: number): string | null =>
     table.find((row) => row.pid === pid)?.command ?? null;
 
+  const row = table.find((entry) => entry.pid === status.pid) ?? null;
+  if (row && !matchesSignature(row.command, signature)) {
+    log.info(
+      { pid: row.pid, pidPath },
+      "Worker PID file names a live process this runtime does not recognise as its worker; reusing it rather than signalling it",
+    );
+  }
+
   return decideWorkerSlot(
     status,
-    table.find((row) => row.pid === status.pid) ?? null,
+    row,
     signature,
     process.pid,
     (pid) => isDaemonCommand(commandOf(pid)),


### PR DESCRIPTION
## TL;DR

- **The bug:** After an upgrade, the new daemon **adopted the previous version's workers** (schedule, route host, monitoring, memory jobs). The PID-file check only asks "is this PID alive", never "is this my worker" - so a stale schedule worker kept executing schedules with old code against an already-migrated database, silently, until reboot.
- **The fix:** Ownership comes from the **process tree** - a worker's parent IS its owner, the exact model the embed worker already uses (JARVIS-1125). An orphan (parent gone, or not a daemon) is stopped and replaced; everything else is reused.
- **Why this way:** The PID file has been patched five times to fake ownership it cannot express; `ppid` needs no string matching, survives quoting, and works in source checkouts where version-sniffing is a no-op. This extends the codebase's existing model instead of adding a sixth patch.
- **Why it is safe:** A kill requires **two independent signals to agree** - the command line marks the process as *this* worker AND parentage says no daemon owns it. Every uncertain input (unreadable table, missing row, partial match, unkillable orphan) resolves to *reuse*, i.e. today's behaviour. Every branch that can reach a kill is a pure function with direct tests, and an unrecognised occupant is logged so a silent no-op is distinguishable from "no stale workers".
- **User impact:** Schedules, `/x/*` routes, monitoring and memory jobs actually run the version you just installed; existing stranded workers self-heal on next boot.
- **Reviewer:** Maddie - the packaged-worker signature (`vellum-worker.exe` + subcommand) encodes Windows claims worth your eyes. Replaces #41664 (was 20 files; this is the 3-file core).
## Why this is needed

`stopLocalProcesses` gives the daemon 2000 ms before SIGKILL while its graceful shutdown budgets 30 s and stops workers near the end of that sequence (#41658 fixes that half). So an upgrade kills the daemon mid-shutdown and its four PID-file workers reparent to launchd, still holding their PID files. The next daemon called `spawnWorkerProcess`, which reused any live PID:

```ts
const current = probeWorkerPidFile(args.pidPath);
if (current.status === "running" && current.pid != null) {
  return { pid: current.pid, alreadyRunning: true };
}
```

`probeWorkerPidFile` is `process.kill(pid, 0)`. It answers "is this PID alive", never "is this my worker".

Nothing else recovered them. The daemon's force-exit path stops in-process timers only. The CLI's process-listing and cleanup commands classify these workers' command lines as `unknown` (`classifyProcess` recognises `daemon/main` and no worker entry), and `getKnownPidsFromAssistants` reads the daemon, gateway, qdrant and embed-worker PID files but none of these four. The PID-file identity guard (#38489) is documented not to fire here: "A worker a successor daemon reuses via the `alreadyRunning` path is still named by the file, so the guard never fires for it."

## What the user experienced before

Silently, and durably. After updating (reported across 0.10.11 to 0.11.7) the schedule worker, route host, resource monitor and memory jobs worker kept running the **old** version's code. The schedule worker is the sole runner of schedule execution and hosts real agent turns: it loads the config schema, the feature-flag registry, the tool registry, the plugin surface, and the shared SQLite database. So scheduled tasks kept firing from an 0.10.11 worker against a database 0.11.7 had already migrated, on the old config schema and old flag defaults.

Nothing logged a version mismatch, and the worker survived every subsequent update, so the only thing that cleared it was a crash or a reboot. A user could sit on months-old schedule execution without any signal that it had happened.

## What the user experiences after

Schedules, `/x/*` routes, resource monitoring and memory jobs run the version they just upgraded to. The first boot after this ships reclaims any worker already stranded on an old runtime, so existing installs self-heal without the user doing anything. There is no new UI and nothing to configure.

| Process holding the PID file | Before | After |
| --- | --- | --- |
| Parented to this daemon | Reused | Reused, unchanged |
| Orphan (parented to init, or its owner is gone) | Reused, ran old code forever | Stopped, then replaced |
| Owned by a live daemon | Reused | Reused, unchanged |
| Owner PID recycled to a non-daemon | Reused forever | Stopped, then replaced |
| Not recognisable as this worker | Reused | Reused, never signalled |
| PID file absent or stale | Spawns | Spawns, unchanged |

## Why this is the most correct way

Three levels were available and this is the one that holds.

**Level 1, make workers unable to outlive the daemon.** JARVIS-891 suggests `BUN_DIE_WITH_PARENT`. I probed it rather than assuming: bun 1.3.9, parent spawns a child with the flag, SIGKILL the parent, and the **child survived**. It is `PR_SET_PDEATHSIG` underneath, which is Linux-only, so it cannot address the macOS case this was reported on.

**Level 2, ownership by process tree.** This PR. JARVIS-1125 already reached this conclusion for the embed worker and said why in the code: the process table, unlike a PID file, "survives a crash and cannot be overwritten by a second owner". Those primitives were never embedding-specific, which is why #41661 moved them somewhere usable.

**Level 3, compare the command line against the current install's path.** My first attempt. It works, but it is a sixth patch to a seam that has already been patched five times to shore up ownership it cannot express (#38357, #38395, #38489, #38587, plus `cleanupWorkerPidFile`'s compare-and-delete). `ppid` is strictly stronger: it needs no string matching, so quoting cannot defeat it, and it works in a source checkout where the entry path does not change between versions and a version check is a no-op.

## Why it is safe

- **The owner test is "is a daemon", not "is a live PID".** `classifyWorkerOwnership` takes the caller's definition of a legitimate owner, because the two worker families do not share one: the embed worker passes a liveness probe, since the daemon and the memory-worker process may each legitimately own one. These four have exactly one legitimate owner, so a plain liveness probe would let a recycled owner PID keep a stranded worker looking owned indefinitely. They pass `isDaemonProcess`.
- **The kill is guarded twice, and every uncertainty resolves to reuse.** `reclaim` is the only decision that signals a process, and it needs the command line to mark the process as *this* worker **and** parentage to say nobody live owns it. A missing row, an unreadable process table, a partial match, or an orphan that cannot be signalled all resolve to `adopt`, which is exactly today's behaviour. A failed lookup degrades, it does not misfire.
- **Every branch that can reach a kill is tested.** `decideWorkerSlot` is pure, so the four cases that must never kill are asserted directly: an unrelated process on a recycled PID, another project's `worker.ts`, a different worker kind holding this slot, and an unreadable process table.
- **The kind signature is specific on purpose.** Three trailing path segments (`src/schedule/worker.ts`), and for packaged Windows workers the executable *plus* its subcommand, since all four share one executable and matching the executable alone would let one worker's slot reclaim another's process. Matched as separate fragments because a Windows command line may quote the executable path.
- **The spawn stays in the caller's synchronous prefix.** An `await` before `Bun.spawn` would let a caller's next tick run before the child exists, which the schedule worker's spawn-coalescing test depends on. Only an actual reclaim yields.
- **No new steady-state cost.** The process-table read happens only when a PID file already names a live process, and the PID-1 probe is a thunk evaluated only when ownership is actually consulted. The 15 s liveness watchdog calls `probeWorkerPidFile`, which is untouched.

## Merge order

1. #41672, smallest and independent. Landing it first means the one `embedding-local.ts` import conflict is resolved here rather than there.
2. #41658, independent, and it stops new orphans being created.
3. **This PR.**
4. #41670, which is stacked on this one and cannot land before it.

Only 3 before 4 is a hard requirement. The rest is preference: each PR is safe alone, and any order self-heals once all four land.

## Not in scope

- **Containers are unchanged**, and correctly so: there the daemon is PID 1, so a worker parented to 1 is a live sibling's rather than an orphan. `pid1OwnsWorkers` is what distinguishes the two, and it already existed.
- **The dead `detached` spawn option** and **`embedding-local`'s hand-rolled `isProcessAlive`** are separate PRs, so this one is only the behaviour change.

## Testing

Type check and lint clean. Local test runs are disabled on this machine, so CI is the first execution. The previous revision of this work ran on CI and all ten `decideWorkerSlot` cases passed, including the four that must never kill; the two failures it surfaced are fixed here (an array compared with `toBe`, and the pre-spawn `await` described above).

