### PR TITLE
Write shortcut modifiers in the order each platform uses

### DIFF
--- a/clients/web/src/components/command-palette/command-palette.stories.tsx
+++ b/clients/web/src/components/command-palette/command-palette.stories.tsx
@@ -44,13 +44,13 @@ const SECTIONS: CommandPaletteSection[] = [
         id: "action-new-conversation",
         icon: SquarePen,
         title: "New Conversation",
-        shortcutHint: "⌘⇧O",
+        shortcutHint: "⇧⌘O",
       },
       {
         id: "action-current-conversation",
         icon: Monitor,
         title: "Current Conversation",
-        shortcutHint: "⌘⇧N",
+        shortcutHint: "⇧⌘N",
       },
       {
         id: "action-settings",

--- a/clients/web/src/components/command-palette/command-palette.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette.test.tsx
@@ -44,7 +44,7 @@ const HINTED_SECTIONS = [
     id: "actions",
     label: "Actions",
     items: [
-      { id: "new", title: "New Conversation", shortcutHint: "⌘⇧O" },
+      { id: "new", title: "New Conversation", shortcutHint: "⇧⌘O" },
       { id: "library", title: "Library" },
     ],
   },
@@ -394,7 +394,7 @@ describe("CommandPalette keyboard hints", () => {
 
     renderHintedPalette();
 
-    expect(keyboardHints()).toEqual(["⌘K", "⌘⇧O"]);
+    expect(keyboardHints()).toEqual(["⌘K", "⇧⌘O"]);
   });
 
   test("keeps the hints on a narrow window that still has a keyboard", () => {
@@ -406,7 +406,7 @@ describe("CommandPalette keyboard hints", () => {
     renderHintedPalette();
 
     expect(screen.getByRole("dialog", { name: "Search" })).toBeTruthy();
-    expect(keyboardHints()).toEqual(["⌘K", "⌘⇧O"]);
+    expect(keyboardHints()).toEqual(["⌘K", "⇧⌘O"]);
   });
 
   test("drops the hints on a roomy touch device that cannot press them", () => {

--- a/clients/web/src/domains/chat/new-chat-shortcut.test.ts
+++ b/clients/web/src/domains/chat/new-chat-shortcut.test.ts
@@ -12,9 +12,8 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => electron,
 }));
 
-const { newChatAccelerator, newChatShortcutHint } = await import(
-  "@/domains/chat/new-chat-shortcut"
-);
+const { newChatAccelerator, newChatShortcutHint } =
+  await import("@/domains/chat/new-chat-shortcut");
 
 describe("newChatShortcutHint", () => {
   afterEach(() => {
@@ -30,6 +29,6 @@ describe("newChatShortcutHint", () => {
   test("the web host advertises the in-app Cmd/Ctrl+Shift+O chord", () => {
     electron = false;
     expect(newChatAccelerator()).toBe("CmdOrCtrl+Shift+O");
-    expect(newChatShortcutHint()).toBe("⌘⇧O");
+    expect(newChatShortcutHint()).toBe("⇧⌘O");
   });
 });

--- a/packages/design-library/src/components/menu-item-aside.test.tsx
+++ b/packages/design-library/src/components/menu-item-aside.test.tsx
@@ -35,7 +35,7 @@ describe("menuItemShortcutProps", () => {
     expect(mac).toContain("aria-hidden");
     expect(
       menuItemShortcutProps("CmdOrCtrl+Shift+P")["aria-keyshortcuts"],
-    ).toMatch(/^(Meta|Control)\+Shift\+P$/);
+    ).toMatch(/^(Shift\+Meta|Control\+Shift)\+P$/);
   });
 });
 

--- a/packages/design-library/src/components/shortcut-keys.test.tsx
+++ b/packages/design-library/src/components/shortcut-keys.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   ShortcutKeys,
+  acceleratorToAriaKeyShortcuts,
   detectShortcutPlatform,
   formatAcceleratorHint,
   parseAccelerator,
@@ -12,14 +13,14 @@ import {
 describe("parseAccelerator", () => {
   test("maps modifiers to macOS symbols", () => {
     expect(parseAccelerator("CmdOrCtrl+Shift+N", "mac")).toEqual([
-      "\u2318",
       "\u21e7",
+      "\u2318",
       "N",
     ]);
     expect(parseAccelerator("Command+Control+Alt+K", "mac")).toEqual([
-      "\u2318",
       "\u2303",
       "\u2325",
+      "\u2318",
       "K",
     ]);
   });
@@ -47,6 +48,55 @@ describe("parseAccelerator", () => {
 
   test("returns an empty array for an empty accelerator", () => {
     expect(parseAccelerator("", "mac")).toEqual([]);
+  });
+
+  test("writes macOS modifiers in the Apple order, not the accelerator's", () => {
+    // Apple Style Guide: Control, Option, Shift, Command. The accelerator is a
+    // binding, so every spelling of one shortcut has to render identically.
+    const spellings = [
+      "Control+Alt+Shift+Cmd+K",
+      "Cmd+Shift+Alt+Control+K",
+      "Shift+Control+Cmd+Alt+K",
+    ];
+    for (const spelling of spellings) {
+      expect(parseAccelerator(spelling, "mac")).toEqual([
+        "\u2303",
+        "\u2325",
+        "\u21e7",
+        "\u2318",
+        "K",
+      ]);
+    }
+  });
+
+  test("leads with the Windows key, then Ctrl, Alt, Shift", () => {
+    expect(parseAccelerator("Shift+Alt+Control+Super+K", "windows")).toEqual([
+      "Win",
+      "Ctrl",
+      "Alt",
+      "Shift",
+      "K",
+    ]);
+  });
+
+  test("orders CmdOrCtrl by what it resolves to on the host", () => {
+    // It ranks last on macOS as Command and second on Windows as Ctrl, so the
+    // same accelerator sorts differently per platform.
+    expect(parseAccelerator("CmdOrCtrl+Shift+K", "mac")).toEqual([
+      "\u21e7",
+      "\u2318",
+      "K",
+    ]);
+    expect(parseAccelerator("CmdOrCtrl+Shift+K", "windows")).toEqual([
+      "Ctrl",
+      "Shift",
+      "K",
+    ]);
+  });
+
+  test("keeps the key last even when it sorts before a modifier", () => {
+    expect(parseAccelerator("A+Shift", "mac")).toEqual(["\u21e7", "A"]);
+    expect(parseAccelerator("CmdOrCtrl+", "mac")).toEqual(["\u2318", "+"]);
   });
 
   test("maps tokens to text labels on Windows", () => {
@@ -98,10 +148,36 @@ describe("detectShortcutPlatform", () => {
 describe("formatAcceleratorHint", () => {
   test("runs glyphs together on mac and plus-joins labels on Windows", () => {
     expect(formatAcceleratorHint("CmdOrCtrl+Shift+O", "mac")).toBe(
-      "\u2318\u21e7O",
+      "\u21e7\u2318O",
     );
     expect(formatAcceleratorHint("CmdOrCtrl+Shift+O", "windows")).toBe(
       "Ctrl+Shift+O",
+    );
+  });
+});
+
+describe("acceleratorToAriaKeyShortcuts", () => {
+  test("announces modifiers in the same order the row draws them", () => {
+    expect(acceleratorToAriaKeyShortcuts("CmdOrCtrl+Shift+P", "mac")).toBe(
+      "Shift+Meta+P",
+    );
+    expect(acceleratorToAriaKeyShortcuts("CmdOrCtrl+Shift+P", "windows")).toBe(
+      "Control+Shift+P",
+    );
+  });
+
+  test("is stable across spellings of one binding", () => {
+    expect(acceleratorToAriaKeyShortcuts("Shift+CmdOrCtrl+P", "mac")).toBe(
+      acceleratorToAriaKeyShortcuts("CmdOrCtrl+Shift+P", "mac"),
+    );
+  });
+
+  test("uses UI Events key values rather than glyphs", () => {
+    expect(acceleratorToAriaKeyShortcuts("CmdOrCtrl+Up", "mac")).toBe(
+      "Meta+ArrowUp",
+    );
+    expect(acceleratorToAriaKeyShortcuts("Alt+Return", "windows")).toBe(
+      "Alt+Enter",
     );
   });
 });

--- a/packages/design-library/src/components/shortcut-keys.tsx
+++ b/packages/design-library/src/components/shortcut-keys.tsx
@@ -236,7 +236,7 @@ export const parseAccelerator = (
 
 /**
  * Compact inline form for tooltips and hints: glyphs run together on macOS
- * (`⌘⇧N`), text labels are `+`-joined on Windows (`Ctrl+Shift+N`).
+ * (`⇧⌘N`), text labels are `+`-joined on Windows (`Ctrl+Shift+N`).
  */
 export const formatAcceleratorHint = (
   accelerator: string,

--- a/packages/design-library/src/components/shortcut-keys.tsx
+++ b/packages/design-library/src/components/shortcut-keys.tsx
@@ -141,8 +141,88 @@ const displayToken = (token: string, platform: ShortcutPlatform): string => {
   return modifiers[lower] ?? keys[lower] ?? token.toUpperCase();
 };
 
+type ModifierId = "control" | "alt" | "shift" | "command";
+
 /**
- * Parse an Electron accelerator into the display label for each key cap.
+ * Which modifier a token names, independent of the spelling the accelerator
+ * used. `"platform"` is the `CmdOrCtrl` family, which is a different modifier
+ * on each host and so cannot be ranked until the platform is known.
+ */
+const MODIFIER_IDS: Record<string, ModifierId | "platform"> = {
+  command: "command",
+  cmd: "command",
+  super: "command",
+  meta: "command",
+  commandorcontrol: "platform",
+  cmdorctrl: "platform",
+  control: "control",
+  ctrl: "control",
+  alt: "alt",
+  option: "alt",
+  altgr: "alt",
+  shift: "shift",
+};
+
+/**
+ * The order each platform writes its modifiers in, which is a convention of
+ * the platform rather than of the accelerator that happened to be typed.
+ *
+ * macOS is fixed at Control, Option, Shift, Command by the
+ * [Apple Style Guide](https://support.apple.com/guide/applestyleguide/welcome/web),
+ * so `⇧⌘N` is correct and `⌘⇧N` is not, and Windows leads with the Windows
+ * key then Ctrl, Alt, Shift per
+ * [Microsoft's keyboard UX guidance](https://learn.microsoft.com/en-us/windows/win32/uxguide/inter-keyboard).
+ */
+const MODIFIER_ORDER: Record<ShortcutPlatform, readonly ModifierId[]> = {
+  mac: ["control", "alt", "shift", "command"],
+  windows: ["command", "control", "alt", "shift"],
+};
+
+const modifierId = (
+  token: string,
+  platform: ShortcutPlatform,
+): ModifierId | null => {
+  const id = MODIFIER_IDS[token.toLowerCase()];
+  if (id === undefined) {
+    return null;
+  }
+  if (id === "platform") {
+    return platform === "mac" ? "command" : "control";
+  }
+  return id;
+};
+
+/**
+ * Put an accelerator's tokens in the order the platform writes them: modifiers
+ * first in the platform's fixed order, then the key. An accelerator is a
+ * binding rather than a rendering, so `"CmdOrCtrl+Shift+N"` and
+ * `"Shift+CmdOrCtrl+N"` are the same shortcut and have to read the same way.
+ */
+const orderTokens = (
+  tokens: string[],
+  platform: ShortcutPlatform,
+): string[] => {
+  const order = MODIFIER_ORDER[platform];
+  const modifiers: string[] = [];
+  const keys: string[] = [];
+  for (const token of tokens) {
+    if (modifierId(token, platform)) {
+      modifiers.push(token);
+    } else {
+      keys.push(token);
+    }
+  }
+  modifiers.sort(
+    (a, b) =>
+      order.indexOf(modifierId(a, platform)!) -
+      order.indexOf(modifierId(b, platform)!),
+  );
+  return [...modifiers, ...keys];
+};
+
+/**
+ * Parse an Electron accelerator into the display label for each key cap, in
+ * the order the platform writes them.
  * Exported so non-visual consumers (tests, aria labels) can reuse the mapping.
  * `platform` defaults to the detected host.
  */
@@ -150,7 +230,9 @@ export const parseAccelerator = (
   accelerator: string,
   platform: ShortcutPlatform = detectShortcutPlatform(),
 ): string[] =>
-  tokenize(accelerator).map((token) => displayToken(token, platform));
+  orderTokens(tokenize(accelerator), platform).map((token) =>
+    displayToken(token, platform),
+  );
 
 /**
  * Compact inline form for tooltips and hints: glyphs run together on macOS
@@ -232,7 +314,7 @@ export const acceleratorToAriaKeyShortcuts = (
   accelerator: string,
   platform: ShortcutPlatform = detectShortcutPlatform(),
 ): string =>
-  tokenize(accelerator)
+  orderTokens(tokenize(accelerator), platform)
     .map((token) => {
       const lower = token.toLowerCase();
       return (


### PR DESCRIPTION
## TL;DR

Keyboard shortcut hints drew their modifiers in whatever order the accelerator was typed in, so macOS saw `⌘⇧N` where Apple's convention is `⇧⌘N`. Modifiers are now sorted into each platform's documented order before the hint is built. Every macOS hint in the app changes; Windows hints are unaffected.

## The bug

`parseAccelerator` mapped tokens positionally:

```ts
tokenize(accelerator).map((token) => displayToken(token, platform))
```

So the rendering was a property of how the accelerator string was written rather than of the shortcut it names. `"CmdOrCtrl+Shift+N"` and `"Shift+CmdOrCtrl+N"` are the same binding and rendered differently, and neither matched the platform convention.

Both platforms fix this order, and neither is arbitrary:

- **macOS** is Control, Option, Shift, Command, per the Apple Style Guide. Keeping it fixed is what lets the `⌘` line up vertically down the right edge of a menu, which is the whole reason the convention exists.
- **Windows** leads with the Windows key, then Ctrl, Alt, Shift, per [Microsoft's keyboard UX guidance](https://learn.microsoft.com/en-us/windows/win32/uxguide/inter-keyboard).

## What changes for the user

| Surface | Before | After |
|---|---|---|
| Settings > Keyboard Shortcuts (macOS) | `⌘ ⇧ N` key caps | `⇧ ⌘ N` |
| Command palette (macOS) | `⌘⇧N` | `⇧⌘N` |
| Menu row hints (macOS) | `⌘⇧S` | `⇧⌘S` |
| Anything with a single modifier | `⌘N` | Unchanged |
| Windows and Linux | `Ctrl+Shift+N` | Unchanged, that already matched |
| Screen reader announcement | `Meta+Shift+N` | `Shift+Meta+N`, matching the drawn order |

Nothing changes about which keys a shortcut uses or what it does. This is only how a binding is written down.

## Why it is safe

`orderTokens` runs on the token list before either output is built, so the glyphs and the `aria-keyshortcuts` value come out of one ordering and cannot disagree. Modifier order carries no meaning in `aria-keyshortcuts`, so the announcement change is cosmetic; matching the drawn order just keeps the two forms readable side by side.

`CmdOrCtrl` is ranked by what it resolves to rather than by its spelling, because it is a different modifier per host: last on macOS as Command, second on Windows as Ctrl. Non-modifier tokens keep their position at the end, so the literal `+` key, arrow keys, and an accelerator with the key written first all still parse as they did.

The sort is on a list that is never longer than five tokens, in a function that already ran per render.

## Verified

- `bunx tsc --noEmit` clean in `packages/design-library` and `clients/web`
- `bun run build-storybook` clean; opened the `WithShortcuts` story and read the rendered rows back: `Save as…` now draws `⇧⌘S` and announces `Shift+Meta+S`, while single-modifier rows are untouched
- Exercised the formatter directly across both platforms: all four spellings of a four-modifier binding collapse to one rendering (`⌃⌥⇧⌘K`), Windows gives `Win+Ctrl+Alt+Shift+K`, and the empty, literal-plus, and key-before-modifier cases are unchanged
- Unit tests were not run locally (standing rule on this machine); CI covers them

## Tests

The existing `parseAccelerator` and `formatAcceleratorHint` tests asserted the old order, which means they were pinning the bug. They are corrected, and the new cases pin the rule rather than one example: every spelling of a binding renders identically, `CmdOrCtrl` sorts differently per platform, the key stays last even when written first, and `aria-keyshortcuts` follows the same ordering.

## Not in scope

`ShortcutKeys` still has no compact inline variant, so `command-palette-item.tsx` hand-rolls its own hint span at lines 120 and 148 with two different type sizes. That is a reuse cleanup rather than a correctness fix, and it is easier to review once this lands.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->