### PR TITLE
feat(web): return the saved card from usePaymentMethodSavedSync

### DIFF
--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -52,11 +52,12 @@ export interface AutoTopUpPaymentMethodModalProps {
    *
    * May return a Promise; the modal awaits it before calling `onClose()` so
    * the parent re-renders against fresh data instead of briefly showing
-   * stale payment-method copy after a successful save.
+   * stale payment-method copy after a successful save. Any resolved value
+   * is ignored here.
    */
   onSavedOptimistic: (args: {
     setupIntentId: string | null;
-  }) => void | Promise<void>;
+  }) => void | Promise<unknown>;
 }
 
 /**
@@ -165,9 +166,7 @@ function AutoTopUpPaymentMethodModalContent({
     >
       <Modal.Content size="sm">
         <Modal.Header>
-          <Modal.Title>
-            {t("autoTopUpPaymentMethodModal.title")}
-          </Modal.Title>
+          <Modal.Title>{t("autoTopUpPaymentMethodModal.title")}</Modal.Title>
         </Modal.Header>
         <Modal.Body className="min-h-[260px]">
           {!STRIPE_PK ? (
@@ -237,9 +236,7 @@ function MissingStripeKeyNotice() {
     );
   }, []);
   return (
-    <Notice tone="error">
-      {t("autoTopUpPaymentMethodModal.unavailable")}
-    </Notice>
+    <Notice tone="error">{t("autoTopUpPaymentMethodModal.unavailable")}</Notice>
   );
 }
 

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
@@ -15,7 +15,8 @@
  * the config cache from the response, falling back to the poll when the
  * confirm call fails or no SetupIntent id was derivable.
  *
- * Both resolve with the saved card the config ended up carrying.
+ * Both resolve with the saved card a fresh response carried, and with null
+ * when the poll times out without one.
  */
 
 import {
@@ -264,6 +265,26 @@ describe("usePaymentMethodSavedPoll", () => {
 
     expect(await result.current()).toBeNull();
     expect(retrieveCalls).toBe(1);
+  }, 10_000);
+
+  test("resolves to null on timeout even with a card already cached", async () => {
+    // Replacing a card: the cache carries the previous one, and the refetch
+    // keeps answering with the unchanged marker until the clock jump ends
+    // the loop. The previous card must not be reported as the new one.
+    const cached = {
+      ...makeConfig("2026-08-19T00:00:00Z", true),
+      payment_method_brand: "visa",
+      payment_method_last4: "4242",
+    };
+    retrieveResponses = [cached];
+    retrieveClockJumpMs = PM_SAVED_MAX_POLL_MS + 1000;
+    const { result, client } = setup(cached);
+
+    expect(await result.current()).toBeNull();
+    expect(retrieveCalls).toBe(1);
+    // The cached card stays on screen for the query's normal refetches to
+    // reconcile; only the resolved value withholds it.
+    expect(cachedConfig(client)?.payment_method_last4).toBe("4242");
   }, 10_000);
 });
 

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
@@ -7,15 +7,26 @@
  * whose `stripe_payment_method_updated_at` advanced past the pre-call cache
  * value. While the marker is unchanged (webhook not landed yet) it keeps
  * polling without writing the pre-webhook "no card" responses into the
- * cache, so the flipped config stays visible. The 20s timeout path is not
- * exercised here; it would need real time.
+ * cache, so the flipped config stays visible. The 20s timeout path is
+ * reached by jumping the system clock past the budget from inside the
+ * mocked refetch.
  *
  * usePaymentMethodSavedSync: confirms the SetupIntent server-side and seeds
  * the config cache from the response, falling back to the poll when the
  * confirm call fails or no SetupIntent id was derivable.
+ *
+ * Both resolve with the saved card the config ended up carrying.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -28,6 +39,7 @@ let retrieveCalls = 0;
 let confirmCalls: Array<Record<string, unknown>> = [];
 let confirmResponse: AutoTopUpConfigResponse | null = null;
 let confirmShouldFail = false;
