### PR TITLE
The runtime metadata vocabulary describes its real writers and readers

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -190,18 +190,30 @@ the gateway's Channel Identity Vocabulary, which covers the wire side.
 - **`slackMeta`** is the per-row key describing what a row is in its Slack
   conversation: `channelTs` for the row's own id, `threadTs` for its thread,
   `reaction.targetChannelTs` for the message a reaction was attached to, plus
-  Slack's own file markers and timezone labels. Every channel-path reader goes
-  through it today.
+  Slack's own file markers and timezone labels. Most channel-path readers
+  still go through it directly; the lookups in `persistence/delivery-crud.ts`
+  read through `readProviderMetadata` instead, which serves this envelope and
+  the neutral shape below from one call.
 - **`providerMeta`** is the channel-neutral counterpart of that key
-  (`messaging/provider-message-metadata.ts`): `conversationExternalId`,
-  `messageId`, `threadId`, `actorExternalId`, `eventKind` and
-  `reaction.targetMessageId`, deliberately the same vocabulary the inbound
-  wire uses in `InboundEventBase`, so a channel that can describe itself at
-  ingress can describe its stored rows without a translation of its own.
-  Writable by any channel, including one this repo has no code for. `readProviderMetadata` reads it and maps `slackMeta` onto it.
-  **Nothing writes or reads it yet**; it is the home a new channel should use
-  rather than inventing a sixth key, and existing readers move onto it as
-  channels adopt it.
+  (`messaging/provider-message-metadata.ts`): `source`,
+  `conversationExternalId`, `messageId`, `threadId`, `actorExternalId`,
+  `eventKind`, the `reaction` sub-key, and the `editedAt` / `deletedAt`
+  marks. Deliberately the same vocabulary the inbound wire uses in
+  `InboundEventBase`, so a channel that can describe itself at ingress can
+  describe its stored rows without a translation of its own. Writable by any
+  channel, including one this repo has no code for, which is why a new
+  channel belongs here rather than in a sixth key of its own.
+
+  Every channel except Slack writes it: a reaction row carries the whole
+  shape (`inbound-stages/reaction-intercept.ts`), and an edit or a delete
+  stamps `editedAt` / `deletedAt` onto whatever the row already said about
+  itself through `mergeProviderMessageMetadata`
+  (`inbound-stages/edit-intercept.ts`, `inbound-message-handler.ts`). Slack
+  keeps writing `slackMeta`, and `readProviderMetadata` maps that envelope
+  onto this shape on read, so the channel-agnostic readers in
+  `persistence/delivery-crud.ts` (thread evidence, and finding the
+  conversation that holds a given provider message id) serve both without a
+  per-channel branch.
 
 ### Channel verification: gateway-owned
 


### PR DESCRIPTION
# The runtime metadata vocabulary describes its real writers and readers

Doc-only. Corrects `assistant/src/runtime/AGENTS.md` (its `CLAUDE.md` is a symlink, so one edit covers both) where the "Message metadata vocabulary" section had drifted from the code the reactions and edit/delete arc shipped.

## What was wrong

| Claim in the doc | Verified reality |
| --- | --- |
| `providerMeta`: "**Nothing writes or reads it yet**" | Three writers and two readers. Reaction rows carry the whole shape (`inbound-stages/reaction-intercept.ts`); edits and deletes stamp `editedAt` / `deletedAt` through `mergeProviderMessageMetadata` (`inbound-stages/edit-intercept.ts`, `inbound-message-handler.ts`); the two lookups in `persistence/delivery-crud.ts` read it. |
| `providerMeta` field list: `conversationExternalId`, `messageId`, `threadId`, `actorExternalId`, `eventKind`, `reaction.targetMessageId` | Omits `source` (required) and the `editedAt` / `deletedAt` marks. |
| "existing readers move onto it as channels adopt it" | Already happened for the delivery-crud readers, which call `readProviderMetadata`; that function maps `slackMeta` onto the neutral shape, so one reader serves both. |
| `slackMeta`: "Every channel-path reader goes through it today" | Most still do (about twenty modules), but the delivery-crud lookups no longer read it directly. |

## Why it matters

This is the section a new channel reads to decide where its stored rows describe themselves. "Nothing writes or reads it yet" reads as "this key is aspirational", which invites exactly the sixth bespoke key the section exists to prevent, and it hides the `mergeProviderMessageMetadata` seam that edits and deletes already use.

## Verification

Every claim in the new text was read out of the code rather than inferred: the writers and readers above, the schema fields in `messaging/provider-message-metadata.ts`, and the `slackMeta`-to-neutral mapping in `readProviderMetadata`. One thing I expected to be a defect turned out not to be: the `findSlackConversationByMessageTs` prefilter already ORs `"providerMeta"` with `"slackMeta"`, so neutral-only rows are not excluded from that scan.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->