### PR TITLE
docs(web): name the org-readiness primitive that keeps the wait distinct (LUM-3397)

### DIFF
--- a/clients/web/docs/STATE_MANAGEMENT.md
+++ b/clients/web/docs/STATE_MANAGEMENT.md
@@ -536,6 +536,38 @@ session probe) settles `platformSession: "absent"`, so bearer-auth
 (local/paired gateway) connections never stay org-gated behind a
 dead cookie.
 
+#### When the boolean is not enough
+
+`useIsOrgReady()` answers a yes/no question, which is what `enabled`
+needs: a query either may fire or may not.
+
+A component that renders one thing per outcome needs more than that.
+The boolean is false both while the org id is still arriving and once
+it has resolved to nothing, and those are opposite instructions to a
+caller: keep waiting, or stop. `useOrgHeaderReadiness()` returns
+`"ready" | "resolving" | "unavailable"` for that case, and
+`getOrgHeaderReadiness()` is the imperative read of the same
+derivation, for async sequences outside the render cycle.
+
+The distinction is load-bearing wherever a capability flag is derived
+from queries this gate disables, because `isLoading` is false for a
+query that is disabled. A flag built only from the queries therefore
+reads as settled while the org is still resolving:
+
+```ts
+const orgReadiness = useOrgHeaderReadiness();
+// "resolving" is the one wait not expressed as a query: it disables
+// them, so on the strength of the queries alone they look settled.
+const settled =
+  orgReadiness !== "resolving" && !catalogLoading && !configLoading;
+```
+
+`useManagedVoiceSelection` derives its `settled` this way. Surfaces
+read that rather than `available` to decide whether to draw an outcome
+at all, because `available` is false while the answer is in flight as
+well as once it is a no: a surface reading it alone states a
+conclusion before one exists.
+
 Reference: [TanStack Query — Dependent Queries](https://tanstack.com/query/latest/docs/framework/react/guides/dependent-queries)
 
 ### Canonical migration example


### PR DESCRIPTION
## TL;DR

`STATE_MANAGEMENT.md` documents org-readiness gating only as the boolean `useIsOrgReady()`. The tri-state `useOrgHeaderReadiness()` has existed alongside it for a while and eighteen files read it, but no doc mentions it. This adds the section.

Part of LUM-3397.

## Why it matters beyond completeness

The boolean is the right gate for a query's `enabled`: a query either may fire or may not. It is the wrong input for a component deciding what to *draw*, because its single `false` covers two opposite situations, an org id that has not arrived yet and one that is never arriving.

That collapse is the root of a bug class. `#41651` fixed an instance of it: `VoicePickerCard` read a capability flag that was false during the wait and false after a "no", so on every load it told the user

> Your assistant speaks through a provider you configured yourself.

before correcting itself. The hook it reads derives its `settled` from `useOrgHeaderReadiness()`, precisely because `isLoading` is false for a query the org gate has disabled, so a flag built from the queries alone reads as settled while the org is still resolving. None of that was written down anywhere a reader would find it.

## What changes for the reader

| | Before | After |
|---|---|---|
| Choosing a readiness primitive | Only the boolean is documented | Both are, with the case each one is for |
| Deriving a capability flag | Undocumented, and easy to get wrong in a way that looks right | The derivation is written out, with why `"resolving"` has to be named separately |
| Imperative callers | Not mentioned | `getOrgHeaderReadiness()` named as the non-render read |

## Why this is safe

Documentation only. No code, no behaviour, no dependencies.

The prose is hand-wrapped to match the file rather than run through Prettier: `STATE_MANAGEMENT.md` is not Prettier-clean on `main`, so formatting it would reflow paragraphs and tables that have nothing to do with this change, and would sweep pre-existing em dashes into the diff against the repo's own "existing text is not swept retroactively" rule. The diff is 32 added lines and no deletions.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->