### PR TITLE
feat(notifications): normalized notification record with Linear and Gmail adapters

### DIFF
--- a/assistant/src/messaging/providers/gmail/adapter.ts
+++ b/assistant/src/messaging/providers/gmail/adapter.ts
@@ -22,7 +22,12 @@ import type {
   SendResult,
 } from "../../provider-types.js";
 import * as gmail from "./client.js";
-import type { GmailMessage, GmailMessagePart } from "./types.js";
+import {
+  extractHeader,
+  extractPlainTextBody,
+  parseFromHeader,
+} from "./message-fields.js";
+import type { GmailMessage } from "./types.js";
 
 function requireConnection(
   connection: OAuthConnection | undefined,
@@ -35,53 +40,20 @@ function requireConnection(
   return connection;
 }
 
-function extractHeader(msg: GmailMessage, name: string): string {
-  const lower = name.toLowerCase();
-  return (
-    msg.payload?.headers?.find((h) => h.name.toLowerCase() === lower)?.value ??
-    ""
-  );
-}
-
-function extractPlainTextBody(msg: GmailMessage): string {
-  if (!msg.payload) {
-    return "";
-  }
-
-  function walkParts(part: GmailMessagePart): string | null {
-    if (part.mimeType === "text/plain" && part.body?.data) {
-      return Buffer.from(part.body.data, "base64url").toString("utf-8");
-    }
-    if (part.parts) {
-      for (const child of part.parts) {
-        const result = walkParts(child);
-        if (result) {
-          return result;
-        }
-      }
-    }
-    return null;
-  }
-
-  return walkParts(msg.payload) ?? msg.snippet ?? "";
-}
-
 function mapGmailMessage(msg: GmailMessage): Message {
   const from = extractHeader(msg, "From");
   const subject = extractHeader(msg, "Subject");
   const rfc822MessageId = extractHeader(msg, "Message-ID");
 
-  // Parse sender name/email from "Name <email>" format
-  const emailMatch = from.match(/<([^>]+)>/);
-  const senderEmail = emailMatch?.[1] ?? from;
-  const senderName = emailMatch ? from.replace(/<[^>]+>/, "").trim() : from;
+  const { displayName: senderName, address: senderEmail } =
+    parseFromHeader(from);
 
   return {
     id: msg.id,
     conversationId: msg.threadId,
     sender: {
       id: senderEmail,
-      name: senderName || senderEmail,
+      name: senderName,
       email: senderEmail,
     },
     text: extractPlainTextBody(msg),

--- a/assistant/src/messaging/providers/gmail/message-fields.test.ts
+++ b/assistant/src/messaging/providers/gmail/message-fields.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Pins the shared Gmail field readers. `extractPlainTextBody` is read by both
+ * the messaging adapter and the notification normalizer's `fetchFull`, and the
+ * latter exists only to spend an API call on the real body, so an HTML-only
+ * message returning its snippet would make that call pointless.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractHeader,
+  extractPlainTextBody,
+  parseFromHeader,
+} from "./message-fields.js";
+import type { GmailMessage, GmailMessagePart } from "./types.js";
+
+function part(mimeType: string, body: string): GmailMessagePart {
+  return {
+    mimeType,
+    body: { data: Buffer.from(body).toString("base64url") },
+  };
+}
+
+function message(
+  payload: GmailMessagePart | undefined,
+  snippet?: string,
+): GmailMessage {
+  return { id: "msg-1", threadId: "thread-1", payload, snippet };
+}
+
+describe("extractHeader", () => {
+  test("matches case-insensitively and returns empty for a missing header", () => {
+    const msg: GmailMessage = {
+      id: "msg-1",
+      threadId: "thread-1",
+      payload: { headers: [{ name: "In-Reply-To", value: "<parent@x>" }] },
+    };
+    expect(extractHeader(msg, "in-reply-to")).toBe("<parent@x>");
+    expect(extractHeader(msg, "List-Unsubscribe")).toBe("");
+  });
+});
+
+describe("parseFromHeader", () => {
+  test("splits a display name from its address", () => {
+    expect(parseFromHeader("Example User <user@example.com>")).toEqual({
+      displayName: "Example User",
+      address: "user@example.com",
+    });
+  });
+
+  test("treats a bare address as its own display name", () => {
+    expect(parseFromHeader("user@example.com")).toEqual({
+      displayName: "user@example.com",
+      address: "user@example.com",
+    });
+  });
+});
+
+describe("extractPlainTextBody", () => {
+  test("returns a text/plain body verbatim", () => {
+    expect(
+      extractPlainTextBody(message(part("text/plain", "Line one\nLine two"))),
+    ).toBe("Line one\nLine two");
+  });
+
+  test("prefers text/plain over the HTML alternative", () => {
+    expect(
+      extractPlainTextBody(
+        message({
+          mimeType: "multipart/alternative",
+          parts: [
+            part("text/html", "<p>markup</p>"),
+            part("text/plain", "the plain one"),
+          ],
+        }),
+      ),
+    ).toBe("the plain one");
+  });
+
+  test("converts an HTML-only body instead of falling back to the snippet", () => {
+    const html =
+      "<html><head><style>p{color:red}</style></head><body>" +
+      "<p>Hello there</p><div>Second line</div>" +
+      "<a href='https://example.com'>a link</a></body></html>";
+
+    expect(
+      extractPlainTextBody(
+        message(
+          {
+            mimeType: "multipart/alternative",
+            parts: [part("text/html", html)],
+          },
+          "Hello ther",
+        ),
+      ),
+    ).toBe("Hello there\n\nSecond line\na link");
+  });
+
+  test("decodes named and numeric entities", () => {
+    expect(
+      extractPlainTextBody(
+        message(
+          part(
+            "text/html",
+            "R&amp;D &lt;tag&gt; &quot;quoted&quot; &#39;apos&#39; &#x2705;&nbsp;done",
+          ),
+        ),
+      ),
+    ).toBe("R&D <tag> \"quoted\" 'apos' ✅ done");
+  });
+
+  test("drops script content rather than reading it as text", () => {
+    expect(
+      extractPlainTextBody(
+        message(
+          part(
+            "text/html",
+            "<script>var secret = 1;</script><p>Visible</p><!-- hidden -->",
+          ),
+        ),
+      ),
+    ).toBe("Visible");
+  });
+
+  test("falls back to the snippet only when there is no readable part", () => {
+    expect(
+      extractPlainTextBody(
+        message(
+          { mimeType: "image/png", body: { attachmentId: "att-1" } },
+          "a preview",
+        ),
+      ),
+    ).toBe("a preview");
+  });
+
+  test("falls back to the snippet when the HTML carries no text", () => {
+    expect(
+      extractPlainTextBody(
+        message(part("text/html", "<div><img src='x.png'></div>"), "a preview"),
+      ),
+    ).toBe("a preview");
+  });
+
+  test("returns empty when the message has no payload", () => {
+    expect(extractPlainTextBody(message(undefined, "a preview"))).toBe("");
+  });
+});

--- a/assistant/src/messaging/providers/gmail/message-fields.ts
+++ b/assistant/src/messaging/providers/gmail/message-fields.ts
@@ -30,28 +30,117 @@ export function parseFromHeader(from: string): {
 }
 
 /**
- * Depth-first search for the first `text/plain` part, falling back to the
- * snippet when the message carries only HTML.
+ * Named HTML entities worth decoding in an email body. The long list is not
+ * worth carrying: mail that reaches here is machine-generated HTML whose text
+ * runs use these five plus numeric escapes.
+ */
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: "\u00a0",
+  quot: '"',
+};
+
+/** Tags whose boundaries read as a line break once the markup is gone. */
+const HTML_BREAK_TAGS =
+  /<\s*\/?\s*(?:br|p|div|tr|li|ul|ol|h[1-6]|table|thead|tbody|blockquote|section|article|header|footer|hr|pre)\b[^>]*>/gi;
+
+/** Elements whose content is markup machinery rather than readable text. */
+const HTML_NON_CONTENT_ELEMENTS =
+  /<\s*(script|style|head|title)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi;
+
+function decodeHtmlEntities(text: string): string {
+  return text.replace(
+    /&(#[Xx][0-9A-Fa-f]+|#\d+|[A-Za-z]+);/g,
+    (match, body: string) => {
+      if (body.startsWith("#")) {
+        const hex = body[1] === "x" || body[1] === "X";
+        const code = Number.parseInt(
+          hex ? body.slice(2) : body.slice(1),
+          hex ? 16 : 10,
+        );
+        try {
+          return String.fromCodePoint(code);
+        } catch {
+          // Out of range, or not a code point at all. Leave it as written.
+          return match;
+        }
+      }
+      return NAMED_HTML_ENTITIES[body.toLowerCase()] ?? match;
+    },
+  );
+}
+
+/**
+ * Render an HTML mail body as the text a reader would see.
+ *
+ * This is deliberately a stripper rather than a parser: the output is read by
+ * the model and by the notification tiering layer, neither of which needs the
+ * document structure, and a real HTML parser is a dependency this path does
+ * not otherwise want. Tags become nothing (block-level ones become a line
+ * break), entities are decoded, and whitespace is collapsed, which is what
+ * separates a readable body from a wall of markup.
+ */
+function htmlToPlainText(html: string): string {
+  const withoutMachinery = html
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(HTML_NON_CONTENT_ELEMENTS, " ");
+  const withBreaks = withoutMachinery.replace(HTML_BREAK_TAGS, "\n");
+  const withoutTags = withBreaks.replace(/<[^>]*>/g, "");
+
+  return decodeHtmlEntities(withoutTags)
+    .replace(/\r\n?/g, "\n")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/** Depth-first search for the first part of the given MIME type. */
+function findPartBody(part: GmailMessagePart, mimeType: string): string | null {
+  if (part.mimeType === mimeType && part.body?.data) {
+    return Buffer.from(part.body.data, "base64url").toString("utf-8");
+  }
+  if (part.parts) {
+    for (const child of part.parts) {
+      const result = findPartBody(child, mimeType);
+      if (result) {
+        return result;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * The message body as plain text.
+ *
+ * `text/plain` wins when the message carries one, which is the common case and
+ * the only one that used to be handled. An HTML-only message is converted
+ * rather than skipped: the snippet is a truncated preview, so falling back to
+ * it would hand a caller that asked for the full body the same few hundred
+ * characters it already had. The snippet stays as the last resort, for a
+ * message with no readable body part at all.
  */
 export function extractPlainTextBody(msg: GmailMessage): string {
   if (!msg.payload) {
     return "";
   }
 
-  function walkParts(part: GmailMessagePart): string | null {
-    if (part.mimeType === "text/plain" && part.body?.data) {
-      return Buffer.from(part.body.data, "base64url").toString("utf-8");
-    }
-    if (part.parts) {
-      for (const child of part.parts) {
-        const result = walkParts(child);
-        if (result) {
-          return result;
-        }
-      }
-    }
-    return null;
+  const plain = findPartBody(msg.payload, "text/plain");
+  if (plain) {
+    return plain;
   }
 
-  return walkParts(msg.payload) ?? msg.snippet ?? "";
+  const html = findPartBody(msg.payload, "text/html");
+  if (html) {
+    const text = htmlToPlainText(html);
+    if (text) {
+      return text;
+    }
+  }
+
+  return msg.snippet ?? "";
 }

--- a/assistant/src/messaging/providers/gmail/message-fields.ts
+++ b/assistant/src/messaging/providers/gmail/message-fields.ts
@@ -117,12 +117,11 @@ function findPartBody(part: GmailMessagePart, mimeType: string): string | null {
 /**
  * The message body as plain text.
  *
- * `text/plain` wins when the message carries one, which is the common case and
- * the only one that used to be handled. An HTML-only message is converted
- * rather than skipped: the snippet is a truncated preview, so falling back to
- * it would hand a caller that asked for the full body the same few hundred
- * characters it already had. The snippet stays as the last resort, for a
- * message with no readable body part at all.
+ * `text/plain` wins when the message carries one. Otherwise a `text/html` part
+ * is converted: tags are stripped, block-level ones become line breaks, and
+ * entities are decoded. The snippet is the last resort, for a message with no
+ * readable body part at all, and it is a truncated preview rather than the
+ * body a caller asked for.
  */
 export function extractPlainTextBody(msg: GmailMessage): string {
   if (!msg.payload) {

--- a/assistant/src/messaging/providers/gmail/message-fields.ts
+++ b/assistant/src/messaging/providers/gmail/message-fields.ts
@@ -1,0 +1,57 @@
+/**
+ * Field readers shared by every consumer of a Gmail message: the messaging
+ * adapter and the notification normalizer both need the same header lookup,
+ * sender parsing, and plain-text body extraction.
+ */
+
+import type { GmailMessage, GmailMessagePart } from "./types.js";
+
+/** Read a header value by case-insensitive name. Returns "" when absent. */
+export function extractHeader(msg: GmailMessage, name: string): string {
+  const lower = name.toLowerCase();
+  return (
+    msg.payload?.headers?.find((h) => h.name.toLowerCase() === lower)?.value ??
+    ""
+  );
+}
+
+/**
+ * Split an RFC 5322 `From` value into a display name and an address.
+ * A bare address yields that address as both, matching how Gmail renders it.
+ */
+export function parseFromHeader(from: string): {
+  displayName: string;
+  address: string;
+} {
+  const emailMatch = from.match(/<([^>]+)>/);
+  const address = emailMatch?.[1] ?? from;
+  const displayName = emailMatch ? from.replace(/<[^>]+>/, "").trim() : from;
+  return { displayName: displayName || address, address };
+}
+
+/**
+ * Depth-first search for the first `text/plain` part, falling back to the
+ * snippet when the message carries only HTML.
+ */
+export function extractPlainTextBody(msg: GmailMessage): string {
+  if (!msg.payload) {
+    return "";
+  }
+
+  function walkParts(part: GmailMessagePart): string | null {
+    if (part.mimeType === "text/plain" && part.body?.data) {
+      return Buffer.from(part.body.data, "base64url").toString("utf-8");
+    }
+    if (part.parts) {
+      for (const child of part.parts) {
+        const result = walkParts(child);
+        if (result) {
+          return result;
+        }
+      }
+    }
+    return null;
+  }
+
+  return walkParts(msg.payload) ?? msg.snippet ?? "";
+}

--- a/assistant/src/notifications/filter/normalize/gmail.test.ts
+++ b/assistant/src/notifications/filter/normalize/gmail.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Pins the Gmail mapping, including the split the whole tiering design rests
+ * on: `normalize` is pure and leaves `content.full` null, and only `fetchFull`
+ * spends an API call on the body.
+ *
+ * The Gmail client and OAuth mocks below delegate to the real implementations
+ * by default, so the stubs installed here cannot change behaviour for any
+ * other test file.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { upsertContact } from "../../../contacts/contact-store.js";
+import type { GmailMessage } from "../../../messaging/providers/gmail/types.js";
+import { getSqlite } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import type { WatcherItem } from "../../../watcher/provider-types.js";
+
+const actualGmailClient =
+  await import("../../../messaging/providers/gmail/client.js");
+type BatchGetMessages = typeof actualGmailClient.batchGetMessages;
+let batchGetMessagesImpl: BatchGetMessages = actualGmailClient.batchGetMessages;
+const batchGetMessagesMock = mock(((...args: Parameters<BatchGetMessages>) =>
+  batchGetMessagesImpl(...args)) as BatchGetMessages);
+mock.module("../../../messaging/providers/gmail/client.js", () => ({
+  ...actualGmailClient,
+  batchGetMessages: batchGetMessagesMock,
+}));
+
+const actualConnectionResolver =
+  await import("../../../oauth/connection-resolver.js");
+type ResolveOAuthConnection =
+  typeof actualConnectionResolver.resolveOAuthConnection;
+let resolveOAuthConnectionImpl: ResolveOAuthConnection =
+  actualConnectionResolver.resolveOAuthConnection;
+mock.module("../../../oauth/connection-resolver.js", () => ({
+  ...actualConnectionResolver,
+  resolveOAuthConnection: ((...args: Parameters<ResolveOAuthConnection>) =>
+    resolveOAuthConnectionImpl(...args)) as ResolveOAuthConnection,
+}));
+
+const { gmailNormalizer } = await import("./gmail.js");
+const { NormalizedNotificationSchema } = await import("./types.js");
+
+await initializeDb();
+
+function gmailItem(payload: Record<string, unknown> = {}): WatcherItem {
+  return {
+    externalId: "msg-1",
+    eventType: "new_email",
+    summary: "Email from Example User <user@example.com>: Hello",
+    payload: {
+      id: "msg-1",
+      threadId: "thread-1",
+      from: "Example User <user@example.com>",
+      subject: "Hello",
+      date: "Sat, 1 Aug 2026 00:00:00 +0000",
+      snippet: "Just checking in",
+      labelIds: ["INBOX"],
+      ...payload,
+    },
+    timestamp: 1_700_000_000_000,
+  };
+}
+
+beforeEach(() => {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+  resolveOAuthConnectionImpl = (async () => ({}) as never) as never;
+  batchGetMessagesImpl = async () => [];
+  batchGetMessagesMock.mockClear();
+});
+
+afterAll(() => {
+  resolveOAuthConnectionImpl = actualConnectionResolver.resolveOAuthConnection;
+  batchGetMessagesImpl = actualGmailClient.batchGetMessages;
+});
+
+describe("gmailNormalizer.normalize", () => {
+  test("produces a schema-valid record from a watcher payload", () => {
+    const result = gmailNormalizer.normalize(gmailItem());
+    expect(result).not.toBeNull();
+    expect(NormalizedNotificationSchema.parse(result)).toEqual(result!);
+    expect(result!.source).toBe("gmail");
+    expect(result!.externalId).toBe("msg-1");
+    expect(result!.content.preview).toBe("Just checking in");
+    expect(result!.container).toEqual({
+      type: "inbox",
+      id: "thread-1",
+      displayName: null,
+    });
+  });
+
+  test("performs no network I/O and leaves full null", () => {
+    const result = gmailNormalizer.normalize(gmailItem());
+    expect(result!.content.full).toBeNull();
+    expect(batchGetMessagesMock).not.toHaveBeenCalled();
+  });
+
+  test("parses the From header into a display name and address", () => {
+    const result = gmailNormalizer.normalize(gmailItem());
+    expect(result!.sender?.rawId).toBe("user@example.com");
+    expect(result!.sender?.displayName).toBe("Example User");
+  });
+
+  test("treats a bare address as its own display name", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ from: "user@example.com" }),
+    );
+    expect(result!.sender).toEqual({
+      rawId: "user@example.com",
+      displayName: "user@example.com",
+      contactId: null,
+    });
+  });
+
+  test("drops an item with neither a snippet nor a subject", () => {
+    expect(
+      gmailNormalizer.normalize(gmailItem({ snippet: "", subject: "" })),
+    ).toBeNull();
+  });
+
+  test("falls back to the subject when the snippet is empty", () => {
+    const result = gmailNormalizer.normalize(gmailItem({ snippet: "" }));
+    expect(result!.content.preview).toBe("Hello");
+  });
+
+  test("populates contactId when the sender is a known contact", () => {
+    const contact = upsertContact({
+      displayName: "Example User",
+      channels: [{ type: "email", address: "user@example.com" }],
+    });
+
+    expect(gmailNormalizer.normalize(gmailItem())!.sender?.contactId).toBe(
+      contact.id,
+    );
+  });
+
+  test("leaves contactId null when the sender is unknown", () => {
+    expect(
+      gmailNormalizer.normalize(gmailItem())!.sender?.contactId,
+    ).toBeNull();
+  });
+});
+
+describe("gmailNormalizer category mapping", () => {
+  test("List-Unsubscribe marks a broadcast", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        headers: { "List-Unsubscribe": "<mailto:unsub@example.com>" },
+        to: "user@example.com",
+      }),
+    );
+    expect(result!.content.category).toBe("broadcast");
+  });
+
+  test("a promotions label marks a broadcast", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ labelIds: ["INBOX", "CATEGORY_PROMOTIONS"] }),
+    );
+    expect(result!.content.category).toBe("broadcast");
+  });
+
+  test("an updates label marks a broadcast", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ labelIds: ["INBOX", "CATEGORY_UPDATES"] }),
+    );
+    expect(result!.content.category).toBe("broadcast");
+  });
+
+  test("a single recipient is a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ to: "owner@example.com" }),
+    );
+    expect(result!.content.category).toBe("dm");
+  });
+
+  test("In-Reply-To on a multi-recipient thread is a reply", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        to: "owner@example.com, other@example.com",
+        headers: { "In-Reply-To": "<parent@example.com>" },
+      }),
+    );
+    expect(result!.content.category).toBe("reply");
+  });
+
+  test("anything else is fyi", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ to: "owner@example.com, other@example.com" }),
+    );
+    expect(result!.content.category).toBe("fyi");
+  });
+});
+
+describe("gmailNormalizer.fetchFull", () => {
+  const normalized = () => gmailNormalizer.normalize(gmailItem())!;
+
+  const FULL_MESSAGE: GmailMessage = {
+    id: "msg-1",
+    threadId: "thread-1",
+    payload: {
+      mimeType: "text/plain",
+      body: { data: Buffer.from("The whole body").toString("base64url") },
+    },
+  };
+
+  test("is defined: Gmail's poll yields only a snippet", () => {
+    expect(gmailNormalizer.fetchFull).toBeDefined();
+  });
+
+  test("issues exactly one request and returns the plain-text body", async () => {
+    batchGetMessagesImpl = async () => [FULL_MESSAGE];
+
+    await expect(gmailNormalizer.fetchFull!(normalized())).resolves.toBe(
+      "The whole body",
+    );
+    expect(batchGetMessagesMock).toHaveBeenCalledTimes(1);
+    const [, ids, format] = batchGetMessagesMock.mock.calls[0]!;
+    expect(ids).toEqual(["msg-1"]);
+    expect(format).toBe("full");
+  });
+
+  test("returns null when the fetch fails", async () => {
+    batchGetMessagesImpl = async () => {
+      throw new Error("gmail 500");
+    };
+
+    await expect(gmailNormalizer.fetchFull!(normalized())).resolves.toBeNull();
+  });
+
+  test("returns null when the connection cannot be resolved", async () => {
+    resolveOAuthConnectionImpl = (async () => {
+      throw new Error("no credential");
+    }) as never;
+
+    await expect(gmailNormalizer.fetchFull!(normalized())).resolves.toBeNull();
+    expect(batchGetMessagesMock).not.toHaveBeenCalled();
+  });
+
+  test("returns null when the message comes back empty", async () => {
+    batchGetMessagesImpl = async () => [];
+
+    await expect(gmailNormalizer.fetchFull!(normalized())).resolves.toBeNull();
+  });
+});

