### PR TITLE
Billing tab shell: skeleton stack + pre-settle hold

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -558,7 +558,7 @@ describe("BillingTab lifecycle loading", () => {
       stack.querySelectorAll('[data-slot="skeleton"]').length,
     ).toBeGreaterThan(0);
     expect(stack.getAttribute("aria-label")).toBe("Loading billing\u2026");
-    // The old inline spinner row is gone, and so is its copy.
+    // The loading copy exists only as the aria-label above, never as visible text.
     expect(queryByText("Loading billing\u2026")).toBeNull();
     expect(queryByTestId("plan-card-tier-upgraded")).toBeNull();
     // The real tab chrome is already mounted here, so the lifecycle window

--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -15,7 +15,9 @@
  *
  * The same harness covers the two windows where the tab has nothing to show
  * yet, both of which render the skeleton stack: the assistant lifecycle still
- * resolving, and the platform-session probe not settled.
+ * resolving, and the platform-session probe not settled. The pre-settle hold
+ * renders that stack inside the settled page's own wrappers, so the tests
+ * check the chrome around it as well as the stack itself.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -559,6 +561,10 @@ describe("BillingTab lifecycle loading", () => {
     // The old inline spinner row is gone, and so is its copy.
     expect(queryByText("Loading billing\u2026")).toBeNull();
     expect(queryByTestId("plan-card-tier-upgraded")).toBeNull();
+    // The real tab chrome is already mounted here, so the lifecycle window
+    // never needs the page-level stand-in.
+    expect(queryByTestId("billing-page-skeleton")).toBeNull();
+    expect(stack.closest('[data-slot="tabs-panel"]')).toBeTruthy();
   });
 });
 
