### PR TITLE
The destructive menu row has one definition again

### DIFF
--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -30,7 +30,12 @@ import { useTranslation, type TFunction } from "@/i18n";
 import { openExternalUrl } from "@/runtime/browser";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { READ_ICON, UNREAD_ICON } from "@/utils/read-state-icon";
-import { BottomSheet, ContextMenu, Menu } from "@vellumai/design-library";
+import {
+  BottomSheet,
+  ContextMenu,
+  Menu,
+  actionMenuDestructiveClasses,
+} from "@vellumai/design-library";
 import { cn } from "@vellumai/design-library/utils/cn";
 
 /**
@@ -56,12 +61,6 @@ import { cn } from "@vellumai/design-library/utils/cn";
 
 type MenuSide = "top" | "right" | "bottom" | "left";
 type MenuAlign = "start" | "center" | "end";
-
-/** Destructive row colour shared by the dropdown and the mobile sheet. */
-const DELETE_ITEM_CLASS =
-  "text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-hover)] [&_[data-slot=menu-item-icon]]:text-inherit";
-const DELETE_SHEET_ITEM_CLASS =
-  "text-[var(--system-negative-strong)] [--panel-item-icon-fg:var(--system-negative-strong)]";
 
 /**
  * Subset of the compound-menu API shared by `Menu` and `ContextMenu`. The
@@ -264,7 +263,7 @@ export function renderConversationMenuItems({
     <Primitive.Item
       leftIcon={<Trash2 size={14} />}
       onSelect={onDelete}
-      className={DELETE_ITEM_CLASS}
+      className={actionMenuDestructiveClasses.anchored}
     >
       {t("conversationActions.delete")}
     </Primitive.Item>
@@ -589,7 +588,7 @@ export function renderConversationMenuItemsAsPanelItems({
         key: "delete",
         icon: Trash2,
         label: t("conversationActions.delete"),
-        className: DELETE_SHEET_ITEM_CLASS,
+        className: actionMenuDestructiveClasses.sheet,
         run: onDelete,
         onClose,
       })

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -137,6 +137,7 @@ export {
 } from "./components/confirm-dialog";
 export {
   ActionMenu,
+  actionMenuDestructiveClasses,
   type ActionMenuPresentation,
   type ActionMenuRootProps,
   type ActionMenuTriggerProps,


### PR DESCRIPTION
## TL;DR

`conversation-actions-menu.tsx` declared the destructive row's classes byte for byte identically to `actionMenuDestructiveClasses`, which the design library already exports for exactly this purpose. The local copies are gone. Rendered classes are unchanged, so nothing moves on screen.

## Why it matters rather than being tidying

The constant's own docstring says what the duplication costs:

> a tone that reads as dangerous in one surface and ordinary in the other is the drift this component exists to prevent, and because each surface hands its glyph the row's colour rather than a second colour of its own: a highlighted or pressed row moves label and icon together

That is not hypothetical. It is what already happened once, and it is what the three copies described below are still doing today.

The constant only left its own module, not the package root, so a caller had to know it existed and reach past the barrel to get it. It is now exported beside `ActionMenu`.

## What changes for the user

Nothing. Both strings are identical to the ones they replace, which I verified by extracting and comparing them rather than reading them side by side.

## Found while doing this, and deliberately not fixed here

Three more destructive menu rows carry their own copy, and all three have **drifted** from the canonical one:

- `clients/web/src/domains/settings/ai/profile-row.tsx:203`
- `clients/web/src/domains/settings/ai/provider-row.tsx:127`
- `clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx:1014`

Each uses `data-[highlighted]:text-[var(--system-negative-strong)]` where the canonical rule uses `--system-negative-hover`, and none carry the `[&_[data-slot=menu-item-icon]]:text-inherit` rule. So a destructive row in Settings, AI does not darken when highlighted, and its icon keeps its own colour while the label moves. That is precisely the failure the shared constant was written to stop.

Converting them is a **visible behaviour change** in three places, so it is its own reviewable claim rather than a ride-along in a PR whose entire promise is that nothing moves. Happy to open it next; it is a three-line change plus whatever screenshots the reviewer wants.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->