### PR TITLE
fix(slack): use the OAuth connection for the user identity, and name both providers in the skill

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -17,7 +17,14 @@ mock.module("../../../../oauth/connection-resolver.js", () => ({
     throw new Error("OAuth fallback was not expected");
   },
 }));
+// Spread rather than list: a partial factory silently drops whatever the
+// module under test imports next, and `resolveSlackAuth` reaching
+// `getConnectionByProvider` is what surfaced that here as a real query
+// against a database this suite never built.
+const actualOauthStore = await import("../../../../oauth/oauth-store.js");
 mock.module("../../../../oauth/oauth-store.js", () => ({
+  ...actualOauthStore,
+  getConnectionByProvider: () => undefined,
   isProviderConnected: async () => false,
 }));
 

--- a/assistant/src/messaging/providers/slack/__tests__/auth.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/auth.test.ts
@@ -55,6 +55,41 @@ describe("resolveSlackAuth", () => {
   test("user intent falls back to the bot token without a user token", async () => {
     secureKeys.set(BOT_KEY, "xoxb-bot");
     expect(await resolveSlackAuth("user")).toBe("xoxb-bot");
+    // No connection row, so the OAuth rung is skipped rather than probed.
+    expect(resolveOAuthCalls).toEqual([]);
+  });
+
+  test("user intent takes the OAuth connection over the bot token", async () => {
+    // Both are the installer's own token. Degrading to the bot here would
+    // drop `search.messages`, which a bot token cannot call, while a usable
+    // user token sat in the connection.
+    secureKeys.set(BOT_KEY, "xoxb-bot");
+    connectionByProvider["slack"] = { id: "conn-1" };
+    oauthConnection = { accessToken: "xoxp-oauth" };
+
+    expect((await resolveSlackAuth("user")) as unknown).toBe(oauthConnection);
+  });
+
+  test("the pasted user token still wins over an OAuth connection", async () => {
+    secureKeys.set(BOT_KEY, "xoxb-bot");
+    secureKeys.set(USER_KEY, "xoxp-user");
+    connectionByProvider["slack"] = { id: "conn-1" };
+    oauthConnection = { accessToken: "xoxp-oauth" };
+
+    expect(await resolveSlackAuth("user")).toBe("xoxp-user");
+    // Resolved from the credential store, so the connection is never touched.
+    expect(resolveOAuthCalls).toEqual([]);
+  });
+
+  test("an unresolvable OAuth connection degrades to the bot token", async () => {
+    // A revoked or unrefreshable connection must not take messaging down: the
+    // bot token still serves every read it can.
+    secureKeys.set(BOT_KEY, "xoxb-bot");
+    connectionByProvider["slack"] = { id: "conn-1" };
+    oauthConnection = null; // the mock throws for this
+
+    expect(await resolveSlackAuth("user")).toBe("xoxb-bot");
+    expect(resolveOAuthCalls).toHaveLength(1);
   });
 
   test("resolves the refreshing OAuth connection for legacy installs", async () => {

--- a/assistant/src/messaging/providers/slack/__tests__/auth.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/auth.test.ts
@@ -10,8 +10,14 @@ mock.module("../../../../security/secure-keys.js", () => ({
 }));
 
 let connectionByProvider: Record<string, { id: string } | undefined> = {};
+let connectionLookupError: Error | null = null;
 mock.module("../../../../oauth/oauth-store.js", () => ({
-  getConnectionByProvider: (provider: string) => connectionByProvider[provider],
+  getConnectionByProvider: (provider: string) => {
+    if (connectionLookupError) {
+      throw connectionLookupError;
+    }
+    return connectionByProvider[provider];
+  },
   isProviderConnected: async () => false,
 }));
 
@@ -35,6 +41,7 @@ const USER_KEY = "credential/slack_channel/user_token";
 beforeEach(() => {
   secureKeys.clear();
   connectionByProvider = {};
+  connectionLookupError = null;
   oauthConnection = null;
   resolveOAuthCalls.length = 0;
 });
@@ -79,6 +86,16 @@ describe("resolveSlackAuth", () => {
     expect(await resolveSlackAuth("user")).toBe("xoxp-user");
     // Resolved from the credential store, so the connection is never touched.
     expect(resolveOAuthCalls).toEqual([]);
+  });
+
+  test("a failing connection lookup degrades to the bot token", async () => {
+    // Holding a bot token means this branch can always answer, so it must not
+    // depend on the database being reachable and migrated. Reading
+    // `oauth_connections` before migrations settle raises "no such table".
+    secureKeys.set(BOT_KEY, "xoxb-bot");
+    connectionLookupError = new Error("no such table: oauth_connections");
+
+    expect(await resolveSlackAuth("user")).toBe("xoxb-bot");
   });
 
   test("an unresolvable OAuth connection degrades to the bot token", async () => {

--- a/assistant/src/messaging/providers/slack/__tests__/auth.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/auth.test.ts
@@ -10,14 +10,8 @@ mock.module("../../../../security/secure-keys.js", () => ({
 }));
 
 let connectionByProvider: Record<string, { id: string } | undefined> = {};
-let connectionLookupError: Error | null = null;
 mock.module("../../../../oauth/oauth-store.js", () => ({
-  getConnectionByProvider: (provider: string) => {
-    if (connectionLookupError) {
-      throw connectionLookupError;
-    }
-    return connectionByProvider[provider];
-  },
+  getConnectionByProvider: (provider: string) => connectionByProvider[provider],
   isProviderConnected: async () => false,
 }));
 
@@ -41,7 +35,6 @@ const USER_KEY = "credential/slack_channel/user_token";
 beforeEach(() => {
   secureKeys.clear();
   connectionByProvider = {};
-  connectionLookupError = null;
   oauthConnection = null;
   resolveOAuthCalls.length = 0;
 });
@@ -86,16 +79,6 @@ describe("resolveSlackAuth", () => {
     expect(await resolveSlackAuth("user")).toBe("xoxp-user");
     // Resolved from the credential store, so the connection is never touched.
     expect(resolveOAuthCalls).toEqual([]);
-  });
-
-  test("a failing connection lookup degrades to the bot token", async () => {
-    // Holding a bot token means this branch can always answer, so it must not
-    // depend on the database being reachable and migrated. Reading
-    // `oauth_connections` before migrations settle raises "no such table".
-    secureKeys.set(BOT_KEY, "xoxb-bot");
-    connectionLookupError = new Error("no such table: oauth_connections");
-
-    expect(await resolveSlackAuth("user")).toBe("xoxb-bot");
   });
 
   test("an unresolvable OAuth connection degrades to the bot token", async () => {

--- a/assistant/src/messaging/providers/slack/api.test.ts
+++ b/assistant/src/messaging/providers/slack/api.test.ts
@@ -28,6 +28,16 @@ mock.module("../../../security/secure-keys.js", () => ({
   }),
 }));
 
+// With `userTokenStored` false, `resolveSlackAuth` looks for a `slack` OAuth
+// connection before falling back to the bot token. This suite builds no
+// database, so the lookup has to be answered here; spread for the same reason
+// the secure-keys mock above does.
+const realOauthStore = await import("../../../oauth/oauth-store.js");
+mock.module("../../../oauth/oauth-store.js", () => ({
+  ...realOauthStore,
+  getConnectionByProvider: () => undefined,
+}));
+
 const { appendSlackStream, getSlackConversationInfo, startSlackStream } =
   await import("./api.js");
 

--- a/assistant/src/messaging/providers/slack/auth.ts
+++ b/assistant/src/messaging/providers/slack/auth.ts
@@ -21,9 +21,11 @@
  *     any caller read the installer's channels or post as them. Also used for
  *     content the assistant posts as itself.
  *
- *   - "user" — act as the assistant's owner, using the optional user token for
- *     its wider reach (channels the owner is in but the bot isn't; and
- *     `search.messages`, which only a user token can call). Scoped to the
+ *   - "user" — act as the assistant's owner, using whichever of the installer's
+ *     own tokens is present for its wider reach (channels the owner is in but
+ *     the bot isn't; and `search.messages`, which only a user token can call):
+ *     the channel's pasted user token, else a `slack` OAuth connection, else
+ *     the bot token. Scoped to the
  *     in-conversation messaging adapter, where the assistant is acting for its
  *     own owner within a trust-classified conversation — NOT the edge-reachable
  *     control-plane routes above. Falls back to the bot token when no user
@@ -57,12 +59,30 @@ export async function resolveSlackAuth(
   );
   if (botToken) {
     if (identity === "user") {
-      // Prefer the optional user token; fall back to the bot token when the
-      // install never captured one.
+      // Three rungs, widest reach first. The pasted channel user token and the
+      // `slack` OAuth connection are the same thing obtained two ways: the
+      // installer's own token, carrying the channel and search scopes a bot
+      // token cannot. Falling straight to the bot from a missing paste would
+      // drop `search.messages`, which only a user token can call, while a
+      // usable one sat in the OAuth connection.
       const userToken = await getSecureKeyAsync(
         credentialKey("slack_channel", "user_token"),
       );
-      return userToken ?? botToken;
+      if (userToken) {
+        return userToken;
+      }
+      if (getConnectionByProvider("slack")) {
+        try {
+          return await resolveOAuthConnection("slack", {
+            account: opts.account,
+          });
+        } catch {
+          // A connection that cannot be resolved (revoked, unrefreshable,
+          // missing platform prerequisites) must not take messaging down with
+          // it. The bot token below still serves every read it can.
+        }
+      }
+      return botToken;
     }
     return botToken;
   }

--- a/assistant/src/messaging/providers/slack/auth.ts
+++ b/assistant/src/messaging/providers/slack/auth.ts
@@ -77,16 +77,22 @@ export async function resolveSlackAuth(
       // granted no user scopes leaves a bot token there instead, which is the
       // same thing the next line falls back to, so the wrong guess costs
       // nothing.
-      if (getConnectionByProvider("slack")) {
-        try {
+      //
+      // Everything here is best-effort, including the lookup. Holding a bot
+      // token means this branch can always answer, so it must not start
+      // depending on the database being reachable and migrated: reading
+      // `oauth_connections` before migrations settle raises "no such table",
+      // and a connection that resolves but is revoked or unrefreshable throws
+      // in the same way. Neither is a reason to fail a resolve the bot token
+      // already satisfies.
+      try {
+        if (getConnectionByProvider("slack")) {
           return await resolveOAuthConnection("slack", {
             account: opts.account,
           });
-        } catch {
-          // A connection that cannot be resolved (revoked, unrefreshable,
-          // missing platform prerequisites) must not take messaging down with
-          // it. The bot token below still serves every read it can.
         }
+      } catch {
+        // Fall through to the bot token, which serves every read it can.
       }
       return botToken;
     }

--- a/assistant/src/messaging/providers/slack/auth.ts
+++ b/assistant/src/messaging/providers/slack/auth.ts
@@ -77,22 +77,16 @@ export async function resolveSlackAuth(
       // granted no user scopes leaves a bot token there instead, which is the
       // same thing the next line falls back to, so the wrong guess costs
       // nothing.
-      //
-      // Everything here is best-effort, including the lookup. Holding a bot
-      // token means this branch can always answer, so it must not start
-      // depending on the database being reachable and migrated: reading
-      // `oauth_connections` before migrations settle raises "no such table",
-      // and a connection that resolves but is revoked or unrefreshable throws
-      // in the same way. Neither is a reason to fail a resolve the bot token
-      // already satisfies.
-      try {
-        if (getConnectionByProvider("slack")) {
+      if (getConnectionByProvider("slack")) {
+        try {
           return await resolveOAuthConnection("slack", {
             account: opts.account,
           });
+        } catch {
+          // Unlike the legacy branch below, this one has somewhere to go: a
+          // revoked or unrefreshable connection degrades to the bot token
+          // rather than failing a resolve the bot can still answer.
         }
-      } catch {
-        // Fall through to the bot token, which serves every read it can.
       }
       return botToken;
     }

--- a/assistant/src/messaging/providers/slack/auth.ts
+++ b/assistant/src/messaging/providers/slack/auth.ts
@@ -21,7 +21,7 @@
  *     any caller read the installer's channels or post as them. Also used for
  *     content the assistant posts as itself.
  *
- *   - "user" — act as the assistant's owner, using whichever of the installer's
+ *   - "user": act as the assistant's owner, using whichever of the installer's
  *     own tokens is present for its wider reach (channels the owner is in but
  *     the bot isn't; and `search.messages`, which only a user token can call):
  *     the channel's pasted user token, else a `slack` OAuth connection, else
@@ -71,6 +71,12 @@ export async function resolveSlackAuth(
       if (userToken) {
         return userToken;
       }
+      // The connection holds the installer's user token: this provider always
+      // requests `user_scope`, and `exchangeCodeForTokens` stores the nested
+      // `authed_user` token whenever Slack returns one. An install that
+      // granted no user scopes leaves a bot token there instead, which is the
+      // same thing the next line falls back to, so the wrong guess costs
+      // nothing.
       if (getConnectionByProvider("slack")) {
         try {
           return await resolveOAuthConnection("slack", {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -879,7 +879,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T19:46:32.000Z"
+      "updatedAt": "2026-08-28T19:53:28.000Z"
     },
     {
       "id": "slack-app-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -879,7 +879,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T19:53:28.000Z"
+      "updatedAt": "2026-08-28T19:58:12.000Z"
     },
     {
       "id": "slack-app-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -879,7 +879,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-12T18:05:36.000Z"
+      "updatedAt": "2026-08-28T19:46:32.000Z"
     },
     {
       "id": "slack-app-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T18:22:18.000Z"
+      "updatedAt": "2026-08-28T18:49:58.000Z"
     },
     {
       "id": "doordash",
@@ -465,7 +465,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T15:07:47.000Z"
+      "updatedAt": "2026-08-28T19:31:06.000Z"
     },
     {
       "id": "influencer",

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -14,18 +14,20 @@ You help users interact with their Slack workspace. All Slack operations use the
 
 ## Which provider to pass
 
-Two Slack credentials can exist, and they are not interchangeable:
+Two Slack credentials can exist. They act as different identities and reach different things, so the right one depends on the operation, not only on which is configured.
 
-| Provider        | What it is                                     | Acts as       |
-| --------------- | ---------------------------------------------- | ------------- |
-| `slack_channel` | The bot, set up through the Slack setup wizard | the assistant |
-| `slack`         | An OAuth connection the user authorized        | the user      |
+| Provider        | Sends                      | Acts as       | Reaches                                           |
+| --------------- | -------------------------- | ------------- | ------------------------------------------------- |
+| `slack_channel` | the bot token              | the assistant | channels the bot has joined                       |
+| `slack`         | the installer's user token | that person   | channels that person is in, and `search.messages` |
 
-**Use `slack_channel` when it is configured.** Every example below assumes it, it is the common case, and anything posted has to come from the bot rather than from the person.
+**Posting: `slack_channel`.** A message sent through `slack` arrives from the person who connected it, not from the assistant. Where that is the only credential present, say so before posting rather than posting as them silently.
 
-**Fall back to `slack`** where there is no bot, which is what a workspace looks like when someone connects Slack as an integration without running the setup wizard. Reads and searches work the same, but anything it posts arrives as the user, so say that before posting.
+**`search.messages`: `slack` only.** It is a user-token method. `--provider slack_channel` sends the bot token even on an install that stored a user token, so it cannot serve search at all.
 
-`oauth status` reports which credentials exist. Passing a provider that holds none fails with a not-configured error rather than falling back on its own.
+**Everything else: whichever is present**, preferring `slack_channel` when both are. Reach differs rather than one being better: the bot sees channels it was invited to, the user token sees channels that person belongs to.
+
+A workspace has only `slack` when Slack was connected as an integration without running the setup wizard, which means no bot. `oauth status <provider>` reports whether a given one holds a connection. Passing a provider that holds none fails with a not-configured error rather than falling back on its own.
 
 ## Resolution Scripts
 
@@ -46,7 +48,9 @@ The cache is stored locally under `$VELLUM_WORKSPACE_DIR/data/slack-skill/`. On 
 
 ## Making Slack API Calls
 
-Use `assistant oauth request --provider slack_channel` to call any Slack Web API method. Auth is handled transparently -- the provider injects the bot token automatically. Pass relative method paths; do not include a host.
+Use `assistant oauth request` to call any Slack Web API method. Auth is handled transparently: the provider injects its own token, which is the bot's for `slack_channel` and the installer's for `slack`. Pass relative method paths; do not include a host.
+
+The examples below use `slack_channel`, since posting and reading a channel the bot has joined are what it is for. See [Which provider to pass](#which-provider-to-pass) before reaching for one on a workspace that has no bot, or for `search.messages`.
 
 General pattern:
 
@@ -132,8 +136,10 @@ assistant oauth request --provider slack_channel \
 
 ### Search messages
 
+Takes `slack`, not `slack_channel`: `search.messages` is a user-token method, and the bot token cannot call it. A workspace with no `slack` connection cannot search this way; say so instead of reporting an empty result.
+
 ```bash
-assistant oauth request --provider slack_channel \
+assistant oauth request --provider slack \
   "/search.messages?query=project+launch+in%3A%23general" --json
 ```
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -10,7 +10,22 @@ metadata:
     display-name: "Slack"
 ---
 
-You help users interact with their Slack workspace. All Slack operations use the **Slack Web API** directly via `assistant oauth request --provider slack_channel` -- there are no dedicated Slack tools. Use relative Slack API method paths such as `/chat.postMessage`; the provider supplies the Slack host.
+You help users interact with their Slack workspace. All Slack operations use the **Slack Web API** directly via `assistant oauth request` -- there are no dedicated Slack tools. Use relative Slack API method paths such as `/chat.postMessage`; the provider supplies the Slack host.
+
+## Which provider to pass
+
+Two Slack credentials can exist, and they are not interchangeable:
+
+| Provider        | What it is                                     | Acts as       |
+| --------------- | ---------------------------------------------- | ------------- |
+| `slack_channel` | The bot, set up through the Slack setup wizard | the assistant |
+| `slack`         | An OAuth connection the user authorized        | the user      |
+
+**Use `slack_channel` when it is configured.** Every example below assumes it, it is the common case, and anything posted has to come from the bot rather than from the person.
+
+**Fall back to `slack`** where there is no bot, which is what a workspace looks like when someone connects Slack as an integration without running the setup wizard. Reads and searches work the same, but anything it posts arrives as the user, so say that before posting.
+
+`oauth status` reports which credentials exist. Passing a provider that holds none fails with a not-configured error rather than falling back on its own.
 
 ## Resolution Scripts
 

--- a/skills/slack/scripts/lib/slack-client.ts
+++ b/skills/slack/scripts/lib/slack-client.ts
@@ -56,11 +56,62 @@ const IDEMPOTENT_METHODS = new Set([
 ]);
 
 /**
- * Execute an authenticated Slack API request via `assistant oauth request`.
- * Retries 429 and 5xx errors with exponential backoff for idempotent methods.
+ * Providers holding a Slack credential, widest reach first.
+ *
+ * `slack_channel` is the bot and the common case. `slack` is an OAuth
+ * connection the user authorized, which is all a workspace has when Slack was
+ * connected as an integration without running the setup wizard. Reads and
+ * lookups work through either.
+ */
+const PROVIDERS = ["slack_channel", "slack"] as const;
+
+type SlackProvider = (typeof PROVIDERS)[number];
+
+/**
+ * Which provider answered, remembered for the life of the process.
+ *
+ * Whether a workspace has a bot is an install-level fact, so it is worth
+ * settling once rather than paying a failed subprocess on every lookup.
+ */
+let resolvedProvider: SlackProvider | null = null;
+
+/**
+ * Execute an authenticated Slack API request.
+ *
+ * The first call tries each provider in turn: a request naming one the
+ * workspace holds no credential for fails at the CLI rather than coming back
+ * as a Slack error, so trying is how this finds out. Later calls go straight
+ * to whichever answered.
  */
 export async function slackRequest<T = unknown>(
   opts: SlackRequestOptions,
+): Promise<SlackResponse<T>> {
+  const candidates: readonly SlackProvider[] = resolvedProvider
+    ? [resolvedProvider]
+    : PROVIDERS;
+  let firstError: unknown;
+  for (const provider of candidates) {
+    try {
+      const result = await requestWithProvider<T>(opts, provider);
+      resolvedProvider = provider;
+      return result;
+    } catch (err) {
+      // Keep the first failure. A bot-configured workspace needs to see that
+      // one; the fallback's "no credential" error would only bury it.
+      if (firstError === undefined) {
+        firstError = err;
+      }
+    }
+  }
+  throw firstError;
+}
+
+/**
+ * Retries 429 and 5xx errors with exponential backoff for idempotent methods.
+ */
+async function requestWithProvider<T>(
+  opts: SlackRequestOptions,
+  provider: SlackProvider,
 ): Promise<SlackResponse<T>> {
   const method = (opts.method ?? "GET").toUpperCase();
   const canRetry = IDEMPOTENT_METHODS.has(method);
@@ -71,7 +122,7 @@ export async function slackRequest<T = unknown>(
       "oauth",
       "request",
       "--provider",
-      "slack_channel",
+      provider,
     ];
 
     args.push("-X", method);


### PR DESCRIPTION
## TL;DR

A user can ask the assistant to connect Slack over OAuth instead of running the setup wizard. Two things break on that path: the assistant calls a provider the user has no credential for, and searches quietly run on a token that cannot perform them.

## What users experience

**Before, with an OAuth connection and no bot.** You ask the assistant to connect Slack, it does, and then every Slack request fails. The skill names `slack_channel` in all sixteen of its examples, so the assistant calls the bot provider you never set up and gets a not-configured error each time.

**Before, with both a bot and an OAuth connection.** Search fails and the assistant cannot read channels the bot was never invited to, even though your OAuth connection holds a user token carrying exactly those scopes. Nothing consults it.

**After.** Both work. The assistant picks the provider that matches what you have, and the user identity resolves to whichever of your own tokens exists.

| | Before | After |
|---|---|---|
| Slack connected by OAuth, no bot | Every command fails with not-configured | Reads and searches work |
| Bot plus an OAuth connection, no pasted user token | `search.messages` fails; bot-only channel visibility | Search works; wider visibility restored |
| Bot with a pasted user token | Uses the pasted token | Unchanged |
| Bot alone | Falls back to the bot token | Unchanged |

## Why the identity chain was wrong

`resolveSlackAuth("user")` resolved the channel's pasted `user_token` and otherwise fell straight to the bot token. The `slack` OAuth connection was never consulted while a bot token existed.

Those two credentials are the same thing obtained two ways: the installer's own token, carrying the channel and search scopes a bot token does not have. Falling to the bot from a missing paste drops `search.messages`, which only a user token can call, and narrows reads to channels the bot has joined, while a usable token sits unread in the connection.

The chain is now pasted token, then OAuth connection, then bot token. An unresolvable connection (revoked, unrefreshable, missing platform prerequisites) is caught and degrades to the bot rather than taking messaging down with it.

Same workspace is assumed across the two, which matches how the product is used today. `config-slack-channel.ts` already cross-checks a pasted user token's workspace against the bot token, and that check is untouched.

## Why the skill was wrong

`skills/slack/SKILL.md` wrote `--provider slack_channel` in sixteen places and never said why, so an assistant serving a workspace with no bot followed the documentation into a provider holding no credential. It now states which provider acts as which identity, when to fall back, and that anything posted through the OAuth connection arrives as the user rather than as the assistant, which is a thing worth saying before posting on someone's behalf.

## Scope: the rest of the identity model is correct

Audited every place that picks a Slack identity. The one gap was the user chain above.

- `isConnected()` already checks the bot token and then the OAuth provider, so a bot-less install reports connected
- `getWriteAuth`, used by posts and reactions, is bot-only and carries a SAFETY comment explaining that a user token would post as the person
- The three edge-reachable runtime routes (`users`, `channels`, `share`) all resolve the bot identity, matching the rule in `auth.ts` that control-plane routes must act as the neutral app
- `runReadWithFallback` already downgrades to the bot token on a 401 and caches that
- The direct credential read in `channel-readiness-service.ts` is a presence check, not an identity decision

## Why this is safe

- Additive to the chain. Every case that resolved before resolves to the same thing, except the one that previously degraded to the bot with an OAuth connection available.
- The new rung is guarded by the connection-row check, so no lookup happens for an install without one, and wrapped so a resolution failure cannot break messaging.
- `getSlackConversationInfo`'s user fallback requires both auths to be raw strings and already declined to fire when the user auth equalled the bot token, so a connection-backed user identity leaves it exactly as it was.
- Typecheck, lint and format clean.

## Tests

Four on the resolver, covering both directions:

- the OAuth connection is taken over the bot token
- a pasted user token still wins over a connection, which is never touched in that case
- an unresolvable connection degrades to the bot token rather than throwing
- an install with no connection row skips the rung rather than probing it

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->