### PR TITLE
feat(catalog): add GLM 5.3 and GLM 5.3 Flash via Fireworks

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -2051,3 +2051,66 @@ describe("FireworksProvider reasoning_effort ceiling", () => {
     expect(lastCreateParams!.reasoning_effort).toBe("max");
   });
 });
+
+// GLM 5.3 accepts only low|high|max and 4xxes on the in-between tiers, so
+// the catalog's `supportedEfforts` snaps them down (see
+// snapReasoningEffortToSupported).
+describe("FireworksProvider sparse reasoning_effort support (GLM 5.3)", () => {
+  beforeEach(() => {
+    fakeChunks = [];
+    lastCreateParams = null;
+  });
+
+  const send = async (
+    model: string,
+    effort: "none" | "low" | "medium" | "high" | "xhigh" | "max",
+  ) => {
+    const fw = new FireworksProvider("fw-key", model);
+    await fw.sendMessage([userMsg("hi")], {
+      systemPrompt: "system",
+      config: { effort },
+    });
+    return lastCreateParams!.reasoning_effort;
+  };
+
+  test('GLM 5.3 snaps "medium" down to "low"', async () => {
+    expect(await send("accounts/fireworks/models/glm-5p3", "medium")).toBe(
+      "low",
+    );
+  });
+
+  test('GLM 5.3 snaps "xhigh" down to "high"', async () => {
+    expect(await send("accounts/fireworks/models/glm-5p3", "xhigh")).toBe(
+      "high",
+    );
+  });
+
+  test("GLM 5.3 forwards supported values verbatim", async () => {
+    expect(await send("accounts/fireworks/models/glm-5p3", "low")).toBe("low");
+    expect(await send("accounts/fireworks/models/glm-5p3", "high")).toBe(
+      "high",
+    );
+    expect(await send("accounts/fireworks/models/glm-5p3", "max")).toBe("max");
+  });
+
+  test('GLM 5.3 Flash snaps "medium"/"xhigh" the same way', async () => {
+    expect(
+      await send("accounts/fireworks/models/glm-5p3-flash", "medium"),
+    ).toBe("low");
+    expect(await send("accounts/fireworks/models/glm-5p3-flash", "xhigh")).toBe(
+      "high",
+    );
+  });
+
+  test('effort: "none" is not snapped (opt-out keeps its own handling)', async () => {
+    expect(await send("accounts/fireworks/models/glm-5p3", "none")).toBe(
+      "none",
+    );
+  });
+
+  test("models without supportedEfforts are unaffected", async () => {
+    expect(
+      await send("accounts/fireworks/models/deepseek-v4-pro", "medium"),
+    ).toBe("medium");
+  });
+});

--- a/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
+++ b/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
@@ -187,7 +187,7 @@ describe("retry normalization: adaptive-only thinking models", () => {
       },
     });
 
-    // THEN no `effort: "none"` is synthesized — the model runs at its own
+    // THEN no `effort: "none"` is synthesized: the model runs at its own
     // default instead of tripping the reasoning opt-out rejection retry
     expect(lastConfig()?.thinking).toBeUndefined();
     expect(lastConfig()?.effort).toBeUndefined();

--- a/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
+++ b/assistant/src/__tests__/retry-thinking-adaptive-only.test.ts
@@ -148,6 +148,73 @@ describe("retry normalization: adaptive-only thinking models", () => {
     expect(lastConfig()?.thinking).toEqual({ type: "adaptive" });
   });
 
