### PR TITLE
feat(notifications): add Tier and carry it through delivery

### DIFF
--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -72,16 +72,25 @@ mock.module("../deliveries-store.js", () => ({
   findDeliveryByDecisionAndChannel: () => undefined,
 }));
 
-mock.module("../adapters/macos.js", () => ({
-  isGuardianSensitiveEvent: () => false,
-}));
-
 // Mock conversation-crud so deep-link fallback tests can control which
-// conversation ids resolve to real rows.
+// conversation ids resolve to real rows. Only getConversation is stubbed;
+// keeping the rest real means the mock is harmless if it leaks into another
+// file under a shared run.
+const realConversationCrud =
+  await import("../../persistence/conversation-crud.js");
 let knownConversations: Set<string> = new Set();
 mock.module("../../persistence/conversation-crud.js", () => ({
+  ...realConversationCrud,
   getConversation: (id: string) =>
     knownConversations.has(id) ? { id } : undefined,
+}));
+
+// Stub only isGuardianSensitiveEvent; keep the real VellumAdapter so this
+// mock is harmless if it leaks into another file under a shared run.
+const realMacosAdapter = await import("../adapters/macos.js");
+mock.module("../adapters/macos.js", () => ({
+  ...realMacosAdapter,
+  isGuardianSensitiveEvent: () => false,
 }));
 
 // Mock destination-resolver so platform channel tests get a destination
@@ -761,5 +770,50 @@ describe("NotificationBroadcaster question option actions", () => {
       "approve_once",
       "reject",
     ]);
+  });
+});
+
+describe("NotificationBroadcaster tier projection", () => {
+  function tierDecision(): NotificationDecision {
+    return makeDecision({
+      selectedChannels: ["vellum"],
+      renderedCopy: { vellum: { title: "Title", body: "Body" } },
+    });
+  }
+
+  test("projects a routing-hint tier onto the payload", async () => {
+    const { adapter, sends } = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    await broadcaster.broadcastDecision(
+      makeSignal({ routingHints: { tier: "offer" } }),
+      tierDecision(),
+    );
+
+    expect(sends.length).toBe(1);
+    expect(sends[0]?.payload.tier).toBe("offer");
+  });
+
+  test("a signal with no routing hints carries no tier", async () => {
+    const { adapter, sends } = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    await broadcaster.broadcastDecision(makeSignal(), tierDecision());
+
+    expect(sends.length).toBe(1);
+    expect(sends[0]?.payload.tier).toBeUndefined();
+  });
+
+  test("a routing hint that is not a tier is dropped rather than passed through", async () => {
+    const { adapter, sends } = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    await broadcaster.broadcastDecision(
+      makeSignal({ routingHints: { tier: "urgent", preferred: "slack" } }),
+      tierDecision(),
+    );
+
+    expect(sends.length).toBe(1);
+    expect(sends[0]?.payload.tier).toBeUndefined();
   });
 });

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -946,6 +946,89 @@ describe("NotificationBroadcaster suppress tier", () => {
   });
 });
 
+describe("NotificationBroadcaster inbox-only tiers", () => {
+  /**
+   * A tier that claims no attention is still delivered: the vellum inbox
+   * entry appears, and the platform channel, whose only rendering is a device
+   * alert, is left out.
+   */
+  async function broadcast(
+    tier?: string,
+    urgency: Urgency = "high",
+  ): Promise<{
+    vellum: ReturnType<typeof makeCapturingAdapter>;
+    platform: ReturnType<typeof makeCapturingAdapter>;
+    results: NotificationDeliveryResult[];
+  }> {
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform");
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal({
+        attentionHints: {
+          requiresAction: false,
+          urgency,
+          isAsyncBackground: false,
+          visibleInSourceNow: false,
+        },
+        ...(tier ? { routingHints: { tier } } : {}),
+      }),
+      makeDecision({
+        selectedChannels: ["vellum", "platform"],
+        renderedCopy: {
+          vellum: { title: "Title", body: "Body" },
+          platform: { title: "Title", body: "Body" },
+        },
+      }),
+    );
+
+    return { vellum, platform, results };
+  }
+
+  test("a hint is delivered on vellum and reaches no device push", async () => {
+    const { vellum, platform, results } = await broadcast("hint");
+
+    expect(vellum.sends.length).toBe(1);
+    expect(vellum.sends[0]?.payload.tier).toBe("hint");
+    expect(platform.sends.length).toBe(0);
+
+    expect(results.find((r) => r.channel === "vellum")?.status).toBe("sent");
+    const skipped = results.find((r) => r.channel === "platform");
+    expect(skipped?.status).toBe("skipped");
+    expect(skipped?.errorMessage).toContain("hint");
+  });
+
+  test("an offer pushes to the device", async () => {
+    const { vellum, platform } = await broadcast("offer");
+
+    expect(vellum.sends.length).toBe(1);
+    expect(platform.sends.length).toBe(1);
+  });
+
+  test("a response pushes to the device", async () => {
+    const { vellum, platform } = await broadcast("response");
+
+    expect(vellum.sends.length).toBe(1);
+    expect(platform.sends.length).toBe(1);
+  });
+
+  test("a signal with no tier pushes at every urgency", async () => {
+    // The drop is tier-driven: an untiered signal keeps every channel the
+    // decision selected, however its urgency reads.
+    for (const urgency of ["low", "medium", "high", "critical"] as Urgency[]) {
+      const { vellum, platform, results } = await broadcast(undefined, urgency);
+
+      expect(vellum.sends.length).toBe(1);
+      expect(platform.sends.length).toBe(1);
+      expect(results.map((r) => r.status)).toEqual(["sent", "sent"]);
+    }
+  });
+});
+
 describe("NotificationBroadcaster paired silence", () => {
   /**
    * Runs a real VellumAdapter so the assertion compares the two events a
@@ -1033,8 +1116,8 @@ describe("NotificationBroadcaster paired silence", () => {
   });
 
   test("no tier keeps both events on the urgency-derived value", async () => {
-    // The regression guard: a producer that never reaches the filter must
-    // deliver exactly as it did before Tier existed, on both events.
+    // The regression guard: a signal without a tier retains urgency-derived
+    // behavior on both events.
     const expected: [Urgency, boolean][] = [
       ["low", true],
       ["medium", true],

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -7,6 +7,8 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { AssistantEvent } from "../../api/index.js";
+import type { ConversationCreatedInfo } from "../broadcaster.js";
 import type { PairingResult } from "../conversation-pairing.js";
 import type { NotificationSignal } from "../signal.js";
 import type {
@@ -16,7 +18,9 @@ import type {
   ChannelDestination,
   DeliveryResult,
   NotificationDecision,
+  NotificationDeliveryResult,
 } from "../types.js";
+import type { Urgency } from "../urgency.js";
 
 // ── Module mocks ────────────────────────────────────────────────────────
 //
@@ -815,5 +819,233 @@ describe("NotificationBroadcaster tier projection", () => {
 
     expect(sends.length).toBe(1);
     expect(sends[0]?.payload.tier).toBeUndefined();
+  });
+});
+
+describe("NotificationBroadcaster suppress tier", () => {
+  function suppressDecision(): NotificationDecision {
+    return makeDecision({
+      selectedChannels: ["vellum", "platform"],
+      renderedCopy: {
+        vellum: { title: "Title", body: "Body" },
+        platform: { title: "Title", body: "Body" },
+      },
+    });
+  }
+
+  test("dispatches to no channel", async () => {
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform");
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    await broadcaster.broadcastDecision(
+      makeSignal({ routingHints: { tier: "suppress" } }),
+      suppressDecision(),
+    );
+
+    expect(vellum.sends.length).toBe(0);
+    expect(platform.sends.length).toBe(0);
+  });
+
+  test("records every selected channel as skipped, never failed", async () => {
+    // A suppressed signal was never attempted, so it must not read as a
+    // delivery that could be retried into existence.
+    const vellum = makeCapturingAdapter("vellum");
+    const platform = makeCapturingAdapter("platform");
+    const broadcaster = new NotificationBroadcaster([
+      vellum.adapter,
+      platform.adapter,
+    ]);
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal({ routingHints: { tier: "suppress" } }),
+      suppressDecision(),
+    );
+
+    expect(results.length).toBe(2);
+    expect(results.map((r) => r.status)).toEqual(["skipped", "skipped"]);
+    expect(results.map((r) => r.channel).sort()).toEqual([
+      "platform",
+      "vellum",
+    ]);
+    for (const result of results) {
+      expect(result.errorMessage).toContain("suppress");
+    }
+  });
+
+  test("appends the skipped results to a caller's results sink", async () => {
+    const vellum = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([vellum.adapter]);
+    const sink: NotificationDeliveryResult[] = [];
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal({ routingHints: { tier: "suppress" } }),
+      makeDecision({
+        selectedChannels: ["vellum"],
+        renderedCopy: { vellum: { title: "Title", body: "Body" } },
+      }),
+      { resultsSink: sink },
+    );
+
+    expect(results).toBe(sink);
+    expect(sink.length).toBe(1);
+    expect(sink[0]?.status).toBe("skipped");
+  });
+
+  test("pairs no conversation and emits no conversation-created event", async () => {
+    // "Do not surface at all" also means no sidebar entry appears.
+    pairingByChannel = {
+      vellum: {
+        conversationId: "conv-suppressed",
+        messageId: "msg-1",
+        strategy: "start_new_conversation",
+        createdNewConversation: true,
+        conversationFallbackUsed: false,
+      },
+    };
+    const vellum = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([vellum.adapter]);
+    const created: ConversationCreatedInfo[] = [];
+    broadcaster.setOnConversationCreated((info) => {
+      created.push(info);
+    });
+
+    await broadcaster.broadcastDecision(
+      makeSignal({ routingHints: { tier: "suppress" } }),
+      makeDecision({
+        selectedChannels: ["vellum"],
+        renderedCopy: { vellum: { title: "Title", body: "Body" } },
+      }),
+      {
+        onConversationCreated: (info) => {
+          created.push(info);
+        },
+      },
+    );
+
+    expect(created.length).toBe(0);
+  });
+
+  test("a non-suppress tier still dispatches", async () => {
+    const vellum = makeCapturingAdapter("vellum");
+    const broadcaster = new NotificationBroadcaster([vellum.adapter]);
+
+    const results = await broadcaster.broadcastDecision(
+      makeSignal({ routingHints: { tier: "hint" } }),
+      makeDecision({
+        selectedChannels: ["vellum"],
+        renderedCopy: { vellum: { title: "Title", body: "Body" } },
+      }),
+    );
+
+    expect(vellum.sends.length).toBe(1);
+    expect(results[0]?.status).toBe("sent");
+  });
+});
+
+describe("NotificationBroadcaster paired silence", () => {
+  /**
+   * Runs a real VellumAdapter so the assertion compares the two events a
+   * client actually receives: `notification_intent.silent` and
+   * `ConversationCreatedInfo.silent`. They must never disagree -- a client
+   * using the conversation-created event for a fallback banner would
+   * otherwise surface a hint or hide an offer.
+   */
+  async function broadcastPaired(
+    urgency: Urgency,
+    tier?: string,
+  ): Promise<{ intentSilent?: boolean; conversationSilent?: boolean }> {
+    pairingByChannel = {
+      vellum: {
+        conversationId: "conv-paired",
+        messageId: "msg-1",
+        strategy: "start_new_conversation",
+        createdNewConversation: true,
+        conversationFallbackUsed: false,
+      },
+    };
+    const events: AssistantEvent[] = [];
+    const adapter = new realMacosAdapter.VellumAdapter((event) => {
+      events.push(event);
+    });
+    const broadcaster = new NotificationBroadcaster([adapter]);
+    const created: ConversationCreatedInfo[] = [];
+
+    const signal = makeSignal({
+      attentionHints: {
+        requiresAction: false,
+        urgency,
+        isAsyncBackground: false,
+        visibleInSourceNow: false,
+      },
+      ...(tier ? { routingHints: { tier } } : {}),
+    });
+
+    await broadcaster.broadcastDecision(
+      signal,
+      makeDecision({
+        selectedChannels: ["vellum"],
+        renderedCopy: { vellum: { title: "Title", body: "Body" } },
+      }),
+      {
+        onConversationCreated: (info) => {
+          created.push(info);
+        },
+      },
+    );
+
+    expect(events.length).toBe(1);
+    expect(created.length).toBe(1);
+    return {
+      intentSilent: (events[0] as { silent?: boolean }).silent,
+      conversationSilent: created[0]?.silent,
+    };
+  }
+
+  test("hint at a critical urgency is silent on both events", async () => {
+    const { intentSilent, conversationSilent } = await broadcastPaired(
+      "critical",
+      "hint",
+    );
+    expect(intentSilent).toBe(true);
+    expect(conversationSilent).toBe(true);
+  });
+
+  test("offer at a low urgency banners on both events", async () => {
+    const { intentSilent, conversationSilent } = await broadcastPaired(
+      "low",
+      "offer",
+    );
+    expect(intentSilent).toBe(false);
+    expect(conversationSilent).toBe(false);
+  });
+
+  test("response at a low urgency banners on both events", async () => {
+    const { intentSilent, conversationSilent } = await broadcastPaired(
+      "low",
+      "response",
+    );
+    expect(intentSilent).toBe(false);
+    expect(conversationSilent).toBe(false);
+  });
+
+  test("no tier keeps both events on the urgency-derived value", async () => {
+    // The regression guard: a producer that never reaches the filter must
+    // deliver exactly as it did before Tier existed, on both events.
+    const expected: [Urgency, boolean][] = [
+      ["low", true],
+      ["medium", true],
+      ["high", false],
+      ["critical", false],
+    ];
+    for (const [urgency, silent] of expected) {
+      const { intentSilent, conversationSilent } =
+        await broadcastPaired(urgency);
+      expect(intentSilent).toBe(silent);
+      expect(conversationSilent).toBe(silent);
+    }
   });
 });

