### PR TITLE
fix(approvals): withdraw every projection of a resolved guardian request (LUM-3489)

### DIFF
--- a/assistant/docs/guardian-request-flow.md
+++ b/assistant/docs/guardian-request-flow.md
@@ -156,3 +156,10 @@ this exists to prevent. Telegram group chats carry the same exposure and are
 not covered: only Slack has a chat whose privacy can be read off its id. They remain load-bearing for that flow, and
 the reply router runs first for everything the pipeline owns. Converge new
 work on the pipeline; do not extend the legacy interception.
+
+Any flow that resolves a confirmation in-memory first (this rail, the in-app
+`/v1/confirm` route, the auto-deny sweeps) brings the gateway row to the
+matching terminal status through `approvals/guardian-request-status-sync.ts`,
+which also runs the same cross-surface card withdrawal the decision primitive
+runs whenever its CAS is the one that landed: no projection of a resolved
+request may stay actionable, whichever rail resolved it.

--- a/assistant/src/__tests__/guardian-action-service-scope.test.ts
+++ b/assistant/src/__tests__/guardian-action-service-scope.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Conversation scoping for in-app guardian decisions
+ * (`processGuardianDecision` step 2).
+ *
+ * A guardian request projects an actionable card into every conversation a
+ * delivery was paired with: the vellum card's pinned conversation AND each
+ * channel card's paired conversation (the decision engine injects the same
+ * seed blocks into every channel's copy). Taps from any of those
+ * conversations are legitimate; taps from unrelated conversations are not.
+ * The scope check must therefore accept any recorded delivery destination
+ * conversation regardless of the delivery's channel: narrowing to vellum
+ * rows silently no-opped every tap on a channel card's in-app projection
+ * (LUM-3489's "one request, two independent tasks" confusion).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  bridgeState,
+  gatewayGuardianRequestsStoreBridge,
+} from "./helpers/gateway-guardian-requests-store-bridge.js";
+
+mock.module(
+  "../channels/gateway-guardian-requests.js",
+  () => gatewayGuardianRequestsStoreBridge,
+);
+
+const applyGuardianDecision = mock(async () => ({
+  applied: true as const,
+  requestId: "req",
+  grantMinted: false,
+}));
+const actualPrimitive =
+  await import("../approvals/guardian-decision-primitive.js");
+mock.module("../approvals/guardian-decision-primitive.js", () => ({
+  ...actualPrimitive,
+  applyGuardianDecision,
+}));
+
+import { processGuardianDecision } from "../runtime/guardian-action-service.js";
+
+const PRINCIPAL_ID = "scope-test-principal";
+
+function seedRequestWithProjections() {
+  const req = bridgeState.seedRequest({
+    kind: "tool_approval",
+    sourceType: "channel",
+    sourceChannel: "slack",
+    sourceConversationId: "conv-thread",
+    toolName: "shell",
+    guardianPrincipalId: PRINCIPAL_ID,
+  });
+  bridgeState.seedDelivery({
+    requestId: req.id,
+    destinationChannel: "vellum",
+    destinationConversationId: "conv-thread",
+  });
+  bridgeState.seedDelivery({
+    requestId: req.id,
+    destinationChannel: "slack",
+    destinationChatId: "C1",
+    destinationMessageId: "1.0",
+    destinationConversationId: "conv-dm",
+  });
+  return req;
+}
+
+async function decideFrom(requestId: string, conversationId: string) {
+  return processGuardianDecision({
+    requestId,
+    action: "approve_once",
+    conversationId,
+    channel: "vellum",
+    actorContext: {
+      actorPrincipalId: PRINCIPAL_ID,
+      guardianPrincipalId: PRINCIPAL_ID,
+    },
+  });
+}
+
+describe("processGuardianDecision conversation scoping", () => {
+  beforeEach(() => {
+    bridgeState.reset();
+    applyGuardianDecision.mockClear();
+  });
+
+  test("accepts a tap from the request's source conversation", async () => {
+    const req = seedRequestWithProjections();
+    const result = await decideFrom(req.id, "conv-thread");
+    expect(result).toMatchObject({ ok: true, applied: true });
+    expect(applyGuardianDecision).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts a tap from a channel card's paired conversation", async () => {
+    const req = seedRequestWithProjections();
+    const result = await decideFrom(req.id, "conv-dm");
+    expect(result).toMatchObject({ ok: true, applied: true });
+    expect(applyGuardianDecision).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects a tap from a conversation holding no projection", async () => {
+    const req = seedRequestWithProjections();
+    const result = await decideFrom(req.id, "conv-unrelated");
+    expect(result).toMatchObject({
+      ok: true,
+      applied: false,
+      reason: "not_found",
+    });
+    expect(applyGuardianDecision).not.toHaveBeenCalled();
+  });
+
+  test("threads the acting conversation to the primitive for broadcast suppression", async () => {
+    const req = seedRequestWithProjections();
+    await decideFrom(req.id, "conv-dm");
+    expect(applyGuardianDecision).toHaveBeenCalledWith(
+      expect.objectContaining({ originConversationId: "conv-dm" }),
+    );
+  });
+});

--- a/assistant/src/__tests__/guardian-card-withdrawal.test.ts
+++ b/assistant/src/__tests__/guardian-card-withdrawal.test.ts
@@ -361,6 +361,98 @@ describe("withdrawGuardianRequestCards", () => {
     expect(completeSurfaceAndNotify).toHaveBeenCalledTimes(1);
   });
 
