### PR TITLE
feat(web): handle the SetupIntent redirect return on the billing page

### DIFF
--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -59,6 +59,31 @@ describe("PaymentMethodRow", () => {
     expect(onUpdateCard).toHaveBeenCalledTimes(1);
   });
 
+  test("actionsDisabled disables the row's actions", () => {
+    const onUpdateCard = mock(() => {});
+    const { getByTestId } = render(
+      <PaymentMethodRow
+        brand="Visa"
+        last4="4242"
+        onUpdateCard={onUpdateCard}
+        actionsDisabled
+      />,
+    );
+    const replace = getByTestId("payment-method-update") as HTMLButtonElement;
+    expect(replace.disabled).toBe(true);
+    fireEvent.click(replace);
+    expect(onUpdateCard).not.toHaveBeenCalled();
+  });
+
+  test("leaves the row's actions enabled by default", () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow brand="Visa" last4="4242" onUpdateCard={() => {}} />,
+    );
+    expect(
+      (getByTestId("payment-method-update") as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
   test("offers Replace card as the only action", () => {
     const { getByTestId, queryByTestId } = render(
       <PaymentMethodRow brand="Visa" last4="4242" onUpdateCard={() => {}} />,

--- a/clients/web/src/domains/settings/components/payment-method-row.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.tsx
@@ -9,12 +9,15 @@ export interface PaymentMethodRowProps {
   brand: string | null;
   last4: string | null;
   onUpdateCard: () => void;
+  /** Disables the row's actions, e.g. while a redirect return is resolving. */
+  actionsDisabled?: boolean;
 }
 
 export function PaymentMethodRow({
   brand,
   last4,
   onUpdateCard,
+  actionsDisabled = false,
 }: PaymentMethodRowProps) {
   const { t } = useTranslation("settings");
 
@@ -50,6 +53,7 @@ export function PaymentMethodRow({
       <Button
         variant="ghost"
         onClick={onUpdateCard}
+        disabled={actionsDisabled}
         data-testid="payment-method-update"
         className="shrink-0"
       >

--- a/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -14,7 +14,8 @@
  *    in-flight add into a replace or restate the card being replaced.
  *  - A 3DS redirect return replays its outcome into a freshly opened modal:
  *    a saved card on the success panel alone, a failure back into the form in
- *    the mode the saved card calls for.
+ *    the mode the saved card calls for. The failure waits for the config query
+ *    to settle, so it cannot be pinned to add mode by a still-pending one.
  *  - The config query is gated on org readiness: before the org store
  *    hydrates the card shows the loading state, never the Add button or the
  *    error notice, so a headerless request can't mislabel the org as having
@@ -46,16 +47,35 @@ import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
 let retrieveResponse: AutoTopUpConfigResponse;
 let retrieveShouldFail = false;
+// Set by `holdRetrieve()` to keep the config query in flight, so a test can
+// observe what the card does before the query has settled.
+let retrieveGate: Promise<void> | null = null;
+let releaseRetrieve: (() => void) | null = null;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
-  organizationsBillingAutoTopUpRetrieve: () => {
-    if (retrieveShouldFail) {
-      return Promise.reject(new Error("org header missing"));
+  organizationsBillingAutoTopUpRetrieve: async () => {
+    if (retrieveGate != null) {
+      await retrieveGate;
     }
-    return Promise.resolve({ data: retrieveResponse, response: { ok: true } });
+    if (retrieveShouldFail) {
+      throw new Error("org header missing");
+    }
+    return { data: retrieveResponse, response: { ok: true } };
   },
 }));
+
+function holdRetrieve() {
+  retrieveGate = new Promise<void>((resolve) => {
+    releaseRetrieve = resolve;
+  });
+}
+
+function releaseHeldRetrieve() {
+  retrieveGate = null;
+  releaseRetrieve?.();
+  releaseRetrieve = null;
+}
 
 // Stub the Stripe setup modal: these tests assert only that it is
 // opened/closed and which mode and card on file it is handed.
@@ -177,6 +197,8 @@ async function settleConfigQuery(client: QueryClient) {
 beforeEach(() => {
   retrieveResponse = { ...DISABLED_CONFIG };
   retrieveShouldFail = false;
+  retrieveGate = null;
+  releaseRetrieve = null;
   orgReadiness = "ready";
   pmModalProps = null;
   returnedOutcome = null;
@@ -409,6 +431,34 @@ describe("PaymentMethodsCard redirect return", () => {
     render(wrap(DISABLED_WITH_CARD));
 
     expect(lastPmModalProps().open).toBe(true);
+    expect(lastPmModalProps().initialOutcome).toEqual(returnedOutcome);
+    expect(lastPmModalProps().mode).toBe("replace");
+    expect(lastPmModalProps().cardOnFile).toEqual({
+      brand: "visa",
+      last4: "4242",
+      expMonth: null,
+      expYear: null,
+    });
+  });
+
+  test("holds a failed outcome until the config query settles", async () => {
+    retrieveResponse = { ...DISABLED_WITH_CARD };
+    returnedOutcome = { kind: "error", message: "Your card was declined." };
+    holdRetrieve();
+    const client = makeClient();
+    const { container } = render(wrapWith(client));
+
+    // Snapshotting here would read no cards and pin the modal to add mode.
+    expect(container.querySelector('[data-testid="pm-modal-stub"]')).toBeNull();
+
+    releaseHeldRetrieve();
+    await settleConfigQuery(client);
+
+    await waitFor(() => {
+      if (lastPmModalProps().open !== true) {
+        throw new Error("modal not opened after the config query settled");
+      }
+    });
     expect(lastPmModalProps().initialOutcome).toEqual(returnedOutcome);
     expect(lastPmModalProps().mode).toBe("replace");
     expect(lastPmModalProps().cardOnFile).toEqual({

--- a/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -12,6 +12,9 @@
  *  - The mode and card on file are captured when the modal opens, so the
  *    config the save itself writes back into the query cache cannot turn an
  *    in-flight add into a replace or restate the card being replaced.
+ *  - A 3DS redirect return replays its outcome into a freshly opened modal:
+ *    a saved card on the success panel alone, a failure back into the form in
+ *    the mode the saved card calls for.
  *  - The config query is gated on org readiness: before the org store
  *    hydrates the card shows the loading state, never the Add button or the
  *    error notice, so a headerless request can't mislabel the org as having
@@ -24,9 +27,20 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 
-import type { AutoTopUpPaymentMethodModalProps } from "@/domains/settings/components/auto-top-up-payment-method-modal";
+import { useState } from "react";
+
+import type {
+  AutoTopUpPaymentMethodModalProps,
+  SetupIntentOutcome,
+} from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
@@ -62,6 +76,24 @@ function lastPmModalProps(): AutoTopUpPaymentMethodModalProps {
   }
   return pmModalProps;
 }
+
+// Stands in for the 3DS redirect-return hook. It owns the outcome in state
+// like the real one does, so clearing it on close is what keeps the modal
+// shut rather than the absence of a re-render.
+let returnedOutcome: SetupIntentOutcome | null = null;
+let clearOutcomeCalls = 0;
+mock.module("@/domains/settings/hooks/use-setup-intent-return", () => ({
+  useSetupIntentReturn: () => {
+    const [outcome, setOutcome] = useState(returnedOutcome);
+    return {
+      outcome,
+      clearOutcome: () => {
+        clearOutcomeCalls += 1;
+        setOutcome(null);
+      },
+    };
+  },
+}));
 
 import * as orgReadyModule from "@/hooks/use-is-org-ready";
 
@@ -147,6 +179,8 @@ beforeEach(() => {
   retrieveShouldFail = false;
   orgReadiness = "ready";
   pmModalProps = null;
+  returnedOutcome = null;
+  clearOutcomeCalls = 0;
 });
 
 afterEach(cleanup);
@@ -349,6 +383,54 @@ describe("PaymentMethodsCard modal wiring", () => {
       expMonth: null,
       expYear: null,
     });
+  });
+});
+
+describe("PaymentMethodsCard redirect return", () => {
+  test("replays a saved outcome into the modal on the success panel alone", () => {
+    retrieveResponse = { ...DISABLED_WITH_CARD };
+    returnedOutcome = {
+      kind: "saved",
+      card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
+    };
+    const { container } = render(wrap(DISABLED_WITH_CARD));
+
+    expect(
+      container.querySelector('[data-testid="pm-modal-stub"]'),
+    ).not.toBeNull();
+    expect(lastPmModalProps().initialOutcome).toEqual(returnedOutcome);
+    expect(lastPmModalProps().mode).toBe("add");
+    expect(lastPmModalProps().cardOnFile).toBeNull();
+  });
+
+  test("replays an error outcome into replace mode with the card on file", () => {
+    retrieveResponse = { ...DISABLED_WITH_CARD };
+    returnedOutcome = { kind: "error", message: "Your card was declined." };
+    render(wrap(DISABLED_WITH_CARD));
+
+    expect(lastPmModalProps().open).toBe(true);
+    expect(lastPmModalProps().initialOutcome).toEqual(returnedOutcome);
+    expect(lastPmModalProps().mode).toBe("replace");
+    expect(lastPmModalProps().cardOnFile).toEqual({
+      brand: "visa",
+      last4: "4242",
+      expMonth: null,
+      expYear: null,
+    });
+  });
+
+  test("closing clears the outcome and leaves the modal shut", () => {
+    returnedOutcome = { kind: "saved", card: null };
+    const { container } = render(wrap(DISABLED_CONFIG));
+
+    act(() => {
+      lastPmModalProps().onClose();
+    });
+
+    expect(clearOutcomeCalls).toBe(1);
+    expect(lastPmModalProps().open).toBe(false);
+    expect(lastPmModalProps().initialOutcome).toBeNull();
+    expect(container.querySelector('[data-testid="pm-modal-stub"]')).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -12,6 +12,9 @@
  *  - The mode and card on file are captured when the modal opens, so the
  *    config the save itself writes back into the query cache cannot turn an
  *    in-flight add into a replace or restate the card being replaced.
+ *  - While a 3DS redirect return is still resolving, the Add and Replace
+ *    actions are disabled, so no modal can be opened ahead of the outcome the
+ *    return will replay into one.
  *  - A 3DS redirect return replays its outcome into a freshly opened modal:
  *    a saved card on the success panel alone, a failure back into the form in
  *    the mode the saved card calls for. The failure waits for the config query
@@ -101,12 +104,14 @@ function lastPmModalProps(): AutoTopUpPaymentMethodModalProps {
 // like the real one does, so clearing it on close is what keeps the modal
 // shut rather than the absence of a re-render.
 let returnedOutcome: SetupIntentOutcome | null = null;
+let returnPending = false;
 let clearOutcomeCalls = 0;
 mock.module("@/domains/settings/hooks/use-setup-intent-return", () => ({
   useSetupIntentReturn: () => {
     const [outcome, setOutcome] = useState(returnedOutcome);
     return {
       outcome,
+      pending: returnPending,
       clearOutcome: () => {
         clearOutcomeCalls += 1;
         setOutcome(null);
@@ -202,6 +207,7 @@ beforeEach(() => {
   orgReadiness = "ready";
   pmModalProps = null;
   returnedOutcome = null;
+  returnPending = false;
   clearOutcomeCalls = 0;
 });
 
@@ -467,6 +473,42 @@ describe("PaymentMethodsCard redirect return", () => {
       expMonth: null,
       expYear: null,
     });
+  });
+
+  test("disables Add Payment Method while the return is unresolved", () => {
+    returnPending = true;
+    const { getByTestId } = render(wrap(DISABLED_CONFIG));
+
+    expect(
+      (getByTestId("payment-methods-add") as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  test("disables Replace card while the return is unresolved", () => {
+    returnPending = true;
+    retrieveResponse = { ...DISABLED_WITH_CARD };
+    const { getByTestId } = render(wrap(DISABLED_WITH_CARD));
+
+    expect(
+      (getByTestId("payment-method-update") as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  test("leaves Add Payment Method usable when no return is in flight", () => {
+    const { getByTestId } = render(wrap(DISABLED_CONFIG));
+
+    expect(
+      (getByTestId("payment-methods-add") as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  test("leaves Replace card usable when no return is in flight", () => {
+    retrieveResponse = { ...DISABLED_WITH_CARD };
+    const { getByTestId } = render(wrap(DISABLED_WITH_CARD));
+
+    expect(
+      (getByTestId("payment-method-update") as HTMLButtonElement).disabled,
+    ).toBe(false);
   });
 
   test("closing clears the outcome and leaves the modal shut", () => {

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -89,7 +89,14 @@ export function PaymentMethodsCard() {
   const { t } = useTranslation("settings");
   const configQuery = useAutoTopUpConfigQuery();
   const syncPaymentMethodSaved = usePaymentMethodSavedSync();
-  const { outcome, clearOutcome } = useSetupIntentReturn();
+  // A return that is still resolving keeps the Add and Replace actions
+  // disabled: the modal replays that outcome as its `initialOutcome`, which is
+  // seeded on open alone, so one opened in that window would never show it.
+  const {
+    outcome,
+    pending: returnPending,
+    clearOutcome,
+  } = useSetupIntentReturn();
 
   const [pmModal, setPmModal] = useState<PaymentModalSnapshot | null>(null);
 
@@ -162,6 +169,7 @@ export function PaymentMethodsCard() {
             brand={card.brand}
             last4={card.last4}
             onUpdateCard={openPaymentModal}
+            actionsDisabled={returnPending}
           />
         ))}
       </div>
@@ -177,6 +185,7 @@ export function PaymentMethodsCard() {
             <Button
               variant="outlined"
               onClick={openPaymentModal}
+              disabled={returnPending}
               data-testid="payment-methods-add"
             >
               {t("paymentMethodsCard.addButton")}

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 import { Button } from "@vellumai/design-library/components/button";
@@ -13,6 +13,7 @@ import type {
 } from "@/domains/settings/components/payment-method-modal-shell";
 import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
 import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { useSetupIntentReturn } from "@/domains/settings/hooks/use-setup-intent-return";
 import { useAutoTopUpConfigQuery } from "@/hooks/use-auto-top-up-config";
 import { useTranslation } from "@/i18n";
 
@@ -59,6 +60,24 @@ interface PaymentModalSnapshot {
   cardOnFile: CardOnFile | null;
 }
 
+function modalSnapshotFor(
+  cards: PaymentMethodCardEntry[],
+): PaymentModalSnapshot {
+  const [existing] = cards;
+  if (existing == null) {
+    return { mode: "add", cardOnFile: null };
+  }
+  return {
+    mode: "replace",
+    cardOnFile: {
+      brand: existing.brand,
+      last4: existing.last4,
+      expMonth: existing.expMonth,
+      expYear: existing.expYear,
+    },
+  };
+}
+
 /**
  * Settings → Billing "Payment Methods" section. Card management lives here;
  * the auto-reload toggle and its config stay in `AutoTopUpCard` (Credits
@@ -70,29 +89,34 @@ export function PaymentMethodsCard() {
   const { t } = useTranslation("settings");
   const configQuery = useAutoTopUpConfigQuery();
   const syncPaymentMethodSaved = usePaymentMethodSavedSync();
+  const { outcome, clearOutcome } = useSetupIntentReturn();
 
   const [pmModal, setPmModal] = useState<PaymentModalSnapshot | null>(null);
 
   const config = configQuery.data;
-  const cards = paymentMethodCards(config);
+  const cards = useMemo(() => paymentMethodCards(config), [config]);
   const showAddButton = config != null && cards.length === 0;
 
   const openPaymentModal = () => {
-    const [existing] = cards;
-    if (existing == null) {
-      setPmModal({ mode: "add", cardOnFile: null });
+    setPmModal(modalSnapshotFor(cards));
+  };
+
+  // A 3DS redirect return lands on a freshly loaded page, so the mode the save
+  // was started in is gone: a saved outcome shows the success panel alone, and
+  // a failed one reopens the form in the mode the saved card calls for.
+  useEffect(() => {
+    if (outcome == null) {
       return;
     }
-    setPmModal({
-      mode: "replace",
-      cardOnFile: {
-        brand: existing.brand,
-        last4: existing.last4,
-        expMonth: existing.expMonth,
-        expYear: existing.expYear,
-      },
+    setPmModal((current) => {
+      if (current != null) {
+        return current;
+      }
+      return outcome.kind === "saved"
+        ? { mode: "add", cardOnFile: null }
+        : modalSnapshotFor(cards);
     });
-  };
+  }, [outcome, cards]);
 
   const renderBody = () => {
     // `isPending` rather than `isLoading`: the query idles with no data until
@@ -156,9 +180,13 @@ export function PaymentMethodsCard() {
 
       <AutoTopUpPaymentMethodModal
         open={pmModal != null}
-        onClose={() => setPmModal(null)}
+        onClose={() => {
+          setPmModal(null);
+          clearOutcome();
+        }}
         mode={pmModal?.mode ?? "add"}
         cardOnFile={pmModal?.cardOnFile ?? null}
+        initialOutcome={outcome}
         onSavedOptimistic={syncPaymentMethodSaved}
       />
     </Card>

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -104,8 +104,17 @@ export function PaymentMethodsCard() {
   // A 3DS redirect return lands on a freshly loaded page, so the mode the save
   // was started in is gone: a saved outcome shows the success panel alone, and
   // a failed one reopens the form in the mode the saved card calls for.
+  //
+  // That mode comes from the config query, so a failed outcome waits for it to
+  // settle. Snapshotting while it is still pending would read no cards, and
+  // the updater below preserves that snapshot: the replacement would replay
+  // under the Add title with no card-on-file row for the rest of the visit.
+  const configSettled = configQuery.isSuccess || configQuery.isError;
   useEffect(() => {
     if (outcome == null) {
+      return;
+    }
+    if (outcome.kind !== "saved" && !configSettled) {
       return;
     }
     setPmModal((current) => {
@@ -116,7 +125,7 @@ export function PaymentMethodsCard() {
         ? { mode: "add", cardOnFile: null }
         : modalSnapshotFor(cards);
     });
-  }, [outcome, cards]);
+  }, [outcome, cards, configSettled]);
 
   const renderBody = () => {
     // `isPending` rather than `isLoading`: the query idles with no data until

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
@@ -4,10 +4,11 @@
  * through Stripe.js, and stripped from the URL.
  *
  * Strategy: mock the shared Stripe client so `retrieveSetupIntent` is driven
- * from the test (a real one needs Stripe.js and a live intent), and mock the
- * saved-card sync so the confirm endpoint is not called. The real
- * `setupIntentIdFromClientSecret` is kept, so the id the sync is handed is
- * parsed the way it is in the app.
+ * from the test (a real one needs Stripe.js and a live intent), mock the
+ * saved-card sync so the confirm endpoint is not called, and mock the
+ * org-readiness gate so a test can hold the resolution the way a hydrating org
+ * store does. The real `setupIntentIdFromClientSecret` is kept, so the id the
+ * sync is handed is parsed the way it is in the app.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -68,6 +69,13 @@ mock.module("@/domains/settings/hooks/use-payment-method-saved-poll", () => ({
   usePaymentMethodSavedSync: () => syncPaymentMethodSaved,
 }));
 
+// Drives the org-header gate. The resolution confirms the SetupIntent
+// server-side, so it waits for the header source the billing queries wait for.
+let orgReady = true;
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+
 const { useSetupIntentReturn } = await import("./use-setup-intent-return");
 
 const RETURN_SEARCH =
@@ -109,6 +117,7 @@ beforeEach(() => {
   retrieveResult = { setupIntent: { status: "succeeded" } };
   syncCalls = [];
   syncedCard = { brand: "visa", last4: "4242", autoReloadEnabled: false };
+  orgReady = true;
 });
 
 afterEach(cleanup);
@@ -177,6 +186,30 @@ describe("useSetupIntentReturn", () => {
     expect(result.current.outcome).toBeNull();
     expect(getStripePromiseCalls).toBe(0);
     expect(currentUrl(result)).toBe(STRIPPED_URL);
+  });
+
+  test("holds the resolution until the org header source is ready", async () => {
+    orgReady = false;
+    const { result, rerender } = renderAt(RETURN_SEARCH);
+
+    // The params are already off the URL, so a reload cannot replay them.
+    expect(currentUrl(result)).toBe(STRIPPED_URL);
+    expect(getStripePromiseCalls).toBe(0);
+    expect(retrieveCalls).toEqual([]);
+    expect(syncCalls).toEqual([]);
+    expect(result.current.outcome).toBeNull();
+
+    orgReady = true;
+    rerender();
+    await waitForOutcome(result);
+
+    expect(result.current.outcome).toEqual({
+      kind: "saved",
+      card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
+    });
+    expect(getStripePromiseCalls).toBe(1);
+    expect(retrieveCalls).toEqual(["seti_1_secret_x"]);
+    expect(syncCalls).toEqual([{ setupIntentId: "seti_1" }]);
   });
 
   test("clearOutcome drops the resolved outcome", async () => {

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
@@ -18,6 +18,7 @@ import { MemoryRouter, useLocation } from "react-router";
 
 import * as savedSyncModule from "@/domains/settings/hooks/use-payment-method-saved-poll";
 import type { SavedPaymentMethod } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import type { OrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 
 // Keeps the real stripe-client below from injecting a Stripe.js script tag
 // into happy-dom when it is imported.
@@ -70,10 +71,10 @@ mock.module("@/domains/settings/hooks/use-payment-method-saved-poll", () => ({
 }));
 
 // Drives the org-header gate. The resolution confirms the SetupIntent
-// server-side, so it waits for the header source the billing queries wait for.
-let orgReady = true;
+// server-side, so it waits out `"resolving"` the way the config query does.
+let orgReadiness: OrgHeaderReadiness = "ready";
 mock.module("@/hooks/use-is-org-ready", () => ({
-  useIsOrgReady: () => orgReady,
+  useOrgHeaderReadiness: () => orgReadiness,
 }));
 
 const { useSetupIntentReturn } = await import("./use-setup-intent-return");
@@ -117,7 +118,7 @@ beforeEach(() => {
   retrieveResult = { setupIntent: { status: "succeeded" } };
   syncCalls = [];
   syncedCard = { brand: "visa", last4: "4242", autoReloadEnabled: false };
-  orgReady = true;
+  orgReadiness = "ready";
 });
 
 afterEach(cleanup);
@@ -188,8 +189,8 @@ describe("useSetupIntentReturn", () => {
     expect(currentUrl(result)).toBe(STRIPPED_URL);
   });
 
-  test("holds the resolution until the org header source is ready", async () => {
-    orgReady = false;
+  test("holds the resolution while the org header source is resolving", async () => {
+    orgReadiness = "resolving";
     const { result, rerender } = renderAt(RETURN_SEARCH);
 
     // The params are already off the URL, so a reload cannot replay them.
@@ -199,7 +200,7 @@ describe("useSetupIntentReturn", () => {
     expect(syncCalls).toEqual([]);
     expect(result.current.outcome).toBeNull();
 
-    orgReady = true;
+    orgReadiness = "ready";
     rerender();
     await waitForOutcome(result);
 
@@ -210,6 +211,23 @@ describe("useSetupIntentReturn", () => {
     expect(getStripePromiseCalls).toBe(1);
     expect(retrieveCalls).toEqual(["seti_1_secret_x"]);
     expect(syncCalls).toEqual([{ setupIntentId: "seti_1" }]);
+  });
+
+  test("resolves rather than waiting when org resolution produced no org", async () => {
+    // `"unavailable"` never becomes `"ready"` on its own, so gating on it too
+    // would leave the return unresolved. The request fires and its failure
+    // reaches the user as the error outcome instead.
+    orgReadiness = "unavailable";
+    retrieveResult = { error: { message: "No such setupintent." } };
+
+    const { result } = renderAt(RETURN_SEARCH);
+    await waitForOutcome(result);
+
+    expect(result.current.outcome).toEqual({
+      kind: "error",
+      message: "No such setupintent.",
+    });
+    expect(retrieveCalls).toEqual(["seti_1_secret_x"]);
   });
 
   test("clearOutcome drops the resolved outcome", async () => {

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Tests for `useSetupIntentReturn`: the SetupIntent params Stripe appends to
+ * the `return_url` after an off-page 3DS challenge are read once, resolved
+ * through Stripe.js, and stripped from the URL.
+ *
+ * Strategy: mock the shared Stripe client so `retrieveSetupIntent` is driven
+ * from the test (a real one needs Stripe.js and a live intent), and mock the
+ * saved-card sync so the confirm endpoint is not called. The real
+ * `setupIntentIdFromClientSecret` is kept, so the id the sync is handed is
+ * parsed the way it is in the app.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, useLocation } from "react-router";
+
+import * as savedSyncModule from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import type { SavedPaymentMethod } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+
+// Keeps the real stripe-client below from injecting a Stripe.js script tag
+// into happy-dom when it is imported.
+mock.module("@stripe/stripe-js", () => ({
+  loadStripe: () => Promise.resolve(null),
+}));
+
+const stripeClient = await import("@/domains/settings/billing/stripe-client");
+
+interface RetrieveResult {
+  setupIntent?: {
+    status: string;
+    last_setup_error?: { message?: string };
+  };
+  error?: { message?: string };
+}
+
+let stripeAvailable = true;
+let getStripePromiseCalls = 0;
+let retrieveCalls: string[] = [];
+let retrieveResult: RetrieveResult = {};
+
+mock.module("@/domains/settings/billing/stripe-client", () => ({
+  ...stripeClient,
+  getStripePromise: () => {
+    getStripePromiseCalls += 1;
+    if (!stripeAvailable) {
+      return null;
+    }
+    return Promise.resolve({
+      retrieveSetupIntent: (clientSecret: string) => {
+        retrieveCalls.push(clientSecret);
+        return Promise.resolve(retrieveResult);
+      },
+    });
+  },
+}));
+
+let syncCalls: Array<{ setupIntentId: string | null }> = [];
+let syncedCard: SavedPaymentMethod | null = null;
+
+async function syncPaymentMethodSaved(args: { setupIntentId: string | null }) {
+  syncCalls.push(args);
+  return syncedCard;
+}
+
+mock.module("@/domains/settings/hooks/use-payment-method-saved-poll", () => ({
+  ...savedSyncModule,
+  usePaymentMethodSavedSync: () => syncPaymentMethodSaved,
+}));
+
+const { useSetupIntentReturn } = await import("./use-setup-intent-return");
+
+const RETURN_SEARCH =
+  "?tab=billing&setup_intent=seti_1&setup_intent_client_secret=seti_1_secret_x&redirect_status=succeeded";
+const STRIPPED_URL = "/assistant/settings/usage?tab=billing";
+const CONFIRM_FAILED = "Failed to save payment method.";
+
+function renderAt(search: string) {
+  return renderHook(
+    () => ({ location: useLocation(), ...useSetupIntentReturn() }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <MemoryRouter initialEntries={[`/assistant/settings/usage${search}`]}>
+          {children}
+        </MemoryRouter>
+      ),
+    },
+  );
+}
+
+type HookResult = ReturnType<typeof renderAt>["result"];
+
+function currentUrl(result: HookResult): string {
+  return result.current.location.pathname + result.current.location.search;
+}
+
+async function waitForOutcome(result: HookResult): Promise<void> {
+  await waitFor(() => {
+    if (result.current.outcome == null) {
+      throw new Error("outcome not resolved yet");
+    }
+  });
+}
+
+beforeEach(() => {
+  stripeAvailable = true;
+  getStripePromiseCalls = 0;
+  retrieveCalls = [];
+  retrieveResult = { setupIntent: { status: "succeeded" } };
+  syncCalls = [];
+  syncedCard = { brand: "visa", last4: "4242", autoReloadEnabled: false };
+});
+
+afterEach(cleanup);
+
+describe("useSetupIntentReturn", () => {
+  test("resolves a succeeded return into the synced saved card", async () => {
+    const { result } = renderAt(RETURN_SEARCH);
+    await waitForOutcome(result);
+
+    expect(result.current.outcome).toEqual({
+      kind: "saved",
+      card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
+    });
+    expect(retrieveCalls).toEqual(["seti_1_secret_x"]);
+    expect(syncCalls).toEqual([{ setupIntentId: "seti_1" }]);
+    expect(currentUrl(result)).toBe(STRIPPED_URL);
+  });
+
+  test("carries the SetupIntent's own error message when it did not succeed", async () => {
+    retrieveResult = {
+      setupIntent: {
+        status: "requires_payment_method",
+        last_setup_error: { message: "Your card was declined." },
+      },
+    };
+
+    const { result } = renderAt(RETURN_SEARCH);
+    await waitForOutcome(result);
+
+    expect(result.current.outcome).toEqual({
+      kind: "error",
+      message: "Your card was declined.",
+    });
+    expect(syncCalls).toEqual([]);
+    expect(currentUrl(result)).toBe(STRIPPED_URL);
+  });
+
+  test("carries the retrieval error message when the intent cannot be read", async () => {
+    retrieveResult = { error: { message: "No such setupintent." } };
+
+    const { result } = renderAt(RETURN_SEARCH);
+    await waitForOutcome(result);
+
+    expect(result.current.outcome).toEqual({
+      kind: "error",
+      message: "No such setupintent.",
+    });
+  });
+
+  test("falls back to the generic message when Stripe.js is unavailable", async () => {
+    stripeAvailable = false;
+
+    const { result } = renderAt(RETURN_SEARCH);
+    await waitForOutcome(result);
+
+    expect(result.current.outcome).toEqual({
+      kind: "error",
+      message: CONFIRM_FAILED,
+    });
+    expect(retrieveCalls).toEqual([]);
+  });
+
+  test("does nothing and never loads Stripe on a plain visit", () => {
+    const { result } = renderAt("?tab=billing");
+
+    expect(result.current.outcome).toBeNull();
+    expect(getStripePromiseCalls).toBe(0);
+    expect(currentUrl(result)).toBe(STRIPPED_URL);
+  });
+
+  test("clearOutcome drops the resolved outcome", async () => {
+    const { result } = renderAt(RETURN_SEARCH);
+    await waitForOutcome(result);
+
+    act(() => {
+      result.current.clearOutcome();
+    });
+
+    expect(result.current.outcome).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
@@ -185,8 +185,37 @@ describe("useSetupIntentReturn", () => {
     const { result } = renderAt("?tab=billing");
 
     expect(result.current.outcome).toBeNull();
+    expect(result.current.pending).toBe(false);
     expect(getStripePromiseCalls).toBe(0);
     expect(currentUrl(result)).toBe(STRIPPED_URL);
+  });
+
+  test("stays pending from the captured params until the outcome settles", async () => {
+    orgReadiness = "resolving";
+    const { result, rerender } = renderAt(RETURN_SEARCH);
+
+    expect(result.current.pending).toBe(true);
+    expect(result.current.outcome).toBeNull();
+
+    orgReadiness = "ready";
+    rerender();
+    await waitForOutcome(result);
+
+    expect(result.current.pending).toBe(false);
+  });
+
+  test("stays pending while a failed return resolves", async () => {
+    orgReadiness = "resolving";
+    retrieveResult = { error: { message: "No such setupintent." } };
+    const { result, rerender } = renderAt(RETURN_SEARCH);
+
+    expect(result.current.pending).toBe(true);
+
+    orgReadiness = "ready";
+    rerender();
+    await waitForOutcome(result);
+
+    expect(result.current.pending).toBe(false);
   });
 
   test("holds the resolution while the org header source is resolving", async () => {
@@ -239,5 +268,8 @@ describe("useSetupIntentReturn", () => {
     });
 
     expect(result.current.outcome).toBeNull();
+    // A cleared outcome is a resolved return, not one that went back to being
+    // in flight, so the card's actions stay usable.
+    expect(result.current.pending).toBe(false);
   });
 });

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
@@ -7,8 +7,15 @@ import {
 } from "@/domains/settings/billing/stripe-client";
 import type { SetupIntentOutcome } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { t } from "@/i18n";
 import { routes } from "@/utils/routes";
+
+/** The redirect params, held from the URL strip until the org store settles. */
+interface CapturedReturn {
+  clientSecret: string;
+  redirectStatus: string | null;
+}
 
 /**
  * Resolves the SetupIntent params Stripe appends to the `return_url` after an
@@ -28,9 +35,12 @@ export function useSetupIntentReturn(): {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const syncPaymentMethodSaved = usePaymentMethodSavedSync();
+  const orgReady = useIsOrgReady();
 
+  const [captured, setCaptured] = useState<CapturedReturn | null>(null);
   const [outcome, setOutcome] = useState<SetupIntentOutcome | null>(null);
-  const handledRef = useRef(false);
+  const capturedRef = useRef(false);
+  const resolvedRef = useRef(false);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -42,14 +52,30 @@ export function useSetupIntentReturn(): {
 
   useEffect(() => {
     const clientSecret = searchParams.get("setup_intent_client_secret");
-    if (clientSecret == null || handledRef.current) {
+    if (clientSecret == null || capturedRef.current) {
       return;
     }
-    // One resolution per page load: strict mode runs this effect twice, and
+    // One capture per page load: strict mode runs this effect twice, and
     // stripping the params below re-runs it a third time.
-    handledRef.current = true;
-    const redirectStatus = searchParams.get("redirect_status");
+    capturedRef.current = true;
+    setCaptured({
+      clientSecret,
+      redirectStatus: searchParams.get("redirect_status"),
+    });
     navigate(routes.settings.usageBilling, { replace: true });
+  }, [navigate, searchParams]);
+
+  // A full-page 3DS return remounts the app, so the org store can still be
+  // hydrating when the params are read. The server-side confirm below needs
+  // `Vellum-Organization-Id`, and a headerless one is rejected and falls back
+  // to the 20-second webhook poll, so the resolution waits for the header
+  // source the same way the billing queries do.
+  useEffect(() => {
+    if (captured == null || !orgReady || resolvedRef.current) {
+      return;
+    }
+    resolvedRef.current = true;
+    const { clientSecret, redirectStatus } = captured;
 
     const settle = (next: SetupIntentOutcome) => {
       if (mountedRef.current) {
@@ -88,7 +114,7 @@ export function useSetupIntentReturn(): {
         settleError(undefined);
       }
     })();
-  }, [navigate, searchParams, syncPaymentMethodSaved]);
+  }, [captured, orgReady, syncPaymentMethodSaved]);
 
   const clearOutcome = useCallback(() => setOutcome(null), []);
 

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+
+import {
+  getStripePromise,
+  setupIntentIdFromClientSecret,
+} from "@/domains/settings/billing/stripe-client";
+import type { SetupIntentOutcome } from "@/domains/settings/components/auto-top-up-payment-method-modal";
+import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { t } from "@/i18n";
+import { routes } from "@/utils/routes";
+
+/**
+ * Resolves the SetupIntent params Stripe appends to the `return_url` after an
+ * off-page 3DS challenge (`setup_intent`, `setup_intent_client_secret`,
+ * `redirect_status`) into the outcome `AutoTopUpPaymentMethodModal` replays as
+ * its `initialOutcome`, and strips them from the URL.
+ *
+ * `redirect_status` is a hint only: the SetupIntent is re-read through
+ * Stripe.js, and a succeeded one is confirmed server-side through
+ * `usePaymentMethodSavedSync`, so the success panel and the payment-method row
+ * carry the new card's brand and last4.
+ */
+export function useSetupIntentReturn(): {
+  outcome: SetupIntentOutcome | null;
+  clearOutcome: () => void;
+} {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const syncPaymentMethodSaved = usePaymentMethodSavedSync();
+
+  const [outcome, setOutcome] = useState<SetupIntentOutcome | null>(null);
+  const handledRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const clientSecret = searchParams.get("setup_intent_client_secret");
+    if (clientSecret == null || handledRef.current) {
+      return;
+    }
+    // One resolution per page load: strict mode runs this effect twice, and
+    // stripping the params below re-runs it a third time.
+    handledRef.current = true;
+    const redirectStatus = searchParams.get("redirect_status");
+    navigate(routes.settings.usageBilling, { replace: true });
+
+    const settle = (next: SetupIntentOutcome) => {
+      if (mountedRef.current) {
+        setOutcome(next);
+      }
+    };
+    const settleError = (message: string | undefined) => {
+      console.warn("[useSetupIntentReturn] card not saved on redirect return", {
+        redirectStatus,
+      });
+      settle({
+        kind: "error",
+        message:
+          message ?? t("settings:autoTopUpPaymentMethodModal.confirmFailed"),
+      });
+    };
+
+    void (async () => {
+      try {
+        const stripe = await getStripePromise();
+        if (stripe == null) {
+          settleError(undefined);
+          return;
+        }
+        const { setupIntent, error } =
+          await stripe.retrieveSetupIntent(clientSecret);
+        if (setupIntent?.status === "succeeded") {
+          const card = await syncPaymentMethodSaved({
+            setupIntentId: setupIntentIdFromClientSecret(clientSecret),
+          });
+          settle({ kind: "saved", card });
+          return;
+        }
+        settleError(error?.message ?? setupIntent?.last_setup_error?.message);
+      } catch {
+        settleError(undefined);
+      }
+    })();
+  }, [navigate, searchParams, syncPaymentMethodSaved]);
+
+  const clearOutcome = useCallback(() => setOutcome(null), []);
+
+  return { outcome, clearOutcome };
+}

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
@@ -27,9 +27,15 @@ interface CapturedReturn {
  * Stripe.js, and a succeeded one is confirmed server-side through
  * `usePaymentMethodSavedSync`, so the success panel and the payment-method row
  * carry the new card's brand and last4.
+ *
+ * `pending` spans the window between reading those params and settling them,
+ * which the confirm fallback's webhook poll can stretch to 20 seconds. The
+ * outcome is replayed into a modal the caller opens for it, so the caller uses
+ * `pending` to keep a competing one from being opened first.
  */
 export function useSetupIntentReturn(): {
   outcome: SetupIntentOutcome | null;
+  pending: boolean;
   clearOutcome: () => void;
 } {
   const [searchParams] = useSearchParams();
@@ -39,6 +45,9 @@ export function useSetupIntentReturn(): {
 
   const [captured, setCaptured] = useState<CapturedReturn | null>(null);
   const [outcome, setOutcome] = useState<SetupIntentOutcome | null>(null);
+  // Tracked apart from `outcome` so `clearOutcome()` does not read as a return
+  // that went back to being unresolved.
+  const [settled, setSettled] = useState(false);
   const capturedRef = useRef(false);
   const resolvedRef = useRef(false);
   const mountedRef = useRef(true);
@@ -86,6 +95,7 @@ export function useSetupIntentReturn(): {
     const settle = (next: SetupIntentOutcome) => {
       if (mountedRef.current) {
         setOutcome(next);
+        setSettled(true);
       }
     };
     const settleError = (message: string | undefined) => {
@@ -124,5 +134,5 @@ export function useSetupIntentReturn(): {
 
   const clearOutcome = useCallback(() => setOutcome(null), []);
 
-  return { outcome, clearOutcome };
+  return { outcome, pending: captured != null && !settled, clearOutcome };
 }

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
@@ -7,7 +7,7 @@ import {
 } from "@/domains/settings/billing/stripe-client";
 import type { SetupIntentOutcome } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
-import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
 import { t } from "@/i18n";
 import { routes } from "@/utils/routes";
 
@@ -35,7 +35,7 @@ export function useSetupIntentReturn(): {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const syncPaymentMethodSaved = usePaymentMethodSavedSync();
-  const orgReady = useIsOrgReady();
+  const orgReadiness = useOrgHeaderReadiness();
 
   const [captured, setCaptured] = useState<CapturedReturn | null>(null);
   const [outcome, setOutcome] = useState<SetupIntentOutcome | null>(null);
@@ -68,10 +68,16 @@ export function useSetupIntentReturn(): {
   // A full-page 3DS return remounts the app, so the org store can still be
   // hydrating when the params are read. The server-side confirm below needs
   // `Vellum-Organization-Id`, and a headerless one is rejected and falls back
-  // to the 20-second webhook poll, so the resolution waits for the header
-  // source the same way the billing queries do.
+  // to the 20-second webhook poll, so the resolution waits out `"resolving"`
+  // exactly as the config query does. `"unavailable"` still resolves: the
+  // request fires and fails into the error outcome, rather than leaving the
+  // return unresolved for the rest of the visit.
   useEffect(() => {
-    if (captured == null || !orgReady || resolvedRef.current) {
+    if (
+      captured == null ||
+      orgReadiness === "resolving" ||
+      resolvedRef.current
+    ) {
       return;
     }
     resolvedRef.current = true;
@@ -114,7 +120,7 @@ export function useSetupIntentReturn(): {
         settleError(undefined);
       }
     })();
-  }, [captured, orgReady, syncPaymentMethodSaved]);
+  }, [captured, orgReadiness, syncPaymentMethodSaved]);
 
   const clearOutcome = useCallback(() => setOutcome(null), []);
 


### PR DESCRIPTION
## Summary
- New `useSetupIntentReturn` hook: reads Stripe's SetupIntent redirect params once, strips them from the URL with `navigate(routes.settings.usageBilling, { replace: true })`, re-reads the intent with `retrieveSetupIntent`, and resolves it into the modal's `initialOutcome` (confirming a succeeded one through `usePaymentMethodSavedSync` so brand and last4 are real).
- `PaymentMethodsCard` replays that outcome: a saved return opens the modal on the success panel alone (`add` mode, no card-on-file row) and auto-closes; a failed one reopens the form in the mode the saved card calls for, with the error line pre-filled. Closing clears both the snapshot and the outcome.
- A plain visit to the billing page does nothing and never loads Stripe.js.

Part of plan: payment-modal-v4.md (PR 6 of 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XB7ckoybGsZZWurNBj6cx3