### PR TITLE
The Telegram adapter keys through the shared builder (LUM-2871)

### DIFF
--- a/assistant/src/messaging/providers/telegram-bot/adapter.ts
+++ b/assistant/src/messaging/providers/telegram-bot/adapter.ts
@@ -7,6 +7,7 @@
 import type { OAuthConnection } from "../../../oauth/connection.js";
 import { getConnectionByProvider } from "../../../oauth/oauth-store.js";
 import { getOrCreateConversation } from "../../../persistence/conversation-key-store.js";
+import { buildScopedConversationKey } from "../../../persistence/delivery-crud.js";
 import { upsertOutboundBinding } from "../../../persistence/external-conversation-store.js";
 import { credentialKey } from "../../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../../security/secure-keys.js";
@@ -107,7 +108,10 @@ export const telegramBotMessagingProvider: MessagingProvider = {
     // conversation key mapping and binding exist for the next inbound.
     try {
       const sourceChannel = "telegram";
-      const conversationKey = `asst:self:${sourceChannel}:${conversationId}`;
+      const conversationKey = buildScopedConversationKey(
+        sourceChannel,
+        conversationId,
+      );
       const { conversationId: internalId } =
         getOrCreateConversation(conversationKey);
       upsertOutboundBinding({

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -88,6 +88,12 @@ export const whatsappMessagingProvider: MessagingProvider = {
     // exists for the next inbound WhatsApp message from this number.
     try {
       const sourceChannel = "whatsapp";
+      // Deliberately not `buildScopedConversationKey`: that builder pins the
+      // scope to `asst:self`, and this path carries a caller-supplied
+      // assistant id (`messaging-send` passes its skill context's). Keys
+      // minted under a non-self scope are unreachable to every reader that
+      // goes through the builder, which is why the binding write below is
+      // limited to the self scope.
       const conversationKey = `asst:${assistantId ?? "self"}:${sourceChannel}:${conversationId}`;
       const { conversationId: internalId } =
         getOrCreateConversation(conversationKey);

--- a/assistant/src/messaging/providers/whatsapp/adapter.ts
+++ b/assistant/src/messaging/providers/whatsapp/adapter.ts
@@ -88,12 +88,6 @@ export const whatsappMessagingProvider: MessagingProvider = {
     // exists for the next inbound WhatsApp message from this number.
     try {
       const sourceChannel = "whatsapp";
-      // Deliberately not `buildScopedConversationKey`: that builder pins the
-      // scope to `asst:self`, and this path carries a caller-supplied
-      // assistant id (`messaging-send` passes its skill context's). Keys
-      // minted under a non-self scope are unreachable to every reader that
-      // goes through the builder, which is why the binding write below is
-      // limited to the self scope.
       const conversationKey = `asst:${assistantId ?? "self"}:${sourceChannel}:${conversationId}`;
       const { conversationId: internalId } =
         getOrCreateConversation(conversationKey);


### PR DESCRIPTION
# The Telegram adapter keys through the shared builder

Fixes LUM-2871, though not the way that ticket described. Verifying it against current main falsified two of its claims, and the ticket is corrected in place.

## TL;DR

`telegram-bot/adapter.ts` hand-built its outbound conversation key as a template string. It now calls `buildScopedConversationKey`, the same function every reader uses. Behavior-neutral: the hand-rolled string produced exactly what the builder returns for the inputs this path has. One file, five lines.

## What the ticket got wrong

| Ticket said | Verified |
| --- | --- |
| Call `buildScopedConversationKeyForAssistant`, "which takes the assistant id as a parameter" | No such function. `buildScopedConversationKey(sourceChannel, externalChatId, sourceThreadId?)` pins the scope with a fixed `CONVERSATION_KEY_SCOPE = "asst:self"`, documented as deliberate because the prefix is part of the stored key format |
| Telegram's hardcoded `asst:self` is the defect | Backwards. The scope is deliberately fixed, so Telegram already matched canonical behavior |
| A non-`self` id would make Telegram orphan a conversation per outbound send | Telegram never interpolates an id, so it cannot |

What the ticket was right about is the part this PR fixes: two hand-rolled spellings of one derivation, so a change to the scope prefix or the thread-scoping rule (`THREAD_SCOPED_CHANNELS`, currently slack and telegram) would silently diverge in a copy.

## Scope note

An earlier revision of this PR also touched the WhatsApp adapter, whose key interpolates a caller-supplied assistant id that no reader can resolve. That is reverted: WhatsApp is outside this effort, which covers Slack, Telegram and Discord, so spending attention there is not worth it. The question is also contained. None of the three in-scope channels hand-rolls an assistant-scoped key, so nothing about that path can reach them.

## Verification note

`SendOptions.assistantId` looked dead to several greps and I nearly deleted it. The typechecker found the caller the greps missed (`config/bundled-skills/messaging/tools/messaging-send.ts`), which is the only reason the WhatsApp path above is known to be live rather than vestigial.
