### PR TITLE
Separate a menu row's shortcut hint from its trailing content

### DIFF
--- a/clients/web/src/components/app-nav-bar.tsx
+++ b/clients/web/src/components/app-nav-bar.tsx
@@ -189,9 +189,7 @@ export function AppNavBar({
             variant="outlined"
             iconOnly={isEditing ? <ChevronUp /> : <Pencil />}
             onClick={onEdit}
-            tooltip={
-              isEditing ? t("appNavBar.openApp") : t("appNavBar.edit")
-            }
+            tooltip={isEditing ? t("appNavBar.openApp") : t("appNavBar.edit")}
             aria-label={
               isEditing ? t("appNavBar.openApp") : t("appNavBar.edit")
             }
@@ -363,7 +361,7 @@ function ShareDeployMenuTrigger({
           <>
             <Menu.Item
               leftIcon={<Link2 size={14} />}
-              shortcut={t("appNavBar.copyLink")}
+              trailing={t("appNavBar.copyLink")}
               onSelect={() => onCopyDeployedLink?.()}
               className="whitespace-nowrap"
             >

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -937,7 +937,7 @@ export function ComposerSettingsMenu({
             ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]"
             : ""
         }
-        shortcut={
+        trailing={
           isActive ? (
             <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
           ) : undefined
@@ -966,7 +966,7 @@ export function ComposerSettingsMenu({
             ? "bg-[var(--surface-active)] text-[var(--content-emphasised)]"
             : ""
         }
-        shortcut={
+        trailing={
           isActive ? (
             <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
           ) : undefined

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -23,11 +23,7 @@ import { formatFriendlyDate } from "@/utils/format-date";
 import { cn } from "@/utils/misc";
 import { shareApp } from "@/utils/share-app";
 import type { SwipeAction } from "@/hooks/use-swipe-to-reveal";
-import {
-  ActionMenu,
-  Button,
-  toast,
-} from "@vellumai/design-library";
+import { ActionMenu, Button, toast } from "@vellumai/design-library";
 
 interface LibraryAppCardProps {
   app: AppSummary;
@@ -250,9 +246,7 @@ export function LibraryAppCardActionsMenu({
       <ActionMenu.Content title={title}>
         <ActionMenu.Item
           icon={isPinned ? PinOff : Pin}
-          label={
-            isPinned ? t("libraryAppCard.unpin") : t("libraryAppCard.pin")
-          }
+          label={isPinned ? t("libraryAppCard.unpin") : t("libraryAppCard.pin")}
           onSelect={onPin}
         />
         {onShare ? (
@@ -269,7 +263,7 @@ export function LibraryAppCardActionsMenu({
               icon={Link2}
               label={t("libraryAppCard.deployed")}
               description={<span className="break-all">{deployedUrl}</span>}
-              shortcut={t("libraryAppCard.copyLink")}
+              trailing={t("libraryAppCard.copyLink")}
               onSelect={() => onCopyDeployedLink?.()}
             />
             <ActionMenu.Item

--- a/packages/design-library/src/components/action-menu.stories.tsx
+++ b/packages/design-library/src/components/action-menu.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { ArrowUp, Ellipsis, Pin, Trash2 } from "lucide-react";
+import { ArrowUp, Ellipsis, Link2, Pin, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useArgs } from "storybook/preview-api";
 import { expect, screen, userEvent, waitFor, within } from "storybook/test";
@@ -143,6 +143,33 @@ export const WithGroupLabel: Story = {
         <ActionMenu.Separator />
         <ActionMenu.Label>Everything</ActionMenu.Label>
         <ActionMenu.Item label="Archive all" />
+      </ActionMenu.Content>
+    </ActionMenu.Root>
+  ),
+};
+
+/**
+ * `shortcut` and `trailing` are both right-aligned, and both belong to the
+ * pointer surface only: flip `presentation` to `sheet` and the rows keep their
+ * labels and lose the right column, since a thumb has no keys and the sheet row
+ * has no trailing slot.
+ */
+export const WithTrailingContent: Story = {
+  args: { title: "Deployment", presentation: "anchored" },
+  render: (args) => (
+    <ActionMenu.Root {...rootArgs(args)}>
+      <ActionMenu.Trigger asChild>
+        <Button variant="outlined">Deployment</Button>
+      </ActionMenu.Trigger>
+      <ActionMenu.Content title={args.title}>
+        <ActionMenu.Item
+          icon={Pin}
+          label="Pin conversation"
+          shortcut="⇧⌘P"
+          ariaKeyShortcuts="Meta+Shift+P"
+        />
+        <ActionMenu.Item icon={Link2} label="Deployed" trailing="Copy link" />
+        <ActionMenu.Item icon={ArrowUp} label="Share" />
       </ActionMenu.Content>
     </ActionMenu.Root>
   ),

--- a/packages/design-library/src/components/action-menu.stories.tsx
+++ b/packages/design-library/src/components/action-menu.stories.tsx
@@ -139,7 +139,7 @@ export const WithGroupLabel: Story = {
       <ActionMenu.Content title={args.title}>
         <ActionMenu.Label>This conversation</ActionMenu.Label>
         <ActionMenu.Item label="Rename" />
-        <ActionMenu.Item label="Duplicate" shortcut="⌘D" />
+        <ActionMenu.Item label="Duplicate" shortcut="CmdOrCtrl+D" />
         <ActionMenu.Separator />
         <ActionMenu.Label>Everything</ActionMenu.Label>
         <ActionMenu.Item label="Archive all" />
@@ -149,10 +149,11 @@ export const WithGroupLabel: Story = {
 };
 
 /**
- * `shortcut` and `trailing` are both right-aligned, and both belong to the
- * pointer surface only: flip `presentation` to `sheet` and the rows keep their
- * labels and lose the right column, since a thumb has no keys and the sheet row
- * has no trailing slot.
+ * `shortcut` takes the accelerator and draws it, announcing the same binding
+ * through `aria-keyshortcuts`. Both slots belong to the pointer surface only:
+ * flip `presentation` to `sheet` and the rows keep their labels and lose the
+ * right column, since a thumb has no keys and the sheet row has no trailing
+ * slot.
  */
 export const WithTrailingContent: Story = {
   args: { title: "Deployment", presentation: "anchored" },
@@ -165,8 +166,7 @@ export const WithTrailingContent: Story = {
         <ActionMenu.Item
           icon={Pin}
           label="Pin conversation"
-          shortcut="⇧⌘P"
-          ariaKeyShortcuts="Meta+Shift+P"
+          shortcut="CmdOrCtrl+Shift+P"
         />
         <ActionMenu.Item icon={Link2} label="Deployed" trailing="Copy link" />
         <ActionMenu.Item icon={ArrowUp} label="Share" />

--- a/packages/design-library/src/components/action-menu.tsx
+++ b/packages/design-library/src/components/action-menu.tsx
@@ -234,6 +234,20 @@ interface ActionMenuItemProps {
   /** Keyboard shortcut hint. Pointer surfaces only, since a sheet has no keys. */
   shortcut?: ReactNode;
   /**
+   * The binding {@link ActionMenuItemProps.shortcut} draws, in
+   * [`aria-keyshortcuts`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts)
+   * form (`"Meta+Shift+P"`). The drawn glyphs are hidden from assistive tech,
+   * so this is what a screen reader announces. Travels with `shortcut`:
+   * pointer surfaces only.
+   */
+  ariaKeyShortcuts?: string;
+  /**
+   * Right-aligned trailing content that is not a keyboard shortcut: a status
+   * glyph, secondary hint text. Anchored presentation only; the sheet row has
+   * no trailing column.
+   */
+  trailing?: ReactNode;
+  /**
    * `"destructive"` paints the row in the negative system colour, for an action
    * that deletes or discards. A tone rather than a caller-supplied class, so
    * the warning looks the same in both presentations: a menu row styled red and
@@ -267,6 +281,8 @@ function Item({
   label,
   description,
   shortcut,
+  ariaKeyShortcuts,
+  trailing,
   tone = "default",
   disabled = false,
   onSelect,
@@ -311,6 +327,8 @@ function Item({
     <Menu.Item
       leftIcon={Icon ? <Icon size={14} /> : undefined}
       shortcut={shortcut}
+      aria-keyshortcuts={ariaKeyShortcuts}
+      trailing={trailing}
       disabled={disabled}
       className={cn(
         "whitespace-nowrap",

--- a/packages/design-library/src/components/action-menu.tsx
+++ b/packages/design-library/src/components/action-menu.tsx
@@ -231,16 +231,12 @@ interface ActionMenuItemProps {
    * label rather than carry anything the label omits.
    */
   description?: ReactNode;
-  /** Keyboard shortcut hint. Pointer surfaces only, since a sheet has no keys. */
-  shortcut?: ReactNode;
   /**
-   * The binding {@link ActionMenuItemProps.shortcut} draws, in
-   * [`aria-keyshortcuts`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-keyshortcuts)
-   * form (`"Meta+Shift+P"`). The drawn glyphs are hidden from assistive tech,
-   * so this is what a screen reader announces. Travels with `shortcut`:
-   * pointer surfaces only.
+   * Electron accelerator for the row's binding, e.g. `"CmdOrCtrl+Shift+P"`.
+   * Draws the glyph hint and announces the binding from the one value. Pointer
+   * surfaces only, since a sheet has no keys.
    */
-  ariaKeyShortcuts?: string;
+  shortcut?: string;
   /**
    * Right-aligned trailing content that is not a keyboard shortcut: a status
    * glyph, secondary hint text. Anchored presentation only; the sheet row has
@@ -281,7 +277,6 @@ function Item({
   label,
   description,
   shortcut,
-  ariaKeyShortcuts,
   trailing,
   tone = "default",
   disabled = false,
@@ -327,7 +322,6 @@ function Item({
     <Menu.Item
       leftIcon={Icon ? <Icon size={14} /> : undefined}
       shortcut={shortcut}
-      aria-keyshortcuts={ariaKeyShortcuts}
       trailing={trailing}
       disabled={disabled}
       className={cn(

--- a/packages/design-library/src/components/context-menu.stories.tsx
+++ b/packages/design-library/src/components/context-menu.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Clipboard, Pencil, Trash2 } from "lucide-react";
+import { Clipboard, Pencil, Pin, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { ContextMenu } from "./context-menu";
@@ -74,6 +74,7 @@ export const WithCheckboxItems: Story = {
             checked={bold}
             onCheckedChange={setBold}
             shortcut="⌘B"
+            aria-keyshortcuts="Meta+B"
           >
             Bold
           </ContextMenu.CheckboxItem>
@@ -81,6 +82,7 @@ export const WithCheckboxItems: Story = {
             checked={italic}
             onCheckedChange={setItalic}
             shortcut="⌘I"
+            aria-keyshortcuts="Meta+I"
           >
             Italic
           </ContextMenu.CheckboxItem>
@@ -88,6 +90,62 @@ export const WithCheckboxItems: Story = {
       </ContextMenu.Root>
     );
   },
+};
+
+/** The item slots, driven from Controls so each one can be tried in isolation. */
+interface ItemSlotsArgs {
+  label: string;
+  /** Right-aligned key hint. Hidden from assistive tech. */
+  shortcut: string;
+  /** Announced binding, paired with the visible {@link ItemSlotsArgs.shortcut}. */
+  ariaKeyShortcuts: string;
+  /** Right-aligned content that is not a shortcut. Stays in the accessible name. */
+  trailing: string;
+  showIcon: boolean;
+  disabled: boolean;
+}
+
+/**
+ * Mirrors `Menu`'s story of the same name: the two primitives render identical
+ * rows, so the slots have to look identical here too.
+ */
+export const ItemSlots: StoryObj<ItemSlotsArgs> = {
+  args: {
+    label: "Pin conversation",
+    shortcut: "⇧⌘P",
+    ariaKeyShortcuts: "Meta+Shift+P",
+    trailing: "",
+    showIcon: true,
+    disabled: false,
+  },
+  argTypes: {
+    label: { control: "text" },
+    shortcut: { control: "text" },
+    ariaKeyShortcuts: { control: "text" },
+    trailing: { control: "text" },
+    showIcon: { control: "boolean" },
+    disabled: { control: "boolean" },
+  },
+  render: (args) => (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>
+        <div className="flex h-36 w-72 items-center justify-center rounded-lg border border-dashed border-[var(--border-base)] text-body-medium-lighter text-[var(--content-secondary)]">
+          Right-click to see the row
+        </div>
+      </ContextMenu.Trigger>
+      <ContextMenu.Content>
+        <ContextMenu.Item
+          leftIcon={args.showIcon ? <Pin className="h-4 w-4" /> : undefined}
+          shortcut={args.shortcut || undefined}
+          aria-keyshortcuts={args.ariaKeyShortcuts || undefined}
+          trailing={args.trailing || undefined}
+          disabled={args.disabled}
+        >
+          {args.label}
+        </ContextMenu.Item>
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  ),
 };
 
 export const WithSubmenu: Story = {
@@ -135,9 +193,7 @@ export const WithRadioItems: Story = {
             onValueChange={setAlignment}
           >
             <ContextMenu.RadioItem value="left">Left</ContextMenu.RadioItem>
-            <ContextMenu.RadioItem value="center">
-              Center
-            </ContextMenu.RadioItem>
+            <ContextMenu.RadioItem value="center">Center</ContextMenu.RadioItem>
             <ContextMenu.RadioItem value="right">Right</ContextMenu.RadioItem>
           </ContextMenu.RadioGroup>
         </ContextMenu.Content>

--- a/packages/design-library/src/components/context-menu.stories.tsx
+++ b/packages/design-library/src/components/context-menu.stories.tsx
@@ -73,16 +73,14 @@ export const WithCheckboxItems: Story = {
           <ContextMenu.CheckboxItem
             checked={bold}
             onCheckedChange={setBold}
-            shortcut="⌘B"
-            aria-keyshortcuts="Meta+B"
+            shortcut="CmdOrCtrl+B"
           >
             Bold
           </ContextMenu.CheckboxItem>
           <ContextMenu.CheckboxItem
             checked={italic}
             onCheckedChange={setItalic}
-            shortcut="⌘I"
-            aria-keyshortcuts="Meta+I"
+            shortcut="CmdOrCtrl+I"
           >
             Italic
           </ContextMenu.CheckboxItem>
@@ -95,10 +93,8 @@ export const WithCheckboxItems: Story = {
 /** The item slots, driven from Controls so each one can be tried in isolation. */
 interface ItemSlotsArgs {
   label: string;
-  /** Right-aligned key hint. Hidden from assistive tech. */
+  /** Electron accelerator. Drives both the drawn hint and the announced binding. */
   shortcut: string;
-  /** Announced binding, paired with the visible {@link ItemSlotsArgs.shortcut}. */
-  ariaKeyShortcuts: string;
   /** Right-aligned content that is not a shortcut. Stays in the accessible name. */
   trailing: string;
   showIcon: boolean;
@@ -112,8 +108,7 @@ interface ItemSlotsArgs {
 export const ItemSlots: StoryObj<ItemSlotsArgs> = {
   args: {
     label: "Pin conversation",
-    shortcut: "⇧⌘P",
-    ariaKeyShortcuts: "Meta+Shift+P",
+    shortcut: "CmdOrCtrl+Shift+P",
     trailing: "",
     showIcon: true,
     disabled: false,
@@ -121,7 +116,6 @@ export const ItemSlots: StoryObj<ItemSlotsArgs> = {
   argTypes: {
     label: { control: "text" },
     shortcut: { control: "text" },
-    ariaKeyShortcuts: { control: "text" },
     trailing: { control: "text" },
     showIcon: { control: "boolean" },
     disabled: { control: "boolean" },
@@ -137,7 +131,6 @@ export const ItemSlots: StoryObj<ItemSlotsArgs> = {
         <ContextMenu.Item
           leftIcon={args.showIcon ? <Pin className="h-4 w-4" /> : undefined}
           shortcut={args.shortcut || undefined}
-          aria-keyshortcuts={args.ariaKeyShortcuts || undefined}
           trailing={args.trailing || undefined}
           disabled={args.disabled}
         >

--- a/packages/design-library/src/components/context-menu.tsx
+++ b/packages/design-library/src/components/context-menu.tsx
@@ -5,7 +5,11 @@ import { type ComponentProps, type ReactNode } from "react";
 import { cn } from "../utils/cn";
 import { menuContentBase, menuItemBase } from "../utils/menu-styles";
 
-import { MenuItemShortcut, MenuItemTrailing } from "./menu-item-aside";
+import {
+  MenuItemShortcut,
+  MenuItemTrailing,
+  menuItemShortcutProps,
+} from "./menu-item-aside";
 import { usePortalContainer } from "../utils/portal-container";
 
 /**
@@ -97,11 +101,12 @@ function Content({
 type ItemProps = ComponentProps<typeof ContextMenuPrimitive.Item> & {
   readonly leftIcon?: ReactNode;
   /**
-   * Keyboard shortcut hint, right-aligned in the row. The glyphs are hidden
-   * from assistive tech, so pass `aria-keyshortcuts` on the item alongside
-   * this for screen readers to announce the binding.
+   * Electron accelerator for the row's binding, e.g. `"CmdOrCtrl+Shift+P"`.
+   * Draws the glyph hint and sets the item's `aria-keyshortcuts` from the one
+   * value, so what is shown and what is announced cannot disagree. Right
+   * aligned content that is not a binding belongs in `trailing`.
    */
-  readonly shortcut?: ReactNode;
+  readonly shortcut?: string;
   /**
    * Right-aligned trailing content that is not a keyboard shortcut: a status
    * glyph, secondary hint text. Unlike {@link ItemProps.shortcut} it stays in
@@ -124,6 +129,7 @@ function Item({
       ref={ref}
       data-slot="context-menu-item"
       className={cn(menuItemBase, className)}
+      {...menuItemShortcutProps(shortcut)}
       {...rest}
     >
       {leftIcon ? (
@@ -140,7 +146,7 @@ function Item({
       <span className="flex-1 truncate">{children}</span>
       {trailing ? <MenuItemTrailing>{trailing}</MenuItemTrailing> : null}
       {shortcut ? (
-        <MenuItemShortcut push={!trailing}>{shortcut}</MenuItemShortcut>
+        <MenuItemShortcut accelerator={shortcut} push={!trailing} />
       ) : null}
     </ContextMenuPrimitive.Item>
   );
@@ -153,7 +159,8 @@ function Item({
 type CheckboxItemProps = ComponentProps<
   typeof ContextMenuPrimitive.CheckboxItem
 > & {
-  readonly shortcut?: ReactNode;
+  /** Electron accelerator for the row's binding, e.g. `"CmdOrCtrl+Shift+P"`. */
+  readonly shortcut?: string;
 };
 
 function CheckboxItem({
@@ -170,6 +177,7 @@ function CheckboxItem({
       checked={checked}
       data-slot="context-menu-checkbox-item"
       className={cn(menuItemBase, "pl-7", className)}
+      {...menuItemShortcutProps(shortcut)}
       {...rest}
     >
       <span className="absolute left-1.5 flex h-4 w-4 items-center justify-center">
@@ -181,7 +189,7 @@ function CheckboxItem({
         </ContextMenuPrimitive.ItemIndicator>
       </span>
       <span className="flex-1 truncate">{children}</span>
-      {shortcut ? <MenuItemShortcut>{shortcut}</MenuItemShortcut> : null}
+      {shortcut ? <MenuItemShortcut accelerator={shortcut} /> : null}
     </ContextMenuPrimitive.CheckboxItem>
   );
 }
@@ -203,7 +211,8 @@ function RadioGroup({ ref, ...rest }: RadioGroupProps) {
 }
 
 type RadioItemProps = ComponentProps<typeof ContextMenuPrimitive.RadioItem> & {
-  readonly shortcut?: ReactNode;
+  /** Electron accelerator for the row's binding, e.g. `"CmdOrCtrl+Shift+P"`. */
+  readonly shortcut?: string;
 };
 
 function RadioItem({
@@ -218,6 +227,7 @@ function RadioItem({
       ref={ref}
       data-slot="context-menu-radio-item"
       className={cn(menuItemBase, "pl-7", className)}
+      {...menuItemShortcutProps(shortcut)}
       {...rest}
     >
       <span className="absolute left-1.5 flex h-4 w-4 items-center justify-center">
@@ -229,7 +239,7 @@ function RadioItem({
         </ContextMenuPrimitive.ItemIndicator>
       </span>
       <span className="flex-1 truncate">{children}</span>
-      {shortcut ? <MenuItemShortcut>{shortcut}</MenuItemShortcut> : null}
+      {shortcut ? <MenuItemShortcut accelerator={shortcut} /> : null}
     </ContextMenuPrimitive.RadioItem>
   );
 }

--- a/packages/design-library/src/components/context-menu.tsx
+++ b/packages/design-library/src/components/context-menu.tsx
@@ -3,11 +3,9 @@ import { Check, ChevronRight, Circle } from "lucide-react";
 import { type ComponentProps, type ReactNode } from "react";
 
 import { cn } from "../utils/cn";
-import {
-  menuContentBase,
-  menuItemAsideBase,
-  menuItemBase,
-} from "../utils/menu-styles";
+import { menuContentBase, menuItemBase } from "../utils/menu-styles";
+
+import { MenuItemShortcut, MenuItemTrailing } from "./menu-item-aside";
 import { usePortalContainer } from "../utils/portal-container";
 
 /**
@@ -112,10 +110,6 @@ type ItemProps = ComponentProps<typeof ContextMenuPrimitive.Item> & {
   readonly trailing?: ReactNode;
 };
 
-// The inner spans reuse Menu's slot names (`menu-item-icon` and friends), not
-// a `context-menu-` prefix: the two primitives render identical rows, and
-// shared helpers style items for both through one selector.
-
 function Item({
   className,
   children,
@@ -133,6 +127,8 @@ function Item({
       {...rest}
     >
       {leftIcon ? (
+        // Menu's slot name, not a `context-menu-` prefix: one selector styles
+        // the icon in both primitives.
         <span
           data-slot="menu-item-icon"
           className="flex h-4 w-4 shrink-0 items-center justify-center text-[var(--content-tertiary)]"
@@ -142,22 +138,9 @@ function Item({
         </span>
       ) : null}
       <span className="flex-1 truncate">{children}</span>
-      {trailing ? (
-        <span
-          data-slot="menu-item-trailing"
-          className={cn(menuItemAsideBase, "ml-auto")}
-        >
-          {trailing}
-        </span>
-      ) : null}
+      {trailing ? <MenuItemTrailing>{trailing}</MenuItemTrailing> : null}
       {shortcut ? (
-        <span
-          data-slot="menu-item-shortcut"
-          aria-hidden
-          className={cn(menuItemAsideBase, !trailing && "ml-auto")}
-        >
-          {shortcut}
-        </span>
+        <MenuItemShortcut push={!trailing}>{shortcut}</MenuItemShortcut>
       ) : null}
     </ContextMenuPrimitive.Item>
   );
@@ -198,15 +181,7 @@ function CheckboxItem({
         </ContextMenuPrimitive.ItemIndicator>
       </span>
       <span className="flex-1 truncate">{children}</span>
-      {shortcut ? (
-        <span
-          data-slot="menu-item-shortcut"
-          aria-hidden
-          className={cn(menuItemAsideBase, "ml-auto")}
-        >
-          {shortcut}
-        </span>
-      ) : null}
+      {shortcut ? <MenuItemShortcut>{shortcut}</MenuItemShortcut> : null}
     </ContextMenuPrimitive.CheckboxItem>
   );
 }
@@ -254,15 +229,7 @@ function RadioItem({
         </ContextMenuPrimitive.ItemIndicator>
       </span>
       <span className="flex-1 truncate">{children}</span>
-      {shortcut ? (
-        <span
-          data-slot="menu-item-shortcut"
-          aria-hidden
-          className={cn(menuItemAsideBase, "ml-auto")}
-        >
-          {shortcut}
-        </span>
-      ) : null}
+      {shortcut ? <MenuItemShortcut>{shortcut}</MenuItemShortcut> : null}
     </ContextMenuPrimitive.RadioItem>
   );
 }

--- a/packages/design-library/src/components/context-menu.tsx
+++ b/packages/design-library/src/components/context-menu.tsx
@@ -94,14 +94,30 @@ function Content({
 
 type ItemProps = ComponentProps<typeof ContextMenuPrimitive.Item> & {
   readonly leftIcon?: ReactNode;
+  /**
+   * Keyboard shortcut hint, right-aligned in the row. The glyphs are hidden
+   * from assistive tech, so pass `aria-keyshortcuts` on the item alongside
+   * this for screen readers to announce the binding.
+   */
   readonly shortcut?: ReactNode;
+  /**
+   * Right-aligned trailing content that is not a keyboard shortcut: a status
+   * glyph, secondary hint text. Unlike {@link ItemProps.shortcut} it stays in
+   * the accessible name.
+   */
+  readonly trailing?: ReactNode;
 };
+
+// The inner spans reuse Menu's slot names (`menu-item-icon` and friends), not
+// a `context-menu-` prefix: the two primitives render identical rows, and
+// shared helpers style items for both through one selector.
 
 function Item({
   className,
   children,
   leftIcon,
   shortcut,
+  trailing,
   ref,
   ...rest
 }: ItemProps) {
@@ -114,6 +130,7 @@ function Item({
     >
       {leftIcon ? (
         <span
+          data-slot="menu-item-icon"
           className="flex h-4 w-4 shrink-0 items-center justify-center text-[var(--content-tertiary)]"
           aria-hidden
         >
@@ -121,8 +138,23 @@ function Item({
         </span>
       ) : null}
       <span className="flex-1 truncate">{children}</span>
+      {trailing ? (
+        <span
+          data-slot="menu-item-trailing"
+          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+        >
+          {trailing}
+        </span>
+      ) : null}
       {shortcut ? (
-        <span className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]">
+        <span
+          data-slot="menu-item-shortcut"
+          aria-hidden
+          className={cn(
+            "pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]",
+            !trailing && "ml-auto",
+          )}
+        >
           {shortcut}
         </span>
       ) : null}
@@ -166,7 +198,11 @@ function CheckboxItem({
       </span>
       <span className="flex-1 truncate">{children}</span>
       {shortcut ? (
-        <span className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]">
+        <span
+          data-slot="menu-item-shortcut"
+          aria-hidden
+          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+        >
           {shortcut}
         </span>
       ) : null}
@@ -190,9 +226,7 @@ function RadioGroup({ ref, ...rest }: RadioGroupProps) {
   );
 }
 
-type RadioItemProps = ComponentProps<
-  typeof ContextMenuPrimitive.RadioItem
-> & {
+type RadioItemProps = ComponentProps<typeof ContextMenuPrimitive.RadioItem> & {
   readonly shortcut?: ReactNode;
 };
 
@@ -220,7 +254,11 @@ function RadioItem({
       </span>
       <span className="flex-1 truncate">{children}</span>
       {shortcut ? (
-        <span className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]">
+        <span
+          data-slot="menu-item-shortcut"
+          aria-hidden
+          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+        >
           {shortcut}
         </span>
       ) : null}
@@ -299,6 +337,7 @@ function SubTrigger({
     >
       {leftIcon ? (
         <span
+          data-slot="menu-item-icon"
           className="flex h-4 w-4 shrink-0 items-center justify-center text-[var(--content-tertiary)]"
           aria-hidden
         >
@@ -314,9 +353,7 @@ function SubTrigger({
   );
 }
 
-type SubContentProps = ComponentProps<
-  typeof ContextMenuPrimitive.SubContent
->;
+type SubContentProps = ComponentProps<typeof ContextMenuPrimitive.SubContent>;
 
 function SubContent({ className, ref, ...rest }: SubContentProps) {
   const container = usePortalContainer();

--- a/packages/design-library/src/components/context-menu.tsx
+++ b/packages/design-library/src/components/context-menu.tsx
@@ -3,7 +3,11 @@ import { Check, ChevronRight, Circle } from "lucide-react";
 import { type ComponentProps, type ReactNode } from "react";
 
 import { cn } from "../utils/cn";
-import { menuContentBase, menuItemBase } from "../utils/menu-styles";
+import {
+  menuContentBase,
+  menuItemAsideBase,
+  menuItemBase,
+} from "../utils/menu-styles";
 import { usePortalContainer } from "../utils/portal-container";
 
 /**
@@ -141,7 +145,7 @@ function Item({
       {trailing ? (
         <span
           data-slot="menu-item-trailing"
-          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+          className={cn(menuItemAsideBase, "ml-auto")}
         >
           {trailing}
         </span>
@@ -150,10 +154,7 @@ function Item({
         <span
           data-slot="menu-item-shortcut"
           aria-hidden
-          className={cn(
-            "pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]",
-            !trailing && "ml-auto",
-          )}
+          className={cn(menuItemAsideBase, !trailing && "ml-auto")}
         >
           {shortcut}
         </span>
@@ -201,7 +202,7 @@ function CheckboxItem({
         <span
           data-slot="menu-item-shortcut"
           aria-hidden
-          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+          className={cn(menuItemAsideBase, "ml-auto")}
         >
           {shortcut}
         </span>
@@ -257,7 +258,7 @@ function RadioItem({
         <span
           data-slot="menu-item-shortcut"
           aria-hidden
-          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+          className={cn(menuItemAsideBase, "ml-auto")}
         >
           {shortcut}
         </span>

--- a/packages/design-library/src/components/menu-item-aside.test.tsx
+++ b/packages/design-library/src/components/menu-item-aside.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  MenuItemShortcut,
+  MenuItemTrailing,
+  menuItemShortcutProps,
+} from "./menu-item-aside";
+
+/**
+ * The row's two right-aligned slots carry opposite accessibility meanings, and
+ * the whole point of drawing a key hint from an accelerator is that the drawn
+ * glyphs and the announced binding come from one value. These pin that
+ * contract at the markup level, where a regression would otherwise only be
+ * visible to a screen reader.
+ */
+
+describe("menuItemShortcutProps", () => {
+  test("announces the binding whenever a row draws one", () => {
+    expect(menuItemShortcutProps("CmdOrCtrl+Shift+P")).toEqual({
+      "aria-keyshortcuts": expect.any(String),
+    });
+  });
+
+  test("announces nothing when the row has no binding", () => {
+    expect(menuItemShortcutProps(undefined)).toEqual({});
+  });
+
+  test("resolves CmdOrCtrl per platform, matching the drawn glyphs", () => {
+    // The value is platform-dependent for the same reason the glyph is: a row
+    // showing ⌘ must not announce Control.
+    const mac = renderToStaticMarkup(
+      <MenuItemShortcut accelerator="CmdOrCtrl+Shift+P" />,
+    );
+    expect(mac).toContain("aria-hidden");
+    expect(
+      menuItemShortcutProps("CmdOrCtrl+Shift+P")["aria-keyshortcuts"],
+    ).toMatch(/^(Meta|Control)\+Shift\+P$/);
+  });
+});
+
+describe("MenuItemShortcut", () => {
+  test("draws the accelerator and hides the glyphs from assistive tech", () => {
+    const html = renderToStaticMarkup(
+      <MenuItemShortcut accelerator="CmdOrCtrl+Shift+P" />,
+    );
+    expect(html).toContain('data-slot="menu-item-shortcut"');
+    expect(html).toContain('aria-hidden="true"');
+    // The glyph form, never the raw accelerator.
+    expect(html).not.toContain("CmdOrCtrl");
+  });
+
+  test("pushes to the right edge unless a trailing slot already has", () => {
+    expect(
+      renderToStaticMarkup(<MenuItemShortcut accelerator="CmdOrCtrl+D" />),
+    ).toContain("ml-auto");
+    expect(
+      renderToStaticMarkup(
+        <MenuItemShortcut accelerator="CmdOrCtrl+D" push={false} />,
+      ),
+    ).not.toContain("ml-auto");
+  });
+});
+
+describe("MenuItemTrailing", () => {
+  test("stays in the accessible name", () => {
+    const html = renderToStaticMarkup(
+      <MenuItemTrailing>Copy link</MenuItemTrailing>,
+    );
+    expect(html).toContain('data-slot="menu-item-trailing"');
+    expect(html).toContain("Copy link");
+    expect(html).not.toContain("aria-hidden");
+  });
+});

--- a/packages/design-library/src/components/menu-item-aside.tsx
+++ b/packages/design-library/src/components/menu-item-aside.tsx
@@ -2,6 +2,11 @@ import { type ReactNode } from "react";
 
 import { cn } from "../utils/cn";
 
+import {
+  acceleratorToAriaKeyShortcuts,
+  formatAcceleratorHint,
+} from "./shortcut-keys";
+
 /**
  * The right-aligned column of a menu row, shared by `Menu` and `ContextMenu`
  * so a key hint and a status glyph sit on the same baseline in the same
@@ -20,21 +25,22 @@ const asideBase = [
 ].join(" ");
 
 interface MenuItemShortcutProps {
+  /** Electron accelerator, e.g. `"CmdOrCtrl+Shift+P"`. */
+  readonly accelerator: string;
   /**
    * Whether this element pushes itself to the right edge. False when a
    * trailing slot precedes it and has already taken the free space.
    */
   readonly push?: boolean;
-  readonly children: ReactNode;
 }
 
 /**
- * Presentational key hint. Hidden from assistive tech, so the item itself
- * carries `aria-keyshortcuts` for the binding to be announced.
+ * The drawn key hint. Hidden from assistive tech, which reads the binding
+ * from the item's `aria-keyshortcuts` instead.
  */
 export function MenuItemShortcut({
+  accelerator,
   push = true,
-  children,
 }: MenuItemShortcutProps) {
   return (
     <span
@@ -42,9 +48,24 @@ export function MenuItemShortcut({
       aria-hidden
       className={cn(asideBase, push && "ml-auto")}
     >
-      {children}
+      {formatAcceleratorHint(accelerator)}
     </span>
   );
+}
+
+/**
+ * The attributes a row carries when it draws a key hint, for spreading onto
+ * the item element. Deriving the announced binding here, from the accelerator
+ * the glyphs are drawn from, is what keeps a hidden hint from becoming a
+ * shortcut assistive tech never hears about: a row cannot have one without
+ * the other.
+ */
+export function menuItemShortcutProps(accelerator: string | undefined): {
+  "aria-keyshortcuts"?: string;
+} {
+  return accelerator
+    ? { "aria-keyshortcuts": acceleratorToAriaKeyShortcuts(accelerator) }
+    : {};
 }
 
 /** Right-aligned content that is not a key hint, kept in the accessible name. */

--- a/packages/design-library/src/components/menu-item-aside.tsx
+++ b/packages/design-library/src/components/menu-item-aside.tsx
@@ -1,0 +1,61 @@
+import { type ReactNode } from "react";
+
+import { cn } from "../utils/cn";
+
+/**
+ * The right-aligned column of a menu row, shared by `Menu` and `ContextMenu`
+ * so a key hint and a status glyph sit on the same baseline in the same
+ * colour across both primitives.
+ *
+ * The two slots differ in what they mean to a screen reader, which is why
+ * they are separate components rather than one with a flag: a key hint
+ * repeats what `aria-keyshortcuts` already announces and so is hidden, while
+ * trailing content is part of what the row says and stays in the accessible
+ * name.
+ */
+
+const asideBase = [
+  "pl-4 text-body-small-default tracking-wide",
+  "text-[var(--content-tertiary)]",
+].join(" ");
+
+interface MenuItemShortcutProps {
+  /**
+   * Whether this element pushes itself to the right edge. False when a
+   * trailing slot precedes it and has already taken the free space.
+   */
+  readonly push?: boolean;
+  readonly children: ReactNode;
+}
+
+/**
+ * Presentational key hint. Hidden from assistive tech, so the item itself
+ * carries `aria-keyshortcuts` for the binding to be announced.
+ */
+export function MenuItemShortcut({
+  push = true,
+  children,
+}: MenuItemShortcutProps) {
+  return (
+    <span
+      data-slot="menu-item-shortcut"
+      aria-hidden
+      className={cn(asideBase, push && "ml-auto")}
+    >
+      {children}
+    </span>
+  );
+}
+
+/** Right-aligned content that is not a key hint, kept in the accessible name. */
+export function MenuItemTrailing({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  return (
+    <span data-slot="menu-item-trailing" className={cn(asideBase, "ml-auto")}>
+      {children}
+    </span>
+  );
+}

--- a/packages/design-library/src/components/menu.stories.tsx
+++ b/packages/design-library/src/components/menu.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import {
+  Check,
   Clipboard,
   LogOut,
   Pencil,
+  Pin,
   Settings,
   Trash2,
   UserPlus,
@@ -47,9 +49,7 @@ export const WithIcons: Story = {
       </Menu.Trigger>
       <Menu.Content>
         <Menu.Item leftIcon={<Pencil className="h-4 w-4" />}>Edit</Menu.Item>
-        <Menu.Item leftIcon={<Clipboard className="h-4 w-4" />}>
-          Copy
-        </Menu.Item>
+        <Menu.Item leftIcon={<Clipboard className="h-4 w-4" />}>Copy</Menu.Item>
         <Menu.Separator />
         <Menu.Item leftIcon={<UserPlus className="h-4 w-4" />}>
           Invite
@@ -58,28 +58,119 @@ export const WithIcons: Story = {
           Settings
         </Menu.Item>
         <Menu.Separator />
-        <Menu.Item leftIcon={<Trash2 className="h-4 w-4" />}>
-          Delete
-        </Menu.Item>
+        <Menu.Item leftIcon={<Trash2 className="h-4 w-4" />}>Delete</Menu.Item>
       </Menu.Content>
     </Menu.Root>
   ),
 };
 
+/**
+ * The shortcut glyphs are presentation only (`aria-hidden`), so each item also
+ * carries `aria-keyshortcuts` for assistive tech to announce the binding.
+ */
 export const WithShortcuts: Story = {
+  parameters: { controls: { disable: true } },
   render: () => (
     <Menu.Root>
       <Menu.Trigger>
         <Button>File</Button>
       </Menu.Trigger>
       <Menu.Content>
-        <Menu.Item shortcut="⌘N">New</Menu.Item>
-        <Menu.Item shortcut="⌘O">Open</Menu.Item>
+        <Menu.Item shortcut="⌘N" aria-keyshortcuts="Meta+N">
+          New
+        </Menu.Item>
+        <Menu.Item shortcut="⌘O" aria-keyshortcuts="Meta+O">
+          Open
+        </Menu.Item>
         <Menu.Separator />
-        <Menu.Item shortcut="⌘S">Save</Menu.Item>
-        <Menu.Item shortcut="⇧⌘S">Save as…</Menu.Item>
+        <Menu.Item shortcut="⌘S" aria-keyshortcuts="Meta+S">
+          Save
+        </Menu.Item>
+        <Menu.Item shortcut="⇧⌘S" aria-keyshortcuts="Meta+Shift+S">
+          Save as…
+        </Menu.Item>
         <Menu.Separator />
-        <Menu.Item shortcut="⌘Q">Quit</Menu.Item>
+        <Menu.Item shortcut="⌘Q" aria-keyshortcuts="Meta+Q">
+          Quit
+        </Menu.Item>
+      </Menu.Content>
+    </Menu.Root>
+  ),
+};
+
+/** The item slots, driven from Controls so each one can be tried in isolation. */
+interface ItemSlotsArgs {
+  label: string;
+  /** Right-aligned key hint. Hidden from assistive tech. */
+  shortcut: string;
+  /** Announced binding, paired with the visible {@link ItemSlotsArgs.shortcut}. */
+  ariaKeyShortcuts: string;
+  /** Right-aligned content that is not a shortcut. Stays in the accessible name. */
+  trailing: string;
+  showIcon: boolean;
+  disabled: boolean;
+}
+
+/**
+ * `shortcut` and `trailing` are separate slots because they mean different
+ * things to a screen reader: a key hint is decorative and repeats what
+ * `aria-keyshortcuts` announces, while trailing content (a status glyph, a
+ * secondary hint) is part of what the row says.
+ */
+export const ItemSlots: StoryObj<ItemSlotsArgs> = {
+  args: {
+    label: "Pin conversation",
+    shortcut: "⇧⌘P",
+    ariaKeyShortcuts: "Meta+Shift+P",
+    trailing: "",
+    showIcon: true,
+    disabled: false,
+  },
+  argTypes: {
+    label: { control: "text" },
+    shortcut: { control: "text" },
+    ariaKeyShortcuts: { control: "text" },
+    trailing: { control: "text" },
+    showIcon: { control: "boolean" },
+    disabled: { control: "boolean" },
+  },
+  render: (args) => (
+    <Menu.Root>
+      <Menu.Trigger>
+        <Button variant="outlined">Conversation</Button>
+      </Menu.Trigger>
+      <Menu.Content>
+        <Menu.Item
+          leftIcon={args.showIcon ? <Pin className="h-4 w-4" /> : undefined}
+          shortcut={args.shortcut || undefined}
+          aria-keyshortcuts={args.ariaKeyShortcuts || undefined}
+          trailing={args.trailing || undefined}
+          disabled={args.disabled}
+        >
+          {args.label}
+        </Menu.Item>
+      </Menu.Content>
+    </Menu.Root>
+  ),
+};
+
+/**
+ * `trailing` carrying a status glyph and a secondary hint, next to a row that
+ * has neither, so the shared right column is visible.
+ */
+export const WithTrailingContent: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <Menu.Root>
+      <Menu.Trigger>
+        <Button variant="outlined">Model</Button>
+      </Menu.Trigger>
+      <Menu.Content>
+        <Menu.Item trailing={<Check className="h-3.5 w-3.5" />}>
+          Balanced
+        </Menu.Item>
+        <Menu.Item>Fast</Menu.Item>
+        <Menu.Item trailing="Preview">Reasoning</Menu.Item>
       </Menu.Content>
     </Menu.Root>
   ),

--- a/packages/design-library/src/components/menu.stories.tsx
+++ b/packages/design-library/src/components/menu.stories.tsx
@@ -10,6 +10,7 @@ import {
   UserPlus,
 } from "lucide-react";
 import { useState } from "react";
+import { expect, userEvent, within } from "storybook/test";
 
 import { Button } from "./button";
 import { Menu } from "./menu";
@@ -65,8 +66,9 @@ export const WithIcons: Story = {
 };
 
 /**
- * The shortcut glyphs are presentation only (`aria-hidden`), so each item also
- * carries `aria-keyshortcuts` for assistive tech to announce the binding.
+ * Items take the accelerator, not the glyphs. Each row draws the platform's
+ * key symbols and announces the same binding through `aria-keyshortcuts`, so
+ * the two cannot drift apart.
  */
 export const WithShortcuts: Story = {
   parameters: { controls: { disable: true } },
@@ -76,23 +78,13 @@ export const WithShortcuts: Story = {
         <Button>File</Button>
       </Menu.Trigger>
       <Menu.Content>
-        <Menu.Item shortcut="⌘N" aria-keyshortcuts="Meta+N">
-          New
-        </Menu.Item>
-        <Menu.Item shortcut="⌘O" aria-keyshortcuts="Meta+O">
-          Open
-        </Menu.Item>
+        <Menu.Item shortcut="CmdOrCtrl+N">New</Menu.Item>
+        <Menu.Item shortcut="CmdOrCtrl+O">Open</Menu.Item>
         <Menu.Separator />
-        <Menu.Item shortcut="⌘S" aria-keyshortcuts="Meta+S">
-          Save
-        </Menu.Item>
-        <Menu.Item shortcut="⇧⌘S" aria-keyshortcuts="Meta+Shift+S">
-          Save as…
-        </Menu.Item>
+        <Menu.Item shortcut="CmdOrCtrl+S">Save</Menu.Item>
+        <Menu.Item shortcut="CmdOrCtrl+Shift+S">Save as…</Menu.Item>
         <Menu.Separator />
-        <Menu.Item shortcut="⌘Q" aria-keyshortcuts="Meta+Q">
-          Quit
-        </Menu.Item>
+        <Menu.Item shortcut="CmdOrCtrl+Q">Quit</Menu.Item>
       </Menu.Content>
     </Menu.Root>
   ),
@@ -101,10 +93,8 @@ export const WithShortcuts: Story = {
 /** The item slots, driven from Controls so each one can be tried in isolation. */
 interface ItemSlotsArgs {
   label: string;
-  /** Right-aligned key hint. Hidden from assistive tech. */
+  /** Electron accelerator. Drives both the drawn hint and the announced binding. */
   shortcut: string;
-  /** Announced binding, paired with the visible {@link ItemSlotsArgs.shortcut}. */
-  ariaKeyShortcuts: string;
   /** Right-aligned content that is not a shortcut. Stays in the accessible name. */
   trailing: string;
   showIcon: boolean;
@@ -113,15 +103,14 @@ interface ItemSlotsArgs {
 
 /**
  * `shortcut` and `trailing` are separate slots because they mean different
- * things to a screen reader: a key hint is decorative and repeats what
+ * things to a screen reader: a key hint is drawn but hidden, repeating what
  * `aria-keyshortcuts` announces, while trailing content (a status glyph, a
  * secondary hint) is part of what the row says.
  */
 export const ItemSlots: StoryObj<ItemSlotsArgs> = {
   args: {
     label: "Pin conversation",
-    shortcut: "⇧⌘P",
-    ariaKeyShortcuts: "Meta+Shift+P",
+    shortcut: "CmdOrCtrl+Shift+P",
     trailing: "",
     showIcon: true,
     disabled: false,
@@ -129,10 +118,21 @@ export const ItemSlots: StoryObj<ItemSlotsArgs> = {
   argTypes: {
     label: { control: "text" },
     shortcut: { control: "text" },
-    ariaKeyShortcuts: { control: "text" },
     trailing: { control: "text" },
     showIcon: { control: "boolean" },
     disabled: { control: "boolean" },
+  },
+  // The row draws the hint and hides it, so the binding reaches assistive tech
+  // only through `aria-keyshortcuts`. Asserted on the composed tree, since the
+  // item is what has to carry the attribute.
+  play: async ({ canvasElement, args }) => {
+    await userEvent.click(within(canvasElement).getByRole("button"));
+    const item = await within(document.body).findByRole("menuitem");
+    expect(item).toHaveAttribute("aria-keyshortcuts");
+    expect(
+      item.querySelector('[data-slot="menu-item-shortcut"]'),
+    ).toHaveAttribute("aria-hidden", "true");
+    expect(item).toHaveAccessibleName(args.label);
   },
   render: (args) => (
     <Menu.Root>
@@ -143,7 +143,6 @@ export const ItemSlots: StoryObj<ItemSlotsArgs> = {
         <Menu.Item
           leftIcon={args.showIcon ? <Pin className="h-4 w-4" /> : undefined}
           shortcut={args.shortcut || undefined}
-          aria-keyshortcuts={args.ariaKeyShortcuts || undefined}
           trailing={args.trailing || undefined}
           disabled={args.disabled}
         >

--- a/packages/design-library/src/components/menu.tsx
+++ b/packages/design-library/src/components/menu.tsx
@@ -3,11 +3,9 @@ import { Check, ChevronRight, Circle } from "lucide-react";
 import { type ComponentProps, type ReactNode, useRef } from "react";
 
 import { cn } from "../utils/cn";
-import {
-  menuContentBase,
-  menuItemAsideBase,
-  menuItemBase,
-} from "../utils/menu-styles";
+import { menuContentBase, menuItemBase } from "../utils/menu-styles";
+
+import { MenuItemShortcut, MenuItemTrailing } from "./menu-item-aside";
 import { usePortalContainer } from "../utils/portal-container";
 
 /**
@@ -145,22 +143,9 @@ function Item({
         </span>
       ) : null}
       <span className="flex-1 truncate">{children}</span>
-      {trailing ? (
-        <span
-          data-slot="menu-item-trailing"
-          className={cn(menuItemAsideBase, "ml-auto")}
-        >
-          {trailing}
-        </span>
-      ) : null}
+      {trailing ? <MenuItemTrailing>{trailing}</MenuItemTrailing> : null}
       {shortcut ? (
-        <span
-          data-slot="menu-item-shortcut"
-          aria-hidden
-          className={cn(menuItemAsideBase, !trailing && "ml-auto")}
-        >
-          {shortcut}
-        </span>
+        <MenuItemShortcut push={!trailing}>{shortcut}</MenuItemShortcut>
       ) : null}
     </DropdownMenuPrimitive.Item>
   );
@@ -201,15 +186,7 @@ function CheckboxItem({
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       <span className="flex-1 truncate">{children}</span>
-      {shortcut ? (
-        <span
-          data-slot="menu-item-shortcut"
-          aria-hidden
-          className={cn(menuItemAsideBase, "ml-auto")}
-        >
-          {shortcut}
-        </span>
-      ) : null}
+      {shortcut ? <MenuItemShortcut>{shortcut}</MenuItemShortcut> : null}
     </DropdownMenuPrimitive.CheckboxItem>
   );
 }
@@ -257,15 +234,7 @@ function RadioItem({
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       <span className="flex-1 truncate">{children}</span>
-      {shortcut ? (
-        <span
-          data-slot="menu-item-shortcut"
-          aria-hidden
-          className={cn(menuItemAsideBase, "ml-auto")}
-        >
-          {shortcut}
-        </span>
-      ) : null}
+      {shortcut ? <MenuItemShortcut>{shortcut}</MenuItemShortcut> : null}
     </DropdownMenuPrimitive.RadioItem>
   );
 }

--- a/packages/design-library/src/components/menu.tsx
+++ b/packages/design-library/src/components/menu.tsx
@@ -5,7 +5,11 @@ import { type ComponentProps, type ReactNode, useRef } from "react";
 import { cn } from "../utils/cn";
 import { menuContentBase, menuItemBase } from "../utils/menu-styles";
 
-import { MenuItemShortcut, MenuItemTrailing } from "./menu-item-aside";
+import {
+  MenuItemShortcut,
+  MenuItemTrailing,
+  menuItemShortcutProps,
+} from "./menu-item-aside";
 import { usePortalContainer } from "../utils/portal-container";
 
 /**
@@ -104,11 +108,12 @@ function Content({
 type ItemProps = ComponentProps<typeof DropdownMenuPrimitive.Item> & {
   readonly leftIcon?: ReactNode;
   /**
-   * Keyboard shortcut hint, right-aligned in the row. The glyphs are hidden
-   * from assistive tech, so pass `aria-keyshortcuts` on the item alongside
-   * this for screen readers to announce the binding.
+   * Electron accelerator for the row's binding, e.g. `"CmdOrCtrl+Shift+P"`.
+   * Draws the glyph hint and sets the item's `aria-keyshortcuts` from the one
+   * value, so what is shown and what is announced cannot disagree. Right
+   * aligned content that is not a binding belongs in `trailing`.
    */
-  readonly shortcut?: ReactNode;
+  readonly shortcut?: string;
   /**
    * Right-aligned trailing content that is not a keyboard shortcut: a status
    * glyph, secondary hint text. Unlike {@link ItemProps.shortcut} it stays in
@@ -131,6 +136,7 @@ function Item({
       ref={ref}
       data-slot="menu-item"
       className={cn(menuItemBase, className)}
+      {...menuItemShortcutProps(shortcut)}
       {...rest}
     >
       {leftIcon ? (
@@ -145,7 +151,7 @@ function Item({
       <span className="flex-1 truncate">{children}</span>
       {trailing ? <MenuItemTrailing>{trailing}</MenuItemTrailing> : null}
       {shortcut ? (
-        <MenuItemShortcut push={!trailing}>{shortcut}</MenuItemShortcut>
+        <MenuItemShortcut accelerator={shortcut} push={!trailing} />
       ) : null}
     </DropdownMenuPrimitive.Item>
   );
@@ -158,7 +164,8 @@ function Item({
 type CheckboxItemProps = ComponentProps<
   typeof DropdownMenuPrimitive.CheckboxItem
 > & {
-  readonly shortcut?: ReactNode;
+  /** Electron accelerator for the row's binding, e.g. `"CmdOrCtrl+Shift+P"`. */
+  readonly shortcut?: string;
 };
 
 function CheckboxItem({
@@ -175,6 +182,7 @@ function CheckboxItem({
       checked={checked}
       data-slot="menu-checkbox-item"
       className={cn(menuItemBase, "pl-7", className)}
+      {...menuItemShortcutProps(shortcut)}
       {...rest}
     >
       <span className="absolute left-1.5 flex h-4 w-4 items-center justify-center">
@@ -186,7 +194,7 @@ function CheckboxItem({
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       <span className="flex-1 truncate">{children}</span>
-      {shortcut ? <MenuItemShortcut>{shortcut}</MenuItemShortcut> : null}
+      {shortcut ? <MenuItemShortcut accelerator={shortcut} /> : null}
     </DropdownMenuPrimitive.CheckboxItem>
   );
 }
@@ -208,7 +216,8 @@ function RadioGroup({ ref, ...rest }: RadioGroupProps) {
 }
 
 type RadioItemProps = ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
-  readonly shortcut?: ReactNode;
+  /** Electron accelerator for the row's binding, e.g. `"CmdOrCtrl+Shift+P"`. */
+  readonly shortcut?: string;
 };
 
 function RadioItem({
@@ -223,6 +232,7 @@ function RadioItem({
       ref={ref}
       data-slot="menu-radio-item"
       className={cn(menuItemBase, "pl-7", className)}
+      {...menuItemShortcutProps(shortcut)}
       {...rest}
     >
       <span className="absolute left-1.5 flex h-4 w-4 items-center justify-center">
@@ -234,7 +244,7 @@ function RadioItem({
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       <span className="flex-1 truncate">{children}</span>
-      {shortcut ? <MenuItemShortcut>{shortcut}</MenuItemShortcut> : null}
+      {shortcut ? <MenuItemShortcut accelerator={shortcut} /> : null}
     </DropdownMenuPrimitive.RadioItem>
   );
 }

--- a/packages/design-library/src/components/menu.tsx
+++ b/packages/design-library/src/components/menu.tsx
@@ -101,7 +101,18 @@ function Content({
 
 type ItemProps = ComponentProps<typeof DropdownMenuPrimitive.Item> & {
   readonly leftIcon?: ReactNode;
+  /**
+   * Keyboard shortcut hint, right-aligned in the row. The glyphs are hidden
+   * from assistive tech, so pass `aria-keyshortcuts` on the item alongside
+   * this for screen readers to announce the binding.
+   */
   readonly shortcut?: ReactNode;
+  /**
+   * Right-aligned trailing content that is not a keyboard shortcut: a status
+   * glyph, secondary hint text. Unlike {@link ItemProps.shortcut} it stays in
+   * the accessible name.
+   */
+  readonly trailing?: ReactNode;
 };
 
 function Item({
@@ -109,6 +120,7 @@ function Item({
   children,
   leftIcon,
   shortcut,
+  trailing,
   ref,
   ...rest
 }: ItemProps) {
@@ -129,8 +141,23 @@ function Item({
         </span>
       ) : null}
       <span className="flex-1 truncate">{children}</span>
+      {trailing ? (
+        <span
+          data-slot="menu-item-trailing"
+          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+        >
+          {trailing}
+        </span>
+      ) : null}
       {shortcut ? (
-        <span className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]">
+        <span
+          data-slot="menu-item-shortcut"
+          aria-hidden
+          className={cn(
+            "pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]",
+            !trailing && "ml-auto",
+          )}
+        >
           {shortcut}
         </span>
       ) : null}
@@ -174,7 +201,11 @@ function CheckboxItem({
       </span>
       <span className="flex-1 truncate">{children}</span>
       {shortcut ? (
-        <span className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]">
+        <span
+          data-slot="menu-item-shortcut"
+          aria-hidden
+          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+        >
           {shortcut}
         </span>
       ) : null}
@@ -226,7 +257,11 @@ function RadioItem({
       </span>
       <span className="flex-1 truncate">{children}</span>
       {shortcut ? (
-        <span className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]">
+        <span
+          data-slot="menu-item-shortcut"
+          aria-hidden
+          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+        >
           {shortcut}
         </span>
       ) : null}

--- a/packages/design-library/src/components/menu.tsx
+++ b/packages/design-library/src/components/menu.tsx
@@ -3,7 +3,11 @@ import { Check, ChevronRight, Circle } from "lucide-react";
 import { type ComponentProps, type ReactNode, useRef } from "react";
 
 import { cn } from "../utils/cn";
-import { menuContentBase, menuItemBase } from "../utils/menu-styles";
+import {
+  menuContentBase,
+  menuItemAsideBase,
+  menuItemBase,
+} from "../utils/menu-styles";
 import { usePortalContainer } from "../utils/portal-container";
 
 /**
@@ -144,7 +148,7 @@ function Item({
       {trailing ? (
         <span
           data-slot="menu-item-trailing"
-          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+          className={cn(menuItemAsideBase, "ml-auto")}
         >
           {trailing}
         </span>
@@ -153,10 +157,7 @@ function Item({
         <span
           data-slot="menu-item-shortcut"
           aria-hidden
-          className={cn(
-            "pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]",
-            !trailing && "ml-auto",
-          )}
+          className={cn(menuItemAsideBase, !trailing && "ml-auto")}
         >
           {shortcut}
         </span>
@@ -204,7 +205,7 @@ function CheckboxItem({
         <span
           data-slot="menu-item-shortcut"
           aria-hidden
-          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+          className={cn(menuItemAsideBase, "ml-auto")}
         >
           {shortcut}
         </span>
@@ -260,7 +261,7 @@ function RadioItem({
         <span
           data-slot="menu-item-shortcut"
           aria-hidden
-          className="ml-auto pl-4 text-body-small-default tracking-wide text-[var(--content-tertiary)]"
+          className={cn(menuItemAsideBase, "ml-auto")}
         >
           {shortcut}
         </span>

--- a/packages/design-library/src/components/shortcut-keys.tsx
+++ b/packages/design-library/src/components/shortcut-keys.tsx
@@ -162,6 +162,87 @@ export const formatAcceleratorHint = (
 ): string =>
   parseAccelerator(accelerator, platform).join(platform === "mac" ? "" : "+");
 
+/**
+ * Modifier names [`aria-keyshortcuts`](https://www.w3.org/TR/wai-aria-1.2/#aria-keyshortcuts)
+ * takes, which are the UI Events modifier key values rather than the glyphs a
+ * menu draws. `CmdOrCtrl` resolves per platform exactly as the glyphs do, so
+ * what a screen reader announces matches what the row shows.
+ */
+const ARIA_MODIFIERS: Record<ShortcutPlatform, Record<string, string>> = {
+  mac: {
+    command: "Meta",
+    cmd: "Meta",
+    commandorcontrol: "Meta",
+    cmdorctrl: "Meta",
+    super: "Meta",
+    meta: "Meta",
+    control: "Control",
+    ctrl: "Control",
+    alt: "Alt",
+    option: "Alt",
+    altgr: "AltGraph",
+    shift: "Shift",
+  },
+  windows: {
+    command: "Meta",
+    cmd: "Meta",
+    commandorcontrol: "Control",
+    cmdorctrl: "Control",
+    super: "Meta",
+    meta: "Meta",
+    control: "Control",
+    ctrl: "Control",
+    alt: "Alt",
+    option: "Alt",
+    altgr: "AltGraph",
+    shift: "Shift",
+  },
+};
+
+/** Named keys as their UI Events `KeyboardEvent.key` values. */
+const ARIA_KEYS: Record<string, string> = {
+  up: "ArrowUp",
+  down: "ArrowDown",
+  left: "ArrowLeft",
+  right: "ArrowRight",
+  return: "Enter",
+  enter: "Enter",
+  space: "Space",
+  backspace: "Backspace",
+  delete: "Delete",
+  escape: "Escape",
+  esc: "Escape",
+  tab: "Tab",
+  pageup: "PageUp",
+  pagedown: "PageDown",
+  home: "Home",
+  end: "End",
+  plus: "+",
+};
+
+/**
+ * The `aria-keyshortcuts` value for an accelerator: `"CmdOrCtrl+Shift+P"`
+ * becomes `"Meta+Shift+P"` on macOS and `"Control+Shift+P"` on Windows.
+ *
+ * Menus draw the glyph form and hide it from assistive tech, so this is the
+ * only channel through which a screen reader learns the binding. Derived from
+ * the same accelerator the glyphs come from, so the two cannot disagree.
+ */
+export const acceleratorToAriaKeyShortcuts = (
+  accelerator: string,
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+): string =>
+  tokenize(accelerator)
+    .map((token) => {
+      const lower = token.toLowerCase();
+      return (
+        ARIA_MODIFIERS[platform][lower] ??
+        ARIA_KEYS[lower] ??
+        token.toUpperCase()
+      );
+    })
+    .join("+");
+
 export interface ShortcutKeysProps extends ComponentProps<"span"> {
   /** Electron accelerator string, e.g. `"CmdOrCtrl+Shift+N"`. */
   accelerator: string;

--- a/packages/design-library/src/utils/menu-styles.ts
+++ b/packages/design-library/src/utils/menu-styles.ts
@@ -15,6 +15,17 @@ export const menuItemBase = [
   "transition-colors",
 ].join(" ");
 
+/**
+ * The right-aligned column of a menu row, shared by the shortcut hint and the
+ * trailing slot so a key hint and a status glyph sit on the same baseline in
+ * the same colour. Compose with `ml-auto` on whichever element is first: with
+ * both slots present, only the leading one pushes.
+ */
+export const menuItemAsideBase = [
+  "pl-4 text-body-small-default tracking-wide",
+  "text-[var(--content-tertiary)]",
+].join(" ");
+
 export const menuContentBase = [
   "z-50 min-w-[10rem] overflow-hidden rounded-lg bg-[var(--surface-lift)] p-2 shadow-[var(--shadow-popover)]",
   "data-[state=open]:animate-in data-[state=closed]:animate-out",

--- a/packages/design-library/src/utils/menu-styles.ts
+++ b/packages/design-library/src/utils/menu-styles.ts
@@ -15,17 +15,6 @@ export const menuItemBase = [
   "transition-colors",
 ].join(" ");
 
-/**
- * The right-aligned column of a menu row, shared by the shortcut hint and the
- * trailing slot so a key hint and a status glyph sit on the same baseline in
- * the same colour. Compose with `ml-auto` on whichever element is first: with
- * both slots present, only the leading one pushes.
- */
-export const menuItemAsideBase = [
-  "pl-4 text-body-small-default tracking-wide",
-  "text-[var(--content-tertiary)]",
-].join(" ");
-
 export const menuContentBase = [
   "z-50 min-w-[10rem] overflow-hidden rounded-lg bg-[var(--surface-lift)] p-2 shadow-[var(--shadow-popover)]",
   "data-[state=open]:animate-in data-[state=closed]:animate-out",


### PR DESCRIPTION
## TL;DR

A menu row's right-aligned slot was called `shortcut` but was being used for two unrelated things: real key hints, and content that is not a shortcut at all. This splits them into `shortcut` (a key hint, hidden from screen readers, paired with `aria-keyshortcuts`) and `trailing` (everything else, which stays in the accessible name). Nothing changes on screen.

This is groundwork: the sidebar's Unpin/Rename/Archive menu is going to start showing the pin shortcut, and this is the slot those hints land in.

## Why the split

`shortcut` renders a right-aligned span. Four call sites had reached for it to render things that were never key hints:

- `composer-settings-menu.tsx` put a green check there to mark the active row
- `library-app-card.tsx` and `app-nav-bar.tsx` put the text "Copy link" there

That is harmless visually, and wrong for assistive tech. A key hint is decorative: `⇧⌘P` announced as characters is noise, and the binding should reach a screen reader through `aria-keyshortcuts` instead. A checkmark or a "Copy link" label is the opposite: it is part of what the row says, and must stay in the accessible name. One slot cannot be both, so `shortcut` is now `aria-hidden` and `trailing` is not.

## What changes for the user

| | Before | After |
|---|---|---|
| On screen | Check glyph and "Copy link" right-aligned in their menus | Identical. No visual change anywhere. |
| Screen reader, active-model row | "Balanced" (the check was in the accessible name, but so would a shortcut have been) | "Balanced" plus the check, unchanged, and now for a reason rather than by accident |
| Screen reader, a row with a key hint | Would have read the glyphs as characters | Announces the binding from `aria-keyshortcuts`, derived from the same accelerator the glyphs are drawn from |
| Bottom sheet rows | No shortcut, no trailing content | Unchanged. A sheet has no keys and no trailing column. |

## What is in here

- `Menu.Item`, `ContextMenu.Item`, `ActionMenu.Item` gain `trailing`; the four call sites above move to it
- `shortcut` spans are marked `aria-hidden` on Item, CheckboxItem, and RadioItem across both primitives
- `acceleratorToAriaKeyShortcuts()` joins `parseAccelerator` / `formatAcceleratorHint` in `shortcut-keys.tsx`, mapping accelerator tokens to the UI Events key values the attribute expects and resolving `CmdOrCtrl` per platform, so a row showing the command symbol never announces Control
- `MenuItemShortcut` / `MenuItemTrailing` (`menu-item-aside.tsx`) own the aside markup for both primitives. The span had been written out at six call sites across the two files, which is six chances to forget the `aria-hidden` this PR depends on; now the two slots can only differ in the way they are meant to. Rendered markup is unchanged.
- Inner spans get their own `data-slot` names (`menu-item-shortcut`, `menu-item-trailing`), matching the icon span that already had one. `ContextMenu`'s icon span was missing `data-slot="menu-item-icon"` and now has it, so the destructive-row selector that both primitives share resolves against either one.

## Tests

`menu-item-aside.test.tsx` pins the rendered markup for all three states: a
shortcut (drawn glyphs, `aria-hidden`, raw accelerator never leaking into the
text), trailing content (visible, in the accessible name), and the absent state
(neither). The `ItemSlots` story asserts `aria-keyshortcuts` on the composed
row in a real browser, since the attribute lands on the item and only the full
tree can show that.

## Verified

- `bun run typecheck` clean in `packages/design-library` and `clients/web`
- `bun run build-storybook` clean; the new and changed stories opened in a browser and confirmed rendering, not just building
- DOM checked directly on the rendered row: `aria-keyshortcuts="Meta+Shift+P"` on the item, `aria-hidden="true"` on the glyph span, and both slots present together laying out in the right order
- Sheet presentation confirmed to drop shortcut, trailing, and `aria-keyshortcuts`, keeping only the labels
- Unit tests were not run locally (standing rule on this machine); CI covers them

## Stories

`Menu` and `ContextMenu` each get an args-driven `ItemSlots` story with every slot on a Control, which is the first arg-driven story in either file. `WithTrailingContent` is added to `Menu` and `ActionMenu`, and the existing shortcut galleries now model the `aria-keyshortcuts` pairing so the stories show the accessible form rather than glyphs alone. Composed galleries set `controls: { disable: true }` so they do not advertise dead controls.

## Deferred

- `SubTrigger` still has no `shortcut` slot on either primitive, since the chevron owns `ml-auto`. Nothing needs it today.
- `ShortcutKeys` renders boxed key-caps and has no compact inline form, so the command palette hand-rolls its own hint span at `command-palette-item.tsx:120` and `:148` - and those two branches of the same file already disagree with each other (`text-xs` vs `text-body-small-default`). Worth giving `ShortcutKeys` an inline variant and pointing both the palette and the menu at it, but that is a change to a component this PR does not otherwise touch.
- The shortcut hint renders at `--content-tertiary`, which is 4.05:1 on the light-mode menu surface at 12px, just under the 4.5:1 WCAG AA threshold for normal text. That token is used for secondary text across the whole app, so it is not this PR's to change, but it is worth knowing before we start drawing more of these hints.
