### PR TITLE
Destructive menu rows respond to being highlighted

### DIFF
--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -69,6 +69,7 @@ import {
 } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 import { pairedHostLabel } from "@vellumai/local-mode/contract";
+import { actionMenuDestructiveClasses } from "@vellumai/design-library/components/action-menu";
 import { Button } from "@vellumai/design-library/components/button";
 import { Menu } from "@vellumai/design-library/components/menu";
 import { useTranslation } from "@/i18n";
@@ -1011,7 +1012,7 @@ function RemoveCardMenu({
       <Menu.Content align="end" sideOffset={4}>
         <Menu.Item
           onSelect={onRemove}
-          className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
+          className={actionMenuDestructiveClasses.anchored}
         >
           {t("selectAssistantScreen.removeFromDevice")}
         </Menu.Item>

--- a/clients/web/src/domains/settings/ai/profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/profile-row.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, EllipsisVertical } from "lucide-react";
 
+import { actionMenuDestructiveClasses } from "@vellumai/design-library/components/action-menu";
 import { Button } from "@vellumai/design-library/components/button";
 import { ListRow } from "@vellumai/design-library/components/list-row";
 import { Menu } from "@vellumai/design-library/components/menu";
@@ -200,7 +201,7 @@ export function ProfileRow({
               {!isManaged ? (
                 <Menu.Item
                   onSelect={onDelete}
-                  className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
+                  className={actionMenuDestructiveClasses.anchored}
                 >
                   {t("profileRow.delete")}
                 </Menu.Item>

--- a/clients/web/src/domains/settings/ai/provider-row.tsx
+++ b/clients/web/src/domains/settings/ai/provider-row.tsx
@@ -1,5 +1,6 @@
 import { EllipsisVertical } from "lucide-react";
 
+import { actionMenuDestructiveClasses } from "@vellumai/design-library/components/action-menu";
 import { Button } from "@vellumai/design-library/components/button";
 import { ListRow } from "@vellumai/design-library/components/list-row";
 import { Menu } from "@vellumai/design-library/components/menu";
@@ -124,7 +125,7 @@ export function ProviderRow({
                 {showDelete ? (
                   <Menu.Item
                     onSelect={onDelete}
-                    className="text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-strong)]"
+                    className={actionMenuDestructiveClasses.anchored}
                   >
                     {t("providerRow.delete")}
                   </Menu.Item>


### PR DESCRIPTION
## TL;DR

Three destructive menu rows do not change colour when you highlight them, because they carry a copy of the row's colour rule that repeats the resting tone instead of moving to the hover one. They now use the shared constant, so Delete in Settings, AI and Remove from device in the assistant picker give the same feedback as Delete in the conversation menu.

## The drift

`actionMenuDestructiveClasses.anchored` moves the row to `--system-negative-hover` when highlighted. These three repeat `--system-negative-strong`, which is what the row already is at rest:

```
data-[highlighted]:text-[var(--system-negative-strong)]   <- these three
data-[highlighted]:text-[var(--system-negative-hover)]    <- everywhere else
```

Measured against the real row styling, light theme:

| | at rest | highlighted |
|---|---|---|
| These three, today | `#DA491A` | `#DA491A`, unchanged |
| Every other destructive row | `#DA491A` | `#E86B40` |

So the row a keyboard user has arrowed onto, or a pointer is sitting on, looks identical to the two above it. `menuItemBase` still paints the highlight background, so the row is not invisible; it just does not participate in the colour half of the affordance the way its neighbours do.

## What changes for the user

| Surface | Before | After |
|---|---|---|
| Settings, AI: Delete on a profile | No colour change when highlighted | Moves to the negative hover tone |
| Settings, AI: Delete on a provider | Same | Same |
| Assistant picker: Remove from device | Same | Same |
| Every other destructive row | Already correct | Unchanged |
| Light / dark / velvet | | Follows each theme's own hover token: `#E86B40`, `#AB3F1C`, `#F87171` |

Nothing else about these menus moves. The rows keep their resting colour, their label, and their behaviour.

## On the icon half

The constant also hands a row's icon the row's colour, which is the other half of what it exists for. **None of these three rows has an icon**, so that part is inert today and no glyph colour changes. I checked each call site rather than assuming, because the rule reads like it should matter here and does not. It means an icon added to one of these later inherits the correct behaviour instead of the divergence.

## Why it is safe

Three lines, each swapping a string literal for the constant it was copied from. No behaviour is added, no props change, and the resting appearance is identical: the only difference is a tone the rows should already have been using while highlighted.

## How it was found

Grepping for the literal while removing a byte-identical duplicate in #41722, not from a report. Worth saying plainly: this shipped and nobody noticed, which is the argument for the constant rather than for another copy.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->