### PR TITLE
fix(telemetry): deliver client_* perf events via the daemon relay, one event per boot

### DIFF
--- a/clients/web/src/lib/api-interceptors.test.ts
+++ b/clients/web/src/lib/api-interceptors.test.ts
@@ -789,6 +789,36 @@ describe("api-interceptors / self-hosted contact-family flattening", () => {
     }
   });
 
+  test("keepalive survives the rewrite, so a pagehide-time send is not cancelled", async () => {
+    setSelfHostedConnection({ url: INGRESS, token: ACTOR_TOKEN });
+    // Bun's Request neither stores nor re-exposes `keepalive`, so the flag is
+    // stamped onto the input and the assertion intercepts the init the
+    // rewrite hands the constructor, instead of reading the property back.
+    const input = new Request(
+      `https://platform.test/v1/assistants/${SELF_HOSTED_ID}/telemetry/ingest`,
+      { method: "POST", body: "{}" },
+    );
+    Object.defineProperty(input, "keepalive", { value: true });
+
+    const OriginalRequest = globalThis.Request;
+    let rebuiltInit: RequestInit | undefined;
+    globalThis.Request = class extends OriginalRequest {
+      constructor(info: RequestInfo | URL, init?: RequestInit) {
+        super(info, init);
+        rebuiltInit = init;
+      }
+    } as typeof Request;
+    try {
+      const output = await rewriteForSelfHostedIngress(input, {
+        skipSegmentAllowlist: true,
+      });
+      expect(output).not.toBeNull();
+      expect(rebuiltInit?.keepalive).toBe(true);
+    } finally {
+      globalThis.Request = OriginalRequest;
+    }
+  });
+
   test("no ingress registered — rewrite returns null and the request is untouched", async () => {
     const scopedPath = `/v1/assistants/${SELF_HOSTED_ID}/contacts`;
     const input = new Request(`https://platform.test${scopedPath}`, {

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -290,6 +290,9 @@ export async function rewriteForSelfHostedIngress(
     credentials: "omit",
     redirect: request.redirect,
     signal: request.signal,
+    // A rebuilt Request does not inherit this from `request`, and dropping it
+    // cancels pagehide-time sends (the boot telemetry flush) mid-navigation.
+    keepalive: request.keepalive,
   };
   if (!isLocalClient() && request.body) {
     (init as RequestInit & { duplex: "half" }).duplex = "half";

--- a/clients/web/src/lib/telemetry/boot-telemetry.test.ts
+++ b/clients/web/src/lib/telemetry/boot-telemetry.test.ts
@@ -2,10 +2,26 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { publish } from "@/lib/event-bus";
 
-const postTelemetryEvents = mock(() => {});
+interface SentEvent {
+  checkName: string;
+  value: number | null;
+  detail: Record<string, unknown>;
+  daemonEventId?: string;
+}
+
+const sendClientWatchdogEvent = mock((_event: SentEvent) => {});
+const setClientPerfBootId = mock((_id: string) => {});
 let consent = true;
 
-mock.module("@/lib/telemetry/ingest", () => ({ postTelemetryEvents }));
+// A complete factory rather than a spread of the actual module: the real
+// `client-perf.ts` is the transport layer, and importing it here would drag
+// the daemon SDK client graph into a test that never sends anything.
+mock.module("@/lib/telemetry/client-perf", () => ({
+  sendClientWatchdogEvent,
+  setClientPerfBootId,
+  emitClientPerfEvent: mock(() => {}),
+  __resetClientPerfForTests: mock(() => {}),
+}));
 mock.module("@/lib/telemetry/consent", () => ({
   readAnalyticsConsent: () => consent,
 }));
@@ -20,21 +36,28 @@ const {
   TERMINAL_FLUSH_GRACE_MS,
 } = await import("@/lib/telemetry/boot-telemetry");
 
-/** The events from the most recent flush. */
-function lastBatch(): Array<Record<string, unknown>> {
-  const call = postTelemetryEvents.mock.calls.at(-1) as
-    | [Array<Record<string, unknown>>]
-    | undefined;
-  return call?.[0] ?? [];
+function lastSent(): SentEvent {
+  const call = sendClientWatchdogEvent.mock.calls.at(-1);
+  expect(call).toBeDefined();
+  return call![0];
 }
 
-function checkNames(): string[] {
-  return lastBatch().map((event) => String(event.check_name));
+/** The single `client_boot` event from the most recent flush. */
+function bootEvent(): SentEvent {
+  const event = lastSent();
+  expect(event.checkName).toBe("client_boot");
+  return event;
+}
+
+/** The per-mark duration map inside the boot event's detail. */
+function bootMarks(): Record<string, number> {
+  return bootEvent().detail.marks as Record<string, number>;
 }
 
 beforeEach(() => {
   __resetBootTelemetryForTests();
-  postTelemetryEvents.mockClear();
+  sendClientWatchdogEvent.mockClear();
+  setClientPerfBootId.mockClear();
   consent = true;
 });
 
@@ -68,25 +91,25 @@ describe("bootRouteLabel", () => {
 });
 
 describe("markBoot", () => {
-  test("buffers marks and emits one watchdog event per mark on flush", () => {
+  test("buffers marks and flushes ONE event carrying the whole waterfall", () => {
     startBootTelemetry();
     markBoot("safe_area_ready", { value: 100 });
     markBoot("session_ready", { value: 250 });
     markBoot("react_mount", { value: 300 });
 
-    expect(postTelemetryEvents).not.toHaveBeenCalled();
+    expect(sendClientWatchdogEvent).not.toHaveBeenCalled();
 
     flushBootTelemetry();
 
-    const batch = lastBatch();
-    expect(batch).toHaveLength(3);
-    expect(checkNames()).toEqual([
-      "client_boot.safe_area_ready",
-      "client_boot.session_ready",
-      "client_boot.react_mount",
-    ]);
-    expect(batch.map((e) => e.value)).toEqual([100, 250, 300]);
-    expect(batch.every((e) => e.type === "watchdog")).toBe(true);
+    expect(sendClientWatchdogEvent).toHaveBeenCalledTimes(1);
+    expect(bootMarks()).toMatchObject({
+      safe_area_ready: 100,
+      session_ready: 250,
+      react_mount: 300,
+    });
+    // No terminal mark landed, so the boot has no scalar and no outcome.
+    expect(bootEvent().value).toBeNull();
+    expect(bootEvent().detail.outcome).toBeNull();
   });
 
   test("first write wins, so a later navigation cannot overwrite a cold mark", () => {
@@ -95,10 +118,7 @@ describe("markBoot", () => {
     markBoot("transcript_painted", { value: 9_000 });
     flushBootTelemetry();
 
-    const painted = lastBatch().find(
-      (e) => e.check_name === "client_boot.transcript_painted",
-    );
-    expect(painted?.value).toBe(500);
+    expect(bootMarks().transcript_painted).toBe(500);
   });
 
   test("a terminal mark does not flush synchronously, it arms a grace window", async () => {
@@ -110,15 +130,14 @@ describe("markBoot", () => {
     markBoot("transcript_painted", { value: 700 });
     markBoot("chat_interactive", { value: 800 });
 
-    expect(postTelemetryEvents).not.toHaveBeenCalled();
+    expect(sendClientWatchdogEvent).not.toHaveBeenCalled();
 
-    // A late vital still makes the same batch.
+    // A late vital still makes the same waterfall.
     markBoot("fcp", { value: 2_396 });
     await Bun.sleep(TERMINAL_FLUSH_GRACE_MS + 250);
 
-    expect(postTelemetryEvents).toHaveBeenCalledTimes(1);
-    expect(checkNames()).toContain("client_boot.chat_interactive");
-    expect(checkNames()).toContain("client_boot.fcp");
+    expect(sendClientWatchdogEvent).toHaveBeenCalledTimes(1);
+    expect(bootMarks()).toMatchObject({ chat_interactive: 800, fcp: 2_396 });
   });
 
   test("a slow history fetch is waited for, not flushed past", async () => {
@@ -130,15 +149,17 @@ describe("markBoot", () => {
     markBoot("chat_interactive", { value: 800 });
 
     await Bun.sleep(TERMINAL_FLUSH_GRACE_MS + 250);
-    expect(postTelemetryEvents).not.toHaveBeenCalled();
+    expect(sendClientWatchdogEvent).not.toHaveBeenCalled();
 
     // History finally resolves well after the grace window would have closed.
     markBoot("transcript_painted", { value: 9_000 });
     await Bun.sleep(TERMINAL_FLUSH_GRACE_MS + 250);
 
-    expect(postTelemetryEvents).toHaveBeenCalledTimes(1);
-    expect(checkNames()).toContain("client_boot.transcript_painted");
-    expect(checkNames()).toContain("client_boot.chat_interactive");
+    expect(sendClientWatchdogEvent).toHaveBeenCalledTimes(1);
+    expect(bootMarks()).toMatchObject({
+      chat_interactive: 800,
+      transcript_painted: 9_000,
+    });
     // Two grace windows of real time; well inside the 20s boot deadline.
   }, 15_000);
 
@@ -149,22 +170,20 @@ describe("markBoot", () => {
     markBoot("chat_interactive", { value: 800 });
     flushBootTelemetry("deadline");
 
-    expect(checkNames()).toContain("client_boot.chat_interactive");
-    expect(
-      (lastBatch()[0]?.detail as Record<string, unknown>).flush_trigger,
-    ).toBe("deadline");
+    expect(bootMarks()).toMatchObject({ chat_interactive: 800 });
+    expect(bootEvent().detail.flush_trigger).toBe("deadline");
   });
 
   test("the flush latch closes the family, so nothing is double-sent", () => {
     startBootTelemetry();
     markBoot("chat_interactive", { value: 800 });
     flushBootTelemetry();
-    expect(postTelemetryEvents).toHaveBeenCalledTimes(1);
+    expect(sendClientWatchdogEvent).toHaveBeenCalledTimes(1);
 
     markBoot("transcript_painted", { value: 900 });
     flushBootTelemetry();
 
-    expect(postTelemetryEvents).toHaveBeenCalledTimes(1);
+    expect(sendClientWatchdogEvent).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -193,13 +212,11 @@ describe("navigation timing", () => {
       nav.loadEventEnd = 81;
       flushBootTelemetry();
 
-      const batch = lastBatch();
-      const byName = new Map(
-        batch.map((e) => [String(e.check_name), e.value as number]),
-      );
-      expect(byName.get("client_boot.ttfb")).toBe(6);
-      expect(byName.get("client_boot.dom_content_loaded")).toBe(79);
-      expect(byName.get("client_boot.load_event_end")).toBe(81);
+      expect(bootMarks()).toMatchObject({
+        ttfb: 6,
+        dom_content_loaded: 79,
+        load_event_end: 81,
+      });
     } finally {
       performance.getEntriesByType = original;
     }
@@ -224,7 +241,7 @@ describe("navigation timing", () => {
       markBoot("react_mount", { value: 300 });
       flushBootTelemetry();
 
-      expect(checkNames()).toEqual(["client_boot.react_mount"]);
+      expect(Object.keys(bootMarks())).toEqual(["react_mount"]);
     } finally {
       performance.getEntriesByType = original;
     }
@@ -232,36 +249,28 @@ describe("navigation timing", () => {
 });
 
 describe("units", () => {
-  test("a CLS score survives rounding, and durations stay whole ms", () => {
+  test("the CLS score keeps decimals in its own field, apart from the ms marks", () => {
     // Rounding a score to the nearest integer destroys it: a normal CLS of
     // 0.05 becomes 0 and the whole series reads as "no layout shift anywhere".
+    // Keeping it out of the duration map means nobody can average ms with a
+    // score by iterating `marks`.
     startBootTelemetry();
     markBoot("cls", { value: 0.0523 });
     markBoot("react_mount", { value: 300.7 });
     flushBootTelemetry();
 
-    const byName = new Map(
-      lastBatch().map((e) => [String(e.check_name), e.value as number]),
-    );
-    expect(byName.get("client_boot.cls")).toBe(0.052);
-    expect(byName.get("client_boot.cls")).not.toBe(0);
-    expect(byName.get("client_boot.react_mount")).toBe(301);
+    expect(bootEvent().detail.cls).toBe(0.052);
+    expect(bootEvent().detail.cls).not.toBe(0);
+    expect(bootMarks().react_mount).toBe(301);
+    expect(bootMarks()).not.toHaveProperty("cls");
   });
 
-  test("every event declares its unit so ms and score never get averaged together", () => {
+  test("cls is null, not absent or zero, when the engine never reported one", () => {
     startBootTelemetry();
-    markBoot("cls", { value: 0.05 });
-    markBoot("fcp", { value: 1_200 });
+    markBoot("react_mount", { value: 300 });
     flushBootTelemetry();
 
-    const byName = new Map(
-      lastBatch().map((e) => [
-        String(e.check_name),
-        (e.detail as Record<string, unknown>).unit,
-      ]),
-    );
-    expect(byName.get("client_boot.cls")).toBe("score");
-    expect(byName.get("client_boot.fcp")).toBe("ms");
+    expect(bootEvent().detail.cls).toBeNull();
   });
 });
 
@@ -275,12 +284,8 @@ describe("terminal exclusivity", () => {
     markBoot("chat_interactive", { value: 900 });
     flushBootTelemetry();
 
-    const terminals = checkNames().filter(
-      (n) =>
-        n === "client_boot.chat_blocked" ||
-        n === "client_boot.chat_interactive",
-    );
-    expect(terminals).toEqual(["client_boot.chat_blocked"]);
+    expect(bootEvent().detail.outcome).toBe("blocked");
+    expect(bootMarks()).not.toHaveProperty("chat_interactive");
   });
 
   test("holds in the other order too", () => {
@@ -289,12 +294,10 @@ describe("terminal exclusivity", () => {
     markBootBlocked("stuck_connecting");
     flushBootTelemetry();
 
-    const terminals = checkNames().filter(
-      (n) =>
-        n === "client_boot.chat_blocked" ||
-        n === "client_boot.chat_interactive",
-    );
-    expect(terminals).toEqual(["client_boot.chat_interactive"]);
+    expect(bootEvent().detail.outcome).toBe("interactive");
+    expect(bootEvent().value).toBe(900);
+    expect(bootEvent().detail.blocked_reason).toBeNull();
+    expect(bootMarks()).not.toHaveProperty("chat_blocked");
   });
 });
 
@@ -304,19 +307,15 @@ describe("flush trigger", () => {
     markBoot("react_mount", { value: 300 });
     flushBootTelemetry("pagehide");
 
-    expect(
-      (lastBatch()[0]?.detail as Record<string, unknown>).flush_trigger,
-    ).toBe("pagehide");
+    expect(bootEvent().detail.flush_trigger).toBe("pagehide");
 
     __resetBootTelemetryForTests();
-    postTelemetryEvents.mockClear();
+    sendClientWatchdogEvent.mockClear();
     startBootTelemetry();
     markBoot("react_mount", { value: 300 });
     flushBootTelemetry("deadline");
 
-    expect(
-      (lastBatch()[0]?.detail as Record<string, unknown>).flush_trigger,
-    ).toBe("deadline");
+    expect(bootEvent().detail.flush_trigger).toBe("deadline");
   });
 });
 
@@ -331,15 +330,15 @@ describe("resume", () => {
     publish("app.resume", { signal: "app_state" });
     publish("sse.opened", { assistantId: "a", cause: "resume" });
 
-    expect(postTelemetryEvents).toHaveBeenCalledTimes(1);
-    expect(checkNames()).toEqual(["client_resume.to_sse_open"]);
+    expect(sendClientWatchdogEvent).toHaveBeenCalledTimes(1);
+    expect(lastSent().checkName).toBe("client_resume.to_sse_open");
 
     // A resume with no reopen: nothing is emitted, ever.
-    postTelemetryEvents.mockClear();
+    sendClientWatchdogEvent.mockClear();
     publish("app.resume", { signal: "online" });
     await Bun.sleep(200);
 
-    expect(postTelemetryEvents).not.toHaveBeenCalled();
+    expect(sendClientWatchdogEvent).not.toHaveBeenCalled();
   });
 
   test("away_ms is null when no background preceded the resume", () => {
@@ -349,17 +348,13 @@ describe("resume", () => {
     publish("app.hidden", { signal: "app_state" });
     publish("app.resume", { signal: "app_state" });
     publish("sse.opened", { assistantId: "a", cause: "resume" });
-    expect(
-      (lastBatch()[0]?.detail as Record<string, unknown>).away_ms,
-    ).not.toBeNull();
+    expect(lastSent().detail.away_ms).not.toBeNull();
 
-    postTelemetryEvents.mockClear();
+    sendClientWatchdogEvent.mockClear();
     publish("app.resume", { signal: "online" });
     publish("sse.opened", { assistantId: "a", cause: "error" });
 
-    expect(
-      (lastBatch()[0]?.detail as Record<string, unknown>).away_ms,
-    ).toBeNull();
+    expect(lastSent().detail.away_ms).toBeNull();
   });
 
   test("a second hide during a pending resume cannot corrupt away_ms", async () => {
@@ -376,13 +371,26 @@ describe("resume", () => {
     await Bun.sleep(20);
     publish("sse.opened", { assistantId: "a", cause: "resume" });
 
-    const away = (lastBatch()[0]?.detail as Record<string, unknown>)
-      .away_ms as number;
-    expect(checkNames()).toEqual(["client_resume.to_sse_open"]);
+    expect(lastSent().checkName).toBe("client_resume.to_sse_open");
+    const away = lastSent().detail.away_ms as number;
     expect(away).toBeGreaterThanOrEqual(0);
     // Measured against the hide that actually preceded this resume, so it is
     // bounded by the gap between them, not by the whole elapsed window.
     expect(away).toBeLessThan(200);
+  });
+
+  test("shares the boot's id so the two families stitch together", () => {
+    startBootTelemetry();
+    markBoot("react_mount", { value: 300 });
+    flushBootTelemetry();
+    const bootId = bootEvent().detail.boot_id;
+    expect(typeof bootId).toBe("string");
+
+    publish("app.hidden", { signal: "app_state" });
+    publish("app.resume", { signal: "app_state" });
+    publish("sse.opened", { assistantId: "a", cause: "resume" });
+
+    expect(lastSent().detail.boot_id).toBe(bootId);
   });
 });
 
@@ -400,7 +408,7 @@ describe("registration lifetime", () => {
     publish("app.resume", { signal: "app_state" });
     publish("sse.opened", { assistantId: "a", cause: "resume" });
 
-    expect(checkNames()).toEqual(["client_resume.to_sse_open"]);
+    expect(lastSent().checkName).toBe("client_resume.to_sse_open");
   });
 
   test("a remount does not start a second boot record", () => {
@@ -410,63 +418,60 @@ describe("registration lifetime", () => {
     startBootTelemetry();
     flushBootTelemetry();
 
-    const bootIds = new Set(
-      lastBatch().map(
-        (e) => (e.detail as Record<string, unknown>).boot_id as string,
-      ),
-    );
-    expect(bootIds.size).toBe(1);
-    expect(checkNames()).toEqual(["client_boot.react_mount"]);
+    expect(sendClientWatchdogEvent).toHaveBeenCalledTimes(1);
+    expect(setClientPerfBootId).toHaveBeenCalledTimes(1);
+    expect(Object.keys(bootMarks())).toEqual(["react_mount"]);
   });
 });
 
 describe("markBootBlocked", () => {
-  test("records the failure terminal with its reason in detail", () => {
+  test("records the failure terminal with its reason at the top level", () => {
     startBootTelemetry();
     markBootBlocked("stuck_connecting");
     flushBootTelemetry();
 
-    const batch = lastBatch();
-    expect(batch).toHaveLength(1);
-    expect(batch[0]?.check_name).toBe("client_boot.chat_blocked");
-    expect(batch[0]?.detail).toMatchObject({ reason: "stuck_connecting" });
+    expect(bootEvent().detail.outcome).toBe("blocked");
+    expect(bootEvent().detail.blocked_reason).toBe("stuck_connecting");
+    expect(bootMarks()).toHaveProperty("chat_blocked");
+    // The terminal mark's time is the boot's scalar even on failure, so
+    // time-to-failure is aggregable alongside time-to-interactive.
+    expect(typeof bootEvent().value).toBe("number");
   });
 
-  test("success and failure are distinct check names, not one name with a flag", () => {
-    // The success/failure split has to be a plain count comparison in BigQuery,
-    // so the two outcomes must never collapse onto the same check name.
+  test("success and failure are distinct outcomes, not one value with a flag", () => {
+    // The success/failure split has to be a plain field comparison in
+    // BigQuery, so the two outcomes must never collapse onto the same shape.
     startBootTelemetry();
     markBootBlocked("lifecycle_error");
     flushBootTelemetry();
-    const blockedNames = checkNames();
+    const blocked = bootEvent().detail.outcome;
 
     __resetBootTelemetryForTests();
-    postTelemetryEvents.mockClear();
+    sendClientWatchdogEvent.mockClear();
     startBootTelemetry();
     markBoot("chat_interactive", { value: 800 });
     flushBootTelemetry();
 
-    expect(blockedNames).not.toEqual(checkNames());
-    expect(blockedNames).toEqual(["client_boot.chat_blocked"]);
-    expect(checkNames()).toEqual(["client_boot.chat_interactive"]);
+    expect(blocked).toBe("blocked");
+    expect(bootEvent().detail.outcome).toBe("interactive");
   });
 });
 
 describe("consent", () => {
-  test("an opt-out drops the batch at flush time", () => {
+  test("an opt-out drops the event at flush time", () => {
     startBootTelemetry();
     markBoot("react_mount", { value: 300 });
     consent = false;
     flushBootTelemetry();
 
-    expect(postTelemetryEvents).not.toHaveBeenCalled();
+    expect(sendClientWatchdogEvent).not.toHaveBeenCalled();
   });
 
   test("consent is read at send time, not at record time", () => {
     // Recording a mark is not an upload, so the only check that matters is the
     // one immediately before the request. Here it flips the permissive way;
     // the test above covers the direction that actually protects the user, an
-    // opt-out landing mid-window and suppressing the whole batch.
+    // opt-out landing mid-window and suppressing the whole event.
     consent = false;
     startBootTelemetry();
     markBoot("safe_area_ready", { value: 100 });
@@ -475,27 +480,26 @@ describe("consent", () => {
     consent = true;
     flushBootTelemetry();
 
-    expect(checkNames()).toEqual([
-      "client_boot.safe_area_ready",
-      "client_boot.session_ready",
-    ]);
+    expect(bootMarks()).toMatchObject({
+      safe_area_ready: 100,
+      session_ready: 250,
+    });
   });
 });
 
-describe("detail bag", () => {
+describe("the boot event", () => {
   test("carries shared boot context and stays inside the 4096-byte cap", () => {
     startBootTelemetry();
     markBoot("react_mount", { value: 300 });
     flushBootTelemetry();
 
-    const detail = lastBatch()[0]?.detail as Record<string, unknown>;
+    const detail = bootEvent().detail;
     expect(detail).toMatchObject({
       route: expect.any(String),
       surface: expect.any(String),
       os: expect.any(String),
       lcp_supported: expect.any(Boolean),
       cls_supported: expect.any(Boolean),
-      unit: "ms",
     });
     expect(typeof detail.boot_id).toBe("string");
 
@@ -507,23 +511,21 @@ describe("detail bag", () => {
     ).toBe(true);
     expect(detail.nav_type).not.toBe("unknown");
 
-    // Ingest silently drops a single event whose `detail` exceeds this when
+    // Ingest rejects a single event whose `detail` exceeds this when
     // serialized (WatchdogTelemetryEventSerializer.DETAIL_MAX_JSON_BYTES).
     expect(JSON.stringify(detail).length).toBeLessThan(4096);
   });
 
-  test("every mark in one boot shares a boot_id so the waterfall stitches back together", () => {
+  test("carries a deterministic collapse key derived from the boot id", () => {
+    // A double send of the same boot must collapse downstream instead of
+    // counting twice.
     startBootTelemetry();
-    markBoot("safe_area_ready", { value: 100 });
-    markBoot("session_ready", { value: 250 });
+    markBoot("react_mount", { value: 300 });
     flushBootTelemetry();
 
-    const bootIds = new Set(
-      lastBatch().map(
-        (e) => (e.detail as Record<string, unknown>).boot_id as string,
-      ),
+    expect(bootEvent().daemonEventId).toBe(
+      `client_boot:${String(bootEvent().detail.boot_id)}`,
     );
-    expect(bootIds.size).toBe(1);
   });
 
   test("carries no message, conversation, or assistant identifiers", () => {
@@ -531,8 +533,7 @@ describe("detail bag", () => {
     markBoot("react_mount", { value: 300 });
     flushBootTelemetry();
 
-    const detail = lastBatch()[0]?.detail as Record<string, unknown>;
-    for (const key of Object.keys(detail)) {
+    for (const key of Object.keys(bootEvent().detail)) {
       expect(key).not.toMatch(/conversation|assistant|message|user|path|url/i);
     }
   });

--- a/clients/web/src/lib/telemetry/boot-telemetry.ts
+++ b/clients/web/src/lib/telemetry/boot-telemetry.ts
@@ -1,82 +1,67 @@
 /**
  * Boot / resume performance telemetry, the measure-first baseline (LUM-2907).
  *
- * ## Why this rides the `watchdog` wire shape
+ * ## Transport and shape
  *
- * There is no `client_performance` / `page_load` event type on the platform's
- * ingest, and adding one is a cross-repo sequence that must start platform-side
- * (see `assistant/src/telemetry/AGENTS.md`, the emitter is the *last* step; an
- * emitter shipped ahead of its serializer loses every event, because ingest
- * silently skips unknown types and still 2xxes).
+ * One `watchdog` event per boot, posted through the daemon relay via
+ * `sendClientWatchdogEvent` in `client-perf.ts`, which documents why the
+ * relay is the only transport that works in every mode this client runs in.
+ * `check_name` is `client_boot`, `value` is the milliseconds to the terminal
+ * mark (null when the boot never settled), and `detail` carries the whole
+ * waterfall: the per-mark duration map, the CLS score, the outcome, and the
+ * boot context.
  *
- * `watchdog` is already exactly the shape a timing baseline needs, and its
- * serializer says so in as many words: `check_name` is an open string and "the
- * primary group-by dimension downstream", `value` is "the single measured
- * magnitude for the check ... as a FLOAT", and `detail` is an "open JSON bag ...
- * without a platform-coordinated schema change" (bounded at 4096 serialized
- * bytes). So one event per mark, keyed by check name, gives per-mark p50/p95
- * from a plain `GROUP BY` with no JSON parsing and no backend change, the same
- * ride-an-existing-shape move `memory-telemetry.ts` makes on `onboarding`.
+ * One event per boot rather than one per mark, for three reasons:
+ *   - The relay takes one event per request, and a ten-POST flush on the
+ *     boot path is the wrong trade on exactly the path being measured.
+ *   - Every percentile is computed over the same population. Per-mark rows
+ *     let a partial flush under-report late marks in precisely the slow
+ *     boots that matter, skewing per-mark percentiles against each other.
+ *   - A missing mark is visible as a gap in an otherwise-present waterfall
+ *     instead of an absent row indistinguishable from an unsent one.
  *
- * Destination is live today: `watchdog_raw` (BigQuery) has `check_name STRING`,
- * `value FLOAT`, `detail JSON`, plus `assistant_version`, `organization_id`,
- * and `user_id`, and `stg_telemetry__watchdog` stages it partitioned by day.
+ * A deterministic `daemon_event_id` (`client_boot:` + the boot id) makes a
+ * double send collapse downstream.
  *
  * ## The two families
  *
- * `client_boot.*` is a **cold start** by construction: this module only
+ * `client_boot` is a **cold start** by construction: this module only
  * initializes when a document loads, which on iOS means the shell navigated
  * `WKWebView` at the origin (`clients/ios/README.md`, the app bundles no web
  * assets), so Navigation Timing describes a real page load.
  *
- * `client_resume.*` is a **warm start** by construction: the document survived,
- * the app was merely backgrounded, and the bus published `app.resume`. The two
- * families never overlap, so cold-vs-warm needs no discriminator field, the
- * check-name prefix is the discriminator.
+ * `client_resume.*` is a **warm start** by construction: the document
+ * survived, the app was merely backgrounded, and the bus published
+ * `app.resume`. The two never overlap, so cold-vs-warm needs no
+ * discriminator field, the check name is the discriminator.
  *
- * ## Relationship to `client-perf.ts`
- *
- * `client-perf.ts` (#40106) is the shared emitter for the sibling measure-first
- * families: `client_switch.*`, `client_resume.request_count`, and
- * `client_list.drain`. It rides the same `watchdog` shape and the same detail-bag
- * convention (raw JSON scalars, `null` for unavailable, no ids or raw pathnames),
- * and this module follows that convention so the families stay queryable
- * together. `startBootTelemetry` registers its `boot_id` through
- * `setClientPerfBootId`, which is the join: every sibling event from the same
- * page load then carries the boot it happened in, so a slow switch or list drain
- * can be traced back to its boot waterfall.
- *
- * This module keeps its own envelope construction rather than calling
- * `emitClientPerfEvent` per mark, for two reasons: a boot flushes ~10 marks as
- * ONE batched POST (per-mark emits would mean ten requests on the boot path),
- * and `emitClientPerfEvent` rounds `value` to an integer, which would destroy
- * the CLS score (see `SCORE_MARKS`). Folding the two together needs a shared
- * envelope builder with a unit-aware rounding hook; tracked in LUM-3060.
- *
- * Note that `client_resume.*` is a shared prefix: `to_sse_open` is emitted here,
- * `request_count` by `resume-request-counter.ts`. Both describe the same warm
- * start, so keep new resume check names consistent across the two.
+ * Note that `client_resume.*` is a shared prefix: `to_sse_open` is emitted
+ * here, `request_count` by `resume-request-counter.ts`. Both describe the
+ * same warm start, so keep new resume check names consistent across the two.
  *
  * ## Privacy
  *
- * Metadata only. No message content, no conversation/assistant ids, no URLs:
- * `route` is a fixed label from a closed set (see `bootRouteLabel`), never a
+ * Metadata only. No message content, no conversation ids, no URLs: `route`
+ * is a fixed label from a closed set (see `bootRouteLabel`), never a
  * pathname, so a conversation id can't ride in on it. `boot_id` is a fresh
- * random UUID per page load used only to stitch one waterfall back together.
+ * random UUID per page load used only to stitch the families together.
  *
  * ## Reading the paint marks
  *
  * `fcp` and `lcp` are only comparable across visible page loads. A document
  * that loads while hidden has its paint deferred until it is shown, so those
- * two marks describe "time until the user looked at it", not render cost. Both
- * are therefore floors, not costs, and a long tail on them is the first thing
- * to segment out before concluding anything about render work.
+ * two marks describe "time until the user looked at it", not render cost.
+ * Both are therefore floors, not costs, and a long tail on them is the first
+ * thing to segment out before concluding anything about render work.
  */
 
 import { subscribe } from "@/lib/event-bus";
 import { readAnalyticsConsent } from "@/lib/telemetry/consent";
-import { setClientPerfBootId } from "@/lib/telemetry/client-perf";
-import { postTelemetryEvents } from "@/lib/telemetry/ingest";
+import {
+  type ClientPerfDetail,
+  sendClientWatchdogEvent,
+  setClientPerfBootId,
+} from "@/lib/telemetry/client-perf";
 import { detectClientOs, isNativeMobile } from "@/runtime/platform-detection";
 
 /**
@@ -126,29 +111,14 @@ export type BootMark =
 const TERMINAL_MARKS = new Set<BootMark>(["chat_interactive", "chat_blocked"]);
 
 /**
- * Marks whose `value` is NOT a duration. Only `cls`, which is a unitless
- * layout-shift score in roughly the 0 to 0.5 range.
- *
- * This set exists because rounding a score to the nearest integer destroys it:
- * a perfectly normal CLS of 0.05 becomes 0, and the whole series reads as
- * "no layout shift anywhere". Durations round to whole milliseconds; scores keep
- * three decimals. The `unit` field in the detail bag carries the same
- * distinction downstream, so nobody averages milliseconds together with a score.
+ * `cls` is the one mark whose value is NOT a duration: a unitless
+ * layout-shift score in roughly the 0 to 0.5 range, where rounding to the
+ * nearest integer destroys it (a normal 0.05 becomes 0 and the series reads
+ * as "no layout shift anywhere"). It therefore lives in its own `cls` detail
+ * field with three decimals, structurally apart from the whole-millisecond
+ * `marks` duration map, so nobody averages milliseconds with a score.
  */
-const SCORE_MARKS = new Set<BootMark>(["cls"]);
-
-function markUnit(mark: BootMark): "ms" | "score" {
-  return SCORE_MARKS.has(mark) ? "score" : "ms";
-}
-
-function roundForUnit(mark: BootMark, value: number): number {
-  return SCORE_MARKS.has(mark)
-    ? Math.round(value * 1000) / 1000
-    : Math.round(value);
-}
-
-const BOOT_CHECK_PREFIX = "client_boot";
-const RESUME_CHECK_PREFIX = "client_resume";
+const CLS_MARK: BootMark = "cls";
 
 /**
  * Backstop flush for a boot that never reaches a terminal mark at all: a
@@ -397,34 +367,62 @@ export function markBootBlocked(reason: BootBlockedReason): void {
   markBoot("chat_blocked", { extra: { reason } });
 }
 
+/** The one `client_boot` event a boot flushes. */
+export interface BootEvent {
+  /** Collapse key, so a double send of the same boot dedupes downstream. */
+  daemonEventId: string;
+  /** Milliseconds to the terminal mark, or null when the boot never settled. */
+  value: number | null;
+  detail: ClientPerfDetail;
+}
+
 /**
- * Builds one `watchdog` event per recorded mark.
+ * Builds the single `client_boot` event carrying the whole waterfall.
  *
- * Split into its own export so the shape is testable without a live transport
- * and without the module's flush latch.
+ * Durations round to whole milliseconds (sub-millisecond precision is noise
+ * at this scale, and the raw floats are a small fingerprinting surface); the
+ * CLS score keeps three decimals in its own field (see {@link CLS_MARK}).
+ *
+ * Split into its own export so the shape is testable without a live
+ * transport and without the module's flush latch.
  */
-export function buildBootEvents(
+export function buildBootEvent(
   recorded: ReadonlyMap<BootMark, RecordedMark>,
   ctx: BootContext,
   flushTrigger: BootFlushTrigger,
-): object[] {
-  return [...recorded].map(([mark, { value, extra }]) => ({
-    type: "watchdog" as const,
-    daemon_event_id: crypto.randomUUID(),
-    recorded_at: Date.now(),
-    check_name: `${BOOT_CHECK_PREFIX}.${mark}`,
-    // Durations round to whole milliseconds (sub-millisecond precision is noise
-    // at this scale, and the raw floats are a small fingerprinting surface);
-    // scores keep their decimals. See `SCORE_MARKS`.
-    value: roundForUnit(mark, value),
+): BootEvent {
+  const durations: Record<string, number> = {};
+  let cls: number | null = null;
+  for (const [mark, { value }] of recorded) {
+    if (mark === CLS_MARK) {
+      cls = Math.round(value * 1000) / 1000;
+    } else {
+      durations[mark] = Math.round(value);
+    }
+  }
+  const interactive = recorded.get("chat_interactive");
+  const blocked = recorded.get("chat_blocked");
+  const terminal = interactive ?? blocked;
+  return {
+    daemonEventId: `client_boot:${ctx.boot_id}`,
+    value: terminal === undefined ? null : Math.round(terminal.value),
     detail: {
       ...ctx,
-      unit: markUnit(mark),
       flush_trigger: flushTrigger,
       backgrounded_before_terminal: backgroundedBeforeTerminal,
-      ...extra,
+      // Derived from which terminal mark landed, never from both: `markBoot`
+      // enforces terminal exclusivity, so at most one exists.
+      outcome:
+        interactive !== undefined
+          ? "interactive"
+          : blocked !== undefined
+            ? "blocked"
+            : null,
+      blocked_reason: blocked?.extra?.reason ?? null,
+      cls,
+      marks: durations,
     },
-  }));
+  };
 }
 
 /**
@@ -468,7 +466,13 @@ export function flushBootTelemetry(
   if (!readAnalyticsConsent()) {
     return;
   }
-  postTelemetryEvents(buildBootEvents(marks, context, trigger));
+  const event = buildBootEvent(marks, context, trigger);
+  sendClientWatchdogEvent({
+    checkName: "client_boot",
+    value: event.value,
+    detail: event.detail,
+    daemonEventId: event.daemonEventId,
+  });
 }
 
 /**
@@ -592,25 +596,20 @@ function subscribeResumeTelemetry(): () => void {
   let hiddenAt: number | null = null;
   let pendingTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const emit = (mark: string, value: number, extra: object): void => {
+  const emit = (value: number, extra: object): void => {
     if (!context || !readAnalyticsConsent()) {
       return;
     }
-    postTelemetryEvents([
-      {
-        type: "watchdog",
-        daemon_event_id: crypto.randomUUID(),
-        recorded_at: Date.now(),
-        check_name: `${RESUME_CHECK_PREFIX}.${mark}`,
-        value: Math.round(value),
-        detail: {
-          boot_id: context.boot_id,
-          surface: context.surface,
-          os: context.os,
-          ...extra,
-        },
+    sendClientWatchdogEvent({
+      checkName: "client_resume.to_sse_open",
+      value: Math.round(value),
+      detail: {
+        boot_id: context.boot_id,
+        surface: context.surface,
+        os: context.os,
+        ...extra,
       },
-    ]);
+    });
   };
 
   const clearPending = (): void => {
@@ -665,12 +664,12 @@ function subscribeResumeTelemetry(): () => void {
 
   const unsubOpened = subscribe("sse.opened", () => {
     if (pendingAt === null) {
-      // A cold boot's first open is the `client_boot.sse_open` mark, not a
+      // A cold boot's first open is the boot event's `sse_open` mark, not a
       // resume; only opens with a resume outstanding belong to this family.
       markBoot("sse_open");
       return;
     }
-    emit("to_sse_open", performance.now() - pendingAt, {
+    emit(performance.now() - pendingAt, {
       signal: pendingSignal,
       away_ms: pendingAwayMs,
     });
@@ -759,7 +758,7 @@ export function startBootTelemetry(): () => void {
 
   // A boot that is backgrounded or navigated away mid-flight still reports what
   // it reached, tagged `pagehide` so downstream can tell a cut-short waterfall
-  // from one that genuinely stalled. `postTelemetryEvents` already sends with
+  // from one that genuinely stalled. `sendClientWatchdogEvent` sends with
   // `keepalive`, so the request outlives the page.
   detachPageHide = (): void => flushBootTelemetry("pagehide");
   window.addEventListener("pagehide", detachPageHide);

--- a/clients/web/src/lib/telemetry/client-perf.test.ts
+++ b/clients/web/src/lib/telemetry/client-perf.test.ts
@@ -22,6 +22,15 @@ const telemetryIngestPostMock = mock((_options: unknown) =>
 );
 const detectClientOsMock = mock(() => "web");
 
+const captureErrorMock = mock(
+  (_error: unknown, _opts: { context: string }) => {},
+);
+const actualCapture = await import("@/lib/sentry/capture-error");
+mock.module("@/lib/sentry/capture-error", () => ({
+  ...actualCapture,
+  captureError: captureErrorMock,
+}));
+
 const actualSdk = await import("@/generated/daemon/sdk.gen");
 mock.module("@/generated/daemon/sdk.gen", () => ({
   ...actualSdk,
@@ -102,6 +111,7 @@ beforeEach(() => {
   activeAssistantId = "assistant-1";
   telemetryIngestPostMock.mockClear();
   telemetryIngestPostMock.mockImplementation(() => Promise.resolve({}));
+  captureErrorMock.mockClear();
   detectClientOsMock.mockClear();
   __resetClientPerfForTests();
 });
@@ -184,6 +194,43 @@ describe("sendClientWatchdogEvent", () => {
     });
 
     expect(telemetryIngestPostMock).not.toHaveBeenCalled();
+  });
+
+  test("reports a non-404 rejection once per status, per page load", async () => {
+    telemetryIngestPostMock.mockImplementation(() =>
+      Promise.resolve({ response: { ok: false, status: 400 } }),
+    );
+
+    sendClientWatchdogEvent({ checkName: "client_boot", value: 1, detail: {} });
+    sendClientWatchdogEvent({ checkName: "client_boot", value: 2, detail: {} });
+    await Bun.sleep(0);
+
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect((captureErrorMock.mock.calls[0]![0] as Error).message).toContain(
+      "400",
+    );
+  });
+
+  test("stays quiet on 404: a daemon predating the relay route is expected", async () => {
+    telemetryIngestPostMock.mockImplementation(() =>
+      Promise.resolve({ response: { ok: false, status: 404 } }),
+    );
+
+    sendClientWatchdogEvent({ checkName: "client_boot", value: 1, detail: {} });
+    await Bun.sleep(0);
+
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("stays quiet on 5xx: an unreachable daemon is transport, not contract", async () => {
+    telemetryIngestPostMock.mockImplementation(() =>
+      Promise.resolve({ response: { ok: false, status: 503 } }),
+    );
+
+    sendClientWatchdogEvent({ checkName: "client_boot", value: 1, detail: {} });
+    await Bun.sleep(0);
+
+    expect(captureErrorMock).not.toHaveBeenCalled();
   });
 
   test("swallows a rejecting transport", async () => {

--- a/clients/web/src/lib/telemetry/client-perf.test.ts
+++ b/clients/web/src/lib/telemetry/client-perf.test.ts
@@ -148,6 +148,32 @@ describe("sendClientWatchdogEvent", () => {
     expect(lastCall().body.fields.value).toBeNull();
   });
 
+  test("routes to the caller's owning assistant over the active one", () => {
+    // A switch completing mid-operation must not attribute the measurement,
+    // and its consent decision, to the newly active assistant.
+    sendClientWatchdogEvent({
+      checkName: "client_list.drain",
+      assistantId: "owner-of-the-drained-list",
+      value: 12,
+      detail: {},
+    });
+
+    expect(lastCall().path.assistant_id).toBe("owner-of-the-drained-list");
+  });
+
+  test("an explicit owner still sends when no assistant is active", () => {
+    activeAssistantId = null;
+
+    sendClientWatchdogEvent({
+      checkName: "client_list.drain",
+      assistantId: "owner-of-the-drained-list",
+      value: 12,
+      detail: {},
+    });
+
+    expect(lastCall().path.assistant_id).toBe("owner-of-the-drained-list");
+  });
+
   test("drops the event when no assistant is resolved: there is no relay target", () => {
     activeAssistantId = null;
 
@@ -219,6 +245,11 @@ describe("emitClientPerfEvent", () => {
     expect(typeof first).toBe("string");
     emitClientPerfEvent("client_list.drain", 2);
     expect(lastDetail().page_load_id).toBe(first);
+  });
+
+  test("threads the owning assistant through to the relay path", () => {
+    emitClientPerfEvent("client_list.drain", 3, {}, "owner-a");
+    expect(lastCall().path.assistant_id).toBe("owner-a");
   });
 
   test("merges caller detail last so its keys win", () => {

--- a/clients/web/src/lib/telemetry/client-perf.test.ts
+++ b/clients/web/src/lib/telemetry/client-perf.test.ts
@@ -1,12 +1,12 @@
 /**
- * Pins the shared `client_*` perf emitter's wire contract:
- *   - One watchdog-shaped event carrying the page-load grouping key, surface,
- *     os, and a rounded value, with caller detail merged last.
+ * Pins the shared `client_*` transport and emitter:
+ *   - One relay POST per event, addressed to the active assistant, carrying
+ *     the watchdog `fields` shape with `keepalive` set.
+ *   - No active assistant means no POST: the event has no relay target.
  *   - Nothing is emitted without analytics consent.
- *   - `boot_id` appears only once a boot id has been registered.
- *   - A throwing transport never propagates to the caller.
- *   - The page-load key is minted lazily, and it and the event id both survive
- *     a runtime with no `crypto.randomUUID` (non-secure contexts).
+ *   - A throwing or rejecting transport never propagates to the caller.
+ *   - The page-load key is minted lazily and survives a runtime with no
+ *     `crypto.randomUUID` (non-secure contexts).
  *   - Surface and os come from a single platform probe per emit.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -16,14 +16,26 @@ import type { ClientPerfCheckName } from "./client-perf";
 let consent = true;
 let nativeIOS = false;
 let nativeAndroid = false;
-const postTelemetryEventsMock = mock((_events: readonly object[]) => {});
+let activeAssistantId: string | null = "assistant-1";
+const telemetryIngestPostMock = mock((_options: unknown) =>
+  Promise.resolve({}),
+);
 const detectClientOsMock = mock(() => "web");
 
+const actualSdk = await import("@/generated/daemon/sdk.gen");
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...actualSdk,
+  telemetryIngestPost: telemetryIngestPostMock,
+}));
 mock.module("@/lib/telemetry/consent", () => ({
   readAnalyticsConsent: () => consent,
 }));
-mock.module("@/lib/telemetry/ingest", () => ({
-  postTelemetryEvents: postTelemetryEventsMock,
+// Minimal on purpose: `client-perf.ts` reads only `getState().activeAssistantId`,
+// and the real store module drags the lockfile graph into the test.
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    getState: () => ({ activeAssistantId }),
+  },
 }));
 mock.module("@/runtime/platform-detection", () => ({
   detectClientOs: detectClientOsMock,
@@ -31,19 +43,35 @@ mock.module("@/runtime/platform-detection", () => ({
   isNativeAndroid: () => nativeAndroid,
 }));
 
-const { __resetClientPerfForTests, emitClientPerfEvent, setClientPerfBootId } =
-  await import("./client-perf");
+const {
+  __resetClientPerfForTests,
+  emitClientPerfEvent,
+  sendClientWatchdogEvent,
+  setClientPerfBootId,
+} = await import("./client-perf");
 
-function lastEvent(): Record<string, unknown> {
-  const call = postTelemetryEventsMock.mock.calls.at(-1);
+interface RelayCall {
+  path: { assistant_id: string };
+  body: {
+    type: string;
+    daemon_event_id?: string;
+    fields: {
+      check_name: string;
+      value: number | null;
+      detail: Record<string, unknown>;
+    };
+  };
+  keepalive?: boolean;
+}
+
+function lastCall(): RelayCall {
+  const call = telemetryIngestPostMock.mock.calls.at(-1);
   expect(call).toBeDefined();
-  const events = call![0];
-  expect(events).toHaveLength(1);
-  return events[0] as Record<string, unknown>;
+  return call![0] as RelayCall;
 }
 
 function lastDetail(): Record<string, unknown> {
-  return lastEvent().detail as Record<string, unknown>;
+  return lastCall().body.fields.detail;
 }
 
 /**
@@ -52,10 +80,12 @@ function lastDetail(): Record<string, unknown> {
  * missing from the tuple, so the list stays exhaustive in both directions.
  */
 const ALL_CHECK_NAMES = [
+  "client_boot",
   "client_switch.transcript_painted",
   "client_switch.stalled",
   "client_switch.abandoned",
   "client_resume.request_count",
+  "client_resume.to_sse_open",
   "client_list.drain",
 ] as const satisfies readonly ClientPerfCheckName[];
 
@@ -69,22 +99,104 @@ beforeEach(() => {
   consent = true;
   nativeIOS = false;
   nativeAndroid = false;
-  postTelemetryEventsMock.mockClear();
-  postTelemetryEventsMock.mockImplementation(() => {});
+  activeAssistantId = "assistant-1";
+  telemetryIngestPostMock.mockClear();
+  telemetryIngestPostMock.mockImplementation(() => Promise.resolve({}));
   detectClientOsMock.mockClear();
   __resetClientPerfForTests();
 });
 
+describe("sendClientWatchdogEvent", () => {
+  test("posts one watchdog event to the active assistant's relay with keepalive", () => {
+    sendClientWatchdogEvent({
+      checkName: "client_boot",
+      value: 1820,
+      detail: { boot_id: "boot-1" },
+      daemonEventId: "client_boot:boot-1",
+    });
+
+    const call = lastCall();
+    expect(call.path.assistant_id).toBe("assistant-1");
+    expect(call.body.type).toBe("watchdog");
+    expect(call.body.daemon_event_id).toBe("client_boot:boot-1");
+    expect(call.body.fields).toEqual({
+      check_name: "client_boot",
+      value: 1820,
+      detail: { boot_id: "boot-1" },
+    });
+    // The request must survive a pagehide flush.
+    expect(call.keepalive).toBe(true);
+  });
+
+  test("omits the collapse key when the caller has none, so the daemon mints one", () => {
+    sendClientWatchdogEvent({
+      checkName: "client_list.drain",
+      value: 12,
+      detail: {},
+    });
+
+    expect(lastCall().body).not.toHaveProperty("daemon_event_id");
+  });
+
+  test("passes a null value through for events with no scalar", () => {
+    sendClientWatchdogEvent({
+      checkName: "client_boot",
+      value: null,
+      detail: {},
+    });
+
+    expect(lastCall().body.fields.value).toBeNull();
+  });
+
+  test("drops the event when no assistant is resolved: there is no relay target", () => {
+    activeAssistantId = null;
+
+    sendClientWatchdogEvent({
+      checkName: "client_boot",
+      value: 1,
+      detail: {},
+    });
+
+    expect(telemetryIngestPostMock).not.toHaveBeenCalled();
+  });
+
+  test("swallows a rejecting transport", async () => {
+    telemetryIngestPostMock.mockImplementation(() =>
+      Promise.reject(new Error("relay down")),
+    );
+
+    expect(() => {
+      sendClientWatchdogEvent({
+        checkName: "client_boot",
+        value: 1,
+        detail: {},
+      });
+    }).not.toThrow();
+    // Let the rejection settle; an unhandled rejection would fail the file.
+    await Bun.sleep(0);
+  });
+
+  test("swallows a synchronously throwing transport", () => {
+    telemetryIngestPostMock.mockImplementation(() => {
+      throw new Error("transport down");
+    });
+    expect(() => {
+      sendClientWatchdogEvent({
+        checkName: "client_boot",
+        value: 1,
+        detail: {},
+      });
+    }).not.toThrow();
+  });
+});
+
 describe("emitClientPerfEvent", () => {
-  test("emits one watchdog-shaped event with the perf detail bag", () => {
+  test("emits one event with a rounded value and the perf detail bag", () => {
     emitClientPerfEvent("client_switch.transcript_painted", 412.7);
 
-    const event = lastEvent();
-    expect(event.type).toBe("watchdog");
-    expect(event.check_name).toBe("client_switch.transcript_painted");
-    expect(event.value).toBe(413);
-    expect(typeof event.daemon_event_id).toBe("string");
-    expect(typeof event.recorded_at).toBe("number");
+    const { fields } = lastCall().body;
+    expect(fields.check_name).toBe("client_switch.transcript_painted");
+    expect(fields.value).toBe(413);
 
     const detail = lastDetail();
     expect(typeof detail.page_load_id).toBe("string");
@@ -97,7 +209,7 @@ describe("emitClientPerfEvent", () => {
   test("emits every check name in the union verbatim", () => {
     for (const checkName of ALL_CHECK_NAMES) {
       emitClientPerfEvent(checkName, 1);
-      expect(lastEvent().check_name).toBe(checkName);
+      expect(lastCall().body.fields.check_name).toBe(checkName);
     }
   });
 
@@ -123,7 +235,7 @@ describe("emitClientPerfEvent", () => {
   test("emits nothing without analytics consent", () => {
     consent = false;
     emitClientPerfEvent("client_switch.stalled", 5000);
-    expect(postTelemetryEventsMock).not.toHaveBeenCalled();
+    expect(telemetryIngestPostMock).not.toHaveBeenCalled();
   });
 
   test("omits boot_id until one is registered", () => {
@@ -133,15 +245,6 @@ describe("emitClientPerfEvent", () => {
     setClientPerfBootId("boot-123");
     emitClientPerfEvent("client_list.drain", 1);
     expect(lastDetail().boot_id).toBe("boot-123");
-  });
-
-  test("swallows a throwing transport", () => {
-    postTelemetryEventsMock.mockImplementation(() => {
-      throw new Error("transport down");
-    });
-    expect(() => {
-      emitClientPerfEvent("client_switch.stalled", 1);
-    }).not.toThrow();
   });
 
   test("probes the client OS once per emit", () => {
@@ -182,10 +285,7 @@ describe("emitClientPerfEvent", () => {
         emitClientPerfEvent("client_list.drain", 1);
       }).not.toThrow();
 
-      expect(postTelemetryEventsMock).toHaveBeenCalledTimes(1);
-
-      const event = lastEvent();
-      expect(typeof event.daemon_event_id).toBe("string");
+      expect(telemetryIngestPostMock).toHaveBeenCalledTimes(1);
       const pageLoadId = lastDetail().page_load_id;
       expect(typeof pageLoadId).toBe("string");
 

--- a/clients/web/src/lib/telemetry/client-perf.ts
+++ b/clients/web/src/lib/telemetry/client-perf.ts
@@ -3,6 +3,10 @@ import { captureError } from "@/lib/sentry/capture-error";
 import type { TelemetryJsonValueWritable } from "@/generated/daemon/types.gen";
 import { readAnalyticsConsent } from "@/lib/telemetry/consent";
 import { mintRandomId } from "@/lib/telemetry/random-id";
+import {
+  __resetReportedConditionsForTests,
+  claimUnreportedConditions,
+} from "@/lib/telemetry/report-once";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import {
   detectClientOs,
@@ -74,16 +78,6 @@ export type ClientPerfCheckName =
   | "client_list.drain";
 
 /**
- * Relay rejections already reported this page load, keyed by status.
- *
- * A rejection is systemic (this client sends something the daemon's wire
- * schema refuses), so one report shows it and one per event would flood.
- * 404 is not a condition: a daemon predating the relay route answers 404
- * per event, expected and quiet, and telemetry from it is simply absent.
- */
-const reportedRelayRejections = new Set<number>();
-
-/**
  * Posts one `client_*` watchdog event through the daemon relay. Fire and
  * forget: never throws into the caller, so a probe can sit on a hot render
  * or navigation path without adding a failure mode. Transport failures
@@ -141,15 +135,15 @@ export function sendClientWatchdogEvent(event: {
     })
       .then(({ response }) => {
         const status = response?.status ?? 0;
-        if (
-          status < 400 ||
-          status >= 500 ||
-          status === 404 ||
-          reportedRelayRejections.has(status)
-        ) {
+        // 404 is not a reportable condition: a daemon predating the relay
+        // route answers it per event, expected and quiet, and telemetry from
+        // it is simply absent.
+        if (status < 400 || status >= 500 || status === 404) {
           return;
         }
-        reportedRelayRejections.add(status);
+        if (claimUnreportedConditions([`relay:${status}`]).length === 0) {
+          return;
+        }
         captureError(
           new Error(
             `telemetry relay rejected ${event.checkName} with ${status}`,
@@ -242,5 +236,5 @@ export function emitClientPerfEvent(
 export function __resetClientPerfForTests(): void {
   bootId = null;
   pageLoadId = null;
-  reportedRelayRejections.clear();
+  __resetReportedConditionsForTests();
 }

--- a/clients/web/src/lib/telemetry/client-perf.ts
+++ b/clients/web/src/lib/telemetry/client-perf.ts
@@ -1,4 +1,5 @@
 import { telemetryIngestPost } from "@/generated/daemon/sdk.gen";
+import { captureError } from "@/lib/sentry/capture-error";
 import type { TelemetryJsonValueWritable } from "@/generated/daemon/types.gen";
 import { readAnalyticsConsent } from "@/lib/telemetry/consent";
 import { mintRandomId } from "@/lib/telemetry/random-id";
@@ -73,9 +74,22 @@ export type ClientPerfCheckName =
   | "client_list.drain";
 
 /**
+ * Relay rejections already reported this page load, keyed by status.
+ *
+ * A rejection is systemic (this client sends something the daemon's wire
+ * schema refuses), so one report shows it and one per event would flood.
+ * 404 is not a condition: a daemon predating the relay route answers 404
+ * per event, expected and quiet, and telemetry from it is simply absent.
+ */
+const reportedRelayRejections = new Set<number>();
+
+/**
  * Posts one `client_*` watchdog event through the daemon relay. Fire and
  * forget: never throws into the caller, so a probe can sit on a hot render
- * or navigation path without adding a failure mode.
+ * or navigation path without adding a failure mode. Transport failures
+ * (network, unreachable daemon) are swallowed; a 4xx rejection other than
+ * 404 is reported to Sentry once per status per page load, because a batch
+ * the daemon refuses is silent data loss otherwise.
  *
  * Precision is the caller's: durations arrive already rounded to whole
  * milliseconds, scores keep their decimals, and `value` is null when the
@@ -124,7 +138,30 @@ export function sendClientWatchdogEvent(event: {
       // The request must survive a pagehide flush.
       keepalive: true,
       throwOnError: false,
-    }).catch(() => {});
+    })
+      .then(({ response }) => {
+        const status = response?.status ?? 0;
+        if (
+          status < 400 ||
+          status >= 500 ||
+          status === 404 ||
+          reportedRelayRejections.has(status)
+        ) {
+          return;
+        }
+        reportedRelayRejections.add(status);
+        captureError(
+          new Error(
+            `telemetry relay rejected ${event.checkName} with ${status}`,
+          ),
+          {
+            context: "client-perf-relay",
+            level: "warning",
+            extra: { status, checkName: event.checkName },
+          },
+        );
+      })
+      .catch(() => {});
   } catch {
     // Telemetry is best-effort.
   }
@@ -205,4 +242,5 @@ export function emitClientPerfEvent(
 export function __resetClientPerfForTests(): void {
   bootId = null;
   pageLoadId = null;
+  reportedRelayRejections.clear();
 }

--- a/clients/web/src/lib/telemetry/client-perf.ts
+++ b/clients/web/src/lib/telemetry/client-perf.ts
@@ -1,6 +1,8 @@
+import { telemetryIngestPost } from "@/generated/daemon/sdk.gen";
+import type { TelemetryJsonValueWritable } from "@/generated/daemon/types.gen";
 import { readAnalyticsConsent } from "@/lib/telemetry/consent";
-import { postTelemetryEvents } from "@/lib/telemetry/ingest";
 import { mintRandomId } from "@/lib/telemetry/random-id";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import {
   detectClientOs,
   isNativeAndroid,
@@ -8,14 +10,37 @@ import {
 } from "@/runtime/platform-detection";
 
 /**
- * Shared emitter for the `client_*` performance families.
+ * Shared transport and emitter for the `client_*` performance families.
  *
- * Rides the existing `watchdog` event shape: `check_name` is a closed union
- * client-side but an open string on the wire, `value` a float magnitude,
- * `detail` an open JSON bag. So a new family lands in the existing
- * `stg_telemetry__watchdog` BigQuery model with no platform work. This is the
- * same ride-an-existing-shape move `memory-telemetry.ts` makes on the
- * `onboarding` event type.
+ * ## Transport: the daemon relay, not platform session ingest
+ *
+ * Events post to the daemon's `/v1/assistants/{id}/telemetry/ingest` route
+ * (the same path `onboarding_research` ships on) and reach the warehouse
+ * through the daemon's outbox under its API key. This is the only transport
+ * that works in every mode the web client runs in: platform session ingest
+ * only ever reaches the platform from cloud web, is aborted client-side in
+ * remote-gateway mode (no session exists), and is gated off in local mode.
+ * The relay also buys outbox durability (retry, offline) over a
+ * fire-and-forget beacon.
+ *
+ * The daemon stamps the base fields: `recorded_at` is daemon receipt time,
+ * not emit time, so timing data must ride `value`/`detail`, never be inferred
+ * from `recorded_at`. The daemon also re-checks the owner's `share_analytics`
+ * consent; the client-side `readAnalyticsConsent()` gate stays so the
+ * viewing user's own opt-out holds regardless of the owner's.
+ *
+ * A boot with no resolved assistant has no relay target and is unreportable;
+ * `sendClientWatchdogEvent` drops silently then. Terminal boot flushes run
+ * after resolution, so in practice this loses only early-pagehide boots and
+ * surfaces that never reach an assistant.
+ *
+ * ## Shape
+ *
+ * Rides the `watchdog` event: `check_name` is a closed union client-side but
+ * an open string on the wire, `value` a float magnitude, `detail` an open
+ * JSON bag (4096 serialized bytes, enforced server-side). The `client_`
+ * prefix keeps the families disjoint from the daemon's own health checks in
+ * the shared `watchdog_raw` table.
  *
  * Detail-bag convention, so the families stay queryable together:
  *   - Values are raw JSON scalars. Numbers stay numbers, booleans stay
@@ -23,11 +48,10 @@ import {
  *     like "unknown": both force a cast before any aggregation.
  *   - An unknown or unavailable value is `null`.
  *   - A bounded nested object is allowed when its keys are a closed set (for
- *     example a per-endpoint-group count map). Unbounded key spaces are not.
+ *     example the boot event's per-mark duration map). Unbounded key spaces
+ *     are not.
  *
- * Metadata only: detail bags carry no conversation or assistant ids and no
- * raw pathnames. Consent is read at emit time through the shared
- * `readAnalyticsConsent()`, the same decision every other emitter gates on.
+ * Metadata only: detail bags carry no conversation ids and no raw pathnames.
  */
 
 /**
@@ -35,12 +59,68 @@ import {
  * queried by name downstream, so the union is closed: a typo is a compile
  * error rather than a silent phantom series.
  */
+/**
+ * A detail bag: JSON-safe values only, typed by the wire contract so a
+ * non-serializable value is a compile error at the emit site.
+ */
+export type ClientPerfDetail = Record<string, TelemetryJsonValueWritable>;
+
 export type ClientPerfCheckName =
+  | "client_boot"
   | "client_switch.transcript_painted"
   | "client_switch.stalled"
   | "client_switch.abandoned"
   | "client_resume.request_count"
+  | "client_resume.to_sse_open"
   | "client_list.drain";
+
+/**
+ * Posts one `client_*` watchdog event through the daemon relay. Fire and
+ * forget: never throws into the caller, so a probe can sit on a hot render
+ * or navigation path without adding a failure mode.
+ *
+ * Precision is the caller's: durations arrive already rounded to whole
+ * milliseconds, scores keep their decimals, and `value` is null when the
+ * event carries no scalar. Consent is also the caller's, checked immediately
+ * before calling, because the families read it at different moments (the
+ * boot family buffers marks and checks at flush; the others check at emit).
+ */
+export function sendClientWatchdogEvent(event: {
+  checkName: ClientPerfCheckName;
+  value: number | null;
+  detail: ClientPerfDetail;
+  /** Deterministic collapse key; omitted, the daemon mints a per-row id. */
+  daemonEventId?: string;
+}): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  try {
+    const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+    if (assistantId === null) {
+      return;
+    }
+    void telemetryIngestPost({
+      path: { assistant_id: assistantId },
+      body: {
+        type: "watchdog",
+        ...(event.daemonEventId === undefined
+          ? {}
+          : { daemon_event_id: event.daemonEventId }),
+        fields: {
+          check_name: event.checkName,
+          value: event.value,
+          detail: event.detail,
+        },
+      },
+      // The request must survive a pagehide flush.
+      keepalive: true,
+      throwOnError: false,
+    }).catch(() => {});
+  } catch {
+    // Telemetry is best-effort.
+  }
+}
 
 let pageLoadId: string | null = null;
 
@@ -57,8 +137,9 @@ function getPageLoadId(): string {
 let bootId: string | null = null;
 
 /**
- * Registers a boot id so the perf families become joinable with a boot series.
- * Until a caller registers one, `boot_id` is absent from the detail bag.
+ * Registers a boot id so the perf families become joinable with the boot
+ * series. Until a caller registers one, `boot_id` is absent from the detail
+ * bag.
  */
 export function setClientPerfBootId(id: string): void {
   bootId = id;
@@ -77,13 +158,15 @@ function detectSurface(): PerfSurface {
 }
 
 /**
- * Fire-and-forget: never throws into the caller's path, so a perf probe can sit
- * on a hot render or navigation path without adding a failure mode.
+ * Emits one single-magnitude perf event with the shared context stamp
+ * (page-load id, surface, os, boot id). `value` rounds to whole
+ * milliseconds; a family whose value is a score builds its event through
+ * {@link sendClientWatchdogEvent} directly.
  */
 export function emitClientPerfEvent(
   checkName: ClientPerfCheckName,
   value: number,
-  detail?: Record<string, unknown>,
+  detail?: ClientPerfDetail,
 ): void {
   if (typeof window === "undefined") {
     return;
@@ -92,22 +175,17 @@ export function emitClientPerfEvent(
     if (!readAnalyticsConsent()) {
       return;
     }
-    postTelemetryEvents([
-      {
-        type: "watchdog",
-        daemon_event_id: mintRandomId(),
-        recorded_at: Date.now(),
-        check_name: checkName,
-        value: Math.round(value),
-        detail: {
-          page_load_id: getPageLoadId(),
-          surface: detectSurface(),
-          os: detectClientOs(),
-          ...(bootId === null ? {} : { boot_id: bootId }),
-          ...detail,
-        },
+    sendClientWatchdogEvent({
+      checkName,
+      value: Math.round(value),
+      detail: {
+        page_load_id: getPageLoadId(),
+        surface: detectSurface(),
+        os: detectClientOs(),
+        ...(bootId === null ? {} : { boot_id: bootId }),
+        ...detail,
       },
-    ]);
+    });
   } catch {
     // Telemetry is best-effort.
   }

--- a/clients/web/src/lib/telemetry/client-perf.ts
+++ b/clients/web/src/lib/telemetry/client-perf.ts
@@ -12,16 +12,14 @@ import {
 /**
  * Shared transport and emitter for the `client_*` performance families.
  *
- * ## Transport: the daemon relay, not platform session ingest
+ * ## Transport
  *
  * Events post to the daemon's `/v1/assistants/{id}/telemetry/ingest` route
- * (the same path `onboarding_research` ships on) and reach the warehouse
- * through the daemon's outbox under its API key. This is the only transport
- * that works in every mode the web client runs in: platform session ingest
- * only ever reaches the platform from cloud web, is aborted client-side in
- * remote-gateway mode (no session exists), and is gated off in local mode.
- * The relay also buys outbox durability (retry, offline) over a
- * fire-and-forget beacon.
+ * and reach the warehouse through the daemon's outbox (with its retry and
+ * offline durability) under its API key. The relay is the one transport
+ * reachable in every mode the web client runs in; platform session ingest is
+ * not (its allowlist drops `watchdog` from browsers, and remote-gateway and
+ * local modes cannot reach it at all), so never route these events there.
  *
  * The daemon stamps the base fields: `recorded_at` is daemon receipt time,
  * not emit time, so timing data must ride `value`/`detail`, never be inferred
@@ -29,9 +27,9 @@ import {
  * consent; the client-side `readAnalyticsConsent()` gate stays so the
  * viewing user's own opt-out holds regardless of the owner's.
  *
- * A boot with no resolved assistant has no relay target and is unreportable;
- * `sendClientWatchdogEvent` drops silently then. Terminal boot flushes run
- * after resolution, so in practice this loses only early-pagehide boots and
+ * An event with no resolvable assistant has no relay target and drops
+ * silently in `sendClientWatchdogEvent`. Terminal boot flushes run after
+ * resolution, so in practice this loses only early-pagehide boots and
  * surfaces that never reach an assistant.
  *
  * ## Shape
@@ -91,12 +89,22 @@ export function sendClientWatchdogEvent(event: {
   detail: ClientPerfDetail;
   /** Deterministic collapse key; omitted, the daemon mints a per-row id. */
   daemonEventId?: string;
+  /**
+   * The assistant that owns the measured operation. Events about the surface
+   * the user is on (boot, switch arrival, resume) omit this and route to the
+   * active assistant; events about one assistant's data (a list drain) must
+   * pass the owner, or a switch completing mid-operation would attribute the
+   * measurement, and its consent decision, to the wrong assistant.
+   */
+  assistantId?: string;
 }): void {
   if (typeof window === "undefined") {
     return;
   }
   try {
-    const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
+    const assistantId =
+      event.assistantId ??
+      useResolvedAssistantsStore.getState().activeAssistantId;
     if (assistantId === null) {
       return;
     }
@@ -167,6 +175,8 @@ export function emitClientPerfEvent(
   checkName: ClientPerfCheckName,
   value: number,
   detail?: ClientPerfDetail,
+  /** Owner of the measured operation; see {@link sendClientWatchdogEvent}. */
+  assistantId?: string,
 ): void {
   if (typeof window === "undefined") {
     return;
@@ -177,6 +187,7 @@ export function emitClientPerfEvent(
     }
     sendClientWatchdogEvent({
       checkName,
+      assistantId,
       value: Math.round(value),
       detail: {
         page_load_id: getPageLoadId(),

--- a/clients/web/src/lib/telemetry/ingest.ts
+++ b/clients/web/src/lib/telemetry/ingest.ts
@@ -2,6 +2,10 @@ import { telemetryIngestCreate } from "@/generated/api/sdk.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 
 import { getClientId } from "./client-identity";
+import {
+  __resetReportedConditionsForTests,
+  claimUnreportedConditions,
+} from "./report-once";
 
 /**
  * Drops keys whose value is `undefined` so they are omitted from the wire
@@ -25,32 +29,6 @@ function stripUndefined(event: object): Record<string, unknown> {
  * for every opted-out user.
  */
 const EXPECTED_DROP_REASONS = new Set(["analytics_opt_out"]);
-
-/**
- * Ingest failure conditions (`rejected:<status>`, `dropped:<reason>`) already
- * reported for this page load.
- *
- * An ingest failure is systemic, not per-event: it means this client emits
- * something the server contract does not accept (an event type outside the
- * session allowlist, a serializer that has not shipped yet). One report per
- * condition per page load is enough to see it; one per flush would be a flood.
- */
-const reportedConditions = new Set<string>();
-
-/**
- * Filters to the conditions not yet reported this page load and marks them,
- * per condition rather than per batch, so a reason that already fired alone
- * cannot fire again by arriving alongside a new one.
- */
-function claimUnreported(conditions: readonly string[]): string[] {
-  const fresh = conditions.filter(
-    (condition) => !reportedConditions.has(condition),
-  );
-  for (const condition of fresh) {
-    reportedConditions.add(condition);
-  }
-  return fresh;
-}
 
 /**
  * Wraps events in the telemetry envelope and fire-and-forgets them to the
@@ -81,7 +59,10 @@ export function postTelemetryEvents(events: readonly object[]): void {
     .then(({ data, response }) => {
       if (!response?.ok) {
         const status = response?.status ?? null;
-        if (claimUnreported([`rejected:${status ?? "no-response"}`]).length) {
+        if (
+          claimUnreportedConditions([`rejected:${status ?? "no-response"}`])
+            .length
+        ) {
           captureError(
             new Error(
               `telemetry ingest rejected with ${status ?? "no response"}`,
@@ -101,7 +82,7 @@ export function postTelemetryEvents(events: readonly object[]): void {
       const unexpected = Object.keys(data.dropped)
         .filter((reason) => !EXPECTED_DROP_REASONS.has(reason))
         .sort();
-      const fresh = claimUnreported(
+      const fresh = claimUnreportedConditions(
         unexpected.map((reason) => `dropped:${reason}`),
       );
       if (fresh.length === 0) {
@@ -125,5 +106,5 @@ export function postTelemetryEvents(events: readonly object[]): void {
 }
 
 export function __resetTelemetryIngestForTests(): void {
-  reportedConditions.clear();
+  __resetReportedConditionsForTests();
 }

--- a/clients/web/src/lib/telemetry/report-once.ts
+++ b/clients/web/src/lib/telemetry/report-once.ts
@@ -1,0 +1,32 @@
+/**
+ * Once-per-page-load claim set for telemetry failure reporting.
+ *
+ * A telemetry failure is systemic, not per-event: it means this client emits
+ * something a server contract refuses, so one Sentry report per condition
+ * shows it and one per flush would flood. The session-ingest and daemon-relay
+ * senders share this set so their dedup semantics cannot drift; conditions
+ * are namespaced strings (`rejected:<status>`, `dropped:<reason>`,
+ * `relay:<status>`) so the two senders cannot claim each other's.
+ */
+const reportedConditions = new Set<string>();
+
+/**
+ * Filters to the conditions not yet reported this page load and claims them,
+ * per condition rather than per batch, so a condition that already fired
+ * alone cannot fire again by arriving alongside a new one.
+ */
+export function claimUnreportedConditions(
+  conditions: readonly string[],
+): string[] {
+  const fresh = conditions.filter(
+    (condition) => !reportedConditions.has(condition),
+  );
+  for (const condition of fresh) {
+    reportedConditions.add(condition);
+  }
+  return fresh;
+}
+
+export function __resetReportedConditionsForTests(): void {
+  reportedConditions.clear();
+}

--- a/clients/web/src/lib/telemetry/resume-request-counter.test.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.test.ts
@@ -32,9 +32,8 @@ mock.module("@/lib/telemetry/client-perf", () => ({
   __resetClientPerfForTests: () => {},
 }));
 
-const { publish, subscribe, __resetForTesting } = await import(
-  "@/lib/event-bus"
-);
+const { publish, subscribe, __resetForTesting } =
+  await import("@/lib/event-bus");
 const {
   __resetResumeRequestCounterForTests,
   installResumeRequestCounter,
@@ -130,6 +129,25 @@ describe("installResumeRequestCounter", () => {
     expect(detail.observed_window_ms).toBe(10_000);
     expect(detail.signal).toBe("visibility");
     expect(lastDelay).toBe(10_000);
+  });
+
+  test("does not count the observer's own telemetry requests", () => {
+    // The `client_resume.*` reports this window produces are daemon requests
+    // too (the relay in `client-perf.ts` posts to the telemetry routes), so
+    // counting them would add a synthetic request to exactly the resumes
+    // being measured.
+    installResumeRequestCounter();
+    publish("app.resume", { signal: "visibility" });
+
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/conversations");
+    noteDaemonApiRequest("https://api.test/v1/assistants/a1/telemetry/ingest");
+    noteDaemonApiRequest("https://api.test/v1/telemetry/flush");
+    nowMs = 10_000;
+    fireTimers();
+
+    const { value, detail } = lastEmit();
+    expect(value).toBe(1);
+    expect(detail.by_group).not.toHaveProperty("other");
   });
 
   test("reports the span a mildly thawed window actually covered", () => {

--- a/clients/web/src/lib/telemetry/resume-request-counter.ts
+++ b/clients/web/src/lib/telemetry/resume-request-counter.ts
@@ -77,30 +77,34 @@ type EndpointGroup = (typeof ENDPOINT_GROUPS)[number];
 const KNOWN_GROUPS = new Set<string>(ENDPOINT_GROUPS);
 
 /**
- * Maps a request URL onto the closed label set. Anything unrecognized (and
- * anything unparseable) lands on `"other"` so a new route can never leak a
- * path into telemetry.
+ * The daemon route resource segment (`/v1/<resource>` or the assistant-scoped
+ * `/v1/assistants/<id>/<resource>`), or null when the URL has no `/v1/` shape.
  */
-function groupForUrl(url: string): EndpointGroup {
+function daemonRouteSegment(url: string): string | null {
   try {
     const segments = new URL(url, "http://localhost").pathname
       .split("/")
       .filter(Boolean);
     const v1 = segments.indexOf("v1");
     if (v1 === -1) {
-      return "other";
+      return null;
     }
-    // Daemon routes are either `/v1/<resource>` or the assistant-scoped
-    // `/v1/assistants/<id>/<resource>`.
     const index = segments[v1 + 1] === "assistants" ? v1 + 3 : v1 + 1;
-    const segment = segments[index];
-    if (segment && KNOWN_GROUPS.has(segment)) {
-      return segment as EndpointGroup;
-    }
-    return "other";
+    return segments[index] ?? null;
   } catch {
-    return "other";
+    return null;
   }
+}
+
+/**
+ * Maps a resource segment onto the closed label set. Anything unrecognized
+ * (and anything unparseable) lands on `"other"` so a new route can never leak
+ * a path into telemetry.
+ */
+function groupForSegment(segment: string | null): EndpointGroup {
+  return segment !== null && KNOWN_GROUPS.has(segment)
+    ? (segment as EndpointGroup)
+    : "other";
 }
 
 type ResumeWindow = {
@@ -173,7 +177,15 @@ export function noteDaemonApiRequest(url: string): void {
   if (!resumeWindow) {
     return;
   }
-  const group = groupForUrl(url);
+  const segment = daemonRouteSegment(url);
+  // The observer must not measure itself: the `client_*` perf reports this
+  // window exists to produce are daemon requests too (the `telemetry` routes,
+  // via the relay in `client-perf.ts`), and counting them would add a
+  // synthetic request to exactly the resumes being measured.
+  if (segment === "telemetry") {
+    return;
+  }
+  const group = groupForSegment(segment);
   resumeWindow.total += 1;
   resumeWindow.byGroup[group] = (resumeWindow.byGroup[group] ?? 0) + 1;
 }

--- a/clients/web/src/utils/conversation-list-fetchers.ts
+++ b/clients/web/src/utils/conversation-list-fetchers.ts
@@ -338,15 +338,22 @@ export async function drainConversationList(
       listKind: drainListKind(filter),
     });
     // The ring keeps `assistantId` for feedback bundles; the telemetry rail is
-    // metadata only.
-    emitClientPerfEvent("client_list.drain", totalMs, {
-      outcome,
-      pages,
-      rows: all.length,
-      max_page_ms: maxPageMs,
-      total_bytes: totalBytes,
-      list_kind: drainListKind(filter),
-    });
+    // metadata only. The id is passed as the ROUTING owner (a switch finishing
+    // mid-drain must not attribute this drain to the newly active assistant),
+    // never as detail.
+    emitClientPerfEvent(
+      "client_list.drain",
+      totalMs,
+      {
+        outcome,
+        pages,
+        rows: all.length,
+        max_page_ms: maxPageMs,
+        total_bytes: totalBytes,
+        list_kind: drainListKind(filter),
+      },
+      assistantId,
+    );
   };
 
   try {


### PR DESCRIPTION
## TL;DR

The `client_*` performance families (boot waterfall, assistant switch, resume, list drain) have persisted **zero rows** since they shipped on Aug 5. They post to the platform's session ingest, which drops them by allowlist in cloud web and is unreachable from the other two modes entirely. This PR moves every `client_*` event onto the daemon's `telemetry/ingest` relay (the `onboarding_research` path) and reshapes the boot waterfall to one event per boot.

Part of LUM-3493.

## Why the relay is the right transport

| Mode | Session ingest (before) | Daemon relay (after) |
| --- | --- | --- |
| Cloud web | Reaches the platform, then dropped: `{"accepted":N,"persisted":0,"dropped":{"type_not_allowed_for_session":N}}` | Works via the runtime proxy, live in production for `onboarding_research` |
| Remote gateway (phone over tunnel) | Aborted client-side: no platform session exists, so the request never leaves the browser | Works: the daemon client carries the bearer |
| Local / self-hosted | Gated off with platform features | Works: forwarded to the local gateway |

The relay validates against the wire schema, gates on consent, and forwards through the daemon outbox under its API key, which also buys retry/offline durability over a fire-and-forget beacon. `watchdog` is outbox-backed, so **no daemon change and no platform change**: this PR is entirely client-side.

## What changes for the user

Nothing in the product. Operators gain the boot/perf baseline that LUM-2907 set out to build, from every surface including the phone, and lose a noise source: since #41761 the doomed session-ingest posts fire a known Sentry warning on every cloud-web page load, and this removes the cause.

## One event per boot

`client_boot` now flushes as a single event: `value` is milliseconds to the terminal mark (null when the boot never settled), and `detail` carries the whole waterfall (`marks` duration map, `cls` in its own field with its decimals, `outcome`, `blocked_reason`, flush trigger, boot context). Reasons:

- The relay takes one event per request; ten POSTs on the boot path is the wrong trade on exactly the path being measured.
- Every percentile is computed over the same population: per-mark rows let a partial flush under-report late marks in precisely the slow boots that matter.
- Zero rows exist, so the reshape is free now and never again.
- A deterministic `daemon_event_id` (`client_boot:<boot_id>`) makes a double send collapse downstream.

The other families were already single events and only change transport. `client-perf.ts` now owns the one envelope/transport seam for all of them, which resolves the LUM-3060 drift concern by construction.

## Why it is safe

- Consent is unchanged and double-gated: callers keep the client-side `readAnalyticsConsent()` check (the viewer's own opt-out holds), and the daemon re-checks the owner's `share_analytics` at record time like every outbox event.
- Detail bags are typed by the wire's `TelemetryJsonValueWritable`, so a non-serializable value is a compile error at the emit site.
- Fire-and-forget is preserved: no caller can throw, nothing blocks a flush, `keepalive` still covers pagehide sends.
- Privacy surface shrinks slightly: no client-minted `recorded_at`/event ids except the deterministic boot collapse key; `detail` still carries no conversation ids or pathnames, enforced by the existing key-name test.
- Full-waterfall `detail` measured at ~650 bytes worst case against the serializer's 4096-byte bound.
- 115 tests across the six telemetry-adjacent files pass, rewritten against the new seams where the shape changed.

## Backwards compatibility (per `docs/BACKWARDS_COMPAT.md`)

The relay route shipped in **v0.10.11 (2026-07-16)**; managed daemons auto-update past it. Against an older self-hosted daemon this ships gateless by the doc's own criteria: there is no legacy fallback whose write could mis-mutate (the old transport is deleted, not fallen back to), a 404 degrades to exactly feature-off (no telemetry, which those daemons produce none of today either), and the request stays quiet under failure (single unretried POST, result consumed, nothing thrown). A version gate would add a registry row to protect nothing.

Failure visibility is tiered on the same logic: a **non-404 4xx** (wire-schema rejection) reports to Sentry once per status per page load, because that is the silent-loss class this PR exists to end; **404** stays quiet (pre-0.10.11 daemon, expected); **5xx and network** stay quiet as transport, which the app already surfaces via `assistant.unreachable`.

## Accepted limits (documented in code)

- A boot with no resolved assistant (early pagehide, a surface that never reaches an assistant) has no relay target and stays unreported. Those boots are lost today too, so this is strictly better, but it is a real limit.
- `recorded_at` on the row is daemon receipt time; timing data rides `value`/`detail` and never derives from `recorded_at`.

## What stays on session ingest

`onboarding` funnel events and memory telemetry: they ride the `onboarding` event type, which the session allowlist admits by design, and #41761's production drop reporting keeps guarding them.
