### PR TITLE
fix(web): take the mobile voice sheet full-bleed in camera mode

### DIFF
--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -15,15 +15,20 @@ scrim.
 
 ## iPhone
 
-- [ ] The pill clears the notch. Open the camera in the fullscreen room on a
-      notched device and on a Dynamic Island device. The pill sits below the
-      island, on the minimize control's line, and never behind it.
+- [ ] The pill clears the notch. Open the camera in the fullscreen room and in
+      the mobile sheet, on a notched device and on a Dynamic Island device. The
+      pill sits below the island, on the minimize control's line, and never
+      behind it.
 - [ ] The pill clears the corner control. Give the assistant a name of 40
       characters or more and open the camera at portrait phone width. The name
       truncates to an ellipsis, the dot and "Photo" stay whole, and the pill's
       edge never reaches the minimize control.
 - [ ] The pill clears the grabber. In the mobile sheet, the pill sits below the
       grabber and the grabber still takes the pull-down.
+- [ ] The sheet goes full-bleed for the camera. Open the camera in the mobile
+      sheet: the feed reaches the top of the screen, the rounded top corners are
+      gone, and the grabber sits below the notch. Close it and the sheet drops
+      back to the header's line with its corners back.
 - [ ] Flash fires on the rear camera. Cycle off, auto, on, and take a photo in a
       dark room on each. `on` fires every time, `auto` fires when it is dark,
       `off` never fires.

--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -28,7 +28,9 @@ scrim.
 - [ ] The sheet goes full-bleed for the camera. Open the camera in the mobile
       sheet: the feed reaches the top of the screen, the rounded top corners are
       gone, and the grabber sits below the notch. Close it and the sheet drops
-      back to the header's line with its corners back.
+      back to the header's line with its corners back. With VoiceOver on,
+      swiping past the sheet while the camera is up never lands on the thread
+      header behind it.
 - [ ] Flash fires on the rear camera. Cycle off, auto, on, and take a photo in a
       dark room on each. `on` fires every time, `auto` fires when it is dark,
       `off` never fires.

