### PR TITLE
fix(contacts): invite/verification channel re-parents garbage-collect the stripped donor

### DIFF
--- a/gateway/src/__tests__/delete-contact-if-orphaned.test.ts
+++ b/gateway/src/__tests__/delete-contact-if-orphaned.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Unit tests for the orphaned-seed contact GC (`deleteContactIfOrphaned`).
+ *
+ * Deletion must be provably narrow: only a principal-less `contact`-role row
+ * with no channels and no guardian-authored configuration qualifies, and the
+ * final delete must re-verify that atomically. The mirror probe awaits IPC,
+ * so a concurrent write (an inbound seed attaching a channel) can land in
+ * the gap; the guarded DELETE is what keeps that from cascade-deleting the
+ * fresh channel.
+ *
+ * The gateway DB is real, so assertions count rows. The mirror probe is a
+ * controllable stub: tests park it on a deferred promise to open the race
+ * window deliberately.
+ */
+
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  mock,
+} from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import "./test-preload.js";
+
+// A real socket file so the mirror counts as reachable and the probe runs.
+const socketDir = mkdtempSync(join(tmpdir(), "orphan-gc-"));
+const socketPath = join(socketDir, "assistant.sock");
+writeFileSync(socketPath, "");
+mock.module("../ipc/endpoint.js", () => ({
+  resolveIpcSocketPath: () => ({ path: socketPath, source: "test" }),
+}));
+
+type MirrorProbe = {
+  exists: boolean;
+  hasChannels: boolean;
+  notes: string | null;
+  userFile: string | null;
+  contactType: string | null;
+  hasMetadata: boolean;
+};
+const ABSENT_MIRROR: MirrorProbe = {
+  exists: false,
+  hasChannels: false,
+  notes: null,
+  userFile: null,
+  contactType: null,
+  hasMetadata: false,
+};
+let probeImpl: () => Promise<MirrorProbe> = async () => ABSENT_MIRROR;
+
+const actualContactsInfoClient = await import("../ipc/contacts-info-client.js");
+mock.module("../ipc/contacts-info-client.js", () => ({
+  ...actualContactsInfoClient,
+  probeContactMirror: () => probeImpl(),
+}));
+
+const mirrorCalls: { method: string; body: unknown }[] = [];
+const actualAssistantClient = await import("../ipc/assistant-client.js");
+mock.module("../ipc/assistant-client.js", () => ({
+  ...actualAssistantClient,
+  ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
+    mirrorCalls.push({ method, body: opts?.body });
+    return {};
+  },
+}));
+
+// Import after mocks so the helper binds the stubbed probe.
+const { deleteContactIfOrphaned } =
+  await import("../verification/contact-helpers.js");
+const { initGatewayDb, getGatewayDb, resetGatewayDb } =
+  await import("../db/connection.js");
+const { contacts, contactChannels } = await import("../db/schema.js");
+
+function seedContact(opts: {
+  id: string;
+  role?: string;
+  principalId?: string | null;
+  autoApproveThreshold?: string | null;
+}): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contacts)
+    .values({
+      id: opts.id,
+      displayName: `name-${opts.id}`,
+      role: opts.role ?? "contact",
+      principalId: opts.principalId ?? null,
+      autoApproveThreshold: opts.autoApproveThreshold ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function seedChannel(contactId: string, id: string): void {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(contactChannels)
+    .values({
+      id,
+      contactId,
+      type: "slack",
+      address: `U-${id}`,
+      isPrimary: false,
+      status: "unverified",
+      policy: "allow",
+      interactionCount: 0,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function contactIds(): string[] {
+  return getGatewayDb()
+    .select({ id: contacts.id })
+    .from(contacts)
+    .all()
+    .map((r) => r.id);
+}
+
+beforeAll(async () => {
+  await initGatewayDb();
+});
+
+beforeEach(() => {
+  const db = getGatewayDb();
+  db.delete(contactChannels).run();
+  db.delete(contacts).run();
+  probeImpl = async () => ABSENT_MIRROR;
+  mirrorCalls.length = 0;
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+describe("eligibility", () => {
+  test("a qualifying orphan is deleted (both stores when the mirror row exists)", async () => {
+    seedContact({ id: "orphan" });
+    // A present mirror stub row: default classification, nothing authored.
+    probeImpl = async () => ({
+      ...ABSENT_MIRROR,
+      exists: true,
+      contactType: "human",
+    });
+
+    await deleteContactIfOrphaned("orphan");
+
+    expect(contactIds()).toEqual([]);
+    expect(
+      mirrorCalls.filter((c) => c.method === "contacts_mirror_delete_contact"),
+    ).toHaveLength(1);
+  });
+
+  test("a guardian-set auto-approve ceiling vetoes the delete", async () => {
+    // A threshold is guardian-authored configuration: the contact is real,
+    // not a disposable seed, even with zero channels.
+    seedContact({ id: "configured", autoApproveThreshold: "low" });
+
+    await deleteContactIfOrphaned("configured");
+
+    expect(contactIds()).toEqual(["configured"]);
+  });
+
+  test("a principal-bearing or non-contact-role row is never deleted", async () => {
+    seedContact({ id: "bound", principalId: "principal-1" });
+    seedContact({ id: "guardian", role: "guardian" });
+
+    await deleteContactIfOrphaned("bound");
+    await deleteContactIfOrphaned("guardian");
+
+    expect(contactIds().sort()).toEqual(["bound", "guardian"]);
+  });
+
+  test("a remaining channel vetoes the delete", async () => {
+    seedContact({ id: "has-channel" });
+    seedChannel("has-channel", "ch-1");
+
+    await deleteContactIfOrphaned("has-channel");
+
+    expect(contactIds()).toEqual(["has-channel"]);
+  });
+});
+
+describe("guarded delete under concurrency", () => {
+  test("a channel attached while the mirror probe is pending keeps the contact", async () => {
+    seedContact({ id: "racy" });
+
+    // Park the probe so the pre-checks (which saw zero channels) go stale,
+    // then attach a channel in the gap, exactly like a concurrent inbound
+    // seed. The guarded DELETE must notice and keep contact + channel.
+    let releaseProbe: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+    probeImpl = async () => {
+      await gate;
+      return ABSENT_MIRROR;
+    };
+
+    const gc = deleteContactIfOrphaned("racy");
+    seedChannel("racy", "ch-mid-flight");
+    releaseProbe!();
+    await gc;
+
+    expect(contactIds()).toEqual(["racy"]);
+    expect(getGatewayDb().select().from(contactChannels).all()).toHaveLength(1);
+  });
+});

--- a/gateway/src/__tests__/delete-contact-if-orphaned.test.ts
+++ b/gateway/src/__tests__/delete-contact-if-orphaned.test.ts
@@ -75,7 +75,9 @@ const { deleteContactIfOrphaned } =
   await import("../verification/contact-helpers.js");
 const { initGatewayDb, getGatewayDb, resetGatewayDb } =
   await import("../db/connection.js");
-const { contacts, contactChannels } = await import("../db/schema.js");
+const { contacts, contactChannels, ingressInvites } =
+  await import("../db/schema.js");
+const { seedInvite } = await import("./helpers/contact-fixtures.js");
 
 function seedContact(opts: {
   id: string;
@@ -131,6 +133,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   const db = getGatewayDb();
+  db.delete(ingressInvites).run();
   db.delete(contactChannels).run();
   db.delete(contacts).run();
   probeImpl = async () => ABSENT_MIRROR;
@@ -177,6 +180,18 @@ describe("eligibility", () => {
     await deleteContactIfOrphaned("guardian");
 
     expect(contactIds().sort()).toEqual(["bound", "guardian"]);
+  });
+
+  test("an invite targeting the contact vetoes the delete", async () => {
+    // Invites are guardian-minted, so any row targeting the contact proves
+    // intent, and ingress_invites.contact_id cascades on contact delete: the
+    // GC must never take live invites down with a supposed seed.
+    seedContact({ id: "invitee" });
+    seedInvite({ contactId: "invitee" });
+
+    await deleteContactIfOrphaned("invitee");
+
+    expect(contactIds()).toEqual(["invitee"]);
   });
 
   test("a remaining channel vetoes the delete", async () => {

--- a/gateway/src/__tests__/invite-redemption-engine.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine.test.ts
@@ -9,7 +9,15 @@
  * mocked out — it is a best-effort info mirror and not under test here.
  */
 
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import { sql } from "drizzle-orm";
 
@@ -59,22 +67,16 @@ mock.module("../ipc/contacts-info-client.js", () => ({
   lookupContactChannelIdentity: () => identityLookupImpl(),
 }));
 
-
 await import("./test-preload.js");
 
-const { initGatewayDb, getGatewayDb, resetGatewayDb } = await import(
-  "../db/connection.js"
-);
-const { contacts, contactChannels, ingressInvites } = await import(
-  "../db/schema.js"
-);
+const { initGatewayDb, getGatewayDb, resetGatewayDb } =
+  await import("../db/connection.js");
+const { contacts, contactChannels, ingressInvites } =
+  await import("../db/schema.js");
 const { ContactStore } = await import("../db/contact-store.js");
-const { redeemInviteByCode, redeemInviteByToken } = await import(
-  "../verification/invite-redemption.js"
-);
-const { inviteRow, seedInvite } = await import(
-  "./helpers/contact-fixtures.js"
-);
+const { redeemInviteByCode, redeemInviteByToken } =
+  await import("../verification/invite-redemption.js");
+const { inviteRow, seedInvite } = await import("./helpers/contact-fixtures.js");
 
 const CHANNEL = "telegram";
 const CODE = "123456";
@@ -107,7 +109,13 @@ function seedContact(id: string, displayName = `name-${id}`): void {
   const now = Date.now();
   getGatewayDb()
     .insert(contacts)
-    .values({ id, displayName, role: "contact", createdAt: now, updatedAt: now })
+    .values({
+      id,
+      displayName,
+      role: "contact",
+      createdAt: now,
+      updatedAt: now,
+    })
     .run();
 }
 
@@ -367,6 +375,49 @@ describe("redeemInviteByCode", () => {
     if (result.status !== "redeemed") throw new Error("unreachable");
     expect(result.outcome.contactId).toBe("c1");
     expect(inviteRow(inviteId).useCount).toBe(1);
+    // The bind stripped c2's only channel: the orphan GC riding the mirror
+    // plan reclaims it, so no channel-less duplicate lingers in the pane.
+    expect(
+      getGatewayDb()
+        .select()
+        .from(contacts)
+        .all()
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(["c1"]);
+  });
+
+  test("a donor keeping another channel survives the re-parent GC", async () => {
+    seedContact("c1");
+    seedContact("c2");
+    seedChannel({
+      id: "ch-1",
+      contactId: "c2",
+      address: "U_SENDER",
+      status: "active",
+    });
+    seedChannel({
+      id: "ch-2",
+      contactId: "c2",
+      address: "U_OTHER",
+      status: "active",
+    });
+    seedInvite(); // targets c1
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+    expect(result.status).toBe("redeemed");
+
+    // c2 still parents ch-2, so it is a real contact, not an orphaned seed.
+    expect(gwChannel("U_SENDER")!.contactId).toBe("c1");
+    expect(gwChannel("U_OTHER")!.contactId).toBe("c2");
+    expect(
+      getGatewayDb()
+        .select()
+        .from(contacts)
+        .all()
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(["c1", "c2"]);
   });
 
   test("blocked gateway channel is NEVER reactivated: generic failure, no use consumed", async () => {

--- a/gateway/src/__tests__/invite-redemption-engine.test.ts
+++ b/gateway/src/__tests__/invite-redemption-engine.test.ts
@@ -40,11 +40,17 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 // actual module so the real IpcHandlerError/IpcTransportError classes (and
 // untouched exports) stay importable by later-loaded files.
 let ipcCallAssistantCalls: Array<{ method: string; body: unknown }> = [];
+// When true, the identity-mirror channel upsert fails (a down daemon mid-bind)
+// while every other IPC still acks; the invite path tolerates this softly.
+let mirrorUpsertThrows = false;
 const actualAssistantClient = await import("../ipc/assistant-client.js");
 mock.module("../ipc/assistant-client.js", () => ({
   ...actualAssistantClient,
   ipcCallAssistant: async (method: string, opts?: { body?: unknown }) => {
     ipcCallAssistantCalls.push({ method, body: opts?.body });
+    if (mirrorUpsertThrows && method === "contacts_mirror_upsert_channel") {
+      throw new Error("mirror upsert down");
+    }
     return {};
   },
 }));
@@ -76,6 +82,8 @@ const { contacts, contactChannels, ingressInvites } =
 const { ContactStore } = await import("../db/contact-store.js");
 const { redeemInviteByCode, redeemInviteByToken } =
   await import("../verification/invite-redemption.js");
+const { upsertVerifiedContactChannel } =
+  await import("../verification/contact-helpers.js");
 const { inviteRow, seedInvite } = await import("./helpers/contact-fixtures.js");
 
 const CHANNEL = "telegram";
@@ -95,6 +103,7 @@ beforeEach(() => {
   assistantDbRunImpl = async () => {};
   identityLookupImpl = async () => null;
   ipcCallAssistantCalls = [];
+  mirrorUpsertThrows = false;
 });
 
 function inviteRedeemedEvents() {
@@ -384,6 +393,68 @@ describe("redeemInviteByCode", () => {
         .all()
         .map((c) => c.id)
         .sort(),
+    ).toEqual(["c1"]);
+  });
+
+  test("a soft mirror failure defers donor cleanup; the next bind heals it", async () => {
+    // Bind 1: the gateway re-parent commits but the mirror upsert fails
+    // (tolerated softly by the invite path), so the donor GC cannot run yet
+    // and the seed contact lingers.
+    seedContact("c1");
+    seedContact("c2");
+    seedChannel({
+      id: "ch-1",
+      contactId: "c2",
+      address: "U_SENDER",
+      status: "active",
+    });
+    seedInvite(); // targets c1
+    mirrorUpsertThrows = true;
+
+    const result = await redeemInviteByCode({ code: CODE, ...IDENTITY });
+    expect(result.status).toBe("redeemed");
+    expect(gwChannel("U_SENDER")!.contactId).toBe("c1");
+    expect(
+      getGatewayDb()
+        .select()
+        .from(contacts)
+        .all()
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(["c1", "c2"]);
+
+    // Bind 2 (a later verification of the same identity): the mirror is
+    // reachable again but still records the pre-move owner. The gateway
+    // reassign reports no donor (the row already belongs to the target), so
+    // the plan must carry the mirror's recorded owner as the GC candidate,
+    // finishing the cleanup bind 1 could not run.
+    mirrorUpsertThrows = false;
+    identityLookupImpl = async () => ({
+      id: "ch-1",
+      contactId: "c2",
+      type: CHANNEL,
+      address: "U_SENDER",
+      externalChatId: "chat-1",
+      displayName: null,
+    });
+
+    const { verified } = await upsertVerifiedContactChannel({
+      sourceChannel: CHANNEL,
+      externalUserId: "U_SENDER",
+      externalChatId: "chat-sender",
+      verifiedVia: "invite",
+      contactId: "c1",
+      allowRevokedReactivation: true,
+      softMirrorFailures: true,
+    });
+    expect(verified).toBe(true);
+
+    expect(
+      getGatewayDb()
+        .select()
+        .from(contacts)
+        .all()
+        .map((c) => c.id),
     ).toEqual(["c1"]);
   });
 

--- a/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
+++ b/gateway/src/__tests__/upsert-verified-contact-channel.test.ts
@@ -860,7 +860,9 @@ describe("upsertVerifiedContactChannel — revoked/blocked guards", () => {
 describe("upsertVerifiedContactChannel — invite target-contact binding", () => {
   test("reassigns an existing channel to the supplied target contact", async () => {
     // The redeemer's channel currently lives under a different contact (the
-    // guardian); the invite binds it to the target contact "mom".
+    // guardian); the invite binds it to the target contact "mom". The gateway
+    // row exists too: the re-parent primitive only issues an UPDATE for a row
+    // it actually found under another owner.
     queryRows = [
       {
         channelId: "ch-redeemer",
@@ -868,6 +870,7 @@ describe("upsertVerifiedContactChannel — invite target-contact binding", () =>
         channelStatus: "active",
       },
     ];
+    gwSelectStatus = "active";
 
     await upsertVerifiedContactChannel({
       sourceChannel: "telegram",

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -1553,6 +1553,86 @@ export class ContactStore {
   }
 
   /**
+   * Ensure a plain `role='contact'` row exists for `contactId`. A conflict on
+   * the id is a no-op, so an existing contact (any role, any curated name) is
+   * never touched. Plain statement, composable inside a caller transaction.
+   *
+   * This is the single "make the target contact exist" write for channel
+   * binding paths; identity seeding stays on {@link seedInboundChannel},
+   * whose contact insert is atomic with a channel insert.
+   */
+  ensureContactRow(contactId: string, displayName: string, now: number): void {
+    this.db
+      .insert(contacts)
+      .values({
+        id: contactId,
+        displayName,
+        role: "contact",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoNothing()
+      .run();
+  }
+
+  /**
+   * Re-parent the `(type, address)` channel to `toContactId`, ensuring the
+   * target contact row exists first. Matches by the logical key, not a
+   * channel id: the gateway row can live under a different UUID than the
+   * assistant mirror's, and an id-only update would re-parent nothing.
+   *
+   * Returns the previous owner's contact id when the channel actually moved
+   * (null when no row exists or the target already owns it). Callers that
+   * commit a move MUST hand that donor id to the post-commit orphan GC
+   * (`deleteContactIfOrphaned`) once every re-parent write, gateway AND
+   * assistant mirror, has landed: a re-parent that strips a seed contact's
+   * only channel otherwise leaves a channel-less duplicate in the Contacts
+   * pane. The verified-channel mirror plan carries the id for exactly that
+   * purpose.
+   *
+   * Plain statements, composable inside a caller transaction. ACL columns
+   * are untouched: moving a channel between contacts changes ownership, not
+   * its verification state.
+   */
+  reassignChannelOwner(params: {
+    type: string;
+    /** Canonical address (callers canonicalize via canonicalizeInboundIdentity). */
+    address: string;
+    toContactId: string;
+    /** Name for the target contact only when it has to be created. */
+    displayName: string;
+    now: number;
+  }): { donorContactId: string | null } {
+    this.ensureContactRow(params.toContactId, params.displayName, params.now);
+
+    const current = this.db
+      .select({ contactId: contactChannels.contactId })
+      .from(contactChannels)
+      .where(
+        and(
+          eq(contactChannels.type, params.type),
+          sql`${contactChannels.address} = ${params.address} COLLATE NOCASE`,
+        ),
+      )
+      .get();
+    if (!current || current.contactId === params.toContactId) {
+      return { donorContactId: null };
+    }
+
+    this.db
+      .update(contactChannels)
+      .set({ contactId: params.toContactId, updatedAt: params.now })
+      .where(
+        and(
+          eq(contactChannels.type, params.type),
+          sql`${contactChannels.address} = ${params.address} COLLATE NOCASE`,
+        ),
+      )
+      .run();
+    return { donorContactId: current.contactId };
+  }
+
+  /**
    * Merge two contacts: move channels from donor to survivor, delete the
    * donor. The assistant-DB identity mirror is best-effort.
    *

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -22,6 +22,7 @@ import { ContactStore } from "../db/contact-store.js";
 import {
   contactChannels as gwContactChannels,
   contacts as gwContacts,
+  ingressInvites as gwIngressInvites,
 } from "../db/schema.js";
 import { ipcCallAssistant } from "../ipc/assistant-client.js";
 import {
@@ -221,7 +222,9 @@ function reassignChannelContact(params: {
  * Deletion is deliberately narrow so a claim can never destroy real data:
  * the gateway contact must have role `contact`, no principal, no
  * guardian-set auto-approve ceiling (a threshold is guardian-authored
- * configuration, so a contact carrying one is not a disposable seed), and
+ * configuration, so a contact carrying one is not a disposable seed), no
+ * invite rows targeting it (invites are guardian-minted, so any row proves
+ * intent, and `ingress_invites.contact_id` cascades on contact delete), and
  * no remaining channels; the assistant mirror must agree (no channels) and
  * carry no guardian-authored data (notes, persona-file pointer, non-default
  * contact type, or assistant-species metadata). When any check fails, BOTH
@@ -251,6 +254,7 @@ export async function deleteContactIfOrphaned(
     sql`${gwContacts.principalId} IS NULL`,
     sql`${gwContacts.autoApproveThreshold} IS NULL`,
     sql`NOT EXISTS (SELECT 1 FROM ${gwContactChannels} WHERE ${gwContactChannels.contactId} = ${contactId})`,
+    sql`NOT EXISTS (SELECT 1 FROM ${gwIngressInvites} WHERE ${gwIngressInvites.contactId} = ${contactId})`,
   );
 
   try {
@@ -600,13 +604,21 @@ export function applyVerifiedChannelGatewayWrites(params: {
     const gatewayReparented = boundContactId !== row.contactId;
     let orphanedDonorContactId: string | null = null;
     if (gatewayReparented) {
-      orphanedDonorContactId = reassignChannelContact({
-        type: sourceChannel,
-        address,
-        toContactId: boundContactId,
-        displayName: contactDisplayName,
-        now,
-      });
+      // The gateway-truth donor when the row actually moves now. When the
+      // gateway already belongs to the target (a prior bind whose mirror op
+      // failed softly and left the mirror stale), the reassign reports no
+      // donor, but the mirror's recorded owner IS the stripped donor from
+      // that earlier move whose cleanup never ran. Carry it so the
+      // drift-healing bind finishes the GC; the GC's own guards decide
+      // whether the candidate really is a disposable orphan.
+      orphanedDonorContactId =
+        reassignChannelContact({
+          type: sourceChannel,
+          address,
+          toContactId: boundContactId,
+          displayName: contactDisplayName,
+          now,
+        }) ?? row.contactId;
     }
 
     // The assistant channel id may not exist in the gateway DB

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -160,17 +160,7 @@ function writeVerifiedGatewayChannel(params: {
   // verified channel. onConflictDoNothing preserves an existing blocked/revoked
   // row (it conflicts on the (type,address) unique index), so this never
   // reactivates a blocked actor.
-  gwDb
-    .insert(gwContacts)
-    .values({
-      id: contactId,
-      displayName: address,
-      role: "contact",
-      createdAt: now,
-      updatedAt: now,
-    })
-    .onConflictDoNothing()
-    .run();
+  new ContactStore().ensureContactRow(contactId, address, now);
   const inserted = gwDb
     .insert(gwContactChannels)
     .values({
@@ -191,9 +181,16 @@ function writeVerifiedGatewayChannel(params: {
 }
 
 /**
- * Re-parent a gateway channel to the invite's target contact, ensuring the
- * target contact row exists first. Best-effort: a gateway DB error is logged,
- * not thrown, so a legitimate activation still proceeds.
+ * Re-parent a gateway channel to the invite's target contact via
+ * `ContactStore.reassignChannelOwner` (which ensures the target contact row
+ * exists first and matches by the (type,address) logical key). Best-effort:
+ * a gateway DB error is logged, not thrown, so a legitimate activation still
+ * proceeds.
+ *
+ * Returns the stripped previous owner's contact id when the channel actually
+ * moved, so the caller can thread it onto the mirror plan for the
+ * post-commit orphan GC. Null when nothing moved (or on the best-effort
+ * failure, where there is no committed move to clean up after).
  */
 function reassignChannelContact(params: {
   type: string;
@@ -201,36 +198,13 @@ function reassignChannelContact(params: {
   toContactId: string;
   displayName: string;
   now: number;
-}): void {
-  const { type, address, toContactId, displayName, now } = params;
+}): string | null {
   try {
-    const gwDb = getGatewayDb();
-    gwDb
-      .insert(gwContacts)
-      .values({
-        id: toContactId,
-        displayName,
-        role: "contact",
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing()
-      .run();
-    // Match by the (type,address) logical key, not the assistant channel id:
-    // the gateway row can live under a different UUID (m0006 reconcile), and an
-    // id-only update would re-parent nothing.
-    gwDb
-      .update(gwContactChannels)
-      .set({ contactId: toContactId, updatedAt: now })
-      .where(
-        and(
-          eq(gwContactChannels.type, type),
-          sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
-        ),
-      )
-      .run();
+    const { donorContactId } = new ContactStore().reassignChannelOwner(params);
+    return donorContactId;
   } catch (gwErr) {
     log.warn({ err: gwErr }, "Gateway channel reassignment dual-write failed");
+    return null;
   }
 }
 
@@ -479,6 +453,16 @@ export interface VerifiedChannelMirrorPlan {
   externalChatId: string;
   displayName: string;
   reassignConflictingChannels: boolean;
+  /**
+   * Contact the committed gateway re-parent stripped the channel from, if
+   * any. {@link mirrorVerifiedChannel} garbage-collects it once the mirror
+   * re-parent has landed too, so a seed contact whose only channel was bound
+   * to an invite's target does not linger as a channel-less duplicate. On
+   * the plan rather than at a call site so every executor of the plan
+   * (verification relay, invite redemption, guardian-request decide) gets
+   * the GC without remembering to ask.
+   */
+  orphanedDonorContactId?: string;
 }
 
 export type VerifiedChannelGatewayResult =
@@ -595,8 +579,9 @@ export function applyVerifiedChannelGatewayWrites(params: {
     // the mirror must mirror THAT decision (not the call path) so the two stores
     // never disagree about channel ownership.
     const gatewayReparented = boundContactId !== row.contactId;
+    let orphanedDonorContactId: string | null = null;
     if (gatewayReparented) {
-      reassignChannelContact({
+      orphanedDonorContactId = reassignChannelContact({
         type: sourceChannel,
         address,
         toContactId: boundContactId,
@@ -640,6 +625,7 @@ export function applyVerifiedChannelGatewayWrites(params: {
         externalChatId,
         displayName: contactDisplayName,
         reassignConflictingChannels: gatewayReparented,
+        ...(orphanedDonorContactId ? { orphanedDonorContactId } : {}),
       },
     };
   }
@@ -658,13 +644,14 @@ export function applyVerifiedChannelGatewayWrites(params: {
   // For the channel, resolve by logical key so an existing non-blocked gateway
   // row (e.g. a gateway-created unverified contact) is UPDATED to active/verified
   // rather than silently no-op'd by the (type,address) unique index.
+  let orphanedDonorContactId: string | null = null;
   if (targetContactId) {
     // The assistant mirror missed, but the gateway may already hold this
     // (type,address) row under a different contact. Re-parent it to the
     // target by logical key (writeVerifiedGatewayChannel's update set omits
     // contactId), so the gateway source of truth lands under the invite's
     // contact. No-ops when no gateway row exists.
-    reassignChannelContact({
+    orphanedDonorContactId = reassignChannelContact({
       type: sourceChannel,
       address,
       toContactId: contactId,
@@ -672,17 +659,7 @@ export function applyVerifiedChannelGatewayWrites(params: {
       now,
     });
   } else {
-    getGatewayDb()
-      .insert(gwContacts)
-      .values({
-        id: contactId,
-        displayName: contactDisplayName,
-        role: "contact",
-        createdAt: now,
-        updatedAt: now,
-      })
-      .onConflictDoNothing()
-      .run();
+    new ContactStore().ensureContactRow(contactId, contactDisplayName, now);
   }
 
   const wrote = writeVerifiedGatewayChannel({
@@ -718,6 +695,7 @@ export function applyVerifiedChannelGatewayWrites(params: {
       externalChatId,
       displayName: contactDisplayName,
       reassignConflictingChannels: gatewayReparented,
+      ...(orphanedDonorContactId ? { orphanedDonorContactId } : {}),
     },
   };
 }
@@ -727,6 +705,14 @@ export function applyVerifiedChannelGatewayWrites(params: {
  * Identity/info columns only (ACL columns are gateway-owned); idempotent
  * under retries. Throws on IPC failure — callers choose the soft/hard
  * posture.
+ *
+ * When the committed gateway writes re-parented the channel away from
+ * another contact, the stripped donor is garbage-collected here, AFTER the
+ * mirror re-parent lands: `deleteContactIfOrphaned` inspects the mirror and
+ * vetoes while it still shows the pre-claim channel, so this is the earliest
+ * safe point. A mirror IPC failure skips the GC (the throw propagates before
+ * it), which is the veto-equivalent safe posture: the donor lingers until
+ * the next bind rather than being deleted while the stores disagree.
  */
 export async function mirrorVerifiedChannel(
   plan: VerifiedChannelMirrorPlan,
@@ -742,6 +728,10 @@ export async function mirrorVerifiedChannel(
       reassignConflictingChannels: plan.reassignConflictingChannels,
     },
   });
+
+  if (plan.orphanedDonorContactId) {
+    await deleteContactIfOrphaned(plan.orphanedDonorContactId);
+  }
 }
 
 /**

--- a/gateway/src/verification/contact-helpers.ts
+++ b/gateway/src/verification/contact-helpers.ts
@@ -219,14 +219,23 @@ function reassignChannelContact(params: {
  * duplicate of the guardian in the Contacts pane.
  *
  * Deletion is deliberately narrow so a claim can never destroy real data:
- * the gateway contact must have role `contact`, no principal, and no
- * remaining channels; the assistant mirror must agree (no channels) and
+ * the gateway contact must have role `contact`, no principal, no
+ * guardian-set auto-approve ceiling (a threshold is guardian-authored
+ * configuration, so a contact carrying one is not a disposable seed), and
+ * no remaining channels; the assistant mirror must agree (no channels) and
  * carry no guardian-authored data (notes, persona-file pointer, non-default
  * contact type, or assistant-species metadata). When any check fails, BOTH
  * rows are kept, so the two stores never disagree about the contact's
  * existence. A mirror that is unreachable (IPC socket absent) does not block
  * the gateway-side delete; a leftover mirror row is recoverable via the
  * tolerant contact delete (LUM-2662).
+ *
+ * The gateway reads before the mirror probe are a fast-path only: the mirror
+ * probe awaits IPC, so a concurrent write (e.g. an inbound seed attaching a
+ * fresh channel) can land in the gap. The final DELETE therefore re-encodes
+ * every gateway predicate in its own WHERE clause, one atomic statement, so
+ * a contact that stopped qualifying mid-flight is kept rather than
+ * cascade-deleting a channel the pre-checks never saw.
  *
  * Callers must invoke this only after all re-parent writes (gateway AND
  * assistant mirror) have completed, or the mirror inspection can observe the
@@ -236,26 +245,21 @@ export async function deleteContactIfOrphaned(
   contactId: string,
 ): Promise<void> {
   const gwDb = getGatewayDb();
+  const orphanPredicates = and(
+    eq(gwContacts.id, contactId),
+    eq(gwContacts.role, "contact"),
+    sql`${gwContacts.principalId} IS NULL`,
+    sql`${gwContacts.autoApproveThreshold} IS NULL`,
+    sql`NOT EXISTS (SELECT 1 FROM ${gwContactChannels} WHERE ${gwContactChannels.contactId} = ${contactId})`,
+  );
 
   try {
-    const contact = gwDb
-      .select({
-        role: gwContacts.role,
-        principalId: gwContacts.principalId,
-      })
+    const eligible = gwDb
+      .select({ id: gwContacts.id })
       .from(gwContacts)
-      .where(eq(gwContacts.id, contactId))
+      .where(orphanPredicates)
       .get();
-    if (!contact || contact.role !== "contact" || contact.principalId) {
-      return;
-    }
-    const remainingChannel = gwDb
-      .select({ id: gwContactChannels.id })
-      .from(gwContactChannels)
-      .where(eq(gwContactChannels.contactId, contactId))
-      .limit(1)
-      .get();
-    if (remainingChannel) {
+    if (!eligible) {
       return;
     }
   } catch (gwErr) {
@@ -311,7 +315,22 @@ export async function deleteContactIfOrphaned(
   }
 
   try {
-    gwDb.delete(gwContacts).where(eq(gwContacts.id, contactId)).run();
+    // Guarded delete: the WHERE re-checks every gateway orphan predicate in
+    // the same statement, so a channel attached (or a role/principal/
+    // threshold written) while the mirror probe was awaited keeps the
+    // contact instead of being cascade-deleted with it.
+    const deleted = gwDb
+      .delete(gwContacts)
+      .where(orphanPredicates)
+      .returning({ id: gwContacts.id })
+      .all();
+    if (deleted.length === 0) {
+      log.info(
+        { contactId },
+        "Keeping contact: stopped qualifying as an orphaned seed before the guarded delete",
+      );
+      return;
+    }
     log.info(
       { contactId },
       "Deleted orphaned seed contact after guardian channel claim",


### PR DESCRIPTION
## TL;DR

Step 2 of LUM-3490. An invite or verification bind that moves a `(type, address)` channel to its target contact now garbage-collects the stripped previous owner, the same way the guardian-binding claim already does. Before this, a seeded stub whose only channel was bound away by an invite lingered forever as a channel-less duplicate in the Contacts pane; the original LUM-2672 ticket flagged this exact path, but the GC was only ever wired at the guardian-binding call site.

Part of LUM-3490.

## Design

- `ContactStore.reassignChannelOwner` is the single re-parent primitive: ensures the target contact row exists, matches by the `(type, address)` logical key, and reports the stripped donor's contact id (null when nothing moved). `ContactStore.ensureContactRow` replaces the three hand-rolled `insert contacts onConflictDoNothing` copies in `verification/contact-helpers.ts`.
- The verified-channel mirror plan carries `orphanedDonorContactId`, and `mirrorVerifiedChannel` runs `deleteContactIfOrphaned` after the mirror re-parent lands. Because both executors of the plan (the verification relay / invite redemption via `upsertVerifiedContactChannel`, and the guardian-request decide `postCommit`) funnel through `mirrorVerifiedChannel`, the GC is structural: a future caller of the plan cannot forget it.
- Ordering honors the GC's documented contract: it runs only after gateway AND mirror re-parents have landed (the mirror probe vetoes while it still shows the pre-claim channel). A mirror IPC failure skips the GC, which is the veto-equivalent safe posture: the donor lingers until the next bind instead of being deleted while the stores disagree.
- The guardian-binding claim keeps its bespoke write (it combines re-parent, verified fields, and role/principal stamping in one guarded UPDATE inside its own transaction, with its own pinned protection ordering) and already performs the same post-mirror GC. Collapsing it into this primitive would be a refactor of the most security-sensitive bind path for symmetry, not correctness; deliberately not done here.

## What changes for the user

| Before | After |
| --- | --- |
| Redeeming an invite that bound an already-seen sender's channel to the invite's contact left the old auto-created entry in Contacts as an empty, unlinkable duplicate | The empty leftover is reclaimed automatically at bind time |
| The duplicate-cleanup guarantee existed only for the guardian's own channel claims | Every channel move on the invite/verification rail has it |

## Why this is safe

- Deletion stays deliberately narrow: `deleteContactIfOrphaned` is unchanged, so a donor keeps living if it has any remaining channel, a principal, a non-contact role, or guardian-authored data (notes, persona file, metadata) on the mirror.
- Real-DB regressions added in `invite-redemption-engine.test.ts`: a donor whose only channel moves is reclaimed; a donor with a second channel survives.
- The re-parent primitive only issues an UPDATE for a row it actually found under another owner; a bind with no gateway row behaves exactly as before (the verified write creates it). One mock-suite test was updated to model the gateway row it always claimed to be about.
- Full affected sweep green per-file (invite-redemption-engine 26, upsert-verified 38, guardian-request-decide, contact-handlers, verification-session-consume, discord upgrade/forward, inbound-contact-seed, guardian-binding-channel-reuse, contact-store suites, text-verification lane guard); both packages typecheck clean.

## Deferred (tracked in LUM-3490)

- Step 3: replace per-write `contacts_mirror_*` push ops with a pull reconciler (self-heals LUM-2709-class row drift); needs a mirror reader census first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41781" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->