+let retrieveClockJumpMs = 0;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -35,6 +47,9 @@ mock.module("@/generated/api/sdk.gen", () => ({
     const next =
       retrieveResponses[Math.min(retrieveCalls, retrieveResponses.length - 1)];
     retrieveCalls += 1;
+    if (retrieveClockJumpMs > 0) {
+      setSystemTime(new Date(Date.now() + retrieveClockJumpMs));
+    }
     return Promise.resolve({ data: next, response: { ok: true } });
   },
   organizationsBillingAutoTopUpConfirmSetupIntentCreate: (
@@ -50,8 +65,12 @@ mock.module("@/generated/api/sdk.gen", () => ({
 
 import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 
-const { usePaymentMethodSavedPoll, usePaymentMethodSavedSync } =
-  await import("./use-payment-method-saved-poll");
+const {
+  PM_SAVED_MAX_POLL_MS,
+  savedFromConfig,
+  usePaymentMethodSavedPoll,
+  usePaymentMethodSavedSync,
+} = await import("./use-payment-method-saved-poll");
 const { DISABLED_CONFIG } = await import("../components/auto-top-up-card");
 
 function makeConfig(
@@ -65,14 +84,19 @@ function makeConfig(
   };
 }
 
-function makeClient(cached: AutoTopUpConfigResponse): QueryClient {
+function makeClient(cached?: AutoTopUpConfigResponse): QueryClient {
   const client = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
       mutations: { retry: false },
     },
   });
-  client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), cached);
+  if (cached != null) {
+    client.setQueryData(
+      organizationsBillingAutoTopUpRetrieveQueryKey(),
+      cached,
+    );
+  }
   return client;
 }
 
@@ -82,7 +106,7 @@ function makeWrapper(client: QueryClient) {
   );
 }
 
-function setup(cached: AutoTopUpConfigResponse) {
+function setup(cached?: AutoTopUpConfigResponse) {
   const client = makeClient(cached);
   const rendered = renderHook(() => usePaymentMethodSavedPoll(), {
     wrapper: makeWrapper(client),
@@ -90,7 +114,9 @@ function setup(cached: AutoTopUpConfigResponse) {
   return { ...rendered, client };
 }
 
-function cachedConfig(client: QueryClient): AutoTopUpConfigResponse | undefined {
+function cachedConfig(
+  client: QueryClient,
+): AutoTopUpConfigResponse | undefined {
   return client.getQueryData<AutoTopUpConfigResponse>(
     organizationsBillingAutoTopUpRetrieveQueryKey(),
   );
@@ -110,6 +136,11 @@ beforeEach(() => {
   confirmCalls = [];
   confirmResponse = null;
   confirmShouldFail = false;
+  retrieveClockJumpMs = 0;
+});
+
+afterEach(() => {
+  setSystemTime();
 });
 
 describe("usePaymentMethodSavedPoll", () => {
@@ -205,19 +236,74 @@ describe("usePaymentMethodSavedPoll", () => {
       makeConfig("2026-08-19T00:00:01Z", true),
     );
   }, 10_000);
+
+  test("resolves with the refetched card", async () => {
+    retrieveResponses = [
+      {
+        ...makeConfig("2026-08-19T00:00:01Z", true),
+        enabled: true,
+        payment_method_brand: "mastercard",
+        payment_method_last4: "1881",
+      },
+    ];
+    const { result } = setup(makeConfig(null, false));
+
+    expect(await result.current()).toEqual({
+      brand: "mastercard",
+      last4: "1881",
+      autoReloadEnabled: true,
+    });
+  });
+
+  test("resolves to null when the poll times out without a card", async () => {
+    // Nothing cached, so there is no config to flip to a saved card; the
+    // refetch jumps the clock past the poll budget to end the loop.
+    retrieveResponses = [makeConfig(null, false)];
+    retrieveClockJumpMs = PM_SAVED_MAX_POLL_MS + 1000;
+    const { result } = setup();
+
+    expect(await result.current()).toBeNull();
+    expect(retrieveCalls).toBe(1);
+  }, 10_000);
+});
+
+describe("savedFromConfig", () => {
+  test("returns null without a config", () => {
+    expect(savedFromConfig(undefined)).toBeNull();
+  });
+
+  test("returns null when the config reports no card", () => {
+    expect(savedFromConfig(makeConfig(null, false))).toBeNull();
+  });
+
+  test("returns the card the config carries", () => {
+    expect(
+      savedFromConfig({
+        ...makeConfig("2026-08-19T00:00:01Z", true),
+        enabled: true,
+        payment_method_brand: "amex",
+        payment_method_last4: "0005",
+      }),
+    ).toEqual({ brand: "amex", last4: "0005", autoReloadEnabled: true });
+  });
 });
 
 describe("usePaymentMethodSavedSync", () => {
   test("seeds the config cache from the confirm response without polling", async () => {
     const confirmed = {
       ...makeConfig("2026-08-19T00:00:01Z", true),
+      enabled: true,
       payment_method_brand: "visa",
       payment_method_last4: "4242",
     };
     confirmResponse = confirmed;
     const { result, client } = setupSync(makeConfig(null, false));
 
-    await result.current({ setupIntentId: "seti_abc" });
+    expect(await result.current({ setupIntentId: "seti_abc" })).toEqual({
+      brand: "visa",
+      last4: "4242",
+      autoReloadEnabled: true,
+    });
 
     expect(confirmCalls.length).toBe(1);
     expect(
@@ -233,10 +319,20 @@ describe("usePaymentMethodSavedSync", () => {
 
   test("falls back to the poll when the confirm call fails", async () => {
     confirmShouldFail = true;
-    retrieveResponses = [makeConfig("2026-08-19T00:00:01Z", true)];
+    retrieveResponses = [
+      {
+        ...makeConfig("2026-08-19T00:00:01Z", true),
+        payment_method_brand: "visa",
+        payment_method_last4: "4242",
+      },
+    ];
     const { result } = setupSync(makeConfig("2026-08-19T00:00:00Z", true));
 
-    await result.current({ setupIntentId: "seti_abc" });
+    expect(await result.current({ setupIntentId: "seti_abc" })).toEqual({
+      brand: "visa",
+      last4: "4242",
+      autoReloadEnabled: false,
+    });
 
     expect(confirmCalls.length).toBe(1);
     expect(retrieveCalls).toBe(1);

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
@@ -11,6 +11,25 @@ import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 export const PM_SAVED_POLL_INTERVAL_MS = 1500;
 export const PM_SAVED_MAX_POLL_MS = 20_000;
 
+export interface SavedPaymentMethod {
+  brand: string | null;
+  last4: string | null;
+  autoReloadEnabled: boolean;
+}
+
+export function savedFromConfig(
+  config: AutoTopUpConfigResponse | undefined,
+): SavedPaymentMethod | null {
+  if (config == null || !config.has_payment_method) {
+    return null;
+  }
+  return {
+    brand: config.payment_method_brand,
+    last4: config.payment_method_last4,
+    autoReloadEnabled: config.enabled,
+  };
+}
+
 /**
  * Returns the follow-up for `AutoTopUpPaymentMethodModal`'s
  * `onSavedOptimistic`: the `setup_intent.succeeded` webhook persists
@@ -34,9 +53,10 @@ export const PM_SAVED_MAX_POLL_MS = 20_000;
  *
  * If the webhook still hasn't landed at the timeout, the flipped config
  * stays put and the query's normal refetches reconcile with the server.
- * Always resolves.
+ * Always resolves, with the saved card the config ended up carrying (null
+ * when it still reports no card).
  */
-export function usePaymentMethodSavedPoll(): () => Promise<void> {
+export function usePaymentMethodSavedPoll(): () => Promise<SavedPaymentMethod | null> {
   const queryClient = useQueryClient();
 
   return async () => {
@@ -85,7 +105,7 @@ export function usePaymentMethodSavedPoll(): () => Promise<void> {
               undefined,
               refetched,
             );
-            return;
+            return savedFromConfig(refetched);
           }
         } catch {
           // sleep and retry
@@ -97,6 +117,10 @@ export function usePaymentMethodSavedPoll(): () => Promise<void> {
     } finally {
       unsubscribe();
     }
+
+    return savedFromConfig(
+      queryClient.getQueryData<AutoTopUpConfigResponse>(queryKey),
+    );
   };
 }
 
@@ -111,10 +135,13 @@ export function usePaymentMethodSavedPoll(): () => Promise<void> {
  * The poll stays as the fallback: when the confirm call fails for any reason
  * (the endpoint is unavailable on this server, or the request errors), the
  * webhook remains the durable writer and the poll waits for its write.
+ *
+ * Resolves with the saved card, from the confirm response or from whatever
+ * the fallback poll ended up with, and null when neither reports one.
  */
 export function usePaymentMethodSavedSync(): (args: {
   setupIntentId: string | null;
-}) => Promise<void> {
+}) => Promise<SavedPaymentMethod | null> {
   const queryClient = useQueryClient();
   const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
   const { mutateAsync: confirmSetupIntent } = useMutation(
@@ -135,11 +162,11 @@ export function usePaymentMethodSavedSync(): (args: {
           undefined,
           config,
         );
-        return;
+        return savedFromConfig(config);
       } catch {
         // fall through to the poll below
       }
     }
-    await pollPaymentMethodSaved();
+    return pollPaymentMethodSaved();
   };
 }

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
@@ -53,8 +53,9 @@ export function savedFromConfig(
  *
  * If the webhook still hasn't landed at the timeout, the flipped config
  * stays put and the query's normal refetches reconcile with the server.
- * Always resolves, with the saved card the config ended up carrying (null
- * when it still reports no card).
+ * Always resolves: with the card a fresh response carried, or with null on
+ * timeout, since the cache then holds only the optimistic flip (or, when a
+ * card is being replaced, the previous card).
  */
 export function usePaymentMethodSavedPoll(): () => Promise<SavedPaymentMethod | null> {
   const queryClient = useQueryClient();
@@ -118,9 +119,7 @@ export function usePaymentMethodSavedPoll(): () => Promise<SavedPaymentMethod | 
       unsubscribe();
     }
 
-    return savedFromConfig(
-      queryClient.getQueryData<AutoTopUpConfigResponse>(queryKey),
-    );
+    return null;
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `SavedPaymentMethod` and `savedFromConfig(config)` to `use-payment-method-saved-poll.ts`; both hooks now resolve with the saved card (or `null`) instead of `void`. Poll timing and cache writes are unchanged.
- Widen `AutoTopUpPaymentMethodModal`'s `onSavedOptimistic` return type to `void | Promise<unknown>` so `payment-methods-card.tsx` keeps compiling while passing the hook directly (the modal already ignores the resolved value). Prettier also normalised two pre-existing formatting spots in that file.
- Tests cover the confirm path, the poll path, a timeout with no card, and `savedFromConfig` directly; the timeout case jumps the system clock from inside the mocked refetch.

Part of plan: payment-modal-v4.md (PR 3 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XB7ckoybGsZZWurNBj6cx3