### PR TITLE
feat(persistence): notification filter rule columns and tables

### DIFF
--- a/assistant/src/persistence/migrations/375-notification-filter-rules.ts
+++ b/assistant/src/persistence/migrations/375-notification-filter-rules.ts
@@ -1,0 +1,77 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+import { tableHasColumn } from "./schema-introspection.js";
+
+const PREFERENCES_TABLE = "notification_preferences";
+
+const PREFERENCE_COLUMNS: Array<{ name: string; definition: string }> = [
+  { name: "match_json", definition: "TEXT NOT NULL DEFAULT '{}'" },
+  { name: "tier", definition: "TEXT" },
+  { name: "provenance", definition: "TEXT NOT NULL DEFAULT 'user'" },
+  { name: "source_request_id", definition: "TEXT" },
+  { name: "status", definition: "TEXT NOT NULL DEFAULT 'active'" },
+];
+
+/**
+ * Give notification preferences a deterministic layer, and record the two
+ * things prose cannot say.
+ *
+ * `notification_preferences` holds natural-language preferences that are read
+ * into a prompt. That is the right shape for nuance and the wrong shape for a
+ * verdict the filter has to reach the same way every time. The new columns sit
+ * beside the prose rather than replacing it: `match_json` is a structured
+ * predicate, `tier` is the verdict the rule asserts when that predicate holds,
+ * `provenance` separates a rule the user wrote from one the assistant
+ * proposed, `source_request_id` links a proposed rule back to the approval
+ * that created it, and `status` retires a rule without deleting it.
+ *
+ * `tier` is nullable and that nullability is the compatibility story: every
+ * row written before this migration keeps `tier = NULL` and stays advisory
+ * prose, so an upgrade changes no existing behavior. A row only becomes
+ * deterministic once something sets a tier on it.
+ *
+ * `notification_rule_declines` records the user saying no to a proposal. The
+ * `scope_key` is unique because the record is a fact about a scope, not a log
+ * of how often it was asked: one row means never ask again. It is separate
+ * from the preferences table because a decline is the absence of a rule, and
+ * storing it as a disabled rule would let it be read as one.
+ *
+ * `notification_interactions` is observation, not policy: what the user did
+ * with a delivery, keyed to the normalized shape of what was delivered, so
+ * behavior can be summarized without re-deriving it from deliveries whose
+ * rendering has since changed.
+ *
+ * Idempotent: each column is guarded by a column-exists check because SQLite
+ * has no `ADD COLUMN IF NOT EXISTS`, and the tables and index use
+ * `IF NOT EXISTS`.
+ */
+export function migrateNotificationFilterRules(database: DrizzleDb): void {
+  const sqlite = getSqliteFrom(database);
+
+  for (const { name, definition } of PREFERENCE_COLUMNS) {
+    if (!tableHasColumn(database, PREFERENCES_TABLE, name)) {
+      sqlite.exec(
+        /*sql*/ `ALTER TABLE ${PREFERENCES_TABLE} ADD COLUMN ${name} ${definition}`,
+      );
+    }
+  }
+
+  sqlite.exec(/*sql*/ `CREATE TABLE IF NOT EXISTS notification_rule_declines (
+       id TEXT PRIMARY KEY,
+       scope_key TEXT NOT NULL UNIQUE,
+       proposed_tier TEXT NOT NULL,
+       request_id TEXT,
+       declined_at INTEGER NOT NULL
+     )`);
+
+  sqlite.exec(/*sql*/ `CREATE TABLE IF NOT EXISTS notification_interactions (
+       id TEXT PRIMARY KEY,
+       delivery_id TEXT NOT NULL,
+       normalized_json TEXT NOT NULL,
+       tier TEXT NOT NULL,
+       kind TEXT NOT NULL,
+       observed_at INTEGER NOT NULL
+     )`);
+
+  sqlite.exec(/*sql*/ `CREATE INDEX IF NOT EXISTS idx_notif_interactions_observed
+       ON notification_interactions (observed_at)`);
+}

