### PR TITLE
fix: move the credits-row rule beside its hook and trim the last review leftovers

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -122,6 +122,9 @@ mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   organizationsBillingSummaryRetrieveOptions: () => ({
     queryKey: [{ _id: "organizationsBillingSummaryRetrieve" }],
   }),
+  organizationsBillingSubscriptionRetrieveOptions: () => ({
+    queryKey: [{ _id: "organizationsBillingSubscriptionRetrieve" }],
+  }),
   referralCodesMeRetrieveOptions: () => ({
     queryKey: [{ _id: "referralCodesMeRetrieve" }],
   }),
@@ -195,7 +198,13 @@ const usageRef: { value: PreferencesUsage | null; opts: unknown } = {
   value: null,
   opts: undefined,
 };
+// Spread the real module so `showsMenuCredits` stays the production rule;
+// only the reading it works off is overridden.
+const actualPreferencesUsage = await import(
+  "@/domains/chat/hooks/use-preferences-usage"
+);
 mock.module("@/domains/chat/hooks/use-preferences-usage", () => ({
+  ...actualPreferencesUsage,
   usePreferencesUsage: (opts?: unknown) => {
     usageRef.opts = opts;
     return usageRef.value;

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -24,8 +24,10 @@ import {
   ShareFeedbackModalLazy,
 } from "@/components/share-feedback-modal-lazy";
 import { ThemeToggle } from "@/components/theme-toggle";
-import type { PreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
-import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
+import {
+  showsMenuCredits,
+  usePreferencesUsage,
+} from "@/domains/chat/hooks/use-preferences-usage";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
@@ -321,11 +323,6 @@ function PreferencesMenuContent({
       />
     </>
   );
-}
-
-/** The credits row stands in for the usage panel when there is no reading. */
-export function showsMenuCredits(usage: PreferencesUsage | null): boolean {
-  return usage == null;
 }
 
 function formatWholeCredits(value: string): string {

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
@@ -21,9 +21,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import { CreditsCard } from "@/domains/chat/components/credits-card";
-import { showsMenuCredits } from "@/domains/chat/components/preferences-menu";
 import { PreferencesUsagePanel } from "@/domains/chat/components/preferences-usage-panel";
-import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
+import {
+  showsMenuCredits,
+  usePreferencesUsage,
+} from "@/domains/chat/hooks/use-preferences-usage";
 import {
   organizationsBillingSubscriptionRetrieveOptions,
   organizationsBillingSummaryRetrieveQueryKey,
@@ -83,10 +85,11 @@ function PanelOnly() {
 
 /**
  * The panel with the compact credits row beneath it, composed the way
- * `PreferencesMenuContent` composes them: `showsMenuCredits` decides whether
- * the row belongs on screen and `displayedCreditsUsd` decides what it names,
- * so the story exercises both real rules. The seeded balance is already in the
- * two-decimal shape the menu formats it to.
+ * `PreferencesMenuContent` composes them: `showsMenuCredits` supplies the
+ * credits-row condition the menu combines with its billing gates, and
+ * `displayedCreditsUsd` decides what the row names, so the story exercises
+ * both real rules. The seeded balance is already in the two-decimal shape the
+ * menu formats it to.
  */
 function PanelWithCredits() {
   const usage = usePreferencesUsage();

--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
@@ -92,3 +92,8 @@ export function usePreferencesUsage(
     usingExtraCredits: spent && hasWalletCredit && !routeSkipsWallet,
   };
 }
+
+/** The credits row stands in for the usage panel when there is no reading. */
+export function showsMenuCredits(usage: PreferencesUsage | null): boolean {
+  return usage == null;
+}

--- a/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
@@ -263,9 +263,6 @@ export const NextPlanPending: Story = {
  * below the `lg` breakpoint: select `Mobile` in the viewport toolbar to see
  * that treatment, since the Canvas holds a desktop width regardless of window
  * size.
- *
- * The current tile carries the Usage Balance bar, which is what a subscription
- * with a usage reading shows; `CurrentPaidNoUsageReading` has the price row.
  */
 export const SideBySide: Story = {
   parameters: {

--- a/clients/web/src/domains/settings/billing/plan-tile.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.tsx
@@ -22,7 +22,10 @@ export interface PlanTileProps {
   tag: ReactNode;
   /** The tile's spec chips; omitted entirely when null or empty. */
   specs?: PlanSpec[] | null;
-  /** Bottom slot (price row or CTA), pinned to the tile's bottom edge. */
+  /**
+   * Bottom slot (usage balance, price row, or CTA), pinned to the tile's
+   * bottom edge.
+   */
   footer?: ReactNode;
   testId?: string;
   className?: string;
@@ -31,8 +34,9 @@ export interface PlanTileProps {
 /**
  * One tile in the billing "Plan" section's side-by-side comparison: tag,
  * creature avatar and plan name, spec chips, and a bottom slot. Renders both
- * the current-plan tile (inherited theme, price footer) and the next-plan
- * tile (inverted theme scope, upgrade CTA footer).
+ * the current-plan tile (inherited theme, usage balance footer, or the price
+ * row when there is no reading) and the next-plan tile (inverted theme scope,
+ * upgrade CTA footer).
  */
 export function PlanTile({
   theme,

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -1716,19 +1716,21 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
 
 describe("PlansPage: package usage rows", () => {
   test("every package row is named from the package", async () => {
-    const { findByText, getByText } = renderInteractive(freeSubscription());
+    const { findByText, getByText } = renderInteractive(freeSubscription(), {
+      // Titan carries no `usage_label`, so its row holds only if the wording
+      // comes off the package name.
+      plans: plansWith([
+        MIGHTY,
+        SUPER,
+        ULTRA,
+        makeProPackage({ key: "titan", name: "Titan", usage_label: null }),
+      ]),
+    });
 
     // The name-derived usage rows, matching the plan card's chip.
     await findByText("Mighty usage, reset monthly");
     getByText("Super usage, reset monthly");
     getByText("Ultra usage, reset monthly");
-  });
-
-  test("a package with no usage_label still gets a name-derived usage row", async () => {
-    const { findByText } = renderInteractive(freeSubscription(), {
-      plans: plansWith([makeProPackage({ usage_label: null })]),
-    });
-
-    await findByText("Mighty usage, reset monthly");
+    getByText("Titan usage, reset monthly");
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -11,8 +11,7 @@ import { findCreditTier } from "@/lib/billing/credit-tiers";
  * renders ("Mighty Usage", the Stripe product name, so it matches the invoice
  * line). `null` marks the explicit no-bundle side, worded by the caller; an
  * `undefined` from-side is a bundle the catalog can't label, which the chip
- * leaves unstated. An unwordable to-side drops the chip, so the hooks return
- * null instead of a change.
+ * leaves unstated.
  */
 export interface CreditsChange {
   fromLabel: string | null | undefined;

--- a/clients/web/src/lib/billing/displayed-credits.ts
+++ b/clients/web/src/lib/billing/displayed-credits.ts
@@ -13,7 +13,6 @@
 
 import { parseUsd } from "@/lib/billing/parse-usd";
 
-/** Clamped at zero; passes the balance through when no grant figure lands. */
 export function displayedCreditsUsd(
   balance: string,
   availableUsageBalance: string | null | undefined,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 3) for remove-obscure-credits-flag.md.

- showsMenuCredits lives in use-preferences-usage.ts beside the type it reads; the menu and its story import it from there.
- PlanTile docs name the usage balance as the current tile's footer; three comments that restated code or narrated a change are gone.
- The plans-page usage_label test is folded into its sibling.