### PR TITLE
Enable Windows artifacts for dev releases

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2251,7 +2251,6 @@ jobs:
 
   release-windows:
     needs: [compute-version, register-release, build-chrome-extension]
-    if: vars.WINDOWS_DEV_RELEASE_ENABLED == 'true'
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -282,5 +282,8 @@ jobs:
             fi
             gcloud storage cp "$INSTALLER" "gs://${BUCKET}/${PREFIX}/$(basename "$INSTALLER")"
             gcloud storage cp "$BLOCKMAP" "gs://${BUCKET}/${PREFIX}/$(basename "$BLOCKMAP")"
+            if [ "$ENVIRONMENT" = "dev" ]; then
+              gcloud storage cp "$INSTALLER" "gs://${BUCKET}/${PREFIX}/vellum-assistant-dev-${ARCH}.exe"
+            fi
             gcloud storage cp "$YML" "gs://${BUCKET}/${PREFIX}/${ENVIRONMENT}.yml"
           done

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -2,8 +2,9 @@ name: Release Windows
 
 # Reusable Windows desktop release: build, sign, verify, and publish the NSIS
 # installers and electron-updater feed for one environment. Called by
-# dev-release.yaml and release.yml behind the WINDOWS_<ENV>_RELEASE_ENABLED
-# variables; never dispatched on its own.
+# dev-release.yaml and release.yml. Dev runs on every dev release; staging and
+# production remain behind their WINDOWS_<ENV>_RELEASE_ENABLED variables.
+# Never dispatched on its own.
 #
 # External gates (per GitHub environment):
 #   vars.WINDOWS_SIGNING_PROVIDER   pfx | azure-trusted-signing | command

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -144,9 +144,9 @@ uninstall-tests the installer.
 ## Release
 
 `.github/workflows/release-windows.yaml` is the reusable release: both
-`dev-release.yaml` and `release.yml` call it with `{ environment, version }`
-behind the `WINDOWS_{DEV,STAGING,PRODUCTION}_RELEASE_ENABLED` variables, so
-each channel stays off until its variable is set. Per
+`dev-release.yaml` and `release.yml` call it with `{ environment, version }`.
+Dev runs on every dev release, while staging and production stay behind the
+`WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED` variables. Per
 architecture (x64 on `windows-2025`, arm64 on the `windows-11-vs2026-arm`
 preview runner) it stamps the version, builds the helper, preview handler,
 CLI runtime, and renderer, packages and signs through `electron-builder`,

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -153,7 +153,8 @@ CLI runtime, and renderer, packages and signs through `electron-builder`,
 verifies every manifest binary and the installer with
 `Get-AuthenticodeSignature`, and publishes to the
 `vellum-ai-<env>-releases/win-electron/<arch>/` feed: installer and blockmap
-first, then the `<env>.yml` channel manifest.
+first, then the `<env>.yml` channel manifest. Dev also publishes the installer
+as `vellum-assistant-dev-<arch>.exe` for stable download-page links.
 
 The executable, installer, and uninstaller use the environment-specific icon
 from `build-resources/icons/<environment>/icon.ico`, matching the local, dev,

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -616,7 +616,7 @@ Creating the GitHub Release triggers three workflows in parallel:
 - **Publish velly to npm** (`publish-velly.yml`): Publishes the `velly` CLI package to npm with provenance.
 - **Slack Release Notification** (`slack-release-notification.yml`): Posts a summary message to the releases Slack channel with a threaded changelog.
 
-- **Release Windows** (`release-windows` job, reusable `release-windows.yaml`): Builds, signs, and verifies the NSIS installer per architecture on native Windows runners, then publishes the installer, blockmap, and `{env}.yml` manifest to the GCS feed at `win-electron/{arch}/`. Dev runs on every dev release; staging and production are enabled by `WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED`. Signing credentials are an explicit gate documented in `clients/windows/README.md`.
+- **Release Windows** (`release-windows` job, reusable `release-windows.yaml`): Builds, signs, and verifies the NSIS installer per architecture on native Windows runners, then publishes the installer, blockmap, and `{env}.yml` manifest to the GCS feed at `win-electron/{arch}/`. Dev runs on every dev release and also publishes a stable installer alias for the dev download page; staging and production are enabled by `WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED`. Signing credentials are an explicit gate documented in `clients/windows/README.md`.
 
 #### Auto-updates for macOS clients
 

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -616,7 +616,7 @@ Creating the GitHub Release triggers three workflows in parallel:
 - **Publish velly to npm** (`publish-velly.yml`): Publishes the `velly` CLI package to npm with provenance.
 - **Slack Release Notification** (`slack-release-notification.yml`): Posts a summary message to the releases Slack channel with a threaded changelog.
 
-- **Release Windows** (`release-windows` job, reusable `release-windows.yaml`): Builds, signs, and verifies the NSIS installer per architecture on native Windows runners, then publishes the installer, blockmap, and `{env}.yml` manifest to the GCS feed at `win-electron/{arch}/`. Enabled per channel by `WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED` (and `WINDOWS_DEV_RELEASE_ENABLED` in `dev-release.yaml`); signing credentials are an explicit gate documented in `clients/windows/README.md`.
+- **Release Windows** (`release-windows` job, reusable `release-windows.yaml`): Builds, signs, and verifies the NSIS installer per architecture on native Windows runners, then publishes the installer, blockmap, and `{env}.yml` manifest to the GCS feed at `win-electron/{arch}/`. Dev runs on every dev release; staging and production are enabled by `WINDOWS_{STAGING,PRODUCTION}_RELEASE_ENABLED`. Signing credentials are an explicit gate documented in `clients/windows/README.md`.
 
 #### Auto-updates for macOS clients
 


### PR DESCRIPTION
## Summary

- run the signed Windows release workflow for every dev release
- publish the dev installer under a stable x64 and arm64 GCS alias for download-page links
- keep staging and production behind their existing release gates and update the release documentation

## Original prompt

Set up the end-to-end Windows installer path from GitHub Actions to the marketing download page for the dev non-production environment only. Keep production and staging unchanged, and split the work into the logical repository PRs needed to deliver it.