### PR TITLE
fix(assistant): stamp llm_request_logs with the turn call site

### DIFF
--- a/assistant/src/__tests__/compactor-call-site-logging.test.ts
+++ b/assistant/src/__tests__/compactor-call-site-logging.test.ts
@@ -154,6 +154,7 @@ describe("compactor records llm_request_logs with call_site=compactionAgent", ()
     expect(recordRequestLogCalls.length).toBe(1);
     expect(recordRequestLogCalls[0]!.callSite).toBe("compactionAgent");
     expect(result.summaryCallSite).toBe("compactionAgent");
+    expect(result.summaryResolutionCallSite).toBe("mainAgent");
     expect(recordRequestLogCalls[0]!.conversationId).toBe(
       "conv-compaction-log-1",
     );
@@ -231,6 +232,7 @@ describe("compaction result reports what actually served the summary", () => {
     expect(result.summaryOverrideProfile).toBe("primaryProfile");
     // Request log and usage attribution share the observability call site.
     expect(result.summaryCallSite).toBe("compactionAgent");
+    expect(result.summaryResolutionCallSite).toBe("mainAgent");
     expect(recordRequestLogCalls[0]!.callSite).toBe("compactionAgent");
     // Same value the request log recorded: one source of truth, not two.
     expect(recordRequestLogCalls[0]!.provider).toBe("anthropic");

--- a/assistant/src/__tests__/compactor-call-site-logging.test.ts
+++ b/assistant/src/__tests__/compactor-call-site-logging.test.ts
@@ -149,10 +149,11 @@ describe("compactor records llm_request_logs with call_site=compactionAgent", ()
   });
 
   test("successful compaction call stamps call_site = compactionAgent", async () => {
-    await runAssistantDrivenCompaction(args(makeProvider()));
+    const result = await runAssistantDrivenCompaction(args(makeProvider()));
 
     expect(recordRequestLogCalls.length).toBe(1);
     expect(recordRequestLogCalls[0]!.callSite).toBe("compactionAgent");
+    expect(result.summaryCallSite).toBe("compactionAgent");
     expect(recordRequestLogCalls[0]!.conversationId).toBe(
       "conv-compaction-log-1",
     );
@@ -228,6 +229,9 @@ describe("compaction result reports what actually served the summary", () => {
     expect(result.summaryActualInferenceProfile).toBe("backupProfile");
     // The primary's resolution is still reported, just outranked downstream.
     expect(result.summaryOverrideProfile).toBe("primaryProfile");
+    // Request log and usage attribution share the observability call site.
+    expect(result.summaryCallSite).toBe("compactionAgent");
+    expect(recordRequestLogCalls[0]!.callSite).toBe("compactionAgent");
     // Same value the request log recorded: one source of truth, not two.
     expect(recordRequestLogCalls[0]!.provider).toBe("anthropic");
   });

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -4240,6 +4240,7 @@ describe("session-agent-loop", () => {
           summaryModel: "claude-sonnet-5",
           summaryText: "summary",
           summaryCallSite: "compactionAgent",
+          summaryResolutionCallSite: "mainAgent",
           // What the compactor resolved before the call...
           summaryOverrideProfile: "primaryProfile",
           // ...and what the reroute actually served.
@@ -4260,6 +4261,7 @@ describe("session-agent-loop", () => {
       expect(compactorCall?.[3]).toBe("claude-sonnet-5");
       expect(compactorCall?.[12]).toEqual({
         callSite: "compactionAgent",
+        profileResolutionCallSite: "mainAgent",
         overrideProfile: "backupProfile",
         forceOverrideProfile: true,
       });
@@ -4286,6 +4288,7 @@ describe("session-agent-loop", () => {
           summaryModel: "mock-model",
           summaryText: "summary",
           summaryCallSite: "compactionAgent",
+          summaryResolutionCallSite: "mainAgent",
           summaryOverrideProfile: "primaryProfile",
           summaryActualProvider: "openai",
         },
@@ -4302,6 +4305,7 @@ describe("session-agent-loop", () => {
       expect(compactorCall?.[3]).toBe("mock-model");
       expect(compactorCall?.[12]).toEqual({
         callSite: "compactionAgent",
+        profileResolutionCallSite: "mainAgent",
         overrideProfile: "primaryProfile",
       });
     });
@@ -4331,6 +4335,7 @@ describe("session-agent-loop", () => {
           summaryModel: "mock-model",
           summaryText: "summary",
           summaryCallSite: "compactionAgent",
+          summaryResolutionCallSite: "mainAgent",
           summaryOverrideProfile: "primaryProfile",
         },
         () => {},
@@ -4347,6 +4352,7 @@ describe("session-agent-loop", () => {
       });
       expect(compactorCall?.[12]).toEqual({
         callSite: "compactionAgent",
+        profileResolutionCallSite: "mainAgent",
         overrideProfile: "primaryProfile",
       });
     });

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -1699,6 +1699,91 @@ describe("session-agent-loop", () => {
       expect(call[1]).toBe(JSON.stringify(rawRequest));
       expect(call[2]).toBe(JSON.stringify(rawResponse));
     });
+
+    test("request log and usage event share the turn call site", async () => {
+      const rawRequest = {
+        model: "gpt-4.1",
+        messages: [{ role: "user", content: "Hello" }],
+      };
+      const rawResponse = {
+        model: "gpt-4.1-2026-03-01",
+        choices: [
+          {
+            finish_reason: "stop",
+            message: { role: "assistant", content: "Hi there." },
+          },
+        ],
+      };
+      const ctx = makeCtx({
+        providerResponses: [
+          {
+            content: [{ type: "text", text: "Hi there." }],
+            model: "gpt-4.1-2026-03-01",
+            usage: { inputTokens: 12, outputTokens: 3 },
+            stopReason: "end_turn",
+            actualProvider: "openai",
+            rawRequest,
+            rawResponse,
+          },
+        ],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {}, {
+        callSite: "callAgent",
+      });
+
+      expect(recordRequestLogMock).toHaveBeenCalledTimes(1);
+      const call = recordRequestLogMock.mock.calls[0] as unknown as unknown[];
+      expect(call[5]).toBe("callAgent");
+
+      const usageCall = recordUsageMock.mock.calls.find(
+        (entry) => (entry as unknown[])[5] === "main_agent",
+      ) as unknown[] | undefined;
+      expect(usageCall).toBeDefined();
+      const attribution = usageCall?.[12] as UsageAttributionInput;
+      expect(attribution.callSite).toBe("callAgent");
+    });
+
+    test("stamps voiceFrontDoor on the request log for a front-door turn", async () => {
+      const ctx = makeCtx({
+        providerResponses: [
+          {
+            content: [{ type: "text", text: "Hi." }],
+            model: "mock-model",
+            usage: { inputTokens: 8, outputTokens: 2 },
+            stopReason: "end_turn",
+            rawRequest: { model: "mock-model", messages: [] },
+            rawResponse: { id: "resp-1" },
+          },
+        ],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {}, {
+        callSite: "voiceFrontDoor",
+      });
+
+      const call = recordRequestLogMock.mock.calls[0] as unknown as unknown[];
+      expect(call[5]).toBe("voiceFrontDoor");
+    });
+
+    test("provider-error request logs carry the turn call site", async () => {
+      const ctx = makeCtx({
+        loopProvider: {
+          name: "mock-provider",
+          async sendMessage() {
+            throw new Error("upstream 500");
+          },
+        } as unknown as Provider,
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {}, {
+        callSite: "callAgent",
+      });
+
+      expect(recordRequestLogMock).toHaveBeenCalledTimes(1);
+      const call = recordRequestLogMock.mock.calls[0] as unknown as unknown[];
+      expect(call[5]).toBe("callAgent");
+    });
   });
 
   describe("usage accounting", () => {

--- a/assistant/src/__tests__/usage-attribution.test.ts
+++ b/assistant/src/__tests__/usage-attribution.test.ts
@@ -295,6 +295,32 @@ describe("resolveUsageAttribution — single-winner semantics", () => {
     });
   });
 
+  test("compaction observability site still resolves the profile through mainAgent", () => {
+    setLlmConfig({
+      profiles: { mine: completeProfile },
+      activeProfile: "mine",
+      callSites: { compactionAgent: { profile: "cost-optimized" } },
+      defaultProvider: { provider: "anthropic" },
+    });
+
+    const snapshot = resolveUsageAttribution({
+      callSite: "compactionAgent",
+      profileResolutionCallSite: "mainAgent",
+    });
+
+    expect(snapshot.callSite).toBe("compactionAgent");
+    expect(snapshot.appliedProfile).toBe("mine");
+    expect(snapshot.profileSource).toBe("active");
+    expect(snapshot.resolvedModel).toBe("gpt-5.5");
+    expect(
+      resolveUsageAttribution({ callSite: "compactionAgent" }),
+    ).toMatchObject({
+      callSite: "compactionAgent",
+      appliedProfile: "cost-optimized",
+      profileSource: "call_site",
+    });
+  });
+
   test("attribution provider/model agree with the resolver", () => {
     setLlmConfig({
       profiles: { mine: completeProfile },

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -76,6 +76,19 @@ const COMPACTION_CALL_SITE: LLMCallSite = "mainAgent";
  */
 const COMPACTION_LOG_CALL_SITE: LLMCallSite = "compactionAgent";
 
+function compactionUsageAttribution(
+  args: Pick<CompactionRunArgs, "overrideProfile">,
+): Pick<
+  CompactionRunResult,
+  "summaryCallSite" | "summaryResolutionCallSite" | "summaryOverrideProfile"
+> {
+  return {
+    summaryCallSite: COMPACTION_LOG_CALL_SITE,
+    summaryResolutionCallSite: COMPACTION_CALL_SITE,
+    summaryOverrideProfile: args.overrideProfile ?? null,
+  };
+}
+
 /**
  * What actually served a compaction call, for attribution on both the request
  * log and the usage row. A wrapper may reroute the request away from the
@@ -355,6 +368,14 @@ export interface CompactionRunResult {
   summaryOutputTokens: number;
   summaryModel: string;
   summaryCallSite?: LLMCallSite;
+  /**
+   * Call site used to resolve the winning inference profile for the
+   * summary. Compaction invokes the provider as `mainAgent` so the
+   * prefix cache stays warm; {@link summaryCallSite} is the observability
+   * tag (`compactionAgent`). Attribution uses this field for profile
+   * selection and {@link summaryCallSite} for the usage-row call site.
+   */
+  summaryResolutionCallSite?: LLMCallSite;
   summaryOverrideProfile?: string | null;
   /**
    * Provider that actually served the summary call: the response's
@@ -1419,8 +1440,7 @@ export async function runAssistantDrivenCompaction(
       summaryCacheCreationInputTokens:
         response.usage.cacheCreationInputTokens ?? 0,
       summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
-      summaryCallSite: COMPACTION_LOG_CALL_SITE,
-      summaryOverrideProfile: args.overrideProfile ?? null,
+      ...compactionUsageAttribution(args),
       summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
       summaryRequestLogId,
       summaryCalls: 1,
@@ -1458,8 +1478,7 @@ export async function runAssistantDrivenCompaction(
         summaryCacheCreationInputTokens:
           response.usage.cacheCreationInputTokens ?? 0,
         summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
-        summaryCallSite: COMPACTION_LOG_CALL_SITE,
-        summaryOverrideProfile: args.overrideProfile ?? null,
+        ...compactionUsageAttribution(args),
         summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
         summaryCalls: 1,
       };
@@ -1629,8 +1648,7 @@ export async function runAssistantDrivenCompaction(
       summaryCacheCreationInputTokens:
         response.usage.cacheCreationInputTokens ?? 0,
       summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
-      summaryCallSite: COMPACTION_LOG_CALL_SITE,
-      summaryOverrideProfile: args.overrideProfile ?? null,
+      ...compactionUsageAttribution(args),
       summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
       summaryRequestLogId,
       summaryCalls: 1,
@@ -1699,8 +1717,7 @@ export async function runAssistantDrivenCompaction(
     summaryInputTokens: response.usage.inputTokens,
     summaryOutputTokens: response.usage.outputTokens,
     summaryModel: response.model,
-    summaryCallSite: COMPACTION_LOG_CALL_SITE,
-    summaryOverrideProfile: args.overrideProfile ?? null,
+    ...compactionUsageAttribution(args),
     ...servedAttribution(response, args.provider),
     summaryCacheCreationInputTokens:
       response.usage.cacheCreationInputTokens ?? 0,
@@ -1891,8 +1908,7 @@ export async function runEmergencyCompaction(
       // override profile must follow the same attribution as every other
       // call-bearing compaction path.
       ...servedAttribution(response, args.provider),
-      summaryCallSite: COMPACTION_LOG_CALL_SITE,
-      summaryOverrideProfile: args.overrideProfile ?? null,
+      ...compactionUsageAttribution(args),
     };
   }
 
@@ -1938,8 +1954,7 @@ export async function runEmergencyCompaction(
     summaryInputTokens: response.usage.inputTokens,
     summaryOutputTokens: response.usage.outputTokens,
     summaryModel: response.model,
-    summaryCallSite: COMPACTION_LOG_CALL_SITE,
-    summaryOverrideProfile: args.overrideProfile ?? null,
+    ...compactionUsageAttribution(args),
     ...servedAttribution(response, args.provider),
     summaryCacheCreationInputTokens:
       response.usage.cacheCreationInputTokens ?? 0,

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -64,13 +64,14 @@ const log = getLogger("compactor");
 const COMPACTION_CALL_SITE: LLMCallSite = "mainAgent";
 
 /**
- * Tag stamped on `llm_request_logs.call_site` for compaction-driven rows.
+ * Tag stamped on `llm_request_logs.call_site` and the usage event's
+ * `callSite` for compaction-driven rows.
  *
  * Distinct from `COMPACTION_CALL_SITE` (above) on purpose: that constant
- * names the **provider config resolution** site (set to `mainAgent` so we
+ * names the provider-config resolution site (set to `mainAgent` so we
  * inherit the agent's profile and keep the prefix cache warm). This
- * constant names the **observability** site — what the row IS — so
- * inspectors can filter "show me only compaction calls". They're
+ * constant names the observability site (what the row is) so
+ * inspectors and usage breakdowns can filter compaction calls. They're
  * semantically different even though both come from the same enum.
  */
 const COMPACTION_LOG_CALL_SITE: LLMCallSite = "compactionAgent";
@@ -1418,7 +1419,7 @@ export async function runAssistantDrivenCompaction(
       summaryCacheCreationInputTokens:
         response.usage.cacheCreationInputTokens ?? 0,
       summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
-      summaryCallSite: COMPACTION_CALL_SITE,
+      summaryCallSite: COMPACTION_LOG_CALL_SITE,
       summaryOverrideProfile: args.overrideProfile ?? null,
       summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
       summaryRequestLogId,
@@ -1457,7 +1458,7 @@ export async function runAssistantDrivenCompaction(
         summaryCacheCreationInputTokens:
           response.usage.cacheCreationInputTokens ?? 0,
         summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
-        summaryCallSite: COMPACTION_CALL_SITE,
+        summaryCallSite: COMPACTION_LOG_CALL_SITE,
         summaryOverrideProfile: args.overrideProfile ?? null,
         summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
         summaryCalls: 1,
@@ -1628,7 +1629,7 @@ export async function runAssistantDrivenCompaction(
       summaryCacheCreationInputTokens:
         response.usage.cacheCreationInputTokens ?? 0,
       summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
-      summaryCallSite: COMPACTION_CALL_SITE,
+      summaryCallSite: COMPACTION_LOG_CALL_SITE,
       summaryOverrideProfile: args.overrideProfile ?? null,
       summaryRawResponses: response.rawResponse ? [response.rawResponse] : [],
       summaryRequestLogId,
@@ -1698,7 +1699,7 @@ export async function runAssistantDrivenCompaction(
     summaryInputTokens: response.usage.inputTokens,
     summaryOutputTokens: response.usage.outputTokens,
     summaryModel: response.model,
-    summaryCallSite: COMPACTION_CALL_SITE,
+    summaryCallSite: COMPACTION_LOG_CALL_SITE,
     summaryOverrideProfile: args.overrideProfile ?? null,
     ...servedAttribution(response, args.provider),
     summaryCacheCreationInputTokens:
@@ -1886,12 +1887,12 @@ export async function runEmergencyCompaction(
       summaryInputTokens: response.usage.inputTokens,
       summaryOutputTokens: response.usage.outputTokens,
       summaryModel: response.model,
-      // This path bills real tokens, so its provider must follow a reroute
-      // like every other call-bearing path. It is the one such path that sets
-      // no `summaryCallSite`/`summaryOverrideProfile`, which leaves its
-      // profile attribution null; that gap predates this change and is not
-      // widened by it.
+      // This path bills real tokens, so its provider, call site, and
+      // override profile must follow the same attribution as every other
+      // call-bearing compaction path.
       ...servedAttribution(response, args.provider),
+      summaryCallSite: COMPACTION_LOG_CALL_SITE,
+      summaryOverrideProfile: args.overrideProfile ?? null,
     };
   }
 
@@ -1937,7 +1938,7 @@ export async function runEmergencyCompaction(
     summaryInputTokens: response.usage.inputTokens,
     summaryOutputTokens: response.usage.outputTokens,
     summaryModel: response.model,
-    summaryCallSite: COMPACTION_CALL_SITE,
+    summaryCallSite: COMPACTION_LOG_CALL_SITE,
     summaryOverrideProfile: args.overrideProfile ?? null,
     ...servedAttribution(response, args.provider),
     summaryCacheCreationInputTokens:

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -3163,7 +3163,7 @@ function handleUsage(
         JSON.stringify(event.rawResponse),
         undefined,
         providerName,
-        "mainAgent",
+        deps.ctx.currentCallSite,
         latencyBreakdownJson,
       );
     } catch (err) {
@@ -3244,7 +3244,7 @@ function handleProviderError(
       JSON.stringify(buildProviderErrorResponsePayload(event.error)),
       undefined,
       event.actualProvider,
-      "mainAgent",
+      deps.ctx.currentCallSite,
     );
   } catch (err) {
     deps.rlog.warn(

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2123,6 +2123,7 @@ export async function applyCompactionResult(
     summaryCacheReadInputTokens?: number;
     summaryRawResponses?: unknown[];
     summaryCallSite?: LLMCallSite;
+    summaryResolutionCallSite?: LLMCallSite;
     summaryOverrideProfile?: string | null;
     summaryActualProvider?: string;
     summaryActualInferenceProfile?: string;
@@ -2213,6 +2214,9 @@ export async function applyCompactionResult(
     // this parameter independently off their own state and never share it.
     {
       callSite: result.summaryCallSite ?? null,
+      ...(result.summaryResolutionCallSite != null
+        ? { profileResolutionCallSite: result.summaryResolutionCallSite }
+        : {}),
       overrideProfile:
         result.summaryActualInferenceProfile ??
         result.summaryOverrideProfile ??

--- a/assistant/src/persistence/llm-request-log-store.ts
+++ b/assistant/src/persistence/llm-request-log-store.ts
@@ -346,7 +346,7 @@ export function recordRequestLog(
     // plumb call sites through one site at a time.
     callSite: callSite ?? null,
     // JSON first-token latency waterfall, supplied by `handleUsage` for
-    // main-agent calls. NULL for failed/non-instrumented call paths.
+    // instrumented calls. NULL for failed/non-instrumented call paths.
     latencyBreakdown: latencyBreakdown ?? null,
   });
   return id;

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -83,6 +83,8 @@ export interface ContextWindowResult {
   summaryOutputTokens: number;
   summaryModel: string;
   summaryCallSite?: LLMCallSite;
+  /** See {@link CompactionRunResult.summaryResolutionCallSite}. */
+  summaryResolutionCallSite?: LLMCallSite;
   summaryOverrideProfile?: string | null;
   /** See {@link CompactionRunResult.summaryActualProvider}. */
   summaryActualProvider?: string;

--- a/assistant/src/usage/attribution.ts
+++ b/assistant/src/usage/attribution.ts
@@ -19,6 +19,13 @@ export type UsageAttributionProfileSource =
 
 export interface UsageAttributionInput {
   callSite: LLMCallSite | null;
+  /**
+   * Call site used to pick the winning profile. Defaults to {@link callSite}.
+   * Compaction invokes the provider as `mainAgent` (prefix cache) but tags
+   * the usage row as `compactionAgent`; pass `mainAgent` here so
+   * `appliedProfile` / `profileSource` match the request that ran.
+   */
+  profileResolutionCallSite?: LLMCallSite | null;
   overrideProfile?: string | null;
   /**
    * Mirrors `ResolveCallSiteOpts.forceOverrideProfile`: the override profile
@@ -130,9 +137,10 @@ export function resolveUsageAttribution(
 ): UsageAttributionSnapshot {
   const llm = getConfig().llm;
   const callSite = input.callSite;
+  const resolutionCallSite = input.profileResolutionCallSite ?? callSite;
   const overrideProfile = normalizeProfileId(input.overrideProfile);
 
-  if (callSite == null) {
+  if (resolutionCallSite == null) {
     const resolvedMainAgent = resolveCallSiteConfig("mainAgent", llm, {
       ...(input.selectionSeed != null
         ? { selectionSeed: input.selectionSeed }
@@ -158,7 +166,7 @@ export function resolveUsageAttribution(
   // Capture which arm each expanded mix resolved to so we can attribute usage
   // to the arm behind the applied (mix) profile below.
   const mixSelections = new Map<string, string>();
-  const resolved = resolveCallSiteConfig(callSite, llm, {
+  const resolved = resolveCallSiteConfig(resolutionCallSite, llm, {
     ...(overrideProfile != null ? { overrideProfile } : {}),
     ...(input.forceOverrideProfile === true
       ? { forceOverrideProfile: true }
@@ -171,13 +179,13 @@ export function resolveUsageAttribution(
   });
   const activeProfile = normalizeProfileId(llm.activeProfile);
   const callSiteProfile = normalizeProfileId(
-    llm.callSites?.[callSite]?.profile,
+    llm.callSites?.[resolutionCallSite]?.profile,
   );
   // The resolver's own winner selection is the single source of truth for which
   // profile applied — attribution must never re-derive precedence and drift
   // from dispatch.
   const profile = appliedProfileFromWinnerSelection(
-    callSite,
+    resolutionCallSite,
     llm,
     overrideProfile,
     input,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Agent-loop `llm_request_logs` rows now stamp `ctx.currentCallSite` (the same value usage events already attribute) instead of a hardcoded `mainAgent`. Voice front-door and escalated call legs no longer look like main-agent traffic in the request log.
- Compaction usage events tag `callSite` as `compactionAgent` so they agree with the request log. Profile resolution still runs through `mainAgent` (`profileResolutionCallSite`) so `llm.activeProfile` and main-agent pins match the request that actually served. Provider calls still use `mainAgent` so the prefix cache stays warm.
- Closes JARVIS-1682.

## Test Plan
- `cd assistant && bun test src/__tests__/usage-attribution.test.ts` (includes compaction observability vs mainAgent resolution)
- `cd assistant && bun test src/__tests__/compactor-call-site-logging.test.ts`
- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts --grep "request log|turn call site|voiceFrontDoor|provider-error request logs|usage accounting|rerouted compaction|non-rerouted compaction|compaction that served"`

## Risk
- Low. Write-path attribution only. Existing inspector filters on `compactionAgent` keep working. No schema or migration change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-746930f8-ca66-4803-b29b-7351ae155039?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-746930f8-ca66-4803-b29b-7351ae155039&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

