### PR TITLE
fix: trim the takeover credits chip plumbing and the last assertions on deleted plan copy

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -29,11 +29,8 @@ import {
 export const NO_EXTRA_CREDITS = "__none__";
 export type CreditChoice = CreditTierEnum | typeof NO_EXTRA_CREDITS;
 
-/**
- * Fallback wording for the no-bundle sentinel when a caller supplies no
- * `noBundleLabel`. The modal always passes its translated copy.
- */
-export const NO_CREDITS_LABEL = "No extra credits";
+/** Fallback wording when a caller supplies no `noBundleLabel`. */
+const NO_CREDITS_LABEL = "No extra credits";
 
 /**
  * Sentinel for the baseline machine. `MachineTierEnum` names only the paid

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -1715,7 +1715,7 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
 });
 
 describe("PlansPage: package usage rows", () => {
-  test("every package row reads as the package's usage, never as credits", async () => {
+  test("every package row is named from the package", async () => {
     const { findByText, getByText } = renderInteractive(freeSubscription());
 
     // The name-derived usage rows, matching the plan card's chip.
@@ -1724,12 +1724,11 @@ describe("PlansPage: package usage rows", () => {
     getByText("Ultra usage, reset monthly");
   });
 
-  test("a package with no usage_label still never falls back to credits", async () => {
-    const { findByText, container } = renderInteractive(freeSubscription(), {
+  test("a package with no usage_label still gets a name-derived usage row", async () => {
+    const { findByText } = renderInteractive(freeSubscription(), {
       plans: plansWith([makeProPackage({ usage_label: null })]),
     });
 
     await findByText("Mighty usage, reset monthly");
-    expect(container.textContent).not.toContain("in credits included");
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -1393,8 +1393,8 @@ describe("credits chip wording", () => {
     expect(queryByTestId("chip-credits")).toBeNull();
   });
 
-  test("the confirming custom-intent chip names the bundle, not a count", () => {
-    const { getByText, queryByText } = renderState({
+  test("the confirming custom-intent chip names the bundle", () => {
+    const { getByText } = renderState({
       state: "CONFIRMING",
       intent: {
         kind: "custom",
@@ -1406,6 +1406,5 @@ describe("credits chip wording", () => {
     });
 
     expect(getByText("Mighty Usage")).toBeTruthy();
-    expect(queryByText("50 credits")).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -475,10 +475,9 @@ type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
 /**
  * The credits chip's strings, where no amount may render: each side names its
  * bundle by catalog label, the no-bundle side reads as the "No extra usage"
- * sentinel, and a side the catalog can't label is left unstated: an unstated
- * from-side just drops the arrow, an unstated to-side drops the whole chip
- * rather than asserting a bundle it cannot name. The row label reads "Usage"
- * so the chip never introduces credits as a concept.
+ * sentinel, and a from-side the catalog can't label is left unstated, dropping
+ * the arrow. The row label reads "Usage" so the chip never introduces credits
+ * as a concept.
  */
 function creditsChipContent(
   credits: CreditsChange | null,
@@ -488,14 +487,10 @@ function creditsChipContent(
     return null;
   }
   const noExtraUsage = t("provisioningState.noExtraUsage");
-  const to = credits.toLabel === null ? noExtraUsage : credits.toLabel;
-  if (to == null) {
-    return null;
-  }
   return {
     label: t("provisioningState.usageLabel"),
     from: credits.fromLabel === null ? noExtraUsage : credits.fromLabel,
-    to,
+    to: credits.toLabel === null ? noExtraUsage : credits.toLabel,
   };
 }
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
@@ -105,23 +105,6 @@ describe("buildResourceChanges", () => {
     expect(changes.map((c) => c.key)).toEqual(["credits"]);
   });
 
-  test("renders a credits-only change from the wording the caller passes", () => {
-    const changes = buildResourceChanges({
-      targets: { machineSize: null, storageGib: null },
-      fromSnapshot: { machineSize: null, storageGib: null },
-      credits: { label: "Usage", from: "No extra usage", to: "Mighty Usage" },
-    });
-
-    expect(changes).toEqual([
-      {
-        key: "credits",
-        label: "Usage",
-        from: "No extra usage",
-        to: "Mighty Usage",
-      },
-    ]);
-  });
-
   test("keeps a storage-only change free of a machine row", () => {
     const changes = buildResourceChanges({
       targets: { machineSize: "medium", storageGib: 50 },

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
@@ -14,14 +14,10 @@ export interface ResourceChange {
 
 /**
  * The credits chip's pre-worded strings: each side names its bundle, under the
- * row label the caller supplies ("Usage"). The from-side is left unstated when
- * the catalog can't word it.
+ * row label the caller supplies ("Usage"). An unwordable from-side is left
+ * unstated.
  */
-export interface CreditsChipContent {
-  label: string;
-  from?: string;
-  to: string;
-}
+export type CreditsChipContent = Omit<ResourceChange, "key">;
 
 /**
  * Flattens the provisioning targets into the ordered list of resource changes
@@ -104,12 +100,7 @@ export function buildResourceChanges(input: {
   }
 
   if (credits != null) {
-    changes.push({
-      key: "credits",
-      label: credits.label,
-      from: credits.from,
-      to: credits.to,
-    });
+    changes.push({ key: "credits", ...credits });
   }
 
   return changes;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -39,8 +39,7 @@ const { useProvisioningCredits, useResizeCreditsChange } =
  * label-precedence assertions can tell the two apart.
  *
  * The packages differ in what words their bundle: Mighty carries its own
- * `usage_label`, Tierless leans on the tier's, and Unpriced names a bundle the
- * catalog neither lists nor prices.
+ * `usage_label` and Tierless leans on the tier's.
  */
 function plansResponse(): PlanListResponse {
   return {
@@ -77,25 +76,6 @@ function plansResponse(): PlanListResponse {
             storage_gib: 10,
             credits_usd: 50,
             usage_label: "Mighty Usage",
-            include_platform_fee: false,
-            base_price_cents: 4000,
-            machine_price_cents: 0,
-            storage_price_cents: 0,
-            credit_price_cents: 0,
-            total_price_cents: 4000,
-          },
-          {
-            key: "unpriced",
-            name: "Unpriced",
-            description: "",
-            version: 1,
-            machine_tier: null,
-            storage_tier: "xs",
-            credit_tier: "credits_100",
-            machine_size: null,
-            storage_gib: 10,
-            credits_usd: null,
-            usage_label: "Boundless Usage",
             include_platform_fee: false,
             base_price_cents: 4000,
             machine_price_cents: 0,
@@ -226,18 +206,6 @@ describe("useProvisioningCredits", () => {
     ).toEqual({ fromLabel: null, toLabel: "Mighty Usage" });
   });
 
-  test("names a bundle the catalog carries no amount for", () => {
-    // The package prices no credits of its own and its tier is absent from the
-    // catalog, so nothing about it resolves to an amount; its usage_label still
-    // words the chip.
-    expect(
-      renderCredits(
-        { kind: "package", packageKey: "unpriced", savedAt: 0 },
-        plansResponse(),
-      ),
-    ).toEqual({ fromLabel: null, toLabel: "Boundless Usage" });
-  });
-
   test("returns null for an unknown package key", () => {
     expect(
       renderCredits(
@@ -297,7 +265,8 @@ describe("useResizeCreditsChange", () => {
   });
 
   test("reads a dropped bundle as a move to the no-bundle side", () => {
-    // "No extra credits" is a real endpoint of the change, not a missing side.
+    // The explicit no-bundle choice is a real endpoint of the change, not a
+    // missing side.
     expect(
       renderChange({ fromTier: "credits_50", toTier: null }, plansResponse()),
     ).toEqual({ fromLabel: "Mighty Usage Monthly", toLabel: null });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -9,17 +9,19 @@ import { findCreditTier } from "@/lib/billing/credit-tiers";
 /**
  * The two sides of a credit bundle change, each as the catalog label the chip
  * renders ("Mighty Usage", the Stripe product name, so it matches the invoice
- * line). `null` marks the explicit no-bundle side, worded by the caller;
- * `undefined` a bundle the catalog can't label, which the chip leaves unstated.
+ * line). `null` marks the explicit no-bundle side, worded by the caller; an
+ * `undefined` from-side is a bundle the catalog can't label, which the chip
+ * leaves unstated. An unwordable to-side drops the chip, so the hooks return
+ * null instead of a change.
  */
 export interface CreditsChange {
   fromLabel: string | null | undefined;
-  toLabel: string | null | undefined;
+  toLabel: string | null;
 }
 
 /**
  * The credit tiers an in-place plan change moves between. `null` on either side
- * is the explicit "No extra credits" choice.
+ * is the explicit no-bundle choice.
  */
 export interface CreditTierChange {
   fromTier: CreditTierEnum | null;
@@ -45,8 +47,8 @@ function useProPlan(enabled: boolean): ProPlan | undefined {
 }
 
 /**
- * The catalog label for a tier. A null tier is the explicit "No extra credits"
- * choice (`null` here), and a tier the catalog doesn't list has no label to give
+ * The catalog label for a tier. A null tier is the explicit no-bundle choice
+ * (`null` here), and a tier the catalog doesn't list has no label to give
  * (`undefined`): a key like `credits_115` carries no wording to fall back to.
  */
 function creditTierLabel(
@@ -98,8 +100,7 @@ export function useProvisioningCredits(
  * The bundle labels an in-place plan change moves between. Both endpoints come
  * from the tiers the plans page captured before the change landed, so the chip
  * states the move rather than the outcome. Returns null when no credit change is
- * threaded and when the catalog can't word the to-side, and the chip is omitted;
- * an unwordable from-side is left unstated instead. Display-only.
+ * threaded or the catalog can't word the to-side. Display-only.
  */
 export function useResizeCreditsChange(
   change: CreditTierChange | null | undefined,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 2) for remove-obscure-credits-flag.md.

- CreditsChipContent is ResourceChange without its key; CreditsChange.toLabel is string or null, so the chip builder no longer carries an unreachable to-side guard.
- A duplicate resource-changes test and an unpriced fixture that exercised an already-covered path are removed; the remaining no-bundle comments use the no-bundle wording.
- The last assertions on copy whose i18n keys were deleted are gone and their tests are titled for what they check; NO_CREDITS_LABEL is module-local.