### PR TITLE
fix(web): copy the transcript clean, not just one message

### DIFF
--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -161,7 +161,10 @@ export function MessageHoverActions({
   }, [content]);
 
   return (
+    // The timestamp and these controls are chrome, not message content: a
+    // selection that overshoots onto them still copies as the message alone.
     <div
+      data-copy-exclude
       className={`flex items-center gap-0.5 ${
         role === "user" ? "justify-end" : "justify-start"
       }`}

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -259,6 +259,7 @@ export const TranscriptRow = memo(function TranscriptRow({
         <div
           data-testid="transcript-thinking-row"
           data-active={item.active ? "true" : "false"}
+          data-copy-exclude
           aria-hidden={!item.active}
           className={`flex items-center overflow-hidden text-[13px] font-medium text-[var(--content-secondary)] transition-[height,opacity] duration-300 ease-out motion-reduce:transition-none ${
             item.active ? "h-7 opacity-100" : "h-0 opacity-0"

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -6,8 +6,11 @@ import {
   useImperativeHandle,
   useMemo,
   useRef,
+  type ClipboardEvent as ReactClipboardEvent,
   type ReactNode,
 } from "react";
+
+import { writeSelectionClipboard } from "@vellumai/design-library";
 
 import { partitionLatestTurn } from "@/domains/chat/transcript/partition-latest-turn";
 import { resolveResponseArtifacts } from "@/domains/chat/transcript/resolve-response-artifacts";
@@ -156,6 +159,32 @@ export interface TranscriptHandle {
     showScrollToLatest: boolean;
     shouldLoadOlder: boolean;
   };
+}
+
+/**
+ * Copy the selected transcript as semantic HTML and markdown.
+ *
+ * The browser's own `text/html` flavor inlines the computed style of every
+ * selected node, so a transcript copied out of the app pastes into Gmail or
+ * Outlook carrying the chat's own background color, text color, and font
+ * size. Its `text/plain` flavor is a flat dump that drops every marker the
+ * reader could see.
+ *
+ * The handler sits on the scroll container rather than on each message
+ * because one assistant turn is several sibling blocks (prose, diagrams,
+ * tool cards) and a drag over "the message" routinely covers more than the
+ * rendered markdown. `MarkdownMessage` keeps its own handler for the
+ * selection that stays inside one message; whichever runs first wins, and
+ * both write the same flavors.
+ */
+function handleTranscriptCopy(event: ReactClipboardEvent<HTMLDivElement>) {
+  if (
+    !event.defaultPrevented &&
+    event.clipboardData &&
+    writeSelectionClipboard(event.clipboardData, event.currentTarget)
+  ) {
+    event.preventDefault();
+  }
 }
 
 export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
@@ -331,6 +360,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
         key={conversationId}
         ref={scrollRef}
         data-testid="transcript-scroll-container"
+        onCopy={handleTranscriptCopy}
         className={`flex h-full w-full flex-col overflow-y-auto overscroll-none [overflow-anchor:none] ${
           hideIdleScrollbar
             ? "[&::-webkit-scrollbar]:hidden [scrollbar-width:none]"
@@ -424,6 +454,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
               {rest.renderAvatar && (
                 <div
                   data-latest-assistant-avatar="true"
+                  data-copy-exclude
                   className="flex justify-start pl-1 pt-3 pb-2"
                 >
                   {rest.renderAvatar()}

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -21,10 +21,7 @@ import type { Components } from "react-markdown";
 import "katex/dist/katex.min.css";
 
 import { cn } from "../utils/cn";
-import {
-  buildSelectionClipboardPayload,
-  isSelectionWithin,
-} from "../utils/selection-clipboard";
+import { writeSelectionClipboard } from "../utils/selection-clipboard";
 
 const MAX_CODE_BLOCK_HEIGHT = 400;
 
@@ -909,29 +906,25 @@ function remarkPreserveOrderedListNumbers() {
 }
 
 /**
- * Replace the browser's `copy` payload for a selection that lies entirely
- * within the rendered markdown. The browser's own HTML flavor inlines
- * computed background colors (grey shading when pasted into Outlook) and its
+ * Replace the browser's `copy` payload for a selection that covers nothing
+ * but the rendered markdown. The browser's own HTML flavor inlines computed
+ * colors, background colors and font sizes (grey shading when pasted into
+ * Outlook, the message's own dark theme when pasted into Gmail) and its
  * plain-text flavor is a flat dump with a blank line after every block. The
  * replacement is semantic HTML plus markdown. See
  * `buildSelectionClipboardPayload`.
  *
- * A selection that reaches outside the message is left to the browser.
+ * A selection that also covers content outside the message is left to the
+ * browser. See `selectionRangesWithin` for why a boundary node outside the
+ * message does not on its own mean the reader selected anything outside.
  */
 function handleSelectionCopy(event: ClipboardEvent<HTMLDivElement>) {
-  const root = event.currentTarget;
-  const selection = root.ownerDocument.defaultView?.getSelection();
   if (
-    !selection ||
-    !event.clipboardData ||
-    !isSelectionWithin(selection, root)
+    event.clipboardData &&
+    writeSelectionClipboard(event.clipboardData, event.currentTarget)
   ) {
-    return;
+    event.preventDefault();
   }
-  const payload = buildSelectionClipboardPayload(selection, root.ownerDocument);
-  event.clipboardData.setData("text/html", payload.html);
-  event.clipboardData.setData("text/plain", payload.text);
-  event.preventDefault();
 }
 
 export interface MarkdownMessageProps {

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -283,6 +283,7 @@ export {
 export { cn } from "./utils/cn";
 export type { CustomPropertyStyle } from "./utils/custom-property-style";
 export { initInputModality } from "./utils/input-modality";
+export { writeSelectionClipboard } from "./utils/selection-clipboard";
 export {
   PANEL_ITEM_WASH,
   panelItemWashStyle,

--- a/packages/design-library/src/utils/selection-clipboard.test.ts
+++ b/packages/design-library/src/utils/selection-clipboard.test.ts
@@ -3,7 +3,7 @@ import { Window } from "happy-dom";
 
 import {
   buildSelectionClipboardPayload,
-  isSelectionWithin,
+  selectionRangesWithin,
 } from "./selection-clipboard";
 
 const window = new Window();
@@ -36,7 +36,7 @@ function selectIn(html: string, target?: string) {
 
 function payloadFor(html: string, target?: string) {
   const { selection } = selectIn(html, target);
-  return buildSelectionClipboardPayload(selection, document);
+  return buildSelectionClipboardPayload([selection.getRangeAt(0)], document);
 }
 
 describe("html flavor", () => {
@@ -250,31 +250,103 @@ describe("markdown flavor", () => {
     range.setStart(textNode, 6);
     range.setEnd(textNode, 10);
     selection.addRange(range);
-    const payload = buildSelectionClipboardPayload(selection, document);
+    const payload = buildSelectionClipboardPayload([range], document);
     expect(payload.text).toBe("wide");
     expect(payload.html).toBe("wide");
   });
 });
 
-describe("isSelectionWithin", () => {
-  test("is true when the whole selection is inside the container", () => {
-    const { root, selection } = selectIn("<p>a</p><p>b</p>", "p:last-child");
-    expect(isSelectionWithin(selection, root)).toBe(true);
+describe("embedded documents", () => {
+  test("drops an embedded frame and the wrappers it leaves empty", () => {
+    const { html, text } = payloadFor(
+      '<div><div><iframe src="about:blank"></iframe></div></div><p>After</p>',
+    );
+    expect(html).toBe("<p>After</p>");
+    expect(text).toBe("After");
   });
 
-  test("is false for a collapsed selection", () => {
+  test("keeps a wrapper that still holds an image", () => {
+    const { html } = payloadFor(
+      '<div><img src="https://example.com/a.png" alt="A"></div><p>After</p>',
+    );
+    expect(html).toBe(
+      '<div><img src="https://example.com/a.png" alt="A"></div><p>After</p>',
+    );
+  });
+
+  test("keeps an empty table cell, which is part of the shape", () => {
+    const { html } = payloadFor(
+      "<table><tbody><tr><td>a</td><td></td></tr></tbody></table>",
+    );
+    expect(html).toContain("<td></td>");
+  });
+});
+
+describe("selectionRangesWithin", () => {
+  test("returns the selection when it is entirely inside the container", () => {
+    const { root, selection } = selectIn("<p>a</p><p>b</p>", "p:last-child");
+    const ranges = selectionRangesWithin(selection, root);
+    expect(ranges?.map((range) => range.toString())).toEqual(["b"]);
+  });
+
+  test("returns null for a collapsed selection", () => {
     const { root, selection } = selectIn("<p>a</p>");
     selection.collapseToStart();
-    expect(isSelectionWithin(selection, root)).toBe(false);
+    expect(selectionRangesWithin(selection, root)).toBeNull();
   });
 
-  test("is false when the selection reaches outside the container", () => {
+  test("returns null when the selection covers content outside the container", () => {
     const { root, selection } = selectIn("<p>a</p>");
     const outside = document.createElement("p");
     outside.textContent = "outside";
     document.body.appendChild(outside);
-    const range = selection.getRangeAt(0);
-    range.setEnd(outside.firstChild as Node, 3);
-    expect(isSelectionWithin(selection, root)).toBe(false);
+    selection.getRangeAt(0).setEnd(outside.firstChild as Node, 3);
+    expect(selectionRangesWithin(selection, root)).toBeNull();
+  });
+
+  /**
+   * The whole-message drag: Chromium reports an ancestor of the container as
+   * the start node, but nothing outside the container is actually selected.
+   */
+  test("clamps a boundary that sits outside but selects nothing outside", () => {
+    const wrapper = document.createElement("div");
+    const root = document.createElement("div");
+    root.innerHTML = "<p>inside</p>";
+    wrapper.appendChild(root);
+    document.body.appendChild(wrapper);
+    const selection = document.getSelection();
+    if (!selection) {
+      throw new Error("no selection");
+    }
+    selection.removeAllRanges();
+    const range = document.createRange();
+    range.setStart(wrapper, 0);
+    range.setEnd(root.querySelector("p")?.firstChild as Node, 6);
+    selection.addRange(range);
+    const ranges = selectionRangesWithin(selection, root);
+    expect(ranges?.map((entry) => entry.toString())).toEqual(["inside"]);
+    expect(buildSelectionClipboardPayload(ranges ?? [], document).html).toBe(
+      "<p>inside</p>",
+    );
+  });
+
+  test("returns null when the part outside the container holds an image", () => {
+    const wrapper = document.createElement("div");
+    const image = document.createElement("img");
+    image.setAttribute("src", "https://example.com/a.png");
+    const root = document.createElement("div");
+    root.innerHTML = "<p>inside</p>";
+    wrapper.append(image, root);
+    document.body.appendChild(wrapper);
+    const selection = document.getSelection();
+    if (!selection) {
+      throw new Error("no selection");
+    }
+    selection.removeAllRanges();
+    const range = document.createRange();
+    range.setStart(wrapper, 0);
+    range.setEnd(root.querySelector("p")?.firstChild as Node, 6);
+    selection.addRange(range);
+    expect(selectionRangesWithin(selection, root)).toBeNull();
   });
 });

--- a/packages/design-library/src/utils/selection-clipboard.test.ts
+++ b/packages/design-library/src/utils/selection-clipboard.test.ts
@@ -4,6 +4,7 @@ import { Window } from "happy-dom";
 import {
   buildSelectionClipboardPayload,
   selectionRangesWithin,
+  writeSelectionClipboard,
 } from "./selection-clipboard";
 
 const window = new Window();
@@ -279,6 +280,40 @@ describe("embedded documents", () => {
       "<table><tbody><tr><td>a</td><td></td></tr></tbody></table>",
     );
     expect(html).toContain("<td></td>");
+  });
+});
+
+describe("writeSelectionClipboard", () => {
+  /** Minimal stand-in for the event's `DataTransfer`. */
+  function fakeClipboardData() {
+    const written: Record<string, string> = {};
+    return {
+      written,
+      transfer: {
+        setData: (type: string, value: string) => {
+          written[type] = value;
+        },
+      } as unknown as DataTransfer,
+    };
+  }
+
+  test("writes both flavors for a selection of real content", () => {
+    const { root } = selectIn("<p>Hello</p>");
+    const { written, transfer } = fakeClipboardData();
+    expect(writeSelectionClipboard(transfer, root)).toBe(true);
+    expect(written["text/html"]).toBe("<p>Hello</p>");
+    expect(written["text/plain"]).toBe("Hello");
+  });
+
+  /**
+   * Emptying the clipboard is worse than whatever the browser would have put
+   * there, so a selection that renders to nothing is left to the browser.
+   */
+  test("declines a selection holding only prunable content", () => {
+    const { root } = selectIn('<div><iframe src="about:blank"></iframe></div>');
+    const { written, transfer } = fakeClipboardData();
+    expect(writeSelectionClipboard(transfer, root)).toBe(false);
+    expect(written).toEqual({});
   });
 });
 

--- a/packages/design-library/src/utils/selection-clipboard.ts
+++ b/packages/design-library/src/utils/selection-clipboard.ts
@@ -560,6 +560,13 @@ export function writeSelectionClipboard(
     ranges,
     container.ownerDocument,
   );
+  // A selection of nothing but prunable content (a rendered diagram on its
+  // own, a message's controls) renders to nothing. Writing that would empty
+  // the clipboard, which is worse than whatever the browser would have put
+  // there, so the copy is left alone.
+  if (payload.html === "" && payload.text === "") {
+    return false;
+  }
   clipboardData.setData("text/html", payload.html);
   clipboardData.setData("text/plain", payload.text);
   return true;

--- a/packages/design-library/src/utils/selection-clipboard.ts
+++ b/packages/design-library/src/utils/selection-clipboard.ts
@@ -33,9 +33,11 @@ const KEPT_ATTRIBUTES: Readonly<Record<string, readonly string[]>> = {
 /**
  * Elements that never carry copyable content: marked chrome (the code block
  * copy control and the header row it sits in, whose language label the
- * markdown fence already states) and presentational duplicates (KaTeX renders
- * both a visual `aria-hidden` layer and an accessible MathML layer for one
- * formula; copying both would repeat the formula).
+ * markdown fence already states, plus anything a consumer marks with
+ * `data-copy-exclude`, such as a message's hover controls or its timestamp)
+ * and presentational duplicates (KaTeX renders both a visual `aria-hidden`
+ * layer and an accessible MathML layer for one formula; copying both would
+ * repeat the formula).
  *
  * Matching is by marker, not by tag: a consumer can render real content inside
  * a `<button>` (a workspace path that opens a file, a previewable image), and
@@ -45,14 +47,68 @@ function isChrome(element: Element): boolean {
   return (
     element.hasAttribute("data-copy-control") ||
     element.hasAttribute("data-code-block-header") ||
+    element.hasAttribute("data-copy-exclude") ||
     element.getAttribute("aria-hidden") === "true"
   );
 }
 
-/** Drop every chrome element from a cloned fragment. */
+/**
+ * Elements that carry content even when they hold no text. A selection whose
+ * outside part is whitespace but includes one of these is still a selection
+ * that reaches beyond `container`.
+ */
+const VOID_CONTENT_TAGS = "img, input, svg, video, audio, canvas, iframe";
+
+/**
+ * Embedded documents (a rendered diagram, an embedded player) hold nothing the
+ * clipboard can carry: their content belongs to another document, so a copy
+ * keeps only an empty frame.
+ */
+const EMBEDDED_DOCUMENT_TAGS = "iframe, object, embed";
+
+/**
+ * Wrappers worth dropping once they are empty. Structural tags stay: an empty
+ * table cell, list item, or heading is part of the shape the reader selected.
+ */
+const DROPPABLE_WHEN_EMPTY: ReadonlySet<string> = new Set([
+  "ARTICLE",
+  "ASIDE",
+  "DIV",
+  "FIGURE",
+  "FOOTER",
+  "HEADER",
+  "P",
+  "SECTION",
+  "SPAN",
+]);
+
+/** True when `element` holds neither text nor a self-contained element. */
+function isEmptyWrapper(element: Element): boolean {
+  return (
+    DROPPABLE_WHEN_EMPTY.has(element.tagName) &&
+    element.textContent?.trim() === "" &&
+    element.querySelector(`br, hr, ${VOID_CONTENT_TAGS}`) === null
+  );
+}
+
+/**
+ * Drop every chrome element from a cloned fragment, then the wrappers left
+ * holding nothing, innermost first, so a pruned embed does not paste as a run
+ * of empty blocks.
+ */
 function pruneChrome(root: ParentNode): void {
   for (const element of Array.from(root.querySelectorAll("*"))) {
     if (isChrome(element)) {
+      element.remove();
+    }
+  }
+  for (const embed of Array.from(
+    root.querySelectorAll(EMBEDDED_DOCUMENT_TAGS),
+  )) {
+    embed.remove();
+  }
+  for (const element of Array.from(root.querySelectorAll("*")).reverse()) {
+    if (isEmptyWrapper(element)) {
       element.remove();
     }
   }
@@ -480,42 +536,122 @@ function renderLink(anchor: Element, text: string): string {
   return `${lead}[${core}](${href})${trail}`;
 }
 
+/**
+ * Write the clean flavors for the part of the current selection that lies
+ * inside `container`, and report whether it did.
+ *
+ * A `copy` handler calls `preventDefault()` on a `true` return, so the
+ * browser's own serialization (which inlines computed colors, background
+ * colors, and font sizes) never reaches the clipboard.
+ */
+export function writeSelectionClipboard(
+  clipboardData: DataTransfer,
+  container: Element,
+): boolean {
+  const selection = container.ownerDocument.defaultView?.getSelection();
+  if (!selection) {
+    return false;
+  }
+  const ranges = selectionRangesWithin(selection, container);
+  if (!ranges) {
+    return false;
+  }
+  const payload = buildSelectionClipboardPayload(
+    ranges,
+    container.ownerDocument,
+  );
+  clipboardData.setData("text/html", payload.html);
+  clipboardData.setData("text/plain", payload.text);
+  return true;
+}
+
 export interface SelectionClipboardPayload {
   html: string;
   text: string;
 }
 
 /**
- * True when every end of `selection` lies inside `container`. A selection
- * that reaches outside is left to the browser, since building a payload from
- * only the inside part would silently drop the rest.
+ * True when `fragment` holds nothing a reader would miss. Chrome and embedded
+ * documents are pruned first: a drag that overshoots onto a message's
+ * timestamp, or across a rendered diagram, has picked up nothing the clipboard
+ * could have carried anyway.
  */
-export function isSelectionWithin(
-  selection: Selection,
-  container: Node,
-): boolean {
-  if (selection.rangeCount === 0 || selection.isCollapsed) {
-    return false;
-  }
-  for (let i = 0; i < selection.rangeCount; i++) {
-    const range = selection.getRangeAt(i);
-    if (
-      !container.contains(range.startContainer) ||
-      !container.contains(range.endContainer)
-    ) {
-      return false;
-    }
-  }
-  return true;
+function isBlankFragment(fragment: DocumentFragment): boolean {
+  pruneChrome(fragment);
+  return (
+    fragment.textContent?.trim() === "" &&
+    fragment.querySelector(VOID_CONTENT_TAGS) === null
+  );
 }
 
-function cloneSelection(
+/**
+ * The parts of `selection` that lie inside `container`, or `null` when the
+ * selection also covers content outside it.
+ *
+ * A boundary node outside `container` does not by itself mean the reader
+ * selected anything outside: Chromium normalizes a drag that starts at the
+ * left edge of a block, or above the first line, up to an ancestor element,
+ * so a drag over one whole message commonly reports a start container that is
+ * the message row rather than the message. Clamping to `container` and then
+ * checking that the leftover parts hold no content keeps both cases right:
+ * the whole-message drag is served, while a selection that genuinely reaches
+ * other content is left to the browser rather than silently dropping the rest.
+ */
+export function selectionRangesWithin(
   selection: Selection,
+  container: Node,
+): Range[] | null {
+  if (selection.rangeCount === 0 || selection.isCollapsed) {
+    return null;
+  }
+  const ownerDocument = container.ownerDocument;
+  if (!ownerDocument) {
+    return null;
+  }
+  const containerRange = ownerDocument.createRange();
+  containerRange.selectNodeContents(container);
+
+  const clampedRanges: Range[] = [];
+  for (let i = 0; i < selection.rangeCount; i++) {
+    const range = selection.getRangeAt(i);
+
+    const before = range.cloneRange();
+    before.setEnd(containerRange.startContainer, containerRange.startOffset);
+    const after = range.cloneRange();
+    after.setStart(containerRange.endContainer, containerRange.endOffset);
+    if (
+      !isBlankFragment(before.cloneContents()) ||
+      !isBlankFragment(after.cloneContents())
+    ) {
+      return null;
+    }
+
+    const clamped = range.cloneRange();
+    if (
+      clamped.compareBoundaryPoints(clamped.START_TO_START, containerRange) < 0
+    ) {
+      clamped.setStart(
+        containerRange.startContainer,
+        containerRange.startOffset,
+      );
+    }
+    if (clamped.compareBoundaryPoints(clamped.END_TO_END, containerRange) > 0) {
+      clamped.setEnd(containerRange.endContainer, containerRange.endOffset);
+    }
+    if (!clamped.collapsed) {
+      clampedRanges.push(clamped);
+    }
+  }
+  return clampedRanges.length > 0 ? clampedRanges : null;
+}
+
+function cloneRanges(
+  ranges: readonly Range[],
   ownerDocument: Document,
 ): HTMLElement {
   const container = ownerDocument.createElement("div");
-  for (let i = 0; i < selection.rangeCount; i++) {
-    container.appendChild(selection.getRangeAt(i).cloneContents());
+  for (const range of ranges) {
+    container.appendChild(range.cloneContents());
   }
   pruneChrome(container);
   unwrapButtons(container);
@@ -523,17 +659,17 @@ function cloneSelection(
 }
 
 /**
- * Build clean `text/html` and markdown `text/plain` payloads for `selection`.
+ * Build clean `text/html` and markdown `text/plain` payloads for `ranges`.
  * Each flavor gets its own clone, since markdown reads the class names that
  * the HTML flavor strips. The live DOM is untouched.
  */
 export function buildSelectionClipboardPayload(
-  selection: Selection,
+  ranges: readonly Range[],
   ownerDocument: Document,
 ): SelectionClipboardPayload {
-  const htmlRoot = cloneSelection(selection, ownerDocument);
+  const htmlRoot = cloneRanges(ranges, ownerDocument);
   stripAttributes(htmlRoot);
-  const markdownRoot = cloneSelection(selection, ownerDocument);
+  const markdownRoot = cloneRanges(ranges, ownerDocument);
   return {
     html: htmlRoot.innerHTML,
     text: renderContainer(markdownRoot).trim(),


### PR DESCRIPTION
## Summary

Follow-up to #41600. Copying an assistant reply out of the web chat and pasting it into Gmail still produced a dark band behind the text (and carried the font size), because the clean-copy handler almost never ran in the real app.

Reproduced end to end against a live assistant in Chrome, on `main`: drag-select a reply, Cmd+C, and the `copy` event reaches the handler with `defaultPrevented: false`. The range's `startContainer` is `DIV.w-full.overflow-hidden`, the message row wrapper, not the message.

Two reasons, both structural:

- An assistant turn is several sibling blocks. Only the prose is a `MarkdownMessage`; the diagram frame, tool cards, and the timestamp row are siblings outside it. A drag over "the message" covers more than the rendered markdown, so a handler scoped to that root correctly declines.
- Chromium normalizes a drag that starts at the left edge of a block, or above the first line, up to an ancestor element. A boundary node outside the message is therefore not evidence that the reader selected anything outside, but `isSelectionWithin` treated it as such.

Storybook never showed either, because there the message is the outermost element.

## Approach

- **The handler moves to the transcript scroll container** (`transcript.tsx`), which covers every row and nothing else. `MarkdownMessage` keeps its own handler for standalone consumers; both call the same `writeSelectionClipboard`, and whichever runs first wins.
- **`isSelectionWithin` becomes `selectionRangesWithin`**, which clamps the selection to the container and returns the inside parts when the parts left outside hold nothing a reader would miss. A selection that genuinely reaches other content still returns `null` and falls through to the browser, so nothing is silently dropped.
- **Embedded documents are pruned**, along with the wrappers they leave empty. An `<iframe>`'s content belongs to another document, so it copies as an empty frame either way; without this the diagram pasted as a stray empty block above the text.
- **Message chrome is marked `data-copy-exclude`** (the timestamp and hover controls, the thinking row, the latest-assistant avatar), so a drag that overshoots onto them still copies as the message alone. `pruneChrome` honors the marker, and the outside-parts check prunes before testing, so overshooting onto chrome no longer forces a fall-through.

## Test plan

- `bun test src/utils/selection-clipboard.test.ts src/components/markdown-message.test.tsx` in `packages/design-library`: 91 pass. New cases cover the clamped boundary that sits outside while selecting nothing outside, an outside part holding an image (still falls through), the pruned frame and its empty wrappers, and an empty table cell surviving.
- `bunx tsc --noEmit` clean in `packages/design-library` and `clients/web`; `bun run lint` in `clients/web` reports 0 errors.
- `bun test` on `transcript.test.tsx`, `transcript-row.test.tsx`, `transcript-thinking-shimmer.test.tsx`, `message-hover-actions.test.tsx` individually: all pass. Running several of those files in one process fails 4 tests, and the same 4 fail identically on an untouched checkout, so it is the known multi-file isolation trap, not this change. CI's `test:ci` runs files isolated.
- **End to end against a live assistant**, dev server on current `main`, real mouse drag and real Cmd+C, reading both clipboard flavors back from the `copy` event:
  - Before: `defaultPrevented: false` on a whole-message drag.
  - After: `defaultPrevented: true`; the HTML has no `style=`, `class=`, `background`, `font-size`, `<iframe>`, `<button>`, or timestamp; the plain text is markdown with its list markers and bold intact.
  - A drag that starts over the diagram and ends past the last line is served, and the diagram no longer leaves an empty block.

Gmail itself was not exercised. As in #41600, the claim rests on the absence of any style declaration in the HTML payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8f77CSRjV9Y48nbVh8FpB

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->