### PR TITLE
fix(embeddings): treat a worker we cannot signal as alive, not as an orphan

### DIFF
--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -18,6 +18,7 @@ import {
   getEmbeddingModelsDir,
   getEmbedWorkerPidPath,
 } from "../../util/platform.js";
+import { isProcessAlive } from "../../util/process-liveness.js";
 import { PromiseGuard } from "../../util/promise-guard.js";
 import { workerComputeEnv } from "../../util/worker-compute.js";
 import { workerMemoryEnv } from "../../util/worker-memory.js";
@@ -86,17 +87,6 @@ async function didSettle(
     Bun.sleep(timeoutMs).then(() => timeout),
   ]);
   return result !== timeout;
-}
-
-/** Whether a PID names a live process. */
-function isProcessAlive(pid: number): boolean {
-  try {
-    // Signal 0 probes for liveness without delivering a signal.
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**


### PR DESCRIPTION
## TL;DR

`embedding-local` carried its own `isProcessAlive` that reported a process we lack permission to signal as **dead**. That predicate decides whether an embed worker's owner is still running, so another user's worker classified as an orphan and got signalled. Uses the shared helper instead, whose docstring exists for exactly this case.

Found while working ATL-1349; independent of it and of the other PRs in that set.

## Why this is needed

Two implementations of the same probe disagreed on one error code:

```ts
// embedding-local.ts (deleted here)
try { process.kill(pid, 0); return true; } catch { return false; }
```

```ts
// util/process-liveness.ts (kept)
// EPERM means the PID exists but we cannot signal it, treat as alive so
// we don't accidentally take over another user's lock.
if (code === "EPERM") return true;
```

`kill(pid, 0)` throws `EPERM` when the process **exists** and belongs to another user. The local copy read that as "gone".

That predicate is passed to `classifyWorkerOwnership` as `isOwnerAlive`, which decides:

```ts
if (!isOwnerAlive(worker.ppid)) return "orphan";
```

So a worker whose owner is another user's live process was classified `orphan`, and `reclaimOwnedWorkers` then SIGTERMs orphans.

## What the user experienced before

On a shared machine, or any setup where an embed worker's parent belongs to another user, the daemon would try to reap a worker it had no permission to signal. The kill fails with `EPERM`, but the code has already decided the slot is free: `reclaimOwnedWorkers` waits for an exit that never comes, and the reclaim path can publish a replacement over a worker that is still running and still holding roughly 570 MB. Two ONNX workers, one of them untrackable.

Single-user machines never hit it, which is why it has gone unnoticed.

## What the user experiences after

The other user's worker is classified `foreign` and left alone, which is what the classifier's own docstring says should happen: "owned by another live process... signalling it is what made the two replace each other in a loop." No signal, no duplicate worker, no leaked memory.

Nothing changes on a single-user machine, where `kill(pid, 0)` never returns `EPERM` for our own processes.

## Why it is safe

- **`EPERM` is the only differing case.** Both implementations return `true` on success and `false` on `ESRCH`. The shared helper additionally rejects non-integer and non-positive PIDs, which is stricter, not looser.
- **The shared helper is already the one used everywhere else,** including by the file-locking helpers it was written for and by the worker spawn path.
- **The change is a deletion.** Ten lines removed, one import added; no call site changes, since the name is identical.

## Why this shape

The alternative is keeping two probes and documenting the difference. That is what produced the bug: the copy looks correct in isolation, and nothing at the call site says which semantics `classifyWorkerOwnership` needs. One implementation, with the reasoning attached to it, is the only version that cannot drift again.

## Testing

Type check and lint clean. Local test runs are disabled on this machine, so CI is the first execution; the embed lifecycle suite exercises `classifyWorkerOwnership` with an injected predicate, so it is unaffected by which implementation production passes in.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->