### PR TITLE
fix(web): scope onboarding completion to a specific assistant

### DIFF
--- a/clients/web/src/assistant/retire-service.ts
+++ b/clients/web/src/assistant/retire-service.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/local-mode";
 import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { buildNavigationState } from "@/lib/navigation/build-state";
+import { forgetAssistantOnboarded } from "@/domains/onboarding/onboarded-assistant-record";
 import { clearResearchSnapshot } from "@/domains/onboarding/research-onboarding-persistence";
 import { removeLocalSetting } from "@/utils/local-settings";
 import { useAuthStore } from "@/stores/auth-store";
@@ -122,6 +123,8 @@ export async function retireAssistant(
     // form instead of resuming the retired assistant's run deep in the flow
     // (e.g. straight onto the wake gate).
     clearResearchSnapshot(useAuthStore.getState().user?.id ?? null);
+    // The completion record goes with it, so a reused id is never pre-marked.
+    forgetAssistantOnboarded(assistantId);
     // Drop the marketing nav's cached assistant name (same-origin localStorage,
     // written by the platform's `useNavbarAuth`). Otherwise the marketing site
     // keeps optimistically showing "My Assistant" after a retire until its own

--- a/clients/web/src/domains/onboarding/onboarded-assistant-record.test.ts
+++ b/clients/web/src/domains/onboarding/onboarded-assistant-record.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  ONBOARDED_ASSISTANTS_STORAGE_KEY,
+  forgetAssistantOnboarded,
+  markAssistantOnboarded,
+  readOnboardedAt,
+} from "@/domains/onboarding/onboarded-assistant-record";
+
+describe("onboarded-assistant-record", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("stamps and reads back per assistant", () => {
+    markAssistantOnboarded("asst-1", "2026-08-31T00:00:00.000Z");
+
+    expect(readOnboardedAt("asst-1")).toBe("2026-08-31T00:00:00.000Z");
+    expect(readOnboardedAt("asst-2")).toBeUndefined();
+  });
+
+  test("keeps the first stamp so a replayed funnel does not rewrite it", () => {
+    markAssistantOnboarded("asst-1", "2026-08-01T00:00:00.000Z");
+    markAssistantOnboarded("asst-1", "2026-08-31T00:00:00.000Z");
+
+    expect(readOnboardedAt("asst-1")).toBe("2026-08-01T00:00:00.000Z");
+  });
+
+  test("forget drops one entry and leaves the others", () => {
+    markAssistantOnboarded("asst-1", "2026-08-01T00:00:00.000Z");
+    markAssistantOnboarded("asst-2", "2026-08-02T00:00:00.000Z");
+
+    forgetAssistantOnboarded("asst-1");
+
+    expect(readOnboardedAt("asst-1")).toBeUndefined();
+    expect(readOnboardedAt("asst-2")).toBe("2026-08-02T00:00:00.000Z");
+  });
+
+  test("malformed storage reads as empty rather than throwing", () => {
+    localStorage.setItem(ONBOARDED_ASSISTANTS_STORAGE_KEY, "not-json");
+    expect(readOnboardedAt("asst-1")).toBeUndefined();
+
+    localStorage.setItem(ONBOARDED_ASSISTANTS_STORAGE_KEY, '["asst-1"]');
+    expect(readOnboardedAt("asst-1")).toBeUndefined();
+
+    localStorage.setItem(ONBOARDED_ASSISTANTS_STORAGE_KEY, '{"asst-1":7}');
+    expect(readOnboardedAt("asst-1")).toBeUndefined();
+  });
+
+  // Onboarding completion belongs to the assistant, not the session, so the
+  // key is `device:`-scoped and survives the logout sweep in session-cleanup.
+  test("is device-scoped", () => {
+    expect(ONBOARDED_ASSISTANTS_STORAGE_KEY.startsWith("device:")).toBe(true);
+  });
+});

--- a/clients/web/src/domains/onboarding/onboarded-assistant-record.ts
+++ b/clients/web/src/domains/onboarding/onboarded-assistant-record.ts
@@ -1,0 +1,74 @@
+/**
+ * Durable per-assistant record of "this assistant finished first-run
+ * onboarding", stamped where the research/personality funnel terminates.
+ *
+ * Device-scoped on purpose. Onboarding completion is a property of the
+ * assistant, not of the session, so it must survive the logout sweep in
+ * `lib/auth/session-cleanup.ts`, which deletes every `vellum:`-prefixed key.
+ *
+ * Deliberately depends on nothing but `typed-storage`: the resolved-assistants
+ * store reads this module, so pulling `local-mode` in here would drag the
+ * lockfile transport into the store's import graph. The lockfile mirror lives
+ * in `stamp-assistant-onboarded.ts` instead.
+ */
+
+import { createStorageAccessor } from "@/utils/typed-storage";
+
+/** assistantId -> ISO timestamp of the completion. */
+type OnboardedRecord = Record<string, string>;
+
+function parseRecord(raw: string): OnboardedRecord | null {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const result: OnboardedRecord = {};
+  for (const [id, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value === "string" && value) {
+      result[id] = value;
+    }
+  }
+  return result;
+}
+
+const storage = createStorageAccessor<OnboardedRecord>({
+  key: "device:onboarded_assistants",
+  scope: "device",
+  parse: parseRecord,
+  serialize: JSON.stringify,
+  fallback: {},
+});
+
+/** ISO completion timestamp for `assistantId`, or undefined when unstamped. */
+export function readOnboardedAt(assistantId: string): string | undefined {
+  return storage.load()[assistantId];
+}
+
+/**
+ * Stamp `assistantId` as onboarded. Idempotent: an existing stamp is kept, so
+ * a replayed funnel never rewrites the original completion time.
+ */
+export function markAssistantOnboarded(
+  assistantId: string,
+  at: string = new Date().toISOString(),
+): void {
+  const record = storage.load();
+  if (record[assistantId]) {
+    return;
+  }
+  storage.save({ ...record, [assistantId]: at });
+}
+
+/** Drop the stamp, so a retired id is not pre-marked if it is ever reused. */
+export function forgetAssistantOnboarded(assistantId: string): void {
+  const record = storage.load();
+  if (!(assistantId in record)) {
+    return;
+  }
+  const { [assistantId]: _removed, ...rest } = record;
+  storage.save(rest);
+}
+
+/** Test seam: the underlying localStorage key. */
+export const ONBOARDED_ASSISTANTS_STORAGE_KEY = storage.key;
+

--- a/clients/web/src/domains/onboarding/onboarded-assistant.test.ts
+++ b/clients/web/src/domains/onboarding/onboarded-assistant.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import {
   ONBOARDED_HATCH_AGE_MS,
-  hasOnboardedAssistant,
+  isAssistantOnboarded,
   isHatchedOnboarded,
+  isSelectedAssistantOnboarded,
+  userHasOnboardedAssistant,
 } from "@/domains/onboarding/onboarded-assistant";
 
 const NOW = Date.parse("2026-08-21T12:00:00.000Z");
@@ -41,10 +43,10 @@ describe("isHatchedOnboarded", () => {
   });
 });
 