--- a/assistant/src/notifications/__tests__/emit-signal-suppress-tier.test.ts
+++ b/assistant/src/notifications/__tests__/emit-signal-suppress-tier.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Regression tests for the pipeline-level attention-tier gate.
+ *
+ * A `suppress` tier means "do not surface at all", and `emitNotificationSignal`
+ * drives more than one surface: channel dispatch is one, the home feed mirror
+ * is another. The gate therefore sits in the pipeline, above both, rather than
+ * inside the broadcaster -- a broadcaster-only gate stopped the channels and
+ * still let the home feed publish a visible card.
+ *
+ * The gate runs after the decision stage, so a suppressed signal keeps its
+ * full audit trail: the `notification_events` row and the
+ * `notification_decisions` row both survive.
+ *
+ * The events store, the decisions store, their DB, and the deterministic
+ * checks are the real ones; only the decision engine's judgment, the dispatch
+ * step, the home-feed write, and the adapter graph around them are stubbed.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { NotificationSignal } from "../signal.js";
+import type { NotificationDecision } from "../types.js";
+
+const dispatchDecisionMock = mock();
+const homeFeedWriteMock = mock();
+
+mock.module("../../channels/config.js", () => ({
+  getDeliverableChannels: () => ["vellum"],
+}));
+
+mock.module("../../contacts/guardian-delivery-reader.js", () => ({
+  getGuardianDelivery: async () => [],
+  guardianForChannel: () => undefined,
+}));
+
+mock.module("../../platform/client.js", () => ({
+  VellumPlatformClient: class {
+    static async create(): Promise<null> {
+      return null;
+    }
+  },
+  isPlatformClientConfigured: async () => false,
+}));
+
+mock.module("../broadcaster.js", () => ({
+  NotificationBroadcaster: class {
+    constructor(_adapters: unknown[]) {}
+    setOnConversationCreated(_fn: unknown) {}
+  },
+}));
+
+// The real decisions store, so the audit assertion below reads a row the
+// production path would have written.
+const { createDecision } = await import("../decisions-store.js");
+
+const evaluateSignalMock = mock(
+  async (signal: NotificationSignal): Promise<NotificationDecision> => {
+    const persistedDecisionId = `decision-${signal.signalId}`;
+    const decision: NotificationDecision = {
+      shouldNotify: true,
+      selectedChannels: ["vellum"],
+      reasoningSummary: "deliver",
+      renderedCopy: {
+        vellum: { title: "Background job finished", body: "It finished." },
+      },
+      confidence: 0.9,
+      fallbackUsed: false,
+      // The deterministic checks reject a decision with no dedupe key, so the
+      // control cases need one to reach dispatch at all.
+      dedupeKey: "activity-completed:job-1",
+      persistedDecisionId,
+    };
+    createDecision({
+      id: persistedDecisionId,
+      notificationEventId: signal.signalId,
+      shouldNotify: decision.shouldNotify,
+      selectedChannels: decision.selectedChannels,
+      reasoningSummary: decision.reasoningSummary,
+      confidence: decision.confidence,
+      fallbackUsed: decision.fallbackUsed,
+    });
+    return decision;
+  },
+);
+
+mock.module("../decision-engine.js", () => ({
+  evaluateSignal: (signal: NotificationSignal) => evaluateSignalMock(signal),
+  enforceRoutingIntent: (decision: unknown) => decision,
+}));
+
+mock.module("../home-feed-side-effect.js", () => ({
+  writeHomeFeedItemForSignal: (...args: unknown[]) =>
+    homeFeedWriteMock(...args),
+}));
+
+mock.module("../runtime-dispatch.js", () => ({
+  dispatchDecision: (...args: unknown[]) => dispatchDecisionMock(...args),
+}));
+
+import { getDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import {
+  notificationDecisions,
+  notificationEvents,
+} from "../../persistence/schema/index.js";
+import type { EmitSignalParams } from "../emit-signal.js";
+
+await initializeDb();
+
+const { emitNotificationSignal } = await import("../emit-signal.js");
+
+/**
+ * A background-origin signal: `isAsyncBackground` is what makes the home feed
+ * mirror fire, so the control case proves the gate is what stops it in the
+ * suppress case and not some unrelated filter.
+ */
+function emit(tier?: string) {
+  const params: EmitSignalParams<string> = {
+    sourceEventName: "activity.completed",
+    sourceChannel: "scheduler",
+    sourceContextId: "job-1",
+    contextPayload: { title: "Background job finished" },
+    attentionHints: {
+      requiresAction: false,
+      urgency: "medium",
+      isAsyncBackground: true,
+      visibleInSourceNow: false,
+    },
+    ...(tier ? { routingHints: { tier } } : {}),
+  };
+  return emitNotificationSignal(params);
+}
+
+beforeEach(() => {
+  getDb().delete(notificationDecisions).run();
+  getDb().delete(notificationEvents).run();
+  evaluateSignalMock.mockClear();
+  dispatchDecisionMock.mockReset();
+  dispatchDecisionMock.mockResolvedValue({
+    dispatched: true,
+    reason: "Dispatched to 1/1 channels",
+    deliveryResults: [],
+  });
+  homeFeedWriteMock.mockReset();
+  homeFeedWriteMock.mockResolvedValue(null);
+});
+
+describe("emitNotificationSignal attention-tier gate", () => {
+  test("a suppress tier reaches no surface", async () => {
+    const result = await emit("suppress");
+
+    expect(dispatchDecisionMock).toHaveBeenCalledTimes(0);
+    expect(homeFeedWriteMock).toHaveBeenCalledTimes(0);
+
+    expect(result.dispatched).toBe(false);
+    expect(result.deduplicated).toBe(false);
+    // A suppressed signal is a verdict, not a failure: callers that latch on
+    // a completed emit must not treat it as an error.
+    expect(result.pipelineFailed).toBe(false);
+    expect(result.deliveryResults).toEqual([]);
+    expect(result.reason).toContain("suppress");
+  });
+
+  test("a suppressed signal keeps its event and decision rows", async () => {
+    const result = await emit("suppress");
+
+    // The decision engine ran, so the tier gate cannot be short-circuiting
+    // the audit trail it is supposed to preserve.
+    expect(evaluateSignalMock).toHaveBeenCalledTimes(1);
+
+    const events = getDb().select().from(notificationEvents).all();
+    expect(events.map((e) => e.id)).toEqual([result.signalId]);
+
+    const decisions = getDb().select().from(notificationDecisions).all();
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]!.notificationEventId).toBe(result.signalId);
+  });
+
+  test("a hint tier still dispatches and still mirrors to the home feed", async () => {
+    const result = await emit("hint");
+
+    expect(dispatchDecisionMock).toHaveBeenCalledTimes(1);
+    expect(homeFeedWriteMock).toHaveBeenCalledTimes(1);
+    expect(result.dispatched).toBe(true);
+    expect(result.pipelineFailed).toBe(false);
+  });
+
+  test("a signal with no tier is unaffected", async () => {
+    const result = await emit();
+
+    expect(dispatchDecisionMock).toHaveBeenCalledTimes(1);
+    expect(homeFeedWriteMock).toHaveBeenCalledTimes(1);
+    expect(result.dispatched).toBe(true);
+  });
+
+  test("a routing hint that is not a tier does not suppress", async () => {
+    // An unrecognized hint must not be read as "do not surface": silently
+    // dropping notifications is the worse failure mode.
+    const result = await emit("urgent");
+
+    expect(dispatchDecisionMock).toHaveBeenCalledTimes(1);
+    expect(homeFeedWriteMock).toHaveBeenCalledTimes(1);
+    expect(result.dispatched).toBe(true);
+  });
+});

