### PR TITLE
Make the bundle-name credits chips permanent in the Pro provisioning takeover

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/billing-onboarding-modal.test.tsx
@@ -178,11 +178,11 @@ function makeEnsureResponse(
   };
 }
 
-/** A credit tier the chip can price from the catalog rather than its key. */
-function creditTier(usd: number) {
+/** A credit tier the chip can name from the catalog rather than its key. */
+function creditTier(usd: number, label: string) {
   return {
     tier: `credits_${usd}`,
-    label: `$${usd} credits/mo`,
+    label,
     credits_usd: usd,
     price_cents: usd * 100,
     lookup_key: `credits_${usd}_key`,
@@ -203,7 +203,11 @@ function plansWithCredits(): PlanListResponse {
         included_features: [],
         machine_tiers: [],
         storage_tiers: [],
-        credit_tiers: [creditTier(25), creditTier(45), creditTier(50)],
+        credit_tiers: [
+          creditTier(25, "Mighty Usage"),
+          creditTier(45, "Super Usage"),
+          creditTier(50, "Extra Usage"),
+        ],
         packages: [],
       },
     ],
@@ -1219,7 +1223,7 @@ describe("BillingOnboardingModal — resize mode", () => {
     );
     // One credits surface: the chip is on screen for the whole wait, not held
     // back for the terminal phase.
-    expect(getByTestId("chip-credits").textContent).toContain("$25/mo");
+    expect(getByTestId("chip-credits").textContent).toContain("Mighty Usage");
 
     assistantResponse = makeAssistant("large", 50);
     await client.invalidateQueries();
@@ -1227,8 +1231,8 @@ describe("BillingOnboardingModal — resize mode", () => {
       timeout: 5000,
     });
     const chip = getByTestId("chip-credits");
-    expect(chip.textContent).toContain("$25/mo");
-    expect(chip.textContent).toContain("$50/mo");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(chip.textContent).toContain("Extra Usage");
   });
 
   test("resize mode draws its from-sides from the captured context, not live actuals", async () => {
@@ -1737,8 +1741,8 @@ describe("BillingOnboardingModal (package downgrade)", () => {
       timeout: 5000,
     });
     const credits = getByTestId("chip-credits");
-    expect(credits.textContent).toContain("$45/mo");
-    expect(credits.textContent).toContain("$25/mo");
+    expect(credits.textContent).toContain("Super Usage");
+    expect(credits.textContent).toContain("Mighty Usage");
     expect(within(credits).getByTestId("chip-check")).toBeTruthy();
 
     const machine = getByTestId("chip-machine");
@@ -1797,7 +1801,7 @@ describe("BillingOnboardingModal (package downgrade)", () => {
       timeout: 5000,
     });
     expect(queryByTestId("chip-machine")).toBeNull();
-    expect(getByTestId("chip-credits").textContent).toContain("$25/mo");
+    expect(getByTestId("chip-credits").textContent).toContain("Mighty Usage");
   }, 20_000);
 
   test("Mighty → Super shows all three chips, storage pending until the grow lands", async () => {
@@ -1835,8 +1839,8 @@ describe("BillingOnboardingModal (package downgrade)", () => {
     expect(machine.textContent).toContain("Small");
     expect(machine.textContent).toContain("Medium");
     const credits = getByTestId("chip-credits");
-    expect(credits.textContent).toContain("$25/mo");
-    expect(credits.textContent).toContain("$45/mo");
+    expect(credits.textContent).toContain("Mighty Usage");
+    expect(credits.textContent).toContain("Super Usage");
 
     assistantResponse = makeAssistant("medium", 30);
     await client.invalidateQueries();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.stories.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.stories.tsx
@@ -13,9 +13,8 @@
  * STALLED reads, and `avatar` swaps the seeded assistant between a bundled
  * creature, an uploaded image, and one nothing was seeded for. `landedMachine`,
  * `landedStorage`, `softWaiting`, and `escapeAvailable` drive the wait's own
- * progress and affordances, and `obscureCredits` flips the feature flag that
- * replaces every credit amount with its bundle name. Each is a URL arg too, so
- * a state links directly: `?args=phase:STALLED;snag:submissionFailed`.
+ * progress and affordances. Each is a URL arg too, so a state links directly:
+ * `?args=phase:STALLED;snag:submissionFailed`.
  *
  * The decorators supply what the modal supplies: the plan catalog and avatar
  * reads in a story-local query cache, and the takeover frame (a black ground, a
@@ -30,7 +29,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { ProvisioningStateKind } from "./provisioning-machine";
 import { ProvisioningState } from "./provisioning-state";
 import {
-  obscureCreditsDecorator,
   TAKEOVER_AVATARS,
   TAKEOVER_CONSTANT_PROPS,
   TAKEOVER_SCENARIOS,
@@ -45,8 +43,8 @@ import {
 
 /**
  * The playground's controls, which are not `ProvisioningState` props: each one
- * either names a row in a fixture table the render expands, or drives something
- * outside the component entirely (`obscureCredits` is a feature flag).
+ * either names a row in a fixture table the render expands, or composes into a
+ * prop the render assembles.
  *
  * The three table-backed controls hold the row's name rather than the row, and
  * the render looks it up. That keeps a story's `args` type-checked against the
@@ -67,7 +65,6 @@ interface TakeoverPlaygroundArgs {
   escapeAvailable: boolean;
   snag: TakeoverSnagKey;
   avatar: TakeoverAvatarKey;
-  obscureCredits: boolean;
 }
 
 const PHASES: ProvisioningStateKind[] = [
@@ -145,14 +142,6 @@ const meta: Meta<TakeoverPlaygroundArgs> = {
       description: "Offer the background escape hatch.",
       control: "boolean",
     },
-    obscureCredits: {
-      description:
-        "Flip `obscure-credits`, which states bundles by catalog name instead of by monthly rate. Live only on `Playground`.",
-      // Hidden everywhere but `Playground`: the flag is a module-level singleton,
-      // and the docs page mounts every curated story into one iframe, so a
-      // control there would flip the treatment for all of them at once.
-      control: false,
-    },
   },
   args: {
     phase: "WAITING",
@@ -163,28 +152,15 @@ const meta: Meta<TakeoverPlaygroundArgs> = {
     escapeAvailable: false,
     snag: "none",
     avatar: "creature",
-    obscureCredits: false,
   },
   render: renderTakeover,
-  // Storybook applies decorators innermost first, so the flag is already set for
-  // the frame and the takeover, both of which sit inside the query provider that
-  // answers their reads.
-  decorators: [
-    takeoverFrameDecorator,
-    obscureCreditsDecorator,
-    takeoverQueryDecorator,
-  ],
+  // Storybook applies decorators innermost first, so the frame and the takeover
+  // both sit inside the query provider that answers their reads.
+  decorators: [takeoverFrameDecorator, takeoverQueryDecorator],
 };
 
 export default meta;
 type Story = StoryObj<TakeoverPlaygroundArgs>;
-
-// Every curated story below pins `obscureCredits: false` and exposes no control
-// for it. The flag is a module-level Zustand singleton and the docs page mounts
-// all of these into one iframe at once, so a story that flipped it would flip it
-// for its neighbours too, and their decorators would not re-run to undo it. The
-// flag-on treatment belongs to `Playground`, which carries the only live control
-// and stays off the docs page so it is never mounted beside them.
 
 /**
  * The whole surface, driven from the Controls panel. Opens on the rollout of a
@@ -192,19 +168,13 @@ type Story = StoryObj<TakeoverPlaygroundArgs>;
  * and the bundle applied the moment the subscription was accepted, so its chip
  * is already checked.
  */
-export const Playground: Story = {
-  tags: ["!autodocs"],
-  argTypes: {
-    obscureCredits: { control: "boolean" },
-  },
-};
+export const Playground: Story = {};
 
 /** Waiting on Stripe after a package checkout: the package names itself. */
 export const Confirming: Story = {
   args: {
     phase: "CONFIRMING",
     change: "packageIntent",
-    obscureCredits: false,
   },
 };
 
@@ -216,7 +186,6 @@ export const Confirming: Story = {
 export const ConfirmTimeout: Story = {
   args: {
     phase: "CONFIRM_TIMEOUT",
-    obscureCredits: false,
   },
 };
 
@@ -229,7 +198,6 @@ export const Waiting: Story = {
   args: {
     phase: "WAITING",
     change: "baseToSuper",
-    obscureCredits: false,
   },
 };
 
@@ -241,7 +209,6 @@ export const Waiting: Story = {
 export const Done: Story = {
   args: {
     phase: "DONE",
-    obscureCredits: false,
   },
 };
 
@@ -254,7 +221,6 @@ export const NotApplicable: Story = {
   args: {
     phase: "NOT_APPLICABLE",
     change: "creditOnlySwitch",
-    obscureCredits: false,
   },
 };
 
@@ -268,6 +234,5 @@ export const Stalled: Story = {
     phase: "STALLED",
     snag: "submissionFailed",
     escapeAvailable: true,
-    obscureCredits: false,
   },
 };

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -9,7 +9,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
-  act,
   cleanup,
   fireEvent,
   render,
@@ -21,7 +20,6 @@ import * as motionReact from "motion/react";
 import { organizationsBillingPlansRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import type { PlanListResponse } from "@/generated/api/types.gen";
 import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
@@ -218,21 +216,6 @@ describe("confirming", () => {
     // CONFIRMING is target-only: no current→new arrow while actuals are unknown.
     expect(container.querySelector(".lucide-arrow-right")).toBeNull();
   });
-
-  test("renders a credits chip when the custom intent bundles credits", () => {
-    const { getByText } = renderState({
-      state: "CONFIRMING",
-      intent: {
-        kind: "custom",
-        machineTier: "medium",
-        storageTier: "s",
-        creditTier: "credits_50",
-        savedAt: Date.now(),
-      },
-    });
-
-    expect(getByText("50 credits")).toBeTruthy();
-  });
 });
 
 describe("waiting / resizing", () => {
@@ -293,36 +276,8 @@ describe("waiting / resizing", () => {
     ).toBeTruthy();
   });
 
-  test("renders a checkout credits chip as a monthly rate from $0", () => {
-    const { getByText } = renderState({
-      state: "WAITING",
-      intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
-      targets: { machineSize: null, storageGib: null },
-      fromSnapshot: { machineSize: null, storageGib: null },
-    });
-
-    expect(getByText("Credits")).toBeTruthy();
-    expect(getByText("$0/mo")).toBeTruthy();
-    expect(getByText("$50/mo")).toBeTruthy();
-  });
-
-  test("an in-place credit change renders the same from-to rate, in either direction", () => {
-    // One format for checkout and for a switch: the chip states the move, so a
-    // downgrade reads as plainly as an upgrade.
-    const { getByTestId } = renderState({
-      state: "WAITING",
-      creditsChange: { fromTier: "credits_50", toTier: "credits_25" },
-      targets: { machineSize: null, storageGib: null },
-      fromSnapshot: { machineSize: null, storageGib: null },
-    });
-
-    const chip = getByTestId("chip-credits");
-    expect(chip.textContent).toContain("$50/mo");
-    expect(chip.textContent).toContain("$25/mo");
-  });
-
-  test("omits the credits chip when the catalog can't resolve a label", () => {
-    const { queryByText } = renderState(
+  test("omits the credits chip when the catalog can't resolve a bundle", () => {
+    const { queryByTestId } = renderState(
       {
         state: "WAITING",
         intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
@@ -332,7 +287,7 @@ describe("waiting / resizing", () => {
       null,
     );
 
-    expect(queryByText("Credits")).toBeNull();
+    expect(queryByTestId("chip-credits")).toBeNull();
   });
 
   for (const reduce of [false, true]) {
@@ -353,8 +308,8 @@ describe("waiting / resizing", () => {
       expect(getByText("Large")).toBeTruthy();
       expect(getByText("Storage")).toBeTruthy();
       expect(getByText("100 GB")).toBeTruthy();
-      expect(getByText("Credits")).toBeTruthy();
-      expect(getByText("$50/mo")).toBeTruthy();
+      expect(getByText("Usage")).toBeTruthy();
+      expect(getByText("Mighty Usage")).toBeTruthy();
       // One row holds all three; there is no sibling row to wrap onto.
       const row = chipRow(container);
       expect(within(row).getAllByTestId(CHIP_TESTID).length).toBe(3);
@@ -437,8 +392,8 @@ describe("per-chip progress", () => {
   });
 
   test("the credits chip is landed from first paint", () => {
-    // The rate flips when the plan change is accepted; nothing rolls out, so
-    // waiting on the machine would leave it spinning for no reason.
+    // The bundle applies when the plan change is accepted; nothing rolls out,
+    // so waiting on the machine would leave it spinning for no reason.
     const { getByTestId } = renderState({
       state: "WAITING",
       intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
@@ -607,7 +562,7 @@ describe("chip fit at narrow widths", () => {
     const cases: Array<[string, string, string]> = [
       ["chip-machine", "Machine", "Large"],
       ["chip-storage", "Storage", "100 GB"],
-      ["chip-credits", "Credits", "$50/mo"],
+      ["chip-credits", "Usage", "Mighty Usage"],
     ];
 
     for (const [key, label, value] of cases) {
@@ -697,13 +652,13 @@ describe("done / not_applicable", () => {
     // is the one surface where it can state what changed.
     const { getByText, getByTestId } = renderState({
       state: "NOT_APPLICABLE",
-      creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
+      creditsChange: { fromTier: null, toTier: "credits_50" },
     });
 
     expect(getByText("Your plan is ready")).toBeTruthy();
     const chip = getByTestId("chip-credits");
-    expect(chip.textContent).toContain("$25/mo");
-    expect(chip.textContent).toContain("$50/mo");
+    expect(chip.textContent).toContain("No extra usage");
+    expect(chip.textContent).toContain("Mighty Usage");
     expect(within(chip).getByTestId("chip-check")).toBeTruthy();
   });
 
@@ -748,19 +703,6 @@ describe("done / not_applicable", () => {
     expect(getByTestId("chip-credits")).toBeTruthy();
   });
 
-  test("not_applicable renders a dropped bundle as a move to $0", () => {
-    // "No extra credits" is an endpoint of the change like any other, so the
-    // chip prices it rather than falling back to a bare status word.
-    const { getByTestId } = renderState({
-      state: "NOT_APPLICABLE",
-      creditsChange: { fromTier: "credits_50", toTier: null },
-    });
-
-    const chip = getByTestId("chip-credits");
-    expect(chip.textContent).toContain("$50/mo");
-    expect(chip.textContent).toContain("$0/mo");
-  });
-
   test("done carries the credits chip alongside the resource chips", () => {
     const { getByText, getByTestId } = renderState({
       state: "DONE",
@@ -772,8 +714,8 @@ describe("done / not_applicable", () => {
     expect(getByText("All done!")).toBeTruthy();
     expect(getByText("Large")).toBeTruthy();
     const chip = getByTestId("chip-credits");
-    expect(chip.textContent).toContain("$0/mo");
-    expect(chip.textContent).toContain("$50/mo");
+    expect(chip.textContent).toContain("No extra usage");
+    expect(chip.textContent).toContain("Mighty Usage");
   });
 });
 
@@ -1391,101 +1333,81 @@ describe("ProvisioningState phase hold", () => {
 });
 
 // ---------------------------------------------------------------------------
-// obscure-credits flag: the chips name usage bundles, never a credit amount
+// Credits chip wording: the chips name usage bundles, never a credit amount
 // ---------------------------------------------------------------------------
 
-/** Drives the `obscure-credits` client flag the way the app's LD sync does. */
-function setObscureCredits(value: boolean): void {
-  act(() => {
-    useClientFeatureFlagStore
-      .getState()
-      .setFlags({ obscureCredits: value }, null);
-  });
-}
-
-describe("obscure-credits flag", () => {
-  beforeEach(() => {
-    setObscureCredits(true);
+test("the resize credits chip names the bundle on each side", () => {
+  const { getByTestId } = renderState({
+    state: "WAITING",
+    creditsChange: { fromTier: null, toTier: "credits_50" },
   });
 
-  afterEach(() => {
-    setObscureCredits(false);
+  const chip = getByTestId("chip-credits");
+  expect(within(chip).getByText("Usage")).toBeTruthy();
+  expect(chip.textContent).toContain("No extra usage");
+  expect(chip.textContent).toContain("Mighty Usage");
+  expect(chip.textContent).not.toContain("$");
+});
+
+test("a dropped bundle reads down to the no-extra-usage sentinel", () => {
+  const { getByTestId } = renderState({
+    state: "NOT_APPLICABLE",
+    creditsChange: { fromTier: "credits_50", toTier: null },
   });
 
-  test("the resize credits chip names the bundles, not monthly rates", () => {
-    const { getByTestId } = renderState({
-      state: "WAITING",
-      creditsChange: { fromTier: null, toTier: "credits_50" },
-    });
+  const chip = getByTestId("chip-credits");
+  expect(chip.textContent).toContain("Mighty Usage");
+  expect(chip.textContent).toContain("No extra usage");
+  expect(chip.textContent).not.toContain("$");
+});
 
-    const chip = getByTestId("chip-credits");
-    expect(within(chip).getByText("Usage")).toBeTruthy();
-    expect(chip.textContent).toContain("No extra usage");
-    expect(chip.textContent).toContain("Mighty Usage");
-    expect(chip.textContent).not.toContain("$");
+test("a checkout credits chip reads as bundles too", () => {
+  const { getByTestId } = renderState({
+    state: "WAITING",
+    intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
   });
 
-  test("a dropped bundle reads down to the no-extra-usage sentinel", () => {
-    const { getByTestId } = renderState({
-      state: "NOT_APPLICABLE",
-      creditsChange: { fromTier: "credits_50", toTier: null },
-    });
+  const chip = getByTestId("chip-credits");
+  expect(chip.textContent).toContain("No extra usage");
+  expect(chip.textContent).toContain("Mighty Usage");
+  expect(chip.textContent).not.toContain("$");
+});
 
-    const chip = getByTestId("chip-credits");
-    expect(chip.textContent).toContain("Mighty Usage");
-    expect(chip.textContent).toContain("No extra usage");
-    expect(chip.textContent).not.toContain("$");
+test("a from-side the catalog can't label is left unstated", () => {
+  // credits_25 is absent from the fixture catalog, so nothing words its side of
+  // the move.
+  const { getByTestId } = renderState({
+    state: "WAITING",
+    creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
   });
 
-  test("a checkout credits chip reads as bundles too", () => {
-    const { getByTestId, queryByText } = renderState({
-      state: "WAITING",
-      intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
-    });
+  const chip = getByTestId("chip-credits");
+  expect(chip.textContent).toContain("Mighty Usage");
+  expect(chip.textContent).not.toContain("25");
+  expect(chip.querySelector(".lucide-arrow-right")).toBeNull();
+});
 
-    const chip = getByTestId("chip-credits");
-    expect(chip.textContent).toContain("No extra usage");
-    expect(chip.textContent).toContain("Mighty Usage");
-    expect(queryByText("$0/mo")).toBeNull();
-    expect(queryByText("Credits")).toBeNull();
+test("a to-side the catalog can't label drops the whole chip", () => {
+  const { queryByTestId } = renderState({
+    state: "WAITING",
+    creditsChange: { fromTier: "credits_50", toTier: "credits_25" },
   });
 
-  test("a from-side the catalog can't label is left unstated", () => {
-    // credits_25 is absent from the fixture catalog: its key still prices the
-    // off-flag rate, but under the flag there is no wording to show for it.
-    const { getByTestId } = renderState({
-      state: "WAITING",
-      creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
-    });
+  expect(queryByTestId("chip-credits")).toBeNull();
+});
 
-    const chip = getByTestId("chip-credits");
-    expect(chip.textContent).toContain("Mighty Usage");
-    expect(chip.textContent).not.toContain("25");
-    expect(chip.querySelector(".lucide-arrow-right")).toBeNull();
+test("the confirming custom-intent chip names the bundle, not a count", () => {
+  const { getByText, queryByText } = renderState({
+    state: "CONFIRMING",
+    intent: {
+      kind: "custom",
+      machineTier: "medium",
+      storageTier: "s",
+      creditTier: "credits_50",
+      savedAt: Date.now(),
+    },
   });
 
-  test("a to-side the catalog can't label drops the chip, not the disguise", () => {
-    const { queryByTestId } = renderState({
-      state: "WAITING",
-      creditsChange: { fromTier: "credits_50", toTier: "credits_25" },
-    });
-
-    expect(queryByTestId("chip-credits")).toBeNull();
-  });
-
-  test("the confirming custom-intent chip names the bundle, not a count", () => {
-    const { getByText, queryByText } = renderState({
-      state: "CONFIRMING",
-      intent: {
-        kind: "custom",
-        machineTier: "medium",
-        storageTier: "s",
-        creditTier: "credits_50",
-        savedAt: Date.now(),
-      },
-    });
-
-    expect(getByText("Mighty Usage")).toBeTruthy();
-    expect(queryByText("50 credits")).toBeNull();
-  });
+  expect(getByText("Mighty Usage")).toBeTruthy();
+  expect(queryByText("50 credits")).toBeNull();
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -16,9 +16,7 @@ import {
 } from "react";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
-import { formatMonthly } from "@/domains/settings/components/tier-pricing";
 import type { MachineSizeEnum } from "@/generated/api/types.gen";
-import { useObscureCredits } from "@/hooks/use-obscure-credits-flag";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import type { ProvisioningDimensionFlags } from "@/lib/billing/provisioning-targets";
@@ -475,27 +473,19 @@ function chipDone(
 type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
 
 /**
- * The credits chip's strings. Off the flag, a from-to pair of monthly rates
- * ("$0/mo" → "$50/mo"). Under `obscure-credits` no amount may render: each
- * side names its bundle by catalog label, the no-bundle side reads as the "No
- * extra usage" sentinel, and a side the catalog can't label is left unstated:
- * an unstated from-side just drops the arrow, an unstated to-side drops the
- * whole chip rather than asserting a bundle it cannot name. The row label
- * swaps to "Usage" so the chip never introduces credits as a concept.
+ * The credits chip's strings, where no amount may render: each side names its
+ * bundle by catalog label, the no-bundle side reads as the "No extra usage"
+ * sentinel, and a side the catalog can't label is left unstated: an unstated
+ * from-side just drops the arrow, an unstated to-side drops the whole chip
+ * rather than asserting a bundle it cannot name. The row label reads "Usage"
+ * so the chip never introduces credits as a concept.
  */
 function creditsChipContent(
   credits: CreditsChange | null,
-  obscureCredits: boolean,
   t: SettingsTranslate,
 ): CreditsChipContent | null {
   if (credits == null) {
     return null;
-  }
-  if (!obscureCredits) {
-    return {
-      from: formatMonthly(credits.fromUsd * 100),
-      to: formatMonthly(credits.toUsd * 100),
-    };
   }
   const noExtraUsage = t("provisioningState.noExtraUsage");
   const to = credits.toLabel === null ? noExtraUsage : credits.toLabel;
@@ -512,9 +502,7 @@ function creditsChipContent(
 /**
  * The takeover's resource chips: every applicable change as a `{current} ->
  * {new}` chip (machine and storage from `targets`, `fromSnapshot` and the
- * display-only `machineFloor`; credits as a from-to monthly rate, `$0/mo` on
- * the from-side for a base-to-pro checkout, or as `creditsChipContent`'s
- * obscured bundle names when the flag is on).
+ * display-only `machineFloor`; credits as `creditsChipContent`'s bundle names).
  *
  * All of them render together from the first paint of the wait, each carrying
  * its own progress: dimmed with a spinner while its dimension is still moving,
@@ -556,7 +544,6 @@ function ResourceChangeChips({
   creditsOnly?: boolean;
 }) {
   const { t } = useTranslation("settings");
-  const obscureCredits = useObscureCredits();
   // Checkout reads the stashed intent, an in-place change carries its own
   // tiers, and a takeover runs in exactly one of those modes, so at most one of
   // these resolves.
@@ -567,7 +554,7 @@ function ResourceChangeChips({
     targets,
     fromSnapshot,
     machineFloor,
-    credits: creditsChipContent(credits, obscureCredits, t),
+    credits: creditsChipContent(credits, t),
   });
   const changes = creditsOnly
     ? built.filter((change) => change.key === "credits")
@@ -615,16 +602,15 @@ function ResourceChangeChips({
 
 /**
  * CONFIRMING chips: derived from the stashed intent before any API data lands.
- * The one exception is the custom intent's bundle chip under `obscure-credits`:
- * its wording is the bundle's catalog label rather than a credit count, so it
- * waits on the plan catalog (usually already cached by the page that stashed
- * the intent) and is simply absent until that resolves.
+ * The one exception is the custom intent's bundle chip: its wording is the
+ * bundle's catalog label rather than a credit count, so it waits on the plan
+ * catalog (usually already cached by the page that stashed the intent) and is
+ * simply absent until that resolves.
  */
 function IntentChips({ intent }: { intent: CheckoutIntent }) {
   const { t } = useTranslation("settings");
-  const obscureCredits = useObscureCredits();
   const credits = useProvisioningCredits(
-    obscureCredits && intent.kind === "custom" ? intent : null,
+    intent.kind === "custom" ? intent : null,
   );
   if (intent.kind === "package") {
     const name =
@@ -660,16 +646,9 @@ function IntentChips({ intent }: { intent: CheckoutIntent }) {
           to={intent.storageTier.toUpperCase()}
         />
       )}
-      {intent.creditTier != null &&
-        (obscureCredits ? (
-          credits?.toLabel != null && <TextChip label={credits.toLabel} />
-        ) : (
-          <TextChip
-            label={t("provisioningState.creditsChip", {
-              count: intent.creditTier.replace("credits_", ""),
-            })}
-          />
-        ))}
+      {intent.creditTier != null && credits?.toLabel != null && (
+        <TextChip label={credits.toLabel} />
+      )}
     </ChipRow>
   );
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
@@ -14,7 +14,7 @@ describe("buildResourceChanges", () => {
     const changes = buildResourceChanges({
       targets,
       fromSnapshot: from,
-      credits: { from: "0", to: "50 credits" },
+      credits: { label: "Usage", from: "No extra usage", to: "Mighty Usage" },
     });
 
     expect(changes.map((c) => c.key)).toEqual([
@@ -36,9 +36,9 @@ describe("buildResourceChanges", () => {
     });
     expect(changes[2]).toEqual({
       key: "credits",
-      label: "Credits",
-      from: "0",
-      to: "50 credits",
+      label: "Usage",
+      from: "No extra usage",
+      to: "Mighty Usage",
     });
   });
 
@@ -99,13 +99,13 @@ describe("buildResourceChanges", () => {
     const changes = buildResourceChanges({
       targets: { machineSize: "large", storageGib: 50 },
       fromSnapshot: { machineSize: "large", storageGib: 50 },
-      credits: { from: "$25/mo", to: "$50/mo" },
+      credits: { label: "Usage", from: "Mighty Usage", to: "Super Usage" },
     });
 
     expect(changes.map((c) => c.key)).toEqual(["credits"]);
   });
 
-  test("takes the credits label override the obscured wording passes", () => {
+  test("renders a credits-only change from the wording the caller passes", () => {
     const changes = buildResourceChanges({
       targets: { machineSize: null, storageGib: null },
       fromSnapshot: { machineSize: null, storageGib: null },

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
@@ -13,12 +13,12 @@ export interface ResourceChange {
 }
 
 /**
- * The credits chip's pre-worded strings: monthly rates by default, bundle
- * names under `obscure-credits`, which also overrides the row label ("Usage")
- * and may leave the from-side unstated when the catalog can't word it.
+ * The credits chip's pre-worded strings: each side names its bundle, under the
+ * row label the caller supplies ("Usage"). The from-side is left unstated when
+ * the catalog can't word it.
  */
 export interface CreditsChipContent {
-  label?: string;
+  label: string;
   from?: string;
   to: string;
 }
@@ -106,7 +106,7 @@ export function buildResourceChanges(input: {
   if (credits != null) {
     changes.push({
       key: "credits",
-      label: credits.label ?? "Credits",
+      label: credits.label,
       from: credits.from,
       to: credits.to,
     });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-story-support.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-story-support.tsx
@@ -8,15 +8,15 @@
  * from (the plan move, the captured reconcile failure, the seeded assistant).
  *
  * The catalog fixture mirrors the platform's real Pro catalog (Mighty on
- * `credits_25`, Super on `credits_45`), so the credits chip quotes the amounts a
- * subscriber is actually billed, and each scenario's dimensions are the ones its
- * packages really carry.
+ * `credits_25`, Super on `credits_45`), so the credits chip names the bundles a
+ * subscriber is actually billed for, and each scenario's dimensions are the ones
+ * its packages really carry.
  *
  * Not a `.stories.tsx` file, so Storybook does not index it.
  */
 import type { Decorator } from "@storybook/react-vite";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useLayoutEffect, type CSSProperties } from "react";
+import type { CSSProperties } from "react";
 
 import {
   makeProPackage,
@@ -31,7 +31,6 @@ import type {
 } from "@/generated/api/types.gen";
 import { avatarQueryKey, type AvatarData } from "@/hooks/use-assistant-avatar";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
-import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import type { CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { preloadBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
@@ -78,8 +77,8 @@ const ULTRA = makeUltraPackage();
 /**
  * The credit bundles the packages above are built on. `label` is the bundle's
  * customer-facing usage name, the same wording the package carries in
- * `usage_label`: the `obscure-credits` chip renders it verbatim in place of a
- * monthly rate, so a dollar-denominated label would defeat the flag.
+ * `usage_label`: the credits chip renders it verbatim, so a dollar-denominated
+ * label would put an amount on screen.
  */
 function creditTier(
   tier: string,
@@ -411,30 +410,6 @@ export const takeoverQueryDecorator: Decorator = (Story) => (
     <Story />
   </QueryClientProvider>
 );
-
-/**
- * Puts the `obscure-credits` flag where the `obscureCredits` control says, so
- * the flag-on treatment is one toggle away rather than its own story file.
- *
- * Written straight into the store rather than through `setFlags`, which layers
- * local and env overrides back on top (an override to `false` would win) and
- * marks the store hydrated as if a server response had landed. The write sits in
- * an effect because the tree below subscribes to this store, and the whole
- * previous state is handed back on unmount so nothing set here outlives the
- * story.
- */
-export const obscureCreditsDecorator: Decorator<{ obscureCredits: boolean }> =
-  function ObscureCreditsFlag(Story, context) {
-    const { obscureCredits } = context.args;
-    useLayoutEffect(() => {
-      const previous = useClientFeatureFlagStore.getState();
-      useClientFeatureFlagStore.setState({ obscureCredits });
-      return () => {
-        useClientFeatureFlagStore.setState(previous, true);
-      };
-    }, [obscureCredits]);
-    return <Story />;
-  };
 
 /**
  * The takeover frame: a black ground, a viewport-tall box, `data-theme="dark"`,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -11,10 +11,10 @@ import { creditTierKeyUsd, findCreditTier } from "@/lib/billing/credit-tiers";
  * number: "No extra credits" is $0, not an absent side.
  *
  * Each side also carries the bundle's catalog label ("Mighty Usage", the
- * Stripe product name, so it matches the invoice line), which the
- * `obscure-credits` rendering shows in place of the dollar rate. `null` marks
- * the explicit no-bundle side, worded by the caller; `undefined` a bundle the
- * catalog can't label, which the obscured chip leaves unstated.
+ * Stripe product name, so it matches the invoice line), which is what the chip
+ * renders. `null` marks the explicit no-bundle side, worded by the caller;
+ * `undefined` a bundle the catalog can't label, which the chip leaves
+ * unstated.
  */
 export interface CreditsChange {
   fromUsd: number;
@@ -106,8 +106,8 @@ export function useProvisioningCredits(
     const tier = findCreditTier(proPlan, pkg?.credit_tier);
     toUsd = pkg?.credits_usd ?? tier?.credits_usd;
     // The package's customer-facing usage_label is preferred: a tier label
-    // can be dollar-denominated ("$50 credits/mo"), which the obscured chip
-    // must never render. The tier label covers a package without one.
+    // can be dollar-denominated ("$50 credits/mo"), which the chip must never
+    // render. The tier label covers a package without one.
     toLabel = pkg?.usage_label ?? tier?.label ?? undefined;
   } else {
     const tier = findCreditTier(proPlan, intent.creditTier);

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1635,7 +1635,6 @@
     "allDoneStatus": "All done!",
     "confirmingCaption": "This might take a couple seconds.",
     "continueInBackground": "Continue in the background",
-    "creditsChip": "{count} credits",
     "dimensionsComplete": "{dimensions} complete",
     "goToBilling": "Go to billing",
     "machineLabel": "Machine",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1635,7 +1635,6 @@
     "allDoneStatus": "¡Todo listo!",
     "confirmingCaption": "Esto puede tardar unos segundos.",
     "continueInBackground": "Continuar en segundo plano",
-    "creditsChip": "{count} créditos",
     "dimensionsComplete": "{dimensions} completado",
     "goToBilling": "Ir a facturación",
     "machineLabel": "Máquina",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1620,7 +1620,6 @@
     "allDoneStatus": "Готово!",
     "confirmingCaption": "Это может занять пару секунд.",
     "continueInBackground": "Продолжить в фоне",
-    "creditsChip": "{count} кредитов",
     "dimensionsComplete": "{dimensions} готово",
     "goToBilling": "К оплате",
     "machineLabel": "Машина",

--- a/clients/web/src/i18n/locales/zh/settings.json
+++ b/clients/web/src/i18n/locales/zh/settings.json
@@ -1630,7 +1630,6 @@
     "allDoneStatus": "全部完成！",
     "confirmingCaption": "这可能需要几秒钟。",
     "continueInBackground": "在后台继续",
-    "creditsChip": "{count} 积分",
     "dimensionsComplete": "{dimensions} 已完成",
     "goToBilling": "前往账单",
     "machineLabel": "机器",


### PR DESCRIPTION
## Summary

- The provisioning takeover's credits chips now always name the usage bundle (`No extra usage` to `Mighty Usage`) under a `Usage` row label. The monthly-rate wording and the `{count} credits` intent chip are gone, and `provisioningState.creditsChip` is deleted from all four locales.
- `CreditsChipContent.label` is now required, so `resource-changes.ts` no longer carries an untranslated `"Credits"` fallback.
- The plan-catalog query behind `useProvisioningCredits` now fires for every custom checkout intent, not only for a subset: `IntentChips` needs the catalog to word the bundle chip. TanStack Query dedupes it with the takeover's other catalog read and with the page that stashed the intent, so this adds no extra request in practice.
- Storybook: the `obscureCredits` control, its decorator, and the `!autodocs` tag that kept `Playground` off the docs page are removed, so `Playground` rejoins autodocs.
- `billing-onboarding-modal.test.tsx` is included beyond the planned file list: its catalog fixture labelled every credit tier with a dollar string, which the chip now renders verbatim. The fixture labels are bundle names and the four chip assertions follow.

Part of plan: remove-obscure-credits-flag.md (PR 5 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
