### PR TITLE
PlanCard skeleton + reveal

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1539,6 +1539,17 @@ describe("PlanCard loading state", () => {
     expect(host.textContent).not.toContain("Loading plan");
   });
 
+  test("stacks the tile placeholders the way the resolved tiles stack", () => {
+    const host = renderLoadingCardDom();
+    const tiles = Array.from(
+      host.querySelectorAll('[data-slot="skeleton"]'),
+    ).slice(-2);
+    const row = tiles[0]?.parentElement;
+    expect(tiles[1]?.parentElement).toBe(row);
+    expect(row?.className).toContain("flex-col");
+    expect(row?.className).toContain("lg:flex-row");
+  });
+
   test("announces the placeholder region", () => {
     const status = renderLoadingCardDom().querySelector('[role="status"]');
     expect(status?.getAttribute("aria-label")).toBe("Loading plan");

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -338,11 +338,7 @@ function makeClient(
   return client;
 }
 
-function renderCard(
-  subscription: SubscriptionResponse,
-  plans: PlanListResponse,
-): string {
-  const client = makeClient(subscription, plans);
+function renderCardWith(client: QueryClient): string {
   return renderToStaticMarkup(
     // MemoryRouter supplies the router context PlanCard's useNavigate needs.
     <reactRouter.MemoryRouter>
@@ -351,6 +347,20 @@ function renderCard(
       </QueryClientProvider>
     </reactRouter.MemoryRouter>,
   );
+}
+
+function renderCard(
+  subscription: SubscriptionResponse,
+  plans: PlanListResponse,
+): string {
+  return renderCardWith(makeClient(subscription, plans));
+}
+
+/** Detached DOM node holding the given static markup. */
+function toDom(markup: string): HTMLElement {
+  const host = document.createElement("div");
+  host.innerHTML = markup;
+  return host;
 }
 
 /**
@@ -362,9 +372,15 @@ function renderCardDom(
   subscription: SubscriptionResponse,
   plans: PlanListResponse,
 ): HTMLElement {
-  const host = document.createElement("div");
-  host.innerHTML = renderCard(subscription, plans);
-  return host;
+  return toDom(renderCard(subscription, plans));
+}
+
+/**
+ * The card with both queries still pending: nothing is seeded into the cache
+ * and a static render never runs the effects that would start a fetch.
+ */
+function renderLoadingCardDom(): HTMLElement {
+  return toDom(renderCardWith(new QueryClient()));
 }
 
 /** The current-plan tile, which inherits the app theme. */
@@ -1510,5 +1526,27 @@ describe("PlanCard with obscure-credits on", () => {
     expect(
       within(currentTile(container)).getByTestId("plan-card-price").textContent,
     ).toBe("Free Forever");
+  });
+});
+
+describe("PlanCard loading state", () => {
+  test("keeps the card chrome and stands the layout in with shimmer", () => {
+    const host = renderLoadingCardDom();
+    expect(host.querySelector("h2")?.textContent).toBe("Plan");
+    // Plan name, renewal line, usage bar, and one per plan tile.
+    expect(host.querySelectorAll('[data-slot="skeleton"]').length).toBe(5);
+    expect(host.querySelectorAll(".animate-spin").length).toBe(0);
+    expect(host.textContent).not.toContain("Loading plan");
+  });
+
+  test("announces the placeholder region", () => {
+    const status = renderLoadingCardDom().querySelector('[role="status"]');
+    expect(status?.getAttribute("aria-label")).toBe("Loading plan");
+  });
+
+  test("drops the placeholders once the queries resolve", () => {
+    const host = renderCardDom(baseSubscription(), basePlansResponse());
+    expect(host.querySelectorAll('[data-slot="skeleton"]').length).toBe(0);
+    expect(host.querySelector('[data-testid="plan-card-name"]')).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -111,9 +111,12 @@ function PlanCardSkeleton() {
           <Skeleton aria-hidden className="h-4 w-56 rounded-md" />
         </div>
         <Skeleton aria-hidden className="h-3 w-full rounded-full" />
-        <div className="grid grid-cols-2 gap-4">
-          <Skeleton aria-hidden className="h-24 rounded-lg" />
-          <Skeleton aria-hidden className="h-24 rounded-lg" />
+        {/* Same container as the resolved tile row, so the placeholders stack
+            below `lg` exactly as the tiles do. The height is a real tile's:
+            tag, avatar row, three spec chips and a footer row. */}
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
+          <Skeleton aria-hidden className="h-84 rounded-xl lg:flex-1" />
+          <Skeleton aria-hidden className="h-84 rounded-xl lg:flex-1" />
         </div>
       </div>
     </Card>

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -54,9 +54,11 @@ import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Card } from "@vellumai/design-library/components/card";
 import { Notice } from "@vellumai/design-library/components/notice";
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 import { Tag } from "@vellumai/design-library/components/tag";
 import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
+import { ContentReveal } from "@/domains/settings/components/content-reveal";
 import {
   formatDollars,
   priceLabelFromCents,
@@ -86,6 +88,35 @@ function PlanHeading() {
     >
       {t("planCard.heading")}
     </Typography>
+  );
+}
+
+/**
+ * Stand-in for the resolved card: a plan-name row, the renewal line, the usage
+ * bar and the two plan tiles, so the card holds its height while the
+ * subscription and plan catalog land.
+ */
+function PlanCardSkeleton() {
+  const { t } = useTranslation("settings");
+  return (
+    <Card padding="md">
+      <PlanHeading />
+      <div
+        role="status"
+        aria-label={t("planCard.loadingAriaLabel")}
+        className="mt-4 flex flex-col gap-4"
+      >
+        <div className="flex flex-col gap-2">
+          <Skeleton aria-hidden className="h-6 w-40 rounded-md" />
+          <Skeleton aria-hidden className="h-4 w-56 rounded-md" />
+        </div>
+        <Skeleton aria-hidden className="h-3 w-full rounded-full" />
+        <div className="grid grid-cols-2 gap-4">
+          <Skeleton aria-hidden className="h-24 rounded-lg" />
+          <Skeleton aria-hidden className="h-24 rounded-lg" />
+        </div>
+      </div>
+    </Card>
   );
 }
 
@@ -389,17 +420,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
   });
 
   if (subscriptionQuery.isLoading || plansQuery.isLoading) {
-    return (
-      <Card padding="md">
-        <PlanHeading />
-        <div className="mt-4 flex items-center gap-2 text-[var(--content-tertiary)]">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <Typography as="span" variant="body-small-default">
-            {t("planCard.loading")}
-          </Typography>
-        </div>
-      </Card>
-    );
+    return <PlanCardSkeleton />;
   }
 
   const subscription = subscriptionQuery.data;
@@ -540,7 +561,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
 
   return (
     <Card padding="md">
-      <div className="flex flex-col gap-4">
+      <ContentReveal className="flex flex-col gap-4">
         <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 flex-col gap-1">
             <PlanHeading />
@@ -609,7 +630,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
             onTierUpgraded={onTierUpgraded}
           />
         </div>
-      </div>
+      </ContentReveal>
       <AddCreditsModal open={addCreditsOpen} onOpenChange={setAddCreditsOpen} />
     </Card>
   );

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1286,7 +1286,7 @@
     "freeForever": "Free Forever",
     "heading": "Plan",
     "loadError": "Failed to load plan.",
-    "loading": "Loading plan...",
+    "loadingAriaLabel": "Loading plan",
     "manageSubscription": "Manage Subscription",
     "nextPlan": "Next Plan",
     "powerUp": "Power Up",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1286,7 +1286,7 @@
     "freeForever": "Gratis para siempre",
     "heading": "Plan",
     "loadError": "No se pudo cargar el plan.",
-    "loading": "Cargando plan...",
+    "loadingAriaLabel": "Cargando plan",
     "manageSubscription": "Gestionar suscripción",
     "nextPlan": "Siguiente plan",
     "powerUp": "Potenciar",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1273,7 +1273,7 @@
     "freeForever": "Бесплатно навсегда",
     "heading": "План",
     "loadError": "Не удалось загрузить план.",
-    "loading": "Загрузка плана...",
+    "loadingAriaLabel": "Загрузка плана",
     "manageSubscription": "Управление подпиской",
     "nextPlan": "Следующий план",
     "powerUp": "Усилить",

--- a/clients/web/src/i18n/locales/zh-TW/settings.json
+++ b/clients/web/src/i18n/locales/zh-TW/settings.json
@@ -1286,7 +1286,7 @@
     "freeForever": "永久免費",
     "heading": "方案",
     "loadError": "載入方案失敗。",
-    "loading": "正在載入方案...",
+    "loadingAriaLabel": "正在載入方案",
     "manageSubscription": "管理訂閱",
     "nextPlan": "下一個方案",
     "powerUp": "升級",

--- a/clients/web/src/i18n/locales/zh/settings.json
+++ b/clients/web/src/i18n/locales/zh/settings.json
@@ -1286,7 +1286,7 @@
     "freeForever": "永久免费",
     "heading": "套餐",
     "loadError": "加载套餐失败。",
-    "loading": "正在加载套餐...",
+    "loadingAriaLabel": "正在加载套餐",
     "manageSubscription": "管理订阅",
     "nextPlan": "下一套餐",
     "powerUp": "升级",


### PR DESCRIPTION
## Summary
- PlanCard loading branch renders shimmer skeletons mirroring the resolved layout instead of a spinner row
- resolved content fades in via ContentReveal; aria-label keys in all five locales

Part of plan: billing-skeleton-loading.md (PR 2 of 7)