### PR TITLE
The assistant sees reactions, edits, and deletes

### DIFF
--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -471,7 +471,7 @@ describe("loadFromDb history repair", () => {
               targetMessageId: "555.1",
               emoji: "thumbsup",
               op: "added",
-              actorDisplayName: "Ashlee",
+              actorDisplayName: "Alice",
             },
           }),
         }),
@@ -492,7 +492,7 @@ describe("loadFromDb history repair", () => {
       .join("\n");
     expect(allText).not.toContain("[reaction]");
     expect(allText).toContain(
-      'Ashlee reacted with :thumbsup: to the message "Deploy is done"',
+      'Alice reacted with :thumbsup: to the message "Deploy is done"',
     );
     expect(allText).toContain("<external_content");
   });
@@ -542,6 +542,153 @@ describe("loadFromDb history repair", () => {
     conversation.markHistoryStale();
     await conversation.ensureActorScopedHistory();
     expect(conversation.getMessages()).toHaveLength(3);
+  });
+
+  test("a deleted row loads as the deletion marker, not its original text", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: [
+          { type: "text", text: "Please forget this password: hunter2" },
+        ],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            messageId: "555.1",
+            eventKind: "message",
+            deletedAt: 1700000001000,
+          }),
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: [{ type: "text", text: "Understood" }],
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const allText = conversation
+      .getMessages()
+      .flatMap((m) => m.content)
+      .filter((b) => b.type === "text")
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    expect(allText).toContain("[This message was deleted]");
+    expect(allText).not.toContain("hunter2");
+  });
+
+  test("a reaction never quotes a target that was later deleted", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "secret text" }],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            messageId: "555.1",
+            eventKind: "message",
+            deletedAt: 1700000001000,
+          }),
+        }),
+      },
+      {
+        id: "m2",
+        role: "user",
+        content: [{ type: "text", text: "[reaction]" }],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            eventKind: "reaction",
+            reaction: {
+              targetMessageId: "555.1",
+              emoji: "thumbsup",
+              op: "added",
+              actorDisplayName: "Alice",
+            },
+          }),
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const allText = conversation
+      .getMessages()
+      .flatMap((m) => m.content)
+      .filter((b) => b.type === "text")
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    expect(allText).toContain("reacted with :thumbsup: to an earlier message");
+    expect(allText).not.toContain("secret text");
+  });
+
+  test("a reaction row does not count as a turn on rehydration", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: [{ type: "text", text: "Hi" }],
+      },
+      {
+        id: "m3",
+        role: "user",
+        content: [{ type: "text", text: "[reaction]" }],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            eventKind: "reaction",
+            reaction: {
+              targetMessageId: "555.1",
+              emoji: "thumbsup",
+              op: "added",
+            },
+          }),
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    // One real user message; the reaction row never dispatched a turn, so
+    // the rehydrated counter must match the live counter's one increment.
+    expect(conversation.turnCount).toBe(1);
   });
 
   test("persistUserMessage reloads actor-scoped history before persisting on role switch", async () => {

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -435,6 +435,115 @@ describe("loadFromDb history repair", () => {
     ]);
   });
 
