### PR TITLE
fix(contacts): seed inbound identities gateway-first so the guardian can't be minted as a duplicate contact

### DIFF
--- a/assistant/src/__tests__/contacts-write.test.ts
+++ b/assistant/src/__tests__/contacts-write.test.ts
@@ -39,6 +39,24 @@ function channelCount(type: string, address: string): number {
   return row.n;
 }
 
+function contactExists(contactId: string): boolean {
+  // bun:sqlite .get() returns null (not undefined) when no row matches.
+  const row = getSqlite()
+    .query("SELECT 1 AS one FROM contacts WHERE id = ?")
+    .get(contactId) as { one: number } | null;
+  return row !== null;
+}
+
+/** Contacts parenting zero channels: the duplicate shape LUM-2672 surfaced. */
+function channelLessContactCount(): number {
+  const row = getSqlite()
+    .query(
+      "SELECT COUNT(*) AS n FROM contacts c WHERE NOT EXISTS (SELECT 1 FROM contact_channels ch WHERE ch.contact_id = c.id)",
+    )
+    .get() as { n: number };
+  return row.n;
+}
+
 function workspaceDir(): string {
   const dir = process.env.VELLUM_WORKSPACE_DIR;
   if (!dir) {
@@ -219,6 +237,42 @@ describe("mirror channel-reparenting race semantics", () => {
     expect(channelOwnerById("gw-ch-race-1")).toBe("co-race-1");
     expect(channelOwnerById("gw-ch-race-2")).toBeUndefined();
     expect(channelCount("slack", "URACE")).toBe(1);
+    // The losing seed adopts contact #1 rather than minting a channel-less
+    // contact under its own id (LUM-2672 family, mirror side).
+    expect(contactExists("co-race-2")).toBe(false);
+    expect(channelLessContactCount()).toBe(0);
+  });
+
+  test("explicit-id create over a conflicting channel adopts the owner instead of minting an empty contact", () => {
+    upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UADOPT",
+      externalChatId: "DADOPT",
+      displayName: "Owner",
+      contactId: "co-adopt-owner",
+      channelId: "gw-ch-adopt",
+      refreshDisplayName: true,
+      userFileOnCreate: null,
+      reassignConflictingChannels: false,
+    });
+
+    // A divergence-shaped write: the gateway hands down a contact id the
+    // mirror has never seen, for an identity the mirror already parents.
+    const result = upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UADOPT",
+      displayName: "Owner Renamed",
+      contactId: "co-adopt-foreign",
+      refreshDisplayName: true,
+      userFileOnCreate: null,
+      reassignConflictingChannels: false,
+    });
+
+    expect(result?.contact.id).toBe("co-adopt-owner");
+    expect(result?.contact.displayName).toBe("Owner Renamed");
+    expect(channelOwnerById("gw-ch-adopt")).toBe("co-adopt-owner");
+    expect(contactExists("co-adopt-foreign")).toBe(false);
+    expect(channelLessContactCount()).toBe(0);
   });
 
   test("INVITE-binding path (reassignConflictingChannels:true) DOES reparent", () => {

--- a/assistant/src/__tests__/contacts-write.test.ts
+++ b/assistant/src/__tests__/contacts-write.test.ts
@@ -47,7 +47,7 @@ function contactExists(contactId: string): boolean {
   return row !== null;
 }
 
-/** Contacts parenting zero channels: the duplicate shape LUM-2672 surfaced. */
+/** Contacts parenting zero channels: the guardian-duplicate shape. */
 function channelLessContactCount(): number {
   const row = getSqlite()
     .query(
@@ -238,9 +238,63 @@ describe("mirror channel-reparenting race semantics", () => {
     expect(channelOwnerById("gw-ch-race-2")).toBeUndefined();
     expect(channelCount("slack", "URACE")).toBe(1);
     // The losing seed adopts contact #1 rather than minting a channel-less
-    // contact under its own id (LUM-2672 family, mirror side).
+    // contact under its own id.
     expect(contactExists("co-race-2")).toBe(false);
     expect(channelLessContactCount()).toBe(0);
+  });
+
+  test("adoption and re-seen seeds never clobber curated record fields", () => {
+    // First-seen bot sender: classification and notes land on CREATE.
+    const created = upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UCURATED",
+      externalChatId: "DCURATED",
+      displayName: "Peer Assistant",
+      contactId: "co-curated",
+      channelId: "gw-ch-curated",
+      contactType: "assistant",
+      notes: "Automated Slack bot",
+      refreshDisplayName: true,
+      userFileOnCreate: null,
+      reassignConflictingChannels: false,
+    });
+    expect(created?.contact.contactType).toBe("assistant");
+    expect(created?.contact.notes).toBe("Automated Slack bot");
+
+    // A later seed for the same identity (mirror row present) carries record
+    // fields for gap recovery, but they are create-only: the stored
+    // classification and notes stand.
+    const reseen = upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UCURATED",
+      contactId: "co-curated",
+      displayName: "Peer Assistant",
+      contactType: "human",
+      notes: "seed-refresh notes that must not land",
+      refreshDisplayName: true,
+      userFileOnCreate: null,
+      reassignConflictingChannels: false,
+    });
+    expect(reseen?.contact.contactType).toBe("assistant");
+    expect(reseen?.contact.notes).toBe("Automated Slack bot");
+
+    // Adoption (a create-shaped op under a foreign id for the same identity)
+    // is equally forbidden from touching the adopted contact's record fields.
+    const adopted = upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UCURATED",
+      contactId: "co-curated-foreign",
+      displayName: "Peer Assistant",
+      contactType: "human",
+      notes: "adoption notes that must not land",
+      refreshDisplayName: true,
+      userFileOnCreate: null,
+      reassignConflictingChannels: false,
+    });
+    expect(adopted?.contact.id).toBe("co-curated");
+    expect(adopted?.contact.contactType).toBe("assistant");
+    expect(adopted?.contact.notes).toBe("Automated Slack bot");
+    expect(contactExists("co-curated-foreign")).toBe(false);
   });
 
   test("explicit-id create over a conflicting channel adopts the owner instead of minting an empty contact", () => {

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -256,6 +256,16 @@ export function upsertContact(params: {
    *  mirror to create faithful null-user_file stubs. `userFile` takes
    *  precedence when both are supplied. */
   userFileOnCreate?: string | null;
+  /** contactType to seed ONLY when inserting a new contact; ignored on update
+   *  (and on channel-identity adoption) so a guardian-curated classification
+   *  is never clobbered by an inbound seed. `contactType` takes precedence
+   *  when both are supplied. */
+  contactTypeOnCreate?: ContactType;
+  /** notes to seed ONLY when inserting a new contact; ignored on update (and
+   *  on channel-identity adoption) so guardian-authored notes are never
+   *  clobbered by an inbound seed. `notes` takes precedence when both are
+   *  supplied. */
+  notesOnCreate?: string | null;
   channels?: SyncChannelData[];
   /** When true, conflicting channels on other contacts are reassigned to this
    *  contact instead of being skipped. Used by invite redemption to bind a
@@ -321,10 +331,11 @@ export function upsertContact(params: {
   // covers an explicit-id CREATE (the id was not found above) when the caller
   // did not opt into reassignment: syncChannels would skip a channel owned by
   // another contact, so inserting the supplied id would mint a channel-less
-  // duplicate of that contact (LUM-2672 family, mirror side). Adopting the
-  // existing owner instead keeps one contact per channel identity; the
-  // supplied id is dropped. Reassigning callers (invite binding, the guardian
-  // bootstrap mirror) skip this and keep their bind-to-target semantics.
+  // duplicate of that contact. Adopting the existing owner instead keeps one
+  // contact per channel identity; the supplied id is dropped, and the
+  // *OnCreate record fields never apply here. Reassigning callers (invite
+  // binding, the guardian bootstrap mirror) skip this and keep their
+  // bind-to-target semantics.
   if (
     canonicalChannels &&
     canonicalChannels.length > 0 &&
@@ -373,8 +384,8 @@ export function upsertContact(params: {
     .values({
       id: contactId,
       displayName: params.displayName,
-      notes: params.notes ?? null,
-      contactType: params.contactType ?? "human",
+      notes: params.notes ?? params.notesOnCreate ?? null,
+      contactType: params.contactType ?? params.contactTypeOnCreate ?? "human",
       userFile: resolvedUserFile,
       createdAt: now,
       updatedAt: now,

--- a/assistant/src/contacts/contact-store.ts
+++ b/assistant/src/contacts/contact-store.ts
@@ -317,8 +317,19 @@ export function upsertContact(params: {
     }
   }
 
-  // Try to find by channel canonical identity to avoid duplicates
-  if (!contactId && canonicalChannels && canonicalChannels.length > 0) {
+  // Try to find by channel canonical identity to avoid duplicates. This also
+  // covers an explicit-id CREATE (the id was not found above) when the caller
+  // did not opt into reassignment: syncChannels would skip a channel owned by
+  // another contact, so inserting the supplied id would mint a channel-less
+  // duplicate of that contact (LUM-2672 family, mirror side). Adopting the
+  // existing owner instead keeps one contact per channel identity; the
+  // supplied id is dropped. Reassigning callers (invite binding, the guardian
+  // bootstrap mirror) skip this and keep their bind-to-target semantics.
+  if (
+    canonicalChannels &&
+    canonicalChannels.length > 0 &&
+    (!contactId || !params.reassignConflictingChannels)
+  ) {
     for (const ch of canonicalChannels) {
       const existingChannel = findConflictingChannel(db, ch.type, ch.address);
 

--- a/assistant/src/contacts/contacts-write.ts
+++ b/assistant/src/contacts/contacts-write.ts
@@ -82,8 +82,11 @@ export function upsertContactChannel(params: {
   upsertContact({
     id: params.contactId,
     displayName,
-    contactType: params.contactType,
-    notes: params.notes,
+    // Classification and notes are create-only on this path (see the param
+    // docs above): applying them on update or on channel-identity adoption
+    // would let an inbound seed clobber guardian-authored record fields.
+    contactTypeOnCreate: params.contactType,
+    notesOnCreate: params.notes,
     userFileOnCreate: params.userFileOnCreate,
     channels: [
       {

--- a/gateway/src/__tests__/contact-handlers.test.ts
+++ b/gateway/src/__tests__/contact-handlers.test.ts
@@ -96,7 +96,11 @@ mock.module("../ipc/assistant-client.js", () => ({
 
 // resolveGatewayChannel resolves the assistant channel's (type,address) via the
 // typed identity-lookup IPC; serve it from the same fake channel store.
+// Spread the actual module so unstubbed named exports keep resolving when the
+// transitive import graph grows.
+const actualContactsInfoClient = await import("../ipc/contacts-info-client.js");
 mock.module("../ipc/contacts-info-client.js", () => ({
+  ...actualContactsInfoClient,
   lookupContactChannelIdentity: mock(
     async (selector: { channelId?: string }) => {
       if (selector.channelId == null) return null;

--- a/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
+++ b/gateway/src/__tests__/guardian-binding-channel-reuse.test.ts
@@ -84,7 +84,11 @@ mock.module("../ipc/assistant-client.js", () => ({
 
 // The orphan-GC mirror inspection now goes through typed IPC instead of raw
 // SELECTs; serve it from the same in-memory assistant DB.
+// Spread the actual module so unstubbed named exports keep resolving when the
+// transitive import graph grows.
+const actualContactsInfoClient = await import("../ipc/contacts-info-client.js");
 mock.module("../ipc/contacts-info-client.js", () => ({
+  ...actualContactsInfoClient,
   async probeContactMirror(contactId: string) {
     const contactRow = db()
       .prepare(

--- a/gateway/src/__tests__/inbound-contact-seed.test.ts
+++ b/gateway/src/__tests__/inbound-contact-seed.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Inbound contact seeding must dedupe against the gateway DB (the source of
+ * truth) and never mint a channel-less contact.
+ *
+ * The defect class under test is LUM-2672's second act: seeding used to
+ * dedupe via a daemon identity lookup, so an assistant-mirror gap for an
+ * already-bound address (the guardian's own Slack identity, after the
+ * best-effort binding mirror failed) created a fresh gateway contact whose
+ * channel insert then no-op'd on the (type, address) unique index. The
+ * guardian saw themselves as a second, unlinkable contact.
+ *
+ * The gateway DB is real and file-backed, so the assertions count rows
+ * rather than calls. The assistant mirror is reduced to a recorder: the seed
+ * path must never read it, and what it sends there is asserted as payload.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import "./test-preload.js";
+
+const socketDir = mkdtempSync(join(tmpdir(), "inbound-contact-seed-"));
+const socketPath = join(socketDir, "assistant.sock");
+// Per-test switch: when false, resolveIpcSocketPath points at a missing file,
+// modeling a daemon that is not running.
+let socketPresent = true;
+
+mock.module("../ipc/endpoint.js", () => ({
+  resolveIpcSocketPath: () => ({
+    path: socketPresent ? socketPath : join(socketDir, "absent.sock"),
+    source: "test",
+  }),
+}));
+
+/** Recorded contacts_mirror_* IPC calls, in order. */
+const mirrorCalls: { method: string; body: Record<string, unknown> }[] = [];
+let mirrorThrow = false;
+
+mock.module("../ipc/assistant-client.js", () => ({
+  ipcCallAssistant: mock(
+    async (method: string, params: { body: Record<string, unknown> }) => {
+      mirrorCalls.push({ method, body: params.body });
+      if (mirrorThrow) {
+        throw new Error(`mirror unavailable: ${method}`);
+      }
+      return {};
+    },
+  ),
+}));
+
+// The seed path must not consult the mirror for dedupe. A throwing stub makes
+// any regression to mirror-first dedupe fail loudly rather than pass by
+// coincidence.
+mock.module("../ipc/contacts-info-client.js", () => ({
+  lookupContactChannelIdentity: mock(async () => {
+    throw new Error(
+      "seed path consulted the assistant mirror for dedupe (gateway DB is the source of truth)",
+    );
+  }),
+  probeContactMirror: mock(async () => {
+    throw new Error("probeContactMirror not exercised by seeding");
+  }),
+}));
+
+import { upsertContactChannel } from "../verification/contact-helpers.js";
+import {
+  initGatewayDb,
+  getGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { contacts, contactChannels } from "../db/schema.js";
+
+const SLACK_USER = "U06GUARDIAN1";
+
+function allContacts() {
+  return getGatewayDb().select().from(contacts).all();
+}
+
+function allChannels() {
+  return getGatewayDb().select().from(contactChannels).all();
+}
+
+/** Contacts parenting zero channels: the duplicate shape LUM-2672 surfaced. */
+function channelLessContacts() {
+  const channelOwners = new Set(allChannels().map((ch) => ch.contactId));
+  return allContacts().filter((c) => !channelOwners.has(c.id));
+}
+
+const mirrorUpserts = () =>
+  mirrorCalls.filter((c) => c.method === "contacts_mirror_upsert_channel");
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  mirrorCalls.length = 0;
+  mirrorThrow = false;
+  socketPresent = true;
+  writeFileSync(socketPath, "");
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+/** Insert a contact + channel directly, modeling pre-existing gateway state. */
+function insertBoundIdentity(opts: {
+  contactId: string;
+  channelId: string;
+  displayName: string;
+  role?: string;
+  status?: string;
+  address?: string;
+  externalChatId?: string | null;
+}): void {
+  const now = Date.now();
+  const db = getGatewayDb();
+  db.insert(contacts)
+    .values({
+      id: opts.contactId,
+      displayName: opts.displayName,
+      role: opts.role ?? "contact",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+  db.insert(contactChannels)
+    .values({
+      id: opts.channelId,
+      contactId: opts.contactId,
+      type: "slack",
+      address: opts.address ?? SLACK_USER,
+      isPrimary: true,
+      externalChatId: opts.externalChatId ?? null,
+      status: opts.status ?? "active",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+describe("first-seen seeding", () => {
+  test("creates one contact + one unverified channel, ids shared with the mirror", async () => {
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: SLACK_USER,
+      externalChatId: "D001",
+      displayName: "Alice Example",
+      username: "alice",
+    });
+
+    const rows = allChannels();
+    expect(rows).toHaveLength(1);
+    expect(allContacts()).toHaveLength(1);
+    expect(rows[0].status).toBe("unverified");
+    expect(rows[0].policy).toBe("allow");
+    // Casing preserved: canonical Slack ids keep their original form.
+    expect(rows[0].address).toBe(SLACK_USER);
+    expect(rows[0].externalChatId).toBe("D001");
+    expect(allContacts()[0].displayName).toBe("Alice Example");
+
+    const op = mirrorUpserts()[0];
+    expect(op).toBeTruthy();
+    expect(op!.body.contactId).toBe(rows[0].contactId);
+    expect(op!.body.channelId).toBe(rows[0].id);
+    expect(op!.body.contactType).toBe("human");
+    expect(op!.body.refreshDisplayName).toBe(true);
+    expect(op!.body.reassignConflictingChannels).toBe(false);
+  });
+
+  test("classifies a bot sender as 'assistant' with a provenance note on create only", async () => {
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UBOT99",
+      displayName: "Peer Assistant",
+      contactType: "assistant",
+      notes: "Automated Slack bot",
+    });
+    expect(mirrorUpserts()[0]!.body.contactType).toBe("assistant");
+    expect(mirrorUpserts()[0]!.body.notes).toBe("Automated Slack bot");
+
+    // A later seed for the same identity must not resend classification: the
+    // record fields are create-only, so guardian edits are never clobbered.
+    mirrorCalls.length = 0;
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UBOT99",
+      contactType: "assistant",
+      notes: "Automated Slack bot",
+    });
+    expect(mirrorUpserts()[0]!.body.contactType).toBeUndefined();
+    expect(mirrorUpserts()[0]!.body.notes).toBeUndefined();
+    expect(allContacts()).toHaveLength(1);
+  });
+
+  test("gateway write lands even when the assistant socket is absent (mirror skipped)", async () => {
+    socketPresent = false;
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: SLACK_USER,
+      displayName: "Alice Example",
+    });
+
+    expect(allChannels()).toHaveLength(1);
+    expect(mirrorCalls).toHaveLength(0);
+  });
+});
+
+describe("re-seen identity", () => {
+  test("updates in place: no new rows, delivery chat id persisted, curated gateway name preserved", async () => {
+    insertBoundIdentity({
+      contactId: "co-1",
+      channelId: "ch-1",
+      displayName: "Mom",
+      status: "unverified",
+    });
+
+    // The platform profile says "Alice Example", a DM supplies the chat id.
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: SLACK_USER,
+      externalChatId: "D-dm",
+      displayName: "Alice Example",
+    });
+
+    expect(allContacts()).toHaveLength(1);
+    const rows = allChannels();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe("ch-1");
+    expect(rows[0].externalChatId).toBe("D-dm");
+    // The gateway name is the guardian-curated one; only the mirror tracks
+    // the live platform profile.
+    expect(allContacts()[0].displayName).toBe("Mom");
+    const op = mirrorUpserts()[0];
+    expect(op!.body.contactId).toBeUndefined();
+    expect(op!.body.displayName).toBe("Alice Example");
+    expect(op!.body.refreshDisplayName).toBe(true);
+  });
+
+  test("an omitted delivery chat id preserves the stored one", async () => {
+    insertBoundIdentity({
+      contactId: "co-1",
+      channelId: "ch-1",
+      displayName: "Alice",
+      externalChatId: "D-kept",
+    });
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: SLACK_USER,
+      displayName: "Alice",
+    });
+
+    expect(allChannels()[0].externalChatId).toBe("D-kept");
+  });
+
+  test("a revoked channel gets its identity refreshed but stays revoked", async () => {
+    insertBoundIdentity({
+      contactId: "co-1",
+      channelId: "ch-1",
+      displayName: "Alice",
+      status: "revoked",
+      address: "u06guardian1",
+    });
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: SLACK_USER,
+      displayName: "Alice",
+    });
+
+    const rows = allChannels();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].status).toBe("revoked");
+    // Canonical casing self-heal on the NOCASE-matched row.
+    expect(rows[0].address).toBe(SLACK_USER);
+  });
+
+  test("a blocked channel short-circuits: no writes, no mirror op", async () => {
+    insertBoundIdentity({
+      contactId: "co-1",
+      channelId: "ch-1",
+      displayName: "Blocked Actor",
+      status: "blocked",
+      externalChatId: null,
+    });
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: SLACK_USER,
+      externalChatId: "D-block",
+      displayName: "Blocked Actor",
+    });
+
+    expect(allChannels()[0].externalChatId).toBeNull();
+    expect(mirrorCalls).toHaveLength(0);
+  });
+});
+
+describe("guardian duplicate regression (LUM-2672 second act)", () => {
+  test("a mirror gap for a guardian-bound identity mints nothing", async () => {
+    // The guardian's Slack identity is bound gateway-side; the assistant
+    // mirror knows nothing (the best-effort binding mirror failed). The
+    // throwing lookup stub above IS the mirror gap: the seed must not ask.
+    insertBoundIdentity({
+      contactId: "co-guardian",
+      channelId: "ch-guardian",
+      displayName: "Boss",
+      role: "guardian",
+    });
+
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: SLACK_USER,
+      externalChatId: "D-own-dm",
+      displayName: "Ashlee Radka",
+    });
+
+    // The counts are the assertion: one contact, one channel, zero
+    // channel-less contacts. Before the gateway-first dedupe this seeded a
+    // second "Ashlee Radka" contact with no channel.
+    expect(allContacts()).toHaveLength(1);
+    expect(allChannels()).toHaveLength(1);
+    expect(channelLessContacts()).toHaveLength(0);
+    expect(allContacts()[0].displayName).toBe("Boss");
+    // The mirror heal op resolves by identity, not by contact id, so a
+    // divergent mirror updates its own row in place.
+    const op = mirrorUpserts()[0];
+    expect(op).toBeTruthy();
+    expect(op!.body.contactId).toBeUndefined();
+  });
+
+  test("a mirror failure never rolls back or duplicates the gateway write", async () => {
+    mirrorThrow = true;
+
+    await expect(
+      upsertContactChannel({
+        sourceChannel: "slack",
+        externalUserId: SLACK_USER,
+        displayName: "Alice Example",
+      }),
+    ).rejects.toThrow("mirror unavailable");
+
+    expect(allContacts()).toHaveLength(1);
+    expect(allChannels()).toHaveLength(1);
+    expect(channelLessContacts()).toHaveLength(0);
+  });
+});

