### PR TITLE
fix(web): keep overlay chats scrollable above floating pills

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -1720,6 +1720,78 @@ describe("AssistantSideMenu · equal section treatment", () => {
     }
   });
 
+  test("the overlay drawer lets the body scroll Chats clear of the floating pills", () => {
+    const { container } = render(
+      createElement(SideMenuUnderTest, {
+        assistantId: "asst-1",
+        collapsed: false,
+        variant: "overlay",
+        conversations: LAYOUT_CONVERSATIONS,
+        conversationGroups: LAYOUT_GROUPS,
+        onSelectConversation: () => {},
+        onStartNewConversation: () => {},
+        footerAction: createElement("span", null, "Preferences"),
+      }),
+    );
+    try {
+      const root = container.querySelector<HTMLElement>(
+        '[data-slot="collapsible"]',
+      );
+      expect(root?.classList.contains("flex-1")).toBe(false);
+
+      const sections = sectionElements(container);
+      const labels = sectionLabels(container);
+      const chats = sections[labels.indexOf("Chats")];
+      if (!chats) {
+        throw new Error("expected the Chats section");
+      }
+
+      expect(chats.querySelector(".overflow-y-auto")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("the overlay windows a long Chats list against the drawer body", async () => {
+    localStorage.setItem("vellum:sidebar-view-mode:asst-1", "all");
+    const { container } = render(
+      createElement(SideMenuUnderTest, {
+        assistantId: "asst-1",
+        collapsed: false,
+        variant: "overlay",
+        conversations: Array.from(
+          { length: CONVERSATION_LIST_VIRTUALIZE_THRESHOLD + 1 },
+          (_, index) =>
+            makeConversation({
+              conversationId: `r${index}`,
+              title: `Recent ${index}`,
+            }),
+        ),
+        onSelectConversation: () => {},
+        onStartNewConversation: () => {},
+      }),
+    );
+    try {
+      const chats = sectionElements(container)[
+        sectionLabels(container).indexOf("Chats")
+      ];
+      if (!chats) {
+        throw new Error("expected the Chats section");
+      }
+
+      await waitFor(() => {
+        expect(chats.querySelector('[data-slot="virtual-list"]')).not.toBeNull();
+      });
+      expect(chats.querySelector(".overflow-y-auto")).toBeNull();
+      expect(
+        chats.querySelector('[data-slot="virtual-list"]')?.parentElement
+          ?.style.minHeight,
+      ).toBe("");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("ungrouped, Chats is bottom-most and fills instead of capping", () => {
     // The reported 0.11.3 case: no channel sections, so Chats sits last and
     // holds every conversation the curated sections didn't claim.

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -405,6 +405,7 @@ export function AssistantSideMenu({
 
   const listContext: ConversationListContextValue = {
     overlayCards: variant === "overlay",
+    scrollParent: variant === "overlay" ? (bodyElement ?? undefined) : undefined,
     activeConversationId,
     activeConversationProcessing,
     processingConversationIds,
@@ -485,12 +486,14 @@ export function AssistantSideMenu({
       }
       drag={sectionDragFor(section)}
       collapsedIndicator={collapsedActivityDot}
-      // Only the bottom-most section ever claims the sidebar's leftover
-      // space (see `unbounded` on `ConversationRowList`): flex-grow doesn't
-      // know which open section "needs" the room, so giving every open
-      // section a share stretched a small one (e.g. a two-row group) into a
-      // near-empty box the same size as a busy one beside it.
-      isLast={index === sidebar.sections.length - 1}
+      // The rail's bottom-most section claims leftover space (see
+      // `unbounded` on `ConversationRowList`): flex-grow doesn't know
+      // which open section "needs" the room, so giving every open section
+      // a share stretched a small one (e.g. a two-row group) into a
+      // near-empty box the same size as a busy one beside it. The overlay
+      // skips that fill: its lists scroll with the drawer body so rows
+      // can travel clear of the floating action pills.
+      isLast={variant === "rail" && index === sidebar.sections.length - 1}
     />
   );
 
@@ -649,13 +652,18 @@ export function AssistantSideMenu({
                   action. */}
                 <CollapsibleNavSection.Root
                   type="multiple"
-                  /* min-h-0 flex-1: the root must claim the body's height so
+                  /* On the rail, min-h-0 flex-1 claims the body's height so
                      the bottom-most open card's flex-fill has leftover space
                      to take. Without it every layer below sizes to content,
                      and a windowed row list (which renders only what fits a
                      bounded viewport) resolves to zero height and draws no
-                     rows at all. */
-                  className={cn(SIDEBAR_STACK_GAP, "min-h-0 flex-1")}
+                     rows at all. The overlay sizes to content instead: a
+                     flex-1 root would pin the body to the viewport and trap
+                     Chats under the floating pills. */
+                  className={cn(
+                    SIDEBAR_STACK_GAP,
+                    variant === "rail" && "min-h-0 flex-1",
+                  )}
                   value={sidebar.effectiveOpenSections}
                   onValueChange={sidebar.onOpenSectionsChange}
                 >

--- a/clients/web/src/domains/chat/components/conversation-list-context.tsx
+++ b/clients/web/src/domains/chat/components/conversation-list-context.tsx
@@ -23,6 +23,13 @@ export interface ConversationListContextValue {
    * below the menu that knows which variant is mounted.
    */
   overlayCards?: boolean;
+  /**
+   * The overlay drawer's scrollport. Overlay lists grow with this ancestor
+   * and virtualize against it, so conversation rows can travel into the
+   * padding reserved for the floating Preferences and New Chat pills.
+   * Unset on the rail, where each section owns its own scroller.
+   */
+  scrollParent?: HTMLElement;
   activeConversationId?: string;
   /** Whether the *active* conversation is mid-turn (its row shows a spinner). */
   activeConversationProcessing?: boolean;

--- a/clients/web/src/domains/chat/components/conversation-nav-section.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.test.tsx
@@ -38,12 +38,27 @@ const ROWS: Conversation[] = [
   { conversationId: "c2", title: "Two" },
 ];
 
-function renderList(onEndReached?: () => void) {
+function renderList(
+  onEndReached?: () => void,
+  extras?: {
+    overlayCards?: boolean;
+    isLast?: boolean;
+  },
+) {
   const { container } = render(
     createElement(
       ConversationListProvider,
-      { value: { onSelect: () => {} } },
-      createElement(ConversationRowList, { items: ROWS, onEndReached }),
+      {
+        value: {
+          onSelect: () => {},
+          overlayCards: extras?.overlayCards,
+        },
+      },
+      createElement(ConversationRowList, {
+        items: ROWS,
+        onEndReached,
+        isLast: extras?.isLast,
+      }),
     ),
   );
   return container;
@@ -70,5 +85,23 @@ describe("ConversationRowList load-more seam", () => {
     expect(
       container.querySelectorAll('[data-slot="load-more-sentinel"]'),
     ).toHaveLength(0);
+  });
+});
+
+describe("ConversationRowList overlay scroll", () => {
+  test("overlay cards grow with the drawer body instead of nesting a scroller", () => {
+    const container = renderList(undefined, {
+      overlayCards: true,
+      isLast: true,
+    });
+
+    expect(container.querySelector(".overflow-y-auto")).toBeNull();
+    expect(container.querySelectorAll('[data-testid="row"]')).toHaveLength(2);
+  });
+
+  test("a rail last-section still owns an inner scroller", () => {
+    const container = renderList(undefined, { isLast: true });
+
+    expect(container.querySelector(".overflow-y-auto")).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -9,18 +9,19 @@
  *
  * A windowed section paginates: `onEndReached` fires at the bottom of the
  * rows and pages more in (LUM-2444). What differs per section is where the
- * rows scroll. Only the bottom-most section (`isLast`) grows to fill whatever
- * space the sidebar has left above the pinned footer, then scrolls within
- * itself once its rows outgrow that: flex-grow has no notion of "this
- * section needs the room," so letting every open section claim a share
- * stretched a two-row group into a mostly-empty box the same size as a busy
- * one beside it. Every section above the last one caps at a fixed height
- * and scrolls within itself instead, since an uncapped busy section would
- * otherwise push its neighbours off screen - unless it opts out via
+ * rows scroll. On the rail, only the bottom-most section (`isLast`) grows
+ * to fill whatever space the sidebar has left above the pinned footer, then
+ * scrolls within itself once its rows outgrow that: flex-grow has no notion
+ * of "this section needs the room," so letting every open section claim a
+ * share stretched a two-row group into a mostly-empty box the same size as
+ * a busy one beside it. Every section above the last one caps at a fixed
+ * height and scrolls within itself instead, since an uncapped busy section
+ * would otherwise push its neighbours off screen - unless it opts out via
  * `unbounded` (Pinned: expected to stay short, and grows to fit its rows
- * instead). The flat list instead scrolls against the sidebar body it
- * already fills (`scrollParent`), which keeps the rail to a single
- * scrollbar.
+ * instead). The overlay drawer and the flat list instead scroll against the
+ * sidebar body (`scrollParent` / `overlayCards`), which keeps those
+ * surfaces to a single scrollbar so nested lists cannot trap rows behind
+ * the floating action pills.
  *
  * Either way a list past {@link CONVERSATION_LIST_VIRTUALIZE_THRESHOLD} rows
  * windows rather than mounting every one, because an assistant accumulates
@@ -101,6 +102,15 @@ export function ConversationRowList({
   isLast,
   onEndReached,
 }: ConversationRowListProps) {
+  const { overlayCards, scrollParent: contextScrollParent } =
+    useConversationListContext();
+  const listScrollParent = scrollParent ?? contextScrollParent;
+  /* Overlay cards and any list given an ancestor scroller grow with that
+     ancestor. A nested `overflow-y-auto` on the overlay would trap its
+     last rows behind the floating pills: the inner list cannot move those
+     rows into the body's reserved padding. */
+  const scrollWithBody = overlayCards === true || listScrollParent != null;
+
   const renderRow = (conversation: Conversation) => (
     <ConversationRow
       key={conversation.conversationId}
@@ -119,10 +129,7 @@ export function ConversationRowList({
     !unbounded && items.length > CONVERSATION_LIST_VIRTUALIZE_THRESHOLD;
 
   if (!windows) {
-    if (unbounded) {
-      return rows;
-    }
-    if (scrollParent) {
+    if (unbounded || scrollWithBody) {
       return rows;
     }
     return isLast ? (
@@ -142,16 +149,23 @@ export function ConversationRowList({
   const windowed = (
     <VirtualList
       items={items}
-      customScrollParent={scrollParent}
+      customScrollParent={listScrollParent}
       computeItemKey={(_, conversation) => conversation.conversationId}
       itemContent={(_, conversation) => renderRow(conversation)}
       endReached={onEndReached}
-      className={scrollParent ? "bg-transparent" : "h-full bg-transparent"}
+      className={
+        listScrollParent || scrollWithBody
+          ? "bg-transparent"
+          : "h-full bg-transparent"
+      }
     />
   );
 
-  if (scrollParent) {
-    return windowed;
+  if (scrollWithBody) {
+    /* The overlay body's ref lands one commit after first paint. Until it
+       does, mount the rows directly so a windowed list is not an empty
+       virtuoso viewport with no scroll parent. */
+    return listScrollParent ? windowed : rows;
   }
 
   /* Scrolling against an ancestor means no height of our own. Otherwise


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

A mobile support report: Preferences and New Chat sit over the lower sidebar, covering the Chats header and conversation rows so those chats cannot be reached.

The overlay drawer flex-filled the last section (usually Chats) into leftover rail space and gave that section its own scroller. The floating pills overlay that leftover, and a nested scroller cannot move its rows into the body's reserved padding. When earlier sections consume the viewport, Chats is squeezed under the pills and the body cannot scroll.

The overlay now treats the drawer body as the only scrollport. Section lists grow with that body (and virtualize against it once the body ref lands). The measured bottom padding still keeps the last rows clear of the pills. The rail is unchanged: non-last sections still cap, and the last section still flex-fills.

## Test plan

- [x] `cd clients/web && bun test src/domains/chat/components/conversation-nav-section.test.tsx src/domains/chat/components/assistant-side-menu.test.tsx` (77 pass)
- [x] Storybook Overlay drawer at phone width: scrolled the list through Chats and all 80 threads. Thread 80 and Back to top sit fully above Preferences / New Chat.
- [x] Existing rail tests still assert non-last sections cap and the last section flex-fills.

[Overlay drawer initial state](https://cursor.com/agents/bc-acea3831-aa59-4661-80f7-6ed3504c4a56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverlay_sidebar_initial.webp)
[Scrolled to last chat row above the pills](https://cursor.com/agents/bc-acea3831-aa59-4661-80f7-6ed3504c4a56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverlay_sidebar_scrolled_to_last_row.webp)
[overlay_sidebar_scroll_clears_pills.mp4](https://cursor.com/agents/bc-acea3831-aa59-4661-80f7-6ed3504c4a56/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverlay_sidebar_scroll_clears_pills.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acea3831-aa59-4661-80f7-6ed3504c4a56?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acea3831-aa59-4661-80f7-6ed3504c4a56&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