+  test("a stored reaction row loads as rendered text, not the sentinel", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "Deploy is done" }],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            messageId: "555.1",
+            eventKind: "message",
+          }),
+        }),
+      },
+      {
+        id: "m2",
+        role: "user",
+        content: [{ type: "text", text: "[reaction]" }],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            eventKind: "reaction",
+            reaction: {
+              targetMessageId: "555.1",
+              emoji: "thumbsup",
+              op: "added",
+              actorDisplayName: "Ashlee",
+            },
+          }),
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const messages = conversation.getMessages();
+
+    // History repair merges the two adjacent user rows into one message;
+    // what matters is that the model reads the rendered fact, never the
+    // sentinel.
+    const allText = messages
+      .flatMap((m) => m.content)
+      .filter((b) => b.type === "text")
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    expect(allText).not.toContain("[reaction]");
+    expect(allText).toContain(
+      'Ashlee reacted with :thumbsup: to the message "Deploy is done"',
+    );
+    expect(allText).toContain("<external_content");
+  });
+
+  test("markHistoryStale makes the next ensureActorScopedHistory reload", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "Hello" }],
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: [{ type: "text", text: "Hi" }],
+      },
+    ];
+
+    const conversation = makeConversation();
+    conversation.setTrustContext({
+      trustClass: "guardian",
+      sourceChannel: "telegram",
+    });
+    await conversation.loadFromDb();
+    expect(conversation.getMessages()).toHaveLength(2);
+
+    // A channel event lands straight in the store while the conversation
+    // stays resident.
+    mockDbMessages.push({
+      id: "m3",
+      role: "user",
+      content: [{ type: "text", text: "[reaction]" }],
+    });
+
+    // Same actor, no stale mark: the resident history is reused.
+    await conversation.ensureActorScopedHistory();
+    expect(conversation.getMessages()).toHaveLength(2);
+
+    conversation.markHistoryStale();
+    await conversation.ensureActorScopedHistory();
+    expect(conversation.getMessages()).toHaveLength(3);
+  });
+
   test("persistUserMessage reloads actor-scoped history before persisting on role switch", async () => {
     mockConversation = {
       id: "conv-1",

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -691,6 +691,51 @@ describe("loadFromDb history repair", () => {
     expect(conversation.turnCount).toBe(1);
   });
 
+  test("a slackMeta-shaped reaction row renders with its actor id as origin", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "[reaction]" }],
+        metadata: JSON.stringify({
+          slackMeta: JSON.stringify({
+            source: "slack",
+            channelId: "C123",
+            channelTs: "1700000000.111111",
+            eventKind: "reaction",
+            actorExternalUserId: "U_REACTOR",
+            displayName: "Alice",
+            reaction: {
+              emoji: "tada",
+              targetChannelTs: "1700000000.111111",
+              op: "added",
+              actorDisplayName: "Alice",
+            },
+          }),
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const allText = conversation
+      .getMessages()
+      .flatMap((m) => m.content)
+      .filter((b) => b.type === "text")
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    expect(allText).toContain("Alice reacted with :tada:");
+    expect(allText).toContain('origin="U_REACTOR"');
+  });
+
   test("persistUserMessage reloads actor-scoped history before persisting on role switch", async () => {
     mockConversation = {
       id: "conv-1",

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -265,6 +265,10 @@ describe("Slack reaction event persistence", () => {
     expect(row.content).toBe("[reaction]");
 
     const envelope = JSON.parse(row.metadata!) as Record<string, unknown>;
+    // Provenance keeps the row visible to actor-scoped history loads:
+    // filterMessagesForUntrustedActor drops rows with no trust class.
+    expect(envelope.provenanceTrustClass).toBe("trusted_contact");
+    expect(envelope.provenanceSourceChannel).toBe("slack");
     const slackMetaRaw = envelope.slackMeta;
     expect(typeof slackMetaRaw).toBe("string");
 

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -106,6 +106,7 @@ function resetState(): void {
   db.run("DELETE FROM contact_channels");
   db.run("DELETE FROM contacts");
   gatewayGuardians = [];
+  _conversationMocks.clear();
 }
 
 function seedActiveMember(): void {
@@ -412,6 +413,39 @@ describe("Slack reaction event persistence", () => {
       (r) => r.content === "[reaction]",
     );
     expect(rows.length).toBe(1);
+  });
+
+  test("a persisted reaction stale-marks the resident conversation", async () => {
+    const conversationId = seedStoredMessage("1700000000.111111");
+    const markHistoryStale = mock(() => {});
+    _conversationMocks.set(conversationId, {
+      markHistoryStale,
+    } as unknown as Conversation);
+
+    const resp = await handleChannelInbound(
+      buildReactionRequest("reaction:thumbsup"),
+      undefined,
+      TEST_BEARER_TOKEN,
+    );
+    expect(resp.status).toBe(200);
+    expect(markHistoryStale).toHaveBeenCalledTimes(1);
+  });
+
+  test("a duplicate reaction does not stale-mark again", async () => {
+    const conversationId = seedStoredMessage("1700000000.111111");
+    const markHistoryStale = mock(() => {});
+    _conversationMocks.set(conversationId, {
+      markHistoryStale,
+    } as unknown as Conversation);
+    const sharedExternalMessageId = `${SLACK_CHANNEL_ID}:1700000000.777777:bob`;
+    const makeReq = () =>
+      buildReactionRequest("reaction:tada", {
+        externalMessageId: sharedExternalMessageId,
+      });
+
+    await handleChannelInbound(makeReq(), undefined, TEST_BEARER_TOKEN);
+    await handleChannelInbound(makeReq(), undefined, TEST_BEARER_TOKEN);
+    expect(markHistoryStale).toHaveBeenCalledTimes(1);
   });
 
   test("reaction on the assistant's own post lands in that conversation", async () => {

--- a/assistant/src/__tests__/reaction-persistence.test.ts
+++ b/assistant/src/__tests__/reaction-persistence.test.ts
@@ -281,6 +281,9 @@ describe("Slack reaction event persistence", () => {
     // Slack sends no thread on a reaction, so the row claims none.
     expect(slackMeta!.threadTs).toBeUndefined();
     expect(slackMeta!.displayName).toBe(SLACK_DISPLAY_NAME);
+    // Stable identity, not the sender-controlled label: the history
+    // renderer attributes the fenced line's origin by this id.
+    expect(slackMeta!.actorExternalUserId).toBe(SLACK_USER_ID);
     expect(slackMeta!.reaction).toEqual({
       emoji: "thumbsup",
       actorDisplayName: SLACK_DISPLAY_NAME,

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1173,8 +1173,11 @@ export class Conversation {
         reactionTargetIndexMemo = new Map();
         for (const row of dbMessages) {
           const rowMeta = readProviderMetadata(row.metadata);
+          // A deleted target is a logical erasure (same rule as the Slack
+          // transcript renderer), so its text is never quoted back.
           if (
             rowMeta?.eventKind === "message" &&
+            rowMeta.deletedAt === undefined &&
             rowMeta.messageId &&
             !reactionTargetIndexMemo.has(rowMeta.messageId)
           ) {
@@ -1194,13 +1197,20 @@ export class Conversation {
 
       content = reinjectAttachmentPathAnnotations(content, role, m.metadata);
 
-      // A reaction row's stored content is the "[reaction]" sentinel; the
-      // fact lives in its metadata. Rendered here rather than at persist
-      // time so every stored row reads legibly to the model, whenever it
-      // was written. The substring guard keeps the per-row metadata parse
-      // off rows that cannot be reactions: every reaction envelope carries
-      // the literal key, in providerMeta and in nested slackMeta alike.
-      if (role === "user" && m.metadata?.includes("reaction")) {
+      // Channel facts stamped in metadata render at load time rather than
+      // at persist time, so every stored row reads correctly whenever it
+      // was written: a reaction row's "[reaction]" sentinel renders as who
+      // reacted with what to which message, and a deleted row's original
+      // text gives way to a deletion marker (the delete intercepts stamp
+      // metadata and deliberately leave the content column untouched). The
+      // substring guard keeps the per-row metadata parse off rows that can
+      // carry neither fact: both envelopes spell these keys literally, in
+      // providerMeta and in nested slackMeta alike.
+      if (
+        role === "user" &&
+        m.metadata &&
+        (m.metadata.includes("reaction") || m.metadata.includes("deletedAt"))
+      ) {
         const providerMeta = readProviderMetadata(m.metadata);
         if (providerMeta?.eventKind === "reaction") {
           const rendered = renderReactionHistoryText(
@@ -1210,6 +1220,10 @@ export class Conversation {
           if (rendered) {
             content = [{ type: "text", text: rendered }];
           }
+        } else if (providerMeta?.deletedAt !== undefined) {
+          // Neutral marker, no actor: Discord deletes can be authorless
+          // (`actorUnattributed`), so the marker never claims who deleted.
+          content = [{ type: "text", text: "[This message was deleted]" }];
         }
       }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -41,6 +41,7 @@ import {
   derefToolResultReReads,
   postTurnTruncateToolResults,
 } from "../context/post-turn-tool-result-truncation.js";
+import { readProviderMetadata } from "../messaging/read-provider-metadata.js";
 import { isGuardianCardRow } from "../notifications/approval-card-data.js";
 import { PermissionPrompter } from "../permissions/prompter.js";
 import { SecretPrompter } from "../permissions/secret-prompter.js";
@@ -55,6 +56,7 @@ import {
   setConversationProcessingStartedAt,
 } from "../persistence/conversation-crud.js";
 import { getResolvedConversationDirPath } from "../persistence/conversation-directories.js";
+import { extractTextFromStoredMessageContent } from "../persistence/message-content.js";
 import { reportSlowSync } from "../persistence/slow-sync-log.js";
 import { defaultCompact } from "../plugins/defaults/compaction/compact.js";
 import {
@@ -173,6 +175,7 @@ import { filterMessagesForUntrustedActor } from "./message-provenance.js";
 import type { ConversationTransportMetadata } from "./message-types/conversations.js";
 import { isHostProxyTransport } from "./message-types/conversations.js";
 import { conversationMetadataSyncTag } from "./message-types/sync.js";
+import { renderReactionHistoryText } from "./reaction-history-render.js";
 import {
   resolveSummarizeBoundary,
   startsNewTurn,
@@ -539,6 +542,7 @@ export class Conversation {
   /** @internal */ currentTurnSourceActorPrincipalId?: string;
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
   /** @internal */ loadedHistoryPersonalMemoryAllowed?: boolean;
+  /** @internal */ loadedHistoryStale = false;
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ transportHints?: string[];
   /**
@@ -1063,6 +1067,9 @@ export class Conversation {
 
   async loadFromDb(): Promise<LoadFromDbResult> {
     const loadStartedAt = performance.now();
+    // Cleared before the rows are read: a channel event persisted mid-load
+    // re-marks the flag, so the next turn reloads rather than missing it.
+    this.loadedHistoryStale = false;
     const trustClass = this.trustContext?.trustClass;
     const canAccessMemory = resolveCapabilities(trustClass).canAccessMemory;
     const allDbMessages = getMessages(this.conversationId);
@@ -1153,12 +1160,56 @@ export class Conversation {
       }
       return v3PrunedSlugsMemo;
     };
+    // Provider-id → row-text index for reaction target resolution, built
+    // lazily on the first reaction row: most conversations carry none, so
+    // most loads never walk the rows a second time. Keyed over the full
+    // (unsliced) history so a reaction whose target was compacted out of
+    // context still resolves its quote.
+    let reactionTargetIndexMemo: Map<string, string> | null = null;
+    const resolveReactionTarget = (
+      targetMessageId: string,
+    ): string | undefined => {
+      if (reactionTargetIndexMemo === null) {
+        reactionTargetIndexMemo = new Map();
+        for (const row of dbMessages) {
+          const rowMeta = readProviderMetadata(row.metadata);
+          if (
+            rowMeta?.eventKind === "message" &&
+            rowMeta.messageId &&
+            !reactionTargetIndexMemo.has(rowMeta.messageId)
+          ) {
+            const text = extractTextFromStoredMessageContent(row.content);
+            if (text) {
+              reactionTargetIndexMemo.set(rowMeta.messageId, text);
+            }
+          }
+        }
+      }
+      return reactionTargetIndexMemo.get(targetMessageId);
+    };
     const parsedMessages: Message[] = slicedDbMessages.map((m, index, arr) => {
       const isPreStripped = index < preStrippedCount;
       const role = m.role as "user" | "assistant";
       let content: ContentBlock[] = m.content;
 
       content = reinjectAttachmentPathAnnotations(content, role, m.metadata);
+
+      // A reaction row's stored content is the "[reaction]" sentinel; the
+      // fact lives in its metadata. Rendered here rather than at persist
+      // time so every stored row reads legibly to the model, whenever it
+      // was written.
+      if (role === "user") {
+        const providerMeta = readProviderMetadata(m.metadata);
+        if (providerMeta?.eventKind === "reaction") {
+          const rendered = renderReactionHistoryText(
+            providerMeta,
+            resolveReactionTarget,
+          );
+          if (rendered) {
+            content = [{ type: "text", text: rendered }];
+          }
+        }
+      }
 
       // Re-inject persisted injection blocks from metadata so it survives
       // conversation reloads (eviction, restart, fork).
@@ -1533,12 +1584,24 @@ export class Conversation {
       this.trustContext,
     );
     if (
+      !this.loadedHistoryStale &&
       this.loadedHistoryTrustClass === currentTrustClass &&
       this.loadedHistoryPersonalMemoryAllowed === currentPersonalMemoryAllowed
     ) {
       return;
     }
     await this.loadFromDb();
+  }
+
+  /**
+   * Mark the resident history stale: a channel event (a reaction, edit, or
+   * delete) was persisted straight to the store while this conversation was
+   * loaded, so `this.messages` no longer reflects the rows. The next
+   * {@link ensureActorScopedHistory} reloads instead of reusing the resident
+   * history.
+   */
+  markHistoryStale(): void {
+    this.loadedHistoryStale = true;
   }
 
   /**

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1197,8 +1197,10 @@ export class Conversation {
       // A reaction row's stored content is the "[reaction]" sentinel; the
       // fact lives in its metadata. Rendered here rather than at persist
       // time so every stored row reads legibly to the model, whenever it
-      // was written.
-      if (role === "user") {
+      // was written. The substring guard keeps the per-row metadata parse
+      // off rows that cannot be reactions: every reaction envelope carries
+      // the literal key, in providerMeta and in nested slackMeta alike.
+      if (role === "user" && m.metadata?.includes("reaction")) {
         const providerMeta = readProviderMetadata(m.metadata);
         if (providerMeta?.eventKind === "reaction") {
           const rendered = renderReactionHistoryText(

--- a/assistant/src/daemon/reaction-history-render.test.ts
+++ b/assistant/src/daemon/reaction-history-render.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
+import { renderReactionHistoryText } from "./reaction-history-render.js";
+
+function reactionMeta(
+  overrides: Omit<Partial<ProviderMessageMetadata>, "reaction"> & {
+    reaction?: Partial<NonNullable<ProviderMessageMetadata["reaction"]>>;
+  } = {},
+): ProviderMessageMetadata {
+  const { reaction, ...rest } = overrides;
+  return {
+    source: "slack",
+    conversationExternalId: "C123",
+    eventKind: "reaction",
+    reaction: {
+      targetMessageId: "1716000000.000001",
+      emoji: "thumbsup",
+      op: "added",
+      actorDisplayName: "Ashlee",
+      ...reaction,
+    },
+    ...rest,
+  } as ProviderMessageMetadata;
+}
+
+const noTarget = () => undefined;
+
+describe("renderReactionHistoryText", () => {
+  test("renders an added reaction with the quoted target", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta(),
+      () => "Deploy is done",
+    );
+    expect(rendered).toContain(
+      'Ashlee reacted with :thumbsup: to the message "Deploy is done"',
+    );
+  });
+
+  test("renders a removed reaction", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ reaction: { op: "removed" } }),
+      noTarget,
+    );
+    expect(rendered).toContain(
+      "Ashlee removed their :thumbsup: reaction from an earlier message",
+    );
+  });
+
+  test("fences the line as untrusted channel content", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ actorExternalId: "U123" }),
+      noTarget,
+    );
+    expect(rendered).toContain('<external_content source="slack"');
+    expect(rendered).toContain('origin="U123"');
+    expect(rendered).toContain("</external_content>");
+  });
+
+  test("non-slack channels fence with the webhook source", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ source: "discord" }),
+      noTarget,
+    );
+    expect(rendered).toContain('<external_content source="webhook"');
+  });
+
+  test("keeps a Discord custom-emoji mention form as-is", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ reaction: { emoji: "<:vex:12345>" } }),
+      noTarget,
+    );
+    expect(rendered).toContain("reacted with <:vex:12345> to");
+  });
+
+  test("keeps a unicode emoji as-is", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ reaction: { emoji: "👍" } }),
+      noTarget,
+    );
+    expect(rendered).toContain("reacted with 👍 to");
+  });
+
+  test("strips ingress fences and collapses whitespace in the quote", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta(),
+      () =>
+        '<external_content source="slack">\nline one\n  line two\n</external_content>',
+    );
+    expect(rendered).toContain('the message "line one line two"');
+  });
+
+  test("truncates a long quoted target", () => {
+    const rendered = renderReactionHistoryText(reactionMeta(), () =>
+      "x".repeat(500),
+    );
+    expect(rendered).toContain(`"${"x".repeat(120)}..."`);
+    expect(rendered).not.toContain("x".repeat(121));
+  });
+
+  test("falls back to Someone when no display name is stored", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ reaction: { actorDisplayName: undefined } }),
+      noTarget,
+    );
+    expect(rendered).toContain("Someone reacted with");
+  });
+
+  test("prefers the row-level display name over the fallback", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({
+        displayName: "Vargas",
+        reaction: { actorDisplayName: undefined },
+      }),
+      noTarget,
+    );
+    expect(rendered).toContain("Vargas reacted with");
+  });
+
+  test("returns null for a message row", () => {
+    const meta: ProviderMessageMetadata = {
+      source: "slack",
+      conversationExternalId: "C123",
+      messageId: "1716000000.000001",
+      eventKind: "message",
+    } as ProviderMessageMetadata;
+    expect(renderReactionHistoryText(meta, noTarget)).toBeNull();
+  });
+});

--- a/assistant/src/daemon/reaction-history-render.test.ts
+++ b/assistant/src/daemon/reaction-history-render.test.ts
@@ -17,7 +17,7 @@ function reactionMeta(
       targetMessageId: "1716000000.000001",
       emoji: "thumbsup",
       op: "added",
-      actorDisplayName: "Ashlee",
+      actorDisplayName: "Alice",
       ...reaction,
     },
     ...rest,
@@ -33,7 +33,7 @@ describe("renderReactionHistoryText", () => {
       () => "Deploy is done",
     );
     expect(rendered).toContain(
-      'Ashlee reacted with :thumbsup: to the message "Deploy is done"',
+      'Alice reacted with :thumbsup: to the message "Deploy is done"',
     );
   });
 
@@ -43,7 +43,7 @@ describe("renderReactionHistoryText", () => {
       noTarget,
     );
     expect(rendered).toContain(
-      "Ashlee removed their :thumbsup: reaction from an earlier message",
+      "Alice removed their :thumbsup: reaction from an earlier message",
     );
   });
 
@@ -109,12 +109,12 @@ describe("renderReactionHistoryText", () => {
   test("prefers the row-level display name over the fallback", () => {
     const rendered = renderReactionHistoryText(
       reactionMeta({
-        displayName: "Vargas",
+        displayName: "Bob",
         reaction: { actorDisplayName: undefined },
       }),
       noTarget,
     );
-    expect(rendered).toContain("Vargas reacted with");
+    expect(rendered).toContain("Bob reacted with");
   });
 
   test("returns null for a message row", () => {

--- a/assistant/src/daemon/reaction-history-render.ts
+++ b/assistant/src/daemon/reaction-history-render.ts
@@ -4,9 +4,9 @@
  * A reaction is stored as a user row whose content is the "[reaction]"
  * sentinel; the fact lives in the row's metadata (`providerMeta.reaction`:
  * who reacted, with which emoji, on which message). The stored row stays
- * canonical and rendering happens at history-load time, so rows persisted
- * before this renderer existed render too, and no formatting is frozen into
- * persistence.
+ * canonical and rendering happens at history-load time, so every stored row
+ * renders regardless of when it was written and no formatting is frozen
+ * into persistence.
  *
  * The actor's display name and the quoted target are sender-authored, so
  * the rendered line is fenced as untrusted content the same way channel

--- a/assistant/src/daemon/reaction-history-render.ts
+++ b/assistant/src/daemon/reaction-history-render.ts
@@ -11,9 +11,18 @@
  * The actor's display name and the quoted target are sender-authored, so
  * the rendered line is fenced as untrusted content the same way channel
  * message text is fenced at ingress (`inbound-content-prep.ts`).
+ *
+ * Serves consumers of `Conversation.loadFromDb` history. Slack channel
+ * turns build their provider history from rows instead and render
+ * reactions through their own transcript renderer
+ * (`messaging/providers/slack/render-transcript.ts`), whose tag-line
+ * format references targets by alias rather than by quote.
  */
 import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
-import { wrapUntrustedContent } from "../security/untrusted-content.js";
+import {
+  unwrapExternalContentForDisplay,
+  wrapUntrustedContent,
+} from "../security/untrusted-content.js";
 
 /**
  * Slack-style emoji names render in colon form. Anything else (a unicode
@@ -28,12 +37,12 @@ function formatEmoji(emoji: string): string {
 }
 
 /**
- * Flatten a quoted target to one line: ingress fences are markup around the
- * target's own text, not part of it, so they are dropped rather than quoted.
+ * Flatten a quoted target to one line: the ingress fence is markup around
+ * the target's own text, not part of it, so it is unwrapped rather than
+ * quoted.
  */
 function snippetOf(text: string): string {
-  const flat = text
-    .replace(/<\/?external_content[^>]*>/g, " ")
+  const flat = unwrapExternalContentForDisplay(text)
     .replace(/\s+/g, " ")
     .trim();
   if (flat.length <= TARGET_SNIPPET_MAX_CHARS) {

--- a/assistant/src/daemon/reaction-history-render.ts
+++ b/assistant/src/daemon/reaction-history-render.ts
@@ -1,0 +1,75 @@
+/**
+ * Render a persisted reaction row into the text the model reads.
+ *
+ * A reaction is stored as a user row whose content is the "[reaction]"
+ * sentinel; the fact lives in the row's metadata (`providerMeta.reaction`:
+ * who reacted, with which emoji, on which message). The stored row stays
+ * canonical and rendering happens at history-load time, so rows persisted
+ * before this renderer existed render too, and no formatting is frozen into
+ * persistence.
+ *
+ * The actor's display name and the quoted target are sender-authored, so
+ * the rendered line is fenced as untrusted content the same way channel
+ * message text is fenced at ingress (`inbound-content-prep.ts`).
+ */
+import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
+import { wrapUntrustedContent } from "../security/untrusted-content.js";
+
+/**
+ * Slack-style emoji names render in colon form. Anything else (a unicode
+ * emoji, Discord's `<:name:id>` mention form) is already self-delimiting.
+ */
+const EMOJI_NAME_PATTERN = /^[\w+'-]+$/;
+
+const TARGET_SNIPPET_MAX_CHARS = 120;
+
+function formatEmoji(emoji: string): string {
+  return EMOJI_NAME_PATTERN.test(emoji) ? `:${emoji}:` : emoji;
+}
+
+/**
+ * Flatten a quoted target to one line: ingress fences are markup around the
+ * target's own text, not part of it, so they are dropped rather than quoted.
+ */
+function snippetOf(text: string): string {
+  const flat = text
+    .replace(/<\/?external_content[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (flat.length <= TARGET_SNIPPET_MAX_CHARS) {
+    return flat;
+  }
+  return `${flat.slice(0, TARGET_SNIPPET_MAX_CHARS)}...`;
+}
+
+/**
+ * The readable line for a reaction row, fenced, or null when the metadata
+ * does not describe a reaction (callers keep the row's stored content then).
+ *
+ * `resolveTargetText` maps the reaction's `targetMessageId` to the target
+ * row's text in the same provider id namespace; returning undefined (target
+ * compacted away, or never stored) degrades to "an earlier message".
+ */
+export function renderReactionHistoryText(
+  meta: ProviderMessageMetadata,
+  resolveTargetText: (targetMessageId: string) => string | undefined,
+): string | null {
+  if (meta.eventKind !== "reaction" || !meta.reaction) {
+    return null;
+  }
+  const { emoji, op, targetMessageId } = meta.reaction;
+  const actor = meta.reaction.actorDisplayName ?? meta.displayName ?? "Someone";
+  const verb =
+    op === "removed"
+      ? `removed their ${formatEmoji(emoji)} reaction from`
+      : `reacted with ${formatEmoji(emoji)} to`;
+  const target = resolveTargetText(targetMessageId);
+  const snippet = target ? snippetOf(target) : "";
+  const line = snippet
+    ? `${actor} ${verb} the message "${snippet}"`
+    : `${actor} ${verb} an earlier message`;
+  return wrapUntrustedContent(line, {
+    source: meta.source === "slack" ? "slack" : "webhook",
+    ...(meta.actorExternalId ? { sourceDetail: meta.actorExternalId } : {}),
+  });
+}

--- a/assistant/src/daemon/summarize-boundary.ts
+++ b/assistant/src/daemon/summarize-boundary.ts
@@ -1,4 +1,5 @@
 import { isToolResultOnlyUserMessage } from "../conversations/message-consolidation.js";
+import { readProviderMetadata } from "../messaging/read-provider-metadata.js";
 import type { MessageRow } from "../persistence/conversation-crud.js";
 import { UserError } from "../util/errors.js";
 
@@ -17,6 +18,17 @@ import { UserError } from "../util/errors.js";
  */
 export function startsNewTurn(msg: MessageRow): boolean {
   if (msg.role !== "user") {
+    return false;
+  }
+  // A reaction row is a channel fact attached to the turn it landed in, not
+  // a message that ran one: the agent loop never dispatches for reactions,
+  // so counting them would rehydrate a `turnCount` above the live counter
+  // and shift turn-indexed memory selection. The substring guard keeps the
+  // metadata parse off rows that cannot carry the envelope.
+  if (
+    msg.metadata?.includes("reaction") &&
+    readProviderMetadata(msg.metadata)?.eventKind === "reaction"
+  ) {
     return false;
   }
   return !isToolResultOnlyUserMessage(msg);

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -630,6 +630,9 @@ export async function handleChannelInbound({
         { deletedAt: Date.now() },
       );
       updateMessageMetadata(original.messageId, { providerMeta });
+      // The stamp lands in the store only; stale-marking makes a resident
+      // conversation's next turn reload and see the row as deleted.
+      findConversation(original.conversationId)?.markHistoryStale();
       log.info(
         {
           conversationExternalId,
@@ -650,6 +653,7 @@ export async function handleChannelInbound({
     // (channel, interface, provenance, etc.) untouched. Content column
     // is intentionally not updated.
     updateMessageMetadata(original.messageId, { slackMeta: updatedSlackMeta });
+    findConversation(original.conversationId)?.markHistoryStale();
 
     log.info(
       {

--- a/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/edit-intercept.ts
@@ -16,6 +16,7 @@
  * resolvable target is dropped.
  */
 import type { ChannelId } from "../../../channels/types.js";
+import { findConversation } from "../../../daemon/conversation-registry.js";
 import {
   mergeSlackMetadata,
   readSlackMetadata,
@@ -227,6 +228,11 @@ export async function handleEditIntercept(
   // path, so reindex the message into the lexical index — the idempotent
   // upsert replaces the stale Qdrant point with the edited content.
   enqueueLexicalIndexForMessage(original.messageId);
+  // The rewrite lands in the store only; a resident conversation keeps the
+  // pre-edit text in memory until it reloads, so the next turn would answer
+  // a revision the sender already replaced. Stale-marking makes that turn's
+  // history reload pick up the edit.
+  findConversation(original.conversationId)?.markHistoryStale();
   markProcessed(editResult.eventId);
   log.info(
     { assistantId, sourceMessageId, messageId: original.messageId },

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -255,6 +255,7 @@ export async function handleReactionIntercept(
       sourceChannel,
       reaction,
       actorDisplayName,
+      actorExternalId: canonicalSenderId ?? rawSenderId ?? undefined,
       reactedMessageTs,
       duplicate: result.duplicate,
       trustCtx: toTrustContext(trustCtx, conversationExternalId),
@@ -296,6 +297,13 @@ async function persistReactionAsMessage(params: {
   sourceChannel: ChannelId;
   reaction: InboundReactionPayload;
   actorDisplayName?: string;
+  /**
+   * The reactor's stable channel identity, canonical when resolution
+   * succeeded. Persisted as the envelope's actor id: a display name is
+   * sender-controlled labeling, and the rendered history line attributes
+   * its fenced content by this id (`origin`), never by the label.
+   */
+  actorExternalId?: string;
   reactedMessageTs: string;
   duplicate: boolean;
   /**
@@ -319,6 +327,9 @@ async function persistReactionAsMessage(params: {
       source: params.sourceChannel,
       conversationExternalId: params.conversationExternalId,
       eventKind: "reaction",
+      ...(params.actorExternalId
+        ? { actorExternalId: params.actorExternalId }
+        : {}),
       ...(params.actorDisplayName
         ? { displayName: params.actorDisplayName }
         : {}),
@@ -358,6 +369,9 @@ async function persistReactionAsMessage(params: {
     // every reader treats as "not in a thread" anyway, and storing it makes
     // the row false evidence that a thread belongs to this conversation
     // (`legacySlackConversationHasThreadEvidence`).
+    ...(params.actorExternalId
+      ? { actorExternalUserId: params.actorExternalId }
+      : {}),
     ...(params.actorDisplayName
       ? { displayName: params.actorDisplayName }
       : {}),

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -26,6 +26,7 @@ import {
 } from "@vellumai/gateway-client";
 
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
+import { findConversation } from "../../../daemon/conversation-registry.js";
 import { getDiskPressureStatus } from "../../../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../../../daemon/disk-pressure-policy.js";
 import type { ProviderMessageMetadata } from "../../../messaging/provider-message-metadata.js";
@@ -252,6 +253,12 @@ export async function handleReactionIntercept(
       reactedMessageTs,
       duplicate: result.duplicate,
     });
+    if (!result.duplicate) {
+      // Reactions never drive a turn, so a resident conversation would
+      // otherwise carry the new row only after eviction. Marking it stale
+      // makes the next turn's history reload pick the reaction up.
+      findConversation(result.conversationId)?.markHistoryStale();
+    }
   } catch (err) {
     log.error(
       { err, conversationId: result.conversationId, eventId: result.eventId },

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -29,12 +29,16 @@ import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import { findConversation } from "../../../daemon/conversation-registry.js";
 import { getDiskPressureStatus } from "../../../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../../../daemon/disk-pressure-policy.js";
+import type { TrustContext } from "../../../daemon/trust-context-types.js";
 import type { ProviderMessageMetadata } from "../../../messaging/provider-message-metadata.js";
 import {
   type SlackMessageMetadata,
   writeSlackMetadata,
 } from "../../../messaging/providers/slack/message-metadata.js";
-import { addMessage } from "../../../persistence/conversation-crud.js";
+import {
+  addMessage,
+  provenanceFromTrustContext,
+} from "../../../persistence/conversation-crud.js";
 import {
   findInboundEvent,
   findMessageBySourceId,
@@ -44,6 +48,7 @@ import {
 } from "../../../persistence/delivery-crud.js";
 import { markProcessed } from "../../../persistence/delivery-status.js";
 import { getLogger } from "../../../util/logger.js";
+import { toTrustContext } from "../../actor-trust-resolver.js";
 import type { ApprovalConversationGenerator } from "../../http-types.js";
 import {
   actorTrustContextFromVerdict,
@@ -252,6 +257,7 @@ export async function handleReactionIntercept(
       actorDisplayName,
       reactedMessageTs,
       duplicate: result.duplicate,
+      trustCtx: toTrustContext(trustCtx, conversationExternalId),
     });
     if (!result.duplicate) {
       // Reactions never drive a turn, so a resident conversation would
@@ -292,6 +298,13 @@ async function persistReactionAsMessage(params: {
   actorDisplayName?: string;
   reactedMessageTs: string;
   duplicate: boolean;
+  /**
+   * The reactor's trust context. Persisted as row provenance so actor-scoped
+   * history loads keep the row: `filterMessagesForUntrustedActor` drops any
+   * row with no `provenanceTrustClass`, which would hide every reaction from
+   * non-guardian turns.
+   */
+  trustCtx: TrustContext;
 }): Promise<void> {
   if (params.duplicate) {
     return;
@@ -323,7 +336,10 @@ async function persistReactionAsMessage(params: {
       "user",
       "[reaction]",
       {
-        metadata: { providerMeta: JSON.stringify(providerMeta) },
+        metadata: {
+          ...provenanceFromTrustContext(params.trustCtx),
+          providerMeta: JSON.stringify(providerMeta),
+        },
         skipIndexing: true,
       },
     );
@@ -362,7 +378,10 @@ async function persistReactionAsMessage(params: {
     "user",
     "[reaction]",
     {
-      metadata: { slackMeta: writeSlackMetadata(slackMeta) },
+      metadata: {
+        ...provenanceFromTrustContext(params.trustCtx),
+        slackMeta: writeSlackMetadata(slackMeta),
+      },
       skipIndexing: true,
     },
   );


### PR DESCRIPTION
# The assistant sees reactions, edits, and deletes

First PR of the reactions arc: reactions become symmetric information. This is the inbound half; the outbound react capability (transport operation + tool) follows separately.

## TL;DR

Two fixes with one claim between them: what happens in a channel between turns now actually reaches the model.

1. **Reaction rows render legibly.** A reaction is persisted as a user row whose content is the literal `[reaction]`; the actor, emoji, and target message sat unread in the row's metadata, so the model saw an opaque token. The row now renders at history-load time as fenced readable text: `Ashlee reacted with :thumbsup: to the message "Deploy is done"`.
2. **Resident conversations notice.** Reactions, edits, and deletes write straight to the store and never drive a turn, but history loads once per residency, so a conversation that stayed loaded carried none of them until eviction. The three intercept paths now stale-mark a resident conversation; the existing pre-turn `ensureActorScopedHistory` gate reloads it.

## Scope

Slack channel turns are already covered by a different mechanism: they build their provider history from rows every turn, and that transcript renders reactions with its own tag-line format (`render-transcript.ts`). This PR covers every consumer of `Conversation.loadFromDb` history, which is where the sentinel and the residency gap were live: Discord and Telegram channel turns, and app-side turns on a channel-origin conversation. The renderer docstring cross-references the Slack one.

## What changes for someone using it

| Before | After |
| --- | --- |
| Someone reacts on Discord; the assistant's next turn sees the token `[reaction]` with no actor, emoji, or target (Slack turns already rendered reactions via their transcript path) | The next turn reads who reacted, with what, to which message |
| A message is edited on Telegram or Discord while the conversation stays resident; the assistant keeps answering the old text until the daemon evicts the conversation | The next turn reads the edited text |
| A message is deleted mid-conversation on a resident conversation; the assistant still treats it as present | The next turn sees the delete mark |

## Why it is safe

- **Rendering is read-side only.** The stored row stays canonical (`[reaction]` + metadata); rendering happens in `loadFromDb`, so rows persisted before this change render too, and nothing about persistence, the web transcript, or the Slack chronological renderer changes.
- **Sender-authored text stays fenced.** The rendered line embeds the reactor's display name and a quote of the target, both sender-controlled, so it is wrapped in the same `<external_content>` fence channel text gets at ingress, with the actor's external id as origin.
- **The reload reuses the existing loader.** Staleness is a flag consumed at the turn boundary by the same `ensureActorScopedHistory` → `loadFromDb` path that already handles trust flips, so there is no mid-turn history mutation and no hand-merged state. The flag clears before rows are read, so an event landing mid-load re-marks it.
- Reaction target resolution walks rows already in memory (lazily, only when a reaction row exists), so loads without reactions do no extra work.

## Notes for review

- History repair may merge a rendered reaction row into an adjacent user message (consecutive same-role rows). The integration test asserts the invariant that matters: the model reads the rendered fact and never the sentinel.
- Telegram inbound reactions remain a platform limit (reaction updates reach only chat admins, which a bot cannot be in a DM); nothing here changes that.
