### PR TITLE
fix: final review polish for the payment modal redirect return, appearance guard, and helpers

### DIFF
--- a/clients/web/src/domains/settings/billing/stripe-appearance.test.ts
+++ b/clients/web/src/domains/settings/billing/stripe-appearance.test.ts
@@ -178,7 +178,16 @@ describe("appearanceFromTokens", () => {
   });
 
   test("never hands Stripe an empty or half-built value", () => {
-    for (const tokens of [{}, { text: TOKENS.text, danger: TOKENS.danger }]) {
+    // The input is a `Partial`, so `""` is representable even though the token
+    // read never produces one: an empty accent would build `"0 0 0 3px "`.
+    const emptyTokens = Object.fromEntries(
+      Object.keys(TOKENS).map((key) => [key, ""]),
+    ) as Partial<StripeAppearanceTokens>;
+    for (const tokens of [
+      {},
+      emptyTokens,
+      { text: TOKENS.text, danger: TOKENS.danger },
+    ]) {
       for (const value of stringValues(appearanceFromTokens(tokens, "night"))) {
         expect(value).not.toBe("");
         expect(value).not.toMatch(/\s$/);

--- a/clients/web/src/domains/settings/billing/stripe-appearance.ts
+++ b/clients/web/src/domains/settings/billing/stripe-appearance.ts
@@ -83,7 +83,7 @@ export function withAlpha(color: string, alpha: number): string {
 type Declarations = Record<string, string | undefined>;
 
 function isResolved(value: string | undefined): value is string {
-  return value !== undefined;
+  return value !== undefined && value !== "";
 }
 
 /**

--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.tsx
@@ -14,9 +14,8 @@ import {
   brandDisplayLabel,
   brandLabel,
   cardExpiryLabel,
-  savedPanelTitle,
 } from "@/domains/settings/utils/payment-method-brand";
-import { useTranslation } from "@/i18n";
+import { useTranslation, type TFunction } from "@/i18n";
 import { Button } from "@vellumai/design-library/components/button";
 import { Modal } from "@vellumai/design-library/components/modal";
 import { cn } from "@vellumai/design-library/utils/cn";
@@ -295,6 +294,19 @@ function CardOnFileRow({ card }: { card: CardOnFile }) {
       </span>
     </div>
   );
+}
+
+/** Titles the success panel, and the screen-reader title above it. */
+function savedPanelTitle(
+  t: TFunction<"settings">,
+  card: SavedCard | null,
+): string {
+  return card?.brand && card.last4
+    ? t("autoTopUpPaymentMethodModal.savedTitle", {
+        brand: brandLabel(card.brand),
+        last4: card.last4,
+      })
+    : t("autoTopUpPaymentMethodModal.savedTitleGeneric");
 }
 
 function SavedPanel({

--- a/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -20,7 +20,9 @@
  *    tab switch without losing it.
  *  - A saved 3DS return also invalidates the config query through this card's
  *    own QueryClient, because the resolution's writes went to the client it
- *    captured when it started, which a request-scope change can discard.
+ *    captured when it started, which a request-scope change can discard. A
+ *    saved outcome carrying no card is left alone: the cache then holds only
+ *    the saved-poll's optimistic flip, which a refetch would wipe.
  *  - A 3DS redirect return replays its outcome into a freshly opened modal:
  *    a saved card on the success panel alone, a failure back into the form in
  *    the mode the saved card calls for. The failure waits for the config query
@@ -126,8 +128,6 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 
 const { PaymentMethodsCard } = await import("./payment-methods-card");
-const { paymentMethodCards } =
-  await import("@/domains/settings/utils/payment-method-cards");
 const { useSetupIntentReturnStore } =
   await import("@/domains/settings/setup-intent-return-store");
 const { DISABLED_CONFIG } = await import("./auto-top-up-card");
@@ -212,6 +212,18 @@ function wrapWith(client: QueryClient) {
 
 function wrap(config?: AutoTopUpConfigResponse) {
   return wrapWith(makeClient(config));
+}
+
+/** Records what the card invalidates, leaving the real behaviour in place. */
+function trackInvalidations(client: QueryClient) {
+  const invalidated: Array<Parameters<QueryClient["invalidateQueries"]>[0]> =
+    [];
+  const invalidateQueries = client.invalidateQueries.bind(client);
+  client.invalidateQueries = (filters) => {
+    invalidated.push(filters);
+    return invalidateQueries(filters);
+  };
+  return invalidated;
 }
 
 /**
@@ -465,13 +477,7 @@ describe("PaymentMethodsCard redirect return", () => {
     // swapping the user id) remounts that client: without this the section can
     // keep showing the empty state until an unrelated GET lands.
     const client = makeClient(DISABLED_CONFIG);
-    const invalidated: Array<Parameters<QueryClient["invalidateQueries"]>[0]> =
-      [];
-    const invalidateQueries = client.invalidateQueries.bind(client);
-    client.invalidateQueries = (filters) => {
-      invalidated.push(filters);
-      return invalidateQueries(filters);
-    };
+    const invalidated = trackInvalidations(client);
     seedReturnOutcome({
       kind: "saved",
       card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
@@ -486,6 +492,20 @@ describe("PaymentMethodsCard redirect return", () => {
     expect(invalidated).toContainEqual({
       queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
     });
+  });
+
+  test("leaves the cache alone when the confirm produced no card", () => {
+    // The confirm failed and the 20s poll timed out, so the cache holds only
+    // the poll's deliberate optimistic flip: a refetch would wipe it while the
+    // modal still reads "Card saved".
+    const client = makeClient(DISABLED_CONFIG);
+    const invalidated = trackInvalidations(client);
+    seedReturnOutcome({ kind: "saved", card: null });
+    render(wrapWith(client));
+
+    // The outcome did reach the card: it opened the modal on the success panel.
+    expect(lastPmModalProps().open).toBe(true);
+    expect(invalidated).toEqual([]);
   });
 
   test("replays an error outcome into replace mode with the card on file", () => {
@@ -633,40 +653,5 @@ describe("PaymentMethodsCard expiry and billing address", () => {
       expYear: null,
     });
     expect(lastPmModalProps().billingAddress).toBeNull();
-  });
-});
-
-/**
- * The backend stores at most one payment method and has no list endpoint, so
- * the multi-card shape is only reachable through the pure helper.
- */
-describe("paymentMethodCards", () => {
-  test("maps a saved card onto a single stably-keyed entry", () => {
-    expect(paymentMethodCards(ENABLED_WITH_CARD)).toEqual([
-      {
-        id: "primary",
-        brand: "visa",
-        last4: "4242",
-        expMonth: null,
-        expYear: null,
-      },
-    ]);
-  });
-
-  test("reads the expiry the platform sends", () => {
-    expect(paymentMethodCards(WITH_EXPIRY_AND_ADDRESS)).toEqual([
-      {
-        id: "primary",
-        brand: "visa",
-        last4: "4242",
-        expMonth: 4,
-        expYear: 2042,
-      },
-    ]);
-  });
-
-  test("maps no card and a missing config onto an empty list", () => {
-    expect(paymentMethodCards(DISABLED_CONFIG)).toEqual([]);
-    expect(paymentMethodCards(undefined)).toEqual([]);
   });
 });

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -80,8 +80,11 @@ export function PaymentMethodsCard() {
   // The resolution confirmed the card through the QueryClient it captured when
   // it started, which a request-scope change can have discarded since. This
   // card's own client is the one the section renders from.
+  //
+  // A null card means the confirm failed and the poll timed out, so the cache
+  // holds only the poll's deliberate optimistic flip, which a refetch wipes.
   useEffect(() => {
-    if (outcome?.kind !== "saved") {
+    if (outcome?.kind !== "saved" || outcome.card == null) {
       return;
     }
     void queryClient.invalidateQueries({

--- a/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-setup-intent-return.test.tsx
@@ -123,9 +123,13 @@ function pending(): boolean {
   return useSetupIntentReturnStore.getState().pending;
 }
 
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /** Long enough for an ungated resolution to have run its Stripe read. */
 async function flushResolution(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 30));
+  await wait(30);
 }
 
 async function waitForOutcome(): Promise<void> {
@@ -287,6 +291,31 @@ describe("useSetupIntentReturn", () => {
       kind: "saved",
       card: { brand: "visa", last4: "4242", autoReloadEnabled: false },
     });
+  });
+
+  test("gives the platform-session wait its own ceiling", async () => {
+    // Under one shared budget a slow org header starves the probe, and the wait
+    // gives up and confirms through the client that is about to be discarded.
+    orgReadiness = "resolving";
+    useAuthStore.setState({ platformSession: "unknown" });
+
+    renderAt(RETURN_SEARCH);
+
+    // Spend most of the header's 200ms ceiling before it answers.
+    await wait(150);
+    orgReadiness = "ready";
+
+    // Past where a single shared budget would already have expired.
+    await wait(150);
+    expect(syncCalls).toEqual([]);
+    expect(pending()).toBe(true);
+
+    act(() => {
+      useAuthStore.setState({ platformSession: "present" });
+    });
+    await waitForOutcome();
+
+    expect(syncCalls).toEqual([{ setupIntentId: "seti_1" }]);
   });
 
   test("stops waiting on a platform session that never settles", async () => {

--- a/clients/web/src/domains/settings/utils/payment-method-brand.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-brand.ts
@@ -26,19 +26,6 @@ export function brandDisplayLabel(
   return brand ? brandLabel(brand) : t("paymentMethodRow.savedCard");
 }
 
-/** Titles the success panel, and the screen-reader title above it. */
-export function savedPanelTitle(
-  t: TFunction<"settings">,
-  card: { brand: string | null; last4: string | null } | null,
-): string {
-  return card?.brand && card.last4
-    ? t("autoTopUpPaymentMethodModal.savedTitle", {
-        brand: brandLabel(card.brand),
-        last4: card.last4,
-      })
-    : t("autoTopUpPaymentMethodModal.savedTitleGeneric");
-}
-
 /** Carries its own leading separator, so callers render it as-is. */
 export function cardExpiryLabel(
   t: TFunction<"settings">,

--- a/clients/web/src/domains/settings/utils/payment-method-cards.test.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-cards.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The backend stores at most one payment method and has no list endpoint, so
+ * the multi-card shape `PaymentMethodsCard` renders is only reachable through
+ * this pure helper.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+
+import { paymentMethodCards } from "./payment-method-cards";
+
+// Local rather than the `DISABLED_CONFIG` the card tests share: that one lives
+// in a component module, which pulls Stripe.js into this otherwise pure test.
+const NO_CARD: AutoTopUpConfigResponse = {
+  enabled: false,
+  threshold_usd: null,
+  amount_usd: null,
+  monthly_cap_usd: null,
+  has_payment_method: false,
+  payment_method_brand: null,
+  payment_method_last4: null,
+  payment_method_exp_month: null,
+  payment_method_exp_year: null,
+  billing_address: null,
+  stripe_payment_method_updated_at: null,
+  last_charge_at: null,
+  last_failure_at: null,
+  last_failure_reason: null,
+  paused_until: null,
+  current_month_credits_purchased_usd: "0.00",
+  current_month_charged_usd: "0.00",
+  next_trigger_amount_usd: null,
+  disabled_due_to_repeated_failures: false,
+  stubbed: false,
+};
+
+const WITH_CARD: AutoTopUpConfigResponse = {
+  ...NO_CARD,
+  has_payment_method: true,
+  payment_method_brand: "visa",
+  payment_method_last4: "4242",
+};
+
+const WITH_EXPIRY: AutoTopUpConfigResponse = {
+  ...WITH_CARD,
+  payment_method_exp_month: 4,
+  payment_method_exp_year: 2042,
+};
+
+describe("paymentMethodCards", () => {
+  test("maps a saved card onto a single stably-keyed entry", () => {
+    expect(paymentMethodCards(WITH_CARD)).toEqual([
+      {
+        id: "primary",
+        brand: "visa",
+        last4: "4242",
+        expMonth: null,
+        expYear: null,
+      },
+    ]);
+  });
+
+  test("reads the expiry the platform sends", () => {
+    expect(paymentMethodCards(WITH_EXPIRY)).toEqual([
+      {
+        id: "primary",
+        brand: "visa",
+        last4: "4242",
+        expMonth: 4,
+        expYear: 2042,
+      },
+    ]);
+  });
+
+  test("maps no card and a missing config onto an empty list", () => {
+    expect(paymentMethodCards(NO_CARD)).toEqual([]);
+    expect(paymentMethodCards(undefined)).toEqual([]);
+  });
+});

--- a/clients/web/src/hooks/await-org-header-settled.ts
+++ b/clients/web/src/hooks/await-org-header-settled.ts
@@ -12,15 +12,9 @@ import {
 const ORG_HEADER_POLL_INTERVAL_MS = 100;
 
 /** How {@link awaitOrgHeaderSettled} ended. */
-export type OrgHeaderWaitOutcome =
-  "ready" | "unavailable" | "timeout" | "cancelled";
+type OrgHeaderWaitOutcome = "ready" | "cancelled" | "failed";
 
-export interface AwaitOrgHeaderSettledOptions {
-  /**
-   * Ceiling on `"resolving"`, defaulting to
-   * {@link ORG_HEADER_SETTLE_TIMEOUT_MS}.
-   */
-  timeoutMs?: number;
+interface AwaitOrgHeaderSettledOptions {
   /** Cooperative cancellation, checked before every readiness read. */
   isCancelled?: () => boolean;
   /**
@@ -31,7 +25,8 @@ export interface AwaitOrgHeaderSettledOptions {
   /**
    * An extra condition that must hold before a `"ready"` header resolves the
    * wait, for callers whose readiness is the header source plus something else.
-   * Held to the same ceiling.
+   * Held to its own ceiling, which starts when the header first reads
+   * `"ready"`, so a slow header cannot starve this one.
    */
   alsoReady?: () => boolean;
   /**
@@ -53,18 +48,18 @@ export interface AwaitOrgHeaderSettledOptions {
  * Bounded on purpose. `"resolving"` is transient by construction, but a wait
  * with no ceiling would hold the caller's sequence for the rest of the visit if
  * it ever weren't, and `"unavailable"` never becomes `"ready"` on its own. What
- * a non-`"ready"` outcome means is the caller's call: the background hatch
- * fails retryably, the SetupIntent return fires its request anyway and reports
- * the failure.
+ * a `"failed"` outcome means is the caller's call: the background hatch fails
+ * retryably, the SetupIntent return fires its request anyway and reports the
+ * failure.
  */
 export async function awaitOrgHeaderSettled({
-  timeoutMs = ORG_HEADER_SETTLE_TIMEOUT_MS,
   isCancelled,
   registerTimer,
   alsoReady,
   onWaiting,
 }: AwaitOrgHeaderSettledOptions = {}): Promise<OrgHeaderWaitOutcome> {
-  const startedAt = Date.now();
+  let phaseStartedAt = Date.now();
+  let headerSettled = false;
   // Parks the pending handle so a caller can clear it, and once cancelled
   // resolves without scheduling anything, so the loop reaches its next check
   // with no timer left behind.
@@ -89,12 +84,18 @@ export async function awaitOrgHeaderSettled({
     if (readiness === "ready" && (alsoReady?.() ?? true)) {
       return "ready";
     }
+    // The header and `alsoReady` are sequential waits on unrelated sources, so
+    // each gets the full ceiling rather than sharing one budget.
+    if (!headerSettled && readiness === "ready") {
+      headerSettled = true;
+      phaseStartedAt = Date.now();
+    }
     if (onWaiting?.(readiness) !== true) {
       if (readiness === "unavailable") {
-        return "unavailable";
+        return "failed";
       }
-      if (Date.now() - startedAt >= timeoutMs) {
-        return "timeout";
+      if (Date.now() - phaseStartedAt >= ORG_HEADER_SETTLE_TIMEOUT_MS) {
+        return "failed";
       }
     }
     await sleep();

--- a/packages/design-library/src/tokens.css
+++ b/packages/design-library/src/tokens.css
@@ -230,8 +230,10 @@
  * The Stripe Elements appearance reads `--radius-lg` off
  * `getComputedStyle(document.documentElement)` at runtime
  * (`clients/web/src/domains/settings/billing/stripe-appearance.ts`) so the
- * card fields match the app's corners. Under a plain `@theme` block that only
- * resolves while some utility happens to reference the variable.
+ * card fields match the app's corners. Today that read resolves only because
+ * the widget-token bridge (`clients/web/src/utils/widget-tokens.ts`) names
+ * every step, which keeps them emitted; `static` makes the values reach
+ * `:root` on their own rather than depending on that second consumer.
  * --------------------------------------------------------------------------- */
 @theme static inline {
   --radius-xs: 2px;


### PR DESCRIPTION
## Summary
Fixes gaps identified during round-3 plan review for payment-modal-v4.md.

- **Skip the saved-outcome invalidation when the card is null.** A `{ kind: "saved", card: null }` outcome means the confirm failed and the 20s poll timed out, so the cache holds only the poll's deliberate optimistic `has_payment_method: true` flip. Invalidating there wiped it while the modal still read "Card saved".
- **Give the platform-session phase its own timeout budget.** `awaitOrgHeaderSettled` applied one ceiling across the org-header wait and the caller's `alsoReady` wait, so a slow header starved the session probe. The budget now restarts the first time the header reads ready. Dropped the unused `timeoutMs` option, collapsed the outcome union to `"ready" | "cancelled" | "failed"`, and un-exported the option/outcome types.
- **Restore the empty-string guard in `stripe-appearance.ts`.** `isResolved` is back to `value !== undefined && value !== ""`, matching `keepResolved`'s docstring: `appearanceFromTokens` takes a `Partial`, where an empty accent builds the trailing-space `"0 0 0 3px "`.
- **Reword the `tokens.css` radius comment** to say that the variables already reach `:root` because the widget-token bridge names them, so `static` hardens the Stripe runtime read against that coincidence.
- **Move `savedPanelTitle` back into `payment-method-modal-shell.tsx`** as a private function (its only consumer); `brandDisplayLabel` stays shared.
- **Move the `paymentMethodCards` unit tests** beside the module in `utils/payment-method-cards.test.ts`.

## Test plan
`bun test` on payment-methods-card, payment-method-cards, use-setup-intent-return, use-background-hatch (30 unchanged), stripe-appearance, payment-method-modal-shell, auto-top-up-payment-method-modal: all green. `bun run typecheck` clean apart from the pre-existing ipc-contract environment error; `bun run lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XB7ckoybGsZZWurNBj6cx3