### PR TITLE
guard(gateway): refuse non-tmpdir workspace/security paths in test processes

### DIFF
--- a/assistant/src/persistence/db-connection.ts
+++ b/assistant/src/persistence/db-connection.ts
@@ -1,8 +1,9 @@
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { join, sep } from "node:path";
 import { Database } from "bun:sqlite";
 
+import { canonicalizePathThroughExistingParent } from "@vellumai/environments/test-path-guard";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import { getLogsDbPath } from "../util/logs-db-path.js";
@@ -14,25 +15,6 @@ import * as schema from "./schema/index.js";
 import { wrapSqliteForSlowQueryLogging } from "./slow-query-log.js";
 
 export type DrizzleDb = ReturnType<typeof drizzle<typeof schema>>;
-
-function canonicalizePathThroughExistingParent(path: string): string {
-  const resolvedPath = resolve(path);
-  const pendingSegments: string[] = [];
-  let currentPath = resolvedPath;
-
-  while (true) {
-    try {
-      return resolve(realpathSync(currentPath), ...pendingSegments.reverse());
-    } catch {
-      const parentPath = dirname(currentPath);
-      if (parentPath === currentPath) {
-        return resolvedPath;
-      }
-      pendingSegments.push(basename(currentPath));
-      currentPath = parentPath;
-    }
-  }
-}
 
 /**
  * Guard against opening a real workspace database during tests. Shared by

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -400,8 +400,8 @@ export function getProcPidPath(name: string): string {
 // real, non-temp directory: production code exercised by a test would then
 // read and destructively write live state. The containment assertion is
 // shared with the gateway via @vellumai/environments/test-path-guard;
-// src/__tests__/assert-not-live-db.ts keeps its own copy of the containment
-// walk because test machinery must not import production dependencies.
+// src/__tests__/assert-not-live-db.ts keeps its own containment check
+// because test machinery must not import production dependencies.
 
 function assertTestPathIsEphemeral(dir: string): void {
   assertEphemeralInTests(dir, {

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -1,14 +1,6 @@
-import { chmodSync, existsSync, mkdirSync, realpathSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
-import {
-  basename,
-  delimiter,
-  dirname,
-  isAbsolute,
-  join,
-  relative,
-  sep,
-} from "node:path";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, dirname, isAbsolute, join, relative, sep } from "node:path";
 
 import {
   AVATAR_IMAGE_FILENAME,
@@ -16,6 +8,7 @@ import {
   resolveAvatarDir,
 } from "@vellumai/avatar-manifest";
 import { SEEDS } from "@vellumai/environments";
+import { assertTestPathIsEphemeral as assertEphemeralInTests } from "@vellumai/environments/test-path-guard";
 
 import { getWorkspaceDirOverride } from "../config/env-registry.js";
 
@@ -405,78 +398,17 @@ export function getProcPidPath(name: string): string {
 //
 // A test process must never resolve the workspace (or the vellum root) to a
 // real, non-temp directory: production code exercised by a test would then
-// read and destructively write live state. The tmpdir redirection normally
-// comes from the bunfig.toml test preload, but bun only loads bunfig from the
-// cwd, so `bun test` run from any other directory (for example a source
-// checkout inside a deployed container's workspace) skips the preload and
-// inherits the ambient VELLUM_WORKSPACE_DIR. The containment assertion
-// therefore lives here, in production code, where it fires no matter how the
-// test process was launched.
-//
-// Containment logic mirrors src/__tests__/assert-not-live-db.ts, which cannot
-// be imported here (production code must not depend on test machinery).
-
-/** Lazily computed: is this process a `bun test` run? */
-let isTestProcess: boolean | undefined;
-
-/**
- * Resolve symlinks in the deepest existing ancestor of `p`, then re-append
- * the not-yet-created tail. This keeps the containment check honest both for
- * paths under a symlinked temp root (macOS /var/folders) and for symlinks
- * that point outside it, whether or not the leaf exists yet.
- */
-function canonicalizeForWorkspaceGuard(p: string): string {
-  let cur = p;
-  const tail: string[] = [];
-  for (;;) {
-    try {
-      return join(realpathSync(cur), ...tail);
-    } catch {
-      const parent = dirname(cur);
-      if (parent === cur) {
-        return p;
-      }
-      tail.unshift(basename(cur));
-      cur = parent;
-    }
-  }
-}
+// read and destructively write live state. The containment assertion is
+// shared with the gateway via @vellumai/environments/test-path-guard;
+// src/__tests__/assert-not-live-db.ts keeps its own copy of the containment
+// walk because test machinery must not import production dependencies.
 
 function assertTestPathIsEphemeral(dir: string): void {
-  isTestProcess ??=
-    process.env.NODE_ENV === "test" ||
-    process.env.BUN_TEST === "1" ||
-    // `bun test` sets NODE_ENV=test only when unset; Bun.main being the test
-    // file itself is the backstop signal that survives a preset NODE_ENV.
-    (typeof Bun !== "undefined" &&
-      /\.(test|spec)\.[cm]?[jt]sx?$/.test(Bun.main));
-  if (!isTestProcess) {
-    return;
-  }
-  // Escape hatch for the rare intentional run against a real workspace,
-  // shared with assertTestDbIsIsolated() in persistence/db-connection.ts.
-  // Deliberately NOT added to tools/terminal/safe-env.ts: a daemon-level
-  // opt-out must not propagate into agent-spawned shells and disarm the
-  // guard for tests run from there.
-  if (process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS === "1") {
-    return;
-  }
-  const tmpRoot = canonicalizeForWorkspaceGuard(tmpdir());
-  const resolved = canonicalizeForWorkspaceGuard(dir);
-  if (resolved !== tmpRoot && !resolved.startsWith(tmpRoot + sep)) {
-    throw new Error(
-      [
-        `Refusing to use ${dir} (resolves to ${resolved}) in a test process: it is not under the temp directory (${tmpRoot}).`,
-        "",
-        "Tests must only touch an ephemeral workspace; a real one would expose",
-        "live assistant state to destructive test fixtures. This usually means",
-        "`bun test` ran from a cwd without the repo bunfig.toml, so the test",
-        "preload that redirects VELLUM_WORKSPACE_DIR to a tmpdir never loaded.",
-        "Run tests from the assistant package root, or set",
-        "VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS=1 to bypass deliberately.",
-      ].join("\n"),
-    );
-  }
+  assertEphemeralInTests(dir, {
+    // Shared with assertTestDbIsIsolated() in persistence/db-connection.ts.
+    allowEnvVar: "VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS",
+    runHint: "Run tests from the assistant package root.",
+  });
 }
 
 /**

--- a/bun.lock
+++ b/bun.lock
@@ -363,6 +363,7 @@
       "dependencies": {
         "@vellumai/assistant-client": "workspace:*",
         "@vellumai/ces-client": "workspace:*",
+        "@vellumai/environments": "workspace:*",
         "@vellumai/gateway-client": "workspace:*",
         "@vellumai/ipc-server-utils": "workspace:*",
         "@vellumai/service-contracts": "workspace:*",

--- a/gateway/knip.json
+++ b/gateway/knip.json
@@ -1,13 +1,10 @@
 {
-  "entry": [
-    "src/**/*.test.ts",
-    "src/**/__tests__/**/*.ts",
-    "src/cli/index.ts"
-  ],
+  "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts", "src/cli/index.ts"],
   "project": ["src/**/*.ts"],
   "ignoreDependencies": [
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
+    "@vellumai/environments",
     "@vellumai/gateway-client",
     "@vellumai/ipc-server-utils",
     "@vellumai/service-contracts",

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@vellumai/assistant-client": "workspace:*",
     "@vellumai/ces-client": "workspace:*",
+    "@vellumai/environments": "workspace:*",
     "@vellumai/gateway-client": "workspace:*",
     "@vellumai/ipc-server-utils": "workspace:*",
     "@vellumai/service-contracts": "workspace:*",
@@ -49,6 +50,7 @@
   "bundledDependencies": [
     "@vellumai/assistant-client",
     "@vellumai/ces-client",
+    "@vellumai/environments",
     "@vellumai/gateway-client",
     "@vellumai/ipc-server-utils",
     "@vellumai/service-contracts",

--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -39,6 +39,7 @@ const ACTOR_SUB = "actor:self:guardian-001";
 const actorClaims = { sub: ACTOR_SUB } as TokenClaims;
 
 let testRoot: string;
+let savedSecurityDir: string | undefined;
 
 function insertTokenRecord(
   rawToken: string,
@@ -119,6 +120,7 @@ function insertGuardianContact() {
 }
 
 beforeEach(async () => {
+  savedSecurityDir = process.env.GATEWAY_SECURITY_DIR;
   testRoot = mkdtempSync(join(tmpdir(), "revocation-test-"));
   const securityDir = join(testRoot, "protected");
   mkdirSync(securityDir, { recursive: true });
@@ -141,7 +143,11 @@ afterEach(() => {
   resetGatewayDb();
   resetGuardianIntegrityReporterForTesting();
   bustGuardianIntegrityCache();
-  delete process.env.GATEWAY_SECURITY_DIR;
+  if (savedSecurityDir === undefined) {
+    delete process.env.GATEWAY_SECURITY_DIR;
+  } else {
+    process.env.GATEWAY_SECURITY_DIR = savedSecurityDir;
+  }
   try {
     rmSync(testRoot, { recursive: true, force: true });
   } catch {

--- a/gateway/src/__tests__/ipc-socket-path.test.ts
+++ b/gateway/src/__tests__/ipc-socket-path.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { resolveIpcSocketPath } from "../ipc/endpoint.js";
+
+// Fake workspace under tmpdir so the live-path guard accepts it.
+const WS_DIR = join(tmpdir(), "vellum-workspace-test");
 
 let savedWorkspaceDir: string | undefined;
 let savedGatewayIpcSocketDir: string | undefined;
@@ -27,7 +31,7 @@ afterEach(() => {
 describe("resolveIpcSocketPath", () => {
   test("uses env var override when set", () => {
     process.env.GATEWAY_IPC_SOCKET_DIR = "/run/gateway-ipc";
-    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-workspace-test";
+    process.env.VELLUM_WORKSPACE_DIR = WS_DIR;
 
     const resolved = resolveIpcSocketPath("gateway");
 
@@ -37,28 +41,32 @@ describe("resolveIpcSocketPath", () => {
 
   test("ignores empty env var override", () => {
     process.env.GATEWAY_IPC_SOCKET_DIR = "  ";
-    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-workspace-test";
+    process.env.VELLUM_WORKSPACE_DIR = WS_DIR;
 
     const resolved = resolveIpcSocketPath("gateway");
 
     expect(resolved.source).toBe("workspace");
-    expect(resolved.path).toBe("/tmp/vellum-workspace-test/gateway.sock");
+    expect(resolved.path).toBe(join(WS_DIR, "gateway.sock"));
   });
 
   test("uses workspace path by default", () => {
     delete process.env.GATEWAY_IPC_SOCKET_DIR;
-    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-workspace-test";
+    process.env.VELLUM_WORKSPACE_DIR = WS_DIR;
 
     const resolved = resolveIpcSocketPath("gateway");
 
     expect(resolved.source).toBe("workspace");
-    expect(resolved.path).toBe("/tmp/vellum-workspace-test/gateway.sock");
+    expect(resolved.path).toBe(join(WS_DIR, "gateway.sock"));
   });
 
   test("falls back to tmpdir when workspace path exceeds AF_UNIX limit", () => {
     delete process.env.GATEWAY_IPC_SOCKET_DIR;
     // 90-char workspace dir + /gateway.sock = well over 103 bytes
-    process.env.VELLUM_WORKSPACE_DIR = "/tmp/" + "a".repeat(85) + "/workspace";
+    process.env.VELLUM_WORKSPACE_DIR = join(
+      tmpdir(),
+      "a".repeat(90),
+      "workspace",
+    );
 
     const resolved = resolveIpcSocketPath("gateway");
 
@@ -68,7 +76,7 @@ describe("resolveIpcSocketPath", () => {
 
   test("derives env var name from socket name", () => {
     process.env.ASSISTANT_IPC_SOCKET_DIR = "/run/assistant-ipc";
-    process.env.VELLUM_WORKSPACE_DIR = "/tmp/vellum-workspace-test";
+    process.env.VELLUM_WORKSPACE_DIR = WS_DIR;
 
     const resolved = resolveIpcSocketPath("assistant");
 

--- a/gateway/src/__tests__/live-paths-guard.test.ts
+++ b/gateway/src/__tests__/live-paths-guard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the live-path guard in paths.ts: a test process must never
+ * resolve the workspace or the gateway security directory to a directory
+ * outside os.tmpdir().
+ */
+
+import { rmSync, symlinkSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { getGatewaySecurityDir, getWorkspaceDir } from "../paths.js";
+
+const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+const originalSecurityDir = process.env.GATEWAY_SECURITY_DIR;
+const originalAllowRealWorkspace =
+  process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+const originalAllowRealSecurity =
+  process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+
+function restore(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+afterEach(() => {
+  restore("VELLUM_WORKSPACE_DIR", originalWorkspaceDir);
+  restore("GATEWAY_SECURITY_DIR", originalSecurityDir);
+  restore("VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS", originalAllowRealWorkspace);
+  restore(
+    "VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS",
+    originalAllowRealSecurity,
+  );
+});
+
+describe("live-path guard: workspace", () => {
+  test("allows the preload's tmpdir workspace", () => {
+    expect(getWorkspaceDir()).toBe(process.env.VELLUM_WORKSPACE_DIR!);
+  });
+
+  test("allows a not-yet-created nested path under tmpdir", () => {
+    const dir = join(tmpdir(), "vellum-guard-nonexistent", "workspace");
+    process.env.VELLUM_WORKSPACE_DIR = dir;
+    expect(getWorkspaceDir()).toBe(dir);
+  });
+
+  test("refuses a non-tmpdir workspace in a test process", () => {
+    delete process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+    process.env.VELLUM_WORKSPACE_DIR = join(homedir(), "vellum-guard-live");
+    expect(() => getWorkspaceDir()).toThrow(/Refusing to use/);
+  });
+
+  test("refuses the ~/.vellum fallback when the env var is unset", () => {
+    delete process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS;
+    delete process.env.VELLUM_WORKSPACE_DIR;
+    expect(() => getWorkspaceDir()).toThrow(/Refusing to use/);
+  });
+
+  test("VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS=1 bypasses the guard", () => {
+    const dir = join(homedir(), "vellum-guard-live-optout");
+    process.env.VELLUM_WORKSPACE_DIR = dir;
+    process.env.VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS = "1";
+    expect(getWorkspaceDir()).toBe(dir);
+  });
+});
+
+describe("live-path guard: gateway security dir", () => {
+  test("allows the preload's tmpdir security dir", () => {
+    expect(getGatewaySecurityDir()).toBe(process.env.GATEWAY_SECURITY_DIR!);
+  });
+
+  test("refuses a non-tmpdir security dir in a test process", () => {
+    delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+    process.env.GATEWAY_SECURITY_DIR = join(homedir(), ".vellum", "protected");
+    expect(() => getGatewaySecurityDir()).toThrow(/Refusing to use/);
+  });
+
+  test("refuses the ~/.vellum/protected fallback when the env var is unset", () => {
+    delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+    delete process.env.GATEWAY_SECURITY_DIR;
+    expect(() => getGatewaySecurityDir()).toThrow(/Refusing to use/);
+  });
+
+  test("refuses a tmpdir symlink that resolves outside tmpdir", () => {
+    delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+    const link = join(tmpdir(), `vellum-guard-escape-${process.pid}`);
+    rmSync(link, { force: true });
+    symlinkSync(homedir(), link);
+    try {
+      process.env.GATEWAY_SECURITY_DIR = link;
+      expect(() => getGatewaySecurityDir()).toThrow(/Refusing to use/);
+    } finally {
+      rmSync(link, { force: true });
+    }
+  });
+
+  test("opt-out is per-call, not cached: same dir throws once the var clears", () => {
+    const dir = join(homedir(), "vellum-guard-security-optout");
+    process.env.GATEWAY_SECURITY_DIR = dir;
+    process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS = "1";
+    expect(getGatewaySecurityDir()).toBe(dir);
+    delete process.env.VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS;
+    expect(() => getGatewaySecurityDir()).toThrow(/Refusing to use/);
+  });
+});

--- a/gateway/src/__tests__/live-voice-websocket.test.ts
+++ b/gateway/src/__tests__/live-voice-websocket.test.ts
@@ -730,11 +730,13 @@ describe("createLiveVoiceWebsocketHandler — revocation", () => {
   // suites run without a DB; the revocation check is fail-open when the DB is
   // absent, so they upgrade as before.)
   let testRoot: string;
+  let savedSecurityDir: string | undefined;
 
   beforeEach(async () => {
     const { mkdtempSync, mkdirSync } = await import("node:fs");
     const { tmpdir } = await import("node:os");
     const { join } = await import("node:path");
+    savedSecurityDir = process.env.GATEWAY_SECURITY_DIR;
     testRoot = mkdtempSync(join(tmpdir(), "live-voice-revocation-"));
     mkdirSync(join(testRoot, "protected"), { recursive: true });
     process.env.GATEWAY_SECURITY_DIR = join(testRoot, "protected");
@@ -745,7 +747,11 @@ describe("createLiveVoiceWebsocketHandler — revocation", () => {
   afterEach(async () => {
     const { resetGatewayDb } = await import("../db/connection.js");
     resetGatewayDb();
-    delete process.env.GATEWAY_SECURITY_DIR;
+    if (savedSecurityDir === undefined) {
+      delete process.env.GATEWAY_SECURITY_DIR;
+    } else {
+      process.env.GATEWAY_SECURITY_DIR = savedSecurityDir;
+    }
     const { rmSync } = await import("node:fs");
     try {
       rmSync(testRoot, { recursive: true, force: true });

--- a/gateway/src/__tests__/pair-device-bound.test.ts
+++ b/gateway/src/__tests__/pair-device-bound.test.ts
@@ -40,6 +40,7 @@ const PROD_ORIGIN = "chrome-extension://hphbdmpffeigpcdjkckleobjmhhokpne";
 const GUARDIAN_ID = "guardian-001";
 
 let testRoot: string;
+let savedSecurityDir: string | undefined;
 
 function makePairRequest(body?: Record<string, unknown>): Request {
   return new Request("http://localhost:7830/v1/pair", {
@@ -64,6 +65,7 @@ function activeTokens() {
 
 beforeEach(async () => {
   resetPairRateLimiterForTests();
+  savedSecurityDir = process.env.GATEWAY_SECURITY_DIR;
   testRoot = mkdtempSync(join(tmpdir(), "pair-device-test-"));
   const securityDir = join(testRoot, "protected");
   mkdirSync(securityDir, { recursive: true });
@@ -103,7 +105,11 @@ beforeEach(async () => {
 
 afterEach(() => {
   resetGatewayDb();
-  delete process.env.GATEWAY_SECURITY_DIR;
+  if (savedSecurityDir === undefined) {
+    delete process.env.GATEWAY_SECURITY_DIR;
+  } else {
+    process.env.GATEWAY_SECURITY_DIR = savedSecurityDir;
+  }
   try {
     rmSync(testRoot, { recursive: true, force: true });
   } catch {

--- a/gateway/src/__tests__/refresh-device-binding.test.ts
+++ b/gateway/src/__tests__/refresh-device-binding.test.ts
@@ -34,6 +34,7 @@ const DEVICE_B = "device-B";
 const FAMILY = "family-001";
 
 let testRoot: string;
+let savedSecurityDir: string | undefined;
 
 function insertRefreshRecord(
   rawToken: string,
@@ -113,6 +114,7 @@ function insertGuardianContact() {
 }
 
 beforeEach(async () => {
+  savedSecurityDir = process.env.GATEWAY_SECURITY_DIR;
   testRoot = mkdtempSync(join(tmpdir(), "refresh-device-binding-"));
   const securityDir = join(testRoot, "protected");
   mkdirSync(securityDir, { recursive: true });
@@ -136,7 +138,11 @@ afterEach(() => {
   resetGatewayDb();
   resetGuardianIntegrityReporterForTesting();
   bustGuardianIntegrityCache();
-  delete process.env.GATEWAY_SECURITY_DIR;
+  if (savedSecurityDir === undefined) {
+    delete process.env.GATEWAY_SECURITY_DIR;
+  } else {
+    process.env.GATEWAY_SECURITY_DIR = savedSecurityDir;
+  }
   try {
     rmSync(testRoot, { recursive: true, force: true });
   } catch {

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -3,11 +3,9 @@ import { drizzle } from "drizzle-orm/bun-sqlite";
 import { existsSync, mkdirSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, sep } from "node:path";
-import {
-  canonicalizePathThroughExistingParent,
-  getGatewaySecurityDir,
-  getLegacyRootDir,
-} from "../paths.js";
+import { canonicalizePathThroughExistingParent } from "@vellumai/environments/test-path-guard";
+
+import { getGatewaySecurityDir, getLegacyRootDir } from "../paths.js";
 import * as schema from "./schema.js";
 import { AdmissionPolicyStore } from "./admission-policy-store.js";
 import { seedAdmissionPolicyDefaults } from "./seed-admission-policy.js";

--- a/gateway/src/db/connection.ts
+++ b/gateway/src/db/connection.ts
@@ -1,9 +1,13 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
-import { existsSync, mkdirSync, realpathSync, renameSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve, sep } from "node:path";
-import { getGatewaySecurityDir, getLegacyRootDir } from "../paths.js";
+import { join, sep } from "node:path";
+import {
+  canonicalizePathThroughExistingParent,
+  getGatewaySecurityDir,
+  getLegacyRootDir,
+} from "../paths.js";
 import * as schema from "./schema.js";
 import { AdmissionPolicyStore } from "./admission-policy-store.js";
 import { seedAdmissionPolicyDefaults } from "./seed-admission-policy.js";
@@ -73,25 +77,6 @@ async function pushSchemaNoPrompt(
 }
 
 let db: GatewayDb | null = null;
-
-function canonicalizePathThroughExistingParent(path: string): string {
-  const resolvedPath = resolve(path);
-  const pendingSegments: string[] = [];
-  let currentPath = resolvedPath;
-
-  while (true) {
-    try {
-      return resolve(realpathSync(currentPath), ...pendingSegments.reverse());
-    } catch {
-      const parentPath = dirname(currentPath);
-      if (parentPath === currentPath) {
-        return resolvedPath;
-      }
-      pendingSegments.push(basename(currentPath));
-      currentPath = parentPath;
-    }
-  }
-}
 
 function assertTestDbIsIsolated(): void {
   if (

--- a/gateway/src/paths.ts
+++ b/gateway/src/paths.ts
@@ -6,8 +6,9 @@
  * without pulling in the full credential-reader dependency tree.
  */
 
-import { join } from "node:path";
-import { homedir, userInfo } from "node:os";
+import { realpathSync } from "node:fs";
+import { basename, dirname, join, resolve, sep } from "node:path";
+import { homedir, tmpdir, userInfo } from "node:os";
 
 function safeUserInfoHomedir(): string {
   try {
@@ -42,6 +43,85 @@ export function getLegacyRootDir(): string {
 let warnedWorkspaceDir = false;
 let warnedSecurityDir = false;
 
+// --- Live-path guard for test processes ------------------------------------
+//
+// A test process must never resolve the workspace or the gateway security
+// directory to a real, non-temp path: gateway code exercised by a test would
+// then read and write live state (the gateway DB, the actor-token signing
+// key, the backup key). The tmpdir redirection normally comes from the
+// bunfig.toml test preload, but bun only loads bunfig from the cwd, so
+// `bun test` run from any other directory skips the preload and inherits the
+// ambient env (or the ~/.vellum fallback). The containment assertion
+// therefore lives here, in production code, where it fires no matter how the
+// test process was launched.
+//
+// Detection and containment mirror assistant/src/util/platform.ts, which
+// cannot be imported here (cross-package boundary).
+
+/** Lazily computed: is this process a `bun test` run? */
+let isTestProcess: boolean | undefined;
+
+/**
+ * Resolve symlinks in the deepest existing ancestor of `path`, then
+ * re-append the not-yet-created tail. This keeps containment checks honest
+ * both for paths under a symlinked temp root (macOS /var/folders) and for
+ * symlinks that point outside it, whether or not the leaf exists yet.
+ */
+export function canonicalizePathThroughExistingParent(path: string): string {
+  const resolvedPath = resolve(path);
+  const pendingSegments: string[] = [];
+  let currentPath = resolvedPath;
+
+  while (true) {
+    try {
+      return resolve(realpathSync(currentPath), ...pendingSegments.reverse());
+    } catch {
+      const parentPath = dirname(currentPath);
+      if (parentPath === currentPath) {
+        return resolvedPath;
+      }
+      pendingSegments.push(basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+}
+
+function assertTestPathIsEphemeral(dir: string, allowEnvVar: string): void {
+  isTestProcess ??=
+    process.env.NODE_ENV === "test" ||
+    process.env.BUN_TEST === "1" ||
+    // `bun test` sets NODE_ENV=test only when unset; Bun.main being the test
+    // file itself is the backstop signal that survives a preset NODE_ENV.
+    (typeof Bun !== "undefined" &&
+      /\.(test|spec)\.[cm]?[jt]sx?$/.test(Bun.main));
+  if (!isTestProcess) {
+    return;
+  }
+  // Escape hatch for the rare intentional run against real state, shared
+  // with the DB-open guard in db/connection.ts. Deliberately not forwarded
+  // into agent-spawned shells (assistant/src/tools/terminal/safe-env.ts), so
+  // a daemon-level opt-out cannot disarm the guard for tests run from there.
+  if (process.env[allowEnvVar] === "1") {
+    return;
+  }
+  const tmpRoot = canonicalizePathThroughExistingParent(tmpdir());
+  const resolved = canonicalizePathThroughExistingParent(dir);
+  if (resolved !== tmpRoot && !resolved.startsWith(tmpRoot + sep)) {
+    throw new Error(
+      [
+        `Refusing to use ${dir} (resolves to ${resolved}) in a test process: it is not under the temp directory (${tmpRoot}).`,
+        "",
+        "Tests must only touch ephemeral state; a real directory would expose",
+        "live gateway state (DB, signing keys) to test fixtures. This usually",
+        "means `bun test` ran from a cwd without the gateway bunfig.toml, so",
+        "the test preload that redirects paths to a tmpdir never loaded.",
+        "Run tests from the gateway package root, or set",
+        `${allowEnvVar}=1 to bypass deliberately.`,
+      ].join("\n"),
+    );
+  }
+}
+
 /**
  * Returns the workspace root for user-facing state.
  *
@@ -51,7 +131,10 @@ let warnedSecurityDir = false;
  */
 export function getWorkspaceDir(): string {
   const override = process.env.VELLUM_WORKSPACE_DIR?.trim();
-  if (override) return override;
+  if (override) {
+    assertTestPathIsEphemeral(override, "VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS");
+    return override;
+  }
   if (!warnedWorkspaceDir) {
     warnedWorkspaceDir = true;
     console.warn(
@@ -59,7 +142,9 @@ export function getWorkspaceDir(): string {
         "Set VELLUM_WORKSPACE_DIR explicitly in the entrypoint.",
     );
   }
-  return join(getLegacyRootDir(), "workspace");
+  const dir = join(getLegacyRootDir(), "workspace");
+  assertTestPathIsEphemeral(dir, "VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS");
+  return dir;
 }
 
 /**
@@ -71,7 +156,13 @@ export function getWorkspaceDir(): string {
  */
 export function getGatewaySecurityDir(): string {
   const override = process.env.GATEWAY_SECURITY_DIR?.trim();
-  if (override) return override;
+  if (override) {
+    assertTestPathIsEphemeral(
+      override,
+      "VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS",
+    );
+    return override;
+  }
   if (!warnedSecurityDir) {
     warnedSecurityDir = true;
     console.warn(
@@ -79,5 +170,7 @@ export function getGatewaySecurityDir(): string {
         "Set GATEWAY_SECURITY_DIR explicitly in the entrypoint.",
     );
   }
-  return join(getLegacyRootDir(), "protected");
+  const dir = join(getLegacyRootDir(), "protected");
+  assertTestPathIsEphemeral(dir, "VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS");
+  return dir;
 }

--- a/gateway/src/paths.ts
+++ b/gateway/src/paths.ts
@@ -6,9 +6,10 @@
  * without pulling in the full credential-reader dependency tree.
  */
 
-import { realpathSync } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
-import { homedir, tmpdir, userInfo } from "node:os";
+import { join } from "node:path";
+import { homedir, userInfo } from "node:os";
+
+import { assertTestPathIsEphemeral } from "@vellumai/environments/test-path-guard";
 
 function safeUserInfoHomedir(): string {
   try {
@@ -43,84 +44,22 @@ export function getLegacyRootDir(): string {
 let warnedWorkspaceDir = false;
 let warnedSecurityDir = false;
 
-// --- Live-path guard for test processes ------------------------------------
-//
-// A test process must never resolve the workspace or the gateway security
-// directory to a real, non-temp path: gateway code exercised by a test would
-// then read and write live state (the gateway DB, the actor-token signing
-// key, the backup key). The tmpdir redirection normally comes from the
-// bunfig.toml test preload, but bun only loads bunfig from the cwd, so
-// `bun test` run from any other directory skips the preload and inherits the
-// ambient env (or the ~/.vellum fallback). The containment assertion
-// therefore lives here, in production code, where it fires no matter how the
-// test process was launched.
-//
-// Detection and containment mirror assistant/src/util/platform.ts, which
-// cannot be imported here (cross-package boundary).
+// In test processes both resolvers below must stay under os.tmpdir():
+// gateway code exercised by a test would otherwise read and write live state
+// (the gateway DB, the actor-token signing key, the backup key). The guard is
+// shared with the assistant in @vellumai/environments/test-path-guard; the
+// escape hatches are the same variables the DB-open guard in db/connection.ts
+// honors.
 
-/** Lazily computed: is this process a `bun test` run? */
-let isTestProcess: boolean | undefined;
+const WORKSPACE_GUARD = {
+  allowEnvVar: "VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS",
+  runHint: "Run tests from the gateway package root.",
+};
 
-/**
- * Resolve symlinks in the deepest existing ancestor of `path`, then
- * re-append the not-yet-created tail. This keeps containment checks honest
- * both for paths under a symlinked temp root (macOS /var/folders) and for
- * symlinks that point outside it, whether or not the leaf exists yet.
- */
-export function canonicalizePathThroughExistingParent(path: string): string {
-  const resolvedPath = resolve(path);
-  const pendingSegments: string[] = [];
-  let currentPath = resolvedPath;
-
-  while (true) {
-    try {
-      return resolve(realpathSync(currentPath), ...pendingSegments.reverse());
-    } catch {
-      const parentPath = dirname(currentPath);
-      if (parentPath === currentPath) {
-        return resolvedPath;
-      }
-      pendingSegments.push(basename(currentPath));
-      currentPath = parentPath;
-    }
-  }
-}
-
-function assertTestPathIsEphemeral(dir: string, allowEnvVar: string): void {
-  isTestProcess ??=
-    process.env.NODE_ENV === "test" ||
-    process.env.BUN_TEST === "1" ||
-    // `bun test` sets NODE_ENV=test only when unset; Bun.main being the test
-    // file itself is the backstop signal that survives a preset NODE_ENV.
-    (typeof Bun !== "undefined" &&
-      /\.(test|spec)\.[cm]?[jt]sx?$/.test(Bun.main));
-  if (!isTestProcess) {
-    return;
-  }
-  // Escape hatch for the rare intentional run against real state, shared
-  // with the DB-open guard in db/connection.ts. Deliberately not forwarded
-  // into agent-spawned shells (assistant/src/tools/terminal/safe-env.ts), so
-  // a daemon-level opt-out cannot disarm the guard for tests run from there.
-  if (process.env[allowEnvVar] === "1") {
-    return;
-  }
-  const tmpRoot = canonicalizePathThroughExistingParent(tmpdir());
-  const resolved = canonicalizePathThroughExistingParent(dir);
-  if (resolved !== tmpRoot && !resolved.startsWith(tmpRoot + sep)) {
-    throw new Error(
-      [
-        `Refusing to use ${dir} (resolves to ${resolved}) in a test process: it is not under the temp directory (${tmpRoot}).`,
-        "",
-        "Tests must only touch ephemeral state; a real directory would expose",
-        "live gateway state (DB, signing keys) to test fixtures. This usually",
-        "means `bun test` ran from a cwd without the gateway bunfig.toml, so",
-        "the test preload that redirects paths to a tmpdir never loaded.",
-        "Run tests from the gateway package root, or set",
-        `${allowEnvVar}=1 to bypass deliberately.`,
-      ].join("\n"),
-    );
-  }
-}
+const SECURITY_GUARD = {
+  allowEnvVar: "VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS",
+  runHint: "Run tests from the gateway package root.",
+};
 
 /**
  * Returns the workspace root for user-facing state.
@@ -132,7 +71,7 @@ function assertTestPathIsEphemeral(dir: string, allowEnvVar: string): void {
 export function getWorkspaceDir(): string {
   const override = process.env.VELLUM_WORKSPACE_DIR?.trim();
   if (override) {
-    assertTestPathIsEphemeral(override, "VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS");
+    assertTestPathIsEphemeral(override, WORKSPACE_GUARD);
     return override;
   }
   if (!warnedWorkspaceDir) {
@@ -143,7 +82,7 @@ export function getWorkspaceDir(): string {
     );
   }
   const dir = join(getLegacyRootDir(), "workspace");
-  assertTestPathIsEphemeral(dir, "VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS");
+  assertTestPathIsEphemeral(dir, WORKSPACE_GUARD);
   return dir;
 }
 
@@ -157,10 +96,7 @@ export function getWorkspaceDir(): string {
 export function getGatewaySecurityDir(): string {
   const override = process.env.GATEWAY_SECURITY_DIR?.trim();
   if (override) {
-    assertTestPathIsEphemeral(
-      override,
-      "VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS",
-    );
+    assertTestPathIsEphemeral(override, SECURITY_GUARD);
     return override;
   }
   if (!warnedSecurityDir) {
@@ -171,6 +107,6 @@ export function getGatewaySecurityDir(): string {
     );
   }
   const dir = join(getLegacyRootDir(), "protected");
-  assertTestPathIsEphemeral(dir, "VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS");
+  assertTestPathIsEphemeral(dir, SECURITY_GUARD);
   return dir;
 }

--- a/packages/environments/package.json
+++ b/packages/environments/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./seeds": "./src/seeds.ts",
-    "./shell": "./src/shell.ts"
+    "./shell": "./src/shell.ts",
+    "./test-path-guard": "./src/test-path-guard.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",

--- a/packages/environments/src/__tests__/test-path-guard.test.ts
+++ b/packages/environments/src/__tests__/test-path-guard.test.ts
@@ -56,7 +56,7 @@ describe("assertTestPathIsEphemeral", () => {
     delete process.env[OPTIONS.allowEnvVar];
     const dir = join(homedir(), "test-path-guard-live");
     expect(() => assertTestPathIsEphemeral(dir, OPTIONS)).toThrow(
-      /Refusing to use[\s\S]*TEST_PATH_GUARD_ALLOW[\s\S]*package root/,
+      /Refusing to use[\s\S]*package root[\s\S]*TEST_PATH_GUARD_ALLOW/,
     );
   });
 

--- a/packages/environments/src/__tests__/test-path-guard.test.ts
+++ b/packages/environments/src/__tests__/test-path-guard.test.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import {
+  assertTestPathIsEphemeral,
+  canonicalizePathThroughExistingParent,
+  isBunTestProcess,
+} from "../test-path-guard.js";
+
+const OPTIONS = {
+  allowEnvVar: "TEST_PATH_GUARD_ALLOW",
+  runHint: "Run tests from the package root.",
+};
+
+describe("isBunTestProcess", () => {
+  test("detects this bun test run", () => {
+    expect(isBunTestProcess()).toBe(true);
+  });
+});
+
+describe("canonicalizePathThroughExistingParent", () => {
+  test("resolves symlinks on the deepest existing ancestor", () => {
+    const root = mkdtempSync(join(tmpdir(), "test-path-guard-"));
+    try {
+      const target = join(root, "target");
+      mkdirSync(target);
+      const link = join(root, "link");
+      symlinkSync(target, link, "dir");
+      expect(
+        canonicalizePathThroughExistingParent(join(link, "missing", "leaf")),
+      ).toBe(
+        join(canonicalizePathThroughExistingParent(target), "missing", "leaf"),
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("returns the input path when no ancestor exists", () => {
+    expect(canonicalizePathThroughExistingParent("/nonexistent-root-x/y")).toBe(
+      "/nonexistent-root-x/y",
+    );
+  });
+});
+
+describe("assertTestPathIsEphemeral", () => {
+  test("allows paths under tmpdir, existing or not", () => {
+    expect(() =>
+      assertTestPathIsEphemeral(join(tmpdir(), "guard-missing", "x"), OPTIONS),
+    ).not.toThrow();
+  });
+
+  test("refuses paths outside tmpdir, naming the escape hatch and hint", () => {
+    delete process.env[OPTIONS.allowEnvVar];
+    const dir = join(homedir(), "test-path-guard-live");
+    expect(() => assertTestPathIsEphemeral(dir, OPTIONS)).toThrow(
+      /Refusing to use[\s\S]*TEST_PATH_GUARD_ALLOW[\s\S]*package root/,
+    );
+  });
+
+  test("refuses a tmpdir symlink that resolves outside tmpdir", () => {
+    delete process.env[OPTIONS.allowEnvVar];
+    const link = join(tmpdir(), `test-path-guard-escape-${process.pid}`);
+    rmSync(link, { force: true });
+    symlinkSync(homedir(), link);
+    try {
+      expect(() => assertTestPathIsEphemeral(link, OPTIONS)).toThrow(
+        /Refusing to use/,
+      );
+    } finally {
+      rmSync(link, { force: true });
+    }
+  });
+
+  test("the allow env var bypasses the guard, per call", () => {
+    const dir = join(homedir(), "test-path-guard-optout");
+    process.env[OPTIONS.allowEnvVar] = "1";
+    try {
+      expect(() => assertTestPathIsEphemeral(dir, OPTIONS)).not.toThrow();
+    } finally {
+      delete process.env[OPTIONS.allowEnvVar];
+    }
+    expect(() => assertTestPathIsEphemeral(dir, OPTIONS)).toThrow(
+      /Refusing to use/,
+    );
+  });
+});

--- a/packages/environments/src/test-path-guard.ts
+++ b/packages/environments/src/test-path-guard.ts
@@ -1,0 +1,107 @@
+/**
+ * Live-path guard for test processes, shared by every service that resolves
+ * install-layout paths (the assistant daemon's workspace/root, the gateway's
+ * workspace and security dirs).
+ *
+ * A test process must never resolve one of those paths to a real, non-temp
+ * directory: production code exercised by a test would then read and
+ * destructively write live state. The tmpdir redirection normally comes from
+ * each package's bunfig.toml test preload, but bun only loads bunfig from
+ * the cwd, so `bun test` run from any other directory skips the preload and
+ * inherits the ambient env (or a ~/.vellum fallback). The containment
+ * assertion therefore lives in production code, where it fires no matter how
+ * the test process was launched.
+ *
+ * assistant/src/__tests__/assert-not-live-db.ts keeps its own copy of the
+ * containment walk: test machinery must not import production dependencies.
+ */
+
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, resolve, sep } from "node:path";
+
+/**
+ * Resolve symlinks in the deepest existing ancestor of `path`, then
+ * re-append the not-yet-created tail. This keeps containment checks honest
+ * both for paths under a symlinked temp root (macOS /var/folders) and for
+ * symlinks that point outside it, whether or not the leaf exists yet.
+ */
+export function canonicalizePathThroughExistingParent(path: string): string {
+  const resolvedPath = resolve(path);
+  const pendingSegments: string[] = [];
+  let currentPath = resolvedPath;
+
+  while (true) {
+    try {
+      return resolve(realpathSync(currentPath), ...pendingSegments.reverse());
+    } catch {
+      const parentPath = dirname(currentPath);
+      if (parentPath === currentPath) {
+        return resolvedPath;
+      }
+      pendingSegments.push(basename(currentPath));
+      currentPath = parentPath;
+    }
+  }
+}
+
+/** Lazily computed: is this process a `bun test` run? */
+let isTestProcess: boolean | undefined;
+
+export function isBunTestProcess(): boolean {
+  isTestProcess ??=
+    process.env.NODE_ENV === "test" ||
+    process.env.BUN_TEST === "1" ||
+    // `bun test` sets NODE_ENV=test only when unset; Bun.main being the test
+    // file itself is the backstop signal that survives a preset NODE_ENV.
+    (typeof Bun !== "undefined" &&
+      /\.(test|spec)\.[cm]?[jt]sx?$/.test(Bun.main));
+  return isTestProcess;
+}
+
+export interface EphemeralTestPathOptions {
+  /**
+   * Escape hatch for the rare intentional run against real state: setting
+   * this env var to "1" bypasses the guard. Callers reuse the variable their
+   * DB-open guard already honors. Deliberately not forwarded into
+   * agent-spawned shells (assistant/src/tools/terminal/safe-env.ts), so a
+   * daemon-level opt-out cannot disarm the guard for tests run from there.
+   */
+  allowEnvVar: string;
+  /** Package-specific line telling the reader where to run tests from. */
+  runHint: string;
+}
+
+/**
+ * Throws when called in a bun-test process and `dir` does not resolve under
+ * `os.tmpdir()`. Inert outside test processes. Canonicalizes on every call
+ * (no memo): a previously validated path could later be replaced by a
+ * symlink, and the guard only runs in test processes anyway.
+ */
+export function assertTestPathIsEphemeral(
+  dir: string,
+  options: EphemeralTestPathOptions,
+): void {
+  if (!isBunTestProcess()) {
+    return;
+  }
+  if (process.env[options.allowEnvVar] === "1") {
+    return;
+  }
+  const tmpRoot = canonicalizePathThroughExistingParent(tmpdir());
+  const resolved = canonicalizePathThroughExistingParent(dir);
+  if (resolved !== tmpRoot && !resolved.startsWith(tmpRoot + sep)) {
+    throw new Error(
+      [
+        `Refusing to use ${dir} (resolves to ${resolved}) in a test process: it is not under the temp directory (${tmpRoot}).`,
+        "",
+        "Tests must only touch ephemeral state; a real directory would expose",
+        "live install state to destructive test fixtures. This usually means",
+        "`bun test` ran from a cwd without the package's bunfig.toml, so the",
+        "test preload that redirects paths to a tmpdir never loaded.",
+        options.runHint,
+        `Set ${options.allowEnvVar}=1 to bypass deliberately.`,
+      ].join("\n"),
+    );
+  }
+}

--- a/packages/environments/src/test-path-guard.ts
+++ b/packages/environments/src/test-path-guard.ts
@@ -48,6 +48,12 @@ export function canonicalizePathThroughExistingParent(path: string): string {
 /** Lazily computed: is this process a `bun test` run? */
 let isTestProcess: boolean | undefined;
 
+/**
+ * True when this process is a `bun test` run. Computed once and cached for
+ * the process lifetime, so a runtime flip of NODE_ENV or BUN_TEST does not
+ * change the answer. Test-mode behavior toggles that must observe such
+ * flips read the env directly instead of calling this.
+ */
 export function isBunTestProcess(): boolean {
   isTestProcess ??=
     process.env.NODE_ENV === "test" ||

--- a/packages/environments/src/test-path-guard.ts
+++ b/packages/environments/src/test-path-guard.ts
@@ -12,8 +12,8 @@
  * assertion therefore lives in production code, where it fires no matter how
  * the test process was launched.
  *
- * assistant/src/__tests__/assert-not-live-db.ts keeps its own copy of the
- * containment walk: test machinery must not import production dependencies.
+ * assistant/src/__tests__/assert-not-live-db.ts keeps its own containment
+ * check: test machinery must not import production dependencies.
  */
 
 import { realpathSync } from "node:fs";


### PR DESCRIPTION
## TL;DR

Extend the production-code test-path guard the assistant got in #40946 to the gateway: in a bun-test process, `getWorkspaceDir()` and `getGatewaySecurityDir()` refuse to resolve to any directory outside `os.tmpdir()`. The guard is defined once, in `@vellumai/environments/test-path-guard`, and consumed by both services. Part of [JARVIS-1643](https://linear.app/vellum/issue/JARVIS-1643).

## Why

Bun only loads `bunfig.toml` from the cwd, so `bun test` run from the wrong directory loads no preload and inherits ambient env, or falls through to the `~/.vellum` fallback. #40946 closed that hole for the assistant workspace, but the gateway's only production-code guard was `assertTestDbIsIsolated()` in `db/connection.ts`, which fires on DB opens only. Non-DB writers resolve paths through `paths.ts` directly:

- `auth/token-service.ts` writes the actor-token signing key under `getGatewaySecurityDir()`
- `backup/paths.ts` and `backup/backup-worker.ts` resolve `backup.key` there
- `config-file-utils.ts`, `feature-flag-store.ts`, and others write under both helpers

With no preload and no env, those writes land in the real `~/.vellum/protected`. The guard makes that a loud failure instead.

## What changed

**`packages/environments/src/test-path-guard.ts`** (new): the single definition of the guard, in the leaf package both services depend on. Exports `canonicalizePathThroughExistingParent()` (deepest-existing-ancestor symlink walk), `isBunTestProcess()` (three-way detection: `NODE_ENV === "test"`, `BUN_TEST === "1"`, `Bun.main` matching a test file), and `assertTestPathIsEphemeral(dir, {allowEnvVar, runHint})`, which fails closed unless the resolved path is under `os.tmpdir()`. Canonicalization is per-call, not memoized. Unit tests live beside it.

**Consumers** (each previously carried its own copy of some or all of this logic):

- `assistant/src/util/platform.ts`: `getWorkspaceDir()` / `vellumRoot()` keep their existing behavior and escape hatch (`VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS`), now through the shared guard.
- `assistant/src/persistence/db-connection.ts`: imports the shared canonicalize walk.
- `gateway/src/paths.ts`: both resolvers call the shared guard; escape hatches are the variables the gateway DB-open guard already honors (`VELLUM_ALLOW_REAL_WORKSPACE_IN_TESTS`, `VELLUM_ALLOW_REAL_GATEWAY_SECURITY_IN_TESTS`).
- `gateway/src/db/connection.ts`: imports the shared canonicalize walk.

The one deliberate remaining copy is in `assistant/src/__tests__/assert-not-live-db.ts`: test machinery must not import production dependencies (assistant/CLAUDE.md), so it keeps its own containment walk.

Neither escape-hatch variable is forwarded by `safe-env.ts`, so a daemon-level opt-out cannot reach agent-spawned shells.

**Latent test fixes the guard exposes** (same class #40946 had to fix assistant-side):

- `ipc-socket-path.test.ts` used literal `/tmp/...` workspace paths, which are not under `tmpdir()` on macOS. Now mirrors the assistant twin fixed in #40946.
- `actor-token-revocation`, `pair-device-bound`, `refresh-device-binding`, and `live-voice-websocket` deleted `GATEWAY_SECURITY_DIR` in teardown instead of restoring the preload's value, stripping isolation from any later file in the same process that relies on the preload env.

**New tests**: `gateway/src/__tests__/live-paths-guard.test.ts` (mirrors `live-workspace-guard.test.ts`: tmpdir paths pass, non-tmp paths and the `~/.vellum` fallbacks throw, symlink escapes throw, opt-out works and is per-call) and `packages/environments/src/__tests__/test-path-guard.test.ts`.

## Why this is safe

- The guard is inert outside test processes: `isBunTestProcess()` is computed once and the assertion returns immediately in production.
- The assistant's guard behavior is unchanged: same detection, same containment, same escape hatch, same first line of the error message; only the definition moved.
- Every existing gateway test resolves these paths through the preload's tmpdir values or per-test `mkdtemp` dirs; I audited all env assignment sites by reading (`db-connection-isolation` intentionally sets real paths, but `assertTestDbIsIsolated()` throws before `getGatewaySecurityDir()` is reached on that path). The spawned-gateway suites (`credential-watcher*`) pass tmpdir-based env to the child, which inherits `NODE_ENV=test` and therefore runs the guard.
- `@vellumai/environments` stays a leaf: the new module imports node builtins only, which its package-boundary test enforces.

## Before / after

| Scenario | Before | After |
| --- | --- | --- |
| `bun test` from a cwd without `gateway/bunfig.toml`, code writes the signing key | Key material written to the real `~/.vellum/protected`, silently | Throws with a message naming the path and the missing-preload cause |
| Test file sets `GATEWAY_SECURITY_DIR` to a non-tmp dir | Silently used | Throws unless the per-store escape hatch is set |
| A fix to test detection or symlink handling | Must be re-applied in each package's copy | Lands once in the shared module, both services pick it up |
| Normal `cd gateway && bun test <file>` | Passes | Passes, guard sees tmpdir paths |
| Production daemon and gateway | Unaffected | Unaffected (guard short-circuits) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
