### PR TITLE
fix: resolve the takeover credits chip by bundle label alone

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -1332,82 +1332,80 @@ describe("ProvisioningState phase hold", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Credits chip wording: the chips name usage bundles, never a credit amount
-// ---------------------------------------------------------------------------
+describe("credits chip wording", () => {
+  test("the resize credits chip names the bundle on each side", () => {
+    const { getByTestId } = renderState({
+      state: "WAITING",
+      creditsChange: { fromTier: null, toTier: "credits_50" },
+    });
 
-test("the resize credits chip names the bundle on each side", () => {
-  const { getByTestId } = renderState({
-    state: "WAITING",
-    creditsChange: { fromTier: null, toTier: "credits_50" },
+    const chip = getByTestId("chip-credits");
+    expect(within(chip).getByText("Usage")).toBeTruthy();
+    expect(chip.textContent).toContain("No extra usage");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(chip.textContent).not.toContain("$");
   });
 
-  const chip = getByTestId("chip-credits");
-  expect(within(chip).getByText("Usage")).toBeTruthy();
-  expect(chip.textContent).toContain("No extra usage");
-  expect(chip.textContent).toContain("Mighty Usage");
-  expect(chip.textContent).not.toContain("$");
-});
+  test("a dropped bundle reads down to the no-extra-usage sentinel", () => {
+    const { getByTestId } = renderState({
+      state: "NOT_APPLICABLE",
+      creditsChange: { fromTier: "credits_50", toTier: null },
+    });
 
-test("a dropped bundle reads down to the no-extra-usage sentinel", () => {
-  const { getByTestId } = renderState({
-    state: "NOT_APPLICABLE",
-    creditsChange: { fromTier: "credits_50", toTier: null },
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(chip.textContent).toContain("No extra usage");
+    expect(chip.textContent).not.toContain("$");
   });
 
-  const chip = getByTestId("chip-credits");
-  expect(chip.textContent).toContain("Mighty Usage");
-  expect(chip.textContent).toContain("No extra usage");
-  expect(chip.textContent).not.toContain("$");
-});
+  test("a checkout credits chip reads as bundles too", () => {
+    const { getByTestId } = renderState({
+      state: "WAITING",
+      intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
+    });
 
-test("a checkout credits chip reads as bundles too", () => {
-  const { getByTestId } = renderState({
-    state: "WAITING",
-    intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("No extra usage");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(chip.textContent).not.toContain("$");
   });
 
-  const chip = getByTestId("chip-credits");
-  expect(chip.textContent).toContain("No extra usage");
-  expect(chip.textContent).toContain("Mighty Usage");
-  expect(chip.textContent).not.toContain("$");
-});
+  test("a from-side the catalog can't label is left unstated", () => {
+    // credits_25 is absent from the fixture catalog, so nothing words its side of
+    // the move.
+    const { getByTestId } = renderState({
+      state: "WAITING",
+      creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
+    });
 
-test("a from-side the catalog can't label is left unstated", () => {
-  // credits_25 is absent from the fixture catalog, so nothing words its side of
-  // the move.
-  const { getByTestId } = renderState({
-    state: "WAITING",
-    creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(chip.textContent).not.toContain("25");
+    expect(chip.querySelector(".lucide-arrow-right")).toBeNull();
   });
 
-  const chip = getByTestId("chip-credits");
-  expect(chip.textContent).toContain("Mighty Usage");
-  expect(chip.textContent).not.toContain("25");
-  expect(chip.querySelector(".lucide-arrow-right")).toBeNull();
-});
+  test("a to-side the catalog can't label drops the whole chip", () => {
+    const { queryByTestId } = renderState({
+      state: "WAITING",
+      creditsChange: { fromTier: "credits_50", toTier: "credits_25" },
+    });
 
-test("a to-side the catalog can't label drops the whole chip", () => {
-  const { queryByTestId } = renderState({
-    state: "WAITING",
-    creditsChange: { fromTier: "credits_50", toTier: "credits_25" },
+    expect(queryByTestId("chip-credits")).toBeNull();
   });
 
-  expect(queryByTestId("chip-credits")).toBeNull();
-});
+  test("the confirming custom-intent chip names the bundle, not a count", () => {
+    const { getByText, queryByText } = renderState({
+      state: "CONFIRMING",
+      intent: {
+        kind: "custom",
+        machineTier: "medium",
+        storageTier: "s",
+        creditTier: "credits_50",
+        savedAt: Date.now(),
+      },
+    });
 
-test("the confirming custom-intent chip names the bundle, not a count", () => {
-  const { getByText, queryByText } = renderState({
-    state: "CONFIRMING",
-    intent: {
-      kind: "custom",
-      machineTier: "medium",
-      storageTier: "s",
-      creditTier: "credits_50",
-      savedAt: Date.now(),
-    },
+    expect(getByText("Mighty Usage")).toBeTruthy();
+    expect(queryByText("50 credits")).toBeNull();
   });
-
-  expect(getByText("Mighty Usage")).toBeTruthy();
-  expect(queryByText("50 credits")).toBeNull();
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/takeover-story-support.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/takeover-story-support.tsx
@@ -98,8 +98,8 @@ function creditTier(
 
 /**
  * One catalog for every story. `machine_tiers` and `storage_tiers` are empty
- * because the takeover reads only `credit_tiers` (to price and name the credits
- * chip) and `packages` (to resolve a package intent's bundle).
+ * because the takeover reads only `credit_tiers` (to name the credits chip) and
+ * `packages` (to resolve a package intent's bundle).
  *
  * `credits_45` and `credits_115` are the packages' own bundles, which the
  * platform does not offer in the picker, so they carry the `legacy` marking the

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -33,10 +33,14 @@ const { useProvisioningCredits, useResizeCreditsChange } =
   await import("./use-provisioning-credits");
 
 /**
- * A pro-plan catalog with a `credits_50` tier and a Mighty package on it. The
- * tier label is a usage bundle's Stripe product name, amount-free like the
- * real catalog's, and deliberately distinct from the package's `usage_label`
- * so the label-precedence assertions can tell the two apart.
+ * A pro-plan catalog with a `credits_50` tier and packages on it. The tier label
+ * is a usage bundle's Stripe product name, amount-free like the real catalog's,
+ * and deliberately distinct from the package's `usage_label` so the
+ * label-precedence assertions can tell the two apart.
+ *
+ * The packages differ in what words their bundle: Mighty carries its own
+ * `usage_label`, Tierless leans on the tier's, and Unpriced names a bundle the
+ * catalog neither lists nor prices.
  */
 function plansResponse(): PlanListResponse {
   return {
@@ -73,6 +77,25 @@ function plansResponse(): PlanListResponse {
             storage_gib: 10,
             credits_usd: 50,
             usage_label: "Mighty Usage",
+            include_platform_fee: false,
+            base_price_cents: 4000,
+            machine_price_cents: 0,
+            storage_price_cents: 0,
+            credit_price_cents: 0,
+            total_price_cents: 4000,
+          },
+          {
+            key: "unpriced",
+            name: "Unpriced",
+            description: "",
+            version: 1,
+            machine_tier: null,
+            storage_tier: "xs",
+            credit_tier: "credits_100",
+            machine_size: null,
+            storage_gib: 10,
+            credits_usd: null,
+            usage_label: "Boundless Usage",
             include_platform_fee: false,
             base_price_cents: 4000,
             machine_price_cents: 0,
@@ -170,33 +193,26 @@ describe("useProvisioningCredits", () => {
     ).toBeNull();
   });
 
-  test("resolves a package's credits from $0, since the base plan bundles none", () => {
+  test("names a package's bundle, moving from the base plan's no-bundle side", () => {
     expect(
       renderCredits(
         { kind: "package", packageKey: "mighty", savedAt: 0 },
         plansResponse(),
       ),
     ).toEqual({
-      fromUsd: 0,
-      toUsd: 50,
       fromLabel: null,
       // The customer-facing usage_label wins over the tier label.
       toLabel: "Mighty Usage",
     });
   });
 
-  test("falls back to the package's credit tier when it carries no credits_usd", () => {
+  test("falls back to the package's credit tier when it carries no usage_label", () => {
     expect(
       renderCredits(
         { kind: "package", packageKey: "tierless", savedAt: 0 },
         plansResponse(),
       ),
-    ).toEqual({
-      fromUsd: 0,
-      toUsd: 50,
-      fromLabel: null,
-      toLabel: "Mighty Usage Monthly",
-    });
+    ).toEqual({ fromLabel: null, toLabel: "Mighty Usage Monthly" });
   });
 
   test("labels from the package's usage_label when its tier is missing from the catalog", () => {
@@ -207,12 +223,19 @@ describe("useProvisioningCredits", () => {
         { kind: "package", packageKey: "mighty", savedAt: 0 },
         plans,
       ),
-    ).toEqual({
-      fromUsd: 0,
-      toUsd: 50,
-      fromLabel: null,
-      toLabel: "Mighty Usage",
-    });
+    ).toEqual({ fromLabel: null, toLabel: "Mighty Usage" });
+  });
+
+  test("names a bundle the catalog carries no amount for", () => {
+    // The package prices no credits of its own and its tier is absent from the
+    // catalog, so nothing about it resolves to an amount; its usage_label still
+    // words the chip.
+    expect(
+      renderCredits(
+        { kind: "package", packageKey: "unpriced", savedAt: 0 },
+        plansResponse(),
+      ),
+    ).toEqual({ fromLabel: null, toLabel: "Boundless Usage" });
   });
 
   test("returns null for an unknown package key", () => {
@@ -236,12 +259,7 @@ describe("useProvisioningCredits", () => {
         },
         plansResponse(),
       ),
-    ).toEqual({
-      fromUsd: 0,
-      toUsd: 50,
-      fromLabel: null,
-      toLabel: "Mighty Usage Monthly",
-    });
+    ).toEqual({ fromLabel: null, toLabel: "Mighty Usage Monthly" });
   });
 
   test("returns null for a custom intent without credits", () => {
@@ -272,53 +290,38 @@ describe("useResizeCreditsChange", () => {
     return withClient(() => useResizeCreditsChange(change), plans).value;
   }
 
-  test("resolves both sides from the catalog", () => {
+  test("names both sides from the catalog", () => {
     expect(
       renderChange({ fromTier: null, toTier: "credits_50" }, plansResponse()),
-    ).toEqual({
-      fromUsd: 0,
-      toUsd: 50,
-      fromLabel: null,
-      toLabel: "Mighty Usage Monthly",
-    });
+    ).toEqual({ fromLabel: null, toLabel: "Mighty Usage Monthly" });
   });
 
-  test("reads a dropped bundle as a move down to $0", () => {
+  test("reads a dropped bundle as a move to the no-bundle side", () => {
     // "No extra credits" is a real endpoint of the change, not a missing side.
     expect(
       renderChange({ fromTier: "credits_50", toTier: null }, plansResponse()),
-    ).toEqual({
-      fromUsd: 50,
-      toUsd: 0,
-      fromLabel: "Mighty Usage Monthly",
-      toLabel: null,
-    });
+    ).toEqual({ fromLabel: "Mighty Usage Monthly", toLabel: null });
   });
 
-  test("reads a held tier the catalog no longer lists off its key", () => {
-    // A grandfathered bundle is absent from the offered tiers, so the catalog
-    // can't price it; its key carries the dollars.
+  test("leaves a held tier the catalog no longer lists unstated", () => {
+    // A grandfathered bundle is absent from the offered tiers, so nothing words
+    // that side and the chip states only where the move lands.
     expect(
       renderChange(
         { fromTier: "credits_115", toTier: "credits_50" },
         plansResponse(),
       ),
-    ).toEqual({
-      fromUsd: 115,
-      toUsd: 50,
-      // No catalog entry to word the held tier, so its label side is absent.
-      fromLabel: undefined,
-      toLabel: "Mighty Usage Monthly",
-    });
+    ).toEqual({ fromLabel: undefined, toLabel: "Mighty Usage Monthly" });
   });
 
-  test("omits the chip when a tier carries no resolvable amount", () => {
-    // Version skew: the server names a tier this bundle's enum doesn't list and
-    // whose key holds no dollar figure. A wrong number is worse than no chip.
+  test("omits the chip when the catalog can't word the to-side", () => {
+    // Version skew: the server names a tier this bundle's enum doesn't list.
+    // A chip that can't name where the move lands says nothing worth showing,
+    // whatever it could have said about the side it left.
     const skewedTier = "credits_unlimited" as unknown as CreditTierEnum;
     expect(
       renderChange(
-        { fromTier: skewedTier, toTier: "credits_50" },
+        { fromTier: "credits_50", toTier: skewedTier },
         plansResponse(),
       ),
     ).toBeNull();

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -4,21 +4,15 @@ import { organizationsBillingPlansRetrieveOptions } from "@/generated/api/@tanst
 import type { CreditTierEnum, ProPlan } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
-import { creditTierKeyUsd, findCreditTier } from "@/lib/billing/credit-tiers";
+import { findCreditTier } from "@/lib/billing/credit-tiers";
 
 /**
- * A credit bundle change as monthly dollar amounts. Both sides always carry a
- * number: "No extra credits" is $0, not an absent side.
- *
- * Each side also carries the bundle's catalog label ("Mighty Usage", the
- * Stripe product name, so it matches the invoice line), which is what the chip
- * renders. `null` marks the explicit no-bundle side, worded by the caller;
- * `undefined` a bundle the catalog can't label, which the chip leaves
- * unstated.
+ * The two sides of a credit bundle change, each as the catalog label the chip
+ * renders ("Mighty Usage", the Stripe product name, so it matches the invoice
+ * line). `null` marks the explicit no-bundle side, worded by the caller;
+ * `undefined` a bundle the catalog can't label, which the chip leaves unstated.
  */
 export interface CreditsChange {
-  fromUsd: number;
-  toUsd: number;
   fromLabel: string | null | undefined;
   toLabel: string | null | undefined;
 }
@@ -51,28 +45,9 @@ function useProPlan(enabled: boolean): ProPlan | undefined {
 }
 
 /**
- * The monthly dollars a credit tier bundles. A null tier is the "No extra
- * credits" choice and costs nothing, and the catalog prices everything it
- * lists; a tier it doesn't falls back to the amount its key names. Anything
- * else stays unresolved, so the chip is dropped rather than rendering a wrong
- * number.
- */
-function creditTierUsd(
-  proPlan: ProPlan | undefined,
-  tier: CreditTierEnum | null,
-): number | null {
-  if (tier == null) {
-    return 0;
-  }
-  return findCreditTier(proPlan, tier)?.credits_usd ?? creditTierKeyUsd(tier);
-}
-
-/**
- * The catalog label for a tier, with the same null-tier reading as
- * `creditTierUsd`: a null tier is the explicit "No extra credits" choice
- * (`null` here), and a tier the catalog doesn't list has no label to give
- * (`undefined`); unlike the dollars, a key like `credits_115` carries no
- * wording to fall back to.
+ * The catalog label for a tier. A null tier is the explicit "No extra credits"
+ * choice (`null` here), and a tier the catalog doesn't list has no label to give
+ * (`undefined`): a key like `credits_115` carries no wording to fall back to.
  */
 function creditTierLabel(
   proPlan: ProPlan | undefined,
@@ -85,10 +60,10 @@ function creditTierLabel(
 }
 
 /**
- * The credits a post-Stripe checkout buys, as a from-to dollar pair. The base
- * plan bundles none, so the from-side is $0. Returns null while the catalog
- * loads, when the intent carries no credits, or when the amount can't be
- * resolved, and the chip is omitted. Display-only.
+ * The bundle labels a post-Stripe checkout's chip states. The base plan bundles
+ * none, so the from-side is the explicit no-bundle choice. Returns null while
+ * the catalog loads, when the intent carries no credits, and when the catalog
+ * can't word the bundle bought, and the chip is omitted. Display-only.
  */
 export function useProvisioningCredits(
   intent: CheckoutIntent | null,
@@ -99,33 +74,32 @@ export function useProvisioningCredits(
     return null;
   }
 
-  let toUsd: number | null | undefined;
-  let toLabel: string | null | undefined;
+  let toLabel: string | undefined;
   if (intent.kind === "package") {
     const pkg = proPlan.packages.find((p) => p.key === intent.packageKey);
-    const tier = findCreditTier(proPlan, pkg?.credit_tier);
-    toUsd = pkg?.credits_usd ?? tier?.credits_usd;
     // The package's customer-facing usage_label is preferred: a tier label
     // can be dollar-denominated ("$50 credits/mo"), which the chip must never
     // render. The tier label covers a package without one.
-    toLabel = pkg?.usage_label ?? tier?.label ?? undefined;
+    toLabel =
+      pkg?.usage_label ?? findCreditTier(proPlan, pkg?.credit_tier)?.label;
   } else {
-    const tier = findCreditTier(proPlan, intent.creditTier);
-    toUsd = tier?.credits_usd;
-    toLabel = tier?.label;
+    // A custom checkout without a bundle has no move to state, so an absent
+    // tier resolves undefined and the chip is dropped, not worded as a
+    // no-bundle side the way a resize's endpoint is.
+    toLabel = findCreditTier(proPlan, intent.creditTier)?.label;
   }
 
   // The base plan bundles no credits, so the from-side is the explicit
   // no-bundle choice, not an unlabelled one.
-  return toUsd != null ? { fromUsd: 0, toUsd, fromLabel: null, toLabel } : null;
+  return toLabel !== undefined ? { fromLabel: null, toLabel } : null;
 }
 
 /**
- * The credits an in-place plan change moves between, as a from-to dollar pair.
- * Both endpoints come from the tiers the plans page captured before the change
- * landed, so the chip states the move rather than the outcome. Returns null when
- * no credit change is threaded or when either side can't be resolved, and the
- * chip is omitted. Display-only.
+ * The bundle labels an in-place plan change moves between. Both endpoints come
+ * from the tiers the plans page captured before the change landed, so the chip
+ * states the move rather than the outcome. Returns null when no credit change is
+ * threaded and when the catalog can't word the to-side, and the chip is omitted;
+ * an unwordable from-side is left unstated instead. Display-only.
  */
 export function useResizeCreditsChange(
   change: CreditTierChange | null | undefined,
@@ -135,15 +109,9 @@ export function useResizeCreditsChange(
   if (change == null) {
     return null;
   }
-  const fromUsd = creditTierUsd(proPlan, change.fromTier);
-  const toUsd = creditTierUsd(proPlan, change.toTier);
-  if (fromUsd == null || toUsd == null) {
+  const toLabel = creditTierLabel(proPlan, change.toTier);
+  if (toLabel === undefined) {
     return null;
   }
-  return {
-    fromUsd,
-    toUsd,
-    fromLabel: creditTierLabel(proPlan, change.fromTier),
-    toLabel: creditTierLabel(proPlan, change.toTier),
-  };
+  return { fromLabel: creditTierLabel(proPlan, change.fromTier), toLabel };
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for remove-obscure-credits-flag.md.

- CreditsChange carries only the from and to bundle labels; the dead dollar fields and their null gates are gone, so a labelled tier renders its chip even when its key carries no amount.
- use-provisioning-credits docstrings describe the labels the hooks produce.
- The hoisted credits chip tests are grouped under a describe; the story-support comment no longer talks about pricing.