### PR TITLE
refactor(guardian-forms): extract the parking and submit rails from contacts

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -12812,8 +12812,9 @@ paths:
       summary: Claim a pending guardian form for one submission
       description:
         Marks a pending form as answered so a second client submitting the same form writes nothing. Returns
-        claimed=false with reason 'already_claimed' when somebody got there first, or 'unknown' when no such form is
-        pending. A granted claim carries the window its write has to report back in.
+        claimed=false with reason 'already_claimed' when somebody got there first, 'unknown' when no such form is
+        pending, or 'wrong_kind' when the id belongs to a different form than the caller named. A granted claim carries
+        the window its write has to report back in.
       tags:
         - guardian-forms
       requestBody:
@@ -12826,6 +12827,11 @@ paths:
                 requestId:
                   type: string
                   description: The pending form's id.
+                kind:
+                  description:
+                    The form the caller believes it is writing for. Rejected when it is not what the id is holding. Omitted by
+                    callers that predate the check.
+                  type: string
               required:
                 - requestId
       responses:
@@ -12843,6 +12849,7 @@ paths:
                     enum:
                       - already_claimed
                       - unknown
+                      - wrong_kind
                   settleMs:
                     description: How long a granted claim has to report its write back before the waiting call gives up.
                     type: number

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -12806,6 +12806,49 @@ paths:
                 additionalProperties: false
         "403":
           description: Cannot reorder system groups
+  /v1/guardian_form_claim:
+    post:
+      operationId: guardian_form_claim_post
+      summary: Claim a pending guardian form for one submission
+      description:
+        Marks a pending form as answered so a second client submitting the same form writes nothing. Returns
+        claimed=false with reason 'already_claimed' when somebody got there first, or 'unknown' when no such form is
+        pending. A granted claim carries the window its write has to report back in.
+      tags:
+        - guardian-forms
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: The pending form's id.
+              required:
+                - requestId
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  claimed:
+                    type: boolean
+                  reason:
+                    type: string
+                    enum:
+                      - already_claimed
+                      - unknown
+                  settleMs:
+                    description: How long a granted claim has to report its write back before the waiting call gives up.
+                    type: number
+                required:
+                  - claimed
+                additionalProperties: false
   /v1/guardian-actions/decision:
     post:
       operationId: guardianactions_decision_post
@@ -26184,6 +26227,41 @@ paths:
       responses:
         "200":
           description: Successful response
+  /v1/resolve_guardian_form:
+    post:
+      operationId: resolve_guardian_form_post
+      summary: Report a guardian form's outcome back to the waiting command
+      description:
+        Called by the writer once it has committed (or failed). Fields other than requestId and error are passed
+        through to the parked caller untouched; an error makes the outcome a failure.
+      tags:
+        - guardian-forms
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                requestId:
+                  type: string
+                  description: The pending form's id.
+              required:
+                - requestId
+              additionalProperties: {}
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  resolved:
+                    type: boolean
+                required:
+                  - resolved
+                additionalProperties: false
   /v1/resource-pressure/status:
     get:
       operationId: resourcepressure_status_get

--- a/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
@@ -10,7 +10,7 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { CONTACT_FORM_SETTLE_MS } from "../../util/contact-form-timeouts.js";
+import { GUARDIAN_FORM_SETTLE_MS } from "../../util/guardian-form-timeouts.js";
 
 interface IpcCall {
   operationId: string;
@@ -184,7 +184,7 @@ describe("contacts record prompts", () => {
     // starts the settle window from there. Giving up sooner would report a
     // failure while the write went on to commit.
     expect(call!.callOptions?.timeoutMs).toBeGreaterThan(
-      1000 + CONTACT_FORM_SETTLE_MS,
+      1000 + GUARDIAN_FORM_SETTLE_MS,
     );
   });
 

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -2,10 +2,10 @@ import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
 import {
-  CONTACT_FORM_DEFAULT_TIMEOUT_MS,
-  CONTACT_FORM_MAX_TIMEOUT_MS,
-  contactFormCallBudgetMs,
-} from "../../util/contact-form-timeouts.js";
+  GUARDIAN_FORM_DEFAULT_TIMEOUT_MS,
+  GUARDIAN_FORM_MAX_TIMEOUT_MS,
+  guardianFormCallBudgetMs,
+} from "../../util/guardian-form-timeouts.js";
 import { applyCommandHelp, subcommand } from "../lib/cli-command-help.js";
 import { registerCommand } from "../lib/register-command.js";
 import { shouldOutputJson, writeError, writeOutput } from "../output.js";
@@ -175,7 +175,7 @@ function parseFormTimeout(
   cmd: Command,
 ): number | null {
   if (raw === undefined) {
-    return CONTACT_FORM_DEFAULT_TIMEOUT_MS;
+    return GUARDIAN_FORM_DEFAULT_TIMEOUT_MS;
   }
   // The whole token has to be digits: parseInt takes a valid prefix, so
   // "1e3" would pass as 1 and "100.5" as 100, quietly giving a form a
@@ -189,10 +189,10 @@ function parseFormTimeout(
     process.exitCode = 1;
     return null;
   }
-  if (parsed > CONTACT_FORM_MAX_TIMEOUT_MS) {
+  if (parsed > GUARDIAN_FORM_MAX_TIMEOUT_MS) {
     writeError(
       cmd,
-      `Invalid --timeout "${raw}": the longest a form stays open is ${CONTACT_FORM_MAX_TIMEOUT_MS}ms`,
+      `Invalid --timeout "${raw}": the longest a form stays open is ${GUARDIAN_FORM_MAX_TIMEOUT_MS}ms`,
     );
     process.exitCode = 1;
     return null;
@@ -280,7 +280,7 @@ async function runRecordPrompt(
   }>(
     "contacts_record_prompt",
     { body: { ...body, timeoutMs } },
-    { timeoutMs: contactFormCallBudgetMs(timeoutMs) },
+    { timeoutMs: guardianFormCallBudgetMs(timeoutMs) },
   );
 
   if (!r.ok) {
@@ -619,7 +619,7 @@ export function registerContactsCommand(program: Command): void {
                 timeoutMs,
               },
             },
-            { timeoutMs: contactFormCallBudgetMs(timeoutMs) },
+            { timeoutMs: guardianFormCallBudgetMs(timeoutMs) },
           );
 
           if (!r.ok) {

--- a/assistant/src/runtime/__tests__/guardian-form-registry.test.ts
+++ b/assistant/src/runtime/__tests__/guardian-form-registry.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Unit tests for the guardian-form registry.
+ *
+ * The registry is the rail every form-backed command parks on, so the
+ * concurrency rules are tested here directly rather than only through the
+ * contact forms that happen to use them today. What matters: a form is
+ * answered once, a claim stops the answer deadline without ending the form,
+ * and a form that nobody answers ends by telling the clients showing it.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  claimGuardianForm,
+  type GuardianFormClosedReason,
+  hasUnclaimedGuardianForm,
+  openGuardianForm,
+  resolveGuardianForm,
+} from "../guardian-form-registry.js";
+
+interface TestResult {
+  ok: boolean;
+  error?: string;
+  wrote?: string;
+}
+
+/** Open a form and hand back its requestId plus the parked promise. */
+function openForm(options: { kind?: string; timeoutMs?: number } = {}) {
+  const closed = mock((_id: string, _reason: GuardianFormClosedReason) => {});
+  let requestId = "";
+  const settled = openGuardianForm<TestResult>({
+    kind: options.kind ?? "test.form",
+    timeoutMs: options.timeoutMs ?? 30_000,
+    meta: { verify: true },
+    broadcast: {
+      open: (id) => {
+        requestId = id;
+      },
+      closed,
+    },
+  });
+  return { requestId, settled, closed };
+}
+
+const tick = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("openGuardianForm", () => {
+  test("broadcasts the form and parks until something resolves it", async () => {
+    const { requestId, settled } = openForm();
+    expect(requestId).toMatch(/^[0-9a-f-]{36}$/);
+
+    let done = false;
+    void settled.then(() => {
+      done = true;
+    });
+    await tick(10);
+    expect(done).toBe(false);
+
+    resolveGuardianForm(requestId, { ok: true, wrote: "contact-1" });
+    expect(await settled).toEqual({ ok: true, wrote: "contact-1" });
+  });
+
+  test("hands the writer's own fields back to the parked call", async () => {
+    const { requestId, settled } = openForm();
+    resolveGuardianForm(requestId, { ok: false, error: "Cancelled by user" });
+    expect(await settled).toEqual({ ok: false, error: "Cancelled by user" });
+  });
+
+  test("an unanswered form ends and tells the clients showing it", async () => {
+    const { requestId, settled, closed } = openForm({ timeoutMs: 30 });
+
+    expect(await settled).toEqual({ ok: false, error: "Prompt timed out" });
+    expect(closed).toHaveBeenCalledWith(requestId, "timed_out");
+  });
+});
+
+describe("claimGuardianForm", () => {
+  test("only the first claim wins", async () => {
+    const { requestId, settled } = openForm();
+
+    const first = claimGuardianForm(requestId);
+    const second = claimGuardianForm(requestId);
+
+    expect(first.claimed).toBe(true);
+    expect(first.settleMs).toBeGreaterThan(0);
+    expect(second).toEqual({ claimed: false, reason: "already_claimed" });
+
+    resolveGuardianForm(requestId, { ok: true });
+    await settled;
+  });
+
+  test("a form nobody is holding claims as unknown", () => {
+    expect(claimGuardianForm("no-such-form")).toEqual({
+      claimed: false,
+      reason: "unknown",
+    });
+  });
+
+  test("claiming disarms the answer deadline", async () => {
+    // The form is open for 30ms, and the claim lands inside that window. If the
+    // claim did not swap the deadline for the settle window, the parked call
+    // would report a timeout while the write it started was still running.
+    const { requestId, settled, closed } = openForm({ timeoutMs: 30 });
+    expect(claimGuardianForm(requestId).claimed).toBe(true);
+
+    let done = false;
+    void settled.then(() => {
+      done = true;
+    });
+    await tick(80);
+
+    expect(done).toBe(false);
+    expect(closed).not.toHaveBeenCalled();
+
+    resolveGuardianForm(requestId, { ok: true, wrote: "late" });
+    expect(await settled).toEqual({ ok: true, wrote: "late" });
+  });
+
+  test("a resolved form cannot be claimed again", async () => {
+    const { requestId, settled } = openForm();
+    resolveGuardianForm(requestId, { ok: true });
+    await settled;
+
+    expect(claimGuardianForm(requestId)).toEqual({
+      claimed: false,
+      reason: "unknown",
+    });
+  });
+});
+
+describe("resolveGuardianForm", () => {
+  test("retires the card as answered or cancelled", async () => {
+    const answered = openForm();
+    resolveGuardianForm(answered.requestId, { ok: true });
+    await answered.settled;
+    expect(answered.closed).toHaveBeenCalledWith(
+      answered.requestId,
+      "answered",
+    );
+
+    const cancelled = openForm();
+    resolveGuardianForm(cancelled.requestId, { ok: false, error: "no" });
+    await cancelled.settled;
+    expect(cancelled.closed).toHaveBeenCalledWith(
+      cancelled.requestId,
+      "cancelled",
+    );
+  });
+
+  test("reports that nothing was waiting for an unknown form", () => {
+    expect(resolveGuardianForm("no-such-form", { ok: true })).toEqual({
+      resolved: false,
+    });
+  });
+});
+
+describe("hasUnclaimedGuardianForm", () => {
+  test("sees only the kinds it is asked about", async () => {
+    const { requestId, settled } = openForm({ kind: "kind.a" });
+
+    expect(hasUnclaimedGuardianForm(["kind.a"])).toBe(true);
+    // The point of taking kinds: an open form of one kind must not block a
+    // form of another, which a registry-wide sweep would do.
+    expect(hasUnclaimedGuardianForm(["kind.b"])).toBe(false);
+    expect(hasUnclaimedGuardianForm(["kind.b", "kind.a"])).toBe(true);
+
+    resolveGuardianForm(requestId, { ok: true });
+    await settled;
+    expect(hasUnclaimedGuardianForm(["kind.a"])).toBe(false);
+  });
+
+  test("a claimed form no longer counts as open", async () => {
+    const { requestId, settled } = openForm({ kind: "kind.c" });
+    expect(hasUnclaimedGuardianForm(["kind.c"])).toBe(true);
+
+    claimGuardianForm(requestId);
+    // Claimed means answered: its card is gone, so the next command should not
+    // be refused on account of it.
+    expect(hasUnclaimedGuardianForm(["kind.c"])).toBe(false);
+
+    resolveGuardianForm(requestId, { ok: true });
+    await settled;
+  });
+});

--- a/assistant/src/runtime/__tests__/guardian-form-registry.test.ts
+++ b/assistant/src/runtime/__tests__/guardian-form-registry.test.ts
@@ -214,3 +214,29 @@ describe("resolveFormFromCallback", () => {
     expect(await settled).toEqual({ ok: false, error: "nope" });
   });
 });
+
+describe("claiming names the form", () => {
+  test("a claim for a different kind is refused", async () => {
+    // An id alone does not say which form it belongs to. Without this check a
+    // submission to form B could claim an open form A, run B's write, and hand
+    // A's caller a result for a form it never showed.
+    const { requestId, settled } = openForm({ kind: "kind.real" });
+
+    expect(claimGuardianForm(requestId, "kind.other")).toEqual({
+      claimed: false,
+      reason: "wrong_kind",
+    });
+    // Refused, not consumed: the right caller can still claim it.
+    expect(claimGuardianForm(requestId, "kind.real").claimed).toBe(true);
+
+    resolveGuardianForm(requestId, { ok: true });
+    await settled;
+  });
+
+  test("a caller that names no kind still claims, as before", async () => {
+    const { requestId, settled } = openForm({ kind: "kind.real" });
+    expect(claimGuardianForm(requestId).claimed).toBe(true);
+    resolveGuardianForm(requestId, { ok: true });
+    await settled;
+  });
+});