--- a/assistant/src/notifications/__tests__/emit-signal-suppress-tier.test.ts
+++ b/assistant/src/notifications/__tests__/emit-signal-suppress-tier.test.ts
@@ -4,8 +4,8 @@
  * A `suppress` tier means "do not surface at all", and `emitNotificationSignal`
  * drives more than one surface: channel dispatch is one, the home feed mirror
  * is another. The gate therefore sits in the pipeline, above both, rather than
- * inside the broadcaster -- a broadcaster-only gate stopped the channels and
- * still let the home feed publish a visible card.
+ * inside the broadcaster: a broadcaster-only gate reaches the channels and
+ * leaves the home feed free to publish a visible card.
  *
  * The gate runs after the decision stage, so a suppressed signal keeps its
  * full audit trail: the `notification_events` row and the
@@ -19,7 +19,8 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { NotificationSignal } from "../signal.js";
-import type { NotificationDecision } from "../types.js";
+import type { NotificationChannel, NotificationDecision } from "../types.js";
+import type { Urgency } from "../urgency.js";
 
 const dispatchDecisionMock = mock();
 const homeFeedWriteMock = mock();
@@ -33,13 +34,15 @@ mock.module("../../contacts/guardian-delivery-reader.js", () => ({
   guardianForChannel: () => undefined,
 }));
 
