### PR TITLE
fix(web): keep the bundled avatar SVG data out of the boot graph

### DIFF
--- a/clients/web/src/domains/chat/utils/pin-color-registry.ts
+++ b/clients/web/src/domains/chat/utils/pin-color-registry.ts
@@ -10,7 +10,7 @@
  * or absent id resolves to no tint, which is also what an uncoloured pin
  * stores.
  *
- * Sourced from the bundled copy of the character components rather than
+ * Sourced from the bundled copy of the avatar palette rather than
  * `useAssistantAvatar`, because a sidebar row paints on first render and the
  * picker opens inside a context menu. Neither can wait on a fetch.
  */
@@ -18,7 +18,7 @@
 import type { CSSProperties } from "react";
 import { panelItemWashStyle } from "@vellumai/design-library";
 
-import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { BUNDLED_COLORS } from "@/utils/avatar-bundled-colors";
 
 /**
  * The name each colour is announced by, as a catalog key rather than the
@@ -63,7 +63,7 @@ export function pinColorNameKey(
  * choice, and the omission is loud enough to fix because the colour simply
  * does not appear.
  */
-export const PIN_COLORS: readonly PinColor[] = BUNDLED_COMPONENTS.colors.filter(
+export const PIN_COLORS: readonly PinColor[] = BUNDLED_COLORS.filter(
   (color): color is PinColor => color.id in COLOR_NAME_KEYS,
 );
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -103,17 +103,16 @@ export function useTakeoverSurface(
   const effectiveCustomImageUrl = drawnStash ? null : customImageUrl;
   const ready = liveSettled || stashUsable;
 
+  const drawnPalette = effectiveComponents
+    ? effectiveComponents.colors
+    : BUNDLED_COLORS;
   const accent =
     resolveAvatarAccentHex(effectiveComponents, effectiveTraits) ??
     // ChatAvatar draws from `components ?? bundled`, so the surface tints from
     // the same source it does — the first bundled color when the query settles
     // with none — and matches whatever creature is on screen instead of falling
     // through to neutral.
-    (effectiveCustomImageUrl
-      ? null
-      : effectiveComponents
-        ? (effectiveComponents.colors?.[0]?.hex ?? null)
-        : (BUNDLED_COLORS[0]?.hex ?? null));
+    (effectiveCustomImageUrl ? null : (drawnPalette?.[0]?.hex ?? null));
 
   return {
     tintHex: ready && accent ? avatarSurfaceHex(accent) : SURFACE_GROUND,

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-takeover-surface.ts
@@ -6,7 +6,7 @@ import {
 } from "@/hooks/use-assistant-avatar";
 import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { BUNDLED_COLORS } from "@/utils/avatar-bundled-colors";
 import { SURFACE_GROUND, avatarSurfaceHex } from "@/utils/avatar-tone";
 
 import {
@@ -111,7 +111,9 @@ export function useTakeoverSurface(
     // through to neutral.
     (effectiveCustomImageUrl
       ? null
-      : ((effectiveComponents ?? BUNDLED_COMPONENTS).colors?.[0]?.hex ?? null));
+      : effectiveComponents
+        ? (effectiveComponents.colors?.[0]?.hex ?? null)
+        : (BUNDLED_COLORS[0]?.hex ?? null));
 
   return {
     tintHex: ready && accent ? avatarSurfaceHex(accent) : SURFACE_GROUND,

--- a/clients/web/src/hooks/use-avatar-accent-var.ts
+++ b/clients/web/src/hooks/use-avatar-accent-var.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
-import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { BUNDLED_COLORS } from "@/utils/avatar-bundled-colors";
 
 /**
  * The CSS custom property carrying the active assistant's avatar accent hex
@@ -25,7 +25,7 @@ export function resolveAvatarAccentHex(
   if (!colorId) {
     return null;
   }
-  const palette = components?.colors ?? BUNDLED_COMPONENTS.colors;
+  const palette = components?.colors ?? BUNDLED_COLORS;
   return palette.find((c) => c.id === colorId)?.hex ?? null;
 }
 

--- a/clients/web/src/utils/avatar-bundled-colors.ts
+++ b/clients/web/src/utils/avatar-bundled-colors.ts
@@ -1,0 +1,22 @@
+/**
+ * Static bundled copy of the avatar color palette, split from
+ * `avatar-bundled-components` so palette-only consumers on the boot path
+ * (pin colors, the accent-var fallback) don't pull the ~47 kB of SVG path
+ * data into the boot graph. `avatar-bundled-components` re-exposes this
+ * array as `BUNDLED_COMPONENTS.colors`, so there is exactly one bundled
+ * definition of the palette.
+ *
+ * Canonical source: assistant/src/avatar/character-components.ts
+ * Keep in sync when colors change.
+ */
+
+import type { ColorDefinition } from "@/types/avatar";
+
+export const BUNDLED_COLORS: ColorDefinition[] = [
+  { id: "green", hex: "#4C9B50" },
+  { id: "orange", hex: "#E9642F" },
+  { id: "pink", hex: "#DB4B77" },
+  { id: "purple", hex: "#A665C9" },
+  { id: "teal", hex: "#0E9B8B" },
+  { id: "yellow", hex: "#E9C91A" },
+];

--- a/clients/web/src/utils/avatar-bundled-components.ts
+++ b/clients/web/src/utils/avatar-bundled-components.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CharacterComponents } from "@/types/avatar";
+import { BUNDLED_COLORS } from "@/utils/avatar-bundled-colors";
 
 const SCLERA = "#F2F2F2";
 const PUPIL = "#1A1A1A";
@@ -341,14 +342,9 @@ export const BUNDLED_COMPONENTS: CharacterComponents = {
     },
   ],
 
-  colors: [
-    { id: "green", hex: "#4C9B50" },
-    { id: "orange", hex: "#E9642F" },
-    { id: "pink", hex: "#DB4B77" },
-    { id: "purple", hex: "#A665C9" },
-    { id: "teal", hex: "#0E9B8B" },
-    { id: "yellow", hex: "#E9C91A" },
-  ],
+  // Palette lives in its own module so boot-path palette consumers don't
+  // statically depend on this file's SVG data.
+  colors: BUNDLED_COLORS,
 
   faceCenterOverrides: [
     // Ghost body — shift non-native eyes from y=167 -> y=200


### PR DESCRIPTION
## TL;DR

The 47 kB bundled avatar SVG payload (`avatar-bundled-components`) was split out of the boot bundle once (LUM-1940), but boot-path modules statically re-imported it and pulled it back into the entry chunk; the build has been emitting an `INEFFECTIVE_DYNAMIC_IMPORT` warning about it. The three boot-path importers only ever read the six-entry color palette, never the SVG paths, so the palette moves to its own module and the SVG data leaves the boot graph again. Boot-critical JS drops from 1,157 kB to 1,136 kB gzip.

## What changes for the user

| | Before | After |
|---|---|---|
| Cold app boot | Downloads and parses 47 kB of avatar SVG path data before first paint | That payload loads with the screens that draw full avatars |
| Hatching, companion window, research onboarding | Avatar data in the boot bundle | Avatar data ships inside those routes' own chunks, still no fetch and still offline-capable |
| Transcript subagent chips | Lazy-load via `useBundledAvatarComponents` (unchanged seam) | Same, now actually effective |

## Design

- `avatar-bundled-colors.ts` holds the palette; `avatar-bundled-components.ts` imports it and re-exposes it as `BUNDLED_COMPONENTS.colors`, so there is exactly one bundled palette definition and no consumer-visible shape change.
- Palette-only consumers (`pin-color-registry`, `use-avatar-accent-var`, `use-takeover-surface`) import the palette module directly. `use-takeover-surface` keeps its exact fallback semantics: the bundled palette only stands in when components are absent entirely.
- The full-data static importers that remain (hatching screen, companion surface, research onboarding) are all lazy routes that must render avatars without a running daemon, so their static imports are correct: the payload now lands in a shared lazy chunk instead of the entry.

## Why this is safe

- No data or type changes; the palette values are byte-identical and typed from the same generated `ColorDefinition`.
- Verified on a production build: the payload sits in its own lazy chunk, imported statically by the three lazy routes and dynamically from the transcript seam; the entry chunk carries only the 0.3 kB palette; the `INEFFECTIVE_DYNAMIC_IMPORT` warning for this module is gone; the Settings navigation chunk set is unchanged.
- Typecheck, eslint, and prettier pass; the app was booted against the built output and renders normally.

Part of Phase 0 of the web bundle load-performance investigation; the two serving fixes (local cache headers, remote ingress gzip) ship separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->