### PR TITLE
Discord invites redeem like every other channel

### DIFF
--- a/assistant/src/__tests__/channel-invite-transport.test.ts
+++ b/assistant/src/__tests__/channel-invite-transport.test.ts
@@ -109,6 +109,7 @@ describe("resolveAdapterHandle", () => {
 
 describe("createInviteAdapterRegistry", () => {
   const builtInChannels = [
+    "discord",
     "email",
     "slack",
     "telegram",

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -172,7 +172,7 @@ Replace `<channel_id>` with the channel's `id` from the contact's `channels` arr
 
 ## Invite Links
 
-Invite links let the guardian share a link or code that automatically grants access when used. Telegram invites use a deep link; voice invites use a phone number + numeric code; email, WhatsApp, and Slack invites use a 6-digit code that the invitee sends to the assistant on the respective channel.
+Invite links let the guardian share a link or code that automatically grants access when used. Telegram invites use a deep link; voice invites use a phone number + numeric code; email, WhatsApp, Slack, and Discord invites use a 6-digit code that the invitee sends to the assistant on the respective channel. Discord invitees must share a server with the bot and have DMs from server members enabled before they can send it the code.
 
 **Every invite must be bound to a contact.** Before creating an invite, look up the contact with `assistant contacts list` and pass the contact's `id` via the required `--contact-id` flag. If the target contact doesn't exist yet, create it first with `assistant contacts create --name "<name>"` and wait for the guardian to confirm; the invite needs only a name, never the invitee's address on that channel.
 

--- a/assistant/src/runtime/channel-invite-transport.ts
+++ b/assistant/src/runtime/channel-invite-transport.ts
@@ -13,6 +13,7 @@
  */
 
 import type { ChannelId } from "../channels/types.js";
+import { discordInviteAdapter } from "./channel-invite-transports/discord.js";
 import { emailInviteAdapter } from "./channel-invite-transports/email.js";
 import { slackInviteAdapter } from "./channel-invite-transports/slack.js";
 import { telegramInviteAdapter } from "./channel-invite-transports/telegram.js";
@@ -96,6 +97,7 @@ export async function resolveAdapterHandle(
 /** Create a registry instance with built-in adapters registered. */
 export function createInviteAdapterRegistry(): InviteAdapterRegistry {
   const registry = new InviteAdapterRegistry();
+  registry.register(discordInviteAdapter);
   registry.register(emailInviteAdapter);
   registry.register(slackInviteAdapter);
   registry.register(telegramInviteAdapter);

--- a/assistant/src/runtime/channel-invite-transports/discord.ts
+++ b/assistant/src/runtime/channel-invite-transports/discord.ts
@@ -1,0 +1,27 @@
+/**
+ * Discord channel invite adapter.
+ *
+ * Resolves the assistant's Discord bot username for use in invite
+ * instructions. Discord invites use the universal 6-digit code path for
+ * redemption, so this adapter only implements `resolveChannelHandle`,
+ * no `buildShareLink` or `extractInboundToken` needed. The platform
+ * constraint that shapes the instruction copy lives with the copy
+ * (`invite-instruction-generator.ts`): a person can only DM the bot once
+ * they share a server with it.
+ */
+
+import type { ChannelId } from "../../channels/types.js";
+import { getConfig } from "../../config/loader.js";
+import type { ChannelInviteAdapter } from "../channel-invite-types.js";
+
+export const discordInviteAdapter: ChannelInviteAdapter = {
+  channel: "discord" as ChannelId,
+
+  resolveChannelHandle(): string | undefined {
+    const { botUsername } = getConfig().discord;
+    if (!botUsername) {
+      return undefined;
+    }
+    return `@${botUsername}`;
+  },
+};

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -66,9 +66,15 @@ export async function generateInviteInstruction(params: {
   const handle = params.channelHandle
     ? ` at ${params.channelHandle}`
     : ` on ${channelLabel}`;
+  // Discord DMs only open between accounts that share a server, so the
+  // instruction has to say so or the invitee dead-ends before the code.
+  const discordCaveat =
+    params.channelType === "discord"
+      ? " They need to be in a server with me before they can DM me."
+      : "";
   const fallback = params.shareUrl
-    ? `Send ${contact} this link: ${params.shareUrl} — or tell them to message me${handle} with the code below.`
-    : `Tell ${contact} to message me${handle} with the code below.`;
+    ? `Send ${contact} this link: ${params.shareUrl}, or tell them to message me${handle} with the code below.${discordCaveat}`
+    : `Tell ${contact} to message me${handle} with the code below.${discordCaveat}`;
 
   const resolved = await resolveConfiguredProvider(
     "inviteInstructionGenerator",
@@ -99,6 +105,11 @@ export async function generateInviteInstruction(params: {
     } else {
       parts.push(
         "No share link is available for this channel. Do NOT mention sharing a link or URL.",
+      );
+    }
+    if (params.channelType === "discord") {
+      parts.push(
+        "Platform constraint: the contact must share a Discord server with the bot before they can send it a direct message. Mention this.",
       );
     }
     parts.push(

--- a/assistant/src/runtime/invite-instruction-generator.ts
+++ b/assistant/src/runtime/invite-instruction-generator.ts
@@ -66,11 +66,12 @@ export async function generateInviteInstruction(params: {
   const handle = params.channelHandle
     ? ` at ${params.channelHandle}`
     : ` on ${channelLabel}`;
-  // Discord DMs only open between accounts that share a server, so the
-  // instruction has to say so or the invitee dead-ends before the code.
+  // Discord DMs only open between accounts that share a server, and a
+  // member can still have server-member DMs turned off, so the instruction
+  // names both or the invitee dead-ends before the code.
   const discordCaveat =
     params.channelType === "discord"
-      ? " They need to be in a server with me before they can DM me."
+      ? " They need to be in a server with me, with DMs from server members enabled, before they can DM me."
       : "";
   const fallback = params.shareUrl
     ? `Send ${contact} this link: ${params.shareUrl}, or tell them to message me${handle} with the code below.${discordCaveat}`
@@ -109,7 +110,7 @@ export async function generateInviteInstruction(params: {
     }
     if (params.channelType === "discord") {
       parts.push(
-        "Platform constraint: the contact must share a Discord server with the bot before they can send it a direct message. Mention this.",
+        "Platform constraint: the contact must share a Discord server with the bot, and have DMs from server members enabled in their privacy settings, before they can send it a direct message. Mention this.",
       );
     }
     parts.push(

--- a/packages/gateway-client/src/__tests__/invite-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/invite-contract.test.ts
@@ -94,6 +94,7 @@ describe("isValidE164", () => {
 describe("invite-code channel gating", () => {
   test("allows exactly the redemption-enabled channels", () => {
     expect([...INVITE_CODE_REDEMPTION_CHANNELS].sort()).toEqual([
+      "discord",
       "email",
       "slack",
       "telegram",

--- a/packages/gateway-client/src/invite-contract.ts
+++ b/packages/gateway-client/src/invite-contract.ts
@@ -84,6 +84,7 @@ export const INVITE_CODE_REDEMPTION_CHANNELS: ReadonlySet<string> = new Set([
   "whatsapp",
   "slack",
   "email",
+  "discord",
 ]);
 
 /** Whether invite code redemption is enabled for the given channel. */

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -15,7 +15,7 @@
     },
     "contacts": {
       "docsSlug": "contacts",
-      "sha256": "e9dc4ef02aaf0d687236d8788c9a805bfccc1c479dec19da4f6b7daff9c1af26"
+      "sha256": "d05c59f82a164a376055d8f6ecd470b76d56ab4755304bcc8ddb711365456cc3"
     },
     "document-editor": {
       "docsSlug": "document",


### PR DESCRIPTION
# Discord invites redeem like every other channel

## TL;DR

The capability map marked Discord's "Can invite someone" as not built. The gap turned out to be one allowlist: minting a Discord invite already worked (`contacts invites create --source-channel discord` succeeds today), but the redemption intercept consults `INVITE_CODE_REDEMPTION_CHANNELS`, which named telegram, whatsapp, slack, and email, so a minted Discord invite could never be redeemed. Discord joins the set, gains the invite adapter that resolves the bot's `@username` for instruction copy, and the guardian-facing instruction states the platform constraint that shapes the flow.

## What changes for someone using it

| Before | After |
| --- | --- |
| A guardian can mint a Discord invite that silently never works: the invitee's code message is treated as a normal message and the invitee is never bound | The invitee DMs the bot the 6-digit code and is bound as a verified contact, the same flow as Telegram and Slack |
| No guardian instruction copy exists for Discord invites | "Tell them to message me at @bot with the code below. They need to be in a server with me before they can DM me." |

## Why it is safe

- The redemption engine is channel-generic (code parsing, contact binding, reply delivery through the channel callback); Discord ingress already flows through it with actor ids and reply callbacks. This PR only lifts the channel gate and adds display metadata.
- All redemption guards apply unchanged: unauthenticated senders never redeem, only user-authored text is scanned (reactions, presses, and deletes are never parsed for codes), and a code matching no invite falls through as a normal message.
- The Discord platform constraint is encoded in copy rather than code: a stranger can only DM a bot from a shared server, so the guardian instruction says to get the invitee into the server first. Redemption itself needs nothing special, since once the DM arrives it is ordinary inbound.
- The allowlist is contract-shared (gateway and daemon read the same set) and its pin test is updated.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41763" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->