--- a/assistant/src/runtime/__tests__/guardian-form-registry.test.ts
+++ b/assistant/src/runtime/__tests__/guardian-form-registry.test.ts
@@ -182,3 +182,35 @@ describe("hasUnclaimedGuardianForm", () => {
     await settled;
   });
 });
+
+describe("resolveFormFromCallback", () => {
+  test("passes a writer's own fields through untouched", async () => {
+    // The rail is only reusable if a new form's result reaches its caller. A
+    // callback that enumerated contact fields would drop everything else.
+    const { requestId, settled } = openForm();
+
+    const { resolveFormFromCallback } =
+      await import("../routes/guardian-form-routes.js");
+    resolveFormFromCallback({
+      body: { requestId, id: "row-7", rows: 3, skipped: false },
+    } as never);
+
+    expect(await settled).toEqual({
+      ok: true,
+      id: "row-7",
+      rows: 3,
+      skipped: false,
+    } as never);
+  });
+
+  test("an error makes the outcome a failure", async () => {
+    const { requestId, settled } = openForm();
+    const { resolveFormFromCallback } =
+      await import("../routes/guardian-form-routes.js");
+    resolveFormFromCallback({
+      body: { requestId, error: "nope", id: "ignored" },
+    } as never);
+
+    expect(await settled).toEqual({ ok: false, error: "nope" });
+  });
+});

