### PR TITLE
fix: make the wrapped spec row the plan tile's only layout

### DIFF
--- a/clients/web/src/components/upsell-walls-overview.stories.tsx
+++ b/clients/web/src/components/upsell-walls-overview.stories.tsx
@@ -366,7 +366,6 @@ export const ResourceAndEntitlementWalls: Story = {
                   SUPER_PACKAGE,
                   "Super usage, reset monthly",
                 )}
-                specsWrap
                 footer={
                   <Button
                     variant="primary"

--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -32,7 +32,7 @@ describe("freePlanSpecs", () => {
 
   test("gives the credits chip a row of its own", () => {
     // The machine and storage chips are short enough to share a row; the
-    // credits chip is a phrase, so the wrapped layout drops it onto its own.
+    // credits chip is a phrase, so it drops onto a row of its own.
     expect(freePlanSpecs().map((s) => s.ownRow)).toEqual([
       undefined,
       undefined,
@@ -48,7 +48,6 @@ describe("packageSpecs", () => {
         key: "mighty",
         name: "Mighty",
         machine_size: null,
-        credits_usd: 25,
         storage_gib: 10,
       } as ProPackage,
       "Mighty usage, reset monthly",
@@ -66,7 +65,6 @@ describe("packageSpecs", () => {
       {
         key: "unknown",
         machine_size: "medium",
-        credits_usd: 45,
         storage_gib: 30,
       } as ProPackage,
       "Super usage, reset monthly",
@@ -83,7 +81,6 @@ describe("packageSpecs", () => {
       {
         key: "super",
         machine_size: "medium",
-        credits_usd: 45,
         storage_gib: 30,
       } as ProPackage,
       "Super usage, reset monthly",
@@ -102,7 +99,6 @@ describe("packageSpecs", () => {
       {
         key: "super",
         machine_size: "medium",
-        credits_usd: 45,
         storage_gib: 30,
       } as ProPackage,
       "Super usage, reset monthly",
@@ -115,14 +111,6 @@ describe("packageSpecs", () => {
       true,
       true,
     ]);
-  });
-
-  test("keeps the credits chip on its own row", () => {
-    const specs = packageSpecs(
-      { key: "mighty", credits_usd: 25, storage_gib: 10 } as ProPackage,
-      "Mighty usage, reset monthly",
-    );
-    expect(specs[2].ownRow).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -32,10 +32,8 @@ export interface PlanSpec {
   /** Render the chip as a wrap-capable pill for long summary labels. */
   multiline?: boolean;
   /**
-   * Give the chip a full-width row of its own instead of letting it flow in the
-   * wrapping row beside the short chips. The plan card lays its chips out as a
-   * wrapping row (`PlanTile`'s `specsWrap`), so this takes effect there; the
-   * vertical stack gives every chip its own row and ignores it.
+   * Give the chip a full-width row of its own instead of letting it flow in
+   * the wrapping row beside the short chips.
    */
   ownRow?: boolean;
 }
@@ -62,8 +60,7 @@ export function machineLabel(pkg: ProPackage | null): string {
  * its own mapping).
  *
  * The machine and storage chips are short enough to sit side by side; the
- * credits chip and the extras are sentences, so they take a row each wherever
- * the chips are laid out as a wrapping row.
+ * credits chip and the extras are sentences, so they take a row each.
  *
  * `usageLabel` is the localized credits chip text, supplied by the caller
  * because this pure module has no `t()`.

--- a/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
@@ -149,7 +149,6 @@ export const CurrentFree: Story = {
     nameTestId: "plan-card-name",
     tag: CURRENT_TAG,
     specs: freePlanSpecs(),
-    specsWrap: true,
     footer: <UsageBalancePanel ratio={0.68} />,
   },
 };
@@ -169,7 +168,6 @@ export const CurrentPaid: Story = {
     nameTestId: "plan-card-name",
     tag: CURRENT_TAG,
     specs: packageSpecs(MIGHTY, usageChip(MIGHTY.name)),
-    specsWrap: true,
     footer: <UsageBalancePanel ratio={0.42} />,
   },
 };
@@ -201,7 +199,6 @@ export const CurrentPaidNoUsageReading: Story = {
     nameTestId: "plan-card-name",
     tag: CURRENT_TAG,
     specs: packageSpecs(MIGHTY, usageChip(MIGHTY.name)),
-    specsWrap: true,
     footer: priceFooter(priceLabelFromCents(MIGHTY.total_price_cents)),
   },
 };
@@ -241,7 +238,6 @@ export const NextPlan: Story = {
     name: SUPER.name,
     tag: NEXT_PLAN_TAG,
     specs: packageSpecs(SUPER, usageChip(SUPER.name)),
-    specsWrap: true,
     footer: upgradeCta(),
   },
 };
@@ -267,6 +263,9 @@ export const NextPlanPending: Story = {
  * below the `lg` breakpoint: select `Mobile` in the viewport toolbar to see
  * that treatment, since the Canvas holds a desktop width regardless of window
  * size.
+ *
+ * The current tile carries the Usage Balance bar, which is what a subscription
+ * with a usage reading shows; `CurrentPaidNoUsageReading` has the price row.
  */
 export const SideBySide: Story = {
   parameters: {
@@ -284,8 +283,7 @@ export const SideBySide: Story = {
           nameTestId="plan-card-name"
           tag={CURRENT_TAG}
           specs={packageSpecs(MIGHTY, usageChip(MIGHTY.name))}
-          specsWrap
-          footer={priceFooter(priceLabelFromCents(MIGHTY.total_price_cents))}
+          footer={<UsageBalancePanel ratio={0.42} />}
         />
         <PlanTile
           theme={inverted}
@@ -294,7 +292,6 @@ export const SideBySide: Story = {
           name={SUPER.name}
           tag={NEXT_PLAN_TAG}
           specs={packageSpecs(SUPER, usageChip(SUPER.name))}
-          specsWrap
           footer={upgradeCta()}
         />
       </div>

--- a/clients/web/src/domains/settings/billing/plan-tile.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.test.tsx
@@ -1,11 +1,11 @@
 /**
  * Tests for PlanTile: the shared tile of the billing "Plan" section. Verifies
  * it renders the tag, the 48px avatar slot, the name (forwarding `nameTestId`),
- * the spec-chip stack and the footer slot; splits the wrapped layout into the
- * wrapping row and the chips that asked for a row of their own; drops the chip
- * stack for null and empty `specs` and the footer wrapper when no footer is
- * passed; stamps a nested `data-theme` scope only when `theme` is set; and
- * forwards `testId` and `className` to the root.
+ * the spec chips and the footer slot; splits those chips into the wrapping row
+ * and the chips that asked for a row of their own; drops the chips for null and
+ * empty `specs` and the footer wrapper when no footer is passed; stamps a
+ * nested `data-theme` scope only when `theme` is set; and forwards `testId` and
+ * `className` to the root.
  *
  * The lazy `PlanTierAvatar` compositor bundle is mocked away so the avatar
  * renders its deterministic same-size placeholder (mirrors
@@ -27,10 +27,6 @@ mock.module("@/utils/use-bundled-avatar-components", () => ({
 
 const { PlanTile } = await import("./plan-tile");
 
-/**
- * Chips with no `ownRow`: the vertical stack, or a wrapping row with nothing
- * split out below it.
- */
 const SPECS: PlanSpec[] = [
   { icon: Computer, label: "Small Machine" },
   { icon: HardDrive, label: "10 GB Storage" },
@@ -80,7 +76,7 @@ describe("PlanTile", () => {
     expect(placeholder?.style.height).toBe("48px");
   });
 
-  test("omits the chip stack when specs is null", () => {
+  test("omits the chips when specs is null", () => {
     const { getByTestId, queryByText } = render(
       <PlanTile
         testId={TILE_TEST_ID}
@@ -95,11 +91,11 @@ describe("PlanTile", () => {
     for (const spec of SPECS) {
       expect(queryByText(spec.label)).toBeNull();
     }
-    // Header row and footer only: no chip-stack wrapper in between.
+    // Header row and footer only: no chip wrapper in between.
     expect(getByTestId(TILE_TEST_ID).childElementCount).toBe(2);
   });
 
-  test("omits the chip stack when specs is empty", () => {
+  test("omits the chips when specs is empty", () => {
     const { getByTestId, queryByText } = render(
       <PlanTile
         testId={TILE_TEST_ID}
@@ -129,7 +125,7 @@ describe("PlanTile", () => {
     );
 
     const root = getByTestId(TILE_TEST_ID);
-    // Header row and chip stack only, and the last child is the chip stack
+    // Header row and chips only, and the last child is the chip container
     // rather than an empty footer slot.
     expect(root.childElementCount).toBe(2);
     expect(root.lastElementChild?.textContent).toContain("Small Machine");
@@ -148,7 +144,7 @@ describe("PlanTile", () => {
     expect(getByTestId(TILE_TEST_ID).childElementCount).toBe(1);
   });
 
-  test("stacks the chips vertically by default", () => {
+  test("lays the chips out as a wrapping row", () => {
     const { getByTestId } = render(
       <PlanTile
         testId={TILE_TEST_ID}
@@ -159,25 +155,8 @@ describe("PlanTile", () => {
       />,
     );
 
-    // Child 0 is the header row; child 1 is the chip container.
-    const container = getByTestId(TILE_TEST_ID).children[1] as HTMLElement;
-    expect(container.className).toContain("flex-col");
-    expect(container.className).not.toContain("flex-wrap");
-  });
-
-  test("lays the chips out as a wrapping row when specsWrap is set", () => {
-    const { getByTestId } = render(
-      <PlanTile
-        testId={TILE_TEST_ID}
-        tierKey="mighty"
-        name="Mighty"
-        tag={<span>Current</span>}
-        specs={SPECS}
-        specsWrap
-      />,
-    );
-
-    // No spec asks for its own row, so the whole set flows in the one wrap row.
+    // Child 0 is the header row; child 1 is the chip container. No spec asks
+    // for its own row, so the whole set flows in the one wrap row.
     const container = getByTestId(TILE_TEST_ID).children[1] as HTMLElement;
     expect(container.className).toContain("flex-col");
     expect(container.childElementCount).toBe(1);
@@ -195,7 +174,6 @@ describe("PlanTile", () => {
         name="Mighty"
         tag={<span>Current</span>}
         specs={OWN_ROW_SPECS}
-        specsWrap
       />,
     );
 
@@ -227,33 +205,12 @@ describe("PlanTile", () => {
         name="Mighty"
         tag={<span>Current</span>}
         specs={OWN_ROW_SPECS.filter((spec) => spec.ownRow)}
-        specsWrap
       />,
     );
 
     const container = getByTestId(TILE_TEST_ID).children[1] as HTMLElement;
     expect(container.childElementCount).toBe(2);
     expect(container.firstElementChild?.className).not.toContain("flex-wrap");
-  });
-
-  test("ignores ownRow in the vertical stack", () => {
-    const { getByTestId, getByText } = render(
-      <PlanTile
-        testId={TILE_TEST_ID}
-        tierKey="mighty"
-        name="Mighty"
-        tag={<span>Current</span>}
-        specs={OWN_ROW_SPECS}
-      />,
-    );
-
-    // Every chip already has a row of its own, in the order it was given.
-    const container = getByTestId(TILE_TEST_ID).children[1] as HTMLElement;
-    expect(container.childElementCount).toBe(OWN_ROW_SPECS.length);
-    expect(container.className).toContain("flex-col");
-    expect(getByText("Mighty usage, reset monthly").className).toContain(
-      "whitespace-nowrap",
-    );
   });
 
   test("stamps a nested data-theme scope when theme is set", () => {

--- a/clients/web/src/domains/settings/billing/plan-tile.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.tsx
@@ -20,14 +20,8 @@ export interface PlanTileProps {
   nameTestId?: string;
   /** The "Current" / "Next Plan" tag rendered above the avatar row. */
   tag: ReactNode;
-  /** Vertical spec-chip stack; omitted entirely when null or empty. */
+  /** The tile's spec chips; omitted entirely when null or empty. */
   specs?: PlanSpec[] | null;
-  /**
-   * Lay the short chips out as a wrapping row instead of a vertical stack. Any
-   * spec flagged `ownRow` still gets a full-width row of its own below that
-   * group, which is where the long usage and extras labels go.
-   */
-  specsWrap?: boolean;
   /** Bottom slot (price row or CTA), pinned to the tile's bottom edge. */
   footer?: ReactNode;
   testId?: string;
@@ -47,7 +41,6 @@ export function PlanTile({
   nameTestId,
   tag,
   specs,
-  specsWrap = false,
   footer,
   testId,
   className,
@@ -78,43 +71,30 @@ export function PlanTile({
         </div>
       </div>
       {specs?.length ? (
-        specsWrap ? (
-          <div className="flex flex-col items-start gap-1">
-            {rowSpecs.length ? (
-              <div className="flex flex-row flex-wrap items-start gap-1">
-                {rowSpecs.map((spec) => (
-                  <SpecChip
-                    key={spec.label}
-                    icon={spec.icon}
-                    label={spec.label}
-                    multiline={spec.multiline}
-                  />
-                ))}
-              </div>
-            ) : null}
-            {ownRowSpecs.map((spec) => (
-              // An own-row chip has the whole tile width, so let a long label
-              // wrap inside the pill rather than pushing past the tile.
-              <SpecChip
-                key={spec.label}
-                icon={spec.icon}
-                label={spec.label}
-                multiline
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="flex flex-col items-start gap-2">
-            {specs.map((spec) => (
-              <SpecChip
-                key={spec.label}
-                icon={spec.icon}
-                label={spec.label}
-                multiline={spec.multiline}
-              />
-            ))}
-          </div>
-        )
+        <div className="flex flex-col items-start gap-1">
+          {rowSpecs.length ? (
+            <div className="flex flex-row flex-wrap items-start gap-1">
+              {rowSpecs.map((spec) => (
+                <SpecChip
+                  key={spec.label}
+                  icon={spec.icon}
+                  label={spec.label}
+                  multiline={spec.multiline}
+                />
+              ))}
+            </div>
+          ) : null}
+          {ownRowSpecs.map((spec) => (
+            // An own-row chip has the whole tile width, so let a long label
+            // wrap inside the pill rather than pushing past the tile.
+            <SpecChip
+              key={spec.label}
+              icon={spec.icon}
+              label={spec.label}
+              multiline
+            />
+          ))}
+        </div>
       ) : null}
       {footer ? <div className="mt-auto w-full">{footer}</div> : null}
     </div>

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1137,22 +1137,6 @@ describe("PlanCard usage balance footer", () => {
     expect(within(currentTile(container)).queryByText("$30/month")).toBeNull();
   });
 
-  test("both tiles name the package's usage rather than a dollar bundle", () => {
-    const { container } = renderCardInteractive(
-      proMightySubscription(),
-      plansWithSuper(),
-      () => {},
-    );
-
-    const current = within(currentTile(container));
-    expect(current.getByText("Mighty usage, reset monthly")).toBeTruthy();
-    // Machine and storage chips keep their own copy.
-    expect(current.getByText("10 GB Storage")).toBeTruthy();
-
-    const next = within(nextTile(container));
-    expect(next.getByText("Super usage, reset monthly")).toBeTruthy();
-  });
-
   test("both tiles wrap their short chips into a row, usage below", () => {
     const { container } = renderCardInteractive(
       proMightySubscription(),
@@ -1161,8 +1145,8 @@ describe("PlanCard usage balance footer", () => {
     );
 
     for (const [tile, usageLabel] of [
-      [currentTile(container), "Mighty usage, reset monthly"],
-      [nextTile(container), "Super usage, reset monthly"],
+      [currentTile(container), MIGHTY_CHIPS[2]],
+      [nextTile(container), SUPER_CHIPS[2]],
     ] as const) {
       // Child 0 is the header row; child 1 is the chip container.
       const chips = tile.children[1] as HTMLElement;
@@ -1212,8 +1196,9 @@ describe("PlanCard usage balance footer", () => {
     expect(panel.textContent).toContain("20% used");
     // A Custom sub still enumerates nothing and still quotes no price.
     const current = within(currentTile(container));
-    expect(current.queryByText("Mighty usage, reset monthly")).toBeNull();
-    expect(current.queryByText("10 GB Storage")).toBeNull();
+    for (const label of MIGHTY_CHIPS) {
+      expect(current.queryByText(label)).toBeNull();
+    }
     expect(current.queryByTestId("plan-card-price")).toBeNull();
   });
 

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -291,7 +291,6 @@ function RecommendedUpgrade({
           recommended,
           t("planCard.usageChip", { name: recommended.name }),
         )}
-        specsWrap
         footer={
           <Button
             variant="primary"
@@ -567,7 +566,6 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
             nameTestId="plan-card-name"
             tag={<Tag tone="info">{t("planCard.current")}</Tag>}
             specs={currentSpecs}
-            specsWrap
             footer={currentFooter}
           />
           <RecommendedUpgrade


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 2) for remove-obscure-credits-flag.md.

- PlanTile always lays its specs out as a wrapping row; the specsWrap prop and the vertical stack it selected are gone, along with their stack-only tests.
- The SideBySide story's current tile shows the Usage Balance footer like the plan card does; the price-row state keeps its own story.
- Two tests that had become strict subsets of a sibling are removed.