### PR TITLE
fix: keep the payment redirect return alive across tab switches and align both modal mount points

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -1,5 +1,6 @@
 /**
- * BillingTab pro-onboarding re-entry wiring.
+ * BillingTab pro-onboarding re-entry wiring, and where the Stripe redirect
+ * return is driven from.
  *
  * `?pro_onboarding` reopens the post-checkout onboarding wizard without a
  * Stripe `session_id`, and the "Finish Pro setup" nudge renders only for a
@@ -15,6 +16,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 
@@ -31,6 +33,7 @@ import type {
   SubscriptionPackage,
   SubscriptionResponse,
 } from "@/generated/api/types.gen";
+import * as activeAssistantIdModule from "@/assistant/use-active-assistant-id";
 import * as platformGate from "@/hooks/use-platform-gate";
 import * as platformDetection from "@/runtime/platform-detection";
 import * as authStore from "@/stores/auth-store";
@@ -92,6 +95,13 @@ mock.module("@/hooks/use-platform-gate", () => ({
   useActiveAssistantLifecycleIsLoading: () => false,
 }));
 
+// The Usage tab reads the active assistant, which normally comes from the
+// route gate this test does not mount.
+mock.module("@/assistant/use-active-assistant-id", () => ({
+  ...activeAssistantIdModule,
+  useActiveAssistantId: () => "assistant-1",
+}));
+
 mock.module("@/stores/auth-store", () => ({
   ...authStore,
   useIsPlatformSessionSettled: () => true,
@@ -150,6 +160,19 @@ mock.module("@/domains/settings/components/invoices-table", () => ({
 }));
 mock.module("@/domains/settings/components/payment-methods-card", () => ({
   PaymentMethodsCard: () => null,
+}));
+// Reports where `useSetupIntentReturn` is mounted. The real hook drops its
+// params from the URL up front, so a resolution mounted inside the billing tab
+// panel would be lost the moment the user looks at the Usage tab.
+let setupIntentReturnUnmounts = 0;
+mock.module("@/domains/settings/hooks/use-setup-intent-return", () => ({
+  useSetupIntentReturn: () => {
+    useEffect(() => {
+      return () => {
+        setupIntentReturnUnmounts += 1;
+      };
+    }, []);
+  },
 }));
 mock.module("@/domains/settings/components/plan-card", () => ({
   PlanCard: ({ onTierUpgraded }: { onTierUpgraded?: () => void }) => (
@@ -240,6 +263,7 @@ beforeEach(() => {
   orgReady = true;
   nativeAndroid = false;
   activeAssistantIsPlatformHosted = true;
+  setupIntentReturnUnmounts = 0;
 });
 
 afterEach(() => {
@@ -481,5 +505,26 @@ describe("Finish Pro setup nudge", () => {
     );
     expect(queryByTestId("finish-pro-setup-notice")).toBeNull();
     expect(domainsCalls).toBe(0);
+  });
+});
+
+describe("BillingPage Stripe redirect return", () => {
+  test("keeps the return mounted when the user switches to the Usage tab", async () => {
+    const { getByText, queryByTestId } = renderPage();
+
+    expect(queryByTestId("plan-card-tier-upgraded")).not.toBeNull();
+
+    // Radix tab triggers select on mousedown, not on a synthesized click.
+    fireEvent.mouseDown(getByText("Usage"));
+
+    // The billing panel is gone, but the return that outlives it is not: a
+    // resolution can run for up to 20 seconds, and the params are already off
+    // the URL.
+    await waitFor(() => {
+      if (queryByTestId("plan-card-tier-upgraded") != null) {
+        throw new Error("billing panel still mounted");
+      }
+    });
+    expect(setupIntentReturnUnmounts).toBe(0);
   });
 });

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -21,6 +21,7 @@ import { GracePeriodBanner } from "@/domains/settings/components/grace-period-ba
 import { InvoicesTable } from "@/domains/settings/components/invoices-table";
 import { PaymentMethodsCard } from "@/domains/settings/components/payment-methods-card";
 import { PlanCard } from "@/domains/settings/components/plan-card";
+import { useSetupIntentReturn } from "@/domains/settings/hooks/use-setup-intent-return";
 import { useAssistantDomains } from "@/domains/settings/billing/pro-onboarding/use-assistant-domains";
 import {
   organizationsBillingSubscriptionOnboardingRetrieveOptions,
@@ -355,6 +356,11 @@ export function BillingPage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { hash } = useLocation();
+  // Driven here rather than in `PaymentMethodsCard`, which replays the
+  // outcome: that card sits inside the billing tab panel, and a switch to
+  // Usage would unmount the resolution after the params have already been
+  // stripped from the URL. This component owns `Tabs.Root` and survives it.
+  useSetupIntentReturn();
   // Shown when signed in (`"full"`); for a signed-out-but-reachable viewer
   // (`"disabled"`) it stays reachable only when the URL carries billing intent
   // (a deeplink / upgrade CTA / Stripe return), so the BillingTab login notice

--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -18,6 +18,14 @@
  *    fires an update mutation.
  *  - A successful enable invalidates the daily-limit and billing summary
  *    queries so the daily-limit card picks up the server-applied default.
+ *  - Save and Disable both seed the config cache from a response that carries
+ *    no payment-method fields, so both carry the cached ones forward: the card
+ *    expiry and the saved billing address survive until the next GET.
+ *  - Both add-a-card gates open the same modal in the mode the config calls
+ *    for (the repeated-declines cutoff still has the declined card attached,
+ *    so it replaces) and seed it with the saved billing address.
+ *  - Both gates are disabled while a 3DS redirect return is still resolving,
+ *    so no second modal can stack on the one that outcome replays into.
  *
  * Strategy: the render-only cases pre-populate the React Query cache so the
  * card's `useQuery` resolves synchronously — `renderToStaticMarkup` is
@@ -36,8 +44,10 @@ import { MemoryRouter } from "react-router";
 import * as sdkGen from "@/generated/api/sdk.gen";
 import * as platformDetection from "@/runtime/platform-detection";
 import * as runtimeBrowser from "@/runtime/browser";
+import type { AutoTopUpPaymentMethodModalProps } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import type {
   AutoTopUpConfigResponse,
+  BillingAddress,
   DailyCreditLimitResponse,
 } from "@/generated/api/types.gen";
 
@@ -58,6 +68,10 @@ mock.module("@/runtime/browser", () => ({
 
 let updateCalls: Array<Record<string, unknown>> = [];
 let retrieveResponse: AutoTopUpConfigResponse;
+// What the PUT answers with, when it differs from the GET: the real endpoint
+// skips the Stripe payment-method retrieve, so its payment-method fields come
+// back null.
+let updateResponse: AutoTopUpConfigResponse | null = null;
 let dailyLimitResponse: DailyCreditLimitResponse;
 
 mock.module("@/generated/api/sdk.gen", () => ({
@@ -66,13 +80,61 @@ mock.module("@/generated/api/sdk.gen", () => ({
   // `configure_top_up` deeplink must never trigger this on mount.
   organizationsBillingAutoTopUpUpdate: (opts: Record<string, unknown>) => {
     updateCalls.push(opts);
-    return Promise.resolve({ data: retrieveResponse, response: { ok: true } });
+    return Promise.resolve({
+      data: updateResponse ?? retrieveResponse,
+      response: { ok: true },
+    });
   },
   organizationsBillingAutoTopUpRetrieve: () =>
     Promise.resolve({ data: retrieveResponse, response: { ok: true } }),
+  // The real disable response only echoes the enabled bit, which is what makes
+  // the card seed the cache from `DISABLED_CONFIG` instead.
+  organizationsBillingAutoTopUpDisableCreate: () =>
+    Promise.resolve({
+      data: { enabled: false, stubbed: false, message: "" },
+      response: { ok: true },
+    }),
   organizationsBillingDailyCreditLimitRetrieve: () =>
     Promise.resolve({ data: dailyLimitResponse, response: { ok: true } }),
 }));
+
+// Stub the Stripe setup modal: these tests assert only which mode, card on
+// file, and billing address each gate hands it.
+let pmModalProps: AutoTopUpPaymentMethodModalProps | null = null;
+mock.module(
+  "@/domains/settings/components/auto-top-up-payment-method-modal",
+  () => ({
+    AutoTopUpPaymentMethodModal: (props: AutoTopUpPaymentMethodModalProps) => {
+      pmModalProps = props;
+      return props.open ? <div data-testid="pm-modal-stub" /> : null;
+    },
+  }),
+);
+
+// The real confirm is a portalled dialog; a bare button keeps the disable path
+// reachable from a test.
+mock.module(
+  "@/domains/settings/components/auto-top-up-disable-confirm",
+  () => ({
+    AutoTopUpDisableConfirm: ({
+      open,
+      onConfirm,
+    }: {
+      open: boolean;
+      onConfirm: () => void;
+    }) =>
+      open ? (
+        <button data-testid="disable-confirm" onClick={onConfirm} />
+      ) : null,
+  }),
+);
+
+function lastPmModalProps(): AutoTopUpPaymentMethodModalProps {
+  if (pmModalProps == null) {
+    throw new Error("AutoTopUpPaymentMethodModal was never rendered");
+  }
+  return pmModalProps;
+}
 
 import {
   organizationsBillingAutoTopUpRetrieveQueryKey,
@@ -81,6 +143,8 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 
 const { AutoTopUpCard, DISABLED_CONFIG } = await import("./auto-top-up-card");
+const { useSetupIntentReturnStore } =
+  await import("@/domains/settings/setup-intent-return-store");
 
 function makeClient(config: AutoTopUpConfigResponse): QueryClient {
   const client = new QueryClient({
@@ -141,10 +205,75 @@ const DISABLED_WITH_CARD: AutoTopUpConfigResponse = {
   payment_method_last4: "4242",
 };
 
+const BILLING_ADDRESS: BillingAddress = {
+  line1: "100 Example Ave",
+  line2: null,
+  city: "Springfield",
+  state: "CA",
+  postal_code: "94000",
+  country: "US",
+};
+
+const CARD_ON_FILE = {
+  brand: "visa",
+  last4: "4242",
+  expMonth: 4,
+  expYear: 2042,
+};
+
+/** Configs carrying every payment-method field the GET can fill in. */
+const WITH_EXPIRY_AND_ADDRESS: AutoTopUpConfigResponse = {
+  ...DISABLED_WITH_CARD,
+  payment_method_exp_month: 4,
+  payment_method_exp_year: 2042,
+  billing_address: BILLING_ADDRESS,
+};
+
+const ENABLED_WITH_EXPIRY_AND_ADDRESS: AutoTopUpConfigResponse = {
+  ...ENABLED_WITH_CARD,
+  payment_method_exp_month: 4,
+  payment_method_exp_year: 2042,
+  billing_address: BILLING_ADDRESS,
+};
+
+/** The payment-method fields neither the PUT nor the disable response carries. */
+const NO_PAYMENT_METHOD_FIELDS = {
+  payment_method_brand: null,
+  payment_method_last4: null,
+  payment_method_exp_month: null,
+  payment_method_exp_year: null,
+  billing_address: null,
+};
+
+function cachedConfig(client: QueryClient): AutoTopUpConfigResponse {
+  const config = client.getQueryData<AutoTopUpConfigResponse>(
+    organizationsBillingAutoTopUpRetrieveQueryKey(),
+  );
+  if (config == null) {
+    throw new Error("config query cache is empty");
+  }
+  return config;
+}
+
+/**
+ * Wait out the mount-time background refetch so a later cache write is not
+ * clobbered when that response lands.
+ */
+async function settleConfigQuery(client: QueryClient) {
+  await waitFor(() => {
+    if (client.isFetching() > 0) {
+      throw new Error("config refetch still in flight");
+    }
+  });
+}
+
 beforeEach(() => {
   updateCalls = [];
   nativeAndroid = false;
   openedUrl = null;
+  pmModalProps = null;
+  updateResponse = null;
+  useSetupIntentReturnStore.setState({ pending: false, outcome: null });
   retrieveResponse = { ...DISABLED_CONFIG };
   dailyLimitResponse = {
     daily_credit_limit_usd: null,
@@ -236,11 +365,7 @@ describe("AutoTopUpCard payment-method removal reaction", () => {
     // Let the mount-time background refetch settle first, so its (stale)
     // result cannot land after the removal write below and mask the
     // transition.
-    await waitFor(() => {
-      if (client.isFetching() > 0) {
-        throw new Error("config refetch still in flight");
-      }
-    });
+    await settleConfigQuery(client);
 
     fireEvent.click(getByTestId("auto-top-up-edit-button"));
     expect(
@@ -419,11 +544,7 @@ describe("AutoTopUpCard enable gate", () => {
 
     // Let the mount-time background refetch settle so it cannot overwrite the
     // card-appeared write below.
-    await waitFor(() => {
-      if (client.isFetching() > 0) {
-        throw new Error("config refetch still in flight");
-      }
-    });
+    await settleConfigQuery(client);
 
     // Toggle on with no card: the add-card gate shows, no form.
     fireEvent.click(getByLabelText("Enable auto-reload"));
@@ -475,11 +596,7 @@ describe("AutoTopUpCard enable gate", () => {
     const client = makeClient(cutOff);
     const { container, getByLabelText } = render(wrap(cutOff, "/", client));
 
-    await waitFor(() => {
-      if (client.isFetching() > 0) {
-        throw new Error("config refetch still in flight");
-      }
-    });
+    await settleConfigQuery(client);
 
     fireEvent.click(getByLabelText("Enable auto-reload"));
     expect(
@@ -678,5 +795,155 @@ describe("AutoTopUpCard default daily credit limit", () => {
     expect(invalidated).not.toContain(
       JSON.stringify(organizationsBillingDailyCreditLimitRetrieveQueryKey()),
     );
+  });
+});
+
+describe("AutoTopUpCard payment-method fields in the config cache", () => {
+  test("a save keeps the cached expiry and billing address", async () => {
+    // The PUT skips the Stripe payment-method retrieve, so its response has no
+    // payment-method fields; dropping them here empties the card expiry and the
+    // modal's address prefill until the next GET.
+    retrieveResponse = { ...ENABLED_WITH_EXPIRY_AND_ADDRESS };
+    const client = makeClient(ENABLED_WITH_EXPIRY_AND_ADDRESS);
+    const { getByTestId } = render(
+      wrap(ENABLED_WITH_EXPIRY_AND_ADDRESS, "/", client),
+    );
+    await settleConfigQuery(client);
+
+    updateResponse = {
+      ...ENABLED_WITH_EXPIRY_AND_ADDRESS,
+      ...NO_PAYMENT_METHOD_FIELDS,
+    };
+    fireEvent.click(getByTestId("auto-top-up-edit-button"));
+    fireEvent.click(getByTestId("auto-top-up-save-button"));
+
+    await waitFor(() => {
+      if (updateCalls.length === 0) {
+        throw new Error("update endpoint not called");
+      }
+    });
+    await waitFor(() => {
+      if (cachedConfig(client).payment_method_exp_month == null) {
+        throw new Error("expiry not preserved in the config cache");
+      }
+    });
+
+    const cached = cachedConfig(client);
+    expect(cached.payment_method_brand).toBe("visa");
+    expect(cached.payment_method_last4).toBe("4242");
+    expect(cached.payment_method_exp_month).toBe(4);
+    expect(cached.payment_method_exp_year).toBe(2042);
+    expect(cached.billing_address).toEqual(BILLING_ADDRESS);
+  });
+
+  test("a disable keeps the cached expiry and billing address", async () => {
+    // The disable response echoes only the enabled bit, and the endpoint
+    // leaves the saved card attached, so the seeded config must still describe
+    // that card in full.
+    retrieveResponse = { ...ENABLED_WITH_EXPIRY_AND_ADDRESS };
+    const client = makeClient(ENABLED_WITH_EXPIRY_AND_ADDRESS);
+    const { getByLabelText, getByTestId } = render(
+      wrap(ENABLED_WITH_EXPIRY_AND_ADDRESS, "/", client),
+    );
+    await settleConfigQuery(client);
+
+    fireEvent.click(getByLabelText("Enable auto-reload"));
+    fireEvent.click(getByTestId("disable-confirm"));
+
+    await waitFor(() => {
+      if (cachedConfig(client).enabled) {
+        throw new Error("config cache still reports auto-reload enabled");
+      }
+    });
+
+    const cached = cachedConfig(client);
+    expect(cached.has_payment_method).toBe(true);
+    expect(cached.payment_method_brand).toBe("visa");
+    expect(cached.payment_method_last4).toBe("4242");
+    expect(cached.payment_method_exp_month).toBe(4);
+    expect(cached.payment_method_exp_year).toBe(2042);
+    expect(cached.billing_address).toEqual(BILLING_ADDRESS);
+  });
+});
+
+describe("AutoTopUpCard add-a-card gates", () => {
+  test("the declines cutoff opens the modal in replace mode on the declined card", () => {
+    // The cutoff keeps the declined card attached, so this entry point is a
+    // replacement; opening it in add mode would contradict the Billing card,
+    // which offers Replace for the same state.
+    const config: AutoTopUpConfigResponse = {
+      ...WITH_EXPIRY_AND_ADDRESS,
+      disabled_due_to_repeated_failures: true,
+    };
+    retrieveResponse = config;
+    const { container } = render(wrap(config));
+
+    const cutoffButton = container.querySelector(
+      '[data-testid="auto-top-up-declined-cutoff"] [data-testid="auto-top-up-add-pm-button"]',
+    );
+    expect(cutoffButton).not.toBeNull();
+    fireEvent.click(cutoffButton as HTMLElement);
+
+    expect(lastPmModalProps().open).toBe(true);
+    expect(lastPmModalProps().mode).toBe("replace");
+    expect(lastPmModalProps().cardOnFile).toEqual(CARD_ON_FILE);
+    expect(lastPmModalProps().billingAddress).toEqual(BILLING_ADDRESS);
+  });
+
+  test("the no-payment-method gate opens the modal in add mode", () => {
+    const config: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      has_payment_method: false,
+    };
+    retrieveResponse = config;
+    const { container, getByLabelText } = render(wrap(config));
+
+    fireEvent.click(getByLabelText("Enable auto-reload"));
+    const gateButton = container.querySelector(
+      '[data-testid="auto-top-up-add-pm-button"]',
+    );
+    fireEvent.click(gateButton as HTMLElement);
+
+    expect(lastPmModalProps().open).toBe(true);
+    expect(lastPmModalProps().mode).toBe("add");
+    expect(lastPmModalProps().cardOnFile).toBeNull();
+    expect(lastPmModalProps().billingAddress).toBeNull();
+  });
+
+  test("both gates are disabled while a redirect return is unresolved", () => {
+    // The outcome replays into `PaymentMethodsCard`'s modal, so a second one
+    // opened here would stack on it and start an orphan SetupIntent.
+    useSetupIntentReturnStore.setState({ pending: true });
+    const config: AutoTopUpConfigResponse = {
+      ...WITH_EXPIRY_AND_ADDRESS,
+      disabled_due_to_repeated_failures: true,
+    };
+    retrieveResponse = config;
+    const { container } = render(wrap(config));
+
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '[data-testid="auto-top-up-add-pm-button"]',
+    );
+    expect(buttons.length).toBe(2);
+    for (const button of buttons) {
+      expect(button.disabled).toBe(true);
+    }
+  });
+
+  test("both gates stay usable when no return is in flight", () => {
+    const config: AutoTopUpConfigResponse = {
+      ...WITH_EXPIRY_AND_ADDRESS,
+      disabled_due_to_repeated_failures: true,
+    };
+    retrieveResponse = config;
+    const { container } = render(wrap(config));
+
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '[data-testid="auto-top-up-add-pm-button"]',
+    );
+    expect(buttons.length).toBe(2);
+    for (const button of buttons) {
+      expect(button.disabled).toBe(false);
+    }
   });
 });

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -24,7 +24,13 @@ import {
   type AutoTopUpFormValues,
 } from "@/domains/settings/components/auto-top-up-form";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
+import {
+  modalSnapshotFor,
+  paymentMethodCards,
+  type PaymentModalSnapshot,
+} from "@/domains/settings/components/payment-method-cards";
 import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { useSetupIntentReturnStore } from "@/domains/settings/setup-intent-return-store";
 import { useAutoTopUpConfigQuery } from "@/hooks/use-auto-top-up-config";
 import { extractDrfFieldErrors } from "@/domains/settings/utils/drf-errors";
 import { useTranslation } from "@/i18n";
@@ -75,6 +81,32 @@ export const DISABLED_CONFIG: AutoTopUpConfigResponse = {
 };
 
 /**
+ * The payment-method fields neither the auto-reload PUT response nor the
+ * disable response carries. Both writers below seed the GET cache from their
+ * own response, so these come forward from the prior cached config until the
+ * next GET: without them the saved-card row loses its expiry and the payment
+ * modal loses its address prefill right after a Save or a Disable.
+ */
+function preservePaymentMethodFields(
+  prior: AutoTopUpConfigResponse | undefined,
+): Pick<
+  AutoTopUpConfigResponse,
+  | "payment_method_brand"
+  | "payment_method_last4"
+  | "payment_method_exp_month"
+  | "payment_method_exp_year"
+  | "billing_address"
+> {
+  return {
+    payment_method_brand: prior?.payment_method_brand ?? null,
+    payment_method_last4: prior?.payment_method_last4 ?? null,
+    payment_method_exp_month: prior?.payment_method_exp_month ?? null,
+    payment_method_exp_year: prior?.payment_method_exp_year ?? null,
+    billing_address: prior?.billing_address ?? null,
+  };
+}
+
+/**
  * Neutral pill shared by the enabled-state summary row — the "add $X under
  * $Y" chip and the monthly-cap progress chip use identical chrome so they
  * read as one control group.
@@ -123,6 +155,10 @@ export function AutoTopUpCard() {
     organizationsBillingAutoTopUpDisableCreateMutation(),
   );
   const syncPaymentMethodSaved = usePaymentMethodSavedSync();
+  // A 3DS redirect return that is still resolving keeps both add-a-card gates
+  // below disabled: its outcome replays into `PaymentMethodsCard`'s modal, so
+  // one opened here would stack on that one and start an orphan SetupIntent.
+  const returnPending = useSetupIntentReturnStore.use.pending();
   // Native Android configures auto-reload on the web app's billing page in
   // the browser; the deep link below reopens this same configurator there.
   const isNativeAndroid = useIsNativeAndroid();
@@ -135,7 +171,7 @@ export function AutoTopUpCard() {
   const [confirmingDisable, setConfirmingDisable] = useState(false);
   const [showAddPm, setShowAddPm] = useState(false);
   const [bannerDismissed, setBannerDismissed] = useState(false);
-  const [pmModalOpen, setPmModalOpen] = useState(false);
+  const [pmModal, setPmModal] = useState<PaymentModalSnapshot | null>(null);
 
   // Removing the card (in `PaymentMethodsCard`) disables auto-reload
   // server-side, so when the shared config's PM goes away, leave the add-card
@@ -298,6 +334,17 @@ export function AutoTopUpCard() {
   };
 
   /**
+   * Open the setup modal from either gate below, in the mode the config calls
+   * for: the no-PM gate adds a card, while the repeated-declines cutoff still
+   * has the declined card attached and is replacing it. Snapshotted on the
+   * click for the same reason `PaymentMethodsCard` does it: a successful save
+   * writes the new card into the config cache before the modal closes.
+   */
+  const openPmModal = () => {
+    setPmModal(modalSnapshotFor(paymentMethodCards(config)));
+  };
+
+  /**
    * Dismiss the disable-confirm dialog. Also clears any prior
    * `disableMutation` error so the user doesn't see a stale failure
    * banner persist after they've decided not to retry.
@@ -332,21 +379,16 @@ export function AutoTopUpCard() {
         // refetch lands.
         //
         // The PUT response intentionally skips the Stripe PM retrieve to
-        // avoid a ~100-300ms latency tax per save, so its
-        // `payment_method_brand` / `payment_method_last4` come back null.
-        // Merge with the prior cache value to preserve those fields (a
-        // config edit doesn't change the PM), then invalidate to refresh
-        // brand/last4 from GET in the background — that keeps them in
-        // sync if the user just changed cards.
+        // avoid a ~100-300ms latency tax per save, so the payment-method
+        // fields come back null. Merge with the prior cache value to preserve
+        // them (a config edit doesn't change the PM), then invalidate to
+        // refresh them from GET in the background, which keeps them in sync
+        // if the user just changed cards.
         onSuccess: (data) => {
           organizationsBillingAutoTopUpRetrieveSetQueryData(
             queryClient,
             undefined,
-            (prior) => ({
-              ...data,
-              payment_method_brand: prior?.payment_method_brand ?? null,
-              payment_method_last4: prior?.payment_method_last4 ?? null,
-            }),
+            (prior) => ({ ...data, ...preservePaymentMethodFields(prior) }),
           );
           void queryClient.invalidateQueries({
             queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
@@ -389,9 +431,8 @@ export function AutoTopUpCard() {
             undefined,
             (prior) => ({
               ...DISABLED_CONFIG,
+              ...preservePaymentMethodFields(prior),
               has_payment_method: prior?.has_payment_method ?? false,
-              payment_method_brand: prior?.payment_method_brand ?? null,
-              payment_method_last4: prior?.payment_method_last4 ?? null,
               // Preserve the SetupIntent staleness marker. The disable
               // endpoint flips `enabled=False` but does NOT clear
               // `stripe_payment_method_id` or its updated_at marker — so
@@ -544,7 +585,8 @@ export function AutoTopUpCard() {
           actions={
             <Button
               variant="outlined"
-              onClick={() => setPmModalOpen(true)}
+              onClick={openPmModal}
+              disabled={returnPending}
               data-testid="auto-top-up-add-pm-button"
             >
               {t("autoTopUpCard.addPaymentMethod")}
@@ -593,7 +635,8 @@ export function AutoTopUpCard() {
             )}
             <Button
               variant="primary"
-              onClick={() => setPmModalOpen(true)}
+              onClick={openPmModal}
+              disabled={returnPending}
               data-testid="auto-top-up-add-pm-button"
               className="self-start"
             >
@@ -648,12 +691,12 @@ export function AutoTopUpCard() {
         onConfirm={handleConfirmDisable}
       />
 
-      {/* The cutoff gate has a declined card on file but asks for a different
-          one, so both gates open this modal in add mode. */}
       <AutoTopUpPaymentMethodModal
-        open={pmModalOpen}
-        onClose={() => setPmModalOpen(false)}
-        mode="add"
+        open={pmModal != null}
+        onClose={() => setPmModal(null)}
+        mode={pmModal?.mode ?? "add"}
+        cardOnFile={pmModal?.cardOnFile ?? null}
+        billingAddress={config.billing_address ?? null}
         onSavedOptimistic={handlePmSaved}
       />
     </div>

--- a/clients/web/src/domains/settings/components/payment-method-cards.ts
+++ b/clients/web/src/domains/settings/components/payment-method-cards.ts
@@ -1,0 +1,72 @@
+import type {
+  CardOnFile,
+  PaymentMethodModalMode,
+} from "@/domains/settings/components/payment-method-modal-shell";
+import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+
+export interface PaymentMethodCardEntry {
+  id: string;
+  brand: string | null;
+  last4: string | null;
+  expMonth: number | null;
+  expYear: number | null;
+}
+
+/**
+ * The cards to list. The backend keeps at most one payment method and has no
+ * list endpoint, so this is always length 0 or 1 today; the array is what the
+ * multi-card render in `PaymentMethodsCard` is written against.
+ */
+export function paymentMethodCards(
+  config: AutoTopUpConfigResponse | undefined,
+): PaymentMethodCardEntry[] {
+  if (config == null || !config.has_payment_method) {
+    return [];
+  }
+  return [
+    {
+      id: "primary",
+      brand: config.payment_method_brand,
+      last4: config.payment_method_last4,
+      // `?? null` because a platform deployment older than the expiry fields
+      // omits the keys entirely rather than sending them null.
+      expMonth: config.payment_method_exp_month ?? null,
+      expYear: config.payment_method_exp_year ?? null,
+    },
+  ];
+}
+
+/**
+ * What the payment modal was opened with. Captured on the click that opens it,
+ * because a successful save writes the new card into the config query cache
+ * before the modal closes: derived props would flip an in-flight add into
+ * replace mode and swap the card-on-file row for the card that was just saved.
+ */
+export interface PaymentModalSnapshot {
+  mode: PaymentMethodModalMode;
+  cardOnFile: CardOnFile | null;
+}
+
+/**
+ * The mode a card on file calls for: replacing the saved card once one exists,
+ * adding one otherwise. Every entry point saves through the same setup flow,
+ * including the repeated-declines cutoff, where the declined card is still
+ * attached and is the one being replaced.
+ */
+export function modalSnapshotFor(
+  cards: PaymentMethodCardEntry[],
+): PaymentModalSnapshot {
+  const [existing] = cards;
+  if (existing == null) {
+    return { mode: "add", cardOnFile: null };
+  }
+  return {
+    mode: "replace",
+    cardOnFile: {
+      brand: existing.brand,
+      last4: existing.last4,
+      expMonth: existing.expMonth,
+      expYear: existing.expYear,
+    },
+  };
+}

--- a/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -14,7 +14,10 @@
  *    in-flight add into a replace or restate the card being replaced.
  *  - While a 3DS redirect return is still resolving, the Add and Replace
  *    actions are disabled, so no modal can be opened ahead of the outcome the
- *    return will replay into one.
+ *    return will replay into one. That state is read from
+ *    `useSetupIntentReturnStore`, which the resolution driven from
+ *    `BillingPage` writes, so this card can be unmounted and remounted by a
+ *    tab switch without losing it.
  *  - A 3DS redirect return replays its outcome into a freshly opened modal:
  *    a saved card on the success panel alone, a failure back into the form in
  *    the mode the saved card calls for. The failure waits for the config query
@@ -42,8 +45,6 @@ import {
   render,
   waitFor,
 } from "@testing-library/react";
-
-import { useState } from "react";
 
 import type {
   AutoTopUpPaymentMethodModalProps,
@@ -107,26 +108,6 @@ function lastPmModalProps(): AutoTopUpPaymentMethodModalProps {
   return pmModalProps;
 }
 
-// Stands in for the 3DS redirect-return hook. It owns the outcome in state
-// like the real one does, so clearing it on close is what keeps the modal
-// shut rather than the absence of a re-render.
-let returnedOutcome: SetupIntentOutcome | null = null;
-let returnPending = false;
-let clearOutcomeCalls = 0;
-mock.module("@/domains/settings/hooks/use-setup-intent-return", () => ({
-  useSetupIntentReturn: () => {
-    const [outcome, setOutcome] = useState(returnedOutcome);
-    return {
-      outcome,
-      pending: returnPending,
-      clearOutcome: () => {
-        clearOutcomeCalls += 1;
-        setOutcome(null);
-      },
-    };
-  },
-}));
-
 import * as orgReadyModule from "@/hooks/use-is-org-ready";
 
 // Drives the org-readiness gate. `"ready"` matches the default test
@@ -141,9 +122,20 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 
 import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 
-const { PaymentMethodsCard, paymentMethodCards } =
-  await import("./payment-methods-card");
+const { PaymentMethodsCard } = await import("./payment-methods-card");
+const { paymentMethodCards } = await import("./payment-method-cards");
+const { useSetupIntentReturnStore } =
+  await import("@/domains/settings/setup-intent-return-store");
 const { DISABLED_CONFIG } = await import("./auto-top-up-card");
+
+/**
+ * Park an outcome in the redirect-return store the way the resolution driven
+ * from `BillingPage` does, and hand it back for the assertions.
+ */
+function seedReturnOutcome(outcome: SetupIntentOutcome): SetupIntentOutcome {
+  useSetupIntentReturnStore.setState({ pending: false, outcome });
+  return outcome;
+}
 
 const ENABLED_WITH_CARD: AutoTopUpConfigResponse = {
   ...DISABLED_CONFIG,
@@ -240,9 +232,7 @@ beforeEach(() => {
   releaseRetrieve = null;
   orgReadiness = "ready";
   pmModalProps = null;
-  returnedOutcome = null;
-  returnPending = false;
-  clearOutcomeCalls = 0;
+  useSetupIntentReturnStore.setState({ pending: false, outcome: null });
 });
 
 afterEach(cleanup);
@@ -451,10 +441,10 @@ describe("PaymentMethodsCard modal wiring", () => {
 describe("PaymentMethodsCard redirect return", () => {
   test("replays a saved outcome into the modal on the success panel alone", () => {
     retrieveResponse = { ...DISABLED_WITH_CARD };
-    returnedOutcome = {
+    const returnedOutcome = seedReturnOutcome({
       kind: "saved",
       card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
-    };
+    });
     const { container } = render(wrap(DISABLED_WITH_CARD));
 
     expect(
@@ -467,7 +457,10 @@ describe("PaymentMethodsCard redirect return", () => {
 
   test("replays an error outcome into replace mode with the card on file", () => {
     retrieveResponse = { ...DISABLED_WITH_CARD };
-    returnedOutcome = { kind: "error", message: "Your card was declined." };
+    const returnedOutcome = seedReturnOutcome({
+      kind: "error",
+      message: "Your card was declined.",
+    });
     render(wrap(DISABLED_WITH_CARD));
 
     expect(lastPmModalProps().open).toBe(true);
@@ -483,7 +476,10 @@ describe("PaymentMethodsCard redirect return", () => {
 
   test("holds a failed outcome until the config query settles", async () => {
     retrieveResponse = { ...DISABLED_WITH_CARD };
-    returnedOutcome = { kind: "error", message: "Your card was declined." };
+    const returnedOutcome = seedReturnOutcome({
+      kind: "error",
+      message: "Your card was declined.",
+    });
     holdRetrieve();
     const client = makeClient();
     const { container } = render(wrapWith(client));
@@ -510,7 +506,7 @@ describe("PaymentMethodsCard redirect return", () => {
   });
 
   test("disables Add Payment Method while the return is unresolved", () => {
-    returnPending = true;
+    useSetupIntentReturnStore.setState({ pending: true });
     const { getByTestId } = render(wrap(DISABLED_CONFIG));
 
     expect(
@@ -519,7 +515,7 @@ describe("PaymentMethodsCard redirect return", () => {
   });
 
   test("disables Replace card while the return is unresolved", () => {
-    returnPending = true;
+    useSetupIntentReturnStore.setState({ pending: true });
     retrieveResponse = { ...DISABLED_WITH_CARD };
     const { getByTestId } = render(wrap(DISABLED_WITH_CARD));
 
@@ -546,14 +542,14 @@ describe("PaymentMethodsCard redirect return", () => {
   });
 
   test("closing clears the outcome and leaves the modal shut", () => {
-    returnedOutcome = { kind: "saved", card: null };
+    seedReturnOutcome({ kind: "saved", card: null });
     const { container } = render(wrap(DISABLED_CONFIG));
 
     act(() => {
       lastPmModalProps().onClose();
     });
 
-    expect(clearOutcomeCalls).toBe(1);
+    expect(useSetupIntentReturnStore.getState().outcome).toBeNull();
     expect(lastPmModalProps().open).toBe(false);
     expect(lastPmModalProps().initialOutcome).toBeNull();
     expect(container.querySelector('[data-testid="pm-modal-stub"]')).toBeNull();

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -1,82 +1,21 @@
 import { useEffect, useMemo, useState } from "react";
 
-import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Notice } from "@vellumai/design-library/components/notice";
 
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
-import type {
-  CardOnFile,
-  PaymentMethodModalMode,
-} from "@/domains/settings/components/payment-method-modal-shell";
+import {
+  modalSnapshotFor,
+  paymentMethodCards,
+  type PaymentModalSnapshot,
+} from "@/domains/settings/components/payment-method-cards";
 import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
 import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
-import { useSetupIntentReturn } from "@/domains/settings/hooks/use-setup-intent-return";
+import { useSetupIntentReturnStore } from "@/domains/settings/setup-intent-return-store";
 import { useAutoTopUpConfigQuery } from "@/hooks/use-auto-top-up-config";
 import { useTranslation } from "@/i18n";
-
-export interface PaymentMethodCardEntry {
-  id: string;
-  brand: string | null;
-  last4: string | null;
-  expMonth: number | null;
-  expYear: number | null;
-}
-
-/**
- * The cards to list. The backend keeps at most one payment method and has no
- * list endpoint, so this is always length 0 or 1 today; the array is what the
- * multi-card render below is written against.
- */
-export function paymentMethodCards(
-  config: AutoTopUpConfigResponse | undefined,
-): PaymentMethodCardEntry[] {
-  if (config == null || !config.has_payment_method) {
-    return [];
-  }
-  return [
-    {
-      id: "primary",
-      brand: config.payment_method_brand,
-      last4: config.payment_method_last4,
-      // `?? null` because a platform deployment older than the expiry fields
-      // omits the keys entirely rather than sending them null.
-      expMonth: config.payment_method_exp_month ?? null,
-      expYear: config.payment_method_exp_year ?? null,
-    },
-  ];
-}
-
-/**
- * What the modal was opened with. Captured on the click that opens it, because
- * a successful save writes the new card into the config query cache before the
- * modal closes: derived props would flip an in-flight add into replace mode and
- * swap the card-on-file row for the card that was just saved.
- */
-interface PaymentModalSnapshot {
-  mode: PaymentMethodModalMode;
-  cardOnFile: CardOnFile | null;
-}
-
-function modalSnapshotFor(
-  cards: PaymentMethodCardEntry[],
-): PaymentModalSnapshot {
-  const [existing] = cards;
-  if (existing == null) {
-    return { mode: "add", cardOnFile: null };
-  }
-  return {
-    mode: "replace",
-    cardOnFile: {
-      brand: existing.brand,
-      last4: existing.last4,
-      expMonth: existing.expMonth,
-      expYear: existing.expYear,
-    },
-  };
-}
 
 /**
  * Settings → Billing "Payment Methods" section. Card management lives here;
@@ -92,11 +31,11 @@ export function PaymentMethodsCard() {
   // A return that is still resolving keeps the Add and Replace actions
   // disabled: the modal replays that outcome as its `initialOutcome`, which is
   // seeded on open alone, so one opened in that window would never show it.
-  const {
-    outcome,
-    pending: returnPending,
-    clearOutcome,
-  } = useSetupIntentReturn();
+  // The return is driven from `BillingPage` and parked in the store, so it
+  // survives this card being unmounted by a tab switch mid-resolution.
+  const outcome = useSetupIntentReturnStore.use.outcome();
+  const returnPending = useSetupIntentReturnStore.use.pending();
+  const clearOutcome = useSetupIntentReturnStore.use.clearOutcome();
 
   const [pmModal, setPmModal] = useState<PaymentModalSnapshot | null>(null);
 

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
@@ -1,14 +1,16 @@
 /**
  * Tests for `useSetupIntentReturn`: the SetupIntent params Stripe appends to
  * the `return_url` after an off-page 3DS challenge are read once, resolved
- * through Stripe.js, and stripped from the URL.
+ * through Stripe.js into `useSetupIntentReturnStore`, and stripped from the
+ * URL without disturbing the hash or any unrelated param.
  *
  * Strategy: mock the shared Stripe client so `retrieveSetupIntent` is driven
  * from the test (a real one needs Stripe.js and a live intent), mock the
  * saved-card sync so the confirm endpoint is not called, and mock the
  * org-readiness gate so a test can hold the resolution the way a hydrating org
- * store does. The real `setupIntentIdFromClientSecret` is kept, so the id the
- * sync is handed is parsed the way it is in the app.
+ * store does (with a short settle ceiling, so the bounded wait is observable).
+ * The real `setupIntentIdFromClientSecret` is kept, so the id the sync is
+ * handed is parsed the way it is in the app.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -72,12 +74,16 @@ mock.module("@/domains/settings/hooks/use-payment-method-saved-poll", () => ({
 
 // Drives the org-header gate. The resolution confirms the SetupIntent
 // server-side, so it waits out `"resolving"` the way the config query does.
+// The real ceiling is 5s; a short one here keeps the bounded-wait case fast.
 let orgReadiness: OrgHeaderReadiness = "ready";
 mock.module("@/hooks/use-is-org-ready", () => ({
-  useOrgHeaderReadiness: () => orgReadiness,
+  getOrgHeaderReadiness: () => orgReadiness,
+  ORG_HEADER_SETTLE_TIMEOUT_MS: 200,
 }));
 
 const { useSetupIntentReturn } = await import("./use-setup-intent-return");
+const { useSetupIntentReturnStore } =
+  await import("@/domains/settings/setup-intent-return-store");
 
 const RETURN_SEARCH =
   "?tab=billing&setup_intent=seti_1&setup_intent_client_secret=seti_1_secret_x&redirect_status=succeeded";
@@ -86,7 +92,10 @@ const CONFIRM_FAILED = "Failed to save payment method.";
 
 function renderAt(search: string) {
   return renderHook(
-    () => ({ location: useLocation(), ...useSetupIntentReturn() }),
+    () => {
+      useSetupIntentReturn();
+      return useLocation();
+    },
     {
       wrapper: ({ children }: { children: ReactNode }) => (
         <MemoryRouter initialEntries={[`/assistant/settings/usage${search}`]}>
@@ -100,12 +109,21 @@ function renderAt(search: string) {
 type HookResult = ReturnType<typeof renderAt>["result"];
 
 function currentUrl(result: HookResult): string {
-  return result.current.location.pathname + result.current.location.search;
+  const { pathname, search, hash } = result.current;
+  return pathname + search + hash;
 }
 
-async function waitForOutcome(result: HookResult): Promise<void> {
+function outcome() {
+  return useSetupIntentReturnStore.getState().outcome;
+}
+
+function pending(): boolean {
+  return useSetupIntentReturnStore.getState().pending;
+}
+
+async function waitForOutcome(): Promise<void> {
   await waitFor(() => {
-    if (result.current.outcome == null) {
+    if (outcome() == null) {
       throw new Error("outcome not resolved yet");
     }
   });
@@ -119,6 +137,7 @@ beforeEach(() => {
   syncCalls = [];
   syncedCard = { brand: "visa", last4: "4242", autoReloadEnabled: false };
   orgReadiness = "ready";
+  useSetupIntentReturnStore.setState({ pending: false, outcome: null });
 });
 
 afterEach(cleanup);
@@ -126,9 +145,9 @@ afterEach(cleanup);
 describe("useSetupIntentReturn", () => {
   test("resolves a succeeded return into the synced saved card", async () => {
     const { result } = renderAt(RETURN_SEARCH);
-    await waitForOutcome(result);
+    await waitForOutcome();
 
-    expect(result.current.outcome).toEqual({
+    expect(outcome()).toEqual({
       kind: "saved",
       card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
     });
@@ -146,9 +165,9 @@ describe("useSetupIntentReturn", () => {
     };
 
     const { result } = renderAt(RETURN_SEARCH);
-    await waitForOutcome(result);
+    await waitForOutcome();
 
-    expect(result.current.outcome).toEqual({
+    expect(outcome()).toEqual({
       kind: "error",
       message: "Your card was declined.",
     });
@@ -159,10 +178,10 @@ describe("useSetupIntentReturn", () => {
   test("carries the retrieval error message when the intent cannot be read", async () => {
     retrieveResult = { error: { message: "No such setupintent." } };
 
-    const { result } = renderAt(RETURN_SEARCH);
-    await waitForOutcome(result);
+    renderAt(RETURN_SEARCH);
+    await waitForOutcome();
 
-    expect(result.current.outcome).toEqual({
+    expect(outcome()).toEqual({
       kind: "error",
       message: "No such setupintent.",
     });
@@ -171,75 +190,97 @@ describe("useSetupIntentReturn", () => {
   test("falls back to the generic message when Stripe.js is unavailable", async () => {
     stripeAvailable = false;
 
-    const { result } = renderAt(RETURN_SEARCH);
-    await waitForOutcome(result);
+    renderAt(RETURN_SEARCH);
+    await waitForOutcome();
 
-    expect(result.current.outcome).toEqual({
-      kind: "error",
-      message: CONFIRM_FAILED,
-    });
+    expect(outcome()).toEqual({ kind: "error", message: CONFIRM_FAILED });
     expect(retrieveCalls).toEqual([]);
   });
 
   test("does nothing and never loads Stripe on a plain visit", () => {
     const { result } = renderAt("?tab=billing");
 
-    expect(result.current.outcome).toBeNull();
-    expect(result.current.pending).toBe(false);
+    expect(outcome()).toBeNull();
+    expect(pending()).toBe(false);
     expect(getStripePromiseCalls).toBe(0);
     expect(currentUrl(result)).toBe(STRIPPED_URL);
   });
 
+  test("strips only Stripe's params, keeping the hash and unrelated ones", () => {
+    // An anchor deep link (`#daily-credit-limit`, from the daily-limit email)
+    // has to survive a Stripe return, so the strip rebuilds the URL from the
+    // live location instead of replacing it with the canonical billing route.
+    const { result } = renderAt(`${RETURN_SEARCH}&foo=1#daily-credit-limit`);
+
+    expect(currentUrl(result)).toBe(
+      "/assistant/settings/usage?tab=billing&foo=1#daily-credit-limit",
+    );
+  });
+
   test("stays pending from the captured params until the outcome settles", async () => {
     orgReadiness = "resolving";
-    const { result, rerender } = renderAt(RETURN_SEARCH);
+    renderAt(RETURN_SEARCH);
 
-    expect(result.current.pending).toBe(true);
-    expect(result.current.outcome).toBeNull();
+    expect(pending()).toBe(true);
+    expect(outcome()).toBeNull();
 
     orgReadiness = "ready";
-    rerender();
-    await waitForOutcome(result);
+    await waitForOutcome();
 
-    expect(result.current.pending).toBe(false);
+    expect(pending()).toBe(false);
   });
 
   test("stays pending while a failed return resolves", async () => {
     orgReadiness = "resolving";
     retrieveResult = { error: { message: "No such setupintent." } };
-    const { result, rerender } = renderAt(RETURN_SEARCH);
+    renderAt(RETURN_SEARCH);
 
-    expect(result.current.pending).toBe(true);
+    expect(pending()).toBe(true);
 
     orgReadiness = "ready";
-    rerender();
-    await waitForOutcome(result);
+    await waitForOutcome();
 
-    expect(result.current.pending).toBe(false);
+    expect(pending()).toBe(false);
   });
 
   test("holds the resolution while the org header source is resolving", async () => {
     orgReadiness = "resolving";
-    const { result, rerender } = renderAt(RETURN_SEARCH);
+    const { result } = renderAt(RETURN_SEARCH);
 
     // The params are already off the URL, so a reload cannot replay them.
     expect(currentUrl(result)).toBe(STRIPPED_URL);
     expect(getStripePromiseCalls).toBe(0);
     expect(retrieveCalls).toEqual([]);
     expect(syncCalls).toEqual([]);
-    expect(result.current.outcome).toBeNull();
+    expect(outcome()).toBeNull();
 
     orgReadiness = "ready";
-    rerender();
-    await waitForOutcome(result);
+    await waitForOutcome();
 
-    expect(result.current.outcome).toEqual({
+    expect(outcome()).toEqual({
       kind: "saved",
       card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
     });
     expect(getStripePromiseCalls).toBe(1);
     expect(retrieveCalls).toEqual(["seti_1_secret_x"]);
     expect(syncCalls).toEqual([{ setupIntentId: "seti_1" }]);
+  });
+
+  test("stops waiting on an org header that never settles", async () => {
+    // `"resolving"` is transient by construction, but a wait with no ceiling
+    // would leave the return pending (and the add-a-card actions disabled) for
+    // the rest of the visit if it ever weren't.
+    orgReadiness = "resolving";
+    retrieveResult = { error: { message: "No such setupintent." } };
+
+    renderAt(RETURN_SEARCH);
+    await waitForOutcome();
+
+    expect(outcome()).toEqual({
+      kind: "error",
+      message: "No such setupintent.",
+    });
+    expect(retrieveCalls).toEqual(["seti_1_secret_x"]);
   });
 
   test("resolves rather than waiting when org resolution produced no org", async () => {
@@ -249,27 +290,46 @@ describe("useSetupIntentReturn", () => {
     orgReadiness = "unavailable";
     retrieveResult = { error: { message: "No such setupintent." } };
 
-    const { result } = renderAt(RETURN_SEARCH);
-    await waitForOutcome(result);
+    renderAt(RETURN_SEARCH);
+    await waitForOutcome();
 
-    expect(result.current.outcome).toEqual({
+    expect(outcome()).toEqual({
       kind: "error",
       message: "No such setupintent.",
     });
     expect(retrieveCalls).toEqual(["seti_1_secret_x"]);
   });
 
+  test("settles into the store after the caller unmounts", async () => {
+    // The billing tab panel unmounts on a switch to Usage, and by then the
+    // params are off the URL: a resolution tied to a component lifecycle would
+    // strand the return with no way to replay it.
+    orgReadiness = "resolving";
+    const { unmount } = renderAt(RETURN_SEARCH);
+
+    expect(pending()).toBe(true);
+    unmount();
+
+    orgReadiness = "ready";
+    await waitForOutcome();
+
+    expect(outcome()).toEqual({
+      kind: "saved",
+      card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
+    });
+  });
+
   test("clearOutcome drops the resolved outcome", async () => {
-    const { result } = renderAt(RETURN_SEARCH);
-    await waitForOutcome(result);
+    renderAt(RETURN_SEARCH);
+    await waitForOutcome();
 
     act(() => {
-      result.current.clearOutcome();
+      useSetupIntentReturnStore.getState().clearOutcome();
     });
 
-    expect(result.current.outcome).toBeNull();
+    expect(outcome()).toBeNull();
     // A cleared outcome is a resolved return, not one that went back to being
     // in flight, so the card's actions stay usable.
-    expect(result.current.pending).toBe(false);
+    expect(pending()).toBe(false);
   });
 });

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.ts
@@ -1,138 +1,166 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router";
+import { useEffect, useRef } from "react";
+import { useLocation, useNavigate, useSearchParams } from "react-router";
 
 import {
   getStripePromise,
   setupIntentIdFromClientSecret,
 } from "@/domains/settings/billing/stripe-client";
-import type { SetupIntentOutcome } from "@/domains/settings/components/auto-top-up-payment-method-modal";
-import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
-import { useOrgHeaderReadiness } from "@/hooks/use-is-org-ready";
+import {
+  usePaymentMethodSavedSync,
+  type SavedPaymentMethod,
+} from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { useSetupIntentReturnStore } from "@/domains/settings/setup-intent-return-store";
+import {
+  getOrgHeaderReadiness,
+  ORG_HEADER_SETTLE_TIMEOUT_MS,
+} from "@/hooks/use-is-org-ready";
 import { t } from "@/i18n";
-import { routes } from "@/utils/routes";
 
-/** The redirect params, held from the URL strip until the org store settles. */
-interface CapturedReturn {
-  clientSecret: string;
-  redirectStatus: string | null;
+const CLIENT_SECRET_PARAM = "setup_intent_client_secret";
+const REDIRECT_STATUS_PARAM = "redirect_status";
+
+/** What Stripe appends to the `return_url`, and what the strip below drops. */
+const STRIPE_RETURN_PARAMS = [
+  "setup_intent",
+  CLIENT_SECRET_PARAM,
+  REDIRECT_STATUS_PARAM,
+];
+
+const ORG_HEADER_POLL_INTERVAL_MS = 100;
+
+type ConfirmSaved = (args: {
+  setupIntentId: string | null;
+}) => Promise<SavedPaymentMethod | null>;
+
+/**
+ * A full-page 3DS return remounts the app, so the org store can still be
+ * hydrating when the params are read. The server-side confirm below needs
+ * `Vellum-Organization-Id`, and a headerless one is rejected and falls back to
+ * the 20-second webhook poll, so the resolution waits out `"resolving"` the
+ * way the config query does.
+ *
+ * Bounded by the same ceiling imperative callers use elsewhere: a return that
+ * never resolves leaves the add-a-card actions disabled for the rest of the
+ * visit. Past it, and for `"unavailable"`, the request fires and fails into
+ * the error outcome instead.
+ */
+async function waitForOrgHeader(): Promise<void> {
+  const startedAt = Date.now();
+  while (
+    getOrgHeaderReadiness() === "resolving" &&
+    Date.now() - startedAt < ORG_HEADER_SETTLE_TIMEOUT_MS
+  ) {
+    await new Promise((resolve) =>
+      setTimeout(resolve, ORG_HEADER_POLL_INTERVAL_MS),
+    );
+  }
 }
 
 /**
- * Resolves the SetupIntent params Stripe appends to the `return_url` after an
+ * Resolves the captured params into the outcome the modal replays and writes
+ * it to the store. A plain function rather than an effect body, so it outlives
+ * whatever mounted the hook that started it.
+ */
+async function resolveSetupIntentReturn({
+  clientSecret,
+  redirectStatus,
+  confirmSaved,
+}: {
+  clientSecret: string;
+  redirectStatus: string | null;
+  confirmSaved: ConfirmSaved;
+}): Promise<void> {
+  const { settleOutcome } = useSetupIntentReturnStore.getState();
+
+  const settleError = (message: string | undefined) => {
+    console.warn("[useSetupIntentReturn] card not saved on redirect return", {
+      redirectStatus,
+    });
+    settleOutcome({
+      kind: "error",
+      message:
+        message ?? t("settings:autoTopUpPaymentMethodModal.confirmFailed"),
+    });
+  };
+
+  await waitForOrgHeader();
+
+  try {
+    const stripe = await getStripePromise();
+    if (stripe == null) {
+      settleError(undefined);
+      return;
+    }
+    const { setupIntent, error } =
+      await stripe.retrieveSetupIntent(clientSecret);
+    if (setupIntent?.status === "succeeded") {
+      const card = await confirmSaved({
+        setupIntentId: setupIntentIdFromClientSecret(clientSecret),
+      });
+      settleOutcome({ kind: "saved", card });
+      return;
+    }
+    settleError(error?.message ?? setupIntent?.last_setup_error?.message);
+  } catch {
+    settleError(undefined);
+  }
+}
+
+/**
+ * Drives the SetupIntent params Stripe appends to the `return_url` after an
  * off-page 3DS challenge (`setup_intent`, `setup_intent_client_secret`,
- * `redirect_status`) into the outcome `AutoTopUpPaymentMethodModal` replays as
- * its `initialOutcome`, and strips them from the URL.
+ * `redirect_status`): they are read once, stripped from the URL, and resolved
+ * into the outcome `AutoTopUpPaymentMethodModal` replays as its
+ * `initialOutcome`. The result lands in `useSetupIntentReturnStore`, which is
+ * where the cards read it from.
  *
  * `redirect_status` is a hint only: the SetupIntent is re-read through
  * Stripe.js, and a succeeded one is confirmed server-side through
  * `usePaymentMethodSavedSync`, so the success panel and the payment-method row
  * carry the new card's brand and last4.
  *
- * `pending` spans the window between reading those params and settling them,
- * which the confirm fallback's webhook poll can stretch to 20 seconds. The
- * outcome is replayed into a modal the caller opens for it, so the caller uses
- * `pending` to keep a competing one from being opened first.
+ * Call this once ABOVE the billing tab panel (it lives in `BillingPage`). The
+ * panel unmounts on a switch to the Usage tab and the params are off the URL
+ * by then, so a return driven from inside it would be lost for the rest of the
+ * visit.
  */
-export function useSetupIntentReturn(): {
-  outcome: SetupIntentOutcome | null;
-  pending: boolean;
-  clearOutcome: () => void;
-} {
+export function useSetupIntentReturn(): void {
   const [searchParams] = useSearchParams();
+  const { pathname, hash } = useLocation();
   const navigate = useNavigate();
   const syncPaymentMethodSaved = usePaymentMethodSavedSync();
-  const orgReadiness = useOrgHeaderReadiness();
 
-  const [captured, setCaptured] = useState<CapturedReturn | null>(null);
-  const [outcome, setOutcome] = useState<SetupIntentOutcome | null>(null);
-  // Tracked apart from `outcome` so `clearOutcome()` does not read as a return
-  // that went back to being unresolved.
-  const [settled, setSettled] = useState(false);
   const capturedRef = useRef(false);
-  const resolvedRef = useRef(false);
-  const mountedRef = useRef(true);
 
   useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    const clientSecret = searchParams.get("setup_intent_client_secret");
+    const clientSecret = searchParams.get(CLIENT_SECRET_PARAM);
     if (clientSecret == null || capturedRef.current) {
       return;
     }
     // One capture per page load: strict mode runs this effect twice, and
     // stripping the params below re-runs it a third time.
     capturedRef.current = true;
-    setCaptured({
-      clientSecret,
-      redirectStatus: searchParams.get("redirect_status"),
-    });
-    navigate(routes.settings.usageBilling, { replace: true });
-  }, [navigate, searchParams]);
+    const redirectStatus = searchParams.get(REDIRECT_STATUS_PARAM);
 
-  // A full-page 3DS return remounts the app, so the org store can still be
-  // hydrating when the params are read. The server-side confirm below needs
-  // `Vellum-Organization-Id`, and a headerless one is rejected and falls back
-  // to the 20-second webhook poll, so the resolution waits out `"resolving"`
-  // exactly as the config query does. `"unavailable"` still resolves: the
-  // request fires and fails into the error outcome, rather than leaving the
-  // return unresolved for the rest of the visit.
-  useEffect(() => {
-    if (
-      captured == null ||
-      orgReadiness === "resolving" ||
-      resolvedRef.current
-    ) {
-      return;
+    // Rebuilt from the live location rather than navigating to the canonical
+    // billing route, which would drop the URL hash along with every unrelated
+    // param: anchor deep links (`#daily-credit-limit` from the daily-limit
+    // email) must survive a Stripe return the way they survive the tab
+    // normalization in `BillingPage`.
+    const next = new URLSearchParams(searchParams);
+    for (const param of STRIPE_RETURN_PARAMS) {
+      next.delete(param);
     }
-    resolvedRef.current = true;
-    const { clientSecret, redirectStatus } = captured;
+    next.set("tab", "billing");
+    void navigate({ pathname, search: `?${next}`, hash }, { replace: true });
 
-    const settle = (next: SetupIntentOutcome) => {
-      if (mountedRef.current) {
-        setOutcome(next);
-        setSettled(true);
-      }
-    };
-    const settleError = (message: string | undefined) => {
-      console.warn("[useSetupIntentReturn] card not saved on redirect return", {
-        redirectStatus,
-      });
-      settle({
-        kind: "error",
-        message:
-          message ?? t("settings:autoTopUpPaymentMethodModal.confirmFailed"),
-      });
-    };
-
-    void (async () => {
-      try {
-        const stripe = await getStripePromise();
-        if (stripe == null) {
-          settleError(undefined);
-          return;
-        }
-        const { setupIntent, error } =
-          await stripe.retrieveSetupIntent(clientSecret);
-        if (setupIntent?.status === "succeeded") {
-          const card = await syncPaymentMethodSaved({
-            setupIntentId: setupIntentIdFromClientSecret(clientSecret),
-          });
-          settle({ kind: "saved", card });
-          return;
-        }
-        settleError(error?.message ?? setupIntent?.last_setup_error?.message);
-      } catch {
-        settleError(undefined);
-      }
-    })();
-  }, [captured, orgReadiness, syncPaymentMethodSaved]);
-
-  const clearOutcome = useCallback(() => setOutcome(null), []);
-
-  return { outcome, pending: captured != null && !settled, clearOutcome };
+    useSetupIntentReturnStore.getState().beginResolving();
+    void resolveSetupIntentReturn({
+      clientSecret,
+      redirectStatus,
+      confirmSaved: syncPaymentMethodSaved,
+    });
+    // `syncPaymentMethodSaved` is rebuilt every render, so this effect re-runs
+    // often; the capture guard above makes every run after the first a no-op.
+  }, [hash, navigate, pathname, searchParams, syncPaymentMethodSaved]);
 }

--- a/clients/web/src/domains/settings/setup-intent-return-store.ts
+++ b/clients/web/src/domains/settings/setup-intent-return-store.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+
+import type { SetupIntentOutcome } from "@/domains/settings/components/auto-top-up-payment-method-modal";
+import { createSelectors } from "@/utils/create-selectors";
+
+/**
+ * The 3DS redirect return, held outside the cards that render it.
+ *
+ * Stripe sends the user back to a freshly loaded billing page, where resolving
+ * the SetupIntent takes a Stripe.js read plus a server-side confirm whose
+ * webhook-poll fallback runs for up to 20 seconds. Every consumer of that
+ * outcome sits inside the billing tab panel, which unmounts the moment the
+ * user switches to Usage, so the state lives here instead: the resolution
+ * writes into the store and a panel picks it up whenever it mounts.
+ *
+ * Reference: {@link https://zustand.docs.pmnd.rs/}
+ */
+interface SetupIntentReturnState {
+  /**
+   * True from reading Stripe's redirect params until the outcome settles. The
+   * outcome is replayed into a modal opened for it, so the cards gate their
+   * add-a-card actions on this to keep a competing modal from opening first.
+   */
+  pending: boolean;
+  outcome: SetupIntentOutcome | null;
+}
+
+interface SetupIntentReturnActions {
+  beginResolving: () => void;
+  settleOutcome: (outcome: SetupIntentOutcome) => void;
+  clearOutcome: () => void;
+}
+
+const useSetupIntentReturnStoreBase = create<
+  SetupIntentReturnState & SetupIntentReturnActions
+>()((set) => ({
+  pending: false,
+  outcome: null,
+
+  beginResolving: () => set({ pending: true, outcome: null }),
+  settleOutcome: (outcome) => set({ pending: false, outcome }),
+  // `pending` is left alone: a cleared outcome is a resolved return, not one
+  // that went back to being in flight.
+  clearOutcome: () => set({ outcome: null }),
+}));
+
+export const useSetupIntentReturnStore = createSelectors(
+  useSetupIntentReturnStoreBase,
+);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for payment-modal-v4.md.

- **A** `useSetupIntentReturn()` now runs in `BillingPage` (which owns `Tabs.Root`) and writes into a new `setup-intent-return-store`, with the async resolution as a plain function, so switching to Usage mid-resolution no longer strands the return.
- **B** The strip rebuilds the URL from the live location, deleting only Stripe's three params and keeping the hash and every unrelated param.
- **C** The `"resolving"` org-header wait is bounded by `ORG_HEADER_SETTLE_TIMEOUT_MS` and falls through to the same path `"unavailable"` takes.
- **D** Both of `AutoTopUpCard`'s add-a-card buttons are disabled while a return is pending, so no second modal can stack on the one the outcome replays into.
- **E** One `preservePaymentMethodFields()` helper feeds both config-cache writers, so card expiry and billing address survive a Save and a Disable.
- **F** `AutoTopUpCard`'s modal now opens in the mode the config calls for (replace on the repeated-declines cutoff, add with no card) and is seeded with the saved billing address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XB7ckoybGsZZWurNBj6cx3