--- a/assistant/src/notifications/filter/normalize/gmail.test.ts
+++ b/assistant/src/notifications/filter/normalize/gmail.test.ts
@@ -156,6 +156,20 @@ describe("gmailNormalizer.normalize", () => {
     expect(result!.credentialService).toBeNull();
   });
 
+  test("carries the mailbox the watcher polled as the credential account", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ mailboxAddress: "second@example.com" }),
+    );
+    expect(result!.credentialAccount).toBe("second@example.com");
+  });
+
+  test("leaves the credential account null when the payload has none", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ mailboxAddress: undefined }),
+    );
+    expect(result!.credentialAccount).toBeNull();
+  });
+
   test("leaves contactId null when the sender is unknown", () => {
     expect(
       gmailNormalizer.normalize(gmailItem())!.sender?.contactId,
@@ -181,9 +195,53 @@ describe("gmailNormalizer category mapping", () => {
     expect(result!.content.category).toBe("broadcast");
   });
 
-  test("an updates label marks a broadcast", () => {
+  test("an updates label alone does not mark a broadcast", () => {
     const result = gmailNormalizer.normalize(
-      gmailItem({ labelIds: ["INBOX", "CATEGORY_UPDATES"] }),
+      gmailItem({
+        labelIds: ["INBOX", "CATEGORY_UPDATES"],
+        to: "owner@example.com",
+      }),
+    );
+    expect(result!.content.category).toBe("dm");
+  });
+
+  test("an updates label leaves the rest of the determination alone", () => {
+    expect(
+      gmailNormalizer.normalize(
+        gmailItem({
+          labelIds: ["INBOX", "CATEGORY_UPDATES"],
+          to: "owner@example.com, other@example.com",
+        }),
+      )!.content.category,
+    ).toBe("fyi");
+    expect(
+      gmailNormalizer.normalize(
+        gmailItem({
+          labelIds: ["INBOX", "CATEGORY_UPDATES"],
+          to: "owner@example.com, other@example.com",
+          headers: { "In-Reply-To": "<parent@example.com>" },
+        }),
+      )!.content.category,
+    ).toBe("reply");
+  });
+
+  test("an updates label with an unsubscribe header is still a broadcast", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        labelIds: ["INBOX", "CATEGORY_UPDATES"],
+        to: "owner@example.com",
+        headers: { "List-Unsubscribe": "<mailto:unsub@example.com>" },
+      }),
+    );
+    expect(result!.content.category).toBe("broadcast");
+  });
+
+  test("an updates label alongside promotions is still a broadcast", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        labelIds: ["INBOX", "CATEGORY_UPDATES", "CATEGORY_PROMOTIONS"],
+        to: "owner@example.com",
+      }),
     );
     expect(result!.content.category).toBe("broadcast");
   });
