### PR TITLE
fix: inline the preferences credits row check and describe the usage code as it is

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -220,7 +220,7 @@ mock.module("@/domains/chat/components/credits-card", () => ({
     ),
 }));
 
-const { PreferencesMenu, showsMenuCredits } =
+const { PreferencesMenu } =
   await import("@/domains/chat/components/preferences-menu");
 
 /** Opens the menu the way a touch user does, and returns the open surface. */
@@ -546,17 +546,5 @@ describe("PreferencesMenu", () => {
     // The real panel renders nothing without a reading, so the row is the only
     // balance and the only way to buy more.
     expect(screen.getByTestId("credits-card")).toBeTruthy();
-  });
-});
-
-describe("showsMenuCredits", () => {
-  test("hides the row whenever there is a reading", () => {
-    expect(showsMenuCredits(usage(0.99))).toBe(false);
-    expect(showsMenuCredits(usage(1))).toBe(false);
-    expect(showsMenuCredits(usage(1, true))).toBe(false);
-  });
-
-  test("an unmeasurable reading falls back to showing the row", () => {
-    expect(showsMenuCredits(null)).toBe(true);
   });
 });

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -24,7 +24,6 @@ import {
   ShareFeedbackModalLazy,
 } from "@/components/share-feedback-modal-lazy";
 import { ThemeToggle } from "@/components/theme-toggle";
-import type { PreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
@@ -47,30 +46,6 @@ const AddCreditsModal = lazy(() =>
   })),
 );
 