+  test("preserves effort when dropping stale disabled thinking for Fireworks GLM 5.3", async () => {
+    // GIVEN a profile that kept `thinking: { enabled: false }` after switching
+    // to an always-on GLM 5.3 model, plus an explicit effort
+    setLlmConfig({
+      callSites: {
+        memoryExtraction: {
+          provider: "fireworks",
+          model: "accounts/fireworks/models/glm-5p3",
+          thinking: { enabled: false },
+          effort: "high",
+        },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("fireworks");
+
+    // WHEN a request resolves through the call-site config
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "memoryExtraction" },
+    });
+
+    // THEN the disabled thinking is dropped BEFORE it can be encoded as
+    // `effort: "none"` (which GLM 5.3 rejects), and the chosen effort survives
+    expect(lastConfig()?.thinking).toBeUndefined();
+    expect(lastConfig()?.effort).toBe("high");
+  });
+
+  test("does not generate the opt-out effort for GLM 5.3 Flash with disabled thinking", async () => {
+    // GIVEN a pass-through caller with the wire-shape disabled config and no
+    // explicit effort
+    const { provider, lastConfig } = makePipeline("fireworks");
+
+    // WHEN sending against the always-on Flash model
+    await provider.sendMessage([userMessage], {
+      config: {
+        model: "accounts/fireworks/models/glm-5p3-flash",
+        thinking: { type: "disabled" },
+      },
+    });
+
+    // THEN no `effort: "none"` is synthesized — the model runs at its own
+    // default instead of tripping the reasoning opt-out rejection retry
+    expect(lastConfig()?.thinking).toBeUndefined();
+    expect(lastConfig()?.effort).toBeUndefined();
+  });
+
+  test("still encodes the opt-out for Fireworks models that support disabling thinking", async () => {
+    // GIVEN a disabled thinking config on GLM 5.2, which is not adaptive-only
+    setLlmConfig({
+      callSites: {
+        memoryExtraction: {
+          provider: "fireworks",
+          model: "accounts/fireworks/models/glm-5p2",
+          thinking: { enabled: false },
+        },
+      },
+    });
+    const { provider, lastConfig } = makePipeline("fireworks");
+
+    // WHEN a request resolves through the call-site config
+    await provider.sendMessage([userMessage], {
+      config: { callSite: "memoryExtraction" },
+    });
+
+    // THEN the opt-out is still encoded through the effort knob
+    expect(lastConfig()?.effort).toBe("none");
+  });
+
   test("preserves disabled thinking for models that support disabling it", async () => {
     // GIVEN a call-site config disabling thinking for a non-adaptive-only model
     setLlmConfig({

--- a/assistant/src/providers/fireworks/client.ts
+++ b/assistant/src/providers/fireworks/client.ts
@@ -1,4 +1,7 @@
-import { modelEffortCeilings } from "../model-catalog.js";
+import {
+  modelEffortCeilings,
+  modelSupportedEfforts,
+} from "../model-catalog.js";
 import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provider.js";
 
 export interface FireworksProviderOptions {
@@ -10,6 +13,7 @@ export interface FireworksProviderOptions {
 const DEFAULT_FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 
 const FIREWORKS_MODEL_EFFORT_CEILINGS = modelEffortCeilings("fireworks");
+const FIREWORKS_MODEL_SUPPORTED_EFFORTS = modelSupportedEfforts("fireworks");
 
 export class FireworksProvider extends OpenAIChatCompletionsProvider {
   constructor(
@@ -38,5 +42,9 @@ export class FireworksProvider extends OpenAIChatCompletionsProvider {
     model: string,
   ): "high" | "xhigh" | "max" {
     return FIREWORKS_MODEL_EFFORT_CEILINGS.get(model) ?? "high";
+  }
+
+  protected override resolveSupportedReasoningEfforts(model: string) {
+    return FIREWORKS_MODEL_SUPPORTED_EFFORTS.get(model);
   }
 }

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -893,6 +893,43 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
           cacheReadPer1mTokens: 0.26,
         },
       },
+      {
+        id: "accounts/fireworks/models/glm-5p3",
+        displayName: "GLM 5.3",
+        contextWindowTokens: 1040000,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        // GLM 5.3 reasoning is always on (reasoning_effort low/high/max);
+        // it cannot be disabled upstream.
+        adaptiveThinkingOnly: true,
+        supportsCaching: true,
+        supportsVision: false,
+        supportsToolUse: true,
+        maxEffort: "max",
+        pricing: {
+          inputPer1mTokens: 1.4,
+          outputPer1mTokens: 4.4,
+          cacheReadPer1mTokens: 0.26,
+        },
+      },
+      {
+        id: "accounts/fireworks/models/glm-5p3-flash",
+        displayName: "GLM 5.3 Flash",
+        contextWindowTokens: 1040000,
+        maxOutputTokens: 131072,
+        supportsThinking: true,
+        // Same always-on reasoning as GLM 5.3.
+        adaptiveThinkingOnly: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        maxEffort: "max",
+        pricing: {
+          inputPer1mTokens: 0.15,
+          outputPer1mTokens: 0.5,
+          cacheReadPer1mTokens: 0.029,
+        },
+      },
       // Kimi K2.5 (accounts/fireworks/models/kimi-k2p5) is intentionally
       // absent: Fireworks serves it on-demand/dedicated only, so serverless
       // chat/completions calls 404 ("not found, inaccessible, and/or not

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -78,6 +78,16 @@ export interface CatalogModel {
    */
   maxEffort?: "high" | "xhigh" | "max";
   /**
+   * Wire `reasoning_effort` values this model's upstream accepts, for models
+   * whose accepted set is sparse rather than a contiguous range under
+   * `maxEffort` (e.g. GLM 5.3 accepts only low/high/max). After the
+   * `maxEffort` ceiling clamp, provider clients snap an unsupported value
+   * down to the nearest listed value ("none" is exempt: it is the explicit
+   * opt-out and keeps its own rejection handling). Daemon-only: not
+   * projected into the client catalog (see scripts/sync-llm-catalog.ts).
+   */
+  supportedEfforts?: readonly ("low" | "medium" | "high" | "xhigh" | "max")[];
+  /**
    * Daemon-only: when true, the direct-OpenAI Responses transport sends
    * explicit prompt-cache breakpoints for this model (GPT-5.6+ semantics:
    * request-wide `prompt_cache_options: { mode: "explicit" }` plus
@@ -906,6 +916,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         maxEffort: "max",
+        supportedEfforts: ["low", "high", "max"],
         pricing: {
           inputPer1mTokens: 1.4,
           outputPer1mTokens: 4.4,
@@ -924,6 +935,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: true,
         supportsToolUse: true,
         maxEffort: "max",
+        supportedEfforts: ["low", "high", "max"],
         pricing: {
           inputPer1mTokens: 0.15,
           outputPer1mTokens: 0.5,
@@ -2399,6 +2411,24 @@ export function modelEffortCeilings(
   return new Map(
     PROVIDER_CATALOG.find((p) => p.id === providerId)?.models.flatMap((m) =>
       m.maxEffort ? ([[m.id, m.maxEffort]] as const) : [],
+    ) ?? [],
+  );
+}
+
+/**
+ * Per-model sparse `reasoning_effort` support for a provider, keyed by model
+ * ID (same derivation pattern as {@link modelEffortCeilings}). Models without
+ * `supportedEfforts` are absent and accept any value under their ceiling.
+ */
+export function modelSupportedEfforts(
+  providerId: string,
+): ReadonlyMap<
+  string,
+  readonly ("low" | "medium" | "high" | "xhigh" | "max")[]
+> {
+  return new Map(
+    PROVIDER_CATALOG.find((p) => p.id === providerId)?.models.flatMap((m) =>
+      m.supportedEfforts ? ([[m.id, m.supportedEfforts]] as const) : [],
     ) ?? [],
   );
 }

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -225,6 +225,28 @@ export function clampReasoningEffort(
     : value;
 }
 
+/** Snap a wire effort onto a model's sparse accepted set: the nearest
+ *  supported value at or below it, or the smallest supported value when the
+ *  request sits below all of them. Models like GLM 5.3 accept only
+ *  `low|high|max` and 4xx on the in-between tiers instead of rounding, so the
+ *  client rounds for them. `"none"` is never snapped: it is the explicit
+ *  opt-out and has its own rejection retry. */
+export function snapReasoningEffortToSupported(
+  value: ReasoningEffortWire,
+  supported: readonly ReasoningEffortWire[],
+): ReasoningEffortWire {
+  if (value === "none" || supported.includes(value)) {
+    return value;
+  }
+  const ranked = [...supported].sort(
+    (a, b) => REASONING_EFFORT_RANK[a] - REASONING_EFFORT_RANK[b],
+  );
+  const atOrBelow = ranked.filter(
+    (s) => REASONING_EFFORT_RANK[s] < REASONING_EFFORT_RANK[value],
+  );
+  return atOrBelow[atOrBelow.length - 1] ?? ranked[0] ?? value;
+}
+
 /** Human-readable text from an OpenAI-compatible error, including wrapped
  *  upstream detail (OpenRouter `metadata.raw`). Used by the one-shot
  *  compatibility retries so a generic SDK wrapper message cannot hide the
@@ -781,12 +803,16 @@ export class OpenAIChatCompletionsProvider implements Provider {
         ? EFFORT_TO_REASONING_EFFORT[effort]
         : undefined;
       if (reasoningEffort && typeof nestedReasoningEffort !== "string") {
-        const ceiling = this.resolveMaxReasoningEffort(
-          modelOverride ?? this.model,
-        );
-        params.reasoning_effort = clampReasoningEffort(
+        const effortModel = modelOverride ?? this.model;
+        const clamped = clampReasoningEffort(
           reasoningEffort,
-          ceiling,
+          this.resolveMaxReasoningEffort(effortModel),
+        );
+        const supported = this.resolveSupportedReasoningEfforts(effortModel);
+        params.reasoning_effort = (
+          supported
+            ? snapReasoningEffortToSupported(clamped, supported)
+            : clamped
         ) as OpenAI.Chat.Completions.ChatCompletionCreateParams["reasoning_effort"];
       }
 
@@ -1350,6 +1376,19 @@ export class OpenAIChatCompletionsProvider implements Provider {
     _model: string,
   ): "high" | "xhigh" | "max" {
     return this.maxReasoningEffort;
+  }
+
+  /**
+   * Per-model sparse `reasoning_effort` support. Subclasses return the
+   * accepted values for models that 4xx on in-between tiers (e.g. GLM 5.3's
+   * `low|high|max`); the outbound value is snapped onto that set after the
+   * ceiling clamp (see {@link snapReasoningEffortToSupported}). Undefined
+   * means any value under the ceiling is accepted.
+   */
+  protected resolveSupportedReasoningEfforts(
+    _model: string,
+  ): readonly ReasoningEffortWire[] | undefined {
+    return undefined;
   }
 
   /** Convert neutral messages + system prompt to OpenAI message format. */

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -813,23 +813,28 @@ function normalizeSendMessageOptions(
     }
   }
 
-  if (
-    isThinkingConfigDisabled(nextConfig.thinking) &&
-    disabledThinkingForcesEffortNone(providerName, nextConfig.model)
-  ) {
-    nextConfig.effort = "none";
-  }
-
-  // Claude Fable always reasons with adaptive thinking and rejects an explicit
-  // `thinking: { type: "disabled" }` (Anthropic 400s the request). Drop a
-  // disabled thinking config for these models so they fall back to their
-  // always-on adaptive thinking; effort and other params are unaffected.
+  // Adaptive-thinking-only models (Claude Fable, Fireworks Kimi K3 / GLM 5.3)
+  // always reason and reject an explicit opt-out — Anthropic 400s
+  // `thinking: { type: "disabled" }`, and effort-encoding providers 4xx a
+  // generated `reasoning_effort: "none"`. Drop a disabled thinking config for
+  // these models BEFORE the opt-out is encoded as `effort: "none"` below, so
+  // they fall back to their always-on thinking with the user's chosen effort
+  // and other params unaffected. Profiles can retain a stale
+  // `thinking: { enabled: false }` after switching to such a model, so this
+  // state is reachable from the profile editor.
   if (
     typeof nextConfig.model === "string" &&
     isAdaptiveThinkingOnlyModel(nextConfig.model) &&
     isThinkingConfigDisabled(nextConfig.thinking)
   ) {
     delete nextConfig.thinking;
+  }
+
+  if (
+    isThinkingConfigDisabled(nextConfig.thinking) &&
+    disabledThinkingForcesEffortNone(providerName, nextConfig.model)
+  ) {
+    nextConfig.effort = "none";
   }
 
   // Pre-adaptive Claude models (Haiku 4.5, Opus 4.5, Sonnet 4.5) reject

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -814,7 +814,7 @@ function normalizeSendMessageOptions(
   }
 
   // Adaptive-thinking-only models (Claude Fable, Fireworks Kimi K3 / GLM 5.3)
-  // always reason and reject an explicit opt-out — Anthropic 400s
+  // always reason and reject an explicit opt-out: Anthropic 400s
   // `thinking: { type: "disabled" }`, and effort-encoding providers 4xx a
   // generated `reasoning_effort: "none"`. Drop a disabled thinking config for
   // these models BEFORE the opt-out is encoded as `effort: "none"` below, so

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -327,6 +327,24 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 131_072,
       supportsThinking: true,
     },
+    {
+      id: "accounts/fireworks/models/glm-5p3",
+      displayName: "GLM 5.3",
+      contextWindowTokens: 1_040_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+      adaptiveThinkingOnly: true,
+    },
+    {
+      id: "accounts/fireworks/models/glm-5p3-flash",
+      displayName: "GLM 5.3 Flash",
+      contextWindowTokens: 1_040_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 131_072,
+      supportsThinking: true,
+      adaptiveThinkingOnly: true,
+    },
     // Kimi K2.5 (kimi-k2p5) is intentionally absent: Fireworks serves it
     // on-demand/dedicated only, so serverless calls 404.
     {

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -777,6 +777,42 @@
           }
         },
         {
+          "id": "accounts/fireworks/models/glm-5p3",
+          "displayName": "GLM 5.3",
+          "contextWindowTokens": 1040000,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "adaptiveThinkingOnly": true,
+          "supportsCaching": true,
+          "supportsVision": false,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.4,
+            "outputPer1mTokens": 4.4,
+            "cacheReadPer1mTokens": 0.26
+          }
+        },
+        {
+          "id": "accounts/fireworks/models/glm-5p3-flash",
+          "displayName": "GLM 5.3 Flash",
+          "contextWindowTokens": 1040000,
+          "maxOutputTokens": 131072,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "adaptiveThinkingOnly": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 0.15,
+            "outputPer1mTokens": 0.5,
+            "cacheReadPer1mTokens": 0.029
+          }
+        },
+        {
           "id": "accounts/fireworks/models/minimax-m3",
           "displayName": "MiniMax M3",
           "contextWindowTokens": 524288,


### PR DESCRIPTION
## Summary
- Add `accounts/fireworks/models/glm-5p3` and `accounts/fireworks/models/glm-5p3-flash` to the canonical daemon catalog (`assistant/src/providers/model-catalog.ts`): 1,040k context, 131,072 max output, thinking + caching + tool use, `maxEffort: "max"`, and `adaptiveThinkingOnly` (GLM 5.3 reasoning is always on and cannot be disabled upstream; effort stays adjustable). Flash additionally supports vision. Pricing from Fireworks serverless: $1.40/$0.26/$4.40 per MTok for GLM 5.3, $0.15/$0.029/$0.50 for Flash.
- Regenerate `meta/llm-provider-catalog.json` via `bun run sync:llm-catalog` and mirror the entries into `clients/web/src/assistant/llm-model-catalog.ts`; daemon and web parity tests pass.
- The platform-side gate is already open: the runtime-proxy rate cards for both models merged in vellum-assistant-platform #10213 and #10214 (this PR is the follow-up that lets clients offer the models).

## Original prompt
Follow-up to vellum-assistant-platform #10213 / #10214, which added GLM 5.3 and GLM 5.3 Flash (Fireworks serverless) to the managed LLM proxy's rate cards and vendored web catalog. This PR adds both models to the daemon-owned catalog in this repo so the assistant and its clients actually offer them, per the agreed merge order (platform gate first, then client catalog).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->