--- a/assistant/src/runtime/guardian-form-registry.ts
+++ b/assistant/src/runtime/guardian-form-registry.ts
@@ -1,0 +1,240 @@
+/**
+ * The parking rail behind every guardian form.
+ *
+ * A form-backed command does not write. It parks here, its form goes to every
+ * connected client, and the write happens elsewhere (today the gateway, which
+ * owns contact writes) and reports back. With no human at a form, nothing is
+ * written and the call times out. That property is what makes these commands
+ * guardian-gated, and it lives in this file rather than in any one form.
+ *
+ * What a form owner supplies: how to broadcast it, how to take it down, and
+ * what its result looks like. Everything below is the same for all of them.
+ *
+ * Lifecycle:
+ *   open   -> the call parks, the form goes out, a deadline starts
+ *   claim  -> one submission wins; the answer deadline is swapped for a
+ *             bounded settle window while the write runs
+ *   resolve-> the write reports back, the parked call returns, the card is
+ *             retired everywhere it is showing
+ *
+ * See `docs/guardian-forms.md` for how to add one.
+ */
+
+import { v4 as uuid } from "uuid";
+
+import {
+  GUARDIAN_FORM_DEFAULT_TIMEOUT_MS,
+  GUARDIAN_FORM_SETTLE_MS,
+} from "../util/guardian-form-timeouts.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("guardian-form-registry");
+
+/** Every form's result carries at least this; owners widen it. */
+export interface GuardianFormResult {
+  ok: boolean;
+  error?: string;
+}
+
+export type GuardianFormClosedReason = "answered" | "cancelled" | "timed_out";
+
+/**
+ * How a form reaches clients and how it leaves them.
+ *
+ * Both are the owner's, because the event names are wire contract. The
+ * registry decides *when* they fire.
+ */
+export interface GuardianFormBroadcast {
+  open: (requestId: string) => void;
+  closed: (requestId: string, reason: GuardianFormClosedReason) => void;
+}
+
+interface PendingGuardianForm {
+  kind: string;
+  resolve: (result: GuardianFormResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+  closed: GuardianFormBroadcast["closed"];
+  /**
+   * Owner-defined state the write may need to read back out of band, for a
+   * client with no field to echo it in. Opaque here.
+   */
+  meta: Record<string, unknown>;
+  logContext: Record<string, unknown>;
+  /**
+   * Set once a submission has been accepted. The form went to every connected
+   * client, so more than one can answer it; the first claim wins and the rest
+   * write nothing.
+   */
+  claimed: boolean;
+}
+
+const pendingForms = new Map<string, PendingGuardianForm>();
+
+export interface OpenGuardianFormOptions {
+  /** Which form this is, for logs and for scoping the open-form check. */
+  kind: string;
+  broadcast: GuardianFormBroadcast;
+  /** How long to hold it open. Defaults to the shared 5 minutes. */
+  timeoutMs?: number;
+  meta?: Record<string, unknown>;
+  /** Form-specific fields folded into this form's log lines. */
+  logContext?: Record<string, unknown>;
+  /** What the parked call is told when nobody answers. */
+  timeoutError?: string;
+}
+
+/**
+ * Park a call until the guardian answers its form.
+ *
+ * The returned promise settles exactly once: on an answer, on a dismissal, or
+ * on the deadline. It never rejects, because the caller's failure is a result
+ * it has to report, not an exception to unwind through.
+ */
+export function openGuardianForm<TResult extends GuardianFormResult>(
+  options: OpenGuardianFormOptions,
+): Promise<TResult> {
+  const {
+    kind,
+    broadcast,
+    timeoutMs,
+    meta = {},
+    logContext = {},
+    timeoutError = "Prompt timed out",
+  } = options;
+  const requestId = uuid();
+
+  return new Promise<TResult>((resolve) => {
+    const timer = setTimeout(() => {
+      const pending = pendingForms.get(requestId);
+      if (!pending) {
+        return;
+      }
+      log.warn({ requestId, kind, ...logContext }, "Guardian form timed out");
+      expireForm(requestId, pending, timeoutError);
+    }, timeoutMs ?? GUARDIAN_FORM_DEFAULT_TIMEOUT_MS);
+
+    pendingForms.set(requestId, {
+      kind,
+      // The registry knows only the base shape; the owner's extra fields ride
+      // through resolveGuardianForm untouched, so the cast is confined here.
+      resolve: resolve as (result: GuardianFormResult) => void,
+      timer,
+      closed: broadcast.closed,
+      meta,
+      logContext,
+      claimed: false,
+    });
+
+    broadcast.open(requestId);
+    log.info({ requestId, kind, ...logContext }, "Guardian form broadcast");
+  });
+}
+
+/**
+ * End a form nobody answered in time, and tell the clients showing it.
+ *
+ * Without the broadcast the card stays up offering an answer that would now be
+ * refused: a form that has closed accepts no submission.
+ */
+function expireForm(
+  requestId: string,
+  pending: PendingGuardianForm,
+  error: string,
+): void {
+  pendingForms.delete(requestId);
+  pending.resolve({ ok: false, error });
+  pending.closed(requestId, "timed_out");
+}
+
+/**
+ * Claim a pending form so exactly one submission can write.
+ *
+ * The daemon holds the only record of which forms are still open, so it is the
+ * one place that can decide a race between two clients answering the same
+ * broadcast. First caller wins; the rest are told why they lost, so the writer
+ * can tell "somebody already answered this" (leave their answer alone) apart
+ * from "no such form" (expired or already resolved, so nothing should be
+ * written at all).
+ */
+export function claimGuardianForm(requestId: string): {
+  claimed: boolean;
+  reason?: "already_claimed" | "unknown";
+  settleMs?: number;
+} {
+  const pending = pendingForms.get(requestId);
+  if (!pending) {
+    return { claimed: false, reason: "unknown" };
+  }
+  if (pending.claimed) {
+    return { claimed: false, reason: "already_claimed" };
+  }
+  pending.claimed = true;
+  // Answered, so its open-for-answers deadline gives way to a bounded settle
+  // window while the write reports back.
+  clearTimeout(pending.timer);
+  pending.timer = setTimeout(() => {
+    log.warn(
+      { requestId, kind: pending.kind, ...pending.logContext },
+      "Guardian form claimed but never settled; the write never reported back",
+    );
+    expireForm(requestId, pending, "The submitted form never completed");
+  }, GUARDIAN_FORM_SETTLE_MS);
+  // The claimer needs the window too: it is how long its write has to report
+  // back before the caller gives up, and it should not have to know the number
+  // independently.
+  return { claimed: true, settleMs: GUARDIAN_FORM_SETTLE_MS };
+}
+
+/**
+ * Hand a form's answer to the call parked on it and retire the card.
+ *
+ * An error covers a dismissal and a failed write alike: the form is over
+ * either way, and the caller is the one told why.
+ */
+export function resolveGuardianForm<TResult extends GuardianFormResult>(
+  requestId: string,
+  result: TResult,
+): { resolved: boolean } {
+  const pending = pendingForms.get(requestId);
+  if (!pending) {
+    log.warn({ requestId }, "resolve: no pending guardian form found");
+    return { resolved: false };
+  }
+
+  clearTimeout(pending.timer);
+  pendingForms.delete(requestId);
+  pending.resolve(result);
+  pending.closed(requestId, result.ok ? "answered" : "cancelled");
+
+  log.info(
+    { requestId, kind: pending.kind, ...pending.logContext },
+    "Guardian form resolved",
+  );
+  return { resolved: true };
+}
+
+/**
+ * Whether any form of these kinds is open and still unanswered.
+ *
+ * Takes the kinds to check rather than sweeping the whole registry. Clients
+ * hold one card per kind, so a second broadcast of a kind already on screen
+ * replaces the first and leaves its command waiting on a form nobody can
+ * answer. A registry-wide check would go further than that and let any pending
+ * form block every other one, which is a rule each form should opt into rather
+ * than inherit.
+ */
+export function hasUnclaimedGuardianForm(kinds: readonly string[]): boolean {
+  for (const pending of pendingForms.values()) {
+    if (!pending.claimed && kinds.includes(pending.kind)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Owner-defined state parked with a form, for a writer that must read it back. */
+export function getGuardianFormMeta(
+  requestId: string,
+): Record<string, unknown> | undefined {
+  return pendingForms.get(requestId)?.meta;
+}

--- a/assistant/src/runtime/guardian-form-registry.ts
+++ b/assistant/src/runtime/guardian-form-registry.ts
@@ -151,19 +151,35 @@ function expireForm(
  *
  * The daemon holds the only record of which forms are still open, so it is the
  * one place that can decide a race between two clients answering the same
- * broadcast. First caller wins; the rest are told why they lost, so the writer
+ * broadcast, and the only one that can tell whether an id is even the right
+ * form. Pass `expectedKind` whenever the caller knows which form it is
+ * writing for. First caller wins; the rest are told why they lost, so the writer
  * can tell "somebody already answered this" (leave their answer alone) apart
  * from "no such form" (expired or already resolved, so nothing should be
  * written at all).
  */
-export function claimGuardianForm(requestId: string): {
+export function claimGuardianForm(
+  requestId: string,
+  expectedKind?: string,
+): {
   claimed: boolean;
-  reason?: "already_claimed" | "unknown";
+  reason?: "already_claimed" | "unknown" | "wrong_kind";
   settleMs?: number;
 } {
   const pending = pendingForms.get(requestId);
   if (!pending) {
     return { claimed: false, reason: "unknown" };
+  }
+  if (expectedKind !== undefined && pending.kind !== expectedKind) {
+    // An id alone does not say which form it belongs to. Without this, a
+    // submission to form B's endpoint could claim an open form A: B's write
+    // would run, and A's parked caller would be handed B's result for a form
+    // it never showed.
+    log.warn(
+      { requestId, expectedKind, actualKind: pending.kind },
+      "Guardian form claim rejected: the id belongs to a different form",
+    );
+    return { claimed: false, reason: "wrong_kind" };
   }
   if (pending.claimed) {
     return { claimed: false, reason: "already_claimed" };

--- a/assistant/src/runtime/routes/__tests__/contact-form-kinds.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-form-kinds.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Pins the contact form kinds the daemon opens its forms under.
+ *
+ * The gateway names these same strings when it claims a form, and a claim
+ * naming a different kind is rejected. Nothing at compile time links the two
+ * packages, so a rename on one side alone would show up only as contact forms
+ * failing to submit. The gateway has the matching test; both must be edited
+ * together for a rename to land.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  CONTACT_ADDRESS_FORM_KIND,
+  CONTACT_RECORD_FORM_KIND,
+} from "../contact-prompt-routes.js";
+
+describe("contact form kinds", () => {
+  test("match the strings the gateway claims under", () => {
+    expect(CONTACT_ADDRESS_FORM_KIND).toBe("contacts.address");
+    expect(CONTACT_RECORD_FORM_KIND).toBe("contacts.record");
+  });
+});

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -41,9 +41,18 @@ import {
 import { claimForm, resolveFormFromCallback } from "./guardian-form-routes.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
-/** Form kinds on the guardian-form rail that carry a contact card. */
-const ADDRESS_FORM = "contacts.address";
-const RECORD_FORM = "contacts.record";
+/**
+ * Form kinds on the guardian-form rail that carry a contact card.
+ *
+ * The gateway names the same kind when it claims, so these two strings are a
+ * cross-package contract. `contact-form-kinds.test.ts` on each side pins the
+ * literals, since a rename on one side alone would only surface as claims
+ * rejected at runtime.
+ */
+export const CONTACT_ADDRESS_FORM_KIND = "contacts.address";
+export const CONTACT_RECORD_FORM_KIND = "contacts.record";
+const ADDRESS_FORM = CONTACT_ADDRESS_FORM_KIND;
+const RECORD_FORM = CONTACT_RECORD_FORM_KIND;
 const CONTACT_FORMS = [ADDRESS_FORM, RECORD_FORM] as const;
 
 const TimeoutMsParam = z

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -1,57 +1,63 @@
 /**
  * IPC routes for the contact forms the guardian fills in their app.
  *
- * Two commands park on this rail:
+ * Two commands park on the guardian-form rail:
  *   - `contacts/prompt` collects a channel address and binds a channel.
  *   - `contacts/record-prompt` confirms a contact record write the assistant
  *     proposed (create, update, delete). No channel is touched.
  *
  * Flow, identical for both:
  *   1. CLI calls the IPC route with what the assistant proposes.
- *   2. Daemon broadcasts a `contact_request` / `contact_record_request` to all
- *      connected clients and parks the call.
+ *   2. The route parks the call in the guardian-form registry, which broadcasts
+ *      a `contact_request` / `contact_record_request` to connected clients.
  *   3. Client shows the form. The guardian edits and submits, or dismisses.
  *   4. Client POSTs to the gateway (`/v1/contacts/prompt/submit` or
  *      `/v1/contacts/record/submit`).
  *   5. Gateway performs the write (gateway owns all contact writes), attesting
  *      the channel when the guardian left the verify box checked.
  *   6. Gateway calls daemon IPC `resolve_contact_prompt`.
- *   7. Daemon resolves the pending promise and the CLI call returns.
+ *   7. The registry resolves the parked promise and the CLI call returns.
  *
  * The daemon only broadcasts and waits. It never writes contacts. That is what
  * makes these commands guardian-gated: with no human at a form, nothing is
  * written, and the call times out.
+ *
+ * The lifecycle itself lives in `runtime/guardian-form-registry.ts` and is
+ * shared by every guardian form. What is here is the contact-shaped half: the
+ * schemas, the two wire events, and the result the CLI gets back.
  */
 
-import { v4 as uuid } from "uuid";
 import { z } from "zod";
 
-import {
-  CONTACT_FORM_DEFAULT_TIMEOUT_MS,
-  CONTACT_FORM_MAX_TIMEOUT_MS,
-  CONTACT_FORM_SETTLE_MS,
-} from "../../util/contact-form-timeouts.js";
-import { getLogger } from "../../util/logger.js";
+import { GUARDIAN_FORM_MAX_TIMEOUT_MS } from "../../util/guardian-form-timeouts.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import {
+  claimGuardianForm,
+  getGuardianFormMeta,
+  type GuardianFormClosedReason,
+  hasUnclaimedGuardianForm,
+  openGuardianForm,
+  resolveGuardianForm,
+} from "../guardian-form-registry.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
-const log = getLogger("contact-prompt-routes");
+/** Form kinds on the guardian-form rail that carry a contact card. */
+const ADDRESS_FORM = "contacts.address";
+const RECORD_FORM = "contacts.record";
+const CONTACT_FORMS = [ADDRESS_FORM, RECORD_FORM] as const;
 
 const TimeoutMsParam = z
   .number()
   .int()
   .positive()
-  .max(CONTACT_FORM_MAX_TIMEOUT_MS)
+  .max(GUARDIAN_FORM_MAX_TIMEOUT_MS)
   .optional()
   .describe(
     "How long to hold the form open (ms). The caller waits slightly longer than this, so the form closing is what ends the wait. Defaults to 300000.",
   );
 
-// ---------------------------------------------------------------------------
-// Pending contact prompts
-// ---------------------------------------------------------------------------
-
+/** What the CLI gets back once the guardian has answered, or not. */
 export interface ContactPromptResult {
   ok: boolean;
   error?: string;
@@ -70,53 +76,22 @@ export interface ContactPromptResult {
   nothingWritten?: boolean;
 }
 
-interface PendingContactPrompt {
-  resolve: (result: ContactPromptResult) => void;
-  timer: ReturnType<typeof setTimeout>;
-  /** When true, the gateway marks the submitted channel verified (manual attest). */
-  verify: boolean;
-  /**
-   * Set once a submission has been accepted for this form. The form is
-   * broadcast to every connected client, so more than one can answer it; the
-   * first claim wins and the rest write nothing.
-   */
-  claimed?: boolean;
-}
-
-const pendingContactPrompts = new Map<string, PendingContactPrompt>();
-
 /**
- * End a form that nobody answered in time, and tell the clients showing it.
- *
- * Without the broadcast the card stays up offering an answer the gateway
- * would refuse: a form that has closed accepts no submission.
- */
-function expireContactPrompt(
-  requestId: string,
-  pending: PendingContactPrompt,
-  error: string,
-): void {
-  pendingContactPrompts.delete(requestId);
-  pending.resolve({ ok: false, error });
-  announceFormClosed(requestId, "timed_out");
-}
-
-/**
- * Tell every client a form is over.
+ * Tell every client a contact form is over.
  *
  * The form went to all of them, so one client answering leaves the others
  * holding a card that would now be refused. This is what takes those down.
  */
-function announceFormClosed(
+function announceContactFormClosed(
   requestId: string,
-  reason: "answered" | "cancelled" | "timed_out",
+  reason: GuardianFormClosedReason,
 ): void {
   broadcastMessage({ type: "contact_form_closed", requestId, reason });
 }
 
 /**
- * Called by the gateway after it writes the contact and channel.
- * Resolves the pending promise so the CLI's `contacts/prompt` IPC call returns.
+ * Called by the gateway after it writes the contact and channel. Resolves the
+ * parked promise so the CLI's `contacts/prompt` IPC call returns.
  */
 function resolveContactPrompt({ body = {} }: RouteHandlerArgs): {
   resolved: boolean;
@@ -142,37 +117,22 @@ function resolveContactPrompt({ body = {} }: RouteHandlerArgs): {
     nothingWritten?: boolean;
     error?: string;
   };
-  const pending = pendingContactPrompts.get(requestId);
-  if (!pending) {
-    log.warn({ requestId }, "resolve_contact_prompt: no pending prompt found");
-    return { resolved: false };
-  }
 
-  clearTimeout(pending.timer);
-  pendingContactPrompts.delete(requestId);
-
-  if (error) {
-    pending.resolve({ ok: false, error });
-  } else {
-    pending.resolve({
-      ok: true,
-      contactId,
-      channelId,
-      channelType,
-      address,
-      verified,
-      notesSaved,
-      nothingWritten,
-    });
-  }
-
-  // Retire the card everywhere it is showing, not just on the client that
-  // answered. An error here covers a dismissal and a failed write alike: the
-  // form is over either way, and the caller is the one told why.
-  announceFormClosed(requestId, error ? "cancelled" : "answered");
-
-  log.info({ requestId, contactId }, "Contact prompt resolved");
-  return { resolved: true };
+  return resolveGuardianForm(
+    requestId,
+    error
+      ? { ok: false, error }
+      : {
+          ok: true,
+          contactId,
+          channelId,
+          channelType,
+          address,
+          verified,
+          notesSaved,
+          nothingWritten,
+        },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -275,7 +235,7 @@ const ContactPromptFlagsParams = z.object({
 });
 
 // ---------------------------------------------------------------------------
-// Handler
+// Handlers
 // ---------------------------------------------------------------------------
 
 async function handleContactPrompt({
@@ -292,43 +252,31 @@ async function handleContactPrompt({
     timeoutMs,
   } = ContactPromptParams.parse(body);
 
-  const requestId = uuid();
-
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      const pending = pendingContactPrompts.get(requestId);
-      if (!pending) {
-        return;
-      }
-      log.warn({ requestId }, "Contact prompt timed out");
-      expireContactPrompt(requestId, pending, "Prompt timed out");
-    }, timeoutMs ?? CONTACT_FORM_DEFAULT_TIMEOUT_MS);
-
-    pendingContactPrompts.set(requestId, {
-      resolve,
-      timer,
-      verify: verify === true,
-    });
-
-    broadcastMessage({
-      type: "contact_request",
-      requestId,
-      channel,
-      placeholder,
-      defaultValue,
-      label,
-      description,
-      role,
-      // The checkbox's initial state. Carried in the broadcast so the form can
-      // show what submitting will do; the client's answer is what the gateway
-      // acts on.
-      verify: verify === true,
-    });
-
-    log.info(
-      { requestId, channel, role, verify: verify === true },
-      "Contact prompt broadcast",
-    );
+  return openGuardianForm<ContactPromptResult>({
+    kind: ADDRESS_FORM,
+    timeoutMs,
+    // Read back by the gateway when a client too old for the checkbox submits
+    // no answer of its own.
+    meta: { verify: verify === true },
+    logContext: { channel, role, verify: verify === true },
+    broadcast: {
+      open: (requestId) =>
+        broadcastMessage({
+          type: "contact_request",
+          requestId,
+          channel,
+          placeholder,
+          defaultValue,
+          label,
+          description,
+          role,
+          // The checkbox's initial state. Carried in the broadcast so the form
+          // can show what submitting will do; the client's answer is what the
+          // gateway acts on.
+          verify: verify === true,
+        }),
+      closed: announceContactFormClosed,
+    },
   });
 }
 
@@ -360,14 +308,11 @@ async function handleContactRecordPrompt({
     return { ok: false, error: `contactId is required to ${operation}` };
   }
 
-  // Clients hold one contact form at a time, so a second broadcast replaces the
-  // first card and leaves its command waiting on a form nobody can answer.
-  // Refusing here fails the second command immediately instead, which is a
-  // caller that can retry rather than one that hangs.
-  const openForm = [...pendingContactPrompts.values()].some(
-    (pending) => !pending.claimed,
-  );
-  if (openForm) {
+  // Clients hold one contact card at a time, so a second broadcast replaces the
+  // first and leaves its command waiting on a form nobody can answer. Refusing
+  // here fails the second command immediately instead, which is a caller that
+  // can retry rather than one that hangs.
+  if (hasUnclaimedGuardianForm(CONTACT_FORMS)) {
     return {
       ok: false,
       error:
@@ -375,97 +320,50 @@ async function handleContactRecordPrompt({
     };
   }
 
-  const requestId = uuid();
-
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      const pending = pendingContactPrompts.get(requestId);
-      if (!pending) {
-        return;
-      }
-      log.warn({ requestId, operation }, "Contact record prompt timed out");
-      expireContactPrompt(requestId, pending, "Prompt timed out");
-    }, timeoutMs ?? CONTACT_FORM_DEFAULT_TIMEOUT_MS);
-
-    pendingContactPrompts.set(requestId, { resolve, timer, verify: false });
-
-    broadcastMessage({
-      type: "contact_record_request",
-      requestId,
-      operation,
-      contactId,
-      currentDisplayName,
-      currentNotes,
-      channels,
-      displayName,
-      notes,
-      notesProposed,
-      label,
-      description,
-    });
-
-    log.info(
-      { requestId, operation, contactId },
-      "Contact record prompt broadcast",
-    );
+  return openGuardianForm<ContactPromptResult>({
+    kind: RECORD_FORM,
+    timeoutMs,
+    logContext: { operation, contactId },
+    broadcast: {
+      open: (requestId) =>
+        broadcastMessage({
+          type: "contact_record_request",
+          requestId,
+          operation,
+          contactId,
+          currentDisplayName,
+          currentNotes,
+          channels,
+          displayName,
+          notes,
+          notesProposed,
+          label,
+          description,
+        }),
+      closed: announceContactFormClosed,
+    },
   });
 }
 
-/**
- * Claim a pending form so exactly one submission can write.
- *
- * The daemon holds the only record of which forms are still open, so it is the
- * one place that can decide a race between two clients answering the same
- * broadcast. First caller wins; the rest are told why they lost, so the
- * gateway can tell "somebody already answered this" (leave their answer alone)
- * apart from "no such form" (expired or already resolved, so nothing should be
- * written at all).
- */
 function claimContactPrompt({ body = {} }: RouteHandlerArgs): {
   claimed: boolean;
   reason?: "already_claimed" | "unknown";
   settleMs?: number;
 } {
   const { requestId } = ContactPromptFlagsParams.parse(body);
-  const pending = pendingContactPrompts.get(requestId);
-  if (!pending) {
-    return { claimed: false, reason: "unknown" };
-  }
-  if (pending.claimed) {
-    return { claimed: false, reason: "already_claimed" };
-  }
-  pending.claimed = true;
-  // The form has been answered, so swap its open-for-answers deadline for a
-  // bounded settle window while the write reports back.
-  clearTimeout(pending.timer);
-  pending.timer = setTimeout(() => {
-    log.warn(
-      { requestId },
-      "Contact prompt claimed but never settled; the write never reported back",
-    );
-    expireContactPrompt(
-      requestId,
-      pending,
-      "The submitted form never completed",
-    );
-  }, CONTACT_FORM_SETTLE_MS);
-  // The claimer needs the window too: it is how long its write has to report
-  // back before the caller gives up, and it should not have to know the number
-  // independently.
-  return { claimed: true, settleMs: CONTACT_FORM_SETTLE_MS };
+  return claimGuardianForm(requestId);
 }
 
 /**
- * Read-only flags for a pending prompt. The gateway asks this after it
- * writes the channel so a `--verify` prompt can attest without the client
- * having to echo the flag on submit.
+ * Read-only flags for a pending prompt. The gateway asks this after it writes
+ * the channel so a `--verify` prompt can attest without the client having to
+ * echo the flag on submit.
  */
 function readContactPromptFlags({ body = {} }: RouteHandlerArgs): {
   verify: boolean;
 } {
   const { requestId } = ContactPromptFlagsParams.parse(body);
-  const pending = pendingContactPrompts.get(requestId);
-  return { verify: pending?.verify === true };
+  return { verify: getGuardianFormMeta(requestId)?.verify === true };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -40,6 +40,7 @@ import {
   openGuardianForm,
   resolveGuardianForm,
 } from "../guardian-form-registry.js";
+import { claimForm, resolveFormFromCallback } from "./guardian-form-routes.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 /** Form kinds on the guardian-form rail that carry a contact card. */
@@ -87,52 +88,6 @@ function announceContactFormClosed(
   reason: GuardianFormClosedReason,
 ): void {
   broadcastMessage({ type: "contact_form_closed", requestId, reason });
-}
-
-/**
- * Called by the gateway after it writes the contact and channel. Resolves the
- * parked promise so the CLI's `contacts/prompt` IPC call returns.
- */
-function resolveContactPrompt({ body = {} }: RouteHandlerArgs): {
-  resolved: boolean;
-} {
-  const {
-    requestId,
-    contactId,
-    channelId,
-    channelType,
-    address,
-    verified,
-    notesSaved,
-    nothingWritten,
-    error,
-  } = body as {
-    requestId: string;
-    contactId?: string;
-    channelId?: string;
-    channelType?: string;
-    address?: string;
-    verified?: boolean;
-    notesSaved?: boolean;
-    nothingWritten?: boolean;
-    error?: string;
-  };
-
-  return resolveGuardianForm(
-    requestId,
-    error
-      ? { ok: false, error }
-      : {
-          ok: true,
-          contactId,
-          channelId,
-          channelType,
-          address,
-          verified,
-          notesSaved,
-          nothingWritten,
-        },
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -345,15 +300,6 @@ async function handleContactRecordPrompt({
   });
 }
 
-function claimContactPrompt({ body = {} }: RouteHandlerArgs): {
-  claimed: boolean;
-  reason?: "already_claimed" | "unknown";
-  settleMs?: number;
-} {
-  const { requestId } = ContactPromptFlagsParams.parse(body);
-  return claimGuardianForm(requestId);
-}
-
 /**
  * Read-only flags for a pending prompt. The gateway asks this after it writes
  * the channel so a `--verify` prompt can attest without the client having to
@@ -425,7 +371,7 @@ export const CONTACT_PROMPT_ROUTES: RouteDefinition[] = [
       requiredScopes: ["settings.write"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
-    handler: resolveContactPrompt,
+    handler: resolveFormFromCallback,
     summary: "Gateway callback: resolve a pending contact prompt",
     description:
       "Called by the gateway after it writes the contact and channel. Unblocks the waiting contacts/prompt call.",
@@ -439,7 +385,7 @@ export const CONTACT_PROMPT_ROUTES: RouteDefinition[] = [
       requiredScopes: ["settings.write"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
-    handler: claimContactPrompt,
+    handler: claimForm,
     summary: "Claim a pending contact form for one submission",
     description:
       "Marks a pending form as answered so a second client submitting the same form writes nothing. Returns claimed=false with reason 'already_claimed' when somebody got there first, or 'unknown' when no such form is pending. A granted claim carries the window its write has to report back in.",

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -33,12 +33,10 @@ import { GUARDIAN_FORM_MAX_TIMEOUT_MS } from "../../util/guardian-form-timeouts.
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
-  claimGuardianForm,
   getGuardianFormMeta,
   type GuardianFormClosedReason,
   hasUnclaimedGuardianForm,
   openGuardianForm,
-  resolveGuardianForm,
 } from "../guardian-form-registry.js";
 import { claimForm, resolveFormFromCallback } from "./guardian-form-routes.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";

--- a/assistant/src/runtime/routes/guardian-form-routes.ts
+++ b/assistant/src/runtime/routes/guardian-form-routes.ts
@@ -1,0 +1,106 @@
+/**
+ * The form-agnostic half of the guardian-form IPC surface.
+ *
+ * A form's own route carries its schema and its wire events; these two are the
+ * same for every form, so a new one gets them without adding routes of its own:
+ *
+ *   - `guardian_form_claim`   the writer takes the form before writing
+ *   - `resolve_guardian_form` the writer reports back, unblocking the command
+ *
+ * The contact forms predate these and keep their own `contact_prompt_claim` /
+ * `resolve_contact_prompt` names, because the gateway that calls them ships
+ * separately from the daemon and an older one still uses the old names. New
+ * forms should use these.
+ */
+
+import { z } from "zod";
+
+import {
+  claimGuardianForm,
+  type GuardianFormResult,
+  resolveGuardianForm,
+} from "../guardian-form-registry.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const RequestIdParams = z.object({
+  requestId: z.string().describe("The pending form's id."),
+});
+
+/**
+ * Hand a writer's report to the call parked on the form.
+ *
+ * Everything but `requestId` and `error` is passed through untouched, so a
+ * form's result is whatever its writer chose to send. An `error` is what makes
+ * it a failure; there is no other flag.
+ */
+export function resolveFormFromCallback({ body = {} }: RouteHandlerArgs): {
+  resolved: boolean;
+} {
+  const {
+    requestId,
+    error,
+    ...rest
+  }: { requestId: string; error?: string } & Record<string, unknown> =
+    body as never;
+
+  const result: GuardianFormResult = error
+    ? { ok: false, error }
+    : { ok: true, ...rest };
+  return resolveGuardianForm(requestId, result);
+}
+
+export function claimForm({ body = {} }: RouteHandlerArgs): {
+  claimed: boolean;
+  reason?: "already_claimed" | "unknown";
+  settleMs?: number;
+} {
+  const { requestId } = RequestIdParams.parse(body);
+  return claimGuardianForm(requestId);
+}
+
+const CLAIM_RESPONSE = z.object({
+  claimed: z.boolean(),
+  reason: z.enum(["already_claimed", "unknown"]).optional(),
+  settleMs: z
+    .number()
+    .optional()
+    .describe(
+      "How long a granted claim has to report its write back before the waiting call gives up.",
+    ),
+});
+
+export const GUARDIAN_FORM_ROUTES: RouteDefinition[] = [
+  {
+    operationId: "guardian_form_claim",
+    endpoint: "guardian_form_claim",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: claimForm,
+    summary: "Claim a pending guardian form for one submission",
+    description:
+      "Marks a pending form as answered so a second client submitting the same form writes nothing. Returns claimed=false with reason 'already_claimed' when somebody got there first, or 'unknown' when no such form is pending. A granted claim carries the window its write has to report back in.",
+    tags: ["guardian-forms"],
+    requestBody: RequestIdParams,
+    responseBody: CLAIM_RESPONSE,
+  },
+  {
+    operationId: "resolve_guardian_form",
+    endpoint: "resolve_guardian_form",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    handler: resolveFormFromCallback,
+    summary: "Report a guardian form's outcome back to the waiting command",
+    description:
+      "Called by the writer once it has committed (or failed). Fields other than requestId and error are passed through to the parked caller untouched; an error makes the outcome a failure.",
+    tags: ["guardian-forms"],
+    requestBody: RequestIdParams.catchall(z.unknown()),
+    responseBody: z.object({ resolved: z.boolean() }),
+  },
+];

--- a/assistant/src/runtime/routes/guardian-form-routes.ts
+++ b/assistant/src/runtime/routes/guardian-form-routes.ts
@@ -27,6 +27,15 @@ const RequestIdParams = z.object({
   requestId: z.string().describe("The pending form's id."),
 });
 
+const ClaimParams = RequestIdParams.extend({
+  kind: z
+    .string()
+    .optional()
+    .describe(
+      "The form the caller believes it is writing for. Rejected when it is not what the id is holding. Omitted by callers that predate the check.",
+    ),
+});
+
 /**
  * Hand a writer's report to the call parked on the form.
  *
@@ -52,16 +61,16 @@ export function resolveFormFromCallback({ body = {} }: RouteHandlerArgs): {
 
 export function claimForm({ body = {} }: RouteHandlerArgs): {
   claimed: boolean;
-  reason?: "already_claimed" | "unknown";
+  reason?: "already_claimed" | "unknown" | "wrong_kind";
   settleMs?: number;
 } {
-  const { requestId } = RequestIdParams.parse(body);
-  return claimGuardianForm(requestId);
+  const { requestId, kind } = ClaimParams.parse(body);
+  return claimGuardianForm(requestId, kind);
 }
 
 const CLAIM_RESPONSE = z.object({
   claimed: z.boolean(),
-  reason: z.enum(["already_claimed", "unknown"]).optional(),
+  reason: z.enum(["already_claimed", "unknown", "wrong_kind"]).optional(),
   settleMs: z
     .number()
     .optional()
@@ -82,9 +91,9 @@ export const GUARDIAN_FORM_ROUTES: RouteDefinition[] = [
     handler: claimForm,
     summary: "Claim a pending guardian form for one submission",
     description:
-      "Marks a pending form as answered so a second client submitting the same form writes nothing. Returns claimed=false with reason 'already_claimed' when somebody got there first, or 'unknown' when no such form is pending. A granted claim carries the window its write has to report back in.",
+      "Marks a pending form as answered so a second client submitting the same form writes nothing. Returns claimed=false with reason 'already_claimed' when somebody got there first, 'unknown' when no such form is pending, or 'wrong_kind' when the id belongs to a different form than the caller named. A granted claim carries the window its write has to report back in.",
     tags: ["guardian-forms"],
-    requestBody: RequestIdParams,
+    requestBody: ClaimParams,
     responseBody: CLAIM_RESPONSE,
   },
   {

--- a/assistant/src/runtime/routes/guardian-form-routes.ts
+++ b/assistant/src/runtime/routes/guardian-form-routes.ts
@@ -15,12 +15,12 @@
 
 import { z } from "zod";
 
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   claimGuardianForm,
   type GuardianFormResult,
   resolveGuardianForm,
 } from "../guardian-form-registry.js";
-import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 const RequestIdParams = z.object({

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -43,6 +43,7 @@ import { ROUTES as CHATGPT_SUBSCRIPTION_AUTH_ROUTES } from "./chatgpt-subscripti
 import { ROUTES as CLIENT_ROUTES } from "./client-routes.js";
 import { ROUTES as CONSOLIDATION_ROUTES } from "./consolidation-routes.js";
 import { CONTACT_PROMPT_ROUTES } from "./contact-prompt-routes.js";
+import { GUARDIAN_FORM_ROUTES } from "./guardian-form-routes.js";
 import { ROUTES as CONTACT_ROUTES } from "./contact-routes.js";
 import { ROUTES as CONTENT_SOURCE_ROUTES } from "./content-source-routes.js";
 import { ROUTES as CONVERSATION_ATTENTION_ROUTES } from "./conversation-attention-routes.js";
@@ -193,6 +194,7 @@ export const ROUTES: RouteDefinition[] = [
   ...CLIENT_ROUTES,
   ...CONTENT_SOURCE_ROUTES,
   ...CONTACT_PROMPT_ROUTES,
+  ...GUARDIAN_FORM_ROUTES,
   ...CONTACT_ROUTES,
   ...CONVERSATION_ATTENTION_ROUTES,
   ...CONVERSATION_CLI_ROUTES,

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -43,7 +43,6 @@ import { ROUTES as CHATGPT_SUBSCRIPTION_AUTH_ROUTES } from "./chatgpt-subscripti
 import { ROUTES as CLIENT_ROUTES } from "./client-routes.js";
 import { ROUTES as CONSOLIDATION_ROUTES } from "./consolidation-routes.js";
 import { CONTACT_PROMPT_ROUTES } from "./contact-prompt-routes.js";
-import { GUARDIAN_FORM_ROUTES } from "./guardian-form-routes.js";
 import { ROUTES as CONTACT_ROUTES } from "./contact-routes.js";
 import { ROUTES as CONTENT_SOURCE_ROUTES } from "./content-source-routes.js";
 import { ROUTES as CONVERSATION_ATTENTION_ROUTES } from "./conversation-attention-routes.js";
@@ -75,6 +74,7 @@ import { ROUTES as GATEWAY_STATUS_ROUTES } from "./gateway-status-routes.js";
 import { ROUTES as GLOBAL_SEARCH_ROUTES } from "./global-search-routes.js";
 import { ROUTES as GROUP_ROUTES } from "./group-routes.js";
 import { ROUTES as GUARDIAN_ACTION_ROUTES } from "./guardian-action-routes.js";
+import { GUARDIAN_FORM_ROUTES } from "./guardian-form-routes.js";
 import { ROUTES as HEARTBEAT_ROUTES } from "./heartbeat-routes.js";
 import { ROUTES as HOME_FEED_ROUTES } from "./home-feed-routes.js";
 import { ROUTES as HOME_STATE_ROUTES } from "./home-state-routes.js";

--- a/assistant/src/util/guardian-form-timeouts.ts
+++ b/assistant/src/util/guardian-form-timeouts.ts
@@ -1,6 +1,6 @@
 /**
- * Timings for the contact forms the guardian fills in their app, shared by the
- * CLI that waits and the daemon route that holds the form open.
+ * Timings for the forms the guardian fills in their app, shared by the CLI
+ * that waits and the registry that holds the form open.
  *
  * One budget split across a socket and a timer, so the numbers live together
  * and the caller's wait is derived from the deadlines rather than written down
@@ -13,13 +13,13 @@
  */
 
 /** Default time a form stays open for an answer (5 min). */
-export const CONTACT_FORM_DEFAULT_TIMEOUT_MS = 300_000;
+export const GUARDIAN_FORM_DEFAULT_TIMEOUT_MS = 300_000;
 
 /**
  * Ceiling on a caller-supplied wait (1 hour), so a bad value cannot park a
  * pending form indefinitely.
  */
-export const CONTACT_FORM_MAX_TIMEOUT_MS = 3_600_000;
+export const GUARDIAN_FORM_MAX_TIMEOUT_MS = 3_600_000;
 
 /**
  * How long a claimed form is held while its write settles (3 min).
@@ -30,10 +30,10 @@ export const CONTACT_FORM_MAX_TIMEOUT_MS = 3_600_000;
  * makes three in sequence (mirror probe, mirror delete, then the resolve
  * back).
  */
-export const CONTACT_FORM_SETTLE_MS = 180_000;
+export const GUARDIAN_FORM_SETTLE_MS = 180_000;
 
 /** Slack on top of the deadlines, so the socket is never the first to give up. */
-const CONTACT_FORM_TRANSPORT_BUFFER_MS = 10_000;
+const GUARDIAN_FORM_TRANSPORT_BUFFER_MS = 10_000;
 
 /**
  * How long a caller waits on a form that stays open for `timeoutMs`.
@@ -43,6 +43,8 @@ const CONTACT_FORM_TRANSPORT_BUFFER_MS = 10_000;
  * first reports a failure while the write proceeds, which for a delete means a
  * contact removed against a command that reported nothing happened.
  */
-export function contactFormCallBudgetMs(timeoutMs: number): number {
-  return timeoutMs + CONTACT_FORM_SETTLE_MS + CONTACT_FORM_TRANSPORT_BUFFER_MS;
+export function guardianFormCallBudgetMs(timeoutMs: number): number {
+  return (
+    timeoutMs + GUARDIAN_FORM_SETTLE_MS + GUARDIAN_FORM_TRANSPORT_BUFFER_MS
+  );
 }

--- a/docs/guardian-forms.md
+++ b/docs/guardian-forms.md
@@ -83,7 +83,9 @@ throwing; a throw is caught as a backstop and reported as a 500, which loses
 the status you meant.
 
 Whatever you put in `resolution` reaches the parked caller untouched, via the
-form-agnostic `resolve_guardian_form` callback. Contacts pin the older
+form-agnostic `resolve_guardian_form` callback, except `requestId` and
+`error`: those are the rail's, one addressing the callback and the other
+marking the outcome a failure. Contacts pin the older
 `resolve_contact_prompt` name, so pass `resolveOperation` only if you have the
 same reason.
 

--- a/docs/guardian-forms.md
+++ b/docs/guardian-forms.md
@@ -58,10 +58,13 @@ never rejects. Whatever the writer reports comes back to the caller verbatim.
 `submitGuardianForm`:
 
 ```ts
+if (body.cancelled === true) {
+  return submitGuardianForm({ requestId, cancelled: true, logContext });
+}
+
 return submitGuardianForm({
   requestId,
-  cancelled: body.cancelled === true,
-  logContext: { form: "my-feature.thing" },
+  logContext,
   write: async () => {
     try {
       const row = await doTheWrite(...);
@@ -73,8 +76,16 @@ return submitGuardianForm({
 });
 ```
 
-Classify expected failures into `failure` rather than throwing. A throw is
-caught as a backstop and reported as a 500, which loses the status you meant.
+A dismissal and a write are separate calls: the options type takes one or the
+other, so a caller cannot accidentally report "cancelled" over a form the
+guardian answered. Classify expected failures into `failure` rather than
+throwing; a throw is caught as a backstop and reported as a 500, which loses
+the status you meant.
+
+Whatever you put in `resolution` reaches the parked caller untouched, via the
+form-agnostic `resolve_guardian_form` callback. Contacts pin the older
+`resolve_contact_prompt` name, so pass `resolveOperation` only if you have the
+same reason.
 
 **3. Render the card.** Add the form event to the web client's pending
 interaction pipeline and give it a card. This is still per-form wiring; see

--- a/docs/guardian-forms.md
+++ b/docs/guardian-forms.md
@@ -1,0 +1,102 @@
+# Guardian forms
+
+A guardian form is how a CLI command asks a human to confirm something before
+it happens. The command parks, a form appears in the guardian's app, and the
+write happens only if somebody answers it.
+
+The property that makes this worth having: **the daemon does not write.** With
+nobody at a form, nothing is written and the command times out. That is
+enforced by where the code lives, not by a policy check.
+
+## The rail
+
+```
+CLI            daemon                guardian's app          gateway
+ |  command      |                        |                     |
+ |------------->|  openGuardianForm       |                     |
+ |  (parks)     |----- form event ------->|                     |
+ |              |                         |  guardian answers   |
+ |              |                         |--- POST ----------->| submitGuardianForm
+ |              |                         |                     |   claim
+ |              |                         |                     |   write
+ |              |<---- resolve callback --------------------- |
+ |<-- result ---|                         |                     |
+```
+
+Two files own everything that is the same for every form:
+
+- `assistant/src/runtime/guardian-form-registry.ts` holds the open forms, the
+  deadlines, the claim, and the settle window.
+- `gateway/src/http/routes/guardian-form-submit.ts` takes the claim, runs the
+  write, and reports the outcome back to the parked call.
+
+`assistant/src/runtime/routes/contact-prompt-routes.ts` and
+`gateway/src/http/routes/contact-prompt.ts` are the worked example.
+
+## Adding a form
+
+**1. Park the command.** In a daemon route, call `openGuardianForm` with a kind,
+how to broadcast the form, and how to take it down:
+
+```ts
+return openGuardianForm<MyResult>({
+  kind: "my-feature.thing",
+  timeoutMs,
+  logContext: { operation },
+  broadcast: {
+    open: (requestId) => broadcastMessage({ type: "my_form_request", requestId, ... }),
+    closed: (requestId, reason) =>
+      broadcastMessage({ type: "my_form_closed", requestId, reason }),
+  },
+});
+```
+
+The returned promise settles on an answer, a dismissal, or the deadline, and
+never rejects. Whatever the writer reports comes back to the caller verbatim.
+
+**2. Write on submit.** In a gateway route, hand the write to
+`submitGuardianForm`:
+
+```ts
+return submitGuardianForm({
+  requestId,
+  cancelled: body.cancelled === true,
+  logContext: { form: "my-feature.thing" },
+  write: async () => {
+    try {
+      const row = await doTheWrite(...);
+      return { resolution: { id: row.id } };
+    } catch (err) {
+      return { failure: { error: "...", status: 422 } };
+    }
+  },
+});
+```
+
+Classify expected failures into `failure` rather than throwing. A throw is
+caught as a backstop and reported as a 500, which loses the status you meant.
+
+**3. Render the card.** Add the form event to the web client's pending
+interaction pipeline and give it a card. This is still per-form wiring; see
+`clients/web/src/domains/chat/components/contact-record-card.tsx`.
+
+## Things that are easy to get wrong
+
+- **The claim is what makes concurrency safe.** The form goes to every
+  connected client, so more than one can answer it. The first claim wins, and
+  the claim is also what stops the answer deadline: an answer landing near the
+  deadline must not race the write it started. Do not write before claiming,
+  and do not reimplement the claim.
+- **A dismissal takes the same claim as a write.** Otherwise one client
+  dismissing while another is mid-submit tells the caller nothing happened
+  while the other answer is still on its way to the database.
+- **A claimed form owes a report.** Once claimed, the caller is waiting on you.
+  A failure has to be reported too, or the command sits until its settle timer
+  while the client's retry comes back as a duplicate.
+- **Only the gateway can offer the "daemon never writes" guarantee today.** The
+  rail's safety comes from the write living in a different process that the
+  client reaches directly. A form over something the daemon itself owns would
+  need its own enforcement story; do not assume this one carries over.
+- **`hasUnclaimedGuardianForm` takes the kinds to check.** Pass only the kinds
+  whose cards actually collide. Sweeping the whole registry would let any
+  pending form block every other one.

--- a/gateway/src/__tests__/contact-form-kinds.test.ts
+++ b/gateway/src/__tests__/contact-form-kinds.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Pins the contact form kinds the gateway claims under.
+ *
+ * The daemon opens its contact forms under these same strings and rejects a
+ * claim naming a different one. Nothing at compile time links the two
+ * packages, so a rename on one side alone would show up only as contact forms
+ * failing to submit against a running daemon. The daemon has the matching
+ * test; both must be edited together for a rename to land.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { ADDRESS_FORM, RECORD_FORM } from "../http/routes/contact-prompt.js";
+
+describe("contact form kinds", () => {
+  test("match the strings the daemon opens its forms under", () => {
+    expect(ADDRESS_FORM).toBe("contacts.address");
+    expect(RECORD_FORM).toBe("contacts.record");
+  });
+});

--- a/gateway/src/__tests__/guardian-form-submit.test.ts
+++ b/gateway/src/__tests__/guardian-form-submit.test.ts
@@ -180,3 +180,32 @@ describe("submitGuardianForm", () => {
     ]);
   });
 });
+
+describe("reserved result keys", () => {
+  test("a stray error on a success does not become a cancellation", async () => {
+    // resolveFormFromCallback reads any truthy `error` as a failure, so a
+    // result carrying its own would report a cancellation over a write that
+    // committed, and drop the rest of the result with it.
+    await submitGuardianForm({
+      requestId: "req-9",
+      write: async () => ({
+        resolution: { error: "a field of my own", id: "row-2" },
+      }),
+    });
+
+    expect(resolveCall()?.body).toEqual({ requestId: "req-9", id: "row-2" });
+  });
+
+  test("the form it is writing for is named on the claim", async () => {
+    await submitGuardianForm({
+      requestId: "req-10",
+      formKind: "my.form",
+      write: async () => ({ resolution: {} }),
+    });
+
+    expect(calls[0]).toEqual({
+      method: "guardian_form_claim",
+      body: { requestId: "req-10", kind: "my.form" },
+    });
+  });
+});

--- a/gateway/src/__tests__/guardian-form-submit.test.ts
+++ b/gateway/src/__tests__/guardian-form-submit.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the write half of the guardian-form rail.
+ *
+ * These pin the parts every form depends on and none of them implements: the
+ * claim is taken before the write, a client that lost the race is told
+ * something it can act on, and every outcome reports back so the parked
+ * command never hangs on a write that already happened.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface IpcCall {
+  method: string;
+  body: Record<string, unknown>;
+}
+
+let calls: IpcCall[] = [];
+let claimAnswer: Record<string, unknown> = { claimed: true, settleMs: 5_000 };
+let claimThrows = false;
+
+const ipcMock = mock(
+  async (method: string, options?: { body?: Record<string, unknown> }) => {
+    calls.push({ method, body: options?.body ?? {} });
+    if (method.includes("claim")) {
+      if (claimThrows) {
+        throw new Error("socket closed");
+      }
+      return claimAnswer;
+    }
+    return { resolved: true };
+  },
+);
+
+const actualAssistantClient = await import("../ipc/assistant-client.js");
+mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
+  ipcCallAssistant: ipcMock,
+}));
+
+const { submitGuardianForm } =
+  await import("../http/routes/guardian-form-submit.js");
+
+const resolveCall = () => calls.find((c) => c.method.includes("resolve"));
+
+beforeEach(() => {
+  calls = [];
+  claimAnswer = { claimed: true, settleMs: 5_000 };
+  claimThrows = false;
+});
+
+describe("submitGuardianForm", () => {
+  test("claims before writing, then reports the writer's fields", async () => {
+    const order: string[] = [];
+    ipcMock.mockImplementationOnce(async (method: string) => {
+      order.push(method);
+      return { claimed: true, settleMs: 5_000 };
+    });
+
+    const res = await submitGuardianForm({
+      requestId: "req-1",
+      write: async () => {
+        order.push("write");
+        return { resolution: { id: "row-7", rows: 3 } };
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ accepted: true });
+    expect(order).toEqual(["guardian_form_claim", "write"]);
+    expect(resolveCall()?.body).toEqual({
+      requestId: "req-1",
+      id: "row-7",
+      rows: 3,
+    });
+  });
+
+  test("the rail's requestId survives a result that carries its own", async () => {
+    // A form whose result happened to carry `requestId` would otherwise
+    // redirect its own callback, and its caller would time out over a write
+    // that committed.
+    await submitGuardianForm({
+      requestId: "req-real",
+      write: async () => ({
+        resolution: { requestId: "req-somebody-else", id: "row-1" },
+      }),
+    });
+
+    expect(resolveCall()?.body.requestId).toBe("req-real");
+  });
+
+  test("a dismissal reports without running the write", async () => {
+    const write = mock(async () => ({ resolution: {} }));
+
+    const res = await submitGuardianForm({
+      requestId: "req-2",
+      cancelled: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(write).not.toHaveBeenCalled();
+    expect(resolveCall()?.body).toEqual({
+      requestId: "req-2",
+      error: "Cancelled by user",
+    });
+  });
+
+  test("a failure the writer classified keeps its own status", async () => {
+    const res = await submitGuardianForm({
+      requestId: "req-3",
+      write: async () => ({
+        failure: { error: "Contact not found", status: 404 },
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(resolveCall()?.body).toEqual({
+      requestId: "req-3",
+      error: "Contact not found",
+    });
+  });
+
+  test("a write that throws still reports, so the command does not hang", async () => {
+    const res = await submitGuardianForm({
+      requestId: "req-4",
+      write: async () => {
+        throw new Error("unexpected");
+      },
+    });
+
+    expect(res.status).toBe(500);
+    expect(resolveCall()?.body).toEqual({
+      requestId: "req-4",
+      error: "The write failed",
+    });
+  });
+
+  test("losing the claim to another client reads as success, and writes nothing", async () => {
+    claimAnswer = { claimed: false, reason: "already_claimed" };
+    const write = mock(async () => ({ resolution: {} }));
+
+    const res = await submitGuardianForm({ requestId: "req-5", write });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ accepted: true, duplicate: true });
+    expect(write).not.toHaveBeenCalled();
+    expect(resolveCall()).toBeUndefined();
+  });
+
+  test("an unreachable assistant is a 503 the client can retry", async () => {
+    claimThrows = true;
+    const write = mock(async () => ({ resolution: {} }));
+
+    const res = await submitGuardianForm({ requestId: "req-6", write });
+
+    expect(res.status).toBe(503);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  test("a form nobody is waiting on is a 409", async () => {
+    claimAnswer = { claimed: false, reason: "unknown" };
+
+    const res = await submitGuardianForm({
+      requestId: "req-7",
+      write: async () => ({ resolution: {} }),
+    });
+
+    expect(res.status).toBe(409);
+  });
+
+  test("a form can pin its own callback operations", async () => {
+    await submitGuardianForm({
+      requestId: "req-8",
+      claimOperation: "contact_prompt_claim",
+      resolveOperation: "resolve_contact_prompt",
+      write: async () => ({ resolution: { contactId: "c1" } }),
+    });
+
+    expect(calls.map((c) => c.method)).toEqual([
+      "contact_prompt_claim",
+      "resolve_contact_prompt",
+    ]);
+  });
+});

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -36,9 +36,15 @@ import {
 
 const log = getLogger("contact-prompt");
 
-/** Guardian-form kinds these routes write for, matching the daemon's. */
-const ADDRESS_FORM = "contacts.address";
-const RECORD_FORM = "contacts.record";
+/**
+ * Guardian-form kinds these routes write for.
+ *
+ * The daemon opens its forms under the same strings and now rejects a claim
+ * that names a different one, so these are a cross-package contract, pinned on
+ * both sides by `contact-form-kinds.test.ts`.
+ */
+export const ADDRESS_FORM = "contacts.address";
+export const RECORD_FORM = "contacts.record";
 
 /**
  * The contact forms' own IPC names, which predate the form-agnostic pair. Kept
@@ -149,6 +155,7 @@ export async function handleContactPromptSubmit(
       requestId,
       cancelled: true,
       logContext: { form: ADDRESS_FORM },
+      formKind: ADDRESS_FORM,
       ...CONTACT_FORM_IPC,
     });
   }
@@ -156,6 +163,7 @@ export async function handleContactPromptSubmit(
   return submitGuardianForm({
     requestId,
     logContext: { form: ADDRESS_FORM, channelType },
+    formKind: ADDRESS_FORM,
     ...CONTACT_FORM_IPC,
     write: () =>
       bindSubmittedChannel({
@@ -603,6 +611,7 @@ export async function handleContactRecordSubmit(
       requestId,
       cancelled: true,
       logContext: { form: RECORD_FORM },
+      formKind: RECORD_FORM,
       ...CONTACT_FORM_IPC,
     });
   }
@@ -637,6 +646,7 @@ export async function handleContactRecordSubmit(
   return submitGuardianForm({
     requestId,
     logContext: { form: RECORD_FORM, operation, contactId },
+    formKind: RECORD_FORM,
     ...CONTACT_FORM_IPC,
     write: () =>
       writeContactRecord({

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -40,6 +40,15 @@ const log = getLogger("contact-prompt");
 const ADDRESS_FORM = "contacts.address";
 const RECORD_FORM = "contacts.record";
 
+/**
+ * The contact forms' own IPC names, which predate the form-agnostic pair. Kept
+ * so a gateway running against an older daemon still reaches routes it serves.
+ */
+const CONTACT_FORM_IPC = {
+  claimOperation: "contact_prompt_claim",
+  resolveOperation: "resolve_contact_prompt",
+} as const;
+
 let store: ContactStore | null = null;
 
 function getStore(): ContactStore {
@@ -140,12 +149,14 @@ export async function handleContactPromptSubmit(
       requestId,
       cancelled: true,
       logContext: { form: ADDRESS_FORM },
+      ...CONTACT_FORM_IPC,
     });
   }
 
   return submitGuardianForm({
     requestId,
     logContext: { form: ADDRESS_FORM, channelType },
+    ...CONTACT_FORM_IPC,
     write: () =>
       bindSubmittedChannel({
         requestId,
@@ -592,6 +603,7 @@ export async function handleContactRecordSubmit(
       requestId,
       cancelled: true,
       logContext: { form: RECORD_FORM },
+      ...CONTACT_FORM_IPC,
     });
   }
 
@@ -625,6 +637,7 @@ export async function handleContactRecordSubmit(
   return submitGuardianForm({
     requestId,
     logContext: { form: RECORD_FORM, operation, contactId },
+    ...CONTACT_FORM_IPC,
     write: () =>
       writeContactRecord({
         requestId,

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -29,8 +29,16 @@ import {
   deleteContactCore,
   upsertContactRecordCore,
 } from "./contacts-control-plane-proxy.js";
+import {
+  type GuardianFormWriteOutcome,
+  submitGuardianForm,
+} from "./guardian-form-submit.js";
 
 const log = getLogger("contact-prompt");
+
+/** Guardian-form kinds these routes write for, matching the daemon's. */
+const ADDRESS_FORM = "contacts.address";
+const RECORD_FORM = "contacts.record";
 
 let store: ContactStore | null = null;
 
@@ -127,25 +135,44 @@ export async function handleContactPromptSubmit(
     }
   }
 
-  // Claim before writing anything, exactly as the record form does: the form
-  // went to every connected client, and an answer landing near the deadline
-  // must stop that deadline rather than race the write it started. A dismissal
-  // takes the same claim, so it cannot report "cancelled" over an answer that
-  // is already committing.
-  const claim = await claimPrompt(requestId);
-  if (!claim.claimed) {
-    log.warn(
-      { requestId, reason: claim.reason },
-      "contact-prompt-submit: submission did not get the claim",
-    );
-    return lostClaimResponse(claim.reason);
-  }
-  const settleDeadline = Date.now() + (claim.settleMs ?? DEFAULT_SETTLE_MS);
-
   if (body.cancelled === true) {
-    await reportFailure(requestId, "Cancelled by user", settleDeadline);
-    return Response.json({ accepted: true });
+    return submitGuardianForm({
+      requestId,
+      cancelled: true,
+      logContext: { form: ADDRESS_FORM },
+    });
   }
+
+  return submitGuardianForm({
+    requestId,
+    logContext: { form: ADDRESS_FORM, channelType },
+    write: () =>
+      bindSubmittedChannel({
+        requestId,
+        address,
+        channelType,
+        role,
+        displayName,
+        verify: body.verify,
+      }),
+  });
+}
+
+/**
+ * Bind the address the guardian submitted to a contact and a channel.
+ *
+ * Runs with the form's claim already held, so the submission it is writing is
+ * the only one that will land.
+ */
+async function bindSubmittedChannel(input: {
+  requestId: string;
+  address: string;
+  channelType: string;
+  role?: "guardian" | "trusted-contact" | "unknown";
+  displayName?: string;
+  verify?: boolean;
+}): Promise<GuardianFormWriteOutcome> {
+  const { requestId, address, channelType, role, displayName } = input;
 
   const normalizedAddress =
     canonicalizeInboundIdentity(channelType, address) ?? address.trim();
@@ -250,19 +277,18 @@ export async function handleContactPromptSubmit(
           { channelType, address: normalizedAddress, contactId },
           "contact-prompt-submit: channel resolution failed after upsert",
         );
-        return await channelResolutionError(requestId, settleDeadline);
+        return CHANNEL_RESOLUTION_FAILED;
       }
 
       // Non-guardian is fully resolved by upsertContact; skip the guardian-only
       // Phase 2 channel-creation block below and go straight to resolve.
-      return await resolveContactPrompt({
+      return await channelResolution({
         requestId,
         contactId,
         channelId,
         channelType,
         address: normalizedAddress,
-        verify: body.verify,
-        settleDeadline,
+        verify: input.verify,
       });
     }
 
@@ -325,18 +351,12 @@ export async function handleContactPromptSubmit(
         },
         "contact-prompt-submit: channel already assigned to another contact",
       );
-      await reportFailure(
-        requestId,
-        "Channel already assigned to another contact",
-        settleDeadline,
-      );
-      return Response.json(
-        {
-          accepted: false,
+      return {
+        failure: {
           error: "Channel already assigned to another contact",
+          status: 409,
         },
-        { status: 409 },
-      );
+      };
     } else {
       // Compensating delete — only remove the contact if we created it here.
       // "Stale over lost": delete gateway-first, then mirror the delete to
@@ -378,16 +398,9 @@ export async function handleContactPromptSubmit(
         );
         await rollbackCreatedContact();
 
-        // Notify daemon of failure so the CLI doesn't hang.
-        await reportFailure(
-          requestId,
-          "Failed to create contact channel",
-          settleDeadline,
-        );
-        return Response.json(
-          { accepted: false, error: "Failed to create contact channel" },
-          { status: 500 },
-        );
+        return {
+          failure: { error: "Failed to create contact channel", status: 500 },
+        };
       }
 
       if (!channelId) {
@@ -404,7 +417,7 @@ export async function handleContactPromptSubmit(
             body: { kind: "contacts_changed" },
           } as unknown as Record<string, unknown>).catch(() => {});
         }
-        return await channelResolutionError(requestId, settleDeadline);
+        return CHANNEL_RESOLUTION_FAILED;
       }
 
       log.info(
@@ -414,11 +427,7 @@ export async function handleContactPromptSubmit(
     }
   } catch (err) {
     log.error({ err, requestId }, "contact-prompt-submit: DB error");
-    await reportFailure(requestId, "Database error", settleDeadline);
-    return Response.json(
-      { accepted: false, error: "Database error" },
-      { status: 500 },
-    );
+    return { failure: { error: "Database error", status: 500 } };
   }
 
   // Invalidate the daemon guardian-id/role caches after a gateway-owned
@@ -427,37 +436,26 @@ export async function handleContactPromptSubmit(
     body: { kind: "contacts_changed" },
   } as unknown as Record<string, unknown>).catch(() => {});
 
-  return await resolveContactPrompt({
+  return await channelResolution({
     requestId,
     contactId,
     channelId,
     channelType,
     address: normalizedAddress,
-    verify: body.verify,
-    settleDeadline,
+    verify: input.verify,
   });
 }
 
 /**
- * Notify the daemon of a failed channel resolution and return 500. Used when the
- * gateway DB read can't find the just-bound channel — resolving the prompt with
- * an empty channelId would falsely report success for a channel-less contact.
+ * The read-back after a bind could not find the channel. Reporting an empty
+ * channelId would claim success for a channel-less contact.
  */
-async function channelResolutionError(
-  requestId: string,
-  deadline: number,
-): Promise<Response> {
-  await reportFailure(requestId, "Channel resolution failed", deadline);
-  return Response.json(
-    { accepted: false, error: "Channel resolution failed" },
-    { status: 500 },
-  );
-}
+const CHANNEL_RESOLUTION_FAILED: GuardianFormWriteOutcome = {
+  failure: { error: "Channel resolution failed", status: 500 },
+};
 
 /**
- * Notify the daemon to unblock the waiting contacts/prompt IPC call, then
- * return { accepted: true }. IPC failures are best-effort — they only mean the
- * CLI may time out, not that the write failed.
+ * Whether the guardian left the "mark verified" box checked.
  */
 async function promptWantsVerify(
   requestId: string,
@@ -485,15 +483,18 @@ async function promptWantsVerify(
   }
 }
 
-async function resolveContactPrompt(args: {
+/**
+ * The outcome for a committed channel bind, attesting it first if the guardian
+ * asked for that.
+ */
+async function channelResolution(args: {
   requestId: string;
   contactId: string;
   channelId: string;
   channelType: string;
   address: string;
   verify: boolean | undefined;
-  settleDeadline: number;
-}): Promise<Response> {
+}): Promise<GuardianFormWriteOutcome> {
   const { requestId, contactId, channelId, channelType, address } = args;
   // What the channel ends up as, not what was asked for: the guardian's box
   // decides, an attest that fails leaves it unverified, and an address that
@@ -507,10 +508,9 @@ async function resolveContactPrompt(args: {
       verified = (await getStore().markChannelVerified(channelId)) !== null;
     } catch (err) {
       // The binding is already committed, so a failed attest is a channel that
-      // exists as it stood, not a failed submission. Letting this throw would
-      // skip the report and park the command on a claimed form. Read the
-      // channel rather than assuming unverified: attesting one that already
-      // was leaves it verified, and reporting otherwise invents a downgrade.
+      // exists as it stood, not a failed submission. Read the channel rather
+      // than assuming unverified: attesting one that already was leaves it
+      // verified, and reporting otherwise invents a downgrade.
       log.error(
         { err, requestId, contactId, channelId },
         "contact-prompt-submit: attesting the channel threw",
@@ -526,30 +526,10 @@ async function resolveContactPrompt(args: {
   } else {
     verified = isChannelVerified(contactId, channelId);
   }
-  await reportResolution(
-    requestId,
-    { requestId, contactId, channelId, channelType, address, verified },
-    args.settleDeadline,
-  );
 
-  return Response.json({ accepted: true });
-}
-
-/**
- * Tell the waiting call that its form ended in an error.
- *
- * Claiming a form takes ownership of its ending, so a failure owes the caller
- * a report as much as a success does: a claimed form nobody reports on parks
- * the command until its settle timer, and the client's retry comes back as a
- * duplicate because the claim is still held. Retried on the same window a
- * committed write gets.
- */
-async function reportFailure(
-  requestId: string,
-  error: string,
-  deadline: number,
-): Promise<void> {
-  await reportResolution(requestId, { requestId, error }, deadline);
+  return {
+    resolution: { contactId, channelId, channelType, address, verified },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -608,20 +588,11 @@ export async function handleContactRecordSubmit(
   // mid-submit would otherwise tell the caller nothing happened while the
   // other answer was still on its way to the database.
   if (body.cancelled === true) {
-    const cancelClaim = await claimPrompt(requestId);
-    if (!cancelClaim.claimed) {
-      log.info(
-        { requestId, reason: cancelClaim.reason },
-        "contact-record-submit: dismissal did not get the claim",
-      );
-      return lostClaimResponse(cancelClaim.reason);
-    }
-    await reportResolution(
+    return submitGuardianForm({
       requestId,
-      { requestId, error: "Cancelled by user" },
-      Date.now() + (cancelClaim.settleMs ?? DEFAULT_SETTLE_MS),
-    );
-    return Response.json({ accepted: true });
+      cancelled: true,
+      logContext: { form: RECORD_FORM },
+    });
   }
 
   if (
@@ -651,18 +622,39 @@ export async function handleContactRecordSubmit(
   const displayName =
     typeof body.displayName === "string" ? body.displayName : undefined;
 
-  // Claim the form before writing. It is broadcast to every connected client,
-  // so a second one can answer it with the values it was seeded with and
-  // overwrite the answer the guardian actually gave on the first.
-  const claim = await claimPrompt(requestId);
-  if (!claim.claimed) {
-    log.warn(
-      { requestId, operation, reason: claim.reason },
-      "contact-record-submit: submission did not get the claim",
-    );
-    return lostClaimResponse(claim.reason);
-  }
-  const settleDeadline = Date.now() + (claim.settleMs ?? DEFAULT_SETTLE_MS);
+  return submitGuardianForm({
+    requestId,
+    logContext: { form: RECORD_FORM, operation, contactId },
+    write: () =>
+      writeContactRecord({
+        requestId,
+        operation,
+        contactId,
+        displayName,
+        notes: body.notes,
+        expectedChannels: Array.isArray(body.expectedChannels)
+          ? body.expectedChannels
+          : undefined,
+      }),
+  });
+}
+
+/**
+ * Apply the record write the guardian confirmed.
+ *
+ * Runs with the form's claim already held: the form is broadcast to every
+ * connected client, so without it a second one could answer with the values it
+ * was seeded with and overwrite the answer the guardian actually gave.
+ */
+async function writeContactRecord(input: {
+  requestId: string;
+  operation: "create" | "update" | "delete";
+  contactId?: string;
+  displayName?: string;
+  notes?: string | null;
+  expectedChannels?: Array<{ type: string; address: string }>;
+}): Promise<GuardianFormWriteOutcome> {
+  const { requestId, operation, contactId, displayName, notes } = input;
 
   try {
     if (operation === "delete") {
@@ -671,14 +663,9 @@ export async function handleContactRecordSubmit(
       // the contact's channels in the same transaction as the delete, so a
       // channel reparented in between (an invite redeemed, say) is not
       // cascaded away unseen.
-      await deleteContactCore(
-        contactId!,
-        Array.isArray(body.expectedChannels)
-          ? body.expectedChannels
-          : undefined,
-      );
+      await deleteContactCore(contactId!, input.expectedChannels);
       log.info({ requestId, contactId }, "contact-record-submit: deleted");
-      return await resolveRecordPrompt(requestId, contactId!, settleDeadline);
+      return { resolution: { contactId } };
     }
 
     const { contact, notesSaved, nothingWritten } =
@@ -686,60 +673,20 @@ export async function handleContactRecordSubmit(
         operation,
         contactId: operation === "update" ? contactId : undefined,
         displayName,
-        notes: body.notes,
+        notes,
       });
     const writtenId = contact.id as string;
     log.info(
       { requestId, contactId: writtenId, operation },
       "contact-record-submit: wrote contact record",
     );
-    return await resolveRecordPrompt(
-      requestId,
-      writtenId,
-      settleDeadline,
-      notesSaved,
-      nothingWritten,
-    );
+    return { resolution: { contactId: writtenId, notesSaved, nothingWritten } };
   } catch (err) {
     if (err instanceof ContactRecordNativeError) {
-      await reportFailure(requestId, err.message, settleDeadline);
-      return Response.json(
-        { accepted: false, error: err.message },
-        { status: err.statusCode },
-      );
+      return { failure: { error: err.message, status: err.statusCode } };
     }
     log.error({ err, requestId, operation }, "contact-record-submit: failed");
-    await reportFailure(requestId, "Contact write failed", settleDeadline);
-    return Response.json(
-      { accepted: false, error: "Contact write failed" },
-      { status: 500 },
-    );
-  }
-}
-
-/**
- * Ask the daemon to claim this form for the caller.
- *
- * A transport failure is a lost claim rather than a granted one: the daemon
- * holds the waiting call, so a write it cannot hear about has nobody to report
- * to. `unreachable` is kept distinct from the daemon's own answers, because a
- * caller that cannot be reached says nothing about whether the form was
- * already answered.
- */
-async function claimPrompt(
-  requestId: string,
-): Promise<{ claimed: boolean; reason?: string; settleMs?: number }> {
-  try {
-    const result = await ipcCallAssistant("contact_prompt_claim", {
-      body: { requestId },
-    });
-    return result as { claimed: boolean; reason?: string; settleMs?: number };
-  } catch (err) {
-    log.warn(
-      { err, requestId },
-      "contact-record-submit: contact_prompt_claim IPC failed; refusing the write",
-    );
-    return { claimed: false, reason: "unreachable" };
+    return { failure: { error: "Contact write failed", status: 500 } };
   }
 }
 
@@ -762,136 +709,4 @@ function isChannelVerified(contactId: string, channelId: string): boolean {
     );
     return false;
   }
-}
-
-/** Fallback settle window when a claim did not carry one. */
-const DEFAULT_SETTLE_MS = 180_000;
-
-/** Longest a submission waits on the callback before answering its client. */
-const RESOLVE_INLINE_BUDGET_MS = 2_000;
-
-/**
- * Report a committed write back to the assistant, retrying until the claimed
- * form's settle window runs out.
- *
- * The write has already happened by the time this runs, so a lost callback is
- * not a lost write: it is a command told its form failed while the contact was
- * created, renamed, or deleted. Retries run to the claim's deadline rather
- * than to a fixed count, which a fast-failing socket would burn through in
- * seconds. The deadline is absolute and dates from the claim, because the
- * window is the daemon's and started running there: measuring it again after
- * a slow write would retry against a form that has already expired.
- *
- * The first couple of seconds are awaited so the ordinary case answers the
- * client with the callback already delivered; past that the retries continue
- * on their own, since the client is waiting on a write that is already done.
- *
- * A callback that never lands leaves the command reporting failure over a
- * write that happened. Nothing here can close that gap, so it is logged at
- * error rather than papered over.
- */
-async function reportResolution(
-  requestId: string,
-  body: Record<string, unknown>,
-  deadline: number,
-): Promise<void> {
-  const inlineUntil = Date.now() + RESOLVE_INLINE_BUDGET_MS;
-
-  const attempt = async (): Promise<boolean> => {
-    try {
-      const result = await ipcCallAssistant("resolve_contact_prompt", { body });
-      if ((result as { resolved?: boolean }).resolved === false) {
-        // The form is gone, so nobody is waiting. Retrying cannot change that.
-        log.warn(
-          { requestId },
-          "contact-prompt: resolve found no pending form; the command may already have given up",
-        );
-      }
-      return true;
-    } catch (err) {
-      log.warn({ err, requestId }, "contact-prompt: resolve failed, retrying");
-      return false;
-    }
-  };
-
-  const retryUntilDeadline = async (waitMs: number): Promise<void> => {
-    let backoff = waitMs;
-    while (Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, backoff));
-      if (Date.now() >= deadline) {
-        break;
-      }
-      if (await attempt()) {
-        return;
-      }
-      backoff = Math.min(backoff * 2, 10_000);
-    }
-    log.error(
-      { requestId, body },
-      "contact-prompt: could not report a committed write to the assistant; the command will report failure over a write that happened",
-    );
-  };
-
-  if (await attempt()) {
-    return;
-  }
-
-  // Inline retries while the client's own wait is still short, then hand the
-  // rest to the background so the response is not held for the whole window.
-  let backoff = 500;
-  while (Date.now() < inlineUntil) {
-    await new Promise((resolve) => setTimeout(resolve, backoff));
-    if (await attempt()) {
-      return;
-    }
-    backoff = Math.min(backoff * 2, 10_000);
-  }
-  void retryUntilDeadline(backoff);
-}
-
-/**
- * The response for a claim the caller did not get.
- *
- * A competing claim is success from this client's side: the form it was
- * showing has been answered, and there is nothing for it to fix. Anything else
- * is a failure it needs to see, so its card stays and can be retried: an
- * unreachable assistant means the submission never landed, and an unknown form
- * means nothing is waiting for one.
- */
-function lostClaimResponse(reason: string | undefined): Response {
-  if (reason === "already_claimed") {
-    return Response.json({ accepted: true, duplicate: true });
-  }
-  if (reason === "unreachable") {
-    return Response.json(
-      { accepted: false, error: "Could not reach the assistant" },
-      { status: 503 },
-    );
-  }
-  return Response.json(
-    {
-      accepted: false,
-      error: "This request is no longer waiting for an answer",
-    },
-    { status: 409 },
-  );
-}
-
-/**
- * Unblock the parked CLI call after a record write. There is no channel to
- * report, so only the contact id crosses back.
- */
-async function resolveRecordPrompt(
-  requestId: string,
-  contactId: string,
-  deadline: number,
-  notesSaved?: boolean,
-  nothingWritten?: boolean,
-): Promise<Response> {
-  await reportResolution(
-    requestId,
-    { requestId, contactId, notesSaved, nothingWritten },
-    deadline,
-  );
-  return Response.json({ accepted: true });
 }

--- a/gateway/src/http/routes/guardian-form-submit.ts
+++ b/gateway/src/http/routes/guardian-form-submit.ts
@@ -31,6 +31,10 @@ export interface GuardianFormWriteFailure {
  * What a write reports. `resolution` is merged into the callback the parked
  * call receives; `failure` becomes both the client's response and what the
  * parked call is told went wrong.
+ *
+ * `requestId` and `error` are the rail's: a resolution carrying either has it
+ * overwritten, since one addresses the callback and the other is what makes an
+ * outcome a failure.
  */
 export type GuardianFormWriteOutcome =
   | { resolution: Record<string, unknown> }
@@ -150,7 +154,10 @@ export async function submitGuardianForm(
 
   await reportResolution(
     requestId,
-    { requestId, ...outcome.resolution },
+    // The rail's id wins. A form whose result happened to carry `requestId`
+    // would otherwise redirect its own callback to a different form or to
+    // none, and its caller would time out over a write that committed.
+    { ...outcome.resolution, requestId },
     settleDeadline,
     resolveOperation,
   );

--- a/gateway/src/http/routes/guardian-form-submit.ts
+++ b/gateway/src/http/routes/guardian-form-submit.ts
@@ -1,0 +1,271 @@
+/**
+ * The write half of the guardian-form rail.
+ *
+ * A form-backed command parks in the daemon and its form goes to every
+ * connected client. The client that answers posts here, and this file owns
+ * everything around the write that is the same for every form: taking the
+ * claim so only one submission lands, reporting the outcome back so the parked
+ * call returns, and answering a client that lost the race.
+ *
+ * A form owner supplies only the write itself.
+ */
+
+import { ipcCallAssistant } from "../../ipc/assistant-client.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("guardian-form-submit");
+
+/** Fallback settle window when a claim did not carry one. */
+const DEFAULT_SETTLE_MS = 180_000;
+
+/** Longest a submission waits on the callback before answering its client. */
+const RESOLVE_INLINE_BUDGET_MS = 2_000;
+
+/** A write that could not happen, and the status its client should see. */
+export interface GuardianFormWriteFailure {
+  error: string;
+  status: number;
+}
+
+/**
+ * What a write reports. `resolution` is merged into the callback the parked
+ * call receives; `failure` becomes both the client's response and what the
+ * parked call is told went wrong.
+ */
+export type GuardianFormWriteOutcome =
+  | { resolution: Record<string, unknown> }
+  | { failure: GuardianFormWriteFailure };
+
+interface SubmitGuardianFormBase {
+  requestId: string;
+  /** Form-specific fields folded into this submission's log lines. */
+  logContext?: Record<string, unknown>;
+}
+
+/**
+ * Either a write or a dismissal, never a maybe-write. An optional callback
+ * would let a caller that forgot one report "cancelled" over a form the
+ * guardian actually answered.
+ */
+export type SubmitGuardianFormOptions = SubmitGuardianFormBase &
+  (
+    | {
+        /**
+         * Runs once the claim is held. Classify expected failures into
+         * `failure` rather than throwing; a throw is caught as a backstop and
+         * reported as a 500, which loses the status you meant.
+         */
+        write: () => Promise<GuardianFormWriteOutcome>;
+        cancelled?: never;
+      }
+    | { cancelled: true; write?: never }
+  );
+
+/**
+ * Claim the form, run the write, and report the outcome to the parked call.
+ *
+ * The claim comes first because the form went to every connected client: an
+ * answer landing near the deadline must stop that deadline rather than race
+ * the write it started, and a second client must not overwrite the answer the
+ * guardian gave on the first. A dismissal takes the same claim, so it cannot
+ * report "cancelled" over an answer that is already committing.
+ */
+export async function submitGuardianForm(
+  options: SubmitGuardianFormOptions,
+): Promise<Response> {
+  const { requestId, logContext = {} } = options;
+
+  const claim = await claimForm(requestId);
+  if (!claim.claimed) {
+    log.warn(
+      { requestId, reason: claim.reason, ...logContext },
+      "guardian-form: submission did not get the claim",
+    );
+    return lostClaimResponse(claim.reason);
+  }
+  // Absolute, and dated from the claim: the window is the daemon's and started
+  // running there, so measuring it again after a slow write would retry against
+  // a form that has already expired.
+  const settleDeadline = Date.now() + (claim.settleMs ?? DEFAULT_SETTLE_MS);
+
+  if (options.cancelled === true) {
+    await reportResolution(
+      requestId,
+      { requestId, error: "Cancelled by user" },
+      settleDeadline,
+    );
+    return Response.json({ accepted: true });
+  }
+
+  let outcome: GuardianFormWriteOutcome;
+  try {
+    outcome = await options.write();
+  } catch (err) {
+    // Claiming a form takes ownership of ending it, so an unexpected throw
+    // still owes the parked call a report: without one the command sits until
+    // its settle timer while the client's retry comes back as a duplicate,
+    // because the claim is still held.
+    log.error(
+      { err, requestId, ...logContext },
+      "guardian-form: the write threw",
+    );
+    await reportResolution(
+      requestId,
+      { requestId, error: "The write failed" },
+      settleDeadline,
+    );
+    return Response.json(
+      { accepted: false, error: "The write failed" },
+      { status: 500 },
+    );
+  }
+
+  if ("failure" in outcome) {
+    await reportResolution(
+      requestId,
+      { requestId, error: outcome.failure.error },
+      settleDeadline,
+    );
+    return Response.json(
+      { accepted: false, error: outcome.failure.error },
+      { status: outcome.failure.status },
+    );
+  }
+
+  await reportResolution(
+    requestId,
+    { requestId, ...outcome.resolution },
+    settleDeadline,
+  );
+  return Response.json({ accepted: true });
+}
+
+/**
+ * Ask the daemon to claim this form for the caller.
+ *
+ * A transport failure is a lost claim rather than a granted one: the daemon
+ * holds the waiting call, so a write it cannot hear about has nobody to report
+ * to. `unreachable` is kept distinct from the daemon's own answers, because a
+ * caller that cannot be reached says nothing about whether the form was
+ * already answered.
+ */
+async function claimForm(
+  requestId: string,
+): Promise<{ claimed: boolean; reason?: string; settleMs?: number }> {
+  try {
+    const result = await ipcCallAssistant("contact_prompt_claim", {
+      body: { requestId },
+    });
+    return result as { claimed: boolean; reason?: string; settleMs?: number };
+  } catch (err) {
+    log.warn(
+      { err, requestId },
+      "guardian-form: claim IPC failed; refusing the write",
+    );
+    return { claimed: false, reason: "unreachable" };
+  }
+}
+
+/**
+ * The response for a claim the caller did not get.
+ *
+ * A competing claim is success from this client's side: the form it was
+ * showing has been answered, and there is nothing for it to fix. Anything else
+ * is a failure it needs to see, so its card stays and can be retried: an
+ * unreachable assistant means the submission never landed, and an unknown form
+ * means nothing is waiting for one.
+ */
+function lostClaimResponse(reason: string | undefined): Response {
+  if (reason === "already_claimed") {
+    return Response.json({ accepted: true, duplicate: true });
+  }
+  if (reason === "unreachable") {
+    return Response.json(
+      { accepted: false, error: "Could not reach the assistant" },
+      { status: 503 },
+    );
+  }
+  return Response.json(
+    {
+      accepted: false,
+      error: "This request is no longer waiting for an answer",
+    },
+    { status: 409 },
+  );
+}
+
+/**
+ * Report an outcome back to the assistant, retrying until the claimed form's
+ * settle window runs out.
+ *
+ * The write has already happened by the time this runs, so a lost callback is
+ * not a lost write: it is a command told its form failed while the contact was
+ * created, renamed, or deleted. Retries run to the deadline rather than to a
+ * fixed count, which a fast-failing socket would burn through in seconds.
+ *
+ * The first couple of seconds are awaited so the ordinary case answers the
+ * client with the callback already delivered; past that the retries continue
+ * on their own, since the client is waiting on a write that is already done.
+ *
+ * A callback that never lands leaves the command reporting failure over a
+ * write that happened. Nothing here can close that gap, so it is logged at
+ * error rather than papered over.
+ */
+async function reportResolution(
+  requestId: string,
+  body: Record<string, unknown>,
+  deadline: number,
+): Promise<void> {
+  const inlineUntil = Date.now() + RESOLVE_INLINE_BUDGET_MS;
+
+  const attempt = async (): Promise<boolean> => {
+    try {
+      const result = await ipcCallAssistant("resolve_contact_prompt", { body });
+      if ((result as { resolved?: boolean }).resolved === false) {
+        // The form is gone, so nobody is waiting. Retrying cannot change that.
+        log.warn(
+          { requestId },
+          "guardian-form: resolve found no pending form; the command may already have given up",
+        );
+      }
+      return true;
+    } catch (err) {
+      log.warn({ err, requestId }, "guardian-form: resolve failed, retrying");
+      return false;
+    }
+  };
+
+  const retryUntilDeadline = async (waitMs: number): Promise<void> => {
+    let backoff = waitMs;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, backoff));
+      if (Date.now() >= deadline) {
+        break;
+      }
+      if (await attempt()) {
+        return;
+      }
+      backoff = Math.min(backoff * 2, 10_000);
+    }
+    log.error(
+      { requestId, body },
+      "guardian-form: could not report a committed write to the assistant; the command will report failure over a write that happened",
+    );
+  };
+
+  if (await attempt()) {
+    return;
+  }
+
+  // Inline retries while the client's own wait is still short, then hand the
+  // rest to the background so the response is not held for the whole window.
+  let backoff = 500;
+  while (Date.now() < inlineUntil) {
+    await new Promise((resolve) => setTimeout(resolve, backoff));
+    if (await attempt()) {
+      return;
+    }
+    backoff = Math.min(backoff * 2, 10_000);
+  }
+  void retryUntilDeadline(backoff);
+}

--- a/gateway/src/http/routes/guardian-form-submit.ts
+++ b/gateway/src/http/routes/guardian-form-submit.ts
@@ -40,6 +40,14 @@ interface SubmitGuardianFormBase {
   requestId: string;
   /** Form-specific fields folded into this submission's log lines. */
   logContext?: Record<string, unknown>;
+  /**
+   * The daemon IPC operations to claim through and report back on. Default to
+   * the form-agnostic pair. The contact forms pin their own older names,
+   * because the gateway ships separately from the daemon and one running
+   * against an older daemon must keep calling what that daemon serves.
+   */
+  claimOperation?: string;
+  resolveOperation?: string;
 }
 
 /**
@@ -73,9 +81,14 @@ export type SubmitGuardianFormOptions = SubmitGuardianFormBase &
 export async function submitGuardianForm(
   options: SubmitGuardianFormOptions,
 ): Promise<Response> {
-  const { requestId, logContext = {} } = options;
+  const {
+    requestId,
+    logContext = {},
+    claimOperation = "guardian_form_claim",
+    resolveOperation = "resolve_guardian_form",
+  } = options;
 
-  const claim = await claimForm(requestId);
+  const claim = await claimForm(requestId, claimOperation);
   if (!claim.claimed) {
     log.warn(
       { requestId, reason: claim.reason, ...logContext },
@@ -93,6 +106,7 @@ export async function submitGuardianForm(
       requestId,
       { requestId, error: "Cancelled by user" },
       settleDeadline,
+      resolveOperation,
     );
     return Response.json({ accepted: true });
   }
@@ -113,6 +127,7 @@ export async function submitGuardianForm(
       requestId,
       { requestId, error: "The write failed" },
       settleDeadline,
+      resolveOperation,
     );
     return Response.json(
       { accepted: false, error: "The write failed" },
@@ -125,6 +140,7 @@ export async function submitGuardianForm(
       requestId,
       { requestId, error: outcome.failure.error },
       settleDeadline,
+      resolveOperation,
     );
     return Response.json(
       { accepted: false, error: outcome.failure.error },
@@ -136,6 +152,7 @@ export async function submitGuardianForm(
     requestId,
     { requestId, ...outcome.resolution },
     settleDeadline,
+    resolveOperation,
   );
   return Response.json({ accepted: true });
 }
@@ -151,9 +168,10 @@ export async function submitGuardianForm(
  */
 async function claimForm(
   requestId: string,
+  operation: string,
 ): Promise<{ claimed: boolean; reason?: string; settleMs?: number }> {
   try {
-    const result = await ipcCallAssistant("contact_prompt_claim", {
+    const result = await ipcCallAssistant(operation, {
       body: { requestId },
     });
     return result as { claimed: boolean; reason?: string; settleMs?: number };
@@ -215,12 +233,13 @@ async function reportResolution(
   requestId: string,
   body: Record<string, unknown>,
   deadline: number,
+  operation: string,
 ): Promise<void> {
   const inlineUntil = Date.now() + RESOLVE_INLINE_BUDGET_MS;
 
   const attempt = async (): Promise<boolean> => {
     try {
-      const result = await ipcCallAssistant("resolve_contact_prompt", { body });
+      const result = await ipcCallAssistant(operation, { body });
       if ((result as { resolved?: boolean }).resolved === false) {
         // The form is gone, so nobody is waiting. Retrying cannot change that.
         log.warn(

--- a/gateway/src/http/routes/guardian-form-submit.ts
+++ b/gateway/src/http/routes/guardian-form-submit.ts
@@ -52,6 +52,11 @@ interface SubmitGuardianFormBase {
    */
   claimOperation?: string;
   resolveOperation?: string;
+  /**
+   * The form this submission is for. The daemon refuses a claim whose id is
+   * holding a different form, so a submission cannot answer somebody else's.
+   */
+  formKind?: string;
 }
 
 /**
@@ -90,9 +95,10 @@ export async function submitGuardianForm(
     logContext = {},
     claimOperation = "guardian_form_claim",
     resolveOperation = "resolve_guardian_form",
+    formKind,
   } = options;
 
-  const claim = await claimForm(requestId, claimOperation);
+  const claim = await claimForm(requestId, claimOperation, formKind);
   if (!claim.claimed) {
     log.warn(
       { requestId, reason: claim.reason, ...logContext },
@@ -152,12 +158,21 @@ export async function submitGuardianForm(
     );
   }
 
+  // `requestId` and `error` are the rail's. A result carrying its own id would
+  // redirect the callback to a different form or to none, and one carrying an
+  // `error` would be read as a failure and reported as a cancellation, both
+  // over a write that committed.
+  const { error: strayError, ...resolution } = outcome.resolution;
+  if (strayError !== undefined) {
+    log.warn(
+      { requestId, ...logContext },
+      "guardian-form: dropped an `error` field from a successful result; the key is reserved",
+    );
+  }
+
   await reportResolution(
     requestId,
-    // The rail's id wins. A form whose result happened to carry `requestId`
-    // would otherwise redirect its own callback to a different form or to
-    // none, and its caller would time out over a write that committed.
-    { ...outcome.resolution, requestId },
+    { ...resolution, requestId },
     settleDeadline,
     resolveOperation,
   );
@@ -176,10 +191,11 @@ export async function submitGuardianForm(
 async function claimForm(
   requestId: string,
   operation: string,
+  kind: string | undefined,
 ): Promise<{ claimed: boolean; reason?: string; settleMs?: number }> {
   try {
     const result = await ipcCallAssistant(operation, {
-      body: { requestId },
+      body: { requestId, kind },
     });
     return result as { claimed: boolean; reason?: string; settleMs?: number };
   } catch (err) {


### PR DESCRIPTION
## Summary

- Extracts the guardian-form lifecycle out of the contact forms into `assistant/src/runtime/guardian-form-registry.ts` (park, deadline, claim, settle window, resolve, announce-closed) and `gateway/src/http/routes/guardian-form-submit.ts` (claim, run the write, report the outcome, answer a client that lost the race). A new form now supplies a payload schema, a card, and a write.
- The contact routes keep everything contact-shaped: their Zod schemas, the `contact_request` / `contact_record_request` / `contact_form_closed` wire events, and the writes themselves. `contact-prompt.ts` drops ~200 net lines, `contact-prompt-routes.ts` ~100.
- Renames `util/contact-form-timeouts.ts` to `util/guardian-form-timeouts.ts` (the timings are the rail's, not contacts').
- Adds `docs/guardian-forms.md` and 11 tests that exercise the claim protocol directly rather than only through contacts.

## Behavior

Preserving, with two things worth a look:

1. **One intentional widening.** An unexpected throw inside the address-form write is now caught by the wrapper and reported to the parked call. Previously it escaped to the HTTP layer and left a claimed form with nobody reporting on it, so the command sat until its settle timer while the client's retry came back as a duplicate.
2. **`hasUnclaimedGuardianForm` takes the kinds to check.** Contacts still pass both of theirs, so today's "one contact form at a time" rule is unchanged. This is the seam that stops the next form from inheriting a registry-wide mutex; scoping it is now a one-line change at the call site rather than a rewrite. Flagging it because it is the one place I chose a different shape than a literal extraction would have given.

## Not in scope

Collapsing `contact_request` and `contact_record_request` into one `guardian_form_request` event. That is the change that removes the twelve per-form registration points on the web side, but it is a wire migration with a skew story to settle, and #41666 showed a version floor cannot separate a tagged release from a source checkout reporting the same version. Worth doing when form #3 has a concrete shape and we know whether one payload envelope fits three forms.

## Verification

- 102 existing tests pass unchanged across the daemon route, CLI, and both gateway submit suites, which is the actual claim that behavior is preserved.
- The 11 new registry tests were mutation-checked: removing the claim's deadline swap, the claim-once guard, and the kind scoping each turns them red.
- `tsc` and `eslint` clean in both packages.

Note: the gateway suites fail on unmodified `main` in a stale local checkout (`@vellumai/environments/test-path-guard` unresolved). That is a `bun install` gap, not a code issue; CI is unaffected.

## Original prompt

Following the guardian-confirmed contact writes that just merged (#41666), Noa expected more CLIs to render forms for guardian interaction and asked whether any of it could be abstracted for reuse. I found that adding one form type touches 24 files, of which about three carry the actual form, and proposed extracting the daemon and gateway rails now while deferring the web-side wire collapse until a third form exists. Noa asked me to do it.