-describe("hasOnboardedAssistant", () => {
+describe("userHasOnboardedAssistant", () => {
   test("is true when any assistant is past the hatch-age threshold", () => {
     expect(
-      hasOnboardedAssistant(
+      userHasOnboardedAssistant(
         [
           { hatchedAt: new Date(NOW).toISOString() },
           {
@@ -58,7 +60,7 @@ describe("hasOnboardedAssistant", () => {
 
   test("is false when every assistant is fresh or undated", () => {
     expect(
-      hasOnboardedAssistant(
+      userHasOnboardedAssistant(
         [
           { hatchedAt: new Date(NOW - 3 * 24 * 60 * 60 * 1000).toISOString() },
           {},
@@ -66,6 +68,43 @@ describe("hasOnboardedAssistant", () => {
         NOW,
       ),
     ).toBe(false);
-    expect(hasOnboardedAssistant([], NOW)).toBe(false);
+    expect(userHasOnboardedAssistant([], NOW)).toBe(false);
+  });
+});
+
+const FRESH = new Date(NOW).toISOString();
+const WEEK_OLD = new Date(NOW - ONBOARDED_HATCH_AGE_MS).toISOString();
+
+describe("isAssistantOnboarded", () => {
+  test("a stamped assistant is onboarded however fresh its hatch", () => {
+    expect(
+      isAssistantOnboarded({ hatchedAt: FRESH, onboardedAt: FRESH }, NOW),
+    ).toBe(true);
+  });
+
+  test("falls back to hatch age when unstamped", () => {
+    expect(isAssistantOnboarded({ hatchedAt: WEEK_OLD }, NOW)).toBe(true);
+    expect(isAssistantOnboarded({ hatchedAt: FRESH }, NOW)).toBe(false);
+    expect(isAssistantOnboarded({}, NOW)).toBe(false);
+  });
+});
+
+describe("isSelectedAssistantOnboarded", () => {
+  const assistants = [
+    { id: "old", hatchedAt: WEEK_OLD },
+    { id: "new", hatchedAt: FRESH },
+    { id: "stamped", hatchedAt: FRESH, onboardedAt: FRESH },
+  ];
+
+  test("answers for the selected assistant, not the list", () => {
+    expect(isSelectedAssistantOnboarded(assistants, "old", NOW)).toBe(true);
+    expect(isSelectedAssistantOnboarded(assistants, "stamped", NOW)).toBe(true);
+    // The bug this split exists for: a week-old sibling must not answer here.
+    expect(isSelectedAssistantOnboarded(assistants, "new", NOW)).toBe(false);
+  });
+
+  test("is false when nothing is selected or the id is unknown", () => {
+    expect(isSelectedAssistantOnboarded(assistants, null, NOW)).toBe(false);
+    expect(isSelectedAssistantOnboarded(assistants, "missing", NOW)).toBe(false);
   });
 });

--- a/clients/web/src/domains/onboarding/onboarded-assistant.test.ts
+++ b/clients/web/src/domains/onboarding/onboarded-assistant.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
   ONBOARDED_HATCH_AGE_MS,
@@ -7,8 +7,13 @@ import {
   isSelectedAssistantOnboarded,
   userHasOnboardedAssistant,
 } from "@/domains/onboarding/onboarded-assistant";
+import { markAssistantOnboarded } from "@/domains/onboarding/onboarded-assistant-record";
 
 const NOW = Date.parse("2026-08-21T12:00:00.000Z");
+
+beforeEach(() => {
+  localStorage.clear();
+});
 
 describe("isHatchedOnboarded", () => {
   test("treats a hatch at least a week old as onboarded", () => {
@@ -48,8 +53,9 @@ describe("userHasOnboardedAssistant", () => {
     expect(
       userHasOnboardedAssistant(
         [
-          { hatchedAt: new Date(NOW).toISOString() },
+          { id: "a", hatchedAt: new Date(NOW).toISOString() },
           {
+            id: "b",
             hatchedAt: new Date(NOW - ONBOARDED_HATCH_AGE_MS).toISOString(),
           },
         ],
@@ -62,8 +68,11 @@ describe("userHasOnboardedAssistant", () => {
     expect(
       userHasOnboardedAssistant(
         [
-          { hatchedAt: new Date(NOW - 3 * 24 * 60 * 60 * 1000).toISOString() },
-          {},
+          {
+            id: "a",
+            hatchedAt: new Date(NOW - 3 * 24 * 60 * 60 * 1000).toISOString(),
+          },
+          { id: "b" },
         ],
         NOW,
       ),
@@ -76,16 +85,29 @@ const FRESH = new Date(NOW).toISOString();
 const WEEK_OLD = new Date(NOW - ONBOARDED_HATCH_AGE_MS).toISOString();
 
 describe("isAssistantOnboarded", () => {
-  test("a stamped assistant is onboarded however fresh its hatch", () => {
+  test("a lockfile-stamped assistant is onboarded however fresh its hatch", () => {
     expect(
-      isAssistantOnboarded({ hatchedAt: FRESH, onboardedAt: FRESH }, NOW),
+      isAssistantOnboarded({ id: "a", hatchedAt: FRESH, onboardedAt: FRESH }, NOW),
     ).toBe(true);
   });
 
+  // The device half is read live, so a completion answers immediately rather
+  // than waiting for the assistant list to be rebuilt.
+  test("the device record answers for an assistant the lockfile has not stamped", () => {
+    expect(isAssistantOnboarded({ id: "a", hatchedAt: FRESH }, NOW)).toBe(false);
+
+    markAssistantOnboarded("a", FRESH);
+
+    expect(isAssistantOnboarded({ id: "a", hatchedAt: FRESH }, NOW)).toBe(true);
+    expect(isAssistantOnboarded({ id: "b", hatchedAt: FRESH }, NOW)).toBe(false);
+  });
+
   test("falls back to hatch age when unstamped", () => {
-    expect(isAssistantOnboarded({ hatchedAt: WEEK_OLD }, NOW)).toBe(true);
-    expect(isAssistantOnboarded({ hatchedAt: FRESH }, NOW)).toBe(false);
-    expect(isAssistantOnboarded({}, NOW)).toBe(false);
+    expect(isAssistantOnboarded({ id: "a", hatchedAt: WEEK_OLD }, NOW)).toBe(
+      true,
+    );
+    expect(isAssistantOnboarded({ id: "a", hatchedAt: FRESH }, NOW)).toBe(false);
+    expect(isAssistantOnboarded({ id: "a" }, NOW)).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/onboarding/onboarded-assistant.ts
+++ b/clients/web/src/domains/onboarding/onboarded-assistant.ts
@@ -1,12 +1,19 @@
 /**
- * Whether an existing assistant should skip first-run research onboarding.
+ * Whether an assistant is past first-run research onboarding.
  *
- * There is no durable "research completed" flag. Hatch age is the stored
- * proxy: an assistant created at least a week ago has almost certainly
- * finished onboarding, so login, signup, and the privacy screen should not
- * send that user through `/onboarding/research` again.
+ * `onboardedAt` is the real signal, stamped where the funnel terminates (see
+ * `onboarded-assistant-record.ts`). Hatch age is the legacy fallback for
+ * assistants that predate the record: one created at least a week ago has
+ * almost certainly finished, so an upgrade does not re-funnel anybody.
+ *
+ * Ask the right question. `userHasOnboardedAssistant` answers "is this a
+ * returning user" and belongs on post-auth and intercept decisions;
+ * `isSelectedAssistantOnboarded` answers "is THIS assistant past first run"
+ * and belongs on the privacy funnel. Using the first for the second is what
+ * made one week-old assistant bounce every new-assistant walk (#41656).
  */
 
+/** Legacy proxy window, used only when `onboardedAt` is absent. */
 export const ONBOARDED_HATCH_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 export function isHatchedOnboarded(
@@ -23,11 +30,47 @@ export function isHatchedOnboarded(
   return nowMs - hatchedMs >= ONBOARDED_HATCH_AGE_MS;
 }
 
-export function hasOnboardedAssistant(
-  assistants: ReadonlyArray<{ hatchedAt?: string }>,
+interface OnboardingAgeFields {
+  onboardedAt?: string;
+  hatchedAt?: string;
+}
+
+/** A stamped assistant is onboarded; an unstamped one falls back to hatch age. */
+export function isAssistantOnboarded(
+  assistant: OnboardingAgeFields,
   nowMs: number = Date.now(),
 ): boolean {
-  return assistants.some((assistant) =>
-    isHatchedOnboarded(assistant.hatchedAt, nowMs),
-  );
+  if (assistant.onboardedAt) {
+    return true;
+  }
+  return isHatchedOnboarded(assistant.hatchedAt, nowMs);
+}
+
+/**
+ * Does the user own any onboarded assistant? The right question for post-auth
+ * and the onboarding intercept, where the landing assistant is not yet known.
+ */
+export function userHasOnboardedAssistant(
+  assistants: ReadonlyArray<OnboardingAgeFields>,
+  nowMs: number = Date.now(),
+): boolean {
+  return assistants.some((assistant) => isAssistantOnboarded(assistant, nowMs));
+}
+
+/**
+ * Is the assistant the user currently has selected onboarded? False when
+ * nothing is selected or the id is not in the list: an unidentifiable
+ * assistant must not be assumed past first run, or the funnel bounces walks
+ * that legitimately need to run.
+ */
+export function isSelectedAssistantOnboarded(
+  assistants: ReadonlyArray<OnboardingAgeFields & { id: string }>,
+  selectedAssistantId: string | null,
+  nowMs: number = Date.now(),
+): boolean {
+  if (!selectedAssistantId) {
+    return false;
+  }
+  const selected = assistants.find((a) => a.id === selectedAssistantId);
+  return selected ? isAssistantOnboarded(selected, nowMs) : false;
 }

--- a/clients/web/src/domains/onboarding/onboarded-assistant.ts
+++ b/clients/web/src/domains/onboarding/onboarded-assistant.ts
@@ -1,10 +1,16 @@
 /**
  * Whether an assistant is past first-run research onboarding.
  *
- * `onboardedAt` is the real signal, stamped where the funnel terminates (see
- * `onboarded-assistant-record.ts`). Hatch age is the legacy fallback for
- * assistants that predate the record: one created at least a week ago has
- * almost certainly finished, so an upgrade does not re-funnel anybody.
+ * The stamp written where the funnel terminates is the real signal. It lives
+ * in two places: on the lockfile entry (local mode, visible to the CLI and
+ * tray) and in a device-scoped record that also covers cloud and browser
+ * clients. The device half is read live rather than cached on the assistant
+ * row, so a completion in this tab or another one takes effect immediately
+ * instead of waiting for the next assistant-list refresh.
+ *
+ * Hatch age is the legacy fallback for assistants that predate the stamp: one
+ * created at least a week ago has almost certainly finished, so an upgrade
+ * does not re-funnel anybody.
  *
  * Ask the right question. `userHasOnboardedAssistant` answers "is this a
  * returning user" and belongs on post-auth and intercept decisions;
@@ -13,7 +19,9 @@
  * made one week-old assistant bounce every new-assistant walk (#41656).
  */
 
-/** Legacy proxy window, used only when `onboardedAt` is absent. */
+import { readOnboardedAt } from "@/domains/onboarding/onboarded-assistant-record";
+
+/** Legacy proxy window, used only when the stamp is absent. */
 export const ONBOARDED_HATCH_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 export function isHatchedOnboarded(
@@ -30,17 +38,19 @@ export function isHatchedOnboarded(
   return nowMs - hatchedMs >= ONBOARDED_HATCH_AGE_MS;
 }
 
-interface OnboardingAgeFields {
+interface OnboardingSignals {
+  id: string;
+  /** The lockfile half of the stamp; the device half is read here. */
   onboardedAt?: string;
   hatchedAt?: string;
 }
 
 /** A stamped assistant is onboarded; an unstamped one falls back to hatch age. */
 export function isAssistantOnboarded(
-  assistant: OnboardingAgeFields,
+  assistant: OnboardingSignals,
   nowMs: number = Date.now(),
 ): boolean {
-  if (assistant.onboardedAt) {
+  if (assistant.onboardedAt ?? readOnboardedAt(assistant.id)) {
     return true;
   }
   return isHatchedOnboarded(assistant.hatchedAt, nowMs);
@@ -51,7 +61,7 @@ export function isAssistantOnboarded(
  * and the onboarding intercept, where the landing assistant is not yet known.
  */
 export function userHasOnboardedAssistant(
-  assistants: ReadonlyArray<OnboardingAgeFields>,
+  assistants: ReadonlyArray<OnboardingSignals>,
   nowMs: number = Date.now(),
 ): boolean {
   return assistants.some((assistant) => isAssistantOnboarded(assistant, nowMs));
@@ -64,7 +74,7 @@ export function userHasOnboardedAssistant(
  * that legitimately need to run.
  */
 export function isSelectedAssistantOnboarded(
-  assistants: ReadonlyArray<OnboardingAgeFields & { id: string }>,
+  assistants: ReadonlyArray<OnboardingSignals>,
   selectedAssistantId: string | null,
   nowMs: number = Date.now(),
 ): boolean {

--- a/clients/web/src/domains/onboarding/onboarding-destination.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.test.ts
@@ -69,21 +69,21 @@ describe("onboardingDestinationAfterConsent", () => {
     ).toBe(routes.onboarding.research);
   });
 
-  test("an already-onboarded assistant skips research on every build", () => {
+  test("an onboarded selected assistant skips research on every build", () => {
     expect(
       onboardingDestinationAfterConsent({
         isLocalHatch: false,
-        alreadyOnboarded: true,
+        selectedAssistantOnboarded: true,
         env: "production",
       }),
     ).toBe(routes.assistant);
   });
 
-  test("a new-assistant walk hatches even when another assistant is onboarded", () => {
+  test("a new-assistant walk hatches even when the selected assistant is onboarded", () => {
     expect(
       onboardingDestinationAfterConsent({
         isLocalHatch: false,
-        alreadyOnboarded: true,
+        selectedAssistantOnboarded: true,
         newAssistant: true,
         env: "production",
       }),
@@ -91,19 +91,19 @@ describe("onboardingDestinationAfterConsent", () => {
     expect(
       onboardingDestinationAfterConsent({
         isLocalHatch: true,
-        alreadyOnboarded: true,
+        selectedAssistantOnboarded: true,
         newAssistant: true,
         env: "production",
       }),
     ).toBe(routes.onboarding.hatching);
   });
 
-  test("a local hatch outranks the already-onboarded shortcut without the marker", () => {
+  test("a local hatch outranks the onboarded shortcut without the marker", () => {
     expect(
       onboardingDestinationAfterConsent({
         isLocalHatch: true,
         skipResearch: true,
-        alreadyOnboarded: true,
+        selectedAssistantOnboarded: true,
         env: "staging",
       }),
     ).toBe(routes.onboarding.hatching);

--- a/clients/web/src/domains/onboarding/onboarding-destination.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.ts
@@ -10,14 +10,15 @@ export const SKIP_RESEARCH_PARAM = "skip_research";
 
 /**
  * Query param marking a funnel walk that is provisioning a NEW assistant. Set
- * by every handoff into the privacy screen that provisions: the hosting
- * screen's cloud Continue, the api-key screen, and the retry off-ramp on a
- * failed managed hatch.
+ * by every handoff into the privacy screen that provisions: the start screen's
+ * CTA, the hosting screen's cloud Continue, the api-key screen, and the retry
+ * off-ramp on a failed managed hatch.
  *
- * `alreadyOnboarded` is a fact about assistants that already exist, so it can
- * never answer for the one this walk is about to create. The privacy route
- * guard and the post-consent destination both defer to this marker rather than
- * skipping a hatch the user explicitly asked for.
+ * The walk's intent, which no fact about an existing assistant can supply: the
+ * one being created does not exist yet, so however established the selected
+ * assistant is, this visit is its first run. The privacy route guard and the
+ * post-consent destination both defer to the marker rather than skipping a
+ * hatch the user explicitly asked for.
  */
 export const NEW_ASSISTANT_PARAM = "new_assistant";
 
@@ -93,17 +94,17 @@ export function withSkipResearch(
  *   gateway readyz → provider key) runs; the hatching screen then redirects into
  *   the research flow, which adopts that just-hatched assistant. Skipping
  *   hatching here would leave the research flow with no assistant to adopt.
- * - **Already onboarded** (hatched at least a week ago) → `/assistant`. The
- *   assistant is already provisioned and past research, including in
- *   production. Yields to a walk that is provisioning a new assistant: that
- *   one does not exist yet, so no existing assistant's age answers for it.
+ * - **Selected assistant already onboarded** → `/assistant`. That assistant is
+ *   provisioned and past research, including in production. Yields to a walk
+ *   that is provisioning a new assistant: that one does not exist yet, so the
+ *   selected assistant cannot answer for it.
  * - **Skip to chat** (non-production) → hatching as well. There is no research
  *   form, so the hatch screen provisions, then hands off to chat.
  */
 export function onboardingDestinationAfterConsent({
   isLocalHatch,
   skipResearch = false,
-  alreadyOnboarded = false,
+  selectedAssistantOnboarded = false,
   newAssistant = false,
   env = import.meta.env.VITE_SENTRY_ENVIRONMENT,
 }: {
@@ -115,10 +116,10 @@ export function onboardingDestinationAfterConsent({
    */
   skipResearch?: boolean;
   /**
-   * The current assistant has already finished first-run onboarding. Skips
+   * The selected assistant has already finished first-run onboarding. Skips
    * research on every build, including production.
    */
-  alreadyOnboarded?: boolean;
+  selectedAssistantOnboarded?: boolean;
   /**
    * This walk is provisioning a new assistant (see {@link NEW_ASSISTANT_PARAM}),
    * so it must reach a hatch rather than short-circuit to an existing one.
@@ -129,7 +130,7 @@ export function onboardingDestinationAfterConsent({
 }): string {
   // `isLocalHatch` counts as provisioning on its own: it names a foreground
   // hatch that has to run, marker or not.
-  if (alreadyOnboarded && !newAssistant && !isLocalHatch) {
+  if (selectedAssistantOnboarded && !newAssistant && !isLocalHatch) {
     return routes.assistant;
   }
   if (skipResearch && canSkipOnboardingResearch(env)) {

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -318,6 +318,7 @@ mock.module("@/domains/onboarding/plugin-attribution", () => ({
 
 mock.module("@/lib/local-mode", () => ({
   isLocalClient: () => isLocalClientValue,
+  markLockfileAssistantOnboarded: async () => {},
   loadLockfile: async () => {},
   primeLocalGatewayConnection: async () => {},
   probeLocalGatewayReady: async () => true,

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -318,7 +318,6 @@ mock.module("@/domains/onboarding/plugin-attribution", () => ({
 
 mock.module("@/lib/local-mode", () => ({
   isLocalClient: () => isLocalClientValue,
-  markLockfileAssistantOnboarded: async () => {},
   loadLockfile: async () => {},
   primeLocalGatewayConnection: async () => {},
   probeLocalGatewayReady: async () => true,

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -32,6 +32,7 @@ import {
   NEW_ASSISTANT_PARAM,
   shouldSkipResearchAfterHatch,
 } from "@/domains/onboarding/onboarding-destination";
+import { stampAssistantOnboarded } from "@/domains/onboarding/stamp-assistant-onboarded";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
 import {
   awaitPurchasedProvisioning,
@@ -306,8 +307,11 @@ export function HatchingScreen() {
             return;
           }
           // Non-production skip-to-chat: the assistant is live, so drop into
-          // the workspace instead of the research/personality funnel.
+          // the workspace instead of the research/personality funnel. This
+          // bypasses the research route, so it is the terminal that has to
+          // record the completion itself.
           if (shouldSkipResearchAfterHatch(searchParams)) {
+            stampAssistantOnboarded(readyAssistantId);
             void navigate(`${routes.assistant}?onboarding=1`, {
               replace: true,
             });
@@ -650,7 +654,7 @@ export function HatchingScreen() {
         return;
       }
 
-      handleHatchReady();
+      handleHatchReady(assistantId);
     };
 
     const runPoll = async () => {

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -4,6 +4,10 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { SKIP_RESEARCH_PARAM } from "@/domains/onboarding/onboarding-destination";
 import { ONBOARDED_HATCH_AGE_MS } from "@/domains/onboarding/onboarded-assistant";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  clearSelectedAssistantId,
+  writeSelectedAssistantId,
+} from "@/assistant/selected-assistant-storage";
 import { routes } from "@/utils/routes";
 
 // react-router: capture navigate() targets and drive the ?preview flag.
@@ -142,6 +146,7 @@ describe("PrivacyScreen — Start navigation", () => {
     checkoutIntentValue = null;
     takeoverValue = "enabled";
     useResolvedAssistantsStore.setState({ assistants: [] });
+    clearSelectedAssistantId();
   });
   afterEach(() => {
     cleanup();
@@ -150,6 +155,7 @@ describe("PrivacyScreen — Start navigation", () => {
     checkoutIntentValue = null;
     takeoverValue = "enabled";
     useResolvedAssistantsStore.setState({ assistants: [] });
+    clearSelectedAssistantId();
   });
 
   test("preview mode no-ops on Start without persisting consent", () => {
@@ -224,7 +230,7 @@ describe("PrivacyScreen — Start navigation", () => {
     });
   });
 
-  test("skips research when the assistant was hatched over a week ago", () => {
+  test("skips research when the selected assistant is over a week old", () => {
     useResolvedAssistantsStore.setState({
       assistants: [
         {
@@ -236,12 +242,45 @@ describe("PrivacyScreen — Start navigation", () => {
         },
       ],
     });
+    writeSelectedAssistantId("asst-1");
     searchParamsValue = new URLSearchParams();
     render(<PrivacyScreen />);
 
     clickStart();
 
     expect(navigateMock).toHaveBeenCalledWith(routes.assistant, {
+      replace: true,
+    });
+  });
+
+  // The chooser loop: an established sibling must not answer for the assistant
+  // this walk is creating.
+  test("still hatches when a week-old sibling is not the selected assistant", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-old",
+          hatchedAt: new Date(Date.now() - ONBOARDED_HATCH_AGE_MS).toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+        {
+          id: "asst-new",
+          hatchedAt: new Date().toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+      ],
+    });
+    writeSelectedAssistantId("asst-new");
+    searchParamsValue = new URLSearchParams();
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.research, {
       replace: true,
     });
   });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -12,7 +12,8 @@ import {
   getOnboardingFunnelSessionId,
   ONBOARDING_FUNNEL_STEPS,
 } from "@/domains/onboarding/funnel-events";
-import { hasOnboardedAssistant } from "@/domains/onboarding/onboarded-assistant";
+import { isSelectedAssistantOnboarded } from "@/domains/onboarding/onboarded-assistant";
+import { readSelectedAssistantId } from "@/assistant/selected-assistant-storage";
 import {
   canSkipOnboardingResearch,
   isNewAssistantFunnel,
@@ -128,13 +129,14 @@ export function PrivacyScreen() {
     // to chat.
     const isLocalHatch =
       isLocalClient() && hostingParam !== null && hostingParam !== "vellum-cloud";
-    const alreadyOnboarded = hasOnboardedAssistant(
+    const selectedAssistantOnboarded = isSelectedAssistantOnboarded(
       useResolvedAssistantsStore.getState().assistants,
+      readSelectedAssistantId(),
     );
     const destination = onboardingDestinationAfterConsent({
       isLocalHatch,
       skipResearch,
-      alreadyOnboarded,
+      selectedAssistantOnboarded,
       newAssistant: isNewAssistantFunnel(searchParams),
     });
     const onboardingNext = skipResearch

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -141,10 +141,8 @@ mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthMode: () => false,
 }));
 
-const markLockfileOnboardedMock = mock(async (..._args: unknown[]) => {});
 mock.module("@/lib/local-mode", () => ({
   isLocalClient: () => false,
-  markLockfileAssistantOnboarded: markLockfileOnboardedMock,
 }));
 
 // The real module builds its destinations from `routes` at import time, and the
@@ -628,7 +626,6 @@ describe("ResearchOnboardingRoute resume guard", () => {
 
     await waitFor(() => expect(navigateMock).toHaveBeenCalled());
     expect(readOnboardedAt("asst-1")).toBeTruthy();
-    expect(markLockfileOnboardedMock).toHaveBeenCalled();
   });
 
   test("keeping an established assistant stamps it too", async () => {

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -39,6 +39,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { type ReactNode } from "react";
 
 import { PLATFORM_HOSTED_DISABLED_MESSAGE } from "@/assistant/lifecycle";
+import { readOnboardedAt } from "@/domains/onboarding/onboarded-assistant-record";
 import {
   readResearchSnapshot,
   writeResearchSnapshot,
@@ -140,8 +141,10 @@ mock.module("@/lib/auth/gateway-session", () => ({
   isGatewayAuthMode: () => false,
 }));
 
+const markLockfileOnboardedMock = mock(async (..._args: unknown[]) => {});
 mock.module("@/lib/local-mode", () => ({
   isLocalClient: () => false,
+  markLockfileAssistantOnboarded: markLockfileOnboardedMock,
 }));
 
 // The real module builds its destinations from `routes` at import time, and the
@@ -365,8 +368,16 @@ mock.module("@/domains/onboarding/screens/research-result-steps", () => ({
 }));
 
 mock.module("@/domains/onboarding/screens/existing-assistant-step", () => ({
-  ExistingAssistantStep: (props: { assistantName: string | null }) => (
-    <div data-testid="existing-step">{props.assistantName ?? "unknown"}</div>
+  ExistingAssistantStep: (props: {
+    assistantName: string | null;
+    onKeep?: () => void;
+  }) => (
+    <>
+      <div data-testid="existing-step">{props.assistantName ?? "unknown"}</div>
+      <button type="button" data-testid="existing-keep" onClick={props.onKeep}>
+        Keep
+      </button>
+    </>
   ),
 }));
 
@@ -594,6 +605,46 @@ describe("ResearchOnboardingRoute resume guard", () => {
     fireEvent.click(screen.getByTestId("letschat-start"));
     await waitFor(() => expect(navigateMock).toHaveBeenCalled());
     expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  // The completion record: this is the only place the assistant the user just
+  // finished onboarding is known, so it is where the stamp has to happen.
+  test("handing off to chat stamps the assistant as onboarded", async () => {
+    researchStatus = "done";
+    writeResearchSnapshot(USER_ID, doneSnapshot());
+    backgroundHatch.ready = true;
+    backgroundHatch.assistantId = "asst-1";
+
+    render(<ResearchOnboardingRoute />);
+
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("letschat-start") as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+    expect(readOnboardedAt("asst-1")).toBeUndefined();
+
+    fireEvent.click(screen.getByTestId("letschat-start"));
+
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled());
+    expect(readOnboardedAt("asst-1")).toBeTruthy();
+    expect(markLockfileOnboardedMock).toHaveBeenCalled();
+  });
+
+  test("keeping an established assistant stamps it too", async () => {
+    establishedResult = { established: true, assistantName: "Viper" };
+    writeResearchSnapshot(USER_ID, postFormSnapshot());
+    backgroundHatch.ready = true;
+    backgroundHatch.assistantId = "asst-1";
+
+    render(<ResearchOnboardingRoute />);
+    await waitFor(() =>
+      expect(screen.getByTestId("existing-step")).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByTestId("existing-keep"));
+
+    await waitFor(() => expect(readOnboardedAt("asst-1")).toBeTruthy());
   });
 
   test("parking on the guard from a resume never persists a resumable 'existing' snapshot", async () => {

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -61,6 +61,7 @@ import {
   writeResearchSnapshot,
   type ResearchStep,
 } from "@/domains/onboarding/research-onboarding-persistence";
+import { stampAssistantOnboarded } from "@/domains/onboarding/stamp-assistant-onboarded";
 import {
   emitResearchOnboardingStepCompleted,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
@@ -740,6 +741,8 @@ export function ResearchOnboardingRoute() {
     // Handing off to the chat ends the research-onboarding journey — drop the
     // resume snapshot so a later visit starts clean instead of resuming this one.
     clearResearchSnapshot(userId);
+    // The completion record this assistant is judged by from here on.
+    stampAssistantOnboarded(hatchedAssistantId);
 
     const { firstName, lastName, role, hobbies } = values;
     const fullName = [firstName.trim(), lastName.trim()]
@@ -1303,6 +1306,8 @@ export function ResearchOnboardingRoute() {
             { userId, outcome: "completed" },
           );
           clearResearchSnapshot(userId);
+          // Keeping an established assistant settles its onboarding too.
+          stampAssistantOnboarded(hatchedAssistantId);
           // Pin the selection to the adopted assistant, then enter the app —
           // with no pre-chat context, kickoff, or persona write of any kind.
           void lifecycleService

--- a/clients/web/src/domains/onboarding/pages/start-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
+import { NEW_ASSISTANT_PARAM } from "@/domains/onboarding/onboarding-destination";
 import { routes } from "@/utils/routes";
 
 const navigateMock = mock((..._args: unknown[]) => {});
@@ -32,13 +33,18 @@ describe("StartScreen", () => {
   // it once setup finishes (see `onboarding-navigation.ts`). This screen is
   // reached only via Back in the first place, so a push here would put it
   // straight back on the stack.
-  test("the single CTA re-enters the funnel at the privacy screen", () => {
+  // The CTA creates an assistant, so it carries the new-assistant marker: this
+  // screen is the Back target out of privacy, and without the marker a user
+  // whose selected assistant is already onboarded is bounced to /assistant on
+  // the way back in.
+  test("the single CTA re-enters the funnel as a new-assistant walk", () => {
     render(<StartScreen />);
 
     fireEvent.click(screen.getByText("Create your assistant"));
 
-    expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.privacy, {
-      replace: true,
-    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      `${routes.onboarding.privacy}?${NEW_ASSISTANT_PARAM}=1`,
+      { replace: true },
+    );
   });
 });

--- a/clients/web/src/domains/onboarding/pages/start-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router";
 
 import { OnboardingLayout } from "@/components/onboarding-layout";
+import { NEW_ASSISTANT_PARAM } from "@/domains/onboarding/onboarding-destination";
 import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import { useTranslation } from "@/i18n";
 import { routes } from "@/utils/routes";
@@ -52,7 +53,10 @@ export function StartScreen() {
               fullWidth
               className="h-11 text-base"
               onClick={() =>
-                void navigate(routes.onboarding.privacy, SETUP_NAVIGATE)
+                void navigate(
+                  `${routes.onboarding.privacy}?${NEW_ASSISTANT_PARAM}=1`,
+                  SETUP_NAVIGATE,
+                )
               }
             >
               {t("startScreen.createAssistant")}

--- a/clients/web/src/domains/onboarding/stamp-assistant-onboarded.ts
+++ b/clients/web/src/domains/onboarding/stamp-assistant-onboarded.ts
@@ -1,0 +1,28 @@
+/**
+ * Record that an assistant finished first-run onboarding, on both targets:
+ * the device record (every hosting mode) and the lockfile entry when there is
+ * one, so the CLI and tray see it too.
+ *
+ * Separate from `onboarded-assistant-record.ts` because that module is on the
+ * resolved-assistants store's read path and must stay free of the lockfile
+ * transport.
+ */
+
+import { markAssistantOnboarded } from "@/domains/onboarding/onboarded-assistant-record";
+import { markLockfileAssistantOnboarded } from "@/lib/local-mode";
+
+/** No-ops on a null id: a dead hatch has nothing to record. */
+export function stampAssistantOnboarded(
+  assistantId: string | null | undefined,
+): void {
+  if (!assistantId) {
+    return;
+  }
+  const at = new Date().toISOString();
+  markAssistantOnboarded(assistantId, at);
+  // The device record is the one that must not fail; the mirror is
+  // fire-and-forget, matching `local-platform-identity.ts`.
+  void markLockfileAssistantOnboarded(assistantId, at).catch((err: unknown) => {
+    console.warn("Failed to stamp onboardedAt on the lockfile entry", err);
+  });
+}

--- a/clients/web/src/domains/onboarding/stamp-assistant-onboarded.ts
+++ b/clients/web/src/domains/onboarding/stamp-assistant-onboarded.ts
@@ -9,7 +9,6 @@
  */
 
 import { markAssistantOnboarded } from "@/domains/onboarding/onboarded-assistant-record";
-import { markLockfileAssistantOnboarded } from "@/lib/local-mode";
 
 /** No-ops on a null id: a dead hatch has nothing to record. */
 export function stampAssistantOnboarded(
@@ -20,9 +19,13 @@ export function stampAssistantOnboarded(
   }
   const at = new Date().toISOString();
   markAssistantOnboarded(assistantId, at);
-  // The device record is the one that must not fail; the mirror is
-  // fire-and-forget, matching `local-platform-identity.ts`.
-  void markLockfileAssistantOnboarded(assistantId, at).catch((err: unknown) => {
-    console.warn("Failed to stamp onboardedAt on the lockfile entry", err);
-  });
+  // The device record is the one that must not fail. The lockfile mirror is
+  // best-effort and its transport is Electron-only, so it is loaded on demand
+  // rather than dragged into the static graph of the two onboarding screens
+  // that call this. Failure is a warning, matching `local-platform-identity`.
+  void import("@/lib/local-mode")
+    .then((m) => m.markLockfileAssistantOnboarded(assistantId, at))
+    .catch((err: unknown) => {
+      console.warn("Failed to stamp onboardedAt on the lockfile entry", err);
+    });
 }

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -348,6 +348,26 @@ export async function renameLockfileAssistant(
 }
 
 /**
+ * Stamp `onboardedAt` on an existing entry so the CLI and tray see that this
+ * assistant finished first-run onboarding. Field-scoped and never creates an
+ * entry: a cloud-only or unknown assistant simply has no lockfile record, and
+ * the device-scoped record in `onboarded-assistant-record.ts` covers it.
+ */
+export async function markLockfileAssistantOnboarded(
+  assistantId: string,
+  onboardedAt: string,
+): Promise<void> {
+  if (isRemoteGatewayMode() || !isLocalModeHostAvailable()) {
+    return;
+  }
+  const entry = getLockfileAssistant(assistantId);
+  if (!entry || entry.onboardedAt) {
+    return;
+  }
+  await updateLockfileAssistant({ ...entry, onboardedAt });
+}
+
+/**
  * Mark an already-known assistant as the lockfile's active assistant, leaving
  * its other fields untouched. Used when switching managed assistants so the
  * lockfile `activeAssistant` — read by the macOS tray, the CLI, and the native

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -39,6 +39,7 @@ import {
   retireLocalAssistantHost,
   renameLockfileAssistantHost,
   saveLockfileAssistantHost,
+  stampLockfileAssistantOnboardedHost,
   unpairAssistantHost,
   wakeLocalAssistantHost,
 } from "@/runtime/local-mode-host";
@@ -349,9 +350,14 @@ export async function renameLockfileAssistant(
 
 /**
  * Stamp `onboardedAt` on an existing entry so the CLI and tray see that this
- * assistant finished first-run onboarding. Field-scoped and never creates an
- * entry: a cloud-only or unknown assistant simply has no lockfile record, and
- * the device-scoped record in `onboarded-assistant-record.ts` covers it.
+ * assistant finished first-run onboarding. Runs through the host's
+ * stamp-if-present operation for the same reason the rename above does: the
+ * host decides against the on-disk registry, so a completion racing a retire
+ * cannot re-create the entry from a stale renderer snapshot. The guards below
+ * are cheap early-outs, not the safety boundary.
+ *
+ * A cloud-only assistant simply has no lockfile entry; the device-scoped
+ * record in `onboarded-assistant-record.ts` is what covers it.
  */
 export async function markLockfileAssistantOnboarded(
   assistantId: string,
@@ -364,7 +370,13 @@ export async function markLockfileAssistantOnboarded(
   if (!entry || entry.onboardedAt) {
     return;
   }
-  await updateLockfileAssistant({ ...entry, onboardedAt });
+  const result = await stampLockfileAssistantOnboardedHost(
+    assistantId,
+    onboardedAt,
+  );
+  if (result.ok) {
+    commitLockfile(result.lockfile);
+  }
 }
 
 /**

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -33,6 +33,9 @@ const { useAuthStore } = await import("@/stores/auth-store");
 const { useOrganizationStore } = await import("@/stores/organization-store");
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
+const { clearSelectedAssistantId, writeSelectedAssistantId } = await import(
+  "@/assistant/selected-assistant-storage"
+);
 
 const initialAuthState = useAuthStore.getState();
 
@@ -49,6 +52,7 @@ beforeEach(() => {
     assistants: [],
     activeAssistantId: null,
   });
+  clearSelectedAssistantId();
 });
 
 afterEach(() => {
@@ -201,38 +205,58 @@ describe("buildNavigationState — hasPlatformHostedAssistant", () => {
   });
 });
 
-describe("buildNavigationState — alreadyOnboarded", () => {
-  test("false when no assistant is a week old", () => {
-    useResolvedAssistantsStore.setState({
-      assistants: [
-        {
-          id: "asst-fresh",
-          hatchedAt: new Date().toISOString(),
-          isLocal: false,
-          isPlatformHosted: true,
-          isPaired: false,
-        },
-      ],
-    });
-
-    expect(buildNavigationState().alreadyOnboarded).toBe(false);
+describe("buildNavigationState — onboarding scoping", () => {
+  const FRESH = new Date().toISOString();
+  const WEEK_OLD = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+  const row = (id: string, hatchedAt: string) => ({
+    id,
+    hatchedAt,
+    isLocal: false,
+    isPlatformHosted: true,
+    isPaired: false,
   });
 
-  test("true when any assistant was hatched at least a week ago", () => {
+  test("false on both when no assistant is a week old", () => {
     useResolvedAssistantsStore.setState({
-      assistants: [
-        {
-          id: "asst-old",
-          hatchedAt: new Date(
-            Date.now() - 8 * 24 * 60 * 60 * 1000,
-          ).toISOString(),
-          isLocal: false,
-          isPlatformHosted: true,
-          isPaired: false,
-        },
-      ],
+      assistants: [row("asst-fresh", FRESH)],
     });
+    writeSelectedAssistantId("asst-fresh");
 
-    expect(buildNavigationState().alreadyOnboarded).toBe(true);
+    const state = buildNavigationState();
+    expect(state.userHasOnboardedAssistant).toBe(false);
+    expect(state.selectedAssistantOnboarded).toBe(false);
+  });
+
+  test("true on both when the selected assistant is a week old", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [row("asst-old", WEEK_OLD)],
+    });
+    writeSelectedAssistantId("asst-old");
+
+    const state = buildNavigationState();
+    expect(state.userHasOnboardedAssistant).toBe(true);
+    expect(state.selectedAssistantOnboarded).toBe(true);
+  });
+
+  // The chooser loop: a week-old sibling must not answer for a fresh
+  // selection, or every new-assistant walk is bounced back to the chooser.
+  test("a week-old sibling does not make a fresh selection onboarded", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [row("asst-old", WEEK_OLD), row("asst-fresh", FRESH)],
+    });
+    writeSelectedAssistantId("asst-fresh");
+
+    const state = buildNavigationState();
+    expect(state.userHasOnboardedAssistant).toBe(true);
+    expect(state.selectedAssistantOnboarded).toBe(false);
+  });
+
+  test("selectedAssistantOnboarded is false with nothing selected", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [row("asst-old", WEEK_OLD)],
+    });
+    clearSelectedAssistantId();
+
+    expect(buildNavigationState().selectedAssistantOnboarded).toBe(false);
   });
 });

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -15,7 +15,11 @@ import {
   readConsentHydrated,
 } from "@/domains/onboarding/prefs";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
-import { hasOnboardedAssistant } from "@/domains/onboarding/onboarded-assistant";
+import {
+  isSelectedAssistantOnboarded,
+  userHasOnboardedAssistant,
+} from "@/domains/onboarding/onboarded-assistant";
+import { readSelectedAssistantId } from "@/assistant/selected-assistant-storage";
 import {
   assistantsValidForOrg,
   useResolvedAssistantsStore,
@@ -48,6 +52,9 @@ export function buildNavigationState(
   const { sessionStatus, platformSession } = useAuthStore.getState();
   const { assistants, assistantsHydrated } =
     useResolvedAssistantsStore.getState();
+  // The persisted key rather than the store slice: this runs inside route
+  // middleware, before the store has necessarily reconciled a selection.
+  const selectedAssistantId = readSelectedAssistantId();
   const isRemoteGateway = isRemoteGatewayMode();
   return {
     isLocalClient: isLocalClient(),
@@ -73,7 +80,11 @@ export function buildNavigationState(
     diagnosticsConsentCurrent: readDiagnosticsConsentCurrent(),
     consentHydrated: readConsentHydrated(),
     assistantsHydrated,
-    alreadyOnboarded: hasOnboardedAssistant(assistants),
+    userHasOnboardedAssistant: userHasOnboardedAssistant(assistants),
+    selectedAssistantOnboarded: isSelectedAssistantOnboarded(
+      assistants,
+      selectedAssistantId,
+    ),
     ...overrides,
   };
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -35,7 +35,8 @@ const base: NavigationState = {
   // the hydration-gating cases override these explicitly.
   consentHydrated: true,
   assistantsHydrated: true,
-  alreadyOnboarded: false,
+  userHasOnboardedAssistant: false,
+  selectedAssistantOnboarded: false,
 };
 
 function s(overrides: Partial<NavigationState>): NavigationState {
@@ -215,28 +216,28 @@ describe("resolveNavigation", () => {
       ).toEqual(ALLOW);
     });
 
-    test("bounces an already-onboarded user off first-run privacy", () => {
+    test("bounces first-run privacy when the selected assistant is onboarded", () => {
       expect(
-        guard(s({ alreadyOnboarded: true }), "/assistant/onboarding/privacy"),
+        guard(s({ selectedAssistantOnboarded: true }), "/assistant/onboarding/privacy"),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
         guard(
-          s({ alreadyOnboarded: true, hasAssistants: false }),
+          s({ selectedAssistantOnboarded: true, hasAssistants: false }),
           "/assistant/onboarding/privacy?replay=1",
         ),
       ).toEqual({ action: "redirect", to: "/assistant" });
     });
 
-    test("lets a new-assistant walk through privacy despite an onboarded assistant", () => {
+    test("lets a new-assistant walk through privacy despite an onboarded selection", () => {
       expect(
         guard(
-          s({ alreadyOnboarded: true }),
+          s({ selectedAssistantOnboarded: true }),
           `/assistant/onboarding/privacy?hosting=local&${NEW_ASSISTANT_PARAM}=1`,
         ),
       ).toEqual(ALLOW);
       expect(
         guard(
-          s({ alreadyOnboarded: true }),
+          s({ selectedAssistantOnboarded: true }),
           `/assistant/onboarding/privacy?${NEW_ASSISTANT_PARAM}=1`,
         ),
       ).toEqual(ALLOW);
@@ -247,7 +248,7 @@ describe("resolveNavigation", () => {
       const state = s({
         isLocalClient: true,
         isAuthenticated: false,
-        alreadyOnboarded: true,
+        selectedAssistantOnboarded: true,
         hasAssistants: true,
       });
       expect(
@@ -262,18 +263,18 @@ describe("resolveNavigation", () => {
       });
     });
 
-    test("resumes a paid hatch when bouncing an already-onboarded user off privacy", () => {
+    test("resumes a paid hatch when bouncing an onboarded selection off privacy", () => {
       expect(
         guard(
-          s({ alreadyOnboarded: true }),
+          s({ selectedAssistantOnboarded: true }),
           `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(HATCHING_FUNNEL_URL)}`,
         ),
       ).toEqual({ action: "redirect", to: HATCHING_FUNNEL_URL });
     });
 
-    test("keeps research reachable on demand for an already-onboarded user", () => {
+    test("keeps research reachable on demand for an onboarded selection", () => {
       expect(
-        guard(s({ alreadyOnboarded: true }), "/assistant/onboarding/research"),
+        guard(s({ selectedAssistantOnboarded: true }), "/assistant/onboarding/research"),
       ).toEqual(ALLOW);
     });
 
@@ -1493,11 +1494,11 @@ describe("resolveNavigation", () => {
       ).toEqual(ALLOW);
     });
 
-    test("allows an already-onboarded assistant even without local consent flags", () => {
+    test("allows a returning user even without local consent flags", () => {
       expect(
         intercept(
           s({
-            alreadyOnboarded: true,
+            userHasOnboardedAssistant: true,
             tosAccepted: false,
             privacyConsent: false,
           }),
@@ -1853,7 +1854,7 @@ describe("resolveNavigation", () => {
 
     test("signup skips privacy when the assistant is already onboarded", () => {
       expect(
-        resolveNavigation(s({ alreadyOnboarded: true }), {
+        resolveNavigation(s({ userHasOnboardedAssistant: true }), {
           kind: "post-auth",
           authIntent: "signup",
           returnTo: "/assistant/home",
@@ -1865,7 +1866,7 @@ describe("resolveNavigation", () => {
 
     test("signup with a checkout deep link skips privacy when already onboarded", () => {
       expect(
-        resolveNavigation(s({ alreadyOnboarded: true }), {
+        resolveNavigation(s({ userHasOnboardedAssistant: true }), {
           kind: "post-auth",
           authIntent: "signup",
           returnTo: "/assistant/checkout?package=super",
@@ -1880,7 +1881,7 @@ describe("resolveNavigation", () => {
 
     test("login keeps a paid hatch returnTo when already onboarded", () => {
       expect(
-        resolveNavigation(s({ alreadyOnboarded: true }), {
+        resolveNavigation(s({ userHasOnboardedAssistant: true }), {
           kind: "post-auth",
           authIntent: "login",
           returnTo: HATCHING_FUNNEL_URL,
@@ -1891,7 +1892,7 @@ describe("resolveNavigation", () => {
 
     test("login skips a privacy or research returnTo when already onboarded", () => {
       expect(
-        resolveNavigation(s({ alreadyOnboarded: true }), {
+        resolveNavigation(s({ userHasOnboardedAssistant: true }), {
           kind: "post-auth",
           authIntent: "login",
           returnTo: "/assistant/onboarding/privacy",
@@ -1899,7 +1900,7 @@ describe("resolveNavigation", () => {
         }),
       ).toEqual({ action: "redirect", to: "/assistant" });
       expect(
-        resolveNavigation(s({ alreadyOnboarded: true }), {
+        resolveNavigation(s({ userHasOnboardedAssistant: true }), {
           kind: "post-auth",
           authIntent: "login",
           returnTo: "/assistant/onboarding/research?hosting=vellum-cloud",
@@ -1908,9 +1909,21 @@ describe("resolveNavigation", () => {
       ).toEqual({ action: "redirect", to: "/assistant" });
     });
 
+    test("login keeps a new-assistant returnTo when already onboarded", () => {
+      const returnTo = `/assistant/onboarding/privacy?${NEW_ASSISTANT_PARAM}=1`;
+      expect(
+        resolveNavigation(s({ userHasOnboardedAssistant: true }), {
+          kind: "post-auth",
+          authIntent: "login",
+          returnTo,
+          fallback: "/assistant",
+        }),
+      ).toEqual({ action: "redirect", to: returnTo });
+    });
+
     test("signup still goes to privacy for a freshly hatched assistant", () => {
       expect(
-        resolveNavigation(s({ alreadyOnboarded: false, hasAssistants: true }), {
+        resolveNavigation(s({ userHasOnboardedAssistant: false, hasAssistants: true }), {
           kind: "post-auth",
           authIntent: "signup",
           returnTo: "/assistant/home",

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -52,10 +52,17 @@ export interface NavigationState {
   /** Whether the resolved assistants list reflects at least one authoritative load. */
   assistantsHydrated: boolean;
   /**
-   * Whether any resolved assistant is already past first-run onboarding.
-   * Hatch age is the stored proxy (see `hasOnboardedAssistant`).
+   * Whether the user owns ANY assistant past first-run onboarding, i.e. is a
+   * returning user. The right question for post-auth and the onboarding
+   * intercept, where the assistant they will land in is not yet known.
    */
-  alreadyOnboarded: boolean;
+  userHasOnboardedAssistant: boolean;
+  /**
+   * Whether the SELECTED assistant is past first-run onboarding. False when
+   * nothing is selected. The right question for the privacy funnel, which is
+   * always about one assistant.
+   */
+  selectedAssistantOnboarded: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -629,20 +636,15 @@ function allowSetupRoutes(
     return null;
   }
 
-  // An already-onboarded assistant should not re-enter first-run privacy.
-  // Research stays reachable on demand (replay); only the automatic privacy
-  // entry is bounced. A paid hatch riding on `returnTo` is resumed so a
-  // purchased resize is not dropped.
+  // The selected assistant is past first run, so this privacy visit is a
+  // replay rather than its onboarding. Research stays reachable on demand;
+  // only the automatic privacy entry is bounced. A paid hatch riding on
+  // `returnTo` is resumed so a purchased resize is not dropped.
   //
-  // A walk that is provisioning a new assistant is exempt. `alreadyOnboarded`
-  // is `.some()` over every resolved assistant, so without the exemption one
-  // week-old entry bounces the whole provisioning funnel to `/assistant`, which
-  // `requireAuth` sends back to the chooser the walk started from.
-  if (path === routes.onboarding.privacy && state.alreadyOnboarded) {
-    const qIdx = pathnameWithSearch.indexOf("?");
-    const params = new URLSearchParams(
-      qIdx >= 0 ? pathnameWithSearch.slice(qIdx + 1) : "",
-    );
+  // The marker is the walk's INTENT: provisioning a new assistant is first-run
+  // for that assistant no matter how established the selected one is.
+  if (path === routes.onboarding.privacy && state.selectedAssistantOnboarded) {
+    const params = searchParamsOf(pathnameWithSearch);
     if (!isNewAssistantFunnel(params)) {
       const paidReturn = postCheckoutHatchReturnTo(params.get("returnTo"));
       if (paidReturn) {
@@ -837,7 +839,7 @@ function resolveOnboardingIntercept(
   if (state.isLocalClient && state.hasAssistants) {
     return { action: "allow" };
   }
-  if (hasCompletedOnboarding(state) || state.alreadyOnboarded) {
+  if (hasCompletedOnboarding(state) || state.userHasOnboardedAssistant) {
     return { action: "allow" };
   }
 
@@ -898,6 +900,14 @@ function isImportFunnelDestination(destination: string): boolean {
   );
 }
 
+/** The query of a `pathname?search` string the guard was handed. */
+function searchParamsOf(pathnameWithSearch: string): URLSearchParams {
+  const qIdx = pathnameWithSearch.indexOf("?");
+  return new URLSearchParams(
+    qIdx >= 0 ? pathnameWithSearch.slice(qIdx + 1) : "",
+  );
+}
+
 function isOnboardingResearchPath(destination: string): boolean {
   const path = extractPathname(destination);
   const qIdx = path.indexOf("?");
@@ -921,14 +931,17 @@ function resolvePostAuth(
     return { action: "redirect", to: destination };
   }
 
-  // An already-onboarded assistant skips first-run privacy and research.
-  // Treat the auth as a login so a pricing-CTA checkout stash is not marked
-  // for the privacy screen to consume. A paid hatch return keeps its
-  // destination so a purchased resize is not dropped.
-  if (state.alreadyOnboarded) {
-    const skipTarget = postCheckoutHatchReturnTo(destination)
-      ? destination
-      : isOnboardingResearchPath(destination)
+  // A returning user skips first-run privacy and research. Treat the auth as
+  // a login so a pricing-CTA checkout stash is not marked for the privacy
+  // screen to consume. Two funnel destinations are still real work rather
+  // than a re-run, so they survive: a paid hatch, and a walk that is
+  // provisioning a new assistant.
+  if (state.userHasOnboardedAssistant) {
+    const isRealWork =
+      postCheckoutHatchReturnTo(destination) != null ||
+      isNewAssistantFunnel(searchParamsOf(destination));
+    const skipTarget =
+      !isRealWork && isOnboardingResearchPath(destination)
         ? fallback
         : destination;
     resolveSignupCheckoutDestination({

--- a/clients/web/src/lib/onboarding-middleware.test.ts
+++ b/clients/web/src/lib/onboarding-middleware.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { markAssistantOnboarded } from "@/domains/onboarding/onboarded-assistant-record";
 import { NEW_ASSISTANT_PARAM } from "@/domains/onboarding/onboarding-destination";
 import { onboardingCompletedMiddleware } from "@/lib/onboarding-middleware";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -108,6 +109,31 @@ describe("onboardingCompletedMiddleware", () => {
 
       expect(result).toBe("ok");
       expect(next).toHaveBeenCalled();
+    });
+
+    // The stamp is read live, not cached on the assistant row: a completion
+    // has to take effect without waiting for the assistant list to be rebuilt
+    // (and reaches other tabs the same way).
+    test("a fresh stamp arms the bounce with no store refresh", async () => {
+      useResolvedAssistantsStore.setState({
+        assistants: [row("asst-new", new Date().toISOString())],
+        assistantsHydrated: true,
+      });
+      writeSelectedAssistantId("asst-new");
+      const request = () =>
+        ({
+          request: makeRequest(`${routes.onboarding.privacy}?hosting=local`),
+        }) as Parameters<typeof onboardingCompletedMiddleware>[0];
+
+      expect(
+        await onboardingCompletedMiddleware(request(), async () => "ok"),
+      ).toBe("ok");
+
+      markAssistantOnboarded("asst-new");
+
+      await expect(
+        onboardingCompletedMiddleware(request(), async () => "ok"),
+      ).rejects.toThrow();
     });
 
     test("lets a marked provisioning walk through", async () => {

--- a/clients/web/src/lib/onboarding-middleware.test.ts
+++ b/clients/web/src/lib/onboarding-middleware.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { NEW_ASSISTANT_PARAM } from "@/domains/onboarding/onboarding-destination";
 import { onboardingCompletedMiddleware } from "@/lib/onboarding-middleware";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { writeSelectedAssistantId } from "@/assistant/selected-assistant-storage";
 import { routes } from "@/utils/routes";
 
 function makeRequest(path: string): Request {
@@ -52,22 +53,23 @@ describe("onboardingCompletedMiddleware", () => {
   // walk as an unmarked re-entry and bounced it to `/assistant`, which sends a
   // local client back to the chooser it started from.
   describe("new-assistant marker", () => {
+    const WEEK_OLD = () =>
+      new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const row = (id: string, hatchedAt: string) => ({
+      id,
+      hatchedAt,
+      isLocal: true,
+      isPlatformHosted: false,
+      isPaired: false,
+    });
+
     beforeEach(() => {
-      // A week-old assistant is what makes `alreadyOnboarded` true.
+      // An onboarded SELECTED assistant is what arms the privacy bounce.
       useResolvedAssistantsStore.setState({
-        assistants: [
-          {
-            id: "asst-old",
-            hatchedAt: new Date(
-              Date.now() - 30 * 24 * 60 * 60 * 1000,
-            ).toISOString(),
-            isLocal: true,
-            isPlatformHosted: false,
-            isPaired: false,
-          },
-        ],
+        assistants: [row("asst-old", WEEK_OLD())],
         assistantsHydrated: true,
       });
+      writeSelectedAssistantId("asst-old");
     });
 
     test("bounces an unmarked privacy entry", async () => {
@@ -82,6 +84,30 @@ describe("onboardingCompletedMiddleware", () => {
         ),
       ).rejects.toThrow();
       expect(next).not.toHaveBeenCalled();
+    });
+
+    // Scoping, at the layer that actually runs the redirect: an established
+    // sibling must not answer for the assistant the user just selected.
+    test("does not bounce when the selected assistant is unonboarded", async () => {
+      useResolvedAssistantsStore.setState({
+        assistants: [
+          row("asst-old", WEEK_OLD()),
+          row("asst-new", new Date().toISOString()),
+        ],
+        assistantsHydrated: true,
+      });
+      writeSelectedAssistantId("asst-new");
+      const next = mock(async () => "ok");
+
+      const result = await onboardingCompletedMiddleware(
+        {
+          request: makeRequest(`${routes.onboarding.privacy}?hosting=local`),
+        } as Parameters<typeof onboardingCompletedMiddleware>[0],
+        next,
+      );
+
+      expect(result).toBe("ok");
+      expect(next).toHaveBeenCalled();
     });
 
     test("lets a marked provisioning walk through", async () => {

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -233,6 +233,10 @@ declare global {
           assistantId: string,
           name: string,
         ): Promise<LockfileWriteResult>;
+        stampLockfileAssistantOnboarded?(
+          assistantId: string,
+          onboardedAt: string,
+        ): Promise<LockfileWriteResult>;
         replacePlatformAssistants(
           platformAssistants: Array<Record<string, unknown>>,
           organizationId?: string,

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -327,6 +327,36 @@ export async function renameLockfileAssistantHost(
 }
 
 /**
+ * Stamp `onboardedAt` on an existing lockfile entry through the host's
+ * update-only operation, for the same reason {@link renameLockfileAssistantHost}
+ * exists: a completion racing a retire must not resurrect the entry from a
+ * stale renderer snapshot. Older Electron hosts that predate the channel
+ * degrade to a structured failure; the stamp still lands in the renderer's
+ * device-scoped record, which is what the routing guards read.
+ */
+export async function stampLockfileAssistantOnboardedHost(
+  assistantId: string,
+  onboardedAt: string,
+): Promise<LockfileWriteResult> {
+  if (isElectron()) {
+    const stamp = window.vellum!.localMode.stampLockfileAssistantOnboarded;
+    if (!stamp) {
+      return {
+        ok: false,
+        error: "Recording onboarding is not supported by this app version",
+      };
+    }
+    return stamp(assistantId, onboardedAt);
+  }
+
+  return postLocalCommand<LockfileWriteResult>(
+    "/assistant/__local/lockfile",
+    { onboarded: { assistantId, onboardedAt } },
+    LOCAL_HOST_UNAVAILABLE_ERROR,
+  );
+}
+
+/**
  * Replace the platform (`cloud === "vellum"`) assistants in the lockfile with
  * the provided set, preserving local assistants. When `organizationId` is
  * given, only that org's platform entries are replaced — other orgs' entries

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -70,6 +70,9 @@ const { useResolvedAssistantsStore } = await import(
   "@/stores/resolved-assistants-store"
 );
 const { routes } = await import("@/utils/routes");
+const { NEW_ASSISTANT_PARAM } = await import(
+  "@/domains/onboarding/onboarding-destination"
+);
 
 describe("resolveNativePostAuthDestination", () => {
   beforeEach(() => {
@@ -185,6 +188,26 @@ describe("resolveNativePostAuthDestination", () => {
     expect(
       resolveNativePostAuthDestination("login", routes.onboarding.research),
     ).toBe(routes.assistant);
+  });
+
+  // The web funnel got this exemption in #41656; native post-auth is the same
+  // decision and had none, so a returning user's deliberate new-assistant walk
+  // was rewritten away.
+  test("native login keeps a marked new-assistant returnTo", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-1",
+          hatchedAt: new Date(Date.now() - ONBOARDED_HATCH_AGE_MS).toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+      ],
+    });
+    const returnTo = `${routes.onboarding.privacy}?${NEW_ASSISTANT_PARAM}=1`;
+
+    expect(resolveNativePostAuthDestination("login", returnTo)).toBe(returnTo);
   });
 });
 

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -8,7 +8,8 @@ import {
 } from "@/domains/account/social-auth";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
-import { hasOnboardedAssistant } from "@/domains/onboarding/onboarded-assistant";
+import { userHasOnboardedAssistant } from "@/domains/onboarding/onboarded-assistant";
+import { isNewAssistantFunnel } from "@/domains/onboarding/onboarding-destination";
 import { resolveSignupCheckoutDestination } from "@/lib/billing/post-auth-checkout";
 import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -311,19 +312,19 @@ export function getSessionTokenFromCookies(): string | null {
  * Post-auth destination for the native (Capacitor/Electron) flows. Delegates
  * the signup checkout-stash + destination decision to the shared
  * `resolveSignupCheckoutDestination`. A first-run signup routes through
- * consent (privacy) first. An already-onboarded assistant skips hosting,
- * privacy, and research. A login keeps its `returnTo` unless that target is
- * the first-run funnel and the assistant is already onboarded.
+ * consent (privacy) first. A returning user skips hosting, privacy, and
+ * research. A login keeps its `returnTo` unless that target is the first-run
+ * funnel and the user is already onboarded.
  */
 export function resolveNativePostAuthDestination(
   intent: string | undefined,
   returnTo: string | null | undefined,
 ): string | null {
   const isSignup = intent === "signup";
-  const alreadyOnboarded = hasOnboardedAssistant(
+  const returningUser = userHasOnboardedAssistant(
     useResolvedAssistantsStore.getState().assistants,
   );
-  if (alreadyOnboarded) {
+  if (returningUser) {
     const skipTarget = isFirstRunOnboardingReturnTo(returnTo)
       ? routes.assistant
       : (returnTo ?? (isSignup ? routes.assistant : null));
@@ -340,13 +341,21 @@ export function resolveNativePostAuthDestination(
   return isSignup ? destination : (returnTo ?? null);
 }
 
+/**
+ * Whether `returnTo` names the first-run funnel a returning user should skip.
+ * A walk carrying the new-assistant marker is provisioning, so it is first-run
+ * for the assistant it is about to create and must not be skipped.
+ */
 function isFirstRunOnboardingReturnTo(
   returnTo: string | null | undefined,
 ): boolean {
   if (!returnTo) {
     return false;
   }
-  const pathname = returnTo.split(/[?#]/)[0] ?? returnTo;
+  const [pathname = returnTo, search = ""] = returnTo.split(/[?#]/);
+  if (isNewAssistantFunnel(new URLSearchParams(search))) {
+    return false;
+  }
   return (
     pathname === routes.onboarding.hosting ||
     pathname === routes.onboarding.privacy ||

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -40,7 +40,6 @@ import {
   writeSelectedAssistantId,
 } from "@/assistant/selected-assistant-storage";
 import { useLockfileStore } from "@/stores/lockfile-store";
-import { readOnboardedAt } from "@/domains/onboarding/onboarded-assistant-record";
 import type { Lockfile } from "@/runtime/local-mode-host";
 import type { Assistant, ReleaseChannelEnum } from "@/generated/api/types.gen";
 
@@ -49,9 +48,9 @@ export interface ResolvedAssistant {
   name?: string;
   hatchedAt?: string;
   /**
-   * When this assistant finished first-run onboarding. Absent for assistants
-   * that predate the record; `onboarded-assistant.ts` falls back to hatch age
-   * for those.
+   * When this assistant finished first-run onboarding, as recorded on the
+   * lockfile entry. The device-scoped record is the other half of the answer
+   * and is read live, not cached here: see `onboarded-assistant.ts`.
    */
   onboardedAt?: string;
   cloud?: string;
@@ -189,7 +188,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         id: a.assistantId,
         name: a.name,
         hatchedAt: a.hatchedAt,
-        onboardedAt: resolveOnboardedAt(a.assistantId, a.onboardedAt),
+        onboardedAt: a.onboardedAt,
         cloud: a.cloud,
         runtimeVersion: a.resources?.runtimeVersion,
         avatarUrl: existingById.get(a.assistantId)?.avatarUrl,
@@ -229,7 +228,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               id: a.id,
               name: a.name,
               hatchedAt: a.created,
-              onboardedAt: resolveOnboardedAt(a.id, lockfileFields.onboardedAt),
+              onboardedAt: lockfileFields.onboardedAt,
               cloud: lockfileFields.cloud,
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
@@ -259,10 +258,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           id: assistant.id,
           name: assistant.name,
           hatchedAt: assistant.created,
-          onboardedAt: resolveOnboardedAt(
-            assistant.id,
-            lockfileFields.onboardedAt,
-          ),
+          onboardedAt: lockfileFields.onboardedAt,
           ingressUrl: assistant.ingress_url,
           avatarUrl: apiAvatarUrl(assistant),
           currentReleaseVersion: assistant.current_release_version,
@@ -388,17 +384,6 @@ function classifyApiEntry(
     isLocal: isPaired ? false : isLocalFromApi,
     isPlatformHosted: isPaired ? false : !isLocalFromApi,
   };
-}
-
-/**
- * The onboarding stamp, lockfile first. Local mode writes both targets, so the
- * two agree; cloud and browser clients only ever have the device record.
- */
-function resolveOnboardedAt(
-  assistantId: string,
-  fromLockfile: string | undefined,
-): string | undefined {
-  return fromLockfile ?? readOnboardedAt(assistantId);
 }
 
 function getLockfileFields(assistantId: string): {

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -40,6 +40,7 @@ import {
   writeSelectedAssistantId,
 } from "@/assistant/selected-assistant-storage";
 import { useLockfileStore } from "@/stores/lockfile-store";
+import { readOnboardedAt } from "@/domains/onboarding/onboarded-assistant-record";
 import type { Lockfile } from "@/runtime/local-mode-host";
 import type { Assistant, ReleaseChannelEnum } from "@/generated/api/types.gen";
 
@@ -47,6 +48,12 @@ export interface ResolvedAssistant {
   id: string;
   name?: string;
   hatchedAt?: string;
+  /**
+   * When this assistant finished first-run onboarding. Absent for assistants
+   * that predate the record; `onboarded-assistant.ts` falls back to hatch age
+   * for those.
+   */
+  onboardedAt?: string;
   cloud?: string;
   runtimeVersion?: string;
   currentReleaseVersion?: string | null;
@@ -182,6 +189,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         id: a.assistantId,
         name: a.name,
         hatchedAt: a.hatchedAt,
+        onboardedAt: resolveOnboardedAt(a.assistantId, a.onboardedAt),
         cloud: a.cloud,
         runtimeVersion: a.resources?.runtimeVersion,
         avatarUrl: existingById.get(a.assistantId)?.avatarUrl,
@@ -221,6 +229,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               id: a.id,
               name: a.name,
               hatchedAt: a.created,
+              onboardedAt: resolveOnboardedAt(a.id, lockfileFields.onboardedAt),
               cloud: lockfileFields.cloud,
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
@@ -250,6 +259,10 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           id: assistant.id,
           name: assistant.name,
           hatchedAt: assistant.created,
+          onboardedAt: resolveOnboardedAt(
+            assistant.id,
+            lockfileFields.onboardedAt,
+          ),
           ingressUrl: assistant.ingress_url,
           avatarUrl: apiAvatarUrl(assistant),
           currentReleaseVersion: assistant.current_release_version,
@@ -377,9 +390,21 @@ function classifyApiEntry(
   };
 }
 
+/**
+ * The onboarding stamp, lockfile first. Local mode writes both targets, so the
+ * two agree; cloud and browser clients only ever have the device record.
+ */
+function resolveOnboardedAt(
+  assistantId: string,
+  fromLockfile: string | undefined,
+): string | undefined {
+  return fromLockfile ?? readOnboardedAt(assistantId);
+}
+
 function getLockfileFields(assistantId: string): {
   cloud?: string;
   organizationId?: string;
+  onboardedAt?: string;
   runtimeVersion?: string;
   runtimeUrl?: string;
   platformAssistantId?: string;
@@ -394,6 +419,7 @@ function getLockfileFields(assistantId: string): {
   return {
     cloud: entry?.cloud,
     organizationId: entry?.organizationId,
+    onboardedAt: entry?.onboardedAt,
     runtimeVersion: entry?.resources?.runtimeVersion,
     runtimeUrl: entry?.runtimeUrl,
     platformAssistantId: entry?.platformAssistantId,

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -15,6 +15,7 @@ import {
   getLocalAssistantStatus,
   readLockfileAssistantAvatar,
   renameLockfileAssistantIfPresent,
+  stampLockfileAssistantOnboardedIfPresent,
   upsertRendererLockfileAssistant,
   replacePlatformAssistants,
   isActiveAssistant,
@@ -360,6 +361,13 @@ function lockfileMiddleware(
             lockfilePaths,
             rename.assistantId as string,
             rename.name as string,
+          );
+        } else if (body.onboarded && typeof body.onboarded === "object") {
+          const onboarded = body.onboarded as Record<string, unknown>;
+          result = stampLockfileAssistantOnboardedIfPresent(
+            lockfilePaths,
+            onboarded.assistantId as string,
+            onboarded.onboardedAt as string,
           );
         } else {
           result = upsertRendererLockfileAssistant(

--- a/packages/electron-desktop/src/local-mode-bridge.ts
+++ b/packages/electron-desktop/src/local-mode-bridge.ts
@@ -24,6 +24,12 @@ export const createLocalModeBridge = (
   readLockfile: () => ipc.invoke("vellum:localMode:readLockfile"),
   renameLockfileAssistant: (assistantId, name) =>
     ipc.invoke("vellum:localMode:renameLockfileAssistant", assistantId, name),
+  stampLockfileAssistantOnboarded: (assistantId, onboardedAt) =>
+    ipc.invoke(
+      "vellum:localMode:stampLockfileAssistantOnboarded",
+      assistantId,
+      onboardedAt,
+    ),
   replacePlatformAssistants: (assistants, organizationId) =>
     ipc.invoke(
       "vellum:localMode:replacePlatformAssistants",

--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -377,6 +377,15 @@ const renameLockfileAssistant = (
     assistantId,
     name,
   ) as WriteResult;
+const stampLockfileAssistantOnboarded = (
+  assistantId?: unknown,
+  onboardedAt?: unknown,
+): WriteResult =>
+  handlers["vellum:localMode:stampLockfileAssistantOnboarded"](
+    allowedEvent,
+    assistantId,
+    onboardedAt,
+  ) as WriteResult;
 const writePairedLockfileAssistant = (assistantId: string): void => {
   fs.writeFileSync(
     lockfilePath,
@@ -602,6 +611,85 @@ describe("lockfile IPC handlers", () => {
     expect(renameLockfileAssistant("asst-1", undefined)).toEqual({
       ok: false,
       error: "Missing assistantId or name",
+    });
+    expect(fs.existsSync(lockfilePath)).toBe(false);
+  });
+
+  test("stampLockfileAssistantOnboarded records the completion and refreshes", () => {
+    saveLockfileAssistant(
+      { assistantId: "asst-1", cloud: "local", name: "Credence" },
+      "asst-1",
+    );
+    refreshLockfileNowMock.mockClear();
+
+    const result = stampLockfileAssistantOnboarded(
+      "asst-1",
+      "2026-08-31T00:00:00.000Z",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(refreshLockfileNowMock).toHaveBeenCalledTimes(1);
+    const onDisk = JSON.parse(fs.readFileSync(lockfilePath, "utf-8")) as {
+      assistants: Array<Record<string, unknown>>;
+    };
+    expect(onDisk.assistants[0]?.onboardedAt).toBe("2026-08-31T00:00:00.000Z");
+    expect(onDisk.assistants[0]?.name).toBe("Credence");
+  });
+
+  // The whole point of routing this through the host: a completion that lands
+  // after a retire must not re-create the entry from the renderer's snapshot.
+  test("stampLockfileAssistantOnboarded refuses a missing entry without creating the file", () => {
+    const result = stampLockfileAssistantOnboarded(
+      "asst-gone",
+      "2026-08-31T00:00:00.000Z",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(fs.existsSync(lockfilePath)).toBe(false);
+    expect(refreshLockfileNowMock).not.toHaveBeenCalled();
+  });
+
+  test("stampLockfileAssistantOnboarded keeps the first stamp", () => {
+    saveLockfileAssistant(
+      {
+        assistantId: "asst-1",
+        cloud: "local",
+        onboardedAt: "2026-08-01T00:00:00.000Z",
+      },
+      "asst-1",
+    );
+
+    const result = stampLockfileAssistantOnboarded(
+      "asst-1",
+      "2026-08-31T00:00:00.000Z",
+    );
+
+    expect(result.ok).toBe(true);
+    const onDisk = JSON.parse(fs.readFileSync(lockfilePath, "utf-8")) as {
+      assistants: Array<Record<string, unknown>>;
+    };
+    expect(onDisk.assistants[0]?.onboardedAt).toBe("2026-08-01T00:00:00.000Z");
+  });
+
+  test("stampLockfileAssistantOnboarded refuses a corrupt file without clobbering it", () => {
+    fs.writeFileSync(lockfilePath, "{ not json");
+
+    const result = stampLockfileAssistantOnboarded(
+      "asst-1",
+      "2026-08-31T00:00:00.000Z",
+    );
+
+    expect(result.ok).toBe(false);
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe("{ not json");
+  });
+
+  test("stampLockfileAssistantOnboarded rejects a missing id or timestamp", () => {
+    expect(
+      stampLockfileAssistantOnboarded(undefined, "2026-08-31T00:00:00.000Z"),
+    ).toEqual({ ok: false, error: "Missing assistantId or onboardedAt" });
+    expect(stampLockfileAssistantOnboarded("asst-1", undefined)).toEqual({
+      ok: false,
+      error: "Missing assistantId or onboardedAt",
     });
     expect(fs.existsSync(lockfilePath)).toBe(false);
   });

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -6,6 +6,7 @@ import {
   isActiveAssistant,
   isPairedLockfileEntry,
   renameLockfileAssistantIfPresent,
+  stampLockfileAssistantOnboardedIfPresent,
   PAIRED_GUARDIAN_TOKEN_HOST_ONLY_ERROR,
   getLockfileData,
   getLocalAssistantStatus,
@@ -458,6 +459,28 @@ export const installLocalMode = (): void => {
       }
       // Refresh the watcher so lockfile-driven surfaces pick up the new name
       // in the same tick instead of after the next poll.
+      refreshLockfile();
+      return { ok: true, lockfile: result.lockfile };
+    },
+  );
+
+  // Update-only, like the rename above: the host decides against the on-disk
+  // registry so a completion racing a retire cannot resurrect the entry.
+  ipc(
+    "vellum:localMode:stampLockfileAssistantOnboarded",
+    z.tuple([z.string().optional(), z.string().optional()]),
+    ([assistantId, onboardedAt]): LockfileWriteResult => {
+      if (!assistantId || !onboardedAt) {
+        return { ok: false, error: "Missing assistantId or onboardedAt" };
+      }
+      const result = stampLockfileAssistantOnboardedIfPresent(
+        lockfilePaths,
+        assistantId,
+        onboardedAt,
+      );
+      if (!result.ok) {
+        return { ok: false, error: result.error };
+      }
       refreshLockfile();
       return { ok: true, lockfile: result.lockfile };
     },

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -319,6 +319,14 @@ export interface VellumBridge {
       assistantId: string,
       name: string,
     ): Promise<LockfileWriteResult>;
+    /**
+     * Stamp `onboardedAt` on an existing lockfile entry. Update-only on the
+     * same terms as `renameLockfileAssistant`, and keeps an existing stamp.
+     */
+    stampLockfileAssistantOnboarded(
+      assistantId: string,
+      onboardedAt: string,
+    ): Promise<LockfileWriteResult>;
     replacePlatformAssistants(
       platformAssistants: Array<Record<string, unknown>>,
       organizationId?: string,

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -653,6 +653,7 @@ export interface LockfileAssistant {
   runtimeUrl?: string;
   species?: string;
   hatchedAt?: string;
+  onboardedAt?: string;
   organizationId?: string;
   platformAssistantId?: string;
   platformBaseUrl?: string;

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -44,6 +44,7 @@ export {
 export {
   getLockfileData,
   renameLockfileAssistantIfPresent,
+  stampLockfileAssistantOnboardedIfPresent,
   upsertLockfileAssistant,
   upsertRendererLockfileAssistant,
   replacePlatformAssistants,

--- a/packages/local-mode/src/lockfile-contract.ts
+++ b/packages/local-mode/src/lockfile-contract.ts
@@ -179,6 +179,12 @@ export const LockfileAssistantSchema = z.object({
   runtimeUrl: z.string().optional(),
   species: z.string().optional(),
   hatchedAt: z.string().optional(),
+  /**
+   * When this assistant finished first-run onboarding. Absent for entries that
+   * predate the record, which fall back to hatch age (see the web client's
+   * `onboarded-assistant.ts`).
+   */
+  onboardedAt: z.string().optional(),
   /** Owning org for platform assistants; absent for local ones. */
   organizationId: z.string().optional(),
   /** Platform assistant UUID for a self-hosted local assistant registration. */

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -7,6 +7,7 @@ import {
   getLockfileData,
   isPairedLockfileEntry,
   renameLockfileAssistantIfPresent,
+  stampLockfileAssistantOnboardedIfPresent,
   replacePlatformAssistants,
   upsertLockfileAssistant,
   upsertRendererLockfileAssistant,
@@ -277,6 +278,87 @@ describe("upsertLockfileAssistant", () => {
     if (result.ok) {
       expect(result.lockfile.activeAssistant).toBe("asst_active");
     }
+  });
+});
+
+describe("stampLockfileAssistantOnboardedIfPresent", () => {
+  const entry = {
+    assistantId: "asst_1",
+    cloud: "local",
+    name: "Credence",
+    signingKey: "sk-on-disk-secret",
+  };
+  const AT = "2026-08-31T00:00:00.000Z";
+
+  test("stamps the entry preserving its other fields and activeAssistant", () => {
+    writeOnDisk({ activeAssistant: "asst_other", assistants: [entry] });
+
+    const result = stampLockfileAssistantOnboardedIfPresent(
+      [lockfilePath],
+      "asst_1",
+      AT,
+    );
+
+    expect(result.ok).toBe(true);
+    const onDisk = readOnDisk();
+    expect(onDisk.activeAssistant).toBe("asst_other");
+    expect(onDisk.assistants).toEqual([{ ...entry, onboardedAt: AT }]);
+  });
+
+  // Update-only: a completion racing a CLI retire must not resurrect the row.
+  test("refuses a missing entry without writing the file", () => {
+    const result = stampLockfileAssistantOnboardedIfPresent(
+      [lockfilePath],
+      "asst_gone",
+      AT,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: "No lockfile entry for this assistant",
+    });
+    expect(fs.existsSync(lockfilePath)).toBe(false);
+  });
+
+  test("keeps an existing stamp: the first completion is the real one", () => {
+    const stamped = { ...entry, onboardedAt: "2026-08-01T00:00:00.000Z" };
+    writeOnDisk({ activeAssistant: null, assistants: [stamped] });
+
+    const result = stampLockfileAssistantOnboardedIfPresent(
+      [lockfilePath],
+      "asst_1",
+      AT,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(readOnDisk().assistants).toEqual([stamped]);
+  });
+
+  test("refuses a corrupt on-disk file without clobbering it", () => {
+    fs.writeFileSync(lockfilePath, "{ not json");
+
+    const result = stampLockfileAssistantOnboardedIfPresent(
+      [lockfilePath],
+      "asst_1",
+      AT,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(409);
+    }
+    expect(fs.readFileSync(lockfilePath, "utf-8")).toBe("{ not json");
+  });
+
+  test("rejects a missing id or timestamp", () => {
+    expect(
+      stampLockfileAssistantOnboardedIfPresent([lockfilePath], "", AT).ok,
+    ).toBe(false);
+    expect(
+      stampLockfileAssistantOnboardedIfPresent([lockfilePath], "asst_1", "").ok,
+    ).toBe(false);
+    expect(fs.existsSync(lockfilePath)).toBe(false);
   });
 });
 

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -678,6 +678,89 @@ describe("replacePlatformAssistants", () => {
     });
   });
 
+  // `onboardedAt` is recorded by the client and unknown to the platform, so the
+  // rows a sync builds from the API never carry it. Dropping it here would let
+  // a routine session refresh erase the completion record.
+  test("carries an existing onboardedAt onto the replacement row", () => {
+    writeOnDisk({
+      activeAssistant: "asst_p",
+      assistants: [
+        {
+          assistantId: "asst_p",
+          cloud: "vellum",
+          runtimeUrl: "http://old",
+          onboardedAt: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const result = replacePlatformAssistants(
+      [lockfilePath],
+      [{ assistantId: "asst_p", cloud: "vellum", runtimeUrl: "http://new" }],
+    );
+
+    expect(result.ok).toBe(true);
+    expect(readOnDisk().assistants).toEqual([
+      {
+        assistantId: "asst_p",
+        cloud: "vellum",
+        runtimeUrl: "http://new",
+        onboardedAt: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  test("an incoming onboardedAt wins over the stored one", () => {
+    writeOnDisk({
+      activeAssistant: null,
+      assistants: [
+        {
+          assistantId: "asst_p",
+          cloud: "vellum",
+          onboardedAt: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    replacePlatformAssistants(
+      [lockfilePath],
+      [
+        {
+          assistantId: "asst_p",
+          cloud: "vellum",
+          onboardedAt: "2026-08-31T00:00:00.000Z",
+        },
+      ],
+    );
+
+    expect(
+      (readOnDisk().assistants as Array<Record<string, unknown>>)[0]
+        ?.onboardedAt,
+    ).toBe("2026-08-31T00:00:00.000Z");
+  });
+
+  test("a retired-then-recreated id does not inherit a stale stamp from another entry", () => {
+    writeOnDisk({
+      activeAssistant: null,
+      assistants: [
+        {
+          assistantId: "asst_a",
+          cloud: "vellum",
+          onboardedAt: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    replacePlatformAssistants(
+      [lockfilePath],
+      [{ assistantId: "asst_b", cloud: "vellum" }],
+    );
+
+    expect(readOnDisk().assistants).toEqual([
+      { assistantId: "asst_b", cloud: "vellum" },
+    ]);
+  });
+
   test("replaces platform assistants while keeping local ones and unknown fields", () => {
     writeOnDisk({
       schemaVersion: 99,

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -182,11 +182,47 @@ export function renameLockfileAssistantIfPresent(
   assistantId: string,
   name: string,
 ): WriteResult {
-  if (typeof assistantId !== "string" || assistantId === "") {
-    return { ok: false, status: 400, error: "Missing assistantId" };
-  }
   if (typeof name !== "string" || name === "") {
     return { ok: false, status: 400, error: "Missing name" };
+  }
+  return patchLockfileAssistantIfPresent(lockfilePaths, assistantId, { name });
+}
+
+/**
+ * Record when an assistant finished first-run onboarding. Update-only, on the
+ * same terms as {@link renameLockfileAssistantIfPresent}. Keeps an existing
+ * stamp: the first completion is the real one, and a replayed funnel must not
+ * move it.
+ */
+export function stampLockfileAssistantOnboardedIfPresent(
+  lockfilePaths: string[],
+  assistantId: string,
+  onboardedAt: string,
+): WriteResult {
+  if (typeof onboardedAt !== "string" || onboardedAt === "") {
+    return { ok: false, status: 400, error: "Missing onboardedAt" };
+  }
+  return patchLockfileAssistantIfPresent(
+    lockfilePaths,
+    assistantId,
+    { onboardedAt },
+    (entry) => typeof entry.onboardedAt === "string" && entry.onboardedAt !== "",
+  );
+}
+
+/**
+ * The shared update-only write: read the on-disk registry under the lock,
+ * refuse a missing entry, and merge `patch` into it. `skip` short-circuits to
+ * a successful no-op for a field whose current value should win.
+ */
+function patchLockfileAssistantIfPresent(
+  lockfilePaths: string[],
+  assistantId: string,
+  patch: Record<string, unknown>,
+  skip?: (entry: Record<string, unknown>) => boolean,
+): WriteResult {
+  if (typeof assistantId !== "string" || assistantId === "") {
+    return { ok: false, status: 400, error: "Missing assistantId" };
   }
 
   const locked = withLockfileLock(lockfilePaths, (): WriteResult => {
@@ -206,10 +242,14 @@ export function renameLockfileAssistantIfPresent(
         error: "No lockfile entry for this assistant",
       };
     }
-    if (assistants[idx]!.name === name) {
+    const entry = assistants[idx]!;
+    const converged =
+      skip?.(entry) ??
+      Object.entries(patch).every(([key, value]) => entry[key] === value);
+    if (converged) {
       return { ok: true, lockfile: toWireLockfile(lockfile) };
     }
-    assistants[idx] = { ...assistants[idx], name };
+    assistants[idx] = { ...entry, ...patch };
     lockfile.assistants = assistants;
     return writeRawLockfile(lockfilePaths, lockfile);
   });

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -394,7 +394,24 @@ export function replacePlatformAssistants(
       if (syncedIds.has(a.assistantId)) return false;
       return organizationId != null && a.organizationId !== organizationId;
     });
-    lockfile.assistants = [...preserved, ...platformAssistants];
+    // `onboardedAt` is recorded by the client and unknown to the platform, so
+    // the replacement rows never carry it. Without this it is erased by every
+    // routine session sync.
+    const priorOnboardedAt = new Map<string, unknown>();
+    for (const a of existing as Array<Record<string, unknown>>) {
+      if (typeof a?.assistantId === "string" && a.onboardedAt != null) {
+        priorOnboardedAt.set(a.assistantId, a.onboardedAt);
+      }
+    }
+    lockfile.assistants = [
+      ...preserved,
+      ...platformAssistants.map((a) => {
+        const prior = priorOnboardedAt.get(a.assistantId as string);
+        return a.onboardedAt == null && prior != null
+          ? { ...a, onboardedAt: prior }
+          : a;
+      }),
+    ];
 
     const active = lockfile.activeAssistant as string | null;
     if (active) {


### PR DESCRIPTION
## Summary

- **Split `NavigationState.alreadyOnboarded` into the two questions it was actually being asked.** It was `.some()` over every resolved assistant, so one week-old entry answered for all of them. Post-auth and the onboarding intercept genuinely want "is this a returning user" (`userHasOnboardedAssistant`); the privacy funnel is always about one assistant and now asks `selectedAssistantOnboarded`, resolved against `readSelectedAssistantId()`. That is the class of bug behind the chooser loop #41656 unblocked with a URL marker.
- **Backed the answer with a real record instead of hatch age.** `onboardedAt` is stamped where onboarding terminates (research handoff to chat, the established-assistant "keep" off-ramp, and the non-production skip-to-chat exit). It is written to a `device:`-scoped store that survives the logout key sweep, and mirrored onto the lockfile entry so the CLI and tray see it. Hatch age survives only as the fallback for assistants that predate the record, so no existing install is re-funneled. Retiring an assistant drops its record.
- **Closed two live holes of the same shape.** `resolveNativePostAuthDestination` had no new-assistant exemption at all, so the Capacitor/Electron post-auth path rewrote a deliberate new-assistant `returnTo` away. And `start-screen.tsx`'s "Create assistant" CTA (the Back target out of privacy in platform mode) navigated to privacy with no marker, so clicking it with an onboarded assistant selected bounced to `/assistant`.

### Where the answer is read from

The device half of the stamp is read at question time rather than cached on the assistant row, so a completion takes effect immediately instead of waiting for the next assistant-list refresh, and it reaches other tabs. The lockfile half rides on `ResolvedAssistant.onboardedAt` as before.

### New host operation

The lockfile mirror goes through a new update-only host op, `stampLockfileAssistantOnboardedIfPresent`, rather than the existing upsert: the existence check and the field write have to happen together under the lockfile lock, or a completion racing a retire re-creates the entry from a stale renderer snapshot. It is the same shape as the existing rename-if-present path, and the shared read-check-write is now factored out so both have one implementation. `replacePlatformAssistants` carries a stored `onboardedAt` onto its replacement rows, since the platform API does not know the field and a routine session sync would otherwise erase it.

Older Electron shells that predate the IPC channel degrade to a structured failure rather than falling back to the upsert. The stamp still lands in the device record, which is what the routing guards read.

### Deliberately out of scope

Cross-device completion for managed assistants. That needs a per-assistant field on the platform `Assistant` model, which does not exist and whose PATCH allowlist is `name` / `description` / `handle` only, so it is a companion PR in the platform repo plus a version gate here. Not a regression: a second device answers from hatch age today and still does. The cloud managed hatch also still uses `ensure` mode; that follow-up is unchanged by this PR.

## Original prompt

Follow-up to #41656, which unblocked "Create a new assistant" for anyone who already owned a week-old assistant. That fix was a marker routed around the bad boolean, not a fix to the boolean. Noa's call was that "onboarding completed" has to be a per-assistant record rather than a `.some()` over every assistant using hatch age as the proxy, so this PR does the scoping and adds the durable record, keeping hatch age only as the back-compat fallback. It also folds in the two residual holes found while mapping the call sites, which are the same bug in the native post-auth path and on the platform start screen.

## Test plan

Run solo (this repo's `mock.module` leaks across a shared `bun test` run):

- `src/domains/onboarding/onboarded-assistant.test.ts` (`isAssistantOnboarded` / `isSelectedAssistantOnboarded`, including the live device read)
- `src/domains/onboarding/onboarded-assistant-record.test.ts` (new)
- `src/lib/navigation/build-state.test.ts` (a week-old sibling no longer answers for a fresh selection)
- `src/lib/onboarding-middleware.test.ts` (the same assertion at the layer that actually runs the redirect, plus "a fresh stamp arms the bounce with no store refresh")
- `src/lib/navigation/navigation-resolver.test.ts`, `src/domains/onboarding/onboarding-destination.test.ts`
- `src/runtime/native-auth.test.ts`, `src/domains/onboarding/pages/start-screen.test.tsx` (the two residual holes)
- `src/domains/onboarding/pages/research-onboarding-route.test.tsx` (both terminals stamp), `pages/privacy-screen.test.tsx`, `pages/hatching-screen.test.tsx`, `assistant/retire-service.test.ts`, `lib/local-mode.test.ts`
- `packages/local-mode` (update-only op, replacement preservation) and `packages/electron-desktop/src/local-mode.test.ts` (the IPC handler): full suites

`bunx tsc --noEmit` and `bun run lint` are clean.

## Manual QA still owed

Not walked yet, and this is the path that broke:

1. With a week-old assistant, chooser → "Create a new assistant" → local hosting → api-key → privacy → hatch.
2. The same on the cloud hosting branch, which #41656 never exercised end to end.
3. Back out of privacy to `/assistant/onboarding/start`, then "Create assistant" (fails on main today).
4. Finish research on a fresh local assistant, confirm `onboardedAt` lands on the lockfile entry and in `device:onboarded_assistants`, and that it survives a session refresh.
5. Log out and back in: still lands in chat, and the record survives the logout sweep.
