### PR TITLE
Stop the palette hint collector assuming Command leads

### DIFF
--- a/clients/web/src/components/command-palette/command-palette.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette.test.tsx
@@ -85,7 +85,9 @@ function keyboardHints(): string[] {
   const itemHints = Array.from(dialog.querySelectorAll("span"))
     .filter((el) => el.children.length === 0)
     .map((el) => el.textContent ?? "")
-    .filter((text) => text.startsWith("⌘"));
+    // Any modifier glyph, not Command specifically: a hint leads with the
+    // first modifier in the platform's order, which for ⇧⌘O is Shift.
+    .filter((text) => /[\u2318\u2303\u2325\u21e7]/.test(text));
   return [...caps, ...itemHints];
 }
 


### PR DESCRIPTION
## TL;DR

`main` is red. #41703 merged with this failing and it is my miss. One line in a test helper, no product code involved.

## What broke

`keyboardHints()` in `command-palette.test.tsx` collected each row's hint by matching text that **starts with the Command glyph**:

```ts
.filter((text) => text.startsWith("⌘"))
```

#41703 made modifiers render in the platform's order, so the new-chat hint became `⇧⌘O`, which starts with Shift. The collector skipped it, `keyboardHints()` returned `["⌘K"]`, and the assertion for "every chord hint" failed against a list with the chord silently missing.

I updated the fixture and the expectation in that file and did not notice the helper doing the collecting, which is the part that actually encoded the assumption.

## The fix

Match any modifier glyph rather than one specific leading one. That is what the helper's own docstring says it does: "Every keyboard hint the palette renders ... Counted rather than probed for presence, so a regression that drops one of the two still fails." Keying on a leading `⌘` is exactly what stopped that from being true, since a dropped hint read as an absent one.

## Why it merged red

The approving review and the merge landed on the same head that CI had already failed on. Worth knowing regardless of this PR: an approval did not wait for the checks.

## Follow-up, not in this PR

The palette hand-rolls its hint span rather than using a shared component, which is why a test has to find hints by scanning `span` text at all. `ShortcutKeys` has no compact inline variant, so `command-palette-item.tsx` writes its own at lines 120 and 148 with two different type sizes. Giving it that variant, and a `data-slot`, would let this helper query a slot instead of guessing from glyphs. Tracked and queued behind the menu-hint work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->