--- a/gateway/src/__tests__/inbound-contact-seed.test.ts
+++ b/gateway/src/__tests__/inbound-contact-seed.test.ts
@@ -2,12 +2,11 @@
  * Inbound contact seeding must dedupe against the gateway DB (the source of
  * truth) and never mint a channel-less contact.
  *
- * The defect class under test is LUM-2672's second act: seeding used to
- * dedupe via a daemon identity lookup, so an assistant-mirror gap for an
- * already-bound address (the guardian's own Slack identity, after the
- * best-effort binding mirror failed) created a fresh gateway contact whose
- * channel insert then no-op'd on the (type, address) unique index. The
- * guardian saw themselves as a second, unlinkable contact.
+ * The defect class under test: a seed that dedupes via the assistant mirror
+ * mints a fresh gateway contact whenever the mirror is missing a row for an
+ * already-bound address (the guardian's own channel identity included), and
+ * the channel insert then no-ops on the (type, address) unique index. The
+ * guardian sees themselves as a second, unlinkable contact.
  *
  * The gateway DB is real and file-backed, so the assertions count rows
  * rather than calls. The assistant mirror is reduced to a recorder: the seed
@@ -60,8 +59,11 @@ mock.module("../ipc/assistant-client.js", () => ({
 
 // The seed path must not consult the mirror for dedupe. A throwing stub makes
 // any regression to mirror-first dedupe fail loudly rather than pass by
-// coincidence.
+// coincidence. The actual module is spread so unstubbed named exports keep
+// resolving when the transitive import graph grows.
+const actualContactsInfoClient = await import("../ipc/contacts-info-client.js");
 mock.module("../ipc/contacts-info-client.js", () => ({
+  ...actualContactsInfoClient,
   lookupContactChannelIdentity: mock(async () => {
     throw new Error(
       "seed path consulted the assistant mirror for dedupe (gateway DB is the source of truth)",
@@ -90,7 +92,7 @@ function allChannels() {
   return getGatewayDb().select().from(contactChannels).all();
 }
 
-/** Contacts parenting zero channels: the duplicate shape LUM-2672 surfaced. */
+/** Contacts parenting zero channels: the guardian-duplicate shape. */
 function channelLessContacts() {
   const channelOwners = new Set(allChannels().map((ch) => ch.contactId));
   return allContacts().filter((c) => !channelOwners.has(c.id));
@@ -195,8 +197,11 @@ describe("first-seen seeding", () => {
     expect(mirrorUpserts()[0]!.body.contactType).toBe("assistant");
     expect(mirrorUpserts()[0]!.body.notes).toBe("Automated Slack bot");
 
-    // A later seed for the same identity must not resend classification: the
-    // record fields are create-only, so guardian edits are never clobbered.
+    // A later seed for the same identity still carries the classification, so
+    // a mirror missing the row can recreate it faithfully. The daemon applies
+    // these fields on mirror-row CREATE only (create-only semantics pinned in
+    // the assistant's contacts-write suite), so guardian edits on an existing
+    // mirror record are never clobbered.
     mirrorCalls.length = 0;
     await upsertContactChannel({
       sourceChannel: "slack",
@@ -204,8 +209,8 @@ describe("first-seen seeding", () => {
       contactType: "assistant",
       notes: "Automated Slack bot",
     });
-    expect(mirrorUpserts()[0]!.body.contactType).toBeUndefined();
-    expect(mirrorUpserts()[0]!.body.notes).toBeUndefined();
+    expect(mirrorUpserts()[0]!.body.contactType).toBe("assistant");
+    expect(mirrorUpserts()[0]!.body.notes).toBe("Automated Slack bot");
     expect(allContacts()).toHaveLength(1);
   });
 
@@ -248,8 +253,11 @@ describe("re-seen identity", () => {
     // The gateway name is the guardian-curated one; only the mirror tracks
     // the live platform profile.
     expect(allContacts()[0].displayName).toBe("Mom");
+    // The op projects the gateway's owner ids so a mirror gap heals under the
+    // same keys.
     const op = mirrorUpserts()[0];
-    expect(op!.body.contactId).toBeUndefined();
+    expect(op!.body.contactId).toBe("co-1");
+    expect(op!.body.channelId).toBe("ch-1");
     expect(op!.body.displayName).toBe("Alice Example");
     expect(op!.body.refreshDisplayName).toBe(true);
   });
@@ -314,7 +322,7 @@ describe("re-seen identity", () => {
   });
 });
 
-describe("guardian duplicate regression (LUM-2672 second act)", () => {
+describe("guardian duplicate regression", () => {
   test("a mirror gap for a guardian-bound identity mints nothing", async () => {
     // The guardian's Slack identity is bound gateway-side; the assistant
     // mirror knows nothing (the best-effort binding mirror failed). The
@@ -330,21 +338,23 @@ describe("guardian duplicate regression (LUM-2672 second act)", () => {
       sourceChannel: "slack",
       externalUserId: SLACK_USER,
       externalChatId: "D-own-dm",
-      displayName: "Ashlee Radka",
+      displayName: "Alice Example",
     });
 
     // The counts are the assertion: one contact, one channel, zero
-    // channel-less contacts. Before the gateway-first dedupe this seeded a
-    // second "Ashlee Radka" contact with no channel.
+    // channel-less contacts. A mirror-first dedupe seeds a second contact
+    // here, carrying the guardian's platform profile name and no channel.
     expect(allContacts()).toHaveLength(1);
     expect(allChannels()).toHaveLength(1);
     expect(channelLessContacts()).toHaveLength(0);
     expect(allContacts()[0].displayName).toBe("Boss");
-    // The mirror heal op resolves by identity, not by contact id, so a
-    // divergent mirror updates its own row in place.
+    // The mirror heal op carries the gateway owner's ids, so the gap is
+    // recreated under the same keys; the daemon's channel-identity adoption
+    // keeps a divergent mirror from minting an empty contact for them.
     const op = mirrorUpserts()[0];
     expect(op).toBeTruthy();
-    expect(op!.body.contactId).toBeUndefined();
+    expect(op!.body.contactId).toBe("co-guardian");
+    expect(op!.body.channelId).toBe("ch-guardian");
   });
 
   test("a mirror failure never rolls back or duplicates the gateway write", async () => {
@@ -361,5 +371,41 @@ describe("guardian duplicate regression (LUM-2672 second act)", () => {
     expect(allContacts()).toHaveLength(1);
     expect(allChannels()).toHaveLength(1);
     expect(channelLessContacts()).toHaveLength(0);
+  });
+
+  test("a retry after a failed mirror write recovers the mirror faithfully", async () => {
+    // First seed of a bot sender: the gateway commit lands, the mirror op is
+    // lost.
+    mirrorThrow = true;
+    await expect(
+      upsertContactChannel({
+        sourceChannel: "slack",
+        externalUserId: "UBOT99",
+        displayName: "Peer Assistant",
+        contactType: "assistant",
+        notes: "Automated Slack bot",
+      }),
+    ).rejects.toThrow("mirror unavailable");
+    const gwRow = allChannels()[0];
+
+    // The next message from the same sender must hand the mirror the SAME
+    // gateway ids and the same classification, so the recovered mirror row
+    // is not an unrelated human record under divergent keys.
+    mirrorThrow = false;
+    mirrorCalls.length = 0;
+    await upsertContactChannel({
+      sourceChannel: "slack",
+      externalUserId: "UBOT99",
+      displayName: "Peer Assistant",
+      contactType: "assistant",
+      notes: "Automated Slack bot",
+    });
+
+    expect(allContacts()).toHaveLength(1);
+    const op = mirrorUpserts()[0];
+    expect(op!.body.contactId).toBe(gwRow.contactId);
+    expect(op!.body.channelId).toBe(gwRow.id);
+    expect(op!.body.contactType).toBe("assistant");
+    expect(op!.body.notes).toBe("Automated Slack bot");
   });
 });

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -151,6 +151,14 @@ mock.module("../ipc/contacts-info-client.js", () => ({
   probeContactMirror: async () => {
     throw new Error("probeContactMirror not stubbed for this suite");
   },
+  // Not exercised here (ContactStore info joins only); present so the module
+  // graph links (contact-helpers → ContactStore → contacts-info-joiner).
+  fetchContactsInfoBatch: async () => {
+    throw new Error("fetchContactsInfoBatch not stubbed for this suite");
+  },
+  listContactUserFileSlugs: async () => {
+    throw new Error("listContactUserFileSlugs not stubbed for this suite");
+  },
 }));
 
 mock.module("../ipc/assistant-client.js", () => ({
@@ -176,6 +184,8 @@ mock.module("../db/schema.js", () => ({
     status: "status",
   },
   contacts: "contacts",
+  // Not exercised here; present so ContactStore's module graph links.
+  ingressInvites: {},
 }));
 
 mock.module("drizzle-orm", () => ({
@@ -186,6 +196,10 @@ mock.module("drizzle-orm", () => ({
     strings: Array.from(strings),
     vals,
   }),
+  // Not exercised here; present so ContactStore's module graph links.
+  desc: (col: unknown) => ({ op: "desc", col }),
+  gt: (col: unknown, val: unknown) => ({ op: "gt", col, val }),
+  ne: (col: unknown, val: unknown) => ({ op: "ne", col, val }),
 }));
 
 mock.module("../verification/identity.js", () => ({
@@ -197,7 +211,7 @@ mock.module("../ipc/endpoint.js", () => ({
 }));
 
 // Import after mocks
-const { upsertContactChannel, upsertVerifiedContactChannel } =
+const { upsertVerifiedContactChannel } =
   await import("../verification/contact-helpers.js");
 
 beforeEach(() => {
@@ -1106,119 +1120,17 @@ describe("identity lookup failure posture", () => {
     expect(gwInserts).toHaveLength(0);
   });
 
-  test("upsertContactChannel: a thrown identity lookup propagates (no soft mode)", async () => {
-    lookupThrow = true;
-
-    await expect(
-      upsertContactChannel({
-        sourceChannel: "slack",
-        externalUserId: "ULOOKUPFAIL",
-        externalChatId: "DLOOKUPFAIL",
-      }),
-    ).rejects.toThrow("identity lookup IPC failed");
-    expect(mirrorUpserts()).toHaveLength(0);
-    expect(gwInserts).toHaveLength(0);
-  });
+  // Inbound seeding (upsertContactChannel) is covered by the real-DB suite in
+  // inbound-contact-seed.test.ts: it dedupes against the gateway DB inside a
+  // ContactStore transaction, which this suite's call-recording gateway fake
+  // cannot express.
 });
 
-describe("upsertContactChannel — channel address casing", () => {
-  test("preserves original Slack address casing", async () => {
-    queryRows = [];
-
-    await upsertContactChannel({
-      sourceChannel: "slack",
-      externalUserId: "U123EXAMPLE",
-      externalChatId: "D123EXAMPLE",
-    });
-
-    const upsert = mirrorUpserts()[0];
-    expect(upsert).toBeTruthy();
-    // address preserves original casing
-    expect(upsert!.body.address).toBe("U123EXAMPLE");
-
-    // The typed identity lookup receives the original casing; the daemon
-    // handler owns the NOCASE match.
-    expect(lookupCalls[0]).toEqual({ type: "slack", address: "U123EXAMPLE" });
-  });
-});
-
-describe("upsertContactChannel — inbound seed identity mirror (id alignment + display refresh)", () => {
-  test("Finding B: shares the gateway-minted channel id with the mirror on create", async () => {
-    // First-seen actor: no existing mirror channel.
-    queryRows = [];
-
-    await upsertContactChannel({
-      sourceChannel: "slack",
-      externalUserId: "USEED1",
-      externalChatId: "DSEED1",
-      displayName: "Seed One",
-    });
-
-    // The mirror create carries the SAME channel id the gateway inserted, so
-    // both stores key the channel identically (id-keyed read-backs match).
-    const mirror = mirrorUpserts()[0];
-    expect(mirror).toBeTruthy();
-    const gwChannel = gwInserts.find(
-      (i) => i.values.type === "slack" && i.values.address === "USEED1",
-    );
-    expect(gwChannel).toBeTruthy();
-    expect(mirror!.body.channelId).toBe(gwChannel!.values.id);
-    // Inbound seed refreshes the mirror display name.
-    expect(mirror!.body.refreshDisplayName).toBe(true);
-    // Inbound seed never reparents (gateway insert uses onConflictDoNothing).
-    expect(mirror!.body.reassignConflictingChannels).toBe(false);
-  });
-
-  test("Finding B: a follow-up seed update targets the aligned id and persists externalChatId", async () => {
-    // The mirror row created by the first seed reads back with the SAME
-    // (gateway-aligned) channel id.
-    const alignedChannelId = "gw-aligned-ch";
-    queryRows = [
-      {
-        channelId: alignedChannelId,
-        contactId: "co-seed",
-        channelStatus: "unverified",
-      },
-    ];
-
-    await upsertContactChannel({
-      sourceChannel: "slack",
-      externalUserId: "USEED1",
-      externalChatId: "DSEED1-dm", // workspace seed → DM: new external chat id
-      displayName: "Seed One",
-    });
-
-    // The gateway update keys on the aligned channel id (read back from the
-    // mirror) and persists the new externalChatId. Before id-alignment the
-    // mirror minted a divergent id, so this update matched 0 gateway rows.
-    const gwUpdate = gwUpdates.find(
-      (u) =>
-        (u.set as { externalChatId?: string }).externalChatId === "DSEED1-dm",
-    );
-    expect(gwUpdate).toBeTruthy();
-    expect(gwUpdate!.where).toMatchObject({
-      op: "eq",
-      col: "id",
-      val: alignedChannelId,
-    });
-  });
-
-  test("Finding C: seed refreshes the mirror name; invite binding preserves it", async () => {
-    // Inbound seed (existing channel) → refresh flag set.
-    queryRows = [
-      { channelId: "ch-a", contactId: "co-a", channelStatus: "unverified" },
-    ];
-    await upsertContactChannel({
-      sourceChannel: "slack",
-      externalUserId: "UREF",
-      externalChatId: "DREF",
-      displayName: "Renamed",
-    });
-    expect(mirrorUpserts()[0]!.body.refreshDisplayName).toBe(true);
-
+describe("invite binding preserves a curated mirror name", () => {
+  test("the verified path sends no refresh flag", async () => {
     // Invite-binding (verified) path → NO refresh flag, so the primitive
-    // preserves a guardian-curated contact name.
-    mirrorCalls.length = 0;
+    // preserves a guardian-curated contact name. (The inbound seed's refresh
+    // flag is pinned in inbound-contact-seed.test.ts.)
     queryRows = [
       { channelId: "ch-b", contactId: "co-guardian", channelStatus: "active" },
     ];
@@ -1230,68 +1142,5 @@ describe("upsertContactChannel — inbound seed identity mirror (id alignment + 
       contactId: "co-target",
     });
     expect(mirrorUpserts()[0]!.body.refreshDisplayName).toBeUndefined();
-  });
-});
-
-describe("upsertContactChannel — bot sender classification", () => {
-  test("creates a bot sender's contact as 'assistant' with a provenance note, not 'human'", async () => {
-    queryRows = [];
-
-    await upsertContactChannel({
-      sourceChannel: "slack",
-      externalUserId: "UBOT99",
-      externalChatId: "D123EXAMPLE",
-      displayName: "Peer Assistant",
-      contactType: "assistant",
-      notes:
-        "Automated Slack bot — messages from this contact are sent by an app, not a person.",
-    });
-
-    const upsert = mirrorUpserts()[0];
-    expect(upsert).toBeTruthy();
-    expect(upsert!.body.displayName).toBe("Peer Assistant");
-    expect(upsert!.body.notes).toContain("Automated Slack bot");
-    expect(upsert!.body.contactType).toBe("assistant");
-    expect(upsert!.body.contactType).not.toBe("human");
-  });
-
-  test("creates a human sender's contact as 'human' with no notes by default", async () => {
-    queryRows = [];
-
-    await upsertContactChannel({
-      sourceChannel: "slack",
-      externalUserId: "U123EXAMPLE",
-      externalChatId: "D123EXAMPLE",
-      displayName: "Alice",
-    });
-
-    const upsert = mirrorUpserts()[0];
-    expect(upsert).toBeTruthy();
-    expect(upsert!.body.notes).toBeUndefined();
-    expect(upsert!.body.contactType).toBe("human");
-  });
-
-  test("does not overwrite contact type or notes for an existing channel", async () => {
-    queryRows = [
-      {
-        channelId: "ch-bot",
-        contactId: "co-bot",
-        channelStatus: "unverified",
-      },
-    ];
-
-    await upsertContactChannel({
-      sourceChannel: "slack",
-      externalUserId: "UBOT99",
-      contactType: "assistant",
-      notes: "Automated Slack bot",
-    });
-
-    // The existing-channel branch upserts identity only — contactType/notes are
-    // omitted so guardian-authored classification is never clobbered.
-    const upsert = mirrorUpserts()[0];
-    expect(upsert).toBeTruthy();
-    expect(upsert!.body.contactType).toBeUndefined();
-    expect(upsert!.body.notes).toBeUndefined();
   });
 });

--- a/gateway/src/__tests__/verification-session-consume.test.ts
+++ b/gateway/src/__tests__/verification-session-consume.test.ts
@@ -78,8 +78,12 @@ mock.module("../ipc/assistant-client.js", () => ({
 
 // Contact-info reads (daemon-backed) — no known contacts by default; the
 // lookup impl is mutable so a test can induce an assistant-IPC failure.
+// Spread the actual module so unstubbed named exports keep resolving when the
+// transitive import graph grows.
 let lookupContactChannelIdentityImpl: () => Promise<null> = async () => null;
+const actualContactsInfoClient = await import("../ipc/contacts-info-client.js");
 mock.module("../ipc/contacts-info-client.js", () => ({
+  ...actualContactsInfoClient,
   lookupContactChannelIdentity: () => lookupContactChannelIdentityImpl(),
   probeContactMirror: async () => ({ exists: false, hasChannels: false }),
 }));

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -54,6 +54,16 @@ export type IngressInviteRow = typeof ingressInvites.$inferSelect;
  */
 export const NO_INVITE_CODE_HASH = "";
 
+/**
+ * Outcome of {@link ContactStore.seedInboundChannel}. `blocked` means the
+ * authoritative row refused the seed (no writes happened); the other two carry
+ * the gateway ids the assistant mirror should key the same identity under.
+ */
+export type SeedInboundChannelResult =
+  | { outcome: "existing"; contactId: string; channelId: string }
+  | { outcome: "created"; contactId: string; channelId: string }
+  | { outcome: "blocked" };
+
 export class ContactStore {
   private injectedDb?: GatewayDb;
 
@@ -1413,6 +1423,135 @@ export class ContactStore {
         );
       }
     }
+  }
+
+  /**
+   * Gateway-DB core of inbound contact seeding: resolve a first-seen actor's
+   * `(type, address)` identity to a contact, creating one when none exists.
+   *
+   * The lookup runs against the gateway DB (the source of truth), never the
+   * assistant mirror. Seeding used to dedupe via a daemon identity lookup, so
+   * any mirror gap for an already-bound address (e.g. the guardian's own
+   * Slack identity after a failed best-effort binding mirror) minted a fresh
+   * gateway contact whose channel insert then no-op'd on the (type, address)
+   * unique index: a channel-less duplicate of an existing contact in the
+   * Contacts pane (LUM-2672 family).
+   *
+   * One transaction, and the contact row is keyed to its channel landing: a
+   * create either commits contact + channel together or nothing. The belt-and-
+   * suspenders conflict re-check inside the transaction downgrades a raced
+   * create to the update path rather than ever leaving a channel-less contact.
+   *
+   * ACL is untouched: an existing row keeps its status/policy (revoked stays
+   * revoked, and a `blocked` row short-circuits with no writes at all); a new
+   * channel seeds the schema defaults (`unverified`/`allow`). The existing
+   * contact's displayName is also left alone: the gateway name is the
+   * guardian-curated one; only the assistant mirror tracks the live platform
+   * profile name (the caller's mirror op carries `refreshDisplayName`).
+   */
+  seedInboundChannel(params: {
+    type: string;
+    /** Canonical address (callers canonicalize via canonicalizeInboundIdentity). */
+    address: string;
+    externalChatId?: string;
+    /** Name for a newly created contact only; existing names are preserved. */
+    displayName: string;
+  }): SeedInboundChannelResult {
+    const now = Date.now();
+
+    return this.db.transaction((tx) => {
+      const findExisting = () =>
+        tx
+          .select({
+            id: contactChannels.id,
+            contactId: contactChannels.contactId,
+            status: contactChannels.status,
+          })
+          .from(contactChannels)
+          .where(
+            and(
+              eq(contactChannels.type, params.type),
+              sql`${contactChannels.address} = ${params.address} COLLATE NOCASE`,
+            ),
+          )
+          .get();
+      const refreshIdentity = (channelId: string): void => {
+        // Identity refresh only: canonical address casing self-heal, and the
+        // delivery chat id when the caller learned one (a DM). Omitted
+        // externalChatId preserves the stored value.
+        tx.update(contactChannels)
+          .set({
+            address: params.address,
+            ...(params.externalChatId
+              ? { externalChatId: params.externalChatId }
+              : {}),
+            updatedAt: now,
+          })
+          .where(eq(contactChannels.id, channelId))
+          .run();
+      };
+
+      const existing = findExisting();
+      if (existing) {
+        if (existing.status === "blocked") {
+          return { outcome: "blocked" };
+        }
+        refreshIdentity(existing.id);
+        return {
+          outcome: "existing",
+          contactId: existing.contactId,
+          channelId: existing.id,
+        };
+      }
+
+      const contactId = crypto.randomUUID();
+      const channelId = crypto.randomUUID();
+      tx.insert(contacts)
+        .values({
+          id: contactId,
+          displayName: params.displayName,
+          role: "contact",
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+      const inserted = tx
+        .insert(contactChannels)
+        .values({
+          id: channelId,
+          contactId,
+          type: params.type,
+          address: params.address,
+          isPrimary: false,
+          externalChatId: params.externalChatId ?? null,
+          status: "unverified",
+          policy: "allow",
+          interactionCount: 0,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .onConflictDoNothing()
+        .returning({ id: contactChannels.id })
+        .all();
+      if (inserted.length === 0) {
+        // A foreign writer landed the (type, address) row between the lookup
+        // and the insert. Take the contact insert back and downgrade to the
+        // update path: a contact must never outlive a channel insert that
+        // didn't happen.
+        tx.delete(contacts).where(eq(contacts.id, contactId)).run();
+        const raced = findExisting();
+        if (!raced || raced.status === "blocked") {
+          return { outcome: "blocked" };
+        }
+        refreshIdentity(raced.id);
+        return {
+          outcome: "existing",
+          contactId: raced.contactId,
+          channelId: raced.id,
+        };
+      }
+      return { outcome: "created", contactId, channelId };
+    });
   }
 
   /**

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1429,18 +1429,16 @@ export class ContactStore {
    * Gateway-DB core of inbound contact seeding: resolve a first-seen actor's
    * `(type, address)` identity to a contact, creating one when none exists.
    *
-   * The lookup runs against the gateway DB (the source of truth), never the
-   * assistant mirror. Seeding used to dedupe via a daemon identity lookup, so
-   * any mirror gap for an already-bound address (e.g. the guardian's own
-   * Slack identity after a failed best-effort binding mirror) minted a fresh
-   * gateway contact whose channel insert then no-op'd on the (type, address)
-   * unique index: a channel-less duplicate of an existing contact in the
-   * Contacts pane (LUM-2672 family).
+   * The dedupe lookup runs against the gateway DB (the source of truth),
+   * never the assistant mirror: the mirror is a lossy best-effort copy, and a
+   * dedupe keyed off it can re-mint a contact for an identity the gateway
+   * already binds (including the guardian's own), leaving a channel-less
+   * duplicate in the Contacts pane.
    *
    * One transaction, and the contact row is keyed to its channel landing: a
-   * create either commits contact + channel together or nothing. The belt-and-
-   * suspenders conflict re-check inside the transaction downgrades a raced
-   * create to the update path rather than ever leaving a channel-less contact.
+   * create either commits contact + channel together or nothing. The
+   * conflict re-check inside the transaction downgrades a raced create to
+   * the update path rather than ever leaving a channel-less contact.
    *
    * ACL is untouched: an existing row keeps its status/policy (revoked stays
    * revoked, and a `blocked` row short-circuits with no writes at all); a new

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -18,6 +18,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { isBindingDemotion } from "@vellumai/gateway-client";
 
 import { getGatewayDb } from "../db/connection.js";
+import { ContactStore } from "../db/contact-store.js";
 import {
   contactChannels as gwContactChannels,
   contacts as gwContacts,
@@ -864,18 +865,27 @@ export async function upsertVerifiedContactChannel(params: {
  * existing status/policy. Used to seed contact records when new users are
  * first seen on a channel.
  *
- * - Existing channel: updates display name, external_chat_id.
- *   Status and policy live in the gateway DB and are left unchanged so
- *   blocked/revoked channels stay that way. `contactType`/`notes` are also
- *   left unchanged so guardian-authored edits are never clobbered.
- * - New channel: inserts contact + channel, classified via `contactType`
- *   (default 'human') and seeded with `notes` when provided. ACL columns
- *   (status, policy) are gateway-owned; the gateway DB seeds
- *   status='unverified', policy='allow'.
+ * Gateway-first: the gateway DB (source of truth) decides whether this
+ * `(type, address)` identity already exists, via the transactional
+ * `ContactStore.seedInboundChannel` (contact row atomic with its channel row).
+ * The assistant mirror is a best-effort identity follower of that decision,
+ * never the dedupe authority. It used to be: the seed deduped via a daemon
+ * identity lookup, so a mirror gap for an already-bound address minted a
+ * channel-less duplicate gateway contact (LUM-2672 family).
  *
- * Dual-writes to both the assistant DB (identity/info mirror) and the gateway
- * DB (ACL source of truth). Skips silently when the assistant IPC socket is
- * unavailable (test environments).
+ * - Existing channel: refreshes identity fields (canonical address casing,
+ *   external_chat_id when provided). ACL columns stay untouched so
+ *   blocked/revoked channels stay that way (`blocked` skips even the identity
+ *   refresh), and `contactType`/`notes` are left alone so guardian-authored
+ *   edits are never clobbered. The mirror op refreshes the mirror display
+ *   name to the current platform profile (unlike invite binding, which
+ *   preserves a curated name); the gateway contact name is never rewritten.
+ * - New channel: inserts contact + channel, classified via `contactType`
+ *   (default 'human') and seeded with `notes` when provided. ACL columns are
+ *   gateway-owned (status='unverified', policy='allow').
+ *
+ * The mirror write is skipped silently when the assistant IPC socket is
+ * unavailable (test environments); the gateway write happens regardless.
  */
 export async function upsertContactChannel(params: {
   sourceChannel: string;
@@ -888,130 +898,62 @@ export async function upsertContactChannel(params: {
   /** Notes seeded onto a newly created contact (e.g. bot/app provenance). */
   notes?: string;
 }): Promise<void> {
-  const { path: socketPath } = resolveIpcSocketPath("assistant");
-  if (!existsSync(socketPath)) return;
-
   const { sourceChannel, externalChatId, displayName, username } = params;
-  const now = Date.now();
   const address =
     canonicalizeInboundIdentity(sourceChannel, params.externalUserId) ??
     params.externalUserId;
   const contactDisplayName = displayName ?? username ?? address;
 
-  // Most-recently-updated mirror row wins. Socket presence was guarded above;
-  // an IPC failure propagates.
-  const existing = await lookupContactChannelIdentity({
+  const seeded = new ContactStore().seedInboundChannel({
     type: sourceChannel,
     address,
+    externalChatId,
+    displayName: contactDisplayName,
   });
+  // Gateway DB is the source of truth for ACL: a blocked channel stays
+  // blocked, and gets no identity refresh in either store.
+  if (seeded.outcome === "blocked") return;
 
-  if (existing) {
-    const row = { channelId: existing.id, contactId: existing.contactId };
-    // Gateway DB is the source of truth for ACL: a blocked channel stays blocked.
-    if (gatewayChannelStatus(sourceChannel, address) === "blocked") return;
+  const { path: socketPath } = resolveIpcSocketPath("assistant");
+  if (!existsSync(socketPath)) return;
 
-    // Update identity/display fields; ACL columns (status, policy) are
-    // gateway-owned and left untouched by the mirror. externalChatId is omitted
-    // when absent so the existing value is preserved. refreshDisplayName: an
-    // inbound seed intends to sync the mirror name to the current platform
-    // profile (unlike invite binding, which preserves a curated name).
+  if (seeded.outcome === "created") {
+    // Share BOTH gateway-minted ids with the mirror so the two stores key the
+    // contact and channel identically (id-keyed gateway read-backs on later
+    // seed updates match). The mirror contact keeps user_file NULL.
     await ipcCallAssistant("contacts_mirror_upsert_channel", {
       body: {
-        contactId: row.contactId,
+        contactId: seeded.contactId,
+        channelId: seeded.channelId,
         type: sourceChannel,
         address,
         externalChatId,
         displayName: contactDisplayName,
+        contactType: params.contactType ?? "human",
+        notes: params.notes,
         refreshDisplayName: true,
-        // Inbound seed: never reparent a conflicting channel. Match the gateway
-        // insert's onConflictDoNothing so a first-seen race keeps the channel
-        // under the contact the gateway kept.
+        // Inbound seed: never reparent a conflicting channel. The gateway
+        // transaction kept exactly one row for this (type,address); the mirror
+        // must not steal a divergent mirror row from whichever contact holds
+        // it, or the two stores would disagree about the channel's contact.
         reassignConflictingChannels: false,
       },
     });
-
-    try {
-      const gwDb = getGatewayDb();
-      gwDb
-        .update(gwContactChannels)
-        .set({
-          address,
-          ...(externalChatId ? { externalChatId } : {}),
-          updatedAt: now,
-        })
-        .where(eq(gwContactChannels.id, row.channelId))
-        .run();
-    } catch (gwErr) {
-      log.warn(
-        { err: gwErr },
-        "Gateway DB contact channel update dual-write failed",
-      );
-    }
     return;
   }
 
-  // New contact + channel. Share BOTH the gateway-generated contact id and
-  // channel id with the mirror so the two stores key the contact and channel
-  // identically (id-keyed gateway read-backs on later seed updates match). ACL
-  // columns are gateway-owned (schema defaults status='unverified',
-  // policy='allow'); the mirror contact keeps user_file NULL.
-  const contactId = crypto.randomUUID();
-  const channelId = crypto.randomUUID();
-
+  // Existing channel: identity/display refresh only. The mirror resolves the
+  // row by (type, address) itself (no contactId), so a divergent mirror
+  // updates ITS owner in place, and a mirror gap heals by creating the row
+  // rather than minting anything gateway-side.
   await ipcCallAssistant("contacts_mirror_upsert_channel", {
     body: {
-      contactId,
-      channelId,
       type: sourceChannel,
       address,
       externalChatId,
       displayName: contactDisplayName,
-      contactType: params.contactType ?? "human",
-      notes: params.notes,
       refreshDisplayName: true,
-      // Inbound seed: never reparent a conflicting channel. Two first-seen
-      // events for the same (type,address) both reach this create path with
-      // different fresh contact ids; the gateway insert uses onConflictDoNothing
-      // and keeps the FIRST, so the mirror must not reparent to the second or
-      // the two stores would disagree about the channel's contact.
       reassignConflictingChannels: false,
     },
   });
-
-  try {
-    const gwDb = getGatewayDb();
-    gwDb
-      .insert(gwContacts)
-      .values({
-        id: contactId,
-        displayName: contactDisplayName,
-        role: "contact",
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing()
-      .run();
-    gwDb
-      .insert(gwContactChannels)
-      .values({
-        id: channelId,
-        contactId,
-        type: sourceChannel,
-        address,
-        isPrimary: false,
-        externalChatId: externalChatId ?? null,
-        status: "unverified",
-        policy: "allow",
-        interactionCount: 0,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing()
-      .run();
-  } catch (gwErr) {
-    log.warn(
-      { err: gwErr },
-      "Gateway DB contact channel create dual-write failed",
-    );
-  }
 }

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -867,19 +867,21 @@ export async function upsertVerifiedContactChannel(params: {
  *
  * Gateway-first: the gateway DB (source of truth) decides whether this
  * `(type, address)` identity already exists, via the transactional
- * `ContactStore.seedInboundChannel` (contact row atomic with its channel row).
- * The assistant mirror is a best-effort identity follower of that decision,
- * never the dedupe authority. It used to be: the seed deduped via a daemon
- * identity lookup, so a mirror gap for an already-bound address minted a
- * channel-less duplicate gateway contact (LUM-2672 family).
+ * `ContactStore.seedInboundChannel` (contact row atomic with its channel
+ * row). The assistant mirror is a best-effort identity follower of that
+ * decision, never the dedupe authority: the mirror op carries the gateway's
+ * contact/channel ids plus the classification fields, so a mirror missing
+ * the row recreates it faithfully (same ids, same `contactType`/`notes`)
+ * instead of inventing a divergent one. The daemon applies
+ * `contactType`/`notes` on mirror-row CREATE only, so guardian-authored
+ * edits on an existing mirror contact are never clobbered.
  *
  * - Existing channel: refreshes identity fields (canonical address casing,
  *   external_chat_id when provided). ACL columns stay untouched so
  *   blocked/revoked channels stay that way (`blocked` skips even the identity
- *   refresh), and `contactType`/`notes` are left alone so guardian-authored
- *   edits are never clobbered. The mirror op refreshes the mirror display
- *   name to the current platform profile (unlike invite binding, which
- *   preserves a curated name); the gateway contact name is never rewritten.
+ *   refresh). The mirror op refreshes the mirror display name to the current
+ *   platform profile (unlike invite binding, which preserves a curated name);
+ *   the gateway contact name is never rewritten.
  * - New channel: inserts contact + channel, classified via `contactType`
  *   (default 'human') and seeded with `notes` when provided. ACL columns are
  *   gateway-owned (status='unverified', policy='allow').
@@ -917,42 +919,27 @@ export async function upsertContactChannel(params: {
   const { path: socketPath } = resolveIpcSocketPath("assistant");
   if (!existsSync(socketPath)) return;
 
-  if (seeded.outcome === "created") {
-    // Share BOTH gateway-minted ids with the mirror so the two stores key the
-    // contact and channel identically (id-keyed gateway read-backs on later
-    // seed updates match). The mirror contact keeps user_file NULL.
-    await ipcCallAssistant("contacts_mirror_upsert_channel", {
-      body: {
-        contactId: seeded.contactId,
-        channelId: seeded.channelId,
-        type: sourceChannel,
-        address,
-        externalChatId,
-        displayName: contactDisplayName,
-        contactType: params.contactType ?? "human",
-        notes: params.notes,
-        refreshDisplayName: true,
-        // Inbound seed: never reparent a conflicting channel. The gateway
-        // transaction kept exactly one row for this (type,address); the mirror
-        // must not steal a divergent mirror row from whichever contact holds
-        // it, or the two stores would disagree about the channel's contact.
-        reassignConflictingChannels: false,
-      },
-    });
-    return;
-  }
-
-  // Existing channel: identity/display refresh only. The mirror resolves the
-  // row by (type, address) itself (no contactId), so a divergent mirror
-  // updates ITS owner in place, and a mirror gap heals by creating the row
-  // rather than minting anything gateway-side.
+  // One follower op for create and existing alike, projecting the gateway's
+  // decision: both gateway-minted ids (so the two stores key the contact and
+  // channel identically, and a mirror gap recreates the row under the same
+  // ids) plus the classification fields (applied by the daemon on mirror-row
+  // CREATE only, so a curated mirror record is never clobbered). The mirror
+  // contact keeps user_file NULL.
   await ipcCallAssistant("contacts_mirror_upsert_channel", {
     body: {
+      contactId: seeded.contactId,
+      channelId: seeded.channelId,
       type: sourceChannel,
       address,
       externalChatId,
       displayName: contactDisplayName,
+      contactType: params.contactType ?? "human",
+      notes: params.notes,
       refreshDisplayName: true,
+      // Inbound seed: never reparent a conflicting channel. The gateway
+      // transaction kept exactly one row for this (type,address); the mirror
+      // must not steal a divergent mirror row from whichever contact holds
+      // it, or the two stores would disagree about the channel's contact.
       reassignConflictingChannels: false,
     },
   });

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -914,10 +914,14 @@ export async function upsertContactChannel(params: {
   });
   // Gateway DB is the source of truth for ACL: a blocked channel stays
   // blocked, and gets no identity refresh in either store.
-  if (seeded.outcome === "blocked") return;
+  if (seeded.outcome === "blocked") {
+    return;
+  }
 
   const { path: socketPath } = resolveIpcSocketPath("assistant");
-  if (!existsSync(socketPath)) return;
+  if (!existsSync(socketPath)) {
+    return;
+  }
 
   // One follower op for create and existing alike, projecting the gateway's
   // decision: both gateway-minted ids (so the two stores key the contact and


### PR DESCRIPTION
## TL;DR

Inbound contact seeding now dedupes against the gateway DB (the source of truth) inside one `ContactStore.seedInboundChannel` transaction, with the contact row atomic with its channel row. This closes the last live path that could mint the guardian (or any bound identity) as a second, channel-less, unlinkable contact in the Contacts pane (the LUM-2672 family, which resurfaced on the dogfood instance on Aug 31). The assistant mirror becomes a pure follower of the gateway decision: every seed's mirror op carries the gateway-minted contact/channel ids plus the classification fields, and the daemon applies classification and notes on mirror-row create only, so curated record fields are never clobbered and a mirror gap recovers faithfully under the same keys.

Part of LUM-3490 (step 1 of 3; the bind/claim primitive and the mirror pull reconciler are the follow-ups).

## Root cause

Every inbound Slack/Discord message seeds a contact for its sender. The seed's existence check read the assistant mirror over IPC, a best-effort copy, while the gateway create path inserted the contact row unconditionally and let the channel insert silently no-op on the `(type, address)` unique index. Any mirror gap for an already-bound address (for example the guardian's own Slack identity after the best-effort binding mirror failed) therefore minted a fresh gateway contact with zero channels. The Jul fix for LUM-2672 (#36851) only garbage-collects orphans at guardian-binding claim time, so this seed path stayed open.

## What changes for the user

| Before | After |
| --- | --- |
| Messaging from an already-bound identity while the assistant mirror was out of sync created a duplicate contact entry (no channels, "Unverified", cannot be linked because the account "is already linked to another contact") | No duplicate is ever created; the existing contact is refreshed in place |
| The guardian could appear in the Contacts list a second time under their platform profile name | The guardian appears once, as the Guardian entry |
| After a lost mirror write, the next message recreated the mirror record as an unrelated human row under divergent ids | The mirror recovers the row under the gateway's own ids with its original classification and notes |

## Design

- `ContactStore.seedInboundChannel` (gateway): one transaction; dedupe by `(type, address)` against the gateway DB; a create commits contact + channel together or nothing; blocked rows short-circuit with no writes; ACL and the curated gateway display name stay untouched.
- The seed helper emits one mirror op for create and existing alike, projecting the gateway decision: gateway ids, platform-profile display name (`refreshDisplayName`), `contactType`/`notes`, and never a reparent.
- Daemon `upsertContact` gains `contactTypeOnCreate`/`notesOnCreate` (modeled on `userFileOnCreate`): applied on insert only, ignored on update and on channel-identity adoption, so guardian-authored record fields always stand.
- Daemon `upsertContact` also extends its channel-identity dedupe to explicit-id creates without reassignment: a create-shaped write whose channel already belongs to another contact adopts that owner instead of minting an empty contact. Reassigning callers (invite binding, guardian bootstrap mirror) keep their bind-to-target semantics.

## Why this is safe

- Every deliberate seed semantic is preserved and pinned by a real-DB suite (`gateway/src/__tests__/inbound-contact-seed.test.ts`): blocked stays blocked, revoked gets identity refresh but stays revoked, ACL columns untouched, curated gateway name preserved, bot classification lands on create, gateway ids shared with the mirror, no reparenting. New regressions cover the guardian mirror-gap scenario, recovery after a failed mirror write, and create-only record fields (daemon suite).
- The verified/invite/guardian-binding paths are untouched; their 38-test suite passes unchanged.
- Affected suites run green per-file in both packages and both typecheck clean. The partial `mock.module` factories for `contacts-info-client` in four gateway suites now spread the actual module, so transitive import-graph growth cannot break them again.

## Deferred (tracked in LUM-3490)

- Step 2: single `bindChannelToContact` claim/re-parent primitive with donor orphan-GC inside it (covers the invite re-parent path that #36851 never wired).
- Step 3: replace per-write `contacts_mirror_*` push ops with a pull reconciler (self-heals LUM-2709-class row drift); needs a mirror reader census first.
- The existing duplicate row on the dogfood instance predates this fix and is data, not code: it gets merged away in the UI (Guardian entry, Merge, absorb the duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
