### PR TITLE
Deliberate silence resolves visibly

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20830,6 +20830,8 @@ paths:
                           additionalProperties: false
                         systemCard:
                           type: boolean
+                        noResponse:
+                          type: boolean
                         providerError:
                           type: object
                           properties:

--- a/assistant/src/__tests__/list-messages-system-card.test.ts
+++ b/assistant/src/__tests__/list-messages-system-card.test.ts
@@ -19,6 +19,7 @@ import { ConversationMessageSchema } from "../api/responses/conversation-message
 import {
   addMessage,
   createConversation,
+  NO_RESPONSE_MESSAGE_KIND,
   SYSTEM_CARD_MESSAGE_KIND,
 } from "../persistence/conversation-crud.js";
 import { getDb } from "../persistence/db-connection.js";
@@ -39,6 +40,7 @@ interface ProjectedMessage {
   id: string;
   role: string;
   systemCard?: boolean;
+  noResponse?: boolean;
 }
 
 describe("handleListMessages system-card projection", () => {
@@ -72,6 +74,34 @@ describe("handleListMessages system-card projection", () => {
     const cardRow = response.messages.find((m) => m.id === card.id);
     expect(cardRow).toBeDefined();
     expect(cardRow?.systemCard).toBe(true);
+  });
+
+  test("projects noResponse from the deliberate-silence marker", async () => {
+    const conv = createConversation();
+    await addMessage(
+      conv.id,
+      "user",
+      JSON.stringify([{ type: "text", text: "thanks!" }]),
+    );
+    // Mirror the agent loop's turn-boundary stamp: the row keeps the raw
+    // sentinel as content and carries the marker in metadata.
+    const silent = await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "<no_response/>" }]),
+      { metadata: { messageKind: NO_RESPONSE_MESSAGE_KIND } },
+    );
+
+    const response = (await handleListMessages({
+      queryParams: { conversationId: conv.id },
+    })) as { messages: ProjectedMessage[] };
+
+    for (const message of response.messages) {
+      expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
+    }
+
+    const silentRow = response.messages.find((m) => m.id === silent.id);
+    expect(silentRow?.noResponse).toBe(true);
   });
 
   test("omits systemCard on ordinary user and assistant rows", async () => {

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -607,6 +607,12 @@ export const ConversationMessageSchema = z.object({
    *  system notices — no avatar, no persona bubble — and never group them
    *  with adjacent assistant turns. */
   systemCard: z.boolean().optional(),
+  /** Set on a turn whose whole reply was the `<no_response/>` sentinel
+   *  (`metadata.messageKind === "no_response"`): the assistant deliberately
+   *  chose silence. Clients render a quiet standalone notice instead of the
+   *  sentinel text, and treat the row as the turn's reply so nothing keeps
+   *  waiting for one. */
+  noResponse: z.boolean().optional(),
   /** Present when this assistant row is a daemon-persisted provider-failure
    *  notice (`metadata.messageKind === "provider_error"`); clients may render
    *  a themed card instead of a persona bubble. `code` is the stable

--- a/assistant/src/conversations/message-consolidation.ts
+++ b/assistant/src/conversations/message-consolidation.ts
@@ -39,8 +39,8 @@ import { getLogger } from "../util/logger.js";
 const log = getLogger("message-consolidation");
 
 /**
- * True when an assistant row is a standalone display turn (system card or
- * provider-error notice) that never merges with adjacent assistant rows in
+ * True when an assistant row is a standalone display turn (system card,
+ * provider-error notice, or deliberate-silence marker) that never merges with adjacent assistant rows in
  * either direction. Merging one into an adjacent run would let the anchor's
  * metadata win and drop the `messageKind` marker from the wire (or stamp it
  * onto a bubble containing real assistant text).

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -51,8 +51,10 @@ import {
   resolveOverrideProfile,
   updateConversationContextWindow,
   updateConversationSlackContextWatermark,
+  updateMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { isReplaceableTitle } from "../persistence/conversation-title-service.js";
+import { NO_RESPONSE_MESSAGE_KIND } from "../persistence/conversation-types.js";
 import {
   backfillMessageIdOnLogs,
   recordSyntheticAgentErrorMessageLog,
@@ -73,6 +75,7 @@ import {
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { Provider } from "../providers/types.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
+import { isNoResponseOnlyText } from "../runtime/no-response.js";
 import { publishConversationMessagesChanged } from "../runtime/sync/resource-sync-events.js";
 import { stampTurnOutcome } from "../telemetry/turn-outcome.js";
 import {
@@ -1576,6 +1579,32 @@ export async function runAgentLoopImpl(
     // of why the turn stopped.
     const hasAssistantResponse =
       newMessages[newMessages.length - 1]?.role === "assistant";
+    // A reply that is nothing but the `<no_response/>` sentinel is deliberate
+    // silence. Stamp the persisted row so clients render a quiet notice and
+    // resolve their pending-response state, instead of showing the raw
+    // sentinel or waiting forever; the content keeps the sentinel so the
+    // model reads its own convention back from history.
+    if (hasAssistantResponse && state.lastAssistantMessageId) {
+      const tail = newMessages[newMessages.length - 1]!;
+      const tailText = Array.isArray(tail.content)
+        ? tail.content
+            .filter((b) => b.type === "text")
+            .map((b) => (b.type === "text" ? b.text : ""))
+            .join("\n")
+        : "";
+      if (isNoResponseOnlyText(tailText)) {
+        try {
+          updateMessageMetadata(state.lastAssistantMessageId, {
+            messageKind: NO_RESPONSE_MESSAGE_KIND,
+          });
+        } catch (err) {
+          rlog.warn(
+            { err, messageId: state.lastAssistantMessageId },
+            "Failed to stamp deliberate-silence marker (non-fatal)",
+          );
+        }
+      }
+    }
     if (
       !hasAssistantResponse &&
       state.providerErrorUserMessage &&

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -490,7 +490,7 @@ export function isProviderErrorMetadata(
 
 /**
  * True when an assistant row is a standalone display turn: a system card or
- * a provider-error notice. Standalone rows never merge with adjacent
+ * a provider-error notice, or a deliberate-silence marker. Standalone rows never merge with adjacent
  * assistant rows, and turn grouping closes on them, so display merging and
  * the turn resolver agree on boundaries. Takes the raw persisted `metadata`
  * JSON string; malformed JSON and non-assistant roles are never standalone.

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -91,6 +91,7 @@ import {
   type ConversationCreateType,
   type ConversationOrigin,
   isHiddenMessageMetadata,
+  isNoResponseMetadata,
   isSystemCardMetadata,
   PINNED_GROUP_ID,
   SIGHT_FRAME_ATTACHMENT_IDS_KEY,
@@ -460,7 +461,9 @@ export {
  * alongside the schema that carries them.
  */
 export {
+  isNoResponseMetadata,
   isSystemCardMetadata,
+  NO_RESPONSE_MESSAGE_KIND,
   SYSTEM_CARD_MESSAGE_KIND,
 } from "./conversation-types.js";
 
@@ -501,7 +504,11 @@ export function isStandaloneAssistantMessage(
   }
   try {
     const parsed = JSON.parse(metadata) as Record<string, unknown>;
-    return isSystemCardMetadata(parsed) || isProviderErrorMetadata(parsed);
+    return (
+      isSystemCardMetadata(parsed) ||
+      isProviderErrorMetadata(parsed) ||
+      isNoResponseMetadata(parsed)
+    );
   } catch {
     return false;
   }

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -158,6 +158,27 @@ export function isSystemCardMetadata(
 }
 
 /**
+ * Marker for a turn whose whole reply was the `<no_response/>` sentinel: the
+ * assistant deliberately chose silence. The row's content keeps the raw
+ * sentinel (the model reads its own convention back from history); clients
+ * switch on the marker to render a quiet standalone notice and to resolve
+ * their pending-response state, instead of showing the sentinel text or
+ * waiting forever for a reply that was never coming.
+ */
+export const NO_RESPONSE_MESSAGE_KIND = "no_response";
+
+/**
+ * Shared predicate for the deliberate-silence marker, mirroring
+ * {@link isSystemCardMetadata} so display merging, transcript rendering, and
+ * turn grouping cannot drift.
+ */
+export function isNoResponseMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  return metadata?.messageKind === NO_RESPONSE_MESSAGE_KIND;
+}
+
+/**
  * True when a role-`"user"` row is internal scaffolding rather than a person's
  * prompt: a daemon-injected run lifecycle notification (subagent
  * `subagentNotification`, ACP run `acpNotification`, or any wake trigger, the

--- a/assistant/src/runtime/no-response.ts
+++ b/assistant/src/runtime/no-response.ts
@@ -12,6 +12,15 @@
 /** Matches a message whose entire content is the sentinel. */
 const NO_RESPONSE_ONLY_RE = /^\s*<no_response\s*\/?>\s*$/i;
 
+/**
+ * Whether `text` is nothing but the sentinel: the whole reply is a
+ * deliberate non-response, as opposed to real content with an inline
+ * sentinel mixed in.
+ */
+export function isNoResponseOnlyText(text: string): boolean {
+  return NO_RESPONSE_ONLY_RE.test(text);
+}
+
 /** Matches every sentinel occurrence for stripping it out of mixed content. */
 export const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
 

--- a/assistant/src/runtime/no-response.ts
+++ b/assistant/src/runtime/no-response.ts
@@ -1,84 +1,14 @@
 /**
- * The assistant emits a `<no_response/>` sentinel to signal that a turn should
- * produce no user-visible reply. Channel delivery must hide the sentinel
- * itself without hiding real content it happens to coexist with. Slack
- * surfaces that begin work on the first deliverable text (the thinking-status
- * indicator and native reply streaming) additionally must not act on a
- * partially-arrived sentinel: a slow stream can surface just `<` or `<no_resp`
- * before the rest lands, and starting on that leaks a stray message that
- * later resolves to empty.
+ * Daemon door for the shared `<no_response/>` sentinel convention. The
+ * definitions live in `@vellumai/service-contracts/no-response` so the
+ * daemon, gateway, and clients parse identically; this module exists so
+ * daemon-internal imports keep one stable path.
  */
-
-/** Matches a message whose entire content is the sentinel. */
-const NO_RESPONSE_ONLY_RE = /^\s*<no_response\s*\/?>\s*$/i;
-
-/**
- * Whether `text` is nothing but the sentinel: the whole reply is a
- * deliberate non-response, as opposed to real content with an inline
- * sentinel mixed in.
- */
-export function isNoResponseOnlyText(text: string): boolean {
-  return NO_RESPONSE_ONLY_RE.test(text);
-}
-
-/** Matches every sentinel occurrence for stripping it out of mixed content. */
-export const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
-
-/**
- * Detection variant without the `g` flag: a `g`-flagged regex is stateful
- * under `.test()` (it resumes from `lastIndex`), so reusing
- * {@link NO_RESPONSE_INLINE_RE} for detection would alternate between
- * matches and misses across calls.
- */
-const NO_RESPONSE_MARKER_RE = new RegExp(NO_RESPONSE_INLINE_RE.source, "i");
-
-/** Whether `text` contains the sentinel anywhere. */
-export function containsNoResponseMarker(text: string): boolean {
-  return NO_RESPONSE_MARKER_RE.test(text);
-}
-
-/** Removes every sentinel occurrence, trimming the leftover whitespace. */
-export function stripNoResponseMarkers(text: string): string {
-  return text.replace(NO_RESPONSE_INLINE_RE, "").trim();
-}
-
-const NO_RESPONSE_SENTINEL_FORMS = [
-  "<no_response/>",
-  "<no_response />",
-  "<no_response>",
-] as const;
-
-/**
- * Whether `text` could still grow into the sentinel — i.e. it is a leading
- * substring of one of its forms. Holding on these keeps a slowly-streamed
- * `<no_response/>` from surfacing as visible partial content.
- */
-function isPotentialNoResponsePrefix(text: string): boolean {
-  const lower = text.trim().toLowerCase();
-  if (lower.length === 0) {
-    return false;
-  }
-  return NO_RESPONSE_SENTINEL_FORMS.some((sentinel) =>
-    sentinel.startsWith(lower),
-  );
-}
-
-/**
- * Whether `text` carries user-visible content worth acting on now. Returns
- * `false` for empty text, the standalone sentinel, and any prefix that could
- * still complete into one; returns `true` once real content remains after
- * stripping inline sentinels.
- */
-export function hasDeliverableAssistantText(text: string): boolean {
-  const trimmed = text.trim();
-  if (trimmed.length === 0) {
-    return false;
-  }
-  if (NO_RESPONSE_ONLY_RE.test(trimmed)) {
-    return false;
-  }
-  if (isPotentialNoResponsePrefix(trimmed)) {
-    return false;
-  }
-  return stripNoResponseMarkers(trimmed).length > 0;
-}
+export {
+  containsNoResponseMarker,
+  hasDeliverableAssistantText,
+  isNoResponseOnlyText,
+  isPotentialNoResponsePrefix,
+  NO_RESPONSE_INLINE_RE,
+  stripNoResponseMarkers,
+} from "@vellumai/service-contracts/no-response";

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -127,6 +127,7 @@ import {
   getOrCreateConversation,
 } from "../../persistence/conversation-key-store.js";
 import { searchConversations } from "../../persistence/conversation-queries.js";
+import { isNoResponseMetadata } from "../../persistence/conversation-types.js";
 import { linkRequestLogsToMessage } from "../../persistence/llm-request-log-store.js";
 import { MEMORY_RETROSPECTIVE_FORK_SOURCE } from "../../plugins/defaults/memory/memory-retrospective-constants.js";
 import { normalizeOnboardingContext } from "../../prompts/normalize-onboarding.js";
@@ -997,6 +998,7 @@ export async function handleListMessages({
       {};
     let backgroundToolCompletion: ConversationMessage["backgroundToolCompletion"];
     let systemCard: boolean | undefined;
+    let noResponse: boolean | undefined;
     let providerError: ConversationMessage["providerError"];
     if (msg.metadata) {
       try {
@@ -1008,6 +1010,9 @@ export async function handleListMessages({
         // render as standalone system notices, not persona speech.
         if (isSystemCardMetadata(meta)) {
           systemCard = true;
+        }
+        if (isNoResponseMetadata(meta)) {
+          noResponse = true;
         }
         // Daemon-persisted provider-failure notices carry the classified
         // error code/category so clients can render a themed card instead
@@ -1061,6 +1066,7 @@ export async function handleListMessages({
       backgroundEventNotification: notifications.backgroundEventNotification,
       backgroundToolCompletion,
       systemCard,
+      noResponse,
       providerError,
       slackMessage,
       clientMessageId: msg.clientMessageId ?? undefined,
@@ -1271,6 +1277,7 @@ export async function handleListMessages({
           ? { backgroundToolCompletion: m.backgroundToolCompletion }
           : {}),
         ...(m.systemCard ? { systemCard: true } : {}),
+        ...(m.noResponse ? { noResponse: true } : {}),
         ...(m.providerError ? { providerError: m.providerError } : {}),
         ...(m.slackMessage ? { slackMessage: m.slackMessage } : {}),
       };

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -164,6 +164,7 @@ import {
   resolveActorPrincipalIdForLocalGuardian,
 } from "../local-actor-identity.js";
 import { resolveLocalPrincipalTrustContext } from "../local-principal-trust.js";
+import { stripNoResponseMarkers } from "../no-response.js";
 import * as pendingInteractions from "../pending-interactions.js";
 import {
   publishConversationListAndMetadataChanged,
@@ -195,8 +196,6 @@ import { RouteResponse } from "./types.js";
 
 const log = getLogger("conversation-routes");
 
-/** Matches the `<no_response/>` sentinel used by channel delivery suppression. */
-const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/g;
 const ATTACHMENT_ENTRY_RE = /^attachment:(\d+)$/;
 
 /** Rewrites a rendered `contentOrder` to reflect attachment alignment. */
@@ -1181,9 +1180,7 @@ export async function handleListMessages({
         const keepIndices: number[] = [];
         const filteredSegments: string[] = [];
         for (let i = 0; i < rendered.textSegments.length; i++) {
-          const cleaned = rendered.textSegments[i]
-            .replace(NO_RESPONSE_INLINE_RE, "")
-            .trim();
+          const cleaned = stripNoResponseMarkers(rendered.textSegments[i]);
           if (cleaned.length > 0) {
             keepIndices.push(i);
             filteredSegments.push(cleaned);
@@ -1207,7 +1204,7 @@ export async function handleListMessages({
             block.type === "text"
               ? {
                   type: "text" as const,
-                  text: block.text.replace(NO_RESPONSE_INLINE_RE, "").trim(),
+                  text: stripNoResponseMarkers(block.text),
                 }
               : block,
           )

--- a/clients/web/src/domains/chat/transcript/no-response-row.tsx
+++ b/clients/web/src/domains/chat/transcript/no-response-row.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "@/i18n";
 
 /**
  * Quiet standalone marker for a turn whose whole reply was deliberate

--- a/clients/web/src/domains/chat/transcript/no-response-row.tsx
+++ b/clients/web/src/domains/chat/transcript/no-response-row.tsx
@@ -1,0 +1,20 @@
+import { useTranslation } from "react-i18next";
+
+/**
+ * Quiet standalone marker for a turn whose whole reply was deliberate
+ * silence (flagged `isNoResponse`: the assistant output the no-response
+ * sentinel as its entire reply). Renders fixed copy rather than the row's
+ * content, which is the raw sentinel kept for the model's own history.
+ * The row's presence is what resolves the pending-response state, so
+ * silence reads as a decision instead of a reply that never arrives.
+ */
+export function NoResponseRow() {
+  const { t } = useTranslation("chat");
+  return (
+    <div data-testid="no-response-row" className="flex justify-center">
+      <div className="text-body-small-default text-[var(--content-tertiary)] italic">
+        {t("transcript.noResponse")}
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -1,4 +1,8 @@
 import {
+  isNoResponseOnlyText,
+  isPotentialNoResponsePrefix,
+} from "@vellumai/service-contracts/no-response";
+import {
   Fragment,
   type MouseEvent as ReactMouseEvent,
   type ReactNode,
@@ -921,7 +925,8 @@ export function TranscriptMessageBody({
     items: Array<{ kind: "text" | "nonText"; node: ReactNode }>,
   ): ReactNode => {
     type Slot =
-      { kind: "bubble"; nodes: ReactNode[] } | { kind: "raw"; node: ReactNode };
+      | { kind: "bubble"; nodes: ReactNode[] }
+      | { kind: "raw"; node: ReactNode };
     const slots: Slot[] = [];
     let textRun: ReactNode[] = [];
 
@@ -1034,6 +1039,19 @@ export function TranscriptMessageBody({
     if (group.type === "text") {
       const isSmoothedTrailing =
         gi === lastGroupIndex && smoothedTrailingText !== null;
+      // A live-streamed sentinel (or a prefix that could still become one)
+      // is held back from display, mirroring the Slack stream's own
+      // partial-sentinel suppression: once the turn settles, the fold marks
+      // the message isNoResponse and the quiet marker takes over.
+      if (
+        isStreaming &&
+        !isUser &&
+        gi === lastGroupIndex &&
+        (isNoResponseOnlyText(group.text.trim()) ||
+          isPotentialNoResponsePrefix(group.text))
+      ) {
+        return null;
+      }
       // `useSmoothStreamText` returns the target string itself (identity,
       // not a copy) once the reveal has drained the backlog — that identity
       // check is what flips the sweep from "revealing" to "caughtUp".

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -44,6 +44,25 @@ const PROACTIVE_ITEM: CreditsUpsellItem = {
   key: "credits-upsell-proactive",
 };
 
+describe("TranscriptRow deliberate-silence dispatch", () => {
+  test("an isNoResponse message renders the quiet marker, never its sentinel content", () => {
+    const message: DisplayMessage = {
+      id: "m-silent",
+      role: "assistant",
+      ...textBody("<no_response/>"),
+      isNoResponse: true,
+    };
+    const { getByTestId, queryByText } = render(
+      <TranscriptRow
+        item={{ kind: "message", key: "m-silent", message }}
+        onSurfaceAction={() => {}}
+      />,
+    );
+    expect(getByTestId("no-response-row")).toBeTruthy();
+    expect(queryByText("<no_response/>")).toBeNull();
+  });
+});
+
 describe("TranscriptRow creditsUpsell dispatch", () => {
   test("renders a creditsUpsell item via CreditsUpsellCard", () => {
     const { getByTestId } = render(
@@ -63,8 +82,9 @@ describe("TranscriptRow creditsUpsell dispatch", () => {
 
     const anchor = container.querySelector("#msg-m1");
     expect(anchor).toBeTruthy();
-    expect(anchor!.querySelector('[data-testid="credits-upsell-card-stub"]'))
-      .toBeTruthy();
+    expect(
+      anchor!.querySelector('[data-testid="credits-upsell-card-stub"]'),
+    ).toBeTruthy();
   });
 
   test("the proactive card (no backing message) renders without a msg anchor", () => {

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -45,20 +45,41 @@ const PROACTIVE_ITEM: CreditsUpsellItem = {
 };
 
 describe("TranscriptRow deliberate-silence dispatch", () => {
-  test("an isNoResponse message renders the quiet marker, never its sentinel content", () => {
+  test("an isNoResponse message renders the quiet marker in the message shell", () => {
+    // The wire shape: the route strips sentinel text from projected content,
+    // so a silent row arrives with the flag and no text. The marker must not
+    // depend on content, and the shell must keep the row addressable.
     const message: DisplayMessage = {
       id: "m-silent",
       role: "assistant",
-      ...textBody("<no_response/>"),
       isNoResponse: true,
     };
-    const { getByTestId, queryByText } = render(
+    const { getByTestId, container } = render(
       <TranscriptRow
         item={{ kind: "message", key: "m-silent", message }}
         onSurfaceAction={() => {}}
       />,
     );
     expect(getByTestId("no-response-row")).toBeTruthy();
+    expect(container.querySelector("#msg-m-silent")).toBeTruthy();
+    expect(
+      container.querySelector('[data-message-id="m-silent"]'),
+    ).toBeTruthy();
+  });
+
+  test("a flagged row that still carries sentinel text never renders it", () => {
+    const message: DisplayMessage = {
+      id: "m-silent-2",
+      role: "assistant",
+      ...textBody("<no_response/>"),
+      isNoResponse: true,
+    };
+    const { queryByText } = render(
+      <TranscriptRow
+        item={{ kind: "message", key: "m-silent-2", message }}
+        onSurfaceAction={() => {}}
+      />,
+    );
     expect(queryByText("<no_response/>")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -16,6 +16,7 @@ import { PendingConfirmationRow } from "@/domains/chat/transcript/pending-confir
 import { PendingContactRecordRequestRow } from "@/domains/chat/transcript/pending-contact-record-request-row";
 import { PendingContactRequestRow } from "@/domains/chat/transcript/pending-contact-request-row";
 import { PendingSecretRow } from "@/domains/chat/transcript/pending-secret-row";
+import { NoResponseRow } from "@/domains/chat/transcript/no-response-row";
 import { SystemCardRow } from "@/domains/chat/transcript/system-card-row";
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
 import { isInteractiveClickTarget } from "@/domains/chat/transcript/transcript-message-body-shared";
@@ -201,6 +202,11 @@ export const TranscriptRow = memo(function TranscriptRow({
         return (
           <SystemCardRow message={item.message} assistantId={assistantId} />
         );
+      }
+      // A deliberate-silence turn renders as a quiet marker with fixed copy;
+      // the row's stored content is the raw sentinel and never shows.
+      if (item.message.isNoResponse) {
+        return <NoResponseRow />;
       }
       return (
         <TranscriptMessageBody

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -118,14 +118,22 @@ export interface TranscriptRowProps {
  * coarse pointers via tap (dismissed by tapping outside), mirroring
  * `TranscriptMessageBody`'s reveal behavior.
  */
-function CreditsUpsellMessageRow({
+/**
+ * Shell for a row that substitutes custom content for the ordinary message
+ * body while keeping the backing message's identity and affordances: the
+ * `msg-<id>` anchor deep links and programmatic scrolling locate, the
+ * `data-message-id` attribute, and the hover/coarse-pointer Inspect action.
+ */
+function SubstitutedMessageShell({
   message,
   conversationId,
   onInspectMessage,
+  children,
 }: {
   message: DisplayMessage;
   conversationId?: string | null;
   onInspectMessage?: (messageId: string) => void;
+  children: ReactNode;
 }) {
   const { wrapperRef, revealed, toggleRevealed } = useCoarsePointerReveal();
   const handleClick = (e: ReactMouseEvent<HTMLDivElement>) => {
@@ -152,7 +160,7 @@ function CreditsUpsellMessageRow({
       onClick={handleClick}
       className="group/msg flex flex-col gap-2"
     >
-      <CreditsUpsellCard />
+      {children}
       {inspectHandler && (
         <div className="h-6 overflow-hidden opacity-0 transition-opacity duration-200 ease-out group-hover/msg:opacity-100 has-[:focus-visible]:opacity-100 group-data-[revealed=true]/msg:opacity-100 motion-reduce:transition-none">
           <MessageHoverActions
@@ -163,6 +171,26 @@ function CreditsUpsellMessageRow({
         </div>
       )}
     </div>
+  );
+}
+
+function CreditsUpsellMessageRow({
+  message,
+  conversationId,
+  onInspectMessage,
+}: {
+  message: DisplayMessage;
+  conversationId?: string | null;
+  onInspectMessage?: (messageId: string) => void;
+}) {
+  return (
+    <SubstitutedMessageShell
+      message={message}
+      conversationId={conversationId}
+      onInspectMessage={onInspectMessage}
+    >
+      <CreditsUpsellCard />
+    </SubstitutedMessageShell>
   );
 }
 
@@ -203,10 +231,19 @@ export const TranscriptRow = memo(function TranscriptRow({
           <SystemCardRow message={item.message} assistantId={assistantId} />
         );
       }
-      // A deliberate-silence turn renders as a quiet marker with fixed copy;
-      // the row's stored content is the raw sentinel and never shows.
+      // A deliberate-silence turn renders as a quiet marker with fixed copy
+      // inside the standard message shell, so deep links, scrolling, and
+      // Inspect still address the row; its stored content never shows.
       if (item.message.isNoResponse) {
-        return <NoResponseRow />;
+        return (
+          <SubstitutedMessageShell
+            message={item.message}
+            conversationId={conversationId}
+            onInspectMessage={onInspectMessage}
+          >
+            <NoResponseRow />
+          </SubstitutedMessageShell>
+        );
       }
       return (
         <TranscriptMessageBody

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -163,6 +163,10 @@ export interface DisplayMessage {
    *  summarize-up-to results). Rendered as a standalone system notice —
    *  no avatar, no persona bubble — never as assistant speech. */
   isSystemCard?: boolean;
+  /** Deliberate-silence turn: the whole reply was the no-response sentinel.
+   *  Mirrors `ConversationMessage["noResponse"]`; renders as a quiet marker
+   *  and counts as the turn's reply. */
+  isNoResponse?: boolean;
   /** Provider-failure notice metadata, carried from the wire
    *  `ConversationMessage["providerError"]`. `code` is the stable classified
    *  error code (e.g. `"PROVIDER_BILLING"`), `category` the classified

--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -172,6 +172,18 @@ describe("mapRuntimeToDisplayMessage", () => {
     expect(mapRuntimeToDisplayMessage(m).isSystemCard).toBe(true);
   });
 
+  test("flags a noResponse message as isNoResponse", () => {
+    const plain = makeMessage({ id: "m-plain", role: "assistant" });
+    expect(mapRuntimeToDisplayMessage(plain).isNoResponse).toBeUndefined();
+
+    const m = makeMessage({
+      id: "m-silent",
+      role: "assistant",
+      noResponse: true,
+    });
+    expect(mapRuntimeToDisplayMessage(m).isNoResponse).toBe(true);
+  });
+
   test("carries providerError code and category onto the display message", () => {
     const plain = makeMessage({ id: "m-plain", role: "assistant" });
     expect(mapRuntimeToDisplayMessage(plain).providerError).toBeUndefined();
@@ -179,7 +191,10 @@ describe("mapRuntimeToDisplayMessage", () => {
     const m = makeMessage({
       id: "m-err",
       role: "assistant",
-      providerError: { code: "PROVIDER_BILLING", category: "credits_exhausted" },
+      providerError: {
+        code: "PROVIDER_BILLING",
+        category: "credits_exhausted",
+      },
     });
     expect(mapRuntimeToDisplayMessage(m).providerError).toEqual({
       code: "PROVIDER_BILLING",

--- a/clients/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.ts
@@ -186,6 +186,9 @@ export function mapRuntimeToDisplayMessage(
   if (m.systemCard) {
     msg.isSystemCard = true;
   }
+  if (m.noResponse) {
+    msg.isNoResponse = true;
+  }
   if (m.providerError) {
     msg.providerError = {
       code: m.providerError.code,

--- a/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
+++ b/clients/web/src/domains/chat/utils/stream-updaters/message-updaters.ts
@@ -9,6 +9,8 @@
  * `(prev: DisplayMessage[], ...args) => DisplayMessage[]`.
  */
 
+import { isNoResponseOnlyText } from "@vellumai/service-contracts/no-response";
+
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { messagePlainText } from "@/domains/chat/utils/message-plain-text";
 import { toDisplayAttachments } from "@/utils/display-attachments";
@@ -399,6 +401,14 @@ export function finalizeMessageComplete(
       ...(adoptServerId ? { id: event.messageId!, isOptimistic: false } : {}),
       ...(attachments ? { attachments } : {}),
       ...(finalized ?? {}),
+      // Deliberate silence, derived at fold time from the shared sentinel
+      // contract: the daemon stamps the durable row after the turn, but the
+      // live bubble would otherwise render the raw sentinel until a refetch.
+      // Deriving here from the same predicate keeps the live view truthful
+      // even if that refetch never lands.
+      ...(isNoResponseOnlyText((last.textSegments ?? []).join("\n").trim())
+        ? { isNoResponse: true }
+        : {}),
     },
   ];
 }

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1761,5 +1761,8 @@
   },
   "workspacePathLink": {
     "openTitle": "Open {path}"
+  },
+  "transcript": {
+    "noResponse": "Chose not to respond"
   }
 }

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1750,5 +1750,8 @@
   },
   "workspacePathLink": {
     "openTitle": "Abrir {path}"
+  },
+  "transcript": {
+    "noResponse": "Decidió no responder"
   }
 }

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -806,5 +806,8 @@
     "takePhoto": "Сделать фото",
     "unmuteAssistant": "Включить звук ассистента",
     "unmuteMicrophone": "Включить микрофон"
+  },
+  "transcript": {
+    "noResponse": "Решил не отвечать"
   }
 }

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -1728,5 +1728,8 @@
   },
   "workspacePathLink": {
     "openTitle": "開啟 {path}"
+  },
+  "transcript": {
+    "noResponse": "決定不回覆"
   }
 }

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -1728,5 +1728,8 @@
   },
   "workspacePathLink": {
     "openTitle": "打开 {path}"
+  },
+  "transcript": {
+    "noResponse": "决定不回复"
   }
 }

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -11,6 +11,7 @@
     "./client-metadata": "./src/client-metadata.ts",
     "./credential-rpc": "./src/credential-rpc.ts",
     "./ingress": "./src/ingress.ts",
+    "./no-response": "./src/no-response.ts",
     "./remote-web-pairing": "./src/remote-web-pairing.ts",
     "./twilio-ingress": "./src/twilio-ingress.ts",
     "./trust-rules": "./src/trust-rules.ts",

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -27,6 +27,7 @@ export * from "./handles.js";
 export * from "./rpc.js";
 export * from "./trust-rules.js";
 export * from "./ingress.js";
+export * from "./no-response.js";
 export * from "./remote-web-pairing.js";
 export * from "./twilio-ingress.js";
 export * from "./url-normalization.js";

--- a/packages/service-contracts/src/no-response.ts
+++ b/packages/service-contracts/src/no-response.ts
@@ -1,0 +1,84 @@
+/**
+ * The `<no_response/>` sentinel: the cross-service convention for a turn
+ * that deliberately produces no user-visible reply.
+ *
+ * The model emits it, the daemon stamps and strips it, channel delivery
+ * suppresses it, and clients hold live-streamed prefixes of it back from
+ * display. One definition here keeps every consumer's parsing identical;
+ * a hand-rolled copy in any one of them is how the case-sensitivity of a
+ * regex drifts.
+ */
+
+/** Matches a message whose entire content is the sentinel. */
+const NO_RESPONSE_ONLY_RE = /^\s*<no_response\s*\/?>\s*$/i;
+
+/**
+ * Whether `text` is nothing but the sentinel: the whole reply is a
+ * deliberate non-response, as opposed to real content with an inline
+ * sentinel mixed in.
+ */
+export function isNoResponseOnlyText(text: string): boolean {
+  return NO_RESPONSE_ONLY_RE.test(text);
+}
+
+/** Matches every sentinel occurrence for stripping it out of mixed content. */
+export const NO_RESPONSE_INLINE_RE = /<no_response\s*\/?>/gi;
+
+/**
+ * Detection variant without the `g` flag: a `g`-flagged regex is stateful
+ * under `.test()` (it resumes from `lastIndex`), so reusing
+ * {@link NO_RESPONSE_INLINE_RE} for detection would alternate between
+ * matches and misses across calls.
+ */
+const NO_RESPONSE_MARKER_RE = new RegExp(NO_RESPONSE_INLINE_RE.source, "i");
+
+/** Whether `text` contains the sentinel anywhere. */
+export function containsNoResponseMarker(text: string): boolean {
+  return NO_RESPONSE_MARKER_RE.test(text);
+}
+
+/** Removes every sentinel occurrence, trimming the leftover whitespace. */
+export function stripNoResponseMarkers(text: string): string {
+  return text.replace(NO_RESPONSE_INLINE_RE, "").trim();
+}
+
+const NO_RESPONSE_SENTINEL_FORMS = [
+  "<no_response/>",
+  "<no_response />",
+  "<no_response>",
+] as const;
+
+/**
+ * Whether `text` could still grow into the sentinel, i.e. it is a leading
+ * substring of one of its forms. Holding on these keeps a slowly-streamed
+ * `<no_response/>` from surfacing as visible partial content.
+ */
+export function isPotentialNoResponsePrefix(text: string): boolean {
+  const lower = text.trim().toLowerCase();
+  if (lower.length === 0) {
+    return false;
+  }
+  return NO_RESPONSE_SENTINEL_FORMS.some((sentinel) =>
+    sentinel.startsWith(lower),
+  );
+}
+
+/**
+ * Whether `text` carries user-visible content worth acting on now. Returns
+ * `false` for empty text, the standalone sentinel, and any prefix that could
+ * still complete into one; returns `true` once real content remains after
+ * stripping inline sentinels.
+ */
+export function hasDeliverableAssistantText(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  if (NO_RESPONSE_ONLY_RE.test(trimmed)) {
+    return false;
+  }
+  if (isPotentialNoResponsePrefix(trimmed)) {
+    return false;
+  }
+  return stripNoResponseMarkers(trimmed).length > 0;
+}


### PR DESCRIPTION
# Deliberate silence resolves visibly

## TL;DR

When a turn's whole reply is the `<no_response/>` sentinel (a valid outcome the model is taught for channel discretion, and now also the reaction-only-turn convention), the app was left hanging: the thinking indicator never resolved and nothing visible explained why. Reported live by the guardian of a dogfood instance. The sentinel machinery was channel-egress-only; no client knew the convention existed.

Now the agent loop stamps a sentinel-only reply with `messageKind: "no_response"` at the turn boundary, the wire projects it as a `noResponse` flag beside `systemCard`, and the web renders a quiet localized marker ("Chose not to respond") in place of the sentinel text.

## The hang, mechanically

The web's thinking indicator stays on while `hasPendingAssistantResponse` is true, which reads the display transcript: the last non-queued user message must be followed by an assistant message. Both the phase-driven path and the authoritative daemon-idle close are gated on it. A silent turn produced no assistant row the transcript would show, so the flag never cleared, through both gates, forever. The marker row is a real assistant transcript row, which is what resolves the state; the fix is representational, not a timer or special case in the indicator logic.

## What changes for someone using it

| Before | After |
| --- | --- |
| Assistant validly decides not to respond; the app shows "thinking" indefinitely with no resolution | A quiet italic marker, "Chose not to respond," and the turn reads as settled |
| Raw `<no_response/>` text could surface in transcripts on clients with no rule for it | Clients that know the flag render the marker; the sentinel text never shows on web |

## Why it is safe

- **The row's content keeps the raw sentinel.** The model reads its own convention back from history, so the fix cannot teach it to imitate prose instead of the sentinel. Rendering is driven by the metadata kind, never the text.
- **The kind joins the existing standalone family** (`system_card`, `provider_error`): consolidation never merges the row, turn grouping closes on it, and the wire projection mirrors `systemCard` exactly. One mechanism, third member.
- **The stamp is metadata-only and non-fatal** (guarded, logged on failure), applied only when the turn ends normally with an assistant tail whose entire text is the sentinel. Mixed content (real text plus an inline sentinel) is untouched.
- Channel delivery is unchanged: channels already strip the sentinel and suppress delivery; this PR only makes the app-side representation truthful.
- All five locale catalogs carry the new key (the catalog parity guard passes; en/es/ru/zh/zh-TW).

## Verification

Daemon: the projection test pins `noResponse` on a stamped row and validates every projected message against the wire schema; the standalone-family and turn-boundary suites pass with the widened predicate. Web: mapping test pins `noResponse` → `isNoResponse`; a dispatch test pins that a flagged row renders the marker and the literal sentinel text never renders; catalog guard (210 assertions) and both typechecks pass. OpenAPI and generated web types regenerated.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->