### PR TITLE
feat(daemon): persist each kept camera frame as its own message

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -811,6 +811,40 @@ describe("AssistantConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  test("applies sight defaults", () => {
+    expect(AssistantConfigSchema.parse({}).sight).toEqual({
+      keepLatestFrames: 2,
+    });
+  });
+
+  test("accepts a custom sight.keepLatestFrames", () => {
+    const result = AssistantConfigSchema.parse({
+      sight: { keepLatestFrames: 4 },
+    });
+    expect(result.sight.keepLatestFrames).toBe(4);
+  });
+
+  test("keeps an out-of-range sight.keepLatestFrames for the reader to clamp", () => {
+    // Rejecting it would reset the key to the default, which is fewer frames
+    // than either the config or the guardrail asked for. The clamp lives at
+    // read (`resolveSightKeepLatestFrames`).
+    const result = AssistantConfigSchema.parse({
+      sight: { keepLatestFrames: 99 },
+    });
+    expect(result.sight.keepLatestFrames).toBe(99);
+  });
+
+  test("rejects a non-integer sight.keepLatestFrames", () => {
+    expect(
+      AssistantConfigSchema.safeParse({ sight: { keepLatestFrames: 2.5 } })
+        .success,
+    ).toBe(false);
+    expect(
+      AssistantConfigSchema.safeParse({ sight: { keepLatestFrames: "two" } })
+        .success,
+    ).toBe(false);
+  });
+
   // ── commitMessageLLM config ──────────────────────────────────────────
 
   test("default commitMessageLLM values are correct", () => {

--- a/assistant/src/__tests__/conversation-sight-frames.test.ts
+++ b/assistant/src/__tests__/conversation-sight-frames.test.ts
@@ -14,7 +14,7 @@ import {
   stripAgedSightFrames,
 } from "../daemon/conversation-sight-frames.js";
 import {
-  messageMetadataCarriesSightFrames,
+  messageMetadataIsAmbientSightKeep,
   sightFrameAttachmentIdsFromMetadata,
 } from "../persistence/conversation-types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
@@ -547,10 +547,11 @@ describe("sightFrameAttachmentIdsFromMetadata", () => {
   });
 });
 
