### PR TITLE
fix: drop assertions on deleted plan copy, describe the no-bundle label as it is, and complete the flag guard

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -21,15 +21,18 @@ import {
 } from "@/lib/billing/machine-sizes";
 
 /**
- * Sentinel for the "No extra credits" entry. `CreditChoice` is a string union,
- * so the absence of a tier needs a value to carry through the picker and the
- * diff. `Select` can now express this directly with a `null` option and
+ * Sentinel for the no-bundle entry. `CreditChoice` is a string union, so the
+ * absence of a tier needs a value to carry through the picker and the diff.
+ * `Select` can now express this directly with a `null` option and
  * `onSelectNone`, which would make the sentinel unnecessary.
  */
 export const NO_EXTRA_CREDITS = "__none__";
 export type CreditChoice = CreditTierEnum | typeof NO_EXTRA_CREDITS;
 
-/** Shared by the credit dropdown's sentinel option and its recap row. */
+/**
+ * Fallback wording for the no-bundle sentinel when a caller supplies no
+ * `noBundleLabel`. The modal always passes its translated copy.
+ */
 export const NO_CREDITS_LABEL = "No extra credits";
 
 /**
@@ -180,8 +183,8 @@ export function computeCustomPlanDiff(input: {
     });
   }
 
-  // A concrete bundle the catalog can no longer resolve gets no row at all —
-  // "No extra credits" would be affirmatively false for a sub paying for one.
+  // A concrete bundle the catalog can no longer resolve gets no row at all:
+  // the no-bundle label would be affirmatively false for a sub paying for one.
   const selectedCreditLabel =
     creditChoice === NO_EXTRA_CREDITS
       ? noBundleLabel
@@ -193,7 +196,7 @@ export function computeCustomPlanDiff(input: {
 
   if (selectedCreditLabel != null) {
     // Compare the raw keys: a delisted seed bundle resolves to null, which
-    // would otherwise read identically to "no credits" and hide the change.
+    // would otherwise read as the no-bundle choice and hide the change.
     const changed =
       seed != null && (seed.creditTier ?? NO_EXTRA_CREDITS) !== creditChoice;
     const previousCreditLabel =

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -50,7 +50,7 @@ export interface CustomPlanSelection {
   /** `null` is the baseline machine: the absence of a paid tier. */
   machineTier: MachineTierEnum | null;
   storageTier: StorageTierEnum;
-  /** `null` is the explicit "No extra credits" choice. */
+  /** `null` is the explicit no-bundle choice. */
   creditTier: CreditTierEnum | null;
 }
 
@@ -133,8 +133,8 @@ function PickerLabel({
  * white dialog over the dark takeover in the pricing mocks. The three pickers
  * render as dropdowns and start unselected for base checkout (or seeded from
  * the current plan for a Pro reconfigure); Continue stays disabled until every
- * dimension has an explicit choice ("No extra credits" counts) and, for a Pro
- * reconfigure, until at least one dimension differs from the seeded plan.
+ * dimension has an explicit choice (the no-bundle option counts) and, for a
+ * Pro reconfigure, until at least one dimension differs from the seeded plan.
  */
 export function CustomPlanModal({
   open,
@@ -151,7 +151,7 @@ export function CustomPlanModal({
   // A Pro reconfigure seeds the current tiers so the default is a no-op; base
   // checkout passes none and leaves every dimension empty. A baseline machine
   // (null) seeds the sentinel, mirroring how a null credit tier seeds
-  // "No extra credits".
+  // NO_EXTRA_CREDITS.
   const seed = open ? (initialSelection ?? null) : null;
   const [machineTier, setMachineTier] = useState<MachineChoice | "">(() =>
     seed ? (seed.machineTier ?? BASELINE_MACHINE) : "",

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -1714,23 +1714,14 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// The package rows never name a credit amount
-// ---------------------------------------------------------------------------
-
 describe("PlansPage: package usage rows", () => {
   test("every package row reads as the package's usage, never as credits", async () => {
-    const { findByText, getByText, queryByText, container } =
-      renderInteractive(freeSubscription());
+    const { findByText, getByText } = renderInteractive(freeSubscription());
 
     // The name-derived usage rows, matching the plan card's chip.
     await findByText("Mighty usage, reset monthly");
     getByText("Super usage, reset monthly");
     getByText("Ultra usage, reset monthly");
-    // The usage wording wins even though the fixtures carry a usage_label.
-    expect(queryByText("Mighty Usage included")).toBeNull();
-    // No card names a credit amount.
-    expect(container.textContent).not.toContain("in credits included");
   });
 
   test("a package with no usage_label still never falls back to credits", async () => {

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -55,6 +55,7 @@ describe("feature flag catalog", () => {
   });
 
   test("does not expose the retired obscure-credits flag", () => {
+    expect("obscureCredits" in CLIENT_STRING_FLAG_DEFAULTS).toBe(false);
     expect("obscureCredits" in CLIENT_FLAG_DEFAULTS).toBe(false);
     expect("obscureCredits" in ASSISTANT_FLAG_DEFAULTS).toBe(false);
   });


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for remove-obscure-credits-flag.md.

- plans-page tests no longer assert the absence of copy whose i18n keys were deleted; the duplicate banner comment is gone.
- custom-plan-diff and custom-plan-modal comments describe the no-bundle label as the code now supplies it instead of quoting retired copy.
- The obscure-credits catalog guard also checks CLIENT_STRING_FLAG_DEFAULTS, matching its sibling guard.