-/**
- * The trigger names the menu it opens, never the signed-in account. This is a
- * settings entry point rather than a profile row, and the account's identity
- * belongs on the Settings page the menu links to.
- */
-
-/**
- * Whether the credits row belongs below the usage panel.
- *
- * The dollar balance stays hidden whenever there is a usage reading to stand
- * in for it. While the included bundle has room the bar is the reading that
- * matters, and a second number beside it only invites arithmetic. Once the
- * bundle is spent the panel itself says the next turn draws on extra usage
- * credits, and once the wallet is empty too its add-credits strip takes over,
- * so the row never earns its place.
- *
- * With no reading to hide behind, the row stays: the panel renders nothing
- * without one, and hiding the row too would leave the menu with no balance and
- * no way to buy more.
- */
-export function showsMenuCredits(usage: PreferencesUsage | null): boolean {
-  return usage == null;
-}
-
 export interface PreferencesMenuProps {
   assistantId?: string | null;
   assistantVersion?: string | null;
@@ -82,6 +57,11 @@ export interface PreferencesMenuProps {
   triggerVariant?: "item" | "pill";
 }
 
+/**
+ * The trigger names the menu it opens, never the signed-in account. This is a
+ * settings entry point rather than a profile row, and the account's identity
+ * belongs on the Settings page the menu links to.
+ */
 export function PreferencesMenu({
   assistantId,
   assistantVersion,
@@ -269,7 +249,8 @@ function PreferencesMenuContent({
   /* The same reading the usage panel below draws, composed once so the row and
      the bar can never disagree about how much of the bundle is left. */
   const usage = usePreferencesUsage({ conversationId: activeConversationId });
-  const showCredits = showsMenuCredits(usage);
+  // The credits row shows only when there is no usage reading to draw instead.
+  const showCredits = usage == null;
 
   return (
     <>

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
@@ -21,7 +21,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { CreditsCard } from "@/domains/chat/components/credits-card";
-import { showsMenuCredits } from "@/domains/chat/components/preferences-menu";
 import { PreferencesUsagePanel } from "@/domains/chat/components/preferences-usage-panel";
 import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import {
@@ -83,9 +82,9 @@ function PanelOnly() {
 
 /**
  * The panel with the compact credits row beneath it, composed the way
- * `PreferencesMenuContent` composes them: `showsMenuCredits` decides whether
- * the row belongs on screen, and `displayedCreditsUsd` decides what it names,
- * so the story exercises both real rules. The seeded balance is already in the
+ * `PreferencesMenuContent` composes them: the row belongs on screen only
+ * without a usage reading, and `displayedCreditsUsd` decides what it names, so
+ * the story exercises both real rules. The seeded balance is already in the
  * two-decimal shape the menu formats it to.
  */
 function PanelWithCredits() {
@@ -95,7 +94,7 @@ function PanelWithCredits() {
     balance,
     availableUsageBalance,
   } = useBillingBalanceStatus();
-  const showCredits = showsMenuCredits(usage);
+  const showCredits = usage == null;
 
   return (
     <>
@@ -261,9 +260,8 @@ export const NoLiveGrants: Story = {
 /**
  * The same spent grants as `SpentBundle`, now with the menu's composition
  * around it: the panel's amber line already names what the next turn draws
- * on, so `showsMenuCredits` keeps the compact credits row off screen. The
- * row only appears when there is no usage reading for the flag to hide the
- * dollar balance behind.
+ * on, so the compact credits row stays off screen. The row only appears when
+ * there is no usage reading to stand in for the dollar balance.
  */
 export const SpentWithoutCreditsRow: Story = {
   name: "Spent bundle, no credits row",

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.tsx
@@ -19,9 +19,9 @@ export interface PreferencesUsagePanelProps {
 /**
  * The preferences menu's usage reading: the same usage-balance reading the
  * billing Plan tile draws, close to where the work is being done.
- * `usePreferencesUsage` decides whether there is anything honest to say, and
- * returns nothing when the org has no managed billing to read or before a real
- * number lands, so the menu is otherwise exactly what it has always been.
+ * `usePreferencesUsage` decides whether there is anything honest to say, so
+ * this renders nothing until the org has managed billing and a real number has
+ * landed.
  */
 export function PreferencesUsagePanel({
   onOpenBilling,

--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
@@ -35,9 +35,8 @@ export interface PreferencesUsage {
 }
 
 /**
- * Null while the org has no managed billing to read, and before an honest
- * number lands, so every caller renders exactly what it always has until there
- * is something real to say.
+ * Null until the org has managed billing and a real reading has landed, so no
+ * caller draws a usage figure it cannot stand behind.
  *
  * `conversationId` is the chat the reading is for. It reaches the wallet
  * status so a managed per-conversation profile pin classifies `exhausted`

--- a/clients/web/src/lib/billing/displayed-credits.ts
+++ b/clients/web/src/lib/billing/displayed-credits.ts
@@ -1,24 +1,22 @@
 /**
- * What the credit figures name.
+ * The dollar figure the "Credits" labels name: what was bought or earned on
+ * top of the usage grants.
  *
  * The initial credit grant and a Pro sub's monthly bundle are what the Usage
- * Balance bar measures, so the numbers labelled "Credits" state only what was
- * bought or earned on top of them. Shared by the billing page's balance tile
- * and the preferences menu's credits row so the two can never quote different
- * amounts for the same wallet.
+ * Balance bar measures, so the credits figures leave those out. Shared by the
+ * billing page's balance tile and the preferences menu's credits row so the
+ * two can never quote different amounts for the same wallet.
  *
  * The banners and the exhausted/low-balance flags stay keyed on the full
- * effective balance: what the next turn can actually spend has not changed,
- * only what is worth naming separately.
+ * effective balance, which is what the next turn can actually spend.
  */
 
 import { parseUsd } from "@/lib/billing/parse-usd";
 
 /**
  * The balance to display: the effective balance less whatever is still unused
- * on the usage grants, never below zero. Returns the balance untouched on a
- * platform that reports no grant figure at all, so both call sites stay
- * byte-identical in that case without repeating the check.
+ * on the usage grants, never below zero. Returns the balance untouched when
+ * the platform reports no grant figure.
  */
 export function displayedCreditsUsd(
   balance: string,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for remove-obscure-credits-flag.md.

- The credits row check is an inline null test at its two call sites; the showsMenuCredits export and its test block are gone.
- Story and module comments in the chat preferences hook, panel, and displayed-credits helper describe the current behaviour rather than the retired flag.