### PR TITLE
fix: pass the usage label to packageSpecs directly and align plan tile stories

### DIFF
--- a/clients/web/src/components/upsell-walls-overview.stories.tsx
+++ b/clients/web/src/components/upsell-walls-overview.stories.tsx
@@ -362,9 +362,11 @@ export const ResourceAndEntitlementWalls: Story = {
                     Next Plan
                   </Tag>
                 }
-                specs={packageSpecs(SUPER_PACKAGE, {
-                  usageLabel: "Super usage, reset monthly",
-                })}
+                specs={packageSpecs(
+                  SUPER_PACKAGE,
+                  "Super usage, reset monthly",
+                )}
+                specsWrap
                 footer={
                   <Button
                     variant="primary"

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -51,7 +51,7 @@ describe("packageSpecs", () => {
         credits_usd: 25,
         storage_gib: 10,
       } as ProPackage,
-      { usageLabel: "Mighty usage, reset monthly" },
+      "Mighty usage, reset monthly",
     );
     expect(specs.map((s) => s.label)).toEqual([
       "Small Machine",
@@ -69,7 +69,7 @@ describe("packageSpecs", () => {
         credits_usd: 45,
         storage_gib: 30,
       } as ProPackage,
-      { usageLabel: "Super usage, reset monthly" },
+      "Super usage, reset monthly",
     );
     expect(specs.map((s) => s.label)).toEqual([
       "Medium Machine",
@@ -86,7 +86,7 @@ describe("packageSpecs", () => {
         credits_usd: 45,
         storage_gib: 30,
       } as ProPackage,
-      { usageLabel: "Super usage, reset monthly" },
+      "Super usage, reset monthly",
     );
     expect(specs.map((s) => s.label)).toEqual([
       "Medium Machine",
@@ -105,7 +105,7 @@ describe("packageSpecs", () => {
         credits_usd: 45,
         storage_gib: 30,
       } as ProPackage,
-      { usageLabel: "Super usage, reset monthly" },
+      "Super usage, reset monthly",
     );
     // Machine and storage share the wrapping row; the credits phrase and the
     // email/subdomain extra each take a full row below it.
@@ -120,7 +120,7 @@ describe("packageSpecs", () => {
   test("keeps the credits chip on its own row", () => {
     const specs = packageSpecs(
       { key: "mighty", credits_usd: 25, storage_gib: 10 } as ProPackage,
-      { usageLabel: "Mighty usage, reset monthly" },
+      "Mighty usage, reset monthly",
     );
     expect(specs[2].ownRow).toBe(true);
   });

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -33,9 +33,9 @@ export interface PlanSpec {
   multiline?: boolean;
   /**
    * Give the chip a full-width row of its own instead of letting it flow in the
-   * wrapping row beside the short chips. Read only by the wrapped layout
-   * (`PlanTile`'s `specsWrap`); the vertical stack gives every chip its own row
-   * already.
+   * wrapping row beside the short chips. The plan card lays its chips out as a
+   * wrapping row (`PlanTile`'s `specsWrap`), so this takes effect there; the
+   * vertical stack gives every chip its own row and ignores it.
    */
   ownRow?: boolean;
 }
@@ -55,14 +55,6 @@ export function machineLabel(pkg: ProPackage | null): string {
   return SIZE_LABEL[size] ?? pkg.machine_size;
 }
 
-export interface PackageSpecsOptions {
-  /**
-   * The localized credits chip text, supplied by the caller because this pure
-   * module has no `t()`.
-   */
-  usageLabel: string;
-}
-
 /**
  * The spec chips for a package, in mock order: machine, storage, credits,
  * then any static extras from the tier copy (today only the email/subdomain
@@ -72,16 +64,16 @@ export interface PackageSpecsOptions {
  * The machine and storage chips are short enough to sit side by side; the
  * credits chip and the extras are sentences, so they take a row each wherever
  * the chips are laid out as a wrapping row.
+ *
+ * `usageLabel` is the localized credits chip text, supplied by the caller
+ * because this pure module has no `t()`.
  */
-export function packageSpecs(
-  pkg: ProPackage,
-  opts: PackageSpecsOptions,
-): PlanSpec[] {
+export function packageSpecs(pkg: ProPackage, usageLabel: string): PlanSpec[] {
   const extras = getPlanTierCopy(pkg.key)?.extraFeatures ?? [];
   return [
     { icon: Computer, label: `${machineLabel(pkg)} Machine` },
     { icon: HardDrive, label: `${pkg.storage_gib} GB Storage` },
-    { icon: Coins, label: opts.usageLabel, ownRow: true },
+    { icon: Coins, label: usageLabel, ownRow: true },
     ...extras.map((label) => ({ icon: Mail, label, ownRow: true })),
   ];
 }

--- a/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
@@ -168,9 +168,7 @@ export const CurrentPaid: Story = {
     name: MIGHTY.name,
     nameTestId: "plan-card-name",
     tag: CURRENT_TAG,
-    specs: packageSpecs(MIGHTY, {
-      usageLabel: usageChip(MIGHTY.name),
-    }),
+    specs: packageSpecs(MIGHTY, usageChip(MIGHTY.name)),
     specsWrap: true,
     footer: <UsageBalancePanel ratio={0.42} />,
   },
@@ -202,9 +200,7 @@ export const CurrentPaidNoUsageReading: Story = {
     name: MIGHTY.name,
     nameTestId: "plan-card-name",
     tag: CURRENT_TAG,
-    specs: packageSpecs(MIGHTY, {
-      usageLabel: usageChip(MIGHTY.name),
-    }),
+    specs: packageSpecs(MIGHTY, usageChip(MIGHTY.name)),
     specsWrap: true,
     footer: priceFooter(priceLabelFromCents(MIGHTY.total_price_cents)),
   },
@@ -244,9 +240,7 @@ export const NextPlan: Story = {
     tierKey: SUPER.key,
     name: SUPER.name,
     tag: NEXT_PLAN_TAG,
-    specs: packageSpecs(SUPER, {
-      usageLabel: usageChip(SUPER.name),
-    }),
+    specs: packageSpecs(SUPER, usageChip(SUPER.name)),
     specsWrap: true,
     footer: upgradeCta(),
   },
@@ -289,9 +283,7 @@ export const SideBySide: Story = {
           name={MIGHTY.name}
           nameTestId="plan-card-name"
           tag={CURRENT_TAG}
-          specs={packageSpecs(MIGHTY, {
-            usageLabel: usageChip(MIGHTY.name),
-          })}
+          specs={packageSpecs(MIGHTY, usageChip(MIGHTY.name))}
           specsWrap
           footer={priceFooter(priceLabelFromCents(MIGHTY.total_price_cents))}
         />
@@ -301,9 +293,7 @@ export const SideBySide: Story = {
           tierKey={SUPER.key}
           name={SUPER.name}
           tag={NEXT_PLAN_TAG}
-          specs={packageSpecs(SUPER, {
-            usageLabel: usageChip(SUPER.name),
-          })}
+          specs={packageSpecs(SUPER, usageChip(SUPER.name))}
           specsWrap
           footer={upgradeCta()}
         />

--- a/clients/web/src/domains/settings/billing/plan-tile.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.test.tsx
@@ -27,10 +27,14 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 
 const { PlanTile } = await import("./plan-tile");
 
+/**
+ * Chips with no `ownRow`: the vertical stack, or a wrapping row with nothing
+ * split out below it.
+ */
 const SPECS: PlanSpec[] = [
   { icon: Computer, label: "Small Machine" },
   { icon: HardDrive, label: "10 GB Storage" },
-  { icon: Coins, label: "$25 in credits included" },
+  { icon: Coins, label: "Mighty usage, reset monthly" },
 ];
 
 /** The production shape: two short chips, then two full-width rows. */

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1117,344 +1117,348 @@ describe("PlanCard recommended upgrade — change-package", () => {
  * `renderToStaticMarkup`: a static render is single-pass, so the billing reads
  * behind the bar would never settle.
  */
-test("a Pro clean pin trades its price footer for the usage balance", async () => {
-  totalUsageBalance = "25.00";
-  availableUsageBalance = "15.00";
-  const { container, findByTestId, queryByTestId } = renderCardInteractive(
-    proMightySubscription(),
-    plansWithSuper(),
-    () => {},
-  );
+describe("PlanCard usage balance footer", () => {
+  test("a Pro clean pin trades its price footer for the usage balance", async () => {
+    totalUsageBalance = "25.00";
+    availableUsageBalance = "15.00";
+    const { container, findByTestId, queryByTestId } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+    );
 
-  // $10 of the $25 the cycle granted is gone.
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("Usage Balance");
-  expect(panel.textContent).toContain("40% used");
-  // The bar is the replacement, so the monthly price must not stand beside
-  // it on the current tile.
-  expect(queryByTestId("plan-card-price")).toBeNull();
-  expect(within(currentTile(container)).queryByText("$30/month")).toBeNull();
-});
-
-test("both tiles name the package's usage rather than a dollar bundle", () => {
-  const { container } = renderCardInteractive(
-    proMightySubscription(),
-    plansWithSuper(),
-    () => {},
-  );
-
-  const current = within(currentTile(container));
-  expect(current.getByText("Mighty usage, reset monthly")).toBeTruthy();
-  // Machine and storage chips keep their own copy.
-  expect(current.getByText("10 GB Storage")).toBeTruthy();
-
-  const next = within(nextTile(container));
-  expect(next.getByText("Super usage, reset monthly")).toBeTruthy();
-});
-
-test("both tiles wrap their short chips into a row, usage below", () => {
-  const { container } = renderCardInteractive(
-    proMightySubscription(),
-    plansWithSuper(),
-    () => {},
-  );
-
-  for (const [tile, usageLabel] of [
-    [currentTile(container), "Mighty usage, reset monthly"],
-    [nextTile(container), "Super usage, reset monthly"],
-  ] as const) {
-    // Child 0 is the header row; child 1 is the chip container.
-    const chips = tile.children[1] as HTMLElement;
-    const wrapRow = chips.firstElementChild as HTMLElement;
-    expect(wrapRow.className).toContain("flex-wrap");
-    expect(wrapRow.textContent).toContain("Machine");
-    expect(wrapRow.textContent).toContain("Storage");
-    expect(wrapRow.textContent).not.toContain(usageLabel);
-    // The usage chip is the first full-width row underneath (Super's email
-    // extra takes another below it).
-    expect(chips.children[1]?.textContent).toBe(usageLabel);
-  }
-});
-
-test("keeps the price row when the summary reports no grant figures", async () => {
-  // An older platform omits both usage-grant fields, so there is no honest
-  // reading. The tile keeps its price rather than an empty footer.
-  const { container } = renderCardInteractive(
-    proMightySubscription(),
-    plansWithSuper(),
-    () => {},
-  );
-
-  await act(async () => {
-    await Promise.resolve();
+    // $10 of the $25 the cycle granted is gone.
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("Usage Balance");
+    expect(panel.textContent).toContain("40% used");
+    // The bar is the replacement, so the monthly price must not stand beside
+    // it on the current tile.
+    expect(queryByTestId("plan-card-price")).toBeNull();
+    expect(within(currentTile(container)).queryByText("$30/month")).toBeNull();
   });
-  expect(
-    container.querySelector('[data-testid="plan-usage-balance"]'),
-  ).toBeNull();
-  expect(
-    within(currentTile(container)).getByTestId("plan-card-price").textContent,
-  ).toBe("$30/month");
-});
 
-test("a Custom sub reads the same summary and still shows no chips", async () => {
-  // A customized pin matches no stock package, but the bar never needs one:
-  // the summary's grant figures say what the sub actually holds.
-  totalUsageBalance = "45.00";
-  availableUsageBalance = "36.00";
-  const { container, findByTestId } = renderCardInteractive(
-    customProSubscription("credits_45"),
-    plansWithCreditTiers(),
-    () => {},
-  );
+  test("both tiles name the package's usage rather than a dollar bundle", () => {
+    const { container } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+    );
 
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("20% used");
-  // A Custom sub still enumerates nothing and still quotes no price.
-  const current = within(currentTile(container));
-  expect(current.queryByText("Mighty usage, reset monthly")).toBeNull();
-  expect(current.queryByText("10 GB Storage")).toBeNull();
-  expect(current.queryByTestId("plan-card-price")).toBeNull();
-});
+    const current = within(currentTile(container));
+    expect(current.getByText("Mighty usage, reset monthly")).toBeTruthy();
+    // Machine and storage chips keep their own copy.
+    expect(current.getByText("10 GB Storage")).toBeTruthy();
 
-test("a Custom sub with no live grants reads as fully spent", async () => {
-  // Every grant this sub ever held is used or expired, so the summary's
-  // total is zero. The plan has nothing left to give, which is a full bar
-  // with no reset date, not a missing one.
-  totalUsageBalance = "0.00";
-  availableUsageBalance = "0.00";
-  const { findByTestId, queryByTestId, queryByText } = renderCardInteractive(
-    customProSubscription(null),
-    plansWithCreditTiers(),
-    () => {},
-  );
-
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("100% used");
-  expect(
-    panel
-      .querySelector('[data-slot="progress-bar-fill"]')
-      ?.getAttribute("style"),
-  ).toContain("--system-negative-strong");
-  expect(queryByTestId("plan-card-price")).toBeNull();
-  // The wallet is not known to be empty, so nothing is being offered.
-  expect(
-    queryByText("Add credits to continue using your assistant"),
-  ).toBeNull();
-});
-
-test("no live grants with an empty wallet alarms and offers credits", async () => {
-  totalUsageBalance = "0.00";
-  availableUsageBalance = "0.00";
-  walletBalance = "0";
-  const { findByTestId, getByText } = renderCardInteractive(
-    customProSubscription(null),
-    plansWithCreditTiers(),
-    () => {},
-  );
-
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("100% used");
-  expect(
-    getByText("Add credits to continue using your assistant"),
-  ).toBeTruthy();
-});
-
-test("a spent bundle with an empty wallet alarms and offers credits", async () => {
-  // The whole $25 the cycle granted is gone, and no purchased credits
-  // behind it.
-  totalUsageBalance = "25.00";
-  availableUsageBalance = "0.00";
-  walletBalance = "0";
-  const { findByTestId, getByText, queryByTestId } = renderCardInteractive(
-    proMightySubscription(),
-    plansWithSuper(),
-    () => {},
-  );
-
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("100% used");
-  expect(
-    getByText("Add credits to continue using your assistant"),
-  ).toBeTruthy();
-  expect(
-    panel
-      .querySelector('[data-slot="progress-bar-fill"]')
-      ?.getAttribute("style"),
-  ).toContain("--system-negative-strong");
-
-  expect(queryByTestId("add-credits-modal")).toBeNull();
-  fireEvent.click(await findByTestId("plan-usage-add-credits"));
-  expect(await findByTestId("add-credits-modal")).toBeTruthy();
-});
-
-test("a BYOK org with an empty wallet still gets the strip", async () => {
-  // The hook holds `isExhausted` down for a provably BYOK chat route, where
-  // a turn never spends the managed wallet. This surface reports the wallet
-  // itself, so an empty one alarms regardless of how chat dispatches.
-  totalUsageBalance = "25.00";
-  availableUsageBalance = "0.00";
-  walletBalance = "0";
-  byokSuppressed = true;
-  const { findByTestId, getByText } = renderCardInteractive(
-    proMightySubscription(),
-    plansWithSuper(),
-    () => {},
-  );
-
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("100% used");
-  expect(
-    getByText("Add credits to continue using your assistant"),
-  ).toBeTruthy();
-});
-
-test("a spent bundle turns negative with credits still in hand", async () => {
-  // 100% of the granted usage, and the wallet still covers the next turn.
-  // The reading goes red anyway; only the strip waits on the wallet.
-  totalUsageBalance = "25.00";
-  availableUsageBalance = "0.00";
-  walletBalance = "12.50";
-  const { findByTestId, getByText, queryByText, queryByTestId } =
-    renderCardInteractive(proMightySubscription(), plansWithSuper(), () => {});
-
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("100% used");
-  expect(
-    panel
-      .querySelector('[data-slot="progress-bar-fill"]')
-      ?.getAttribute("style"),
-  ).toContain("--system-negative-strong");
-  expect(getByText("100% used").className).toContain(
-    "--system-negative-strong",
-  );
-  expect(
-    queryByText("Add credits to continue using your assistant"),
-  ).toBeNull();
-  expect(queryByTestId("plan-usage-add-credits")).toBeNull();
-});
-
-test("an empty wallet mid-cycle leaves the bar alone", async () => {
-  // The strip belongs to a spent bundle, and so does the negative reading.
-  // Below 100% the tile reads the same as it always has, whatever the wallet
-  // says.
-  totalUsageBalance = "25.00";
-  availableUsageBalance = "15.00";
-  walletBalance = "0";
-  const { findByTestId, queryByText } = renderCardInteractive(
-    proMightySubscription(),
-    plansWithSuper(),
-    () => {},
-  );
-
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("40% used");
-  expect(
-    panel
-      .querySelector('[data-slot="progress-bar-fill"]')
-      ?.getAttribute("style"),
-  ).not.toContain("--system-negative-strong");
-  expect(
-    queryByText("Add credits to continue using your assistant"),
-  ).toBeNull();
-});
-
-test("a free plan with no grant falls back to Free Forever and its own chips", () => {
-  // Nothing has reported a usage grant, so there is no denominator for the
-  // free tile's bar. Suppressing the footer here would leave the tile with an
-  // empty bottom slot, so the price row stays as the fallback.
-  const { container } = renderCardInteractive(
-    baseSubscription(),
-    basePlansResponse(),
-    () => {},
-  );
-
-  const current = within(currentTile(container));
-  expect(current.getByTestId("plan-card-price").textContent).toBe(
-    "Free Forever",
-  );
-  expect(
-    container.querySelector('[data-testid="plan-usage-balance"]'),
-  ).toBeNull();
-  expect(current.getByText("Pay as you go credits")).toBeTruthy();
-});
-
-test("a free plan hides Free Forever once its usage-grant bar renders", async () => {
-  // $3.40 of the $5.00 this account was granted, so the bar reads 68% and
-  // takes the footer over from the price row.
-  totalUsageBalance = "5.00";
-  availableUsageBalance = "1.60";
-  const { container, findByTestId } = renderCardInteractive(
-    baseSubscription(),
-    basePlansResponse(),
-    () => {},
-  );
-
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("Usage Balance");
-  expect(panel.textContent).toContain("68% used");
-  const current = within(currentTile(container));
-  expect(current.queryByTestId("plan-card-price")).toBeNull();
-  expect(current.queryByText("Free Forever")).toBeNull();
-});
-
-test("a free plan that was never granted credit keeps only its price row", async () => {
-  totalUsageBalance = "0.00";
-  availableUsageBalance = "0.00";
-  const { container } = renderCardInteractive(
-    baseSubscription(),
-    basePlansResponse(),
-    () => {},
-  );
-
-  await act(async () => {
-    await Promise.resolve();
+    const next = within(nextTile(container));
+    expect(next.getByText("Super usage, reset monthly")).toBeTruthy();
   });
-  // Nothing granted is not a reading, so the tile renders exactly what it
-  // always has.
-  expect(
-    container.querySelector('[data-testid="plan-usage-balance"]'),
-  ).toBeNull();
-  expect(
-    within(currentTile(container)).getByTestId("plan-card-price").textContent,
-  ).toBe("Free Forever");
-});
 
-test("a fully used grant alarms only once the wallet is empty too", async () => {
-  // The whole $5.00 grant used, and no purchased credits behind it.
-  totalUsageBalance = "5.00";
-  availableUsageBalance = "0.00";
-  walletBalance = "0";
-  const { findByTestId, getByText } = renderCardInteractive(
-    baseSubscription(),
-    basePlansResponse(),
-    () => {},
-  );
+  test("both tiles wrap their short chips into a row, usage below", () => {
+    const { container } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+    );
 
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("100% used");
-  expect(
-    getByText("Add credits to continue using your assistant"),
-  ).toBeTruthy();
-});
+    for (const [tile, usageLabel] of [
+      [currentTile(container), "Mighty usage, reset monthly"],
+      [nextTile(container), "Super usage, reset monthly"],
+    ] as const) {
+      // Child 0 is the header row; child 1 is the chip container.
+      const chips = tile.children[1] as HTMLElement;
+      const wrapRow = chips.firstElementChild as HTMLElement;
+      expect(wrapRow.className).toContain("flex-wrap");
+      expect(wrapRow.textContent).toContain("Machine");
+      expect(wrapRow.textContent).toContain("Storage");
+      expect(wrapRow.textContent).not.toContain(usageLabel);
+      // The usage chip is the first full-width row underneath (Super's email
+      // extra takes another below it).
+      expect(chips.children[1]?.textContent).toBe(usageLabel);
+    }
+  });
 
-test("a fully used grant with purchased credits stays red without a strip", async () => {
-  totalUsageBalance = "5.00";
-  availableUsageBalance = "0.00";
-  walletBalance = "12.50";
-  const { findByTestId, queryByText } = renderCardInteractive(
-    baseSubscription(),
-    basePlansResponse(),
-    () => {},
-  );
+  test("keeps the price row when the summary reports no grant figures", async () => {
+    // An older platform omits both usage-grant fields, so there is no honest
+    // reading. The tile keeps its price rather than an empty footer.
+    const { container } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+    );
 
-  const panel = await findByTestId("plan-usage-balance");
-  expect(panel.textContent).toContain("100% used");
-  expect(
-    panel
-      .querySelector('[data-slot="progress-bar-fill"]')
-      ?.getAttribute("style"),
-  ).toContain("--system-negative-strong");
-  expect(
-    queryByText("Add credits to continue using your assistant"),
-  ).toBeNull();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(
+      container.querySelector('[data-testid="plan-usage-balance"]'),
+    ).toBeNull();
+    expect(
+      within(currentTile(container)).getByTestId("plan-card-price").textContent,
+    ).toBe("$30/month");
+  });
+
+  test("a Custom sub reads the same summary and still shows no chips", async () => {
+    // A customized pin matches no stock package, but the bar never needs one:
+    // the summary's grant figures say what the sub actually holds.
+    totalUsageBalance = "45.00";
+    availableUsageBalance = "36.00";
+    const { container, findByTestId } = renderCardInteractive(
+      customProSubscription("credits_45"),
+      plansWithCreditTiers(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("20% used");
+    // A Custom sub still enumerates nothing and still quotes no price.
+    const current = within(currentTile(container));
+    expect(current.queryByText("Mighty usage, reset monthly")).toBeNull();
+    expect(current.queryByText("10 GB Storage")).toBeNull();
+    expect(current.queryByTestId("plan-card-price")).toBeNull();
+  });
+
+  test("a Custom sub with no live grants reads as fully spent", async () => {
+    // Every grant this sub ever held is used or expired, so the summary's
+    // total is zero. The plan has nothing left to give, which is a full bar
+    // with no reset date, not a missing one.
+    totalUsageBalance = "0.00";
+    availableUsageBalance = "0.00";
+    const { findByTestId, queryByTestId, queryByText } = renderCardInteractive(
+      customProSubscription(null),
+      plansWithCreditTiers(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("100% used");
+    expect(
+      panel
+        .querySelector('[data-slot="progress-bar-fill"]')
+        ?.getAttribute("style"),
+    ).toContain("--system-negative-strong");
+    expect(queryByTestId("plan-card-price")).toBeNull();
+    // The wallet is not known to be empty, so nothing is being offered.
+    expect(
+      queryByText("Add credits to continue using your assistant"),
+    ).toBeNull();
+  });
+
+  test("no live grants with an empty wallet alarms and offers credits", async () => {
+    totalUsageBalance = "0.00";
+    availableUsageBalance = "0.00";
+    walletBalance = "0";
+    const { findByTestId, getByText } = renderCardInteractive(
+      customProSubscription(null),
+      plansWithCreditTiers(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("100% used");
+    expect(
+      getByText("Add credits to continue using your assistant"),
+    ).toBeTruthy();
+  });
+
+  test("a spent bundle with an empty wallet alarms and offers credits", async () => {
+    // The whole $25 the cycle granted is gone, and no purchased credits
+    // behind it.
+    totalUsageBalance = "25.00";
+    availableUsageBalance = "0.00";
+    walletBalance = "0";
+    const { findByTestId, getByText, queryByTestId } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("100% used");
+    expect(
+      getByText("Add credits to continue using your assistant"),
+    ).toBeTruthy();
+    expect(
+      panel
+        .querySelector('[data-slot="progress-bar-fill"]')
+        ?.getAttribute("style"),
+    ).toContain("--system-negative-strong");
+
+    expect(queryByTestId("add-credits-modal")).toBeNull();
+    fireEvent.click(await findByTestId("plan-usage-add-credits"));
+    expect(await findByTestId("add-credits-modal")).toBeTruthy();
+  });
+
+  test("a BYOK org with an empty wallet still gets the strip", async () => {
+    // The hook holds `isExhausted` down for a provably BYOK chat route, where
+    // a turn never spends the managed wallet. This surface reports the wallet
+    // itself, so an empty one alarms regardless of how chat dispatches.
+    totalUsageBalance = "25.00";
+    availableUsageBalance = "0.00";
+    walletBalance = "0";
+    byokSuppressed = true;
+    const { findByTestId, getByText } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("100% used");
+    expect(
+      getByText("Add credits to continue using your assistant"),
+    ).toBeTruthy();
+  });
+
+  test("a spent bundle turns negative with credits still in hand", async () => {
+    // 100% of the granted usage, and the wallet still covers the next turn.
+    // The reading goes red anyway; only the strip waits on the wallet.
+    totalUsageBalance = "25.00";
+    availableUsageBalance = "0.00";
+    walletBalance = "12.50";
+    const { findByTestId, getByText, queryByText, queryByTestId } =
+      renderCardInteractive(
+        proMightySubscription(),
+        plansWithSuper(),
+        () => {},
+      );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("100% used");
+    expect(
+      panel
+        .querySelector('[data-slot="progress-bar-fill"]')
+        ?.getAttribute("style"),
+    ).toContain("--system-negative-strong");
+    expect(getByText("100% used").className).toContain(
+      "--system-negative-strong",
+    );
+    expect(
+      queryByText("Add credits to continue using your assistant"),
+    ).toBeNull();
+    expect(queryByTestId("plan-usage-add-credits")).toBeNull();
+  });
+
+  test("an empty wallet mid-cycle leaves the bar alone", async () => {
+    // The strip belongs to a spent bundle, and so does the negative reading.
+    // Below 100% the wallet balance does not reach the bar.
+    totalUsageBalance = "25.00";
+    availableUsageBalance = "15.00";
+    walletBalance = "0";
+    const { findByTestId, queryByText } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("40% used");
+    expect(
+      panel
+        .querySelector('[data-slot="progress-bar-fill"]')
+        ?.getAttribute("style"),
+    ).not.toContain("--system-negative-strong");
+    expect(
+      queryByText("Add credits to continue using your assistant"),
+    ).toBeNull();
+  });
+
+  test("a free plan with no grant falls back to Free Forever and its own chips", () => {
+    // Nothing has reported a usage grant, so there is no denominator for the
+    // free tile's bar. Suppressing the footer here would leave the tile with an
+    // empty bottom slot, so the price row stays as the fallback.
+    const { container } = renderCardInteractive(
+      baseSubscription(),
+      basePlansResponse(),
+      () => {},
+    );
+
+    const current = within(currentTile(container));
+    expect(current.getByTestId("plan-card-price").textContent).toBe(
+      "Free Forever",
+    );
+    expect(
+      container.querySelector('[data-testid="plan-usage-balance"]'),
+    ).toBeNull();
+    expect(current.getByText("Pay as you go credits")).toBeTruthy();
+  });
+
+  test("a free plan hides Free Forever once its usage-grant bar renders", async () => {
+    // $3.40 of the $5.00 this account was granted, so the bar reads 68% and
+    // takes the footer over from the price row.
+    totalUsageBalance = "5.00";
+    availableUsageBalance = "1.60";
+    const { container, findByTestId } = renderCardInteractive(
+      baseSubscription(),
+      basePlansResponse(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("Usage Balance");
+    expect(panel.textContent).toContain("68% used");
+    const current = within(currentTile(container));
+    expect(current.queryByTestId("plan-card-price")).toBeNull();
+    expect(current.queryByText("Free Forever")).toBeNull();
+  });
+
+  test("a free plan that was never granted credit keeps only its price row", async () => {
+    totalUsageBalance = "0.00";
+    availableUsageBalance = "0.00";
+    const { container } = renderCardInteractive(
+      baseSubscription(),
+      basePlansResponse(),
+      () => {},
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Nothing granted is not a reading, so the tile keeps its price row.
+    expect(
+      container.querySelector('[data-testid="plan-usage-balance"]'),
+    ).toBeNull();
+    expect(
+      within(currentTile(container)).getByTestId("plan-card-price").textContent,
+    ).toBe("Free Forever");
+  });
+
+  test("a fully used grant alarms only once the wallet is empty too", async () => {
+    // The whole $5.00 grant used, and no purchased credits behind it.
+    totalUsageBalance = "5.00";
+    availableUsageBalance = "0.00";
+    walletBalance = "0";
+    const { findByTestId, getByText } = renderCardInteractive(
+      baseSubscription(),
+      basePlansResponse(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("100% used");
+    expect(
+      getByText("Add credits to continue using your assistant"),
+    ).toBeTruthy();
+  });
+
+  test("a fully used grant with purchased credits stays red without a strip", async () => {
+    totalUsageBalance = "5.00";
+    availableUsageBalance = "0.00";
+    walletBalance = "12.50";
+    const { findByTestId, queryByText } = renderCardInteractive(
+      baseSubscription(),
+      basePlansResponse(),
+      () => {},
+    );
+
+    const panel = await findByTestId("plan-usage-balance");
+    expect(panel.textContent).toContain("100% used");
+    expect(
+      panel
+        .querySelector('[data-slot="progress-bar-fill"]')
+        ?.getAttribute("style"),
+    ).toContain("--system-negative-strong");
+    expect(
+      queryByText("Add credits to continue using your assistant"),
+    ).toBeNull();
+  });
 });

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -287,9 +287,10 @@ function RecommendedUpgrade({
             {t("planCard.nextPlan")}
           </Tag>
         }
-        specs={packageSpecs(recommended, {
-          usageLabel: t("planCard.usageChip", { name: recommended.name }),
-        })}
+        specs={packageSpecs(
+          recommended,
+          t("planCard.usageChip", { name: recommended.name }),
+        )}
         specsWrap
         footer={
           <Button
@@ -464,9 +465,10 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   const currentSpecs = isFreePlan
     ? freePlanSpecs()
     : currentPackage
-      ? packageSpecs(currentPackage, {
-          usageLabel: t("planCard.usageChip", { name: currentPackage.name }),
-        })
+      ? packageSpecs(
+          currentPackage,
+          t("planCard.usageChip", { name: currentPackage.name }),
+        )
       : null;
   const currentPriceCents = isFreePlan
     ? 0


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for remove-obscure-credits-flag.md.

- packageSpecs takes the usage label as a plain string; the one-field PackageSpecsOptions wrapper is gone.
- The upsell-walls overview Next plan tile passes specsWrap like the plan card does; the ownRow docstring describes the wrapped layout.
- Plan tile test fixture wording matches what packageSpecs emits; the plan card usage balance tests are grouped under a describe again.