### PR TITLE
fix: never hand Stripe empty appearance values and read the field radius from tokens

### DIFF
--- a/clients/web/src/domains/settings/billing/stripe-appearance.test.ts
+++ b/clients/web/src/domains/settings/billing/stripe-appearance.test.ts
@@ -18,6 +18,7 @@ const TOKENS: StripeAppearanceTokens = {
   danger: "#DA491A",
   dangerText: "#DA491A",
   icon: "#71808E",
+  radius: "12px",
 };
 
 const TOKEN_PROPERTIES: Array<[string, string]> = [
@@ -29,12 +30,58 @@ const TOKEN_PROPERTIES: Array<[string, string]> = [
   ["--system-info-strong", TOKENS.accent],
   ["--system-negative-strong", TOKENS.danger],
   ["--system-negative-on-weak", TOKENS.dangerText],
+  ["--radius-lg", TOKENS.radius],
 ];
+
+/** The variables that never come from a token, so they survive an empty read. */
+const STATIC_VARIABLES = {
+  fontFamily: '"DM Sans", system-ui, sans-serif',
+  fontSizeBase: "15px",
+  fontSizeSm: "11px",
+  fontWeightMedium: "500",
+  spacingUnit: "4px",
+  spacingGridRow: "10px",
+  spacingGridColumn: "10px",
+  focusOutline: "none",
+};
+
+const EMPTY_TOKENS: StripeAppearanceTokens = {
+  text: "",
+  textSecondary: "",
+  placeholder: "",
+  surface: "",
+  field: "",
+  accent: "",
+  danger: "",
+  dangerText: "",
+  icon: "",
+  radius: "",
+};
 
 function paintTokens(root: HTMLElement) {
   for (const [name, value] of TOKEN_PROPERTIES) {
     root.style.setProperty(name, value);
   }
+}
+
+function withRoot(run: (root: HTMLElement) => void) {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  try {
+    run(root);
+  } finally {
+    root.remove();
+  }
+}
+
+function stringValues(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.values(value).flatMap(stringValues);
+  }
+  return [];
 }
 
 afterEach(() => {
@@ -79,9 +126,15 @@ describe("appearanceFromTokens", () => {
   });
 
   test("uses the radius-lg token value for the field radius", () => {
-    expect(appearanceFromTokens(TOKENS, "stripe").variables?.borderRadius).toBe(
-      "12px",
-    );
+    withRoot((root) => {
+      paintTokens(root);
+      root.style.setProperty("--radius-lg", "10px");
+      const appearance = appearanceFromTokens(
+        readAppearanceTokens(root),
+        "stripe",
+      );
+      expect(appearance.variables?.borderRadius).toBe("10px");
+    });
   });
 
   test("outlines a focused field with the accent and a 14% accent ring", () => {
@@ -112,18 +165,78 @@ describe("appearanceFromTokens", () => {
       color: TOKENS.dangerText,
     });
   });
+
+  test("drops every token-driven value when nothing resolves", () => {
+    const appearance = appearanceFromTokens(EMPTY_TOKENS, "night");
+    expect(appearance.variables).toEqual(STATIC_VARIABLES);
+    expect(appearance.rules).toEqual({
+      ".Input": {
+        border: "1px solid transparent",
+        boxShadow: "none",
+        padding: "9px 14px",
+        transition:
+          "background-color 120ms, border-color 120ms, box-shadow 120ms",
+      },
+      ".Input--invalid": {
+        boxShadow: "none",
+      },
+      ".Label": {
+        fontSize: "11px",
+        fontWeight: "500",
+      },
+      ".Error": {
+        fontSize: "12.5px",
+      },
+    });
+  });
+
+  test("never hands Stripe an empty or half-built value", () => {
+    for (const tokens of [EMPTY_TOKENS, {}]) {
+      for (const value of stringValues(appearanceFromTokens(tokens, "night"))) {
+        expect(value).not.toBe("");
+        expect(value).not.toMatch(/\s$/);
+      }
+    }
+  });
+
+  test("keeps the tokens that did resolve when only some are painted", () => {
+    const appearance = appearanceFromTokens(
+      { text: TOKENS.text, danger: TOKENS.danger },
+      "stripe",
+    );
+    expect(appearance.variables).toEqual({
+      ...STATIC_VARIABLES,
+      colorText: TOKENS.text,
+      colorDanger: TOKENS.danger,
+    });
+    expect(appearance.rules?.[".Input--invalid"]).toEqual({
+      border: `1px solid ${TOKENS.danger}`,
+      boxShadow: "none",
+    });
+    expect(appearance.rules?.[".Input:focus"]).toBeUndefined();
+    expect(appearance.rules?.[".Label--invalid"]).toEqual({
+      color: TOKENS.danger,
+    });
+  });
 });
 
 describe("readAppearanceTokens", () => {
   test("resolves every token from the given root", () => {
-    const root = document.createElement("div");
-    paintTokens(root);
-    document.body.appendChild(root);
-    try {
+    withRoot((root) => {
+      paintTokens(root);
       expect(readAppearanceTokens(root)).toEqual(TOKENS);
-    } finally {
-      root.remove();
-    }
+    });
+  });
+
+  test("leaves out a token that resolves to nothing", () => {
+    withRoot((root) => {
+      root.style.setProperty("--content-emphasised", TOKENS.text);
+      const tokens = readAppearanceTokens(root);
+      expect(tokens.text).toBe(TOKENS.text);
+      expect(tokens.surface).toBeUndefined();
+      expect(tokens.accent).toBeUndefined();
+      expect(tokens.radius).toBeUndefined();
+    });
   });
 
   test("defaults to the document element", () => {

--- a/clients/web/src/domains/settings/billing/stripe-appearance.ts
+++ b/clients/web/src/domains/settings/billing/stripe-appearance.ts
@@ -19,19 +19,22 @@ export interface StripeAppearanceTokens {
   danger: string;
   dangerText: string;
   icon: string;
+  radius: string;
 }
 
 /**
  * Resolves the design-library custom properties the Stripe Appearance needs.
  * `getComputedStyle` returns the declared value for a custom property, which
  * is a hex string in `tokens.css`; Stripe accepts hex and rgb alike, so the
- * values pass through unchanged.
+ * values pass through unchanged. A property resolves to nothing before the
+ * stylesheets apply, or when a token is renamed, so every field is optional.
  */
 export function readAppearanceTokens(
   root: Element = document.documentElement,
-): StripeAppearanceTokens {
+): Partial<StripeAppearanceTokens> {
   const styles = getComputedStyle(root);
-  const read = (name: string) => styles.getPropertyValue(name).trim();
+  const read = (name: string) =>
+    styles.getPropertyValue(name).trim() || undefined;
   const textSecondary = read("--content-tertiary");
   return {
     text: read("--content-emphasised"),
@@ -43,6 +46,7 @@ export function readAppearanceTokens(
     danger: read("--system-negative-strong"),
     dangerText: read("--system-negative-on-weak"),
     icon: textSecondary,
+    radius: read("--radius-lg"),
   };
 }
 
@@ -76,20 +80,57 @@ export function withAlpha(color: string, alpha: number): string {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
+type Declarations = Record<string, string | undefined>;
+
+function isResolved(value: string | undefined): value is string {
+  return value !== undefined && value !== "";
+}
+
+/**
+ * Stripe can reject an appearance that carries an empty value, so a token that
+ * did not resolve is dropped and the Stripe base theme's default stands.
+ */
+function keepResolved(declarations: Declarations): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(declarations).filter((entry): entry is [string, string] =>
+      isResolved(entry[1]),
+    ),
+  );
+}
+
+function keepResolvedRules(
+  rules: Record<string, Declarations>,
+): NonNullable<Appearance["rules"]> {
+  const kept: NonNullable<Appearance["rules"]> = {};
+  for (const [selector, declarations] of Object.entries(rules)) {
+    const values = keepResolved(declarations);
+    if (Object.keys(values).length > 0) {
+      kept[selector] = values;
+    }
+  }
+  return kept;
+}
+
+function solidBorder(color: string | undefined): string | undefined {
+  return isResolved(color) ? `1px solid ${color}` : undefined;
+}
+
 export function appearanceFromTokens(
-  tokens: StripeAppearanceTokens,
+  tokens: Partial<StripeAppearanceTokens>,
   base: "stripe" | "night",
 ): Appearance {
-  const focusRing = `0 0 0 3px ${withAlpha(tokens.accent, 0.14)}`;
+  const focusRing = isResolved(tokens.accent)
+    ? `0 0 0 3px ${withAlpha(tokens.accent, 0.14)}`
+    : undefined;
   return {
     theme: base,
     labels: "floating",
-    variables: {
+    variables: keepResolved({
       fontFamily: '"DM Sans", system-ui, sans-serif',
       fontSizeBase: "15px",
       fontSizeSm: "11px",
       fontWeightMedium: "500",
-      borderRadius: "12px",
+      borderRadius: tokens.radius,
       spacingUnit: "4px",
       spacingGridRow: "10px",
       spacingGridColumn: "10px",
@@ -102,8 +143,8 @@ export function appearanceFromTokens(
       colorIcon: tokens.icon,
       focusOutline: "none",
       focusBoxShadow: focusRing,
-    },
-    rules: {
+    } satisfies NonNullable<Appearance["variables"]>),
+    rules: keepResolvedRules({
       ".Input": {
         backgroundColor: tokens.field,
         border: "1px solid transparent",
@@ -114,11 +155,11 @@ export function appearanceFromTokens(
       },
       ".Input:focus": {
         backgroundColor: tokens.surface,
-        border: `1px solid ${tokens.accent}`,
+        border: solidBorder(tokens.accent),
         boxShadow: focusRing,
       },
       ".Input--invalid": {
-        border: `1px solid ${tokens.danger}`,
+        border: solidBorder(tokens.danger),
         boxShadow: "none",
       },
       ".Input::placeholder": {
@@ -136,7 +177,7 @@ export function appearanceFromTokens(
         fontSize: "12.5px",
         color: tokens.dangerText,
       },
-    },
+    }),
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for payment-modal-v4.md.

- Unresolved design tokens are skipped instead of being passed to Stripe as empty strings.
- The field radius comes from --radius-lg like the other appearance values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XB7ckoybGsZZWurNBj6cx3