@@ -567,7 +573,23 @@ describe("BillingPage platform-session pre-settle hold", () => {
     platformSessionPending = true;
     const { getByTestId, queryByTestId } = renderPage("");
 
-    expect(getByTestId("billing-tab-skeleton")).toBeTruthy();
+    const stack = getByTestId("billing-tab-skeleton");
+    // The hold renders inside the same wrappers the settled page uses, so the
+    // tab bar and the panel padding are already holding their space: settling
+    // swaps content in place rather than pushing the cards down.
+    const shell = getByTestId("billing-page-skeleton");
+    expect(shell.className).toContain("space-y-6");
+    const tabList = shell.querySelector('[data-slot="tabs-list"]');
+    expect(tabList).toBeTruthy();
+    const panel = stack.closest('[data-slot="tabs-panel"]');
+    expect(panel).toBeTruthy();
+    expect(panel?.className).toContain("pt-4");
+    // The tab-bar stand-ins hold space only: they stay out of the
+    // accessibility tree, so the card stack is still the one announced region.
+    expect(tabList?.getAttribute("aria-hidden")).toBe("true");
+    const announced = shell.querySelectorAll('[role="status"][aria-label]');
+    expect(announced.length).toBe(1);
+    expect(announced[0]).toBe(stack);
     // The Usage tree would otherwise mount its own skeletons here, only to be
     // torn down once the probe lands on a Billing destination.
     expect(queryByTestId("usage-tab")).toBeNull();
@@ -582,6 +604,11 @@ describe("BillingPage platform-session pre-settle hold", () => {
 
     expect(getByTestId("billing-tab-skeleton")).toBeTruthy();
     expect(
+      getByTestId("billing-page-skeleton").querySelector(
+        '[data-slot="tabs-list"]',
+      ),
+    ).toBeTruthy();
+    expect(
       queryByText("Log in to the Vellum platform to manage billing and usage."),
     ).toBeNull();
   });
@@ -592,6 +619,7 @@ describe("BillingPage platform-session pre-settle hold", () => {
 
     expect(getByTestId("usage-tab")).toBeTruthy();
     expect(queryByTestId("billing-tab-skeleton")).toBeNull();
+    expect(queryByTestId("billing-page-skeleton")).toBeNull();
   });
 
   test("renders the billing tab once the session settles", async () => {
@@ -601,6 +629,7 @@ describe("BillingPage platform-session pre-settle hold", () => {
       expect(getByTestId("plan-card-tier-upgraded")).toBeTruthy(),
     );
     expect(queryByTestId("billing-tab-skeleton")).toBeNull();
+    expect(queryByTestId("billing-page-skeleton")).toBeNull();
     expect(getByTestId("loc").textContent).toBe(
       "/assistant/settings/usage?tab=billing",
     );

--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -12,6 +12,10 @@
  * mutable responses, force the platform-hosted gate open, and stub the heavy
  * billing children so the page wiring under test is the only moving part. The
  * onboarding modal stub reports its `open` prop via a data attribute.
+ *
+ * The same harness covers the two windows where the tab has nothing to show
+ * yet, both of which render the skeleton stack: the assistant lifecycle still
+ * resolving, and the platform-session probe not settled.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -49,6 +53,12 @@ let domainsListPaths: string[] = [];
 // login where the org store hasn't hydrated yet.
 let orgReady = true;
 let nativeAndroid = false;
+// Drives the active assistant's lifecycle window (hatching / cleaning up),
+// where the billing tab has nothing to render yet.
+let lifecycleIsLoading = false;
+// Drives the platform-session pre-settle window: the gate reports "pending",
+// `usePlatformGate` collapses it to "disabled", and nothing is settled yet.
+let platformSessionPending = false;
 
 const ACTIVE_ASSISTANT = { id: "assistant-1" } as unknown as Assistant;
 
@@ -87,12 +97,19 @@ let activeAssistantIsPlatformHosted = true;
 
 mock.module("@/hooks/use-platform-gate", () => ({
   ...platformGate,
-  usePlatformGate: (options?: { platformHostedOnly?: boolean }) =>
-    options?.platformHostedOnly === true && !activeAssistantIsPlatformHosted
-      ? "gated"
-      : "full",
+  usePlatformGate: (options?: { platformHostedOnly?: boolean }) => {
+    if (
+      options?.platformHostedOnly === true &&
+      !activeAssistantIsPlatformHosted
+    ) {
+      return "gated";
+    }
+    return platformSessionPending ? "disabled" : "full";
+  },
+  usePlatformGateWithPending: () =>
+    platformSessionPending ? "pending" : "full",
   useActiveAssistantIsPlatformHosted: () => activeAssistantIsPlatformHosted,
-  useActiveAssistantLifecycleIsLoading: () => false,
+  useActiveAssistantLifecycleIsLoading: () => lifecycleIsLoading,
 }));
 
 // The Usage tab reads the active assistant, which normally comes from the
@@ -104,7 +121,7 @@ mock.module("@/assistant/use-active-assistant-id", () => ({
 
 mock.module("@/stores/auth-store", () => ({
   ...authStore,
-  useIsPlatformSessionSettled: () => true,
+  useIsPlatformSessionSettled: () => !platformSessionPending,
 }));
 
 mock.module("@/hooks/use-is-org-ready", () => ({
@@ -136,7 +153,7 @@ mock.module(
   }),
 );
 mock.module("@/domains/settings/billing/usage/usage-tab", () => ({
-  UsageTab: () => null,
+  UsageTab: () => <div data-testid="usage-tab" />,
 }));
 mock.module("@/domains/settings/components/adjust-plan-modal", () => ({
   AdjustPlanModal: () => null,
@@ -262,6 +279,8 @@ beforeEach(() => {
   domainsListPaths = [];
   orgReady = true;
   nativeAndroid = false;
+  lifecycleIsLoading = false;
+  platformSessionPending = false;
   activeAssistantIsPlatformHosted = true;
   setupIntentReturnUnmounts = 0;
 });
@@ -277,9 +296,7 @@ describe("BillingTab on native Android", () => {
 
     expect(getByTestId("plan-card-tier-upgraded")).toBeTruthy();
     expect(getByTestId("onboarding-modal")).toBeTruthy();
-    expect(
-      queryByText("Manage your subscription on our website."),
-    ).toBeNull();
+    expect(queryByText("Manage your subscription on our website.")).toBeNull();
   });
 });
 
@@ -526,5 +543,66 @@ describe("BillingPage Stripe redirect return", () => {
       }
     });
     expect(setupIntentReturnUnmounts).toBe(0);
+  });
+});
+
+describe("BillingTab lifecycle loading", () => {
+  test("renders the skeleton stack instead of a spinner row", () => {
+    lifecycleIsLoading = true;
+    const { getByTestId, queryByTestId, queryByText } = renderPage();
+
+    const stack = getByTestId("billing-tab-skeleton");
+    expect(
+      stack.querySelectorAll('[data-slot="skeleton"]').length,
+    ).toBeGreaterThan(0);
+    expect(stack.getAttribute("aria-label")).toBe("Loading billing\u2026");
+    // The old inline spinner row is gone, and so is its copy.
+    expect(queryByText("Loading billing\u2026")).toBeNull();
+    expect(queryByTestId("plan-card-tier-upgraded")).toBeNull();
+  });
+});
+
+describe("BillingPage platform-session pre-settle hold", () => {
+  test("holds the skeleton stack rather than flashing the Usage tab", () => {
+    platformSessionPending = true;
+    const { getByTestId, queryByTestId } = renderPage("");
+
+    expect(getByTestId("billing-tab-skeleton")).toBeTruthy();
+    // The Usage tree would otherwise mount its own skeletons here, only to be
+    // torn down once the probe lands on a Billing destination.
+    expect(queryByTestId("usage-tab")).toBeNull();
+    expect(queryByTestId("plan-card-tier-upgraded")).toBeNull();
+    // Nothing settles the tab into the URL while the hold is up.
+    expect(getByTestId("loc").textContent).toBe("/assistant/settings/usage");
+  });
+
+  test("holds on a billing deeplink instead of flashing the login notice", () => {
+    platformSessionPending = true;
+    const { getByTestId, queryByText } = renderPage();
+
+    expect(getByTestId("billing-tab-skeleton")).toBeTruthy();
+    expect(
+      queryByText("Log in to the Vellum platform to manage billing and usage."),
+    ).toBeNull();
+  });
+
+  test("mounts Usage right away when the URL asks for it", () => {
+    platformSessionPending = true;
+    const { getByTestId, queryByTestId } = renderPage("?tab=usage");
+
+    expect(getByTestId("usage-tab")).toBeTruthy();
+    expect(queryByTestId("billing-tab-skeleton")).toBeNull();
+  });
+
+  test("renders the billing tab once the session settles", async () => {
+    const { getByTestId, queryByTestId } = renderPage("");
+
+    await waitFor(() =>
+      expect(getByTestId("plan-card-tier-upgraded")).toBeTruthy(),
+    );
+    expect(queryByTestId("billing-tab-skeleton")).toBeNull();
+    expect(getByTestId("loc").textContent).toBe(
+      "/assistant/settings/usage?tab=billing",
+    );
   });
 });

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -1,5 +1,4 @@
-import { Loader2 } from "lucide-react";
-import { Suspense, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useLocation, useNavigate, useSearchParams } from "react-router";
 
@@ -21,6 +20,7 @@ import { GracePeriodBanner } from "@/domains/settings/components/grace-period-ba
 import { InvoicesTable } from "@/domains/settings/components/invoices-table";
 import { PaymentMethodsCard } from "@/domains/settings/components/payment-methods-card";
 import { PlanCard } from "@/domains/settings/components/plan-card";
+import { SkeletonCardBlock } from "@/domains/settings/components/skeleton-card-block";
 import { useSetupIntentReturn } from "@/domains/settings/hooks/use-setup-intent-return";
 import { replaceSearchParams } from "@/domains/settings/utils/replace-search-params";
 import { useAssistantDomains } from "@/domains/settings/billing/pro-onboarding/use-assistant-domains";
@@ -35,6 +35,7 @@ import {
   useActiveAssistantIsPlatformHosted,
   useActiveAssistantLifecycleIsLoading,
   usePlatformGate,
+  usePlatformGateWithPending,
 } from "@/hooks/use-platform-gate";
 import { useIsPlatformSessionSettled } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
@@ -147,6 +148,28 @@ function FinishProSetupNotice({
   );
 }
 
+/**
+ * Stand-in for the whole Billing tab while it cannot render yet: three blocks
+ * for the plan, payment-method, and credits cards, so the swap to real content
+ * does not jump. Only the stack is labeled, so a screen reader hears one
+ * announcement rather than one per block.
+ */
+function BillingTabSkeleton() {
+  const { t } = useTranslation("settings");
+  return (
+    <div
+      role="status"
+      aria-label={t("billingPage.loadingBillingAriaLabel")}
+      className="space-y-4"
+      data-testid="billing-tab-skeleton"
+    >
+      <SkeletonCardBlock />
+      <SkeletonCardBlock />
+      <SkeletonCardBlock />
+    </div>
+  );
+}
+
 function BillingTabContent() {
   const { t } = useTranslation("settings");
   const platformGate = usePlatformGate({ platformHostedOnly: true });
@@ -250,14 +273,7 @@ function BillingTabContent() {
   }
 
   if (isLifecycleLoading) {
-    return (
-      <div className="space-y-4">
-        <div className="flex items-center gap-2 py-6 text-body-medium-lighter text-[var(--content-secondary)]">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          {t("billingPage.loadingBilling")}
-        </div>
-      </div>
-    );
+    return <BillingTabSkeleton />;
   }
 
   const showPlanManagement = isPlatformHosted;
@@ -275,19 +291,15 @@ function BillingTabContent() {
   if (!isPlatformHosted && platformGate !== "gated") {
     return (
       <div className="space-y-4">
-        <Notice tone="warning">
-          {t("billingPage.billingUnavailable")}
-        </Notice>
+        <Notice tone="warning">{t("billingPage.billingUnavailable")}</Notice>
       </div>
     );
   }
 
   return (
     <div className="space-y-4">
-      <Suspense fallback={null}>
-        <BillingStatusHandler onCheckoutCancelled={onCheckoutCancelled} />
-        <BillingPortalReturnHandler />
-      </Suspense>
+      <BillingStatusHandler onCheckoutCancelled={onCheckoutCancelled} />
+      <BillingPortalReturnHandler />
       {showPlanManagement && <GracePeriodBanner />}
       {showPlanManagement && (
         <FinishProSetupNotice onFinishSetup={openProOnboarding} />
@@ -307,15 +319,9 @@ function BillingTabContent() {
         onOpenChange={onBonusOpenChange}
         amountUsd={amountUsd}
       />
-      <Suspense fallback={null}>
-        <PaymentMethodsCard />
-      </Suspense>
-      <Suspense fallback={null}>
-        <BillingPanel />
-      </Suspense>
-      <Suspense fallback={null}>
-        <InvoicesTable />
-      </Suspense>
+      <PaymentMethodsCard />
+      <BillingPanel />
+      <InvoicesTable />
       {showProOnboarding && (
         <BillingOnboardingModal
           open={hasSessionId || proOnboardingOpen}
@@ -354,6 +360,9 @@ function UsagePanel() {
 export function BillingPage() {
   const { t } = useTranslation("settings");
   const billingGate = usePlatformGate();
+  // The same gate with the pre-settle window kept distinct, for the hold
+  // below. Every other branch here reads that window as `"disabled"`.
+  const platformSessionPending = usePlatformGateWithPending() === "pending";
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const location = useLocation();
@@ -373,8 +382,15 @@ export function BillingPage() {
   // When Billing is available it leads the tab list and is the default;
   // Usage is reached via `?tab=usage`. With no Billing tab, Usage is all
   // there is.
-  const activeTab =
-    showBillingTab && searchParams.get("tab") !== "usage" ? "billing" : "usage";
+  const wantsUsageTab = searchParams.get("tab") === "usage";
+  const activeTab = showBillingTab && !wantsUsageTab ? "billing" : "usage";
+
+  // Hold the tab decision through the pre-settle window unless the URL asks
+  // for Usage: no session has resolved yet, so `activeTab` falls to "usage"
+  // and a viewer heading for Billing would watch the Usage tree mount its own
+  // skeletons and then get torn down when the probe lands. The gate bounds
+  // its own pending state, so this cannot hold forever.
+  const holdForPlatformSession = platformSessionPending && !wantsUsageTab;
 
   // Keep the active tab explicit in the URL so both tabs are symmetric and
   // the address bar always names what's shown: a bare `/settings/usage` — or
@@ -400,6 +416,10 @@ export function BillingPage() {
   const handleTabChange = (value: string) => {
     replaceSearchParams(navigate, location, (next) => next.set("tab", value));
   };
+
+  if (holdForPlatformSession) {
+    return <BillingTabSkeleton />;
+  }
 
   return (
     <div className="space-y-6">

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -41,6 +41,7 @@ import { useIsPlatformSessionSettled } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 import { Tabs } from "@vellumai/design-library/components/tabs";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -166,6 +167,39 @@ function BillingTabSkeleton() {
       <SkeletonCardBlock />
       <SkeletonCardBlock />
       <SkeletonCardBlock />
+    </div>
+  );
+}
+
+/**
+ * Stand-in for the whole page while the platform-session probe is still
+ * pending. It reuses the settled render's wrappers exactly: the `space-y-6`
+ * shell, a `Tabs.List` built from the real trigger parts so the bar's height
+ * matches to the pixel, and the panel's `pt-4` around the card stack. Settling
+ * therefore swaps content in place instead of mounting chrome above the cards.
+ *
+ * The triggers stand in for labels the probe has not decided on yet, so they
+ * are disabled and hidden from the accessibility tree; the card stack inside
+ * carries the loading announcement.
+ */
+function BillingPageSkeleton() {
+  return (
+    <div className="space-y-6" data-testid="billing-page-skeleton">
+      <Tabs.Root value="billing">
+        <Tabs.List aria-hidden>
+          <Tabs.Trigger value="billing" disabled>
+            {/* Matches the trigger's 18px line box, so the placeholder bar is
+                exactly as tall as one holding a real label. */}
+            <Skeleton className="h-[18px] w-12 rounded-md" />
+          </Tabs.Trigger>
+          <Tabs.Trigger value="usage" disabled>
+            <Skeleton className="h-[18px] w-12 rounded-md" />
+          </Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Panel value="billing" className="pt-4">
+          <BillingTabSkeleton />
+        </Tabs.Panel>
+      </Tabs.Root>
     </div>
   );
 }
@@ -418,7 +452,7 @@ export function BillingPage() {
   };
 
   if (holdForPlatformSession) {
-    return <BillingTabSkeleton />;
+    return <BillingPageSkeleton />;
   }
 
   return (

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -308,7 +308,7 @@
     "finishSetupBody": "Your assistant's email address hasn't been set up yet.",
     "finishSetupButton": "Finish setup",
     "finishSetupTitle": "Finish setting up your {plan} plan",
-    "loadingBilling": "Loading billing…",
+    "loadingBillingAriaLabel": "Loading billing…",
     "platformLoginNotice": "Log in to the Vellum platform to manage billing and usage.",
     "usageTab": "Usage"
   },

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -308,7 +308,7 @@
     "finishSetupBody": "La dirección de correo de tu asistente aún no se ha configurado.",
     "finishSetupButton": "Finalizar configuración",
     "finishSetupTitle": "Termina de configurar tu plan {plan}",
-    "loadingBilling": "Cargando facturación…",
+    "loadingBillingAriaLabel": "Cargando facturación…",
     "platformLoginNotice": "Inicia sesión en la plataforma Vellum para administrar la facturación y el uso.",
     "usageTab": "Uso"
   },

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -296,7 +296,7 @@
     "finishSetupBody": "Почта ассистента ещё не настроена.",
     "finishSetupButton": "Завершить настройку",
     "finishSetupTitle": "Завершение настройки плана {plan}",
-    "loadingBilling": "Загрузка оплаты…",
+    "loadingBillingAriaLabel": "Загрузка оплаты…",
     "platformLoginNotice": "Вход на платформу Vellum для управления оплатой и использованием.",
     "usageTab": "Использование"
   },

--- a/clients/web/src/i18n/locales/zh-TW/settings.json
+++ b/clients/web/src/i18n/locales/zh-TW/settings.json
@@ -308,7 +308,7 @@
     "finishSetupBody": "您的助理電子郵件地址尚未設定。",
     "finishSetupButton": "完成設定",
     "finishSetupTitle": "完成 {plan} 方案的設定",
-    "loadingBilling": "載入帳單中…",
+    "loadingBillingAriaLabel": "載入帳單中…",
     "platformLoginNotice": "登入 Vellum 平台以管理帳單和用量。",
     "usageTab": "用量"
   },

--- a/clients/web/src/i18n/locales/zh/settings.json
+++ b/clients/web/src/i18n/locales/zh/settings.json
@@ -308,7 +308,7 @@
     "finishSetupBody": "您的助手电子邮件地址尚未设置。",
     "finishSetupButton": "完成设置",
     "finishSetupTitle": "完成 {plan} 套餐的设置",
-    "loadingBilling": "加载账单中…",
+    "loadingBillingAriaLabel": "加载账单中…",
     "platformLoginNotice": "登录 Vellum 平台以管理账单和用量。",
     "usageTab": "用量"
   },


### PR DESCRIPTION
## Summary
- lifecycle loading and the pre-settle window render one continuous skeleton card stack
- the Usage tab's bones no longer flash when navigating to Billing; explicit ?tab=usage unchanged
- removed four no-op Suspense wrappers

Part of plan: billing-skeleton-loading.md (PR 5 of 7)