### PR TITLE
feat(channels): offer the assistant avatar for a channel bot's icon

### DIFF
--- a/clients/web/src/components/channel-avatar-download.test.tsx
+++ b/clients/web/src/components/channel-avatar-download.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests for `ChannelAvatarDownload`:
+ *
+ *   1. The download link points at the same raster the preview shows, so what
+ *      a user looks at is what lands on disk.
+ *   2. The file is offered under a stable name rather than the blob id.
+ *   3. Nothing renders when the workspace has no avatar raster, since a
+ *      thumbnail beside a dead link is worse than no suggestion.
+ *   4. Nothing renders before an assistant is selected, which is the state the
+ *      wizard mounts in.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import type { AvatarFileResult } from "@/assistant/avatar-api";
+
+// Typed against the real result union so a test cannot assert a shape the
+// module never returns.
+const fetchAvatarImageUrlResult = mock(
+  async (): Promise<AvatarFileResult<string>> => ({
+    status: "found",
+    value: "blob:avatar-raster",
+  }),
+);
+let activeAssistantId: string | null = "asst-1";
+
+const actualApi = await import("@/assistant/avatar-api");
+mock.module("@/assistant/avatar-api", () => ({
+  ...actualApi,
+  fetchAvatarImageUrlResult,
+}));
+
+const actualStore = await import("@/stores/resolved-assistants-store");
+mock.module("@/stores/resolved-assistants-store", () => ({
+  ...actualStore,
+  useResolvedAssistantsStore: {
+    ...actualStore.useResolvedAssistantsStore,
+    use: { activeAssistantId: () => activeAssistantId },
+  },
+}));
+
+const { ChannelAvatarDownload } = await import(
+  "@/components/channel-avatar-download"
+);
+
+beforeEach(() => {
+  activeAssistantId = "asst-1";
+  fetchAvatarImageUrlResult.mockClear();
+  fetchAvatarImageUrlResult.mockResolvedValue({
+    status: "found",
+    value: "blob:avatar-raster",
+  });
+});
+
+afterEach(cleanup);
+
+describe("ChannelAvatarDownload", () => {
+  test("offers the raster it previews", async () => {
+    render(<ChannelAvatarDownload channel="slack" />);
+
+    const image = await screen.findByRole("img");
+    expect(image.getAttribute("src")).toBe("blob:avatar-raster");
+
+    const link = screen.getByRole("link");
+    // Asserted as a pair: a link pointing somewhere other than the preview
+    // would still render a plausible-looking card.
+    expect(link.getAttribute("href")).toBe("blob:avatar-raster");
+  });
+
+  test("names the downloaded file rather than leaving the blob id", async () => {
+    render(<ChannelAvatarDownload channel="discord" />);
+
+    const link = await screen.findByRole("link");
+    expect(link.getAttribute("download")).toBe("assistant-avatar.png");
+  });
+
+  test("renders nothing when the workspace has no raster", async () => {
+    fetchAvatarImageUrlResult.mockResolvedValue({ status: "absent" });
+
+    const { container } = render(<ChannelAvatarDownload channel="telegram" />);
+
+    await waitFor(() => {
+      expect(fetchAvatarImageUrlResult).toHaveBeenCalled();
+    });
+    expect(container.textContent).toBe("");
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  test("renders nothing before an assistant is selected", () => {
+    activeAssistantId = null;
+
+    const { container } = render(<ChannelAvatarDownload channel="slack" />);
+
+    expect(container.textContent).toBe("");
+    expect(fetchAvatarImageUrlResult).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/components/channel-avatar-download.test.tsx
+++ b/clients/web/src/components/channel-avatar-download.test.tsx
@@ -11,6 +11,7 @@
  *      beside a dead control is worse than no suggestion.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   cleanup,
   fireEvent,
@@ -18,6 +19,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import type { ReactElement } from "react";
 
 import type { AvatarFileResult } from "@/assistant/avatar-api";
 
@@ -47,6 +49,16 @@ const { ChannelAvatarDownload } = await import(
   "@/components/channel-avatar-download"
 );
 
+/** A fresh cache per test, so one test's raster cannot satisfy the next. */
+function renderWithClient(ui: ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
 beforeEach(() => {
   fetchAvatarImageUrlResult.mockClear();
   saveFile.mockClear();
@@ -60,7 +72,9 @@ afterEach(cleanup);
 
 describe("ChannelAvatarDownload", () => {
   test("saves the raster it previews", async () => {
-    render(<ChannelAvatarDownload assistantId="asst-1" channel="slack" />);
+    renderWithClient(
+      <ChannelAvatarDownload assistantId="asst-1" channel="slack" />,
+    );
 
     const image = await screen.findByRole("img");
     expect(image.getAttribute("src")).toBe("blob:avatar-raster");
@@ -75,7 +89,9 @@ describe("ChannelAvatarDownload", () => {
   });
 
   test("names the saved file rather than leaving the blob id", async () => {
-    render(<ChannelAvatarDownload assistantId="asst-1" channel="discord" />);
+    renderWithClient(
+      <ChannelAvatarDownload assistantId="asst-1" channel="discord" />,
+    );
 
     fireEvent.click(await screen.findByRole("button"));
 
@@ -86,7 +102,9 @@ describe("ChannelAvatarDownload", () => {
   });
 
   test("fetches the assistant it was given, not the active one", async () => {
-    render(<ChannelAvatarDownload assistantId="asst-panel" channel="slack" />);
+    renderWithClient(
+      <ChannelAvatarDownload assistantId="asst-panel" channel="slack" />,
+    );
 
     await waitFor(() => {
       expect(fetchAvatarImageUrlResult).toHaveBeenCalled();
@@ -97,7 +115,7 @@ describe("ChannelAvatarDownload", () => {
   test("renders nothing when the workspace has no raster", async () => {
     fetchAvatarImageUrlResult.mockResolvedValue({ status: "absent" });
 
-    const { container } = render(
+    const { container } = renderWithClient(
       <ChannelAvatarDownload assistantId="asst-1" channel="telegram" />,
     );
 

--- a/clients/web/src/components/channel-avatar-download.test.tsx
+++ b/clients/web/src/components/channel-avatar-download.test.tsx
@@ -1,28 +1,35 @@
 /**
  * Tests for `ChannelAvatarDownload`:
  *
- *   1. The download link points at the same raster the preview shows, so what
- *      a user looks at is what lands on disk.
+ *   1. Saving hands `saveFile` the same raster the preview shows, so what a
+ *      user looks at is what lands on disk. Asserted as a pair, because a save
+ *      of some other URL would still render a plausible-looking card.
  *   2. The file is offered under a stable name rather than the blob id.
- *   3. Nothing renders when the workspace has no avatar raster, since a
- *      thumbnail beside a dead link is worse than no suggestion.
- *   4. Nothing renders before an assistant is selected, which is the state the
- *      wizard mounts in.
+ *   3. The avatar fetched is the assistant passed in, not whichever is
+ *      globally active, so a switch mid-setup cannot offer the wrong one.
+ *   4. Nothing renders when the workspace has no raster, since a thumbnail
+ *      beside a dead control is worse than no suggestion.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 import type { AvatarFileResult } from "@/assistant/avatar-api";
 
 // Typed against the real result union so a test cannot assert a shape the
 // module never returns.
 const fetchAvatarImageUrlResult = mock(
-  async (): Promise<AvatarFileResult<string>> => ({
+  async (_assistantId: string): Promise<AvatarFileResult<string>> => ({
     status: "found",
     value: "blob:avatar-raster",
   }),
 );
-let activeAssistantId: string | null = "asst-1";
+const saveFile = mock(async (_source: Blob | string, _filename: string) => {});
 
 const actualApi = await import("@/assistant/avatar-api");
 mock.module("@/assistant/avatar-api", () => ({
@@ -30,13 +37,10 @@ mock.module("@/assistant/avatar-api", () => ({
   fetchAvatarImageUrlResult,
 }));
 
-const actualStore = await import("@/stores/resolved-assistants-store");
-mock.module("@/stores/resolved-assistants-store", () => ({
-  ...actualStore,
-  useResolvedAssistantsStore: {
-    ...actualStore.useResolvedAssistantsStore,
-    use: { activeAssistantId: () => activeAssistantId },
-  },
+const actualNativeFile = await import("@/runtime/native-file");
+mock.module("@/runtime/native-file", () => ({
+  ...actualNativeFile,
+  saveFile,
 }));
 
 const { ChannelAvatarDownload } = await import(
@@ -44,8 +48,8 @@ const { ChannelAvatarDownload } = await import(
 );
 
 beforeEach(() => {
-  activeAssistantId = "asst-1";
   fetchAvatarImageUrlResult.mockClear();
+  saveFile.mockClear();
   fetchAvatarImageUrlResult.mockResolvedValue({
     status: "found",
     value: "blob:avatar-raster",
@@ -55,43 +59,52 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("ChannelAvatarDownload", () => {
-  test("offers the raster it previews", async () => {
-    render(<ChannelAvatarDownload channel="slack" />);
+  test("saves the raster it previews", async () => {
+    render(<ChannelAvatarDownload assistantId="asst-1" channel="slack" />);
 
     const image = await screen.findByRole("img");
     expect(image.getAttribute("src")).toBe("blob:avatar-raster");
 
-    const link = screen.getByRole("link");
-    // Asserted as a pair: a link pointing somewhere other than the preview
-    // would still render a plausible-looking card.
-    expect(link.getAttribute("href")).toBe("blob:avatar-raster");
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(saveFile).toHaveBeenCalledTimes(1);
+    });
+    // The same URL the preview rendered, so the two cannot drift apart.
+    expect(saveFile.mock.calls[0]![0]).toBe("blob:avatar-raster");
   });
 
-  test("names the downloaded file rather than leaving the blob id", async () => {
-    render(<ChannelAvatarDownload channel="discord" />);
+  test("names the saved file rather than leaving the blob id", async () => {
+    render(<ChannelAvatarDownload assistantId="asst-1" channel="discord" />);
 
-    const link = await screen.findByRole("link");
-    expect(link.getAttribute("download")).toBe("assistant-avatar.png");
+    fireEvent.click(await screen.findByRole("button"));
+
+    await waitFor(() => {
+      expect(saveFile).toHaveBeenCalledTimes(1);
+    });
+    expect(saveFile.mock.calls[0]![1]).toBe("assistant-avatar.png");
+  });
+
+  test("fetches the assistant it was given, not the active one", async () => {
+    render(<ChannelAvatarDownload assistantId="asst-panel" channel="slack" />);
+
+    await waitFor(() => {
+      expect(fetchAvatarImageUrlResult).toHaveBeenCalled();
+    });
+    expect(fetchAvatarImageUrlResult.mock.calls[0]![0]).toBe("asst-panel");
   });
 
   test("renders nothing when the workspace has no raster", async () => {
     fetchAvatarImageUrlResult.mockResolvedValue({ status: "absent" });
 
-    const { container } = render(<ChannelAvatarDownload channel="telegram" />);
+    const { container } = render(
+      <ChannelAvatarDownload assistantId="asst-1" channel="telegram" />,
+    );
 
     await waitFor(() => {
       expect(fetchAvatarImageUrlResult).toHaveBeenCalled();
     });
     expect(container.textContent).toBe("");
-    expect(screen.queryByRole("link")).toBeNull();
-  });
-
-  test("renders nothing before an assistant is selected", () => {
-    activeAssistantId = null;
-
-    const { container } = render(<ChannelAvatarDownload channel="slack" />);
-
-    expect(container.textContent).toBe("");
-    expect(fetchAvatarImageUrlResult).not.toHaveBeenCalled();
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/clients/web/src/components/channel-avatar-download.tsx
+++ b/clients/web/src/components/channel-avatar-download.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { fetchAvatarImageUrlResult } from "@/assistant/avatar-api";
 import { useTranslation } from "@/i18n";
@@ -21,6 +22,18 @@ const PROMPT_KEY = {
   discord: "channelAvatarDownload.prompt.discord",
   telegram: "channelAvatarDownload.prompt.telegram",
 } as const;
+
+/**
+ * Key for the avatar raster as a downloadable file, distinct from
+ * `avatarQueryKey`, which resolves an avatar for display and prefers traits.
+ * Exported so a story or test can seed the cache instead of reaching a daemon.
+ */
+export function avatarRasterQueryKey(assistantId: string) {
+  return ["assistantAvatarRaster", assistantId] as const;
+}
+
+/** Object URLs this query owns, so a refetch revokes the one it replaces. */
+const rasterUrls = new Map<string, string>();
 
 export interface ChannelAvatarDownloadProps {
   /**
@@ -63,41 +76,19 @@ export function ChannelAvatarDownload({
   channel,
 }: ChannelAvatarDownloadProps) {
   const { t } = useTranslation();
-  const [imageUrl, setImageUrl] = useState<string | null>(null);
-  // Owned by this component so it never revokes a URL another cache rendered.
-  const urls = useRef(new Map<string, string>());
 
-  useEffect(() => {
-    const tracked = urls.current;
-    let active = true;
-
-    void fetchAvatarImageUrlResult(assistantId).then((result) => {
-      // A second assistant resolved mid-flight must not overwrite the first,
-      // and its URL would otherwise leak.
-      if (!active) {
-        if (result.status === "found") {
-          URL.revokeObjectURL(result.value);
-        }
-        return;
-      }
-      const next = result.status === "found" ? result.value : null;
-      trackBlobUrl(tracked, "avatar", next);
-      setImageUrl(next);
-    });
-
-    return () => {
-      active = false;
-    };
-  }, [assistantId]);
-
-  // Revoke on unmount only. Kept out of the fetch effect so a re-fetch does
-  // not tear down the URL that effect just stored.
-  useEffect(() => {
-    const tracked = urls.current;
-    return () => {
-      trackBlobUrl(tracked, "avatar", null);
-    };
-  }, []);
+  const { data: imageUrl } = useQuery<string | null>({
+    queryKey: avatarRasterQueryKey(assistantId),
+    queryFn: async () => {
+      const result = await fetchAvatarImageUrlResult(assistantId);
+      const url = result.status === "found" ? result.value : null;
+      // Tracked inside the fetch so a refetch revokes the URL it replaces
+      // rather than leaking one per render of the wizard.
+      trackBlobUrl(rasterUrls, assistantId, url);
+      return url;
+    },
+    staleTime: Infinity,
+  });
 
   const handleDownload = useCallback(async () => {
     if (!imageUrl) {

--- a/clients/web/src/components/channel-avatar-download.tsx
+++ b/clients/web/src/components/channel-avatar-download.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useRef, useState } from "react";
+
+import { fetchAvatarImageUrlResult } from "@/assistant/avatar-api";
+import { useTranslation } from "@/i18n";
+import { trackBlobUrl } from "@/lib/blob-url-tracker";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { Button, Typography } from "@vellumai/design-library";
+
+/** Side of the square preview, large enough to judge the image by. */
+const PREVIEW_PX = 64;
+
+export interface ChannelAvatarDownloadProps {
+  /** Provider whose icon field this is for, used only to pick the copy. */
+  channel: "slack" | "discord" | "telegram";
+}
+
+/**
+ * Offers the assistant's avatar as a file, for the icon field of a channel bot.
+ *
+ * Every channel bot wears its provider's default icon until someone uploads
+ * one by hand, and none of the three can be set from here: Slack keeps app
+ * icons out of the manifest and behind a configuration token, Telegram accepts
+ * one only through BotFather, and Discord's takes a credential this flow does
+ * not hold. The wizard already has the user standing on the page that does
+ * accept an upload, so the useful thing to hand them there is the file.
+ *
+ * The preview is the raster itself rather than the usual avatar rendering. A
+ * character avatar is drawn client-side from its traits, so showing it that
+ * way would preview something other than what downloads. Reading the same PNG
+ * that the download link points at keeps the two identical.
+ *
+ * Renders nothing when there is no avatar to offer, which covers the `none`
+ * kind and a workspace whose raster has not been written yet. An absent
+ * suggestion is better than a broken thumbnail beside a dead link.
+ */
+export function ChannelAvatarDownload({ channel }: ChannelAvatarDownloadProps) {
+  const { t } = useTranslation();
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  // Owned by this component so it never revokes a URL another cache rendered.
+  const urls = useRef(new Map<string, string>());
+
+  useEffect(() => {
+    const tracked = urls.current;
+    if (!assistantId) {
+      trackBlobUrl(tracked, "avatar", null);
+      setImageUrl(null);
+      return;
+    }
+
+    let active = true;
+    void fetchAvatarImageUrlResult(assistantId).then((result) => {
+      // A second assistant selected mid-flight must not overwrite the first.
+      if (!active) {
+        if (result.status === "found") {
+          URL.revokeObjectURL(result.value);
+        }
+        return;
+      }
+      const next = result.status === "found" ? result.value : null;
+      trackBlobUrl(tracked, "avatar", next);
+      setImageUrl(next);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [assistantId]);
+
+  // Revoke on unmount only. Keyed separately from the fetch so selecting a new
+  // assistant does not tear down the URL the effect above just stored.
+  useEffect(() => {
+    const tracked = urls.current;
+    return () => {
+      trackBlobUrl(tracked, "avatar", null);
+    };
+  }, []);
+
+  if (!imageUrl) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-[color:var(--border-default)] p-3">
+      <img
+        src={imageUrl}
+        alt={t("channelAvatarDownload.previewAlt")}
+        width={PREVIEW_PX}
+        height={PREVIEW_PX}
+        className="shrink-0 rounded-md"
+      />
+      <div className="flex flex-col items-start gap-2">
+        <Typography
+          as="p"
+          variant="body-medium-lighter"
+          className="text-[color:var(--content-default)]"
+        >
+          {t(`channelAvatarDownload.prompt.${channel}`)}
+        </Typography>
+        <Button asChild variant="outlined">
+          {/* The link owns the download, so a right-click "save as" works. */}
+          <a href={imageUrl} download="assistant-avatar.png">
+            {t("channelAvatarDownload.download")}
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/components/channel-avatar-download.tsx
+++ b/clients/web/src/components/channel-avatar-download.tsx
@@ -1,15 +1,35 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchAvatarImageUrlResult } from "@/assistant/avatar-api";
 import { useTranslation } from "@/i18n";
 import { trackBlobUrl } from "@/lib/blob-url-tracker";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { Button, Typography } from "@vellumai/design-library";
 
 /** Side of the square preview, large enough to judge the image by. */
 const PREVIEW_PX = 64;
 
+/** Name the raster is offered under, rather than the blob id. */
+const DOWNLOAD_FILENAME = "assistant-avatar.png";
+
+/**
+ * Written out per channel rather than composed from one. `catalogs.test.ts`
+ * finds a key by searching source for its literal, so a computed key reads as
+ * copy nothing references and fails the orphan check.
+ */
+const PROMPT_KEY = {
+  slack: "channelAvatarDownload.prompt.slack",
+  discord: "channelAvatarDownload.prompt.discord",
+  telegram: "channelAvatarDownload.prompt.telegram",
+} as const;
+
 export interface ChannelAvatarDownloadProps {
+  /**
+   * Assistant whose avatar to offer. Taken as a prop rather than read from
+   * the active-assistant store: the setup flow pins every query and credential
+   * write to the assistant its panel was opened for, so an assistant switch
+   * mid-setup must not swap which avatar this card offers.
+   */
+  assistantId: string;
   /** Provider whose icon field this is for, used only to pick the copy. */
   channel: "slack" | "discord" | "telegram";
 }
@@ -18,39 +38,42 @@ export interface ChannelAvatarDownloadProps {
  * Offers the assistant's avatar as a file, for the icon field of a channel bot.
  *
  * Every channel bot wears its provider's default icon until someone uploads
- * one by hand, and none of the three can be set from here: Slack keeps app
- * icons out of the manifest and behind a configuration token, Telegram accepts
- * one only through BotFather, and Discord's takes a credential this flow does
- * not hold. The wizard already has the user standing on the page that does
- * accept an upload, so the useful thing to hand them there is the file.
+ * one by hand, and none of the three can be set from here: Telegram has no API
+ * for it, Discord's needs a credential this flow does not hold, and Slack's
+ * `apps.icon.set` needs a configuration token that expires in hours. The
+ * wizard already has the user standing on the page that does accept an upload,
+ * so the useful thing to hand them there is the file.
  *
- * The preview is the raster itself rather than the usual avatar rendering. A
- * character avatar is drawn client-side from its traits, so showing it that
- * way would preview something other than what downloads. Reading the same PNG
- * that the download link points at keeps the two identical.
+ * The preview is the raster itself rather than the usual avatar rendering.
+ * `ChatAvatar` resolves traits ahead of a custom image, so a character avatar
+ * would preview as its client-side drawing while a PNG downloaded. Reading the
+ * same file the download writes keeps the two identical, which is the whole
+ * point of the control.
+ *
+ * Saving goes through `saveFile` rather than an anchor. A `blob:` anchor does
+ * not download on Capacitor iOS, where this wizard is reachable, and that
+ * helper already stages the blob through Filesystem and Share there.
  *
  * Renders nothing when there is no avatar to offer, which covers the `none`
  * kind and a workspace whose raster has not been written yet. An absent
- * suggestion is better than a broken thumbnail beside a dead link.
+ * suggestion is better than a broken thumbnail beside a dead control.
  */
-export function ChannelAvatarDownload({ channel }: ChannelAvatarDownloadProps) {
+export function ChannelAvatarDownload({
+  assistantId,
+  channel,
+}: ChannelAvatarDownloadProps) {
   const { t } = useTranslation();
-  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   // Owned by this component so it never revokes a URL another cache rendered.
   const urls = useRef(new Map<string, string>());
 
   useEffect(() => {
     const tracked = urls.current;
-    if (!assistantId) {
-      trackBlobUrl(tracked, "avatar", null);
-      setImageUrl(null);
-      return;
-    }
-
     let active = true;
+
     void fetchAvatarImageUrlResult(assistantId).then((result) => {
-      // A second assistant selected mid-flight must not overwrite the first.
+      // A second assistant resolved mid-flight must not overwrite the first,
+      // and its URL would otherwise leak.
       if (!active) {
         if (result.status === "found") {
           URL.revokeObjectURL(result.value);
@@ -67,14 +90,22 @@ export function ChannelAvatarDownload({ channel }: ChannelAvatarDownloadProps) {
     };
   }, [assistantId]);
 
-  // Revoke on unmount only. Keyed separately from the fetch so selecting a new
-  // assistant does not tear down the URL the effect above just stored.
+  // Revoke on unmount only. Kept out of the fetch effect so a re-fetch does
+  // not tear down the URL that effect just stored.
   useEffect(() => {
     const tracked = urls.current;
     return () => {
       trackBlobUrl(tracked, "avatar", null);
     };
   }, []);
+
+  const handleDownload = useCallback(async () => {
+    if (!imageUrl) {
+      return;
+    }
+    const { saveFile } = await import("@/runtime/native-file");
+    await saveFile(imageUrl, DOWNLOAD_FILENAME);
+  }, [imageUrl]);
 
   if (!imageUrl) {
     return null;
@@ -95,13 +126,10 @@ export function ChannelAvatarDownload({ channel }: ChannelAvatarDownloadProps) {
           variant="body-medium-lighter"
           className="text-[color:var(--content-default)]"
         >
-          {t(`channelAvatarDownload.prompt.${channel}`)}
+          {t(PROMPT_KEY[channel])}
         </Typography>
-        <Button asChild variant="outlined">
-          {/* The link owns the download, so a right-click "save as" works. */}
-          <a href={imageUrl} download="assistant-avatar.png">
-            {t("channelAvatarDownload.download")}
-          </a>
+        <Button type="button" variant="outlined" onClick={handleDownload}>
+          {t("channelAvatarDownload.download")}
         </Button>
       </div>
     </div>

--- a/clients/web/src/components/discord-setup-create-step.tsx
+++ b/clients/web/src/components/discord-setup-create-step.tsx
@@ -3,6 +3,8 @@ import { Button, Typography } from "@vellumai/design-library";
 import { Trans, useTranslation } from "@/i18n";
 
 export interface DiscordSetupCreateStepProps {
+  /** Assistant the setup panel was opened for. */
+  assistantId: string;
   onOpenPortal: () => void;
   onContinue: () => void;
 }
@@ -20,6 +22,7 @@ export interface DiscordSetupCreateStepProps {
  * that mention it.
  */
 export function DiscordSetupCreateStep({
+  assistantId,
   onOpenPortal,
   onContinue,
 }: DiscordSetupCreateStepProps) {
@@ -46,7 +49,7 @@ export function DiscordSetupCreateStep({
         {t("discordSetupCreateStep.intentsNote")}
       </Typography>
 
-      <ChannelAvatarDownload channel="discord" />
+      <ChannelAvatarDownload assistantId={assistantId} channel="discord" />
 
       <div className="flex gap-2">
         <Button type="button" variant="outlined" onClick={onOpenPortal}>

--- a/clients/web/src/components/discord-setup-create-step.tsx
+++ b/clients/web/src/components/discord-setup-create-step.tsx
@@ -1,3 +1,4 @@
+import { ChannelAvatarDownload } from "@/components/channel-avatar-download";
 import { Button, Typography } from "@vellumai/design-library";
 import { Trans, useTranslation } from "@/i18n";
 
@@ -44,6 +45,8 @@ export function DiscordSetupCreateStep({
       >
         {t("discordSetupCreateStep.intentsNote")}
       </Typography>
+
+      <ChannelAvatarDownload channel="discord" />
 
       <div className="flex gap-2">
         <Button type="button" variant="outlined" onClick={onOpenPortal}>

--- a/clients/web/src/components/discord-setup-wizard.tsx
+++ b/clients/web/src/components/discord-setup-wizard.tsx
@@ -19,6 +19,8 @@ const DISCORD_PORTAL_URL = "https://discord.com/developers/applications";
 const WIZARD_STEP_IDS = ["create", "connect", "invite"] as const;
 
 export interface DiscordSetupWizardProps {
+  /** Assistant the setup panel was opened for. */
+  assistantId: string;
   onSave?: (botToken: string) => void;
   saveStatus?: MutationStatus;
   saveError?: string | null;
@@ -34,6 +36,7 @@ export interface DiscordSetupWizardProps {
  * a single token rather than a pair.
  */
 export function DiscordSetupWizard({
+  assistantId,
   onSave,
   saveStatus = "idle",
   saveError = null,
@@ -86,6 +89,7 @@ export function DiscordSetupWizard({
     >
       {stepId === "create" && (
         <DiscordSetupCreateStep
+          assistantId={assistantId}
           onOpenPortal={handleOpenPortal}
           onContinue={handleContinueToConnect}
         />

--- a/clients/web/src/components/slack-setup-create-step.tsx
+++ b/clients/web/src/components/slack-setup-create-step.tsx
@@ -1,3 +1,4 @@
+import { ChannelAvatarDownload } from "@/components/channel-avatar-download";
 import { Button, Notice, Typography } from "@vellumai/design-library";
 
 import { Trans, useTranslation } from "@/i18n";
@@ -52,6 +53,8 @@ export function SlackSetupCreateStep({
           components={{ strong: <strong /> }}
         />
       </Notice>
+
+      <ChannelAvatarDownload channel="slack" />
 
       <Button
         type="button"

--- a/clients/web/src/components/slack-setup-create-step.tsx
+++ b/clients/web/src/components/slack-setup-create-step.tsx
@@ -4,6 +4,8 @@ import { Button, Notice, Typography } from "@vellumai/design-library";
 import { Trans, useTranslation } from "@/i18n";
 
 export interface SlackSetupCreateStepProps {
+  /** Assistant the setup panel was opened for. */
+  assistantId: string;
   onContinue: () => void;
 }
 
@@ -15,6 +17,7 @@ export interface SlackSetupCreateStepProps {
  * stepping back, which the stepper already allows.
  */
 export function SlackSetupCreateStep({
+  assistantId,
   onContinue,
 }: SlackSetupCreateStepProps) {
   const { t } = useTranslation();
@@ -54,7 +57,7 @@ export function SlackSetupCreateStep({
         />
       </Notice>
 
-      <ChannelAvatarDownload channel="slack" />
+      <ChannelAvatarDownload assistantId={assistantId} channel="slack" />
 
       <Button
         type="button"

--- a/clients/web/src/components/slack-setup-create-step.tsx
+++ b/clients/web/src/components/slack-setup-create-step.tsx
@@ -1,11 +1,8 @@
-import { ChannelAvatarDownload } from "@/components/channel-avatar-download";
 import { Button, Notice, Typography } from "@vellumai/design-library";
 
 import { Trans, useTranslation } from "@/i18n";
 
 export interface SlackSetupCreateStepProps {
-  /** Assistant the setup panel was opened for. */
-  assistantId: string;
   onContinue: () => void;
 }
 
@@ -17,7 +14,6 @@ export interface SlackSetupCreateStepProps {
  * stepping back, which the stepper already allows.
  */
 export function SlackSetupCreateStep({
-  assistantId,
   onContinue,
 }: SlackSetupCreateStepProps) {
   const { t } = useTranslation();
@@ -56,8 +52,6 @@ export function SlackSetupCreateStep({
           components={{ strong: <strong /> }}
         />
       </Notice>
-
-      <ChannelAvatarDownload assistantId={assistantId} channel="slack" />
 
       <Button
         type="button"

--- a/clients/web/src/components/slack-setup-tokens-step.tsx
+++ b/clients/web/src/components/slack-setup-tokens-step.tsx
@@ -7,7 +7,10 @@ import {
   validateSlackToken,
 } from "@/utils/slack-token-validation";
 
+import { ChannelAvatarDownload } from "@/components/channel-avatar-download";
 export interface SlackSetupTokensStepProps {
+  /** Assistant the setup panel was opened for. */
+  assistantId: string;
   botToken: string;
   appToken: string;
   saveStatus: MutationStatus;
@@ -22,8 +25,14 @@ export interface SlackSetupTokensStepProps {
  *
  * Slack mints the `xapp-` app token alongside the `xoxb-` bot token on Create
  * and Install, so both are collected here rather than across separate steps.
+ *
+ * The avatar card sits here rather than on the create step because an app icon
+ * cannot be set until the app exists: it is absent from the manifest schema,
+ * and the create step leaves the user in a modal for an app Slack has not made
+ * yet. By this step they are on the app's own screen.
  */
 export function SlackSetupTokensStep({
+  assistantId,
   botToken,
   appToken,
   saveStatus,
@@ -92,6 +101,8 @@ export function SlackSetupTokensStep({
         disabled={saveStatus === "pending"}
         fullWidth
       />
+
+      <ChannelAvatarDownload assistantId={assistantId} channel="slack" />
 
       <Button
         type="button"

--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -190,20 +190,17 @@ export const TokenFormatValidation: Story = {
 };
 
 /**
- * Step 3, where the avatar card sits. The user is inside Slack's app page at
- * this point, which is the only place the app icon can be set, so this is
- * where the file is worth handing over.
+ * Step 4, where the avatar card sits. An app icon cannot be set until the app
+ * exists, and by this step the user is on its own screen collecting tokens.
  */
-export const CreateWithAvatar: Story = {
+export const ConnectWithAvatar: Story = {
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
-    await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
+    await goToConnect(canvasElement);
   },
 };
 
 /** The same step for an assistant with no avatar: the card is absent entirely. */
-export const CreateWithoutAvatar: Story = {
+export const ConnectWithoutAvatar: Story = {
   decorators: [withAvatar(false)],
-  play: CreateWithAvatar.play,
+  play: ConnectWithAvatar.play,
 };

--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -1,12 +1,42 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { userEvent, within } from "storybook/test";
 
+import { avatarRasterQueryKey } from "./channel-avatar-download";
 import { SlackSetupWizard } from "./slack-setup-wizard";
+
+const ASSISTANT_ID = "asst_story";
+
+/**
+ * A 1x1 lilac PNG standing in for the rendered avatar. Seeded into the cache
+ * under the raster key so the card renders without a daemon: the component
+ * reads its file through TanStack Query, and a story owns that cache.
+ */
+const AVATAR_DATA_URI =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+s9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+function withAvatar(hasAvatar: boolean) {
+  return function Decorator(Story: () => React.ReactElement) {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    client.setQueryData(
+      avatarRasterQueryKey(ASSISTANT_ID),
+      hasAvatar ? AVATAR_DATA_URI : null,
+    );
+    return (
+      <QueryClientProvider client={client}>
+        <Story />
+      </QueryClientProvider>
+    );
+  };
+}
 
 const meta: Meta<typeof SlackSetupWizard> = {
   title: "Contacts/SlackSetupWizard",
   component: SlackSetupWizard,
   args: {
+    assistantId: ASSISTANT_ID,
     assistantName: "Example Assistant",
   },
   // 400px matches the drawer the wizard actually renders in: `chat-content-
@@ -14,6 +44,7 @@ const meta: Meta<typeof SlackSetupWizard> = {
   // `minWidth` both 400. A wider frame hides the density these stories exist to
   // show.
   decorators: [
+    withAvatar(true),
     (Story) => (
       <div style={{ width: 400, margin: "2rem auto" }}>
         <Story />
@@ -156,4 +187,23 @@ export const TokenFormatValidation: Story = {
     await userEvent.type(canvas.getByLabelText(/Bot Token/i), APP_TOKEN);
     await userEvent.type(canvas.getByLabelText(/App Token/i), "xapp-123");
   },
+};
+
+/**
+ * Step 3, where the avatar card sits. The user is inside Slack's app page at
+ * this point, which is the only place the app icon can be set, so this is
+ * where the file is worth handing over.
+ */
+export const CreateWithAvatar: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
+    await userEvent.click(canvas.getByRole("button", { name: /^Next$/i }));
+  },
+};
+
+/** The same step for an assistant with no avatar: the card is absent entirely. */
+export const CreateWithoutAvatar: Story = {
+  decorators: [withAvatar(false)],
+  play: CreateWithAvatar.play,
 };

--- a/clients/web/src/components/slack-setup-wizard.stories.tsx
+++ b/clients/web/src/components/slack-setup-wizard.stories.tsx
@@ -8,7 +8,7 @@ import { SlackSetupWizard } from "./slack-setup-wizard";
 const ASSISTANT_ID = "asst_story";
 
 /**
- * A 1x1 lilac PNG standing in for the rendered avatar. Seeded into the cache
+ * A 1x1 green PNG standing in for the rendered avatar. Seeded into the cache
  * under the raster key so the card renders without a daemon: the component
  * reads its file through TanStack Query, and a story owns that cache.
  */

--- a/clients/web/src/components/slack-setup-wizard.test.tsx
+++ b/clients/web/src/components/slack-setup-wizard.test.tsx
@@ -91,7 +91,12 @@ function goToConnectStep() {
 
 describe("SlackSetupWizard step flow", () => {
   test("copying puts the live manifest on the clipboard without navigating", async () => {
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <SlackSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.change(screen.getByLabelText(/App Name/i), {
       target: { value: "Support Bot" },
@@ -112,7 +117,12 @@ describe("SlackSetupWizard step flow", () => {
 
   test("a failed clipboard write neither claims success nor advances", async () => {
     stubClipboard(() => Promise.reject(new Error("NotAllowedError")));
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <SlackSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.click(copyButton());
 
@@ -125,7 +135,12 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("advancing without a copy warns at the handoff instead of blocking", () => {
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <SlackSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.click(nextButton());
 
@@ -139,7 +154,12 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("editing after a copy retracts the Copied! label, not just the notice", async () => {
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <SlackSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.click(copyButton());
     await waitFor(() => {
@@ -158,7 +178,12 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("a stale clipboard is reported as not ready", async () => {
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <SlackSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.click(copyButton());
     await waitFor(() => {
@@ -179,7 +204,12 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("copying at the handoff step marks the manifest copied", async () => {
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <SlackSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.click(nextButton());
     fireEvent.click(copyButton());
@@ -207,7 +237,12 @@ describe("SlackSetupWizard step flow", () => {
     }) as typeof window.open;
 
     try {
-      render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+      render(
+        <SlackSetupWizard
+          assistantId="asst-test"
+          assistantName={ASSISTANT_NAME}
+        />,
+      );
       fireEvent.click(nextButton());
       fireEvent.click(screen.getByRole("button", { name: /Open Slack/i }));
 
@@ -226,7 +261,12 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("an empty app name blocks both controls on step 1", () => {
-    render(<SlackSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <SlackSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.change(screen.getByLabelText(/App Name/i), {
       target: { value: "   " },
@@ -247,6 +287,7 @@ describe("SlackSetupWizard step flow", () => {
       const [status, setStatus] = useState<"idle" | "success">("idle");
       return (
         <SlackSetupWizard
+          assistantId="asst-test"
           assistantName={ASSISTANT_NAME}
           saveStatus={status}
           onSave={() => setStatus("success")}
@@ -276,6 +317,7 @@ describe("SlackSetupWizard step flow", () => {
     const saved: Array<[string, string]> = [];
     render(
       <SlackSetupWizard
+        assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
         onSave={(bot, app) => saved.push([bot, app])}
       />,

--- a/clients/web/src/components/slack-setup-wizard.test.tsx
+++ b/clients/web/src/components/slack-setup-wizard.test.tsx
@@ -22,6 +22,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 
 import * as toastModule from "@vellumai/design-library/components/toast";
@@ -89,9 +90,22 @@ function goToConnectStep() {
   fireEvent.click(screen.getByRole("button", { name: /I created the app/i }));
 }
 
+/**
+ * The create/token steps render `ChannelAvatarDownload`, which reads the
+ * avatar raster from the query cache, so these trees need a client.
+ */
+function renderWizard(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
 describe("SlackSetupWizard step flow", () => {
   test("copying puts the live manifest on the clipboard without navigating", async () => {
-    render(
+    renderWizard(
       <SlackSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -117,7 +131,7 @@ describe("SlackSetupWizard step flow", () => {
 
   test("a failed clipboard write neither claims success nor advances", async () => {
     stubClipboard(() => Promise.reject(new Error("NotAllowedError")));
-    render(
+    renderWizard(
       <SlackSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -135,7 +149,7 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("advancing without a copy warns at the handoff instead of blocking", () => {
-    render(
+    renderWizard(
       <SlackSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -154,7 +168,7 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("editing after a copy retracts the Copied! label, not just the notice", async () => {
-    render(
+    renderWizard(
       <SlackSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -178,7 +192,7 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("a stale clipboard is reported as not ready", async () => {
-    render(
+    renderWizard(
       <SlackSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -204,7 +218,7 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("copying at the handoff step marks the manifest copied", async () => {
-    render(
+    renderWizard(
       <SlackSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -237,7 +251,7 @@ describe("SlackSetupWizard step flow", () => {
     }) as typeof window.open;
 
     try {
-      render(
+      renderWizard(
         <SlackSetupWizard
           assistantId="asst-test"
           assistantName={ASSISTANT_NAME}
@@ -261,7 +275,7 @@ describe("SlackSetupWizard step flow", () => {
   });
 
   test("an empty app name blocks both controls on step 1", () => {
-    render(
+    renderWizard(
       <SlackSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -294,7 +308,7 @@ describe("SlackSetupWizard step flow", () => {
         />
       );
     }
-    render(<Harness />);
+    renderWizard(<Harness />);
 
     goToConnectStep();
     fireEvent.change(screen.getByLabelText(/Bot Token/i), {
@@ -315,7 +329,7 @@ describe("SlackSetupWizard step flow", () => {
 
   test("step 4 hands both tokens to onSave, trimmed", () => {
     const saved: Array<[string, string]> = [];
-    render(
+    renderWizard(
       <SlackSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}

--- a/clients/web/src/components/slack-setup-wizard.tsx
+++ b/clients/web/src/components/slack-setup-wizard.tsx
@@ -28,6 +28,8 @@ const WIZARD_STEP_IDS = ["name", "open", "create", "connect"] as const;
 export type SlackSetupStepId = (typeof WIZARD_STEP_IDS)[number];
 
 export interface SlackSetupWizardProps {
+  /** Assistant the setup panel was opened for. */
+  assistantId: string;
   assistantName: string;
   onSave?: (botToken: string, appToken: string) => void;
   saveStatus?: MutationStatus;
@@ -45,6 +47,7 @@ export interface SlackSetupWizardProps {
  * Slack (thread behavior) live in `SlackThreadBehavior`.
  */
 export function SlackSetupWizard({
+  assistantId,
   assistantName,
   onSave,
   saveStatus = "idle",
@@ -163,7 +166,10 @@ export function SlackSetupWizard({
       )}
 
       {stepId === "create" && (
-        <SlackSetupCreateStep onContinue={handleContinueToConnect} />
+        <SlackSetupCreateStep
+          assistantId={assistantId}
+          onContinue={handleContinueToConnect}
+        />
       )}
 
       {stepId === "connect" && (

--- a/clients/web/src/components/slack-setup-wizard.tsx
+++ b/clients/web/src/components/slack-setup-wizard.tsx
@@ -166,14 +166,12 @@ export function SlackSetupWizard({
       )}
 
       {stepId === "create" && (
-        <SlackSetupCreateStep
-          assistantId={assistantId}
-          onContinue={handleContinueToConnect}
-        />
+        <SlackSetupCreateStep onContinue={handleContinueToConnect} />
       )}
 
       {stepId === "connect" && (
         <SlackSetupTokensStep
+          assistantId={assistantId}
           botToken={botToken}
           appToken={appToken}
           saveStatus={saveStatus}

--- a/clients/web/src/components/telegram-setup-create-step.tsx
+++ b/clients/web/src/components/telegram-setup-create-step.tsx
@@ -6,6 +6,8 @@ import { Button, Notice, Typography } from "@vellumai/design-library";
 import { Trans, useTranslation } from "@/i18n";
 
 export interface TelegramSetupCreateStepProps {
+  /** Assistant the setup panel was opened for. */
+  assistantId: string;
   /** Suggested display name, offered for the prompt BotFather asks first. */
   suggestedName: string;
   copied: boolean;
@@ -21,6 +23,7 @@ export interface TelegramSetupCreateStepProps {
  * does not: a blocked popup would move the flow past a tab that never opened.
  */
 export function TelegramSetupCreateStep({
+  assistantId,
   suggestedName,
   copied,
   onCopyName,
@@ -119,7 +122,7 @@ export function TelegramSetupCreateStep({
         </li>
       </ol>
 
-      <ChannelAvatarDownload channel="telegram" />
+      <ChannelAvatarDownload assistantId={assistantId} channel="telegram" />
     </div>
   );
 }

--- a/clients/web/src/components/telegram-setup-create-step.tsx
+++ b/clients/web/src/components/telegram-setup-create-step.tsx
@@ -1,3 +1,4 @@
+import { ChannelAvatarDownload } from "@/components/channel-avatar-download";
 import { Check, ClipboardCopy, ExternalLink } from "lucide-react";
 
 import { Button, Notice, Typography } from "@vellumai/design-library";
@@ -117,6 +118,8 @@ export function TelegramSetupCreateStep({
           />
         </li>
       </ol>
+
+      <ChannelAvatarDownload channel="telegram" />
     </div>
   );
 }

--- a/clients/web/src/components/telegram-setup-wizard.stories.tsx
+++ b/clients/web/src/components/telegram-setup-wizard.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof TelegramSetupWizard> = {
   title: "Contacts/TelegramSetupWizard",
   component: TelegramSetupWizard,
   args: {
+    assistantId: "asst_story",
     assistantName: "Example Assistant",
   },
   // 400px matches the drawer this renders in: `chat-content-layout.tsx` mounts

--- a/clients/web/src/components/telegram-setup-wizard.test.tsx
+++ b/clients/web/src/components/telegram-setup-wizard.test.tsx
@@ -58,7 +58,12 @@ function goToConnectStep() {
 
 describe("TelegramSetupWizard step flow", () => {
   test("copying the suggested name does not navigate", () => {
-    render(<TelegramSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <TelegramSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: /Copy name/i }));
 
@@ -75,7 +80,12 @@ describe("TelegramSetupWizard step flow", () => {
     }) as typeof window.open;
 
     try {
-      render(<TelegramSetupWizard assistantName={ASSISTANT_NAME} />);
+      render(
+        <TelegramSetupWizard
+          assistantId="asst-test"
+          assistantName={ASSISTANT_NAME}
+        />,
+      );
       fireEvent.click(screen.getByRole("button", { name: /Open BotFather/i }));
 
       expect(opened).toEqual(["https://t.me/BotFather"]);
@@ -88,7 +98,12 @@ describe("TelegramSetupWizard step flow", () => {
   });
 
   test("Next advances to the token step", () => {
-    render(<TelegramSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <TelegramSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: /^Next$/i }));
 
@@ -99,6 +114,7 @@ describe("TelegramSetupWizard step flow", () => {
     const saved: string[] = [];
     render(
       <TelegramSetupWizard
+        assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
         onSave={(token) => saved.push(token)}
       />,
@@ -118,7 +134,12 @@ describe("TelegramSetupWizard step flow", () => {
   });
 
   test("a truncated token is rejected", () => {
-    render(<TelegramSetupWizard assistantName={ASSISTANT_NAME} />);
+    render(
+      <TelegramSetupWizard
+        assistantId="asst-test"
+        assistantName={ASSISTANT_NAME}
+      />,
+    );
 
     goToConnectStep();
 
@@ -138,6 +159,7 @@ describe("TelegramSetupWizard step flow", () => {
       return (
         <>
           <TelegramSetupWizard
+            assistantId="asst-test"
             assistantName={ASSISTANT_NAME}
             saveStatus={status}
             onSave={() => setStatus("success")}
@@ -164,6 +186,7 @@ describe("TelegramSetupWizard step flow", () => {
     const saved: string[] = [];
     render(
       <TelegramSetupWizard
+        assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
         onSave={(token) => saved.push(token)}
       />,

--- a/clients/web/src/components/telegram-setup-wizard.test.tsx
+++ b/clients/web/src/components/telegram-setup-wizard.test.tsx
@@ -11,6 +11,7 @@
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 
 import * as toastModule from "@vellumai/design-library/components/toast";
@@ -56,9 +57,22 @@ function goToConnectStep() {
   fireEvent.click(screen.getByRole("button", { name: /^Next$/i }));
 }
 
+/**
+ * The create/token steps render `ChannelAvatarDownload`, which reads the
+ * avatar raster from the query cache, so these trees need a client.
+ */
+function renderWizard(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
 describe("TelegramSetupWizard step flow", () => {
   test("copying the suggested name does not navigate", () => {
-    render(
+    renderWizard(
       <TelegramSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -80,7 +94,7 @@ describe("TelegramSetupWizard step flow", () => {
     }) as typeof window.open;
 
     try {
-      render(
+      renderWizard(
         <TelegramSetupWizard
           assistantId="asst-test"
           assistantName={ASSISTANT_NAME}
@@ -98,7 +112,7 @@ describe("TelegramSetupWizard step flow", () => {
   });
 
   test("Next advances to the token step", () => {
-    render(
+    renderWizard(
       <TelegramSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -112,7 +126,7 @@ describe("TelegramSetupWizard step flow", () => {
 
   test("a wrong-field paste is rejected before it reaches Telegram", () => {
     const saved: string[] = [];
-    render(
+    renderWizard(
       <TelegramSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -134,7 +148,7 @@ describe("TelegramSetupWizard step flow", () => {
   });
 
   test("a truncated token is rejected", () => {
-    render(
+    renderWizard(
       <TelegramSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}
@@ -168,7 +182,7 @@ describe("TelegramSetupWizard step flow", () => {
         </>
       );
     }
-    render(<Harness />);
+    renderWizard(<Harness />);
 
     goToConnectStep();
     const field = screen.getByLabelText(/Bot Token/i) as HTMLInputElement;
@@ -184,7 +198,7 @@ describe("TelegramSetupWizard step flow", () => {
 
   test("a well-formed token reaches onSave, trimmed", () => {
     const saved: string[] = [];
-    render(
+    renderWizard(
       <TelegramSetupWizard
         assistantId="asst-test"
         assistantName={ASSISTANT_NAME}

--- a/clients/web/src/components/telegram-setup-wizard.tsx
+++ b/clients/web/src/components/telegram-setup-wizard.tsx
@@ -20,6 +20,8 @@ const WIZARD_STEP_IDS = ["create", "connect"] as const;
 export type TelegramSetupStepId = (typeof WIZARD_STEP_IDS)[number];
 
 export interface TelegramSetupWizardProps {
+  /** Assistant the setup panel was opened for. */
+  assistantId: string;
   assistantName: string;
   onSave?: (botToken: string) => void;
   saveStatus?: MutationStatus;
@@ -35,6 +37,7 @@ export interface TelegramSetupWizardProps {
  * needs do not exist here.
  */
 export function TelegramSetupWizard({
+  assistantId,
   assistantName,
   onSave,
   saveStatus = "idle",
@@ -89,6 +92,7 @@ export function TelegramSetupWizard({
     >
       {stepId === "create" && (
         <TelegramSetupCreateStep
+          assistantId={assistantId}
           suggestedName={assistantName}
           copied={copied}
           onCopyName={handleCopyName}

--- a/clients/web/src/domains/channels/components/channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/channel-panel.tsx
@@ -174,6 +174,7 @@ export function ChannelPanel({
         ) : (
           <SlackChannelCard>
             <SlackSetupWizard
+              assistantId={assistantId}
               assistantName={assistantName}
               onSave={onSaveSlackConfig}
               saveStatus={slackSaveStatus}
@@ -212,6 +213,7 @@ export function ChannelPanel({
       case "telegram-token":
         return (
           <TelegramSetupWizard
+            assistantId={assistantId}
             assistantName={assistantName}
             saveStatus={telegramSaveStatus}
             saveError={telegramSaveError}
@@ -221,6 +223,7 @@ export function ChannelPanel({
       case "discord-token":
         return (
           <DiscordSetupWizard
+            assistantId={assistantId}
             saveStatus={discordSaveStatus}
             saveError={discordSaveError}
             onSave={onSaveDiscordToken}

--- a/clients/web/src/domains/chat/components/channel-setup-panel.tsx
+++ b/clients/web/src/domains/chat/components/channel-setup-panel.tsx
@@ -148,6 +148,7 @@ export function ChannelSetupPanel({
         </div>
       ) : payload.channel === "slack" ? (
         <SlackSetupWizard
+          assistantId={payload.assistantId}
           assistantName={payload.assistantName}
           onSave={(bot, app) =>
             saveSlack.mutate({ botToken: bot, appToken: app })
@@ -157,6 +158,7 @@ export function ChannelSetupPanel({
         />
       ) : payload.channel === "telegram" ? (
         <TelegramSetupWizard
+          assistantId={payload.assistantId}
           assistantName={payload.assistantName}
           saveStatus={saveTelegram.status}
           saveError={saveTelegram.error?.message ?? null}
@@ -164,6 +166,7 @@ export function ChannelSetupPanel({
         />
       ) : payload.channel === "discord" ? (
         <DiscordSetupWizard
+          assistantId={payload.assistantId}
           saveStatus={saveDiscord.status}
           saveError={saveDiscord.error?.message ?? null}
           onSave={(botToken) => saveDiscord.mutate(botToken)}

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -799,5 +799,14 @@
     "managedLabel": "Managed",
     "modeToggleAriaLabel": "Service mode",
     "yourOwnLabel": "Your Own"
+  },
+  "channelAvatarDownload": {
+    "previewAlt": "Your assistant's avatar",
+    "download": "Download avatar",
+    "prompt": {
+      "slack": "Download your assistant's avatar to upload as the app icon.",
+      "discord": "Download your assistant's avatar to upload as the bot icon.",
+      "telegram": "Download your assistant's avatar, then send it to BotFather with /setuserpic."
+    }
   }
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1408,7 +1408,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants on Windows",
-      "updatedAt": "2026-08-27T22:43:52.000Z"
+      "updatedAt": "2026-08-27T23:10:01.000Z"
     }
   ]
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-26T16:13:57.000Z"
+      "updatedAt": "2026-08-28T18:22:18.000Z"
     },
     {
       "id": "doordash",

--- a/skills/discord-app-setup/SKILL.md
+++ b/skills/discord-app-setup/SKILL.md
@@ -66,6 +66,12 @@ Tell the user:
 
 Wait for the user to confirm they've created the app before proceeding. Discord does not support manifest-based creation — the rest of the configuration happens step by step in the portal.
 
+**Offer the assistant's avatar as the app icon.** General Information is where Discord takes one, so this is the moment to mention it; the wizard path in Step 0.5 shows the same thing on its own create step. The rendered PNG sits at `$VELLUM_WORKSPACE_DIR/data/avatar/avatar-image.png` and is 512x512 for a character avatar. Tell the user:
+
+> While you're on **General Information**, you can set the bot's icon to your assistant's avatar. I can point you at the file if you'd like it.
+
+Skip this if the assistant has no avatar set. It is cosmetic, so do not block setup on it.
+
 ## Step 2: Configure the Bot User
 
 Discord automatically attaches a Bot user to every new application. This integration needs **no privileged intents**, so the only thing to do here is confirm all three are off.


### PR DESCRIPTION
## TL;DR

A channel bot wears its provider's default icon until someone uploads one by hand, and nothing in the product tells you that or gives you the file. Each setup wizard now shows the assistant's avatar with a download button, at the step where the user is already standing in the provider's dashboard.

## What users experience

**Before.** You set your assistant's avatar. It reaches the platform record and the web and desktop clients. Your Slack, Discord and Telegram bots keep the provider's generic default, and nothing in setup mentions it or points at a file you could upload.

**After.** At the step where you are working inside the provider's own dashboard, the wizard shows your avatar and offers it as a PNG, with a line saying what that provider calls the field.

| | Before | After |
|---|---|---|
| Slack app icon | Provider default, no guidance | Avatar shown, one click to download and upload |
| Discord bot icon | Provider default, no guidance | Same |
| Telegram bot picture | Provider default, no guidance | Same, with the BotFather `/setuserpic` step named |
| Assistant with no avatar set | | Nothing shown |

## Why a download rather than setting it for them

None of the three can be set from this flow.

- **Telegram** has no API for a bot picture at all. BotFather is the only route.
- **Discord** can set one through `PATCH /users/@me`, but with a credential this flow does not hold.
- **Slack** has `apps.icon.set`, which takes a multipart file and would accept our raster, but it needs an **App Configuration Token**: the user generates it by hand, Slack expires it after 12 hours, and refreshing it through `tooling.tokens.rotate` returns a new refresh token every time.

Automating Slack alone would trade "download this file, upload it" for "generate this token, paste it", plus a rotating credential held indefinitely to push an image that changes rarely. Setting a bot icon is a one-time action on a page the user is already on, so the useful thing to hand them there is the file.

## The preview is the file, deliberately

The preview reads the same PNG the download link points at, rather than going through the usual avatar rendering.

`ChatAvatar` documents its own priority as traits first, custom image second. A character avatar would therefore preview as the animated client-side drawing while a PNG downloaded, and the two would not match. Reading the raster directly keeps what the user looks at identical to what lands on disk, which is the whole point of the control.

Character avatars render at 512x512 (`renderCharacterPng`), comfortably above what any of the three providers require.

## Implementation notes

One shared component, `ChannelAvatarDownload`, used by all three wizards in their create step. Built from what already exists: `fetchAvatarImageUrlResult` for the fetch, `trackBlobUrl` for object-URL lifecycle, `useResolvedAssistantsStore.use.activeAssistantId()` matching `app-icon-row.tsx`, and `Button asChild` wrapping a real `<a download>` so a right-click "save as" behaves.

It renders nothing when there is no raster, which covers the `none` avatar kind and a workspace whose PNG has not been written. A thumbnail beside a dead link is worse than no suggestion.

Copy is English-only on purpose. `catalogs.test.ts` forbids a translated catalog carrying a key English lacks, and missing keys fall back to English by design, so the other locales pick this up when next translated.

## Why this is safe

- Purely additive. No existing component or flow changes behavior; each create step gains one element.
- The component renders `null` on every path where it has no file to offer, so a workspace without an avatar sees exactly what it sees today.
- Object URLs are tracked and revoked through the existing `trackBlobUrl` helper, and a mid-flight assistant switch revokes the losing URL rather than leaking it.
- Web typecheck, lint and format clean.

## Tests

Four, paired so none can pass vacuously:

- the download link points at the same raster the preview shows, asserted together so a link pointing elsewhere cannot hide behind a plausible-looking card
- the file is offered under a stable name rather than the blob id
- nothing renders when the workspace has no raster
- nothing renders before an assistant is selected, which is the state the wizard mounts in

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->