--- a/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.test.ts
@@ -15,8 +15,9 @@ import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { OVERLAY_HOST_ID, useInertBehindSheet } from "./use-inert-behind-sheet";
 
 /**
- * Stand in for `root-layout.tsx`'s app shell: the sheet's portal host and the
- * chrome around it, one of which is already inert for reasons of its own.
+ * Stand in for `root-layout.tsx`'s app shell: the portal host with the sheet's
+ * own portal node and another overlay parked in it, and the chrome around the
+ * host, one piece of which is already inert for reasons of its own.
  */
 function mountShell() {
   const shell = document.createElement("div");
@@ -25,9 +26,22 @@ function mountShell() {
   const header = document.createElement("div");
   const host = document.createElement("div");
   host.id = OVERLAY_HOST_ID;
+  const sheetPortal = document.createElement("div");
+  const sheet = document.createElement("div");
+  sheetPortal.append(sheet);
+  const parkedOverlay = document.createElement("div");
+  host.append(parkedOverlay, sheetPortal);
   shell.append(banner, header, host);
   document.body.append(shell);
-  return { shell, banner, header, host };
+  return { shell, banner, header, host, sheetPortal, sheet, parkedOverlay };
+}
+
+function renderGate(active: boolean, sheet: HTMLElement | null) {
+  const sheetRef = { current: sheet };
+  return renderHook(
+    ({ active: isActive }) => useInertBehindSheet(isActive, sheetRef),
+    { initialProps: { active } },
+  );
 }
 
 afterEach(() => {
@@ -36,29 +50,30 @@ afterEach(() => {
 });
 
 describe("useInertBehindSheet", () => {
-  test("takes the host's siblings out of reach while the sheet covers them", () => {
+  test("takes everything around the sheet out of reach while it covers them", () => {
     const shell = mountShell();
 
-    renderHook(({ active }) => useInertBehindSheet(active), {
-      initialProps: { active: true },
-    });
+    renderGate(true, shell.sheet);
 
     expect(shell.header.hasAttribute("inert")).toBe(true);
-    // The sheet lives in the host, so inerting it would take the room down
-    // with the chrome behind it.
+    // The other overlays share the host and sit beside the sheet's portal
+    // node, covered just the same.
+    expect(shell.parkedOverlay.hasAttribute("inert")).toBe(true);
+    // Neither the host nor the sheet's own node: either would take the room
+    // down with the chrome behind it.
     expect(shell.host.hasAttribute("inert")).toBe(false);
+    expect(shell.sheetPortal.hasAttribute("inert")).toBe(false);
+    expect(shell.sheet.hasAttribute("inert")).toBe(false);
   });
 
   test("hands back only what it took", () => {
     const shell = mountShell();
 
-    const { rerender } = renderHook(
-      ({ active }) => useInertBehindSheet(active),
-      { initialProps: { active: true } },
-    );
+    const { rerender } = renderGate(true, shell.sheet);
     rerender({ active: false });
 
     expect(shell.header.hasAttribute("inert")).toBe(false);
+    expect(shell.parkedOverlay.hasAttribute("inert")).toBe(false);
     // Inert before the camera opened, so inert after it closes.
     expect(shell.banner.hasAttribute("inert")).toBe(true);
   });
@@ -66,21 +81,17 @@ describe("useInertBehindSheet", () => {
   test("marks nothing while the sheet rests below the header", () => {
     const shell = mountShell();
 
-    renderHook(({ active }) => useInertBehindSheet(active), {
-      initialProps: { active: false },
-    });
+    renderGate(false, shell.sheet);
 
     expect(shell.header.hasAttribute("inert")).toBe(false);
+    expect(shell.parkedOverlay.hasAttribute("inert")).toBe(false);
   });
 
-  test("covers a sibling that mounts while the sheet is flush", async () => {
+  test("covers what mounts beside the host while the sheet is flush", async () => {
     // The status banner is the concrete case: it renders nothing until
     // assistant state changes, then lands beside the host mid-camera.
     const shell = mountShell();
-    const { rerender } = renderHook(
-      ({ active }) => useInertBehindSheet(active),
-      { initialProps: { active: true } },
-    );
+    const { rerender } = renderGate(true, shell.sheet);
 
     const banner = document.createElement("div");
     shell.shell.append(banner);
@@ -92,19 +103,31 @@ describe("useInertBehindSheet", () => {
     expect(banner.hasAttribute("inert")).toBe(false);
   });
 
-  test("leaves the sheet's own churn inside the host alone", async () => {
+  test("covers an overlay that mounts inside the host while the sheet is flush", async () => {
     const shell = mountShell();
-    renderHook(({ active }) => useInertBehindSheet(active), {
-      initialProps: { active: true },
+    const { rerender } = renderGate(true, shell.sheet);
+
+    const overlay = document.createElement("div");
+    shell.host.append(overlay);
+    await waitFor(() => {
+      expect(overlay.hasAttribute("inert")).toBe(true);
     });
 
+    rerender({ active: false });
+    expect(overlay.hasAttribute("inert")).toBe(false);
+  });
+
+  test("leaves the sheet's own churn alone", async () => {
+    const shell = mountShell();
+    renderGate(true, shell.sheet);
+
     const sheetChild = document.createElement("div");
-    shell.host.append(sheetChild);
-    // Give the observer a turn to report, so a wrong subtree watch would show.
+    shell.sheet.append(sheetChild);
+    // Give the observer a turn to report, so a subtree watch would show.
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(sheetChild.hasAttribute("inert")).toBe(false);
-    expect(shell.host.hasAttribute("inert")).toBe(false);
+    expect(shell.sheet.hasAttribute("inert")).toBe(false);
   });
 
   test("is a no-op with no portal host in the document", () => {
@@ -112,10 +135,10 @@ describe("useInertBehindSheet", () => {
     // falls back to the body there, so there is no shell to hold back.
     const stray = document.createElement("div");
     document.body.append(stray);
+    const sheet = document.createElement("div");
+    stray.append(sheet);
 
-    renderHook(({ active }) => useInertBehindSheet(active), {
-      initialProps: { active: true },
-    });
+    renderGate(true, sheet);
 
     expect(stray.hasAttribute("inert")).toBe(false);
   });

--- a/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for {@link useInertBehindSheet}.
+ *
+ * The gate is what keeps the flush camera sheet honest: the sheet is
+ * non-modal, so nothing but this stops VoiceOver and the tab key from walking
+ * into a thread header buried under a full-screen viewfinder. The restore is
+ * the other half. Closing the camera has to hand back exactly what the gate
+ * took, and nothing it found already inert.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { OVERLAY_HOST_ID, useInertBehindSheet } from "./use-inert-behind-sheet";
+
+/**
+ * Stand in for `root-layout.tsx`'s app shell: the sheet's portal host and the
+ * chrome around it, one of which is already inert for reasons of its own.
+ */
+function mountShell() {
+  const shell = document.createElement("div");
+  const banner = document.createElement("div");
+  banner.setAttribute("inert", "");
+  const header = document.createElement("div");
+  const host = document.createElement("div");
+  host.id = OVERLAY_HOST_ID;
+  shell.append(banner, header, host);
+  document.body.append(shell);
+  return { banner, header, host };
+}
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+});
+
+describe("useInertBehindSheet", () => {
+  test("takes the host's siblings out of reach while the sheet covers them", () => {
+    const shell = mountShell();
+
+    renderHook(({ active }) => useInertBehindSheet(active), {
+      initialProps: { active: true },
+    });
+
+    expect(shell.header.hasAttribute("inert")).toBe(true);
+    // The sheet lives in the host, so inerting it would take the room down
+    // with the chrome behind it.
+    expect(shell.host.hasAttribute("inert")).toBe(false);
+  });
+
+  test("hands back only what it took", () => {
+    const shell = mountShell();
+
+    const { rerender } = renderHook(
+      ({ active }) => useInertBehindSheet(active),
+      { initialProps: { active: true } },
+    );
+    rerender({ active: false });
+
+    expect(shell.header.hasAttribute("inert")).toBe(false);
+    // Inert before the camera opened, so inert after it closes.
+    expect(shell.banner.hasAttribute("inert")).toBe(true);
+  });
+
+  test("marks nothing while the sheet rests below the header", () => {
+    const shell = mountShell();
+
+    renderHook(({ active }) => useInertBehindSheet(active), {
+      initialProps: { active: false },
+    });
+
+    expect(shell.header.hasAttribute("inert")).toBe(false);
+  });
+
+  test("is a no-op with no portal host in the document", () => {
+    // Pop-out windows and the very first commit render no host. The sheet
+    // falls back to the body there, so there is no shell to hold back.
+    const stray = document.createElement("div");
+    document.body.append(stray);
+
+    renderHook(({ active }) => useInertBehindSheet(active), {
+      initialProps: { active: true },
+    });
+
+    expect(stray.hasAttribute("inert")).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.test.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.test.ts
@@ -10,7 +10,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { cleanup, renderHook } from "@testing-library/react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import { OVERLAY_HOST_ID, useInertBehindSheet } from "./use-inert-behind-sheet";
 
@@ -27,7 +27,7 @@ function mountShell() {
   host.id = OVERLAY_HOST_ID;
   shell.append(banner, header, host);
   document.body.append(shell);
-  return { banner, header, host };
+  return { shell, banner, header, host };
 }
 
 afterEach(() => {
@@ -71,6 +71,40 @@ describe("useInertBehindSheet", () => {
     });
 
     expect(shell.header.hasAttribute("inert")).toBe(false);
+  });
+
+  test("covers a sibling that mounts while the sheet is flush", async () => {
+    // The status banner is the concrete case: it renders nothing until
+    // assistant state changes, then lands beside the host mid-camera.
+    const shell = mountShell();
+    const { rerender } = renderHook(
+      ({ active }) => useInertBehindSheet(active),
+      { initialProps: { active: true } },
+    );
+
+    const banner = document.createElement("div");
+    shell.shell.append(banner);
+    await waitFor(() => {
+      expect(banner.hasAttribute("inert")).toBe(true);
+    });
+
+    rerender({ active: false });
+    expect(banner.hasAttribute("inert")).toBe(false);
+  });
+
+  test("leaves the sheet's own churn inside the host alone", async () => {
+    const shell = mountShell();
+    renderHook(({ active }) => useInertBehindSheet(active), {
+      initialProps: { active: true },
+    });
+
+    const sheetChild = document.createElement("div");
+    shell.host.append(sheetChild);
+    // Give the observer a turn to report, so a wrong subtree watch would show.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(sheetChild.hasAttribute("inert")).toBe(false);
+    expect(shell.host.hasAttribute("inert")).toBe(false);
   });
 
   test("is a no-op with no portal host in the document", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.ts
@@ -1,0 +1,52 @@
+/**
+ * Hold the app shell inert while the voice sheet covers it.
+ *
+ * The mobile sheet is non-modal on purpose: resting below the thread header
+ * only means anything if that header stays lit and usable (see
+ * `VoiceRoomSheet`). Flush to the top of the screen for the camera, it covers
+ * the header and the status banner instead, and leaving them tabbable and
+ * speakable behind an opaque viewfinder is the reach the non-modal sheet was
+ * never meant to leave open.
+ *
+ * Radix cannot answer that by going modal for the camera: it renders a
+ * different content component per `modal`, so flipping the prop mid-session
+ * remounts the sheet, replays the slide-up and tears down the live preview.
+ * The attribute does the same job without touching the tree: `inert` takes a
+ * subtree out of the tab order and the accessibility tree at once.
+ *
+ * The sheet portals into `#viewport-overlays` inside the app shell, so
+ * everything it covers is an element sibling of that host. The route content
+ * under `<main>` already goes inert with the room (`chat-layout.tsx`); this is
+ * the header's and the banner's share, held for exactly as long as the sheet
+ * is flush. A sibling that arrived inert stays inert, since that attribute is
+ * someone else's to remove.
+ */
+
+import { useEffect } from "react";
+
+/** `RootLayout`'s portal container, inside the app shell's isolation. */
+export const OVERLAY_HOST_ID = "viewport-overlays";
+
+export function useInertBehindSheet(active: boolean): void {
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const host = document.getElementById(OVERLAY_HOST_ID);
+    const shell = host?.parentElement;
+    if (!host || !shell) {
+      return;
+    }
+    const covered = Array.from(shell.children).filter(
+      (element) => element !== host && !element.hasAttribute("inert"),
+    );
+    for (const element of covered) {
+      element.setAttribute("inert", "");
+    }
+    return () => {
+      for (const element of covered) {
+        element.removeAttribute("inert");
+      }
+    };
+  }, [active]);
+}

--- a/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.ts
@@ -14,42 +14,57 @@
  * The attribute does the same job without touching the tree: `inert` takes a
  * subtree out of the tab order and the accessibility tree at once.
  *
- * The sheet portals into `#viewport-overlays` inside the app shell, so
- * everything it covers is an element sibling of that host. The route content
- * under `<main>` already goes inert with the room (`chat-layout.tsx`); this is
- * the header's and the banner's share, held for exactly as long as the sheet
- * is flush. A sibling that arrived inert stays inert, since that attribute is
- * someone else's to remove. The shell's children change under an open camera
- * (the status banner mounts beside the host when assistant state changes), so
- * the gate watches the shell's child list and covers late arrivals too.
+ * The sheet portals into `#viewport-overlays` inside the app shell, a host it
+ * shares with the other mobile overlays. So the covered set is every element
+ * sibling of that host, plus every child of the host that is not the sheet's
+ * own portal node. The route content under `<main>` already goes inert with
+ * the room (`chat-layout.tsx`); this is the rest's share, held for exactly as
+ * long as the sheet is flush. A node that arrived inert stays inert, since
+ * that attribute is someone else's to remove. Both lists change under an open
+ * camera (the status banner mounts beside the host when assistant state
+ * changes; another overlay can mount inside it), so the gate watches both
+ * child lists and covers late arrivals too.
  */
 
-import { useEffect } from "react";
+import { type RefObject, useEffect } from "react";
 
 /** `RootLayout`'s portal container, inside the app shell's isolation. */
 export const OVERLAY_HOST_ID = "viewport-overlays";
 
-export function useInertBehindSheet(active: boolean): void {
+export function useInertBehindSheet(
+  active: boolean,
+  /** The sheet's dialog element, so its own portal node is left alone. */
+  sheetRef: RefObject<HTMLElement | null>,
+): void {
   useEffect(() => {
     if (!active) {
       return;
     }
     const host = document.getElementById(OVERLAY_HOST_ID);
     const shell = host?.parentElement;
-    if (!host || !shell) {
+    const sheet = sheetRef.current;
+    if (!host || !shell || !sheet) {
       return;
     }
     const covered = new Set<Element>();
     const cover = (element: Element) => {
-      if (element !== host && !element.hasAttribute("inert")) {
-        element.setAttribute("inert", "");
-        covered.add(element);
+      if (
+        element === host ||
+        element.contains(sheet) ||
+        element.hasAttribute("inert")
+      ) {
+        return;
       }
+      element.setAttribute("inert", "");
+      covered.add(element);
     };
     for (const element of Array.from(shell.children)) {
       cover(element);
     }
-    // Direct children only: the sheet's own churn inside the host never lands
+    for (const element of Array.from(host.children)) {
+      cover(element);
+    }
+    // Direct children of each list only: churn inside the sheet never lands
     // here.
     const observer = new MutationObserver((records) => {
       for (const record of records) {
@@ -61,11 +76,12 @@ export function useInertBehindSheet(active: boolean): void {
       }
     });
     observer.observe(shell, { childList: true });
+    observer.observe(host, { childList: true });
     return () => {
       observer.disconnect();
       for (const element of covered) {
         element.removeAttribute("inert");
       }
     };
-  }, [active]);
+  }, [active, sheetRef]);
 }

--- a/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-inert-behind-sheet.ts
@@ -19,7 +19,9 @@
  * under `<main>` already goes inert with the room (`chat-layout.tsx`); this is
  * the header's and the banner's share, held for exactly as long as the sheet
  * is flush. A sibling that arrived inert stays inert, since that attribute is
- * someone else's to remove.
+ * someone else's to remove. The shell's children change under an open camera
+ * (the status banner mounts beside the host when assistant state changes), so
+ * the gate watches the shell's child list and covers late arrivals too.
  */
 
 import { useEffect } from "react";
@@ -37,13 +39,30 @@ export function useInertBehindSheet(active: boolean): void {
     if (!host || !shell) {
       return;
     }
-    const covered = Array.from(shell.children).filter(
-      (element) => element !== host && !element.hasAttribute("inert"),
-    );
-    for (const element of covered) {
-      element.setAttribute("inert", "");
+    const covered = new Set<Element>();
+    const cover = (element: Element) => {
+      if (element !== host && !element.hasAttribute("inert")) {
+        element.setAttribute("inert", "");
+        covered.add(element);
+      }
+    };
+    for (const element of Array.from(shell.children)) {
+      cover(element);
     }
+    // Direct children only: the sheet's own churn inside the host never lands
+    // here.
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of Array.from(record.addedNodes)) {
+          if (node instanceof Element) {
+            cover(node);
+          }
+        }
+      }
+    });
+    observer.observe(shell, { childList: true });
     return () => {
+      observer.disconnect();
       for (const element of covered) {
         element.removeAttribute("inert");
       }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -689,6 +689,9 @@ describe("VoiceRoom: mobile sheet", () => {
     // them float a third of the way down over a feed that already covers the
     // rest. Closing the camera puts the sheet back below the header.
     const overlays = mountOverlayHost();
+    // Another mobile overlay parked in the shared host, beside the sheet.
+    const parkedOverlay = document.createElement("div");
+    overlays.host.append(parkedOverlay);
     const removeHeader = mountHeader({ top: 47, height: 96 });
     const header = document.querySelector('[data-slot="chat-layout-header"]')!;
     stubMediaDevices(async () => fakeStream());
@@ -703,6 +706,7 @@ describe("VoiceRoom: mobile sheet", () => {
       // Resting below it, the sheet leaves the header usable, which is what
       // being non-modal buys.
       expect(header.hasAttribute("inert")).toBe(false);
+      expect(parkedOverlay.hasAttribute("inert")).toBe(false);
 
       await act(async () => {
         fireEvent.click(cameraToggle()!);
@@ -712,8 +716,11 @@ describe("VoiceRoom: mobile sheet", () => {
       expect(sheet.className).toContain("rounded-t-none");
       expect(roomBox().className).toContain("rounded-t-none");
       // Covered by the feed, so out of the tab order and out of VoiceOver's
-      // way rather than lit and reachable behind it.
+      // way rather than lit and reachable behind it. The sheet itself stays
+      // reachable, which is the whole point.
       expect(header.hasAttribute("inert")).toBe(true);
+      expect(parkedOverlay.hasAttribute("inert")).toBe(true);
+      expect(sheet.closest("[inert]")).toBeNull();
 
       // The pull-down survives the mode switch, and the band it shares with the
       // camera pill clears the notch the sheet now reaches.
@@ -736,6 +743,7 @@ describe("VoiceRoom: mobile sheet", () => {
       expect(sheet.style.getPropertyValue("--voice-sheet-top")).toBe("143px");
       expect(sheet.className).not.toContain("rounded-t-none");
       expect(header.hasAttribute("inert")).toBe(false);
+      expect(parkedOverlay.hasAttribute("inert")).toBe(false);
       // Back below the header, where nothing above the sheet is the notch.
       expect(roomBox().getAttribute("style")).toContain(
         "--room-grabber-top: 0.5rem",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -721,6 +721,12 @@ describe("VoiceRoom: mobile sheet", () => {
       expect(header.hasAttribute("inert")).toBe(true);
       expect(parkedOverlay.hasAttribute("inert")).toBe(true);
       expect(sheet.closest("[inert]")).toBeNull();
+      // A takeover now: above the tier the host's other overlays share, so
+      // one mounting mid-camera cannot paint over the viewfinder, and still
+      // under the palette.
+      expect(sheet.className).toContain("z-40");
+      expect(sheet.className).not.toContain("z-30");
+      expect(sheet.className).not.toContain("z-50");
 
       // The pull-down survives the mode switch, and the band it shares with the
       // camera pill clears the notch the sheet now reaches.
@@ -742,6 +748,8 @@ describe("VoiceRoom: mobile sheet", () => {
 
       expect(sheet.style.getPropertyValue("--voice-sheet-top")).toBe("143px");
       expect(sheet.className).not.toContain("rounded-t-none");
+      expect(sheet.className).toContain("z-30");
+      expect(sheet.className).not.toContain("z-40");
       expect(header.hasAttribute("inert")).toBe(false);
       expect(parkedOverlay.hasAttribute("inert")).toBe(false);
       // Back below the header, where nothing above the sheet is the notch.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -443,6 +443,15 @@ const minimizeButton = () =>
 /** The row's mic, named for the act it offers, so this is the LIVE one. */
 const micButton = () =>
   screen.queryByRole("button", { name: "Mute microphone" });
+/** The row's camera: opens and closes the viewfinder. */
+const cameraToggle = () => screen.queryByTestId("voice-room-camera-toggle");
+
+/** An assistant new enough to accept `attach_image`. */
+function seedCameraCapableAssistant() {
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("test-asst", CAMERA_MIN_VERSION, ASSISTANT_ID);
+}
 
 describe("VoiceRoom — visibility", () => {
   test("renders nothing when no session is active", () => {
@@ -664,6 +673,62 @@ describe("VoiceRoom: mobile sheet", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(screen.queryByTestId("voice-room-grabber")).toBeNull();
+  });
+
+  test("with the viewfinder open the sheet reaches the top edge", async () => {
+    // The camera fills the screen, so the sheet framing it leaves the header's
+    // line: parked there, its corners, its grabber and the chrome line under
+    // them float a third of the way down over a feed that already covers the
+    // rest. Closing the camera puts the sheet back below the header.
+    const removeHeader = mountHeader({ top: 47, height: 96 });
+    stubMediaDevices(async () => fakeStream());
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    try {
+      render(<VoiceRoom variant="sheet" />);
+
+      const sheet = screen.getByRole("dialog", { name: "Voice session" });
+      expect(sheet.style.getPropertyValue("--voice-sheet-top")).toBe("143px");
+
+      await act(async () => {
+        fireEvent.click(cameraToggle()!);
+      });
+
+      expect(sheet.style.getPropertyValue("--voice-sheet-top")).toBe("0px");
+      expect(sheet.className).toContain("rounded-t-none");
+      expect(roomBox().className).toContain("rounded-t-none");
+
+      // The pull-down survives the mode switch, and the band it shares with the
+      // camera pill clears the notch the sheet now reaches.
+      const grabber = screen.getByTestId("voice-room-grabber");
+      expect(grabber.className).toContain("top-[var(--room-grabber-top)]");
+      expect(screen.getByTestId("camera-status-pill-slot").className).toContain(
+        "top-[var(--room-chrome-top)]",
+      );
+      expect(roomBox().getAttribute("style")).toContain(
+        "--room-grabber-top: calc(0.5rem + var(--safe-area-inset-top",
+      );
+      expect(roomBox().getAttribute("style")).toContain(
+        "--room-chrome-top: calc(1.25rem + var(--safe-area-inset-top",
+      );
+
+      await act(async () => {
+        fireEvent.click(cameraToggle()!);
+      });
+
+      expect(sheet.style.getPropertyValue("--voice-sheet-top")).toBe("143px");
+      expect(sheet.className).not.toContain("rounded-t-none");
+      // Back below the header, where nothing above the sheet is the notch.
+      expect(roomBox().getAttribute("style")).toContain(
+        "--room-grabber-top: 0.5rem",
+      );
+      expect(roomBox().getAttribute("style")).toContain(
+        "--room-chrome-top: 1.25rem",
+      );
+    } finally {
+      restoreMediaDevices();
+      removeHeader();
+    }
   });
 
   test("with no header present the sheet rests at the top edge", () => {
@@ -1542,14 +1607,6 @@ describe("VoiceRoom: camera", () => {
     };
   }
 
-  /** An assistant new enough to accept `attach_image`. */
-  function seedCameraCapableAssistant() {
-    useAssistantIdentityStore
-      .getState()
-      .setIdentity("test-asst", CAMERA_MIN_VERSION, ASSISTANT_ID);
-  }
-
-  const cameraToggle = () => screen.queryByTestId("voice-room-camera-toggle");
   const viewfinder = () => screen.queryByTestId("voice-room-viewfinder");
 
   afterEach(() => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -576,6 +576,14 @@ describe("VoiceRoom: mobile sheet", () => {
     return () => header.remove();
   }
 
+  /** Stand in for `root-layout.tsx`'s portal container. */
+  function mountOverlayHost() {
+    const host = document.createElement("div");
+    host.id = "viewport-overlays";
+    document.body.appendChild(host);
+    return { host, remove: () => host.remove() };
+  }
+
   /** The room's own box, held by the sheet's content wrapper as its child. */
   function roomBox(): HTMLElement {
     const inner = document.querySelector(
@@ -680,7 +688,9 @@ describe("VoiceRoom: mobile sheet", () => {
     // line: parked there, its corners, its grabber and the chrome line under
     // them float a third of the way down over a feed that already covers the
     // rest. Closing the camera puts the sheet back below the header.
+    const overlays = mountOverlayHost();
     const removeHeader = mountHeader({ top: 47, height: 96 });
+    const header = document.querySelector('[data-slot="chat-layout-header"]')!;
     stubMediaDevices(async () => fakeStream());
     seedCameraCapableAssistant();
     startOwnedSession("listening");
@@ -689,6 +699,10 @@ describe("VoiceRoom: mobile sheet", () => {
 
       const sheet = screen.getByRole("dialog", { name: "Voice session" });
       expect(sheet.style.getPropertyValue("--voice-sheet-top")).toBe("143px");
+      expect(overlays.host.contains(sheet)).toBe(true);
+      // Resting below it, the sheet leaves the header usable, which is what
+      // being non-modal buys.
+      expect(header.hasAttribute("inert")).toBe(false);
 
       await act(async () => {
         fireEvent.click(cameraToggle()!);
@@ -697,6 +711,9 @@ describe("VoiceRoom: mobile sheet", () => {
       expect(sheet.style.getPropertyValue("--voice-sheet-top")).toBe("0px");
       expect(sheet.className).toContain("rounded-t-none");
       expect(roomBox().className).toContain("rounded-t-none");
+      // Covered by the feed, so out of the tab order and out of VoiceOver's
+      // way rather than lit and reachable behind it.
+      expect(header.hasAttribute("inert")).toBe(true);
 
       // The pull-down survives the mode switch, and the band it shares with the
       // camera pill clears the notch the sheet now reaches.
@@ -718,6 +735,7 @@ describe("VoiceRoom: mobile sheet", () => {
 
       expect(sheet.style.getPropertyValue("--voice-sheet-top")).toBe("143px");
       expect(sheet.className).not.toContain("rounded-t-none");
+      expect(header.hasAttribute("inert")).toBe(false);
       // Back below the header, where nothing above the sheet is the notch.
       expect(roomBox().getAttribute("style")).toContain(
         "--room-grabber-top: 0.5rem",
@@ -728,6 +746,7 @@ describe("VoiceRoom: mobile sheet", () => {
     } finally {
       restoreMediaDevices();
       removeHeader();
+      overlays.remove();
     }
   });
 
@@ -811,14 +830,6 @@ describe("VoiceRoom: mobile sheet", () => {
   // navigation drawer opened invisibly behind the room and search opened behind
   // it. The room belongs inside the shell, under both.
   describe("stacking against the surfaces the header opens", () => {
-    /** Stand in for `root-layout.tsx`'s portal container. */
-    function mountOverlayHost() {
-      const host = document.createElement("div");
-      host.id = "viewport-overlays";
-      document.body.appendChild(host);
-      return { host, remove: () => host.remove() };
-    }
-
     test("portals into the app shell's overlay host, not the body", () => {
       const overlays = mountOverlayHost();
       const removeHeader = mountHeader();

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -260,6 +260,16 @@ export type VoiceRoomVariant = "fullscreen" | "content" | "sheet";
 const SHEET_LAYER = "z-30";
 
 /**
+ * The sheet's tier while it is flush for the camera. A takeover rather than a
+ * surface under the header, so it rises above the tier the other mobile
+ * overlays share with it in the portal host: one of those mounting mid-camera
+ * would otherwise paint over the viewfinder in DOM order, inert and dead. The
+ * drawer's tier, which the flush sheet follows in the DOM, and still under the
+ * palette a hotkey can raise.
+ */
+const SHEET_FLUSH_LAYER = "z-40";
+
+/**
  * Marks a `role="dialog"` element as belonging to the room, so the global
  * Escape handler can tell the room's own dialog apart from one layered over it.
  * Carried by whichever element is the dialog for the variant: the room's box
@@ -438,7 +448,7 @@ function VoiceRoomSheet({
         // the bottom edge.
         className={cn(
           "top-[var(--voice-sheet-top)] max-h-none min-h-0 overflow-hidden border-t-0 bg-transparent p-0",
-          SHEET_LAYER,
+          flushToTop ? SHEET_FLUSH_LAYER : SHEET_LAYER,
           // Corners belong to a sheet that stops below the header. Against the
           // top of the screen they would cut two notches out of the feed.
           flushToTop && "rounded-t-none",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -36,7 +36,9 @@ import { useTranslation } from "@/i18n";
  *   thread header, the mobile counterpart of the inset panel. Radix portals it
  *   out of the layout and positions it `fixed`, so it is told where the header
  *   ends ({@link useChatHeaderBottom}) rather than inheriting that edge from
- *   the DOM. Non-modal, so the header it rests below stays lit and usable,
+ *   the DOM. Opening the camera takes it to the top of the screen instead, with
+ *   square corners: the viewfinder is full-bleed, so the chrome framing it is
+ *   too. Non-modal, so the header it rests below stays lit and usable,
  *   which takes suppressing several of Radix's modal reflexes: see
  *   {@link VoiceRoomSheet}. It portals into `RootLayout`'s `#viewport-overlays`
  *   rather than the body, which is what keeps the surfaces the header opens
@@ -378,11 +380,18 @@ export function VoiceRoom({
  */
 function VoiceRoomSheet({
   headerBottom,
+  flushToTop,
   motionProps,
   children,
 }: {
   /** Where the sheet's top edge rests. See {@link useChatHeaderBottom}. */
   headerBottom: number;
+  /**
+   * Take the sheet to the top of the screen, square-cornered, rather than to
+   * the header's edge. The camera's viewfinder fills the screen, so the sheet
+   * framing it has to reach the same edges.
+   */
+  flushToTop: boolean;
   /** The slide-down exit. See `voice-room-entrance.ts`. */
   motionProps: MotionProps;
   children: ReactNode;
@@ -421,6 +430,9 @@ function VoiceRoomSheet({
         className={cn(
           "top-[var(--voice-sheet-top)] max-h-none min-h-0 overflow-hidden border-t-0 bg-transparent p-0",
           SHEET_LAYER,
+          // Corners belong to a sheet that stops below the header. Against the
+          // top of the screen they would cut two notches out of the feed.
+          flushToTop && "rounded-t-none",
         )}
         // Marks the sheet as the room's own dialog. See {@link ROOM_DIALOG_ATTR}.
         {...{ [ROOM_DIALOG_ATTR]: "" }}
@@ -439,7 +451,11 @@ function VoiceRoomSheet({
             event.currentTarget.focus();
           }
         }}
-        style={{ "--voice-sheet-top": `${headerBottom}px` } as CSSProperties}
+        style={
+          {
+            "--voice-sheet-top": flushToTop ? "0px" : `${headerBottom}px`,
+          } as CSSProperties
+        }
         aria-label={t("voiceRoom.ariaLabel")}
         // The room narrates itself through its own live region; a description
         // element would be a second, redundant announcement.
@@ -669,6 +685,27 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   }, []);
 
   const fullscreen = variant === "fullscreen";
+  // The mobile sheet with the viewfinder up: it leaves the header's line and
+  // goes full-bleed, so the camera is the whole screen rather than a feed
+  // showing past a band of sheet chrome parked a third of the way down it.
+  const cameraSheet = sheet && cameraOpen;
+  // Where the room's top band sits, published on the box and read back through
+  // `top-[var(--room-*)]` the way the tone colors are, so the pill and the
+  // minimize control beside it share one line. Only the fullscreen room and the
+  // flush camera sheet reach the notch: the former clamps its gap up to the
+  // inset, the latter adds the gap to it so the grabber fits between. The panel
+  // and the header-resting sheet start below the app's own chrome, where the
+  // inset is not their edge to clear.
+  const topBandVars = {
+    "--room-chrome-top": fullscreen
+      ? `max(${CORNER_GAP}, ${SAFE_AREA_TOP})`
+      : cameraSheet
+        ? `calc(${CORNER_GAP} + ${SAFE_AREA_TOP})`
+        : CORNER_GAP,
+    "--room-grabber-top": cameraSheet
+      ? `calc(0.5rem + ${SAFE_AREA_TOP})`
+      : "0.5rem",
+  } as CSSProperties;
 
   const body = (
     <motion.div
@@ -687,6 +724,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         // The sheet's own box is the Radix content element, which is already
         // positioned and rounded; the room fills it.
         sheet && "absolute inset-0 rounded-t-[24px]",
+        // Square with the sheet, so the clip follows the chrome to the top of
+        // the screen instead of shaving the feed's corners.
+        cameraSheet && "rounded-t-none",
       )}
       // Theme tokens (the connect label, the ambient transcript) follow the
       // look: dark over the void and the dark avatar colors, light over the
@@ -718,6 +758,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
               paddingRight: SAFE_AREA_RIGHT,
             }
           : null),
+        ...topBandVars,
         ...toneVars,
         ...(accentHex ? { [AVATAR_ACCENT_CSS_VAR]: accentHex } : {}),
       }}
@@ -893,7 +934,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         <div
           aria-hidden
           data-testid="voice-room-grabber"
-          className="pointer-events-none absolute left-1/2 top-2 z-10 h-1 w-9 -translate-x-1/2 rounded-full bg-[var(--room-fg-muted)] opacity-60"
+          className="pointer-events-none absolute left-1/2 top-[var(--room-grabber-top)] z-10 h-1 w-9 -translate-x-1/2 rounded-full bg-[var(--room-fg-muted)] opacity-60"
         />
       ) : null}
 
@@ -910,13 +951,8 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       {cameraOpen ? (
         <div
           data-testid="camera-status-pill-slot"
-          className="pointer-events-none absolute left-1/2 z-10 -translate-x-1/2"
-          style={{
-            top: fullscreen
-              ? `max(${CORNER_GAP}, ${SAFE_AREA_TOP})`
-              : CORNER_GAP,
-            maxWidth: CAMERA_PILL_MAX_WIDTH,
-          }}
+          className="pointer-events-none absolute left-1/2 top-[var(--room-chrome-top)] z-10 -translate-x-1/2"
+          style={{ maxWidth: CAMERA_PILL_MAX_WIDTH }}
         >
           <CameraStatusPill
             voiceState={cameraVoiceState}
@@ -943,19 +979,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           listening language are Settings' now. */}
       <div
         // An equal gap from both edges, so the control reads as sitting in the
-        // corner rather than floating near it.
-        //
-        // Only the fullscreen variant reaches the notch / Dynamic Island and
-        // has to clear it. The panel and the sheet both start below the app's
-        // own chrome, so clamping their top to the notch inset would push the
-        // control a further ~59px down on a notched phone while the right stays
-        // at the base gap: visibly lopsided, and measured against an edge the
-        // room does not have.
-        style={{
-          top: fullscreen ? `max(${CORNER_GAP}, ${SAFE_AREA_TOP})` : CORNER_GAP,
-          right: `max(${CORNER_GAP}, ${SAFE_AREA_RIGHT})`,
-        }}
-        className="absolute z-10 flex items-center gap-1"
+        // corner rather than floating near it. The top comes off the room's own
+        // band, shared with the camera pill; see `--room-chrome-top`.
+        style={{ right: `max(${CORNER_GAP}, ${SAFE_AREA_RIGHT})` }}
+        className="absolute top-[var(--room-chrome-top)] z-10 flex items-center gap-1"
       >
         <VoiceRoomControl
           label={t("voiceRoom.minimizeAria")}
@@ -1347,6 +1374,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   return sheet && choreography.sheetChrome ? (
     <VoiceRoomSheet
       headerBottom={headerBottom}
+      flushToTop={cameraSheet}
       motionProps={choreography.sheetChrome}
     >
       {body}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -167,6 +167,7 @@ import {
 import { useActiveConnectSurface } from "./use-active-connect-surface";
 import { useCameraVoiceState } from "./use-camera-voice-state";
 import { useChatHeaderBottom } from "./use-chat-header-bottom";
+import { OVERLAY_HOST_ID, useInertBehindSheet } from "./use-inert-behind-sheet";
 import { isVoiceCameraSupported } from "./voice-camera";
 import { useVoiceRoomCamera } from "./use-voice-room-camera";
 import { toRoomLocal, useRoomBox } from "./use-room-box";
@@ -275,9 +276,6 @@ const ROOM_DIALOG_ATTR = "data-voice-room";
  */
 const MotionBottomSheetContent = motion.create(BottomSheet.Content);
 
-/** `RootLayout`'s portal container, inside the app shell's isolation. */
-const OVERLAY_HOST_ID = "viewport-overlays";
-
 /**
  * The element the mobile sheet portals into.
  *
@@ -363,6 +361,13 @@ export function VoiceRoom({
  * Escape is therefore left to the room's own handler, shared with the other
  * variants, rather than Radix's, so one keypress is one minimize.
  *
+ * Flush to the top for the camera, it covers that chrome instead of resting
+ * below it, and {@link useInertBehindSheet} takes the covered shell out of the
+ * tab order and the accessibility tree for as long as it does. Not by turning
+ * `modal` on: Radix renders a different content component per `modal`, so
+ * flipping it mid-session would remount the sheet, replay the slide-up and
+ * tear down the live viewfinder.
+ *
  * The exit rides this element rather than the room's box inside it. Radix
  * portals the content out of the layout and positions it `fixed`, so it is the
  * outermost thing the sheet owns; sliding the room's box instead would travel
@@ -397,6 +402,7 @@ function VoiceRoomSheet({
   children: ReactNode;
 }) {
   const { t } = useTranslation("chat");
+  useInertBehindSheet(flushToTop);
   return (
     <BottomSheet.Root open modal={false} onOpenChange={minimizeVoiceRoom}>
       <MotionBottomSheetContent

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -362,8 +362,9 @@ export function VoiceRoom({
  * variants, rather than Radix's, so one keypress is one minimize.
  *
  * Flush to the top for the camera, it covers that chrome instead of resting
- * below it, and {@link useInertBehindSheet} takes the covered shell out of the
- * tab order and the accessibility tree for as long as it does. Not by turning
+ * below it, and {@link useInertBehindSheet} takes the covered shell, the other
+ * overlays sharing its portal host included, out of the tab order and the
+ * accessibility tree for as long as it does. Not by turning
  * `modal` on: Radix renders a different content component per `modal`, so
  * flipping it mid-session would remount the sheet, replay the slide-up and
  * tear down the live viewfinder.
@@ -402,10 +403,12 @@ function VoiceRoomSheet({
   children: ReactNode;
 }) {
   const { t } = useTranslation("chat");
-  useInertBehindSheet(flushToTop);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  useInertBehindSheet(flushToTop, contentRef);
   return (
     <BottomSheet.Root open modal={false} onOpenChange={minimizeVoiceRoom}>
       <MotionBottomSheetContent
+        ref={contentRef}
         {...motionProps}
         drag="y"
         // A voice room is a tall surface with controls near its bottom edge;


### PR DESCRIPTION
Summary:
The mobile voice room is a bottom sheet that rests below the chat header. With the camera viewfinder open, the native preview fills the screen but the sheet stayed parked at the header line, so its rounded top, grabber, top scrim and status-pill band floated a third of the way down over the feed. The sheet now goes full-bleed to the top of the screen while the camera is open, matching the camera-mode handoff (arrangement A), and returns to the header line when it closes.

Changes:
- `VoiceRoomSheet` takes a `flushToTop` flag: with the camera open the sheet's top is `0px` and its top corners are square (`rounded-t-none` on the Radix content and the room box)
- The top band's offsets (grabber, camera status pill, minimize control) are computed once and published on the room box as `--room-chrome-top` / `--room-grabber-top`; the flush camera sheet adds the safe-area inset so the band clears the notch, and the fullscreen, panel and camera-closed sheet values are unchanged
- New sheet test covering the flip on camera open and its reversal on close; the two small camera helpers move to module scope so both describe blocks share them
- `CAMERA_MODE_QA.md`: the notch check covers the mobile sheet, plus a full-bleed open/close item

Testing:
- `bun run test:ci src/domains/chat/voice/voice-room/voice-room.test.tsx` (114 cases), `eslint`, `prettier --check`, `tsc --noEmit` all clean
- Device QA on a notched iPhone still owed (tracked in `CAMERA_MODE_QA.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W18kb8gtQAHo249fszrLJd
