### PR TITLE
Late-inserting banner polish (GracePeriodBanner + FinishProSetupNotice)

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -407,6 +407,9 @@ describe("Finish Pro setup nudge", () => {
     await waitFor(() =>
       expect(getByTestId("finish-pro-setup-notice")).toBeTruthy(),
     );
+    expect(getByTestId("finish-pro-setup-notice").textContent).toContain(
+      "Your assistant's email address hasn't been set up yet.",
+    );
     expect(getByTestId("onboarding-modal").getAttribute("data-open")).toBe(
       "false",
     );

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -17,6 +17,7 @@ import { AdjustPlanModal } from "@/domains/settings/components/adjust-plan-modal
 import { BillingPanel } from "@/domains/settings/components/billing-panel";
 import { BillingPortalReturnHandler } from "@/domains/settings/components/billing-portal-return-handler";
 import { BillingUsagePanel } from "@/domains/settings/components/billing-usage/billing-usage-panel";
+import { ContentReveal } from "@/domains/settings/components/content-reveal";
 import { GracePeriodBanner } from "@/domains/settings/components/grace-period-banner";
 import { InvoicesTable } from "@/domains/settings/components/invoices-table";
 import { PaymentMethodsCard } from "@/domains/settings/components/payment-methods-card";
@@ -125,25 +126,27 @@ function FinishProSetupNotice({
   }
 
   return (
-    <Notice
-      tone="info"
-      title={t("billingPage.finishSetupTitle", {
-        plan: proPackageDisplayName(subscription?.package),
-      })}
-      actions={
-        <Button
-          variant="outlined"
-          size="compact"
-          onClick={onFinishSetup}
-          data-testid="finish-pro-setup-button"
-        >
-          {t("billingPage.finishSetupButton")}
-        </Button>
-      }
-      data-testid="finish-pro-setup-notice"
-    >
-      {t("billingPage.finishSetupBody")}
-    </Notice>
+    <ContentReveal>
+      <Notice
+        tone="info"
+        title={t("billingPage.finishSetupTitle", {
+          plan: proPackageDisplayName(subscription?.package),
+        })}
+        actions={
+          <Button
+            variant="outlined"
+            size="compact"
+            onClick={onFinishSetup}
+            data-testid="finish-pro-setup-button"
+          >
+            {t("billingPage.finishSetupButton")}
+          </Button>
+        }
+        data-testid="finish-pro-setup-notice"
+      >
+        {t("billingPage.finishSetupBody")}
+      </Notice>
+    </ContentReveal>
   );
 }
 

--- a/clients/web/src/domains/settings/components/grace-period-banner.test.tsx
+++ b/clients/web/src/domains/settings/components/grace-period-banner.test.tsx
@@ -98,6 +98,32 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
+describe("GracePeriodBanner", () => {
+  test("renders the banner content through the reveal wrapper", () => {
+    const { getByTestId } = renderBanner();
+
+    const banner = getByTestId("grace-period-banner");
+    expect(banner.textContent).toContain(
+      "You'll keep Pro features until then.",
+    );
+    expect(banner.textContent).toContain("Your Pro plan will end on");
+    expect(getByTestId("grace-period-reactivate-button")).toBeDefined();
+  });
+
+  test("renders no wrapper at all without a pending cancellation", () => {
+    const { container, queryByTestId } = renderBanner({
+      ...gracePeriodSubscription(),
+      cancel_at_period_end: false,
+      cancel_at: null,
+    });
+
+    expect(queryByTestId("grace-period-banner")).toBeNull();
+    // The reveal wrapper sits inside the guards, so a hidden banner leaves
+    // nothing behind for the surrounding `space-y-*` stack to space around.
+    expect(container.firstChild).toBeNull();
+  });
+});
+
 describe("GracePeriodBanner Reactivate", () => {
   test("posts the reactivate endpoint and clears the banner", async () => {
     const { getByTestId, queryByTestId } = renderBanner();

--- a/clients/web/src/domains/settings/components/grace-period-banner.tsx
+++ b/clients/web/src/domains/settings/components/grace-period-banner.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useReactivateSubscription } from "@/domains/settings/billing/use-reactivate-subscription";
 import { isDirectCancelEligible } from "@/domains/settings/components/adjust-plan-utils";
+import { ContentReveal } from "@/domains/settings/components/content-reveal";
 import {
   buildPortalReturnSnapshot,
   formatGraceDate,
@@ -58,36 +59,38 @@ export function GracePeriodBanner() {
   const formatted = formatGraceDate(cancelDate);
 
   return (
-    <Notice
-      tone="info"
-      title={t("gracePeriodBanner.title", { date: formatted })}
-      actions={
-        <Button
-          variant="outlined"
-          size="compact"
-          onClick={() => {
-            if (isNativeAndroid) {
-              openBillingPathInBrowser(routes.settings.usageBilling);
-              return;
+    <ContentReveal>
+      <Notice
+        tone="info"
+        title={t("gracePeriodBanner.title", { date: formatted })}
+        actions={
+          <Button
+            variant="outlined"
+            size="compact"
+            onClick={() => {
+              if (isNativeAndroid) {
+                openBillingPathInBrowser(routes.settings.usageBilling);
+                return;
+              }
+              if (!isDirectCancelEligible(data)) {
+                portalMutation.mutate({});
+                return;
+              }
+              void reactivateSubscription();
+            }}
+            disabled={isPending}
+            leftIcon={
+              isPending ? <Loader2 className="animate-spin" /> : undefined
             }
-            if (!isDirectCancelEligible(data)) {
-              portalMutation.mutate({});
-              return;
-            }
-            void reactivateSubscription();
-          }}
-          disabled={isPending}
-          leftIcon={
-            isPending ? <Loader2 className="animate-spin" /> : undefined
-          }
-          data-testid="grace-period-reactivate-button"
-        >
-          {t("gracePeriodBanner.reactivate")}
-        </Button>
-      }
-      data-testid="grace-period-banner"
-    >
-      {t("gracePeriodBanner.body")}
-    </Notice>
+            data-testid="grace-period-reactivate-button"
+          >
+            {t("gracePeriodBanner.reactivate")}
+          </Button>
+        }
+        data-testid="grace-period-banner"
+      >
+        {t("gracePeriodBanner.body")}
+      </Notice>
+    </ContentReveal>
   );
 }


### PR DESCRIPTION
## Summary
- both late-appearing banners enter via ContentReveal (reduced-motion aware)
- no change to when they appear

Part of plan: billing-skeleton-loading.md (PR 7 of 7)