### PR TITLE
refactor(cli): name the web host's two cache policies once

### DIFF
--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -409,6 +409,20 @@ async function maybeHydratePlatformAssistantName(
 const SPA_BASE = "/assistant/";
 
 /**
+ * Cache policy for hashed build output under `dist/assets/`: the content hash
+ * is part of the filename, so a new build emits new names and a stored copy can
+ * never be stale.
+ */
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+/**
+ * Cache policy for everything whose name is stable across builds: the HTML
+ * shell and unhashed `public/` files. Storing is allowed, serving without
+ * revalidating is not, so an assistant update is never masked by a cached copy.
+ */
+const REVALIDATE_CACHE_CONTROL = "no-cache";
+
+/**
  * Locate the clients/web source directory for running the Vite dev server.
  * Only works from a source checkout (not npm-installed).
  */
@@ -1303,6 +1317,17 @@ async function runWebInterface(
     `<script>window.__VELLUM_CONFIG__=${configJson}${flagOverridesSnippet}</script></head>`,
   );
 
+  // The shell names this build's hashed chunks and carries the host's injected
+  // config snippet, so every route that falls back to it serves the same body
+  // under the same revalidating policy.
+  const spaShellResponse = () =>
+    new Response(indexHtml, {
+      headers: {
+        "Content-Type": "text/html; charset=utf-8",
+        "Cache-Control": REVALIDATE_CACHE_CONTROL,
+      },
+    });
+
   const fetchHandler: WebFetchHandler = async (req, server) => {
     const url = new URL(req.url);
     const { pathname } = url;
@@ -1399,38 +1424,21 @@ async function runWebInterface(
         const filePath = path.join(distDir, relPath);
         const file = Bun.file(filePath);
         if (await file.exists()) {
-          // Everything under dist/assets/ carries a content hash in its
-          // filename, so it can be cached forever: a new build references new
-          // filenames. Without this header the WebView is free to revalidate
-          // or re-fetch every chunk on every lazy-route navigation. Unhashed
-          // files (public/ copies) must revalidate instead.
-          const cacheControl = relPath.startsWith("assets/")
-            ? "public, max-age=31536000, immutable"
-            : "no-cache";
           return new Response(file, {
-            headers: { "Cache-Control": cacheControl },
+            headers: {
+              "Cache-Control": relPath.startsWith("assets/")
+                ? IMMUTABLE_CACHE_CONTROL
+                : REVALIDATE_CACHE_CONTROL,
+            },
           });
         }
       }
-      return new Response(indexHtml, {
-        headers: {
-          "Content-Type": "text/html; charset=utf-8",
-          // The HTML names the current build's hashed chunks and embeds the
-          // server's config snippet; a cached copy would pin a stale build
-          // (or stale flags) across an assistant update.
-          "Cache-Control": "no-cache",
-        },
-      });
+      return spaShellResponse();
     }
 
     // SPA fallback for /account/* routes (login, callback, etc.)
     if (pathname.startsWith("/account/")) {
-      return new Response(indexHtml, {
-        headers: {
-          "Content-Type": "text/html; charset=utf-8",
-          "Cache-Control": "no-cache",
-        },
-      });
+      return spaShellResponse();
     }
 
     return new Response("Not Found", { status: 404 });


### PR DESCRIPTION
## TL;DR

Follow-up tidy-up on [#41698](https://github.com/vellum-ai/vellum-assistant/pull/41698), which landed cache headers on the paired web host. That PR spelled its Cache-Control values inline: the revalidating policy appeared three times and the HTML shell was constructed twice from byte-identical header objects. This names both policies once and gives the shell a single builder. No behavior change.

## What changes for the user

Nothing. Every route serves the same bytes under the same headers as before.

## Why this is safe

- Purely a naming and de-duplication change: the two policy strings are unchanged, and the shell response is the same object built in one place instead of two.
- Verified against the running host on the real dist-serving path, all four cases matching pre-refactor output exactly:

| Request | Cache-Control |
|---|---|
| `/assistant/assets/<hashed>.js` | `public, max-age=31536000, immutable` |
| `/assistant/` (shell) | `no-cache` |
| `/assistant/favicon.svg` (unhashed) | `no-cache` |
| `/account/login` (SPA fallback) | `no-cache` |

- Each constant carries the invariant that justifies it, which is the part that was previously buried in a comment about what the code would do without the header.

## Note for reviewers

The remote-web nginx ingress spells the same immutable-asset policy in its own generated config, and uses `no-store` where this host uses `no-cache` for the shell. Both are safe, and unifying them is a behavior decision on the nginx side rather than a rename, so this PR leaves that alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41704" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->