### PR TITLE
fix(bash): cap stdout while it streams

### DIFF
--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 // ── Mock modules ────────────────────────────────────────────────────────────
@@ -40,7 +40,11 @@ mock.module("../tools/network/script-proxy/index.js", () => ({
 
 // ── Imports (after mocks) ───────────────────────────────────────────────────
 
-import { formatShellOutput } from "../tools/shared/shell-output.js";
+import {
+  formatShellOutput,
+  MAX_OUTPUT_LENGTH,
+  OUTPUT_TRUNCATED_TAG,
+} from "../tools/shared/shell-output.js";
 import {
   ALWAYS_INJECTED_ENV_VARS,
   buildSanitizedEnv,
@@ -360,12 +364,8 @@ describe("formatShellOutput", () => {
   test("truncates very long output", () => {
     const longOutput = "x".repeat(30_000);
     const result = formatShellOutput(longOutput, "", 0, false, 120);
-    expect(result.content).toContain('limit="20K"');
-    // Extract the file="..." attribute from the truncation tag
-    const fileMatch = result.content.match(/file="([^"]+)"/);
-    expect(fileMatch).not.toBeNull();
-    const filePath = fileMatch![1];
-    expect(existsSync(filePath)).toBe(true);
-    expect(readFileSync(filePath, "utf-8")).toBe(longOutput);
+    expect(result.content).toContain(OUTPUT_TRUNCATED_TAG);
+    expect(result.content).not.toContain("file=");
+    expect(result.content.length).toBeLessThan(MAX_OUTPUT_LENGTH + 80);
   });
 });

--- a/assistant/src/daemon/shutdown-handlers.ts
+++ b/assistant/src/daemon/shutdown-handlers.ts
@@ -21,7 +21,6 @@ import { stopScheduler } from "../schedule/scheduler.js";
 import { getSubagentManager } from "../subagent/index.js";
 import { stopUsageTelemetryReporter } from "../telemetry/usage-telemetry-reporter.js";
 import { browserManager } from "../tools/browser/browser-manager.js";
-import { cleanupShellOutputTempFiles } from "../tools/shared/shell-output.js";
 import { getLogger } from "../util/logger.js";
 import { APP_VERSION } from "../version.js";
 import { getEnrichmentService } from "../workspace/commit-message-enrichment-service.js";
@@ -167,7 +166,6 @@ async function shutdown(): Promise<void> {
 
   await stopRuntimeHttpServer();
   await browserManager.closeAllPages();
-  cleanupShellOutputTempFiles();
   stopScheduler();
 
   // The memory jobs worker process is SIGTERM'd by the memory plugin's own

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1158,10 +1158,10 @@ describe("wakeAgentForOpportunity", () => {
       },
     });
 
-    // Mirror formatShellOutput on large output: ~20KB body + a recovery marker
-    // pointing at the full-output temp file. The default tool_result budget
-    // would re-truncate the marker off; the caller passes a larger maxChars.
-    const marker = '<output_truncated limit="20K" file="/tmp/bg-xyz.txt" />';
+    // Mirror formatShellOutput on large output: ~20KB body + a truncation
+    // marker. The default tool_result budget would slice the marker off; the
+    // caller passes a larger maxChars.
+    const marker = '<output_truncated limit="20K" />';
     const big = `${"x".repeat(20_000)}\n${marker}`;
 
     await wakeAgentForOpportunity(
@@ -1182,8 +1182,7 @@ describe("wakeAgentForOpportunity", () => {
     const text = (
       conversation.persistedTailCalls[0]!.content as Array<{ text: string }>
     )[0]!.text;
-    // The trailing recovery marker survives (not re-truncated off) and the
-    // fence is still well-formed.
+    // The trailing truncation marker survives and the fence is well-formed.
     expect(text).toContain(marker);
     expect(text).toContain('<external_content source="tool_result">');
     expect(text.endsWith("</background_event>")).toBe(true);

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -145,9 +145,9 @@ function sanitizeEventAttr(value: string): string {
 /**
  * Untrusted third-party output to fence inside a persisted wake trigger via
  * {@link wrapUntrustedContent}. `maxChars` overrides the per-source character
- * budget — used for preformatted shell output that `formatShellOutput` already
- * bounded (to `MAX_OUTPUT_LENGTH`) and appended an `<output_truncated file=…/>`
- * recovery marker to, so the wrapper does not re-truncate that marker off.
+ * budget. Used for preformatted shell output that is already bounded to
+ * `MAX_OUTPUT_LENGTH` with an `<output_truncated />` marker, so the wrapper
+ * does not slice that marker off.
  */
 interface WakeUntrustedOutput {
   content: string;

--- a/assistant/src/tools/host-terminal/host-shell.test.ts
+++ b/assistant/src/tools/host-terminal/host-shell.test.ts
@@ -104,6 +104,10 @@ mock.module("../../daemon/host-bash-proxy.js", () => ({
 // Import under test — MUST come after mock.module calls.
 // ---------------------------------------------------------------------------
 
+import {
+  MAX_OUTPUT_LENGTH,
+  OUTPUT_TRUNCATED_TAG,
+} from "../shared/shell-output.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
 import { hostShellTool } from "./host-shell.js";
 
@@ -361,5 +365,25 @@ describe("host_bash background lifecycle events — direct spawn path", () => {
     // Cancellation must surface a cancellation message, not "failed" framing.
     expect(completed[0]!.output).toContain("cancelled");
     expect(completed[0]!.output).not.toContain("failed");
+  });
+
+  test("drops stdout past the cap without a recovery file", async () => {
+    await hostShellTool.execute(
+      { command: "yes", background: true },
+      makeContext(),
+    );
+
+    latestChild!.stdout.emit("data", Buffer.alloc(80_000, 0x78));
+    latestChild!.stdout.emit("data", Buffer.alloc(80_000, 0x79));
+    latestChild!.emit("close", 0);
+    await flush();
+
+    const completed = completedEvents();
+    expect(completed).toHaveLength(1);
+    const output = String(completed[0]!.output);
+    expect(output).toContain(OUTPUT_TRUNCATED_TAG);
+    expect(output).not.toContain("file=");
+    expect(output.length).toBeLessThan(MAX_OUTPUT_LENGTH + 80);
+    expect(output).not.toContain("y");
   });
 });

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -40,7 +40,7 @@ import {
   removeBackgroundTool,
 } from "../background-tool-registry.js";
 import {
-  formatShellOutput,
+  attachBoundedStdio,
   MAX_OUTPUT_LENGTH,
 } from "../shared/shell-output.js";
 import {
@@ -336,7 +336,7 @@ export const hostShellTool = {
               untrustedOutput: {
                 content: output || "(no output)",
                 source: "tool_result",
-                // Preserve formatShellOutput's recovery marker (see shell.ts).
+                // Bounded output plus the truncation marker (see shell.ts).
                 maxChars: MAX_OUTPUT_LENGTH * 2,
               },
             });
@@ -475,8 +475,7 @@ export const hostShellTool = {
         windowsHide: true,
       });
 
-      const stdoutChunks: Buffer[] = [];
-      const stderrChunks: Buffer[] = [];
+      const collector = attachBoundedStdio(child);
       let timedOut = false;
       // Set when cancelled via the registry's cancel callback so the completion
       // event reports "cancelled" rather than "failed".
@@ -489,9 +488,6 @@ export const hostShellTool = {
         killTree();
       }, timeoutMs);
 
-      child.stdout.on("data", (data: Buffer) => stdoutChunks.push(data));
-      child.stderr.on("data", (data: Buffer) => stderrChunks.push(data));
-
       // Guard against double-wake: when spawn fails (e.g. invalid cwd),
       // Node emits both 'error' and 'close' for the same child process.
       // Only the first handler to fire should wake the agent.
@@ -503,15 +499,7 @@ export const hostShellTool = {
         }
         completed = true;
         clearTimeout(timer);
-        const stdout = Buffer.concat(stdoutChunks).toString();
-        const stderr = Buffer.concat(stderrChunks).toString();
-        const result = formatShellOutput(
-          stdout,
-          stderr,
-          code,
-          timedOut,
-          timeoutSec,
-        );
+        const result = collector.format(code, timedOut, timeoutSec);
         // Cancel takes precedence over the SIGKILL-induced error result.
         const status = aborted
           ? "cancelled"
@@ -564,7 +552,7 @@ export const hostShellTool = {
           untrustedOutput: {
             content: output || "(no output)",
             source: "tool_result",
-            // Preserve formatShellOutput's recovery marker (see shell.ts).
+            // Bounded output plus the truncation marker (see shell.ts).
             maxChars: MAX_OUTPUT_LENGTH * 2,
           },
         });
@@ -650,8 +638,6 @@ export const hostShellTool = {
     }
 
     return new Promise<ToolExecutionResult>((resolve) => {
-      const stdoutChunks: Buffer[] = [];
-      const stderrChunks: Buffer[] = [];
       let timedOut = false;
 
       const wrapped = buildShellInvocation(command);
@@ -661,6 +647,9 @@ export const hostShellTool = {
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
         windowsHide: true,
+      });
+      const collector = attachBoundedStdio(child, {
+        onOutput: context.onOutput,
       });
 
       const killTree = () => terminateProcessTree(child);
@@ -680,29 +669,11 @@ export const hostShellTool = {
         }
       }
 
-      child.stdout.on("data", (data: Buffer) => {
-        stdoutChunks.push(data);
-        context.onOutput?.(data.toString());
-      });
-
-      child.stderr.on("data", (data: Buffer) => {
-        stderrChunks.push(data);
-        context.onOutput?.(data.toString());
-      });
-
       child.on("close", (code) => {
         clearTimeout(timer);
         context.signal?.removeEventListener("abort", onAbort);
 
-        const stdout = Buffer.concat(stdoutChunks).toString();
-        const stderr = Buffer.concat(stderrChunks).toString();
-        const result = formatShellOutput(
-          stdout,
-          stderr,
-          code,
-          timedOut,
-          timeoutSec,
-        );
+        const result = collector.format(code, timedOut, timeoutSec);
 
         resolve({
           content: result.content,

--- a/assistant/src/tools/shared/shell-output.test.ts
+++ b/assistant/src/tools/shared/shell-output.test.ts
@@ -1,0 +1,106 @@
+import { EventEmitter } from "node:events";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  attachBoundedStdio,
+  BoundedStdioCollector,
+  formatShellOutput,
+  MAX_OUTPUT_LENGTH,
+  OUTPUT_TRUNCATED_TAG,
+} from "./shell-output.js";
+
+describe("BoundedStdioCollector", () => {
+  test("keeps output under the cap", () => {
+    const collector = new BoundedStdioCollector();
+    collector.consume("stdout", Buffer.from("hello"));
+    const result = collector.format(0, false, 120);
+    expect(result.content).toBe("hello");
+    expect(collector.didTruncate).toBe(false);
+    expect(collector.keptByteLength).toBe(5);
+  });
+
+  test("caps a single oversized chunk without retaining the tail", () => {
+    const collector = new BoundedStdioCollector();
+    const huge = Buffer.alloc(MAX_OUTPUT_LENGTH + 50_000, 0x78);
+    collector.consume("stdout", huge);
+    expect(collector.keptByteLength).toBe(MAX_OUTPUT_LENGTH);
+    expect(collector.didTruncate).toBe(true);
+    const result = collector.format(0, false, 120);
+    expect(result.content).toContain(OUTPUT_TRUNCATED_TAG);
+    expect(result.content).not.toContain("file=");
+    expect(result.content.startsWith("x".repeat(MAX_OUTPUT_LENGTH))).toBe(true);
+    expect(result.content.length).toBeLessThan(MAX_OUTPUT_LENGTH + 80);
+  });
+
+  test("shares the budget across stdout and stderr", () => {
+    const collector = new BoundedStdioCollector();
+    collector.consume("stdout", Buffer.alloc(MAX_OUTPUT_LENGTH - 10, 0x61));
+    collector.consume("stderr", Buffer.alloc(100, 0x62));
+    expect(collector.keptByteLength).toBe(MAX_OUTPUT_LENGTH);
+    expect(collector.didTruncate).toBe(true);
+    const result = collector.format(0, false, 120);
+    expect(result.content).toContain(OUTPUT_TRUNCATED_TAG);
+    expect(result.content.includes("b")).toBe(true);
+  });
+
+  test("ignores chunks after the cap", () => {
+    const collector = new BoundedStdioCollector();
+    collector.consume("stdout", Buffer.alloc(MAX_OUTPUT_LENGTH, 0x78));
+    const afterCap = collector.keptByteLength;
+    collector.consume("stdout", Buffer.alloc(10_000, 0x79));
+    collector.consume("stderr", Buffer.alloc(10_000, 0x7a));
+    expect(collector.keptByteLength).toBe(afterCap);
+    const result = collector.format(0, false, 120);
+    expect(result.content).not.toContain("y");
+    expect(result.content).not.toContain("z");
+  });
+
+  test("does not call onOutput for discarded bytes", () => {
+    const seen: string[] = [];
+    const collector = new BoundedStdioCollector();
+    collector.consume("stdout", Buffer.from("abc"), (text) => seen.push(text));
+    collector.consume(
+      "stdout",
+      Buffer.alloc(MAX_OUTPUT_LENGTH, 0x78),
+      (text) => seen.push(text),
+    );
+    collector.consume("stdout", Buffer.from("TAIL"), (text) => seen.push(text));
+    const forwarded = seen.join("");
+    expect(forwarded).not.toContain("TAIL");
+    expect(Buffer.byteLength(forwarded)).toBe(MAX_OUTPUT_LENGTH);
+  });
+});
+
+describe("attachBoundedStdio", () => {
+  test("drains further data events after the cap without growing kept bytes", () => {
+    const child = {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+    };
+    const collector = attachBoundedStdio(child);
+    child.stdout.emit("data", Buffer.alloc(MAX_OUTPUT_LENGTH + 1000, 0x78));
+    child.stdout.emit("data", Buffer.alloc(20_000, 0x79));
+    child.stderr.emit("data", Buffer.alloc(20_000, 0x7a));
+    expect(collector.keptByteLength).toBe(MAX_OUTPUT_LENGTH);
+    expect(collector.didTruncate).toBe(true);
+  });
+});
+
+describe("formatShellOutput truncation", () => {
+  test("truncates an already-materialized oversized string without a file path", () => {
+    const longOutput = "x".repeat(30_000);
+    const result = formatShellOutput(longOutput, "", 0, false, 120);
+    expect(result.content).toContain(OUTPUT_TRUNCATED_TAG);
+    expect(result.content).not.toContain("file=");
+    expect(result.content.length).toBeLessThan(MAX_OUTPUT_LENGTH + 80);
+  });
+
+  test("honors an explicit truncated flag at the exact cap", () => {
+    const exact = "x".repeat(MAX_OUTPUT_LENGTH);
+    const result = formatShellOutput(exact, "", 0, false, 120, {
+      truncated: true,
+    });
+    expect(result.content).toContain(OUTPUT_TRUNCATED_TAG);
+  });
+});

--- a/assistant/src/tools/shared/shell-output.test.ts
+++ b/assistant/src/tools/shared/shell-output.test.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "node:events";
-
 import { describe, expect, test } from "bun:test";
 
 import {
@@ -24,6 +23,7 @@ describe("BoundedStdioCollector", () => {
     const collector = new BoundedStdioCollector();
     const huge = Buffer.alloc(MAX_OUTPUT_LENGTH + 50_000, 0x78);
     collector.consume("stdout", huge);
+    huge.fill(0x79);
     expect(collector.keptByteLength).toBe(MAX_OUTPUT_LENGTH);
     expect(collector.didTruncate).toBe(true);
     const result = collector.format(0, false, 120);
@@ -60,10 +60,8 @@ describe("BoundedStdioCollector", () => {
     const seen: string[] = [];
     const collector = new BoundedStdioCollector();
     collector.consume("stdout", Buffer.from("abc"), (text) => seen.push(text));
-    collector.consume(
-      "stdout",
-      Buffer.alloc(MAX_OUTPUT_LENGTH, 0x78),
-      (text) => seen.push(text),
+    collector.consume("stdout", Buffer.alloc(MAX_OUTPUT_LENGTH, 0x78), (text) =>
+      seen.push(text),
     );
     collector.consume("stdout", Buffer.from("TAIL"), (text) => seen.push(text));
     const forwarded = seen.join("");

--- a/assistant/src/tools/shared/shell-output.ts
+++ b/assistant/src/tools/shared/shell-output.ts
@@ -1,26 +1,8 @@
-import { randomUUID } from "node:crypto";
-import { unlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-
 import { safeStringSlice } from "../../util/unicode.js";
 
 export const MAX_OUTPUT_LENGTH = 20_000;
 
-/** Tracks temp files created for truncated shell output so they can be cleaned up on shutdown. */
-const trackedTempFiles = new Set<string>();
-
-/** Remove all tracked truncated-output temp files. Safe to call multiple times. */
-export function cleanupShellOutputTempFiles(): void {
-  for (const filePath of trackedTempFiles) {
-    try {
-      unlinkSync(filePath);
-    } catch {
-      // File may already be gone — ignore.
-    }
-  }
-  trackedTempFiles.clear();
-}
+export const OUTPUT_TRUNCATED_TAG = `<output_truncated limit="20K" />`;
 
 export interface ShellOutputResult {
   content: string;
@@ -28,11 +10,20 @@ export interface ShellOutputResult {
   isError: boolean;
 }
 
+type StdioStream = "stdout" | "stderr";
+
+type DataListener = (data: Buffer | string) => void;
+
+type ReadableLike = {
+  on(event: "data", listener: DataListener): unknown;
+};
+
 /**
- * Format the raw stdout/stderr/exit-code from a spawned shell command into the
- * final tool result.  Both `shell.ts` (sandbox bash) and `host-shell.ts`
- * (host_bash) must produce identical output formatting - this shared function
- * is the single source of truth for that logic.
+ * Format already-materialized stdout/stderr into the tool result. Spawn sites
+ * that read pipes should collect through {@link BoundedStdioCollector} so the
+ * oversized tail never lands in memory. This helper still truncates a string
+ * that is already over the cap (desktop host-bash payloads) without writing
+ * the discarded tail to disk.
  */
 export function formatShellOutput(
   stdout: string,
@@ -40,6 +31,7 @@ export function formatShellOutput(
   code: number | null,
   timedOut: boolean,
   timeoutSec: number,
+  options?: { truncated?: boolean },
 ): ShellOutputResult {
   let output = stdout;
   if (stderr) {
@@ -54,22 +46,10 @@ export function formatShellOutput(
     statusParts.push(msg);
   }
 
-  if (output.length > MAX_OUTPUT_LENGTH) {
-    let fullOutputPath: string | undefined;
-    try {
-      fullOutputPath = join(
-        tmpdir(),
-        `vellum-shell-output-${randomUUID()}.txt`,
-      );
-      writeFileSync(fullOutputPath, output, { encoding: "utf-8", mode: 0o600 });
-      trackedTempFiles.add(fullOutputPath);
-    } catch {
-      fullOutputPath = undefined;
-    }
-    const fileAttr = fullOutputPath ? ` file="${fullOutputPath}"` : "";
-    const msg = `<output_truncated limit="20K"${fileAttr} />`;
-    output = safeStringSlice(output, 0, MAX_OUTPUT_LENGTH) + `\n${msg}`;
-    statusParts.push(msg);
+  const truncated = options?.truncated === true || output.length > MAX_OUTPUT_LENGTH;
+  if (truncated) {
+    output = safeStringSlice(output, 0, MAX_OUTPUT_LENGTH) + `\n${OUTPUT_TRUNCATED_TAG}`;
+    statusParts.push(OUTPUT_TRUNCATED_TAG);
   }
 
   if (!output.trim()) {
@@ -89,4 +69,90 @@ export function formatShellOutput(
     status: statusParts.length > 0 ? statusParts.join("\n") : undefined,
     isError: code !== 0 || timedOut,
   };
+}
+
+function toBuffer(data: Buffer | string): Buffer {
+  if (Buffer.isBuffer(data)) {
+    return data;
+  }
+  return Buffer.from(data);
+}
+
+/**
+ * Caps bash stdout/stderr while they stream. Bytes past {@link MAX_OUTPUT_LENGTH}
+ * are dropped (the process is left running so the pipe can drain). stdout and
+ * stderr share one budget, matching the concatenated tool-result cap.
+ */
+export class BoundedStdioCollector {
+  private readonly stdoutParts: Buffer[] = [];
+  private readonly stderrParts: Buffer[] = [];
+  private keptBytes = 0;
+  private truncated = false;
+
+  consume(
+    stream: StdioStream,
+    chunk: Buffer,
+    onOutput?: (text: string) => void,
+  ): void {
+    if (this.truncated || chunk.length === 0) {
+      return;
+    }
+
+    const remaining = MAX_OUTPUT_LENGTH - this.keptBytes;
+    if (remaining <= 0) {
+      this.truncated = true;
+      return;
+    }
+
+    const kept =
+      chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
+    if (stream === "stdout") {
+      this.stdoutParts.push(kept);
+    } else {
+      this.stderrParts.push(kept);
+    }
+    this.keptBytes += kept.length;
+    if (kept.length < chunk.length) {
+      this.truncated = true;
+    }
+    onOutput?.(kept.toString());
+  }
+
+  get keptByteLength(): number {
+    return this.keptBytes;
+  }
+
+  get didTruncate(): boolean {
+    return this.truncated;
+  }
+
+  format(
+    code: number | null,
+    timedOut: boolean,
+    timeoutSec: number,
+  ): ShellOutputResult {
+    return formatShellOutput(
+      Buffer.concat(this.stdoutParts).toString(),
+      Buffer.concat(this.stderrParts).toString(),
+      code,
+      timedOut,
+      timeoutSec,
+      { truncated: this.truncated },
+    );
+  }
+}
+
+/** Attach a shared-budget collector to a child's stdout and stderr pipes. */
+export function attachBoundedStdio(
+  child: { stdout?: ReadableLike | null; stderr?: ReadableLike | null },
+  options?: { onOutput?: (text: string) => void },
+): BoundedStdioCollector {
+  const collector = new BoundedStdioCollector();
+  child.stdout?.on("data", (data) => {
+    collector.consume("stdout", toBuffer(data), options?.onOutput);
+  });
+  child.stderr?.on("data", (data) => {
+    collector.consume("stderr", toBuffer(data), options?.onOutput);
+  });
+  return collector;
 }

--- a/assistant/src/tools/shared/shell-output.ts
+++ b/assistant/src/tools/shared/shell-output.ts
@@ -46,9 +46,12 @@ export function formatShellOutput(
     statusParts.push(msg);
   }
 
-  const truncated = options?.truncated === true || output.length > MAX_OUTPUT_LENGTH;
+  const truncated =
+    options?.truncated === true || output.length > MAX_OUTPUT_LENGTH;
   if (truncated) {
-    output = safeStringSlice(output, 0, MAX_OUTPUT_LENGTH) + `\n${OUTPUT_TRUNCATED_TAG}`;
+    output =
+      safeStringSlice(output, 0, MAX_OUTPUT_LENGTH) +
+      `\n${OUTPUT_TRUNCATED_TAG}`;
     statusParts.push(OUTPUT_TRUNCATED_TAG);
   }
 
@@ -104,8 +107,12 @@ export class BoundedStdioCollector {
       return;
     }
 
+    // Copy a prefix so a single oversized chunk can be GC'd. subarray()
+    // would keep the whole allocation alive through the kept view.
     const kept =
-      chunk.length <= remaining ? chunk : chunk.subarray(0, remaining);
+      chunk.length <= remaining
+        ? chunk
+        : Buffer.from(chunk.subarray(0, remaining));
     if (stream === "stdout") {
       this.stdoutParts.push(kept);
     } else {

--- a/assistant/src/tools/terminal/shell.test.ts
+++ b/assistant/src/tools/terminal/shell.test.ts
@@ -1,15 +1,14 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { setConfig } from "../../__tests__/helpers/set-config.js";
-import type { ToolContext } from "../types.js";
 import {
   MAX_OUTPUT_LENGTH,
   OUTPUT_TRUNCATED_TAG,
 } from "../shared/shell-output.js";
+import type { ToolContext } from "../types.js";
 
 // ---------------------------------------------------------------------------
 // Singleton mocks — must precede the tool import so bun's module mock applies.

--- a/assistant/src/tools/terminal/shell.test.ts
+++ b/assistant/src/tools/terminal/shell.test.ts
@@ -1,7 +1,15 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { setConfig } from "../../__tests__/helpers/set-config.js";
 import type { ToolContext } from "../types.js";
+import {
+  MAX_OUTPUT_LENGTH,
+  OUTPUT_TRUNCATED_TAG,
+} from "../shared/shell-output.js";
 
 // ---------------------------------------------------------------------------
 // Singleton mocks — must precede the tool import so bun's module mock applies.
@@ -197,5 +205,61 @@ describe("foreground stdin handling", () => {
     expect(result.isError).toBeFalsy();
     expect(result.content).toContain("done");
     expect(result.content).not.toContain("ENXIO");
+  });
+});
+
+describe("streaming stdout cap", () => {
+  let tmpDir = "";
+
+  beforeEach(async () => {
+    events.length = 0;
+    _clearRegistryForTesting();
+    tmpDir = await mkdtemp(join(tmpdir(), "bash-cap-"));
+  });
+
+  afterEach(async () => {
+    _clearRegistryForTesting();
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("foreground drops stdout past the cap and lets the process finish", async () => {
+    const result = await shellTool.execute(
+      {
+        command: `${process.execPath} -e "process.stdout.write('x'.repeat(100000)); require('node:fs').writeFileSync('sentinel.txt','done')"`,
+        activity: "test",
+      },
+      { ...makeContext(), workingDir: tmpDir },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain(OUTPUT_TRUNCATED_TAG);
+    expect(result.content).not.toContain("file=");
+    expect(result.content.length).toBeLessThan(MAX_OUTPUT_LENGTH + 80);
+    expect(await readFile(join(tmpDir, "sentinel.txt"), "utf-8")).toBe("done");
+  });
+
+  test("background drops stdout past the cap and lets the process finish", async () => {
+    const result = await shellTool.execute(
+      {
+        command: `${process.execPath} -e "process.stdout.write('x'.repeat(100000)); require('node:fs').writeFileSync('sentinel.txt','done')"`,
+        activity: "test",
+        background: true,
+      },
+      { ...makeContext(), workingDir: tmpDir },
+    );
+    expect(result.isError).toBeFalsy();
+
+    await waitFor(() => completedEvents().length > 0);
+    const completed = completedEvents();
+    expect(completed).toHaveLength(1);
+    expect(completed[0]).toMatchObject({ status: "completed", exitCode: 0 });
+    expect(String(completed[0]?.output)).toContain(OUTPUT_TRUNCATED_TAG);
+    expect(String(completed[0]?.output)).not.toContain("file=");
+    expect(String(completed[0]?.output).length).toBeLessThan(
+      MAX_OUTPUT_LENGTH + 80,
+    );
+    expect(await readFile(join(tmpDir, "sentinel.txt"), "utf-8")).toBe("done");
   });
 });

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -32,7 +32,7 @@ import {
   getSessionEnv,
 } from "../network/script-proxy/index.js";
 import {
-  formatShellOutput,
+  attachBoundedStdio,
   MAX_OUTPUT_LENGTH,
 } from "../shared/shell-output.js";
 import {
@@ -316,8 +316,6 @@ export const shellTool = {
       }
 
       const bgId = generateBackgroundToolId();
-      const stdoutChunks: Buffer[] = [];
-      const stderrChunks: Buffer[] = [];
       let timedOut = false;
       let aborted = false;
       const startedAt = Date.now();
@@ -329,6 +327,7 @@ export const shellTool = {
         detached: true,
         windowsHide: true,
       });
+      const collector = attachBoundedStdio(child);
 
       const killTree = buildKillTree(child, {
         toolName: "bash",
@@ -342,14 +341,6 @@ export const shellTool = {
         timedOut = true;
         killTree("timeout");
       }, timeoutMs);
-
-      child.stdout.on("data", (data: Buffer) => {
-        stdoutChunks.push(data);
-      });
-
-      child.stderr.on("data", (data: Buffer) => {
-        stderrChunks.push(data);
-      });
 
       // Guard against double-wake: when spawn fails (e.g. invalid cwd),
       // Node emits both 'error' and 'close' for the same child process.
@@ -376,15 +367,7 @@ export const shellTool = {
           timedOut,
         });
 
-        const stdout = Buffer.concat(stdoutChunks).toString();
-        const stderr = Buffer.concat(stderrChunks).toString();
-        const fmtResult = formatShellOutput(
-          stdout,
-          stderr,
-          code,
-          timedOut,
-          timeoutSec,
-        );
+        const fmtResult = collector.format(code, timedOut, timeoutSec);
 
         const status: BackgroundToolCompletedEvent["status"] = aborted
           ? "cancelled"
@@ -393,7 +376,7 @@ export const shellTool = {
             : code === 0
               ? "completed"
               : "failed";
-        // A cancelled command exits with a null code, which formatShellOutput
+        // A cancelled command exits with a null code, which the formatter
         // frames as "failed"; surface the cancellation instead.
         const output =
           status === "cancelled"
@@ -428,8 +411,8 @@ export const shellTool = {
           untrustedOutput: {
             content: output,
             source: "tool_result",
-            // Already bounded + recovery-marked by formatShellOutput; a larger
-            // budget keeps wrapUntrustedContent from re-truncating the marker.
+            // Bounded output plus the truncation marker; a larger budget
+            // keeps wrapUntrustedContent from slicing the marker off.
             maxChars: MAX_OUTPUT_LENGTH * 2,
           },
         });
@@ -539,8 +522,6 @@ export const shellTool = {
     // Foreground mode: await the process and return its output.
     // -----------------------------------------------------------------------
     const result = await new Promise<ToolExecutionResult>((resolve) => {
-      const stdoutChunks: Buffer[] = [];
-      const stderrChunks: Buffer[] = [];
       let timedOut = false;
       const startedAt = Date.now();
 
@@ -550,6 +531,9 @@ export const shellTool = {
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
         windowsHide: true,
+      });
+      const collector = attachBoundedStdio(child, {
+        onOutput: context.onOutput,
       });
 
       const killTree = buildKillTree(child, {
@@ -574,16 +558,6 @@ export const shellTool = {
         }
       }
 
-      child.stdout.on("data", (data: Buffer) => {
-        stdoutChunks.push(data);
-        context.onOutput?.(data.toString());
-      });
-
-      child.stderr.on("data", (data: Buffer) => {
-        stderrChunks.push(data);
-        context.onOutput?.(data.toString());
-      });
-
       child.on("close", (code, signal) => {
         clearTimeout(timer);
         context.signal?.removeEventListener("abort", onAbort);
@@ -599,15 +573,7 @@ export const shellTool = {
           timedOut,
         });
 
-        const stdout = Buffer.concat(stdoutChunks).toString();
-        const stderr = Buffer.concat(stderrChunks).toString();
-        const fmtResult = formatShellOutput(
-          stdout,
-          stderr,
-          code,
-          timedOut,
-          timeoutSec,
-        );
+        const fmtResult = collector.format(code, timedOut, timeoutSec);
 
         resolve({
           content: fmtResult.content,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Cap bash stdout while it streams (drop past N bytes, do not buffer-then-truncate). This is the first prevention PR from the persistence-reliability investigation: unbounded `bash` / `host_bash` collection was buffering every stdout/stderr chunk, concatenating, then writing the full blob to `/tmp` before slicing to 20K.

Part of ATL-1309

## Summary
- Add `BoundedStdioCollector` / `attachBoundedStdio` so sandbox `bash` and `host_bash` (foreground and background) keep only the first 20K bytes across stdout+stderr.
- Bytes past the cap are dropped. The process keeps running so the pipe drains. `onOutput` is not called for discarded bytes.
- A prefix of an oversized chunk is copied so the original allocation can be freed. A `subarray` view would pin it.
- `formatShellOutput` still truncates already-materialized strings (desktop host-bash proxy) but no longer writes the discarded tail to a temp file.
- Overflow is not spilled to disk. The truncation marker is `<output_truncated limit="20K" />` with no `file=` recovery path.

Out of scope (same unbounded chunk pattern, follow-up): `sandbox-runner.ts`, `inline-command-runner.ts`, `debug-bash-routes.ts`. Desktop host-bash still materializes the full payload before the proxy formats it.

## Test plan
Focused tests, each in its own process (host-shell mocks `spawn`):
- `cd assistant && bun test src/tools/shared/shell-output.test.ts` (8 pass)
- `cd assistant && bun test src/tools/terminal/shell.test.ts` (8 pass, including real 100K stdout foreground and background)
- `cd assistant && bun test src/tools/host-terminal/host-shell.test.ts` (9 pass)
- `cd assistant && bun test src/__tests__/terminal-tools.test.ts` (25 pass)
- `cd assistant && bun test src/runtime/__tests__/agent-wake.test.ts --grep "trailing marker"` (1 pass)

## Risk
- Models can no longer `cat` a temp file to recover discarded output. That path was itself a memory/disk footgun for multi-megabyte or multi-gigabyte commands.
- Existing wakes that already persisted a `file=` marker are unchanged. New truncations omit `file=`.
- `host_bash` via the desktop proxy still receives a fully buffered payload from the client. This PR only stops the second copy to disk.

## CLI verb checklist
No new routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7b57476-0626-4355-abcc-c56b0a275829?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7b57476-0626-4355-abcc-c56b0a275829&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

