### PR TITLE
feat(daemon): stub aged camera frames before the model sees them

### DIFF
--- a/assistant/src/__tests__/agent-loop-compacted-history-transform.test.ts
+++ b/assistant/src/__tests__/agent-loop-compacted-history-transform.test.ts
@@ -1,0 +1,304 @@
+/**
+ * The agent loop's post-compaction history transform.
+ *
+ * In-place compaction rebuilds history from the stored rows, so it can
+ * reintroduce content the caller had already trimmed out of the array it handed
+ * to `run()`. The rebuilt array is installed and sent on the very next request
+ * of the same turn, so the caller's trim has to be re-applied at the
+ * installation site rather than only before the run. The loop stays
+ * conversation-ignorant: the caller injects a closure, and this suite drives
+ * that seam with the real camera-frame retention transform.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { PostCompactContext } from "@vellumai/plugin-api";
+
+import { AgentLoop } from "../agent/loop.js";
+import type { ContextWindowConfig } from "../config/types.js";
+import { stripAgedSightFrames } from "../daemon/conversation-sight-frames.js";
+import type { TrustContext } from "../daemon/trust-context-types.js";
+import { HOOKS } from "../plugin-api/constants.js";
+import {
+  createContextWindowManager,
+  disposeContextWindowManager,
+  getContextWindowManager,
+} from "../plugins/defaults/compaction/manager-store.js";
+import {
+  registerPlugin,
+  resetPluginRegistryForTests,
+} from "../plugins/registry.js";
+import type {
+  ContentBlock,
+  Message,
+  Provider,
+  ProviderResponse,
+} from "../providers/types.js";
+import { ContextOverflowError } from "../providers/types.js";
+
+const testPostCompactPlugin = {
+  manifest: { name: "test-post-compact-transform", version: "0.0.0" },
+  hooks: {
+    [HOOKS.POST_COMPACT]: async (input: PostCompactContext): Promise<void> => {
+      void input;
+    },
+  },
+};
+
+const CONVERSATION_ID = "compacted-history-transform-conversation";
+
+/** Capture times one second apart, the shape the row read produces. */
+const CAPTURE_TIMES = new Map<string, number>([
+  ["f1", 1000],
+  ["f2", 2000],
+  ["f3", 3000],
+  ["f4", 4000],
+]);
+
+/** A retained frame as `buildRetainedImageBlocks` rebuilds it: inline + id. */
+function retainedFrame(
+  attachmentId: string,
+): Extract<ContentBlock, { type: "image" }> {
+  return {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: "AAAAAAAA" },
+    _attachmentId: attachmentId,
+  };
+}
+
+/**
+ * The history compaction rebuilds here: four tagged frames in one synthetic
+ * message, which is two more than the retention bound allows.
+ */
+function compactedHistoryWithFourFrames(): Message[] {
+  return [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Images retained from the compacted portion:" },
+        retainedFrame("f1"),
+        retainedFrame("f2"),
+        retainedFrame("f3"),
+        retainedFrame("f4"),
+      ],
+    },
+  ];
+}
+
+function textResponse(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "mock-model",
+    usage: { inputTokens: 10, outputTokens: 5 },
+    stopReason: "end_turn",
+  };
+}
+
+/** Records every history the provider is asked to send. */
+function createRecordingProvider(requests: Message[][]): Provider {
+  return {
+    name: "mock",
+    async sendMessage(messages: Message[]): Promise<ProviderResponse> {
+      requests.push(messages);
+      return textResponse("done");
+    },
+  };
+}
+
+/** A provider that rejects once as context-too-large, then answers. */
+function createOverflowingProvider(requests: Message[][]): Provider {
+  let throwOnce = true;
+  return {
+    name: "mock",
+    async sendMessage(messages: Message[]): Promise<ProviderResponse> {
+      requests.push(messages);
+      if (throwOnce) {
+        throwOnce = false;
+        throw new ContextOverflowError("prompt too long", "mock", {
+          actualTokens: 999_999,
+        });
+      }
+      return textResponse("done after overflow recovery");
+    },
+  };
+}
+
+/**
+ * Install a manager whose compaction returns the four-frame history, so the
+ * loop installs more frames than the bound allows.
+ */
+function installOverfullCompactionManager(): { trust: TrustContext } {
+  createContextWindowManager({
+    provider: { name: "mock-provider" } as unknown as Provider,
+    config: {} as unknown as ContextWindowConfig,
+    conversationId: CONVERSATION_ID,
+  });
+  const manager = getContextWindowManager(CONVERSATION_ID);
+  if (manager) {
+    const rebuild = async () => ({
+      messages: compactedHistoryWithFourFrames(),
+      compacted: true,
+      exhausted: false,
+    });
+    manager.maybeCompact = rebuild as unknown as typeof manager.maybeCompact;
+    manager.recoverContextOverflow =
+      rebuild as unknown as typeof manager.recoverContextOverflow;
+  }
+  return { trust: { sourceChannel: "vellum", trustClass: "unknown" } };
+}
+
+/** Image blocks in the last history the provider was asked to send. */
+function imagesInLastRequest(requests: Message[][]): ContentBlock[] {
+  const last = requests.at(-1) ?? [];
+  return last.flatMap((message) =>
+    message.content.filter((block) => block.type === "image"),
+  );
+}
+
+function frameStubsInLastRequest(requests: Message[][]): string[] {
+  const last = requests.at(-1) ?? [];
+  return last.flatMap((message) =>
+    message.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .filter((text) => text.startsWith("[Camera frame omitted from context:")),
+  );
+}
+
+describe("AgentLoop post-compaction history transform", () => {
+  beforeEach(() => {
+    resetPluginRegistryForTests();
+    registerPlugin(testPostCompactPlugin);
+  });
+
+  afterEach(() => {
+    disposeContextWindowManager(CONVERSATION_ID);
+  });
+
+  test("trims a budget-gate compaction before the next provider call", async () => {
+    const requests: Message[][] = [];
+    const loop = new AgentLoop({
+      provider: createRecordingProvider(requests),
+      systemPrompt: "system",
+      conversationId: CONVERSATION_ID,
+      tools: [],
+      toolExecutor: async () => ({ content: "ok", isError: false }),
+      transformCompactedHistory: (messages) =>
+        stripAgedSightFrames(messages, CAPTURE_TIMES).messages,
+    });
+
+    await loop.run({
+      requestId: "req",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      onEvent: () => {},
+      modelProfileKey: "balanced",
+      resolveContextWindow: () => ({
+        maxInputTokens: 10,
+        overflowRecovery: { enabled: true, safetyMarginRatio: 0 },
+      }),
+      compactInPlace: true,
+      ...installOverfullCompactionManager(),
+    });
+
+    // The request that went out after compaction carries the bound, not the
+    // four frames compaction rebuilt.
+    expect(imagesInLastRequest(requests)).toHaveLength(2);
+    expect(frameStubsInLastRequest(requests)).toHaveLength(2);
+    // The newest two survived.
+    expect(imagesInLastRequest(requests)).toEqual([
+      retainedFrame("f3"),
+      retainedFrame("f4"),
+    ]);
+  });
+
+  test("trims an overflow-driven compaction before the retry", async () => {
+    const requests: Message[][] = [];
+    const loop = new AgentLoop({
+      provider: createOverflowingProvider(requests),
+      systemPrompt: "system",
+      conversationId: CONVERSATION_ID,
+      tools: [],
+      toolExecutor: async () => ({ content: "ok", isError: false }),
+      transformCompactedHistory: (messages) =>
+        stripAgedSightFrames(messages, CAPTURE_TIMES).messages,
+    });
+    // Blocks the budget gate so only the overflow rejection drives compaction.
+    loop.compactionCircuit.lastPostCompactionEstimate = 0;
+
+    await loop.run({
+      requestId: "req",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      onEvent: () => {},
+      modelProfileKey: "balanced",
+      resolveContextWindow: () => ({
+        maxInputTokens: 10,
+        overflowRecovery: { enabled: true, safetyMarginRatio: 0 },
+      }),
+      compactInPlace: false,
+      ...installOverfullCompactionManager(),
+    });
+
+    // The overflow retry is a second provider call, and it too is bounded.
+    expect(requests.length).toBeGreaterThan(1);
+    expect(imagesInLastRequest(requests)).toHaveLength(2);
+    expect(frameStubsInLastRequest(requests)).toHaveLength(2);
+  });
+
+  test("installs the compacted history as built when no transform is configured", async () => {
+    // The workflow leaf runner builds a loop with no conversation behind it.
+    const requests: Message[][] = [];
+    const loop = new AgentLoop({
+      provider: createRecordingProvider(requests),
+      systemPrompt: "system",
+      conversationId: CONVERSATION_ID,
+      tools: [],
+      toolExecutor: async () => ({ content: "ok", isError: false }),
+    });
+
+    await loop.run({
+      requestId: "req",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      onEvent: () => {},
+      modelProfileKey: "balanced",
+      resolveContextWindow: () => ({
+        maxInputTokens: 10,
+        overflowRecovery: { enabled: true, safetyMarginRatio: 0 },
+      }),
+      compactInPlace: true,
+      ...installOverfullCompactionManager(),
+    });
+
+    expect(imagesInLastRequest(requests)).toHaveLength(4);
+    expect(frameStubsInLastRequest(requests)).toHaveLength(0);
+  });
+
+  test("keeps the compacted history when the transform throws", async () => {
+    const requests: Message[][] = [];
+    const loop = new AgentLoop({
+      provider: createRecordingProvider(requests),
+      systemPrompt: "system",
+      conversationId: CONVERSATION_ID,
+      tools: [],
+      toolExecutor: async () => ({ content: "ok", isError: false }),
+      transformCompactedHistory: () => {
+        throw new Error("row read failed");
+      },
+    });
+
+    await loop.run({
+      requestId: "req",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      onEvent: () => {},
+      modelProfileKey: "balanced",
+      resolveContextWindow: () => ({
+        maxInputTokens: 10,
+        overflowRecovery: { enabled: true, safetyMarginRatio: 0 },
+      }),
+      compactInPlace: true,
+      ...installOverfullCompactionManager(),
+    });
+
+    // The turn still completed against the untrimmed compacted history.
+    expect(requests.length).toBeGreaterThan(0);
+    expect(imagesInLastRequest(requests)).toHaveLength(4);
+  });
+});

--- a/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
+++ b/assistant/src/__tests__/agent-wake-disk-pressure-callsite.test.ts
@@ -78,6 +78,9 @@ function makeTarget(): Conversation {
       }),
     },
     messages,
+    // The wake trims its own run input; no row here is tagged as a camera
+    // frame, so the real pass would return the array unchanged too.
+    trimAgedSightFrames: (msgs: Message[]) => msgs,
     getMessages: () => messages,
     isProcessing: () => processing,
     waitForIdle: async () => !processing,

--- a/assistant/src/__tests__/agent-wake-override-profile.test.ts
+++ b/assistant/src/__tests__/agent-wake-override-profile.test.ts
@@ -90,6 +90,9 @@ function makeTarget(): {
       },
     },
     messages,
+    // The wake trims its own run input; no row here is tagged as a camera
+    // frame, so the real pass would return the array unchanged too.
+    trimAgedSightFrames: (msgs: Message[]) => msgs,
     getMessages: () => messages,
     isProcessing: () => processing,
     waitForIdle: async () => !processing,

--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -2974,6 +2974,62 @@ describe("AnthropicProvider — Managed Proxy Fallback", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests - internal `_attachmentId` never reaches the wire
+// ---------------------------------------------------------------------------
+
+describe("AnthropicProvider - internal attachment id", () => {
+  let provider: AnthropicProvider;
+
+  beforeEach(() => {
+    lastStreamParams = null;
+    provider = new AnthropicProvider("sk-ant-test", "claude-sonnet-4-6");
+  });
+
+  test("drops _attachmentId from image and file blocks", async () => {
+    // The declared media type matches the bytes, so `resolveMediaReferences`
+    // takes its identity fast path and hands the block through untouched. What
+    // keeps the field off the wire is the client rebuilding each payload out of
+    // `source` alone.
+    const messages: Message[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "what is this" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: PNG_B64,
+            },
+            _attachmentId: "att-image-1",
+          },
+          {
+            type: "file",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "cGRm",
+              filename: "notes.pdf",
+            },
+            _attachmentId: "att-file-1",
+          },
+        ],
+      },
+    ];
+
+    await provider.sendMessage(messages);
+
+    const sent = JSON.stringify(lastStreamParams!.messages);
+    expect(sent).not.toContain("_attachmentId");
+    expect(sent).not.toContain("att-image-1");
+    expect(sent).not.toContain("att-file-1");
+    // The image itself still went out.
+    expect(sent).toContain(PNG_B64);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests — Orphaned UTF-16 surrogate sanitization
 // ---------------------------------------------------------------------------
 

--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -6,7 +6,10 @@ import {
   enrichMessageWithSourcePaths,
 } from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
-import { attachmentIdFragment } from "../providers/types.js";
+import {
+  attachmentIdFragment,
+  mediaBlockAttachmentId,
+} from "../providers/types.js";
 
 // ---------------------------------------------------------------------------
 // attachmentIdFragment
