### PR TITLE
perf(ingress): serve the boot graph's modulepreload hints on the phone path

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -72,6 +72,7 @@ import {
   hasIpv6Loopback,
   buildRemoteWebIndexHtml,
   cloudWebHubUrl,
+  MAX_PRESERVED_MODULE_PRELOADS,
   ensureTunnelEdge,
   EDGE_TEMPLATE_VERSION,
   startRemoteWebIngress,
@@ -462,22 +463,61 @@ describe("buildRemoteWebIndexHtml", () => {
     expect(result).toContain("\\u003c/script\\u003e");
   });
 
-  test("drops modulepreload hints but keeps the entry script and stylesheet", () => {
+  test("keeps the consolidated boot graph's modulepreload hints", () => {
     const html = [
       "<html><head>",
       '<link rel="modulepreload" crossorigin href="/assistant/assets/a-1.js">',
       '<link rel="modulepreload" crossorigin href="/assistant/assets/b-2.js">',
-      '<link rel="stylesheet" crossorigin href="/assistant/assets/main-3.css">',
-      '<script type="module" crossorigin src="/assistant/assets/index-4.js"></script>',
+      '<link rel="modulepreload" crossorigin href="/assistant/assets/c-3.js">',
+      '<link rel="modulepreload" crossorigin href="/assistant/assets/d-4.js">',
+      '<link rel="stylesheet" crossorigin href="/assistant/assets/main-5.css">',
+      '<script type="module" crossorigin src="/assistant/assets/index-6.js"></script>',
+      "</head><body></body></html>",
+    ].join("\n");
+
+    const result = buildRemoteWebIndexHtml(html, { mode: "remote-gateway" });
+
+    expect(result.match(/rel="modulepreload"/g)).toHaveLength(4);
+    expect(result).toContain('href="/assistant/assets/a-1.js"');
+    expect(result).toContain('href="/assistant/assets/main-5.css"');
+    expect(result).toContain('src="/assistant/assets/index-6.js"');
+  });
+
+  test("strips a whole-graph preload set past the threshold, keeping entry and stylesheet", () => {
+    const preloads = Array.from(
+      { length: MAX_PRESERVED_MODULE_PRELOADS + 1 },
+      (_, i) =>
+        `<link rel="modulepreload" crossorigin href="/assistant/assets/chunk-${i}.js">`,
+    );
+    const html = [
+      "<html><head>",
+      ...preloads,
+      '<link rel="stylesheet" crossorigin href="/assistant/assets/main-x.css">',
+      '<script type="module" crossorigin src="/assistant/assets/index-y.js"></script>',
       "</head><body></body></html>",
     ].join("\n");
 
     const result = buildRemoteWebIndexHtml(html, { mode: "remote-gateway" });
 
     expect(result).not.toContain("modulepreload");
-    expect(result).not.toContain("/assistant/assets/a-1.js");
-    expect(result).toContain('href="/assistant/assets/main-3.css"');
-    expect(result).toContain('src="/assistant/assets/index-4.js"');
+    expect(result).not.toContain("/assistant/assets/chunk-0.js");
+    expect(result).toContain('href="/assistant/assets/main-x.css"');
+    expect(result).toContain('src="/assistant/assets/index-y.js"');
+  });
+
+  test("keeps exactly the threshold count of hints", () => {
+    const preloads = Array.from(
+      { length: MAX_PRESERVED_MODULE_PRELOADS },
+      (_, i) =>
+        `<link rel="modulepreload" crossorigin href="/assistant/assets/chunk-${i}.js">`,
+    );
+    const html = `<html><head>${preloads.join("\n")}</head><body></body></html>`;
+
+    const result = buildRemoteWebIndexHtml(html, { mode: "remote-gateway" });
+
+    expect(result.match(/rel="modulepreload"/g)).toHaveLength(
+      MAX_PRESERVED_MODULE_PRELOADS,
+    );
   });
 });
 

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -224,7 +224,18 @@ export const MAX_PRESERVED_MODULE_PRELOADS = 12;
 
 const MODULE_PRELOAD_RE = /<link[^>]+rel="modulepreload"[^>]*>\s*/g;
 
-/** Hints only either way; the entry module still pulls what it needs. */
+/**
+ * A failed module fetch is cached in the document's module map (HTML's
+ * "fetch a single module script" stores the failure, and a later import
+ * returns it without refetching), so a dropped request for a BOOT chunk
+ * blanks the app whether or not the chunk was hinted: the entry's static
+ * imports fetch the same URLs through the same map moments later, with the
+ * same no-retry semantics. Hints for the boot set therefore add no failure
+ * surface; they only start the same fetches earlier. What the strip guards
+ * against is the whole-graph shape, where hundreds of NON-boot fetches
+ * amplify the odds of any failure and a dropped lazy chunk poisons a later
+ * dynamic import.
+ */
 function stripExcessModulePreloads(html: string): string {
   const count = html.match(MODULE_PRELOAD_RE)?.length ?? 0;
   if (count <= MAX_PRESERVED_MODULE_PRELOADS) {

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -180,7 +180,7 @@ function remoteWebIngressConfig(
  * fingerprint matches, so this must change whenever the generated index or
  * nginx template does.
  */
-export const EDGE_TEMPLATE_VERSION = 6;
+export const EDGE_TEMPLATE_VERSION = 7;
 
 /**
  * Stable fingerprint of the SPA config injected into the served index and
@@ -201,19 +201,43 @@ function safeScriptJson(value: unknown): string {
 }
 
 /**
- * Preloading the whole chunk graph opens ~290 tunnel connections on a cold
- * load, and one dropped request blanks the app before React can report it.
- * These are hints only; the entry module still pulls what it needs.
+ * How many modulepreload hints the served index may carry before they are
+ * stripped wholesale.
+ *
+ * The consolidated boot graph emits 4 hints (the entry chunk's static
+ * imports). Serving them lets a phone fetch the whole boot set in parallel;
+ * without them the browser cannot discover the other chunks until the entry
+ * has downloaded AND parsed, so ~515 kB gzip serializes behind ~623 kB plus
+ * a phone-CPU parse of ~2.2 MB of JavaScript.
+ *
+ * The strip exists for the pathological shape: a whole-chunk-graph index
+ * (~290 hints) floods the tunnel with requests, and one dropped *import*
+ * blanks the app before React can report it. A build that regresses toward
+ * that shape trips this threshold and gets the protective strip.
+ * All-or-nothing, because preserving an arbitrary prefix of a broken graph
+ * would be luck, not policy. 12 sits comfortably above the consolidated
+ * graph and within two rounds of the browser's six-per-origin HTTP/1.1
+ * connection pool, so kept hints never widen concurrency much beyond what
+ * the entry's own imports would open.
  */
-function stripModulePreloads(html: string): string {
-  return html.replace(/<link[^>]+rel="modulepreload"[^>]*>\s*/g, "");
+export const MAX_PRESERVED_MODULE_PRELOADS = 12;
+
+const MODULE_PRELOAD_RE = /<link[^>]+rel="modulepreload"[^>]*>\s*/g;
+
+/** Hints only either way; the entry module still pulls what it needs. */
+function stripExcessModulePreloads(html: string): string {
+  const count = html.match(MODULE_PRELOAD_RE)?.length ?? 0;
+  if (count <= MAX_PRESERVED_MODULE_PRELOADS) {
+    return html;
+  }
+  return html.replace(MODULE_PRELOAD_RE, "");
 }
 
 export function buildRemoteWebIndexHtml(
   rawHtml: string,
   config: Record<string, unknown>,
 ): string {
-  const html = stripModulePreloads(rawHtml);
+  const html = stripExcessModulePreloads(rawHtml);
   const script = `<script>window.__VELLUM_CONFIG__=${safeScriptJson(config)}</script>`;
   if (html.includes("</head>")) {
     return html.replace("</head>", `${script}</head>`);

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -225,15 +225,17 @@ export const MAX_PRESERVED_MODULE_PRELOADS = 12;
 const MODULE_PRELOAD_RE = /<link[^>]+rel="modulepreload"[^>]*>\s*/g;
 
 /**
- * A failed module fetch is cached in the document's module map (HTML's
- * "fetch a single module script" stores the failure, and a later import
- * returns it without refetching), so a dropped request for a BOOT chunk
- * blanks the app whether or not the chunk was hinted: the entry's static
- * imports fetch the same URLs through the same map moments later, with the
- * same no-retry semantics. Hints for the boot set therefore add no failure
- * surface; they only start the same fetches earlier. What the strip guards
- * against is the whole-graph shape, where hundreds of NON-boot fetches
- * amplify the odds of any failure and a dropped lazy chunk poisons a later
+ * Failure semantics are engine-dependent while whatwg/html#10327 rolls out:
+ * older engines cache a failed module fetch in the module map (a later
+ * import returns the failure without refetching), newer ones evict it so a
+ * later import refetches. The invariant that matters holds in both models:
+ * the preserved hints name exactly the URLs the entry's static imports
+ * fetch anyway, through the same module map, so a dropped request for a
+ * BOOT chunk has the same outcome whether or not the chunk was hinted.
+ * Hints for the boot set add no failure surface; they only start the same
+ * fetches earlier. What the strip guards against is the whole-graph shape,
+ * where hundreds of speculative NON-boot fetches amplify the odds of any
+ * failure and (on old-model engines) a dropped lazy chunk poisons a later
  * dynamic import.
  */
 function stripExcessModulePreloads(html: string): string {


### PR DESCRIPTION
## TL;DR

The tunnel ingress strips every `modulepreload` hint from the index it serves, so a phone boots in two waves: download the entry chunk (623 kB gzip), parse its ~2.2 MB of JavaScript on phone-class CPU, and only then discover and download the other four boot chunks (515 kB gzip). This gates the strip at a threshold instead of applying it unconditionally, so the consolidated boot graph's 4 hints are served and the whole boot set downloads in parallel from the HTML.

## Why the strip existed, and why it is stale

The strip shipped when the built index carried ~290 preload hints (the whole chunk graph); that request flood over the tunnel amplified the odds of a dropped request, and a dropped module fetch is cached in the module map, blanking the app or poisoning a later route load. The boot-graph consolidation later cut the index to 4 hints, but the strip still removed them, leaving the phone path serialized.

| | Hints in built index | Hints served remotely |
| --- | --- | --- |
| When the strip shipped | ~290 | 0 (correct) |
| Today, before this PR | 4 | 0 (stale) |
| After this PR | 4 | 4 |

## What changes for the user

Nothing visually; the phone's cold boot gets faster. The four non-entry boot chunks start downloading with the entry chunk instead of after it has fully downloaded and parsed. The win is the wave boundary: tunnel round trips plus the phone-CPU parse of ~2.2 MB that currently sits between wave 1 and wave 2. Local and cloud web are untouched (their index already serves hints).

## Why it is safe

- Failure semantics are engine-dependent while [whatwg/html#10327](https://github.com/whatwg/html/pull/10327) (merged 2026-07-15) rolls out: older engines cache a failed module fetch in the module map without retry, newer ones evict it so a later import refetches. The invariant holds in both models: the preserved hints name exactly the URLs the entry's static imports fetch anyway, through the same map, so a dropped boot-chunk request has the same outcome hinted or not. Hinting only starts the same fetches earlier. No failure mode exists with 4 hints that does not exist with 0.
- 4 concurrent requests sit inside the browser's six-per-origin HTTP/1.1 connection pool.
- The protection is kept, not removed: past `MAX_PRESERVED_MODULE_PRELOADS` (12) the strip applies wholesale, so a build regressing toward the whole-graph shape (where non-boot fetches amplify failure odds and can poison later dynamic imports) gets the old behavior. All-or-nothing on purpose: preserving an arbitrary prefix of a broken graph would be luck, not policy.
- `EDGE_TEMPLATE_VERSION` bumps 6 to 7, so detached edges are not reused on the old index fingerprint. Tests import the constant rather than pinning a literal.
- Verified against the real production dist: 4 hints in, 4 served, config injection and entry script intact; a synthetic 294-hint index strips to 0.

## Out of scope

Boot-weight reductions are separate byte-level work; #41768 (lazy KaTeX) is the first. This PR only removes the discovery serialization.
