### PR TITLE
Daemon-boot expiry never strands persistent-kind side effects

### DIFF
--- a/assistant/src/__tests__/guardian-gateway-sim.test.ts
+++ b/assistant/src/__tests__/guardian-gateway-sim.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import { createGuardianGatewaySim } from "./guardian-gateway-sim.js";
+
+import "./test-preload.js";
+
+/**
+ * Pins the simulator to the gateway's authorization-lifecycle contract.
+ * Fifteen assistant suites prove behavior against this sim, so a sim that
+ * models semantics the gateway no longer has lets them pass against a
+ * production shape that does not exist.
+ */
+describe("guardian gateway sim: boot expiry contract", () => {
+  test("expires only interaction-bound kinds, never persistent kinds", async () => {
+    const sim = createGuardianGatewaySim();
+    const past = Date.now() - 60_000;
+    sim.seedRequest({ id: "ta", kind: "tool_approval", status: "pending" });
+    sim.seedRequest({
+      id: "pq",
+      kind: "pending_question",
+      status: "pending",
+    });
+    // Past-deadline persistent rows stay pending for the sweep, which owns
+    // the card-withdrawal and requester-notice fan-out; boot must not
+    // pre-empt it (the gateway contract this sim mirrors).
+    sim.seedRequest({
+      id: "ar",
+      kind: "access_request",
+      status: "pending",
+      expiresAt: past,
+    });
+    sim.seedRequest({
+      id: "tg",
+      kind: "tool_grant_request",
+      status: "pending",
+      expiresAt: past,
+    });
+
+    const expired = await sim.module.expireInteractionBoundGuardianRequests();
+
+    expect(expired).toBe(2);
+    expect(sim.getRequest("ta")?.status).toBe("expired");
+    expect(sim.getRequest("pq")?.status).toBe("expired");
+    expect(sim.getRequest("ar")?.status).toBe("pending");
+    expect(sim.getRequest("tg")?.status).toBe("pending");
+  });
+});