@@ -23,6 +26,70 @@ describe("attachmentIdFragment", () => {
     expect(attachmentIdFragment(undefined)).toEqual({});
     expect(attachmentIdFragment("")).toEqual({});
     expect("_attachmentId" in attachmentIdFragment("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mediaBlockAttachmentId
+// ---------------------------------------------------------------------------
+
+describe("mediaBlockAttachmentId", () => {
+  test("reads a reference's id off its source", () => {
+    expect(
+      mediaBlockAttachmentId({
+        type: "image",
+        source: {
+          type: "workspace_ref",
+          media_type: "image/png",
+          attachmentId: "att-ref",
+          sizeBytes: 10,
+        },
+      }),
+    ).toBe("att-ref");
+  });
+
+  test("reads an inline block's id off the top-level field", () => {
+    expect(
+      mediaBlockAttachmentId({
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "AAAA" },
+        _attachmentId: "att-inline",
+      }),
+    ).toBe("att-inline");
+  });
+
+  test("is undefined for a block that came from no attachment", () => {
+    expect(
+      mediaBlockAttachmentId({
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "AAAA" },
+      }),
+    ).toBeUndefined();
+  });
+
+  test("covers file blocks in both shapes", () => {
+    expect(
+      mediaBlockAttachmentId({
+        type: "file",
+        source: {
+          type: "workspace_ref",
+          media_type: "application/pdf",
+          attachmentId: "att-file-ref",
+          sizeBytes: 10,
+        },
+      }),
+    ).toBe("att-file-ref");
+    expect(
+      mediaBlockAttachmentId({
+        type: "file",
+        source: {
+          type: "base64",
+          media_type: "application/pdf",
+          data: "AAAA",
+        },
+        _attachmentId: "att-file-inline",
+      }),
+    ).toBe("att-file-inline");
   });
 });
 

--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -6,6 +6,25 @@ import {
   enrichMessageWithSourcePaths,
 } from "../agent/attachments.js";
 import { createUserMessage } from "../agent/message-types.js";
+import { attachmentIdFragment } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// attachmentIdFragment
+// ---------------------------------------------------------------------------
+
+describe("attachmentIdFragment", () => {
+  test("yields the property when an id is present", () => {
+    expect(attachmentIdFragment("att-1")).toEqual({ _attachmentId: "att-1" });
+  });
+
+  test("yields nothing for a missing or empty id", () => {
+    // Absent rather than present-and-empty: the read side requires a non-empty
+    // string before it treats the field as an id.
+    expect(attachmentIdFragment(undefined)).toEqual({});
+    expect(attachmentIdFragment("")).toEqual({});
+    expect("_attachmentId" in attachmentIdFragment("")).toBe(false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // attachmentsToReferenceBlocks

--- a/assistant/src/__tests__/attachments.test.ts
+++ b/assistant/src/__tests__/attachments.test.ts
@@ -152,6 +152,42 @@ describe("attachmentsToContentBlocks", () => {
     const blocks = await attachmentsToContentBlocks([]);
     expect(blocks).toHaveLength(0);
   });
+
+  test("stamps the attachment id on image and file blocks alike", async () => {
+    const blocks = await attachmentsToContentBlocks([
+      {
+        id: "att-img",
+        filename: "photo.jpg",
+        mimeType: "image/jpeg",
+        data: "imgdata",
+      },
+      {
+        id: "att-doc",
+        filename: "doc.pdf",
+        mimeType: "application/pdf",
+        data: "pdfdata",
+      },
+    ]);
+
+    expect(blocks[0].type).toBe("image");
+    expect((blocks[0] as { _attachmentId?: string })._attachmentId).toBe(
+      "att-img",
+    );
+    expect(blocks[1].type).toBe("file");
+    expect((blocks[1] as { _attachmentId?: string })._attachmentId).toBe(
+      "att-doc",
+    );
+  });
+
+  test("omits the attachment id when the upload has none", async () => {
+    const blocks = await attachmentsToContentBlocks([
+      { filename: "photo.jpg", mimeType: "image/jpeg", data: "imgdata" },
+      { filename: "doc.pdf", mimeType: "application/pdf", data: "pdfdata" },
+    ]);
+
+    expect("_attachmentId" in blocks[0]).toBe(false);
+    expect("_attachmentId" in blocks[1]).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/__tests__/compactor-retained-image-validation.test.ts
+++ b/assistant/src/__tests__/compactor-retained-image-validation.test.ts
@@ -125,6 +125,21 @@ describe("buildRetainedImageBlocks corrupt-bytes gate", () => {
     expect(blocks).toHaveLength(0);
   });
 
+  test("a retained block carries the attachment id it rehydrated from", async () => {
+    // The rebuilt block is inline bytes, so this id is the only handle left on
+    // the row it came from. Camera-frame retention matches on it: without it a
+    // frame compaction chose to keep would be invisible to every later pass.
+    const conv = createConversation();
+    await addImageMessage(conv.id, "good.png", PNG_1X1_BASE64);
+    const manifest = collectImageManifest(conv.id, "guardian");
+
+    const { blocks } = await buildRetainedImageBlocks(["good.png"], manifest);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]._attachmentId).toBe(manifest[0].attachmentId);
+    expect(blocks[0]._attachmentId).toBeTruthy();
+  });
+
   test("unresolvable filenames still land in missing", async () => {
     const conv = createConversation();
     await addImageMessage(conv.id, "good.png", PNG_1X1_BASE64);

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -346,6 +346,10 @@ mock.module("../persistence/conversation-crud.js", () => ({
   updateMessageMetadata: updateMessageMetadataMock,
   setConversationHistoryStrippedAt: setConversationHistoryStrippedAtMock,
   getMessages: () => mockStoredMessages,
+  // Read by the pre-run camera-frame retention pass for any history holding
+  // attachment references. This suite seeds none, so an empty map is the same
+  // answer the real accessor would give.
+  selectSightFrameCaptureTimes: () => new Map<string, number>(),
   getConversation: () => mockConversationRow,
   provenanceFromTrustContext: () => ({
     source: "user",

--- a/assistant/src/__tests__/conversation-media-retry.test.ts
+++ b/assistant/src/__tests__/conversation-media-retry.test.ts
@@ -68,9 +68,40 @@ describe("stripMediaPayloadsForRetry", () => {
     // The image in the first message should be replaced with a text stub
     const firstMsg = result.messages[0];
     expect(firstMsg.content[1].type).toBe("text");
+    // Pinned whole, not just the prefix: the descriptor half comes from the
+    // shared `mediaSourceDescriptor`, and this is what keeps this stub and the
+    // camera-frame stub describing dropped media the same way. `makeImageBlock`
+    // carries 4 base64 chars, which decode to 3 bytes.
+    expect((firstMsg.content[1] as { type: "text"; text: string }).text).toBe(
+      "[Image omitted from retry context: image/png, 3 bytes]",
+    );
+  });
+
+  test("a stripped file block reports the same descriptor as an image", () => {
+    const fileBlock: ContentBlock = {
+      type: "file",
+      source: {
+        type: "workspace_ref",
+        media_type: "application/pdf",
+        attachmentId: "att-1",
+        sizeBytes: 2048,
+        filename: "notes.pdf",
+      },
+    };
+    const messages: Message[] = [
+      makeUserMessage({ type: "text", text: "old" }, fileBlock),
+      makeAssistantMessage({ type: "text", text: "response" }),
+      makeUserMessage({ type: "text", text: "new" }),
+    ];
+
+    const result = stripMediaPayloadsForRetry(messages);
+
+    expect(result.replacedBlocks).toBe(1);
     expect(
-      (firstMsg.content[1] as { type: "text"; text: string }).text,
-    ).toContain("Image omitted");
+      (result.messages[0].content[1] as { type: "text"; text: string }).text,
+    ).toBe(
+      "[File omitted from retry context: notes.pdf (application/pdf, 2048 bytes)]",
+    );
   });
 
   test("strips images from older user turns, keeps images in latest kept turn", () => {

--- a/assistant/src/__tests__/conversation-queue.test.ts
+++ b/assistant/src/__tests__/conversation-queue.test.ts
@@ -88,6 +88,10 @@ mock.module("../persistence/conversation-crud.js", () => ({
   getConversationOriginInterface: () => null,
   getConversationOriginChannel: () => null,
   getMessages: () => [],
+  // The batched-drain attachment cases put real image blocks in the history,
+  // which is what makes the camera-frame retention pass read rows. None of
+  // them is tagged, so an empty map is the answer the real accessor gives.
+  selectSightFrameCaptureTimes: () => new Map<string, number>(),
   getConversation: () => ({
     id: "conv-1",
     contextSummary: null,

--- a/assistant/src/__tests__/conversation-sight-frames.test.ts
+++ b/assistant/src/__tests__/conversation-sight-frames.test.ts
@@ -54,6 +54,20 @@ function liveImage(
   };
 }
 
+/**
+ * A block in the shape `buildRetainedImageBlocks` rebuilds: inline bytes
+ * re-hydrated from the attachment store, stamped with the manifest entry's id.
+ */
+function retainedImage(
+  attachmentId: string,
+): Extract<ContentBlock, { type: "image" }> {
+  return {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: "AAAAAAAA" },
+    _attachmentId: attachmentId,
+  };
+}
+
 function user(...blocks: ContentBlock[]): Message {
   return { role: "user", content: blocks };
 }
@@ -272,6 +286,44 @@ describe("stripAgedSightFrames", () => {
     expect(result.replacedBlocks).toBe(1);
     expect(result.messages[0].content[0]).toEqual(liveImage("picked-1"));
     expect(result.messages[1].content[0].type).toBe("text");
+  });
+
+  test("re-stubs frames that compaction pulled back into the history", () => {
+    // Compaction builds its image manifest from the stored rows, not from the
+    // trimmed copy a turn sent, so a frame this pass already stubbed can come
+    // back as a rebuilt inline block. The history below is the shape compaction
+    // leaves behind (summary, retained-images message, verbatim tail), written
+    // out rather than produced by a real compaction run, which would need a
+    // provider call. The bound has to re-apply over it.
+    const messages: Message[] = [
+      assistant("<context_summary>earlier call</context_summary>"),
+      user(
+        {
+          type: "text",
+          text: "Images retained from the compacted portion of the conversation:",
+        },
+        retainedImage("f1"),
+        retainedImage("f2"),
+        retainedImage("f3"),
+      ),
+      user({ type: "text", text: "and now" }, liveImage("f4")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3", "f4"),
+    );
+
+    expect(result.replacedBlocks).toBe(2);
+    expect(textOf(result.messages[1], 1)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:00.000Z, image/png, 6 bytes]",
+    );
+    expect(textOf(result.messages[1], 2)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:01.000Z, image/png, 6 bytes]",
+    );
+    // The newest retained frame and the tail's live frame are the survivors.
+    expect(result.messages[1].content[3]).toEqual(retainedImage("f3"));
+    expect(result.messages[2].content[1]).toEqual(liveImage("f4"));
   });
 
   test("leaves a conversation at or under the budget untouched", () => {

--- a/assistant/src/__tests__/conversation-sight-frames.test.ts
+++ b/assistant/src/__tests__/conversation-sight-frames.test.ts
@@ -326,6 +326,62 @@ describe("stripAgedSightFrames", () => {
     expect(result.messages[2].content[1]).toEqual(liveImage("f4"));
   });
 
+  test("ranks compaction-rebuilt frames by capture time, not position", () => {
+    // Compaction lists the frames it keeps in the MODEL's order inside one
+    // synthetic message, so their position stops tracking recency. Here the
+    // newest frame (f4) sits first and the oldest (f1) last. Ranking by
+    // position would stub f4 and keep f1; ranking by capture time keeps f4.
+    const times = captureTimes("f1", "f2", "f3", "f4");
+    const messages: Message[] = [
+      assistant("<context_summary>earlier call</context_summary>"),
+      user(
+        {
+          type: "text",
+          text: "Images retained from the compacted portion of the conversation:",
+        },
+        retainedImage("f4"),
+        retainedImage("f3"),
+        retainedImage("f2"),
+        retainedImage("f1"),
+      ),
+    ];
+
+    const result = stripAgedSightFrames(messages, times);
+
+    expect(result.replacedBlocks).toBe(2);
+    const retained = result.messages[1];
+    // The two newest survive wherever they sit.
+    expect(retained.content[1]).toEqual(retainedImage("f4"));
+    expect(retained.content[2]).toEqual(retainedImage("f3"));
+    // The two oldest are stubbed, each naming its own capture time.
+    expect(textOf(retained, 3)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:01.000Z, image/png, 6 bytes]",
+    );
+    expect(textOf(retained, 4)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:00.000Z, image/png, 6 bytes]",
+    );
+  });
+
+  test("falls back to history order for frames sharing a capture time", () => {
+    // Frames attached to the same row share its `createdAt`, so the tiebreak
+    // is the order they sit in the history, which is the order they arrived.
+    const sameRow = new Map([
+      ["f1", 1000],
+      ["f2", 1000],
+      ["f3", 1000],
+    ]);
+    const messages: Message[] = [
+      user(retainedImage("f1"), retainedImage("f2"), retainedImage("f3")),
+    ];
+
+    const result = stripAgedSightFrames(messages, sameRow);
+
+    expect(result.replacedBlocks).toBe(1);
+    expect(result.messages[0].content[0].type).toBe("text");
+    expect(result.messages[0].content[1]).toEqual(retainedImage("f2"));
+    expect(result.messages[0].content[2]).toEqual(retainedImage("f3"));
+  });
+
   test("leaves a conversation at or under the budget untouched", () => {
     const messages: Message[] = [
       user(referenceImage("f1")),

--- a/assistant/src/__tests__/conversation-sight-frames.test.ts
+++ b/assistant/src/__tests__/conversation-sight-frames.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  countMediaBlocks,
+  stripMediaPayloadsForRetry,
+} from "../daemon/conversation-media-retry.js";
+import {
+  KEEP_LATEST_SIGHT_FRAMES,
+  stripAgedSightFrames,
+} from "../daemon/conversation-sight-frames.js";
+import { sightFrameAttachmentIdsFromMetadata } from "../persistence/conversation-types.js";
+import type { ContentBlock, Message } from "../providers/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** An attachment reference block, the shape persisted history carries. */
+function referenceImage(
+  attachmentId: string,
+  sizeBytes = 1024,
+): Extract<ContentBlock, { type: "image" }> {
+  return {
+    type: "image",
+    source: {
+      type: "workspace_ref",
+      media_type: "image/jpeg",
+      attachmentId,
+      sizeBytes,
+    },
+  };
+}
+
+/** An inline upload, which carries no attachment id to match against. */
+function inlineImage(): Extract<ContentBlock, { type: "image" }> {
+  return {
+    type: "image",
+    source: { type: "base64", media_type: "image/png", data: "AAAA" },
+  };
+}
+
+function user(...blocks: ContentBlock[]): Message {
+  return { role: "user", content: blocks };
+}
+
+function assistant(text: string): Message {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+
+/** Capture times for tagged frames, one second apart from a fixed instant. */
+function captureTimes(...attachmentIds: string[]): Map<string, number> {
+  const base = Date.parse("2026-08-30T14:25:00.000Z");
+  return new Map(attachmentIds.map((id, i) => [id, base + i * 1000]));
+}
+
+function textOf(message: Message, index: number): string {
+  const block = message.content[index];
+  return block.type === "text" ? block.text : "";
+}
+
+// ---------------------------------------------------------------------------
+// stripAgedSightFrames
+// ---------------------------------------------------------------------------
+
+describe("stripAgedSightFrames", () => {
+  test("keeps the newest frames and stubs the rest", () => {
+    const messages: Message[] = [
+      user({ type: "text", text: "one" }, referenceImage("f1")),
+      assistant("ok"),
+      user({ type: "text", text: "two" }, referenceImage("f2")),
+      assistant("ok"),
+      user({ type: "text", text: "three" }, referenceImage("f3")),
+      assistant("ok"),
+      user({ type: "text", text: "four" }, referenceImage("f4")),
+      user({ type: "text", text: "five" }, referenceImage("f5")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3", "f4", "f5"),
+    );
+
+    expect(result.modified).toBe(true);
+    expect(result.replacedBlocks).toBe(3);
+
+    const surviving = result.messages.flatMap((m) =>
+      m.content.filter((b) => b.type === "image"),
+    );
+    expect(surviving).toHaveLength(KEEP_LATEST_SIGHT_FRAMES);
+    expect(surviving).toEqual([referenceImage("f4"), referenceImage("f5")]);
+
+    expect(textOf(result.messages[0], 1)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:00.000Z, image/jpeg, 1024 bytes]",
+    );
+    expect(textOf(result.messages[2], 1)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:01.000Z, image/jpeg, 1024 bytes]",
+    );
+    expect(textOf(result.messages[4], 1)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:02.000Z, image/jpeg, 1024 bytes]",
+    );
+  });
+
+  test("stubs several frames on one message independently", () => {
+    const messages: Message[] = [
+      user(referenceImage("f1"), referenceImage("f2"), referenceImage("f3")),
+      user(referenceImage("f4")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3", "f4"),
+    );
+
+    expect(result.replacedBlocks).toBe(2);
+    expect(result.messages[0].content.map((b) => b.type)).toEqual([
+      "text",
+      "text",
+      "image",
+    ]);
+    expect(result.messages[1].content.map((b) => b.type)).toEqual(["image"]);
+  });
+
+  test("leaves untagged media alone, even interleaved with frames", () => {
+    const pickedReference = referenceImage("picked-1", 4096);
+    const pickedInline = inlineImage();
+    const pickedFile: ContentBlock = {
+      type: "file",
+      source: {
+        type: "workspace_ref",
+        media_type: "application/pdf",
+        attachmentId: "picked-2",
+        sizeBytes: 2048,
+        filename: "notes.pdf",
+      },
+    };
+    const messages: Message[] = [
+      user(referenceImage("f1"), pickedReference),
+      user(pickedInline, referenceImage("f2"), pickedFile),
+      user(referenceImage("f3"), referenceImage("f4")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3", "f4"),
+    );
+
+    expect(result.replacedBlocks).toBe(2);
+    expect(result.messages[0].content[1]).toBe(pickedReference);
+    expect(result.messages[1].content[0]).toBe(pickedInline);
+    expect(result.messages[1].content[2]).toBe(pickedFile);
+    expect(result.messages[2]).toBe(messages[2]);
+  });
+
+  test("ignores tagged ids that match no attachment on the row", () => {
+    const messages: Message[] = [
+      user(referenceImage("f1")),
+      user(referenceImage("f2")),
+      user(referenceImage("f3")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("gone-1", "gone-2", "gone-3"),
+    );
+
+    expect(result.modified).toBe(false);
+    expect(result.replacedBlocks).toBe(0);
+    expect(result.messages).toBe(messages);
+  });
+
+  test("is inert when nothing is tagged", () => {
+    const messages: Message[] = [
+      user({ type: "text", text: "look" }, referenceImage("a1")),
+      assistant("ok"),
+      user(inlineImage(), referenceImage("a2"), referenceImage("a3")),
+      assistant("ok"),
+      user(referenceImage("a4"), { type: "text", text: "and this" }),
+    ];
+    const before = structuredClone(messages);
+
+    const result = stripAgedSightFrames(messages, new Map());
+
+    expect(result.modified).toBe(false);
+    expect(result.replacedBlocks).toBe(0);
+    expect(result.messages).toBe(messages);
+    expect(result.messages).toEqual(before);
+  });
+
+  test("leaves a conversation at or under the budget untouched", () => {
+    const messages: Message[] = [
+      user(referenceImage("f1")),
+      user(referenceImage("f2")),
+    ];
+
+    const result = stripAgedSightFrames(messages, captureTimes("f1", "f2"));
+
+    expect(result.modified).toBe(false);
+    expect(result.messages).toBe(messages);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composition with the reactive retry path
+// ---------------------------------------------------------------------------
+
+describe("stripAgedSightFrames composed with stripMediaPayloadsForRetry", () => {
+  test("proactive stubs are invisible to the retry path", () => {
+    const messages: Message[] = [
+      user(referenceImage("f1"), referenceImage("picked-1", 4096)),
+      assistant("ok"),
+      user(referenceImage("f2")),
+      assistant("ok"),
+      user(
+        { type: "text", text: "latest" },
+        referenceImage("f3"),
+        referenceImage("f4"),
+        referenceImage("picked-2", 4096),
+        referenceImage("picked-3", 4096),
+      ),
+    ];
+    expect(countMediaBlocks(messages)).toBe(7);
+
+    const trimmed = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3", "f4"),
+    ).messages;
+    // The two stubbed frames are text now, so the retry path cannot see them.
+    expect(countMediaBlocks(trimmed)).toBe(5);
+
+    const retried = stripMediaPayloadsForRetry(trimmed);
+
+    // Only the real media the retry path owns is replaced: the older message's
+    // picked image, plus the fourth media block of the latest user message.
+    expect(retried.replacedBlocks).toBe(2);
+    expect(countMediaBlocks(retried.messages)).toBe(3);
+
+    const stubTexts = retried.messages.flatMap((m) =>
+      m.content.filter((b) => b.type === "text").map((b) => b.text),
+    );
+    const cameraStubs = stubTexts.filter((t) =>
+      t.startsWith("[Camera frame omitted from context:"),
+    );
+    expect(cameraStubs).toHaveLength(2);
+    expect(
+      stubTexts.filter((t) =>
+        t.startsWith("[Image omitted from retry context:"),
+      ),
+    ).toHaveLength(2);
+    // Nothing wrapped a camera stub in a retry stub.
+    for (const stub of cameraStubs) {
+      expect(stub.includes("retry context")).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metadata reader
+// ---------------------------------------------------------------------------
+
+describe("sightFrameAttachmentIdsFromMetadata", () => {
+  test("reads the tagged ids", () => {
+    expect(
+      sightFrameAttachmentIdsFromMetadata({
+        voiceSessionTurn: true,
+        sightFrameAttachmentIds: ["att-1", "att-2"],
+      }),
+    ).toEqual(["att-1", "att-2"]);
+  });
+
+  test("yields nothing for absent, null, or malformed values", () => {
+    expect(sightFrameAttachmentIdsFromMetadata(undefined)).toEqual([]);
+    expect(sightFrameAttachmentIdsFromMetadata(null)).toEqual([]);
+    expect(sightFrameAttachmentIdsFromMetadata({})).toEqual([]);
+    expect(
+      sightFrameAttachmentIdsFromMetadata({ sightFrameAttachmentIds: "att-1" }),
+    ).toEqual([]);
+    expect(
+      sightFrameAttachmentIdsFromMetadata({
+        sightFrameAttachmentIds: ["att-1", "", 7, null],
+      }),
+    ).toEqual(["att-1"]);
+  });
+});

--- a/assistant/src/__tests__/conversation-sight-frames.test.ts
+++ b/assistant/src/__tests__/conversation-sight-frames.test.ts
@@ -39,6 +39,21 @@ function inlineImage(): Extract<ContentBlock, { type: "image" }> {
   };
 }
 
+/**
+ * The live in-memory copy of an upload: inline bytes plus the attachment id
+ * that ties it to the row persisted as a reference. `data` is 8 base64 chars,
+ * so `mediaSourceByteLength` reports 6 bytes.
+ */
+function liveImage(
+  attachmentId: string,
+): Extract<ContentBlock, { type: "image" }> {
+  return {
+    type: "image",
+    source: { type: "base64", media_type: "image/jpeg", data: "AAAAAAAA" },
+    _attachmentId: attachmentId,
+  };
+}
+
 function user(...blocks: ContentBlock[]): Message {
   return { role: "user", content: blocks };
 }
@@ -172,9 +187,9 @@ describe("stripAgedSightFrames", () => {
     const messages: Message[] = [
       user({ type: "text", text: "look" }, referenceImage("a1")),
       assistant("ok"),
-      user(inlineImage(), referenceImage("a2"), referenceImage("a3")),
+      user(inlineImage(), referenceImage("a2"), liveImage("a3")),
       assistant("ok"),
-      user(referenceImage("a4"), { type: "text", text: "and this" }),
+      user(liveImage("a4"), { type: "text", text: "and this" }),
     ];
     const before = structuredClone(messages);
 
@@ -184,6 +199,79 @@ describe("stripAgedSightFrames", () => {
     expect(result.replacedBlocks).toBe(0);
     expect(result.messages).toBe(messages);
     expect(result.messages).toEqual(before);
+  });
+
+  test("stubs live inline frames on a call that never reloaded", () => {
+    // Every frame is the in-memory copy a turn pushed, so nothing in this
+    // history is a `workspace_ref`. This is the uninterrupted-call case.
+    const messages: Message[] = [
+      user({ type: "text", text: "one" }, liveImage("f1")),
+      assistant("ok"),
+      user({ type: "text", text: "two" }, liveImage("f2")),
+      assistant("ok"),
+      user({ type: "text", text: "three" }, liveImage("f3")),
+      assistant("ok"),
+      user({ type: "text", text: "four" }, liveImage("f4")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3", "f4"),
+    );
+
+    expect(result.modified).toBe(true);
+    expect(result.replacedBlocks).toBe(2);
+    expect(textOf(result.messages[0], 1)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:00.000Z, image/jpeg, 6 bytes]",
+    );
+    expect(textOf(result.messages[2], 1)).toBe(
+      "[Camera frame omitted from context: captured 2026-08-30T14:25:01.000Z, image/jpeg, 6 bytes]",
+    );
+    expect(result.messages[4].content[1]).toEqual(liveImage("f3"));
+    expect(result.messages[6].content[1]).toEqual(liveImage("f4"));
+  });
+
+  test("ranks live and reloaded frames in one pool", () => {
+    // A conversation reloaded mid-call: the older turns came back from the DB
+    // as references, the newer ones are still the live copies. The newest two
+    // survive regardless of which shape they are.
+    const messages: Message[] = [
+      user(referenceImage("f1")),
+      user(referenceImage("f2")),
+      user(liveImage("f3")),
+      user(referenceImage("f4")),
+      user(liveImage("f5")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3", "f4", "f5"),
+    );
+
+    expect(result.replacedBlocks).toBe(3);
+    expect(result.messages[0].content[0].type).toBe("text");
+    expect(result.messages[1].content[0].type).toBe("text");
+    expect(result.messages[2].content[0].type).toBe("text");
+    expect(result.messages[3].content[0]).toEqual(referenceImage("f4"));
+    expect(result.messages[4].content[0]).toEqual(liveImage("f5"));
+  });
+
+  test("ignores an inline image whose id was never tagged", () => {
+    const messages: Message[] = [
+      user(liveImage("picked-1")),
+      user(liveImage("f1")),
+      user(liveImage("f2")),
+      user(liveImage("f3")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3"),
+    );
+
+    expect(result.replacedBlocks).toBe(1);
+    expect(result.messages[0].content[0]).toEqual(liveImage("picked-1"));
+    expect(result.messages[1].content[0].type).toBe("text");
   });
 
   test("leaves a conversation at or under the budget untouched", () => {

--- a/assistant/src/__tests__/conversation-summarize-up-to.test.ts
+++ b/assistant/src/__tests__/conversation-summarize-up-to.test.ts
@@ -101,6 +101,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
   getConversationOriginInterface: () => null,
   getConversationOriginChannel: () => null,
   getMessages: () => mockDbMessages,
+  // Read by camera-frame retention on the compaction pipeline's summarizer
+  // input. Empty unless a test seeds tagged frames.
+  selectSightFrameCaptureTimes: () => sightFrameCaptureTimes,
   getConversation: () => mockConversation,
   createConversation: () => ({ id: "conv-1" }),
   addMessage: () => ({ id: `msg-${Date.now()}` }),
@@ -113,6 +116,9 @@ mock.module("../persistence/conversation-crud.js", () => ({
 mock.module("../persistence/conversation-queries.js", () => ({
   listConversations: () => [],
 }));
+
+/** Tagged camera frames for the retention pass; seeded per test. */
+let sightFrameCaptureTimes = new Map<string, number>();
 
 // Captured defaultCompact invocations + per-test canned result.
 let compactCalls: CompactionContext[] = [];
@@ -366,6 +372,7 @@ describe("Conversation.summarizeUpToMessage", () => {
     mockCompactResult = makeNoopResult();
     mockDbMessages = threeTurnRows();
     mockConversation = baseConversationRow();
+    sightFrameCaptureTimes = new Map();
   });
 
   test("maps the boundary row straight through when there is no context summary", async () => {
@@ -937,5 +944,100 @@ describe("formatSummarizeUpToResult", () => {
 
     expect(card).toContain("Summarized 12 earlier messages.");
     expect(card).toContain("4 recent messages kept in full.");
+  });
+});
+
+/**
+ * `forceCompact`, `maybeCompact`, and `summarizeUpToMessage` all funnel through
+ * the private `runCompaction`, so the retention applied to its summarizer input
+ * covers all three. `forceCompact` is the cheapest of them to drive.
+ */
+describe("direct compaction trims the summarizer's own input", () => {
+  beforeEach(() => {
+    compactCalls = [];
+    slackWatermarkCalls = [];
+    mockCompactResult = makeNoopResult();
+    mockDbMessages = threeTurnRows();
+    mockConversation = baseConversationRow();
+    sightFrameCaptureTimes = new Map();
+  });
+
+  /** A frame as the live history carries it: inline bytes plus its row id. */
+  function frame(attachmentId: string): Message {
+    return {
+      role: "user",
+      content: [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "AAAAAAAA" },
+          _attachmentId: attachmentId,
+        },
+      ],
+    };
+  }
+
+  function framesInCompactCall(): number {
+    return (compactCalls[0]?.messages ?? []).flatMap((message) =>
+      message.content.filter((block) => block.type === "image"),
+    ).length;
+  }
+
+  function frameStubsInCompactCall(): number {
+    return (compactCalls[0]?.messages ?? []).flatMap((message) =>
+      message.content.filter(
+        (block) =>
+          block.type === "text" &&
+          block.text.startsWith("[Camera frame omitted from context:"),
+      ),
+    ).length;
+  }
+
+  test("bounds an over-full camera history before the summary call", async () => {
+    sightFrameCaptureTimes = new Map([
+      ["f1", 1000],
+      ["f2", 2000],
+      ["f3", 3000],
+      ["f4", 4000],
+    ]);
+    const conversation = makeConversation();
+    conversation.messages = [
+      frame("f1"),
+      frame("f2"),
+      frame("f3"),
+      frame("f4"),
+    ];
+
+    await conversation.forceCompact();
+
+    // The summary call is a provider request like any other, so it carries the
+    // bound rather than every frame the session captured.
+    expect(compactCalls).toHaveLength(1);
+    expect(framesInCompactCall()).toBe(2);
+    expect(frameStubsInCompactCall()).toBe(2);
+  });
+
+  test("leaves an untagged history untouched", async () => {
+    const conversation = makeConversation();
+    conversation.messages = [frame("f1"), frame("f2"), frame("f3")];
+
+    await conversation.forceCompact();
+
+    expect(framesInCompactCall()).toBe(3);
+    expect(frameStubsInCompactCall()).toBe(0);
+  });
+
+  test("summarizeUpToMessage reaches the same trim through the shared seam", async () => {
+    sightFrameCaptureTimes = new Map([
+      ["f1", 1000],
+      ["f2", 2000],
+      ["f3", 3000],
+      ["f4", 4000],
+    ]);
+    const conversation = makeConversation();
+    await conversation.summarizeUpToMessage("m4");
+    // The boundary machinery reloads history from the mocked rows, so this
+    // asserts the seam ran, not the frame maths (covered above).
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0].fixedTailStartIndex).toBeDefined();
   });
 });

--- a/assistant/src/__tests__/media-resolve-image-validation.test.ts
+++ b/assistant/src/__tests__/media-resolve-image-validation.test.ts
@@ -221,6 +221,73 @@ describe("resolveMediaReferences image validation", () => {
   });
 });
 
+describe("resolveMediaReferences attachment id", () => {
+  beforeEach(resetTables);
+
+  test("carries a file block's attachment id across reference resolution", async () => {
+    // Resolving a reference rebuilds the block around freshly read bytes. The
+    // id is the block's only remaining link to its attachment row, so it has to
+    // survive the rebuild.
+    const conv = createConversation();
+    const stored = await createInlineAttachment(
+      conv.id,
+      conv.createdAt,
+      "notes.txt",
+      "text/plain",
+      Buffer.from("hello").toString("base64"),
+    );
+    const message = userMessage([
+      {
+        type: "file",
+        source: {
+          type: "workspace_ref",
+          media_type: "text/plain",
+          attachmentId: stored.id,
+          sizeBytes: stored.sizeBytes,
+          filename: "notes.txt",
+        },
+        _attachmentId: stored.id,
+      },
+    ]);
+
+    const [resolved] = await resolveMediaReferences([message]);
+
+    const block = resolved.content[0];
+    expect(block.type).toBe("file");
+    expect(block).toMatchObject({
+      source: { type: "base64" },
+      _attachmentId: stored.id,
+    });
+  });
+
+  test("omits the field when the source block carries no id", async () => {
+    const conv = createConversation();
+    const stored = await createInlineAttachment(
+      conv.id,
+      conv.createdAt,
+      "plain.txt",
+      "text/plain",
+      Buffer.from("hi").toString("base64"),
+    );
+    const message = userMessage([
+      {
+        type: "file",
+        source: {
+          type: "workspace_ref",
+          media_type: "text/plain",
+          attachmentId: stored.id,
+          sizeBytes: stored.sizeBytes,
+          filename: "plain.txt",
+        },
+      },
+    ]);
+
+    const [resolved] = await resolveMediaReferences([message]);
+
+    expect("_attachmentId" in resolved.content[0]).toBe(false);
+  });
+});
+
 describe("isUnsendableImageSource", () => {
   beforeEach(resetTables);
 

--- a/assistant/src/__tests__/media-resolve-image-validation.test.ts
+++ b/assistant/src/__tests__/media-resolve-image-validation.test.ts
@@ -13,6 +13,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   isUnsendableImageSource,
+  mediaSourceDescriptor,
   resolveMediaReferences,
   UNSENDABLE_IMAGE_FORMAT_NOTE,
 } from "../providers/media-resolve.js";
@@ -285,6 +286,44 @@ describe("resolveMediaReferences attachment id", () => {
     const [resolved] = await resolveMediaReferences([message]);
 
     expect("_attachmentId" in resolved.content[0]).toBe(false);
+  });
+});
+
+describe("mediaSourceDescriptor", () => {
+  // The fragment every media stub embeds. Both the retry path's stubs and the
+  // camera-frame stub read it from here, so this pins what they all report.
+  test("describes a reference from its persisted size hint", () => {
+    expect(
+      mediaSourceDescriptor({
+        type: "workspace_ref",
+        media_type: "image/jpeg",
+        attachmentId: "att-1",
+        sizeBytes: 1024,
+      }),
+    ).toBe("image/jpeg, 1024 bytes");
+  });
+
+  test("describes an inline block from its base64 length", () => {
+    // 8 base64 chars decode to 6 bytes.
+    expect(
+      mediaSourceDescriptor({
+        type: "base64",
+        media_type: "image/png",
+        data: "AAAAAAAA",
+      }),
+    ).toBe("image/png, 6 bytes");
+  });
+
+  test("covers non-image media too", () => {
+    expect(
+      mediaSourceDescriptor({
+        type: "workspace_ref",
+        media_type: "application/pdf",
+        attachmentId: "att-2",
+        sizeBytes: 42,
+        filename: "notes.pdf",
+      }),
+    ).toBe("application/pdf, 42 bytes");
   });
 });
 

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -33,6 +33,7 @@ mock.module("../agent/image-optimize.js", () => ({
   }),
 }));
 
+import { uploadAttachment } from "../persistence/attachments-store.js";
 import {
   addMessage,
   createConversation,
@@ -40,7 +41,10 @@ import {
 } from "../persistence/conversation-crud.js";
 import { getDb, getMemorySqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
-import { persistUnsendableImageDowngrades } from "../plugins/defaults/image-recovery/recover.js";
+import {
+  persistUnsendableImageDowngrades,
+  unsendableImageReplacement,
+} from "../plugins/defaults/image-recovery/recover.js";
 import { base64Source } from "../providers/media-resolve.js";
 import type { ContentBlock } from "../providers/types.js";
 
@@ -145,6 +149,64 @@ describe("persistUnsendableImageDowngrades (downscalable host)", () => {
       base64Source((nested as Extract<ContentBlock, { type: "image" }>).source)
         .data,
     ).toBe(SHRUNK_DATA);
+  });
+
+  /** The resize replaces the block's whole source, so a reference-backed image
+   *  loses `source.attachmentId` along with the reference. The id has to be
+   *  derived from either shape and re-stamped, or the durable rewrite untags a
+   *  camera frame permanently. */
+  test("a resized workspace_ref keeps its attachment id on the rebuilt block", async () => {
+    const stored = await uploadAttachment(
+      "frame.png",
+      "image/png",
+      oversizedPngBase64(),
+    );
+    const referenceBlock = {
+      type: "image",
+      source: {
+        type: "workspace_ref",
+        media_type: "image/png",
+        attachmentId: stored.id,
+        sizeBytes: 128,
+        // Persisted references carry the dimension hints the provider caps are
+        // judged against (see `attachmentsToReferenceBlocks`).
+        width: 12000,
+        height: 9000,
+      },
+    } as Extract<ContentBlock, { type: "image" }>;
+
+    const replacement = await unsendableImageReplacement(referenceBlock);
+
+    // The source was flattened to the shrunk inline bytes...
+    expect(replacement).toMatchObject({
+      type: "image",
+      source: { type: "base64", data: SHRUNK_DATA },
+    });
+    // ...and the link to the attachment row survived the flattening.
+    expect((replacement as { _attachmentId?: string })._attachmentId).toBe(
+      stored.id,
+    );
+  });
+
+  /** An inline resize input carries its id on the top-level field instead. */
+  test("a resized inline block keeps its top-level attachment id", async () => {
+    const inlineBlock = {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: oversizedPngBase64(),
+      },
+      _attachmentId: "att-inline-1",
+    } as Extract<ContentBlock, { type: "image" }>;
+
+    const replacement = await unsendableImageReplacement(inlineBlock);
+
+    expect(replacement).toMatchObject({
+      type: "image",
+      source: { type: "base64", data: SHRUNK_DATA },
+      _attachmentId: "att-inline-1",
+    });
   });
 
   /** Re-running is a no-op: the downscaled payload is within limits. */

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -392,6 +392,25 @@ describe("unsendableImageReplacement", () => {
     });
   });
 
+  /** Relabeling rebuilds the block, and the rebuilt form is written back to
+   *  the stored row. Losing the internal attachment id there would untag a
+   *  camera frame for good, so the relabel carries it across. */
+  test("relabeling preserves the internal attachment id", async () => {
+    const pngData = makePngBase64(1024, 768);
+    const mislabeled = {
+      ...(imageBlock(pngData, "image/jpeg") as Extract<
+        ContentBlock,
+        { type: "image" }
+      >),
+      _attachmentId: "att-frame-1",
+    };
+    const replacement = await unsendableImageReplacement(mislabeled);
+    expect(replacement).toMatchObject({
+      type: "image",
+      _attachmentId: "att-frame-1",
+    });
+  });
+
   /** Relabeling a persisted (workspace_ref) image keeps the reference shape —
    *  inlining it would bake the full payload into the stored message row. */
   test("relabels a mislabeled workspace_ref without inlining the payload", async () => {

--- a/assistant/src/__tests__/server-history-render.test.ts
+++ b/assistant/src/__tests__/server-history-render.test.ts
@@ -161,6 +161,28 @@ describe("renderHistoryContent", () => {
     expect(output.textSegments[1]).toContain("[File attachment] dream-015.md");
   });
 
+  test("an image block's _attachmentId contributes no attachment ref", () => {
+    // Chip positioning joins DB attachment rows against the refs collected
+    // here, and only `file` blocks are collected. An image carrying the same
+    // internal id must stay out of that join, or a user upload would gain a
+    // second, duplicate chip.
+    const output = renderHistoryContent([
+      { type: "text", text: "what is this" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/jpeg",
+          data: Buffer.from("img").toString("base64"),
+        },
+        _attachmentId: "att-image-1",
+      },
+    ]);
+
+    expect(output.attachments).toEqual([]);
+    expect(output.contentOrder).toEqual(["text:0"]);
+  });
+
   test("omits attachmentId when file block has no _attachmentId", () => {
     const output = renderHistoryContent([
       {

--- a/assistant/src/__tests__/sight-frame-retention.test.ts
+++ b/assistant/src/__tests__/sight-frame-retention.test.ts
@@ -2,7 +2,14 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { applySightFrameRetention } from "../daemon/conversation-runtime-assembly.js";
 import {
+  getAttachmentMetadataForMessage,
+  linkAttachmentToMessage,
+  uploadAttachment,
+} from "../persistence/attachments-store.js";
+import {
   addMessage,
+  createConversation,
+  forkConversation,
   getMessages,
   selectSightFrameCaptureTimes,
 } from "../persistence/conversation-crud.js";
@@ -175,5 +182,111 @@ describe("applySightFrameRetention", () => {
     ];
 
     expect(applySightFrameRetention(assembled, conversationId)).toBe(assembled);
+  });
+});
+
+describe("forked conversations", () => {
+  test("a fork's tag covers both its source and cloned attachment ids", async () => {
+    // A fork copies `messages.content` verbatim, so its blocks still name the
+    // SOURCE attachment ids, while `message_attachments` is re-linked to
+    // freshly CLONED rows. The compactor reads the link side and stamps cloned
+    // ids onto the frames it rebuilds, so a tag naming only one vocabulary
+    // goes blind on the other.
+    const db = getDb();
+    db.run("DELETE FROM message_attachments");
+    db.run("DELETE FROM attachments");
+
+    const source = createConversation("camera call");
+    const uploaded = await uploadAttachment(
+      "frame.png",
+      "image/png",
+      "iVBORw0K",
+    );
+    const row = await addMessage(
+      source.id,
+      "user",
+      JSON.stringify([
+        {
+          type: "image",
+          source: {
+            type: "workspace_ref",
+            media_type: "image/png",
+            attachmentId: uploaded.id,
+            sizeBytes: 8,
+          },
+        },
+      ]),
+      {
+        metadata: { sightFrameAttachmentIds: [uploaded.id] },
+        skipIndexing: true,
+      },
+    );
+    linkAttachmentToMessage(row.id, uploaded.id, 0);
+
+    const fork = forkConversation({ conversationId: source.id });
+    const forkRow = getMessages(fork.id)[0];
+    const clonedId = getAttachmentMetadataForMessage(forkRow.id)[0]?.id;
+
+    // The fork really did clone the attachment under a new id.
+    expect(clonedId).toBeDefined();
+    expect(clonedId).not.toBe(uploaded.id);
+
+    const captureTimes = selectSightFrameCaptureTimes(fork.id);
+    // Both vocabularies resolve, so a frame is matchable whether it arrived
+    // through the copied content or through the compactor's manifest.
+    expect(captureTimes.has(uploaded.id)).toBe(true);
+    expect(captureTimes.has(clonedId!)).toBe(true);
+
+    // The source conversation is untouched by the widening.
+    expect([...selectSightFrameCaptureTimes(source.id).keys()]).toEqual([
+      uploaded.id,
+    ]);
+  });
+
+  test("retention still matches the frames a fork holds directly", async () => {
+    const db = getDb();
+    db.run("DELETE FROM message_attachments");
+    db.run("DELETE FROM attachments");
+
+    const source = createConversation("camera call 2");
+    const ids: string[] = [];
+    for (const name of ["a.png", "b.png", "c.png"]) {
+      const uploaded = await uploadAttachment(name, "image/png", "iVBORw0K");
+      const row = await addMessage(
+        source.id,
+        "user",
+        JSON.stringify([
+          {
+            type: "image",
+            source: {
+              type: "workspace_ref",
+              media_type: "image/png",
+              attachmentId: uploaded.id,
+              sizeBytes: 8,
+            },
+          },
+        ]),
+        {
+          metadata: { sightFrameAttachmentIds: [uploaded.id] },
+          skipIndexing: true,
+        },
+      );
+      linkAttachmentToMessage(row.id, uploaded.id, 0);
+      ids.push(uploaded.id);
+    }
+
+    const fork = forkConversation({ conversationId: source.id });
+    // The fork's own rows, exactly as its history assembles them.
+    const assembled: Message[] = getMessages(fork.id).map((r) => ({
+      role: "user" as const,
+      content: r.content,
+    }));
+
+    const retained = applySightFrameRetention(assembled, fork.id);
+
+    // Oldest of the three is stubbed; the newest two survive.
+    expect(retained[0].content[0].type).toBe("text");
+    expect(retained[1].content[0].type).toBe("image");
+    expect(retained[2].content[0].type).toBe("image");
   });
 });

--- a/assistant/src/__tests__/sight-frame-retention.test.ts
+++ b/assistant/src/__tests__/sight-frame-retention.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { applySightFrameRetention } from "../daemon/conversation-runtime-assembly.js";
+import {
+  addMessage,
+  getMessages,
+  selectSightFrameCaptureTimes,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { conversations } from "../persistence/schema.js";
+import type { ContentBlock, Message } from "../providers/types.js";
+
+await initializeDb();
+
+function ensureConversation(id: string): void {
+  const db = getDb();
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id,
+      title: "test",
+      createdAt: now,
+      updatedAt: now,
+      lastMessageAt: now,
+    })
+    .onConflictDoNothing()
+    .run();
+}
+
+function frameContent(attachmentId: string): string {
+  return JSON.stringify([
+    { type: "text", text: "what am I looking at" },
+    {
+      type: "image",
+      source: {
+        type: "workspace_ref",
+        media_type: "image/jpeg",
+        attachmentId,
+        sizeBytes: 1024,
+      },
+    },
+  ]);
+}
+
+function referenceImage(
+  attachmentId: string,
+): Extract<ContentBlock, { type: "image" }> {
+  return {
+    type: "image",
+    source: {
+      type: "workspace_ref",
+      media_type: "image/jpeg",
+      attachmentId,
+      sizeBytes: 1024,
+    },
+  };
+}
+
+describe("selectSightFrameCaptureTimes", () => {
+  const conversationId = "conv-sight-frame-times";
+
+  beforeEach(() => {
+    ensureConversation(conversationId);
+  });
+
+  test("maps tagged attachment ids to the row that carried them", async () => {
+    const first = await addMessage(
+      conversationId,
+      "user",
+      frameContent("att-1"),
+      { metadata: { sightFrameAttachmentIds: ["att-1"] } },
+    );
+    const second = await addMessage(
+      conversationId,
+      "user",
+      frameContent("att-2"),
+      { metadata: { sightFrameAttachmentIds: ["att-2", "att-3"] } },
+    );
+
+    const rows = getMessages(conversationId);
+    const createdAtById = new Map(rows.map((r) => [r.id, r.createdAt]));
+    const captureTimes = selectSightFrameCaptureTimes(conversationId);
+
+    expect(captureTimes.get("att-1")).toBe(createdAtById.get(first.id)!);
+    expect(captureTimes.get("att-2")).toBe(createdAtById.get(second.id)!);
+    expect(captureTimes.get("att-3")).toBe(createdAtById.get(second.id)!);
+  });
+
+  test("is empty for a conversation whose rows carry no tag", async () => {
+    const untaggedId = "conv-sight-frame-untagged";
+    ensureConversation(untaggedId);
+    await addMessage(untaggedId, "user", frameContent("att-9"), {
+      metadata: { voiceSessionTurn: true },
+    });
+    await addMessage(untaggedId, "assistant", "sure");
+
+    expect(selectSightFrameCaptureTimes(untaggedId).size).toBe(0);
+  });
+
+  test("drops a row that only mentions the key in an unrelated value", async () => {
+    const mentionId = "conv-sight-frame-mention";
+    ensureConversation(mentionId);
+    await addMessage(mentionId, "user", "hello", {
+      metadata: { backgroundEventSource: "sightFrameAttachmentIds" },
+    });
+
+    expect(selectSightFrameCaptureTimes(mentionId).size).toBe(0);
+  });
+});
+
+describe("applySightFrameRetention", () => {
+  test("stubs the aged frames of a tagged conversation", async () => {
+    const conversationId = "conv-sight-frame-retention";
+    ensureConversation(conversationId);
+    for (const attachmentId of ["att-a", "att-b", "att-c"]) {
+      await addMessage(conversationId, "user", frameContent(attachmentId), {
+        metadata: { sightFrameAttachmentIds: [attachmentId] },
+      });
+    }
+
+    const assembled: Message[] = [
+      { role: "user", content: [referenceImage("att-a")] },
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      { role: "user", content: [referenceImage("att-b")] },
+      { role: "user", content: [referenceImage("att-c")] },
+    ];
+
+    const retained = applySightFrameRetention(assembled, conversationId);
+
+    expect(retained[0].content[0].type).toBe("text");
+    expect(retained[2].content[0]).toEqual(referenceImage("att-b"));
+    expect(retained[3].content[0]).toEqual(referenceImage("att-c"));
+  });
+
+  test("returns the same array for a conversation with no tagged rows", async () => {
+    const conversationId = "conv-sight-frame-retention-untagged";
+    ensureConversation(conversationId);
+    await addMessage(conversationId, "user", frameContent("att-z"));
+
+    const assembled: Message[] = [
+      { role: "user", content: [referenceImage("att-z")] },
+    ];
+
+    expect(applySightFrameRetention(assembled, conversationId)).toBe(assembled);
+  });
+});

--- a/assistant/src/__tests__/sight-frame-retention.test.ts
+++ b/assistant/src/__tests__/sight-frame-retention.test.ts
@@ -133,6 +133,38 @@ describe("applySightFrameRetention", () => {
     expect(retained[3].content[0]).toEqual(referenceImage("att-c"));
   });
 
+  test("reaches live inline frames that never reloaded from the DB", async () => {
+    const conversationId = "conv-sight-frame-retention-live";
+    ensureConversation(conversationId);
+    for (const attachmentId of ["live-a", "live-b", "live-c"]) {
+      await addMessage(conversationId, "user", frameContent(attachmentId), {
+        metadata: { sightFrameAttachmentIds: [attachmentId] },
+      });
+    }
+
+    // What `persistQueuedMessageBody` pushes into `ctx.messages`: inline bytes
+    // carrying the id of the row persisted as a reference.
+    const liveImage = (
+      attachmentId: string,
+    ): Extract<ContentBlock, { type: "image" }> => ({
+      type: "image",
+      source: { type: "base64", media_type: "image/jpeg", data: "AAAAAAAA" },
+      _attachmentId: attachmentId,
+    });
+    const assembled: Message[] = [
+      { role: "user", content: [liveImage("live-a")] },
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      { role: "user", content: [liveImage("live-b")] },
+      { role: "user", content: [liveImage("live-c")] },
+    ];
+
+    const retained = applySightFrameRetention(assembled, conversationId);
+
+    expect(retained[0].content[0].type).toBe("text");
+    expect(retained[2].content[0]).toEqual(liveImage("live-b"));
+    expect(retained[3].content[0]).toEqual(liveImage("live-c"));
+  });
+
   test("returns the same array for a conversation with no tagged rows", async () => {
     const conversationId = "conv-sight-frame-retention-untagged";
     ensureConversation(conversationId);

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -1,4 +1,8 @@
-import type { ContentBlock, Message } from "../providers/types.js";
+import {
+  attachmentIdFragment,
+  type ContentBlock,
+  type Message,
+} from "../providers/types.js";
 import { optimizeImageForTransport } from "./image-optimize.js";
 
 export interface MessageAttachmentInput {
@@ -91,7 +95,7 @@ export function attachmentsToContentBlocks(
             media_type: mediaType,
             data,
           },
-          ...(attachment.id ? { _attachmentId: attachment.id } : {}),
+          ...attachmentIdFragment(attachment.id),
         } as ContentBlock;
       }
 
@@ -104,7 +108,7 @@ export function attachmentsToContentBlocks(
           filename: attachment.filename,
         },
         extracted_text: attachment.extractedText,
-        ...(attachment.id ? { _attachmentId: attachment.id } : {}),
+        ...attachmentIdFragment(attachment.id),
       } as ContentBlock;
     }),
   );

--- a/assistant/src/agent/attachments.ts
+++ b/assistant/src/agent/attachments.ts
@@ -91,6 +91,7 @@ export function attachmentsToContentBlocks(
             media_type: mediaType,
             data,
           },
+          ...(attachment.id ? { _attachmentId: attachment.id } : {}),
         } as ContentBlock;
       }
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -797,6 +797,22 @@ export interface AgentLoopConstructorOptions {
    * result-time pass and the post-turn truncation covers the turn instead.
    */
   resolveConversationDir?: () => string | null;
+  /**
+   * Trim a freshly compacted history before it becomes the loop's working set.
+   *
+   * Compaction rebuilds history from the stored rows, so it can reintroduce
+   * content the caller had already trimmed out of the array it handed to
+   * `run()` (camera-frame retention is the case this exists for: the compaction
+   * model may retain any number of older frames, and the rebuilt history is
+   * sent on the very next request). The caller closes over whatever
+   * conversation state its trimming needs, which is what keeps this module free
+   * of any dependency on the daemon's conversation layer.
+   *
+   * Must be total: the loop treats a throw as "no trim" rather than failing the
+   * turn. Callers that hold no conversation (workflow leaf runs) omit it and
+   * the compacted history is installed as built.
+   */
+  transformCompactedHistory?: (messages: Message[]) => Message[];
 }
 
 export class AgentLoop {
@@ -818,6 +834,11 @@ export class AgentLoop {
   /** See {@link AgentLoopConstructorOptions.resolveConversationDir}. */
   private readonly resolveConversationDir: (() => string | null) | null;
 
+  /** See {@link AgentLoopConstructorOptions.transformCompactedHistory}. */
+  private readonly transformCompactedHistory:
+    | ((messages: Message[]) => Message[])
+    | null;
+
   /**
    * Loop-held compaction circuit breaker. The loop has a 1:1 lifetime with its
    * conversation, so it is the source of truth for the cross-turn failure
@@ -837,6 +858,7 @@ export class AgentLoop {
       resolveTools,
       conversationId,
       resolveConversationDir,
+      transformCompactedHistory,
     } = options;
     this.provider = provider;
     this.systemPrompt = systemPrompt;
@@ -846,6 +868,7 @@ export class AgentLoop {
     this.toolExecutor = toolExecutor ?? null;
     this.conversationId = conversationId;
     this.resolveConversationDir = resolveConversationDir ?? null;
+    this.transformCompactedHistory = transformCompactedHistory ?? null;
     this.compactionCircuit = new CompactionCircuit(this.conversationId);
   }
 
@@ -922,6 +945,34 @@ export class AgentLoop {
         { err: recordError, requestId },
         "Recording a compaction outcome against the circuit breaker failed; suppressing to keep the agent loop alive",
       );
+    }
+  }
+
+  /**
+   * Run the caller's post-compaction trim over a freshly compacted history,
+   * falling back to the untrimmed array when no transform is configured or the
+   * transform throws.
+   *
+   * The trim narrows what the next request carries, so failing it is strictly
+   * worse than skipping it: the turn still has a valid history either way, and
+   * the caller's own passes cover the next turn. Kept best-effort for the same
+   * reason the caller's pre-run pass is.
+   */
+  private applyCompactedHistoryTransform(
+    compacted: Message[],
+    rlog: ReturnType<typeof getLogger>,
+  ): Message[] {
+    if (!this.transformCompactedHistory) {
+      return compacted;
+    }
+    try {
+      return this.transformCompactedHistory(compacted);
+    } catch (err) {
+      rlog.warn(
+        { err },
+        "Post-compaction history transform failed (non-fatal); keeping the compacted history as built",
+      );
+      return compacted;
     }
   }
 
@@ -1363,7 +1414,14 @@ export class AgentLoop {
                   overflowSignal ?? undefined,
                 );
                 if (attempt.history) {
-                  history = attempt.history;
+                  // Trim before anything else reads the rebuilt array: the
+                  // provider call further down this same iteration sends it, so
+                  // content compaction reintroduced has to be brought back
+                  // within the caller's bounds here or it ships un-trimmed.
+                  history = this.applyCompactedHistoryTransform(
+                    attempt.history,
+                    rlog,
+                  );
                   // The compacted, re-injected array is the new base; output
                   // produced after this point is what the wrapper persists.
                   newMessagesStart = history.length;

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -977,6 +977,13 @@ export async function buildRetainedImageBlocks(
         media_type: optimized.mediaType,
         data: optimized.data,
       },
+      // The rebuilt block is inline bytes, so the row it came from is only
+      // recoverable from the id the manifest entry already holds. Carrying it
+      // keeps a retained image traceable to its attachment, which is what
+      // camera-frame retention matches on: without it a frame the compaction
+      // model chose to keep would be invisible to every later pass and could
+      // outlive the retention bound.
+      _attachmentId: entry.attachmentId,
     });
     resolved.push(name);
   }

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -983,6 +983,11 @@ export async function buildRetainedImageBlocks(
       // camera-frame retention matches on: without it a frame the compaction
       // model chose to keep would be invisible to every later pass and could
       // outlive the retention bound.
+      //
+      // Assigned rather than spread through `attachmentIdFragment`, the helper
+      // the conditional producers share: a manifest entry always names a row,
+      // so making the field conditional here would describe an absence the
+      // type rules out.
       _attachmentId: entry.attachmentId,
     });
     resolved.push(name);

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -113,6 +113,7 @@ import {
   drainConversationNotices,
 } from "./conversation-notices.js";
 import {
+  applySightFrameRetention,
   getSlackCompactionWatermarkForPrefix,
   loadSlackChronologicalContext,
   resolveTurnInboundActorContext,
@@ -1255,8 +1256,17 @@ export async function runAgentLoopImpl(
     // immediately before the call, after every hook (memory injection, title,
     // user plugins) has settled its shape. Runs unconditionally — a malformed
     // history is a hard provider rejection, never a per-conversation opt-in.
-    const runMessages = repairHistoryForRun(
+    const repairedMessages = repairHistoryForRun(
       finalUserPromptCtx.latestMessages,
+      ctx.conversationId,
+    );
+    // Camera-frame retention: keep only the newest few ambient frames as real
+    // images. Applied to the per-turn copy, after every hook and the repair, so
+    // every turn this loop drives inherits it and the stored transcript keeps
+    // its attachments. The overflow ladder's media stubbing still governs
+    // everything the user deliberately attached.
+    const runMessages = applySightFrameRetention(
+      repairedMessages,
       ctx.conversationId,
     );
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1263,8 +1263,11 @@ export async function runAgentLoopImpl(
     // Camera-frame retention: keep only the newest few ambient frames as real
     // images. Applied to the per-turn copy, after every hook and the repair, so
     // every turn this loop drives inherits it and the stored transcript keeps
-    // its attachments. The overflow ladder's media stubbing still governs
-    // everything the user deliberately attached.
+    // its attachments. The loop re-runs the same pass on any history its
+    // in-place compaction rebuilds (see the `transformCompactedHistory` closure
+    // the conversation supplies), so the bound holds across a compaction rather
+    // than only from the next turn. The overflow ladder's media stubbing still
+    // governs everything the user deliberately attached.
     const runMessages = applySightFrameRetention(
       repairedMessages,
       ctx.conversationId,

--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -6,15 +6,15 @@
  * text stubs to shrink the payload before retrying.
  *
  * The proactive counterpart, applied on every assembly and only to ambient
- * camera frames, is `stripAgedSightFrames` in `conversation-sight-frames.ts`;
- * its stub wording mirrors {@link imageBlockToStub} below. A block that path
- * already stubbed is plain text here, so it is neither counted as media nor
- * stubbed twice.
+ * camera frames, is `stripAgedSightFrames` in `conversation-sight-frames.ts`.
+ * Both paths name what they dropped through `mediaSourceDescriptor`, so the
+ * stubs describe media identically. A block that path already stubbed is plain
+ * text here, so it is neither counted as media nor stubbed twice.
  */
 
 import { estimateContentBlockTokens } from "../context/token-estimator.js";
 import { getSummaryFromContextMessage } from "../plugins/defaults/compaction/window-manager.js";
-import { mediaSourceByteLength } from "../providers/media-resolve.js";
+import { mediaSourceDescriptor } from "../providers/media-resolve.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 
 export interface StripMediaOptions {
@@ -225,17 +225,16 @@ export function estimateUnconditionalStubTokens(
 function imageBlockToStub(
   block: Extract<ContentBlock, { type: "image" }>,
 ): Extract<ContentBlock, { type: "text" }> {
-  const sizeBytes = mediaSourceByteLength(block.source);
   return {
     type: "text",
-    text: `[Image omitted from retry context: ${block.source.media_type}, ${sizeBytes} bytes]`,
+    text: `[Image omitted from retry context: ${mediaSourceDescriptor(block.source)}]`,
   };
 }
 
 function fileBlockToStub(
   block: Extract<ContentBlock, { type: "file" }>,
 ): Extract<ContentBlock, { type: "text" }> {
-  const sizeBytes = mediaSourceByteLength(block.source);
+  const descriptor = mediaSourceDescriptor(block.source);
   const extracted = (block.extracted_text ?? "").trim();
   const preview =
     extracted.length > MAX_MEDIA_STUB_TEXT
@@ -245,8 +244,8 @@ function fileBlockToStub(
     type: "text",
     text:
       preview.length > 0
-        ? `[File omitted from retry context: ${block.source.filename} (${block.source.media_type}, ${sizeBytes} bytes)]\n${preview}`
-        : `[File omitted from retry context: ${block.source.filename} (${block.source.media_type}, ${sizeBytes} bytes)]`,
+        ? `[File omitted from retry context: ${block.source.filename} (${descriptor})]\n${preview}`
+        : `[File omitted from retry context: ${block.source.filename} (${descriptor})]`,
   };
 }
 

--- a/assistant/src/daemon/conversation-media-retry.ts
+++ b/assistant/src/daemon/conversation-media-retry.ts
@@ -4,6 +4,12 @@
  * When the provider rejects a request because the context is too large,
  * this module replaces older image and file content blocks with lightweight
  * text stubs to shrink the payload before retrying.
+ *
+ * The proactive counterpart, applied on every assembly and only to ambient
+ * camera frames, is `stripAgedSightFrames` in `conversation-sight-frames.ts`;
+ * its stub wording mirrors {@link imageBlockToStub} below. A block that path
+ * already stubbed is plain text here, so it is neither counted as media nor
+ * stubbed twice.
  */
 
 import { estimateContentBlockTokens } from "../context/token-estimator.js";

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -48,6 +48,7 @@ import { isGuardianCardRow } from "../notifications/approval-card-data.js";
 import {
   getMessages as defaultGetMessages,
   type MessageRow,
+  selectSightFrameCaptureTimes,
 } from "../persistence/conversation-crud.js";
 import { isBackgroundConversationType } from "../persistence/conversation-types.js";
 import { createContextSummaryMessage } from "../plugins/defaults/compaction/window-manager.js";
@@ -76,8 +77,10 @@ import { resolveCapabilities } from "../runtime/capabilities.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
+import { getLogger } from "../util/logger.js";
 import { channelSupportsInlineOptions } from "./channel-ui-capability.js";
 import { findConversationOrSubagent } from "./conversation-registry.js";
+import { stripAgedSightFrames } from "./conversation-sight-frames.js";
 import type { SurfaceShowPair } from "./conversation-surfaces.js";
 import { canonicalizeTimeZone, formatTurnTimestamp } from "./date-context.js";
 import type {} from "./message-protocol.js";
@@ -88,6 +91,8 @@ import { timeLatencySubSpan } from "./turn-latency-sub-spans.js";
 // The compaction strip lives in the compaction layer (`context/`) so the agent
 // loop can own it; re-exported here for this module's existing consumers.
 export { stripInjectionsForCompaction } from "../context/strip-injections.js";
+
+const log = getLogger("conversation-runtime-assembly");
 
 /**
  * Describes the capabilities of the channel through which the user is
@@ -735,6 +740,59 @@ function injectVoiceCallControlContext(
 /** Strip `<NOW.md>` blocks injected by the `now-md` default injector. */
 export function stripNowScratchpad(messages: Message[]): Message[] {
   return stripUserTextBlocksByPrefix(messages, NOW_SCRATCHPAD_STRIP_PREFIXES);
+}
+
+// ---------------------------------------------------------------------------
+// Camera-frame retention
+// ---------------------------------------------------------------------------
+
+/**
+ * Trim the conversation's ambient camera frames down to the newest few
+ * (`KEEP_LATEST_SIGHT_FRAMES`), replacing the rest with text stubs.
+ *
+ * A camera call samples a frame about once per spoken turn, and history resends
+ * every inline image on every later request, so an hour-long call otherwise
+ * grows its own context until the provider rejects it. Trimming here, on the
+ * assembled copy the turn is about to send, keeps the stored transcript and its
+ * attachments intact.
+ *
+ * The tag that names the frames is per-row metadata, which the assembled
+ * `Message[]` no longer carries, so the ids are read back from the rows and
+ * matched against the `workspace_ref` blocks the history holds. A conversation
+ * with no tagged rows returns the input array unchanged.
+ *
+ * Best-effort: this trims cost, it does not decide what the turn means, so a
+ * failed read degrades to the untrimmed history rather than failing the turn.
+ */
+export function applySightFrameRetention(
+  messages: Message[],
+  conversationId: string,
+): Message[] {
+  // A frame is always an attachment reference, so a history holding none can be
+  // answered without reading any rows. That is the overwhelming majority of
+  // turns, and this pass sits on the per-turn critical path.
+  const hasReferencedImage = messages.some((message) =>
+    message.content.some(
+      (block) =>
+        block.type === "image" && block.source.type === "workspace_ref",
+    ),
+  );
+  if (!hasReferencedImage) {
+    return messages;
+  }
+  try {
+    const captureTimes = selectSightFrameCaptureTimes(conversationId);
+    if (captureTimes.size === 0) {
+      return messages;
+    }
+    return stripAgedSightFrames(messages, captureTimes).messages;
+  } catch (err) {
+    log.warn(
+      { conversationId, err },
+      "Camera-frame retention failed (non-fatal)",
+    );
+    return messages;
+  }
 }
 
 /**

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -759,12 +759,16 @@ export function stripNowScratchpad(messages: Message[]): Message[] {
  * assembled copy the turn is about to send, keeps the stored transcript and its
  * attachments intact.
  *
- * The tag that names the frames is per-row metadata, which the assembled
- * `Message[]` no longer carries, so the ids are read back from the rows and
+ * The tag that names the frames is per-row metadata, and the assembled
+ * `Message[]` omits row metadata, so the ids are read back from the rows and
  * matched against the attachment id each image block carries: `workspace_ref`
  * on a reloaded block, `_attachmentId` on the live copy a turn pushed. One
  * uninterrupted call and a reloaded conversation therefore trim from the same
  * pool. A conversation with no tagged rows returns the input array unchanged.
+ *
+ * Called twice over a turn that compacts: once before the run, and again on the
+ * rebuilt history the agent loop installs, since compaction reads the stored
+ * rows and can retain frames this pass had already stubbed.
  *
  * Best-effort: this trims cost, it does not decide what the turn means, so a
  * failed read degrades to the untrimmed history rather than failing the turn.

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -80,7 +80,10 @@ import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
 import { getLogger } from "../util/logger.js";
 import { channelSupportsInlineOptions } from "./channel-ui-capability.js";
 import { findConversationOrSubagent } from "./conversation-registry.js";
-import { stripAgedSightFrames } from "./conversation-sight-frames.js";
+import {
+  hasAttributableImages,
+  stripAgedSightFrames,
+} from "./conversation-sight-frames.js";
 import type { SurfaceShowPair } from "./conversation-surfaces.js";
 import { canonicalizeTimeZone, formatTurnTimestamp } from "./date-context.js";
 import type {} from "./message-protocol.js";
@@ -758,8 +761,10 @@ export function stripNowScratchpad(messages: Message[]): Message[] {
  *
  * The tag that names the frames is per-row metadata, which the assembled
  * `Message[]` no longer carries, so the ids are read back from the rows and
- * matched against the `workspace_ref` blocks the history holds. A conversation
- * with no tagged rows returns the input array unchanged.
+ * matched against the attachment id each image block carries: `workspace_ref`
+ * on a reloaded block, `_attachmentId` on the live copy a turn pushed. One
+ * uninterrupted call and a reloaded conversation therefore trim from the same
+ * pool. A conversation with no tagged rows returns the input array unchanged.
  *
  * Best-effort: this trims cost, it does not decide what the turn means, so a
  * failed read degrades to the untrimmed history rather than failing the turn.
@@ -768,16 +773,11 @@ export function applySightFrameRetention(
   messages: Message[],
   conversationId: string,
 ): Message[] {
-  // A frame is always an attachment reference, so a history holding none can be
-  // answered without reading any rows. That is the overwhelming majority of
-  // turns, and this pass sits on the per-turn critical path.
-  const hasReferencedImage = messages.some((message) =>
-    message.content.some(
-      (block) =>
-        block.type === "image" && block.source.type === "workspace_ref",
-    ),
-  );
-  if (!hasReferencedImage) {
+  // A frame always traces back to an attachment row, so a history holding no
+  // attributable image can be answered without reading any rows. That is the
+  // overwhelming majority of turns, and this pass sits on the per-turn critical
+  // path.
+  if (!hasAttributableImages(messages)) {
     return messages;
   }
   try {

--- a/assistant/src/daemon/conversation-sight-frames.ts
+++ b/assistant/src/daemon/conversation-sight-frames.ts
@@ -39,13 +39,53 @@ import type { ContentBlock, Message } from "../providers/types.js";
 export const KEEP_LATEST_SIGHT_FRAMES = 2;
 
 /**
+ * The attachment row an image block came from, or null when it came from none.
+ *
+ * Two shapes carry the same fact, because a turn sends its uploads inline while
+ * persisting them as references: a reloaded block names the row on
+ * `source.attachmentId`, and the live in-memory block a turn pushed names it on
+ * `_attachmentId` (see `attachmentsToContentBlocks`). Matching on both is what
+ * lets one uninterrupted call and a reloaded conversation share a single pool
+ * of frames.
+ *
+ * Tool-generated and assistant-authored images carry neither and resolve to
+ * null, so they can never be mistaken for a tagged frame.
+ */
+export function imageAttachmentId(
+  block: Extract<ContentBlock, { type: "image" }>,
+): string | null {
+  if (block.source.type === "workspace_ref") {
+    return block.source.attachmentId;
+  }
+  return block._attachmentId ?? null;
+}
+
+/**
+ * True when any image in the history can be traced back to an attachment row.
+ *
+ * The retention pass reads rows to learn which attachments were camera frames;
+ * a history holding no attributable image has nothing those rows could match,
+ * so callers use this to skip the read entirely. Shares
+ * {@link imageAttachmentId} with the matcher so the two cannot disagree about
+ * what is skippable.
+ */
+export function hasAttributableImages(messages: Message[]): boolean {
+  return messages.some((message) =>
+    message.content.some(
+      (block) => block.type === "image" && imageAttachmentId(block) !== null,
+    ),
+  );
+}
+
+/**
  * Replace every camera frame in `messages` except the newest
  * {@link KEEP_LATEST_SIGHT_FRAMES} with a text stub.
  *
  * `frameCaptureTimes` maps an attachment id the conversation tagged as a camera
  * frame to when the row carrying it was written; an image block counts as a
- * frame only when it references one of those ids. Every other attachment
- * (picked files, pasted images, shutter photos) is left alone here.
+ * frame only when {@link imageAttachmentId} resolves it to one of those ids.
+ * Every other attachment (picked files, pasted images, shutter photos) is left
+ * alone here.
  *
  * Frames are ranked by their position in the history rather than by capture
  * time, so a row backdated by `sentAt` cannot displace a frame the model saw
@@ -66,10 +106,14 @@ export function stripAgedSightFrames(
   }> = [];
   for (const [messageIndex, message] of messages.entries()) {
     for (const [blockIndex, block] of message.content.entries()) {
-      if (block.type !== "image" || block.source.type !== "workspace_ref") {
+      if (block.type !== "image") {
         continue;
       }
-      const capturedAt = frameCaptureTimes.get(block.source.attachmentId);
+      const attachmentId = imageAttachmentId(block);
+      if (attachmentId === null) {
+        continue;
+      }
+      const capturedAt = frameCaptureTimes.get(attachmentId);
       if (capturedAt === undefined) {
         continue;
       }

--- a/assistant/src/daemon/conversation-sight-frames.ts
+++ b/assistant/src/daemon/conversation-sight-frames.ts
@@ -21,7 +21,11 @@
  */
 
 import { mediaSourceByteLength } from "../providers/media-resolve.js";
-import type { ContentBlock, Message } from "../providers/types.js";
+import {
+  type ContentBlock,
+  mediaBlockAttachmentId,
+  type Message,
+} from "../providers/types.js";
 
 /**
  * How many camera frames stay in the context as real images, counted
@@ -39,40 +43,19 @@ import type { ContentBlock, Message } from "../providers/types.js";
 export const KEEP_LATEST_SIGHT_FRAMES = 2;
 
 /**
- * The attachment row an image block came from, or null when it came from none.
- *
- * Two shapes carry the same fact, because a turn sends its uploads inline while
- * persisting them as references: a reloaded block names the row on
- * `source.attachmentId`, and the live in-memory block a turn pushed names it on
- * `_attachmentId` (see `attachmentsToContentBlocks`). Matching on both is what
- * lets one uninterrupted call and a reloaded conversation share a single pool
- * of frames.
- *
- * Tool-generated and assistant-authored images carry neither and resolve to
- * null, so they can never be mistaken for a tagged frame.
- */
-export function imageAttachmentId(
-  block: Extract<ContentBlock, { type: "image" }>,
-): string | null {
-  if (block.source.type === "workspace_ref") {
-    return block.source.attachmentId;
-  }
-  return block._attachmentId ?? null;
-}
-
-/**
  * True when any image in the history can be traced back to an attachment row.
  *
  * The retention pass reads rows to learn which attachments were camera frames;
  * a history holding no attributable image has nothing those rows could match,
  * so callers use this to skip the read entirely. Shares
- * {@link imageAttachmentId} with the matcher so the two cannot disagree about
- * what is skippable.
+ * {@link mediaBlockAttachmentId} with the matcher so the two cannot disagree
+ * about what is skippable.
  */
 export function hasAttributableImages(messages: Message[]): boolean {
   return messages.some((message) =>
     message.content.some(
-      (block) => block.type === "image" && imageAttachmentId(block) !== null,
+      (block) =>
+        block.type === "image" && mediaBlockAttachmentId(block) !== undefined,
     ),
   );
 }
@@ -83,13 +66,19 @@ export function hasAttributableImages(messages: Message[]): boolean {
  *
  * `frameCaptureTimes` maps an attachment id the conversation tagged as a camera
  * frame to when the row carrying it was written; an image block counts as a
- * frame only when {@link imageAttachmentId} resolves it to one of those ids.
- * Every other attachment (picked files, pasted images, shutter photos) is left
- * alone here.
+ * frame only when {@link mediaBlockAttachmentId} resolves it to one of those
+ * ids. Every other attachment (picked files, pasted images, shutter photos) is
+ * left alone here.
  *
- * Frames are ranked by their position in the history rather than by capture
- * time, so a row backdated by `sentAt` cannot displace a frame the model saw
- * more recently. Returns the input array itself when nothing is replaced.
+ * Frames are ranked by capture time, not by where they sit in the history:
+ * compaction rebuilds the frames it keeps into one synthetic message in the
+ * order the model listed them, so position stops tracking recency the moment a
+ * conversation has been compacted. The times come from the rows themselves
+ * (`createdAt`, which `monotonicNow` keeps strictly increasing), so they order
+ * frames the way they were captured and no client-supplied timestamp can perturb
+ * that. Frames sharing a row share a time and fall back to history order, which
+ * is the order they were attached. Returns the input array itself when nothing
+ * is replaced.
  */
 export function stripAgedSightFrames(
   messages: Message[],
@@ -109,8 +98,8 @@ export function stripAgedSightFrames(
       if (block.type !== "image") {
         continue;
       }
-      const attachmentId = imageAttachmentId(block);
-      if (attachmentId === null) {
+      const attachmentId = mediaBlockAttachmentId(block);
+      if (attachmentId === undefined) {
         continue;
       }
       const capturedAt = frameCaptureTimes.get(attachmentId);
@@ -124,11 +113,14 @@ export function stripAgedSightFrames(
     return { messages, modified: false, replacedBlocks: 0 };
   }
 
-  // History runs oldest to newest, so dropping the tail keeps the newest.
+  // Oldest first by capture time, so dropping the tail keeps the newest. The
+  // sort is stable and `frames` was collected in history order, which is what
+  // separates frames that share a row's timestamp.
+  const byCaptureTime = [...frames].sort((a, b) => a.capturedAt - b.capturedAt);
   const aged = new Map<number, Map<number, number>>();
-  for (const frame of frames.slice(
+  for (const frame of byCaptureTime.slice(
     0,
-    frames.length - KEEP_LATEST_SIGHT_FRAMES,
+    byCaptureTime.length - KEEP_LATEST_SIGHT_FRAMES,
   )) {
     const blocks = aged.get(frame.messageIndex) ?? new Map<number, number>();
     blocks.set(frame.blockIndex, frame.capturedAt);

--- a/assistant/src/daemon/conversation-sight-frames.ts
+++ b/assistant/src/daemon/conversation-sight-frames.ts
@@ -1,0 +1,133 @@
+/**
+ * Retention for ambient camera frames, the images a call samples on its own
+ * while the camera is up.
+ *
+ * A frame arrives about once per spoken turn and history resends every inline
+ * image on every later request, so a long call grows its own context until the
+ * provider rejects it. {@link stripAgedSightFrames} keeps only the newest few
+ * frames as real images and replaces the rest with text stubs, on the copy of
+ * the history a turn is about to send.
+ *
+ * This is the proactive counterpart to `stripMediaPayloadsForRetry`
+ * (`conversation-media-retry.ts`), which fires only after a provider has
+ * already rejected a request and which governs every kind of media. The two
+ * live apart because that module reaches the compaction layer for its
+ * summary-message predicate and this one must stay a leaf the assembly path can
+ * import. They agree on the shape of what they leave behind: a `text` block
+ * naming the media that was dropped, so a frame stubbed here is plain text by
+ * the time the retry path walks the history and is neither counted as media nor
+ * stubbed a second time. Keep the stub wording below in step with
+ * `imageBlockToStub` there.
+ */
+
+import { mediaSourceByteLength } from "../providers/media-resolve.js";
+import type { ContentBlock, Message } from "../providers/types.js";
+
+/**
+ * How many camera frames stay in the context as real images, counted
+ * newest-first across the whole conversation so the frames on the most recent
+ * turns are the ones that survive.
+ *
+ * Smaller than `RETRY_KEEP_LATEST_MEDIA_BLOCKS` (3, in
+ * `conversation-media-retry.ts`) because the two budgets answer different
+ * questions. That one is reactive and spends a rejected request's remaining
+ * room across every kind of media, including files the user deliberately sent.
+ * This one is proactive, applied to every assembly, and governs only frames the
+ * camera sampled by itself: background the model glances at, not something
+ * anyone chose to attach.
+ */
+export const KEEP_LATEST_SIGHT_FRAMES = 2;
+
+/**
+ * Replace every camera frame in `messages` except the newest
+ * {@link KEEP_LATEST_SIGHT_FRAMES} with a text stub.
+ *
+ * `frameCaptureTimes` maps an attachment id the conversation tagged as a camera
+ * frame to when the row carrying it was written; an image block counts as a
+ * frame only when it references one of those ids. Every other attachment
+ * (picked files, pasted images, shutter photos) is left alone here.
+ *
+ * Frames are ranked by their position in the history rather than by capture
+ * time, so a row backdated by `sentAt` cannot displace a frame the model saw
+ * more recently. Returns the input array itself when nothing is replaced.
+ */
+export function stripAgedSightFrames(
+  messages: Message[],
+  frameCaptureTimes: ReadonlyMap<string, number>,
+): { messages: Message[]; modified: boolean; replacedBlocks: number } {
+  if (frameCaptureTimes.size === 0) {
+    return { messages, modified: false, replacedBlocks: 0 };
+  }
+
+  const frames: Array<{
+    messageIndex: number;
+    blockIndex: number;
+    capturedAt: number;
+  }> = [];
+  for (const [messageIndex, message] of messages.entries()) {
+    for (const [blockIndex, block] of message.content.entries()) {
+      if (block.type !== "image" || block.source.type !== "workspace_ref") {
+        continue;
+      }
+      const capturedAt = frameCaptureTimes.get(block.source.attachmentId);
+      if (capturedAt === undefined) {
+        continue;
+      }
+      frames.push({ messageIndex, blockIndex, capturedAt });
+    }
+  }
+  if (frames.length <= KEEP_LATEST_SIGHT_FRAMES) {
+    return { messages, modified: false, replacedBlocks: 0 };
+  }
+
+  // History runs oldest to newest, so dropping the tail keeps the newest.
+  const aged = new Map<number, Map<number, number>>();
+  for (const frame of frames.slice(
+    0,
+    frames.length - KEEP_LATEST_SIGHT_FRAMES,
+  )) {
+    const blocks = aged.get(frame.messageIndex) ?? new Map<number, number>();
+    blocks.set(frame.blockIndex, frame.capturedAt);
+    aged.set(frame.messageIndex, blocks);
+  }
+
+  let replacedBlocks = 0;
+  const nextMessages = messages.map((message, messageIndex) => {
+    const blocks = aged.get(messageIndex);
+    if (!blocks) {
+      return message;
+    }
+    return {
+      ...message,
+      content: message.content.map((block, blockIndex) => {
+        const capturedAt = blocks.get(blockIndex);
+        if (capturedAt === undefined || block.type !== "image") {
+          return block;
+        }
+        replacedBlocks += 1;
+        return sightFrameBlockToStub(block, capturedAt);
+      }),
+    };
+  });
+
+  return { messages: nextMessages, modified: true, replacedBlocks };
+}
+
+/**
+ * Stub for a frame that has aged out of the context. Mirrors the media type and
+ * byte size the retry path's image stub reports, and adds the capture time,
+ * which is the only thing telling one ambient frame from another once the
+ * pixels are gone. A frame is always an image, so the extracted-text folding
+ * the retry path does for file blocks has nothing to act on here.
+ */
+function sightFrameBlockToStub(
+  block: Extract<ContentBlock, { type: "image" }>,
+  capturedAt: number,
+): Extract<ContentBlock, { type: "text" }> {
+  const sizeBytes = mediaSourceByteLength(block.source);
+  const capturedAtIso = new Date(capturedAt).toISOString();
+  return {
+    type: "text",
+    text: `[Camera frame omitted from context: captured ${capturedAtIso}, ${block.source.media_type}, ${sizeBytes} bytes]`,
+  };
+}

--- a/assistant/src/daemon/conversation-sight-frames.ts
+++ b/assistant/src/daemon/conversation-sight-frames.ts
@@ -16,11 +16,12 @@
  * import. They agree on the shape of what they leave behind: a `text` block
  * naming the media that was dropped, so a frame stubbed here is plain text by
  * the time the retry path walks the history and is neither counted as media nor
- * stubbed a second time. Keep the stub wording below in step with
- * `imageBlockToStub` there.
+ * stubbed a second time. Both describe that media through
+ * `mediaSourceDescriptor`, which is what holds the two wordings together
+ * without either module importing the other.
  */
 
-import { mediaSourceByteLength } from "../providers/media-resolve.js";
+import { mediaSourceDescriptor } from "../providers/media-resolve.js";
 import {
   type ContentBlock,
   mediaBlockAttachmentId,
@@ -150,20 +151,20 @@ export function stripAgedSightFrames(
 }
 
 /**
- * Stub for a frame that has aged out of the context. Mirrors the media type and
- * byte size the retry path's image stub reports, and adds the capture time,
- * which is the only thing telling one ambient frame from another once the
- * pixels are gone. A frame is always an image, so the extracted-text folding
- * the retry path does for file blocks has nothing to act on here.
+ * Stub for a frame that has aged out of the context. Describes the dropped
+ * media through `mediaSourceDescriptor`, the same way the retry path's stubs
+ * do, and adds the capture time, which is the only thing telling one ambient
+ * frame from another once the pixels are gone. A frame is always an image, so
+ * the extracted-text folding the retry path does for file blocks has nothing to
+ * act on here.
  */
 function sightFrameBlockToStub(
   block: Extract<ContentBlock, { type: "image" }>,
   capturedAt: number,
 ): Extract<ContentBlock, { type: "text" }> {
-  const sizeBytes = mediaSourceByteLength(block.source);
   const capturedAtIso = new Date(capturedAt).toISOString();
   return {
     type: "text",
-    text: `[Camera frame omitted from context: captured ${capturedAtIso}, ${block.source.media_type}, ${sizeBytes} bytes]`,
+    text: `[Camera frame omitted from context: captured ${capturedAtIso}, ${mediaSourceDescriptor(block.source)}]`,
   };
 }

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -137,6 +137,7 @@ import type {
 } from "./conversation-queue-manager.js";
 import { MessageQueue } from "./conversation-queue-manager.js";
 import {
+  applySightFrameRetention,
   type ChannelCapabilities,
   getSlackCompactionWatermarkForPrefix,
   getSlackWatermarkAdvanceForRowPrefix,
@@ -887,6 +888,16 @@ export class Conversation {
           conv.createdAt,
         );
       },
+      // Compaction rebuilds history from the stored rows, so it can retain
+      // camera frames the turn's pre-run pass had already stubbed, and the
+      // rebuilt array is sent on the next request of that same turn. Re-running
+      // the retention pass here is what holds the frame bound across a
+      // compaction instead of only from the next turn onward. The row read
+      // repeats rather than sharing the pre-run pass's map: compactions are
+      // rare, and a map captured before the turn's awaits would describe a
+      // conversation that has since gained rows.
+      transformCompactedHistory: (messages) =>
+        applySightFrameRetention(messages, this.conversationId),
     });
     createContextWindowManager({
       provider,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -2328,6 +2328,20 @@ export class Conversation {
   }
 
   /**
+   * Trim this conversation's aged camera frames out of a history about to be
+   * sent to a provider, keeping only the newest few as real images.
+   *
+   * Thin binding of {@link applySightFrameRetention} to the conversation's own
+   * id, for the send paths that hold the instance rather than a turn context:
+   * the compaction pipeline's summarizer input, and the wake, which sends its
+   * run input itself. Best-effort inside, so a failed row read degrades to the
+   * untrimmed history.
+   */
+  trimAgedSightFrames(messages: Message[]): Message[] {
+    return applySightFrameRetention(messages, this.conversationId);
+  }
+
+  /**
    * Auto-threshold compaction gate. Runs the same durable compaction
    * pipeline as {@link forceCompact} (summary call, circuit-breaker
    * accounting, Slack provenance, in-memory + DB commit) but honors the
@@ -2426,8 +2440,16 @@ export class Conversation {
             },
           )
         : null;
-    const messagesToCompact =
-      slackChronologicalContext?.messages ?? this.messages;
+    // Trim aged camera frames out of the summarizer's own input. Compaction
+    // sends this array to a provider like any other request, so a long camera
+    // session would otherwise put every frame it ever captured into the summary
+    // call, which is the payload-size and many-image rejection retention exists
+    // to prevent. Safe against the caller-fixed boundary below: the pass
+    // replaces blocks inside messages and never adds, drops, or reorders one,
+    // so `fixedTailStartIndex` still names the same message.
+    const messagesToCompact = this.trimAgedSightFrames(
+      slackChronologicalContext?.messages ?? this.messages,
+    );
     const compactedRowCountAtCall = this.contextCompactedMessageCount;
     let result = await defaultCompact({
       conversationId: this.conversationId,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -1677,6 +1677,8 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
     });
   }
 
+  widenForkSightFrameTags(messagesToCopy, forkedMessageIds, attachmentIdMap);
+
   // Set lastMessageAt to the max createdAt of copied messages so the
   // forked conversation sorts correctly by message recency.
   const lastCopiedMessage = messagesToCopy.at(-1);
@@ -1717,6 +1719,75 @@ function populateForkContentsInProcess(args: PopulateForkContentsArgs): void {
       fork.id,
       messagesToCopy.at(-1)?.createdAt ?? null,
     );
+  }
+}
+
+/**
+ * Extend the copied rows' camera-frame tags to name the fork's cloned
+ * attachment ids alongside the source ids they were written with.
+ *
+ * A fork leaves its rows describing their attachments two different ways:
+ * `messages.content` is copied byte for byte and still names the SOURCE
+ * attachment ids, while `message_attachments` is re-linked to freshly CLONED
+ * rows under new ids. Readers split along that seam. Camera-frame retention
+ * matches the tag against the ids in the content blocks (source ids), and the
+ * compactor builds its image manifest from the links (cloned ids) and stamps
+ * those onto the frames it rebuilds. A tag naming only one vocabulary goes
+ * blind on the other, so it names both.
+ *
+ * Widening rather than remapping is deliberate: replacing the source ids would
+ * fix the compactor's frames by breaking every frame the fork holds directly,
+ * which is the common case. Extra ids are inert, since an id no block carries
+ * simply never matches.
+ *
+ * Runs after the attachment loop because that loop is what produces the id map.
+ * Only rows that actually carry a tag are rewritten, so an ordinary fork does
+ * no extra writes.
+ */
+function widenForkSightFrameTags(
+  messagesToCopy: MessageRow[],
+  forkedMessageIds: Map<string, string>,
+  attachmentIdMap: Map<string, string>,
+): void {
+  if (attachmentIdMap.size === 0) {
+    return;
+  }
+  const db = getDb();
+  for (const message of messagesToCopy) {
+    const forkedMessageId = forkedMessageIds.get(message.id);
+    if (!forkedMessageId) {
+      continue;
+    }
+    const sourceMetadata = parseMessageMetadata(message.metadata);
+    const sourceIds = sightFrameAttachmentIdsFromMetadata(sourceMetadata);
+    if (sourceIds.length === 0) {
+      continue;
+    }
+    const widened = new Set(sourceIds);
+    for (const sourceId of sourceIds) {
+      const clonedId = attachmentIdMap.get(sourceId);
+      if (clonedId) {
+        widened.add(clonedId);
+      }
+    }
+    if (widened.size === sourceIds.length) {
+      continue;
+    }
+    const forkedRow = db
+      .select({ metadata: messages.metadata })
+      .from(messages)
+      .where(eq(messages.id, forkedMessageId))
+      .get();
+    const forkedMetadata = parseMessageMetadata(forkedRow?.metadata ?? null);
+    db.update(messages)
+      .set({
+        metadata: JSON.stringify({
+          ...(forkedMetadata ?? {}),
+          [SIGHT_FRAME_ATTACHMENT_IDS_KEY]: [...widened],
+        }),
+      })
+      .where(eq(messages.id, forkedMessageId))
+      .run();
   }
 }
 

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -93,6 +93,8 @@ import {
   isHiddenMessageMetadata,
   isSystemCardMetadata,
   PINNED_GROUP_ID,
+  SIGHT_FRAME_ATTACHMENT_IDS_KEY,
+  sightFrameAttachmentIdsFromMetadata,
   UNGROUPED_GROUP_ID,
 } from "./conversation-types.js";
 import { runAsyncSqlite } from "./db-async-query.js";
@@ -2492,6 +2494,41 @@ export function selectProviderMetaCandidateMetadata(
     }
   }
   return out;
+}
+
+/**
+ * Every attachment the conversation's rows tagged as an ambient camera frame,
+ * mapped to the `createdAt` of the row that carried it.
+ *
+ * Like the Slack prefilter above, the `LIKE` is an indexable narrowing only:
+ * each candidate row is parsed and validated before an id is taken, so a row
+ * that merely mentions the key contributes nothing. Any row state qualifies
+ * because the tag is written with the insert, and the lineage filter is what
+ * lets a fork see the frames it inherited.
+ */
+export function selectSightFrameCaptureTimes(
+  conversationId: string,
+): Map<string, number> {
+  const db = getDb();
+  const rows = db
+    .select({ metadata: messages.metadata, createdAt: messages.createdAt })
+    .from(messages)
+    .where(
+      and(
+        lineageFilter(conversationId),
+        like(messages.metadata, `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`),
+      ),
+    )
+    .orderBy(asc(messages.createdAt))
+    .all();
+  const captureTimes = new Map<string, number>();
+  for (const row of rows) {
+    const metadata = parseMessageMetadata(row.metadata);
+    for (const id of sightFrameAttachmentIdsFromMetadata(metadata)) {
+      captureTimes.set(id, row.createdAt);
+    }
+  }
+  return captureTimes;
 }
 
 /**

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -228,6 +228,34 @@ export function isVoiceSessionUserMessage(
 }
 
 /**
+ * Metadata key naming which of a row's attachments arrived as ambient camera
+ * frames rather than files the user picked. Exported so the SQL prefilter that
+ * finds candidate rows and the reader below name the same key.
+ */
+export const SIGHT_FRAME_ATTACHMENT_IDS_KEY = "sightFrameAttachmentIds";
+
+/**
+ * The row's attachments that arrived as ambient camera frames, by attachment
+ * id. A user attachment carries no metadata of its own, so the marking lives on
+ * the message and refers to the attachments by id.
+ *
+ * Tolerant of any metadata shape: a row without the key, or one whose value is
+ * not an array of ids, yields nothing. Retention consumers therefore treat an
+ * untagged conversation exactly like one that predates the tag.
+ */
+export function sightFrameAttachmentIdsFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): string[] {
+  const ids = metadata?.[SIGHT_FRAME_ATTACHMENT_IDS_KEY];
+  if (!Array.isArray(ids)) {
+    return [];
+  }
+  return ids.filter(
+    (id): id is string => typeof id === "string" && id.length > 0,
+  );
+}
+
+/**
  * True when the row that opened the turn was sent from a desktop app, on that
  * row's own evidence.
  *

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -223,6 +223,12 @@ export { getConfiguredProvider } from "../providers/provider-send-message.js";
 // an image, embedding it, re-encoding it — use this instead of reaching into
 // the host attachment store, so they stay agnostic to how media is persisted.
 export { resolveMediaSourceData } from "../providers/media-resolve.js";
+// Build the `_attachmentId` property of a media block as a spreadable fragment,
+// omitting it when there is no usable id. A plugin that rebuilds a media block
+// (resizing an image, re-encoding a file) uses this to carry the block's link
+// to its attachment row across the rebuild, so host consumers that correlate a
+// block back to its attachment still can.
+export { attachmentIdFragment } from "../providers/types.js";
 // Classify a provider stop reason: whether the turn was truncated at the
 // output token cap (vs. a natural stop or a tool call). A `post-model-call`
 // hook reads it off `PostModelCallContext.stopReason` to decide whether to

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -229,6 +229,12 @@ export { resolveMediaSourceData } from "../providers/media-resolve.js";
 // to its attachment row across the rebuild, so host consumers that correlate a
 // block back to its attachment still can.
 export { attachmentIdFragment } from "../providers/types.js";
+// Read the attachment row a media block came from, whichever shape it is in: a
+// reference names it on `source.attachmentId`, an inline block on
+// `_attachmentId`. A plugin that rebuilds a block into inline bytes derives the
+// id through this before stamping it, since the reference shape's id would
+// otherwise be lost with the source it replaced.
+export { mediaBlockAttachmentId } from "../providers/types.js";
 // Classify a provider stop reason: whether the turn was truncated at the
 // output token cap (vs. a natural stop or a tool call). A `post-model-call`
 // hook reads it off `PostModelCallContext.stopReason` to decide whether to

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -109,6 +109,7 @@ export async function unsendableImageReplacement(
       return {
         type: "image",
         source: { ...block.source, media_type: effectiveMediaType },
+        ...attachmentIdOf(block),
       };
     }
     return null;
@@ -128,9 +129,27 @@ export async function unsendableImageReplacement(
         media_type: optimized.mediaType,
         data: optimized.data,
       },
+      ...attachmentIdOf(block),
     };
   }
   return { type: "text", text: UNSENDABLE_IMAGE_NOTE };
+}
+
+/**
+ * The block's internal attachment id, as a spreadable fragment.
+ *
+ * A relabel or resize above rebuilds the block, and both forms are written back
+ * to the stored row. Carrying the id across keeps the rewritten block traceable
+ * to its attachment, which is what camera-frame retention matches on; dropping
+ * it would untag a frame for good. Mirrors the same re-attachment
+ * `resolveFileBlock` does in `providers/media-resolve.ts`.
+ */
+function attachmentIdOf(block: Extract<ContentBlock, { type: "image" }>): {
+  _attachmentId?: string;
+} {
+  return block._attachmentId !== undefined
+    ? { _attachmentId: block._attachmentId }
+    : {};
 }
 
 /**

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -17,6 +17,7 @@
 import {
   attachmentIdFragment,
   type ContentBlock,
+  mediaBlockAttachmentId,
   type Message,
   resolveMediaSourceData,
 } from "@vellumai/plugin-api";
@@ -106,7 +107,9 @@ export async function unsendableImageReplacement(
     if (mediaTypeMismatch) {
       // Only the label is wrong, so keep the source shape: a workspace_ref
       // stays a reference (inlining it would bake the full payload into the
-      // stored message row) and only media_type is corrected.
+      // stored message row) and only media_type is corrected. Because the
+      // source survives, a reference still names its own attachment through
+      // it, and only an inline block's top-level id needs carrying.
       return {
         type: "image",
         source: { ...block.source, media_type: effectiveMediaType },
@@ -130,7 +133,12 @@ export async function unsendableImageReplacement(
         media_type: optimized.mediaType,
         data: optimized.data,
       },
-      ...attachmentIdFragment(block._attachmentId),
+      // The resized block is inline bytes whatever the input was, so a
+      // reference's `source.attachmentId` is about to be replaced along with
+      // the source that held it. Derive the id from either shape before
+      // stamping, or a reference-backed image loses its attachment here and
+      // the durable rewrite makes that permanent.
+      ...attachmentIdFragment(mediaBlockAttachmentId(block)),
     };
   }
   return { type: "text", text: UNSENDABLE_IMAGE_NOTE };

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  attachmentIdFragment,
   type ContentBlock,
   type Message,
   resolveMediaSourceData,
@@ -109,7 +110,7 @@ export async function unsendableImageReplacement(
       return {
         type: "image",
         source: { ...block.source, media_type: effectiveMediaType },
-        ...attachmentIdOf(block),
+        ...attachmentIdFragment(block._attachmentId),
       };
     }
     return null;
@@ -129,27 +130,10 @@ export async function unsendableImageReplacement(
         media_type: optimized.mediaType,
         data: optimized.data,
       },
-      ...attachmentIdOf(block),
+      ...attachmentIdFragment(block._attachmentId),
     };
   }
   return { type: "text", text: UNSENDABLE_IMAGE_NOTE };
-}
-
-/**
- * The block's internal attachment id, as a spreadable fragment.
- *
- * A relabel or resize above rebuilds the block, and both forms are written back
- * to the stored row. Carrying the id across keeps the rewritten block traceable
- * to its attachment, which is what camera-frame retention matches on; dropping
- * it would untag a frame for good. Mirrors the same re-attachment
- * `resolveFileBlock` does in `providers/media-resolve.ts`.
- */
-function attachmentIdOf(block: Extract<ContentBlock, { type: "image" }>): {
-  _attachmentId?: string;
-} {
-  return block._attachmentId !== undefined
-    ? { _attachmentId: block._attachmentId }
-    : {};
 }
 
 /**

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
@@ -338,6 +338,9 @@ function makeForkConversationDouble(): Conversation {
   const conversation = {
     conversationId: FORK_ID,
     messages,
+    // The wake trims its own run input; nothing here is tagged as a camera
+    // frame, so the real pass would return the array unchanged too.
+    trimAgedSightFrames: (msgs: Message[]) => msgs,
     getMessages: () => messages,
     isProcessing: () => false,
     setProcessing: (_on: boolean) => {},

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
@@ -176,6 +176,9 @@ function makeForkConversationDouble(forkId: string): Conversation {
     provider: scriptedProvider,
     usageStats: {},
     messages,
+    // The wake trims its own run input; nothing here is tagged as a camera
+    // frame, so the real pass would return the array unchanged too.
+    trimAgedSightFrames: (msgs: Message[]) => msgs,
     getMessages: () => messages,
     isProcessing: () => processing,
     setProcessing: (on: boolean) => {

--- a/assistant/src/providers/content-block-schema.ts
+++ b/assistant/src/providers/content-block-schema.ts
@@ -74,6 +74,7 @@ const imageContentSchema = z
   .object({
     type: z.literal("image"),
     source: mediaSourceSchema,
+    _attachmentId: z.string().optional(),
   })
   .passthrough();
 

--- a/assistant/src/providers/media-resolve.ts
+++ b/assistant/src/providers/media-resolve.ts
@@ -28,13 +28,14 @@ import {
   sniffImageMimeType,
 } from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
-import type {
-  Base64MediaSource,
-  ContentBlock,
-  FileContent,
-  ImageContent,
-  MediaSource,
-  Message,
+import {
+  attachmentIdFragment,
+  type Base64MediaSource,
+  type ContentBlock,
+  type FileContent,
+  type ImageContent,
+  type MediaSource,
+  type Message,
 } from "./types.js";
 
 const log = getLogger("media-resolve");
@@ -280,9 +281,7 @@ function resolveFileBlock(block: FileContent): ContentBlock {
     ...(block.extracted_text !== undefined
       ? { extracted_text: block.extracted_text }
       : {}),
-    ...(block._attachmentId !== undefined
-      ? { _attachmentId: block._attachmentId }
-      : {}),
+    ...attachmentIdFragment(block._attachmentId),
   };
 }
 

--- a/assistant/src/providers/media-resolve.ts
+++ b/assistant/src/providers/media-resolve.ts
@@ -145,6 +145,21 @@ export function mediaSourceByteLength(source: MediaSource): number {
 }
 
 /**
+ * What a media source was, as the text that stands in for it once the bytes are
+ * gone: its media type and payload size.
+ *
+ * Every path that replaces a media block with a text stub naming what it
+ * dropped reports these same two facts, so they are derived once here. Each
+ * stub keeps its own surrounding sentence (which path dropped it, and why) and
+ * embeds this for the what. Reads the size through
+ * {@link mediaSourceByteLength}, so a reference and an inline block describe
+ * themselves the same way.
+ */
+export function mediaSourceDescriptor(source: MediaSource): string {
+  return `${source.media_type}, ${mediaSourceByteLength(source)} bytes`;
+}
+
+/**
  * Resolve a media source to inline base64, reading a reference source back from
  * its workspace location. Returns `null` when a reference can no longer be
  * read. For consumers that hold an individual in-memory block (image

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -116,8 +116,8 @@ export interface FileContent {
  *
  * Every producer of a media block faces the same choice: it either knows the
  * attachment row the block came from, or it does not, and the field has to be
- * absent rather than present-and-empty in the second case. Spelling that out at
- * each site is how the checks drifted apart, so they share this one instead.
+ * absent rather than present-and-empty in the second case. This helper is the
+ * one place that decision lives, so every producer answers it the same way.
  * Callers pass whatever id they hold: the source block's own
  * ({@link ImageContent._attachmentId}) when carrying it across a rebuild, or an
  * upload's row id when stamping a fresh block.

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -110,6 +110,28 @@ export interface FileContent {
   _attachmentId?: string;
 }
 
+/**
+ * The `_attachmentId` property as a spreadable fragment, or nothing when there
+ * is no usable id.
+ *
+ * Every producer of a media block faces the same choice: it either knows the
+ * attachment row the block came from, or it does not, and the field has to be
+ * absent rather than present-and-empty in the second case. Spelling that out at
+ * each site is how the checks drifted apart, so they share this one instead.
+ * Callers pass whatever id they hold: the source block's own
+ * ({@link ImageContent._attachmentId}) when carrying it across a rebuild, or an
+ * upload's row id when stamping a fresh block.
+ *
+ * Empty counts as absent, matching the read side, which requires a non-empty
+ * string before it will treat the field as an id (see
+ * `daemon/handlers/shared.ts`).
+ */
+export function attachmentIdFragment(attachmentId: string | undefined): {
+  _attachmentId?: string;
+} {
+  return attachmentId ? { _attachmentId: attachmentId } : {};
+}
+
 export interface ToolUseContent {
   type: "tool_use";
   id: string;

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -132,6 +132,27 @@ export function attachmentIdFragment(attachmentId: string | undefined): {
   return attachmentId ? { _attachmentId: attachmentId } : {};
 }
 
+/**
+ * The attachment row a media block came from, whichever of the two shapes it
+ * is in, or undefined for a block that came from none (tool-generated and
+ * assistant-authored media).
+ *
+ * A reference names its row on `source.attachmentId`; an inline block has
+ * nowhere to put it but the top-level `_attachmentId`. Both are the same fact,
+ * so anything asking "which attachment is this?" has to read both or it goes
+ * blind on half the histories. Reading only `_attachmentId` in particular is
+ * the sharp edge: it is absent on every reference block, so a rebuild that
+ * flattens a reference to inline bytes drops the link unless it derives the id
+ * through here first.
+ */
+export function mediaBlockAttachmentId(
+  block: ImageContent | FileContent,
+): string | undefined {
+  return block.source.type === "workspace_ref"
+    ? block.source.attachmentId
+    : block._attachmentId;
+}
+
 export interface ToolUseContent {
   type: "tool_use";
   id: string;

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -80,6 +80,19 @@ export type MediaSource = Base64MediaSource | WorkspaceRefMediaSource;
 export interface ImageContent {
   type: "image";
   source: MediaSource;
+  /**
+   * Internal id linking a base64 image block to a row in the attachments table,
+   * the same correlation {@link FileContent._attachmentId} carries. A live turn
+   * sends its uploads inline while persisting them as references, so this is
+   * the only handle on the in-memory copy of an image whose stored form is a
+   * `workspace_ref`; camera-frame retention matches on it. Redundant once the
+   * block is a reference (use `source.attachmentId`).
+   *
+   * Never reaches a provider: every client builds its image payload out of
+   * `source` alone (see the `case "image"` arms of the Anthropic, Gemini, and
+   * both OpenAI clients), so top-level fields are dropped by construction.
+   */
+  _attachmentId?: string;
 }
 
 export interface FileContent {

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -347,6 +347,7 @@ import {
   deleteConversation,
   setConversation,
 } from "../../daemon/conversation-registry.js";
+import { stripAgedSightFrames } from "../../daemon/conversation-sight-frames.js";
 import { ContextOverflowError, type Message } from "../../providers/types.js";
 import {
   __resetWakeChainForTests,
@@ -521,6 +522,11 @@ function makeWakeConversation(options: {
         return runBody(input, onEvent, options);
       },
     },
+    // The wake trims its own run input, the way the orchestrator's pre-run
+    // pass trims a normal turn's. Empty capture times leave the array
+    // untouched, which is what every case but the camera one wants.
+    trimAgedSightFrames: (msgs: Message[]) =>
+      stripAgedSightFrames(msgs, wakeSightFrameCaptureTimes).messages,
     messages,
     getMessages: () => messages,
     isProcessing: () => processing,
@@ -605,8 +611,12 @@ function makeWakeConversation(options: {
   return conversation as unknown as WakeConversation;
 }
 
+/** Tagged camera frames the fake conversation's trim resolves against. */
+let wakeSightFrameCaptureTimes = new Map<string, number>();
+
 beforeEach(() => {
   __resetWakeChainForTests();
+  wakeSightFrameCaptureTimes = new Map();
   wakeConvRegistry.clear();
   recordRequestLogCalls.length = 0;
   recordUsageCalls.length = 0;
@@ -932,6 +942,62 @@ describe("wakeAgentForOpportunity", () => {
 
     expect(conversation.runCalls[0]!.personaOverride).toBeUndefined();
     expect(conversation.personaOverrideSets).toEqual([]);
+  });
+
+  test("bounds camera frames in the run input it sends", async () => {
+    // The wake sends its run input itself and keeps the in-loop budget gate
+    // disabled, so neither the orchestrator's pre-run pass nor the loop's
+    // post-compaction transform ever sees this array. Without its own trim a
+    // long camera session would send every frame it captured.
+    wakeSightFrameCaptureTimes = new Map([
+      ["f1", 1000],
+      ["f2", 2000],
+      ["f3", 3000],
+      ["f4", 4000],
+    ]);
+    const frame = (attachmentId: string): Message => ({
+      role: "user",
+      content: [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "AAAAAAAA" },
+          _attachmentId: attachmentId,
+        },
+      ],
+    });
+    const conversation = makeWakeConversation({
+      baseline: [frame("f1"), frame("f2"), frame("f3"), frame("f4")],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "look around",
+        source: "unit-test",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    const input = conversation.runCalls[0]!.input;
+    const images = input.flatMap((message) =>
+      message.content.filter((block) => block.type === "image"),
+    );
+    const stubs = input.flatMap((message) =>
+      message.content.filter(
+        (block) =>
+          block.type === "text" &&
+          block.text.startsWith("[Camera frame omitted from context:"),
+      ),
+    );
+    expect(images).toHaveLength(2);
+    expect(stubs).toHaveLength(2);
+    // The trim replaces blocks in place, so the wake's tail accounting still
+    // indexes the same positions.
+    expect(input.filter((m) => m.role === "user").length).toBeGreaterThan(0);
   });
 
   test("silent no-op when agent produces no tool calls and no text", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1018,7 +1018,19 @@ export async function wakeAgentForOpportunity(
               },
             ];
     const wakeHintMessageCount = wakeMessages.length;
-    const runInput: Message[] = [...baseline, ...wakeMessages];
+    // Camera-frame retention, the wake's equivalent of the orchestrator's
+    // pre-run pass. The wake sends this array itself and keeps the in-loop
+    // budget gate disabled, so neither the loop's post-compaction transform nor
+    // `runAgentLoopImpl`'s pre-run pass ever sees it; a wake on a long camera
+    // session would otherwise carry every frame the conversation holds,
+    // including any the gate above just retained. The pass replaces blocks
+    // inside messages without adding, dropping, or reordering one, so
+    // `baselineLength` and `wakeHintMessageCount` still index the same
+    // positions.
+    const runInput: Message[] = conversation.trimAgedSightFrames([
+      ...baseline,
+      ...wakeMessages,
+    ]);
 
     // Event handling runs in two modes. While `mode === "buffering"`,
     // events accumulate in `buffered` so that a wake which ultimately


### PR DESCRIPTION
## Summary

PR 3 of the desktop voice vision plan: the cost guard. Conversation history re-sends every inline image on every request, and the only trimming today is reactive (`conversation-media-retry.ts`, after a context-overflow rejection). Ambient camera frames arrive roughly once per spoken turn, so a long camera-up call accumulates them without bound.

- `stripAgedSightFrames` keeps the newest `KEEP_LATEST_SIGHT_FRAMES = 2` ambient frames as real images; older ones become `[Camera frame omitted from context: captured <time>, <type>, <bytes>]` stubs, mirroring the retry ladder's stub conventions.
- Applied at `runAgentLoopImpl`'s per-turn history copy, after the hook chain and repair, so every turn shape (normal, voice legs, escalations, retries, subagents) inherits it and the stored transcript keeps its attachments untouched.
- Only frames named by `sightFrameAttachmentIds` row metadata (from #41744) are eligible; picked files, pasted images, and shutter photos stay under the reactive ladder, whose media counting never sees a stubbed frame (composition tested).
- The constant lives in a dedicated leaf module: importing beside `RETRY_KEEP_LATEST_MEDIA_BLOCKS` adds two import cycles (the retry module drags plugin-api -> live-voice); cross-referencing docstrings link the proactive and reactive halves both ways.

**Merge-safe today**: no producer of the tag exists until #41744 lands, and inertness is verified three layers deep, including a sweep of all 32 turn-driving suites with the row-read's best-effort catch converted to a rethrow.

## Known gaps, deliberate

- `runtime/agent-wake.ts` drives the loop directly and bypasses this pass; a background wake on a camera conversation still resends frames. Cheap follow-up.
- The live in-flight copy of a just-sent frame is inline base64 without an attachment id (`attachmentsToContentBlocks` stamps `_attachmentId` only on file blocks), so retention engages on histories rebuilt from persisted rows. Voice calls reload often (transcript hygiene, discard, eviction), but a pathologically clean call accumulates until reload and falls back to the reactive ladder. The two candidate fixes touch shared attachment code documented as a stopgap and are left for their own PR.

## Verification

- 14 new tests: 9 pure (ordering mutation-verified, untagged media asserted untouched by object identity, no-tags returns the input by identity AND deep-equal), 5 real-SQLite (accessor, LIKE false positive contributes nothing, end-to-end stub).
- Full `tsc --noEmit` clean; eslint, prettier, lint:unused clean; lint:circular 221 = main's baseline; suites per-file: media-retry 7, runtime-assembly 206, agent-loop 88, voice-session-bridge 87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)