@@ -391,6 +449,69 @@ describe("gmailNormalizer.fetchFull", () => {
     await gmailNormalizer.fetchFull!(record);
 
     expect(resolveOAuthConnectionMock.mock.calls[0]![0]).toBe("google");
+  });
+
+  test("pins the account to the mailbox the poll read", async () => {
+    batchGetMessagesImpl = async () => [FULL_MESSAGE];
+    const record = gmailNormalizer.normalize(
+      gmailItem({ mailboxAddress: "second@example.com" }),
+    )!;
+
+    await gmailNormalizer.fetchFull!(record);
+
+    expect(resolveOAuthConnectionMock.mock.calls[0]![1]?.account).toBe(
+      "second@example.com",
+    );
+  });
+
+  test("reads the polled mailbox when two accounts share a service", async () => {
+    const bodyByAccount: Record<string, string> = {
+      "first@example.com": "First mailbox",
+      "second@example.com": "Second mailbox",
+    };
+    // Stands in for the resolver's own selection: without a pinned account it
+    // hands back whichever connection is newest, which is the other mailbox.
+    resolveOAuthConnectionImpl = (async (
+      _service: string,
+      options?: { account?: string },
+    ) => ({
+      account: options?.account ?? "first@example.com",
+    })) as never;
+    batchGetMessagesImpl = (async (connection: unknown) => [
+      {
+        ...FULL_MESSAGE,
+        payload: {
+          mimeType: "text/plain",
+          body: {
+            data: Buffer.from(
+              bodyByAccount[(connection as { account: string }).account]!,
+            ).toString("base64url"),
+          },
+        },
+      },
+    ]) as never;
+
+    const record = gmailNormalizer.normalize(
+      gmailItem({ mailboxAddress: "second@example.com" }),
+    )!;
+
+    await expect(gmailNormalizer.fetchFull!(record)).resolves.toBe(
+      "Second mailbox",
+    );
+  });
+
+  test("leaves the account unpinned when the record carries none", async () => {
+    batchGetMessagesImpl = async () => [FULL_MESSAGE];
+    const record = gmailNormalizer.normalize(
+      gmailItem({ mailboxAddress: undefined }),
+    )!;
+
+    await expect(gmailNormalizer.fetchFull!(record)).resolves.toBe(
+      "The whole body",
+    );
+    expect(
+      resolveOAuthConnectionMock.mock.calls[0]![1]?.account,
+    ).toBeUndefined();
   });
 
   test("returns null when the fetch fails", async () => {

--- a/assistant/src/notifications/filter/normalize/gmail.test.ts
+++ b/assistant/src/notifications/filter/normalize/gmail.test.ts
@@ -57,6 +57,7 @@ function gmailItem(payload: Record<string, unknown> = {}): WatcherItem {
       date: "Sat, 1 Aug 2026 00:00:00 +0000",
       snippet: "Just checking in",
       labelIds: ["INBOX"],
+      mailboxAddress: "owner@example.com",
       ...payload,
     },
     timestamp: 1_700_000_000_000,
@@ -169,11 +170,49 @@ describe("gmailNormalizer category mapping", () => {
     expect(result!.content.category).toBe("broadcast");
   });
 
-  test("a single recipient is a dm", () => {
+  test("mail addressed to the mailbox alone is a dm", () => {
     const result = gmailNormalizer.normalize(
       gmailItem({ to: "owner@example.com" }),
     );
     expect(result!.content.category).toBe("dm");
+  });
+
+  test("matches the mailbox by address, not by the whole header", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ to: "The Owner <Owner@Example.com>" }),
+    );
+    expect(result!.content.category).toBe("dm");
+  });
+
+  test("a dm with someone else copied is still a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        to: "owner@example.com",
+        cc: "colleague@example.com, another@example.com",
+      }),
+    );
+    expect(result!.content.category).toBe("dm");
+  });
+
+  test("a one-address list alias is not a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ to: "team-announce@example.com" }),
+    );
+    expect(result!.content.category).toBe("fyi");
+  });
+
+  test("mail naming the mailbox among other recipients is not a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ to: "owner@example.com, other@example.com" }),
+    );
+    expect(result!.content.category).toBe("fyi");
+  });
+
+  test("without a mailbox address a sole recipient is not a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ to: "owner@example.com", mailboxAddress: undefined }),
+    );
+    expect(result!.content.category).toBe("fyi");
   });
 
   test("In-Reply-To on a multi-recipient thread is a reply", () => {
@@ -184,6 +223,29 @@ describe("gmailNormalizer category mapping", () => {
       }),
     );
     expect(result!.content.category).toBe("reply");
+  });
+
+  test("a reply addressed to the mailbox alone is a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        to: "owner@example.com",
+        headers: { "In-Reply-To": "<parent@example.com>" },
+      }),
+    );
+    expect(result!.content.category).toBe("dm");
+  });
+
+  test("reads the categorizing headers out of the watcher headers record", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        to: undefined,
+        headers: {
+          To: "owner@example.com",
+          "In-Reply-To": "<parent@example.com>",
+        },
+      }),
+    );
+    expect(result!.content.category).toBe("dm");
   });
 
   test("anything else is fyi", () => {
@@ -220,6 +282,33 @@ describe("gmailNormalizer.fetchFull", () => {
     const [, ids, format] = batchGetMessagesMock.mock.calls[0]!;
     expect(ids).toEqual(["msg-1"]);
     expect(format).toBe("full");
+  });
+
+  test("converts an HTML-only body rather than returning the snippet", async () => {
+    batchGetMessagesImpl = async () => [
+      {
+        id: "msg-1",
+        threadId: "thread-1",
+        snippet: "The whole b",
+        payload: {
+          mimeType: "multipart/alternative",
+          parts: [
+            {
+              mimeType: "text/html",
+              body: {
+                data: Buffer.from(
+                  "<html><body><p>The whole body</p><p>Second &amp; last</p></body></html>",
+                ).toString("base64url"),
+              },
+            },
+          ],
+        },
+      },
+    ];
+
+    await expect(gmailNormalizer.fetchFull!(normalized())).resolves.toBe(
+      "The whole body\n\nSecond & last",
+    );
   });
 
   test("returns null when the fetch fails", async () => {

--- a/assistant/src/notifications/filter/normalize/gmail.test.ts
+++ b/assistant/src/notifications/filter/normalize/gmail.test.ts
@@ -33,10 +33,12 @@ type ResolveOAuthConnection =
   typeof actualConnectionResolver.resolveOAuthConnection;
 let resolveOAuthConnectionImpl: ResolveOAuthConnection =
   actualConnectionResolver.resolveOAuthConnection;
+const resolveOAuthConnectionMock = mock(((
+  ...args: Parameters<ResolveOAuthConnection>
+) => resolveOAuthConnectionImpl(...args)) as ResolveOAuthConnection);
 mock.module("../../../oauth/connection-resolver.js", () => ({
   ...actualConnectionResolver,
-  resolveOAuthConnection: ((...args: Parameters<ResolveOAuthConnection>) =>
-    resolveOAuthConnectionImpl(...args)) as ResolveOAuthConnection,
+  resolveOAuthConnection: resolveOAuthConnectionMock,
 }));
 
 const { gmailNormalizer } = await import("./gmail.js");
@@ -58,6 +60,7 @@ function gmailItem(payload: Record<string, unknown> = {}): WatcherItem {
       snippet: "Just checking in",
       labelIds: ["INBOX"],
       mailboxAddress: "owner@example.com",
+      credentialService: "google",
       ...payload,
     },
     timestamp: 1_700_000_000_000,
@@ -69,6 +72,7 @@ beforeEach(() => {
   sqlite.run("DELETE FROM contact_channels");
   sqlite.run("DELETE FROM contacts");
   resolveOAuthConnectionImpl = (async () => ({}) as never) as never;
+  resolveOAuthConnectionMock.mockClear();
   batchGetMessagesImpl = async () => [];
   batchGetMessagesMock.mockClear();
 });
@@ -136,6 +140,20 @@ describe("gmailNormalizer.normalize", () => {
     expect(gmailNormalizer.normalize(gmailItem())!.sender?.contactId).toBe(
       contact.id,
     );
+  });
+
+  test("carries the credential service the watcher polled with", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ credentialService: "google-work" }),
+    );
+    expect(result!.credentialService).toBe("google-work");
+  });
+
+  test("leaves the credential service null when the payload has none", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ credentialService: undefined }),
+    );
+    expect(result!.credentialService).toBeNull();
   });
 
   test("leaves contactId null when the sender is unknown", () => {
@@ -213,6 +231,48 @@ describe("gmailNormalizer category mapping", () => {
       gmailItem({ to: "owner@example.com", mailboxAddress: undefined }),
     );
     expect(result!.content.category).toBe("fyi");
+  });
+
+  test("a quoted comma in a display name is one recipient, so a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ to: '"Owner, The" <owner@example.com>' }),
+    );
+    expect(result!.content.category).toBe("dm");
+  });
+
+  test("a quoted comma alongside another recipient is not a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        to: '"Owner, The" <owner@example.com>, other@example.com',
+      }),
+    );
+    expect(result!.content.category).toBe("fyi");
+  });
+
+  test("a mixed list of quoted, named and bare forms is not a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        to: '"Owner, The" <owner@example.com>, Other Person <other@example.com>, third@example.com',
+      }),
+    );
+    expect(result!.content.category).toBe("fyi");
+  });
+
+  test("a quoted comma in Cc leaves a dm a dm", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({
+        to: "owner@example.com",
+        cc: '"Colleague, A" <colleague@example.com>',
+      }),
+    );
+    expect(result!.content.category).toBe("dm");
+  });
+
+  test("an escaped quote inside a display name does not end the quoting", () => {
+    const result = gmailNormalizer.normalize(
+      gmailItem({ to: '"Owner \\", The" <owner@example.com>' }),
+    );
+    expect(result!.content.category).toBe("dm");
   });
 
   test("In-Reply-To on a multi-recipient thread is a reply", () => {
@@ -309,6 +369,28 @@ describe("gmailNormalizer.fetchFull", () => {
     await expect(gmailNormalizer.fetchFull!(normalized())).resolves.toBe(
       "The whole body\n\nSecond & last",
     );
+  });
+
+  test("resolves the credential service the record carries", async () => {
+    batchGetMessagesImpl = async () => [FULL_MESSAGE];
+    const record = gmailNormalizer.normalize(
+      gmailItem({ credentialService: "google-work" }),
+    )!;
+
+    await gmailNormalizer.fetchFull!(record);
+
+    expect(resolveOAuthConnectionMock.mock.calls[0]![0]).toBe("google-work");
+  });
+
+  test("falls back to the default service when the record carries none", async () => {
+    batchGetMessagesImpl = async () => [FULL_MESSAGE];
+    const record = gmailNormalizer.normalize(
+      gmailItem({ credentialService: undefined }),
+    )!;
+
+    await gmailNormalizer.fetchFull!(record);
+
+    expect(resolveOAuthConnectionMock.mock.calls[0]![0]).toBe("google");
   });
 
   test("returns null when the fetch fails", async () => {

--- a/assistant/src/notifications/filter/normalize/gmail.ts
+++ b/assistant/src/notifications/filter/normalize/gmail.ts
@@ -1,0 +1,183 @@
+/**
+ * Gmail normalizer.
+ *
+ * Gmail's poll returns a snippet, not a body, so `normalize` leaves
+ * `content.full` null and the body costs a second `messages.get`. That is what
+ * `fetchFull` is for, and why the judgment layer tiers on the preview first.
+ */
+
+import {
+  batchGetMessages,
+  GMAIL_REQUIRED_SCOPES,
+} from "../../../messaging/providers/gmail/client.js";
+import {
+  extractPlainTextBody,
+  parseFromHeader,
+} from "../../../messaging/providers/gmail/message-fields.js";
+import { resolveOAuthConnection } from "../../../oauth/connection-resolver.js";
+import { getLogger } from "../../../util/logger.js";
+import type { WatcherItem } from "../../../watcher/provider-types.js";
+import { attachContactId } from "./resolve-sender.js";
+import type {
+  NormalizedNotification,
+  NotificationCategory,
+  NotificationNormalizer,
+} from "./types.js";
+
+const log = getLogger("notification-filter:gmail");
+
+/** Credential service backing the Gmail watcher provider. */
+const GMAIL_CREDENTIAL_SERVICE = "google";
+
+/** Gmail labels that mark bulk mail regardless of who it is addressed to. */
+const BROADCAST_LABEL_IDS = ["CATEGORY_PROMOTIONS", "CATEGORY_UPDATES"];
+
+/** Header keys the watcher payload hoists to top-level scalars. */
+const HOISTED_HEADER_KEYS = ["from", "subject", "date", "to", "cc"];
+
+/**
+ * Case-insensitive header reader over a Gmail watcher payload. The payload
+ * carries a few headers as top-level scalars and may carry the rest under a
+ * `headers` record; both forms answer the same lookup.
+ */
+function headerReader(
+  payload: Record<string, unknown>,
+): (name: string) => string | null {
+  const headers = new Map<string, string>();
+  const raw = payload.headers;
+  if (raw && typeof raw === "object") {
+    for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof value === "string" && value.length > 0) {
+        headers.set(key.toLowerCase(), value);
+      }
+    }
+  }
+  for (const key of HOISTED_HEADER_KEYS) {
+    const value = payload[key];
+    if (typeof value === "string" && value.length > 0 && !headers.has(key)) {
+      headers.set(key, value);
+    }
+  }
+  return (name: string) => headers.get(name.toLowerCase()) ?? null;
+}
+
+function splitAddressList(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function readLabelIds(payload: Record<string, unknown>): string[] {
+  const labelIds = payload.labelIds;
+  if (!Array.isArray(labelIds)) {
+    return [];
+  }
+  return labelIds.filter((id): id is string => typeof id === "string");
+}
+
+/**
+ * Categorize without a profile lookup, which would be network I/O on a path
+ * that runs for every polled message. Bulk mail wins over everything else. A
+ * message sitting in the user's own mailbox with exactly one recipient is
+ * addressed to the user, so recipient count stands in for "addressed to me".
+ */
+function categorize(
+  header: (name: string) => string | null,
+  labelIds: string[],
+): NotificationCategory {
+  if (
+    header("List-Unsubscribe") ||
+    labelIds.some((id) => BROADCAST_LABEL_IDS.includes(id))
+  ) {
+    return "broadcast";
+  }
+
+  const recipientCount =
+    splitAddressList(header("To")).length +
+    splitAddressList(header("Cc")).length;
+  if (recipientCount === 1) {
+    return "dm";
+  }
+
+  return header("In-Reply-To") ? "reply" : "fyi";
+}
+
+export const gmailNormalizer: NotificationNormalizer = {
+  source: "gmail",
+
+  normalize(item: WatcherItem): NormalizedNotification | null {
+    const payload = item.payload;
+    const header = headerReader(payload);
+
+    const snippet = typeof payload.snippet === "string" ? payload.snippet : "";
+    const preview = (snippet.trim() || header("Subject") || "").trim();
+    if (!preview) {
+      log.debug(
+        { externalId: item.externalId },
+        "Dropping Gmail item with no snippet or subject",
+      );
+      return null;
+    }
+
+    const from = header("From");
+    const parsedFrom = from ? parseFromHeader(from) : null;
+    const threadId =
+      typeof payload.threadId === "string" ? payload.threadId : null;
+
+    return {
+      source: "gmail",
+      externalId: item.externalId,
+      sender: parsedFrom
+        ? attachContactId(
+            {
+              rawId: parsedFrom.address,
+              displayName: parsedFrom.displayName,
+            },
+            "email",
+            { address: parsedFrom.address },
+          )
+        : null,
+      container: threadId
+        ? { type: "inbox", id: threadId, displayName: null }
+        : null,
+      content: {
+        preview,
+        full: null,
+        category: categorize(header, readLabelIds(payload)),
+      },
+      meta: {
+        timestamp: item.timestamp,
+        nativePriority: null,
+        threadReplyCount: null,
+        hasAttachments: null,
+      },
+    };
+  },
+
+  async fetchFull(item: NormalizedNotification): Promise<string | null> {
+    try {
+      const connection = await resolveOAuthConnection(
+        GMAIL_CREDENTIAL_SERVICE,
+        {
+          requiredScopes: GMAIL_REQUIRED_SCOPES,
+        },
+      );
+      const [message] = await batchGetMessages(
+        connection,
+        [item.externalId],
+        "full",
+      );
+      if (!message) {
+        return null;
+      }
+      return extractPlainTextBody(message) || null;
+    } catch (err) {
+      log.debug({ err, externalId: item.externalId }, "Gmail fetchFull failed");
+      return null;
+    }
+  },
+};

--- a/assistant/src/notifications/filter/normalize/gmail.ts
+++ b/assistant/src/notifications/filter/normalize/gmail.ts
@@ -32,8 +32,18 @@ const log = getLogger("notification-filter:gmail");
  */
 const DEFAULT_GMAIL_CREDENTIAL_SERVICE = "google";
 
-/** Gmail labels that mark bulk mail regardless of who it is addressed to. */
-const BROADCAST_LABEL_IDS = ["CATEGORY_PROMOTIONS", "CATEGORY_UPDATES"];
+/**
+ * Gmail labels that mark bulk mail regardless of who it is addressed to.
+ *
+ * `CATEGORY_PROMOTIONS` is Gmail's own marketing bucket, so reading it as bulk
+ * is mechanical. `CATEGORY_UPDATES` deliberately stays off this list: it holds
+ * receipts, shipping notices, account changes and security alerts alongside
+ * genuine bulk mail, so mapping it here would tier a fraud alert down as bulk
+ * on a label alone. Those messages take the ordinary determination below and
+ * the judgment layer weighs their content, which is where a call that broad
+ * belongs.
+ */
+const BROADCAST_LABEL_IDS = ["CATEGORY_PROMOTIONS"];
 
 /** Header keys the watcher payload hoists to top-level scalars. */
 const HOISTED_HEADER_KEYS = ["from", "subject", "date", "to", "cc"];
@@ -140,7 +150,9 @@ function readLabelIds(payload: Record<string, unknown>): string[] {
  * Categorize from headers the watcher already carries, with no network I/O on
  * a path that runs for every polled message.
  *
- * Bulk mail wins over everything else. `dm` then means the mailbox is the sole
+ * Bulk mail wins over everything else, and only on the two mechanical signals
+ * that say so outright: the RFC 2369 `List-Unsubscribe` header, and Gmail's
+ * own marketing label. `dm` then means the mailbox is the sole
  * address in `To`: the message was written to the user and to nobody else,
  * whoever else was copied on it. That is a comparison against the authenticated
  * mailbox address, not an inference from how many recipients a message names,
@@ -189,6 +201,28 @@ function readMailboxAddress(payload: Record<string, unknown>): string | null {
   return address ?? null;
 }
 
+/**
+ * The account the poll read this message from, as the connection resolver's
+ * `account` option expects it.
+ *
+ * That option is an account identifier, and the authenticated mailbox address
+ * is the one the resolver can match on both paths: it is the account label
+ * stored on a BYO connection row and the `account_identifier` the platform
+ * lists managed connections by. A connection id would pin only the BYO path,
+ * since a managed connection reports the provider key as its id. The value is
+ * carried verbatim so it matches a stored label exactly.
+ */
+function readCredentialAccount(
+  payload: Record<string, unknown>,
+): string | null {
+  const value = payload.mailboxAddress;
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 export const gmailNormalizer: NotificationNormalizer = {
   source: "gmail",
 
@@ -215,6 +249,7 @@ export const gmailNormalizer: NotificationNormalizer = {
       source: "gmail",
       externalId: item.externalId,
       credentialService: readCredentialService(payload),
+      credentialAccount: readCredentialAccount(payload),
       sender: parsedFrom
         ? attachContactId(
             {
@@ -248,13 +283,17 @@ export const gmailNormalizer: NotificationNormalizer = {
 
   async fetchFull(item: NormalizedNotification): Promise<string | null> {
     try {
-      // The same connection the poll read the message over: a workspace can
-      // hold more than one Gmail credential, and the default service would be
-      // a different account.
+      // The same connection the poll read the message over. A workspace can
+      // hold more than one Gmail credential, so the default service would be a
+      // different account; and several accounts can sit behind one service, so
+      // the service alone resolves to whichever connection is newest at this
+      // moment. The mailbox the poll authenticated as pins both. A message ID
+      // is scoped to its mailbox, so resolving any other one reads nothing.
       const connection = await resolveOAuthConnection(
         item.credentialService ?? DEFAULT_GMAIL_CREDENTIAL_SERVICE,
         {
           requiredScopes: GMAIL_REQUIRED_SCOPES,
+          account: item.credentialAccount ?? undefined,
         },
       );
       const [message] = await batchGetMessages(

--- a/assistant/src/notifications/filter/normalize/gmail.ts
+++ b/assistant/src/notifications/filter/normalize/gmail.ts
@@ -26,8 +26,11 @@ import type {
 
 const log = getLogger("notification-filter:gmail");
 
-/** Credential service backing the Gmail watcher provider. */
-const GMAIL_CREDENTIAL_SERVICE = "google";
+/**
+ * Credential service a Gmail record falls back to when it carries none of its
+ * own, matching `gmailProvider.requiredCredentialService`.
+ */
+const DEFAULT_GMAIL_CREDENTIAL_SERVICE = "google";
 
 /** Gmail labels that mark bulk mail regardless of who it is addressed to. */
 const BROADCAST_LABEL_IDS = ["CATEGORY_PROMOTIONS", "CATEGORY_UPDATES"];
@@ -62,19 +65,62 @@ function headerReader(
 }
 
 /**
- * The addresses in an RFC 5322 address list, lowercased.
+ * The entries of an RFC 5322 address list.
  *
- * Splitting on commas is enough for the comparison below: a display name that
- * contains a comma is quoted, so the fragments it splits into still carry the
- * angle-bracketed address, and a fragment with no address at all cannot match
- * the mailbox anyway.
+ * A comma separates entries only outside a quoted display name and outside an
+ * angle-bracketed address, so `"User, Example" <owner@example.com>` is the one
+ * address it is written as rather than two.
+ */
+function splitAddressList(value: string): string[] {
+  const entries: string[] = [];
+  let current = "";
+  let quoted = false;
+  let escaped = false;
+  let bracketed = false;
+
+  for (const char of value) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (quoted && char === "\\") {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      current += char;
+      continue;
+    }
+    if (!quoted && (char === "<" || char === ">")) {
+      bracketed = char === "<";
+      current += char;
+      continue;
+    }
+    if (char === "," && !quoted && !bracketed) {
+      entries.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  entries.push(current);
+
+  return entries;
+}
+
+/**
+ * The addresses in an RFC 5322 address list, lowercased. An entry yields its
+ * angle-bracketed address when it has one and the entry itself otherwise,
+ * which is the bare-address form.
  */
 function parseAddressList(value: string | null): string[] {
   if (!value) {
     return [];
   }
-  return value
-    .split(",")
+  return splitAddressList(value)
     .map((entry) => {
       const bracketed = entry.match(/<([^>]+)>/);
       return (bracketed?.[1] ?? entry).trim().toLowerCase();
@@ -125,6 +171,14 @@ function categorize(
   return header("In-Reply-To") ? "reply" : "fyi";
 }
 
+/** The credential service the watcher polled this message with. */
+function readCredentialService(
+  payload: Record<string, unknown>,
+): string | null {
+  const value = payload.credentialService;
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
 /** The authenticated mailbox address the watcher stamped on the payload. */
 function readMailboxAddress(payload: Record<string, unknown>): string | null {
   const value = payload.mailboxAddress;
@@ -160,6 +214,7 @@ export const gmailNormalizer: NotificationNormalizer = {
     return {
       source: "gmail",
       externalId: item.externalId,
+      credentialService: readCredentialService(payload),
       sender: parsedFrom
         ? attachContactId(
             {
@@ -193,8 +248,11 @@ export const gmailNormalizer: NotificationNormalizer = {
 
   async fetchFull(item: NormalizedNotification): Promise<string | null> {
     try {
+      // The same connection the poll read the message over: a workspace can
+      // hold more than one Gmail credential, and the default service would be
+      // a different account.
       const connection = await resolveOAuthConnection(
-        GMAIL_CREDENTIAL_SERVICE,
+        item.credentialService ?? DEFAULT_GMAIL_CREDENTIAL_SERVICE,
         {
           requiredScopes: GMAIL_REQUIRED_SCOPES,
         },

--- a/assistant/src/notifications/filter/normalize/gmail.ts
+++ b/assistant/src/notifications/filter/normalize/gmail.ts
@@ -61,13 +61,24 @@ function headerReader(
   return (name: string) => headers.get(name.toLowerCase()) ?? null;
 }
 
-function splitAddressList(value: string | null): string[] {
+/**
+ * The addresses in an RFC 5322 address list, lowercased.
+ *
+ * Splitting on commas is enough for the comparison below: a display name that
+ * contains a comma is quoted, so the fragments it splits into still carry the
+ * angle-bracketed address, and a fragment with no address at all cannot match
+ * the mailbox anyway.
+ */
+function parseAddressList(value: string | null): string[] {
   if (!value) {
     return [];
   }
   return value
     .split(",")
-    .map((entry) => entry.trim())
+    .map((entry) => {
+      const bracketed = entry.match(/<([^>]+)>/);
+      return (bracketed?.[1] ?? entry).trim().toLowerCase();
+    })
     .filter((entry) => entry.length > 0);
 }
 
@@ -80,14 +91,22 @@ function readLabelIds(payload: Record<string, unknown>): string[] {
 }
 
 /**
- * Categorize without a profile lookup, which would be network I/O on a path
- * that runs for every polled message. Bulk mail wins over everything else. A
- * message sitting in the user's own mailbox with exactly one recipient is
- * addressed to the user, so recipient count stands in for "addressed to me".
+ * Categorize from headers the watcher already carries, with no network I/O on
+ * a path that runs for every polled message.
+ *
+ * Bulk mail wins over everything else. `dm` then means the mailbox is the sole
+ * address in `To`: the message was written to the user and to nobody else,
+ * whoever else was copied on it. That is a comparison against the authenticated
+ * mailbox address, not an inference from how many recipients a message names,
+ * which is why a one-address list alias does not read as a direct message and
+ * a direct message with a colleague in `Cc` still does. Without that address
+ * there is nothing to compare, so the message falls through rather than being
+ * guessed at.
  */
 function categorize(
   header: (name: string) => string | null,
   labelIds: string[],
+  mailboxAddress: string | null,
 ): NotificationCategory {
   if (
     header("List-Unsubscribe") ||
@@ -96,14 +115,24 @@ function categorize(
     return "broadcast";
   }
 
-  const recipientCount =
-    splitAddressList(header("To")).length +
-    splitAddressList(header("Cc")).length;
-  if (recipientCount === 1) {
-    return "dm";
+  if (mailboxAddress) {
+    const to = parseAddressList(header("To"));
+    if (to.length === 1 && to[0] === mailboxAddress) {
+      return "dm";
+    }
   }
 
   return header("In-Reply-To") ? "reply" : "fyi";
+}
+
+/** The authenticated mailbox address the watcher stamped on the payload. */
+function readMailboxAddress(payload: Record<string, unknown>): string | null {
+  const value = payload.mailboxAddress;
+  if (typeof value !== "string") {
+    return null;
+  }
+  const [address] = parseAddressList(value);
+  return address ?? null;
 }
 
 export const gmailNormalizer: NotificationNormalizer = {
@@ -147,7 +176,11 @@ export const gmailNormalizer: NotificationNormalizer = {
       content: {
         preview,
         full: null,
-        category: categorize(header, readLabelIds(payload)),
+        category: categorize(
+          header,
+          readLabelIds(payload),
+          readMailboxAddress(payload),
+        ),
       },
       meta: {
         timestamp: item.timestamp,

--- a/assistant/src/notifications/filter/normalize/linear.test.ts
+++ b/assistant/src/notifications/filter/normalize/linear.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Pins the Linear mapping against the payload `watcher/providers/linear.ts`
+ * actually builds, including the fallback that keeps an unrecognized event
+ * type from throwing.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { WatcherItem } from "../../../watcher/provider-types.js";
+import { linearNormalizer } from "./linear.js";
+import { NormalizedNotificationSchema } from "./types.js";
+
+function linearItem(overrides: Partial<WatcherItem> = {}): WatcherItem {
+  return {
+    externalId: "notif-1",
+    eventType: "linear_issue_assigned",
+    summary: "Linear issue assigned to you in Team One / ENG-1: Ship it",
+    payload: {
+      notificationId: "notif-1",
+      type: "issueAssignedToYou",
+      issueId: "issue-1",
+      issueIdentifier: "ENG-1",
+      issueTitle: "Ship it",
+      teamName: "Team One",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+    },
+    timestamp: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+describe("linearNormalizer", () => {
+  test("returns null from fetchFull absence: Linear ships full content in the poll", () => {
+    expect(linearNormalizer.fetchFull).toBeUndefined();
+  });
+
+  test("produces a schema-valid record with no sender", () => {
+    const result = linearNormalizer.normalize(linearItem());
+    expect(result).not.toBeNull();
+    expect(NormalizedNotificationSchema.parse(result)).toEqual(result!);
+    expect(result!.source).toBe("linear");
+    expect(result!.sender).toBeNull();
+    expect(result!.externalId).toBe("notif-1");
+    expect(result!.meta.timestamp).toBe(1_700_000_000_000);
+  });
+
+  test.each([
+    ["linear_issue_assigned", "assignment"],
+    ["linear_mention", "mention"],
+    ["linear_comment_mention", "mention"],
+    ["linear_status_changed", "fyi"],
+    ["linear_notification", "fyi"],
+    ["linear_something_new", "fyi"],
+  ])("maps %s to %s", (eventType, category) => {
+    const result = linearNormalizer.normalize(linearItem({ eventType }));
+    expect(result?.content.category).toBe(category as never);
+  });
+
+  test("uses the issue as the project container with the team as display name", () => {
+    const result = linearNormalizer.normalize(linearItem());
+    expect(result?.container).toEqual({
+      type: "project",
+      id: "issue-1",
+      displayName: "Team One",
+    });
+  });
+
+  test("drops the container when the notification has no issue", () => {
+    const result = linearNormalizer.normalize(
+      linearItem({ payload: { teamName: "Team One" } }),
+    );
+    expect(result?.container).toBeNull();
+  });
+
+  test("uses the summary as the preview", () => {
+    const result = linearNormalizer.normalize(linearItem());
+    expect(result?.content.preview).toBe(
+      "Linear issue assigned to you in Team One / ENG-1: Ship it",
+    );
+  });
+
+  test("prefers the comment body for full content", () => {
+    const result = linearNormalizer.normalize(
+      linearItem({
+        eventType: "linear_comment_mention",
+        payload: {
+          issueId: "issue-1",
+          issueTitle: "Ship it",
+          teamName: "Team One",
+          commentBody: "Can you take a look?",
+        },
+      }),
+    );
+    expect(result?.content.full).toBe("Can you take a look?");
+  });
+
+  test("falls back to the issue title when there is no comment", () => {
+    expect(linearNormalizer.normalize(linearItem())?.content.full).toBe(
+      "Ship it",
+    );
+  });
+
+  test("drops an item with no summary", () => {
+    expect(
+      linearNormalizer.normalize(linearItem({ summary: "  " })),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/notifications/filter/normalize/linear.ts
+++ b/assistant/src/notifications/filter/normalize/linear.ts
@@ -58,6 +58,9 @@ export const linearNormalizer: NotificationNormalizer = {
     return {
       source: "linear",
       externalId: item.externalId,
+      // Linear's poll returns the body, so nothing here resolves a connection
+      // a second time.
+      credentialService: null,
       sender: null,
       container: issueId
         ? {

--- a/assistant/src/notifications/filter/normalize/linear.ts
+++ b/assistant/src/notifications/filter/normalize/linear.ts
@@ -1,0 +1,84 @@
+/**
+ * Linear normalizer.
+ *
+ * Linear returns everything the filter needs in its poll (issue title, comment
+ * body, team), so there is no `fetchFull`: `content.full` is populated inline.
+ * Linear notifications name the issue, not the person who triggered them, so
+ * `sender` is always null.
+ */
+
+import { getLogger } from "../../../util/logger.js";
+import type { WatcherItem } from "../../../watcher/provider-types.js";
+import type {
+  NormalizedNotification,
+  NotificationCategory,
+  NotificationNormalizer,
+} from "./types.js";
+
+const log = getLogger("notification-filter:linear");
+
+/** Watcher event types produced by `providers/linear.ts`. */
+const CATEGORY_BY_EVENT_TYPE: Record<string, NotificationCategory> = {
+  linear_issue_assigned: "assignment",
+  linear_mention: "mention",
+  linear_comment_mention: "mention",
+  linear_status_changed: "fyi",
+  linear_notification: "fyi",
+};
+
+/** Unrecognized event types degrade to `fyi` rather than throwing. */
+function categoryFor(eventType: string): NotificationCategory {
+  return CATEGORY_BY_EVENT_TYPE[eventType] ?? "fyi";
+}
+
+function readString(
+  payload: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = payload[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export const linearNormalizer: NotificationNormalizer = {
+  source: "linear",
+
+  normalize(item: WatcherItem): NormalizedNotification | null {
+    const preview = item.summary.trim();
+    if (!preview) {
+      log.debug(
+        { externalId: item.externalId },
+        "Dropping Linear item with no summary",
+      );
+      return null;
+    }
+
+    const payload = item.payload;
+    const issueId = readString(payload, "issueId");
+
+    return {
+      source: "linear",
+      externalId: item.externalId,
+      sender: null,
+      container: issueId
+        ? {
+            type: "project",
+            id: issueId,
+            displayName: readString(payload, "teamName"),
+          }
+        : null,
+      content: {
+        preview,
+        full:
+          readString(payload, "commentBody") ??
+          readString(payload, "issueTitle"),
+        category: categoryFor(item.eventType),
+      },
+      meta: {
+        timestamp: item.timestamp,
+        nativePriority: null,
+        threadReplyCount: null,
+        hasAttachments: null,
+      },
+    };
+  },
+};

--- a/assistant/src/notifications/filter/normalize/linear.ts
+++ b/assistant/src/notifications/filter/normalize/linear.ts
@@ -61,6 +61,7 @@ export const linearNormalizer: NotificationNormalizer = {
       // Linear's poll returns the body, so nothing here resolves a connection
       // a second time.
       credentialService: null,
+      credentialAccount: null,
       sender: null,
       container: issueId
         ? {

--- a/assistant/src/notifications/filter/normalize/registry.test.ts
+++ b/assistant/src/notifications/filter/normalize/registry.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Registry lookup and the inert-by-default contract for an unmapped provider.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { WatcherItem } from "../../../watcher/provider-types.js";
+import { gmailNormalizer } from "./gmail.js";
+import { linearNormalizer } from "./linear.js";
+import {
+  getNormalizer,
+  listNormalizers,
+  normalizeWatcherItem,
+  registerNormalizer,
+} from "./registry.js";
+import type { NotificationNormalizer } from "./types.js";
+
+const LINEAR_ITEM: WatcherItem = {
+  externalId: "notif-1",
+  eventType: "linear_issue_assigned",
+  summary: "Linear issue assigned to you in Team One / ENG-1: Ship it",
+  payload: {
+    issueId: "issue-1",
+    issueTitle: "Ship it",
+    teamName: "Team One",
+  },
+  timestamp: 1_700_000_000_000,
+};
+
+describe("normalizer registry", () => {
+  test("registers the built-in normalizers at module load", () => {
+    expect(getNormalizer("linear")).toBe(linearNormalizer);
+    expect(getNormalizer("gmail")).toBe(gmailNormalizer);
+    expect(listNormalizers()).toContain(linearNormalizer);
+    expect(listNormalizers()).toContain(gmailNormalizer);
+  });
+
+  test("returns undefined for an unregistered source", () => {
+    expect(getNormalizer("pigeon-post")).toBeUndefined();
+  });
+
+  test("re-registering a source replaces the previous entry", () => {
+    const replacement: NotificationNormalizer = {
+      source: "github",
+      normalize: () => null,
+    };
+    const other: NotificationNormalizer = {
+      source: "github",
+      normalize: () => null,
+    };
+
+    registerNormalizer(replacement);
+    expect(getNormalizer("github")).toBe(replacement);
+
+    registerNormalizer(other);
+    expect(getNormalizer("github")).toBe(other);
+    expect(listNormalizers().filter((n) => n.source === "github")).toHaveLength(
+      1,
+    );
+  });
+});
+
+describe("normalizeWatcherItem", () => {
+  test("round-trips a Linear item through the registered normalizer", () => {
+    expect(normalizeWatcherItem("linear", LINEAR_ITEM)).toEqual(
+      linearNormalizer.normalize(LINEAR_ITEM),
+    );
+  });
+
+  test("returns null for a provider with no normalizer", () => {
+    expect(normalizeWatcherItem("pigeon-post", LINEAR_ITEM)).toBeNull();
+  });
+});

--- a/assistant/src/notifications/filter/normalize/registry.ts
+++ b/assistant/src/notifications/filter/normalize/registry.ts
@@ -1,0 +1,56 @@
+/**
+ * Registry of notification normalizers, mirroring `watcher/provider-registry.ts`.
+ *
+ * Registration is keyed by `source`, so re-registering a source replaces the
+ * previous entry rather than adding a second one.
+ */
+
+import { getLogger } from "../../../util/logger.js";
+import type { WatcherItem } from "../../../watcher/provider-types.js";
+import { gmailNormalizer } from "./gmail.js";
+import { linearNormalizer } from "./linear.js";
+import type {
+  NormalizedNotification,
+  NotificationNormalizer,
+} from "./types.js";
+
+const log = getLogger("notification-filter:registry");
+
+const normalizers = new Map<string, NotificationNormalizer>();
+
+export function registerNormalizer(normalizer: NotificationNormalizer): void {
+  normalizers.set(normalizer.source, normalizer);
+}
+
+export function getNormalizer(
+  source: string,
+): NotificationNormalizer | undefined {
+  return normalizers.get(source);
+}
+
+export function listNormalizers(): NotificationNormalizer[] {
+  return Array.from(normalizers.values());
+}
+
+/**
+ * Normalize a raw watcher item from the provider that produced it.
+ * A provider with no registered normalizer is inert, not fatal: it yields null
+ * so an unmapped source flows through the pipeline untouched.
+ */
+export function normalizeWatcherItem(
+  providerId: string,
+  item: WatcherItem,
+): NormalizedNotification | null {
+  const normalizer = getNormalizer(providerId);
+  if (!normalizer) {
+    log.debug(
+      { providerId, externalId: item.externalId },
+      "No notification normalizer registered for provider",
+    );
+    return null;
+  }
+  return normalizer.normalize(item);
+}
+
+registerNormalizer(linearNormalizer);
+registerNormalizer(gmailNormalizer);

--- a/assistant/src/notifications/filter/normalize/resolve-sender.test.ts
+++ b/assistant/src/notifications/filter/normalize/resolve-sender.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Sender resolution against the real contact store: canonicalization belongs to
+ * `findContactChannel`, so these tests feed it raw addresses rather than
+ * pre-normalized ones.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { upsertContact } from "../../../contacts/contact-store.js";
+import { getSqlite } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { attachContactId, resolveSenderContactId } from "./resolve-sender.js";
+
+await initializeDb();
+
+function resetContactTables(): void {
+  const sqlite = getSqlite();
+  sqlite.run("DELETE FROM contact_channels");
+  sqlite.run("DELETE FROM contacts");
+}
+
+describe("resolveSenderContactId", () => {
+  beforeEach(() => {
+    resetContactTables();
+  });
+
+  test("resolves a known email channel to its contact id", () => {
+    const contact = upsertContact({
+      displayName: "Example User",
+      channels: [{ type: "email", address: "user@example.com" }],
+    });
+
+    expect(
+      resolveSenderContactId("email", { address: "user@example.com" }),
+    ).toBe(contact.id);
+  });
+
+  test("matches case-insensitively via the store's canonicalization", () => {
+    const contact = upsertContact({
+      displayName: "Example User",
+      channels: [{ type: "email", address: "user@example.com" }],
+    });
+
+    expect(
+      resolveSenderContactId("email", {
+        address: "user@example.com".toUpperCase(),
+      }),
+    ).toBe(contact.id);
+  });
+
+  test("returns null for an unknown address", () => {
+    expect(
+      resolveSenderContactId("email", { address: "nobody@example.com" }),
+    ).toBeNull();
+  });
+
+  test("returns null when there is nothing to look up", () => {
+    expect(resolveSenderContactId("email", {})).toBeNull();
+  });
+
+  test("resolves by external chat id", () => {
+    const contact = upsertContact({
+      displayName: "Example User",
+      channels: [{ type: "slack", address: "U123", externalChatId: "D123" }],
+    });
+
+    expect(resolveSenderContactId("slack", { externalChatId: "D123" })).toBe(
+      contact.id,
+    );
+  });
+
+  test("returns null when the contact store throws", () => {
+    const sqlite = getSqlite();
+    sqlite.run("ALTER TABLE contact_channels RENAME TO contact_channels_probe");
+    try {
+      expect(
+        resolveSenderContactId("email", { address: "user@example.com" }),
+      ).toBeNull();
+    } finally {
+      sqlite.run(
+        "ALTER TABLE contact_channels_probe RENAME TO contact_channels",
+      );
+    }
+  });
+});
+
+describe("attachContactId", () => {
+  beforeEach(() => {
+    resetContactTables();
+  });
+
+  test("fills contactId in on the sender it is given", () => {
+    const contact = upsertContact({
+      displayName: "Example User",
+      channels: [{ type: "email", address: "user@example.com" }],
+    });
+
+    expect(
+      attachContactId(
+        { rawId: "user@example.com", displayName: "Example User" },
+        "email",
+        { address: "user@example.com" },
+      ),
+    ).toEqual({
+      rawId: "user@example.com",
+      displayName: "Example User",
+      contactId: contact.id,
+    });
+  });
+
+  test("leaves contactId null for an unknown sender", () => {
+    expect(
+      attachContactId({ rawId: "x@example.com", displayName: null }, "email", {
+        address: "x@example.com",
+      }).contactId,
+    ).toBeNull();
+  });
+});

--- a/assistant/src/notifications/filter/normalize/resolve-sender.ts
+++ b/assistant/src/notifications/filter/normalize/resolve-sender.ts
@@ -1,0 +1,47 @@
+/**
+ * Sender resolution is enrichment, not a precondition. A contact-store failure
+ * must never fail normalization, so every lookup here degrades to null.
+ */
+
+import { findContactChannel } from "../../../contacts/contact-store.js";
+import { getLogger } from "../../../util/logger.js";
+import type { NotificationSender } from "./types.js";
+
+const log = getLogger("notification-filter:resolve-sender");
+
+export interface SenderLookup {
+  address?: string;
+  externalChatId?: string;
+}
+
+/**
+ * Resolve a source-native sender identity to a local contact id.
+ * `findContactChannel` owns address canonicalization; do not pre-normalize.
+ */
+export function resolveSenderContactId(
+  channelType: string,
+  params: SenderLookup,
+): string | null {
+  if (!params.address && !params.externalChatId) {
+    return null;
+  }
+  try {
+    const match = findContactChannel({ channelType, ...params });
+    return match?.contact.id ?? null;
+  } catch (err) {
+    log.debug({ err, channelType }, "Contact lookup failed for sender");
+    return null;
+  }
+}
+
+/** Return `sender` with `contactId` filled in from the contact store. */
+export function attachContactId(
+  sender: Omit<NotificationSender, "contactId">,
+  channelType: string,
+  params: SenderLookup,
+): NotificationSender {
+  return {
+    ...sender,
+    contactId: resolveSenderContactId(channelType, params),
+  };
+}

--- a/assistant/src/notifications/filter/normalize/types.test.ts
+++ b/assistant/src/notifications/filter/normalize/types.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Pins the normalized-record contract: null is a first-class value for a
+ * source that has nothing to put in a field, but `content.preview` is the one
+ * thing every source must supply.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  type NormalizedNotification,
+  NormalizedNotificationSchema,
+} from "./types.js";
+
+const LINEAR_RECORD: NormalizedNotification = {
+  source: "linear",
+  externalId: "notif-1",
+  sender: null,
+  container: { type: "project", id: "issue-1", displayName: "Team One" },
+  content: {
+    preview: "Linear issue assigned to you",
+    full: "Ship the thing",
+    category: "assignment",
+  },
+  meta: {
+    timestamp: 1_700_000_000_000,
+    nativePriority: null,
+    threadReplyCount: null,
+    hasAttachments: null,
+  },
+};
+
+describe("NormalizedNotificationSchema", () => {
+  test("accepts a Linear record with no sender", () => {
+    const parsed = NormalizedNotificationSchema.parse(LINEAR_RECORD);
+    expect(parsed.sender).toBeNull();
+    expect(parsed.container?.type).toBe("project");
+  });
+
+  test("accepts a record whose sender fields are individually null", () => {
+    const parsed = NormalizedNotificationSchema.parse({
+      ...LINEAR_RECORD,
+      sender: { rawId: null, displayName: null, contactId: null },
+    });
+    expect(parsed.sender).toEqual({
+      rawId: null,
+      displayName: null,
+      contactId: null,
+    });
+  });
+
+  test("rejects a record with no preview", () => {
+    const result = NormalizedNotificationSchema.safeParse({
+      ...LINEAR_RECORD,
+      content: { full: null, category: "fyi" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an empty preview", () => {
+    const result = NormalizedNotificationSchema.safeParse({
+      ...LINEAR_RECORD,
+      content: { ...LINEAR_RECORD.content, preview: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts a null container", () => {
+    const parsed = NormalizedNotificationSchema.parse({
+      ...LINEAR_RECORD,
+      container: null,
+    });
+    expect(parsed.container).toBeNull();
+  });
+});

--- a/assistant/src/notifications/filter/normalize/types.test.ts
+++ b/assistant/src/notifications/filter/normalize/types.test.ts
@@ -14,6 +14,7 @@ import {
 const LINEAR_RECORD: NormalizedNotification = {
   source: "linear",
   externalId: "notif-1",
+  credentialService: null,
   sender: null,
   container: { type: "project", id: "issue-1", displayName: "Team One" },
   content: {
@@ -62,6 +63,20 @@ describe("NormalizedNotificationSchema", () => {
       content: { ...LINEAR_RECORD.content, preview: "" },
     });
     expect(result.success).toBe(false);
+  });
+
+  test("defaults a record with no credential service to null", () => {
+    const { credentialService: _omitted, ...withoutService } = LINEAR_RECORD;
+    const parsed = NormalizedNotificationSchema.parse(withoutService);
+    expect(parsed.credentialService).toBeNull();
+  });
+
+  test("keeps the credential service a record carries", () => {
+    const parsed = NormalizedNotificationSchema.parse({
+      ...LINEAR_RECORD,
+      credentialService: "google-work",
+    });
+    expect(parsed.credentialService).toBe("google-work");
   });
 
   test("accepts a null container", () => {

--- a/assistant/src/notifications/filter/normalize/types.test.ts
+++ b/assistant/src/notifications/filter/normalize/types.test.ts
@@ -15,6 +15,7 @@ const LINEAR_RECORD: NormalizedNotification = {
   source: "linear",
   externalId: "notif-1",
   credentialService: null,
+  credentialAccount: null,
   sender: null,
   container: { type: "project", id: "issue-1", displayName: "Team One" },
   content: {
@@ -77,6 +78,20 @@ describe("NormalizedNotificationSchema", () => {
       credentialService: "google-work",
     });
     expect(parsed.credentialService).toBe("google-work");
+  });
+
+  test("defaults a record with no credential account to null", () => {
+    const { credentialAccount: _omitted, ...withoutAccount } = LINEAR_RECORD;
+    const parsed = NormalizedNotificationSchema.parse(withoutAccount);
+    expect(parsed.credentialAccount).toBeNull();
+  });
+
+  test("keeps the credential account a record carries", () => {
+    const parsed = NormalizedNotificationSchema.parse({
+      ...LINEAR_RECORD,
+      credentialAccount: "owner@example.com",
+    });
+    expect(parsed.credentialAccount).toBe("owner@example.com");
   });
 
   test("accepts a null container", () => {

--- a/assistant/src/notifications/filter/normalize/types.ts
+++ b/assistant/src/notifications/filter/normalize/types.ts
@@ -87,6 +87,15 @@ export const NormalizedNotificationSchema = z.object({
    * stamps none, and a normalizer that needs one falls back to its default.
    */
   credentialService: z.string().nullable().default(null),
+  /**
+   * The account within that credential service the item was polled from, as
+   * the account identifier the OAuth connection resolver matches on. Several
+   * accounts can share one service, and resolution without a pinned account
+   * takes the most-recently-created connection, so the service alone leaves a
+   * `fetchFull` free to read a different mailbox than the poll did. Null when
+   * the source stamps none, which leaves resolution to the service.
+   */
+  credentialAccount: z.string().nullable().default(null),
   sender: NotificationSenderSchema.nullable(),
   container: NotificationContainerSchema.nullable(),
   content: NotificationContentSchema,

--- a/assistant/src/notifications/filter/normalize/types.ts
+++ b/assistant/src/notifications/filter/normalize/types.ts
@@ -1,0 +1,111 @@
+/**
+ * The common record every notification source is mapped into, so rules and the
+ * judgment layer can reason about notifications from Slack, Gmail, Linear and
+ * the rest uniformly.
+ *
+ * Null is a first-class value here. An adapter fills in what its source
+ * actually provides and leaves the rest null: Linear assignments have no human
+ * sender, Slack container display names arrive after the item does, Gmail's
+ * poll yields a snippet but no body. A rule that matches on a field a source
+ * never populates simply does not match that source.
+ */
+
+import { z } from "zod";
+
+import type { WatcherItem } from "../../../watcher/provider-types.js";
+
+export const NotificationCategorySchema = z.enum([
+  "dm",
+  "mention",
+  "assignment",
+  "reply",
+  "fyi",
+  "broadcast",
+]);
+
+export type NotificationCategory = z.infer<typeof NotificationCategorySchema>;
+
+export const NotificationSourceSchema = z.enum([
+  "slack",
+  "gmail",
+  "linear",
+  "github",
+  "outlook",
+  "os",
+]);
+
+export type NotificationSource = z.infer<typeof NotificationSourceSchema>;
+
+/**
+ * Who sent it. `null` when the source has no human sender at all (a Linear
+ * status change), as opposed to a sender whose individual fields are unknown.
+ */
+export const NotificationSenderSchema = z.object({
+  /** Source-native identifier (email address, Slack user id). */
+  rawId: z.string().nullable(),
+  displayName: z.string().nullable(),
+  /** Local contact row id when the sender resolves to a known contact. */
+  contactId: z.string().nullable(),
+});
+
+export type NotificationSender = z.infer<typeof NotificationSenderSchema>;
+
+/** Where it landed: a Slack channel, an email thread, a Linear project. */
+export const NotificationContainerSchema = z.object({
+  type: z.enum(["channel", "thread", "project", "inbox"]),
+  id: z.string(),
+  displayName: z.string().nullable(),
+});
+
+export type NotificationContainer = z.infer<typeof NotificationContainerSchema>;
+
+export const NotificationContentSchema = z.object({
+  /** Always present: the cheap text every source can supply without a second call. */
+  preview: z.string().min(1),
+  /** Full body when the source hands it over for free, otherwise null until `fetchFull`. */
+  full: z.string().nullable(),
+  category: NotificationCategorySchema,
+});
+
+export const NotificationMetaSchema = z.object({
+  /** Epoch milliseconds. */
+  timestamp: z.number(),
+  /** Source-native priority label (Linear priority, Gmail importance), verbatim. */
+  nativePriority: z.string().nullable(),
+  threadReplyCount: z.number().nullable(),
+  hasAttachments: z.boolean().nullable(),
+});
+
+export const NormalizedNotificationSchema = z.object({
+  source: NotificationSourceSchema,
+  externalId: z.string(),
+  sender: NotificationSenderSchema.nullable(),
+  container: NotificationContainerSchema.nullable(),
+  content: NotificationContentSchema,
+  meta: NotificationMetaSchema,
+});
+
+export type NormalizedNotification = z.infer<
+  typeof NormalizedNotificationSchema
+>;
+
+/** Maps one source's raw watcher items into `NormalizedNotification`. */
+export interface NotificationNormalizer {
+  source: NormalizedNotification["source"];
+
+  /**
+   * Map a raw watcher item. Return null to drop it entirely (not a tier
+   * decision). Implementations are pure and must not perform network I/O:
+   * normalization runs on every polled item, filtering happens afterwards.
+   */
+  normalize(item: WatcherItem): NormalizedNotification | null;
+
+  /**
+   * Fetch full content on demand. Absent when the source has no cheaper
+   * preview, meaning its poll already returned the full content and
+   * `content.full` is populated by `normalize`. Present only where the body
+   * costs an extra API call (Gmail's poll yields a snippet), which is why the
+   * judgment layer tiers on the preview first. Returns null on failure.
+   */
+  fetchFull?(item: NormalizedNotification): Promise<string | null>;
+}

--- a/assistant/src/notifications/filter/normalize/types.ts
+++ b/assistant/src/notifications/filter/normalize/types.ts
@@ -79,6 +79,14 @@ export const NotificationMetaSchema = z.object({
 export const NormalizedNotificationSchema = z.object({
   source: NotificationSourceSchema,
   externalId: z.string(),
+  /**
+   * The credential service the watcher polled this item with, next to the rest
+   * of the record's provenance. A workspace can hold several connections of
+   * one kind, so a `fetchFull` that resolved the source's default service
+   * would read a different account than the poll did. Null when the source
+   * stamps none, and a normalizer that needs one falls back to its default.
+   */
+  credentialService: z.string().nullable().default(null),
   sender: NotificationSenderSchema.nullable(),
   container: NotificationContainerSchema.nullable(),
   content: NotificationContentSchema,

--- a/assistant/src/watcher/providers/gmail.test.ts
+++ b/assistant/src/watcher/providers/gmail.test.ts
@@ -18,6 +18,7 @@ import { messageToItem, METADATA_HEADERS } from "./gmail.js";
 await initializeDb();
 
 const MAILBOX = "owner@example.com";
+const CREDENTIAL_SERVICE = "google";
 
 function gmailMessage(headers: Record<string, string>): GmailMessage {
   return {
@@ -41,7 +42,11 @@ function categoryOf(
   headers: Record<string, string>,
   mailbox: string | null = MAILBOX,
 ) {
-  const item = messageToItem(gmailMessage({ From: FROM, ...headers }), mailbox);
+  const item = messageToItem(
+    gmailMessage({ From: FROM, ...headers }),
+    mailbox,
+    CREDENTIAL_SERVICE,
+  );
   return gmailNormalizer.normalize(item)?.content.category;
 }
 
@@ -72,6 +77,7 @@ describe("messageToItem", () => {
         "List-Unsubscribe": "<mailto:unsub@example.com>",
       }),
       MAILBOX,
+      CREDENTIAL_SERVICE,
     );
 
     expect(item.payload.headers).toEqual({
@@ -89,6 +95,7 @@ describe("messageToItem", () => {
     const item = messageToItem(
       gmailMessage({ From: FROM, Subject: "Hello", Date: "today" }),
       MAILBOX,
+      CREDENTIAL_SERVICE,
     );
 
     expect(item.payload.from).toBe(FROM);
@@ -102,18 +109,32 @@ describe("messageToItem", () => {
   });
 
   test("omits headers the message does not carry", () => {
-    const item = messageToItem(gmailMessage({ From: FROM }), MAILBOX);
+    const item = messageToItem(
+      gmailMessage({ From: FROM }),
+      MAILBOX,
+      CREDENTIAL_SERVICE,
+    );
     expect(item.payload.headers).toEqual({ From: FROM });
   });
 
   test("stamps the mailbox address, and omits it when unknown", () => {
     expect(
-      messageToItem(gmailMessage({ From: FROM }), MAILBOX).payload
-        .mailboxAddress,
+      messageToItem(gmailMessage({ From: FROM }), MAILBOX, CREDENTIAL_SERVICE)
+        .payload.mailboxAddress,
     ).toBe(MAILBOX);
     expect(
-      messageToItem(gmailMessage({ From: FROM }), null).payload,
+      messageToItem(gmailMessage({ From: FROM }), null, CREDENTIAL_SERVICE)
+        .payload,
     ).not.toHaveProperty("mailboxAddress");
+  });
+
+  test("stamps the credential service the poll used", () => {
+    const item = messageToItem(
+      gmailMessage({ From: FROM }),
+      MAILBOX,
+      "google-work",
+    );
+    expect(item.payload.credentialService).toBe("google-work");
   });
 });
 
@@ -150,5 +171,20 @@ describe("the payload the normalizer categorizes", () => {
 
   test("without a mailbox address a sole recipient does not reach dm", () => {
     expect(categoryOf({ To: MAILBOX }, null)).toBe("fyi");
+  });
+
+  test("a quoted comma in a recipient display name still reaches dm", () => {
+    expect(categoryOf({ To: `"Owner, The" <${MAILBOX}>` })).toBe("dm");
+  });
+
+  test("the credential service reaches the normalized record", () => {
+    const item = messageToItem(
+      gmailMessage({ From: FROM, To: MAILBOX }),
+      MAILBOX,
+      "google-work",
+    );
+    expect(gmailNormalizer.normalize(item)?.credentialService).toBe(
+      "google-work",
+    );
   });
 });

--- a/assistant/src/watcher/providers/gmail.test.ts
+++ b/assistant/src/watcher/providers/gmail.test.ts
@@ -20,11 +20,14 @@ await initializeDb();
 const MAILBOX = "owner@example.com";
 const CREDENTIAL_SERVICE = "google";
 
-function gmailMessage(headers: Record<string, string>): GmailMessage {
+function gmailMessage(
+  headers: Record<string, string>,
+  labelIds: string[] = ["INBOX"],
+): GmailMessage {
   return {
     id: "msg-1",
     threadId: "thread-1",
-    labelIds: ["INBOX"],
+    labelIds,
     snippet: "Just checking in",
     internalDate: "1700000000000",
     payload: {
@@ -186,5 +189,23 @@ describe("the payload the normalizer categorizes", () => {
     expect(gmailNormalizer.normalize(item)?.credentialService).toBe(
       "google-work",
     );
+  });
+
+  test("the polled mailbox reaches the record as the credential account", () => {
+    const item = messageToItem(
+      gmailMessage({ From: FROM, To: MAILBOX }),
+      MAILBOX,
+      "google-work",
+    );
+    expect(gmailNormalizer.normalize(item)?.credentialAccount).toBe(MAILBOX);
+  });
+
+  test("an updates-labelled receipt still reaches its own category", () => {
+    const item = messageToItem(
+      gmailMessage({ From: FROM, To: MAILBOX }, ["INBOX", "CATEGORY_UPDATES"]),
+      MAILBOX,
+      CREDENTIAL_SERVICE,
+    );
+    expect(gmailNormalizer.normalize(item)?.content.category).toBe("dm");
   });
 });

--- a/assistant/src/watcher/providers/gmail.test.ts
+++ b/assistant/src/watcher/providers/gmail.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Pins the seam between the Gmail watcher and the notification normalizer.
+ *
+ * A `format=metadata` fetch returns only the headers it is asked for, so the
+ * header list and the payload shape are one contract with the normalizer, not
+ * two independent details: a header dropped from either end silently collapses
+ * every message to `fyi`. These tests run the real payload through the real
+ * normalizer, so they fail if either end moves alone.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { GmailMessage } from "../../messaging/providers/gmail/types.js";
+import { gmailNormalizer } from "../../notifications/filter/normalize/gmail.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { messageToItem, METADATA_HEADERS } from "./gmail.js";
+
+await initializeDb();
+
+const MAILBOX = "owner@example.com";
+
+function gmailMessage(headers: Record<string, string>): GmailMessage {
+  return {
+    id: "msg-1",
+    threadId: "thread-1",
+    labelIds: ["INBOX"],
+    snippet: "Just checking in",
+    internalDate: "1700000000000",
+    payload: {
+      headers: Object.entries(headers).map(([name, value]) => ({
+        name,
+        value,
+      })),
+    },
+  };
+}
+
+const FROM = "Example User <user@example.com>";
+
+function categoryOf(
+  headers: Record<string, string>,
+  mailbox: string | null = MAILBOX,
+) {
+  const item = messageToItem(gmailMessage({ From: FROM, ...headers }), mailbox);
+  return gmailNormalizer.normalize(item)?.content.category;
+}
+
+describe("METADATA_HEADERS", () => {
+  test("requests every header the normalizer categorizes on", () => {
+    expect(METADATA_HEADERS).toEqual([
+      "From",
+      "Subject",
+      "Date",
+      "To",
+      "Cc",
+      "In-Reply-To",
+      "List-Unsubscribe",
+    ]);
+  });
+});
+
+describe("messageToItem", () => {
+  test("carries the fetched headers through to the payload", () => {
+    const item = messageToItem(
+      gmailMessage({
+        From: FROM,
+        Subject: "Hello",
+        Date: "Sat, 1 Aug 2026 00:00:00 +0000",
+        To: MAILBOX,
+        Cc: "colleague@example.com",
+        "In-Reply-To": "<parent@example.com>",
+        "List-Unsubscribe": "<mailto:unsub@example.com>",
+      }),
+      MAILBOX,
+    );
+
+    expect(item.payload.headers).toEqual({
+      From: FROM,
+      Subject: "Hello",
+      Date: "Sat, 1 Aug 2026 00:00:00 +0000",
+      To: MAILBOX,
+      Cc: "colleague@example.com",
+      "In-Reply-To": "<parent@example.com>",
+      "List-Unsubscribe": "<mailto:unsub@example.com>",
+    });
+  });
+
+  test("keeps the top-level scalars existing readers index", () => {
+    const item = messageToItem(
+      gmailMessage({ From: FROM, Subject: "Hello", Date: "today" }),
+      MAILBOX,
+    );
+
+    expect(item.payload.from).toBe(FROM);
+    expect(item.payload.subject).toBe("Hello");
+    expect(item.payload.date).toBe("today");
+    expect(item.payload.id).toBe("msg-1");
+    expect(item.payload.threadId).toBe("thread-1");
+    expect(item.payload.snippet).toBe("Just checking in");
+    expect(item.payload.labelIds).toEqual(["INBOX"]);
+    expect(item.summary).toBe(`Email from ${FROM}: Hello`);
+  });
+
+  test("omits headers the message does not carry", () => {
+    const item = messageToItem(gmailMessage({ From: FROM }), MAILBOX);
+    expect(item.payload.headers).toEqual({ From: FROM });
+  });
+
+  test("stamps the mailbox address, and omits it when unknown", () => {
+    expect(
+      messageToItem(gmailMessage({ From: FROM }), MAILBOX).payload
+        .mailboxAddress,
+    ).toBe(MAILBOX);
+    expect(
+      messageToItem(gmailMessage({ From: FROM }), null).payload,
+    ).not.toHaveProperty("mailboxAddress");
+  });
+});
+
+describe("the payload the normalizer categorizes", () => {
+  test("mail addressed to the mailbox alone reaches dm", () => {
+    expect(categoryOf({ To: `The Owner <${MAILBOX}>` })).toBe("dm");
+  });
+
+  test("a dm with a colleague copied is still a dm", () => {
+    expect(categoryOf({ To: MAILBOX, Cc: "colleague@example.com" })).toBe("dm");
+  });
+
+  test("a one-address list alias does not reach dm", () => {
+    expect(categoryOf({ To: "team-announce@example.com" })).toBe("fyi");
+  });
+
+  test("In-Reply-To reaches reply", () => {
+    expect(
+      categoryOf({
+        To: "team@example.com, other@example.com",
+        "In-Reply-To": "<parent@example.com>",
+      }),
+    ).toBe("reply");
+  });
+
+  test("List-Unsubscribe reaches broadcast", () => {
+    expect(
+      categoryOf({
+        To: MAILBOX,
+        "List-Unsubscribe": "<mailto:unsub@example.com>",
+      }),
+    ).toBe("broadcast");
+  });
+
+  test("without a mailbox address a sole recipient does not reach dm", () => {
+    expect(categoryOf({ To: MAILBOX }, null)).toBe("fyi");
+  });
+});

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -138,8 +138,11 @@ export function messageToItem(
       date: headers.Date ?? "",
       headers,
       // The normalizer carries this onto its record so a follow-up body fetch
-      // resolves the account this poll read, not the default Gmail credential.
+      // resolves the credential this poll read, not the default Gmail one.
       credentialService,
+      // Serves two readers: the normalizer categorizes against it, and it is
+      // also the account identifier that pins a follow-up body fetch to this
+      // mailbox when several accounts share the credential service.
       ...(mailboxAddress ? { mailboxAddress } : {}),
       snippet: msg.snippet ?? "",
       labelIds: msg.labelIds ?? [],

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -13,6 +13,7 @@ import {
   GMAIL_REQUIRED_SCOPES,
   listMessages,
 } from "../../messaging/providers/gmail/client.js";
+import { extractHeader } from "../../messaging/providers/gmail/message-fields.js";
 import type { GmailMessage } from "../../messaging/providers/gmail/types.js";
 import type { OAuthConnection } from "../../oauth/connection.js";
 import { resolveOAuthConnection } from "../../oauth/connection-resolver.js";
@@ -40,14 +41,6 @@ interface HistoryListResponse {
   history?: HistoryRecord[];
   nextPageToken?: string;
   historyId?: string;
-}
-
-function extractHeader(msg: GmailMessage, name: string): string {
-  return (
-    msg.payload?.headers?.find(
-      (h) => h.name.toLowerCase() === name.toLowerCase(),
-    )?.value ?? ""
-  );
 }
 
 function messageToItem(msg: GmailMessage): WatcherItem {

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -14,7 +14,10 @@ import {
   listMessages,
 } from "../../messaging/providers/gmail/client.js";
 import { extractHeader } from "../../messaging/providers/gmail/message-fields.js";
-import type { GmailMessage } from "../../messaging/providers/gmail/types.js";
+import type {
+  GmailMessage,
+  GmailProfile,
+} from "../../messaging/providers/gmail/types.js";
 import type { OAuthConnection } from "../../oauth/connection.js";
 import { resolveOAuthConnection } from "../../oauth/connection-resolver.js";
 import { getLogger } from "../../util/logger.js";
@@ -43,10 +46,81 @@ interface HistoryListResponse {
   historyId?: string;
 }
 
-function messageToItem(msg: GmailMessage): WatcherItem {
-  const from = extractHeader(msg, "From");
-  const subject = extractHeader(msg, "Subject");
-  const date = extractHeader(msg, "Date");
+/**
+ * Headers requested with `format=metadata`.
+ *
+ * More than the summary line needs: the notification normalizer categorizes a
+ * message from its recipients and from the reply and list headers, and a
+ * metadata fetch returns only what is asked for, so a header left out of this
+ * list is a categorization that silently degrades to `fyi`.
+ */
+export const METADATA_HEADERS = [
+  "From",
+  "Subject",
+  "Date",
+  "To",
+  "Cc",
+  "In-Reply-To",
+  "List-Unsubscribe",
+];
+
+/**
+ * The authenticated mailbox address, per credential service.
+ *
+ * It is a property of the credential rather than of the poll, so it is
+ * resolved once and reused. Without it the normalizer cannot tell a message
+ * addressed to the user from one addressed to a one-address list alias, and
+ * has to fall back rather than guess.
+ */
+const mailboxAddressByService = new Map<string, string>();
+
+function rememberMailboxAddress(
+  credentialService: string,
+  profile: GmailProfile,
+): void {
+  if (profile.emailAddress) {
+    mailboxAddressByService.set(credentialService, profile.emailAddress);
+  }
+}
+
+/**
+ * The mailbox address for this credential, from cache when a profile call has
+ * already happened this process. A failure is not fatal: categorization
+ * degrades, the poll does not.
+ */
+async function resolveMailboxAddress(
+  connection: OAuthConnection,
+  credentialService: string,
+): Promise<string | null> {
+  const cached = mailboxAddressByService.get(credentialService);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const profile = await getProfile(connection);
+    rememberMailboxAddress(credentialService, profile);
+    return profile.emailAddress ?? null;
+  } catch (err) {
+    log.warn({ err }, "Gmail: could not resolve the mailbox address");
+    return null;
+  }
+}
+
+/** Exported for the test that pins the payload the normalizer reads. */
+export function messageToItem(
+  msg: GmailMessage,
+  mailboxAddress: string | null,
+): WatcherItem {
+  const headers: Record<string, string> = {};
+  for (const name of METADATA_HEADERS) {
+    const value = extractHeader(msg, name);
+    if (value) {
+      headers[name] = value;
+    }
+  }
+
+  const from = headers.From ?? "";
+  const subject = headers.Subject ?? "";
 
   return {
     externalId: msg.id,
@@ -55,9 +129,14 @@ function messageToItem(msg: GmailMessage): WatcherItem {
     payload: {
       id: msg.id,
       threadId: msg.threadId,
+      // Kept as top-level scalars alongside the record below: existing readers
+      // (`sequence/reply-matcher.ts`, stored rows written before this) index
+      // `payload.from` directly.
       from,
       subject,
-      date,
+      date: headers.Date ?? "",
+      headers,
+      ...(mailboxAddress ? { mailboxAddress } : {}),
       snippet: msg.snippet ?? "",
       labelIds: msg.labelIds ?? [],
     },
@@ -119,6 +198,7 @@ export const gmailProvider: WatcherProvider = {
       requiredScopes: GMAIL_REQUIRED_SCOPES,
     });
     const profile = await getProfile(connection);
+    rememberMailboxAddress(credentialService, profile);
     if (!profile.historyId) {
       throw new Error("Gmail profile did not return a historyId");
     }
@@ -138,6 +218,7 @@ export const gmailProvider: WatcherProvider = {
     if (!watermark) {
       // No watermark — get initial position, return no items
       const profile = await getProfile(connection);
+      rememberMailboxAddress(credentialService, profile);
       return { items: [], watermark: profile.historyId ?? "0" };
     }
 
@@ -168,7 +249,7 @@ export const gmailProvider: WatcherProvider = {
         connection,
         Array.from(messageIds),
         "metadata",
-        ["From", "Subject", "Date"],
+        METADATA_HEADERS,
       );
 
       // Only include INBOX messages (skip sent, drafts, etc.)
@@ -176,7 +257,11 @@ export const gmailProvider: WatcherProvider = {
         m.labelIds?.includes("INBOX"),
       );
 
-      const items = inboxMessages.map(messageToItem);
+      const mailboxAddress =
+        inboxMessages.length > 0
+          ? await resolveMailboxAddress(connection, credentialService)
+          : null;
+      const items = inboxMessages.map((m) => messageToItem(m, mailboxAddress));
       log.info(
         { count: items.length, watermark: newWatermark },
         "Gmail: fetched new messages",
@@ -188,7 +273,7 @@ export const gmailProvider: WatcherProvider = {
         log.warn(
           "Gmail historyId expired, falling back to recent unread messages",
         );
-        return fallbackFetch(connection);
+        return fallbackFetch(connection, credentialService);
       }
       throw err;
     }
@@ -200,6 +285,7 @@ export const gmailProvider: WatcherProvider = {
  */
 async function fallbackFetch(
   connection: OAuthConnection,
+  credentialService: string,
 ): Promise<FetchResult> {
   const listResp = await listMessages(
     connection,
@@ -211,6 +297,7 @@ async function fallbackFetch(
 
   if (!listResp.messages || listResp.messages.length === 0) {
     const profile = await getProfile(connection);
+    rememberMailboxAddress(credentialService, profile);
     return { items: [], watermark: profile.historyId ?? "0" };
   }
 
@@ -218,12 +305,16 @@ async function fallbackFetch(
     connection,
     listResp.messages.map((m) => m.id),
     "metadata",
-    ["From", "Subject", "Date"],
+    METADATA_HEADERS,
   );
 
-  const items = messages.map(messageToItem);
-
-  // Get fresh historyId for the new watermark
+  // Get fresh historyId for the new watermark. The same call carries the
+  // mailbox address, so categorization costs nothing extra on this path.
   const profile = await getProfile(connection);
+  rememberMailboxAddress(credentialService, profile);
+
+  const mailboxAddress = profile.emailAddress ?? null;
+  const items = messages.map((m) => messageToItem(m, mailboxAddress));
+
   return { items, watermark: profile.historyId ?? "0" };
 }

--- a/assistant/src/watcher/providers/gmail.ts
+++ b/assistant/src/watcher/providers/gmail.ts
@@ -110,6 +110,7 @@ async function resolveMailboxAddress(
 export function messageToItem(
   msg: GmailMessage,
   mailboxAddress: string | null,
+  credentialService: string,
 ): WatcherItem {
   const headers: Record<string, string> = {};
   for (const name of METADATA_HEADERS) {
@@ -136,6 +137,9 @@ export function messageToItem(
       subject,
       date: headers.Date ?? "",
       headers,
+      // The normalizer carries this onto its record so a follow-up body fetch
+      // resolves the account this poll read, not the default Gmail credential.
+      credentialService,
       ...(mailboxAddress ? { mailboxAddress } : {}),
       snippet: msg.snippet ?? "",
       labelIds: msg.labelIds ?? [],
@@ -261,7 +265,9 @@ export const gmailProvider: WatcherProvider = {
         inboxMessages.length > 0
           ? await resolveMailboxAddress(connection, credentialService)
           : null;
-      const items = inboxMessages.map((m) => messageToItem(m, mailboxAddress));
+      const items = inboxMessages.map((m) =>
+        messageToItem(m, mailboxAddress, credentialService),
+      );
       log.info(
         { count: items.length, watermark: newWatermark },
         "Gmail: fetched new messages",
@@ -314,7 +320,9 @@ async function fallbackFetch(
   rememberMailboxAddress(credentialService, profile);
 
   const mailboxAddress = profile.emailAddress ?? null;
-  const items = messages.map((m) => messageToItem(m, mailboxAddress));
+  const items = messages.map((m) =>
+    messageToItem(m, mailboxAddress, credentialService),
+  );
 
   return { items, watermark: profile.historyId ?? "0" };
 }


### PR DESCRIPTION
## Summary
- Adds the `NormalizedNotification` record: the common shape every notification source is mapped into, with null as a first-class value for fields a source does not populate.
- Adds Linear and Gmail normalizers plus a registry, mirroring the existing watcher provider-registry pattern.
- `fetchFull` is optional per adapter: Linear returns full content in its poll, Gmail needs a second API call.

Part of plan: notification-filter.md (PR 2 of 15)