--- a/assistant/src/__tests__/guardian-gateway-sim.test.ts
+++ b/assistant/src/__tests__/guardian-gateway-sim.test.ts
@@ -6,9 +6,9 @@ import "./test-preload.js";
 
 /**
  * Pins the simulator to the gateway's authorization-lifecycle contract.
- * Fifteen assistant suites prove behavior against this sim, so a sim that
- * models semantics the gateway no longer has lets them pass against a
- * production shape that does not exist.
+ * Fifteen assistant suites prove behavior against this sim, so a sim whose
+ * semantics drift from the gateway's lets them pass against a production
+ * shape that does not exist.
  */
 describe("guardian gateway sim: boot expiry contract", () => {
   test("expires only interaction-bound kinds, never persistent kinds", async () => {

--- a/assistant/src/__tests__/guardian-gateway-sim.ts
+++ b/assistant/src/__tests__/guardian-gateway-sim.ts
@@ -364,9 +364,13 @@ export function createGuardianGatewaySim() {
       if (row.status !== "pending") {
         continue;
       }
+      // Mirrors the gateway contract: only the kinds that die with the
+      // daemon's in-memory pendingInteractions map expire at boot.
+      // Persistent kinds stay pending, whatever their deadline; their
+      // expiry belongs to the sweep, which owns the fan-out.
       const interactionBound =
         row.kind === "tool_approval" || row.kind === "pending_question";
-      if (interactionBound || isGuardianRequestExpired(row, now)) {
+      if (interactionBound) {
         row.status = "expired";
         row.updatedAt = now;
         expired += 1;

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -320,9 +320,8 @@ describe("non-member access request notification", () => {
     expect(pending.length).toBe(1);
 
     // A pending row past its deadline never dedupes: it can sit pending
-    // until the sweep expires it (boot no longer pre-empts that), it is
-    // already undecidable, and absorbing the fresh attempt would silently
-    // drop the new guardian notification.
+    // until the sweep expires it, it is already undecidable, and absorbing
+    // the fresh attempt would silently drop the new guardian notification.
     pending[0].expiresAt = Date.now() - 1000;
     const req3 = buildInboundRequest({
       externalMessageId: `msg-third-${Date.now()}`,

--- a/assistant/src/__tests__/non-member-access-request.test.ts
+++ b/assistant/src/__tests__/non-member-access-request.test.ts
@@ -318,6 +318,19 @@ describe("non-member access request notification", () => {
       kind: "access_request",
     });
     expect(pending.length).toBe(1);
+
+    // A pending row past its deadline never dedupes: it can sit pending
+    // until the sweep expires it (boot no longer pre-empts that), it is
+    // already undecidable, and absorbing the fresh attempt would silently
+    // drop the new guardian notification.
+    pending[0].expiresAt = Date.now() - 1000;
+    const req3 = buildInboundRequest({
+      externalMessageId: `msg-third-${Date.now()}`,
+      content: "Still hoping to get access.",
+    });
+    await handleChannelInbound(req3, undefined, TEST_BEARER_TOKEN);
+
+    expect(emitSignalCalls.length).toBe(2);
   });
 
   // A bare guardian deny (a `denied` request with no durable contact seeded)

--- a/assistant/src/channels/gateway-guardian-requests.ts
+++ b/assistant/src/channels/gateway-guardian-requests.ts
@@ -210,9 +210,10 @@ export async function expireGuardianRequest(id: string): Promise<void> {
 
 /**
  * Daemon-boot expiry: interaction-bound kinds die with the daemon's
- * in-memory pendingInteractions map, plus persistent kinds already past
- * `expiresAt`. Returns the expired count. Throws on any failure
- * (fail-closed).
+ * in-memory pendingInteractions map. Persistent kinds are never touched
+ * here, whatever their deadline; their expiry belongs to the sweep, which
+ * owns the card-withdrawal and requester-notice fan-out. Returns the
+ * expired count. Throws on any failure (fail-closed).
  */
 export async function expireInteractionBoundGuardianRequests(): Promise<number> {
   const response = await callGateway(

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -461,19 +461,16 @@ export async function runDaemon(): Promise<void> {
       );
     }
 
-    // Expire stale pending guardian requests left over from before this
-    // process started. Daemon-keyed by design: interaction-bound kinds die
-    // with THIS process's in-memory pendingInteractions map, so the daemon
-    // triggers the gateway op at its own boot — the gateway never runs it
-    // on its own restart. Two categories are cleaned up:
-    //
-    // 1. Interaction-bound kinds (tool_approval, pending_question) — their
-    //    in-memory pending-interaction session references are gone, so they
-    //    can never be completed.
-    // 2. Any pending request whose expiresAt has already passed — persistent
-    //    kinds (access_request, tool_grant_request) that expired while the
-    //    daemon was stopped are transitioned so dedup logic doesn't return
-    //    stale rows.
+    // Expire interaction-bound guardian requests (tool_approval,
+    // pending_question) left over from before this process started: their
+    // in-memory pending-interaction session references are gone, so they
+    // can never be completed. Daemon-keyed by design — the daemon triggers
+    // the gateway op at its own boot; the gateway never runs it on its own
+    // restart. Persistent kinds (access_request, tool_grant_request) are
+    // never touched here, whatever their deadline: their expiry belongs to
+    // the periodic sweep, which owns the card-withdrawal and
+    // requester-notice fan-out, and the dedupe reads are deadline-aware so
+    // a past-deadline row waiting for the sweep suppresses nothing.
     //
     // Startup must not block on the gateway (daemon startup philosophy):
     // on failure the periodic sweep still reaps time-expired rows, and

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -464,9 +464,9 @@ export async function runDaemon(): Promise<void> {
     // Expire interaction-bound guardian requests (tool_approval,
     // pending_question) left over from before this process started: their
     // in-memory pending-interaction session references are gone, so they
-    // can never be completed. Daemon-keyed by design — the daemon triggers
-    // the gateway op at its own boot; the gateway never runs it on its own
-    // restart. Persistent kinds (access_request, tool_grant_request) are
+    // can never be completed. Daemon-keyed by design: the daemon triggers
+    // the gateway op at its own boot, and the gateway never runs it on its
+    // own restart. Persistent kinds (access_request, tool_grant_request) are
     // never touched here, whatever their deadline: their expiry belongs to
     // the periodic sweep, which owns the card-withdrawal and
     // requester-notice fan-out, and the dedupe reads are deadline-aware so

--- a/assistant/src/runtime/access-request-helper.ts
+++ b/assistant/src/runtime/access-request-helper.ts
@@ -11,6 +11,8 @@
  * principal so access requests cannot bind to stale/cross-assistant contacts.
  */
 
+import { isGuardianRequestExpired } from "@vellumai/gateway-client";
+
 import {
   createGuardianRequest,
   listGuardianRequestsOrEmpty,
@@ -228,13 +230,19 @@ export async function notifyGuardianOfAccessRequest(
   // notified: true with the existing request ID so callers know the guardian
   // was already notified. A degraded (empty) read falls through to creation,
   // whose fail-closed throw prevents a prompt without a persisted request.
-  const existingPending = await listGuardianRequestsOrEmpty({
-    status: "pending",
-    requesterExternalUserId: actorExternalId,
-    sourceChannel,
-    kind: "access_request",
-    sourceConversationId: conversationId,
-  });
+  // Past-deadline rows never dedupe: a pending row can sit past its
+  // expiresAt until the sweep expires it, it is already undecidable, and
+  // letting it absorb a fresh attempt would silently drop the new guardian
+  // notification.
+  const existingPending = (
+    await listGuardianRequestsOrEmpty({
+      status: "pending",
+      requesterExternalUserId: actorExternalId,
+      sourceChannel,
+      kind: "access_request",
+      sourceConversationId: conversationId,
+    })
+  ).filter((r) => !isGuardianRequestExpired(r));
   if (existingPending.length > 0) {
     log.debug(
       { sourceChannel, actorExternalId, existingId: existingPending[0].id },

--- a/assistant/src/runtime/tool-grant-request-helper.ts
+++ b/assistant/src/runtime/tool-grant-request-helper.ts
@@ -11,6 +11,8 @@
  * - Notification routing goes through emitNotificationSignal().
  */
 
+import { isGuardianRequestExpired } from "@vellumai/gateway-client";
+
 import {
   createGuardianRequest,
   listGuardianRequestsOrEmpty,
@@ -124,8 +126,10 @@ export async function createOrReuseToolGrantRequest(
     kind: "tool_grant_request",
     toolName,
   });
+  // Past-deadline rows never dedupe: see the access-request helper's note.
   const dedupeMatch = existing.find(
     (r) =>
+      !isGuardianRequestExpired(r) &&
       r.inputDigest === inputDigest &&
       r.guardianExternalUserId === binding.guardianExternalUserId,
   );

--- a/gateway/src/approvals/guardian-request-service.ts
+++ b/gateway/src/approvals/guardian-request-service.ts
@@ -127,8 +127,9 @@ export function expireGuardianRequest(id: string): void {
 }
 
 /**
- * Daemon-boot expiry: interaction-bound kinds unconditionally, persistent
- * kinds only past their `expiresAt`. Returns the expired-row count.
+ * Daemon-boot expiry: interaction-bound kinds only. Persistent kinds are
+ * never touched, whatever their deadline; the periodic sweep owns their
+ * expiry and its side effects. Returns the expired-row count.
  */
 export function expireInteractionBoundRequests(): ExpireInteractionBoundIpcResponse {
   return { expired: expireAllPendingInteractionBound() };

--- a/gateway/src/db/__tests__/guardian-request-store.test.ts
+++ b/gateway/src/db/__tests__/guardian-request-store.test.ts
@@ -428,7 +428,11 @@ describe("expireAllPendingInteractionBound", () => {
     expect(getGuardianRequest(pendingQuestion.id)?.status).toBe("expired");
   });
 
-  test("expires persistent kinds only past their deadline", () => {
+  test("leaves persistent kinds untouched, whatever their deadline", () => {
+    // A past-deadline persistent row's expiry belongs to the sweep, which
+    // fans out the card withdrawal and requester notice for every row it
+    // expires; a bulk flip here strands those side effects, because no
+    // sweep revisits a row that already left pending.
     const staleAccess = createRequest({
       kind: "access_request",
       expiresAt: PAST(),
@@ -443,9 +447,9 @@ describe("expireAllPendingInteractionBound", () => {
     });
     const deadlineless = createRequest({ kind: "tool_grant_request" });
 
-    expect(expireAllPendingInteractionBound()).toBe(2);
-    expect(getGuardianRequest(staleAccess.id)?.status).toBe("expired");
-    expect(getGuardianRequest(staleGrant.id)?.status).toBe("expired");
+    expect(expireAllPendingInteractionBound()).toBe(0);
+    expect(getGuardianRequest(staleAccess.id)?.status).toBe("pending");
+    expect(getGuardianRequest(staleGrant.id)?.status).toBe("pending");
     expect(getGuardianRequest(freshAccess.id)?.status).toBe("pending");
     expect(getGuardianRequest(deadlineless.id)?.status).toBe("pending");
   });

--- a/gateway/src/db/guardian-request-store.ts
+++ b/gateway/src/db/guardian-request-store.ts
@@ -417,7 +417,8 @@ export interface ResolveGuardianRequestDecision {
 }
 
 export type ResolveGuardianRequestResult =
-  { applied: true; request: GuardianRequest } | { applied: false };
+  | { applied: true; request: GuardianRequest }
+  | { applied: false };
 
 /**
  * Compare-and-swap resolve: only transitions the request from
@@ -485,15 +486,21 @@ export function resolveGuardianRequest(
 const INTERACTION_BOUND_KINDS = ["tool_approval", "pending_question"];
 
 /**
- * Bulk-expire stale pending guardian requests. Called via IPC at daemon
- * startup (daemon-keyed — the gateway never runs this on its own restart):
+ * Bulk-expire interaction-bound pending guardian requests. Called via IPC
+ * at daemon startup (daemon-keyed; the gateway never runs this on its own
+ * restart): `tool_approval` and `pending_question` die with the daemon's
+ * in-memory pendingInteractions map, so they can never complete after a
+ * restart.
  *
- * 1. Interaction-bound kinds (`tool_approval`, `pending_question`) expire
- *    unconditionally — they can never complete after a daemon restart.
- * 2. Persistent kinds expire only when already past their `expiresAt`
- *    deadline, so dedup logic sees fresh rows instead of dead pending ones.
+ * Persistent kinds are deliberately untouched, whatever their deadline:
+ * their expiry belongs to the sweep, which fans out the card withdrawal
+ * and requester notice for every row it expires. A bulk flip here strands
+ * those side effects, because no sweep ever revisits a row that already
+ * left `pending`. Dedup reads are time-based
+ * (`isGuardianRequestExpired`), so a past-deadline row waiting for the
+ * sweep suppresses nothing.
  *
- * Returns the number of requests transitioned from pending → expired.
+ * Returns the number of requests transitioned from pending to expired.
  */
 export function expireAllPendingInteractionBound(): number {
   const raw = rawClient();
@@ -505,10 +512,9 @@ export function expireAllPendingInteractionBound(): number {
       `UPDATE guardian_requests
        SET status = 'expired', updated_at = ?
        WHERE status = 'pending'
-         AND (kind IN (${placeholders})
-              OR (expires_at IS NOT NULL AND expires_at < ?))`,
+         AND kind IN (${placeholders})`,
     )
-    .run(now, ...INTERACTION_BOUND_KINDS, now).changes;
+    .run(now, ...INTERACTION_BOUND_KINDS).changes;
 }
 
 /**

--- a/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
+++ b/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
@@ -424,21 +424,23 @@ describe("guardian_requests_expire", () => {
 });
 
 describe("guardian_requests_expire_interaction_bound", () => {
-  test("expires interaction-bound kinds unconditionally, persistent kinds only past deadline", async () => {
+  test("expires interaction-bound kinds unconditionally, never persistent kinds", async () => {
     const toolApproval = await createRequest({
       kind: "tool_approval",
       toolName: "bash",
     });
     const pendingQuestion = await createRequest({ kind: "pending_question" });
     const freshAccess = await createRequest({ expiresAt: FUTURE() });
+    // Past-deadline persistent rows wait for the sweep, which owns their
+    // card-withdrawal and requester-notice fan-out.
     const staleAccess = await createRequest({ expiresAt: PAST() });
 
     expect(await call(METHODS.expireInteractionBound, {})).toEqual({
-      expired: 3,
+      expired: 2,
     });
     expect(getRequestRow(toolApproval.id)?.status).toBe("expired");
     expect(getRequestRow(pendingQuestion.id)?.status).toBe("expired");
-    expect(getRequestRow(staleAccess.id)?.status).toBe("expired");
+    expect(getRequestRow(staleAccess.id)?.status).toBe("pending");
     expect(getRequestRow(freshAccess.id)?.status).toBe("pending");
   });
 


### PR DESCRIPTION
# Daemon-boot expiry never strands persistent-kind side effects

First of a three-PR stack carving LUM-3160 into independently correct claims (this, then the decide-deadline race fix, then the recoverable sweep on #41652).

## TL;DR

Daemon boot bulk-expired every past-deadline pending request, including the persistent kinds (`access_request`, `tool_grant_request`). But the expiry sweep fans out the side effects (withdrawing approval cards on every surface, notifying the requester) only for rows it expires itself, and no sweep revisits a row that already left `pending` — so a restart with a stale backlog silently stranded actionable cards and never-sent notices. This is true on main today, independent of any sweep redesign.

## What changes for the user

| Before | After |
| --- | --- |
| Restarting the daemon while requests were past deadline left their approval cards actionable-looking on every surface and their requesters permanently untold | Those requests are expired by the next sweep round (at most ~60s later), which withdraws the cards and sends the notice |

## Why this is safe

- Interaction-bound kinds (`tool_approval`, `pending_question`) still expire at boot: they die with the daemon's in-memory pendingInteractions map and can never complete after a restart. Only the persistent-kind disjunct is removed.
- The old docstring justified the disjunct as keeping dedup fresh. Review found the access-request and tool-grant dedupes were in fact not deadline-aware (they filtered only on `pending`) — a gap that already existed on main in steady state, since a row sits pending between its deadline and the next sweep tick. Both dedupe reads now skip rows `isGuardianRequestExpired` reports dead, so a past-deadline row waiting for the sweep suppresses nothing, at boot or in steady state.
- Decisions cannot land on the waiting rows: every decision path checks `expiresAt` before any write.

## Provenance (from git history, not inference)

This narrowing was already done once: #16443 (Mar 13) restricted boot expiry to interaction-bound kinds, and #17386 (Mar 17) deliberately re-added the persistent-kind disjunct "so requests that passed expiresAt while the daemon was stopped are cleaned up on startup." That was correct then: the canonical guardian-requests store had no sweep of its own and no expiry fan-out, so boot was its only expirer, and with pending-only dedupes a dead row would otherwise suppress fresh requests indefinitely. The premise expired in July when card withdrawal (#35342) and requester expiry notices (#36021) attached the full fan-out to the sweep, which then became the rightful owner of persistent-kind expiry; ATL-463 (#37911) ported the disjunct verbatim without revisiting it. This PR completes #16443's narrowing now that the reason #17386 reverted it no longer exists, and the deadline-aware dedupes close the gap the boot flip was papering over.

## Stack

The recoverable-sweep PR (#41652) requires this: its read-only listing only ever returns `pending` rows, so a boot flip would recreate the exact stranding it exists to remove (as Codex found in its review there). Landing this first makes that PR's base honest.
