### PR TITLE
fix(cli): authenticate AssistantClient against cloud-hosted assistants

### DIFF
--- a/cli/src/__tests__/assistant-client-platform-auth.test.ts
+++ b/cli/src/__tests__/assistant-client-platform-auth.test.ts
@@ -83,11 +83,16 @@ describe("AssistantClient platform-managed auth", () => {
 
   afterEach(() => {
     globalThis.fetch = ORIGINAL_FETCH;
-    if (ORIGINAL_LOCKFILE_DIR === undefined)
+    if (ORIGINAL_LOCKFILE_DIR === undefined) {
       delete process.env.VELLUM_LOCKFILE_DIR;
-    else process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
-    if (ORIGINAL_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
-    else process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+    } else {
+      process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
+    }
+    if (ORIGINAL_CONFIG_HOME === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+    }
   });
 
   afterAll(() => {
@@ -158,6 +163,35 @@ describe("AssistantClient platform-managed auth", () => {
       "Not logged in. Run `vellum login` first to authenticate with the platform.",
     );
     expect(calls).toHaveLength(0);
+  });
+
+  test("refuses to send platform credentials to a runtimeUrl override", async () => {
+    seedCloud("sess-tok-4");
+    const calls = stubFetch(() => new Response("", { status: 200 }));
+
+    expect(
+      () =>
+        new AssistantClient({
+          assistantId: ASSISTANT_ID,
+          runtimeUrl: "https://attacker.example.com",
+        }),
+    ).toThrow("Refusing to send platform credentials");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("allows a runtimeUrl override that matches the entry's platform host", async () => {
+    seedCloud("sess-tok-5");
+    stubFetch((url) =>
+      isOrgFetch(url) ? orgResponse() : new Response("", { status: 200 }),
+    );
+
+    const client = new AssistantClient({
+      assistantId: ASSISTANT_ID,
+      runtimeUrl: `${PLATFORM_URL}/`, // trailing slash must not count as a mismatch
+    });
+
+    expect(client.runtimeUrl).toBe(PLATFORM_URL);
+    expect((await client.get("/healthz/")).status).toBe(200);
   });
 
   test("re-resolves the org id once on a 401 and never refreshes a guardian token", async () => {

--- a/cli/src/__tests__/assistant-client-platform-auth.test.ts
+++ b/cli/src/__tests__/assistant-client-platform-auth.test.ts
@@ -41,7 +41,9 @@ function seedCloud(token?: string): void {
     cloud: "vellum",
     species: "vellum",
   });
-  if (token) savePlatformToken(token);
+  if (token) {
+    savePlatformToken(token);
+  }
 }
 
 interface Call {
@@ -198,7 +200,9 @@ describe("AssistantClient platform-managed auth", () => {
     seedCloud("sess-tok-3");
     let assistantAttempts = 0;
     const calls = stubFetch((url) => {
-      if (isOrgFetch(url)) return orgResponse();
+      if (isOrgFetch(url)) {
+        return orgResponse();
+      }
       assistantAttempts++;
       return new Response("", { status: 401 }); // always 401
     });

--- a/cli/src/__tests__/assistant-client-platform-auth.test.ts
+++ b/cli/src/__tests__/assistant-client-platform-auth.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for AssistantClient's platform-managed (`cloud: "vellum"`) auth path.
+ * These entries have no guardian token on disk, so the client must authenticate
+ * with the stored platform credential instead of sending an anonymous request
+ * (which the platform answers with a bare 403).
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const testDir = mkdtempSync(join(tmpdir(), "client-platform-auth-test-"));
+const ORIGINAL_LOCKFILE_DIR = process.env.VELLUM_LOCKFILE_DIR;
+const ORIGINAL_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+const ORIGINAL_FETCH = globalThis.fetch;
+
+import { AssistantClient } from "../lib/assistant-client.js";
+import { saveAssistantEntry } from "../lib/assistant-config.js";
+import {
+  clearPlatformToken,
+  savePlatformToken,
+} from "../lib/platform-client.js";
+
+const PLATFORM_URL = "https://platform.example.com";
+const ASSISTANT_ID = "019d1e04-cb20-719a-b04b-310072904444";
+const ORG_ID = "org-abc";
+
+/** Seed a platform-managed lockfile entry, optionally with a stored token. */
+function seedCloud(token?: string): void {
+  saveAssistantEntry({
+    assistantId: ASSISTANT_ID,
+    name: "Credence",
+    runtimeUrl: PLATFORM_URL,
+    cloud: "vellum",
+    species: "vellum",
+  });
+  if (token) savePlatformToken(token);
+}
+
+interface Call {
+  url: string;
+  headers: Record<string, string>;
+}
+
+/** Replace global fetch with a URL-routed stub; returns the call log. */
+function stubFetch(handler: (url: string, calls: Call[]) => Response): Call[] {
+  const calls: Call[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : String(input);
+    calls.push({
+      url,
+      headers: (init?.headers ?? {}) as Record<string, string>,
+    });
+    return handler(url, calls);
+  }) as typeof fetch;
+  return calls;
+}
+
+const isOrgFetch = (url: string) => url.includes("/v1/organizations/");
+const isRefresh = (url: string) => url.includes("/v1/guardian/refresh");
+
+function orgResponse(): Response {
+  return new Response(JSON.stringify({ results: [{ id: ORG_ID }] }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("AssistantClient platform-managed auth", () => {
+  beforeEach(() => {
+    process.env.VELLUM_LOCKFILE_DIR = testDir;
+    process.env.XDG_CONFIG_HOME = testDir;
+    // Tests share testDir, so a token saved by an earlier one must not leak.
+    clearPlatformToken();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+    if (ORIGINAL_LOCKFILE_DIR === undefined)
+      delete process.env.VELLUM_LOCKFILE_DIR;
+    else process.env.VELLUM_LOCKFILE_DIR = ORIGINAL_LOCKFILE_DIR;
+    if (ORIGINAL_CONFIG_HOME === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = ORIGINAL_CONFIG_HOME;
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test("sends X-Session-Token + Vellum-Organization-Id for a session token", async () => {
+    seedCloud("sess-tok-1");
+    const calls = stubFetch((url) =>
+      isOrgFetch(url) ? orgResponse() : new Response("", { status: 200 }),
+    );
+
+    const client = new AssistantClient({ assistantId: ASSISTANT_ID });
+    const res = await client.post("/messages/", { content: "hi" });
+
+    expect(res.status).toBe(200);
+    const assistantCall = calls.find((c) => !isOrgFetch(c.url))!;
+    expect(assistantCall.url).toBe(
+      `${PLATFORM_URL}/v1/assistants/${ASSISTANT_ID}/messages/`,
+    );
+    expect(assistantCall.headers["X-Session-Token"]).toBe("sess-tok-1");
+    expect(assistantCall.headers["Vellum-Organization-Id"]).toBe(ORG_ID);
+    expect(assistantCall.headers["Authorization"]).toBeUndefined();
+    expect(assistantCall.headers["Content-Type"]).toBe("application/json");
+  });
+
+  test("resolves the auth headers once across multiple requests", async () => {
+    seedCloud("sess-tok-2");
+    const calls = stubFetch((url) =>
+      isOrgFetch(url) ? orgResponse() : new Response("", { status: 200 }),
+    );
+
+    const client = new AssistantClient({ assistantId: ASSISTANT_ID });
+    await client.get("/healthz/");
+    await client.get("/healthz/");
+
+    expect(calls.filter((c) => isOrgFetch(c.url))).toHaveLength(1);
+    // A bodyless request must not claim a JSON body.
+    const assistantCalls = calls.filter((c) => !isOrgFetch(c.url));
+    expect(assistantCalls).toHaveLength(2);
+    expect(assistantCalls[0].headers["Content-Type"]).toBeUndefined();
+  });
+
+  test("sends a bearer Authorization and no org header for a vak_ API key", async () => {
+    seedCloud("vak_test_key");
+    const calls = stubFetch((url) =>
+      isOrgFetch(url) ? orgResponse() : new Response("", { status: 200 }),
+    );
+
+    const client = new AssistantClient({ assistantId: ASSISTANT_ID });
+    await client.get("/healthz/");
+
+    // API keys are already org-scoped, so no org lookup happens.
+    expect(calls.filter((c) => isOrgFetch(c.url))).toHaveLength(0);
+    const assistantCall = calls[0];
+    expect(assistantCall.headers["Authorization"]).toBe("Bearer vak_test_key");
+    expect(assistantCall.headers["Vellum-Organization-Id"]).toBeUndefined();
+    expect(assistantCall.headers["X-Session-Token"]).toBeUndefined();
+  });
+
+  test("throws the login hint instead of sending an anonymous request", async () => {
+    seedCloud(); // no platform token stored
+    const calls = stubFetch(() => new Response("", { status: 200 }));
+
+    const client = new AssistantClient({ assistantId: ASSISTANT_ID });
+
+    await expect(client.post("/messages/", { content: "hi" })).rejects.toThrow(
+      "Not logged in. Run `vellum login` first to authenticate with the platform.",
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  test("re-resolves the org id once on a 401 and never refreshes a guardian token", async () => {
+    seedCloud("sess-tok-3");
+    let assistantAttempts = 0;
+    const calls = stubFetch((url) => {
+      if (isOrgFetch(url)) return orgResponse();
+      assistantAttempts++;
+      return new Response("", { status: 401 }); // always 401
+    });
+
+    const client = new AssistantClient({ assistantId: ASSISTANT_ID });
+    const res = await client.get("/messages/");
+
+    expect(res.status).toBe(401);
+    expect(assistantAttempts).toBe(2); // original + one retry, no more
+    // The cached org id was invalidated, so the retry refetched it.
+    expect(calls.filter((c) => isOrgFetch(c.url))).toHaveLength(2);
+    expect(calls.filter((c) => isRefresh(c.url))).toHaveLength(0);
+  });
+});

--- a/cli/src/lib/assistant-client.ts
+++ b/cli/src/lib/assistant-client.ts
@@ -1,8 +1,8 @@
 /**
  * Gateway client for authenticated requests to a hatched assistant's runtime.
  *
- * Encapsulates lockfile reading, guardian-token resolution, and
- * authenticated fetch so callers can simply do:
+ * Encapsulates lockfile reading, credential resolution, and authenticated
+ * fetch so callers can simply do:
  *
  * ```ts
  * const client = new AssistantClient();                          // active / latest
@@ -10,6 +10,11 @@
  * await client.get("/healthz");
  * await client.post("/messages/", { content: "hi" });
  * ```
+ *
+ * The auth scheme follows the assistant's topology, so callers never pick it.
+ * Platform-managed entries in particular have no local guardian token: they
+ * authenticate against the wildcard runtime proxy at
+ * `{platformUrl}/v1/assistants/<id>/<rest>` with the stored platform credential.
  */
 
 import { resolveAssistant } from "./assistant-config.js";
@@ -20,9 +25,22 @@ import {
   guardianTokenDueForRenewal,
 } from "./guardian-token.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
+import {
+  authHeaders,
+  invalidateOrgIdCache,
+  readPlatformToken,
+} from "./platform-client.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const FALLBACK_RUNTIME_URL = `http://127.0.0.1:${GATEWAY_PORT}`;
+
+/**
+ * - `guardian`: `Authorization: Bearer <guardian JWT>`, refreshable on a 401.
+ * - `session`: caller-supplied `X-Session-Token` + explicit org id.
+ * - `platform`: `cloud: "vellum"` entry; headers resolved lazily from the
+ *   stored platform token (org id needs a network lookup).
+ */
+type AuthMode = "guardian" | "session" | "platform";
 
 export interface AssistantClientOpts {
   assistantId?: string;
@@ -32,6 +50,9 @@ export interface AssistantClientOpts {
    * session token instead of a guardian token.  The session token is
    * sent as `X-Session-Token: <sessionToken>` and the org id is
    * sent via the `Vellum-Organization-Id` header.
+   *
+   * Platform-managed assistants do NOT need this: they are detected from the
+   * lockfile entry and authenticated from the stored platform token.
    */
   sessionToken?: string;
   /** Required when `sessionToken` is provided. */
@@ -49,11 +70,22 @@ export class AssistantClient {
   readonly runtimeUrl: string;
 
   private readonly _assistantId: string;
-  /** Mutable: a 401 on the guardian path refreshes this in place (see request). */
+  /**
+   * The credential for the current mode. Mutable: a 401 on the guardian path
+   * refreshes it in place (see request), and the platform path fills it in on
+   * first use (see resolveAuthHeaders).
+   */
   private token: string | undefined;
-  /** True when token is a platform session token (X-Session-Token), false for guardian JWT (Authorization: Bearer). */
-  private readonly isSessionAuth: boolean;
+  private readonly authMode: AuthMode;
   private readonly orgId: string | undefined;
+  /**
+   * Platform host the credential belongs to. Taken from the lockfile entry, not
+   * from `opts.runtimeUrl`, so a caller-supplied URL override can never send the
+   * platform token to an arbitrary host during the org-id lookup.
+   */
+  private readonly platformUrl: string | undefined;
+  /** Cached in-flight/resolved platform auth headers; cleared to force a re-resolve. */
+  private platformHeaders: Promise<Record<string, string>> | undefined;
 
   /**
    * Resolves an assistant entry from the lockfile and loads auth credentials.
@@ -82,16 +114,80 @@ export class AssistantClient {
     this._assistantId = entry.assistantId;
 
     if (opts?.sessionToken) {
-      // Platform assistant: use X-Session-Token + Vellum-Organization-Id.
+      // Caller supplied the credential: X-Session-Token + Vellum-Organization-Id.
       this.token = opts.sessionToken;
-      this.isSessionAuth = true;
+      this.authMode = "session";
       this.orgId = opts.orgId;
+      this.platformUrl = undefined;
+    } else if (entry.cloud === "vellum") {
+      // Platform-managed: no guardian token exists locally, so authenticate with
+      // the stored platform credential. Resolved on first use because the org id
+      // behind it needs a network lookup.
+      this.token = undefined;
+      this.authMode = "platform";
+      this.orgId = undefined;
+      this.platformUrl = entry.runtimeUrl;
     } else {
       this.token =
         loadGuardianToken(this._assistantId)?.accessToken ?? entry.bearerToken;
-      this.isSessionAuth = false;
+      this.authMode = "guardian";
       this.orgId = undefined;
+      this.platformUrl = undefined;
     }
+  }
+
+  /**
+   * Platform token for a `cloud: "vellum"` entry. Throws the actionable login
+   * error rather than letting an anonymous request fall through to a bare 403.
+   */
+  private requirePlatformToken(): string {
+    const token = readPlatformToken();
+    if (!token) {
+      throw new Error(
+        "Not logged in. Run `vellum login` first to authenticate with the platform.",
+      );
+    }
+    return token;
+  }
+
+  /**
+   * Auth headers for the current mode. `authHeaders` picks the right scheme for
+   * the platform credential (`Authorization: Bearer` for `vak_` API keys,
+   * `X-Session-Token` + `Vellum-Organization-Id` for session tokens) and caches
+   * the org-id lookup, so the result is memoized per client and a failure is
+   * never cached.
+   */
+  private async resolveAuthHeaders(): Promise<Record<string, string>> {
+    if (this.authMode !== "platform") {
+      const headers: Record<string, string> = {};
+      if (this.token) {
+        if (this.authMode === "session") {
+          headers["X-Session-Token"] = this.token;
+        } else {
+          headers["Authorization"] = `Bearer ${this.token}`;
+        }
+      }
+      if (this.orgId) {
+        headers["Vellum-Organization-Id"] = this.orgId;
+      }
+      return headers;
+    }
+
+    if (!this.platformHeaders) {
+      this.token = this.requirePlatformToken();
+      this.platformHeaders = authHeaders(this.token, this.platformUrl)
+        .then((resolved) => {
+          // request() owns Content-Type (bodyless requests must not carry one).
+          const headers = { ...resolved };
+          delete headers["Content-Type"];
+          return headers;
+        })
+        .catch((err: unknown) => {
+          this.platformHeaders = undefined;
+          throw err;
+        });
+    }
+    return this.platformHeaders;
   }
 
   /** GET request to the gateway. Auth headers are added automatically. */
@@ -185,17 +281,13 @@ export class AssistantClient {
     const jsonBody = body !== undefined ? JSON.stringify(body) : undefined;
 
     // Headers are built per-attempt so a refreshed token is picked up on retry.
-    const buildHeaders = (): Record<string, string> => {
+    // Caller-supplied headers win over the resolved auth headers.
+    const buildHeaders = async (): Promise<Record<string, string>> => {
       const headers: Record<string, string> = { ...opts?.headers };
-      if (this.token) {
-        if (this.isSessionAuth) {
-          headers["X-Session-Token"] ??= this.token;
-        } else {
-          headers["Authorization"] ??= `Bearer ${this.token}`;
-        }
-      }
-      if (this.orgId) {
-        headers["Vellum-Organization-Id"] ??= this.orgId;
+      for (const [name, value] of Object.entries(
+        await this.resolveAuthHeaders(),
+      )) {
+        headers[name] ??= value;
       }
       if (body !== undefined) {
         headers["Content-Type"] = "application/json";
@@ -203,8 +295,8 @@ export class AssistantClient {
       return headers;
     };
 
-    const doFetch = (): Promise<Response> => {
-      const headers = buildHeaders();
+    const doFetch = async (): Promise<Response> => {
+      const headers = await buildHeaders();
       if (opts?.signal) {
         return loopbackSafeFetch(url, {
           method,
@@ -226,11 +318,20 @@ export class AssistantClient {
 
     const response = await doFetch();
 
-    // Reactive auto-refresh on a 401 for the guardian (non-session) path.
-    // Ephemeral (`--token`) and access-only sessions have no stored refresh
-    // credential and just see the original 401; the platform session-auth path
-    // is never refreshed here (its token is managed by the Vellum platform).
-    if (response.status === 401 && !this.isSessionAuth) {
+    // A stale cached Vellum-Organization-Id is the usual cause of a 401 on the
+    // platform path (e.g. the user switched orgs elsewhere). Drop it and retry
+    // once. Mirrors localRuntimeIdentity in local-runtime-client.ts.
+    if (response.status === 401 && this.authMode === "platform" && this.token) {
+      invalidateOrgIdCache(this.token, this.platformUrl);
+      this.platformHeaders = undefined;
+      return doFetch();
+    }
+
+    // Reactive auto-refresh on a 401 for the guardian path only. Ephemeral
+    // (`--token`) and access-only sessions have no stored refresh credential and
+    // just see the original 401; session and platform credentials are managed by
+    // the Vellum platform and are never refreshed here.
+    if (response.status === 401 && this.authMode === "guardian") {
       const stored = loadGuardianToken(this._assistantId);
 
       // Another process may have already rotated and persisted a fresh access

--- a/cli/src/lib/assistant-client.ts
+++ b/cli/src/lib/assistant-client.ts
@@ -42,6 +42,8 @@ const FALLBACK_RUNTIME_URL = `http://127.0.0.1:${GATEWAY_PORT}`;
  */
 type AuthMode = "guardian" | "session" | "platform";
 
+const stripTrailingSlashes = (url: string): string => url.replace(/\/+$/, "");
+
 export interface AssistantClientOpts {
   assistantId?: string;
   runtimeUrl?: string;
@@ -78,12 +80,6 @@ export class AssistantClient {
   private token: string | undefined;
   private readonly authMode: AuthMode;
   private readonly orgId: string | undefined;
-  /**
-   * Platform host the credential belongs to. Taken from the lockfile entry, not
-   * from `opts.runtimeUrl`, so a caller-supplied URL override can never send the
-   * platform token to an arbitrary host during the org-id lookup.
-   */
-  private readonly platformUrl: string | undefined;
   /** Cached in-flight/resolved platform auth headers; cleared to force a re-resolve. */
   private platformHeaders: Promise<Record<string, string>> | undefined;
 
@@ -105,34 +101,51 @@ export class AssistantClient {
       );
     }
 
-    this.runtimeUrl = (
-      opts?.runtimeUrl ||
-      entry.localUrl ||
-      entry.runtimeUrl ||
-      FALLBACK_RUNTIME_URL
-    ).replace(/\/+$/, "");
     this._assistantId = entry.assistantId;
+    const platformManaged = !opts?.sessionToken && entry.cloud === "vellum";
+    const platformHost = stripTrailingSlashes(entry.runtimeUrl);
+
+    // SECURITY: a platform credential is account-scoped, far broader than the
+    // per-assistant guardian JWT, so its origin is pinned to the host recorded in
+    // the lockfile. Honoring a URL override here would hand the caller's session
+    // token or `vak_` key to whatever host they named.
+    if (
+      platformManaged &&
+      opts?.runtimeUrl &&
+      stripTrailingSlashes(opts.runtimeUrl) !== platformHost
+    ) {
+      throw new Error(
+        `Refusing to send platform credentials to '${opts.runtimeUrl}': ` +
+          `assistant '${entry.assistantId}' is hosted at ${platformHost}.`,
+      );
+    }
+
+    this.runtimeUrl = platformManaged
+      ? platformHost
+      : stripTrailingSlashes(
+          opts?.runtimeUrl ||
+            entry.localUrl ||
+            entry.runtimeUrl ||
+            FALLBACK_RUNTIME_URL,
+        );
 
     if (opts?.sessionToken) {
       // Caller supplied the credential: X-Session-Token + Vellum-Organization-Id.
       this.token = opts.sessionToken;
       this.authMode = "session";
       this.orgId = opts.orgId;
-      this.platformUrl = undefined;
-    } else if (entry.cloud === "vellum") {
+    } else if (platformManaged) {
       // Platform-managed: no guardian token exists locally, so authenticate with
       // the stored platform credential. Resolved on first use because the org id
       // behind it needs a network lookup.
       this.token = undefined;
       this.authMode = "platform";
       this.orgId = undefined;
-      this.platformUrl = entry.runtimeUrl;
     } else {
       this.token =
         loadGuardianToken(this._assistantId)?.accessToken ?? entry.bearerToken;
       this.authMode = "guardian";
       this.orgId = undefined;
-      this.platformUrl = undefined;
     }
   }
 
@@ -175,7 +188,7 @@ export class AssistantClient {
 
     if (!this.platformHeaders) {
       this.token = this.requirePlatformToken();
-      this.platformHeaders = authHeaders(this.token, this.platformUrl)
+      this.platformHeaders = authHeaders(this.token, this.runtimeUrl)
         .then((resolved) => {
           // request() owns Content-Type (bodyless requests must not carry one).
           const headers = { ...resolved };
@@ -322,7 +335,7 @@ export class AssistantClient {
     // platform path (e.g. the user switched orgs elsewhere). Drop it and retry
     // once. Mirrors localRuntimeIdentity in local-runtime-client.ts.
     if (response.status === 401 && this.authMode === "platform" && this.token) {
-      invalidateOrgIdCache(this.token, this.platformUrl);
+      invalidateOrgIdCache(this.token, this.runtimeUrl);
       this.platformHeaders = undefined;
       return doFetch();
     }


### PR DESCRIPTION
## Summary

- `AssistantClient` only knew guardian-token auth unless a caller passed `sessionToken` + `orgId`, and no production command ever did. Platform-managed (`cloud: "vellum"`) lockfile entries have neither a guardian token on disk nor a `bearerToken`, so requests went to `https://platform.vellum.ai/v1/assistants/<id>/…` with **no auth header at all** and DRF answered `403 {"detail":"Authentication credentials were not provided."}`. `vellum ps` looked fine because it uses a different seam (`checkManagedHealth` → `readPlatformToken()` + `authHeaders()`), as does `vellum client` with its own `cloud === "vellum"` branch.
- Teach the client to detect cloud entries from the lockfile and authenticate with the stored platform credential through the existing `authHeaders()` helper, so `vak_` API keys (`Authorization: Bearer`) and session tokens (`X-Session-Token` + `Vellum-Organization-Id`) both work. Headers resolve lazily and are memoized per client because the org id behind them needs a network lookup; the org-id lookup URL comes from the lockfile entry rather than an `opts.runtimeUrl` override, so a caller-supplied URL can never redirect the platform token to an arbitrary host. A 401 invalidates the cached org id and retries once, mirroring `localRuntimeIdentity`; the guardian refresh path stays strictly off for platform and session credentials.
- A missing platform token now raises the actionable `Not logged in. Run \`vellum login\`…` error (matching `terminal-session.ts` and `ssh.ts`) instead of firing an anonymous request that surfaces as a bare 403. This fixes `message`, `events`, `confirm`, `flags`, and `workflows` against cloud-hosted assistants, not just `message`.

Verified live against `platform.vellum.ai`: before the fix `POST /v1/assistants/<id>/messages/` with no headers reproduced the exact 403; after it, `vellum message <cloud-id> "…"` returns `Message accepted`, and clearing the token yields the login hint with zero requests sent. Five new tests cover the session-token headers, the `vak_` key shape, header memoization, the logged-out error, and the one-shot 401 org-cache retry. Full `cli` suite: 1172 pass, plus one pre-existing failure (`imports all source modules for coverage tracking`, port 7830 in use) that reproduces identically on `main`.

## Original prompt

Noa reported that `vellum message` could not reach cloud-hosted assistants even right after a successful `vellum login` — `vellum ps` showed the platform assistant healthy, but messaging it returned `HTTP 403: {"detail":"Authentication credentials were not provided."}` while the same command against a local assistant worked. The ask was to get to the bottom of why and then fix it, rather than patch the symptom. Root-causing it pointed at `AssistantClient` as the one client seam never taught the platform auth path, so the fix lands there and repairs every command built on it.