### PR TITLE
test: delete the dead BUN_TEST=0 flips from the DB migration tests

### DIFF
--- a/assistant/src/__tests__/db-conversation-fork-lineage-migration.test.ts
+++ b/assistant/src/__tests__/db-conversation-fork-lineage-migration.test.ts
@@ -3,8 +3,6 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-const originalBunTest = process.env.BUN_TEST;
-
 import { getSqliteFrom } from "../persistence/db-connection.js";
 import { migrateConversationForkLineage } from "../persistence/migrations/183-add-conversation-fork-lineage.js";
 import * as schema from "../persistence/schema/index.js";
@@ -62,12 +60,10 @@ function resetMigrationTestDb(): void {
 
 describe("conversation fork lineage migration", () => {
   beforeEach(() => {
-    process.env.BUN_TEST = "0";
     resetMigrationTestDb();
   });
 
   afterAll(() => {
-    process.env.BUN_TEST = originalBunTest;
     resetMigrationTestDb();
   });
 

--- a/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
+++ b/assistant/src/__tests__/db-conversation-inference-profile-migration.test.ts
@@ -3,8 +3,6 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-const originalBunTest = process.env.BUN_TEST;
-
 import { _resetDisplayOrderMigrationForTests } from "../persistence/conversation-display-order-migration.js";
 import { _resetGroupMigrationForTests } from "../persistence/conversation-group-migration.js";
 import { getSqliteFrom } from "../persistence/db-connection.js";
@@ -68,12 +66,10 @@ function resetMigrationTestDb(): void {
 
 describe("conversation inference profile migration", () => {
   beforeEach(() => {
-    process.env.BUN_TEST = "0";
     resetMigrationTestDb();
   });
 
   afterAll(() => {
-    process.env.BUN_TEST = originalBunTest;
     resetMigrationTestDb();
   });
 

--- a/assistant/src/__tests__/db-llm-request-log-provider-migration.test.ts
+++ b/assistant/src/__tests__/db-llm-request-log-provider-migration.test.ts
@@ -10,8 +10,6 @@ import {
 
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
-const originalBunTest = process.env.BUN_TEST;
-
 import { getSqliteFrom } from "../persistence/db-connection.js";
 import { migrateLlmRequestLogProvider } from "../persistence/migrations/184-llm-request-log-provider.js";
 import * as schema from "../persistence/schema/index.js";
@@ -48,7 +46,6 @@ function bootstrapPreProviderLlmRequestLogs(raw: Database): void {
 
 describe("llm_request_logs provider migration", () => {
   beforeEach(() => {
-    process.env.BUN_TEST = "0";
     resetDbForTesting();
   });
 
@@ -57,11 +54,6 @@ describe("llm_request_logs provider migration", () => {
   });
 
   afterAll(() => {
-    if (originalBunTest === undefined) {
-      delete process.env.BUN_TEST;
-    } else {
-      process.env.BUN_TEST = originalBunTest;
-    }
     resetDbForTesting();
   });
 


### PR DESCRIPTION
## TL;DR

Delete the `process.env.BUN_TEST = "0"` flips (and their save/restore boilerplate) from the three DB migration tests. The mechanism they bypassed no longer exists, so the flips are dead code that actively misleads readers about how test detection works. Related to [JARVIS-1643](https://linear.app/vellum/issue/JARVIS-1643).

## Why

The flips date from when `db-init.ts` had a `BUN_TEST`-keyed test-mode short-circuit that the migration tests needed to bypass to exercise production migration behavior. Verified against the current tree:

- Nothing in `assistant/src/persistence/` reads `BUN_TEST` or `NODE_ENV` anymore.
- The only production readers of `BUN_TEST` are eight `=== "1"` checks (logger silencing, PBKDF2 iteration reduction, and six `*ForTests()` armor throws). Setting the variable to `"0"` when nothing sets it to `"1"` in the first place (no preload does, and Bun itself does not set it) changes none of them.

So the flip is a no-op, but not a harmless one: it reads as load-bearing test setup, and it has previously been cited (in the #32063 forensics) as evidence that env-based test detection cannot be trusted, an argument that feeds into guard design. Dead code that shapes future decisions is worth deleting on sight.

One of the three restores also carried a latent bug, moot now: assigning `originalBunTest` back when it was `undefined` coerces to the string `"undefined"` on `process.env`.

## Why this is safe

- The tests' own setup path is unaffected: `resetDbForTesting()` / `resetMigrationTestDb()` armor fires on `NODE_ENV === "test"`, which the flip never touched.
- Behavior of the eight `BUN_TEST === "1"` sites is unchanged for these tests: `"0"` and unset both fail that check identically.
- Test-file-only change; no production code touched.

## Before / after

| | Before | After |
| --- | --- | --- |
| Migration test env handling | Flips `BUN_TEST="0"` per test, restores in `afterAll` | No env manipulation |
| Runtime behavior | Identical | Identical |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->