-describe("messageMetadataCarriesSightFrames", () => {
-  test("reads the tag off a stored metadata column", () => {
+describe("messageMetadataIsAmbientSightKeep", () => {
+  test("a standalone keep carries the tag and the scripted marker", () => {
+    // The shape `persistLiveVoiceSightFrame` writes.
     expect(
-      messageMetadataCarriesSightFrames(
+      messageMetadataIsAmbientSightKeep(
         JSON.stringify({
           voiceSessionTurn: true,
           scripted: true,
@@ -560,26 +561,54 @@ describe("messageMetadataCarriesSightFrames", () => {
     ).toBe(true);
   });
 
-  test("an ordinary row is not a frame", () => {
-    expect(messageMetadataCarriesSightFrames(null)).toBe(false);
-    expect(messageMetadataCarriesSightFrames("")).toBe(false);
+  test("a spoken turn that merely carried a frame is not a keep", () => {
+    // The shape the voice bridge writes when a parked frame rides real
+    // speech, which in camera mode is every turn the user takes. Keying on
+    // the tag alone would read all of it as machine output.
     expect(
-      messageMetadataCarriesSightFrames(JSON.stringify({ livePhoto: true })),
+      messageMetadataIsAmbientSightKeep(
+        JSON.stringify({
+          voiceSessionTurn: true,
+          scripted: false,
+          sightFrameAttachmentIds: ["att-frame-1"],
+        }),
+      ),
     ).toBe(false);
+    // Older rows predating the always-stamped default carry no marker at all.
     expect(
-      messageMetadataCarriesSightFrames(
-        JSON.stringify({ sightFrameAttachmentIds: [] }),
+      messageMetadataIsAmbientSightKeep(
+        JSON.stringify({
+          voiceSessionTurn: true,
+          sightFrameAttachmentIds: ["att-frame-1"],
+        }),
       ),
     ).toBe(false);
   });
 
-  test("unreadable metadata is not a frame, so the row keeps its work", () => {
-    // Both callers use this to hold frames BACK, so a row whose marking
-    // cannot be read stays ordinary content and is still indexed or reviewed.
-    expect(messageMetadataCarriesSightFrames("{not json")).toBe(false);
+  test("an auto-sent row without the tag is not a keep", () => {
+    // `scripted` covers every machine-authored send, onboarding prompts
+    // included. Those are none of this predicate's business.
     expect(
-      messageMetadataCarriesSightFrames(
-        JSON.stringify({ sightFrameAttachmentIds: "att-1" }),
+      messageMetadataIsAmbientSightKeep(JSON.stringify({ scripted: true })),
+    ).toBe(false);
+  });
+
+  test("ordinary and unreadable rows are not keeps", () => {
+    expect(messageMetadataIsAmbientSightKeep(null)).toBe(false);
+    expect(messageMetadataIsAmbientSightKeep("")).toBe(false);
+    expect(
+      messageMetadataIsAmbientSightKeep(JSON.stringify({ livePhoto: true })),
+    ).toBe(false);
+    expect(
+      messageMetadataIsAmbientSightKeep(
+        JSON.stringify({ scripted: true, sightFrameAttachmentIds: [] }),
+      ),
+    ).toBe(false);
+    // Unreadable metadata leaves the row ordinary, so it keeps its work.
+    expect(messageMetadataIsAmbientSightKeep("{not json")).toBe(false);
+    expect(
+      messageMetadataIsAmbientSightKeep(
+        JSON.stringify({ scripted: true, sightFrameAttachmentIds: "att-1" }),
       ),
     ).toBe(false);
   });

--- a/assistant/src/__tests__/conversation-sight-frames.test.ts
+++ b/assistant/src/__tests__/conversation-sight-frames.test.ts
@@ -13,7 +13,10 @@ import {
   resolveSightKeepLatestFrames,
   stripAgedSightFrames,
 } from "../daemon/conversation-sight-frames.js";
-import { sightFrameAttachmentIdsFromMetadata } from "../persistence/conversation-types.js";
+import {
+  messageMetadataCarriesSightFrames,
+  sightFrameAttachmentIdsFromMetadata,
+} from "../persistence/conversation-types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import { setConfig } from "./helpers/set-config.js";
 
@@ -541,5 +544,43 @@ describe("sightFrameAttachmentIdsFromMetadata", () => {
         sightFrameAttachmentIds: ["att-1", "", 7, null],
       }),
     ).toEqual(["att-1"]);
+  });
+});
+
+describe("messageMetadataCarriesSightFrames", () => {
+  test("reads the tag off a stored metadata column", () => {
+    expect(
+      messageMetadataCarriesSightFrames(
+        JSON.stringify({
+          voiceSessionTurn: true,
+          scripted: true,
+          sightFrameAttachmentIds: ["att-1"],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("an ordinary row is not a frame", () => {
+    expect(messageMetadataCarriesSightFrames(null)).toBe(false);
+    expect(messageMetadataCarriesSightFrames("")).toBe(false);
+    expect(
+      messageMetadataCarriesSightFrames(JSON.stringify({ livePhoto: true })),
+    ).toBe(false);
+    expect(
+      messageMetadataCarriesSightFrames(
+        JSON.stringify({ sightFrameAttachmentIds: [] }),
+      ),
+    ).toBe(false);
+  });
+
+  test("unreadable metadata is not a frame, so the row keeps its work", () => {
+    // Both callers use this to hold frames BACK, so a row whose marking
+    // cannot be read stays ordinary content and is still indexed or reviewed.
+    expect(messageMetadataCarriesSightFrames("{not json")).toBe(false);
+    expect(
+      messageMetadataCarriesSightFrames(
+        JSON.stringify({ sightFrameAttachmentIds: "att-1" }),
+      ),
+    ).toBe(false);
   });
 });

--- a/assistant/src/__tests__/conversation-sight-frames.test.ts
+++ b/assistant/src/__tests__/conversation-sight-frames.test.ts
@@ -1,15 +1,21 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
+import {
+  KEEP_LATEST_SIGHT_FRAMES,
+  MAX_SIGHT_KEEP_LATEST_FRAMES,
+  MIN_SIGHT_KEEP_LATEST_FRAMES,
+} from "../config/schemas/sight.js";
 import {
   countMediaBlocks,
   stripMediaPayloadsForRetry,
 } from "../daemon/conversation-media-retry.js";
 import {
-  KEEP_LATEST_SIGHT_FRAMES,
+  resolveSightKeepLatestFrames,
   stripAgedSightFrames,
 } from "../daemon/conversation-sight-frames.js";
 import { sightFrameAttachmentIdsFromMetadata } from "../persistence/conversation-types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
+import { setConfig } from "./helpers/set-config.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -127,6 +133,34 @@ describe("stripAgedSightFrames", () => {
     expect(textOf(result.messages[4], 1)).toBe(
       "[Camera frame omitted from context: captured 2026-08-30T14:25:02.000Z, image/jpeg, 1024 bytes]",
     );
+  });
+
+  test("keeps as many frames as the caller's budget allows", () => {
+    const messages: Message[] = [
+      user(referenceImage("f1")),
+      user(referenceImage("f2")),
+      user(referenceImage("f3")),
+      user(referenceImage("f4")),
+      user(referenceImage("f5")),
+    ];
+
+    const result = stripAgedSightFrames(
+      messages,
+      captureTimes("f1", "f2", "f3", "f4", "f5"),
+      4,
+    );
+
+    expect(result.replacedBlocks).toBe(1);
+    expect(
+      result.messages.flatMap((m) =>
+        m.content.filter((b) => b.type === "image"),
+      ),
+    ).toEqual([
+      referenceImage("f2"),
+      referenceImage("f3"),
+      referenceImage("f4"),
+      referenceImage("f5"),
+    ]);
   });
 
   test("stubs several frames on one message independently", () => {
@@ -446,6 +480,38 @@ describe("stripAgedSightFrames composed with stripMediaPayloadsForRetry", () => 
     for (const stub of cameraStubs) {
       expect(stub.includes("retry context")).toBe(false);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Configured retention budget
+// ---------------------------------------------------------------------------
+
+describe("resolveSightKeepLatestFrames", () => {
+  afterEach(() => {
+    setConfig("sight", {});
+  });
+
+  test("defaults to the constant when the workspace configures nothing", () => {
+    expect(resolveSightKeepLatestFrames()).toBe(KEEP_LATEST_SIGHT_FRAMES);
+  });
+
+  test("honors a configured value inside the guardrail", () => {
+    setConfig("sight", { keepLatestFrames: 4 });
+    expect(resolveSightKeepLatestFrames()).toBe(4);
+  });
+
+  test("caps a value above the ceiling instead of resetting it", () => {
+    // Ten live images per request is what the ceiling exists to prevent, and
+    // falling back to the default would show fewer frames than the guardrail
+    // itself allows.
+    setConfig("sight", { keepLatestFrames: 99 });
+    expect(resolveSightKeepLatestFrames()).toBe(MAX_SIGHT_KEEP_LATEST_FRAMES);
+  });
+
+  test("raises a value below the floor", () => {
+    setConfig("sight", { keepLatestFrames: 0 });
+    expect(resolveSightKeepLatestFrames()).toBe(MIN_SIGHT_KEEP_LATEST_FRAMES);
   });
 });
 

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -86,6 +86,7 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../../../messaging/providers/slack/message-metadata.js",
     "../../../../../persistence/auto-analysis-constants.js",
     "../../../../../persistence/checkpoints.js",
+    "../../../../../persistence/conversation-types.js",
     "../../../../../persistence/db-connection.js",
     "../../../../../persistence/embeddings/embed.js",
     "../../../../../persistence/embeddings/embedding-backend.js",

--- a/assistant/src/__tests__/sight-frame-retention.test.ts
+++ b/assistant/src/__tests__/sight-frame-retention.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import {
+  KEEP_LATEST_SIGHT_FRAMES,
+  MAX_SIGHT_KEEP_LATEST_FRAMES,
+} from "../config/schemas/sight.js";
 import { applySightFrameRetention } from "../daemon/conversation-runtime-assembly.js";
 import {
   getAttachmentMetadataForMessage,
@@ -17,6 +21,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { conversations } from "../persistence/schema.js";
 import type { ContentBlock, Message } from "../providers/types.js";
+import { setConfig } from "./helpers/set-config.js";
 
 await initializeDb();
 
@@ -182,6 +187,71 @@ describe("applySightFrameRetention", () => {
     ];
 
     expect(applySightFrameRetention(assembled, conversationId)).toBe(assembled);
+  });
+});
+
+describe("configured retention budget", () => {
+  afterEach(() => {
+    setConfig("sight", {});
+  });
+
+  /** One tagged standalone frame per row, the shape a keep stream leaves. */
+  async function seedFrames(
+    conversationId: string,
+    count: number,
+  ): Promise<Message[]> {
+    ensureConversation(conversationId);
+    const assembled: Message[] = [];
+    for (let index = 0; index < count; index += 1) {
+      const attachmentId = `${conversationId}-att-${index}`;
+      await addMessage(conversationId, "user", frameContent(attachmentId), {
+        metadata: { sightFrameAttachmentIds: [attachmentId] },
+      });
+      assembled.push({
+        role: "user",
+        content: [referenceImage(attachmentId)],
+      });
+    }
+    return assembled;
+  }
+
+  function imageCount(messages: Message[]): number {
+    return messages.filter((message) => message.content[0].type === "image")
+      .length;
+  }
+
+  test("keeps the number of frames the workspace configured", async () => {
+    setConfig("sight", { keepLatestFrames: 4 });
+    const conversationId = "conv-sight-budget-configured";
+    const assembled = await seedFrames(conversationId, 6);
+
+    const retained = applySightFrameRetention(assembled, conversationId);
+
+    expect(imageCount(retained)).toBe(4);
+    expect(retained.length - imageCount(retained)).toBe(2);
+    // The survivors are the newest, which is what recency buys the model.
+    expect(retained.slice(2).every((m) => m.content[0].type === "image")).toBe(
+      true,
+    );
+  });
+
+  test("caps a configured value above the ceiling", async () => {
+    setConfig("sight", { keepLatestFrames: 99 });
+    const conversationId = "conv-sight-budget-capped";
+    const assembled = await seedFrames(conversationId, 8);
+
+    const retained = applySightFrameRetention(assembled, conversationId);
+
+    expect(imageCount(retained)).toBe(MAX_SIGHT_KEEP_LATEST_FRAMES);
+  });
+
+  test("falls back to the default when the workspace configures nothing", async () => {
+    const conversationId = "conv-sight-budget-default";
+    const assembled = await seedFrames(conversationId, 5);
+
+    const retained = applySightFrameRetention(assembled, conversationId);
+
+    expect(imageCount(retained)).toBe(KEEP_LATEST_SIGHT_FRAMES);
   });
 });
 

--- a/assistant/src/config/schema.ts
+++ b/assistant/src/config/schema.ts
@@ -54,6 +54,7 @@ import {
 import { PluginUpdatesConfigSchema } from "./schemas/plugin-updates.js";
 import { SecretDetectionConfigSchema } from "./schemas/security.js";
 import { ServicesSchema } from "./schemas/services.js";
+import { SightConfigSchema } from "./schemas/sight.js";
 import { SkillsConfigSchema } from "./schemas/skills.js";
 import {
   RateLimitConfigSchema,
@@ -118,6 +119,7 @@ export const AssistantConfigSchema = z.object({
   twilio: TwilioConfigSchema.default(TwilioConfigSchema.parse({})),
   calls: CallsConfigSchema.default(CallsConfigSchema.parse({})),
   liveVoice: LiveVoiceConfigSchema.default(LiveVoiceConfigSchema.parse({})),
+  sight: SightConfigSchema.default(SightConfigSchema.parse({})),
   whatsapp: WhatsAppConfigSchema.default(WhatsAppConfigSchema.parse({})),
   telegram: TelegramConfigSchema.default(TelegramConfigSchema.parse({})),
   slack: SlackConfigSchema.default(SlackConfigSchema.parse({})),

--- a/assistant/src/config/schemas/sight.ts
+++ b/assistant/src/config/schemas/sight.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+/**
+ * How many camera frames stay in the model's context as real images, counted
+ * newest-first across the whole conversation so the frames from the last few
+ * moments are the ones that survive. Older frames become timestamped text
+ * stubs (`daemon/conversation-sight-frames.ts`).
+ *
+ * Smaller than `RETRY_KEEP_LATEST_MEDIA_BLOCKS` (3, in
+ * `daemon/conversation-media-retry.ts`) because the two budgets answer
+ * different questions. That one is reactive and spends a rejected request's
+ * remaining room across every kind of media, including files the user
+ * deliberately sent. This one is proactive, applied to every assembly, and
+ * governs only frames the camera sampled by itself: background the model
+ * glances at, not something anyone chose to attach.
+ */
+export const KEEP_LATEST_SIGHT_FRAMES = 2;
+
+/**
+ * Floor for `sight.keepLatestFrames`. A call whose camera is up keeps at least
+ * the current view live; stubbing every frame would leave the model reading
+ * timestamps about pictures it can no longer see.
+ */
+export const MIN_SIGHT_KEEP_LATEST_FRAMES = 1;
+
+/**
+ * Ceiling for `sight.keepLatestFrames`. History resends every inline image on
+ * every later request, so the ceiling is what stops a long call from growing
+ * its own context until the provider rejects it.
+ */
+export const MAX_SIGHT_KEEP_LATEST_FRAMES = 6;
+
+export const SightConfigSchema = z
+  .object({
+    keepLatestFrames: z
+      .number({ error: "sight.keepLatestFrames must be a number" })
+      .int("sight.keepLatestFrames must be an integer")
+      .default(KEEP_LATEST_SIGHT_FRAMES)
+      .describe(
+        `How many of the newest camera frames a live-voice call keeps in the model's context as images; older frames become timestamped text stubs. Clamped to ${MIN_SIGHT_KEEP_LATEST_FRAMES}..${MAX_SIGHT_KEEP_LATEST_FRAMES} when read.`,
+      ),
+  })
+  .describe("Ambient camera frames sampled during a live-voice call");
+
+export type SightConfig = z.infer<typeof SightConfigSchema>;

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -37,6 +37,7 @@ import {
   attachmentExists,
   AttachmentUploadError,
   createInlineAttachment,
+  deleteOrphanAttachments,
   getAttachmentContent,
   getFilePathForAttachment,
   linkAttachmentToMessage,
@@ -435,37 +436,103 @@ async function prepareUserAttachmentReferences(
   attachments: MessageAttachmentInput[],
 ): Promise<PreparedUserAttachment[]> {
   const prepared: PreparedUserAttachment[] = [];
-  for (let i = 0; i < attachments.length; i++) {
-    const a = attachments[i];
-    const outcome = await materializeUserAttachment(
-      conversationId,
-      conversationCreatedAt,
-      a,
-    );
-    if (outcome.kind === "stored") {
-      prepared.push({
-        position: i,
-        block: await referenceBlockForAttachment(a, outcome.stored),
-        link: { attachmentId: outcome.stored.id },
-      });
-      continue;
-    }
-    if (outcome.kind === "rejected") {
-      continue;
-    }
-    // transient: keep the upload by inlining its bytes (dropped only when the
-    // recoverable failure left us with no bytes to inline).
-    const inline = await inlineBlockForAttachment(a);
-    if (inline) {
-      prepared.push({ position: i, block: inline });
-    } else {
-      log.warn(
-        { filename: a.filename },
-        "Dropping user attachment: store write failed and no inline bytes",
+  // Rows this call brought into being, tracked as they are made rather than
+  // read back off `prepared`: building a reference block is awaited between
+  // creating the row and recording it, so a throw there leaves a row nothing
+  // else knows about. The caller only ever sees a returned array, so a throw
+  // out of here makes this the one place that can still give them up.
+  const created: string[] = [];
+  try {
+    for (let i = 0; i < attachments.length; i++) {
+      const a = attachments[i];
+      const outcome = await materializeUserAttachment(
+        conversationId,
+        conversationCreatedAt,
+        a,
       );
+      if (outcome.kind === "stored") {
+        if (outcome.stored.id !== a.id) {
+          created.push(outcome.stored.id);
+        }
+        prepared.push({
+          position: i,
+          block: await referenceBlockForAttachment(a, outcome.stored),
+          link: { attachmentId: outcome.stored.id },
+        });
+        continue;
+      }
+      if (outcome.kind === "rejected") {
+        continue;
+      }
+      // transient: keep the upload by inlining its bytes (dropped only when the
+      // recoverable failure left us with no bytes to inline).
+      const inline = await inlineBlockForAttachment(a);
+      if (inline) {
+        prepared.push({ position: i, block: inline });
+      } else {
+        log.warn(
+          { filename: a.filename },
+          "Dropping user attachment: store write failed and no inline bytes",
+        );
+      }
     }
+  } catch (err) {
+    discardAttemptAttachments(created);
+    throw err;
   }
   return prepared;
+}
+
+/**
+ * Give up attachment rows a failed persist attempt created for itself.
+ *
+ * Conversation scoping CLONES an attachment already linked to another
+ * conversation, and an inline upload creates a fresh row under an id of its
+ * own. Either way the row is an artifact of this attempt that nothing else can
+ * reach: no message names it, and the caller still holds the id it sent or the
+ * bytes behind it. An attempt that dies before its message row exists has to
+ * take those with it, or the row and its copied file stay for good.
+ *
+ * Never the id the caller handed in. When materialization stored the
+ * attachment under that same id, the row IS the caller's upload, and deleting
+ * it would break the retry they are about to make.
+ *
+ * Routed through {@link deleteOrphanAttachments} so link-awareness stays the
+ * backstop, and swallowed on failure: cleaning up must never mask the error
+ * that caused it.
+ */
+function discardAttemptAttachments(attachmentIds: string[]): void {
+  if (attachmentIds.length === 0) {
+    return;
+  }
+  try {
+    deleteOrphanAttachments(attachmentIds);
+  } catch (err) {
+    log.warn(
+      { err, attachmentIds },
+      "Could not discard the attachments of a failed persist attempt",
+    );
+  }
+}
+
+/**
+ * Materialized ids that differ from the id their input arrived with, which is
+ * what separates a row this attempt made from the caller's own upload.
+ */
+function attemptCreatedAttachmentIds(
+  attachmentInputs: MessageAttachmentInput[],
+  prepared: PreparedUserAttachment[],
+): string[] {
+  const created: string[] = [];
+  for (const p of prepared) {
+    if (!p.link) {
+      continue;
+    }
+    if (p.link.attachmentId !== attachmentInputs[p.position]?.id) {
+      created.push(p.link.attachmentId);
+    }
+  }
+  return created;
 }
 
 /** One requested camera frame: the id the caller held, and what was stored. */
@@ -1015,6 +1082,13 @@ export async function persistQueuedMessageBody(
     }),
   );
   let pushedToHistory = false;
+  // Hoisted so the failure path can tell which rows this attempt made, and
+  // whether its message ever landed. From the insert onward the persisted
+  // content references those rows while no link yet protects them, which is
+  // exactly the shape a link-aware delete reads as collectible, so the cleanup
+  // must stop at the insert.
+  let preparedAttachments: PreparedUserAttachment[] = [];
+  let messageInserted = false;
 
   try {
     const turnCtx =
@@ -1167,7 +1241,7 @@ export async function persistQueuedMessageBody(
     // once the message id exists.
     const conversationCreatedAt =
       getConversation(ctx.conversationId)?.createdAt ?? Date.now();
-    const preparedAttachments = await prepareUserAttachmentReferences(
+    preparedAttachments = await prepareUserAttachmentReferences(
       ctx.conversationId,
       conversationCreatedAt,
       attachmentInputs,
@@ -1220,6 +1294,7 @@ export async function persistQueuedMessageBody(
         ...(skipIndexing ? { skipIndexing: true } : {}),
       },
     );
+    messageInserted = true;
 
     if (persistedUserMessage.deduplicated) {
       return { id: persistedUserMessage.id, deduplicated: true };
@@ -1351,6 +1426,11 @@ export async function persistQueuedMessageBody(
   } catch (err) {
     if (pushedToHistory) {
       ctx.messages.pop();
+    }
+    if (!messageInserted) {
+      discardAttemptAttachments(
+        attemptCreatedAttachmentIds(attachmentInputs, preparedAttachments),
+      );
     }
     throw err;
   }

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -60,7 +60,11 @@ import {
   updateMetaFile,
 } from "../persistence/conversation-disk-view.js";
 import { SIGHT_FRAME_ATTACHMENT_IDS_KEY } from "../persistence/conversation-types.js";
-import type { ContentBlock, Message } from "../providers/types.js";
+import {
+  attachmentIdFragment,
+  type ContentBlock,
+  type Message,
+} from "../providers/types.js";
 import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
 import { withSqliteRetry } from "../util/sqlite-retry.js";
@@ -464,10 +468,16 @@ async function prepareUserAttachmentReferences(
   return prepared;
 }
 
+/** One requested camera frame: the id the caller held, and what was stored. */
+interface SightFrameEntry {
+  inputId: string;
+  storedId: string;
+}
+
 /**
- * Translate the caller's ambient-camera-frame ids into the ids the persisted
- * blocks are attributable by, walking each materialized attachment back to the
- * input it came from.
+ * Pair each requested ambient camera frame with the id its persisted block is
+ * attributable by, walking every materialized attachment back to the input it
+ * came from.
  *
  * Which id that is depends on how the attachment landed. A stored one is named
  * by its linked row, which is also what its `workspace_ref` block carries. One
@@ -476,6 +486,32 @@ async function prepareUserAttachmentReferences(
  * reads both shapes through `mediaBlockAttachmentId`, and an inline frame is
  * the heaviest thing in every later request precisely because its bytes are in
  * the row.
+ */
+function requestedSightFrameEntries(
+  requestedIds: readonly string[] | undefined,
+  attachmentInputs: MessageAttachmentInput[],
+  prepared: PreparedUserAttachment[],
+): SightFrameEntry[] {
+  if (!requestedIds || requestedIds.length === 0) {
+    return [];
+  }
+  const requested = new Set(requestedIds);
+  const entries: SightFrameEntry[] = [];
+  for (const p of prepared) {
+    const inputId = attachmentInputs[p.position]?.id;
+    if (inputId === undefined || !requested.has(inputId)) {
+      continue;
+    }
+    entries.push({
+      inputId,
+      storedId: p.link ? p.link.attachmentId : inputId,
+    });
+  }
+  return entries;
+}
+
+/**
+ * The ids to tag the row with.
  *
  * Exactly one id per frame, never both. A stored attachment's pre-clone id
  * belongs to a DIFFERENT conversation's row, so naming it as well would mark
@@ -484,24 +520,81 @@ async function prepareUserAttachmentReferences(
  * fork's widened tag (`widenForkSightFrameTags`), where the two ids are two
  * names for the same image.
  */
-function sightFrameTagIds(
-  requestedIds: readonly string[] | undefined,
-  attachmentInputs: MessageAttachmentInput[],
-  prepared: PreparedUserAttachment[],
-): string[] {
-  if (!requestedIds || requestedIds.length === 0) {
-    return [];
+function sightFrameTagIds(entries: SightFrameEntry[]): string[] {
+  return [...new Set(entries.map((entry) => entry.storedId))];
+}
+
+/**
+ * Frames whose stored id differs from the one the caller handed in, by the
+ * caller's id. Empty unless conversation scoping cloned a row.
+ */
+function sightFrameBlockRenames(
+  entries: SightFrameEntry[],
+): Map<string, string> {
+  return new Map(
+    entries
+      .filter((entry) => entry.storedId !== entry.inputId)
+      .map((entry) => [entry.inputId, entry.storedId]),
+  );
+}
+
+/**
+ * Point an inline media block at the id its attachment was stored under.
+ *
+ * Only the inline shape is restamped. A `workspace_ref` names its row inside
+ * `source`, which materialization already filled with the stored id, so there
+ * is nothing to correct and rewriting `_attachmentId` alone would leave the two
+ * halves disagreeing.
+ */
+function restampInlineAttachmentId(
+  block: ContentBlock,
+  renames: ReadonlyMap<string, string>,
+): ContentBlock {
+  if (block.type !== "image" && block.type !== "file") {
+    return block;
   }
-  const requested = new Set(requestedIds);
-  const tagged = new Set<string>();
-  for (const p of prepared) {
-    const inputId = attachmentInputs[p.position]?.id;
-    if (inputId === undefined || !requested.has(inputId)) {
-      continue;
-    }
-    tagged.add(p.link ? p.link.attachmentId : inputId);
+  if (block.source.type === "workspace_ref") {
+    return block;
   }
-  return [...tagged];
+  const renamed =
+    block._attachmentId === undefined
+      ? undefined
+      : renames.get(block._attachmentId);
+  if (renamed === undefined) {
+    return block;
+  }
+  return { ...block, ...attachmentIdFragment(renamed) };
+}
+
+/**
+ * Rewrite the live message's camera-frame blocks to the ids their rows were
+ * stored under.
+ *
+ * The in-memory message is built from the attachments the caller handed in, so
+ * its blocks name the ids the caller held while the tag names what
+ * materialization stored. Those differ whenever conversation scoping cloned a
+ * row, and retention walking the live history would then find no frame to age:
+ * the tag matches nothing until a reload rebuilds the blocks from the persisted
+ * content. Restamping is what makes the array a turn actually sends agree with
+ * the tag, so a cloned frame is bounded on the turn that created it rather than
+ * only after a restart.
+ *
+ * Matched by id, never by position: `attachmentsToContentBlocks` emits nothing
+ * for an attachment it cannot turn into a block, so positions do not line up.
+ */
+function restampInlineAttachmentIds(
+  message: Message,
+  renames: ReadonlyMap<string, string>,
+): Message {
+  if (renames.size === 0) {
+    return message;
+  }
+  return {
+    ...message,
+    content: message.content.map((block) =>
+      restampInlineAttachmentId(block, renames),
+    ),
+  };
 }
 
 function extractTurnChannelContext(
@@ -1086,7 +1179,18 @@ export async function persistQueuedMessageBody(
     const sentAttachments = preparedAttachments.map(
       (p) => attachmentInputs[p.position],
     );
-    const cleanMessage = await createUserMessage(content, sentAttachments);
+    const sightFrameEntries = requestedSightFrameEntries(
+      options.sightFrameAttachmentIds,
+      attachmentInputs,
+      preparedAttachments,
+    );
+    const sightFrameRenames = sightFrameBlockRenames(sightFrameEntries);
+    // The blocks are built from the ids the caller held, so a cloned frame is
+    // pointed at its stored row before the message reaches the live history.
+    const cleanMessage = restampInlineAttachmentIds(
+      await createUserMessage(content, sentAttachments),
+      sightFrameRenames,
+    );
 
     // When displayContent is provided (e.g. original text before recording
     // intent stripping), persist that to DB so users see the full message
@@ -1099,11 +1203,7 @@ export async function persistQueuedMessageBody(
     );
     // Composed here rather than with the rest of the metadata above, because
     // materialization is what decides the id each frame is stored under.
-    const sightFrameIds = sightFrameTagIds(
-      options.sightFrameAttachmentIds,
-      attachmentInputs,
-      preparedAttachments,
-    );
+    const sightFrameIds = sightFrameTagIds(sightFrameEntries);
     const metadataToPersist =
       sightFrameIds.length > 0
         ? { ...mergedMetadata, [SIGHT_FRAME_ATTACHMENT_IDS_KEY]: sightFrameIds }
@@ -1183,7 +1283,13 @@ export async function persistQueuedMessageBody(
         );
         if (inline) {
           repairedBlocks ??= preparedAttachments.map((pp) => pp.block);
-          repairedBlocks[idx] = inline;
+          // Rebuilt from the caller's attachment, so it names the id the
+          // caller held while the tag written above names the stored row.
+          // Restamping keeps a repaired frame matchable by retention.
+          repairedBlocks[idx] = restampInlineAttachmentId(
+            inline,
+            sightFrameRenames,
+          );
         }
       }
     }

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -465,17 +465,24 @@ async function prepareUserAttachmentReferences(
 }
 
 /**
- * Translate the caller's ambient-camera-frame ids into the ids the row is
- * actually linked to, by walking the materialized attachments back to the
- * input each one came from.
+ * Translate the caller's ambient-camera-frame ids into the ids the persisted
+ * blocks are attributable by, walking each materialized attachment back to the
+ * input it came from.
  *
- * Only the final id is named. On this row the persisted content block and the
- * `message_attachments` link both carry it, so there is a single vocabulary to
- * match, unlike a fork's copied rows where content keeps the source ids while
- * links point at clones of the same image (`widenForkSightFrameTags`). The
- * pre-clone id here names a row belonging to a DIFFERENT conversation, so
- * naming it too would mark that attachment as an ambient frame if it ever
- * entered this lineage, stubbing an image someone deliberately attached.
+ * Which id that is depends on how the attachment landed. A stored one is named
+ * by its linked row, which is also what its `workspace_ref` block carries. One
+ * that fell back to inline base64 has no row, and its block carries the
+ * caller's own id on `_attachmentId`, so that is the id to name: retention
+ * reads both shapes through `mediaBlockAttachmentId`, and an inline frame is
+ * the heaviest thing in every later request precisely because its bytes are in
+ * the row.
+ *
+ * Exactly one id per frame, never both. A stored attachment's pre-clone id
+ * belongs to a DIFFERENT conversation's row, so naming it as well would mark
+ * that attachment as an ambient frame if it ever entered this lineage and stub
+ * an image someone deliberately attached. That is what separates this from a
+ * fork's widened tag (`widenForkSightFrameTags`), where the two ids are two
+ * names for the same image.
  */
 function sightFrameTagIds(
   requestedIds: readonly string[] | undefined,
@@ -488,13 +495,11 @@ function sightFrameTagIds(
   const requested = new Set(requestedIds);
   const tagged = new Set<string>();
   for (const p of prepared) {
-    if (!p.link) {
+    const inputId = attachmentInputs[p.position]?.id;
+    if (inputId === undefined || !requested.has(inputId)) {
       continue;
     }
-    const inputId = attachmentInputs[p.position]?.id;
-    if (inputId !== undefined && requested.has(inputId)) {
-      tagged.add(p.link.attachmentId);
-    }
+    tagged.add(p.link ? p.link.attachmentId : inputId);
   }
   return [...tagged];
 }
@@ -787,10 +792,13 @@ export interface PersistMessageOptions {
    * ahead of that names a row the retention pass can never match, and the
    * frame then rides every later request forever.
    *
-   * An attachment that ended up inlined (a recoverable store failure left it
-   * as base64 with no row) has no id to name and is left out; retention
-   * matches on attachment ids, so an inlined frame is outside its reach
-   * either way.
+   * The tag names whatever id the persisted block is attributable by: the
+   * linked row's id for a materialized attachment, and the caller's own id
+   * for one a recoverable store failure left as inline base64, which is the
+   * id `attachmentsToContentBlocks` stamps on that block. The inline case is
+   * the one that matters most, because such a block carries its full bytes in
+   * `messages.content`, so the frame heaviest in every later request is
+   * exactly the one retention has to be able to stub.
    */
   sightFrameAttachmentIds?: readonly string[];
 }

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -59,6 +59,7 @@ import {
   syncMessageToDisk,
   updateMetaFile,
 } from "../persistence/conversation-disk-view.js";
+import { SIGHT_FRAME_ATTACHMENT_IDS_KEY } from "../persistence/conversation-types.js";
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { AuthContext } from "../runtime/auth/types.js";
 import { getLogger } from "../util/logger.js";
@@ -463,6 +464,41 @@ async function prepareUserAttachmentReferences(
   return prepared;
 }
 
+/**
+ * Translate the caller's ambient-camera-frame ids into the ids the row is
+ * actually linked to, by walking the materialized attachments back to the
+ * input each one came from.
+ *
+ * Only the final id is named. On this row the persisted content block and the
+ * `message_attachments` link both carry it, so there is a single vocabulary to
+ * match, unlike a fork's copied rows where content keeps the source ids while
+ * links point at clones of the same image (`widenForkSightFrameTags`). The
+ * pre-clone id here names a row belonging to a DIFFERENT conversation, so
+ * naming it too would mark that attachment as an ambient frame if it ever
+ * entered this lineage, stubbing an image someone deliberately attached.
+ */
+function sightFrameTagIds(
+  requestedIds: readonly string[] | undefined,
+  attachmentInputs: MessageAttachmentInput[],
+  prepared: PreparedUserAttachment[],
+): string[] {
+  if (!requestedIds || requestedIds.length === 0) {
+    return [];
+  }
+  const requested = new Set(requestedIds);
+  const tagged = new Set<string>();
+  for (const p of prepared) {
+    if (!p.link) {
+      continue;
+    }
+    const inputId = attachmentInputs[p.position]?.id;
+    if (inputId !== undefined && requested.has(inputId)) {
+      tagged.add(p.link.attachmentId);
+    }
+  }
+  return [...tagged];
+}
+
 function extractTurnChannelContext(
   metadata?: Record<string, unknown>,
 ): TurnChannelContext | null {
@@ -736,6 +772,27 @@ export interface PersistMessageOptions {
    * what a consumer that must not misattribute a turn to a surface needs.
    */
   requestClientOs?: string;
+  /**
+   * Which of `attachments`, by the id the caller holds, arrived as ambient
+   * camera frames rather than files the user picked. Stamps
+   * `SIGHT_FRAME_ATTACHMENT_IDS_KEY` on the persisted row, which is what the
+   * retention pass reads to decide which images a later turn still sends in
+   * full and which become timestamped stubs.
+   *
+   * Named through this option rather than written into `metadata` by the
+   * caller because only the persist knows the id the row ends up linked to.
+   * A pre-uploaded attachment already linked to another conversation is
+   * CLONED into this one under a fresh id, and both the persisted content
+   * block and the `message_attachments` row carry the clone. A tag composed
+   * ahead of that names a row the retention pass can never match, and the
+   * frame then rides every later request forever.
+   *
+   * An attachment that ended up inlined (a recoverable store failure left it
+   * as base64 with no row) has no id to name and is left out; retention
+   * matches on attachment ids, so an inlined frame is outside its reach
+   * either way.
+   */
+  sightFrameAttachmentIds?: readonly string[];
 }
 
 // ── persistUserMessage ───────────────────────────────────────────────
@@ -1032,12 +1089,24 @@ export async function persistQueuedMessageBody(
       displayContent,
       preparedAttachments.map((p) => p.block),
     );
+    // Composed here rather than with the rest of the metadata above, because
+    // materialization is what decides the id each frame is stored under.
+    const sightFrameIds = sightFrameTagIds(
+      options.sightFrameAttachmentIds,
+      attachmentInputs,
+      preparedAttachments,
+    );
+    const metadataToPersist =
+      sightFrameIds.length > 0
+        ? { ...mergedMetadata, [SIGHT_FRAME_ATTACHMENT_IDS_KEY]: sightFrameIds }
+        : mergedMetadata;
+
     const persistedUserMessage = await addMessage(
       ctx.conversationId,
       "user",
       contentToPersist,
       {
-        metadata: mergedMetadata,
+        metadata: metadataToPersist,
         clientMessageId,
         id: requestId,
         ...(skipIndexing ? { skipIndexing: true } : {}),

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -82,6 +82,7 @@ import { channelSupportsInlineOptions } from "./channel-ui-capability.js";
 import { findConversationOrSubagent } from "./conversation-registry.js";
 import {
   hasAttributableImages,
+  resolveSightKeepLatestFrames,
   stripAgedSightFrames,
 } from "./conversation-sight-frames.js";
 import type { SurfaceShowPair } from "./conversation-surfaces.js";
@@ -750,10 +751,10 @@ export function stripNowScratchpad(messages: Message[]): Message[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Trim the conversation's ambient camera frames down to the newest few
- * (`KEEP_LATEST_SIGHT_FRAMES`), replacing the rest with text stubs.
+ * Trim the conversation's ambient camera frames down to the newest
+ * `sight.keepLatestFrames`, replacing the rest with text stubs.
  *
- * A camera call samples a frame about once per spoken turn, and history resends
+ * A camera call samples a frame every few seconds, and history resends
  * every inline image on every later request, so an hour-long call otherwise
  * grows its own context until the provider rejects it. Trimming here, on the
  * assembled copy the turn is about to send, keeps the stored transcript and its
@@ -789,7 +790,11 @@ export function applySightFrameRetention(
     if (captureTimes.size === 0) {
       return messages;
     }
-    return stripAgedSightFrames(messages, captureTimes).messages;
+    return stripAgedSightFrames(
+      messages,
+      captureTimes,
+      resolveSightKeepLatestFrames(),
+    ).messages;
   } catch (err) {
     log.warn(
       { conversationId, err },

--- a/assistant/src/daemon/conversation-sight-frames.ts
+++ b/assistant/src/daemon/conversation-sight-frames.ts
@@ -2,11 +2,11 @@
  * Retention for ambient camera frames, the images a call samples on its own
  * while the camera is up.
  *
- * A frame arrives about once per spoken turn and history resends every inline
- * image on every later request, so a long call grows its own context until the
- * provider rejects it. {@link stripAgedSightFrames} keeps only the newest few
- * frames as real images and replaces the rest with text stubs, on the copy of
- * the history a turn is about to send.
+ * Frames arrive every few seconds for as long as the camera is up, and history
+ * resends every inline image on every later request, so a long call grows its
+ * own context until the provider rejects it. {@link stripAgedSightFrames} keeps
+ * only the newest `sight.keepLatestFrames` as real images and replaces the rest
+ * with text stubs, on the copy of the history a turn is about to send.
  *
  * This is the proactive counterpart to `stripMediaPayloadsForRetry`
  * (`conversation-media-retry.ts`), which fires only after a provider has
@@ -21,6 +21,12 @@
  * without either module importing the other.
  */
 
+import { getConfig } from "../config/loader.js";
+import {
+  KEEP_LATEST_SIGHT_FRAMES,
+  MAX_SIGHT_KEEP_LATEST_FRAMES,
+  MIN_SIGHT_KEEP_LATEST_FRAMES,
+} from "../config/schemas/sight.js";
 import { mediaSourceDescriptor } from "../providers/media-resolve.js";
 import {
   type ContentBlock,
@@ -29,19 +35,25 @@ import {
 } from "../providers/types.js";
 
 /**
- * How many camera frames stay in the context as real images, counted
- * newest-first across the whole conversation so the frames on the most recent
- * turns are the ones that survive.
+ * The workspace's `sight.keepLatestFrames`, clamped to
+ * [{@link MIN_SIGHT_KEEP_LATEST_FRAMES}, {@link MAX_SIGHT_KEEP_LATEST_FRAMES}].
  *
- * Smaller than `RETRY_KEEP_LATEST_MEDIA_BLOCKS` (3, in
- * `conversation-media-retry.ts`) because the two budgets answer different
- * questions. That one is reactive and spends a rejected request's remaining
- * room across every kind of media, including files the user deliberately sent.
- * This one is proactive, applied to every assembly, and governs only frames the
- * camera sampled by itself: background the model glances at, not something
- * anyone chose to attach.
+ * Clamped at read rather than rejected by the schema because an out-of-range
+ * value states an intent the guardrail can honor part of the way: capping it
+ * shows the most frames the budget allows, while failing validation would fall
+ * back to the default and show a number neither the config nor the guardrail
+ * asked for.
  */
-export const KEEP_LATEST_SIGHT_FRAMES = 2;
+export function resolveSightKeepLatestFrames(): number {
+  const configured = getConfig().sight.keepLatestFrames;
+  if (!Number.isFinite(configured)) {
+    return KEEP_LATEST_SIGHT_FRAMES;
+  }
+  return Math.min(
+    MAX_SIGHT_KEEP_LATEST_FRAMES,
+    Math.max(MIN_SIGHT_KEEP_LATEST_FRAMES, Math.trunc(configured)),
+  );
+}
 
 /**
  * True when any image in the history can be traced back to an attachment row.
@@ -63,7 +75,11 @@ export function hasAttributableImages(messages: Message[]): boolean {
 
 /**
  * Replace every camera frame in `messages` except the newest
- * {@link KEEP_LATEST_SIGHT_FRAMES} with a text stub.
+ * `keepLatestFrames` with a text stub.
+ *
+ * `keepLatestFrames` defaults to {@link KEEP_LATEST_SIGHT_FRAMES}, the config
+ * default. The assembly path passes {@link resolveSightKeepLatestFrames}
+ * instead, so what a turn sends follows the workspace's own setting.
  *
  * `frameCaptureTimes` maps an attachment id the conversation tagged as a camera
  * frame to when the row carrying it was written; an image block counts as a
@@ -84,6 +100,7 @@ export function hasAttributableImages(messages: Message[]): boolean {
 export function stripAgedSightFrames(
   messages: Message[],
   frameCaptureTimes: ReadonlyMap<string, number>,
+  keepLatestFrames: number = KEEP_LATEST_SIGHT_FRAMES,
 ): { messages: Message[]; modified: boolean; replacedBlocks: number } {
   if (frameCaptureTimes.size === 0) {
     return { messages, modified: false, replacedBlocks: 0 };
@@ -110,7 +127,7 @@ export function stripAgedSightFrames(
       frames.push({ messageIndex, blockIndex, capturedAt });
     }
   }
-  if (frames.length <= KEEP_LATEST_SIGHT_FRAMES) {
+  if (frames.length <= keepLatestFrames) {
     return { messages, modified: false, replacedBlocks: 0 };
   }
 
@@ -121,7 +138,7 @@ export function stripAgedSightFrames(
   const aged = new Map<number, Map<number, number>>();
   for (const frame of byCaptureTime.slice(
     0,
-    byCaptureTime.length - KEEP_LATEST_SIGHT_FRAMES,
+    byCaptureTime.length - keepLatestFrames,
   )) {
     const blocks = aged.get(frame.messageIndex) ?? new Map<number, number>();
     blocks.set(frame.blockIndex, frame.capturedAt);

--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -34,6 +34,7 @@ import { initializeDb } from "../../persistence/db-init.js";
 import { mediaBlockAttachmentId, type Message } from "../../providers/types.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import {
+  _setProcessingWaitMsForTests,
   _standaloneImageQueueSizeForTests,
   persistLiveVoicePhoto,
   persistLiveVoiceSightFrame,
@@ -109,6 +110,22 @@ async function uploadFrame(name: string): Promise<string> {
 /** True while the attachment's row is still in the store. */
 function frameStored(attachmentId: string): boolean {
   return getAttachmentById(attachmentId) !== null;
+}
+
+/**
+ * Attachment ids the conversation's LIVE history is attributable by, which is
+ * the array a turn sends rather than the rows a reload would rebuild.
+ */
+function liveImageIds(conversation: Conversation): Array<string | undefined> {
+  const ids: Array<string | undefined> = [];
+  for (const message of conversation.messages) {
+    for (const block of message.content) {
+      if (block.type === "image") {
+        ids.push(mediaBlockAttachmentId(block));
+      }
+    }
+  }
+  return ids;
 }
 
 /**
@@ -361,6 +378,62 @@ describe("persistLiveVoiceSightFrame", () => {
     }
   });
 
+  test("the live in-memory block names the cloned id, not the arriving one", async () => {
+    // The live message is built from the attachments the caller handed in, so
+    // its block names the id the session held while the tag names what
+    // materialization stored. Left disagreeing, the turn that created the
+    // frame sends it full size and only a reload ever bounds it.
+    const source = liveConversation("Live voice live block source");
+    const live = liveConversation("Live voice live block clone");
+    try {
+      const arrivedAs = await attachmentLinkedElsewhere(source.id);
+
+      expect((await persistLiveVoiceSightFrame(live.id, arrivedAs)).ok).toBe(
+        true,
+      );
+
+      const stored = storedImageId(getMessages(live.id)[0]);
+      expect(stored).toBeDefined();
+      expect(stored).not.toBe(arrivedAs);
+      // The array a turn actually sends agrees with the tag.
+      expect(liveImageIds(live.activeConversation)).toEqual([stored]);
+    } finally {
+      live.dispose();
+      source.dispose();
+    }
+  });
+
+  test("retention ages a cloned frame in the live history", async () => {
+    // The reload path is covered below; this is the same conversation before
+    // any reload, which is where a long call spends all its time.
+    const source = liveConversation("Live voice live retention source");
+    const live = liveConversation("Live voice live retention");
+    try {
+      const arrivedAs = await attachmentLinkedElsewhere(source.id);
+      expect((await persistLiveVoiceSightFrame(live.id, arrivedAs)).ok).toBe(
+        true,
+      );
+      for (const name of ["live-fresh-a.png", "live-fresh-b.png"]) {
+        const fresh = await uploadFrame(name);
+        expect((await persistLiveVoiceSightFrame(live.id, fresh)).ok).toBe(
+          true,
+        );
+      }
+
+      const live_ = live.activeConversation;
+      expect(live_.messages).toHaveLength(3);
+      const retained = live_.trimAgedSightFrames(live_.messages);
+
+      // Three frames, a budget of two: the cloned one is the oldest and goes.
+      expect(retained[0].content.some((b) => b.type === "image")).toBe(false);
+      expect(retained[1].content.some((b) => b.type === "image")).toBe(true);
+      expect(retained[2].content.some((b) => b.type === "image")).toBe(true);
+    } finally {
+      live.dispose();
+      source.dispose();
+    }
+  });
+
   test("retention ages a cloned frame, because the tag matches its block", async () => {
     // The end of the same thread: a tag naming the id the caller held leaves
     // this frame unrecognized, so it is never counted and never stubbed, and
@@ -596,6 +669,52 @@ describe("standalone image persists are serialized per conversation", () => {
       }
     } finally {
       live.dispose();
+    }
+  });
+
+  test("a keep whose wait runs out gives up its upload", async () => {
+    // A turn longer than the wait drops the keep, and nothing else would ever
+    // collect the row: the client's abandon-delete fires on a refused send,
+    // and this send was accepted.
+    const restoreWait = _setProcessingWaitMsForTests(120);
+    const live = liveConversation("Live voice keep wait timeout");
+    try {
+      const frame = await uploadFrame("timed-out.png");
+
+      // A turn that outlasts the wait.
+      live.activeConversation.setProcessing(true);
+      expect(await persistLiveVoiceSightFrame(live.id, frame)).toEqual({
+        ok: false,
+      });
+
+      expect(frameStored(frame)).toBe(false);
+      expect(getMessages(live.id)).toHaveLength(0);
+    } finally {
+      live.activeConversation.setProcessing(false);
+      live.dispose();
+      _setProcessingWaitMsForTests(restoreWait);
+    }
+  });
+
+  test("a photo whose wait runs out keeps its upload", async () => {
+    // A photo is a deliberate upload the user watched themselves make, so a
+    // failed persist is theirs to retry rather than the daemon's to delete.
+    const restoreWait = _setProcessingWaitMsForTests(120);
+    const live = liveConversation("Live voice photo wait timeout");
+    try {
+      const photo = await uploadFrame("timed-out-photo.png");
+
+      live.activeConversation.setProcessing(true);
+      expect(await persistLiveVoicePhoto(live.id, photo)).toEqual({
+        ok: false,
+      });
+
+      expect(frameStored(photo)).toBe(true);
+      expect(getMessages(live.id)).toHaveLength(0);
+    } finally {
+      live.activeConversation.setProcessing(false);
+      live.dispose();
+      _setProcessingWaitMsForTests(restoreWait);
     }
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -15,17 +15,22 @@ import {
   deleteConversation,
   setConversation,
 } from "../../daemon/conversation-registry.js";
+import { applySightFrameRetention } from "../../daemon/conversation-runtime-assembly.js";
 import {
   getAttachmentsForMessage,
+  linkAttachmentToMessage,
   uploadAttachment,
 } from "../../persistence/attachments-store.js";
 import {
   addMessage,
   createConversation,
   getMessages,
+  type MessageRow,
   selectSightFrameCaptureTimes,
 } from "../../persistence/conversation-crud.js";
+import { sightFrameAttachmentIdsFromMetadata } from "../../persistence/conversation-types.js";
 import { initializeDb } from "../../persistence/db-init.js";
+import { mediaBlockAttachmentId, type Message } from "../../providers/types.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import {
   persistLiveVoicePhoto,
@@ -62,6 +67,45 @@ function liveConversation(title: string) {
       activeConversation.dispose();
     },
   };
+}
+
+function metadataOf(row: MessageRow): Record<string, unknown> {
+  return JSON.parse(row.metadata ?? "{}") as Record<string, unknown>;
+}
+
+/** The attachment id the row's persisted image block actually references. */
+function storedImageId(row: MessageRow): string | undefined {
+  for (const block of row.content) {
+    if (block.type !== "image") {
+      continue;
+    }
+    const id = mediaBlockAttachmentId(block);
+    if (id !== undefined) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * An attachment already linked to a message in another conversation, which is
+ * what makes the persist clone it rather than reuse the row.
+ */
+async function attachmentLinkedElsewhere(
+  otherConversationId: string,
+): Promise<string> {
+  const attachment = await uploadAttachment(
+    "frame.png",
+    "image/png",
+    IMAGE_BASE64,
+  );
+  const elsewhere = await addMessage(
+    otherConversationId,
+    "user",
+    "look at this",
+  );
+  linkAttachmentToMessage(elsewhere.id, attachment.id, 0);
+  return attachment.id;
 }
 
 describe("persistLiveVoicePhoto", () => {
@@ -149,6 +193,27 @@ describe("persistLiveVoicePhoto", () => {
       live.dispose();
     }
   });
+
+  test("leaves the photo unscripted, the shutter being a turn the user took", async () => {
+    // Pressing the shutter is the user acting, so the row keeps asserting
+    // "the user did this" and stays inside activation.
+    const live = liveConversation("Live voice photo scripted");
+    try {
+      const attachment = await uploadAttachment(
+        "photo.png",
+        "image/png",
+        IMAGE_BASE64,
+      );
+
+      expect((await persistLiveVoicePhoto(live.id, attachment.id)).ok).toBe(
+        true,
+      );
+
+      expect(metadataOf(getMessages(live.id)[0]).scripted).toBe(false);
+    } finally {
+      live.dispose();
+    }
+  });
 });
 
 describe("persistLiveVoiceSightFrame", () => {
@@ -175,6 +240,91 @@ describe("persistLiveVoiceSightFrame", () => {
       ]);
     } finally {
       live.dispose();
+    }
+  });
+
+  test("marks the row scripted, so keeps are not counted as turns the user took", async () => {
+    // The gate sent this, not the user. A keep every few seconds would
+    // otherwise read downstream as that many turns taken, and activation
+    // believes a row that claims it was typed.
+    const live = liveConversation("Live voice sight frame scripted");
+    try {
+      const attachment = await uploadAttachment(
+        "frame.png",
+        "image/png",
+        IMAGE_BASE64,
+      );
+
+      expect(
+        (await persistLiveVoiceSightFrame(live.id, attachment.id)).ok,
+      ).toBe(true);
+
+      expect(metadataOf(getMessages(live.id)[0]).scripted).toBe(true);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("tags the id the attachment was cloned into, not the one it arrived as", async () => {
+    // An attachment already linked to another conversation is cloned into this
+    // one under a fresh id, and both the persisted block and the link carry the
+    // clone. A tag naming the id the caller held would match nothing.
+    const source = liveConversation("Live voice sight frame source");
+    const live = liveConversation("Live voice sight frame clone");
+    try {
+      const arrivedAs = await attachmentLinkedElsewhere(source.id);
+
+      expect((await persistLiveVoiceSightFrame(live.id, arrivedAs)).ok).toBe(
+        true,
+      );
+
+      const [row] = getMessages(live.id);
+      const stored = storedImageId(row);
+      expect(stored).toBeDefined();
+      expect(stored).not.toBe(arrivedAs);
+      expect(sightFrameAttachmentIdsFromMetadata(metadataOf(row))).toEqual([
+        stored!,
+      ]);
+      expect([...selectSightFrameCaptureTimes(live.id).keys()]).toEqual([
+        stored!,
+      ]);
+    } finally {
+      live.dispose();
+      source.dispose();
+    }
+  });
+
+  test("retention ages a cloned frame, because the tag matches its block", async () => {
+    // The end of the same thread: a tag naming the id the caller held leaves
+    // this frame unrecognized, so it is never counted and never stubbed, and
+    // it rides every later request for the rest of the call.
+    const source = liveConversation("Live voice cloned retention source");
+    const live = liveConversation("Live voice cloned retention");
+    try {
+      const arrivedAs = await attachmentLinkedElsewhere(source.id);
+      expect((await persistLiveVoiceSightFrame(live.id, arrivedAs)).ok).toBe(
+        true,
+      );
+      for (const name of ["later-a.png", "later-b.png"]) {
+        const fresh = await uploadAttachment(name, "image/png", IMAGE_BASE64);
+        expect((await persistLiveVoiceSightFrame(live.id, fresh.id)).ok).toBe(
+          true,
+        );
+      }
+
+      const assembled: Message[] = getMessages(live.id).map((row) => ({
+        role: "user" as const,
+        content: row.content,
+      }));
+      const retained = applySightFrameRetention(assembled, live.id);
+
+      // Three frames, a budget of two: the cloned one is the oldest and goes.
+      expect(retained[0].content.some((b) => b.type === "image")).toBe(false);
+      expect(retained[1].content.some((b) => b.type === "image")).toBe(true);
+      expect(retained[2].content.some((b) => b.type === "image")).toBe(true);
+    } finally {
+      live.dispose();
+      source.dispose();
     }
   });
 

--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../daemon/conversation-registry.js";
 import { applySightFrameRetention } from "../../daemon/conversation-runtime-assembly.js";
 import {
+  getAttachmentById,
   getAttachmentsForMessage,
   linkAttachmentToMessage,
   uploadAttachment,
@@ -103,6 +104,40 @@ function watchProcessing(conversation: Conversation): {
 async function uploadFrame(name: string): Promise<string> {
   const attachment = await uploadAttachment(name, "image/png", IMAGE_BASE64);
   return attachment.id;
+}
+
+/** True while the attachment's row is still in the store. */
+function frameStored(attachmentId: string): boolean {
+  return getAttachmentById(attachmentId) !== null;
+}
+
+/**
+ * Let a turn try to start in the instant right after the persist reads the
+ * flag free. The turn models a correct acquirer: it claims only what it finds
+ * free, so it succeeds exactly when the persist left a gap between its read
+ * and its take.
+ */
+function armTurnStartInTheGap(conversation: Conversation): {
+  claimed: () => boolean;
+} {
+  let armed = true;
+  let claimed = false;
+  const readFlag = conversation.isProcessing.bind(conversation);
+  const writeFlag = conversation.setProcessing.bind(conversation);
+  conversation.isProcessing = (): boolean => {
+    const busy = readFlag();
+    if (armed && !busy) {
+      armed = false;
+      queueMicrotask(() => {
+        if (!readFlag()) {
+          writeFlag(true);
+          claimed = true;
+        }
+      });
+    }
+    return busy;
+  };
+  return { claimed: () => claimed };
 }
 
 /** The attachment id the row's persisted image block actually references. */
@@ -464,6 +499,37 @@ describe("standalone image persists are serialized per conversation", () => {
     }
   });
 
+  test("a turn starting in the gap keeps the flag it claimed", async () => {
+    // The flag is a boolean with no owner, so reading it free and taking it
+    // have to be one step. Split by an await, a turn claims it in between and
+    // the frame writes over a turn that got there first, then clears the flag
+    // that turn is still holding.
+    const live = liveConversation("Live voice turn start race");
+    try {
+      const frame = await uploadFrame("race.png");
+
+      // A turn is running, so the keep goes into the wait.
+      live.activeConversation.setProcessing(true);
+      const keep = persistLiveVoiceSightFrame(live.id, frame);
+      await sleep(150);
+
+      // From here, the next observation of a free flag lets a turn try to
+      // start in the following microtask.
+      const turn = armTurnStartInTheGap(live.activeConversation);
+      live.activeConversation.setProcessing(false);
+
+      expect(await keep).toMatchObject({ ok: true });
+
+      // The keep took the flag in the same step it read it free, so the turn
+      // found it busy and never claimed it.
+      expect(turn.claimed()).toBe(false);
+      expect(live.activeConversation.isProcessing()).toBe(false);
+      expect(getMessages(live.id)).toHaveLength(1);
+    } finally {
+      live.dispose();
+    }
+  });
+
   test("a newer keep replaces one that is still waiting to start", async () => {
     // The chain is bounded this way: keeps arrive every few seconds while each
     // job can wait out a turn for far longer, so a queued keep that a newer
@@ -492,6 +558,14 @@ describe("standalone image persists are serialized per conversation", () => {
         [...selectSightFrameCaptureTimes(live.id).keys()].sort(),
       ).toHaveLength(2);
       expect(getMessages(live.id)).toHaveLength(2);
+
+      // The client uploaded the displaced frame and the daemon chose to drop
+      // it, so this is the only thing that will ever collect it: the client's
+      // own abandon-delete fires on a refused send, and this send succeeded.
+      expect(frameStored(stale)).toBe(false);
+      // The two that reached a message are not this reclaim's to touch.
+      expect(frameStored(running)).toBe(true);
+      expect(frameStored(newest)).toBe(true);
     } finally {
       live.dispose();
     }
@@ -516,6 +590,10 @@ describe("standalone image persists are serialized per conversation", () => {
         expect(result).toMatchObject({ ok: true });
       }
       expect(getMessages(live.id)).toHaveLength(3);
+      // Nothing is ever reclaimed on the photo path: none of them was dropped.
+      for (const id of ids) {
+        expect(frameStored(id)).toBe(true);
+      }
     } finally {
       live.dispose();
     }

--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -33,6 +33,7 @@ import { initializeDb } from "../../persistence/db-init.js";
 import { mediaBlockAttachmentId, type Message } from "../../providers/types.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
 import {
+  _standaloneImageQueueSizeForTests,
   persistLiveVoicePhoto,
   persistLiveVoiceSightFrame,
 } from "../live-voice-photo.js";
@@ -71,6 +72,37 @@ function liveConversation(title: string) {
 
 function metadataOf(row: MessageRow): Record<string, unknown> {
   return JSON.parse(row.metadata ?? "{}") as Record<string, unknown>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Record every `setProcessing` on a conversation and track how many holders
+ * the flag believes it has. A boolean flag cannot count, so a depth above one
+ * is two writers thinking they own it, and the first to finish clearing it
+ * out from under the other.
+ */
+function watchProcessing(conversation: Conversation): {
+  readonly calls: boolean[];
+  depth: number;
+  maxDepth: number;
+} {
+  const seen = { calls: [] as boolean[], depth: 0, maxDepth: 0 };
+  const original = conversation.setProcessing.bind(conversation);
+  conversation.setProcessing = (value: boolean): void => {
+    seen.calls.push(value);
+    seen.depth += value ? 1 : -1;
+    seen.maxDepth = Math.max(seen.maxDepth, seen.depth);
+    original(value);
+  };
+  return seen;
+}
+
+async function uploadFrame(name: string): Promise<string> {
+  const attachment = await uploadAttachment(name, "image/png", IMAGE_BASE64);
+  return attachment.id;
 }
 
 /** The attachment id the row's persisted image block actually references. */
@@ -364,6 +396,142 @@ describe("persistLiveVoiceSightFrame", () => {
 
       const rows = getMessages(live.id);
       expect(rows.map((row) => row.role)).toEqual(["assistant", "user"]);
+    } finally {
+      live.dispose();
+    }
+  });
+});
+
+describe("standalone image persists are serialized per conversation", () => {
+  test("two images arriving together take the flag one at a time", async () => {
+    // The window the boolean flag cannot survive. Both persists interleave
+    // across the awaits between reading the flag and taking it, so both read
+    // idle and both take it; unserialized the calls come out
+    // [true, true, false, false], and that first `false` lands while the
+    // second write is still going, leaving a spoken turn free to launch into
+    // a half-written row and the second finisher free to clear that turn's
+    // flag.
+    const live = liveConversation("Live voice concurrent images");
+    const seen = watchProcessing(live.activeConversation);
+    try {
+      const photo = await uploadFrame("snap.png");
+      const frame = await uploadFrame("ambient.png");
+
+      const photoWrite = persistLiveVoicePhoto(live.id, photo);
+      const frameWrite = persistLiveVoiceSightFrame(live.id, frame);
+
+      expect(await photoWrite).toMatchObject({ ok: true });
+      expect(await frameWrite).toMatchObject({ ok: true });
+
+      // One holder at a time, so no release lands while another write is in
+      // flight, and every take is answered before the next one.
+      expect(seen.calls).toEqual([true, false, true, false]);
+      expect(seen.maxDepth).toBe(1);
+      expect(seen.depth).toBe(0);
+      expect(getMessages(live.id)).toHaveLength(2);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("two frames waiting out one turn write one at a time", async () => {
+    // The same invariant across the wait path: both jobs sit behind a running
+    // turn, and the chain still hands the flag over one at a time when it
+    // ends.
+    const live = liveConversation("Live voice serialized keeps");
+    const seen = watchProcessing(live.activeConversation);
+    try {
+      const first = await uploadFrame("first.png");
+      const second = await uploadFrame("second.png");
+
+      live.activeConversation.setProcessing(true);
+      const firstKeep = persistLiveVoiceSightFrame(live.id, first);
+      // Long enough for the first keep to reach the idle wait, so the second
+      // queues behind a job that has already begun rather than replacing it.
+      await sleep(30);
+      const secondKeep = persistLiveVoiceSightFrame(live.id, second);
+      await sleep(30);
+      live.activeConversation.setProcessing(false);
+
+      expect(await firstKeep).toMatchObject({ ok: true });
+      expect(await secondKeep).toMatchObject({ ok: true });
+
+      expect(seen.maxDepth).toBe(1);
+      expect(seen.depth).toBe(0);
+      expect(getMessages(live.id)).toHaveLength(2);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("a newer keep replaces one that is still waiting to start", async () => {
+    // The chain is bounded this way: keeps arrive every few seconds while each
+    // job can wait out a turn for far longer, so a queued keep that a newer
+    // one has already made stale is given up rather than stacked.
+    const live = liveConversation("Live voice coalesced keeps");
+    try {
+      const running = await uploadFrame("running.png");
+      const stale = await uploadFrame("stale.png");
+      const newest = await uploadFrame("newest.png");
+
+      live.activeConversation.setProcessing(true);
+      const runningKeep = persistLiveVoiceSightFrame(live.id, running);
+      await sleep(30);
+      const staleKeep = persistLiveVoiceSightFrame(live.id, stale);
+      const newestKeep = persistLiveVoiceSightFrame(live.id, newest);
+      await sleep(30);
+      live.activeConversation.setProcessing(false);
+
+      // The one that had already begun still lands; the one it displaced is
+      // reported to its caller as the single lost frame it is.
+      expect(await runningKeep).toMatchObject({ ok: true });
+      expect(await staleKeep).toEqual({ ok: false });
+      expect(await newestKeep).toMatchObject({ ok: true });
+
+      expect(
+        [...selectSightFrameCaptureTimes(live.id).keys()].sort(),
+      ).toHaveLength(2);
+      expect(getMessages(live.id)).toHaveLength(2);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("queued photos are never replaced", async () => {
+    // The user watched themselves take each one, so none of them is stale.
+    const live = liveConversation("Live voice queued photos");
+    try {
+      const ids = [
+        await uploadFrame("one.png"),
+        await uploadFrame("two.png"),
+        await uploadFrame("three.png"),
+      ];
+
+      live.activeConversation.setProcessing(true);
+      const writes = ids.map((id) => persistLiveVoicePhoto(live.id, id));
+      await sleep(30);
+      live.activeConversation.setProcessing(false);
+
+      for (const result of await Promise.all(writes)) {
+        expect(result).toMatchObject({ ok: true });
+      }
+      expect(getMessages(live.id)).toHaveLength(3);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("the conversation's chain is dropped once it drains", async () => {
+    const live = liveConversation("Live voice chain cleanup");
+    try {
+      const frame = await uploadFrame("cleanup.png");
+
+      const pending = persistLiveVoiceSightFrame(live.id, frame);
+      expect(_standaloneImageQueueSizeForTests()).toBe(1);
+      expect(await pending).toMatchObject({ ok: true });
+
+      // Nothing is left behind for a call that ended.
+      expect(_standaloneImageQueueSizeForTests()).toBe(0);
     } finally {
       live.dispose();
     }

--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -20,17 +20,49 @@ import {
   uploadAttachment,
 } from "../../persistence/attachments-store.js";
 import {
+  addMessage,
   createConversation,
   getMessages,
+  selectSightFrameCaptureTimes,
 } from "../../persistence/conversation-crud.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { assistantEventHub } from "../../runtime/assistant-event-hub.js";
-import { persistLiveVoicePhoto } from "../live-voice-photo.js";
+import {
+  persistLiveVoicePhoto,
+  persistLiveVoiceSightFrame,
+} from "../live-voice-photo.js";
 
 await initializeDb();
 
 const IMAGE_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+/** A registered conversation the persist paths can reach, plus its teardown. */
+function liveConversation(title: string) {
+  const conversation = createConversation(title);
+  const { provider } = createMockProvider([textResponse("")]);
+  const activeConversation = new Conversation(
+    conversation.id,
+    provider,
+    "system prompt",
+    () => {},
+    "/tmp",
+    { maxTokens: 4096 },
+  );
+  activeConversation.setTrustContext({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  });
+  setConversation(conversation.id, activeConversation);
+  return {
+    id: conversation.id,
+    activeConversation,
+    dispose: () => {
+      deleteConversation(conversation.id);
+      activeConversation.dispose();
+    },
+  };
+}
 
 describe("persistLiveVoicePhoto", () => {
   test("persists and echoes the image with human-readable context", async () => {
@@ -95,6 +127,95 @@ describe("persistLiveVoicePhoto", () => {
       subscription.dispose();
       deleteConversation(conversation.id);
       activeConversation.dispose();
+    }
+  });
+
+  test("leaves the photo untagged, so retention never ages it out", async () => {
+    // A photo the user chose to take is not an ambient frame; the sight tag
+    // would hand it to the pass that stubs frames out of the context.
+    const live = liveConversation("Live voice photo untagged");
+    try {
+      const attachment = await uploadAttachment(
+        "photo.png",
+        "image/png",
+        IMAGE_BASE64,
+      );
+
+      const result = await persistLiveVoicePhoto(live.id, attachment.id);
+      expect(result.ok).toBe(true);
+
+      expect(selectSightFrameCaptureTimes(live.id).size).toBe(0);
+    } finally {
+      live.dispose();
+    }
+  });
+});
+
+describe("persistLiveVoiceSightFrame", () => {
+  test("tags the row with the attachment it carries", async () => {
+    const live = liveConversation("Live voice sight frame");
+    try {
+      const attachment = await uploadAttachment(
+        "frame.png",
+        "image/png",
+        IMAGE_BASE64,
+      );
+
+      const result = await persistLiveVoiceSightFrame(live.id, attachment.id);
+      expect(result.ok).toBe(true);
+
+      const [message] = getMessages(live.id);
+      expect(message.content.filter((block) => block.type === "text")).toEqual([
+        { type: "text", text: "(camera frame)" },
+      ]);
+      expect(getAttachmentsForMessage(message.id)).toHaveLength(1);
+      // Readable by the retention pass, which is the whole point of the tag.
+      expect([...selectSightFrameCaptureTimes(live.id).keys()]).toEqual([
+        attachment.id,
+      ]);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("reports a frame whose attachment does not resolve", async () => {
+    const live = liveConversation("Live voice sight frame missing");
+    try {
+      expect(await persistLiveVoiceSightFrame(live.id, "att-missing")).toEqual({
+        ok: false,
+      });
+      expect(getMessages(live.id)).toHaveLength(0);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("waits out an in-flight turn instead of splitting its rows", async () => {
+    // A keep landing mid-reply must neither interrupt the reply nor land
+    // between the rows the reply persists. The processing lock is what orders
+    // them: the keep takes it only once the turn has let go.
+    const live = liveConversation("Live voice sight frame interleave");
+    try {
+      const attachment = await uploadAttachment(
+        "frame.png",
+        "image/png",
+        IMAGE_BASE64,
+      );
+
+      live.activeConversation.setProcessing(true);
+      const pending = persistLiveVoiceSightFrame(live.id, attachment.id);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect(getMessages(live.id)).toHaveLength(0);
+
+      // The turn's own persist, while it still holds the lock.
+      await addMessage(live.id, "assistant", "still looking");
+      live.activeConversation.setProcessing(false);
+      expect(await pending).toMatchObject({ ok: true });
+
+      const rows = getMessages(live.id);
+      expect(rows.map((row) => row.role)).toEqual(["assistant", "user"]);
+    } finally {
+      live.dispose();
     }
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
@@ -34,8 +34,23 @@ const realStore = { ...attachmentsStoreNamespace };
 
 const unstorableAttachmentIds = new Set<string>();
 
+// Armed for exactly one link, which is how the persist path's repair branch is
+// reached without breaking the linking a test's own setup depends on.
+let failNextLink = false;
+
 mock.module("../../persistence/attachments-store.js", () => ({
   ...realStore,
+  linkAttachmentToMessage: (
+    messageId: string,
+    attachmentId: string,
+    position: number,
+  ) => {
+    if (failNextLink) {
+      failNextLink = false;
+      throw new Error("simulated message_attachments write failure");
+    }
+    return realStore.linkAttachmentToMessage(messageId, attachmentId, position);
+  },
   scopeAttachmentToMessageConversation: (
     conversationId: string,
     conversationCreatedAt: number,
@@ -57,6 +72,7 @@ import {
 } from "../../daemon/conversation-registry.js";
 import { applySightFrameRetention } from "../../daemon/conversation-runtime-assembly.js";
 import {
+  addMessage,
   createConversation,
   getMessages,
   type MessageRow,
@@ -206,6 +222,42 @@ describe("a camera frame that falls back to inline bytes", () => {
       expect(retained[2].content.some((b) => b.type === "image")).toBe(true);
     } finally {
       live.dispose();
+    }
+  });
+});
+
+describe("a camera frame whose message link fails", () => {
+  test("is repaired to inline bytes naming the id its tag names", async () => {
+    // The tag is written with the row, before the link is attempted, so it
+    // already names the CLONE that scoping stored. The repair rebuilds the
+    // block from the caller's attachment, which names the id the session held.
+    // Left disagreeing, the repaired row's frame never ages out.
+    const source = liveConversation("Live voice repair source");
+    const live = liveConversation("Live voice repair");
+    try {
+      // Linked under another conversation, so materialization clones it.
+      const arrivedAs = await uploadFrame("repair.png");
+      const elsewhere = await addMessage(source.id, "user", "look at this");
+      realStore.linkAttachmentToMessage(elsewhere.id, arrivedAs, 0);
+
+      failNextLink = true;
+      expect((await persistLiveVoiceSightFrame(live.id, arrivedAs)).ok).toBe(
+        true,
+      );
+      expect(failNextLink).toBe(false);
+
+      const [row] = getMessages(live.id);
+      // The repair really fired: bytes in the row rather than a reference.
+      expect(hasInlineImage(row)).toBe(true);
+
+      const tagged = sightFrameAttachmentIdsFromMetadata(metadataOf(row));
+      expect(tagged).toHaveLength(1);
+      expect(tagged[0]).not.toBe(arrivedAs);
+      // The block the retention pass reads names what the tag names.
+      expect(attributableImageId(row)).toBe(tagged[0]);
+    } finally {
+      live.dispose();
+      source.dispose();
     }
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
@@ -171,6 +171,23 @@ mock.module("../../runtime/sync/resource-sync-events.js", () => ({
   },
 }));
 
+// Lexical indexing, the host-infrastructure half of the indexing gate that runs
+// whatever the memory config says. Recorded so a row can be shown to stay out
+// of the extraction pipeline entirely.
+import * as messageLexicalNamespace from "../../persistence/job-handlers/message-lexical.js";
+
+const realMessageLexical = { ...messageLexicalNamespace };
+
+const lexicallyIndexed: string[] = [];
+
+mock.module("../../persistence/job-handlers/message-lexical.js", () => ({
+  ...realMessageLexical,
+  enqueueLexicalIndexForMessage: (messageId: string) => {
+    lexicallyIndexed.push(messageId);
+    return realMessageLexical.enqueueLexicalIndexForMessage(messageId);
+  },
+}));
+
 import { Conversation } from "../../daemon/conversation.js";
 import {
   deleteConversation,
@@ -710,6 +727,47 @@ describe("a clone whose materialization fails", () => {
       expect(existsSync(sharedFile)).toBe(true);
     } finally {
       rmSync(sharedFile, { force: true });
+    }
+  });
+});
+
+describe("ambient frames stay out of the indexing pipeline", () => {
+  test("a kept frame is never handed to the indexer", async () => {
+    // The camera sampled it, so indexing would feed extraction a frame every
+    // few seconds of whatever the room contains, and commit those visuals to
+    // memory with no consent surface. The transcript is the record the design
+    // signed off on.
+    const live = liveConversation("Live voice keep not indexed");
+    try {
+      const frame = await uploadFrame("not-indexed.png");
+
+      lexicallyIndexed.length = 0;
+      expect((await persistLiveVoiceSightFrame(live.id, frame)).ok).toBe(true);
+
+      const [row] = getMessages(live.id);
+      expect(row).toBeDefined();
+      expect(lexicallyIndexed).not.toContain(row.id);
+      expect(lexicallyIndexed).toHaveLength(0);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("a photo is still indexed, being something the user sent", async () => {
+    // Deliberate user content, and its indexing is pre-existing behavior that
+    // this change must not quietly take away.
+    const live = liveConversation("Live voice photo still indexed");
+    try {
+      const photo = await uploadFrame("still-indexed.png");
+
+      lexicallyIndexed.length = 0;
+      expect((await persistLiveVoicePhoto(live.id, photo)).ok).toBe(true);
+
+      const [row] = getMessages(live.id);
+      expect(row).toBeDefined();
+      expect(lexicallyIndexed).toContain(row.id);
+    } finally {
+      live.dispose();
     }
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
@@ -14,6 +14,8 @@
 
 import { describe, expect, mock, test } from "bun:test";
 
+import { eq } from "drizzle-orm";
+
 import {
   createMockProvider,
   textResponse,
@@ -148,6 +150,10 @@ mock.module("../../persistence/conversation-crud.js", () => ({
   },
 }));
 
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
 import { Conversation } from "../../daemon/conversation.js";
 import {
   deleteConversation,
@@ -161,8 +167,11 @@ import {
   type MessageRow,
   selectSightFrameCaptureTimes,
 } from "../../persistence/conversation-crud.js";
+import { getConversationAttachmentsDirPath } from "../../persistence/conversation-directories.js";
 import { sightFrameAttachmentIdsFromMetadata } from "../../persistence/conversation-types.js";
+import { getDb } from "../../persistence/db-connection.js";
 import { initializeDb } from "../../persistence/db-init.js";
+import { attachments } from "../../persistence/schema.js";
 import { mediaBlockAttachmentId, type Message } from "../../providers/types.js";
 import {
   persistLiveVoicePhoto,
@@ -192,6 +201,7 @@ function liveConversation(title: string) {
   setConversation(conversation.id, activeConversation);
   return {
     id: conversation.id,
+    createdAt: conversation.createdAt,
     dispose: () => {
       deleteConversation(conversation.id);
       activeConversation.dispose();
@@ -555,6 +565,105 @@ describe("attachments a failed persist attempt cloned for itself", () => {
       expect(realStore.getAttachmentById(photo)).not.toBeNull();
     } finally {
       live.dispose();
+    }
+  });
+});
+
+describe("a clone whose materialization fails", () => {
+  /** Rows in the attachment store, so a leaked clone shows up as a count. */
+  function attachmentRowCount(): number {
+    return getDb().select({ id: attachments.id }).from(attachments).all()
+      .length;
+  }
+
+  /** Give a row a real file on disk, the shape a clone inherits its path from. */
+  function backWithFile(attachmentId: string, name: string): string {
+    const filePath = join(tmpdir(), `sight-frame-${name}`);
+    writeFileSync(filePath, Buffer.from(IMAGE_BASE64, "base64"));
+    getDb()
+      .update(attachments)
+      .set({ filePath })
+      .where(eq(attachments.id, attachmentId))
+      .run();
+    return filePath;
+  }
+
+  test("leaves no row behind and costs the source nothing", async () => {
+    // Materialization is fallible AFTER the clone row is inserted: it copies
+    // the bytes and repoints the row, and until that lands the clone still
+    // names the file the bytes came FROM. A failure used to leave that row for
+    // good, because the persist recovers by inlining and no error ever reached
+    // the callers that clean up.
+    const source = liveConversation("Live voice clone materialize source");
+    const live = liveConversation("Live voice clone materialize");
+    const attachDir = getConversationAttachmentsDirPath(
+      live.id,
+      live.createdAt,
+    );
+    let sourceFile: string | null = null;
+    try {
+      const arrivedAs = await uploadFrame("clone-materialize.png");
+      const elsewhere = await addMessage(source.id, "user", "look at this");
+      realStore.linkAttachmentToMessage(elsewhere.id, arrivedAs, 0);
+      // The clone is inserted carrying exactly this path.
+      sourceFile = backWithFile(arrivedAs, "source.png");
+
+      const rowsBefore = attachmentRowCount();
+
+      // A plain file where the destination's attachments directory belongs, so
+      // the very first thing materialization does fails.
+      mkdirSync(dirname(attachDir), { recursive: true });
+      writeFileSync(attachDir, "");
+
+      expect((await persistLiveVoiceSightFrame(live.id, arrivedAs)).ok).toBe(
+        true,
+      );
+
+      // The recovery is unchanged: the frame still lands, inline.
+      const [row] = getMessages(live.id);
+      expect(hasInlineImage(row)).toBe(true);
+
+      // No clone row survived the failure.
+      expect(attachmentRowCount()).toBe(rowsBefore);
+
+      // The source keeps its row, the file the clone was aliasing, and its own
+      // message's link.
+      expect(realStore.getAttachmentById(arrivedAs)).not.toBeNull();
+      expect(existsSync(sourceFile)).toBe(true);
+      expect(realStore.getAttachmentsForMessage(elsewhere.id)).toHaveLength(1);
+    } finally {
+      rmSync(attachDir, { force: true });
+      if (sourceFile) {
+        rmSync(sourceFile, { force: true });
+      }
+      live.dispose();
+      source.dispose();
+    }
+  });
+
+  test("orphan collection spares a file another row still names", async () => {
+    // The same aliasing seen from the other side. A clone carries the source's
+    // path until materialization repoints it, so a row being collected can
+    // share its file with one that outlives it, and unlinking then takes the
+    // survivor's bytes.
+    const kept = await uploadFrame("shared-kept.png");
+    const alias = await uploadFrame("shared-alias.png");
+    const sharedFile = backWithFile(kept, "shared.png");
+    getDb()
+      .update(attachments)
+      .set({ filePath: sharedFile })
+      .where(eq(attachments.id, alias))
+      .run();
+
+    try {
+      expect(realStore.deleteOrphanAttachments([alias])).toBe(1);
+
+      expect(realStore.getAttachmentById(alias)).toBeNull();
+      expect(realStore.getAttachmentById(kept)).not.toBeNull();
+      // The survivor's bytes are still there.
+      expect(existsSync(sharedFile)).toBe(true);
+    } finally {
+      rmSync(sharedFile, { force: true });
     }
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
@@ -42,6 +42,15 @@ let failNextLink = false;
 // reaches the message insert.
 let failNextResolve = false;
 
+// Ids conversation scoping handed back, so a test can name the clone it made.
+// A clone is deleted by the failure path, so it cannot be read back after.
+const scopedAttachmentIds: string[] = [];
+
+// Armed for exactly one attachment byte read, which is how a throw is reached
+// while the reference block is being built: after the row was cloned and
+// before the prepared list records it.
+let failNextContentRead = false;
+
 mock.module("../../persistence/attachments-store.js", () => ({
   ...realStore,
   resolveAttachmentsForPersist: (ids: string[]) => {
@@ -62,18 +71,31 @@ mock.module("../../persistence/attachments-store.js", () => ({
     }
     return realStore.linkAttachmentToMessage(messageId, attachmentId, position);
   },
+  getAttachmentContent: (attachmentId: string) => {
+    if (failNextContentRead) {
+      failNextContentRead = false;
+      throw new Error("simulated attachment byte read failure");
+    }
+    return realStore.getAttachmentContent(attachmentId);
+  },
   scopeAttachmentToMessageConversation: (
     conversationId: string,
     conversationCreatedAt: number,
     attachmentId: string,
-  ) =>
-    unstorableAttachmentIds.has(attachmentId)
-      ? null
-      : realStore.scopeAttachmentToMessageConversation(
-          conversationId,
-          conversationCreatedAt,
-          attachmentId,
-        ),
+  ) => {
+    if (unstorableAttachmentIds.has(attachmentId)) {
+      return null;
+    }
+    const scoped = realStore.scopeAttachmentToMessageConversation(
+      conversationId,
+      conversationCreatedAt,
+      attachmentId,
+    );
+    if (scoped) {
+      scopedAttachmentIds.push(scoped.id);
+    }
+    return scoped;
+  },
 }));
 
 // The content rewrite the repair branch performs, which is the statement that
@@ -88,8 +110,28 @@ let failNextContentUpdate = false;
 // row landed" branch is reached.
 let failNextMessageLookup = false;
 
+// Armed for exactly one insert, which fails the persist after materialization
+// has already cloned but before any row exists.
+let failNextAddMessage = false;
+
 mock.module("../../persistence/conversation-crud.js", () => ({
   ...realCrud,
+  addMessage: (
+    conversationId: string,
+    role: string,
+    content: string,
+    options?: unknown,
+  ) => {
+    if (failNextAddMessage) {
+      failNextAddMessage = false;
+      throw new Error("simulated message insert failure");
+    }
+    return (
+      realCrud.addMessage as (
+        ...args: unknown[]
+      ) => ReturnType<typeof realCrud.addMessage>
+    )(conversationId, role, content, options);
+  },
   updateMessageContent: (messageId: string, content: string) => {
     if (failNextContentUpdate) {
       failNextContentUpdate = false;
@@ -122,7 +164,10 @@ import {
 import { sightFrameAttachmentIdsFromMetadata } from "../../persistence/conversation-types.js";
 import { initializeDb } from "../../persistence/db-init.js";
 import { mediaBlockAttachmentId, type Message } from "../../providers/types.js";
-import { persistLiveVoiceSightFrame } from "../live-voice-photo.js";
+import {
+  persistLiveVoicePhoto,
+  persistLiveVoiceSightFrame,
+} from "../live-voice-photo.js";
 
 await initializeDb();
 
@@ -368,6 +413,146 @@ describe("a camera frame whose persist throws", () => {
 
       expect(getMessages(live.id)).toHaveLength(0);
       expect(realStore.getAttachmentById(frame)).not.toBeNull();
+    } finally {
+      live.dispose();
+    }
+  });
+});
+
+describe("attachments a failed persist attempt cloned for itself", () => {
+  /** Link the upload under another conversation, so scoping has to clone it. */
+  async function attachmentLinkedElsewhere(
+    otherConversationId: string,
+    name: string,
+  ): Promise<string> {
+    const attachmentId = await uploadFrame(name);
+    const elsewhere = await addMessage(
+      otherConversationId,
+      "user",
+      "look at this",
+    );
+    realStore.linkAttachmentToMessage(elsewhere.id, attachmentId, 0);
+    return attachmentId;
+  }
+
+  test("the clone is given up when the insert never happened", async () => {
+    // Scoping clones before the row is written, and the caller only ever holds
+    // the id it sent, so a failure here strands the clone and its copied file
+    // where nothing can reach them.
+    const source = liveConversation("Live voice clone leak source");
+    const live = liveConversation("Live voice clone leak");
+    try {
+      const arrivedAs = await attachmentLinkedElsewhere(
+        source.id,
+        "clone-leak.png",
+      );
+      scopedAttachmentIds.length = 0;
+
+      failNextAddMessage = true;
+      expect(await persistLiveVoiceSightFrame(live.id, arrivedAs)).toEqual({
+        ok: false,
+      });
+      expect(failNextAddMessage).toBe(false);
+
+      const cloned = scopedAttachmentIds.at(-1);
+      expect(cloned).toBeDefined();
+      expect(cloned).not.toBe(arrivedAs);
+
+      expect(getMessages(live.id)).toHaveLength(0);
+      expect(realStore.getAttachmentById(cloned!)).toBeNull();
+      // The caller's own upload is untouched, still held by its other
+      // conversation's message.
+      expect(realStore.getAttachmentById(arrivedAs)).not.toBeNull();
+    } finally {
+      live.dispose();
+      source.dispose();
+    }
+  });
+
+  test("the clone is kept when the row already references it", async () => {
+    // Past the insert the persisted content names the clone while no link
+    // protects it yet, so cleaning up here would strip the image out of a
+    // message the transcript still shows.
+    const source = liveConversation("Live voice clone kept source");
+    const live = liveConversation("Live voice clone kept");
+    try {
+      const arrivedAs = await attachmentLinkedElsewhere(
+        source.id,
+        "clone-kept.png",
+      );
+      scopedAttachmentIds.length = 0;
+
+      failNextLink = true;
+      failNextContentUpdate = true;
+      expect(await persistLiveVoiceSightFrame(live.id, arrivedAs)).toEqual({
+        ok: false,
+      });
+      expect(failNextLink).toBe(false);
+      expect(failNextContentUpdate).toBe(false);
+
+      const cloned = scopedAttachmentIds.at(-1);
+      expect(cloned).toBeDefined();
+      expect(cloned).not.toBe(arrivedAs);
+
+      expect(getMessages(live.id)).toHaveLength(1);
+      expect(realStore.getAttachmentById(cloned!)).not.toBeNull();
+      expect(realStore.getAttachmentById(arrivedAs)).not.toBeNull();
+    } finally {
+      live.dispose();
+      source.dispose();
+    }
+  });
+
+  test("a clone is given up when materialization itself throws", async () => {
+    // The reference block is built between creating the row and recording it,
+    // so a throw there leaves a clone the returned list never mentions. Only
+    // the materialization step still knows about it, which is why it cleans up
+    // its own partial work rather than leaving that to the caller.
+    const source = liveConversation("Live voice partial clone source");
+    const live = liveConversation("Live voice partial clone");
+    try {
+      const arrivedAs = await attachmentLinkedElsewhere(
+        source.id,
+        "partial-clone.png",
+      );
+      scopedAttachmentIds.length = 0;
+
+      failNextContentRead = true;
+      expect(await persistLiveVoiceSightFrame(live.id, arrivedAs)).toEqual({
+        ok: false,
+      });
+      expect(failNextContentRead).toBe(false);
+
+      const cloned = scopedAttachmentIds.at(-1);
+      expect(cloned).toBeDefined();
+      expect(cloned).not.toBe(arrivedAs);
+
+      expect(getMessages(live.id)).toHaveLength(0);
+      expect(realStore.getAttachmentById(cloned!)).toBeNull();
+      expect(realStore.getAttachmentById(arrivedAs)).not.toBeNull();
+    } finally {
+      live.dispose();
+      source.dispose();
+    }
+  });
+
+  test("an uncloned upload survives a failed attempt", async () => {
+    // Materialization stored this one under the id it arrived with, so the row
+    // IS the caller's upload and the retry they are about to make needs it.
+    // A photo rather than a keep, so the live-voice reclaim (keeps only) stays
+    // out of the way and the assertion isolates the persist's own cleanup.
+    const live = liveConversation("Live voice uncloned survives");
+    try {
+      const photo = await uploadFrame("uncloned.png");
+
+      failNextAddMessage = true;
+      expect(await persistLiveVoicePhoto(live.id, photo)).toEqual({
+        ok: false,
+      });
+      expect(failNextAddMessage).toBe(false);
+
+      expect(getMessages(live.id)).toHaveLength(0);
+      expect(realStore.getAttachmentById(photo)).not.toBeNull();
     } finally {
       live.dispose();
     }

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
@@ -236,6 +236,7 @@ function liveConversation(title: string) {
   return {
     id: conversation.id,
     createdAt: conversation.createdAt,
+    activeConversation,
     dispose: () => {
       deleteConversation(conversation.id);
       activeConversation.dispose();
@@ -402,6 +403,10 @@ describe("a camera frame whose persist throws", () => {
     const live = liveConversation("Live voice throw after insert");
     try {
       const frame = await uploadFrame("throws-late.png");
+      // Load once so the resident history is not stale for an unrelated
+      // reason: without this the actor-scope check would reload anyway.
+      await live.activeConversation.ensureActorScopedHistory();
+      expect(live.activeConversation.getMessages()).toHaveLength(0);
 
       messagesChangedFor.length = 0;
       failNextLink = true;
@@ -417,6 +422,15 @@ describe("a camera frame whose persist throws", () => {
       expect(realStore.getAttachmentById(frame)).not.toBeNull();
       // And the clients rendering this conversation were told.
       expect(messagesChangedFor).toContain(live.id);
+
+      // The persist unwound its own push, so the resident history is missing
+      // the row it just committed.
+      expect(live.activeConversation.getMessages()).toHaveLength(0);
+      // Marked stale, so the next turn rehydrates and the model sees it. The
+      // trust class is unchanged from the load above, so nothing but the stale
+      // mark can cause this reload.
+      await live.activeConversation.ensureActorScopedHistory();
+      expect(live.activeConversation.getMessages()).toHaveLength(1);
     } finally {
       live.dispose();
     }

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
@@ -154,6 +154,23 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
+// The messages-changed invalidation, which is how a client learns a row it was
+// never told about is there. Recorded so a recovery can be shown to announce
+// itself rather than only returning ok.
+import * as resourceSyncNamespace from "../../runtime/sync/resource-sync-events.js";
+
+const realResourceSync = { ...resourceSyncNamespace };
+
+const messagesChangedFor: string[] = [];
+
+mock.module("../../runtime/sync/resource-sync-events.js", () => ({
+  ...realResourceSync,
+  publishConversationMessagesChanged: (conversationId: string) => {
+    messagesChangedFor.push(conversationId);
+    return realResourceSync.publishConversationMessagesChanged(conversationId);
+  },
+}));
+
 import { Conversation } from "../../daemon/conversation.js";
 import {
   deleteConversation,
@@ -369,18 +386,45 @@ describe("a camera frame whose persist throws", () => {
     try {
       const frame = await uploadFrame("throws-late.png");
 
+      messagesChangedFor.length = 0;
       failNextLink = true;
       failNextContentUpdate = true;
-      expect(await persistLiveVoiceSightFrame(live.id, frame)).toEqual({
-        ok: false,
-      });
+      const result = await persistLiveVoiceSightFrame(live.id, frame);
       expect(failNextLink).toBe(false);
       expect(failNextContentUpdate).toBe(false);
 
-      // The row landed before the throw, so the frame is not the daemon's to
-      // collect however the call reported itself.
-      expect(getMessages(live.id)).toHaveLength(1);
+      // The row landed, so the result says so: the client keeps the frame it
+      // showed instead of retracting a message the next reload would reveal.
+      const [row] = getMessages(live.id);
+      expect(result).toEqual({ ok: true, messageId: row.id });
       expect(realStore.getAttachmentById(frame)).not.toBeNull();
+      // And the clients rendering this conversation were told.
+      expect(messagesChangedFor).toContain(live.id);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("recovers a photo the same way, since the row is what decides", async () => {
+    // Pre-existing duplicate-photo bug: told the snap failed, the user takes
+    // it again and the first one was in the transcript all along. The caller
+    // sends its retract-style error frame only on ok:false, so reporting the
+    // truth here is all it takes.
+    const live = liveConversation("Live voice photo throw after insert");
+    try {
+      const photo = await uploadFrame("photo-throws-late.png");
+
+      messagesChangedFor.length = 0;
+      failNextLink = true;
+      failNextContentUpdate = true;
+      const result = await persistLiveVoicePhoto(live.id, photo);
+      expect(failNextLink).toBe(false);
+      expect(failNextContentUpdate).toBe(false);
+
+      const [row] = getMessages(live.id);
+      expect(result).toEqual({ ok: true, messageId: row.id });
+      expect(realStore.getAttachmentById(photo)).not.toBeNull();
+      expect(messagesChangedFor).toContain(live.id);
     } finally {
       live.dispose();
     }
@@ -416,6 +460,7 @@ describe("a camera frame whose persist throws", () => {
 
       failNextResolve = true;
       failNextMessageLookup = true;
+      // No success claim either: doubt blocks the delete and the ok alike.
       expect(await persistLiveVoiceSightFrame(live.id, frame)).toEqual({
         ok: false,
       });
@@ -494,9 +539,10 @@ describe("attachments a failed persist attempt cloned for itself", () => {
 
       failNextLink = true;
       failNextContentUpdate = true;
-      expect(await persistLiveVoiceSightFrame(live.id, arrivedAs)).toEqual({
-        ok: false,
-      });
+      // Committed despite the throw, which is what makes the clone the row's.
+      expect((await persistLiveVoiceSightFrame(live.id, arrivedAs)).ok).toBe(
+        true,
+      );
       expect(failNextLink).toBe(false);
       expect(failNextContentUpdate).toBe(false);
 

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Camera frames whose store write fails recoverably.
+ *
+ * Such a frame keeps its bytes inline in `messages.content` instead of
+ * referencing an attachment row, which makes it the heaviest thing the
+ * conversation resends on every later request. It is therefore the frame
+ * retention most needs to be able to stub, and it is attributable only by the
+ * id its block carries rather than by a link that was never written.
+ *
+ * Kept apart from `live-voice-photo.test.ts` because forcing the failure means
+ * replacing an attachment-store export for the whole file, and the sibling
+ * suite's clone case depends on that same export behaving for real.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  createMockProvider,
+  textResponse,
+} from "../../__tests__/helpers/mock-provider.js";
+import { setConfig } from "../../__tests__/helpers/set-config.js";
+
+setConfig("memory", { enabled: false });
+
+// Scoping an attachment into the conversation is the step that fails
+// recoverably, and a null return is how the persist path learns it did. Only
+// the ids a test names are refused; everything else runs for real.
+import * as attachmentsStoreNamespace from "../../persistence/attachments-store.js";
+
+// Snapshotted BEFORE the mock is installed. The namespace binding is live, so
+// it points at the replacement once `mock.module` runs, and delegating through
+// it would call this wrapper again forever.
+const realStore = { ...attachmentsStoreNamespace };
+
+const unstorableAttachmentIds = new Set<string>();
+
+mock.module("../../persistence/attachments-store.js", () => ({
+  ...realStore,
+  scopeAttachmentToMessageConversation: (
+    conversationId: string,
+    conversationCreatedAt: number,
+    attachmentId: string,
+  ) =>
+    unstorableAttachmentIds.has(attachmentId)
+      ? null
+      : realStore.scopeAttachmentToMessageConversation(
+          conversationId,
+          conversationCreatedAt,
+          attachmentId,
+        ),
+}));
+
+import { Conversation } from "../../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../../daemon/conversation-registry.js";
+import { applySightFrameRetention } from "../../daemon/conversation-runtime-assembly.js";
+import {
+  createConversation,
+  getMessages,
+  type MessageRow,
+  selectSightFrameCaptureTimes,
+} from "../../persistence/conversation-crud.js";
+import { sightFrameAttachmentIdsFromMetadata } from "../../persistence/conversation-types.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { mediaBlockAttachmentId, type Message } from "../../providers/types.js";
+import { persistLiveVoiceSightFrame } from "../live-voice-photo.js";
+
+await initializeDb();
+
+const IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+function liveConversation(title: string) {
+  const conversation = createConversation(title);
+  const { provider } = createMockProvider([textResponse("")]);
+  const activeConversation = new Conversation(
+    conversation.id,
+    provider,
+    "system prompt",
+    () => {},
+    "/tmp",
+    { maxTokens: 4096 },
+  );
+  activeConversation.setTrustContext({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  });
+  setConversation(conversation.id, activeConversation);
+  return {
+    id: conversation.id,
+    dispose: () => {
+      deleteConversation(conversation.id);
+      activeConversation.dispose();
+    },
+  };
+}
+
+async function uploadFrame(name: string): Promise<string> {
+  const attachment = await realStore.uploadAttachment(
+    name,
+    "image/png",
+    IMAGE_BASE64,
+  );
+  return attachment.id;
+}
+
+/** A frame whose store write fails recoverably, so it persists inline. */
+async function uploadUnstorableFrame(name: string): Promise<string> {
+  const attachmentId = await uploadFrame(name);
+  unstorableAttachmentIds.add(attachmentId);
+  return attachmentId;
+}
+
+function metadataOf(row: MessageRow): Record<string, unknown> {
+  return JSON.parse(row.metadata ?? "{}") as Record<string, unknown>;
+}
+
+/** True when the row kept its bytes rather than referencing an attachment. */
+function hasInlineImage(row: MessageRow): boolean {
+  return row.content.some(
+    (block) => block.type === "image" && block.source.type === "base64",
+  );
+}
+
+/** The attachment id the row's persisted image block is attributable by. */
+function attributableImageId(row: MessageRow): string | undefined {
+  for (const block of row.content) {
+    if (block.type !== "image") {
+      continue;
+    }
+    const id = mediaBlockAttachmentId(block);
+    if (id !== undefined) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+describe("a camera frame that falls back to inline bytes", () => {
+  test("is tagged by the id its own block carries", async () => {
+    const live = liveConversation("Live voice inline fallback tag");
+    try {
+      const inlineFrame = await uploadUnstorableFrame("inline.png");
+
+      expect((await persistLiveVoiceSightFrame(live.id, inlineFrame)).ok).toBe(
+        true,
+      );
+
+      const [row] = getMessages(live.id);
+      // The scenario really fired: bytes in the row, no reference to a row of
+      // their own, and the block naming the id the caller held.
+      expect(hasInlineImage(row)).toBe(true);
+      expect(attributableImageId(row)).toBe(inlineFrame);
+
+      expect(sightFrameAttachmentIdsFromMetadata(metadataOf(row))).toEqual([
+        inlineFrame,
+      ]);
+      // Capture times come from the tag on the row, so an id with no
+      // `message_attachments` row still resolves.
+      expect([...selectSightFrameCaptureTimes(live.id).keys()]).toEqual([
+        inlineFrame,
+      ]);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("is stubbed once it ages past the budget", async () => {
+    // The reason the tag matters. Untagged, the one frame carrying its full
+    // base64 is the one frame retention cannot touch, so it rides every later
+    // request for the rest of the call.
+    const live = liveConversation("Live voice inline fallback retention");
+    try {
+      const inlineFrame = await uploadUnstorableFrame("inline-aged.png");
+      expect((await persistLiveVoiceSightFrame(live.id, inlineFrame)).ok).toBe(
+        true,
+      );
+      for (const name of ["fresh-a.png", "fresh-b.png"]) {
+        const fresh = await uploadFrame(name);
+        expect((await persistLiveVoiceSightFrame(live.id, fresh)).ok).toBe(
+          true,
+        );
+      }
+
+      const assembled: Message[] = getMessages(live.id).map((row) => ({
+        role: "user" as const,
+        content: row.content,
+      }));
+      expect(assembled).toHaveLength(3);
+
+      const retained = applySightFrameRetention(assembled, live.id);
+
+      // Three frames, a budget of two: the inline one is the oldest, so its
+      // bytes give way to the timestamped stub.
+      expect(retained[0].content.some((b) => b.type === "image")).toBe(false);
+      expect(
+        retained[0].content.some(
+          (b) =>
+            b.type === "text" &&
+            b.text.startsWith("[Camera frame omitted from context:"),
+        ),
+      ).toBe(true);
+      expect(retained[1].content.some((b) => b.type === "image")).toBe(true);
+      expect(retained[2].content.some((b) => b.type === "image")).toBe(true);
+    } finally {
+      live.dispose();
+    }
+  });
+});

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame-inline.test.ts
@@ -38,8 +38,19 @@ const unstorableAttachmentIds = new Set<string>();
 // reached without breaking the linking a test's own setup depends on.
 let failNextLink = false;
 
+// Armed for exactly one attachment resolve, which fails the persist before it
+// reaches the message insert.
+let failNextResolve = false;
+
 mock.module("../../persistence/attachments-store.js", () => ({
   ...realStore,
+  resolveAttachmentsForPersist: (ids: string[]) => {
+    if (failNextResolve) {
+      failNextResolve = false;
+      throw new Error("simulated attachment read failure");
+    }
+    return realStore.resolveAttachmentsForPersist(ids);
+  },
   linkAttachmentToMessage: (
     messageId: string,
     attachmentId: string,
@@ -63,6 +74,36 @@ mock.module("../../persistence/attachments-store.js", () => ({
           conversationCreatedAt,
           attachmentId,
         ),
+}));
+
+// The content rewrite the repair branch performs, which is the statement that
+// can throw AFTER the message row is already inserted.
+import * as conversationCrudNamespace from "../../persistence/conversation-crud.js";
+
+const realCrud = { ...conversationCrudNamespace };
+
+let failNextContentUpdate = false;
+
+// Armed for exactly one by-id read, which is how the "cannot tell whether the
+// row landed" branch is reached.
+let failNextMessageLookup = false;
+
+mock.module("../../persistence/conversation-crud.js", () => ({
+  ...realCrud,
+  updateMessageContent: (messageId: string, content: string) => {
+    if (failNextContentUpdate) {
+      failNextContentUpdate = false;
+      throw new Error("simulated content rewrite failure");
+    }
+    return realCrud.updateMessageContent(messageId, content);
+  },
+  getMessageById: (messageId: string, conversationId?: string) => {
+    if (failNextMessageLookup) {
+      failNextMessageLookup = false;
+      throw new Error("simulated message lookup failure");
+    }
+    return realCrud.getMessageById(messageId, conversationId);
+  },
 }));
 
 import { Conversation } from "../../daemon/conversation.js";
@@ -258,6 +299,77 @@ describe("a camera frame whose message link fails", () => {
     } finally {
       live.dispose();
       source.dispose();
+    }
+  });
+});
+
+describe("a camera frame whose persist throws", () => {
+  test("keeps its attachment when the message row already exists", async () => {
+    // A persist can fail well after the insert: the link write fails, the
+    // repair rewrites the content, and that rewrite throws in turn. The row
+    // then references the attachment with no link protecting it, which is
+    // exactly what a link-aware delete reads as collectible, so reclaiming
+    // would strip the image out of a message the transcript still shows.
+    const live = liveConversation("Live voice throw after insert");
+    try {
+      const frame = await uploadFrame("throws-late.png");
+
+      failNextLink = true;
+      failNextContentUpdate = true;
+      expect(await persistLiveVoiceSightFrame(live.id, frame)).toEqual({
+        ok: false,
+      });
+      expect(failNextLink).toBe(false);
+      expect(failNextContentUpdate).toBe(false);
+
+      // The row landed before the throw, so the frame is not the daemon's to
+      // collect however the call reported itself.
+      expect(getMessages(live.id)).toHaveLength(1);
+      expect(realStore.getAttachmentById(frame)).not.toBeNull();
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("gives up its attachment when it threw before the insert", async () => {
+    // Nothing was written, so the upload is stranded exactly as a superseded
+    // or timed-out keep's is.
+    const live = liveConversation("Live voice throw before insert");
+    try {
+      const frame = await uploadFrame("throws-early.png");
+
+      failNextResolve = true;
+      expect(await persistLiveVoiceSightFrame(live.id, frame)).toEqual({
+        ok: false,
+      });
+      expect(failNextResolve).toBe(false);
+
+      expect(getMessages(live.id)).toHaveLength(0);
+      expect(realStore.getAttachmentById(frame)).toBeNull();
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("keeps its attachment when it cannot tell whether the row landed", async () => {
+    // Nothing was inserted here, so the frame would have been reclaimed. The
+    // read that would prove it fails, and an unanswerable question resolves
+    // toward leaking a row rather than risking one a message references.
+    const live = liveConversation("Live voice throw with unreadable row");
+    try {
+      const frame = await uploadFrame("throws-unreadable.png");
+
+      failNextResolve = true;
+      failNextMessageLookup = true;
+      expect(await persistLiveVoiceSightFrame(live.id, frame)).toEqual({
+        ok: false,
+      });
+      expect(failNextMessageLookup).toBe(false);
+
+      expect(getMessages(live.id)).toHaveLength(0);
+      expect(realStore.getAttachmentById(frame)).not.toBeNull();
+    } finally {
+      live.dispose();
     }
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Ambient camera frames kept mid-call (`sight_frame`).
+ *
+ * The behaviour under test is the keep-stream rule: a kept frame persists
+ * immediately as its own tagged user message and dispatches no turn, so the
+ * transcript is the record of what the assistant saw and the model correlates
+ * a frame with speech by adjacency.
+ *
+ * The two neighbouring contracts are pinned by their own suites: a deliberate
+ * snap persists standalone and untagged (`live-voice-attach-image.test.ts`), a
+ * parked frame persists nothing and rides the next turn
+ * (`live-voice-attach-frame.test.ts`).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  createMockProvider,
+  textResponse,
+} from "../../__tests__/helpers/mock-provider.js";
+import { setConfig } from "../../__tests__/helpers/set-config.js";
+import { waitFor } from "../../__tests__/helpers/wait-for.js";
+
+setConfig("memory", { enabled: false });
+
+import type { VoiceTurnOptions } from "../../calls/voice-session-bridge.js";
+import { Conversation } from "../../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../../daemon/conversation-registry.js";
+import {
+  getAttachmentsForMessage,
+  uploadAttachment,
+} from "../../persistence/attachments-store.js";
+import {
+  createConversation,
+  getMessages,
+  selectSightFrameCaptureTimes,
+} from "../../persistence/conversation-crud.js";
+import { sightFrameAttachmentIdsFromMetadata } from "../../persistence/conversation-types.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import {
+  LiveVoiceSession,
+  type LiveVoiceTurnStarter,
+} from "../live-voice-session.js";
+import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
+import {
+  createLiveVoiceServerFrameSequencer,
+  type LiveVoiceServerFrame,
+  validateLiveVoiceClientFrame,
+} from "../protocol.js";
+
+await initializeDb();
+
+const IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+class MockStreamingTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(): void {}
+
+  stop(): void {
+    this.onEvent?.({ type: "closed" });
+  }
+}
+
+/** A real attachment row, so the arrival-time existence check has one to find. */
+async function uploadFrame(): Promise<string> {
+  const attachment = await uploadAttachment(
+    "frame.png",
+    "image/png",
+    IMAGE_BASE64,
+  );
+  return attachment.id;
+}
+
+/**
+ * A session bound to a live conversation, so a kept frame has somewhere real
+ * to land. Returns a `dispose` that unregisters it.
+ */
+function createSessionHarness(title: string) {
+  const conversation = createConversation(title);
+  const { provider } = createMockProvider([textResponse("")]);
+  const activeConversation = new Conversation(
+    conversation.id,
+    provider,
+    "system prompt",
+    () => {},
+    "/tmp",
+    { maxTokens: 4096 },
+  );
+  activeConversation.setTrustContext({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  });
+  setConversation(conversation.id, activeConversation);
+
+  const sequencer = createLiveVoiceServerFrameSequencer();
+  const frames: LiveVoiceServerFrame[] = [];
+  const context: LiveVoiceSessionFactoryContext = {
+    sessionId: "session-sight-frame",
+    startFrame: {
+      type: "start",
+      conversationId: conversation.id,
+      audio: { mimeType: "audio/pcm", sampleRate: 24_000, channels: 1 },
+    },
+    sendFrame: mock(async (payload) => {
+      const frame = sequencer.next(payload);
+      frames.push(frame);
+      return frame;
+    }),
+  };
+
+  const startVoiceTurn: LiveVoiceTurnStarter = mock(
+    async (_options: VoiceTurnOptions) => ({
+      turnId: "bridge-turn-1",
+      abort: mock(),
+    }),
+  );
+
+  const session = new LiveVoiceSession(context, {
+    resolveTranscriber: mock(async () => new MockStreamingTranscriber()),
+    startVoiceTurn,
+    createTurnId: () => "live-turn-1",
+    emitMetrics: false,
+  });
+
+  return {
+    activeConversation,
+    conversationId: conversation.id,
+    frames,
+    session,
+    startVoiceTurn,
+    dispose: () => {
+      deleteConversation(conversation.id);
+      activeConversation.dispose();
+    },
+  };
+}
+
+describe("live-voice sight_frame frame", () => {
+  test("accepts a well-formed frame", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "sight_frame",
+      attachmentId: "att-1",
+    });
+    expect(result).toEqual({
+      ok: true,
+      frame: { type: "sight_frame", attachmentId: "att-1" },
+    });
+  });
+
+  test("rejects a missing attachmentId, naming the frame", () => {
+    const result = validateLiveVoiceClientFrame({ type: "sight_frame" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("missing_required_field");
+      expect(result.error.field).toBe("attachmentId");
+      expect(result.error.frameType).toBe("sight_frame");
+    }
+  });
+
+  test("rejects an empty attachmentId, distinctly from a missing one", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "sight_frame",
+      attachmentId: "",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("invalid_field");
+      expect(result.error.field).toBe("attachmentId");
+      expect(result.error.frameType).toBe("sight_frame");
+    }
+  });
+
+  test("rejects a null attachmentId", () => {
+    // `attach_frame` reads null as an unpark. A keep has nothing staged to
+    // give up, so null is simply malformed here.
+    const result = validateLiveVoiceClientFrame({
+      type: "sight_frame",
+      attachmentId: null,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("invalid_field");
+      expect(result.error.frameType).toBe("sight_frame");
+    }
+  });
+
+  test("rejects a non-string attachmentId", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "sight_frame",
+      attachmentId: 7,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("invalid_field");
+      expect(result.error.frameType).toBe("sight_frame");
+    }
+  });
+});
+
+describe("live-voice camera frames kept mid-call", () => {
+  test("a kept frame persists as its own tagged message and runs no turn", async () => {
+    const harness = createSessionHarness("Sight keep stream");
+    try {
+      await harness.session.start();
+      const attachmentId = await uploadFrame();
+
+      await harness.session.handleClientFrame({
+        type: "sight_frame",
+        attachmentId,
+      });
+      await waitFor(() => getMessages(harness.conversationId).length > 0, {
+        message: "Timed out waiting for the kept frame to persist",
+      });
+
+      const rows = getMessages(harness.conversationId);
+      expect(rows).toHaveLength(1);
+      const [row] = rows;
+      expect(row.role).toBe("user");
+      expect(getAttachmentsForMessage(row.id)).toHaveLength(1);
+
+      // The tag names the attachment on the row that carries it, which is what
+      // retention reads to decide what a later turn still sends in full.
+      const metadata = JSON.parse(row.metadata ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      expect(sightFrameAttachmentIdsFromMetadata(metadata)).toEqual([
+        attachmentId,
+      ]);
+      expect(
+        selectSightFrameCaptureTimes(harness.conversationId).has(attachmentId),
+      ).toBe(true);
+
+      // Nothing is dispatched for the frame itself: answering a picture the
+      // user never asked about would talk over whatever they are saying.
+      expect(harness.startVoiceTurn).not.toHaveBeenCalled();
+      expect(
+        harness.frames.filter((frame) => frame.type === "error"),
+      ).toHaveLength(0);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("an unknown attachment id is refused, recoverably and attributably", async () => {
+    const harness = createSessionHarness("Sight keep unknown id");
+    try {
+      await harness.session.start();
+      const before = harness.frames.length;
+
+      await harness.session.handleClientFrame({
+        type: "sight_frame",
+        attachmentId: "att-missing",
+      });
+      await waitFor(() => harness.frames.length > before, {
+        message: "Timed out waiting for the rejected camera frame's error",
+      });
+
+      expect(
+        harness.frames.slice(before).find((frame) => frame.type === "error"),
+      ).toMatchObject({
+        type: "error",
+        frameType: "sight_frame",
+        recoverable: true,
+      });
+      // Nothing landed and the call carries on.
+      expect(getMessages(harness.conversationId)).toHaveLength(0);
+      expect(harness.startVoiceTurn).not.toHaveBeenCalled();
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("refuses an unknown id while a turn is running, without waiting it out", async () => {
+    // The id is checked before the persist is scheduled. Behind the persist it
+    // would be answered only once the turn released the lock, long after the
+    // client could still retract the preview it showed.
+    const harness = createSessionHarness("Sight keep unknown id mid-turn");
+    try {
+      await harness.session.start();
+      harness.activeConversation.setProcessing(true);
+      const before = harness.frames.length;
+
+      await harness.session.handleClientFrame({
+        type: "sight_frame",
+        attachmentId: "att-missing",
+      });
+      await waitFor(() => harness.frames.length > before, {
+        message: "Timed out waiting for the mid-turn rejection",
+      });
+
+      expect(
+        harness.frames.slice(before).find((frame) => frame.type === "error"),
+      ).toMatchObject({ type: "error", frameType: "sight_frame" });
+    } finally {
+      harness.activeConversation.setProcessing(false);
+      harness.dispose();
+    }
+  });
+
+  test("keeps persist one message each", async () => {
+    // One message per keep, no batching: the gate's rate floor separates them,
+    // so there is no natural batch to form.
+    const harness = createSessionHarness("Sight keep stream repeated");
+    try {
+      await harness.session.start();
+      const first = await uploadFrame();
+      const second = await uploadFrame();
+
+      await harness.session.handleClientFrame({
+        type: "sight_frame",
+        attachmentId: first,
+      });
+      await waitFor(() => getMessages(harness.conversationId).length === 1, {
+        message: "Timed out waiting for the first kept frame",
+      });
+      await harness.session.handleClientFrame({
+        type: "sight_frame",
+        attachmentId: second,
+      });
+      await waitFor(() => getMessages(harness.conversationId).length === 2, {
+        message: "Timed out waiting for the second kept frame",
+      });
+
+      const captureTimes = selectSightFrameCaptureTimes(harness.conversationId);
+      expect([...captureTimes.keys()].sort()).toEqual([first, second].sort());
+      expect(harness.startVoiceTurn).not.toHaveBeenCalled();
+    } finally {
+      harness.dispose();
+    }
+  });
+});

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -56,11 +56,13 @@
  *
  * A persist that throws after its row landed is reported as the success it
  * is, because the transcript has the image and the client's view has to match
- * what a reload will show. Two things are knowingly left behind in that case.
- * The live in-memory history may omit the frame, since the persist unwinds its
- * own push, so the model may not see this one until a reload or a compaction
- * reassembly; that array belongs to `persistQueuedMessageBody` and is not
- * pushed into from out here. And when the failure was a link write, the
+ * what a reload will show. The persist unwinds its own push before rethrowing,
+ * so the resident history is left not matching the rows; rather than reach
+ * into an array `persistQueuedMessageBody` owns, the recovery marks the
+ * conversation's history stale, and the next turn's
+ * `ensureActorScopedHistory` reloads from the DB and sees the frame.
+ *
+ * One thing is knowingly left behind: when the failure was a link write, the
  * persisted content can reference an attachment row with no link. The row
  * survives (nothing reclaims on a committed persist) and collection only ever
  * considers ids a caller hands it, so the reference keeps resolving.
@@ -72,6 +74,7 @@ import {
   type PersistMessageOptions,
   persistQueuedMessageBody,
 } from "../daemon/conversation-messaging.js";
+import { findConversation } from "../daemon/conversation-registry.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import {
   deleteOrphanAttachments,
@@ -383,6 +386,12 @@ async function writeStandaloneImage(
       // over: the client retracts what it showed and stops treating it as
       // pending, and the row it was told never landed appears on the next
       // reload.
+      //
+      // The persist unwound its own push before rethrowing, so the resident
+      // history no longer matches the rows. Same situation a channel edit or
+      // reaction leaves behind, and the same fix: the next turn's
+      // `ensureActorScopedHistory` reloads instead of reusing what it holds.
+      findConversation(conversationId)?.markHistoryStale();
       try {
         announcePersistedImage(conversationId, content, requestId);
       } catch (announceErr) {

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -84,6 +84,19 @@ const log = getLogger("live-voice-photo");
  * say.
  */
 const PROCESSING_WAIT_MS = 30_000;
+
+/**
+ * The wait actually applied. Mutable only so a test can reach the timeout
+ * without holding a conversation busy for the full half minute.
+ */
+let processingWaitMs = PROCESSING_WAIT_MS;
+
+/** Shorten the idle wait for a test. Returns the value it replaced. */
+export function _setProcessingWaitMsForTests(ms: number): number {
+  const previous = processingWaitMs;
+  processingWaitMs = ms;
+  return previous;
+}
 const PROCESSING_POLL_MS = 100;
 
 const PHOTO_MESSAGE_CONTENT = "here's a photo:";
@@ -165,7 +178,7 @@ async function enqueueStandaloneImagePersist(
         { conversationId, attachmentId: ticket.attachmentId },
         "A newer camera frame replaced one still waiting to persist",
       );
-      reclaimSupersededFrame(ticket.attachmentId);
+      reclaimDroppedFrame(ticket.attachmentId);
       return { ok: false };
     }
     return job();
@@ -191,23 +204,30 @@ async function enqueueStandaloneImagePersist(
 }
 
 /**
- * Give up the upload behind a keep no message will ever carry.
+ * Give up the upload behind a keep no message will ever carry: one a newer
+ * frame replaced before it started, one whose wait for an idle conversation
+ * ran out, and one whose write threw.
  *
- * The client uploaded it and then the daemon chose to drop it, so nothing else
- * will ever collect it: the client's own abandon-delete fires only when the
- * send fails, and attachment collection is candidate-driven with no sweep.
- * Link-aware through {@link deleteOrphanAttachments}, so an id that did reach a
- * message is left alone, and only ever called for a job that never wrote.
+ * The client uploaded it and then the daemon dropped it, so nothing else will
+ * ever collect it: the client's own abandon-delete fires only when the send
+ * fails, and attachment collection is candidate-driven with no sweep.
+ * {@link deleteOrphanAttachments} is link-aware, which is the backstop that
+ * makes this safe on the thrown path: a write that failed after linking leaves
+ * a `message_attachments` row, and an id with a link is refused.
+ *
+ * Keeps only. A photo is a deliberate upload the user watched themselves make,
+ * and one that failed to persist is theirs to retry, not the daemon's to
+ * delete.
  *
  * Best effort. Losing a row's bytes is not worth failing a call over.
  */
-function reclaimSupersededFrame(attachmentId: string): void {
+function reclaimDroppedFrame(attachmentId: string): void {
   try {
     deleteOrphanAttachments([attachmentId]);
   } catch (err) {
     log.warn(
       { err, attachmentId },
-      "Could not reclaim a superseded live-voice camera frame",
+      "Could not reclaim a dropped live-voice camera frame",
     );
   }
 }
@@ -235,7 +255,7 @@ async function acquireProcessingFlag(conversation: {
   isProcessing: () => boolean;
   setProcessing: (value: boolean) => void;
 }): Promise<boolean> {
-  const deadline = Date.now() + PROCESSING_WAIT_MS;
+  const deadline = Date.now() + processingWaitMs;
   for (;;) {
     if (!conversation.isProcessing()) {
       conversation.setProcessing(true);
@@ -300,6 +320,9 @@ async function writeStandaloneImage(
         { conversationId, attachmentId, kind },
         "Live-voice image timed out waiting for the conversation to go idle",
       );
+      if (kind === "sight_frame") {
+        reclaimDroppedFrame(attachmentId);
+      }
       return { ok: false };
     }
 
@@ -335,6 +358,9 @@ async function writeStandaloneImage(
       { err, conversationId, attachmentId, kind },
       "Failed to persist a live-voice image",
     );
+    if (kind === "sight_frame") {
+      reclaimDroppedFrame(attachmentId);
+    }
     return { ok: false };
   }
 }

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -53,6 +53,17 @@
  * still overwrites the keep's hold, and the keep's release then clears the
  * turn's. Fixing that means changing how every turn in the daemon acquires,
  * which belongs in `conversation.ts` rather than here.
+ *
+ * A persist that throws after its row landed is reported as the success it
+ * is, because the transcript has the image and the client's view has to match
+ * what a reload will show. Two things are knowingly left behind in that case.
+ * The live in-memory history may omit the frame, since the persist unwinds its
+ * own push, so the model may not see this one until a reload or a compaction
+ * reassembly; that array belongs to `persistQueuedMessageBody` and is not
+ * pushed into from out here. And when the failure was a link write, the
+ * persisted content can reference an attachment row with no link. The row
+ * survives (nothing reclaims on a committed persist) and collection only ever
+ * considers ids a caller hands it, so the reference keeps resolving.
  */
 
 import { v7 as uuidv7 } from "uuid";
@@ -350,17 +361,7 @@ async function writeStandaloneImage(
         requestId,
       });
 
-      // The row exists but no turn will announce it, so the clients that
-      // render this conversation have to be told directly, or the image does
-      // not appear until something else forces a refetch.
-      broadcastMessage({
-        type: "user_message_echo",
-        text: content,
-        conversationId,
-        messageId: persisted.id,
-      });
-      recordConversationPersistedSeq(conversationId, getCurrentSeq());
-      publishConversationMessagesChanged(conversationId);
+      announcePersistedImage(conversationId, content, persisted.id);
 
       return { ok: true, messageId: persisted.id };
     } finally {
@@ -375,7 +376,24 @@ async function writeStandaloneImage(
       { err, conversationId, attachmentId, kind },
       "Failed to persist a live-voice image",
     );
-    if (kind === "sight_frame" && !messageMayExist(conversationId, requestId)) {
+    const inserted = insertedMessageState(conversationId, requestId);
+    if (inserted === "exists") {
+      // The row is in the transcript, so the result has to say so whatever
+      // went wrong afterwards. Reporting failure here loses the frame twice
+      // over: the client retracts what it showed and stops treating it as
+      // pending, and the row it was told never landed appears on the next
+      // reload.
+      try {
+        announcePersistedImage(conversationId, content, requestId);
+      } catch (announceErr) {
+        log.warn(
+          { err: announceErr, conversationId, messageId: requestId },
+          "Persisted a live-voice image but could not announce it",
+        );
+      }
+      return { ok: true, messageId: requestId };
+    }
+    if (kind === "sight_frame" && inserted === "absent") {
       reclaimDroppedFrame(attachmentId);
     }
     return { ok: false };
@@ -383,27 +401,60 @@ async function writeStandaloneImage(
 }
 
 /**
- * Whether the persist may have inserted its row before throwing.
+ * Tell the clients rendering this conversation that a row landed.
+ *
+ * No turn will announce it, so without this the image does not appear until
+ * something else forces a refetch.
+ */
+function announcePersistedImage(
+  conversationId: string,
+  text: string,
+  messageId: string,
+): void {
+  broadcastMessage({
+    type: "user_message_echo",
+    text,
+    conversationId,
+    messageId,
+  });
+  recordConversationPersistedSeq(conversationId, getCurrentSeq());
+  publishConversationMessagesChanged(conversationId);
+}
+
+/**
+ * Whether the persist's own row is in the conversation.
  *
  * A persist can fail well after `addMessage` succeeded: a link write that
  * fails is repaired by rewriting the content, and that rewrite can throw in
- * turn. The row then exists and references the attachment while no
- * `message_attachments` link was ever written, which is exactly the shape
- * link-awareness reads as collectible, so reclaiming would strip an image out
- * of a message the transcript still shows.
+ * turn.
  *
- * True on a failed lookup as well. Leaking one row costs bytes; deleting one a
- * message references breaks that message for good.
+ * Three-valued because its two readers need opposite answers under doubt, and
+ * a boolean can only serve one of them. Reclaiming an attachment on a guess
+ * deletes bytes a message may reference; reporting success on a guess tells
+ * the client a frame landed when it may not have, and the client stops showing
+ * it as pending and stops retrying on the strength of that word. Neither is
+ * recoverable, so `unknown` refuses both: never act on a fact that could not
+ * be read.
+ *
+ * A row found under this id is provably this persist's own. The deduplicating
+ * branch of `addMessage` fires only for a `clientMessageId`, which no image
+ * here sets, and it returns rather than throws, so it cannot leave a half
+ * finished persist behind an id that resolves to someone else's row.
  */
-function messageMayExist(conversationId: string, messageId: string): boolean {
+function insertedMessageState(
+  conversationId: string,
+  messageId: string,
+): "exists" | "absent" | "unknown" {
   try {
-    return getMessageById(messageId, conversationId) !== null;
+    return getMessageById(messageId, conversationId) !== null
+      ? "exists"
+      : "absent";
   } catch (err) {
     log.warn(
       { err, conversationId, messageId },
-      "Could not tell whether a live-voice image persisted; keeping its attachment",
+      "Could not tell whether a live-voice image persisted; keeping its attachment and reporting failure",
     );
-    return true;
+    return "unknown";
   }
 }
 

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -29,11 +29,13 @@
 
 import { v7 as uuidv7 } from "uuid";
 
-import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
+import {
+  type PersistMessageOptions,
+  persistQueuedMessageBody,
+} from "../daemon/conversation-messaging.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import { resolveAttachmentsForPersist } from "../persistence/attachments-store.js";
 import { recordConversationPersistedSeq } from "../persistence/conversation-crud.js";
-import { SIGHT_FRAME_ATTACHMENT_IDS_KEY } from "../persistence/conversation-types.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
@@ -95,13 +97,10 @@ async function waitForIdle(conversation: {
 async function persistStandaloneImage(
   conversationId: string,
   attachmentId: string,
-  options: {
-    readonly kind: "photo" | "sight_frame";
-    readonly content: string;
-    readonly metadata: Record<string, unknown>;
-  },
+  kind: "photo" | "sight_frame",
+  persistOptions: Omit<PersistMessageOptions, "attachments" | "requestId">,
 ): Promise<LiveVoicePhotoResult> {
-  const { kind, content } = options;
+  const { content } = persistOptions;
   try {
     const attachments = resolveAttachmentsForPersist([attachmentId]);
     if (attachments.length === 0) {
@@ -128,10 +127,9 @@ async function persistStandaloneImage(
     conversation.setProcessing(true);
     try {
       const persisted = await persistQueuedMessageBody(conversation, {
-        content,
+        ...persistOptions,
         attachments,
         requestId: uuidv7(),
-        metadata: options.metadata,
       });
 
       // The row exists but no turn will announce it, so the clients that
@@ -174,8 +172,7 @@ export async function persistLiveVoicePhoto(
   conversationId: string,
   attachmentId: string,
 ): Promise<LiveVoicePhotoResult> {
-  return persistStandaloneImage(conversationId, attachmentId, {
-    kind: "photo",
+  return persistStandaloneImage(conversationId, attachmentId, "photo", {
     content: PHOTO_MESSAGE_CONTENT,
     metadata: {
       // Marks the row as something the user did on a call rather than
@@ -192,18 +189,22 @@ export async function persistLiveVoicePhoto(
  * The sight tag names the attachment on the row that carries it, because an
  * attachment holds no metadata of its own. Retention reads the tag to decide
  * which images a turn still sends in full and which become timestamped stubs,
- * so an untagged frame would sit in every later request forever.
+ * so an untagged frame would sit in every later request forever. The persist
+ * stamps it, from the id materialization ended up storing rather than the one
+ * asked for here.
+ *
+ * `scripted` because the camera's gate sent this, not the user: a keep every
+ * few seconds would otherwise read downstream as that many turns the user
+ * took, and activation counts turns that claim they were typed.
  */
 export async function persistLiveVoiceSightFrame(
   conversationId: string,
   attachmentId: string,
 ): Promise<LiveVoicePhotoResult> {
-  return persistStandaloneImage(conversationId, attachmentId, {
-    kind: "sight_frame",
+  return persistStandaloneImage(conversationId, attachmentId, "sight_frame", {
     content: SIGHT_FRAME_MESSAGE_CONTENT,
-    metadata: {
-      voiceSessionTurn: true,
-      [SIGHT_FRAME_ATTACHMENT_IDS_KEY]: [attachmentId],
-    },
+    metadata: { voiceSessionTurn: true },
+    scripted: true,
+    sightFrameAttachmentIds: [attachmentId],
   });
 }

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -25,6 +25,23 @@
  * photo can be stripped where one riding the spoken turn would have survived.
  * Stranding is the worse failure, and it happens every time rather than only
  * under overflow.
+ *
+ * Persists are serialized per conversation ({@link enqueueStandaloneImagePersist}),
+ * because the processing flag they take is a boolean rather than a counted
+ * lock. Two images in flight at once interleave across the awaits that sit
+ * between reading the flag and taking it, so both read idle and both take it.
+ * The first to finish then clears it while the second is still writing, which
+ * leaves a spoken turn free to launch into a half-written row, and the second
+ * finisher goes on to clear THAT turn's flag. Ambient frames make this
+ * routine rather than exotic: they arrive every few seconds for as long as
+ * the camera is up, and a shutter photo can land between any two of them. The
+ * chain holds the flag to one standalone job at a time, which is what makes
+ * the set/clear pairing correct rather than merely usually correct.
+ *
+ * A narrower race is left alone: a real turn can still start inside the 100 ms
+ * gap between the idle poll and `setProcessing(true)`. Closing it means
+ * changing what the flag is in `conversation.ts`, which governs every turn in
+ * the daemon, not just these writes.
  */
 
 import { v7 as uuidv7 } from "uuid";
@@ -68,6 +85,100 @@ export interface LiveVoicePhotoResult {
   readonly messageId?: string;
 }
 
+/**
+ * One conversation's chain of standalone-image persists.
+ *
+ * `queuedSightFrame` holds the keep that is chained but has not begun, and is
+ * what bounds the chain: keeps arrive every few seconds while each job can
+ * wait out a turn for {@link PROCESSING_WAIT_MS}, so without replacement the
+ * chain grows for as long as a turn runs. A job clears the slot as it starts,
+ * so the slot only ever refers to work that can still be called off.
+ */
+interface StandaloneImageQueue {
+  tail: Promise<void>;
+  queuedSightFrame: { superseded: boolean } | null;
+  outstanding: number;
+}
+
+const standaloneImageQueues = new Map<string, StandaloneImageQueue>();
+
+/**
+ * Run `job` after every standalone-image persist already queued for this
+ * conversation has settled.
+ *
+ * Keeps are latest-wins while they wait: a new one supersedes a queued keep
+ * that has not begun, which resolves `ok: false` so its caller reports the one
+ * lost frame. The camera is about to shoot another anyway, and what matters is
+ * the view at the moment the user speaks. Photos are never superseded: the
+ * user watched themselves take each one.
+ *
+ * The map entry is dropped once the chain drains, so a conversation that ends
+ * leaves nothing behind.
+ */
+async function enqueueStandaloneImagePersist(
+  conversationId: string,
+  kind: "photo" | "sight_frame",
+  job: () => Promise<LiveVoicePhotoResult>,
+): Promise<LiveVoicePhotoResult> {
+  let queue = standaloneImageQueues.get(conversationId);
+  if (!queue) {
+    queue = {
+      tail: Promise.resolve(),
+      queuedSightFrame: null,
+      outstanding: 0,
+    };
+    standaloneImageQueues.set(conversationId, queue);
+  }
+  const chained = queue;
+
+  const ticket = { superseded: false };
+  if (kind === "sight_frame") {
+    if (chained.queuedSightFrame) {
+      chained.queuedSightFrame.superseded = true;
+    }
+    chained.queuedSightFrame = ticket;
+  }
+
+  chained.outstanding += 1;
+  const running = chained.tail.then(() => {
+    // Started, so nothing can call it off from here on.
+    if (chained.queuedSightFrame === ticket) {
+      chained.queuedSightFrame = null;
+    }
+    if (ticket.superseded) {
+      log.debug(
+        { conversationId },
+        "A newer camera frame replaced one still waiting to persist",
+      );
+      return { ok: false };
+    }
+    return job();
+  });
+  // The tail must survive a failed job, or one rejection would strand every
+  // image queued behind it.
+  chained.tail = running.then(
+    () => undefined,
+    () => undefined,
+  );
+
+  try {
+    return await running;
+  } finally {
+    chained.outstanding -= 1;
+    if (
+      chained.outstanding === 0 &&
+      standaloneImageQueues.get(conversationId) === chained
+    ) {
+      standaloneImageQueues.delete(conversationId);
+    }
+  }
+}
+
+/** Conversations with a standalone-image persist still in flight. */
+export function _standaloneImageQueueSizeForTests(): number {
+  return standaloneImageQueues.size;
+}
+
 /** Resolve once the conversation is not mid-turn, or false on timeout. */
 async function waitForIdle(conversation: {
   isProcessing: () => boolean;
@@ -91,10 +202,23 @@ async function waitForIdle(conversation: {
  * interleaving with a turn's own persist. An image that arrives mid-reply
  * therefore lands after that reply's rows rather than between them.
  *
- * Never throws. An image that cannot be stored must not take the call down
- * with it, and the caller reports the failure to the user instead.
+ * Queued behind this conversation's other standalone images, so only one of
+ * them ever holds the flag. Never throws. An image that cannot be stored must
+ * not take the call down with it, and the caller reports the failure to the
+ * user instead.
  */
-async function persistStandaloneImage(
+function persistStandaloneImage(
+  conversationId: string,
+  attachmentId: string,
+  kind: "photo" | "sight_frame",
+  persistOptions: Omit<PersistMessageOptions, "attachments" | "requestId">,
+): Promise<LiveVoicePhotoResult> {
+  return enqueueStandaloneImagePersist(conversationId, kind, () =>
+    writeStandaloneImage(conversationId, attachmentId, kind, persistOptions),
+  );
+}
+
+async function writeStandaloneImage(
   conversationId: string,
   attachmentId: string,
   kind: "photo" | "sight_frame",

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -502,6 +502,13 @@ export async function persistLiveVoiceSightFrame(
     content: SIGHT_FRAME_MESSAGE_CONTENT,
     metadata: { voiceSessionTurn: true },
     scripted: true,
+    // The camera sampled this, nobody sent it. Indexing it would feed
+    // extraction a frame every few seconds of whatever the room happens to
+    // contain, and commit those visuals to long-term memory with no consent
+    // surface: the design puts keeps in the TRANSCRIPT, which the user can see
+    // and delete, and says nothing about memory. The text half is worthless to
+    // search anyway, every row reading "(camera frame)".
+    skipIndexing: true,
     sightFrameAttachmentIds: [attachmentId],
   });
 }

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -66,7 +66,10 @@ import {
   deleteOrphanAttachments,
   resolveAttachmentsForPersist,
 } from "../persistence/attachments-store.js";
-import { recordConversationPersistedSeq } from "../persistence/conversation-crud.js";
+import {
+  getMessageById,
+  recordConversationPersistedSeq,
+} from "../persistence/conversation-crud.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
@@ -211,9 +214,20 @@ async function enqueueStandaloneImagePersist(
  * The client uploaded it and then the daemon dropped it, so nothing else will
  * ever collect it: the client's own abandon-delete fires only when the send
  * fails, and attachment collection is candidate-driven with no sweep.
- * {@link deleteOrphanAttachments} is link-aware, which is the backstop that
- * makes this safe on the thrown path: a write that failed after linking leaves
- * a `message_attachments` row, and an id with a link is refused.
+ *
+ * Each caller owes the invariant in the first line. The supersede and timeout
+ * paths have it by construction, neither having reached the persist; the
+ * thrown path establishes it by checking that no row was inserted
+ * ({@link messageMayExist}), because a persist can fail after `addMessage`
+ * succeeded. {@link deleteOrphanAttachments} being link-aware is the second
+ * backstop rather than the only one: a failure between the insert and the link
+ * leaves a row that references the attachment with no link to protect it.
+ *
+ * The reclaim names the id the caller handed in, which is not always the id
+ * the row ended up referencing: conversation scoping clones an attachment
+ * already linked elsewhere, and the persisted block then names the clone. The
+ * insert check still guards the case that matters, because without a clone the
+ * two ids are the same one, and that is the dangling reference this protects.
  *
  * Keeps only. A photo is a deliberate upload the user watched themselves make,
  * and one that failed to persist is theirs to retry, not the daemon's to
@@ -300,6 +314,9 @@ async function writeStandaloneImage(
   persistOptions: Omit<PersistMessageOptions, "attachments" | "requestId">,
 ): Promise<LiveVoicePhotoResult> {
   const { content } = persistOptions;
+  // The id the row is inserted under, so a failure can ask whether the insert
+  // landed before deciding the frame is safe to reclaim.
+  const requestId = uuidv7();
   try {
     const attachments = resolveAttachmentsForPersist([attachmentId]);
     if (attachments.length === 0) {
@@ -330,7 +347,7 @@ async function writeStandaloneImage(
       const persisted = await persistQueuedMessageBody(conversation, {
         ...persistOptions,
         attachments,
-        requestId: uuidv7(),
+        requestId,
       });
 
       // The row exists but no turn will announce it, so the clients that
@@ -358,10 +375,35 @@ async function writeStandaloneImage(
       { err, conversationId, attachmentId, kind },
       "Failed to persist a live-voice image",
     );
-    if (kind === "sight_frame") {
+    if (kind === "sight_frame" && !messageMayExist(conversationId, requestId)) {
       reclaimDroppedFrame(attachmentId);
     }
     return { ok: false };
+  }
+}
+
+/**
+ * Whether the persist may have inserted its row before throwing.
+ *
+ * A persist can fail well after `addMessage` succeeded: a link write that
+ * fails is repaired by rewriting the content, and that rewrite can throw in
+ * turn. The row then exists and references the attachment while no
+ * `message_attachments` link was ever written, which is exactly the shape
+ * link-awareness reads as collectible, so reclaiming would strip an image out
+ * of a message the transcript still shows.
+ *
+ * True on a failed lookup as well. Leaking one row costs bytes; deleting one a
+ * message references breaks that message for good.
+ */
+function messageMayExist(conversationId: string, messageId: string): boolean {
+  try {
+    return getMessageById(messageId, conversationId) !== null;
+  } catch (err) {
+    log.warn(
+      { err, conversationId, messageId },
+      "Could not tell whether a live-voice image persisted; keeping its attachment",
+    );
+    return true;
   }
 }
 

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -1,11 +1,17 @@
 /**
- * Persisting a photo taken during a live-voice call.
+ * Persisting an image that arrives during a live-voice call, on its own.
  *
- * A photo lands in the conversation as its own user message, the moment the
- * shutter fires, and **runs no turn**. That single choice is what makes the
- * order of shutter and speech irrelevant: whatever the user says next, before
- * or after the snap, is answered by a model whose history already contains the
- * image.
+ * Two kinds arrive this way and both take the same route: a photo the user
+ * snapped with the shutter, and an ambient camera frame the client's gate kept.
+ * Each lands in the conversation as its own user message, the moment it
+ * arrives, and **runs no turn**. That single choice is what makes the order of
+ * image and speech irrelevant: whatever the user says next, before or after,
+ * is answered by a model whose history already contains the picture.
+ *
+ * A kept frame carries the sight tag as well, which is what lets retention age
+ * it out of the model's context while the transcript keeps it. A shutter photo
+ * carries no tag: the user chose to take it, so it is not the retention pass's
+ * to trim.
  *
  * The alternatives were both worse and both were tried. Attaching the photo to
  * the *next* spoken turn strands it whenever the user speaks first: the
@@ -27,6 +33,7 @@ import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import { resolveAttachmentsForPersist } from "../persistence/attachments-store.js";
 import { recordConversationPersistedSeq } from "../persistence/conversation-crud.js";
+import { SIGHT_FRAME_ATTACHMENT_IDS_KEY } from "../persistence/conversation-types.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
@@ -35,18 +42,24 @@ import { getLogger } from "../util/logger.js";
 const log = getLogger("live-voice-photo");
 
 /**
- * How long to wait for an in-flight turn before giving up on a photo.
+ * How long to wait for an in-flight turn before giving up on an image.
  *
  * Persisting takes the conversation's processing lock, which a running turn
  * holds for as long as it runs, tools included. The wait is generous because
  * the alternative is dropping a photo the user watched themselves take, and
- * the photo is not urgent: nothing is blocked on it except the next thing they
+ * the image is not urgent: nothing is blocked on it except the next thing they
  * say.
  */
 const PROCESSING_WAIT_MS = 30_000;
 const PROCESSING_POLL_MS = 100;
 
 const PHOTO_MESSAGE_CONTENT = "here's a photo:";
+
+/**
+ * Text the kept frame's row carries. Neutral rather than first person: nobody
+ * spoke this message, the camera simply had something worth showing.
+ */
+const SIGHT_FRAME_MESSAGE_CONTENT = "(camera frame)";
 
 export interface LiveVoicePhotoResult {
   readonly ok: boolean;
@@ -68,24 +81,34 @@ async function waitForIdle(conversation: {
 }
 
 /**
- * Persist a photo into the conversation as a user message, running no turn.
+ * Persist one image into the conversation as a user message, running no turn.
  *
  * Takes and releases the processing lock the way the built-in slash commands
  * do: they are the existing precedent for "persist a user message and answer
  * without the agent loop", and the lock is what keeps this write from
- * interleaving with a turn's own persist.
+ * interleaving with a turn's own persist. An image that arrives mid-reply
+ * therefore lands after that reply's rows rather than between them.
  *
- * Never throws. A photo that cannot be stored must not take the call down with
- * it, and the caller reports the failure to the user instead.
+ * Never throws. An image that cannot be stored must not take the call down
+ * with it, and the caller reports the failure to the user instead.
  */
-export async function persistLiveVoicePhoto(
+async function persistStandaloneImage(
   conversationId: string,
   attachmentId: string,
+  options: {
+    readonly kind: "photo" | "sight_frame";
+    readonly content: string;
+    readonly metadata: Record<string, unknown>;
+  },
 ): Promise<LiveVoicePhotoResult> {
+  const { kind, content } = options;
   try {
     const attachments = resolveAttachmentsForPersist([attachmentId]);
     if (attachments.length === 0) {
-      log.warn({ attachmentId }, "Live-voice photo attachment did not resolve");
+      log.warn(
+        { attachmentId, kind },
+        "Live-voice image attachment did not resolve",
+      );
       return { ok: false };
     }
 
@@ -96,8 +119,8 @@ export async function persistLiveVoicePhoto(
     // must not cause.
     if (!(await waitForIdle(conversation))) {
       log.warn(
-        { conversationId, attachmentId },
-        "Live-voice photo timed out waiting for the conversation to go idle",
+        { conversationId, attachmentId, kind },
+        "Live-voice image timed out waiting for the conversation to go idle",
       );
       return { ok: false };
     }
@@ -105,23 +128,18 @@ export async function persistLiveVoicePhoto(
     conversation.setProcessing(true);
     try {
       const persisted = await persistQueuedMessageBody(conversation, {
-        content: PHOTO_MESSAGE_CONTENT,
+        content,
         attachments,
         requestId: uuidv7(),
-        metadata: {
-          // Marks the row as something the user did on a call rather than
-          // typed, the same way a voice turn's own user message is marked.
-          voiceSessionTurn: true,
-          livePhoto: true,
-        },
+        metadata: options.metadata,
       });
 
       // The row exists but no turn will announce it, so the clients that
-      // render this conversation have to be told directly, or the photo does
+      // render this conversation have to be told directly, or the image does
       // not appear until something else forces a refetch.
       broadcastMessage({
         type: "user_message_echo",
-        text: PHOTO_MESSAGE_CONTENT,
+        text: content,
         conversationId,
         messageId: persisted.id,
       });
@@ -132,15 +150,60 @@ export async function persistLiveVoicePhoto(
     } finally {
       conversation.setProcessing(false);
       // Anything queued behind the lock we just held still has to run. Without
-      // this a message queued during the photo's write sits until the next
+      // this a message queued during the image's write sits until the next
       // turn ends.
-      void conversation.kickDrainQueue("loop_complete", "live_voice_photo");
+      void conversation.kickDrainQueue("loop_complete", `live_voice_${kind}`);
     }
   } catch (err) {
     log.warn(
-      { err, conversationId, attachmentId },
-      "Failed to persist a live-voice photo",
+      { err, conversationId, attachmentId, kind },
+      "Failed to persist a live-voice image",
     );
     return { ok: false };
   }
+}
+
+/**
+ * Persist a photo the user took mid-call.
+ *
+ * Carries `livePhoto`, which is what the client reads to show the snap on its
+ * receipt strip, and no sight tag: a deliberate photo is not retention's to
+ * age out.
+ */
+export async function persistLiveVoicePhoto(
+  conversationId: string,
+  attachmentId: string,
+): Promise<LiveVoicePhotoResult> {
+  return persistStandaloneImage(conversationId, attachmentId, {
+    kind: "photo",
+    content: PHOTO_MESSAGE_CONTENT,
+    metadata: {
+      // Marks the row as something the user did on a call rather than
+      // typed, the same way a voice turn's own user message is marked.
+      voiceSessionTurn: true,
+      livePhoto: true,
+    },
+  });
+}
+
+/**
+ * Persist an ambient camera frame the client's gate kept.
+ *
+ * The sight tag names the attachment on the row that carries it, because an
+ * attachment holds no metadata of its own. Retention reads the tag to decide
+ * which images a turn still sends in full and which become timestamped stubs,
+ * so an untagged frame would sit in every later request forever.
+ */
+export async function persistLiveVoiceSightFrame(
+  conversationId: string,
+  attachmentId: string,
+): Promise<LiveVoicePhotoResult> {
+  return persistStandaloneImage(conversationId, attachmentId, {
+    kind: "sight_frame",
+    content: SIGHT_FRAME_MESSAGE_CONTENT,
+    metadata: {
+      voiceSessionTurn: true,
+      [SIGHT_FRAME_ATTACHMENT_IDS_KEY]: [attachmentId],
+    },
+  });
 }

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -38,10 +38,21 @@
  * chain holds the flag to one standalone job at a time, which is what makes
  * the set/clear pairing correct rather than merely usually correct.
  *
- * A narrower race is left alone: a real turn can still start inside the 100 ms
- * gap between the idle poll and `setProcessing(true)`. Closing it means
- * changing what the flag is in `conversation.ts`, which governs every turn in
- * the daemon, not just these writes.
+ * The flag is taken by {@link acquireProcessingFlag}, which reads it free and
+ * takes it in one synchronous step. That closes the half of the turn race this
+ * module owns: no await sits between the read and the take, so a turn that
+ * starts nearby either loses the flag to a keep that already holds it or holds
+ * it before the keep looks, and a keep can never write over a turn that got
+ * there first. Per `assistant/AGENTS.md`, a resource more than one caller
+ * writes has to be serialised per resource; the chain does that between keeps
+ * and the atomic take does it against turns.
+ *
+ * The other half is not this module's: turn startup takes the flag without
+ * first asking whether anyone holds it (`persistUserMessage` in
+ * `conversation-messaging.ts`), so a turn beginning while a keep is mid-write
+ * still overwrites the keep's hold, and the keep's release then clears the
+ * turn's. Fixing that means changing how every turn in the daemon acquires,
+ * which belongs in `conversation.ts` rather than here.
  */
 
 import { v7 as uuidv7 } from "uuid";
@@ -51,7 +62,10 @@ import {
   persistQueuedMessageBody,
 } from "../daemon/conversation-messaging.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
-import { resolveAttachmentsForPersist } from "../persistence/attachments-store.js";
+import {
+  deleteOrphanAttachments,
+  resolveAttachmentsForPersist,
+} from "../persistence/attachments-store.js";
 import { recordConversationPersistedSeq } from "../persistence/conversation-crud.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import { getCurrentSeq } from "../runtime/assistant-stream-state.js";
@@ -96,7 +110,7 @@ export interface LiveVoicePhotoResult {
  */
 interface StandaloneImageQueue {
   tail: Promise<void>;
-  queuedSightFrame: { superseded: boolean } | null;
+  queuedSightFrame: { superseded: boolean; attachmentId: string } | null;
   outstanding: number;
 }
 
@@ -117,6 +131,7 @@ const standaloneImageQueues = new Map<string, StandaloneImageQueue>();
  */
 async function enqueueStandaloneImagePersist(
   conversationId: string,
+  attachmentId: string,
   kind: "photo" | "sight_frame",
   job: () => Promise<LiveVoicePhotoResult>,
 ): Promise<LiveVoicePhotoResult> {
@@ -131,7 +146,7 @@ async function enqueueStandaloneImagePersist(
   }
   const chained = queue;
 
-  const ticket = { superseded: false };
+  const ticket = { superseded: false, attachmentId };
   if (kind === "sight_frame") {
     if (chained.queuedSightFrame) {
       chained.queuedSightFrame.superseded = true;
@@ -147,9 +162,10 @@ async function enqueueStandaloneImagePersist(
     }
     if (ticket.superseded) {
       log.debug(
-        { conversationId },
+        { conversationId, attachmentId: ticket.attachmentId },
         "A newer camera frame replaced one still waiting to persist",
       );
+      reclaimSupersededFrame(ticket.attachmentId);
       return { ok: false };
     }
     return job();
@@ -174,23 +190,62 @@ async function enqueueStandaloneImagePersist(
   }
 }
 
+/**
+ * Give up the upload behind a keep no message will ever carry.
+ *
+ * The client uploaded it and then the daemon chose to drop it, so nothing else
+ * will ever collect it: the client's own abandon-delete fires only when the
+ * send fails, and attachment collection is candidate-driven with no sweep.
+ * Link-aware through {@link deleteOrphanAttachments}, so an id that did reach a
+ * message is left alone, and only ever called for a job that never wrote.
+ *
+ * Best effort. Losing a row's bytes is not worth failing a call over.
+ */
+function reclaimSupersededFrame(attachmentId: string): void {
+  try {
+    deleteOrphanAttachments([attachmentId]);
+  } catch (err) {
+    log.warn(
+      { err, attachmentId },
+      "Could not reclaim a superseded live-voice camera frame",
+    );
+  }
+}
+
 /** Conversations with a standalone-image persist still in flight. */
 export function _standaloneImageQueueSizeForTests(): number {
   return standaloneImageQueues.size;
 }
 
-/** Resolve once the conversation is not mid-turn, or false on timeout. */
-async function waitForIdle(conversation: {
+/**
+ * Take the conversation's processing flag once it is free, or return false on
+ * timeout having taken nothing.
+ *
+ * The read and the take are one synchronous step on purpose. Run-to-completion
+ * means nothing can interleave between them, so a turn cannot claim the flag
+ * in the instant after this reads it free. Splitting them, with the read here
+ * and the take in the caller, leaves an await between the two and a keep every
+ * few seconds to land in it.
+ *
+ * Throws only if `setProcessing` does, which it does when the flag's persist
+ * fails. That reverts the in-memory flag before rethrowing, so a throw here
+ * means nothing was taken and nothing needs releasing.
+ */
+async function acquireProcessingFlag(conversation: {
   isProcessing: () => boolean;
+  setProcessing: (value: boolean) => void;
 }): Promise<boolean> {
   const deadline = Date.now() + PROCESSING_WAIT_MS;
-  while (conversation.isProcessing()) {
+  for (;;) {
+    if (!conversation.isProcessing()) {
+      conversation.setProcessing(true);
+      return true;
+    }
     if (Date.now() >= deadline) {
       return false;
     }
     await new Promise((resolve) => setTimeout(resolve, PROCESSING_POLL_MS));
   }
-  return true;
 }
 
 /**
@@ -213,7 +268,7 @@ function persistStandaloneImage(
   kind: "photo" | "sight_frame",
   persistOptions: Omit<PersistMessageOptions, "attachments" | "requestId">,
 ): Promise<LiveVoicePhotoResult> {
-  return enqueueStandaloneImagePersist(conversationId, kind, () =>
+  return enqueueStandaloneImagePersist(conversationId, attachmentId, kind, () =>
     writeStandaloneImage(conversationId, attachmentId, kind, persistOptions),
   );
 }
@@ -240,7 +295,7 @@ async function writeStandaloneImage(
     // A turn holds the lock for its whole run. Waiting rather than queueing:
     // the conversation's queue drains into a turn, which is the one thing this
     // must not cause.
-    if (!(await waitForIdle(conversation))) {
+    if (!(await acquireProcessingFlag(conversation))) {
       log.warn(
         { conversationId, attachmentId, kind },
         "Live-voice image timed out waiting for the conversation to go idle",
@@ -248,7 +303,6 @@ async function writeStandaloneImage(
       return { ok: false };
     }
 
-    conversation.setProcessing(true);
     try {
       const persisted = await persistQueuedMessageBody(conversation, {
         ...persistOptions,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -110,7 +110,10 @@ import {
   type VoiceEndpointAction,
   type VoiceEndpointSource,
 } from "./live-voice-metrics.js";
-import { persistLiveVoicePhoto } from "./live-voice-photo.js";
+import {
+  persistLiveVoicePhoto,
+  persistLiveVoiceSightFrame,
+} from "./live-voice-photo.js";
 import {
   type LiveVoiceSession as LiveVoiceSessionContract,
   type LiveVoiceSessionCloseReason,
@@ -137,6 +140,7 @@ import {
   type LiveVoiceClientAttachFrameFrame,
   type LiveVoiceClientAttachImageFrame,
   type LiveVoiceClientFrame,
+  type LiveVoiceClientSightFrameFrame,
   type LiveVoiceClientTextTurnFrame,
   type LiveVoiceClientUpdateConfigFrame,
   LiveVoiceProtocolErrorCode,
@@ -1547,6 +1551,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       case "attach_frame":
         this.parkTurnFrame(frame);
         return;
+      case "sight_frame":
+        this.persistSightFrame(frame);
+        return;
       case "text":
         await this.handleTextTurn(frame);
         return;
@@ -1637,6 +1644,45 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         }
       },
     );
+  }
+
+  /**
+   * Persist a kept camera frame into the conversation, running no turn.
+   *
+   * Fire-and-forget for the same reason the photo is: the persist waits out any
+   * in-flight turn, and the socket must keep pumping audio meanwhile. Waiting
+   * is also what keeps a frame that lands mid-reply from splitting that reply's
+   * own rows.
+   *
+   * The frame becomes its own tagged user message rather than riding a turn, so
+   * the transcript is the record of what the assistant saw and the model
+   * correlates a frame with speech by adjacency. See `live-voice-photo.ts`.
+   *
+   * An id the attachment store cannot resolve is refused there, before the
+   * persist waits on anything, so a bad frame is answered while the client can
+   * still act on it rather than a turn's length later. That resolve is the only
+   * existence check: a second one here would read the same row to learn the
+   * same fact.
+   */
+  private persistSightFrame(frame: LiveVoiceClientSightFrameFrame): void {
+    void persistLiveVoiceSightFrame(
+      this.conversationId,
+      frame.attachmentId,
+    ).then((result) => {
+      if (!result.ok && !this.isClosed) {
+        void this.sendFrame({
+          type: "error",
+          code: LiveVoiceProtocolErrorCode.InvalidFrame,
+          message: "Could not attach that camera frame to the conversation.",
+          // Names the frame as the casualty so the client can retract the
+          // preview it already showed, rather than filing this with the
+          // transient transcriber and TTS blips that share `recoverable`.
+          frameType: "sight_frame",
+          // The session is fine; only this frame failed.
+          recoverable: true,
+        });
+      }
+    });
   }
 
   /**

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -9,6 +9,7 @@ const LIVE_VOICE_CLIENT_FRAME_TYPES = [
   "update_config",
   "attach_image",
   "attach_frame",
+  "sight_frame",
   "text",
 ] as const;
 
@@ -248,6 +249,37 @@ export interface LiveVoiceClientAttachFrameFrame {
 }
 
 /**
+ * An ambient camera frame the client's gate kept, already uploaded over the
+ * normal attachment route and sent here as an id alone for the same reason
+ * {@link LiveVoiceClientAttachImageFrame} sends one.
+ *
+ * Three client frames carry an image and they mean three different things:
+ *
+ * - `attach_image` is a photo the user deliberately snapped. It persists
+ *   standalone the moment it arrives and drives the client's receipt strip.
+ * - `attach_frame` parks one frame on the session for the next spoken turn's
+ *   own user message to carry, and persists nothing by itself.
+ * - `sight_frame` persists an ambient keep immediately as its own user
+ *   message, tagged as a camera frame, and runs no turn.
+ *
+ * A keep is tagged so retention can age it out of the model's context (newest
+ * few stay images, older ones become timestamped stubs) while the transcript
+ * keeps every one of them. The transcript is therefore the record of what the
+ * assistant saw, and the model correlates a frame with speech by adjacency
+ * rather than by any attachment to a turn.
+ *
+ * A frame the attachment store does not know is refused with `frameType:
+ * "sight_frame"` and `recoverable: true`: the session is fine and only this
+ * frame failed. Attributing it is what lets the client retract the preview it
+ * already showed instead of filing the error with the transient transcriber
+ * and TTS blips that share `recoverable`.
+ */
+export interface LiveVoiceClientSightFrameFrame {
+  readonly type: "sight_frame";
+  readonly attachmentId: string;
+}
+
+/**
  * A user turn the client already has as text, taken without the microphone.
  *
  * The session runs it through the same pipeline a spoken turn takes, joining
@@ -295,6 +327,7 @@ export type LiveVoiceClientFrame =
   | LiveVoiceClientUpdateConfigFrame
   | LiveVoiceClientAttachImageFrame
   | LiveVoiceClientAttachFrameFrame
+  | LiveVoiceClientSightFrameFrame
   | LiveVoiceClientTextTurnFrame;
 
 interface LiveVoiceBinaryAudioFrame {
@@ -556,10 +589,11 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
    *
    * It exists so an `unknown_type` is attributable. A client that sends more
    * than one optional frame (today: `update_config`, `attach_image`,
-   * `attach_frame`, and `text`) gets the same code for any of them, and
-   * without this has to assume which one was refused. The wrong assumption is
-   * silent in both directions: settings stop applying for a session, or a
-   * photo the user watched themselves take is dropped with nothing said.
+   * `attach_frame`, `sight_frame`, and `text`) gets the same code for any of
+   * them, and without this has to assume which one was refused. The wrong
+   * assumption is silent in both directions: settings stop applying for a
+   * session, or a photo the user watched themselves take is dropped with
+   * nothing said.
    */
   readonly frameType?: string;
   /**
@@ -698,6 +732,8 @@ export function validateLiveVoiceClientFrame(
       return validateAttachImageFrame(value);
     case "attach_frame":
       return validateAttachFrameFrame(value);
+    case "sight_frame":
+      return validateSightFrameFrame(value);
     case "text":
       return validateTextTurnFrame(value);
   }
@@ -818,6 +854,35 @@ function validateAttachFrameFrame(
   return {
     ok: true,
     frame: { type: "attach_frame", attachmentId: value.attachmentId },
+  };
+}
+
+function validateSightFrameFrame(
+  value: Record<string, unknown>,
+): LiveVoiceParseResult<LiveVoiceClientSightFrameFrame> {
+  if (!("attachmentId" in value)) {
+    return protocolError(
+      "missing_required_field",
+      "sight_frame frame is missing required field attachmentId",
+      "attachmentId",
+      "sight_frame",
+    );
+  }
+
+  // No null form, unlike `attach_frame`. Nothing is staged for a keep to give
+  // up: it persisted on arrival, so a closing viewfinder has nothing to clear.
+  if (!isNonEmptyString(value.attachmentId)) {
+    return protocolError(
+      "invalid_field",
+      "sight_frame frame field attachmentId must be a non-empty string",
+      "attachmentId",
+      "sight_frame",
+    );
+  }
+
+  return {
+    ok: true,
+    frame: { type: "sight_frame", attachmentId: value.attachmentId },
   };
 }
 

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -273,36 +273,52 @@ function materializeAttachmentIntoConversation(
   const resolvedName = resolveUniqueFilename(attachDir, row.originalFilename);
   const targetPath = join(attachDir, resolvedName);
 
-  let sourcePath = row.sourcePath;
-  if (row.dataBase64) {
-    writeFileSync(targetPath, Buffer.from(row.dataBase64, "base64"));
-  } else {
-    const readablePath = [row.filePath, row.sourcePath].find(
-      (path): path is string => !!path && existsSync(path),
-    );
-    if (!readablePath) {
-      return;
-    }
-
-    if (!sourcePath && readablePath !== row.filePath) {
-      sourcePath = readablePath;
-    } else if (
-      !sourcePath &&
-      readablePath === row.filePath &&
-      dirname(readablePath) !== attachDir
-    ) {
-      sourcePath = readablePath;
-    }
-
-    copyFileSync(readablePath, targetPath);
-  }
-
   // Remember the old file path before updating the DB row, so we can
   // clean up the staging copy (e.g. in data/attachments/) after the
   // canonical path moves to the conversation directory.
   const previousFilePath = row.filePath;
 
-  persistAttachmentFilePath(row.id, targetPath, sourcePath);
+  let sourcePath = row.sourcePath;
+  try {
+    if (row.dataBase64) {
+      writeFileSync(targetPath, Buffer.from(row.dataBase64, "base64"));
+    } else {
+      const readablePath = [row.filePath, row.sourcePath].find(
+        (path): path is string => !!path && existsSync(path),
+      );
+      if (!readablePath) {
+        return;
+      }
+
+      if (!sourcePath && readablePath !== row.filePath) {
+        sourcePath = readablePath;
+      } else if (
+        !sourcePath &&
+        readablePath === row.filePath &&
+        dirname(readablePath) !== attachDir
+      ) {
+        sourcePath = readablePath;
+      }
+
+      copyFileSync(readablePath, targetPath);
+    }
+
+    persistAttachmentFilePath(row.id, targetPath, sourcePath);
+  } catch (err) {
+    // Only the copy this call was making. `resolveUniqueFilename` picked a name
+    // nothing occupied, so whatever sits at `targetPath` now is this attempt's
+    // own work. The row's `filePath` is deliberately left alone: until the
+    // update above lands it can still name the file the bytes came FROM, and
+    // for a fresh clone that file belongs to another conversation.
+    if (existsSync(targetPath)) {
+      try {
+        unlinkSync(targetPath);
+      } catch {
+        /* leave the copy rather than fail the failure */
+      }
+    }
+    throw err;
+  }
 
   // Remove the old staging file now that the canonical copy lives in
   // the conversation directory.  Only delete files that live in the
@@ -344,16 +360,56 @@ function scopeAttachmentToConversation(
   }
 
   const linkedConversationIds = listLinkedConversationIds(attachmentId);
-  if (linkedConversationIds.some((id) => id !== conversationId)) {
+  const cloned = linkedConversationIds.some((id) => id !== conversationId);
+  if (cloned) {
     row = cloneAttachmentRow(row);
   }
 
-  materializeAttachmentIntoConversation(
-    row,
-    conversationId,
-    conversationCreatedAt,
-  );
+  try {
+    materializeAttachmentIntoConversation(
+      row,
+      conversationId,
+      conversationCreatedAt,
+    );
+  } catch (err) {
+    if (cloned) {
+      discardFailedCloneRow(row.id);
+    }
+    throw err;
+  }
   return row.id;
+}
+
+/**
+ * Drop the row a failed clone left behind, touching no file at all.
+ *
+ * A clone is inserted carrying the SOURCE row's `filePath`, and only a
+ * successful materialization repoints it at a copy of its own. At the moment
+ * materialization fails the row can therefore still name the original's file,
+ * and deleting that would take the source conversation's data with it. This is
+ * the hazard the staging-dir guard in
+ * {@link materializeAttachmentIntoConversation} exists for, applied to the
+ * other end of the same window.
+ *
+ * The file this attempt was creating is cleaned up by materialization itself,
+ * which is the only code that knows the path it chose.
+ *
+ * Best effort. Rethrowing the original failure matters more than the row, and
+ * the caller converts that failure into an inline fallback either way.
+ */
+function discardFailedCloneRow(clonedId: string): void {
+  try {
+    rawRun(
+      "attachments:discardFailedCloneRow",
+      `DELETE FROM attachments WHERE id = ?`,
+      clonedId,
+    );
+  } catch (err) {
+    getLogger("attachments-store").warn(
+      { err, attachmentId: clonedId },
+      "Could not discard the row left by a failed attachment clone",
+    );
+  }
 }
 
 /**
@@ -1358,6 +1414,16 @@ export function deleteOrphanAttachments(candidateIds: string[]): number {
 
   // Clean up on-disk files only after the DB rows have been removed
   for (const filePath of orphanFilePaths) {
+    // A path is not private to one row. A clone carries the source's
+    // `filePath` until materialization repoints it, and an attachment already
+    // sitting in the destination's directory is scoped without being copied at
+    // all, so a surviving row can still name this file. Unlinking it then
+    // destroys another conversation's data, which is what the staging-dir
+    // guard in `materializeAttachmentIntoConversation` avoids at the other end
+    // of the same window.
+    if (attachmentFilePathStillReferenced(filePath)) {
+      continue;
+    }
     try {
       unlinkSync(filePath);
     } catch {
@@ -1366,4 +1432,15 @@ export function deleteOrphanAttachments(candidateIds: string[]): number {
   }
 
   return deletedCount;
+}
+
+/** True while any surviving attachment row still names this file. */
+function attachmentFilePathStillReferenced(filePath: string): boolean {
+  return (
+    rawGet<{ id: string }>(
+      "attachments:filePathStillReferenced",
+      `SELECT id FROM attachments WHERE file_path = ? LIMIT 1`,
+      filePath,
+    ) !== null
+  );
 }

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -256,35 +256,41 @@ export function sightFrameAttachmentIdsFromMetadata(
 }
 
 /**
- * True when a stored `messages.metadata` column carries ambient camera frames.
+ * True when a stored `messages.metadata` column belongs to a standalone
+ * ambient camera keep: a row the call's own gate sampled, which no one spoke.
  *
  * The raw-column counterpart to {@link sightFrameAttachmentIdsFromMetadata},
  * for consumers holding the JSON string a row was written with rather than a
  * parsed bag: the memory rebuild's re-embed scan and the retrospective's
  * accounting both ask this question of rows they never otherwise decode. It
- * lives here, beside the key and the parser, so the two cannot drift into
- * disagreeing about what a frame is.
+ * lives here, beside the key and the parser, so the two cannot drift.
  *
- * The tag is the only durable marker for these rows: `skipIndexing` is a
- * per-write option with no column behind it, and `scripted` covers every
- * auto-sent row rather than these.
+ * BOTH halves are required, and the tag alone is not enough. A genuine spoken
+ * turn carries the same tag whenever a parked frame rode it (see
+ * `calls/voice-session-bridge.ts`), which in camera mode is every turn the
+ * user speaks, so keying on the tag would read real speech as machine
+ * output. `scripted` is what separates them: the standalone persist sets it
+ * (`live-voice/live-voice-photo.ts`), while a spoken turn leaves it absent
+ * and the persist stamps the `false` default durably. The pair is the
+ * signature of a keep; `scripted` on its own belongs to every auto-sent row,
+ * onboarding prompts included, which are none of this predicate's business.
  *
- * Absent or unparseable metadata is not a frame. Both callers use this to hold
- * frames BACK from work, so a row whose marking cannot be read is treated as
+ * Absent or unparseable metadata is not a keep. Both callers use this to hold
+ * keeps BACK from work, so a row whose marking cannot be read is treated as
  * ordinary content and still gets indexed or reviewed, which is the direction
  * that loses nothing.
  */
-export function messageMetadataCarriesSightFrames(
+export function messageMetadataIsAmbientSightKeep(
   metadata: string | null,
 ): boolean {
   if (!metadata) {
     return false;
   }
   try {
+    const parsed = JSON.parse(metadata) as Record<string, unknown>;
     return (
-      sightFrameAttachmentIdsFromMetadata(
-        JSON.parse(metadata) as Record<string, unknown>,
-      ).length > 0
+      parsed.scripted === true &&
+      sightFrameAttachmentIdsFromMetadata(parsed).length > 0
     );
   } catch {
     return false;

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -256,6 +256,42 @@ export function sightFrameAttachmentIdsFromMetadata(
 }
 
 /**
+ * True when a stored `messages.metadata` column carries ambient camera frames.
+ *
+ * The raw-column counterpart to {@link sightFrameAttachmentIdsFromMetadata},
+ * for consumers holding the JSON string a row was written with rather than a
+ * parsed bag: the memory rebuild's re-embed scan and the retrospective's
+ * accounting both ask this question of rows they never otherwise decode. It
+ * lives here, beside the key and the parser, so the two cannot drift into
+ * disagreeing about what a frame is.
+ *
+ * The tag is the only durable marker for these rows: `skipIndexing` is a
+ * per-write option with no column behind it, and `scripted` covers every
+ * auto-sent row rather than these.
+ *
+ * Absent or unparseable metadata is not a frame. Both callers use this to hold
+ * frames BACK from work, so a row whose marking cannot be read is treated as
+ * ordinary content and still gets indexed or reviewed, which is the direction
+ * that loses nothing.
+ */
+export function messageMetadataCarriesSightFrames(
+  metadata: string | null,
+): boolean {
+  if (!metadata) {
+    return false;
+  }
+  try {
+    return (
+      sightFrameAttachmentIdsFromMetadata(
+        JSON.parse(metadata) as Record<string, unknown>,
+      ).length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True when the row that opened the turn was sent from a desktop app, on that
  * row's own evidence.
  *

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
@@ -10,6 +10,7 @@ import { getDb } from "../../../../persistence/db-connection.js";
 import { initializeDb } from "../../../../persistence/db-init.js";
 import { messages } from "../../../../persistence/schema/index.js";
 import {
+  countRetrospectiveMessagesAfter,
   getRetrospectiveMessagesAfter,
   hasQualifyingUserMessageAfter,
   messagesHaveUserActivity,
@@ -28,12 +29,35 @@ const MIXED = JSON.stringify([
   { type: "text", text: "note" },
 ]);
 
+/** A kept camera frame's row: a user-role image the call sampled by itself. */
+const SIGHT_FRAME_CONTENT = JSON.stringify([
+  { type: "text", text: "(camera frame)" },
+  {
+    type: "image",
+    source: {
+      type: "workspace_ref",
+      media_type: "image/jpeg",
+      attachmentId: "att-frame",
+      sizeBytes: 1024,
+    },
+  },
+]);
+
+function sightFrameMetadata(attachmentId: string): string {
+  return JSON.stringify({
+    voiceSessionTurn: true,
+    scripted: true,
+    sightFrameAttachmentIds: [attachmentId],
+  });
+}
+
 let seq = 0;
 function insertRaw(opts: {
   role: string;
   content: string;
   createdAt: number;
   id?: string;
+  metadata?: string;
 }): string {
   const id = opts.id ?? `msg-${String(++seq).padStart(4, "0")}`;
   getDb()
@@ -44,7 +68,7 @@ function insertRaw(opts: {
       role: opts.role,
       content: opts.content,
       createdAt: opts.createdAt,
-      metadata: null,
+      metadata: opts.metadata ?? null,
     })
     .run();
   return id;
@@ -267,5 +291,69 @@ describe("getRetrospectiveMessagesAfter", () => {
     expect(slice.some((row) => row.finalized === 0)).toBe(false);
     expect(slice.at(-1)?.id).toBe(lastFinalized);
     expect(slice.map((row) => row.id)).not.toContain(streaming);
+  });
+});
+
+describe("ambient camera frames are not retrospective work", () => {
+  beforeEach(() => {
+    const db = getDb();
+    db.run(`DELETE FROM messages`);
+    db.run(`DELETE FROM conversations`);
+    createConversation({ id: CONV });
+  });
+
+  /** One kept frame, as the live-voice persist writes it. */
+  function insertSightFrame(createdAt: number, attachmentId: string): string {
+    return insertRaw({
+      role: "user",
+      content: SIGHT_FRAME_CONTENT,
+      createdAt,
+      metadata: sightFrameMetadata(attachmentId),
+    });
+  }
+
+  test("a camera-only tail does not qualify as user activity", () => {
+    // A phone lying face up on a desk persists one of these every few
+    // seconds. Nobody said anything, so there is nothing to review.
+    insertSightFrame(1_000, "att-a");
+    insertSightFrame(2_000, "att-b");
+    insertSightFrame(3_000, "att-c");
+
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(false);
+  });
+
+  test("one real message among the frames does qualify", () => {
+    insertSightFrame(1_000, "att-a");
+    insertRaw({ role: "user", content: TEXT, createdAt: 2_000 });
+    insertSightFrame(3_000, "att-b");
+
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(true);
+  });
+
+  test("frames are left out of the count that decides a run is due", () => {
+    insertSightFrame(1_000, "att-a");
+    insertSightFrame(2_000, "att-b");
+
+    expect(countRetrospectiveMessagesAfter(CONV, null)).toBe(0);
+
+    insertRaw({ role: "user", content: TEXT, createdAt: 3_000 });
+
+    expect(countRetrospectiveMessagesAfter(CONV, null)).toBe(1);
+  });
+
+  test("frames are left out of the slice a run would review", () => {
+    insertSightFrame(1_000, "att-a");
+    const real = insertRaw({
+      role: "user",
+      content: TEXT,
+      createdAt: 2_000,
+    });
+    insertSightFrame(3_000, "att-b");
+
+    const slice = getRetrospectiveMessagesAfter(CONV, null);
+
+    // The cutoff lands on the real message, so the frames are neither
+    // reviewed nor skipped over.
+    expect(slice.map((row) => row.id)).toEqual([real]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-accounting.test.ts
@@ -43,13 +43,39 @@ const SIGHT_FRAME_CONTENT = JSON.stringify([
   },
 ]);
 
+/**
+ * What `persistLiveVoiceSightFrame` writes: the gate sampled this, nobody
+ * spoke it, so `scripted` rides along with the tag.
+ */
 function sightFrameMetadata(attachmentId: string): string {
   return JSON.stringify({
     voiceSessionTurn: true,
+    provenanceTrustClass: "guardian",
     scripted: true,
     sightFrameAttachmentIds: [attachmentId],
   });
 }
+
+/**
+ * What the voice bridge writes when a parked frame rides real speech
+ * (`calls/voice-session-bridge.ts`, matching its persist test's shape). The
+ * bridge leaves `scripted` absent for a genuine turn and the persist stamps
+ * the `false` default durably, which is what tells the two apart.
+ */
+function riddenTurnMetadata(attachmentId: string): string {
+  return JSON.stringify({
+    voiceSessionTurn: true,
+    provenanceTrustClass: "guardian",
+    scripted: false,
+    sightFrameAttachmentIds: [attachmentId],
+  });
+}
+
+/** An auto-sent row with no camera involvement, e.g. an onboarding prompt. */
+const SCRIPTED_UNTAGGED_METADATA = JSON.stringify({
+  provenanceTrustClass: "guardian",
+  scripted: true,
+});
 
 let seq = 0;
 function insertRaw(opts: {
@@ -355,5 +381,56 @@ describe("ambient camera frames are not retrospective work", () => {
     // The cutoff lands on the real message, so the frames are neither
     // reviewed nor skipped over.
     expect(slice.map((row) => row.id)).toEqual([real]);
+  });
+
+  test("a spoken turn that carried a frame is real work", () => {
+    // Camera mode parks a frame continuously, so in a camera call EVERY
+    // spoken turn carries the tag. Excluding on the tag alone would mean a
+    // conversation held entirely in camera mode never earns a retrospective.
+    const spoken = insertRaw({
+      role: "user",
+      content: TEXT,
+      createdAt: 1_000,
+      metadata: riddenTurnMetadata("att-frame-1"),
+    });
+
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(true);
+    expect(countRetrospectiveMessagesAfter(CONV, null)).toBe(1);
+    expect(getRetrospectiveMessagesAfter(CONV, null).map((r) => r.id)).toEqual([
+      spoken,
+    ]);
+  });
+
+  test("an auto-sent row without the tag is untouched by this exclusion", () => {
+    // `scripted` covers onboarding sends and other machine-authored turns.
+    // They counted before the camera existed and must keep counting.
+    const onboarding = insertRaw({
+      role: "user",
+      content: TEXT,
+      createdAt: 1_000,
+      metadata: SCRIPTED_UNTAGGED_METADATA,
+    });
+
+    expect(countRetrospectiveMessagesAfter(CONV, null)).toBe(1);
+    expect(getRetrospectiveMessagesAfter(CONV, null).map((r) => r.id)).toEqual([
+      onboarding,
+    ]);
+  });
+
+  test("keeps are excluded even among the speech they punctuate", () => {
+    insertSightFrame(1_000, "att-a");
+    const spoken = insertRaw({
+      role: "user",
+      content: TEXT,
+      createdAt: 2_000,
+      metadata: riddenTurnMetadata("att-frame-1"),
+    });
+    insertSightFrame(3_000, "att-b");
+
+    expect(countRetrospectiveMessagesAfter(CONV, null)).toBe(1);
+    expect(getRetrospectiveMessagesAfter(CONV, null).map((r) => r.id)).toEqual([
+      spoken,
+    ]);
+    expect(hasQualifyingUserMessageAfter(CONV, null)).toBe(true);
   });
 });

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
@@ -39,7 +39,7 @@ import {
   type MessageRow,
 } from "../../../persistence/conversation-crud.js";
 import {
-  messageMetadataCarriesSightFrames,
+  messageMetadataIsAmbientSightKeep,
   SIGHT_FRAME_ATTACHMENT_IDS_KEY,
 } from "../../../persistence/conversation-types.js";
 import { getDb } from "../../../persistence/db-connection.js";
@@ -59,7 +59,7 @@ function isExcludedFromRetrospectiveAccounting(row: {
   metadata: string | null;
 }): boolean {
   return (
-    isSkillCardMessage(row) || messageMetadataCarriesSightFrames(row.metadata)
+    isSkillCardMessage(row) || messageMetadataIsAmbientSightKeep(row.metadata)
   );
 }
 
@@ -221,7 +221,7 @@ export function hasQualifyingUserMessageAfter(
 
   return rows.some(
     (row) =>
-      !messageMetadataCarriesSightFrames(row.metadata) &&
+      !messageMetadataIsAmbientSightKeep(row.metadata) &&
       rawUserContentCarriesActivity(row.content),
   );
 }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
@@ -16,6 +16,14 @@
 // zero-new-messages early-out) and the job's new-message slice — without
 // touching the generic persistence helpers' semantics for other callers.
 //
+// Ambient camera frames are excluded on the same three paths and for the same
+// reason, one step further out: a live-voice call with the camera up persists
+// a frame every few seconds whether or not anyone speaks, so counting them
+// would let a phone lying face up on a desk keep declaring its conversation
+// worth reviewing, and reviewing them would hand the model a wall to remember.
+// The user-activity probe excludes them too, so a tail of nothing but frames
+// never satisfies the `requireUserActivity` gate.
+//
 // The cursor is never blindly advanced over a card: the job still takes its
 // cutoff from the last NON-card row of the filtered slice, so a real message
 // that lands between the cutoff snapshot and the card insert can never be
@@ -30,9 +38,50 @@ import {
   getMessagesAfter,
   type MessageRow,
 } from "../../../persistence/conversation-crud.js";
+import {
+  SIGHT_FRAME_ATTACHMENT_IDS_KEY,
+  sightFrameAttachmentIdsFromMetadata,
+} from "../../../persistence/conversation-types.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { messages } from "../../../persistence/schema/index.js";
 import { SKILL_CARD_MESSAGE_KIND } from "./memory-retrospective-constants.js";
+
+/**
+ * True when the row carries ambient camera frames the call sampled by itself.
+ *
+ * The sight tag is the only durable marker for them: `skipIndexing` is a
+ * per-write option with no column behind it, and `scripted` covers every
+ * auto-sent row rather than these.
+ */
+export function isSightFrameMessage(row: { metadata: string | null }): boolean {
+  if (!row.metadata) {
+    return false;
+  }
+  try {
+    return (
+      sightFrameAttachmentIdsFromMetadata(
+        JSON.parse(row.metadata) as Record<string, unknown>,
+      ).length > 0
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Rows the retrospective must not account for: a prior run's own skill card,
+ * and ambient camera frames.
+ *
+ * A frame is machine-sampled, one every few seconds for as long as the camera
+ * is up, so counting them would let an idle camera pointed at a wall keep
+ * declaring a conversation worth reviewing. They are also the wrong thing to
+ * review: nobody said anything.
+ */
+function isExcludedFromRetrospectiveAccounting(row: {
+  metadata: string | null;
+}): boolean {
+  return isSkillCardMessage(row) || isSightFrameMessage(row);
+}
 
 /** True when a message row's metadata carries the skill-card kind. */
 export function isSkillCardMessage(row: { metadata: string | null }): boolean {
@@ -75,7 +124,7 @@ export function getRetrospectiveMessagesAfter(
   const firstUnfinalized = rows.findIndex((row) => row.finalized !== 1);
   const bounded =
     firstUnfinalized === -1 ? rows : rows.slice(0, firstUnfinalized);
-  return bounded.filter((row) => !isSkillCardMessage(row));
+  return bounded.filter((row) => !isExcludedFromRetrospectiveAccounting(row));
 }
 
 /**
@@ -93,8 +142,8 @@ export function countRetrospectiveMessagesAfter(
   if (total === 0) {
     return 0;
   }
-  const cardCount = countSkillCardMessagesAfter(conversationId, afterMessageId);
-  return Math.max(0, total - cardCount);
+  const excluded = countExcludedMessagesAfter(conversationId, afterMessageId);
+  return Math.max(0, total - excluded);
 }
 
 /**
@@ -117,6 +166,12 @@ function blocksCarryNonToolResult(
  * user-role row whose resolved content carries a non-tool_result block. Tool
  * results ride on user-role rows, so a bare role check would count any
  * tool-using assistant stretch as user activity.
+ *
+ * Takes rows rather than reading any itself, and its one caller passes the
+ * slice {@link getRetrospectiveMessagesAfter} already filtered, so ambient
+ * camera frames never reach it. A future caller assembling its own rows has to
+ * filter them first: a frame is a user-role row carrying an image block, which
+ * is indistinguishable from real activity by role and content alone.
  */
 export function messagesHaveUserActivity(
   rows: ReadonlyArray<Pick<MessageRow, "role" | "content">>,
@@ -136,7 +191,9 @@ export function messagesHaveUserActivity(
  *
  * Operates on the raw `content` column: rows that do not parse to a block
  * array (file-backed `{ ref }` rows, legacy plain strings) count as
- * user-authored, so the gate fails toward running the retrospective.
+ * user-authored, so the gate fails toward running the retrospective. Ambient
+ * camera frames are the one user-role row that does NOT count: the camera
+ * sampled them, so they must not be what wakes a review.
  */
 export function hasQualifyingUserMessageAfter(
   conversationId: string,
@@ -171,7 +228,7 @@ export function hasQualifyingUserMessageAfter(
         ]
       : [];
   const rows = db
-    .select({ content: messages.content })
+    .select({ content: messages.content, metadata: messages.metadata })
     .from(messages)
     .where(
       and(
@@ -182,7 +239,10 @@ export function hasQualifyingUserMessageAfter(
     )
     .all();
 
-  return rows.some((row) => rawUserContentCarriesActivity(row.content));
+  return rows.some(
+    (row) =>
+      !isSightFrameMessage(row) && rawUserContentCarriesActivity(row.content),
+  );
 }
 
 /** Raw-column twin of the block check used by {@link messagesHaveUserActivity}. */
@@ -211,7 +271,7 @@ function rawUserContentCarriesActivity(raw: string | null): boolean {
  * tie-breaker semantics, including the null/`""` "count everything" cases
  * and the vanished-reference "no new work" case.
  */
-function countSkillCardMessagesAfter(
+function countExcludedMessagesAfter(
   conversationId: string,
   afterMessageId: string | null,
 ): number {
@@ -230,7 +290,10 @@ function countSkillCardMessagesAfter(
     .where(
       and(
         eq(messages.conversationId, conversationId),
-        like(messages.metadata, `%"kind":"${SKILL_CARD_MESSAGE_KIND}"%`),
+        or(
+          like(messages.metadata, `%"kind":"${SKILL_CARD_MESSAGE_KIND}"%`),
+          like(messages.metadata, `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`),
+        ),
       ),
     )
     .all();
@@ -254,7 +317,7 @@ function countSkillCardMessagesAfter(
 
   let count = 0;
   for (const row of candidates) {
-    if (!isSkillCardMessage(row)) {
+    if (!isExcludedFromRetrospectiveAccounting(row)) {
       continue;
     }
     if (cursorId !== null && ref) {

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-accounting.ts
@@ -39,34 +39,12 @@ import {
   type MessageRow,
 } from "../../../persistence/conversation-crud.js";
 import {
+  messageMetadataCarriesSightFrames,
   SIGHT_FRAME_ATTACHMENT_IDS_KEY,
-  sightFrameAttachmentIdsFromMetadata,
 } from "../../../persistence/conversation-types.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { messages } from "../../../persistence/schema/index.js";
 import { SKILL_CARD_MESSAGE_KIND } from "./memory-retrospective-constants.js";
-
-/**
- * True when the row carries ambient camera frames the call sampled by itself.
- *
- * The sight tag is the only durable marker for them: `skipIndexing` is a
- * per-write option with no column behind it, and `scripted` covers every
- * auto-sent row rather than these.
- */
-export function isSightFrameMessage(row: { metadata: string | null }): boolean {
-  if (!row.metadata) {
-    return false;
-  }
-  try {
-    return (
-      sightFrameAttachmentIdsFromMetadata(
-        JSON.parse(row.metadata) as Record<string, unknown>,
-      ).length > 0
-    );
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Rows the retrospective must not account for: a prior run's own skill card,
@@ -80,7 +58,9 @@ export function isSightFrameMessage(row: { metadata: string | null }): boolean {
 function isExcludedFromRetrospectiveAccounting(row: {
   metadata: string | null;
 }): boolean {
-  return isSkillCardMessage(row) || isSightFrameMessage(row);
+  return (
+    isSkillCardMessage(row) || messageMetadataCarriesSightFrames(row.metadata)
+  );
 }
 
 /** True when a message row's metadata carries the skill-card kind. */
@@ -241,7 +221,8 @@ export function hasQualifyingUserMessageAfter(
 
   return rows.some(
     (row) =>
-      !isSightFrameMessage(row) && rawUserContentCarriesActivity(row.content),
+      !messageMetadataCarriesSightFrames(row.metadata) &&
+      rawUserContentCarriesActivity(row.content),
   );
 }
 

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
@@ -4,7 +4,7 @@ import {
 } from "@vellumai/plugin-api";
 import { and, eq, isNotNull, like, ne } from "drizzle-orm";
 
-import { sightFrameAttachmentIdsFromMetadata } from "../../../../../persistence/conversation-types.js";
+import { messageMetadataCarriesSightFrames } from "../../../../../persistence/conversation-types.js";
 import { getDb } from "../../../../../persistence/db-connection.js";
 import { withQdrantBreaker } from "../../../../../persistence/embeddings/qdrant-circuit-breaker.js";
 import {
@@ -29,22 +29,6 @@ import { memoryDbOrNull } from "../../memory-db.js";
 import { extractMediaBlockMeta } from "../../message-media.js";
 
 const log = getLogger("memory-jobs-worker");
-
-/** True for a row carrying ambient camera frames sampled during a call. */
-function isSightFrameRow(metadata: string | null): boolean {
-  if (!metadata) {
-    return false;
-  }
-  try {
-    return (
-      sightFrameAttachmentIdsFromMetadata(
-        JSON.parse(metadata) as Record<string, unknown>,
-      ).length > 0
-    );
-  } catch {
-    return false;
-  }
-}
 
 export async function rebuildIndexJob(): Promise<void> {
   const db = getDb();
@@ -101,7 +85,7 @@ export async function rebuildIndexJob(): Promise<void> {
       // rebuild must not be the thing that quietly puts them into memory
       // after all. The row's own tag is the only durable record of that
       // choice, `skipIndexing` being a per-write option rather than a column.
-      if (isSightFrameRow(msg.metadata)) {
+      if (messageMetadataCarriesSightFrames(msg.metadata)) {
         continue;
       }
       const blocks = extractMediaBlockMeta(msg.content);

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
@@ -4,7 +4,7 @@ import {
 } from "@vellumai/plugin-api";
 import { and, eq, isNotNull, like, ne } from "drizzle-orm";
 
-import { messageMetadataCarriesSightFrames } from "../../../../../persistence/conversation-types.js";
+import { messageMetadataIsAmbientSightKeep } from "../../../../../persistence/conversation-types.js";
 import { getDb } from "../../../../../persistence/db-connection.js";
 import { withQdrantBreaker } from "../../../../../persistence/embeddings/qdrant-circuit-breaker.js";
 import {
@@ -81,11 +81,13 @@ export async function rebuildIndexJob(): Promise<void> {
       )
       .all();
     for (const msg of imageMessages) {
-      // Ambient camera frames were persisted with indexing skipped, and a
+      // Ambient camera keeps were persisted with indexing skipped, and a
       // rebuild must not be the thing that quietly puts them into memory
-      // after all. The row's own tag is the only durable record of that
-      // choice, `skipIndexing` being a per-write option rather than a column.
-      if (messageMetadataCarriesSightFrames(msg.metadata)) {
+      // after all. `skipIndexing` is a per-write option with no column behind
+      // it, so the row's own tag plus its `scripted` marker is the durable
+      // record of that choice. A spoken turn that merely CARRIED a frame is
+      // indexed by the live path and so is rebuilt like any other message.
+      if (messageMetadataIsAmbientSightKeep(msg.metadata)) {
         continue;
       }
       const blocks = extractMediaBlockMeta(msg.content);

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/index-maintenance.ts
@@ -4,6 +4,7 @@ import {
 } from "@vellumai/plugin-api";
 import { and, eq, isNotNull, like, ne } from "drizzle-orm";
 
+import { sightFrameAttachmentIdsFromMetadata } from "../../../../../persistence/conversation-types.js";
 import { getDb } from "../../../../../persistence/db-connection.js";
 import { withQdrantBreaker } from "../../../../../persistence/embeddings/qdrant-circuit-breaker.js";
 import {
@@ -28,6 +29,22 @@ import { memoryDbOrNull } from "../../memory-db.js";
 import { extractMediaBlockMeta } from "../../message-media.js";
 
 const log = getLogger("memory-jobs-worker");
+
+/** True for a row carrying ambient camera frames sampled during a call. */
+function isSightFrameRow(metadata: string | null): boolean {
+  if (!metadata) {
+    return false;
+  }
+  try {
+    return (
+      sightFrameAttachmentIdsFromMetadata(
+        JSON.parse(metadata) as Record<string, unknown>,
+      ).length > 0
+    );
+  } catch {
+    return false;
+  }
+}
 
 export async function rebuildIndexJob(): Promise<void> {
   const db = getDb();
@@ -66,7 +83,11 @@ export async function rebuildIndexJob(): Promise<void> {
     }
 
     const imageMessages = db
-      .select({ id: messages.id, content: messages.content })
+      .select({
+        id: messages.id,
+        content: messages.content,
+        metadata: messages.metadata,
+      })
       .from(messages)
       .where(
         and(
@@ -76,6 +97,13 @@ export async function rebuildIndexJob(): Promise<void> {
       )
       .all();
     for (const msg of imageMessages) {
+      // Ambient camera frames were persisted with indexing skipped, and a
+      // rebuild must not be the thing that quietly puts them into memory
+      // after all. The row's own tag is the only durable record of that
+      // choice, `skipIndexing` being a per-write option rather than a column.
+      if (isSightFrameRow(msg.metadata)) {
+        continue;
+      }
       const blocks = extractMediaBlockMeta(msg.content);
       for (const block of blocks) {
         enqueueMemoryJob("embed_attachment", {


### PR DESCRIPTION
## Summary
- New live-voice client frame `sight_frame { attachmentId }`: an ambient camera frame the client's gate kept persists immediately as its own sight-tagged standalone user message, running no turn, so the transcript is the record of what the assistant saw and the model correlates frames with speech by adjacency. The shutter photo's standalone-persist path is generalized rather than forked; `attach_image` and `attach_frame` behavior is byte-identical.
- The retention budget becomes workspace config: `sight.keepLatestFrames` (integer, default 2, clamped 1..6 at read) now governs how many of the newest camera frames every send keeps as real images before older ones become timestamped stubs; all four trim paths (pre-run, compaction install, direct compaction, wake) follow it uniformly.
- Rejections are attributable and recoverable (`frameType: "sight_frame"`), answered before the persist waits on any in-flight turn.

Part of plan: sight-keep-stream.md (PR 1 of 3). Nothing sends this frame yet; PR 2 (web) is the only future sender and sits behind the off-by-default vision-mode flag plus a version gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)