### PR TITLE
fix(cli): send cache headers for the paired web client's static assets

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1399,18 +1399,37 @@ async function runWebInterface(
         const filePath = path.join(distDir, relPath);
         const file = Bun.file(filePath);
         if (await file.exists()) {
-          return new Response(file);
+          // Everything under dist/assets/ carries a content hash in its
+          // filename, so it can be cached forever: a new build references new
+          // filenames. Without this header the WebView is free to revalidate
+          // or re-fetch every chunk on every lazy-route navigation. Unhashed
+          // files (public/ copies) must revalidate instead.
+          const cacheControl = relPath.startsWith("assets/")
+            ? "public, max-age=31536000, immutable"
+            : "no-cache";
+          return new Response(file, {
+            headers: { "Cache-Control": cacheControl },
+          });
         }
       }
       return new Response(indexHtml, {
-        headers: { "Content-Type": "text/html; charset=utf-8" },
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          // The HTML names the current build's hashed chunks and embeds the
+          // server's config snippet; a cached copy would pin a stale build
+          // (or stale flags) across an assistant update.
+          "Cache-Control": "no-cache",
+        },
       });
     }
 
     // SPA fallback for /account/* routes (login, callback, etc.)
     if (pathname.startsWith("/account/")) {
       return new Response(indexHtml, {
-        headers: { "Content-Type": "text/html; charset=utf-8" },
+        headers: {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "no-cache",
+        },
       });
     }
 


### PR DESCRIPTION
## TL;DR

The paired web client's local server (`vellum client --interface web` serving the built SPA) returned every file with no `Cache-Control` header. The WebView was free to revalidate or re-fetch every hashed chunk on every lazy-route navigation, and could conversely hold a stale `index.html` across an assistant update. Hashed assets are now immutable; the HTML shell and unhashed files are `no-cache`.

## What changes for the user

| | Before | After |
|---|---|---|
| Navigating to a lazy section (Settings, Logs) after the first visit | Browser may re-request every chunk (15 requests for Settings) | Chunks served from the browser cache, zero requests |
| Opening the app after an assistant update | `index.html` could be served stale from cache, pinning the old build | Shell always revalidates, new build loads |

## Why this is safe

- Everything under `dist/assets/` carries a content hash in its filename, so `public, max-age=31536000, immutable` can never serve a stale file: a new build references new filenames.
- `index.html` (both the SPA base and the `/account/*` fallback) and unhashed `public/` copies get `no-cache`, which permits storage but forces revalidation, strictly safer than the previous headerless response whose caching was left to browser heuristics.
- Verified against the running server: `curl -I` shows `immutable` on hashed assets and `no-cache` on the shell, and a real WebView session shows `transferSize: 0` (pure cache hits) for all 15 Settings chunks on repeat navigations.

Part of the Phase 0 serving fixes from the web bundle load-performance investigation; the remote-web ingress compression fix and the avatar boot-graph fix ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->