### PR TITLE
fix(desktop): honor the daemon's silent flag on native notifications

### DIFF
--- a/clients/web/src/hooks/use-notification-intent-sync.ts
+++ b/clients/web/src/hooks/use-notification-intent-sync.ts
@@ -78,6 +78,7 @@ export function useNotificationIntentSync(assistantId: string | null): void {
       assistantId: assistantId ?? undefined,
       remotePushDispatched: event.remotePushDispatched,
       remotePushPlatforms: event.remotePushPlatforms,
+      silent: event.silent,
     });
   });
 }

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -357,9 +357,9 @@ export interface PostLocalNotificationArgs {
   /** Native platforms that accepted this delivery for remote push. */
   remotePushPlatforms?: ("ios" | "android")[];
   /**
-   * The daemon's urgency-derived flag: true means file the notification
-   * without claiming attention with a banner. Honored on the Electron
-   * path, which forwards it to `electron.Notification`.
+   * The daemon's urgency-derived flag: true means this intent must not
+   * reach the OS notification surface. Honored on the Electron path, where
+   * main skips the notification entirely and still acks a success.
    */
   silent?: boolean;
 }

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -356,6 +356,12 @@ export interface PostLocalNotificationArgs {
   remotePushDispatched?: boolean;
   /** Native platforms that accepted this delivery for remote push. */
   remotePushPlatforms?: ("ios" | "android")[];
+  /**
+   * The daemon's urgency-derived flag: true means file the notification
+   * without claiming attention with a banner. Honored on the Electron
+   * path, which forwards it to `electron.Notification`.
+   */
+  silent?: boolean;
 }
 
 /**
@@ -427,6 +433,7 @@ export async function postLocalNotification(
         deliveryId: args.deliveryId,
         conversationId: extractConversationId(args.deepLinkMetadata),
         deepLinkMetadata: args.deepLinkMetadata,
+        silent: args.silent,
       });
       success = result.success;
       errorMessage = result.errorMessage;

--- a/clients/windows/src/main/notifications-share-feature.test.ts
+++ b/clients/windows/src/main/notifications-share-feature.test.ts
@@ -104,7 +104,6 @@ describe("helper toast factory", () => {
     const toast = create({
       title: "T",
       body: "B",
-      silent: false,
       actions: [
         { type: "button", text: "Allow" },
         { type: "button", text: "Deny" },
@@ -152,7 +151,6 @@ describe("helper toast factory", () => {
       const toast = create({
         title: "T",
         body: "B",
-        silent: false,
         actions: [],
       });
       toast.on("failed", (_event: unknown, message: string) => {

--- a/packages/electron-desktop/src/notifications.test.ts
+++ b/packages/electron-desktop/src/notifications.test.ts
@@ -33,7 +33,6 @@ import type { z } from "zod";
 interface MockNotificationOptions {
   title: string;
   body: string;
-  silent: boolean;
   actions: Array<{ type: "button"; text: string }>;
 }
 
@@ -229,7 +228,10 @@ describe("category action buttons", () => {
 // --- Silent flag -----------------------------------------------------------
 
 describe("silent flag", () => {
-  test("forwards silent: true so the OS files the entry without a banner", async () => {
+  // The wire contract defines `silent` as "do not post to the OS
+  // notification surface", not Electron's "mute the sound but still
+  // banner", so the notification must never be constructed.
+  test("silent: true posts nothing to the OS and still acks a success", async () => {
     const result = await show({
       category: "notificationIntent",
       title: "T",
@@ -238,17 +240,50 @@ describe("silent flag", () => {
       silent: true,
     });
     expect(result.success).toBe(true);
-    expect(constructed[0]!.options.silent).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+    expect(constructed).toHaveLength(0);
   });
 
-  test("defaults to not silent when the payload omits the flag", async () => {
-    await show({
+  test("silent: false posts the banner exactly as an omitted flag does", async () => {
+    expect(
+      (
+        await show({
+          category: "notificationIntent",
+          title: "T",
+          body: "B",
+          deliveryId: "silent-2",
+          silent: false,
+        })
+      ).success,
+    ).toBe(true);
+    expect(constructed).toHaveLength(1);
+
+    expect(
+      (
+        await show({
+          category: "notificationIntent",
+          title: "T",
+          body: "B",
+          deliveryId: "silent-3",
+        })
+      ).success,
+    ).toBe(true);
+    expect(constructed).toHaveLength(2);
+  });
+
+  test("a silent intent is handled even where notifications are unsupported", async () => {
+    // Nothing has to be delivered, so platform support is irrelevant: the
+    // client still handled the intent correctly by not posting it.
+    notificationSupported = false;
+    const result = await show({
       category: "notificationIntent",
       title: "T",
       body: "B",
-      deliveryId: "silent-2",
+      deliveryId: "silent-4",
+      silent: true,
     });
-    expect(constructed[0]!.options.silent).toBe(false);
+    expect(result.success).toBe(true);
+    expect(constructed).toHaveLength(0);
   });
 
   test("the captured schema accepts the silent flag and rejects a non-boolean", () => {
@@ -298,7 +333,7 @@ describe("dedup / cooldown", () => {
     expect(constructed).toHaveLength(2);
   });
 
-  test("the cooldown keys on the notification, not the silent flag", async () => {
+  test("a skipped silent intent does not consume the cooldown window", async () => {
     const payload = {
       category: "notificationIntent",
       title: "T",
@@ -306,9 +341,11 @@ describe("dedup / cooldown", () => {
       deliveryId: "dup-2",
     };
 
+    // Nothing reached the OS, so the follow-up must still be free to banner:
+    // recording the skip would suppress a notification the user never saw.
     at(0);
     expect((await show({ ...payload, silent: true })).success).toBe(true);
-    expect(constructed).toHaveLength(1);
+    expect(constructed).toHaveLength(0);
 
     at(5_000);
     expect((await show(payload)).success).toBe(true);

--- a/packages/electron-desktop/src/notifications.test.ts
+++ b/packages/electron-desktop/src/notifications.test.ts
@@ -226,6 +226,51 @@ describe("category action buttons", () => {
   }
 });
 
+// --- Silent flag -----------------------------------------------------------
+
+describe("silent flag", () => {
+  test("forwards silent: true so the OS files the entry without a banner", async () => {
+    const result = await show({
+      category: "notificationIntent",
+      title: "T",
+      body: "B",
+      deliveryId: "silent-1",
+      silent: true,
+    });
+    expect(result.success).toBe(true);
+    expect(constructed[0]!.options.silent).toBe(true);
+  });
+
+  test("defaults to not silent when the payload omits the flag", async () => {
+    await show({
+      category: "notificationIntent",
+      title: "T",
+      body: "B",
+      deliveryId: "silent-2",
+    });
+    expect(constructed[0]!.options.silent).toBe(false);
+  });
+
+  test("the captured schema accepts the silent flag and rejects a non-boolean", () => {
+    const { schema } = showHandler();
+    expect(() =>
+      schema.parse([
+        { category: "notificationIntent", title: "t", body: "b", silent: true },
+      ]),
+    ).not.toThrow();
+    expect(() =>
+      schema.parse([
+        {
+          category: "notificationIntent",
+          title: "t",
+          body: "b",
+          silent: "yes",
+        },
+      ]),
+    ).toThrow();
+  });
+});
+
 // --- Dedup / cooldown ------------------------------------------------------
 
 describe("dedup / cooldown", () => {
@@ -251,6 +296,23 @@ describe("dedup / cooldown", () => {
     at(11_000);
     expect((await show(payload)).success).toBe(true);
     expect(constructed).toHaveLength(2);
+  });
+
+  test("the cooldown keys on the notification, not the silent flag", async () => {
+    const payload = {
+      category: "notificationIntent",
+      title: "T",
+      body: "B",
+      deliveryId: "dup-2",
+    };
+
+    at(0);
+    expect((await show({ ...payload, silent: true })).success).toBe(true);
+    expect(constructed).toHaveLength(1);
+
+    at(5_000);
+    expect((await show(payload)).success).toBe(true);
+    expect(constructed).toHaveLength(1);
   });
 
   test("toolConfirmation has no cooldown and always posts", async () => {

--- a/packages/electron-desktop/src/notifications.ts
+++ b/packages/electron-desktop/src/notifications.ts
@@ -265,7 +265,7 @@ const showNotification = (
   )({
     title: payload.title,
     body: payload.body,
-    silent: false,
+    silent: payload.silent ?? false,
     actions,
   });
 

--- a/packages/electron-desktop/src/notifications.ts
+++ b/packages/electron-desktop/src/notifications.ts
@@ -62,7 +62,6 @@ export interface NotificationLike {
 export interface NotificationCreateOptions {
   title: string;
   body: string;
-  silent: boolean;
   actions: CategoryAction[];
 }
 
@@ -244,6 +243,23 @@ const showNotification = (
   payload: ShowNotificationPayload,
 ): Promise<ShowResult> => {
   const { ensureVisible, isSupported, create, logger } = requireRuntime();
+
+  if (payload.silent) {
+    // The wire contract (`assistant/src/api/events/notification-intent.ts`)
+    // defines `silent` as "do not post this to the OS notification surface";
+    // the daemon sets it from the signal's urgency. Electron's own `silent`
+    // option only mutes the sound, so honoring the contract means not
+    // constructing the notification at all. Non-banner side effects (the
+    // renderer's in-app chime, the deep link it keeps) still run.
+    //
+    // This acks as a success like the cooldown path does: the client handled
+    // the intent exactly as asked, and recording a failure would put a
+    // phantom delivery error in the daemon's audit trail. Nothing reached
+    // the OS, so the cooldown window is deliberately left untouched: a later
+    // non-silent intent for the same key must still be free to banner.
+    return Promise.resolve({ success: true });
+  }
+
   if (!(isSupported ?? Notification.isSupported)()) {
     return Promise.resolve({
       success: false,
@@ -265,7 +281,6 @@ const showNotification = (
   )({
     title: payload.title,
     body: payload.body,
-    silent: payload.silent ?? false,
     actions,
   });
 

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -42,6 +42,7 @@ export const showNotificationPayloadSchema = z.object({
   conversationId: z.string().optional(),
   toolCallId: z.string().optional(),
   deepLinkMetadata: z.record(z.string(), z.unknown()).optional(),
+  silent: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -544,11 +544,12 @@ export interface ShowNotificationPayload {
   toolCallId?: string;
   deepLinkMetadata?: Record<string, unknown>;
   /**
-   * Suppresses the OS banner while still filing the notification in the
-   * notification center. Originates from the daemon's urgency-derived
-   * flag on the `notification_intent` event
-   * (`assistant/src/notifications/adapters/macos.ts`). Omitted means not
-   * silent.
+   * True means do not post this to the OS notification surface at all:
+   * main skips the notification rather than muting it, because Electron's
+   * own `silent` option only drops the sound and would still banner. Non-
+   * banner side effects (the renderer's in-app chime, the deep link) still
+   * run. Originates from the daemon's urgency-derived flag on the
+   * `notification_intent` event. Omitted means not silent.
    */
   silent?: boolean;
 }

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -543,6 +543,14 @@ export interface ShowNotificationPayload {
   conversationId?: string;
   toolCallId?: string;
   deepLinkMetadata?: Record<string, unknown>;
+  /**
+   * Suppresses the OS banner while still filing the notification in the
+   * notification center. Originates from the daemon's urgency-derived
+   * flag on the `notification_intent` event
+   * (`assistant/src/notifications/adapters/macos.ts`). Omitted means not
+   * silent.
+   */
+  silent?: boolean;
 }
 
 export type TextInsertionResult =


### PR DESCRIPTION
## Summary
- The daemon computes a `silent` flag from urgency and broadcasts it on `notification_intent`, but the Electron main process hardcoded `silent: false` and `ShowNotificationPayload` had no such field, so every notification bannered regardless of intent.
- Adds `silent` to the payload type and schema, threads it from the SSE event through the web runtime, and honors it at the Notification construction with `false` as the default.
- Existing callers that omit the field are unchanged.

Part of plan: notification-filter.md (PR 5 of 15)