### PR TITLE
fix(notifications): describe scheduled credit walls as out of credits

### DIFF
--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -19,6 +19,11 @@ import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { getProviderRoutingSource } from "../providers/registry.js";
 import { isAbortReason } from "../util/abort-reasons.js";
 import {
+  CREDITS_EXHAUSTED_USER_MESSAGE,
+  DAILY_LIMIT_USER_MESSAGE,
+  PROVIDER_BILLING_USER_MESSAGE,
+} from "../util/billing-failure-copy.js";
+import {
   type ProviderCredentialSource,
   ProviderError,
   type ProviderErrorReason,
@@ -781,8 +786,7 @@ function managedBalanceClassification(): Omit<
     // Keep the wording context-neutral so it is true in both places; the
     // terminal persist site in conversation-agent-loop.ts swaps in
     // assistant-voice copy for the synthetic assistant row.
-    userMessage:
-      "You're out of credits. Add credits in Settings → Billing to continue.",
+    userMessage: CREDITS_EXHAUSTED_USER_MESSAGE,
     retryable: false,
     errorCategory: "credits_exhausted",
   };
@@ -794,8 +798,7 @@ function providerBillingClassification(): Omit<
 > {
   return {
     code: "PROVIDER_BILLING",
-    userMessage:
-      "Your API provider account or key needs credits. Add funds with the provider or update the key in Settings → Models & Services.",
+    userMessage: PROVIDER_BILLING_USER_MESSAGE,
     retryable: false,
     errorCategory: "provider_billing",
   };
@@ -807,8 +810,7 @@ function dailyLimitClassification(): Omit<
 > {
   return {
     code: "PROVIDER_BILLING",
-    userMessage:
-      "You've hit your daily credit limit. Raise the limit in Billing settings to keep going today.",
+    userMessage: DAILY_LIMIT_USER_MESSAGE,
     retryable: false,
     errorCategory: "daily_limit_reached",
   };

--- a/assistant/src/notifications/__tests__/copy-composer.test.ts
+++ b/assistant/src/notifications/__tests__/copy-composer.test.ts
@@ -78,17 +78,81 @@ describe("activity.failed copy", () => {
     expect(copy.vellum?.body).toEndWith("...");
   });
 
-  test("constant-shaped raw detail never reaches the body", () => {
+  test("PROVIDER_BILLING without a summary uses the credits fallback", () => {
     const copy = composeFallbackCopy(
       failedSignal({
         jobName: "heartbeat",
         errorKind: "model_provider",
         errorMessage: "Agent turn failed (PROVIDER_BILLING)",
+        failureCode: "PROVIDER_BILLING",
+      }),
+      CHANNELS,
+    );
+    expect(copy.vellum?.body).toBe(
+      "You're out of credits. Add credits in Settings → Billing to continue.",
+    );
+    expect(copy.vellum?.body).not.toContain("PROVIDER_BILLING");
+  });
+
+  test("a namespaced credits_exhausted category uses the credits fallback", () => {
+    const copy = composeFallbackCopy(
+      failedSignal({
+        jobName: "schedule:sniper",
+        errorKind: "model_provider",
+        errorMessage: "Agent turn failed during its LLM call (PROVIDER_BILLING)",
+        errorCategory: "billing.credits_exhausted",
+      }),
+      CHANNELS,
+    );
+    expect(copy.vellum?.body).toBe(
+      "You're out of credits. Add credits in Settings → Billing to continue.",
+    );
+  });
+
+  test("daily_limit_reached without a summary uses the daily-limit fallback", () => {
+    const copy = composeFallbackCopy(
+      failedSignal({
+        jobName: "schedule:nightly",
+        errorKind: "model_provider",
+        errorMessage: "Agent turn failed (PROVIDER_BILLING)",
+        failureCode: "PROVIDER_BILLING",
+        errorCategory: "daily_limit_reached",
+      }),
+      CHANNELS,
+    );
+    expect(copy.vellum?.body).toBe(
+      "You've hit your daily credit limit. Raise the limit in Billing settings to keep going today.",
+    );
+  });
+
+  test("provider_billing without a summary uses the provider-wallet fallback", () => {
+    const copy = composeFallbackCopy(
+      failedSignal({
+        jobName: "schedule:byok",
+        errorKind: "model_provider",
+        errorMessage: "Agent turn failed (PROVIDER_BILLING)",
+        failureCode: "PROVIDER_BILLING",
+        errorCategory: "provider_billing",
+      }),
+      CHANNELS,
+    );
+    expect(copy.vellum?.body).toBe(
+      "Your API provider account or key needs credits. Add funds with the provider or update the key in Settings → Models & Services.",
+    );
+  });
+
+  test("constant-shaped raw detail never reaches the body", () => {
+    const copy = composeFallbackCopy(
+      failedSignal({
+        jobName: "heartbeat",
+        errorKind: "model_provider",
+        errorMessage: "Agent turn failed (PROVIDER_RATE_LIMIT)",
+        failureCode: "PROVIDER_RATE_LIMIT",
       }),
       CHANNELS,
     );
     expect(copy.vellum?.body).toBe("The model provider did not respond.");
-    expect(copy.vellum?.body).not.toContain("PROVIDER_BILLING");
+    expect(copy.vellum?.body).not.toContain("PROVIDER_RATE_LIMIT");
   });
 
   test("readable raw detail is appended to the kind prose", () => {

--- a/assistant/src/notifications/copy-composer.ts
+++ b/assistant/src/notifications/copy-composer.ts
@@ -9,6 +9,7 @@
  * values from the context payload.
  */
 
+import { describeBillingFailureCopy } from "../util/billing-failure-copy.js";
 import { normalizeTitle } from "../util/short-title.js";
 import { truncate } from "../util/truncate.js";
 import {
@@ -44,13 +45,19 @@ type CopyTemplate = (payload: Record<string, unknown>) => RenderedChannelCopy;
 
 /**
  * Failure prose for an `activity.failed` payload with no authored
- * classification message. The classified kind supplies the readable part,
- * and the raw error text is appended only when it reads as prose: a
- * stack-shaped or constant-shaped message (PROVIDER_BILLING and friends)
- * says nothing to the person reading the notification and never lands in
- * the body.
+ * classification message. Classified billing codes get the same user-facing
+ * copy the turn classifier would have written, so a schedule that dies on
+ * credits is not described as a silent provider outage. For every other
+ * kind the classified kind supplies the readable part, and the raw error
+ * text is appended only when it reads as prose: a stack-shaped or
+ * constant-shaped message (PROVIDER_RATE_LIMIT and friends) says nothing
+ * to the person reading the notification and never lands in the body.
  */
 function describeUnclassifiedFailure(payload: Record<string, unknown>): string {
+  const billingCopy = describeBillingFailureCopy(payload);
+  if (billingCopy !== null) {
+    return billingCopy;
+  }
   const kind = str(payload.errorKind, "exception");
   const opening =
     kind === "timeout"

--- a/assistant/src/util/__tests__/billing-failure-copy.test.ts
+++ b/assistant/src/util/__tests__/billing-failure-copy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  CREDITS_EXHAUSTED_USER_MESSAGE,
+  DAILY_LIMIT_USER_MESSAGE,
+  describeBillingFailureCopy,
+  PROVIDER_BILLING_USER_MESSAGE,
+} from "../billing-failure-copy.js";
+
+describe("describeBillingFailureCopy", () => {
+  test("a bare PROVIDER_BILLING code is managed-credits exhaustion", () => {
+    expect(
+      describeBillingFailureCopy({ failureCode: "PROVIDER_BILLING" }),
+    ).toBe(CREDITS_EXHAUSTED_USER_MESSAGE);
+  });
+
+  test("daily_limit_reached wins over a bare PROVIDER_BILLING code", () => {
+    expect(
+      describeBillingFailureCopy({
+        failureCode: "PROVIDER_BILLING",
+        errorCategory: "daily_limit_reached",
+      }),
+    ).toBe(DAILY_LIMIT_USER_MESSAGE);
+  });
+
+  test("provider_billing wins over a bare PROVIDER_BILLING code", () => {
+    expect(
+      describeBillingFailureCopy({
+        failureCode: "PROVIDER_BILLING",
+        errorCategory: "provider_billing",
+      }),
+    ).toBe(PROVIDER_BILLING_USER_MESSAGE);
+  });
+
+  test("namespaced categories classify by suffix", () => {
+    expect(
+      describeBillingFailureCopy({
+        errorCategory: "billing.credits_exhausted",
+      }),
+    ).toBe(CREDITS_EXHAUSTED_USER_MESSAGE);
+  });
+
+  test("unrelated failures stay unclassified", () => {
+    expect(
+      describeBillingFailureCopy({
+        failureCode: "PROVIDER_RATE_LIMIT",
+        errorKind: "model_provider",
+      }),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/util/billing-failure-copy.ts
+++ b/assistant/src/util/billing-failure-copy.ts
@@ -1,0 +1,60 @@
+/**
+ * User-facing copy for classified billing failures.
+ *
+ * Shared by the turn classifier and the activity.failed notification
+ * fallback so a schedule that dies on credits, a daily limit, or a
+ * provider wallet says the same thing whether the turn carried
+ * `failureSummary` or only a `failureCode` / `errorCategory`. Category
+ * matching is suffix-based so namespaced values such as
+ * `billing.credits_exhausted` classify too.
+ */
+
+export const CREDITS_EXHAUSTED_USER_MESSAGE =
+  "You're out of credits. Add credits in Settings → Billing to continue.";
+
+export const PROVIDER_BILLING_USER_MESSAGE =
+  "Your API provider account or key needs credits. Add funds with the provider or update the key in Settings → Models & Services.";
+
+export const DAILY_LIMIT_USER_MESSAGE =
+  "You've hit your daily credit limit. Raise the limit in Billing settings to keep going today.";
+
+const PROVIDER_BILLING_CODE = "PROVIDER_BILLING";
+const CREDITS_EXHAUSTED_CATEGORY = "credits_exhausted";
+const PROVIDER_BILLING_CATEGORY = "provider_billing";
+const DAILY_LIMIT_CATEGORY = "daily_limit_reached";
+
+function categoryOf(payload: Record<string, unknown>): string {
+  return typeof payload.errorCategory === "string" ? payload.errorCategory : "";
+}
+
+function codeOf(payload: Record<string, unknown>): string {
+  return typeof payload.failureCode === "string" ? payload.failureCode : "";
+}
+
+/**
+ * Billing-specific fallback body, or null when the payload is not a
+ * classified billing failure.
+ *
+ * Precedence matches the chat composer: daily limit, then provider-wallet
+ * billing, then managed-credits exhaustion. A bare `PROVIDER_BILLING` code
+ * with no category is treated as managed-credits exhaustion, the same way
+ * persisted provider-error rows classify in the web client.
+ */
+export function describeBillingFailureCopy(
+  payload: Record<string, unknown>,
+): string | null {
+  const category = categoryOf(payload);
+  if (category.endsWith(DAILY_LIMIT_CATEGORY)) {
+    return DAILY_LIMIT_USER_MESSAGE;
+  }
+  if (category.endsWith(PROVIDER_BILLING_CATEGORY)) {
+    return PROVIDER_BILLING_USER_MESSAGE;
+  }
+  if (
+    category.endsWith(CREDITS_EXHAUSTED_CATEGORY) ||
+    codeOf(payload) === PROVIDER_BILLING_CODE
+  ) {
+    return CREDITS_EXHAUSTED_USER_MESSAGE;
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Retention deep-dive for a high-usage Pro user on 2026-08-30 (standard conversation `02e51fd6…`, 4 real messages). The scheduled hypothesis that `low_balance_warning` is missing from the billing summary API is **incorrect**: that field shipped 2026-07-30 (`#9624`) and the in-app banner shipped 2026-08-03 (`#39748`). Both were live on the target date.

**What actually happened**

- Goal: keep an automated auction sniper running (many 5-minute scheduled jobs, huge bash/file tool volume).
- Credits depleted late 2026-08-29 (auto-top-up off). 407 scheduled turns then failed overnight with `PROVIDER_BILLING`.
- The user's machine was also off. First interactive message on Aug 30 (12:21 ET) hit the credit wall; they topped up $30 at 12:21:58 and resumed.
- The in-app low-balance banner cannot warn a user who is not looking at chat. Overnight the only reachable surface is the `activity.failed` notification.

**The bug this PR fixes**

When a schedule or background job dies on `PROVIDER_BILLING` and the turn did not carry `failureSummary`, the `activity.failed` fallback said "The model provider did not respond." That hides the action (add credits / raise the daily limit / fund the provider key) for the exact users who run unattended automated work.

Shared classifier copy now lives in `assistant/src/util/billing-failure-copy.ts` and is used by both `conversation-error.ts` and the notification fallback.

## Test plan

- `cd assistant && bun test src/notifications/__tests__/copy-composer.test.ts src/util/__tests__/billing-failure-copy.test.ts src/__tests__/conversation-error.test.ts`
- `cd assistant && bunx tsc --noEmit` if the shared module import looks risky

## Risk

Low. Copy-only fallback for an already-classified billing failure. Authored `failureSummary` still wins when present. Constant-shaped provider codes such as `PROVIDER_RATE_LIMIT` still stay out of the body.

## Follow-ups (not in this PR)

- Auto-top-up is the real safety net for high-burn scheduled workflows. This user manually topped up every 1-2 days and had auto-top-up off.
- The default low-balance email threshold is $1, which a high-burn schedule can cross while the user is away. A burn-aware threshold or a depletion email that mentions scheduled work is a product decision.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56d679ff-bf87-426a-9f6c-440d6b3118cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56d679ff-bf87-426a-9f6c-440d6b3118cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

