### PR TITLE
feat(voice): attach_frame parks a camera frame to ride the next turn

### DIFF
--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   addMessage,
   createConversation,
+  deleteMessageById,
 } from "../persistence/conversation-crud.js";
 import { getConversationDirPath } from "../persistence/conversation-disk-view.js";
 import { getDb } from "../persistence/db-connection.js";
@@ -676,6 +677,59 @@ describe("deleteOrphanAttachments", () => {
 });
 
 // ---------------------------------------------------------------------------
+// deleteMessageById orphan cleanup
+// ---------------------------------------------------------------------------
+
+describe("deleteMessageById attachment cleanup", () => {
+  beforeEach(resetTables);
+
+  test("collects an attachment the deleted message alone referenced", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "user", "With attachment");
+    const stored = await uploadAttachment("shot.txt", "text/plain", "ZGF0YQ==");
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+    const filePath = getFilePathForAttachment(stored.id);
+
+    deleteMessageById(msg.id);
+
+    expect(getAttachmentById(stored.id)).toBeNull();
+    expect(existsSync(filePath!)).toBe(false);
+  });
+
+  test("retained ids survive the delete, row and bytes", async () => {
+    // A caller rolling a message back rather than deleting it: the attachment
+    // returns to the uploaded-but-unlinked state every attachment sits in
+    // between upload and send, so a later message can still reference it.
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "user", "Rolled back");
+    const stored = await uploadAttachment("shot.txt", "text/plain", "ZGF0YQ==");
+    linkAttachmentToMessage(msg.id, stored.id, 0);
+    const filePath = getFilePathForAttachment(stored.id);
+
+    deleteMessageById(msg.id, { retainAttachmentIds: [stored.id] });
+
+    expect(getAttachmentById(stored.id)).not.toBeNull();
+    expect(existsSync(filePath!)).toBe(true);
+    // The row is gone even though its attachment stayed.
+    expect(getAttachmentsForMessage(msg.id)).toHaveLength(0);
+  });
+
+  test("retaining one id does not spare the others on the row", async () => {
+    const conv = createConversation();
+    const msg = await addMessage(conv.id, "user", "Two attachments");
+    const kept = await uploadAttachment("kept.txt", "text/plain", "AAAA");
+    const dropped = await uploadAttachment("dropped.txt", "text/plain", "BBBB");
+    linkAttachmentToMessage(msg.id, kept.id, 0);
+    linkAttachmentToMessage(msg.id, dropped.id, 1);
+
+    deleteMessageById(msg.id, { retainAttachmentIds: [kept.id] });
+
+    expect(getAttachmentById(kept.id)).not.toBeNull();
+    expect(getAttachmentById(dropped.id)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // validateAttachmentUpload
 // ---------------------------------------------------------------------------
 
@@ -735,9 +789,9 @@ describe("validateAttachmentUpload", () => {
   test("accepts shell scripts as text attachments", () => {
     expect(validateAttachmentUpload("script.sh", "text/plain").ok).toBe(true);
     expect(validateAttachmentUpload("script.SH", "text/plain").ok).toBe(true);
-    expect(
-      validateAttachmentUpload("setup.sh", "application/x-sh").ok,
-    ).toBe(true);
+    expect(validateAttachmentUpload("setup.sh", "application/x-sh").ok).toBe(
+      true,
+    );
     expect(
       validateAttachmentUpload("run.sh", "application/x-shellscript").ok,
     ).toBe(true);
@@ -760,9 +814,9 @@ describe("validateAttachmentUpload", () => {
     expect(
       validateAttachmentUpload("PROGRAM.EXE", "application/octet-stream").ok,
     ).toBe(false);
-    expect(validateAttachmentUpload("INSTALL.DMG", "application/octet-stream").ok).toBe(
-      false,
-    );
+    expect(
+      validateAttachmentUpload("INSTALL.DMG", "application/octet-stream").ok,
+    ).toBe(false);
   });
 
   test("rejects unsupported MIME types", () => {

--- a/assistant/src/__tests__/attachments-store.test.ts
+++ b/assistant/src/__tests__/attachments-store.test.ts
@@ -16,6 +16,7 @@ import {
   isValidBase64,
   linkAttachmentToMessage,
   MAX_UPLOAD_BYTES,
+  resolveAttachmentsForPersist,
   uploadAttachment,
   validateAttachmentUpload,
 } from "../persistence/attachments-store.js";
@@ -673,6 +674,62 @@ describe("deleteOrphanAttachments", () => {
     // The unrelated attachment should still exist
     const fetched = getAttachmentById(unrelated.id);
     expect(fetched).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAttachmentsForPersist
+// ---------------------------------------------------------------------------
+
+describe("resolveAttachmentsForPersist", () => {
+  beforeEach(resetTables);
+
+  // One implementation behind every send path that turns ids into a persisted
+  // user message (HTTP send, processMessage, the voice bridge), so its shape is
+  // pinned here rather than at each caller.
+  test("hydrates ids into the shape a persisted message stores", async () => {
+    const stored = await uploadAttachment("photo.png", "image/png", "ZnJhbWU=");
+
+    expect(resolveAttachmentsForPersist([stored.id])).toEqual([
+      {
+        id: stored.id,
+        filename: "photo.png",
+        mimeType: "image/png",
+        data: "ZnJhbWU=",
+      },
+    ]);
+  });
+
+  test("carries the source path only for attachments that have one", async () => {
+    const withPath = await uploadAttachment(
+      "from-disk.txt",
+      "text/plain",
+      "AA==",
+    );
+    const plain = await uploadAttachment("typed.txt", "text/plain", "BB==");
+    rawRun(
+      "test:setSourcePath",
+      "UPDATE attachments SET source_path = ? WHERE id = ?",
+      "/tmp/from-disk.txt",
+      withPath.id,
+    );
+
+    const resolved = resolveAttachmentsForPersist([withPath.id, plain.id]);
+
+    expect(resolved[0]).toMatchObject({ filePath: "/tmp/from-disk.txt" });
+    expect(resolved[1]).not.toHaveProperty("filePath");
+  });
+
+  test("drops ids with no attachment row", async () => {
+    const stored = await uploadAttachment("kept.txt", "text/plain", "AA==");
+
+    const resolved = resolveAttachmentsForPersist([stored.id, "att-missing"]);
+
+    expect(resolved.map((a) => a.id)).toEqual([stored.id]);
+  });
+
+  test("returns nothing for an empty id list", () => {
+    expect(resolveAttachmentsForPersist([])).toEqual([]);
   });
 });
 

--- a/assistant/src/__tests__/conversation-routes-enabled-plugins.test.ts
+++ b/assistant/src/__tests__/conversation-routes-enabled-plugins.test.ts
@@ -78,7 +78,7 @@ mock.module("../persistence/conversation-disk-view.js", () => ({
 
 mock.module("../persistence/attachments-store.js", () => ({
   getAttachmentsByIds: () => [],
-  getSourcePathsForAttachments: () => new Map(),
+  resolveAttachmentsForPersist: () => [],
   attachmentExists: () => false,
   linkAttachmentToMessage: () => {},
   attachInlineAttachmentToMessage: () => {},

--- a/assistant/src/__tests__/conversation-routes-hidden-queue.test.ts
+++ b/assistant/src/__tests__/conversation-routes-hidden-queue.test.ts
@@ -67,7 +67,7 @@ mock.module("../persistence/conversation-disk-view.js", () => ({
 
 mock.module("../persistence/attachments-store.js", () => ({
   getAttachmentsByIds: () => [],
-  getSourcePathsForAttachments: () => new Map(),
+  resolveAttachmentsForPersist: () => [],
   attachmentExists: () => false,
   linkAttachmentToMessage: () => {},
   attachInlineAttachmentToMessage: () => {},

--- a/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-routes-slash-commands.test.ts
@@ -106,7 +106,7 @@ mock.module("../persistence/conversation-disk-view.js", () => ({
 
 mock.module("../persistence/attachments-store.js", () => ({
   getAttachmentsByIds: () => [],
-  getSourcePathsForAttachments: () => new Map(),
+  resolveAttachmentsForPersist: () => [],
   attachmentExists: () => false,
   linkAttachmentToMessage: () => {},
   attachInlineAttachmentToMessage: () => {},

--- a/assistant/src/__tests__/process-message-background-slack.test.ts
+++ b/assistant/src/__tests__/process-message-background-slack.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 mock.module("../persistence/attachments-store.js", () => ({
   getAttachmentsByIds: () => [],
-  getSourcePathsForAttachments: () => new Map<string, string>(),
+  resolveAttachmentsForPersist: () => [],
 }));
 
 mock.module("../channels/gateway-guardian-requests.js", () => ({

--- a/assistant/src/__tests__/process-message-display-content.test.ts
+++ b/assistant/src/__tests__/process-message-display-content.test.ts
@@ -27,7 +27,7 @@ let validateShouldFail = false;
 
 mock.module("../persistence/attachments-store.js", () => ({
   getAttachmentsByIds: () => [],
-  getSourcePathsForAttachments: () => new Map<string, string>(),
+  resolveAttachmentsForPersist: () => [],
   attachmentExists: () => false,
   linkAttachmentToMessage: () => "att-stored",
   scopeAttachmentToMessageConversation: () => null,

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -39,6 +39,24 @@ mock.module("../../plugin-api/vision-support.js", () => ({
   doesSupportVision: () => pinProfileSupportsVision,
 }));
 
+// Attachment hydration for the parked-camera-frame path. Only `att-frame-*`
+// ids exist; anything else resolves to nothing, which is how an id the client
+// invented reaches the bridge.
+import * as realAttachmentsStore from "../../persistence/attachments-store.js";
+
+mock.module("../../persistence/attachments-store.js", () => ({
+  ...realAttachmentsStore,
+  resolveAttachmentsForPersist: (ids: string[]) =>
+    ids
+      .filter((id) => id.startsWith("att-frame-"))
+      .map((id) => ({
+        id,
+        filename: `${id}.png`,
+        mimeType: "image/png",
+        data: "ZnJhbWU=",
+      })),
+}));
+
 // Conversation-CRUD doubles for the teardown transcript-hygiene pass. The
 // real module is spread so every other export keeps its production behavior;
 // only the functions the hygiene pass (and discard) touch are recorded.
@@ -132,6 +150,7 @@ interface FakeConversation {
     content: string;
     requestId: string;
     metadata?: Record<string, unknown>;
+    attachments?: Array<Record<string, unknown>>;
   }) => Promise<{ id: string }>;
   workingDir: string;
   addEventObserver: (observer: unknown) => () => void;
@@ -167,7 +186,12 @@ function makeFakeConversation(opts: {
   let clientCallback: ((msg: unknown) => Promise<void>) | undefined;
   let persistCount = 0;
   let lastPersistOpts:
-    | { content: string; requestId: string; metadata?: Record<string, unknown> }
+    | {
+        content: string;
+        requestId: string;
+        metadata?: Record<string, unknown>;
+        attachments?: Array<Record<string, unknown>>;
+      }
     | undefined;
   const conversation: FakeConversation = {
     conversationId: "conv-voice-bridge-test",
@@ -493,6 +517,66 @@ describe("startVoiceTurn escalation-continuation persistence", () => {
     // Only live-voice sessions pass `voiceTelemetry`; a phone call has no
     // live-voice session id to attribute a turn to.
     expect(fake.lastPersistOpts()?.metadata).not.toHaveProperty("client");
+  });
+});
+
+describe("startVoiceTurn camera-frame attachments", () => {
+  test("hydrates parked ids onto the turn's own user message", async () => {
+    // The live-voice session parks an ambient camera frame and hands the id
+    // over; the row it lands on is the one carrying the user's words, so the
+    // picture and the sentence about it are one message.
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what is this",
+      attachments: ["att-frame-1"],
+    });
+
+    expect(fake.lastPersistOpts()?.attachments).toEqual([
+      {
+        id: "att-frame-1",
+        filename: "att-frame-1.png",
+        mimeType: "image/png",
+        data: "ZnJhbWU=",
+      },
+    ]);
+    // `UserMessageAttachment` carries no metadata of its own, so which of a
+    // row's attachments were ambient frames is recorded on the message.
+    expect(fake.lastPersistOpts()?.metadata).toMatchObject({
+      voiceSessionTurn: true,
+      sightFrameAttachmentIds: ["att-frame-1"],
+    });
+  });
+
+  test("an id that resolves to nothing costs the caller no turn", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what is this",
+      attachments: ["att-missing"],
+    });
+
+    expect(fake.persistCount()).toBe(1);
+    expect(fake.lastPersistOpts()).not.toHaveProperty("attachments");
+    expect(fake.lastPersistOpts()?.metadata).not.toHaveProperty(
+      "sightFrameAttachmentIds",
+    );
+  });
+
+  test("a turn with no parked frame persists exactly as before", async () => {
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    await startVoiceTurn({ ...makeTurnOptions(), content: "what is this" });
+
+    expect(fake.lastPersistOpts()).not.toHaveProperty("attachments");
+    expect(fake.lastPersistOpts()?.metadata).toEqual({
+      voiceSessionTurn: true,
+    });
   });
 });
 

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -41,14 +41,21 @@ mock.module("../../plugin-api/vision-support.js", () => ({
 
 // Attachment hydration for the parked-camera-frame path. Only `att-frame-*`
 // ids exist; anything else resolves to nothing, which is how an id the client
-// invented reaches the bridge.
+// invented reaches the bridge. `collectedAttachmentIds` is the store's other
+// half: the fake `deleteMessageById` below writes into it under the real
+// orphan rule, so an id the cleanup ate stops resolving here, exactly as a
+// deleted attachment row would.
 import * as realAttachmentsStore from "../../persistence/attachments-store.js";
+
+const collectedAttachmentIds = new Set<string>();
 
 mock.module("../../persistence/attachments-store.js", () => ({
   ...realAttachmentsStore,
   resolveAttachmentsForPersist: (ids: string[]) =>
     ids
-      .filter((id) => id.startsWith("att-frame-"))
+      .filter(
+        (id) => id.startsWith("att-frame-") && !collectedAttachmentIds.has(id),
+      )
       .map((id) => ({
         id,
         filename: `${id}.png`,
@@ -66,15 +73,22 @@ let getMessageByIdImpl: (
   messageId: string,
   conversationId?: string,
 ) => unknown = () => null;
+// Attachment ids each persisted message links, so the fake delete below can
+// apply the orphan rule to the same candidate set the real one would collect.
+const messageAttachmentLinks = new Map<string, string[]>();
 const crudLog: {
   reads: string[];
   updates: Array<{ messageId: string; content: string }>;
   deletes: string[];
-} = { reads: [], updates: [], deletes: [] };
+  retained: Array<{ messageId: string; ids: readonly string[] }>;
+} = { reads: [], updates: [], deletes: [], retained: [] };
 function resetCrudLog(): void {
   crudLog.reads.length = 0;
   crudLog.updates.length = 0;
   crudLog.deletes.length = 0;
+  crudLog.retained.length = 0;
+  messageAttachmentLinks.clear();
+  collectedAttachmentIds.clear();
   getMessageByIdImpl = () => null;
 }
 
@@ -87,8 +101,23 @@ mock.module("../../persistence/conversation-crud.js", () => ({
   updateMessageContent: (messageId: string, content: string) => {
     crudLog.updates.push({ messageId, content });
   },
-  deleteMessageById: (messageId: string) => {
+  deleteMessageById: (
+    messageId: string,
+    options?: { retainAttachmentIds?: readonly string[] },
+  ) => {
     crudLog.deletes.push(messageId);
+    const retained = options?.retainAttachmentIds ?? [];
+    crudLog.retained.push({ messageId, ids: retained });
+    // Mirrors the real cleanup: the row's own attachment links are the
+    // candidate set, and a candidate nothing else references is collected
+    // unless the caller retained it. Every id here is referenced by this one
+    // row, which is the case the rollback path is about.
+    for (const id of messageAttachmentLinks.get(messageId) ?? []) {
+      if (!retained.includes(id)) {
+        collectedAttachmentIds.add(id);
+      }
+    }
+    messageAttachmentLinks.delete(messageId);
     return { segmentIds: [], deletedSummaryIds: [] };
   },
   // The echo path advances the snapshot anchor for a real-user turn; the
@@ -220,6 +249,14 @@ function makeFakeConversation(opts: {
     persistUserMessage: async (persistOpts) => {
       persistCount += 1;
       lastPersistOpts = persistOpts;
+      // The link rows the real persist writes, which is what makes an
+      // attachment a cleanup candidate when this message is deleted.
+      if (persistOpts.attachments && persistOpts.attachments.length > 0) {
+        messageAttachmentLinks.set(
+          `msg-${persistCount}`,
+          persistOpts.attachments.map((a) => a.id as string),
+        );
+      }
       // Recorded before `onPersist` so scripted persist FAILURES also
       // appear in the event stream — ordering tests need the losing
       // attempt visible.
@@ -565,6 +602,65 @@ describe("startVoiceTurn camera-frame attachments", () => {
     expect(fake.lastPersistOpts()?.metadata).not.toHaveProperty(
       "sightFrameAttachmentIds",
     );
+  });
+
+  test("a discarded turn leaves its camera frame attachable again", async () => {
+    // The hold verdict rolls the speculative turn back and the session parks
+    // the id again for the replay. The rollback deletes the row, and the row
+    // was the attachment's only reference, so without the retention the
+    // cleanup takes the frame with it and the replayed utterance speaks
+    // without the picture the user is holding up, with nothing said.
+    resetCrudLog();
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    const handle = await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what is this",
+      attachments: ["att-frame-1"],
+    });
+    expect(fake.lastPersistOpts()?.attachments).toHaveLength(1);
+
+    await handle.discard?.();
+
+    // The replay: the same parked id, and the row it lands on still carries
+    // the frame.
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what is this",
+      attachments: ["att-frame-1"],
+    });
+
+    expect(fake.lastPersistOpts()?.attachments).toEqual([
+      {
+        id: "att-frame-1",
+        filename: "att-frame-1.png",
+        mimeType: "image/png",
+        data: "ZnJhbWU=",
+      },
+    ]);
+    expect(fake.lastPersistOpts()?.metadata).toMatchObject({
+      sightFrameAttachmentIds: ["att-frame-1"],
+    });
+    // The rollback asked for exactly the ids its own row linked.
+    expect(crudLog.retained).toEqual([
+      { messageId: "msg-1", ids: ["att-frame-1"] },
+    ]);
+  });
+
+  test("a discard with no parked frame retains nothing", async () => {
+    resetCrudLog();
+    const fake = makeFakeConversation({ processing: false });
+    fakeConversation = fake.conversation;
+
+    const handle = await startVoiceTurn({
+      ...makeTurnOptions(),
+      content: "what is this",
+    });
+    await handle.discard?.();
+
+    expect(crudLog.deletes).toEqual(["msg-1"]);
+    expect(crudLog.retained).toEqual([{ messageId: "msg-1", ids: [] }]);
   });
 
   test("a turn with no parked frame persists exactly as before", async () => {

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -28,6 +28,7 @@ import { CONVERSATION_BUSY_MESSAGE } from "../daemon/conversation-messaging.js";
 import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import { resolveAttachmentsForPersist } from "../persistence/attachments-store.js";
 import {
   deleteMessageById,
   getMessageById,
@@ -323,6 +324,20 @@ export interface VoiceTurnOptions {
   };
   /** Per-turn control prompt. Undefined uses the phone prompt; null disables it. */
   voiceControlPrompt?: string | null;
+  /**
+   * Ids of already-uploaded attachments to hang on this turn's persisted user
+   * message, hydrated here into the shape the message stores.
+   *
+   * Filled by the live-voice session from the camera frame a client parked on
+   * it (`attach_frame`), which is why these are ambient rather than chosen:
+   * they ride the turn's own user message so the picture and the words about it
+   * are one message, and so the media survives a context-overflow retry, which
+   * preserves it only on the newest user message.
+   *
+   * Ids that resolve to nothing are dropped: an unresolvable frame must not
+   * cost the caller their turn.
+   */
+  attachments?: readonly string[];
   /** The transcribed caller utterance or synthetic marker. */
   content: string;
   /** Assistant scope for multi-assistant channels. */
@@ -1024,8 +1039,15 @@ export async function startVoiceTurn(
   const requestId = uuidv7();
   const turnId = crypto.randomUUID();
   const persistTurnUserMessage = async (): Promise<string> => {
+    // Resolved inside the persist, not once outside it, so the retry after a
+    // lost lock race stores exactly what the first attempt would have.
+    const turnAttachments =
+      opts.attachments && opts.attachments.length > 0
+        ? resolveAttachmentsForPersist([...opts.attachments])
+        : [];
     const persistResult = await conversation.persistUserMessage({
       content: persistedContent,
+      ...(turnAttachments.length > 0 ? { attachments: turnAttachments } : {}),
       requestId,
       metadata: {
         // Durable "this turn came from an open voice session" marker; see
@@ -1068,6 +1090,14 @@ export async function startVoiceTurn(
                   : {}),
               },
             }
+          : {}),
+        // Names which of the row's attachments arrived as ambient camera
+        // frames rather than files the user picked, so retention can treat
+        // them differently. `UserMessageAttachment` carries no metadata of its
+        // own, so the marking lives on the message and refers to the
+        // attachments by id.
+        ...(turnAttachments.length > 0
+          ? { sightFrameAttachmentIds: turnAttachments.map((a) => a.id) }
           : {}),
       },
     });

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1038,6 +1038,9 @@ export async function startVoiceTurn(
 
   const requestId = uuidv7();
   const turnId = crypto.randomUUID();
+  // Ids this turn's row actually links, read back by `discardFn` so a rollback
+  // does not take the attachments down with the row.
+  let linkedAttachmentIds: string[] = [];
   const persistTurnUserMessage = async (): Promise<string> => {
     // Resolved inside the persist, not once outside it, so the retry after a
     // lost lock race stores exactly what the first attempt would have.
@@ -1045,6 +1048,7 @@ export async function startVoiceTurn(
       opts.attachments && opts.attachments.length > 0
         ? resolveAttachmentsForPersist([...opts.attachments])
         : [];
+    linkedAttachmentIds = turnAttachments.map((a) => a.id);
     const persistResult = await conversation.persistUserMessage({
       content: persistedContent,
       ...(turnAttachments.length > 0 ? { attachments: turnAttachments } : {}),
@@ -1895,7 +1899,18 @@ export async function startVoiceTurn(
       // Same rollback pattern as the pointer-turn runner: delete the row,
       // then rebuild in-memory history from the clean DB (a plain pop is
       // fragile against concurrent compaction reassigning the array).
-      deleteMessageById(messageId);
+      //
+      // The row's own attachments are exempted from the orphan cleanup. A
+      // discard unwinds the turn as though it never ran, so an ambient camera
+      // frame goes back to being uploaded-but-unsent, which is exactly what
+      // the live-voice session's parked slot expects to find when the held
+      // utterance is replayed. Collecting it here would delete the row and
+      // the bytes, and the replay would silently speak without the picture.
+      deleteMessageById(messageId, {
+        ...(linkedAttachmentIds.length > 0
+          ? { retainAttachmentIds: linkedAttachmentIds }
+          : {}),
+      });
       await conversation.loadFromDb();
       publishConversationMessagesChanged(opts.conversationId);
     } catch (err) {

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -19,10 +19,7 @@ import {
   parseChannelId,
   parseInterfaceId,
 } from "../channels/types.js";
-import {
-  getAttachmentsByIds,
-  getSourcePathsForAttachments,
-} from "../persistence/attachments-store.js";
+import { resolveAttachmentsForPersist } from "../persistence/attachments-store.js";
 import {
   addMessage,
   getConversation,
@@ -362,19 +359,7 @@ async function prepareConversationForMessage(
   });
 
   const attachments = attachmentIds
-    ? (() => {
-        const resolved = getAttachmentsByIds(attachmentIds, {
-          hydrateFileData: true,
-        });
-        const sourcePaths = getSourcePathsForAttachments(attachmentIds);
-        return resolved.map((a) => ({
-          id: a.id,
-          filename: a.originalFilename,
-          mimeType: a.mimeType,
-          data: a.dataBase64,
-          ...(sourcePaths.has(a.id) ? { filePath: sourcePaths.get(a.id) } : {}),
-        }));
-      })()
+    ? resolveAttachmentsForPersist(attachmentIds)
     : [];
 
   return { conversation, attachments };

--- a/assistant/src/live-voice/__tests__/live-voice-attach-frame.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-attach-frame.test.ts
@@ -331,6 +331,42 @@ describe("live-voice camera frames parked for the next turn", () => {
     expect(parkedFrameId(session)).toBeNull();
   });
 
+  test("a rolled-back turn hands the frame back for the replay", async () => {
+    // A turn that never reached the bridge (and a speculative one the hold
+    // verdict unwinds) must not take the frame down with it: the utterance is
+    // about to be sent again, and the user is still holding the thing up.
+    // The other half of this, that the rollback leaves the attachment itself
+    // alive, is `voice-session-bridge.test.ts`'s discard suite.
+    const attachmentId = await uploadFrame();
+    const turns: VoiceTurnOptions[] = [];
+    let dispatches = 0;
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        dispatches += 1;
+        if (dispatches === 1) {
+          throw new Error("bridge unavailable");
+        }
+        turns.push(options);
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: `bridge-turn-${turns.length}`, abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    await session.start();
+
+    await session.handleClientFrame({ type: "attach_frame", attachmentId });
+    await speakAndRelease(session, () => dispatches, 8_000);
+
+    // Claimed by the failed turn, then handed straight back.
+    expect(parkedFrameId(session)).toBe(attachmentId);
+
+    await speakAndRelease(session, () => dispatches, 9_000);
+
+    expect(turns[0]?.attachments).toEqual([attachmentId]);
+
+    await session.close("websocket_close");
+  });
+
   test("an unknown attachment id is refused and nothing is parked", async () => {
     const turns: VoiceTurnOptions[] = [];
     const startVoiceTurn: LiveVoiceTurnStarter = mock(

--- a/assistant/src/live-voice/__tests__/live-voice-attach-frame.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-attach-frame.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Ambient camera frames sent mid-call (`attach_frame`).
+ *
+ * The behaviour under test is the parking rule: a frame dispatches nothing of
+ * its own. It waits on the session and rides the next spoken turn's own user
+ * message, so the picture and the words about it are one message, and a frame
+ * nobody ever speaks over leaves no trace in the conversation.
+ *
+ * The contrast with `attach_image` is deliberate and is pinned here too: a
+ * deliberate snap persists immediately as its own message and parks nothing
+ * (`live-voice-attach-image.test.ts`).
+ */
+
+import { Buffer } from "node:buffer";
+import { describe, expect, mock, test } from "bun:test";
+
+import type {
+  VoiceTurnCallbacks,
+  VoiceTurnOptions,
+} from "../../calls/voice-session-bridge.js";
+import { uploadAttachment } from "../../persistence/attachments-store.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import {
+  createLiveVoiceSession,
+  type LiveVoiceSession,
+  type LiveVoiceTurnStarter,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import type {
+  LiveVoiceTtsOptions,
+  LiveVoiceTtsResult,
+} from "../live-voice-tts.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceClientStartFrame,
+  type LiveVoiceServerFrame,
+  validateLiveVoiceClientFrame,
+} from "../protocol.js";
+
+await initializeDb();
+
+const IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+const START_FRAME = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: { mimeType: "audio/pcm", sampleRate: 24_000, channels: 1 },
+  turnDetection: "server_vad",
+} as const satisfies LiveVoiceClientStartFrame;
+
+/** A real attachment row, so the park-time existence check has one to find. */
+async function uploadFrame(): Promise<string> {
+  const attachment = await uploadAttachment(
+    "frame.png",
+    "image/png",
+    IMAGE_BASE64,
+  );
+  return attachment.id;
+}
+
+function loudPcmChunk(amplitude: number, sampleCount = 240): Uint8Array {
+  const buffer = Buffer.alloc(sampleCount * 2);
+  for (let index = 0; index < sampleCount; index += 1) {
+    buffer.writeInt16LE(amplitude, index * 2);
+  }
+  return new Uint8Array(buffer);
+}
+
+/** One fresh transcriber per utterance; `stop()` flushes its transcript. */
+class FakeStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  constructor(private readonly transcript: string) {}
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(): void {
+    this.onEvent?.({ type: "partial", text: "wha" });
+  }
+
+  stop(): void {
+    this.onEvent?.({ type: "final", text: this.transcript });
+    this.onEvent?.({ type: "closed" });
+  }
+}
+
+function makeMessageComplete(): Parameters<
+  NonNullable<VoiceTurnCallbacks["message_complete"]>
+>[0] {
+  return {
+    type: "message_complete",
+    conversationId: "conversation-123",
+    messageId: "assistant-message-123",
+  };
+}
+
+function makeTtsResult(text: string): LiveVoiceTtsResult {
+  return {
+    provider: "fish-audio",
+    contentType: "audio/pcm",
+    sampleRate: 24_000,
+    chunks: 1,
+    bytes: Buffer.byteLength(text),
+  };
+}
+
+function createSessionHarness(startVoiceTurn: LiveVoiceTurnStarter) {
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+  const context: LiveVoiceSessionFactoryContext = {
+    sessionId: "session-123",
+    startFrame: START_FRAME,
+    sendFrame: mock(async (payload) => {
+      const frame = sequencer.next(payload);
+      frames.push(frame);
+      return frame;
+    }),
+  };
+
+  let utterances = 0;
+  const session = createLiveVoiceSession(context, {
+    // Credential-free harness: every leg is injected, so skip the preflight.
+    resolveCredentialReadiness: null,
+    // One discrete mic chunk per utterance; keep the adaptive playback
+    // classifier out of the cycle timing.
+    echoBargeInMargin: 1,
+    resolveTranscriber: mock(async () => {
+      utterances += 1;
+      return new FakeStreamingTranscriber(`utterance ${utterances}`);
+    }),
+    startVoiceTurn,
+    streamTtsAudio: mock(async (options: LiveVoiceTtsOptions) =>
+      makeTtsResult(options.text),
+    ),
+    createTurnId: () => `live-turn-${utterances}`,
+    emitMetrics: false,
+  });
+
+  return { frames, session };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(message);
+}
+
+/** Drive one utterance through to its dispatched assistant turn. */
+async function speakAndRelease(
+  session: LiveVoiceSession,
+  seen: () => number,
+  amplitude: number,
+): Promise<void> {
+  const before = seen();
+  await session.handleBinaryAudio(loudPcmChunk(amplitude));
+  await session.handleClientFrame({ type: "ptt_release" });
+  await waitFor(
+    () => seen() > before,
+    "Timed out waiting for the live-voice turn to dispatch",
+  );
+}
+
+function parkedFrameId(session: LiveVoiceSession): string | null {
+  return (session as unknown as { pendingTurnAttachmentId: string | null })
+    .pendingTurnAttachmentId;
+}
+
+describe("live-voice attach_frame frame", () => {
+  test("accepts a well-formed frame", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "attach_frame",
+      attachmentId: "att-1",
+    });
+    expect(result).toEqual({
+      ok: true,
+      frame: { type: "attach_frame", attachmentId: "att-1" },
+    });
+  });
+
+  test("rejects a missing attachmentId, naming the frame", () => {
+    const result = validateLiveVoiceClientFrame({ type: "attach_frame" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("missing_required_field");
+      expect(result.error.field).toBe("attachmentId");
+      expect(result.error.frameType).toBe("attach_frame");
+    }
+  });
+
+  test("rejects an empty attachmentId", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "attach_frame",
+      attachmentId: "",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("invalid_field");
+      expect(result.error.frameType).toBe("attach_frame");
+    }
+  });
+});
+
+describe("live-voice camera frames parked for the next turn", () => {
+  test("a parked frame rides the next turn's user message", async () => {
+    const attachmentId = await uploadFrame();
+    const turns: VoiceTurnOptions[] = [];
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        turns.push(options);
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: `bridge-turn-${turns.length}`, abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    await session.start();
+
+    await session.handleClientFrame({ type: "attach_frame", attachmentId });
+    // Nothing is dispatched for the frame itself; it waits for words.
+    expect(turns).toHaveLength(0);
+    expect(parkedFrameId(session)).toBe(attachmentId);
+
+    await speakAndRelease(session, () => turns.length, 8_000);
+
+    expect(turns[0]?.content).toBe("utterance 1");
+    expect(turns[0]?.attachments).toEqual([attachmentId]);
+    // Drained by the turn that took it, so it cannot ride a second one.
+    expect(parkedFrameId(session)).toBeNull();
+
+    await session.close("websocket_close");
+  });
+
+  test("the newest frame replaces the one before it", async () => {
+    const stale = await uploadFrame();
+    const current = await uploadFrame();
+    const turns: VoiceTurnOptions[] = [];
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        turns.push(options);
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: `bridge-turn-${turns.length}`, abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    await session.start();
+
+    await session.handleClientFrame({
+      type: "attach_frame",
+      attachmentId: stale,
+    });
+    await session.handleClientFrame({
+      type: "attach_frame",
+      attachmentId: current,
+    });
+    await speakAndRelease(session, () => turns.length, 8_000);
+
+    expect(turns[0]?.attachments).toEqual([current]);
+
+    await session.close("websocket_close");
+  });
+
+  test("a frame that arrives mid-turn rides the turn after it", async () => {
+    const first = await uploadFrame();
+    const second = await uploadFrame();
+    const turns: VoiceTurnOptions[] = [];
+    const sessionRef: { current: LiveVoiceSession | null } = { current: null };
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        turns.push(options);
+        if (turns.length === 1) {
+          // The camera keeps shooting while the assistant answers. This frame
+          // belongs to whatever the user says next, not to the turn in flight.
+          await sessionRef.current?.handleClientFrame({
+            type: "attach_frame",
+            attachmentId: second,
+          });
+        }
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: `bridge-turn-${turns.length}`, abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    sessionRef.current = session;
+    await session.start();
+
+    await session.handleClientFrame({
+      type: "attach_frame",
+      attachmentId: first,
+    });
+    await speakAndRelease(session, () => turns.length, 8_000);
+    await speakAndRelease(session, () => turns.length, 9_000);
+
+    expect(turns[0]?.attachments).toEqual([first]);
+    expect(turns[1]?.attachments).toEqual([second]);
+
+    await session.close("websocket_close");
+  });
+
+  test("ending the session drops the parked frame", async () => {
+    const attachmentId = await uploadFrame();
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: "bridge-turn-1", abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    await session.start();
+
+    await session.handleClientFrame({ type: "attach_frame", attachmentId });
+    expect(parkedFrameId(session)).toBe(attachmentId);
+
+    await session.close("websocket_close");
+
+    // A frame is only good for the call it was shot on.
+    expect(parkedFrameId(session)).toBeNull();
+  });
+
+  test("an unknown attachment id is refused and nothing is parked", async () => {
+    const turns: VoiceTurnOptions[] = [];
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        turns.push(options);
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: `bridge-turn-${turns.length}`, abort: mock() };
+      },
+    );
+    const { frames, session } = createSessionHarness(startVoiceTurn);
+    await session.start();
+    const before = frames.length;
+
+    await session.handleClientFrame({
+      type: "attach_frame",
+      attachmentId: "att-missing",
+    });
+    await waitFor(
+      () => frames.length > before,
+      "Timed out waiting for the rejected camera frame's error",
+    );
+
+    // Attributed to the frame it is about, so the client can retract the
+    // preview it already showed instead of filing this with the transient
+    // transcriber and TTS blips that share `recoverable`.
+    expect(
+      frames.slice(before).find((frame) => frame.type === "error"),
+    ).toMatchObject({
+      type: "error",
+      frameType: "attach_frame",
+      recoverable: true,
+    });
+    expect(parkedFrameId(session)).toBeNull();
+
+    await speakAndRelease(session, () => turns.length, 8_000);
+    expect(turns[0]?.attachments).toBeUndefined();
+
+    await session.close("websocket_close");
+  });
+
+  test("attach_image parks nothing", async () => {
+    // A deliberate snap persists as its own message; the spoken turn that
+    // follows carries no attachments and reaches it through history.
+    const turns: VoiceTurnOptions[] = [];
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        turns.push(options);
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: `bridge-turn-${turns.length}`, abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    await session.start();
+
+    await session.handleClientFrame({
+      type: "attach_image",
+      attachmentId: "att-missing",
+    });
+    expect(parkedFrameId(session)).toBeNull();
+
+    await speakAndRelease(session, () => turns.length, 8_000);
+    expect(turns[0]?.attachments).toBeUndefined();
+
+    await session.close("websocket_close");
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-attach-frame.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-attach-frame.test.ts
@@ -18,7 +18,15 @@ import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
-import { uploadAttachment } from "../../persistence/attachments-store.js";
+import {
+  getAttachmentById,
+  linkAttachmentToMessage,
+  uploadAttachment,
+} from "../../persistence/attachments-store.js";
+import {
+  addMessage,
+  createConversation,
+} from "../../persistence/conversation-crud.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import type {
   StreamingTranscriber,
@@ -61,6 +69,11 @@ async function uploadFrame(): Promise<string> {
     IMAGE_BASE64,
   );
   return attachment.id;
+}
+
+/** True while the attachment's row is still in the store. */
+function frameStored(attachmentId: string): boolean {
+  return getAttachmentById(attachmentId) !== null;
 }
 
 function loudPcmChunk(amplitude: number, sampleCount = 240): Uint8Array {
@@ -267,9 +280,50 @@ describe("live-voice camera frames parked for the next turn", () => {
       type: "attach_frame",
       attachmentId: current,
     });
+
+    // A client shooting the camera on a timer parks one of these every few
+    // seconds. Nothing else ever collects them, so the displaced one is given
+    // up here or its row and bytes stay for good.
+    expect(frameStored(stale)).toBe(false);
+    expect(frameStored(current)).toBe(true);
+
     await speakAndRelease(session, () => turns.length, 8_000);
 
     expect(turns[0]?.attachments).toEqual([current]);
+
+    await session.close("websocket_close");
+  });
+
+  test("displacing a frame that already rode a message leaves it alone", async () => {
+    // The reclaim is link-aware, which is what makes it safe to run on an id
+    // the client may have sent before: a frame that reached a message is that
+    // message's, and re-sending its id must not delete it out from under the
+    // transcript.
+    const conversation = createConversation("Live voice frame reuse");
+    const message = await addMessage(conversation.id, "user", "what is this");
+    const sent = await uploadFrame();
+    linkAttachmentToMessage(message.id, sent, 0);
+    const replacement = await uploadFrame();
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: "bridge-turn-1", abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    await session.start();
+
+    await session.handleClientFrame({
+      type: "attach_frame",
+      attachmentId: sent,
+    });
+    await session.handleClientFrame({
+      type: "attach_frame",
+      attachmentId: replacement,
+    });
+
+    expect(frameStored(sent)).toBe(true);
+    expect(parkedFrameId(session)).toBe(replacement);
 
     await session.close("websocket_close");
   });
@@ -327,8 +381,10 @@ describe("live-voice camera frames parked for the next turn", () => {
 
     await session.close("websocket_close");
 
-    // A frame is only good for the call it was shot on.
+    // A frame is only good for the call it was shot on, so the staged row
+    // goes with the call rather than outliving it.
     expect(parkedFrameId(session)).toBeNull();
+    expect(frameStored(attachmentId)).toBe(false);
   });
 
   test("a rolled-back turn hands the frame back for the replay", async () => {
@@ -363,6 +419,50 @@ describe("live-voice camera frames parked for the next turn", () => {
     await speakAndRelease(session, () => dispatches, 9_000);
 
     expect(turns[0]?.attachments).toEqual([attachmentId]);
+
+    await session.close("websocket_close");
+  });
+
+  test("a rollback keeps the newer frame and gives up the one it replaced", async () => {
+    // The camera kept shooting while the doomed turn was in flight, so the
+    // frame coming back off it is already out of date. Latest still wins, and
+    // the one that loses is nobody's to send: it goes.
+    const claimed = await uploadFrame();
+    const newer = await uploadFrame();
+    const turns: VoiceTurnOptions[] = [];
+    let dispatches = 0;
+    const sessionRef: { current: LiveVoiceSession | null } = { current: null };
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        dispatches += 1;
+        if (dispatches === 1) {
+          await sessionRef.current?.handleClientFrame({
+            type: "attach_frame",
+            attachmentId: newer,
+          });
+          throw new Error("bridge unavailable");
+        }
+        turns.push(options);
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: `bridge-turn-${turns.length}`, abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    sessionRef.current = session;
+    await session.start();
+
+    await session.handleClientFrame({
+      type: "attach_frame",
+      attachmentId: claimed,
+    });
+    await speakAndRelease(session, () => dispatches, 8_000);
+
+    expect(parkedFrameId(session)).toBe(newer);
+    expect(frameStored(claimed)).toBe(false);
+
+    await speakAndRelease(session, () => dispatches, 9_000);
+
+    expect(turns[0]?.attachments).toEqual([newer]);
 
     await session.close("websocket_close");
   });

--- a/assistant/src/live-voice/__tests__/live-voice-attach-frame.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-attach-frame.test.ts
@@ -467,6 +467,47 @@ describe("live-voice camera frames parked for the next turn", () => {
     await session.close("websocket_close");
   });
 
+  test("a retransmitted id is the same frame, not a newer one", async () => {
+    // A client that re-sends the id it already sent, while the turn holding it
+    // is in flight, has parked the SAME frame. Reading that as a displacement
+    // would collect the very frame the slot is pointing at, and the replay
+    // would speak without the picture with nothing said.
+    const attachmentId = await uploadFrame();
+    const turns: VoiceTurnOptions[] = [];
+    let dispatches = 0;
+    const sessionRef: { current: LiveVoiceSession | null } = { current: null };
+    const startVoiceTurn: LiveVoiceTurnStarter = mock(
+      async (options: VoiceTurnOptions) => {
+        dispatches += 1;
+        if (dispatches === 1) {
+          await sessionRef.current?.handleClientFrame({
+            type: "attach_frame",
+            attachmentId,
+          });
+          throw new Error("bridge unavailable");
+        }
+        turns.push(options);
+        options.callbacks?.message_complete?.(makeMessageComplete());
+        return { turnId: `bridge-turn-${turns.length}`, abort: mock() };
+      },
+    );
+    const { session } = createSessionHarness(startVoiceTurn);
+    sessionRef.current = session;
+    await session.start();
+
+    await session.handleClientFrame({ type: "attach_frame", attachmentId });
+    await speakAndRelease(session, () => dispatches, 8_000);
+
+    expect(parkedFrameId(session)).toBe(attachmentId);
+    expect(frameStored(attachmentId)).toBe(true);
+
+    await speakAndRelease(session, () => dispatches, 9_000);
+
+    expect(turns[0]?.attachments).toEqual([attachmentId]);
+
+    await session.close("websocket_close");
+  });
+
   test("an unknown attachment id is refused and nothing is parked", async () => {
     const turns: VoiceTurnOptions[] = [];
     const startVoiceTurn: LiveVoiceTurnStarter = mock(

--- a/assistant/src/live-voice/__tests__/live-voice-attach-image.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-attach-image.test.ts
@@ -1,11 +1,14 @@
 /**
  * Photos taken mid-call (the voice room's camera).
  *
- * The behaviour under test is the parking rule: an `attach_image` frame does
- * not dispatch anything, it waits for the next turn and rides that turn's own
- * user message. That is what makes a bare "what's this?" resolve against the
- * picture instead of producing one turn about the image racing another about
- * the words.
+ * The behaviour under test is that an `attach_image` frame stands alone: it
+ * persists the photo as its own user message the moment it arrives and
+ * dispatches no turn, so the spoken turn that follows carries no attachments
+ * of its own and reaches the picture through conversation history. That is
+ * what makes shutter-then-speak and speak-then-shutter answer the same way.
+ *
+ * The parking rule belongs to `attach_frame` instead
+ * (`live-voice-attach-frame.test.ts`), which carries ambient camera frames.
  */
 
 import { describe, expect, mock, test } from "bun:test";

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -25,10 +25,7 @@ import { v7 as uuidv7 } from "uuid";
 
 import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
-import {
-  getAttachmentsByIds,
-  getSourcePathsForAttachments,
-} from "../persistence/attachments-store.js";
+import { resolveAttachmentsForPersist } from "../persistence/attachments-store.js";
 import { recordConversationPersistedSeq } from "../persistence/conversation-crud.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
@@ -54,25 +51,6 @@ const PHOTO_MESSAGE_CONTENT = "here's a photo:";
 export interface LiveVoicePhotoResult {
   readonly ok: boolean;
   readonly messageId?: string;
-}
-
-/**
- * Hydrate attachment ids into the shape `persistQueuedMessageBody` stores.
- * Mirrors the HTTP send path's own `resolveAttachments`, so a photo taken
- * mid-call is stored exactly like one attached to a typed message.
- */
-function resolvePhotoAttachments(attachmentIds: string[]) {
-  const resolved = getAttachmentsByIds(attachmentIds, {
-    hydrateFileData: true,
-  });
-  const sourcePaths = getSourcePathsForAttachments(attachmentIds);
-  return resolved.map((a) => ({
-    id: a.id,
-    filename: a.originalFilename,
-    mimeType: a.mimeType,
-    data: a.dataBase64,
-    ...(sourcePaths.has(a.id) ? { filePath: sourcePaths.get(a.id) } : {}),
-  }));
 }
 
 /** Resolve once the conversation is not mid-turn, or false on timeout. */
@@ -105,7 +83,7 @@ export async function persistLiveVoicePhoto(
   attachmentId: string,
 ): Promise<LiveVoicePhotoResult> {
   try {
-    const attachments = resolvePhotoAttachments([attachmentId]);
+    const attachments = resolveAttachmentsForPersist([attachmentId]);
     if (attachments.length === 0) {
       log.warn({ attachmentId }, "Live-voice photo attachment did not resolve");
       return { ok: false };

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -4795,12 +4795,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     turn.handedOffRequest = null;
     turn.consumedAnnouncement = null;
     turn.turnAttachmentId = null;
+    // Nobody's to send unless the slot already holds it. A client that
+    // retransmits the id this turn claimed parked the SAME frame rather than a
+    // newer one, and collecting it would leave the slot pointing at a row that
+    // is gone: the discard keeps the bytes alive precisely so the replay can
+    // still send them.
+    const orphanedFrameId =
+      turnAttachmentId !== null &&
+      this.pendingTurnAttachmentId !== turnAttachmentId
+        ? turnAttachmentId
+        : null;
     if (
       this.isClosed ||
       this.detachStopGeneration !== turn.pendingContextStopGeneration
     ) {
       // The drop is deliberate, so the frame it drops is nobody's to send.
-      turn.staleFrameId = turnAttachmentId;
+      turn.staleFrameId = orphanedFrameId;
       return;
     }
     if (this.pendingInterruptedRequest === null) {
@@ -4811,8 +4821,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // leave it staged for a turn that will never ask for it.
     if (this.pendingTurnAttachmentId === null) {
       this.pendingTurnAttachmentId = turnAttachmentId;
-    } else if (turnAttachmentId !== null) {
-      turn.staleFrameId = turnAttachmentId;
+    } else {
+      turn.staleFrameId = orphanedFrameId;
     }
     if (this.pendingContinuationResult === null) {
       this.pendingContinuationResult = continuationResult;

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -45,6 +45,7 @@ import {
   recordLiveVoiceSessionStarted,
 } from "../onboarding/onboarding-events-store.js";
 import { isInstalledStaticSkillLoad } from "../permissions/checker.js";
+import { attachmentExists } from "../persistence/attachments-store.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
   listProviderIds,
@@ -130,6 +131,7 @@ import {
   PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE,
 } from "./progress-phrases.js";
 import {
+  type LiveVoiceClientAttachFrameFrame,
   type LiveVoiceClientAttachImageFrame,
   type LiveVoiceClientFrame,
   type LiveVoiceClientTextTurnFrame,
@@ -716,6 +718,10 @@ interface ActiveAssistantTurn {
   // that request's transcript, so the model can tell the user the work is
   // still running instead of appearing to have dropped it.
   handedOffRequest: string | null;
+  // The parked camera frame this turn claimed, hung on the turn's own
+  // persisted user message. Held here so a rolled-back dispatch can hand it
+  // back to the session (see restorePendingTurnContext).
+  turnAttachmentId: string | null;
   // The queued announcement this turn consumed alongside `continuationResult`
   // — the two are routes for one answer, so launching consumes both. Held here
   // so a rolled-back speculative dispatch can re-arm it (see
@@ -1255,6 +1261,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // turn; cleared when the continuation finishes (by then the result note
   // takes over and "still running" would be stale).
   private pendingHandoffRequest: string | null = null;
+  // The camera frame a client parked with `attach_frame`, waiting for the next
+  // turn to ride. One slot, latest wins: the frame is ambient context, so an
+  // older one is simply out of date. Consumed (and cleared) when a turn
+  // launches, handed back if that turn is rolled back, and cleared on close.
+  private pendingTurnAttachmentId: string | null = null;
   private readonly maxPendingAudioBytes: number;
   // Set on VAD speech onset; consumed when the first speech chunk is routed
   // to an utterance so the metric lands on the right turn.
@@ -1526,6 +1537,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       case "attach_image":
         this.persistPhoto(frame);
         return;
+      case "attach_frame":
+        this.parkTurnFrame(frame);
+        return;
       case "text":
         await this.handleTextTurn(frame);
         return;
@@ -1619,6 +1633,44 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
+   * Park a camera frame for the next turn to carry.
+   *
+   * Nothing is persisted and no turn runs: the frame is ambient context, and
+   * on its own it says nothing the user asked to say. It rides the next turn's
+   * own user message instead, so the picture and the words about it are one
+   * message. A frame that arrives while a turn is already running belongs to
+   * the turn after it, which the drain at launch takes care of.
+   *
+   * The id is checked against the attachment store here rather than at the
+   * turn, for the same reason a failed photo is reported: an id that resolves
+   * to nothing would otherwise leave the user believing the assistant can see
+   * something it never received, one turn later and with nothing said.
+   */
+  private parkTurnFrame(frame: LiveVoiceClientAttachFrameFrame): void {
+    let exists = false;
+    try {
+      exists = attachmentExists(frame.attachmentId);
+    } catch (err) {
+      log.warn(
+        { err, attachmentId: frame.attachmentId },
+        "Live-voice camera frame lookup failed",
+      );
+    }
+    if (!exists) {
+      void this.sendFrame({
+        type: "error",
+        code: LiveVoiceProtocolErrorCode.InvalidFrame,
+        message: "Could not attach that camera frame to the conversation.",
+        frameType: "attach_frame",
+        // The session is fine; only this frame failed.
+        recoverable: true,
+      });
+      return;
+    }
+    this.pendingTurnAttachmentId = frame.attachmentId;
+  }
+
+  /**
    * Apply a mid-session `update_config` frame: retune the live turn detector's
    * pause ("pause before reply") and/or the barge-in guard ("interrupt
    * sensitivity") without reconnecting. Each field is optional and independent;
@@ -1681,6 +1733,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.turnDetector?.dispose();
     this.clearEndpointExtensionTimer();
     this.clearProviderTurnEndTimer();
+    // No turn will ever carry it now, and the frame is the client's to send
+    // again on its next session.
+    this.pendingTurnAttachmentId = null;
     // There is no longer anyone on the call to speak to, so a queued
     // announcement cannot be spoken — but the answer behind it is finished
     // work the user asked for, so it takes the same conversation route a
@@ -3852,9 +3907,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   ): void {
     turn.speculativePending = false;
     // The dispatch is being unwound, so the barge-in merge note, the finished
-    // continuation's answer, its queued announcement, and any photos it claimed
-    // all go back to the session. The turn that would have delivered them is
-    // gone, and the utterance they belong to is about to be sent by another.
+    // continuation's answer, its queued announcement, and any camera frame it
+    // claimed all go back to the session. The turn that would have delivered
+    // them is gone, and the utterance they belong to is about to be sent by
+    // another.
     this.restorePendingTurnContext(turn);
     // Latched before the handle check: when the discard beats the bridge
     // handle's resolution (startVoiceTurn still persisting), the handle's
@@ -4622,10 +4678,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
-   * Take the barge-in merge context, the completed-continuation context, and
-   * the handoff note for the turn being launched — each feeds exactly the next
-   * launched turn — and cancel the queued announcement, because the turn this
-   * context rides delivers the same answer and would otherwise say it twice.
+   * Take the barge-in merge context, the completed-continuation context, the
+   * handoff note, and the parked camera frame for the turn being launched
+   * (each feeds exactly the next launched turn) and cancel the queued
+   * announcement, because the turn this context rides delivers the same answer
+   * and would otherwise say it twice.
    *
    * Every real user turn consumes here, speculative or not: a speculative
    * dispatch latches `assistantTurnStarted`, so a turn that skipped this would
@@ -4637,16 +4694,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     continuationResult: string | null;
     handedOffRequest: string | null;
     announcement: ContinuationDelivery | null;
+    turnAttachmentId: string | null;
   } {
     const consumed = {
       interruptedRequest: this.pendingInterruptedRequest,
       continuationResult: this.pendingContinuationResult,
       handedOffRequest: this.pendingHandoffRequest,
       announcement: this.pendingAnnouncement,
+      turnAttachmentId: this.pendingTurnAttachmentId,
     };
     this.pendingInterruptedRequest = null;
     this.pendingContinuationResult = null;
     this.pendingHandoffRequest = null;
+    this.pendingTurnAttachmentId = null;
     this.clearContinuationAnnouncement();
     return consumed;
   }
@@ -4668,12 +4728,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const continuationResult = turn.continuationResult;
     const handedOffRequest = turn.handedOffRequest;
     const announcement = turn.consumedAnnouncement;
+    const turnAttachmentId = turn.turnAttachmentId;
     // One restore per turn: the rollback paths overlap (a discarded turn whose
     // leg start also fails), and the second pass must be a no-op.
     turn.interruptedRequest = null;
     turn.continuationResult = null;
     turn.handedOffRequest = null;
     turn.consumedAnnouncement = null;
+    turn.turnAttachmentId = null;
     if (
       this.isClosed ||
       this.detachStopGeneration !== turn.pendingContextStopGeneration
@@ -4682,6 +4744,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     if (this.pendingInterruptedRequest === null) {
       this.pendingInterruptedRequest = interruptedRequest;
+    }
+    // A frame parked since this turn launched is newer, so it wins outright.
+    if (this.pendingTurnAttachmentId === null) {
+      this.pendingTurnAttachmentId = turnAttachmentId;
     }
     if (this.pendingContinuationResult === null) {
       this.pendingContinuationResult = continuationResult;
@@ -4779,6 +4845,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       interruptedRequest: pending?.interruptedRequest ?? null,
       continuationResult: pending?.continuationResult ?? null,
       handedOffRequest: pending?.handedOffRequest ?? null,
+      turnAttachmentId: pending?.turnAttachmentId ?? null,
       consumedAnnouncement: pending?.announcement ?? null,
       pendingContextStopGeneration: this.detachStopGeneration,
       continuationDelivery: opts?.continuationDelivery ?? null,
@@ -4853,6 +4920,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       content,
       routingLeg: "front-door",
       frontDoor: true,
+      // Only this leg: an escalated leg persists its own continuation row, and
+      // the frame belongs to the row carrying the user's words.
+      ...(activeTurn.turnAttachmentId
+        ? { attachments: [activeTurn.turnAttachmentId] }
+        : {}),
     });
     if (!started) {
       // Nothing was persisted or spoken, so the context this turn consumed goes
@@ -4890,6 +4962,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       routingLeg?: VoiceRoutingLeg;
       frontDoor?: boolean;
       spokenEscalationBridge?: string;
+      attachments?: readonly string[];
     },
   ): Promise<boolean> {
     if (!this.startVoiceTurn) {
@@ -4994,6 +5067,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           this.clearAwaitingApproval(activeTurn);
         },
         content: leg.content,
+        ...(leg.attachments ? { attachments: leg.attachments } : {}),
         isInbound: true,
         launchedAtMs: activeTurn.launchedAtMs,
         signal: activeTurn.abortController.signal,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -45,7 +45,10 @@ import {
   recordLiveVoiceSessionStarted,
 } from "../onboarding/onboarding-events-store.js";
 import { isInstalledStaticSkillLoad } from "../permissions/checker.js";
-import { attachmentExists } from "../persistence/attachments-store.js";
+import {
+  attachmentExists,
+  deleteOrphanAttachments,
+} from "../persistence/attachments-store.js";
 import { ensureConversationExists } from "../persistence/conversation-crud.js";
 import {
   listProviderIds,
@@ -722,6 +725,10 @@ interface ActiveAssistantTurn {
   // persisted user message. Held here so a rolled-back dispatch can hand it
   // back to the session (see restorePendingTurnContext).
   turnAttachmentId: string | null;
+  // The frame the rollback could NOT hand back, because a newer one took the
+  // slot while this turn was in flight. Nothing will ever send it, so it is
+  // collected once the discard has removed the row still linking it.
+  staleFrameId: string | null;
   // The queued announcement this turn consumed alongside `continuationResult`
   // — the two are routes for one answer, so launching consumes both. Held here
   // so a rolled-back speculative dispatch can re-arm it (see
@@ -1667,7 +1674,51 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       });
       return;
     }
+    const displaced = this.pendingTurnAttachmentId;
     this.pendingTurnAttachmentId = frame.attachmentId;
+    if (displaced !== null && displaced !== frame.attachmentId) {
+      this.reclaimParkedFrame(displaced);
+    }
+  }
+
+  /**
+   * Give up a parked camera frame no turn will ever carry: one a newer frame
+   * displaced, one the session end leaves behind, one a rollback could not
+   * hand back. A client shooting the camera on a timer parks one every few
+   * seconds, and attachment collection is scoped to message deletion with no
+   * global sweep, so an id dropped without this leaves its row and its bytes
+   * behind for good.
+   *
+   * Safe because `deleteOrphanAttachments` is link-aware: it removes only ids
+   * with no message link, so a frame that already rode a turn is kept and one
+   * that never left this slot is collected. Nothing waits on the result and a
+   * store that cannot be reached must not take the call down, so a failure is
+   * logged and dropped.
+   */
+  private reclaimParkedFrame(attachmentId: string | null): void {
+    if (attachmentId === null) {
+      return;
+    }
+    try {
+      deleteOrphanAttachments([attachmentId]);
+    } catch (err) {
+      log.warn(
+        { err, attachmentId },
+        "Could not reclaim a parked live-voice camera frame",
+      );
+    }
+  }
+
+  /**
+   * Collect the frame a turn's rollback could not hand back, once the discard
+   * that owns the turn's row has finished. Ordering is the whole point: the
+   * reclaim is link-aware, so running it while the doomed row still links the
+   * frame finds the link, keeps the frame, and leaks it.
+   */
+  private reclaimStaleTurnFrame(turn: ActiveAssistantTurn): void {
+    const staleFrameId = turn.staleFrameId;
+    turn.staleFrameId = null;
+    this.reclaimParkedFrame(staleFrameId);
   }
 
   /**
@@ -1733,8 +1784,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.turnDetector?.dispose();
     this.clearEndpointExtensionTimer();
     this.clearProviderTurnEndTimer();
-    // No turn will ever carry it now, and the frame is the client's to send
-    // again on its next session.
+    // No turn will ever carry it now, and the frame is the client's to shoot
+    // again on its next session, so the staged row and bytes go with the call.
+    this.reclaimParkedFrame(this.pendingTurnAttachmentId);
     this.pendingTurnAttachmentId = null;
     // There is no longer anyone on the call to speak to, so a queued
     // announcement cannot be spoken — but the answer behind it is finished
@@ -3925,12 +3977,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     );
     const handle = turn.handle;
     turn.handle = null;
-    void handle?.discard?.().catch((err: unknown) => {
-      log.warn(
-        { err, turnId: turn.turnId, reason },
-        "Speculative voice turn discard failed",
-      );
-    });
+    void handle
+      ?.discard?.()
+      .catch((err: unknown) => {
+        log.warn(
+          { err, turnId: turn.turnId, reason },
+          "Speculative voice turn discard failed",
+        );
+      })
+      // Only once the discard has deleted the row: until then the row still
+      // links a displaced frame, and the reclaim would keep it forever.
+      .finally(() => {
+        this.reclaimStaleTurnFrame(turn);
+      });
     turn.utterance.assistantTurnStarted = false;
     log.info(
       { turnId: turn.turnId, reason },
@@ -4740,14 +4799,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.isClosed ||
       this.detachStopGeneration !== turn.pendingContextStopGeneration
     ) {
+      // The drop is deliberate, so the frame it drops is nobody's to send.
+      turn.staleFrameId = turnAttachmentId;
       return;
     }
     if (this.pendingInterruptedRequest === null) {
       this.pendingInterruptedRequest = interruptedRequest;
     }
-    // A frame parked since this turn launched is newer, so it wins outright.
+    // A frame parked since this turn launched is newer, so it wins outright
+    // and the one being handed back is the stale one: collect it rather than
+    // leave it staged for a turn that will never ask for it.
     if (this.pendingTurnAttachmentId === null) {
       this.pendingTurnAttachmentId = turnAttachmentId;
+    } else if (turnAttachmentId !== null) {
+      turn.staleFrameId = turnAttachmentId;
     }
     if (this.pendingContinuationResult === null) {
       this.pendingContinuationResult = continuationResult;
@@ -4846,6 +4911,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       continuationResult: pending?.continuationResult ?? null,
       handedOffRequest: pending?.handedOffRequest ?? null,
       turnAttachmentId: pending?.turnAttachmentId ?? null,
+      staleFrameId: null,
       consumedAnnouncement: pending?.announcement ?? null,
       pendingContextStopGeneration: this.detachStopGeneration,
       continuationDelivery: opts?.continuationDelivery ?? null,
@@ -4870,6 +4936,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       await this.sendFrame({ type: "thinking", turnId });
       if (!this.isActiveAssistantTurn(token)) {
         this.restorePendingTurnContext(activeTurn);
+        // Nothing was persisted, so a frame the restore could not hand back
+        // links to no row and is collectible right here.
+        this.reclaimStaleTurnFrame(activeTurn);
         return false;
       }
     } else {
@@ -4928,8 +4997,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     });
     if (!started) {
       // Nothing was persisted or spoken, so the context this turn consumed goes
-      // back to the session rather than dying with the failed dispatch.
+      // back to the session rather than dying with the failed dispatch. A frame
+      // a newer one displaced meanwhile links to no row, so it is collected
+      // here rather than left staged.
       this.restorePendingTurnContext(activeTurn);
+      this.reclaimStaleTurnFrame(activeTurn);
     }
     return started;
   }
@@ -5384,12 +5456,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         // rollback: a plain abort would leave the discarded pause's user
         // row in history.
         if (activeTurn.discardRequested && handle.discard) {
-          void handle.discard().catch((err: unknown) => {
-            log.warn(
-              { err, turnId: activeTurn.turnId },
-              "Late speculative voice turn discard failed",
-            );
-          });
+          void handle
+            .discard()
+            .catch((err: unknown) => {
+              log.warn(
+                { err, turnId: activeTurn.turnId },
+                "Late speculative voice turn discard failed",
+              );
+            })
+            // This discard owns the row, so it owns the reclaim of any frame
+            // the rollback could not hand back (see reclaimStaleTurnFrame).
+            .finally(() => {
+              this.reclaimStaleTurnFrame(activeTurn);
+            });
         } else {
           handle.abort();
         }

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -8,6 +8,7 @@ const LIVE_VOICE_CLIENT_FRAME_TYPES = [
   "end",
   "update_config",
   "attach_image",
+  "attach_frame",
   "text",
 ] as const;
 
@@ -194,15 +195,41 @@ export interface LiveVoiceClientUpdateConfigFrame {
  * caps size, and stores the blob, and routing an image through this socket
  * would duplicate all of it on a transport tuned for 50 ms audio frames.
  *
- * The id is *parked*, not dispatched. It rides the next turn's own user
- * message (see {@link LiveVoiceSession}'s pending-attachment handling), so the
- * photo and the words spoken about it are one message rather than two, which
- * is what lets "what's this?" resolve, and what keeps the image attached to the
- * newest user message, the only one a context-overflow retry preserves media on
- * (`conversation-media-retry.ts`).
+ * The id is persisted the moment it arrives, as a standalone user message that
+ * runs no turn (see `live-voice-photo.ts`). A snap the user watched themselves
+ * take has to show up in the conversation whether or not they ever speak about
+ * it, and landing it in history immediately is what makes shutter-then-speak
+ * and speak-then-shutter answer the same way.
+ *
+ * Deliberately not {@link LiveVoiceClientAttachFrameFrame}, which parks its id
+ * for the next spoken turn instead. The two frames look alike on the wire and
+ * answer opposite questions: a deliberate snap must appear now; an ambient
+ * camera frame is worthless without the words that follow it.
  */
 export interface LiveVoiceClientAttachImageFrame {
   readonly type: "attach_image";
+  readonly attachmentId: string;
+}
+
+/**
+ * An ambient camera frame the client picked for the assistant to see, already
+ * uploaded over the normal attachment route, and sent here as an id alone for
+ * the same reason {@link LiveVoiceClientAttachImageFrame} sends one.
+ *
+ * The id is *parked* on the session rather than persisted. It rides the next
+ * spoken turn's own user message, and the slot is cleared as that turn starts,
+ * so a frame that arrives mid-turn belongs to the turn after it. Nothing the
+ * user asked for happened here: a frame nobody ever speaks over must leave no
+ * trace in the conversation, and a frame that does get words must be part of
+ * the same message as those words. Riding the newest user message is also what
+ * carries it through a context-overflow retry, the only message media survives
+ * on (`conversation-media-retry.ts`).
+ *
+ * Latest wins. A second frame overwrites the first, because what matters is
+ * what the camera is pointed at when the user speaks.
+ */
+export interface LiveVoiceClientAttachFrameFrame {
+  readonly type: "attach_frame";
   readonly attachmentId: string;
 }
 
@@ -253,6 +280,7 @@ export type LiveVoiceClientFrame =
   | LiveVoiceClientEndFrame
   | LiveVoiceClientUpdateConfigFrame
   | LiveVoiceClientAttachImageFrame
+  | LiveVoiceClientAttachFrameFrame
   | LiveVoiceClientTextTurnFrame;
 
 interface LiveVoiceBinaryAudioFrame {
@@ -513,11 +541,11 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
    * daemons predating the field.
    *
    * It exists so an `unknown_type` is attributable. A client that sends more
-   * than one optional frame (today: `update_config` and `attach_image`) gets
-   * the same code for either, and without this has to assume which one was
-   * refused. The wrong assumption is silent in both directions: settings stop
-   * applying for a session, or a photo the user watched themselves take is
-   * dropped with nothing said.
+   * than one optional frame (today: `update_config`, `attach_image`,
+   * `attach_frame`, and `text`) gets the same code for any of them, and
+   * without this has to assume which one was refused. The wrong assumption is
+   * silent in both directions: settings stop applying for a session, or a
+   * photo the user watched themselves take is dropped with nothing said.
    */
   readonly frameType?: string;
   /**
@@ -654,6 +682,8 @@ export function validateLiveVoiceClientFrame(
       return validateUpdateConfigFrame(value);
     case "attach_image":
       return validateAttachImageFrame(value);
+    case "attach_frame":
+      return validateAttachFrameFrame(value);
     case "text":
       return validateTextTurnFrame(value);
   }
@@ -747,6 +777,33 @@ function validateAttachImageFrame(
   return {
     ok: true,
     frame: { type: "attach_image", attachmentId: value.attachmentId },
+  };
+}
+
+function validateAttachFrameFrame(
+  value: Record<string, unknown>,
+): LiveVoiceParseResult<LiveVoiceClientAttachFrameFrame> {
+  if (!("attachmentId" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "attach_frame frame is missing required field attachmentId",
+      "attachmentId",
+      "attach_frame",
+    );
+  }
+
+  if (!isNonEmptyString(value.attachmentId)) {
+    return protocolError(
+      "invalid_field",
+      "attach_frame frame field attachmentId must be a non-empty string",
+      "attachmentId",
+      "attach_frame",
+    );
+  }
+
+  return {
+    ok: true,
+    frame: { type: "attach_frame", attachmentId: value.attachmentId },
   };
 }
 

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1164,6 +1164,32 @@ export function getAttachmentsByIds(
   return results;
 }
 
+/**
+ * Hydrate attachment ids into the shape a persisted user message stores:
+ * base64 data plus the on-disk source path where one is known. Ids with no
+ * attachment row are dropped, so a caller that needs to know an id was bad
+ * compares the returned length against what it asked for.
+ */
+export function resolveAttachmentsForPersist(attachmentIds: string[]): Array<{
+  id: string;
+  filename: string;
+  mimeType: string;
+  data: string;
+  filePath?: string;
+}> {
+  const resolved = getAttachmentsByIds(attachmentIds, {
+    hydrateFileData: true,
+  });
+  const sourcePaths = getSourcePathsForAttachments(attachmentIds);
+  return resolved.map((a) => ({
+    id: a.id,
+    filename: a.originalFilename,
+    mimeType: a.mimeType,
+    data: a.dataBase64,
+    ...(sourcePaths.has(a.id) ? { filePath: sourcePaths.get(a.id) } : {}),
+  }));
+}
+
 export function linkAttachmentToMessage(
   messageId: string,
   attachmentId: string,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -4082,8 +4082,18 @@ export function relinkAttachments(
  *
  * Returns segment IDs so the caller can clean up the corresponding
  * Qdrant vector entries.
+ *
+ * `retainAttachmentIds` exempts attachments from the orphan cleanup below, for
+ * a caller rolling a message back rather than deleting it: the attachment
+ * returns to the uploaded-but-unlinked state it was in before the row existed,
+ * which is a live state (that is where every attachment sits between upload and
+ * send), not a leak. Callers deleting a message for good pass nothing and the
+ * attachments it alone referenced are collected.
  */
-export function deleteMessageById(messageId: string): DeletedMemoryIds {
+export function deleteMessageById(
+  messageId: string,
+  options?: { retainAttachmentIds?: readonly string[] },
+): DeletedMemoryIds {
   const db = getDb();
   const result: DeletedMemoryIds = {
     segmentIds: [],
@@ -4145,7 +4155,12 @@ export function deleteMessageById(messageId: string): DeletedMemoryIds {
     ...purgeMessageSegments([messageId], "deleteMessageById:post-delete"),
   );
 
-  deleteOrphanAttachments(candidateAttachmentIds);
+  const retainAttachmentIds = options?.retainAttachmentIds;
+  deleteOrphanAttachments(
+    retainAttachmentIds && retainAttachmentIds.length > 0
+      ? candidateAttachmentIds.filter((id) => !retainAttachmentIds.includes(id))
+      : candidateAttachmentIds,
+  );
 
   // Remove the deleted message's point from the lexical index. Enqueued only
   // when the row actually existed (`msgRow` set), after the transaction and

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -103,7 +103,7 @@ import {
   getAttachmentById,
   getAttachmentMetadataForMessage,
   getAttachmentsByIds,
-  getSourcePathsForAttachments,
+  resolveAttachmentsForPersist,
 } from "../../persistence/attachments-store.js";
 import {
   addMessage,
@@ -3027,20 +3027,6 @@ async function handleSearchConversations({
 const suggestionCache = new Map<string, string>();
 const suggestionInFlight = new Map<string, Promise<string | null>>();
 
-function resolveAttachments(attachmentIds: string[]) {
-  const resolved = getAttachmentsByIds(attachmentIds, {
-    hydrateFileData: true,
-  });
-  const sourcePaths = getSourcePathsForAttachments(attachmentIds);
-  return resolved.map((a) => ({
-    id: a.id,
-    filename: a.originalFilename,
-    mimeType: a.mimeType,
-    data: a.dataBase64,
-    ...(sourcePaths.has(a.id) ? { filePath: sourcePaths.get(a.id) } : {}),
-  }));
-}
-
 // ---------------------------------------------------------------------------
 // Route definitions
 // ---------------------------------------------------------------------------
@@ -3260,7 +3246,7 @@ export const ROUTES: RouteDefinition[] = [
         sendMessageDeps: {
           getOrCreateConversation: getOrCreateConversationInstance,
           assistantEventHub,
-          resolveAttachments,
+          resolveAttachments: resolveAttachmentsForPersist,
         },
         approvalConversationGenerator: createApprovalConversationGenerator(),
       }),

--- a/clients/web/src/lib/backwards-compat/use-supports-voice-camera.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-voice-camera.ts
@@ -1,22 +1,22 @@
 /**
  * Backwards-compat gate: sending a photo into a live voice call.
  *
- * The camera in the voice room uploads a frame over the ordinary attachment
+ * The camera in the voice room uploads a photo over the ordinary attachment
  * route and then tells the daemon about it with an `attach_image` live-voice
- * frame, which the daemon parks and attaches to the next turn's user message.
- * The upload half works against any assistant; the frame does not.
+ * frame, which the daemon persists as its own user message. The upload half
+ * works against any assistant; the frame does not.
  *
  * The web app always serves the latest bundle while the assistant can be any
  * locally-installed version, and an assistant that predates the frame answers
- * it with a protocol `error` whose code is `unknown_type`. That error is
- * indistinguishable from the one an old assistant returns for `update_config`:
- * the daemon does not forward the rejected frame's type on the error frame
- * (`live-voice-connection.ts`'s `sendError` sends only `code` and `message`),
- * so the transport's `unknown_type` handler cannot tell the two apart. Sending
- * `attach_image` speculatively would therefore do two bad things at once: the
- * photo would silently never reach the model, and the transport would latch
- * `configUpdatesUnsupported` and stop applying the voice-room settings for the
- * rest of the session.
+ * it with a protocol `error` whose code is `unknown_type`, the same code an
+ * old assistant returns for `update_config`. Assistants at or above
+ * `MIN_VERSION` name the rejected frame on the error (`frameType`), so the
+ * transport can tell the two apart; older ones send `code` and `message`
+ * alone, and the transport's `unknown_type` handler has to guess. It guesses
+ * `update_config`, so sending `attach_image` speculatively would do two bad
+ * things at once: the photo would silently never reach the model, and the
+ * transport would latch `configUpdatesUnsupported` and stop applying the
+ * voice-room settings for the rest of the session.
  *
  * So this is a WRITE gate, and write gates hide the affordance rather than
  * letting it fail (see docs/BACKWARDS_COMPAT.md): below `MIN_VERSION` the room


### PR DESCRIPTION
## Summary

PR 1 of the desktop voice vision plan: the daemon seam that lets an ambient camera frame ride a spoken turn.

- New `attach_frame { attachmentId }` live-voice client frame: the session parks the id in a single latest-wins slot; the next user turn drains it onto its own persisted user message. A frame arriving mid-turn rides the following turn.
- `VoiceTurnOptions.attachments` threads ids into `persistTurnUserMessage`, hydrated inside the persist itself so the lost-lock re-persist stores exactly what the first attempt would have. The message metadata names the ambient ids (`sightFrameAttachmentIds`) for the retention work to read; per-attachment metadata does not exist as a channel.
- The slot joins the turn context's consume/restore pair: a speculative hold-verdict rollback hands the frame back instead of losing it. Escalated continuation legs attach nothing (no duplicate image row) and inherit the vision-profile pin through conversation history.
- Deliberate contrast, now documented at the protocol: `attach_frame` parks and rides (ambient context, meaningless without the words); `attach_image` persists a standalone photo message immediately (a deliberate snap must appear now). Three stale docstrings claiming attach_image parks were corrected, including the web compat gate's (no behavior change).
- Hydration is a shared `resolveAttachmentsForPersist` in the attachments store; the photo path now uses it too.

Inert in production: nothing sends `attach_frame` yet (the web trigger is the next PR, gated on `vision-mode` and a new version gate). An unresolvable id answers a recoverable, attributable error and parks nothing; an id deleted between park and turn drops silently rather than costing the turn.

## Verification

- New `live-voice-attach-frame.test.ts`: 9 tests (park-drain-persist, latest-wins, mid-turn rides next, close clears, invalid id attributable, attach_image untouched). Drain and latest-wins mutation-verified.
- Bridge suite grew 3 tests asserting the persisted shape and tag; 90 pass. Full radius green per file: protocol 61, connection 15, attach-image 6, photo 1, integration 7, agent-turn 26, triage-escalate 12+60, text-turn 11, conversation-attachments 4.
- `typecheck:fast` zero errors; eslint and prettier clean on all touched files; no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)