--- a/assistant/src/persistence/migrations/375-notification-filter-rules.ts
+++ b/assistant/src/persistence/migrations/375-notification-filter-rules.ts
@@ -17,17 +17,18 @@ const PREFERENCE_COLUMNS: Array<{ name: string; definition: string }> = [
  *
  * `notification_preferences` holds natural-language preferences that are read
  * into a prompt. That is the right shape for nuance and the wrong shape for a
- * verdict the filter has to reach the same way every time. The new columns sit
- * beside the prose rather than replacing it: `match_json` is a structured
+ * verdict the filter has to reach the same way every time. These columns sit
+ * beside the prose rather than carrying it: `match_json` is a structured
  * predicate, `tier` is the verdict the rule asserts when that predicate holds,
  * `provenance` separates a rule the user wrote from one the assistant
  * proposed, `source_request_id` links a proposed rule back to the approval
- * that created it, and `status` retires a rule without deleting it.
+ * that created it, and `status` gates whether a rule is live or retired
+ * without being deleted.
  *
- * `tier` is nullable and that nullability is the compatibility story: every
- * row written before this migration keeps `tier = NULL` and stays advisory
- * prose, so an upgrade changes no existing behavior. A row only becomes
- * deterministic once something sets a tier on it.
+ * `tier` is nullable, and a row holding `tier = NULL` is advisory prose only:
+ * it is never matched deterministically. A row becomes deterministic when
+ * something sets a tier on it. `match_json` defaults to `'{}'`, a predicate
+ * that matches nothing.
  *
  * `notification_rule_declines` records the user saying no to a proposal. The
  * `scope_key` is unique because the record is a fact about a scope, not a log

--- a/assistant/src/persistence/migrations/__tests__/375-notification-filter-rules.test.ts
+++ b/assistant/src/persistence/migrations/__tests__/375-notification-filter-rules.test.ts
@@ -1,0 +1,158 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import { getSqliteFrom } from "../../db-connection.js";
+import * as schema from "../../schema.js";
+import { migrateNotificationFilterRules } from "../375-notification-filter-rules.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec("PRAGMA journal_mode=WAL");
+  sqlite.exec(
+    `CREATE TABLE notification_preferences (
+       id TEXT PRIMARY KEY,
+       preference_text TEXT NOT NULL,
+       applies_when_json TEXT NOT NULL DEFAULT '{}',
+       priority INTEGER NOT NULL DEFAULT 0,
+       created_at INTEGER NOT NULL,
+       updated_at INTEGER NOT NULL
+     )`,
+  );
+  return drizzle(sqlite, { schema });
+}
+
+function columnNames(raw: Database, table: string): string[] {
+  const rows = raw.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+    name: string;
+  }>;
+  return rows.map((row) => row.name);
+}
+
+function insertPreference(raw: Database, id: string): void {
+  raw.run(
+    `INSERT INTO notification_preferences
+       (id, preference_text, applies_when_json, priority, created_at, updated_at)
+     VALUES (?, 'tell me about outages', '{}', 0, 1000, 1000)`,
+    [id],
+  );
+}
+
+describe("migration 375: notification filter rules", () => {
+  test("adds the rule columns to notification_preferences", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    migrateNotificationFilterRules(db);
+
+    expect(columnNames(raw, "notification_preferences")).toEqual(
+      expect.arrayContaining([
+        "match_json",
+        "tier",
+        "provenance",
+        "source_request_id",
+        "status",
+      ]),
+    );
+  });
+
+  test("leaves an existing preference advisory", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    insertPreference(raw, "pref-1");
+
+    migrateNotificationFilterRules(db);
+
+    const row = raw
+      .prepare(
+        "SELECT match_json, tier, provenance, source_request_id, status FROM notification_preferences WHERE id = 'pref-1'",
+      )
+      .get() as {
+      match_json: string;
+      tier: string | null;
+      provenance: string;
+      source_request_id: string | null;
+      status: string;
+    };
+    expect(row).toEqual({
+      match_json: "{}",
+      tier: null,
+      provenance: "user",
+      source_request_id: null,
+      status: "active",
+    });
+  });
+
+  test("creates the declines and interactions tables", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    migrateNotificationFilterRules(db);
+
+    expect(columnNames(raw, "notification_rule_declines").sort()).toEqual([
+      "declined_at",
+      "id",
+      "proposed_tier",
+      "request_id",
+      "scope_key",
+    ]);
+    expect(columnNames(raw, "notification_interactions").sort()).toEqual([
+      "delivery_id",
+      "id",
+      "kind",
+      "normalized_json",
+      "observed_at",
+      "tier",
+    ]);
+    const indexes = raw
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'notification_interactions' AND sql IS NOT NULL`,
+      )
+      .all() as Array<{ name: string }>;
+    expect(indexes.map((index) => index.name)).toEqual([
+      "idx_notif_interactions_observed",
+    ]);
+  });
+
+  test("one decline per scope", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+
+    migrateNotificationFilterRules(db);
+    raw.run(
+      `INSERT INTO notification_rule_declines (id, scope_key, proposed_tier, request_id, declined_at)
+       VALUES ('decline-1', 'scope-a', 'quiet', NULL, 1000)`,
+    );
+
+    expect(() =>
+      raw.run(
+        `INSERT INTO notification_rule_declines (id, scope_key, proposed_tier, request_id, declined_at)
+         VALUES ('decline-2', 'scope-a', 'quiet', NULL, 2000)`,
+      ),
+    ).toThrow();
+  });
+
+  test("is idempotent and preserves existing rows", () => {
+    const db = createTestDb();
+    const raw = getSqliteFrom(db);
+    insertPreference(raw, "pref-1");
+
+    migrateNotificationFilterRules(db);
+    raw.run(
+      `INSERT INTO notification_interactions (id, delivery_id, normalized_json, tier, kind, observed_at)
+       VALUES ('interaction-1', 'delivery-1', '{}', 'quiet', 'dismissed', 1000)`,
+    );
+
+    expect(() => migrateNotificationFilterRules(db)).not.toThrow();
+
+    const preferences = raw
+      .prepare("SELECT id FROM notification_preferences")
+      .all() as Array<{ id: string }>;
+    expect(preferences).toEqual([{ id: "pref-1" }]);
+    const interactions = raw
+      .prepare("SELECT id FROM notification_interactions")
+      .all() as Array<{ id: string }>;
+    expect(interactions).toEqual([{ id: "interaction-1" }]);
+  });
+});

--- a/assistant/src/persistence/schema/notifications.ts
+++ b/assistant/src/persistence/schema/notifications.ts
@@ -41,9 +41,38 @@ export const notificationPreferences = sqliteTable("notification_preferences", {
   preferenceText: text("preference_text").notNull(),
   appliesWhenJson: text("applies_when_json").notNull().default("{}"),
   priority: integer("priority").notNull().default(0),
+  matchJson: text("match_json").notNull().default("{}"), // structured predicate
+  tier: text("tier"), // NULL keeps the row advisory prose only
+  provenance: text("provenance").notNull().default("user"), // user | agent
+  sourceRequestId: text("source_request_id"),
+  status: text("status").notNull().default("active"), // active | retired
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });
+
+export const notificationRuleDeclines = sqliteTable(
+  "notification_rule_declines",
+  {
+    id: text("id").primaryKey(),
+    scopeKey: text("scope_key").notNull().unique(),
+    proposedTier: text("proposed_tier").notNull(),
+    requestId: text("request_id"),
+    declinedAt: integer("declined_at").notNull(), // epoch ms
+  },
+);
+
+export const notificationInteractions = sqliteTable(
+  "notification_interactions",
+  {
+    id: text("id").primaryKey(),
+    deliveryId: text("delivery_id").notNull(),
+    normalizedJson: text("normalized_json").notNull(),
+    tier: text("tier").notNull(),
+    kind: text("kind").notNull(),
+    observedAt: integer("observed_at").notNull(), // epoch ms
+  },
+  (table) => [index("idx_notif_interactions_observed").on(table.observedAt)],
+);
 
 export const sequences = sqliteTable("sequences", {
   id: text("id").primaryKey(),

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -481,6 +481,7 @@ import { migrateAcpSessionHistoryAuthErrorCode } from "./migrations/370-acp-sess
 import { migrateAcpSessionHistoryAuthErrorCredential } from "./migrations/371-acp-session-history-auth-error-credential.js";
 import { migrateCreateAcpRefusedCredentials } from "./migrations/372-create-acp-refused-credentials.js";
 import { migrateAcpAuthMarkerIndex } from "./migrations/373-acp-auth-marker-index.js";
+import { migrateNotificationFilterRules } from "./migrations/375-notification-filter-rules.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1596,4 +1597,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateAcpSessionHistoryAuthErrorCredential,
   migrateCreateAcpRefusedCredentials,
   migrateAcpAuthMarkerIndex,
+  migrateNotificationFilterRules,
 ];


### PR DESCRIPTION
## Summary
- Migration 375 adds five columns to `notification_preferences` (match_json, tier, provenance, source_request_id, status), each guarded by a PRAGMA check so the migration is re-runnable.
- Adds `notification_rule_declines` (the never-ask-again record) and `notification_interactions` (behavioral observation data).
- Existing preference rows are unaffected: they keep `tier=NULL` and stay advisory.

Part of plan: notification-filter.md (PR 3 of 15)