### PR TITLE
fix: share the preferences credits-row rule between the menu and its story

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -24,6 +24,7 @@ import {
   ShareFeedbackModalLazy,
 } from "@/components/share-feedback-modal-lazy";
 import { ThemeToggle } from "@/components/theme-toggle";
+import type { PreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
@@ -249,8 +250,7 @@ function PreferencesMenuContent({
   /* The same reading the usage panel below draws, composed once so the row and
      the bar can never disagree about how much of the bundle is left. */
   const usage = usePreferencesUsage({ conversationId: activeConversationId });
-  // The credits row shows only when there is no usage reading to draw instead.
-  const showCredits = usage == null;
+  const showCredits = showsMenuCredits(usage);
 
   return (
     <>
@@ -321,6 +321,11 @@ function PreferencesMenuContent({
       />
     </>
   );
+}
+
+/** The credits row stands in for the usage panel when there is no reading. */
+export function showsMenuCredits(usage: PreferencesUsage | null): boolean {
+  return usage == null;
 }
 
 function formatWholeCredits(value: string): string {

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
@@ -21,6 +21,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { CreditsCard } from "@/domains/chat/components/credits-card";
+import { showsMenuCredits } from "@/domains/chat/components/preferences-menu";
 import { PreferencesUsagePanel } from "@/domains/chat/components/preferences-usage-panel";
 import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import {
@@ -82,9 +83,9 @@ function PanelOnly() {
 
 /**
  * The panel with the compact credits row beneath it, composed the way
- * `PreferencesMenuContent` composes them: the row belongs on screen only
- * without a usage reading, and `displayedCreditsUsd` decides what it names, so
- * the story exercises both real rules. The seeded balance is already in the
+ * `PreferencesMenuContent` composes them: `showsMenuCredits` decides whether
+ * the row belongs on screen and `displayedCreditsUsd` decides what it names,
+ * so the story exercises both real rules. The seeded balance is already in the
  * two-decimal shape the menu formats it to.
  */
 function PanelWithCredits() {
@@ -94,7 +95,7 @@ function PanelWithCredits() {
     balance,
     availableUsageBalance,
   } = useBillingBalanceStatus();
-  const showCredits = usage == null;
+  const showCredits = showsMenuCredits(usage);
 
   return (
     <>

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.tsx
@@ -19,9 +19,6 @@ export interface PreferencesUsagePanelProps {
 /**
  * The preferences menu's usage reading: the same usage-balance reading the
  * billing Plan tile draws, close to where the work is being done.
- * `usePreferencesUsage` decides whether there is anything honest to say, so
- * this renders nothing until the org has managed billing and a real number has
- * landed.
  */
 export function PreferencesUsagePanel({
   onOpenBilling,

--- a/clients/web/src/lib/billing/displayed-credits.ts
+++ b/clients/web/src/lib/billing/displayed-credits.ts
@@ -13,11 +13,7 @@
 
 import { parseUsd } from "@/lib/billing/parse-usd";
 
-/**
- * The balance to display: the effective balance less whatever is still unused
- * on the usage grants, never below zero. Returns the balance untouched when
- * the platform reports no grant figure.
- */
+/** Clamped at zero; passes the balance through when no grant figure lands. */
 export function displayedCreditsUsd(
   balance: string,
   availableUsageBalance: string | null | undefined,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 2) for remove-obscure-credits-flag.md, including the Codex P2 on #41681.

- showsMenuCredits is back as the one place the credits-row rule lives; the menu and the usage-panel story both call it.
- The displayed-credits function docstring and the usage panel docstring no longer restate what their neighbours already document.