+  test("completes the in-app projection of a channel card's paired conversation", async () => {
+    // A channel delivery is paired with a conversation whose in-app rendering
+    // carries the same actionable card; the channel edit alone leaves that
+    // projection clickable after the decision (LUM-3489).
+    const req = makeRequest({ kind: "tool_approval", toolName: "shell" });
+    const slack = bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "slack",
+      destinationChatId: "C1",
+      destinationMessageId: "1.0",
+      destinationConversationId: "conv-dm",
+    });
+
+    await withdrawGuardianRequestCards({
+      request: req,
+      status: "approved",
+      originChannel: "slack",
+    });
+
+    expect(withdrawSlackApprovalCard).toHaveBeenCalledTimes(1);
+    expect(completeSurfaceAndNotify).toHaveBeenCalledWith(
+      "conv-dm",
+      `tool-approval-${req.id}`,
+      "Approved",
+    );
+    const byId = new Map(deliveriesFor(req.id).map((d) => [d.id, d.status]));
+    expect(byId.get(slack.id)).toBe("withdrawn");
+  });
+
+  test("suppresses only the acting conversation's broadcast for an in-app decision", async () => {
+    // Same request, two in-app projections: the vellum card and a channel
+    // card's paired conversation. The acting client's optimistic completion
+    // covers only the conversation it acted in; the sibling still needs its
+    // live ui_surface_complete.
+    const req = makeRequest({ kind: "tool_approval", toolName: "shell" });
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-acting",
+    });
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "slack",
+      destinationChatId: "C1",
+      destinationMessageId: "1.0",
+      destinationConversationId: "conv-sibling",
+    });
+
+    await withdrawGuardianRequestCards({
+      request: req,
+      status: "approved",
+      originChannel: "vellum",
+      originConversationId: "conv-acting",
+    });
+
+    expect(markSurfaceCompleted).toHaveBeenCalledWith(
+      { conversationId: "conv-acting" },
+      `tool-approval-${req.id}`,
+      "Approved",
+    );
+    expect(completeSurfaceAndNotify).toHaveBeenCalledWith(
+      "conv-sibling",
+      `tool-approval-${req.id}`,
+      "Approved",
+    );
+    expect(completeSurfaceAndNotify).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failed in-app persist on a channel-paired projection holds the receipt back", async () => {
+    const req = makeRequest({ kind: "tool_approval", toolName: "shell" });
+    const slack = bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "slack",
+      destinationChatId: "C1",
+      destinationMessageId: "1.0",
+      destinationConversationId: "conv-dm",
+    });
+    completeSurfaceAndNotify.mockReturnValueOnce(false);
+
+    const result = await withdrawGuardianRequestCards({
+      request: req,
+      status: "approved",
+      originChannel: "telegram",
+    });
+
+    // The Slack edit landed, but the paired conversation's block would revert
+    // to a clickable card on reload, so the surface stays unreceipted.
+    expect(result.complete).toBe(false);
+    const byId = new Map(deliveriesFor(req.id).map((d) => [d.id, d.status]));
+    expect(byId.get(slack.id)).not.toBe("withdrawn");
+  });
+
   test("tool-approval cards resolve to the tool-approval surface id", async () => {
     const req = makeRequest({ kind: "tool_approval", toolName: "shell" });
     bridgeState.seedDelivery({
@@ -703,6 +795,85 @@ describe("recordGuardianRequestDeliveries", () => {
     });
     const [delivery] = deliveriesFor(req.id);
     expect(delivery.destinationChatId).toBeNull();
+  });
+
+  test("re-runs withdrawal when the request resolved before its rows were recorded", async () => {
+    // Recording happens after the notification pipeline settles, so a
+    // guardian acting the moment the card lands can resolve the request
+    // before any delivery row exists; that decision's withdrawal pass finds
+    // nothing. The recorder reconciles by withdrawing what it just recorded.
+    const req = makeRequest({
+      kind: "tool_approval",
+      toolName: "shell",
+      status: "approved",
+    });
+
+    await recordGuardianRequestDeliveries({
+      requestId: req.id,
+      deliveryResults: [
+        {
+          channel: "slack",
+          destination: "C999",
+          status: "sent",
+          messageId: "1700000000.1234",
+          conversationId: "conv-dm",
+        },
+      ],
+    });
+
+    expect(withdrawSlackApprovalCard).toHaveBeenCalledTimes(1);
+    const [delivery] = deliveriesFor(req.id);
+    expect(delivery.status).toBe("withdrawn");
+  });
+
+  test("leaves rows of a still-pending request alone after recording", async () => {
+    const req = makeRequest({ kind: "tool_approval", toolName: "shell" });
+    await recordGuardianRequestDeliveries({
+      requestId: req.id,
+      deliveryResults: [
+        {
+          channel: "slack",
+          destination: "C999",
+          status: "sent",
+          messageId: "1700000000.1234",
+        },
+      ],
+    });
+
+    expect(withdrawSlackApprovalCard).not.toHaveBeenCalled();
+    const [delivery] = deliveriesFor(req.id);
+    expect(delivery.status).toBe("sent");
+  });
+
+  test("a late status patch cannot resurrect a withdrawn vellum row", async () => {
+    // The pre-created vellum row can be withdrawn by a fast decision while
+    // the broadcast is still settling; the recorder's sent patch must not
+    // overwrite that receipt (mirrors the gateway store's sticky rule).
+    const req = makeRequest({ status: "approved" });
+    const pre = await recordApprovalCardDelivery({
+      requestId: req.id,
+      channel: "vellum",
+      conversationId: "conv-1",
+    });
+    await bridgeState.module.updateGuardianRequestDelivery(pre!.id, {
+      status: "withdrawn",
+    });
+
+    await recordGuardianRequestDeliveries({
+      requestId: req.id,
+      deliveryResults: [
+        {
+          channel: "vellum",
+          destination: "",
+          status: "sent",
+          conversationId: "conv-1",
+        },
+      ],
+      vellumDeliveryId: pre?.id,
+    });
+
+    const [delivery] = deliveriesFor(req.id);
+    expect(delivery.status).toBe("withdrawn");
   });
 
   test("records a Slack delivery the withdrawal path can then edit in place", async () => {

--- a/assistant/src/__tests__/guardian-gateway-sim.ts
+++ b/assistant/src/__tests__/guardian-gateway-sim.ts
@@ -527,7 +527,6 @@ export function createGuardianGatewaySim() {
   async function isGuardianRequestInScope(
     requestId: string,
     conversationId: string,
-    channel?: string,
   ): Promise<boolean> {
     throwIfReadError();
     const request = requests.get(requestId);
@@ -540,8 +539,7 @@ export function createGuardianGatewaySim() {
     return deliveries.some(
       (d) =>
         d.requestId === requestId &&
-        d.destinationConversationId === conversationId &&
-        (!channel || d.destinationChannel === channel),
+        d.destinationConversationId === conversationId,
     );
   }
 

--- a/assistant/src/__tests__/guardian-gateway-sim.ts
+++ b/assistant/src/__tests__/guardian-gateway-sim.ts
@@ -423,7 +423,13 @@ export function createGuardianGatewaySim() {
     if (!row) {
       throw new Error(`sim: delivery ${id} not found`);
     }
-    Object.assign(row, patch, { updatedAt: Date.now() });
+    // Mirrors the gateway store: `withdrawn` is a terminal per-surface
+    // receipt a later status patch never overwrites.
+    const effectivePatch =
+      row.status === "withdrawn" && patch.status !== undefined
+        ? { ...patch, status: row.status }
+        : patch;
+    Object.assign(row, effectivePatch, { updatedAt: Date.now() });
   }
 
   async function listGuardianRequestDeliveries(

--- a/assistant/src/__tests__/guardian-request-status-sync.test.ts
+++ b/assistant/src/__tests__/guardian-request-status-sync.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const completeSurfaceAndNotify = mock(() => true);
+const markSurfaceCompleted = mock(() => true);
+mock.module("../daemon/conversation-surfaces.js", () => ({
+  completeSurfaceAndNotify,
+  markSurfaceCompleted,
+}));
+
+const withdrawSlackApprovalCard = mock(
+  async (_params: Record<string, unknown>) => {},
+);
+mock.module("../messaging/providers/slack/withdraw.js", () => ({
+  withdrawSlackApprovalCard,
+}));
+
+const withdrawDiscordApprovalCard = mock(async (_params: unknown) => undefined);
+mock.module("../messaging/providers/discord/withdraw.js", () => ({
+  withdrawDiscordApprovalCard,
+}));
+
+const withdrawTelegramApprovalCard = mock(
+  async (_params: Record<string, unknown>) => ({ complete: true }),
+);
+mock.module("../messaging/providers/telegram-bot/withdraw.js", () => ({
+  withdrawTelegramApprovalCard,
+}));
+
+import {
+  bridgeState,
+  gatewayGuardianRequestsStoreBridge,
+} from "./helpers/gateway-guardian-requests-store-bridge.js";
+
+mock.module(
+  "../channels/gateway-guardian-requests.js",
+  () => gatewayGuardianRequestsStoreBridge,
+);
+
+import { syncTerminalGuardianRequestStatus } from "../approvals/guardian-request-status-sync.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+const PRINCIPAL_ID = "status-sync-test-principal";
+
+function makeRequest(overrides: Record<string, unknown> = {}) {
+  return bridgeState.seedRequest({
+    kind: "tool_approval",
+    sourceType: "channel",
+    sourceChannel: "slack",
+    toolName: "shell",
+    guardianPrincipalId: PRINCIPAL_ID,
+    ...overrides,
+  });
+}
+
+function deliveriesFor(requestId: string) {
+  return bridgeState.deliveries.filter((d) => d.requestId === requestId);
+}
+
+describe("syncTerminalGuardianRequestStatus", () => {
+  beforeEach(() => {
+    bridgeState.reset();
+    completeSurfaceAndNotify.mockClear();
+    markSurfaceCompleted.mockClear();
+    withdrawSlackApprovalCard.mockClear();
+  });
+
+  test("a landed CAS withdraws every delivered projection", async () => {
+    const req = makeRequest();
+    const vellum = bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-thread",
+    });
+    const slack = bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "slack",
+      destinationChatId: "C1",
+      destinationMessageId: "1.0",
+      destinationConversationId: "conv-dm",
+    });
+
+    await syncTerminalGuardianRequestStatus({
+      requestId: req.id,
+      status: "approved",
+      syncContext: "test",
+    });
+
+    expect(bridgeState.requests.get(req.id)?.status).toBe("approved");
+    // Both in-app projections converge live (no origin channel: the acting
+    // surface was the confirmation prompt, never the card).
+    expect(completeSurfaceAndNotify).toHaveBeenCalledWith(
+      "conv-thread",
+      `tool-approval-${req.id}`,
+      "Approved",
+    );
+    expect(completeSurfaceAndNotify).toHaveBeenCalledWith(
+      "conv-dm",
+      `tool-approval-${req.id}`,
+      "Approved",
+    );
+    expect(withdrawSlackApprovalCard).toHaveBeenCalledTimes(1);
+    const byId = new Map(deliveriesFor(req.id).map((d) => [d.id, d.status]));
+    expect(byId.get(vellum.id)).toBe("withdrawn");
+    expect(byId.get(slack.id)).toBe("withdrawn");
+  });
+
+  test("a denial renders Denied on the withdrawn cards", async () => {
+    const req = makeRequest();
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-thread",
+    });
+
+    await syncTerminalGuardianRequestStatus({
+      requestId: req.id,
+      status: "denied",
+      syncContext: "test",
+    });
+
+    expect(bridgeState.requests.get(req.id)?.status).toBe("denied");
+    expect(completeSurfaceAndNotify).toHaveBeenCalledWith(
+      "conv-thread",
+      `tool-approval-${req.id}`,
+      "Denied",
+    );
+  });
+
+  test("a CAS miss leaves withdrawal to the path that resolved the request", async () => {
+    const req = makeRequest({ status: "approved" });
+    bridgeState.seedDelivery({
+      requestId: req.id,
+      destinationChannel: "vellum",
+      destinationConversationId: "conv-thread",
+    });
+
+    await syncTerminalGuardianRequestStatus({
+      requestId: req.id,
+      status: "approved",
+      syncContext: "test",
+    });
+
+    expect(completeSurfaceAndNotify).not.toHaveBeenCalled();
+    expect(withdrawSlackApprovalCard).not.toHaveBeenCalled();
+  });
+
+  test("never throws when the gateway is unreachable", async () => {
+    const req = makeRequest();
+    bridgeState.state.decideError = new Error("gateway down");
+    await expect(
+      syncTerminalGuardianRequestStatus({
+        requestId: req.id,
+        status: "approved",
+        syncContext: "test",
+      }),
+    ).resolves.toBeUndefined();
+    bridgeState.state.decideError = null;
+    expect(completeSurfaceAndNotify).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/approvals/guardian-card-withdrawal.ts
+++ b/assistant/src/approvals/guardian-card-withdrawal.ts
@@ -76,7 +76,8 @@ export interface WithdrawGuardianCardsParams {
    * the acting conversation's client holds the optimistic completion the
    * broadcast suppression exists to protect; every sibling projection still
    * needs its live `ui_surface_complete`. Absent, every in-app projection is
-   * treated as the acting one (the pre-existing conservative behavior).
+   * treated as the acting one: a vellum-origin decision then suppresses the
+   * broadcast on all of them and only persists their completions.
    */
   originConversationId?: string;
   /**

--- a/assistant/src/approvals/guardian-card-withdrawal.ts
+++ b/assistant/src/approvals/guardian-card-withdrawal.ts
@@ -70,6 +70,16 @@ export interface WithdrawGuardianCardsParams {
    */
   originChannel?: string;
   /**
+   * Conversation the in-app decision was made from, when `originChannel` is
+   * `vellum`. The same request projects a card into several conversations
+   * (the vellum card plus each channel card's paired conversation), and only
+   * the acting conversation's client holds the optimistic completion the
+   * broadcast suppression exists to protect; every sibling projection still
+   * needs its live `ui_surface_complete`. Absent, every in-app projection is
+   * treated as the acting one (the pre-existing conservative behavior).
+   */
+  originConversationId?: string;
+  /**
    * The action the guardian took, when the terminal status came from a decision
    * (omitted for the expiry sweep). A `denied` status can mean either a neutral
    * park (`leave_unverified`) or an active rejection (`block`/`reject`); the
@@ -107,6 +117,7 @@ export async function withdrawGuardianRequestCards(
     request,
     status,
     originChannel,
+    originConversationId,
     decidedAction,
     hasOriginGuardianReply,
   } = params;
@@ -129,17 +140,26 @@ export async function withdrawGuardianRequestCards(
     }
     let withdrawn = false;
     try {
+      // Every delivery can carry two projections of the same card: the
+      // channel-native message, and the in-app rendering of the conversation
+      // the delivery was paired with (`destinationConversationId`; the
+      // decision engine injects the same actionable seed blocks into every
+      // channel's copy). Withdrawal must settle both, or the in-app
+      // projection of a channel card keeps live Approve/Reject buttons after
+      // the decision (LUM-3489).
+      const inAppWithdrawn = completeInAppProjection(
+        request,
+        delivery,
+        status,
+        originChannel,
+        originConversationId,
+        decidedAction,
+      );
       if (delivery.destinationChannel === "vellum") {
-        withdrawn = withdrawVellumCard(
-          request,
-          delivery,
-          status,
-          originChannel,
-          decidedAction,
-        );
+        withdrawn = inAppWithdrawn;
       } else if (delivery.destinationChannel === "slack") {
         await withdrawSlackCard(request, delivery, status, decidedAction);
-        withdrawn = true;
+        withdrawn = inAppWithdrawn;
       } else if (delivery.destinationChannel === "telegram") {
         const telegram = await withdrawTelegramCard(
           delivery,
@@ -148,17 +168,17 @@ export async function withdrawGuardianRequestCards(
           decidedAction,
           hasOriginGuardianReply ?? false,
         );
-        withdrawn = telegram.complete;
+        withdrawn = telegram.complete && inAppWithdrawn;
       } else if (delivery.destinationChannel === "discord") {
         await withdrawDiscordCard(delivery, status, decidedAction);
-        withdrawn = true;
+        withdrawn = inAppWithdrawn;
       } else {
         // WhatsApp direct delivery can't edit a message in place (it would
         // post a new one), so its stale clicks are left to the existing
         // "already resolved" reply until in-place edit support lands.
-        // Nothing a retry could fix, so the row is marked rather than
-        // allowed to pin its request.
-        withdrawn = true;
+        // Nothing a channel retry could fix, so only the in-app projection
+        // gates the row rather than letting it pin its request.
+        withdrawn = inAppWithdrawn;
       }
     } catch (err) {
       log.warn(
@@ -193,8 +213,12 @@ export async function withdrawGuardianRequestCards(
 }
 
 /**
- * Withdraw the in-app approval card so it stops offering live actions while
- * keeping its content.
+ * Complete a delivery's in-app card projection so it stops offering live
+ * actions while keeping its content. Applies to every delivery that records a
+ * paired conversation, not only the vellum card: a channel delivery's paired
+ * conversation renders the same actionable card in-app, and the channel edit
+ * alone leaves that projection clickable. No-ops (successfully) when the
+ * delivery recorded no conversation.
  *
  * The completion is always persisted onto the card's `ui_surface` block. The
  * acting client's optimistic completion is in-memory only, so without this write
@@ -204,13 +228,16 @@ export async function withdrawGuardianRequestCards(
  * The `ui_surface_complete` broadcast is the only origin-sensitive half: when the
  * decision came from in-app, the acting client is already showing the resolver's
  * guardian-facing reply, and broadcasting the canonical status label back would
- * replace that richer summary mid-session.
+ * replace that richer summary mid-session. When the acting conversation is
+ * known (`originConversationId`), only that conversation's broadcast is
+ * suppressed; sibling projections still need theirs to converge live.
  */
-function withdrawVellumCard(
+function completeInAppProjection(
   request: WithdrawableGuardianRequest,
   delivery: GuardianRequestDeliveryWire,
   status: GuardianRequestStatus,
   originChannel: string | undefined,
+  originConversationId: string | undefined,
   decidedAction: ApprovalAction | undefined,
 ): boolean {
   if (!delivery.destinationConversationId) {
@@ -224,7 +251,11 @@ function withdrawVellumCard(
   // A false here is a failed durable write: after a reload the persisted
   // block would revert to a pending, clickable card, so it must hold the
   // expiry sweep's receipt back and be retried.
-  if (originChannel === "vellum") {
+  if (
+    originChannel === "vellum" &&
+    (!originConversationId ||
+      delivery.destinationConversationId === originConversationId)
+  ) {
     return markSurfaceCompleted(
       { conversationId: delivery.destinationConversationId },
       surfaceId,

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -155,6 +155,13 @@ export interface ApplyGuardianDecisionParams {
   action: ApprovalAction;
   /** Actor context for the entity making the decision. */
   actorContext: ActorContext;
+  /**
+   * Conversation an in-app (vellum) decision was made from, when known.
+   * Threaded to card withdrawal so only the acting conversation's completion
+   * broadcast is suppressed; the request's sibling in-app projections still
+   * receive theirs.
+   */
+  originConversationId?: string;
   /** Optional user-supplied text (e.g. answer text for pending questions). */
   userText?: string;
   /** Optional channel delivery context — present when the decision arrived via a channel message. */
@@ -227,6 +234,7 @@ export async function applyGuardianDecision(
     requestId,
     action,
     actorContext,
+    originConversationId,
     userText,
     channelDeliveryContext,
     emissionContext,
@@ -531,6 +539,7 @@ export async function applyGuardianDecision(
     request: resolved,
     status: targetStatus,
     originChannel: actorContext.channel,
+    ...(originConversationId ? { originConversationId } : {}),
     decidedAction: cardAction,
     // Tells the Telegram projection whether the origin chat is about to get
     // the resolver's own guardian-facing reply (delivered by our caller), so

--- a/assistant/src/approvals/guardian-request-status-sync.ts
+++ b/assistant/src/approvals/guardian-request-status-sync.ts
@@ -1,0 +1,89 @@
+/**
+ * Terminal status sync for guardian requests resolved outside the decision
+ * primitive.
+ *
+ * Some flows resolve a pending tool confirmation in-memory first and treat
+ * that as authoritative: the in-app confirm route and the legacy channel
+ * approval rail (`Conversation.handleConfirmationResponse`), and the
+ * auto-deny sweeps that supersede confirmations when a new message arrives.
+ * Those flows still have to move the gateway's `guardian_requests` row to the
+ * matching terminal status so stale "pending" rows can't be matched by later
+ * guardian reply routing.
+ *
+ * A status CAS alone is not enough: the request's approval cards are
+ * projected onto every surface it was delivered to (the in-app card, channel
+ * messages, and each channel card's paired conversation), and a row that goes
+ * terminal without card withdrawal leaves every projection offering live
+ * Approve/Reject actions for a decision that already happened (LUM-3489). So
+ * the sync runs the same cross-surface withdrawal the decision primitive
+ * runs, whenever its CAS is the one that actually landed.
+ *
+ * First-writer-wins: when the primitive already resolved the request (e.g.
+ * the channel approval path decided it and ran withdrawal itself), this CAS
+ * misses and no second withdrawal runs.
+ *
+ * Fire-and-forget by contract: the caller's in-memory resolution is
+ * authoritative and often synchronous, so failures are logged, never thrown,
+ * and lost syncs are reaped by the orphan sweep.
+ *
+ * Transitional: this exists for the flows that resolve confirmations
+ * in-memory first (the legacy rail). New decision paths must route through
+ * `applyGuardianDecision`, which owns the CAS, resolver dispatch, grant
+ * minting, and withdrawal together; do not add callers here for anything the
+ * pipeline can serve.
+ */
+
+import { decideGuardianRequest } from "../channels/gateway-guardian-requests.js";
+import type { ApprovalAction } from "../runtime/channel-approval-types.js";
+import { getLogger } from "../util/logger.js";
+import { withdrawGuardianRequestCards } from "./guardian-card-withdrawal.js";
+
+const log = getLogger("guardian-request-status-sync");
+
+export interface SyncTerminalGuardianRequestStatusParams {
+  requestId: string;
+  status: "approved" | "denied";
+  /** Log line context naming the flow that resolved the confirmation. */
+  syncContext: string;
+}
+
+/**
+ * CAS the gateway request to its terminal status and, when this write is the
+ * one that landed, project the outcome onto every delivered approval card.
+ *
+ * No origin channel is passed to withdrawal: the confirmation flows act on
+ * the conversation's confirmation prompt (or on no client at all, for the
+ * auto-deny sweeps), never on the approval card itself, so every card
+ * projection needs its completion broadcast.
+ */
+export async function syncTerminalGuardianRequestStatus(
+  params: SyncTerminalGuardianRequestStatusParams,
+): Promise<void> {
+  const { requestId, status, syncContext } = params;
+  // The confirmation flows only ever approve or reject, so the resolved
+  // cards' action is the plain decision pair derived from the status.
+  const decidedAction: ApprovalAction =
+    status === "approved" ? "approve_once" : "reject";
+  try {
+    const decided = await decideGuardianRequest({
+      id: requestId,
+      expectedStatus: "pending",
+      status,
+    });
+    if (!decided.applied) {
+      // The decision primitive (or a concurrent sync) resolved it first and
+      // owns the card withdrawal.
+      return;
+    }
+    await withdrawGuardianRequestCards({
+      request: decided.request,
+      status,
+      decidedAction,
+    });
+  } catch (err) {
+    log.warn(
+      { err, requestId, syncContext },
+      "Guardian request terminal status sync failed",
+    );
+  }
+}

--- a/assistant/src/channels/__tests__/gateway-guardian-requests.test.ts
+++ b/assistant/src/channels/__tests__/gateway-guardian-requests.test.ts
@@ -631,11 +631,7 @@ describe("isGuardianRequestInScopeOrFalse", () => {
   test("returns the gateway scope verdict", async () => {
     ipcResponse = { inScope: true };
     expect(
-      await client.isGuardianRequestInScopeOrFalse(
-        "req-1",
-        "conv-1",
-        "telegram",
-      ),
+      await client.isGuardianRequestInScopeOrFalse("req-1", "conv-1"),
     ).toBe(true);
     expect(ipcCalls).toEqual([
       {
@@ -643,7 +639,6 @@ describe("isGuardianRequestInScopeOrFalse", () => {
         params: {
           requestId: "req-1",
           conversationId: "conv-1",
-          channel: "telegram",
         },
       },
     ]);

--- a/assistant/src/channels/gateway-guardian-requests.ts
+++ b/assistant/src/channels/gateway-guardian-requests.ts
@@ -349,17 +349,16 @@ export const listPendingRequestsByScopeOrEmpty = degradeOnFailure(
 
 /**
  * Is a decision from this conversation allowed for the request (source
- * match, or delivery match optionally narrowed by `channel`)? Throws on
+ * match, or delivery match on any channel's paired conversation)? Throws on
  * transport failure.
  */
 async function isGuardianRequestInScope(
   requestId: string,
   conversationId: string,
-  channel?: string,
 ): Promise<boolean> {
   const response = await callGateway(
     GUARDIAN_REQUESTS_IPC_METHODS.inScope,
-    { requestId, conversationId, channel },
+    { requestId, conversationId },
     GuardianRequestInScopeIpcResponseSchema,
   );
   return response.inScope;

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -21,7 +21,7 @@ import { AgentLoop } from "../agent/loop.js";
 import type { AssistantActivityStateEvent } from "../api/events/assistant-activity-state.js";
 import type { ConfirmationStateChangedEvent } from "../api/events/confirmation-state-changed.js";
 import type { AssistantEvent } from "../api/index.js";
-import { decideGuardianRequest } from "../channels/gateway-guardian-requests.js";
+import { syncTerminalGuardianRequestStatus } from "../approvals/guardian-request-status-sync.js";
 import type {
   ChannelId,
   InterfaceId,
@@ -2065,20 +2065,16 @@ export class Conversation {
     });
 
     // Sync the gateway request status so stale "pending" records don't get
-    // matched by later guardian reply routing. Fire-and-forget: this method
-    // is sync with many callers (HTTP handlers, /v1/confirm, channel
-    // bridges), the in-memory resolution above is authoritative, and a CAS
-    // miss (the decision primitive already resolved it, e.g. the channel
-    // approval path) is expected and harmless.
-    void decideGuardianRequest({
-      id: requestId,
-      expectedStatus: "pending",
+    // matched by later guardian reply routing, and withdraw the request's
+    // approval cards when this sync is the write that landed. Fire-and-forget:
+    // this method is sync with many callers (HTTP handlers, /v1/confirm,
+    // channel bridges), the in-memory resolution above is authoritative, and
+    // a CAS miss (the decision primitive already resolved it and withdrew the
+    // cards itself, e.g. the channel approval path) is expected and harmless.
+    void syncTerminalGuardianRequestStatus({
+      requestId,
       status: resolvedState,
-    }).catch((err) => {
-      log.warn(
-        { err, requestId },
-        "Post-confirmation guardian request status sync failed",
-      );
+      syncContext: "post-confirmation",
     });
   }
 

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -1,5 +1,5 @@
 import { peekAcpSessionManager } from "../../acp/index.js";
-import { decideGuardianRequest } from "../../channels/gateway-guardian-requests.js";
+import { syncTerminalGuardianRequestStatus } from "../../approvals/guardian-request-status-sync.js";
 import {
   clearAll,
   getConversation,
@@ -522,18 +522,15 @@ export function supersedePendingInteractionsOnEnqueue(
           source: "auto_deny" as const,
         });
         // Sync the gateway request so stale "pending" rows aren't matched
-        // by later guardian reply routing. Fire-and-forget from this sync
-        // path: the in-memory denial is authoritative, and a CAS miss
+        // by later guardian reply routing, and withdraw the request's
+        // delivered approval cards so no surface keeps offering a decision
+        // that can no longer resolve anything. Fire-and-forget from this
+        // sync path: the in-memory denial is authoritative, and a CAS miss
         // (already decided elsewhere) is expected and harmless.
-        void decideGuardianRequest({
-          id: interaction.requestId,
-          expectedStatus: "pending",
+        void syncTerminalGuardianRequestStatus({
+          requestId: interaction.requestId,
           status: "denied",
-        }).catch((err) => {
-          log.warn(
-            { err, requestId: interaction.requestId },
-            "Auto-deny guardian request status sync failed",
-          );
+          syncContext: "supersede-on-enqueue",
         });
       }
     }

--- a/assistant/src/notifications/guardian-delivery-recorder.ts
+++ b/assistant/src/notifications/guardian-delivery-recorder.ts
@@ -24,6 +24,7 @@ import { DELIVERY_STATUS } from "@vellumai/gateway-client";
 
 import {
   createGuardianRequestDelivery,
+  getGuardianRequestOrNull,
   type GuardianRequestDeliveryWire,
   updateGuardianRequestDelivery,
 } from "../channels/gateway-guardian-requests.js";
@@ -164,5 +165,37 @@ export async function recordGuardianRequestDeliveries(params: {
     }
   }
 
+  await withdrawIfRequestAlreadyTerminal(requestId);
+
   return vellumDeliveryId;
+}
+
+/**
+ * Close the delivery/decision race: recording happens after the notification
+ * pipeline finishes, so a guardian who acts on a card the moment it lands can
+ * resolve the request before its delivery rows exist. That decision's
+ * withdrawal pass then finds nothing to withdraw, and the rows recorded here
+ * would describe live cards for an already-terminal request. Re-running
+ * withdrawal after recording converges them; rows a prior pass already
+ * withdrew are skipped, so the overlap never re-edits a surface.
+ *
+ * Best-effort like the rest of the recorder; the decided action isn't
+ * recoverable here, so denied outcomes render the plain status word.
+ */
+async function withdrawIfRequestAlreadyTerminal(
+  requestId: string,
+): Promise<void> {
+  const request = await getGuardianRequestOrNull(requestId);
+  if (!request || request.status === "pending") {
+    return;
+  }
+  // Imported at call time: the withdrawal module reaches the daemon's
+  // conversation-surface graph, and a static import here would put this
+  // recorder (imported by the guardian-request producers) into that cycle.
+  const { withdrawGuardianRequestCards } =
+    await import("../approvals/guardian-card-withdrawal.js");
+  await withdrawGuardianRequestCards({
+    request,
+    status: request.status,
+  });
 }

--- a/assistant/src/runtime/guardian-action-service.ts
+++ b/assistant/src/runtime/guardian-action-service.ts
@@ -101,6 +101,10 @@ export async function processGuardianDecision(
   // 2. Verify conversationId scoping before applying the decision. The
   //    decision is allowed when the conversationId matches the request's
   //    source conversation OR a recorded delivery destination conversation.
+  //    Deliberately not narrowed by delivery channel: a delivery row's
+  //    destinationConversationId is always an internal conversation id, and
+  //    a channel card's paired conversation renders the same actionable
+  //    in-app card, so its taps are as legitimate as the vellum card's.
   //    Reads degrade fail-closed: an unreachable gateway scopes to not_found
   //    (and the decide below fails loudly anyway).
   if (conversationId) {
@@ -108,11 +112,7 @@ export async function processGuardianDecision(
     if (
       request &&
       request.sourceConversationId &&
-      !(await isGuardianRequestInScopeOrFalse(
-        requestId,
-        conversationId,
-        channel,
-      ))
+      !(await isGuardianRequestInScopeOrFalse(requestId, conversationId))
     ) {
       return { ok: true, applied: false, reason: "not_found" };
     }
@@ -128,6 +128,10 @@ export async function processGuardianDecision(
       channel,
       guardianPrincipalId: actorContext.guardianPrincipalId,
     },
+    // The acting conversation: card withdrawal suppresses only this
+    // conversation's completion broadcast (the acting client already shows
+    // its optimistic completion); sibling in-app projections still get theirs.
+    ...(conversationId ? { originConversationId: conversationId } : {}),
     userText: undefined,
   });
 

--- a/assistant/src/runtime/routes/__tests__/pending-interactions-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/pending-interactions-route.test.ts
@@ -23,7 +23,13 @@ import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
 // The conversation-key lookup is the only path into the unresolvable-conversation
 // early return, and it reads SQLite. Stub it so this stays a unit test of the
 // response shape. Imported dynamically below so the stub is in place first.
+// The factory spreads the real module: the route module's import graph pulls
+// other named exports from this store, and a partial factory fails at import
+// time the moment any transitive module adds one.
+const actualConversationKeyStore =
+  await import("../../../persistence/conversation-key-store.js");
 mock.module("../../../persistence/conversation-key-store.js", () => ({
+  ...actualConversationKeyStore,
   getConversationByKey: () => undefined,
 }));
 

--- a/assistant/src/runtime/routes/approval-routes.ts
+++ b/assistant/src/runtime/routes/approval-routes.ts
@@ -10,6 +10,7 @@
 import { z } from "zod";
 
 import { PendingToolQuestionSchema } from "../../api/responses/conversation-message.js";
+import { syncTerminalGuardianRequestStatus } from "../../approvals/guardian-request-status-sync.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import type {
   SecretDelivery,
@@ -91,6 +92,14 @@ function handleConfirm({ body }: RouteHandlerArgs) {
       effectiveDecision === "allow" ? "approved" : "rejected",
     );
     interaction.directResolve(effectiveDecision as UserDecision);
+    // When a guardian request was promoted for this confirmation, bring its
+    // row to the matching terminal status and withdraw its cards; with no
+    // such row the CAS misses and this is a no-op.
+    void syncTerminalGuardianRequestStatus({
+      requestId,
+      status: effectiveDecision === "allow" ? "approved" : "denied",
+      syncContext: "confirm-direct-resolve",
+    });
     return { accepted: true };
   }
 

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -23,8 +23,8 @@ import {
   type ConversationMessage,
   ConversationMessageSchema,
 } from "../../api/responses/conversation-message.js";
+import { syncTerminalGuardianRequestStatus } from "../../approvals/guardian-request-status-sync.js";
 import {
-  decideGuardianRequest,
   expireGuardianRequest,
   listGuardianRequestsOrEmpty,
   listPendingRequestsByScopeOrEmpty,
@@ -2323,18 +2323,15 @@ export async function handleSendMessage(
           source: "auto_deny" as const,
         });
         // Sync the gateway request status so stale "pending" records don't
-        // get matched by later guardian reply routing. Fire-and-forget: the
+        // get matched by later guardian reply routing, and withdraw the
+        // request's delivered approval cards so no surface keeps offering a
+        // decision that can no longer resolve anything. Fire-and-forget: the
         // in-memory denial is authoritative here; a CAS miss (already
         // decided elsewhere) or a lost sync is reaped by the orphan sweep.
-        void decideGuardianRequest({
-          id: interaction.requestId,
-          expectedStatus: "pending",
+        void syncTerminalGuardianRequestStatus({
+          requestId: interaction.requestId,
           status: "denied",
-        }).catch((err) => {
-          log.warn(
-            { err, requestId: interaction.requestId },
-            "Auto-deny guardian request status sync failed",
-          );
+          syncContext: "auto-deny-idle-send",
         });
       }
     }

--- a/gateway/src/__tests__/guardian-request-delivery-update.test.ts
+++ b/gateway/src/__tests__/guardian-request-delivery-update.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for `updateDelivery`, the per-surface delivery-row patch.
+ *
+ * Pins the terminal-receipt invariant: `withdrawn` is the daemon's receipt
+ * that a card was durably withdrawn, and a later status patch never
+ * overwrites it. Delivery recording lands its sent/failed status after the
+ * notification broadcast settles, so a decision racing that window would
+ * otherwise re-describe an already-withdrawn card as live (LUM-3489).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { DELIVERY_STATUS } from "@vellumai/gateway-client";
+
+import "./test-preload.js";
+
+const { initGatewayDb, resetGatewayDb } = await import("../db/connection.js");
+const {
+  createDelivery,
+  createGuardianRequest,
+  listDeliveries,
+  updateDelivery,
+} = await import("../db/guardian-request-store.js");
+
+let reqSeq = 0;
+
+function seedRequest() {
+  return createGuardianRequest({
+    id: `req-${++reqSeq}`,
+    kind: "tool_approval",
+    sourceChannel: "slack",
+    guardianPrincipalId: "principal-1",
+  });
+}
+
+beforeEach(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterEach(() => {
+  resetGatewayDb();
+});
+
+describe("updateDelivery", () => {
+  test("patches status and destinationMessageId on a live row", () => {
+    const request = seedRequest();
+    const delivery = createDelivery({
+      requestId: request.id,
+      destinationChannel: "slack",
+      destinationChatId: "C1",
+    });
+
+    const updated = updateDelivery(delivery.id, {
+      status: DELIVERY_STATUS.sent,
+      destinationMessageId: "1700000000.0001",
+    });
+
+    expect(updated?.status).toBe(DELIVERY_STATUS.sent);
+    expect(updated?.destinationMessageId).toBe("1700000000.0001");
+  });
+
+  test("a status patch never overwrites the withdrawn receipt", () => {
+    const request = seedRequest();
+    const delivery = createDelivery({
+      requestId: request.id,
+      destinationChannel: "slack",
+      destinationChatId: "C1",
+      destinationMessageId: "1700000000.0001",
+    });
+
+    // The decision's withdrawal pass receipts the surface...
+    updateDelivery(delivery.id, { status: DELIVERY_STATUS.withdrawn });
+    // ...then the recorder's post-broadcast status patch lands late.
+    const updated = updateDelivery(delivery.id, {
+      status: DELIVERY_STATUS.sent,
+    });
+
+    expect(updated?.status).toBe(DELIVERY_STATUS.withdrawn);
+    const [row] = listDeliveries(request.id);
+    expect(row.status).toBe(DELIVERY_STATUS.withdrawn);
+  });
+
+  test("non-status fields still patch a withdrawn row", () => {
+    const request = seedRequest();
+    const delivery = createDelivery({
+      requestId: request.id,
+      destinationChannel: "slack",
+      destinationChatId: "C1",
+      status: DELIVERY_STATUS.withdrawn,
+    });
+
+    const updated = updateDelivery(delivery.id, {
+      destinationMessageId: "1700000000.0002",
+    });
+
+    expect(updated?.status).toBe(DELIVERY_STATUS.withdrawn);
+    expect(updated?.destinationMessageId).toBe("1700000000.0002");
+  });
+});

--- a/gateway/src/approvals/guardian-request-service.ts
+++ b/gateway/src/approvals/guardian-request-service.ts
@@ -219,9 +219,8 @@ export function listPendingRequestsByScope(
 export function isGuardianRequestInScope(
   requestId: string,
   conversationId: string,
-  channel?: string,
 ): boolean {
-  return isRequestInConversationScope(requestId, conversationId, channel);
+  return isRequestInConversationScope(requestId, conversationId);
 }
 
 export function getPendingRequestByCallSession(

--- a/gateway/src/db/__tests__/guardian-request-store.test.ts
+++ b/gateway/src/db/__tests__/guardian-request-store.test.ts
@@ -880,13 +880,9 @@ describe("isRequestInConversationScope", () => {
     });
 
     expect(isRequestInConversationScope(req.id, "access-req-src")).toBe(true);
+    // A channel delivery's paired conversation is in scope: it renders the
+    // same actionable in-app card as the vellum delivery's conversation.
     expect(isRequestInConversationScope(req.id, "guardian-conv")).toBe(true);
-    expect(isRequestInConversationScope(req.id, "guardian-conv", "slack")).toBe(
-      true,
-    );
-    expect(
-      isRequestInConversationScope(req.id, "guardian-conv", "telegram"),
-    ).toBe(false);
     expect(isRequestInConversationScope(req.id, "unrelated-conv")).toBe(false);
     expect(isRequestInConversationScope("missing", "guardian-conv")).toBe(
       false,

--- a/gateway/src/db/guardian-request-store.ts
+++ b/gateway/src/db/guardian-request-store.ts
@@ -866,14 +866,15 @@ export function listPendingByConversationScope(
 /**
  * Check whether a guardian decision's conversation is in scope for a
  * request: either the request's `sourceConversationId` matches, or any
- * recorded delivery has a matching `destinationConversationId` (optionally
- * scoped by `channel`). Returns true when the decision is allowed from the
- * given conversation.
+ * recorded delivery has a matching `destinationConversationId`. Returns true
+ * when the decision is allowed from the given conversation. Deliberately not
+ * narrowed by delivery channel: `destinationConversationId` is always an
+ * internal conversation id, and every delivery's paired conversation renders
+ * the same actionable in-app card.
  */
 export function isRequestInConversationScope(
   requestId: string,
   conversationId: string,
-  channel?: string,
 ): boolean {
   const request = getGuardianRequest(requestId);
   if (!request) {
@@ -885,11 +886,7 @@ export function isRequestInConversationScope(
   }
 
   const deliveries = listDeliveries(requestId);
-  return deliveries.some(
-    (d) =>
-      d.destinationConversationId === conversationId &&
-      (!channel || d.destinationChannel === channel),
-  );
+  return deliveries.some((d) => d.destinationConversationId === conversationId);
 }
 
 // ---------------------------------------------------------------------------

--- a/gateway/src/db/guardian-request-store.ts
+++ b/gateway/src/db/guardian-request-store.ts
@@ -669,9 +669,6 @@ export function updateDelivery(
   const now = Date.now();
 
   const setValues: Record<string, unknown> = { updatedAt: now };
-  if (updates.status !== undefined) {
-    setValues.status = updates.status;
-  }
   if (updates.destinationMessageId !== undefined) {
     setValues.destinationMessageId = updates.destinationMessageId;
   }
@@ -680,6 +677,23 @@ export function updateDelivery(
     .set(setValues)
     .where(eq(guardianRequestDeliveries.id, id))
     .run();
+
+  // `withdrawn` is the terminal per-surface receipt that a card was durably
+  // withdrawn, preserved here the same way the per-request expire preserves
+  // it: delivery recording lands its sent/failed status patch after the
+  // broadcast settles, so a decision racing that window would otherwise
+  // overwrite the receipt and re-describe an already-withdrawn card as live.
+  if (updates.status !== undefined) {
+    db.update(guardianRequestDeliveries)
+      .set({ status: updates.status, updatedAt: now })
+      .where(
+        and(
+          eq(guardianRequestDeliveries.id, id),
+          ne(guardianRequestDeliveries.status, DELIVERY_STATUS.withdrawn),
+        ),
+      )
+      .run();
+  }
 
   const row = db
     .select()

--- a/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
+++ b/gateway/src/ipc/__tests__/guardian-request-routes.test.ts
@@ -628,7 +628,7 @@ describe("scope reads", () => {
     );
   });
 
-  test("in_scope matches by source or delivery, honoring channel narrowing", async () => {
+  test("in_scope matches by source or any delivery's paired conversation", async () => {
     const created = await createRequest({ sourceConversationId: "conv-src" });
     await call(METHODS.createDelivery, {
       requestId: created.id,
@@ -638,19 +638,10 @@ describe("scope reads", () => {
 
     const cases: Array<[Record<string, unknown>, boolean]> = [
       [{ requestId: created.id, conversationId: "conv-src" }, true],
+      // A channel delivery's paired conversation renders the same actionable
+      // in-app card as the vellum delivery's conversation, so it is in scope
+      // regardless of the delivery's channel.
       [{ requestId: created.id, conversationId: "conv-dst" }, true],
-      [
-        {
-          requestId: created.id,
-          conversationId: "conv-dst",
-          channel: "telegram",
-        },
-        true,
-      ],
-      [
-        { requestId: created.id, conversationId: "conv-dst", channel: "slack" },
-        false,
-      ],
       [{ requestId: created.id, conversationId: "conv-nope" }, false],
       [{ requestId: "nope", conversationId: "conv-src" }, false],
     ];

--- a/gateway/src/ipc/guardian-request-handlers.ts
+++ b/gateway/src/ipc/guardian-request-handlers.ts
@@ -222,10 +222,10 @@ export const guardianRequestRoutes: IpcRoute[] = [
     method: GUARDIAN_REQUESTS_IPC_METHODS.inScope,
     schema: GuardianRequestInScopeIpcParamsSchema,
     handler: (params?: Record<string, unknown>) => {
-      const { requestId, conversationId, channel } =
+      const { requestId, conversationId } =
         GuardianRequestInScopeIpcParamsSchema.parse(params);
       return {
-        inScope: isGuardianRequestInScope(requestId, conversationId, channel),
+        inScope: isGuardianRequestInScope(requestId, conversationId),
       };
     },
   },

--- a/packages/gateway-client/src/guardian-request-contract.ts
+++ b/packages/gateway-client/src/guardian-request-contract.ts
@@ -662,13 +662,15 @@ export type ListPendingGuardianRequestsByScopeIpcParams = z.infer<
 
 /**
  * Request for `guardian_requests_in_scope`: is a decision from this
- * conversation allowed for the request (source match, or delivery match
- * optionally narrowed by `channel`)?
+ * conversation allowed for the request (source match, or delivery match)?
+ * Deliberately not narrowed by delivery channel: `destinationConversationId`
+ * is always an internal conversation id, and every delivery's paired
+ * conversation renders the same actionable in-app card, so a match on any
+ * delivery row legitimizes the conversation.
  */
 export const GuardianRequestInScopeIpcParamsSchema = z.object({
   requestId: z.string().min(1),
   conversationId: z.string().min(1),
-  channel: z.string().optional(),
 });
 
 export type GuardianRequestInScopeIpcParams = z.infer<


### PR DESCRIPTION
Fixes LUM-3489

## TL;DR

A tool approval requested from a Slack thread renders as an actionable card in several places at once: the vellum card pinned to the originating conversation, the Slack message in the guardian's DM, and the DM's paired Vellum conversation (the decision engine injects the same actionable seed blocks into every channel's copy). After the guardian decided, some of those projections kept live Approve/Reject buttons and the delivery rows stayed `sent`. This PR makes every projection of a guardian request converge on the terminal outcome, whichever rail resolved it, and makes every projection's buttons actually work.

## Root causes (all code-verified)

1. **Withdrawal never completed channel-paired in-app projections.** `withdrawGuardianRequestCards` edited the channel-native message but ignored the channel delivery's `destinationConversationId`, even though the recorder captures it precisely so a conversation's cards can be found uniformly. The paired conversation's card stayed clickable forever.
2. **Three bare `decideGuardianRequest` status syncs flipped the row terminal with no withdrawal at all** (`Conversation.handleConfirmationResponse`, the enqueue-supersede auto-deny, the idle-send auto-deny; plus the `/v1/confirm` direct-resolve branch, which never synced the row). Any decision landing on these rails (in-app confirm, the legacy channel approval rail, auto-denies) left every card live while the request read Approved, and left both delivery rows `sent`, exactly the evidence in the ticket.
3. **Delivery recording raced fast decisions.** Rows are recorded after the notification pipeline settles, so a decision made the moment a card lands finds no rows to withdraw; and the recorder's late `sent` patch could overwrite a `withdrawn` receipt.
4. **In-app taps on a channel-paired projection silently no-opped.** The decision scope check narrowed deliveries to `vellum` rows, so the DM projection's buttons did nothing in the Vellum app, which is what pushes a guardian to act on the other copy in the first place.

## The fix

- Withdrawal completes every delivery's in-app projection (new shared `completeInAppProjection`, generalizing the old vellum-only branch). For in-app decisions, only the acting conversation's `ui_surface_complete` broadcast is suppressed (`originConversationId`, threaded from the surface/guardian action routes); sibling projections converge live.
- The bare syncs now route through `approvals/guardian-request-status-sync.ts`: same CAS, plus the same cross-surface withdrawal the decision primitive runs, whenever the sync's CAS is the write that landed (a CAS miss means the primitive already resolved it and withdrew). Marked transitional; new decision paths still belong on `applyGuardianDecision`.
- The recorder re-runs withdrawal after recording when the request is already terminal, and the gateway store treats `withdrawn` as sticky against status patches (mirroring how the per-request expire already preserves it).
- The scope check accepts any recorded delivery destination conversation. `destinationConversationId` is always an internal conversation id, so the original "cross-channel namespace overlap" concern does not apply to these rows; principal authorization in `applyGuardianDecision` is unchanged.

## What changes for the user

| Before | After |
| --- | --- |
| Approving in Slack left the request's card in the linked Vellum conversation with live Approve/Reject buttons | Every Vellum projection of the request flips to the outcome (Approved/Denied) when the decision lands |
| Approving via the in-app confirmation prompt (or an auto-deny when you send a new message) left all delivered cards live everywhere | Those resolutions withdraw the cards on every surface too |
| Tapping Approve/Reject on the card in a Slack-paired Vellum conversation did nothing | Those buttons decide the request like any other copy of the card |
| A decision made seconds after the card appeared could permanently strand live cards | The recorder reconciles late-recorded rows against the already-decided request |

## Why this is safe

- The decision primitive's semantics are untouched: CAS, resolver dispatch, and grant minting are unchanged; only the withdrawal projection widened.
- The sync helper is first-writer-wins by construction: on the canonical path its CAS always misses (the primitive commits before the resolver runs), so no double withdrawal. Withdrawal itself is idempotent and skips rows already receipted `withdrawn`.
- The sticky-`withdrawn` rule only affects the two writers that exist (withdrawal writes `withdrawn`, the recorder writes `sent`/`failed`); nothing legitimately downgrades a withdrawn row.
- Widening the scope check does not weaken authorization: principal equality is still enforced in `applyGuardianDecision`, and the accepted conversations are exactly those the daemon itself recorded as hosting the card.
- Covered by new tests: cross-projection withdrawal and origin-suppression precision, sync-helper CAS/withdrawal semantics, recorder race reconciliation, sticky receipts (assistant sim + gateway store), and scope acceptance/rejection. Existing approval/withdrawal/confirmation suites all pass.

## Notes / deferred

- The exact interleaving of the Aug 31 repro could not be confirmed against the live instance (local prod is off-limits to this session); the ticket's evidence (request Approved, both rows `sent`, one projection live) is fully produced by root causes 2 and 3, and every identified path that can strand a projection is closed here.
- `lint:circular` reports the same pre-existing 221 cycles as `main`. The recorder's withdrawal call is a call-time dynamic import so it adds no module-init cycle, though madge still lists the edge.
- A Telegram decision made through the legacy rail can now receive both the legacy "Approved" edit and withdrawal's quoted status reply. Minor duplicate notice, accepted; the direction remains converging the legacy rail onto the pipeline (documented in `guardian-request-flow.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
- Withdrawal on the decision rails (both the primitive and the new status sync) stays fire-and-forget best-effort, matching the documented contract in `guardian-card-withdrawal.ts`: the delivery rows carry per-surface `withdrawn` receipts, so a future reconciliation trigger for decided requests can converge stragglers, but no such sweep exists today (only expiry has one). Shared, pre-existing posture; not widened or narrowed here.
