### PR TITLE
Tie the advertised web chords to the handler that answers them

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.test.tsx
@@ -8,14 +8,12 @@ import { useChatLayoutShortcuts } from "./use-chat-layout-shortcuts";
 
 /**
  * The web build advertises its own chords through `WEB_ACCELERATORS`, and this
- * hook is what actually answers them. Nothing in the types connects the two, so
- * a chord changed on one side leaves the other advertising or answering the
- * wrong key with nothing failing.
+ * hook answers them. Nothing in the types connects the two, so a chord that one
+ * side carries and the other does not is a hint naming a key nothing answers.
  *
- * These drive themselves from the table rather than repeating the chords, so a
- * hint that names a key the handler ignores fails here. The final case fails
- * when the table grows an entry no assertion covers, which is the way the two
- * would otherwise drift apart again.
+ * These drive themselves from the table rather than repeating the chords: an
+ * entry the handler ignores fails here, and the final case fails when the table
+ * carries an entry no assertion covers.
  */
 
 /** The keydown a given accelerator should produce, as a browser would send it. */
@@ -90,8 +88,8 @@ describe("useChatLayoutShortcuts answers every chord the web build advertises", 
   }
 
   test("every advertised chord has a case above", () => {
-    // Adding a chord to the table without teaching the handler, or without
-    // covering it here, is the drift these tests exist to catch.
+    // A chord the table carries and this file does not cover is a hint no
+    // assertion protects.
     expect(Object.keys(WEB_ACCELERATORS).sort()).toEqual(
       Object.keys(answered).sort(),
     );

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-shortcuts.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { WEB_ACCELERATORS } from "@/hooks/use-command-shortcut";
+import { useCommandPaletteStore } from "@/stores/command-palette-store";
+
+import { useChatLayoutShortcuts } from "./use-chat-layout-shortcuts";
+
+/**
+ * The web build advertises its own chords through `WEB_ACCELERATORS`, and this
+ * hook is what actually answers them. Nothing in the types connects the two, so
+ * a chord changed on one side leaves the other advertising or answering the
+ * wrong key with nothing failing.
+ *
+ * These drive themselves from the table rather than repeating the chords, so a
+ * hint that names a key the handler ignores fails here. The final case fails
+ * when the table grows an entry no assertion covers, which is the way the two
+ * would otherwise drift apart again.
+ */
+
+/** The keydown a given accelerator should produce, as a browser would send it. */
+function keydownFor(accelerator: string): KeyboardEvent {
+  const tokens = accelerator.split("+");
+  const key = tokens[tokens.length - 1]!;
+  return new KeyboardEvent("keydown", {
+    // The handler accepts either modifier; a mac sends the command key.
+    metaKey: tokens.includes("CmdOrCtrl"),
+    shiftKey: tokens.includes("Shift"),
+    // A browser reports the character, lowercased for an unshifted letter.
+    key: key.length === 1 ? key.toLowerCase() : key,
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+/**
+ * Wait for a condition the palette reaches asynchronously: opening tries the
+ * Electron window first and falls back to the store only once that resolves,
+ * so the flip is a few microtasks away rather than immediate.
+ */
+async function eventually(condition: () => boolean): Promise<boolean> {
+  for (let i = 0; i < 20 && !condition(); i += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  return condition();
+}
+
+describe("useChatLayoutShortcuts answers every chord the web build advertises", () => {
+  const handlers = {
+    toggleSidebar: mock(() => {}),
+    onGoBack: mock(() => {}),
+    onGoForward: mock(() => {}),
+    onNewConversation: mock(() => {}),
+  };
+
+  beforeEach(() => {
+    for (const fn of Object.values(handlers)) {
+      fn.mockClear();
+    }
+    if (useCommandPaletteStore.getState().isOpen) {
+      useCommandPaletteStore.getState().toggle();
+    }
+    renderHook(() => useChatLayoutShortcuts(handlers));
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /** What proves the app answered a given command, per command. */
+  const answered: Record<string, () => boolean | Promise<boolean>> = {
+    newConversation: () => handlers.onNewConversation.mock.calls.length === 1,
+    sidebarToggle: () => handlers.toggleSidebar.mock.calls.length === 1,
+    navigateBack: () => handlers.onGoBack.mock.calls.length === 1,
+    navigateForward: () => handlers.onGoForward.mock.calls.length === 1,
+    // Off Electron the window open resolves false and the store is the fallback.
+    commandPalette: () =>
+      eventually(() => useCommandPaletteStore.getState().isOpen),
+  };
+
+  for (const [command, accelerator] of Object.entries(WEB_ACCELERATORS)) {
+    test(`${command} (${accelerator})`, async () => {
+      const check = answered[command];
+      expect(check).toBeDefined();
+
+      window.dispatchEvent(keydownFor(accelerator!));
+
+      expect(await check!()).toBe(true);
+    });
+  }
+
+  test("every advertised chord has a case above", () => {
+    // Adding a chord to the table without teaching the handler, or without
+    // covering it here, is the drift these tests exist to catch.
+    expect(Object.keys(WEB_ACCELERATORS).sort()).toEqual(
+      Object.keys(answered).sort(),
+    );
+  });
+});

--- a/clients/web/src/hooks/use-command-shortcut.ts
+++ b/clients/web/src/hooks/use-command-shortcut.ts
@@ -55,8 +55,12 @@ export type CommandShortcutKey =
  * Anything absent here is desktop-only and has no shortcut in a browser, which
  * is the common case: pinning, marking unread, and popping out are all menu
  * commands the web build never binds.
+ *
+ * Exported so the handler's own test can drive itself from this table: a hint
+ * naming a chord the handler does not answer is the failure mode, and nothing
+ * in the types connects the two.
  */
-const WEB_ACCELERATORS: Partial<Record<CommandShortcutKey, string>> = {
+export const WEB_ACCELERATORS: Partial<Record<CommandShortcutKey, string>> = {
   newConversation: "CmdOrCtrl+Shift+O",
   sidebarToggle: "CmdOrCtrl+\\",
   commandPalette: "CmdOrCtrl+K",


### PR DESCRIPTION
## TL;DR

`WEB_ACCELERATORS` names the chords the browser build binds, and `useChatLayoutShortcuts` is the handler that answers them. Nothing connected the two. They agree today by luck, and this makes that a guarantee instead. Test-only, no product change.

## The gap

The hints the palette and the menus draw come from `WEB_ACCELERATORS`. The keydown handler matches its own literals:

```ts
// use-command-shortcut.ts        // use-chat-layout-shortcuts.ts
sidebarToggle: "CmdOrCtrl+\\"    shouldHandleShortcut(event, …, "\\")
commandPalette: "CmdOrCtrl+K"    shouldHandleShortcut(event, …, "k")
```

Change the sidebar toggle in the handler and the hint keeps claiming the old chord, with nothing failing. That is the same shape as the two defects this work already hit: a hint that names a key which does nothing, and a test pinned to a string it did not own.

## What this does

The handler's test drives itself from the table rather than repeating the chords. For every entry, it builds the keydown a browser would send for that accelerator and asserts the command actually fires. A final case asserts the table and the assertions cover the same set, so an entry added to the table without a handler, or without coverage here, fails rather than quietly advertising a key nothing answers.

`WEB_ACCELERATORS` is exported for this, which is the point of the change: the test reads the same table the hints read, so there is no second copy of the chords to drift.

## What is deliberately not done

The obvious-looking fix is to have the handler match through `eventToAccelerator`, which already exists for the rebinding recorder, and compare against the table directly. I did not, because it narrows behaviour: the handler currently accepts `metaKey || ctrlKey` regardless of platform, so `Ctrl+K` opens the palette on a Mac today, and an exact accelerator match would stop that.

That may well be the right change, since `Ctrl+K` is a readline binding inside text inputs, but it is a behaviour change to the keyboard surface and belongs in its own PR with that as its stated claim, rather than arriving inside a test-only one.

## Verified

`bunx tsc --noEmit` and `bun run lint` clean. The tests themselves were not run locally (standing rule on this machine); CI covers them.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41730" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->