+let platformConfigured = false;
+
 mock.module("../../platform/client.js", () => ({
   VellumPlatformClient: class {
     static async create(): Promise<null> {
       return null;
     }
   },
-  isPlatformClientConfigured: async () => false,
+  isPlatformClientConfigured: async () => platformConfigured,
 }));
 
 mock.module("../broadcaster.js", () => ({
@@ -114,7 +117,7 @@ const { emitNotificationSignal } = await import("../emit-signal.js");
  * mirror fire, so the control case proves the gate is what stops it in the
  * suppress case and not some unrelated filter.
  */
-function emit(tier?: string) {
+function emit(tier?: string, urgency: Urgency = "medium") {
   const params: EmitSignalParams<string> = {
     sourceEventName: "activity.completed",
     sourceChannel: "scheduler",
@@ -122,13 +125,21 @@ function emit(tier?: string) {
     contextPayload: { title: "Background job finished" },
     attentionHints: {
       requiresAction: false,
-      urgency: "medium",
+      urgency,
       isAsyncBackground: true,
       visibleInSourceNow: false,
     },
     ...(tier ? { routingHints: { tier } } : {}),
   };
   return emitNotificationSignal(params);
+}
+
+/** The channels the urgency floor handed to dispatch on the last emit. */
+function dispatchedChannels(): NotificationChannel[] {
+  const decision = dispatchDecisionMock.mock.calls[0]?.[1] as
+    | NotificationDecision
+    | undefined;
+  return decision?.selectedChannels ?? [];
 }
 
 beforeEach(() => {
@@ -143,6 +154,7 @@ beforeEach(() => {
   });
   homeFeedWriteMock.mockReset();
   homeFeedWriteMock.mockResolvedValue(null);
+  platformConfigured = false;
 });
 
 describe("emitNotificationSignal attention-tier gate", () => {
@@ -201,5 +213,34 @@ describe("emitNotificationSignal attention-tier gate", () => {
     expect(dispatchDecisionMock).toHaveBeenCalledTimes(1);
     expect(homeFeedWriteMock).toHaveBeenCalledTimes(1);
     expect(result.dispatched).toBe(true);
+  });
+});
+
+describe("emitNotificationSignal urgency floor and attention tier", () => {
+  beforeEach(() => {
+    // The floor only forces a push when the daemon is bound to a platform
+    // assistant, so every case here has to look bound.
+    platformConfigured = true;
+  });
+
+  test("a hint keeps the in-app channel and gains no device push", async () => {
+    // The scheduler files hints at a high urgency, and the platform endpoint
+    // renders every dispatch as a device alert: an inbox-only tier must not
+    // be forced onto it.
+    await emit("hint", "high");
+
+    expect(dispatchedChannels()).toEqual(["vellum"]);
+  });
+
+  test("an offer gains the forced device push", async () => {
+    await emit("offer", "high");
+
+    expect(dispatchedChannels().sort()).toEqual(["platform", "vellum"]);
+  });
+
+  test("a signal with no tier gains the forced device push", async () => {
+    await emit(undefined, "high");
+
+    expect(dispatchedChannels().sort()).toEqual(["platform", "vellum"]);
   });
 });

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -6,10 +6,16 @@
  * client uses for two distinct purposes: paired-conversation bookkeeping
  * (mark-unseen + history catch-up, fallback dedup) and posting an OS
  * banner via `UNUserNotificationCenter`. The banner posting is gated by
- * the `silent` flag — set to true for non-urgent (`low`/`medium`) signals
- * so the notification center inbox still receives the entry but the OS
- * does not surface a push banner. Urgent signals (`high`/`critical`)
- * broadcast with `silent: false` and fire the banner.
+ * the `silent` flag.
+ *
+ * `payload.tier` takes precedence when the filter path set one: Hint is
+ * silent, Offer and Response fire the banner. Offer and Response deliver
+ * identically here because Electron's Notification API exposes no
+ * `interruptionLevel` to distinguish them. A payload with no tier falls back
+ * to urgency: non-urgent (`low`/`medium`) signals are silent so the
+ * notification center inbox still receives the entry but the OS does not
+ * surface a push banner, and urgent signals (`high`/`critical`) broadcast
+ * with `silent: false` and fire the banner.
  *
  * Guardian-sensitive notifications (approval requests, access requests)
  * are annotated with `targetGuardianPrincipalId` so that only clients
@@ -99,8 +105,9 @@ export class VellumAdapter implements ChannelAdapter {
           ? guardianPrincipalId
           : undefined;
 
-      const silent =
-        payload.urgency !== "high" && payload.urgency !== "critical";
+      const silent = payload.tier
+        ? payload.tier === "hint"
+        : payload.urgency !== "high" && payload.urgency !== "critical";
 
       this.broadcast({
         type: "notification_intent",

--- a/assistant/src/notifications/adapters/macos.ts
+++ b/assistant/src/notifications/adapters/macos.ts
@@ -8,12 +8,16 @@
  * banner via `UNUserNotificationCenter`. The banner posting is gated by
  * the `silent` flag.
  *
- * `payload.tier` takes precedence when the filter path set one: Hint is
- * silent, Offer and Response fire the banner. Offer and Response deliver
- * identically here because Electron's Notification API exposes no
- * `interruptionLevel` to distinguish them. A payload with no tier falls back
- * to urgency: non-urgent (`low`/`medium`) signals are silent so the
- * notification center inbox still receives the entry but the OS does not
+ * `resolveSilent` owns that decision, shared with the broadcaster's
+ * `notification_conversation_created` event so a paired delivery cannot
+ * carry two contradictory banner instructions. `payload.tier` takes
+ * precedence when the filter path set one: Suppress and Hint are silent,
+ * Offer and Response fire the banner. Offer and Response deliver identically
+ * here because Electron's Notification API exposes no `interruptionLevel` to
+ * distinguish them, and a Suppress payload should never reach an adapter at
+ * all -- the broadcaster drops it before dispatch. A payload with no tier
+ * falls back to urgency: non-urgent (`low`/`medium`) signals are silent so
+ * the notification center inbox still receives the entry but the OS does not
  * surface a push banner, and urgent signals (`high`/`critical`) broadcast
  * with `silent: false` and fire the banner.
  *
@@ -29,6 +33,7 @@ import type { InterfaceId } from "../../channels/types.js";
 import { updateMessageContent } from "../../persistence/conversation-crud.js";
 import { publishConversationMessagesChanged } from "../../runtime/sync/resource-sync-events.js";
 import { getLogger } from "../../util/logger.js";
+import { resolveSilent } from "../filter/tier.js";
 import type {
   ChannelAdapter,
   ChannelDeliveryPayload,
@@ -105,9 +110,7 @@ export class VellumAdapter implements ChannelAdapter {
           ? guardianPrincipalId
           : undefined;
 
-      const silent = payload.tier
-        ? payload.tier === "hint"
-        : payload.urgency !== "high" && payload.urgency !== "critical";
+      const silent = resolveSilent(payload.tier, payload.urgency);
 
       this.broadcast({
         type: "notification_intent",

--- a/assistant/src/notifications/adapters/platform.ts
+++ b/assistant/src/notifications/adapters/platform.ts
@@ -6,6 +6,12 @@
  * notification out to registered device tokens for the bound user. Provider
  * feature gates return 202 with `{ skipped: "flag_off" }` when no provider runs.
  *
+ * Every dispatch here renders as an APNs/FCM alert, and the endpoint exposes
+ * no silent variant, so this channel always interrupts the device. The
+ * broadcaster keeps inbox-only attention tiers off it for that reason: a
+ * delivery that must not claim attention goes out over the vellum channel
+ * alone.
+ *
  * Guardian-sensitive notifications (approval requests, access requests)
  * are annotated with `targetGuardianPrincipalId` so the platform can
  * scope native fan-out to guardian-bound devices, mirroring the macOS adapter.

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -32,6 +32,7 @@ import {
   updateDeliveryStatus,
 } from "./deliveries-store.js";
 import { resolveDestinations } from "./destination-resolver.js";
+import { type Tier, TierSchema } from "./filter/tier.js";
 import {
   buildQuestionAnswerActions,
   buildToolApprovalSourceView,
@@ -194,6 +195,17 @@ function resolveQuestionOptionsContext(
   };
 }
 
+/**
+ * Attention tier carried on `routingHints.tier` by the filter path, resolved
+ * once per broadcast so channel adapters read it off the payload instead of
+ * re-parsing routing hints. Producers that do not go through the filter carry
+ * no tier and keep their urgency-derived delivery.
+ */
+function resolveTier(signal: NotificationSignal): Tier | undefined {
+  const parsed = TierSchema.safeParse(signal.routingHints?.tier);
+  return parsed.success ? parsed.data : undefined;
+}
+
 /** Callback invoked immediately when a vellum notification conversation is created. */
 export interface ConversationCreatedInfo {
   conversationId: string;
@@ -344,6 +356,7 @@ export class NotificationBroadcaster {
     const resolvedApproval = resolveApprovalContext(signal);
     const approvalContext = resolvedApproval?.approval;
     const toolApprovalSource = resolvedApproval?.toolApprovalSource;
+    const tier = resolveTier(signal);
     const accessRequestContext =
       signal.sourceEventName === "ingress.access_request" &&
       signal.contextPayload
@@ -661,6 +674,7 @@ export class NotificationBroadcaster {
           deepLinkTarget,
           contextPayload: signal.contextPayload,
           urgency: signal.attentionHints.urgency,
+          tier,
           approvalContext,
           accessRequestContext,
           toolApprovalSource,

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -7,6 +7,9 @@
  *   2. Pulls rendered copy from the decision (or falls back to copy-composer)
  *   3. Dispatches through the channel adapter
  *   4. Records a delivery audit row in the deliveries-store
+ *
+ * A signal whose attention tier is `suppress` never enters that loop: it is
+ * dropped up front and every selected channel is reported skipped.
  */
 
 import { v4 as uuid } from "uuid";
@@ -32,7 +35,12 @@ import {
   updateDeliveryStatus,
 } from "./deliveries-store.js";
 import { resolveDestinations } from "./destination-resolver.js";
-import { type Tier, TierSchema } from "./filter/tier.js";
+import {
+  resolveSilent,
+  type Tier,
+  TierSchema,
+  tierShouldNotify,
+} from "./filter/tier.js";
 import {
   buildQuestionAnswerActions,
   buildToolApprovalSourceView,
@@ -197,9 +205,10 @@ function resolveQuestionOptionsContext(
 
 /**
  * Attention tier carried on `routingHints.tier` by the filter path, resolved
- * once per broadcast so channel adapters read it off the payload instead of
- * re-parsing routing hints. Producers that do not go through the filter carry
- * no tier and keep their urgency-derived delivery.
+ * once per broadcast: it gates the broadcast on `tierShouldNotify`, decides
+ * the shared `silent` value, and rides the payload so channel adapters read
+ * it instead of re-parsing routing hints. Producers that do not go through
+ * the filter carry no tier and keep their urgency-derived delivery.
  */
 function resolveTier(signal: NotificationSignal): Tier | undefined {
   const parsed = TierSchema.safeParse(signal.routingHints?.tier);
@@ -218,8 +227,10 @@ export interface ConversationCreatedInfo {
   /** Semantic source from the signal producer (e.g. "schedule", "reminder"). */
   source?: string;
   /**
-   * Mirrors the vellum adapter's `silent` flag. When true the client
-   * must skip the fallback OS banner — the sidebar entry still appears.
+   * The same `silent` flag the vellum adapter puts on `notification_intent`,
+   * derived once per broadcast by `resolveSilent` so the two events cannot
+   * disagree. When true the client must skip the fallback OS banner — the
+   * sidebar entry still appears.
    */
   silent: boolean;
 }
@@ -321,6 +332,39 @@ export class NotificationBroadcaster {
     decision: NotificationDecision,
     options?: BroadcastDecisionOptions,
   ): Promise<NotificationDeliveryResult[]> {
+    const tier = resolveTier(signal);
+
+    // A `suppress` tier means "do not surface at all", so no channel is
+    // dispatched: not the vellum intent, not a device push, not a
+    // channel-native message. Defense in depth -- the filter path returns
+    // early on suppress, but `routingHints` reaches the broadcaster from any
+    // producer, so the drop cannot be left to the caller. The channels are
+    // reported skipped rather than failed: nothing was attempted, so nothing
+    // is worth retrying.
+    if (tier && !tierShouldNotify(tier)) {
+      const suppressed: NotificationDeliveryResult[] =
+        options?.resultsSink ?? [];
+      for (const channel of decision.selectedChannels) {
+        suppressed.push({
+          channel,
+          destination: "",
+          status: "skipped",
+          errorMessage: `Suppressed by attention tier: ${tier}`,
+        });
+      }
+      log.info(
+        {
+          signalId: signal.signalId,
+          tier,
+          channels: decision.selectedChannels,
+        },
+        "Attention tier is suppress -- dispatching to no channel",
+      );
+      return suppressed;
+    }
+
+    const silent = resolveSilent(tier, signal.attentionHints.urgency);
+
     // Pull the guardian list once so the resolver stays pure. A null list
     // (gateway unreachable) falls back to the local contacts read.
     const guardians = await getGuardianDelivery();
@@ -356,7 +400,6 @@ export class NotificationBroadcaster {
     const resolvedApproval = resolveApprovalContext(signal);
     const approvalContext = resolvedApproval?.approval;
     const toolApprovalSource = resolvedApproval?.toolApprovalSource;
-    const tier = resolveTier(signal);
     const accessRequestContext =
       signal.sourceEventName === "ingress.access_request" &&
       signal.contextPayload
@@ -612,9 +655,6 @@ export class NotificationBroadcaster {
 
           const conversationTitle =
             copy.conversationTitle ?? copy.title ?? signal.sourceEventName;
-          const conversationSilent =
-            signal.attentionHints.urgency !== "high" &&
-            signal.attentionHints.urgency !== "critical";
           const info: ConversationCreatedInfo = {
             conversationId: pairing.conversationId,
             title: conversationTitle,
@@ -622,7 +662,9 @@ export class NotificationBroadcaster {
             targetGuardianPrincipalId,
             groupId: signal.conversationMetadata?.groupId,
             source: signal.conversationMetadata?.source,
-            silent: conversationSilent,
+            // The same value the vellum adapter puts on `notification_intent`,
+            // derived once above so the two events cannot disagree.
+            silent,
           };
 
           // The per-dispatch onConversationCreated callback fires whenever a vellum

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -38,7 +38,7 @@ import { resolveDestinations } from "./destination-resolver.js";
 import {
   resolveSilent,
   type Tier,
-  TierSchema,
+  tierFromRoutingHints,
   tierShouldNotify,
 } from "./filter/tier.js";
 import {
@@ -205,14 +205,14 @@ function resolveQuestionOptionsContext(
 
 /**
  * Attention tier carried on `routingHints.tier` by the filter path, resolved
- * once per broadcast: it gates the broadcast on `tierShouldNotify`, decides
- * the shared `silent` value, and rides the payload so channel adapters read
- * it instead of re-parsing routing hints. Producers that do not go through
- * the filter carry no tier and keep their urgency-derived delivery.
+ * once per broadcast: it backstops the broadcast on `tierShouldNotify`,
+ * decides the shared `silent` value, and rides the payload so channel
+ * adapters read it instead of re-parsing routing hints. Producers that do not
+ * go through the filter carry no tier and keep their urgency-derived
+ * delivery.
  */
 function resolveTier(signal: NotificationSignal): Tier | undefined {
-  const parsed = TierSchema.safeParse(signal.routingHints?.tier);
-  return parsed.success ? parsed.data : undefined;
+  return tierFromRoutingHints(signal.routingHints);
 }
 
 /** Callback invoked immediately when a vellum notification conversation is created. */
@@ -336,11 +336,20 @@ export class NotificationBroadcaster {
 
     // A `suppress` tier means "do not surface at all", so no channel is
     // dispatched: not the vellum intent, not a device push, not a
-    // channel-native message. Defense in depth -- the filter path returns
-    // early on suppress, but `routingHints` reaches the broadcaster from any
-    // producer, so the drop cannot be left to the caller. The channels are
-    // reported skipped rather than failed: nothing was attempted, so nothing
-    // is worth retrying.
+    // channel-native message.
+    //
+    // This is a backstop, not the gate. `emitNotificationSignal` drops a
+    // suppressed signal before it reaches dispatch, because the broadcaster
+    // only owns the channel surfaces and suppression has to hold for the
+    // others too (the home feed mirror above all). What this keeps is the
+    // class-level invariant: `NotificationBroadcaster` is constructed
+    // directly in places other than the pipeline, and none of them should be
+    // able to push a suppressed signal onto a channel. It cannot double-count
+    // a delivery, because a signal that reaches here already skipped the
+    // pipeline gate.
+    //
+    // The channels are reported skipped rather than failed: nothing was
+    // attempted, so nothing is worth retrying.
     if (tier && !tierShouldNotify(tier)) {
       const suppressed: NotificationDeliveryResult[] =
         options?.resultsSink ?? [];

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -9,7 +9,9 @@
  *   4. Records a delivery audit row in the deliveries-store
  *
  * A signal whose attention tier is `suppress` never enters that loop: it is
- * dropped up front and every selected channel is reported skipped.
+ * dropped up front and every selected channel is reported skipped. A tier
+ * that claims no attention (`hint`) enters it without the channels that can
+ * only interrupt, so it is delivered without reaching a device alert.
  */
 
 import { v4 as uuid } from "uuid";
@@ -38,6 +40,7 @@ import { resolveDestinations } from "./destination-resolver.js";
 import {
   resolveSilent,
   type Tier,
+  tierClaimsAttention,
   tierFromRoutingHints,
   tierShouldNotify,
 } from "./filter/tier.js";
@@ -215,6 +218,13 @@ function resolveTier(signal: NotificationSignal): Tier | undefined {
   return tierFromRoutingHints(signal.routingHints);
 }
 
+/**
+ * Channels whose only rendering claims attention. `PlatformPushAdapter` asks
+ * the platform for an APNs/FCM alert, and that endpoint exposes no silent
+ * variant, so every delivery over it buzzes the device.
+ */
+const ATTENTION_ONLY_CHANNELS: readonly NotificationChannel[] = ["platform"];
+
 /** Callback invoked immediately when a vellum notification conversation is created. */
 export interface ConversationCreatedInfo {
   conversationId: string;
@@ -229,7 +239,7 @@ export interface ConversationCreatedInfo {
   /**
    * The same `silent` flag the vellum adapter puts on `notification_intent`,
    * derived once per broadcast by `resolveSilent` so the two events cannot
-   * disagree. When true the client must skip the fallback OS banner — the
+   * disagree. When true the client must skip the fallback OS banner: the
    * sidebar entry still appears.
    */
   silent: boolean;
@@ -374,13 +384,23 @@ export class NotificationBroadcaster {
 
     const silent = resolveSilent(tier, signal.attentionHints.urgency);
 
+    // A tier that claims no attention is inbox-only: delivered, but never
+    // interrupting. Channels that can only interrupt are dropped from the
+    // dispatch list, so a `hint` still lands in the vellum inbox with
+    // `silent: true` while the device stays quiet. The drop is tier-driven
+    // only: a signal carrying no tier keeps every channel the decision
+    // selected, however its urgency reads.
+    const quietTier = tier !== undefined && !tierClaimsAttention(tier);
+    const dispatchChannels = quietTier
+      ? decision.selectedChannels.filter(
+          (channel) => !ATTENTION_ONLY_CHANNELS.includes(channel),
+        )
+      : decision.selectedChannels;
+
     // Pull the guardian list once so the resolver stays pure. A null list
     // (gateway unreachable) falls back to the local contacts read.
     const guardians = await getGuardianDelivery();
-    const destinations = resolveDestinations(
-      decision.selectedChannels,
-      guardians,
-    );
+    const destinations = resolveDestinations(dispatchChannels, guardians);
 
     // Ensure vellum is processed first so the notification_conversation_created
     // event fires immediately, before slower channel sends (e.g. Telegram 30s
@@ -397,7 +417,7 @@ export class NotificationBroadcaster {
       }
       return 2;
     };
-    const orderedChannels = [...decision.selectedChannels].sort(
+    const orderedChannels = [...dispatchChannels].sort(
       (a, b) => dispatchRank(a) - dispatchRank(b),
     );
 
@@ -415,6 +435,26 @@ export class NotificationBroadcaster {
         ? parseAccessRequestPayload(signal.contextPayload)
         : undefined;
     const results: NotificationDeliveryResult[] = options?.resultsSink ?? [];
+
+    // Nothing was attempted on a dropped channel, so it reads as skipped
+    // rather than failed: there is no delivery for a retry to recover.
+    if (quietTier) {
+      for (const channel of decision.selectedChannels) {
+        if (dispatchChannels.includes(channel)) {
+          continue;
+        }
+        log.info(
+          { signalId: signal.signalId, tier, channel },
+          "Attention tier claims no attention -- channel dropped",
+        );
+        results.push({
+          channel,
+          destination: "",
+          status: "skipped",
+          errorMessage: `Attention tier ${tier} claims no attention: ${channel} can only interrupt`,
+        });
+      }
+    }
 
     // Vellum pairing carried forward for the platform channel's deep link.
     // A single-pass carry is safe because orderedChannels sorts vellum first.

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -39,6 +39,7 @@ import {
   runDeterministicChecks,
 } from "./deterministic-checks.js";
 import { createEvent, setEventDedupeKey } from "./events-store.js";
+import { tierFromRoutingHints, tierShouldNotify } from "./filter/tier.js";
 import { writeHomeFeedItemForSignal } from "./home-feed-side-effect.js";
 import { dispatchDecision } from "./runtime-dispatch.js";
 import type {
@@ -265,11 +266,18 @@ function hasChannelSideEffect(
 /**
  * Emit a notification signal through the full pipeline:
  * createEvent -> (source-active pre-gate) -> evaluateSignal ->
- * runDeterministicChecks -> dispatchDecision.
+ * (attention-tier gate) -> runDeterministicChecks -> dispatchDecision ->
+ * writeHomeFeedItemForSignal.
  *
  * Source-active suppression runs before the decision engine: it depends only
  * on the signal, so a statically-suppressed signal short-circuits here without
  * paying for an LLM inference whose result would be discarded downstream.
+ *
+ * The attention-tier gate runs after the decision stage on purpose: a
+ * suppressed signal is meant to be answerable ("what did you suppress, and
+ * why?"), which takes both the event row and the decision row. It sits above
+ * every side effect this function drives, so a `suppress` tier reaches no
+ * surface: no channel, no home feed item.
  *
  * Fire-and-forget safe by default: errors are caught and logged unless
  * `throwOnError` is enabled by the caller.
@@ -378,6 +386,46 @@ export async function emitNotificationSignal<TEventName extends string>(
     );
 
     let decision = await evaluateSignal(signal, connectedChannels);
+
+    // Step 2.25: Attention-tier gate. A `suppress` tier means "do not surface
+    // at all", and this pipeline drives more than one surface: channel
+    // dispatch is one, the home feed mirror in step 5 is another. Gating
+    // inside the broadcaster could only ever stop the surfaces the
+    // broadcaster owns, and a suppressed signal still reached the home feed
+    // that way, so the drop is a pipeline-level verdict taken above every
+    // side effect. Every surface added later inherits it for free.
+    //
+    // Placed after `evaluateSignal`, which persists the decision row: the
+    // `notification_events` and `notification_decisions` rows both survive
+    // suppression, so "what did you suppress, and why?" has a real answer.
+    // Placed before the policy steps below because those exist to force
+    // channels onto a delivery, and forcing a channel for a signal that must
+    // not surface would contradict the tier while leaving a decision row
+    // naming channels nothing ever dispatched to.
+    //
+    // `tierShouldNotify` is the shared definition of what suppression means;
+    // the broadcaster backstops the same predicate for callers that construct
+    // it directly.
+    const tier = tierFromRoutingHints(signal.routingHints);
+    if (tier && !tierShouldNotify(tier)) {
+      log.info(
+        {
+          signalId,
+          tier,
+          sourceEventName: params.sourceEventName,
+          channels: decision.selectedChannels,
+        },
+        "Signal suppressed by attention tier before any surface",
+      );
+      return {
+        signalId,
+        deduplicated: false,
+        dispatched: false,
+        reason: `Signal suppressed: attention tier is ${tier}`,
+        deliveryResults: [],
+        pipelineFailed: false,
+      };
+    }
 
     // Baseline for the re-persist check below. Captured before the policy
     // steps (2.5a/2.5b/2.5c) so any of them replacing the decision triggers

--- a/assistant/src/notifications/emit-signal.ts
+++ b/assistant/src/notifications/emit-signal.ts
@@ -39,7 +39,11 @@ import {
   runDeterministicChecks,
 } from "./deterministic-checks.js";
 import { createEvent, setEventDedupeKey } from "./events-store.js";
-import { tierFromRoutingHints, tierShouldNotify } from "./filter/tier.js";
+import {
+  tierClaimsAttention,
+  tierFromRoutingHints,
+  tierShouldNotify,
+} from "./filter/tier.js";
 import { writeHomeFeedItemForSignal } from "./home-feed-side-effect.js";
 import { dispatchDecision } from "./runtime-dispatch.js";
 import type {
@@ -391,9 +395,9 @@ export async function emitNotificationSignal<TEventName extends string>(
     // at all", and this pipeline drives more than one surface: channel
     // dispatch is one, the home feed mirror in step 5 is another. Gating
     // inside the broadcaster could only ever stop the surfaces the
-    // broadcaster owns, and a suppressed signal still reached the home feed
-    // that way, so the drop is a pipeline-level verdict taken above every
-    // side effect. Every surface added later inherits it for free.
+    // broadcaster owns, and a suppressed signal would still reach the home
+    // feed that way, so the drop is a pipeline-level verdict taken above
+    // every side effect. Every surface added later inherits it for free.
     //
     // Placed after `evaluateSignal`, which persists the decision row: the
     // `notification_events` and `notification_decisions` rows both survive
@@ -440,7 +444,10 @@ export async function emitNotificationSignal<TEventName extends string>(
     // platform credentials and an assistant id -- on unbound daemons the
     // dispatch can never succeed and would write a failed delivery row per
     // signal. The probe is deadline-bounded internally, so a slow credential
-    // backend cannot stall the urgent dispatch.
+    // backend cannot stall the urgent dispatch. A tier that claims no
+    // attention is exempt from the push: the platform endpoint renders every
+    // dispatch as a device alert, and an inbox-only tier must not reach one.
+    // Urgency alone still forces both channels when a signal carries no tier.
     //
     // Vellum PREPENDS and platform APPENDS: the broadcaster re-sorts by
     // dispatch rank, so selection order only matters to single_channel
@@ -461,6 +468,7 @@ export async function emitNotificationSignal<TEventName extends string>(
       }
       if (
         !selectedChannels.includes("platform") &&
+        (tier === undefined || tierClaimsAttention(tier)) &&
         (await isPlatformClientConfigured())
       ) {
         selectedChannels.push("platform");

--- a/assistant/src/notifications/filter/tier.test.ts
+++ b/assistant/src/notifications/filter/tier.test.ts
@@ -14,6 +14,7 @@ import type { Urgency } from "../urgency.js";
 import {
   compareTier,
   FALLBACK_TIER,
+  resolveSilent,
   type Tier,
   TIER_ORDER,
   tierShouldNotify,
@@ -76,6 +77,46 @@ describe("tierShouldNotify", () => {
   });
 });
 
+describe("resolveSilent", () => {
+  // Keyed by Tier, and iterated over TIER_ORDER, so a new tier fails to
+  // compile here until its documented banner behavior is written down.
+  const documented: Record<Tier, boolean> = {
+    suppress: true,
+    hint: true,
+    offer: false,
+    response: false,
+  };
+
+  for (const tier of TIER_ORDER) {
+    test(`${tier} resolves silent=${documented[tier]} at every urgency`, () => {
+      const urgencies: Urgency[] = ["low", "medium", "high", "critical"];
+      for (const urgency of urgencies) {
+        expect(resolveSilent(tier, urgency)).toBe(documented[tier]);
+      }
+    });
+  }
+
+  test("no tier falls back to urgency", () => {
+    const expected: [Urgency, boolean][] = [
+      ["low", true],
+      ["medium", true],
+      ["high", false],
+      ["critical", false],
+    ];
+    for (const [urgency, silent] of expected) {
+      expect(resolveSilent(undefined, urgency)).toBe(silent);
+    }
+  });
+
+  test("a tier that must not notify is never allowed a banner", () => {
+    for (const tier of TIER_ORDER) {
+      if (!tierShouldNotify(tier)) {
+        expect(resolveSilent(tier, "critical")).toBe(true);
+      }
+    }
+  });
+});
+
 describe("compareTier", () => {
   test("totally orders TIER_ORDER least to most interrupting", () => {
     expect([...TIER_ORDER].reverse().sort(compareTier)).toEqual([
@@ -118,6 +159,16 @@ describe("vellum adapter tier precedence", () => {
     expect(
       await broadcastSilentFlag(makePayload({ tier: "offer", urgency: "low" })),
     ).toBe(false);
+  });
+
+  test("suppress broadcasts silent: true if it ever reaches the adapter", async () => {
+    // The broadcaster drops suppress before dispatch, so this is the
+    // belt-and-braces case: a payload that got here anyway must not banner.
+    expect(
+      await broadcastSilentFlag(
+        makePayload({ tier: "suppress", urgency: "critical" }),
+      ),
+    ).toBe(true);
   });
 
   test("response broadcasts silent: false", async () => {

--- a/assistant/src/notifications/filter/tier.test.ts
+++ b/assistant/src/notifications/filter/tier.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tier is the notification filter's first-class attention concept; `Urgency`
+ * stays the transport. These tests pin the mapping between the two and the
+ * delivery behavior it produces, including the guarantee that a payload
+ * carrying no tier is delivered exactly as it was before Tier existed.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { AssistantEvent } from "../../api/index.js";
+import { VellumAdapter } from "../adapters/macos.js";
+import type { ChannelDeliveryPayload, ChannelDestination } from "../types.js";
+import type { Urgency } from "../urgency.js";
+import {
+  compareTier,
+  FALLBACK_TIER,
+  type Tier,
+  TIER_ORDER,
+  tierShouldNotify,
+  tierToUrgency,
+} from "./tier.js";
+
+function makePayload(
+  overrides: Partial<ChannelDeliveryPayload> = {},
+): ChannelDeliveryPayload {
+  return {
+    deliveryId: "del-1",
+    correlationId: "sig-1",
+    sourceEventName: "user.send_notification",
+    copy: { title: "Title", body: "Body" },
+    urgency: "medium",
+    ...overrides,
+  };
+}
+
+const DESTINATION: ChannelDestination = {
+  channel: "vellum",
+  endpoint: "vellum",
+  metadata: {},
+};
+
+async function broadcastSilentFlag(
+  payload: ChannelDeliveryPayload,
+): Promise<boolean | undefined> {
+  const events: AssistantEvent[] = [];
+  const adapter = new VellumAdapter((msg) => {
+    events.push(msg);
+  });
+  const result = await adapter.send(payload, DESTINATION);
+  expect(result.success).toBe(true);
+  expect(events.length).toBe(1);
+  return (events[0] as { silent?: boolean }).silent;
+}
+
+describe("tier to urgency mapping", () => {
+  // Keyed by Tier, and iterated over TIER_ORDER, so a new tier fails to
+  // compile here until its documented urgency is written down.
+  const documented: Record<Tier, Urgency> = {
+    suppress: "low",
+    hint: "low",
+    offer: "high",
+    response: "critical",
+  };
+
+  for (const tier of TIER_ORDER) {
+    test(`${tier} maps to ${documented[tier]}`, () => {
+      expect(tierToUrgency(tier)).toBe(documented[tier]);
+    });
+  }
+});
+
+describe("tierShouldNotify", () => {
+  test("is false only for suppress", () => {
+    const notifying = TIER_ORDER.filter(tierShouldNotify);
+    expect(notifying).toEqual(["hint", "offer", "response"]);
+  });
+});
+
+describe("compareTier", () => {
+  test("totally orders TIER_ORDER least to most interrupting", () => {
+    expect([...TIER_ORDER].reverse().sort(compareTier)).toEqual([
+      ...TIER_ORDER,
+    ]);
+  });
+
+  test("is zero for a tier against itself and antisymmetric otherwise", () => {
+    for (const a of TIER_ORDER) {
+      expect(compareTier(a, a)).toBe(0);
+      for (const b of TIER_ORDER) {
+        const forward = Math.sign(compareTier(a, b));
+        const reverse = Math.sign(compareTier(b, a));
+        expect(forward + reverse).toBe(0);
+      }
+    }
+  });
+});
+
+describe("FALLBACK_TIER", () => {
+  test("files quietly: never dropped, never interrupting", () => {
+    // A broken judgment layer must not silently drop a notification, and must
+    // not interrupt on a guess.
+    expect(tierShouldNotify(FALLBACK_TIER)).toBe(true);
+    expect(FALLBACK_TIER).not.toBe("suppress");
+    expect(FALLBACK_TIER).not.toBe("response");
+  });
+});
+
+describe("vellum adapter tier precedence", () => {
+  test("hint broadcasts silent: true even at a banner-worthy urgency", async () => {
+    expect(
+      await broadcastSilentFlag(
+        makePayload({ tier: "hint", urgency: "critical" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("offer broadcasts silent: false even at a silent urgency", async () => {
+    expect(
+      await broadcastSilentFlag(makePayload({ tier: "offer", urgency: "low" })),
+    ).toBe(false);
+  });
+
+  test("response broadcasts silent: false", async () => {
+    expect(
+      await broadcastSilentFlag(
+        makePayload({ tier: "response", urgency: "low" }),
+      ),
+    ).toBe(false);
+  });
+
+  test("no tier keeps the urgency-derived behavior for every urgency", async () => {
+    // The regression guard: every producer that does not go through the
+    // filter must deliver byte-identically to how it did before Tier existed.
+    const expected: [Urgency, boolean][] = [
+      ["low", true],
+      ["medium", true],
+      ["high", false],
+      ["critical", false],
+    ];
+    for (const [urgency, silent] of expected) {
+      expect(await broadcastSilentFlag(makePayload({ urgency }))).toBe(silent);
+    }
+  });
+});

--- a/assistant/src/notifications/filter/tier.test.ts
+++ b/assistant/src/notifications/filter/tier.test.ts
@@ -2,7 +2,7 @@
  * Tier is the notification filter's first-class attention concept; `Urgency`
  * stays the transport. These tests pin the mapping between the two and the
  * delivery behavior it produces, including the guarantee that a payload
- * carrying no tier is delivered exactly as it was before Tier existed.
+ * carrying no tier retains urgency-derived behavior.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -203,8 +203,8 @@ describe("vellum adapter tier precedence", () => {
   });
 
   test("no tier keeps the urgency-derived behavior for every urgency", async () => {
-    // The regression guard: every producer that does not go through the
-    // filter must deliver byte-identically to how it did before Tier existed.
+    // The regression guard: a payload without a tier retains urgency-derived
+    // behavior at every urgency.
     const expected: [Urgency, boolean][] = [
       ["low", true],
       ["medium", true],

--- a/assistant/src/notifications/filter/tier.test.ts
+++ b/assistant/src/notifications/filter/tier.test.ts
@@ -17,6 +17,7 @@ import {
   resolveSilent,
   type Tier,
   TIER_ORDER,
+  tierFromRoutingHints,
   tierShouldNotify,
   tierToUrgency,
 } from "./tier.js";
@@ -74,6 +75,28 @@ describe("tierShouldNotify", () => {
   test("is false only for suppress", () => {
     const notifying = TIER_ORDER.filter(tierShouldNotify);
     expect(notifying).toEqual(["hint", "offer", "response"]);
+  });
+});
+
+describe("tierFromRoutingHints", () => {
+  test("reads every tier back out of a routing hint", () => {
+    for (const tier of TIER_ORDER) {
+      expect(tierFromRoutingHints({ tier })).toBe(tier);
+    }
+  });
+
+  test("is undefined when there is no tier to read", () => {
+    expect(tierFromRoutingHints(undefined)).toBeUndefined();
+    expect(tierFromRoutingHints({})).toBeUndefined();
+    expect(tierFromRoutingHints({ preferred: "slack" })).toBeUndefined();
+  });
+
+  test("drops a hint that is not a tier rather than passing it through", () => {
+    // An unrecognized value must never read as a tier: the suppression gate
+    // reads this, and silently dropping notifications is the worse failure.
+    expect(tierFromRoutingHints({ tier: "urgent" })).toBeUndefined();
+    expect(tierFromRoutingHints({ tier: 3 })).toBeUndefined();
+    expect(tierFromRoutingHints({ tier: null })).toBeUndefined();
   });
 });
 

--- a/assistant/src/notifications/filter/tier.ts
+++ b/assistant/src/notifications/filter/tier.ts
@@ -71,10 +71,18 @@ const TIER_CLAIMS_ATTENTION: Record<Tier, boolean> = {
 };
 
 /**
+ * Whether a tier may interrupt: an OS banner, a device alert. False for
+ * `suppress` and `hint`, which are filed without claiming attention.
+ */
+export function tierClaimsAttention(tier: Tier): boolean {
+  return TIER_CLAIMS_ATTENTION[tier];
+}
+
+/**
  * Whether a delivery must stay silent: the inbox entry still appears, the OS
  * banner does not. Tier decides when the filter path set one; otherwise the
- * urgency scale does, so producers that never reach the filter deliver
- * exactly as they did before Tier existed.
+ * urgency scale does, so a payload without a tier retains urgency-derived
+ * behavior.
  *
  * This is the single definition of that decision. The vellum adapter's
  * `notification_intent` and the broadcaster's
@@ -86,7 +94,7 @@ export function resolveSilent(
   urgency: Urgency,
 ): boolean {
   if (tier) {
-    return !TIER_CLAIMS_ATTENTION[tier];
+    return !tierClaimsAttention(tier);
   }
   return urgency !== "high" && urgency !== "critical";
 }

--- a/assistant/src/notifications/filter/tier.ts
+++ b/assistant/src/notifications/filter/tier.ts
@@ -46,6 +46,22 @@ export function tierShouldNotify(tier: Tier): boolean {
   return tier !== "suppress";
 }
 
+/**
+ * The tier a signal carries on `routingHints.tier`, or undefined when it
+ * carries none (a producer that never reached the filter) or when the hint is
+ * not a tier this build knows.
+ *
+ * The single parse site, so the pipeline's suppression gate and the
+ * broadcaster's payload projection can never disagree about which tier a
+ * signal is on.
+ */
+export function tierFromRoutingHints(
+  routingHints: Record<string, unknown> | undefined,
+): Tier | undefined {
+  const parsed = TierSchema.safeParse(routingHints?.tier);
+  return parsed.success ? parsed.data : undefined;
+}
+
 /** Tiers allowed to claim attention with a banner once they are delivered. */
 const TIER_CLAIMS_ATTENTION: Record<Tier, boolean> = {
   suppress: false,

--- a/assistant/src/notifications/filter/tier.ts
+++ b/assistant/src/notifications/filter/tier.ts
@@ -1,0 +1,52 @@
+/**
+ * Attention tier: how much of the user's attention a notification is allowed
+ * to claim.
+ *
+ * - `suppress`  do not surface at all
+ * - `hint`      delivered, but claims no attention (inbox entry, no banner)
+ * - `offer`     surfaces with a claim on attention, not urgent
+ * - `response`  urgent, breaks through
+ *
+ * `Urgency` stays the transport every channel adapter already understands;
+ * `tierToUrgency` is the one place the two scales are related.
+ */
+
+import { z } from "zod";
+
+import type { Urgency } from "../urgency.js";
+
+/** Declared least to most interrupting; `TIER_ORDER` depends on that order. */
+export const TierSchema = z.enum(["suppress", "hint", "offer", "response"]);
+export type Tier = z.infer<typeof TierSchema>;
+
+/** Tiers ordered least to most interrupting. */
+export const TIER_ORDER: readonly Tier[] = TierSchema.options;
+
+/** Negative, zero, or positive as `a` is less, equally, or more interrupting than `b`. */
+export function compareTier(a: Tier, b: Tier): number {
+  return TIER_ORDER.indexOf(a) - TIER_ORDER.indexOf(b);
+}
+
+const TIER_URGENCY: Record<Tier, Urgency> = {
+  suppress: "low",
+  hint: "low",
+  offer: "high",
+  response: "critical",
+};
+
+/** The urgency a tier travels as once it reaches a channel adapter. */
+export function tierToUrgency(tier: Tier): Urgency {
+  return TIER_URGENCY[tier];
+}
+
+/** False only for `suppress`; every other tier is delivered. */
+export function tierShouldNotify(tier: Tier): boolean {
+  return tier !== "suppress";
+}
+
+/**
+ * Tier to use when the judgment layer produced nothing usable. The fail-safe
+ * policy is to file quietly: a broken judgment layer must never silently drop
+ * a notification, and must never interrupt.
+ */
+export const FALLBACK_TIER: Tier = "hint";

--- a/assistant/src/notifications/filter/tier.ts
+++ b/assistant/src/notifications/filter/tier.ts
@@ -7,8 +7,10 @@
  * - `offer`     surfaces with a claim on attention, not urgent
  * - `response`  urgent, breaks through
  *
- * `Urgency` stays the transport every channel adapter already understands;
- * `tierToUrgency` is the one place the two scales are related.
+ * `Urgency` stays the transport every channel adapter already understands.
+ * `tierToUrgency` is the one place the two scales are related, and
+ * `resolveSilent` is the one place a delivery's banner decision is made from
+ * whichever scale the signal carries.
  */
 
 import { z } from "zod";
@@ -42,6 +44,35 @@ export function tierToUrgency(tier: Tier): Urgency {
 /** False only for `suppress`; every other tier is delivered. */
 export function tierShouldNotify(tier: Tier): boolean {
   return tier !== "suppress";
+}
+
+/** Tiers allowed to claim attention with a banner once they are delivered. */
+const TIER_CLAIMS_ATTENTION: Record<Tier, boolean> = {
+  suppress: false,
+  hint: false,
+  offer: true,
+  response: true,
+};
+
+/**
+ * Whether a delivery must stay silent: the inbox entry still appears, the OS
+ * banner does not. Tier decides when the filter path set one; otherwise the
+ * urgency scale does, so producers that never reach the filter deliver
+ * exactly as they did before Tier existed.
+ *
+ * This is the single definition of that decision. The vellum adapter's
+ * `notification_intent` and the broadcaster's
+ * `notification_conversation_created` both read it, so a paired delivery can
+ * never emit two contradictory banner instructions.
+ */
+export function resolveSilent(
+  tier: Tier | undefined,
+  urgency: Urgency,
+): boolean {
+  if (tier) {
+    return !TIER_CLAIMS_ATTENTION[tier];
+  }
+  return urgency !== "high" && urgency !== "critical";
 }
 
 /**

--- a/assistant/src/notifications/types.ts
+++ b/assistant/src/notifications/types.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 
 import type { DeliverableChannelId } from "../channels/config.js";
 import { AccessRequestPayloadSchema } from "./access-request-copy.js";
+import { TierSchema } from "./filter/tier.js";
 import { ToolApprovalSourceViewSchema } from "./guardian-question-mode.js";
 import { UrgencySchema } from "./urgency.js";
 
@@ -99,6 +100,10 @@ export const ChannelDeliveryPayloadSchema = z.object({
   deepLinkTarget: z.record(z.string(), z.unknown()).optional(),
   contextPayload: z.record(z.string(), z.unknown()).optional(),
   urgency: UrgencySchema,
+  /** Attention tier for this delivery, set only by the filter path. Adapters
+   *  prefer it over `urgency`; producers that do not go through the filter
+   *  leave it unset and keep the urgency-derived behavior. */
+  tier: TierSchema.optional(),
   approvalContext: ApprovalUIMetadataSchema.optional(),
   accessRequestContext: AccessRequestPayloadSchema.optional(),
   /** Source reference for a tool-approval card, projected once by the


### PR DESCRIPTION
## Summary
- Adds the four-value `Tier` type (suppress/hint/offer/response) and its mapping onto the existing `Urgency` scale.
- Carries `tier` on `ChannelDeliveryPayload`, projected once centrally in the broadcaster.
- The macOS adapter prefers an explicit tier when present and falls back to the current urgency-derived `silent` computation otherwise, so non-filter producers are unchanged.

Part of plan: notification-filter.md (PR 1 of 15)