### PR TITLE
perf(design-library): load KaTeX on demand instead of on the boot path

### DIFF
--- a/packages/design-library/src/components/markdown-message.test.tsx
+++ b/packages/design-library/src/components/markdown-message.test.tsx
@@ -5,11 +5,17 @@
  * resulting HTML — no DOM testing library required.
  */
 
-import { describe, expect, test } from "bun:test";
+import { beforeAll, describe, expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { MarkdownMessage } from "./markdown-message";
+import { MarkdownMessage, preloadMarkdownMath } from "./markdown-message";
+
+// KaTeX loads lazily in production; these tests render with
+// renderToStaticMarkup (no effects), so warm the cache once up front.
+beforeAll(async () => {
+  await preloadMarkdownMath();
+});
 
 describe("MarkdownMessage", () => {
   test("root wrapper carries the chat typography token and data-slot", () => {

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -31,9 +31,11 @@ type RehypeKatexPlugin = typeof import("rehype-katex").default;
  * pays the load once, and so a synchronous render (renderToStaticMarkup,
  * and any tree already warmed by {@link preloadMarkdownMath}) can pick the
  * plugin up via `peek()` without an effect. A failed chunk load is not
- * cached (see {@link asyncOnce}): the next math-bearing mount or preload
- * call retries, which current engines honor with a real refetch
- * (whatwg/html#10327 evicts failed fetches from the module map).
+ * cached (see {@link asyncOnce}), so the next math-bearing mount or preload
+ * call invokes import() again. Whether that reaches the network is
+ * engine-dependent while whatwg/html#10327 rolls out: new-model engines
+ * evict failed fetches from the module map and refetch, old-model engines
+ * return the cached failure, where math stays raw TeX until reload.
  */
 const rehypeKatexOnce = asyncOnce<RehypeKatexPlugin>(async () => {
   const [mod] = await Promise.all([

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -18,6 +18,7 @@ import remarkParse from "remark-parse";
 import { unified } from "unified";
 import type { Components } from "react-markdown";
 
+import { asyncOnce } from "../utils/async-once";
 import { cn } from "../utils/cn";
 import { writeSelectionClipboard } from "../utils/selection-clipboard";
 
@@ -25,34 +26,31 @@ type RehypeKatexPlugin = typeof import("rehype-katex").default;
 
 /**
  * KaTeX (the rehype plugin, the katex renderer it pulls in, and the
- * stylesheet — ~445 kB raw) loads on demand instead of with this module:
- * markdown renders on the boot path, and most messages carry no math.
- * Module-level cache so the page pays the load once, and so a synchronous
- * render (renderToStaticMarkup, and any tree already warmed by
- * {@link preloadMarkdownMath}) can pick the plugin up without an effect.
+ * stylesheet, ~445 kB raw) loads on demand: markdown renders on the boot
+ * path, and most messages carry no math. Cached at module level so the page
+ * pays the load once, and so a synchronous render (renderToStaticMarkup,
+ * and any tree already warmed by {@link preloadMarkdownMath}) can pick the
+ * plugin up via `peek()` without an effect. A failed chunk load is not
+ * cached (see {@link asyncOnce}): the next math-bearing mount or preload
+ * call retries, which current engines honor with a real refetch
+ * (whatwg/html#10327 evicts failed fetches from the module map).
  */
-let cachedRehypeKatex: RehypeKatexPlugin | null = null;
-let rehypeKatexLoad: Promise<RehypeKatexPlugin> | null = null;
-
-function loadRehypeKatex(): Promise<RehypeKatexPlugin> {
-  rehypeKatexLoad ??= Promise.all([
+const rehypeKatexOnce = asyncOnce<RehypeKatexPlugin>(async () => {
+  const [mod] = await Promise.all([
     import("rehype-katex"),
     // Vite turns this into an on-demand stylesheet chunk alongside the JS.
     import("katex/dist/katex.min.css"),
-  ]).then(([mod]) => {
-    cachedRehypeKatex = mod.default;
-    return mod.default;
-  });
-  return rehypeKatexLoad;
-}
+  ]);
+  return mod.default;
+});
 
 /**
  * Warms the math pipeline. Await it before rendering when math output must be
- * present synchronously — server/static rendering, or a surface that knows
+ * present synchronously: server/static rendering, or a surface that knows
  * its content is math-heavy and wants to skip the raw-TeX flash.
  */
 export function preloadMarkdownMath(): Promise<void> {
-  return loadRehypeKatex().then(() => undefined);
+  return rehypeKatexOnce.load().then(() => undefined);
 }
 
 /**
@@ -60,19 +58,26 @@ export function preloadMarkdownMath(): Promise<void> {
  * TeX text until the chunk arrives, then formats on the re-render).
  */
 function useRehypeKatex(needed: boolean): RehypeKatexPlugin | null {
-  const [plugin, setPlugin] = useState<RehypeKatexPlugin | null>(
-    () => cachedRehypeKatex,
+  const [plugin, setPlugin] = useState<RehypeKatexPlugin | null>(() =>
+    rehypeKatexOnce.peek(),
   );
   useEffect(() => {
     if (!needed || plugin !== null) {
       return;
     }
     let cancelled = false;
-    void loadRehypeKatex().then((loaded) => {
-      if (!cancelled) {
-        setPlugin(() => loaded);
-      }
-    });
+    rehypeKatexOnce.load().then(
+      (loaded) => {
+        if (!cancelled) {
+          setPlugin(() => loaded);
+        }
+      },
+      () => {
+        // Math stays raw TeX on this mount. Deliberately no same-mount
+        // retry, which would loop while offline; the uncached failure means
+        // the next math-bearing mount attempts a fresh load.
+      },
+    );
     return () => {
       cancelled = true;
     };

--- a/packages/design-library/src/components/markdown-message.tsx
+++ b/packages/design-library/src/components/markdown-message.tsx
@@ -12,16 +12,73 @@ import {
   useState,
 } from "react";
 import ReactMarkdown from "react-markdown";
-import rehypeKatex from "rehype-katex";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 import type { Components } from "react-markdown";
-import "katex/dist/katex.min.css";
 
 import { cn } from "../utils/cn";
 import { writeSelectionClipboard } from "../utils/selection-clipboard";
+
+type RehypeKatexPlugin = typeof import("rehype-katex").default;
+
+/**
+ * KaTeX (the rehype plugin, the katex renderer it pulls in, and the
+ * stylesheet — ~445 kB raw) loads on demand instead of with this module:
+ * markdown renders on the boot path, and most messages carry no math.
+ * Module-level cache so the page pays the load once, and so a synchronous
+ * render (renderToStaticMarkup, and any tree already warmed by
+ * {@link preloadMarkdownMath}) can pick the plugin up without an effect.
+ */
+let cachedRehypeKatex: RehypeKatexPlugin | null = null;
+let rehypeKatexLoad: Promise<RehypeKatexPlugin> | null = null;
+
+function loadRehypeKatex(): Promise<RehypeKatexPlugin> {
+  rehypeKatexLoad ??= Promise.all([
+    import("rehype-katex"),
+    // Vite turns this into an on-demand stylesheet chunk alongside the JS.
+    import("katex/dist/katex.min.css"),
+  ]).then(([mod]) => {
+    cachedRehypeKatex = mod.default;
+    return mod.default;
+  });
+  return rehypeKatexLoad;
+}
+
+/**
+ * Warms the math pipeline. Await it before rendering when math output must be
+ * present synchronously — server/static rendering, or a surface that knows
+ * its content is math-heavy and wants to skip the raw-TeX flash.
+ */
+export function preloadMarkdownMath(): Promise<void> {
+  return loadRehypeKatex().then(() => undefined);
+}
+
+/**
+ * The KaTeX plugin once `needed` and loaded, else null (math renders as raw
+ * TeX text until the chunk arrives, then formats on the re-render).
+ */
+function useRehypeKatex(needed: boolean): RehypeKatexPlugin | null {
+  const [plugin, setPlugin] = useState<RehypeKatexPlugin | null>(
+    () => cachedRehypeKatex,
+  );
+  useEffect(() => {
+    if (!needed || plugin !== null) {
+      return;
+    }
+    let cancelled = false;
+    void loadRehypeKatex().then((loaded) => {
+      if (!cancelled) {
+        setPlugin(() => loaded);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [needed, plugin]);
+  return needed ? plugin : null;
+}
 
 const MAX_CODE_BLOCK_HEIGHT = 400;
 
@@ -1014,9 +1071,20 @@ export function MarkdownMessage({
       }) as Components,
     [Link, imageComponent, extraComponents],
   );
+  // Loosest possible trigger on purpose: every construct remark-math can
+  // treat as math contains a dollar sign after `convertLatexDelimiters`
+  // (which rewrites `\(..\)` / `\[..\]` to the `$` forms), so testing for
+  // the character can over-load KaTeX but can never leave real math
+  // unformatted. Anything cleverer (e.g. skipping escaped `\$`) risks the
+  // reverse, and the only cost of a false positive is a lazy chunk load.
+  const needsMath = processed.includes("$");
+  const katexPlugin = useRehypeKatex(needsMath);
   const rehypePlugins = useMemo(
-    () => [rehypeKatex, ...(extraRehypePlugins ?? [])],
-    [extraRehypePlugins],
+    () => [
+      ...(katexPlugin === null ? [] : [katexPlugin]),
+      ...(extraRehypePlugins ?? []),
+    ],
+    [katexPlugin, extraRehypePlugins],
   );
   return (
     <div

--- a/packages/design-library/src/env.d.ts
+++ b/packages/design-library/src/env.d.ts
@@ -8,3 +8,11 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+/**
+ * A side-effect stylesheet import type-checks without a declaration, but the
+ * dynamic `import()` in `markdown-message.tsx` (lazy KaTeX) needs a module
+ * type. Declared for the one stylesheet imported that way, not `*.css`, so a
+ * typo in any other specifier still fails resolution.
+ */
+declare module "katex/dist/katex.min.css";

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -196,6 +196,7 @@ export {
 export {
   MARKDOWN_INLINE_CODE_CLASS,
   MarkdownMessage,
+  preloadMarkdownMath,
   quoteBlockquoteAccentClassName,
   quoteBlockquoteClassName,
   quoteBlockquoteContentClassName,

--- a/packages/design-library/src/utils/async-once.test.ts
+++ b/packages/design-library/src/utils/async-once.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Pins the failure semantics the lazy KaTeX loader depends on: a rejection
+ * is not cached (the next load retries), a resolution is cached (no reload),
+ * and concurrent callers share one flight.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { asyncOnce } from "./async-once";
+
+function countingLoader(failures: number) {
+  let remaining = failures;
+  let calls = 0;
+  const once = asyncOnce(async () => {
+    calls += 1;
+    if (remaining > 0) {
+      remaining -= 1;
+      throw new Error("load failed");
+    }
+    return "loaded";
+  });
+  return { once, calls: () => calls };
+}
+
+describe("asyncOnce", () => {
+  test("a rejection clears the slot so the next load retries", async () => {
+    const { once, calls } = countingLoader(1);
+
+    expect(once.peek()).toBeNull();
+    await expect(once.load()).rejects.toThrow("load failed");
+    expect(once.peek()).toBeNull();
+
+    await expect(once.load()).resolves.toBe("loaded");
+    expect(once.peek()).toBe("loaded");
+    expect(calls()).toBe(2);
+  });
+
+  test("a resolution is cached: later loads reuse it without reloading", async () => {
+    const { once, calls } = countingLoader(0);
+
+    await once.load();
+    await once.load();
+
+    expect(calls()).toBe(1);
+    expect(once.peek()).toBe("loaded");
+  });
+
+  test("concurrent callers share one flight, on failure too", async () => {
+    const { once, calls } = countingLoader(1);
+
+    const results = await Promise.allSettled([once.load(), once.load()]);
+
+    expect(results.map((r) => r.status)).toEqual(["rejected", "rejected"]);
+    expect(calls()).toBe(1);
+
+    await expect(once.load()).resolves.toBe("loaded");
+    expect(calls()).toBe(2);
+  });
+});

--- a/packages/design-library/src/utils/async-once.ts
+++ b/packages/design-library/src/utils/async-once.ts
@@ -1,0 +1,39 @@
+/**
+ * Single-flight async initializer whose failures are not cached.
+ *
+ * Concurrent callers share one in-flight load, a resolved value is cached
+ * for the lifetime of the module, and a rejection clears the slot so the
+ * next call retries. Retrying is the caller's move (call `load()` again);
+ * nothing here schedules one, so a persistent failure cannot loop.
+ */
+export interface AsyncOnce<T> {
+  /**
+   * The resolved value, or null while unloaded, in flight, or after a
+   * failure. Lets synchronous readers (e.g. a useState initializer under
+   * renderToStaticMarkup, where effects never run) pick up a warm cache.
+   */
+  peek(): T | null;
+  /** Starts or joins the single-flight load. */
+  load(): Promise<T>;
+}
+
+export function asyncOnce<T>(load: () => Promise<T>): AsyncOnce<T> {
+  let value: T | null = null;
+  let inFlight: Promise<T> | null = null;
+  return {
+    peek: () => value,
+    load: () => {
+      inFlight ??= load().then(
+        (loaded) => {
+          value = loaded;
+          return loaded;
+        },
+        (error: unknown) => {
+          inFlight = null;
+          throw error;
+        },
+      );
+      return inFlight;
+    },
+  };
+}


### PR DESCRIPTION
## TL;DR

`MarkdownMessage` statically imported `rehype-katex` and the KaTeX stylesheet, so every boot shipped the katex renderer even though most messages carry no math. KaTeX now loads on demand, triggered the first time rendered content could contain math.

Same-day production A/B (identical `main`, only this change): boot goes **1,181 to 1,097 kB gzip (-84 kB, -7.1%)**, and ~445 kB of raw JavaScript parse moves off the boot path — the parse cost matters most on phone-class CPU, which is the slow case this work targets. KaTeX's 60 font files leave the boot asset set with it.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Every boot | Downloads and parses KaTeX (~85 kB gz / ~445 kB raw JS + CSS) | Neither; boot is 84 kB gz lighter |
| First message containing math | Formats immediately | Shows raw TeX for the chunk-load beat, then formats; later math is instant (module-level cache, one load per page) |
| Messages without math | No change | No change, and KaTeX never loads at all |

## Why the trigger cannot break math

The load trigger is the loosest possible test: any dollar sign in the processed content. Every construct `remark-math` can treat as math contains one after `convertLatexDelimiters` rewrites the backslash forms, so a false positive costs one lazy chunk load, while a false negative would leave real math unformatted forever. Only the first is acceptable, which is why the test is not cleverer (e.g. skipping escaped `\$` risks the reverse for edge cases like a literal backslash before math).

## Why it is safe

- Verified on the production build: no boot chunk references katex; `rehype-katex` (76.7 kB gz) and its stylesheet (7.8 kB gz) are emitted as on-demand chunks.
- All 54 `markdown-message` tests pass. They render with `renderToStaticMarkup` (no effects), which is exactly why the new `preloadMarkdownMath()` export exists: it warms the module-level cache so synchronous renders pick the plugin up without an effect. Also available to any surface that knows math is coming and wants to skip the raw-TeX flash.
- `remark-math` stays static and unconditional (it is tiny), so parse behavior for `$` sequences is unchanged; only the KaTeX formatting pass arrives late.
- The `env.d.ts` module declaration is scoped to the one stylesheet specifier, not `*.css`, so any other mistyped import still fails resolution.

## Sibling PR

#41767 (independent): serves the boot graph's modulepreload hints on the phone path. Different mechanism (discovery serialization vs bytes); either merges without the other.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->