### PR TITLE
The assistant's own reactions persist as rows

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -20832,6 +20832,27 @@ paths:
                           type: boolean
                         noResponse:
                           type: boolean
+                        reaction:
+                          type: object
+                          properties:
+                            emoji:
+                              type: string
+                            op:
+                              type: string
+                              enum:
+                                - added
+                                - removed
+                            targetMessageId:
+                              type: string
+                            actorDisplayName:
+                              type: string
+                            selfAuthored:
+                              type: boolean
+                          required:
+                            - emoji
+                            - op
+                            - targetMessageId
+                          additionalProperties: false
                         providerError:
                           type: object
                           properties:

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -697,10 +697,11 @@ describe("loadFromDb history repair", () => {
       .map((b) => (b.type === "text" ? b.text : ""))
       .join("\n");
     expect(allText).not.toContain("[reaction]");
-    expect(allText).toContain(
-      'You reacted with 🎉 to the message "great work"',
-    );
-    expect(allText).not.toContain("<external_content");
+    expect(allText).toContain("You reacted with 🎉 to this message:");
+    // The quoted target is sender text and stays fenced even in the
+    // assistant's own row.
+    expect(allText).toContain("great work");
+    expect(allText).toContain("<external_content");
   });
 
   test("a reaction row does not count as a turn on rehydration", async () => {

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -645,6 +645,64 @@ describe("loadFromDb history repair", () => {
     expect(allText).not.toContain("secret text");
   });
 
+  test("the assistant's own reaction row renders second-person", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "user",
+        content: [{ type: "text", text: "great work" }],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            messageId: "555.9",
+            eventKind: "message",
+          }),
+        }),
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: [{ type: "text", text: "[reaction]" }],
+        metadata: JSON.stringify({
+          messageKind: "reaction",
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            eventKind: "reaction",
+            reaction: {
+              targetMessageId: "555.9",
+              emoji: "🎉",
+              op: "added",
+            },
+          }),
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const allText = conversation
+      .getMessages()
+      .flatMap((m) => m.content)
+      .filter((b) => b.type === "text")
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    expect(allText).not.toContain("[reaction]");
+    expect(allText).toContain(
+      'You reacted with 🎉 to the message "great work"',
+    );
+    expect(allText).not.toContain("<external_content");
+  });
+
   test("a reaction row does not count as a turn on rehydration", async () => {
     mockConversation = {
       id: "conv-1",

--- a/assistant/src/__tests__/list-messages-system-card.test.ts
+++ b/assistant/src/__tests__/list-messages-system-card.test.ts
@@ -104,6 +104,46 @@ describe("handleListMessages system-card projection", () => {
     expect(silentRow?.noResponse).toBe(true);
   });
 
+  test("projects the reaction fact from a reaction row's envelope", async () => {
+    const conv = createConversation();
+    const row = await addMessage(
+      conv.id,
+      "assistant",
+      JSON.stringify([{ type: "text", text: "[reaction]" }]),
+      {
+        metadata: {
+          messageKind: "reaction",
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            eventKind: "reaction",
+            reaction: {
+              targetMessageId: "555.1",
+              emoji: "🎉",
+              op: "added",
+            },
+          }),
+        },
+      },
+    );
+
+    const response = (await handleListMessages({
+      queryParams: { conversationId: conv.id },
+    })) as {
+      messages: Array<
+        ProjectedMessage & {
+          reaction?: { emoji: string; selfAuthored?: boolean };
+        }
+      >;
+    };
+    for (const message of response.messages) {
+      expect(() => ConversationMessageSchema.parse(message)).not.toThrow();
+    }
+    const projected = response.messages.find((m) => m.id === row.id);
+    expect(projected?.reaction?.emoji).toBe("🎉");
+    expect(projected?.reaction?.selfAuthored).toBe(true);
+  });
+
   test("omits systemCard on ordinary user and assistant rows", async () => {
     const conv = createConversation();
     await addMessage(

--- a/assistant/src/api/responses/conversation-message.ts
+++ b/assistant/src/api/responses/conversation-message.ts
@@ -613,6 +613,20 @@ export const ConversationMessageSchema = z.object({
    *  sentinel text, and treat the row as the turn's reply so nothing keeps
    *  waiting for one. */
   noResponse: z.boolean().optional(),
+  /** Present on a reaction row, either direction: an inbound reaction the
+   *  daemon persisted, or the assistant's own (`selfAuthored`). Clients
+   *  render a reaction line from this instead of the row's stored sentinel
+   *  text. Slack rows additionally carry their own `slackMessage` envelope,
+   *  which Slack-aware renderers may prefer. */
+  reaction: z
+    .object({
+      emoji: z.string(),
+      op: z.enum(["added", "removed"]),
+      targetMessageId: z.string(),
+      actorDisplayName: z.string().optional(),
+      selfAuthored: z.boolean().optional(),
+    })
+    .optional(),
   /** Present when this assistant row is a daemon-persisted provider-failure
    *  notice (`metadata.messageKind === "provider_error"`); clients may render
    *  a themed card instead of a persona bubble. `code` is the stable

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -137,6 +137,7 @@ import {
   unregisterInflightTurn,
 } from "./inflight-turn-registry.js";
 import type { UsageStats } from "./message-protocol.js";
+import { persistReactionRecords } from "./reaction-record.js";
 import type { TrustContext } from "./trust-context-types.js";
 import { turnOrRestingTrust } from "./trust-context-types.js";
 import { resolveTurnCallSite } from "./turn-call-site.js";
@@ -1577,6 +1578,16 @@ export async function runAgentLoopImpl(
     // assistant message. Testing only the tail keeps the synthetic error row
     // below reachable for mid-turn failures, which is the only durable record
     // of why the turn stopped.
+    // Reactions the turn delivered get their durable rows now, after the
+    // turn's own rows are settled, so they never land inside a
+    // tool_use/tool_result pair. The resident history misses them until the
+    // next reload, so the conversation is stale-marked.
+    if (ctx.pendingReactionRecords.length > 0) {
+      const queuedReactions = ctx.pendingReactionRecords.splice(0);
+      await persistReactionRecords(ctx.conversationId, queuedReactions);
+      ctx.markHistoryStale();
+    }
+
     const hasAssistantResponse =
       newMessages[newMessages.length - 1]?.role === "assistant";
     // A reply that is nothing but the `<no_response/>` sentinel is deliberate

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -137,7 +137,10 @@ import {
   unregisterInflightTurn,
 } from "./inflight-turn-registry.js";
 import type { UsageStats } from "./message-protocol.js";
-import { persistReactionRecords } from "./reaction-record.js";
+import {
+  persistReactionRecords,
+  type QueuedReactionRecord,
+} from "./reaction-record.js";
 import type { TrustContext } from "./trust-context-types.js";
 import { turnOrRestingTrust } from "./trust-context-types.js";
 import { resolveTurnCallSite } from "./turn-call-site.js";
@@ -780,6 +783,14 @@ export async function runAgentLoopImpl(
   // turn's content is settled; the `finally` calls it again as the backstop for
   // the cancel/error paths that never reached the early release.
   let turnReleased = false;
+  // The turn's own queued reaction records, captured by `releaseTurn` while
+  // the conversation is still exclusive. The `finally` drains this array,
+  // never the live conversation field: after release a following turn may
+  // queue records of its own there, and draining the shared field would
+  // consume the new turn's record before its tool_result settles, the
+  // cross-turn variant of the pairing corruption the boundary drain
+  // prevents.
+  const ownedReactionRecords: QueuedReactionRecord[] = [];
 
   /**
    * Free the conversation for its next turn.
@@ -818,6 +829,11 @@ export async function runAgentLoopImpl(
           "Failed to stamp turn outcome (non-fatal); releasing the turn anyway",
         );
       }
+    }
+    // Ownership capture happens in the same synchronous step as the
+    // release, so records queued after this point belong to the next turn.
+    if (ctx.pendingReactionRecords?.length) {
+      ownedReactionRecords.push(...ctx.pendingReactionRecords.splice(0));
     }
     ctx.abortController = null;
     ctx.setProcessing(false);
@@ -2041,14 +2057,16 @@ export async function runAgentLoopImpl(
       // the API, enabling stable prefix caching across turns.  Compaction
       // consolidates when it summarizes old messages (cache miss is expected).
     } finally {
+      // Backstop for paths that threw before either release site: still
+      // exclusive here, so the release's ownership capture is race-free.
+      releaseTurn();
       // Reactions the turn delivered get their durable rows on every
       // terminal path, error exits included: the reaction already happened
       // on the channel, and the record must not depend on the turn
-      // finishing cleanly. Writing here, after the turn stops producing
-      // rows, keeps the record out of any tool_use/tool_result pair; the
-      // resident history misses the rows until the next reload, so the
-      // conversation is stale-marked.
-      await drainQueuedReactionRecords(ctx);
+      // finishing cleanly. Only records this turn captured at release are
+      // drained; writing after the turn stops producing rows keeps them out
+      // of any tool_use/tool_result pair.
+      await drainQueuedReactionRecords(ctx, ownedReactionRecords);
       // kickDrainQueue never rejects: a drain failure here would otherwise be
       // an unhandled rejection that strands the queue with nothing left to
       // re-trigger it.
@@ -2066,20 +2084,18 @@ export async function runAgentLoopImpl(
  * `persistReactionRecords` already logs per-record failures.
  */
 export async function drainQueuedReactionRecords(
-  ctx: Pick<
-    Conversation,
-    "conversationId" | "pendingReactionRecords" | "markHistoryStale"
-  >,
+  ctx: Pick<Conversation, "conversationId" | "markHistoryStale">,
+  ownedRecords: QueuedReactionRecord[] | undefined,
 ): Promise<void> {
   // Runs inside the loop's finally, where a throw would mask the turn's own
-  // outcome, so every access sits inside the guard: partial Conversation
-  // doubles in loop tests carry no reaction queue, and the optional chain
-  // makes their absence a no-op rather than a TypeError.
+  // outcome, so every access sits inside the guard. Drains only the records
+  // the finished turn captured at release, never the conversation's live
+  // queue, so one turn cannot consume a following turn's records.
   try {
-    if (!ctx.pendingReactionRecords?.length) {
+    if (!ownedRecords?.length) {
       return;
     }
-    const queuedReactions = ctx.pendingReactionRecords.splice(0);
+    const queuedReactions = ownedRecords.splice(0);
     await persistReactionRecords(ctx.conversationId, queuedReactions);
     ctx.markHistoryStale();
   } catch {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2071,11 +2071,15 @@ export async function drainQueuedReactionRecords(
     "conversationId" | "pendingReactionRecords" | "markHistoryStale"
   >,
 ): Promise<void> {
-  if (ctx.pendingReactionRecords.length === 0) {
-    return;
-  }
-  const queuedReactions = ctx.pendingReactionRecords.splice(0);
+  // Runs inside the loop's finally, where a throw would mask the turn's own
+  // outcome, so every access sits inside the guard: partial Conversation
+  // doubles in loop tests carry no reaction queue, and the optional chain
+  // makes their absence a no-op rather than a TypeError.
   try {
+    if (!ctx.pendingReactionRecords?.length) {
+      return;
+    }
+    const queuedReactions = ctx.pendingReactionRecords.splice(0);
     await persistReactionRecords(ctx.conversationId, queuedReactions);
     ctx.markHistoryStale();
   } catch {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1578,16 +1578,6 @@ export async function runAgentLoopImpl(
     // assistant message. Testing only the tail keeps the synthetic error row
     // below reachable for mid-turn failures, which is the only durable record
     // of why the turn stopped.
-    // Reactions the turn delivered get their durable rows now, after the
-    // turn's own rows are settled, so they never land inside a
-    // tool_use/tool_result pair. The resident history misses them until the
-    // next reload, so the conversation is stale-marked.
-    if (ctx.pendingReactionRecords.length > 0) {
-      const queuedReactions = ctx.pendingReactionRecords.splice(0);
-      await persistReactionRecords(ctx.conversationId, queuedReactions);
-      ctx.markHistoryStale();
-    }
-
     const hasAssistantResponse =
       newMessages[newMessages.length - 1]?.role === "assistant";
     // A reply that is nothing but the `<no_response/>` sentinel is deliberate
@@ -2051,6 +2041,14 @@ export async function runAgentLoopImpl(
       // the API, enabling stable prefix caching across turns.  Compaction
       // consolidates when it summarizes old messages (cache miss is expected).
     } finally {
+      // Reactions the turn delivered get their durable rows on every
+      // terminal path, error exits included: the reaction already happened
+      // on the channel, and the record must not depend on the turn
+      // finishing cleanly. Writing here, after the turn stops producing
+      // rows, keeps the record out of any tool_use/tool_result pair; the
+      // resident history misses the rows until the next reload, so the
+      // conversation is stale-marked.
+      await drainQueuedReactionRecords(ctx);
       // kickDrainQueue never rejects: a drain failure here would otherwise be
       // an unhandled rejection that strands the queue with nothing left to
       // re-trigger it.
@@ -2059,6 +2057,30 @@ export async function runAgentLoopImpl(
         "agent_loop_finally",
       );
     }
+  }
+}
+
+/**
+ * Persist and clear the turn's queued reaction records. Non-throwing: a
+ * failure here must never mask the turn's own outcome, and
+ * `persistReactionRecords` already logs per-record failures.
+ */
+export async function drainQueuedReactionRecords(
+  ctx: Pick<
+    Conversation,
+    "conversationId" | "pendingReactionRecords" | "markHistoryStale"
+  >,
+): Promise<void> {
+  if (ctx.pendingReactionRecords.length === 0) {
+    return;
+  }
+  const queuedReactions = ctx.pendingReactionRecords.splice(0);
+  try {
+    await persistReactionRecords(ctx.conversationId, queuedReactions);
+    ctx.markHistoryStale();
+  } catch {
+    // persistReactionRecords is itself non-throwing per record; this guard
+    // covers only unexpected faults so the finally block stays safe.
   }
 }
 

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1207,7 +1207,6 @@ export class Conversation {
       // carry neither fact: both envelopes spell these keys literally, in
       // providerMeta and in nested slackMeta alike.
       if (
-        role === "user" &&
         m.metadata &&
         (m.metadata.includes("reaction") || m.metadata.includes("deletedAt"))
       ) {
@@ -1216,11 +1215,14 @@ export class Conversation {
           const rendered = renderReactionHistoryText(
             providerMeta,
             resolveReactionTarget,
+            // An assistant-role reaction row is the assistant's own act,
+            // persisted by the react tool.
+            { selfAuthored: role === "assistant" },
           );
           if (rendered) {
             content = [{ type: "text", text: rendered }];
           }
-        } else if (providerMeta?.deletedAt !== undefined) {
+        } else if (role === "user" && providerMeta?.deletedAt !== undefined) {
           // Neutral marker, no actor: Discord deletes can be authorless
           // (`actorUnattributed`), so the marker never claims who deleted.
           content = [{ type: "text", text: "[This message was deleted]" }];

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -176,6 +176,7 @@ import type { ConversationTransportMetadata } from "./message-types/conversation
 import { isHostProxyTransport } from "./message-types/conversations.js";
 import { conversationMetadataSyncTag } from "./message-types/sync.js";
 import { renderReactionHistoryText } from "./reaction-history-render.js";
+import type { QueuedReactionRecord } from "./reaction-record.js";
 import {
   resolveSummarizeBoundary,
   startsNewTurn,
@@ -543,6 +544,13 @@ export class Conversation {
   /** @internal */ loadedHistoryTrustClass?: TrustClass;
   /** @internal */ loadedHistoryPersonalMemoryAllowed?: boolean;
   /** @internal */ loadedHistoryStale = false;
+  /**
+   * @internal Reactions the current turn delivered, awaiting their durable
+   * rows. Written mid-turn by the react tool, drained by the agent loop at
+   * the turn boundary so the rows never land between a tool_use and its
+   * tool_result.
+   */
+  pendingReactionRecords: QueuedReactionRecord[] = [];
   /** @internal */ voiceCallControlPrompt?: string;
   /** @internal */ transportHints?: string[];
   /**
@@ -1620,6 +1628,11 @@ export class Conversation {
    */
   markHistoryStale(): void {
     this.loadedHistoryStale = true;
+  }
+
+  /** Queue a delivered reaction for its durable row at the turn boundary. */
+  queueReactionRecord(record: QueuedReactionRecord): void {
+    this.pendingReactionRecords.push(record);
   }
 
   /**

--- a/assistant/src/daemon/reaction-history-render.test.ts
+++ b/assistant/src/daemon/reaction-history-render.test.ts
@@ -117,6 +117,29 @@ describe("renderReactionHistoryText", () => {
     expect(rendered).toContain("Bob reacted with");
   });
 
+  test("a self-authored row renders second-person and unfenced", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ source: "discord" }),
+      () => "Deploy is done",
+      { selfAuthored: true },
+    );
+    expect(rendered).toBe(
+      'You reacted with :thumbsup: to the message "Deploy is done"',
+    );
+    expect(rendered).not.toContain("<external_content");
+  });
+
+  test("a self-authored removal reads as your reaction", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ reaction: { op: "removed" } }),
+      noTarget,
+      { selfAuthored: true },
+    );
+    expect(rendered).toContain(
+      "You removed your :thumbsup: reaction from an earlier message",
+    );
+  });
+
   test("returns null for a message row", () => {
     const meta: ProviderMessageMetadata = {
       source: "slack",

--- a/assistant/src/daemon/reaction-history-render.test.ts
+++ b/assistant/src/daemon/reaction-history-render.test.ts
@@ -117,15 +117,25 @@ describe("renderReactionHistoryText", () => {
     expect(rendered).toContain("Bob reacted with");
   });
 
-  test("a self-authored row renders second-person and unfenced", () => {
+  test("a self-authored row is second-person with the quoted target fenced", () => {
     const rendered = renderReactionHistoryText(
       reactionMeta({ source: "discord" }),
       () => "Deploy is done",
       { selfAuthored: true },
     );
-    expect(rendered).toBe(
-      'You reacted with :thumbsup: to the message "Deploy is done"',
+    expect(rendered).toContain("You reacted with :thumbsup: to this message:");
+    expect(rendered).toContain('<external_content source="webhook"');
+    expect(rendered).toContain("Deploy is done");
+    expect(rendered).toContain("</external_content>");
+  });
+
+  test("a self-authored row with no target stays unfenced", () => {
+    const rendered = renderReactionHistoryText(
+      reactionMeta({ source: "discord" }),
+      noTarget,
+      { selfAuthored: true },
     );
+    expect(rendered).toBe("You reacted with :thumbsup: to an earlier message");
     expect(rendered).not.toContain("<external_content");
   });
 

--- a/assistant/src/daemon/reaction-history-render.ts
+++ b/assistant/src/daemon/reaction-history-render.ts
@@ -8,9 +8,14 @@
  * renders regardless of when it was written and no formatting is frozen
  * into persistence.
  *
- * The actor's display name and the quoted target are sender-authored, so
- * the rendered line is fenced as untrusted content the same way channel
- * message text is fenced at ingress (`inbound-content-prep.ts`).
+ * Two authorship contracts share the renderer. An inbound row (role user)
+ * is sender activity: the actor's display name and the quoted target are
+ * sender-authored, so the whole line is fenced as untrusted content the
+ * same way channel text is fenced at ingress (`inbound-content-prep.ts`).
+ * A self-authored row (role assistant, written by the react tool) renders
+ * second-person with the verb unfenced, but the quoted target stays
+ * fenced: the emoji and act are the model's own output, the text it
+ * reacted to is not.
  *
  * Serves consumers of `Conversation.loadFromDb` history. Slack channel
  * turns build their provider history from rows instead and render
@@ -83,9 +88,16 @@ export function renderReactionHistoryText(
       op === "removed"
         ? `removed your ${formatEmoji(emoji)} reaction from`
         : `reacted with ${formatEmoji(emoji)} to`;
-    return snippet
-      ? `You ${verb} the message "${snippet}"`
-      : `You ${verb} an earlier message`;
+    if (!snippet) {
+      return `You ${verb} an earlier message`;
+    }
+    // The quoted target is sender-authored text entering an assistant-role
+    // message; unfenced it would replay as trusted content, so a sender
+    // could plant instructions and induce a reaction to launder them.
+    const fencedSnippet = wrapUntrustedContent(snippet, {
+      source: meta.source === "slack" ? "slack" : "webhook",
+    });
+    return `You ${verb} this message: ${fencedSnippet}`;
   }
 
   const actor = meta.reaction.actorDisplayName ?? meta.displayName ?? "Someone";

--- a/assistant/src/daemon/reaction-history-render.ts
+++ b/assistant/src/daemon/reaction-history-render.ts
@@ -62,18 +62,37 @@ function snippetOf(text: string): string {
 export function renderReactionHistoryText(
   meta: ProviderMessageMetadata,
   resolveTargetText: (targetMessageId: string) => string | undefined,
+  options?: {
+    /**
+     * The row is the assistant's own reaction (an assistant-role row the
+     * react tool persisted). Rendered second-person and unfenced: the actor
+     * and emoji are the model's own output, not sender-authored text.
+     */
+    selfAuthored?: boolean;
+  },
 ): string | null {
   if (meta.eventKind !== "reaction" || !meta.reaction) {
     return null;
   }
   const { emoji, op, targetMessageId } = meta.reaction;
+  const target = resolveTargetText(targetMessageId);
+  const snippet = target ? snippetOf(target) : "";
+
+  if (options?.selfAuthored) {
+    const verb =
+      op === "removed"
+        ? `removed your ${formatEmoji(emoji)} reaction from`
+        : `reacted with ${formatEmoji(emoji)} to`;
+    return snippet
+      ? `You ${verb} the message "${snippet}"`
+      : `You ${verb} an earlier message`;
+  }
+
   const actor = meta.reaction.actorDisplayName ?? meta.displayName ?? "Someone";
   const verb =
     op === "removed"
       ? `removed their ${formatEmoji(emoji)} reaction from`
       : `reacted with ${formatEmoji(emoji)} to`;
-  const target = resolveTargetText(targetMessageId);
-  const snippet = target ? snippetOf(target) : "";
   const line = snippet
     ? `${actor} ${verb} the message "${snippet}"`
     : `${actor} ${verb} an earlier message`;

--- a/assistant/src/daemon/reaction-record.test.ts
+++ b/assistant/src/daemon/reaction-record.test.ts
@@ -99,33 +99,53 @@ describe("persistReactionRecords", () => {
     });
   });
 
-  test("the terminal drain persists queued records, clears the queue, and stale-marks", async () => {
+  test("the terminal drain persists the turn's owned records and stale-marks", async () => {
     // The drain runs in the agent loop's finally, so an error exit still
     // reaches it: a delivered reaction's record must not depend on the turn
     // finishing cleanly.
     let staleMarked = 0;
-    const ctx = {
-      conversationId: "conv-1",
-      pendingReactionRecords: [record(), record({ emoji: "👍" })],
-      markHistoryStale: () => {
-        staleMarked += 1;
+    const owned = [record(), record({ emoji: "👍" })];
+    await drainQueuedReactionRecords(
+      {
+        conversationId: "conv-1",
+        markHistoryStale: () => {
+          staleMarked += 1;
+        },
       },
-    };
-    await drainQueuedReactionRecords(ctx);
+      owned,
+    );
     expect(persisted).toHaveLength(2);
-    expect(ctx.pendingReactionRecords).toHaveLength(0);
+    expect(owned).toHaveLength(0);
     expect(staleMarked).toBe(1);
   });
 
-  test("the terminal drain is a no-op on an empty queue", async () => {
-    let staleMarked = 0;
-    await drainQueuedReactionRecords({
+  test("one turn's drain never consumes a following turn's live queue", async () => {
+    // Ownership is captured at release, while the turn is still exclusive;
+    // the drain takes only that captured array. A record a following turn
+    // queued on the conversation's live field stays untouched until that
+    // turn's own boundary, so its row cannot land before its tool_result.
+    const followingTurnQueue = [record({ emoji: "🆕" })];
+    const ctx = {
       conversationId: "conv-1",
-      pendingReactionRecords: [],
-      markHistoryStale: () => {
-        staleMarked += 1;
+      pendingReactionRecords: followingTurnQueue,
+      markHistoryStale: () => {},
+    };
+    await drainQueuedReactionRecords(ctx, []);
+    expect(persisted).toHaveLength(0);
+    expect(followingTurnQueue).toHaveLength(1);
+  });
+
+  test("the terminal drain is a no-op on an empty or absent owned set", async () => {
+    let staleMarked = 0;
+    await drainQueuedReactionRecords(
+      {
+        conversationId: "conv-1",
+        markHistoryStale: () => {
+          staleMarked += 1;
+        },
       },
-    });
+      undefined,
+    );
     expect(persisted).toHaveLength(0);
     expect(staleMarked).toBe(0);
   });

--- a/assistant/src/daemon/reaction-record.test.ts
+++ b/assistant/src/daemon/reaction-record.test.ts
@@ -28,6 +28,8 @@ mock.module("../persistence/conversation-crud.js", () => ({
 }));
 
 const { persistReactionRecords } = await import("./reaction-record.js");
+const { drainQueuedReactionRecords } =
+  await import("./conversation-agent-loop.js");
 
 function record(
   overrides: Partial<QueuedReactionRecord> = {},
@@ -95,6 +97,37 @@ describe("persistReactionRecords", () => {
       targetChannelTs: "1700.1",
       op: "added",
     });
+  });
+
+  test("the terminal drain persists queued records, clears the queue, and stale-marks", async () => {
+    // The drain runs in the agent loop's finally, so an error exit still
+    // reaches it: a delivered reaction's record must not depend on the turn
+    // finishing cleanly.
+    let staleMarked = 0;
+    const ctx = {
+      conversationId: "conv-1",
+      pendingReactionRecords: [record(), record({ emoji: "👍" })],
+      markHistoryStale: () => {
+        staleMarked += 1;
+      },
+    };
+    await drainQueuedReactionRecords(ctx);
+    expect(persisted).toHaveLength(2);
+    expect(ctx.pendingReactionRecords).toHaveLength(0);
+    expect(staleMarked).toBe(1);
+  });
+
+  test("the terminal drain is a no-op on an empty queue", async () => {
+    let staleMarked = 0;
+    await drainQueuedReactionRecords({
+      conversationId: "conv-1",
+      pendingReactionRecords: [],
+      markHistoryStale: () => {
+        staleMarked += 1;
+      },
+    });
+    expect(persisted).toHaveLength(0);
+    expect(staleMarked).toBe(0);
   });
 
   test("a failed write is logged, not thrown, and later records still persist", async () => {

--- a/assistant/src/daemon/reaction-record.test.ts
+++ b/assistant/src/daemon/reaction-record.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { QueuedReactionRecord } from "./reaction-record.js";
+
+let persisted: Array<{
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata: Record<string, unknown> | undefined;
+}> = [];
+let failNext = false;
+const actualCrud = await import("../persistence/conversation-crud.js");
+mock.module("../persistence/conversation-crud.js", () => ({
+  ...actualCrud,
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    content: string,
+    opts?: { metadata?: Record<string, unknown> },
+  ) => {
+    if (failNext) {
+      failNext = false;
+      throw new Error("db closed");
+    }
+    persisted.push({ conversationId, role, content, metadata: opts?.metadata });
+    return { id: `row-${persisted.length}` };
+  },
+}));
+
+const { persistReactionRecords } = await import("./reaction-record.js");
+
+function record(
+  overrides: Partial<QueuedReactionRecord> = {},
+): QueuedReactionRecord {
+  return {
+    channel: "discord",
+    chatId: "chan-1",
+    messageId: "555.1",
+    emoji: "🎉",
+    op: "added",
+    provenanceTrustClass: "guardian",
+    ...overrides,
+  };
+}
+
+describe("persistReactionRecords", () => {
+  beforeEach(() => {
+    persisted = [];
+    failNext = false;
+  });
+
+  test("a neutral-channel record writes the providerMeta envelope", async () => {
+    await persistReactionRecords("conv-1", [record()]);
+    expect(persisted).toHaveLength(1);
+    const row = persisted[0]!;
+    expect(row.role).toBe("assistant");
+    expect(row.content).toBe("[reaction]");
+    expect(row.metadata?.messageKind).toBe("reaction");
+    expect(row.metadata?.provenanceTrustClass).toBe("guardian");
+    expect(row.metadata?.provenanceSourceChannel).toBe("discord");
+    const envelope = JSON.parse(String(row.metadata?.providerMeta)) as {
+      source: string;
+      eventKind: string;
+      reaction: { targetMessageId: string; emoji: string; op: string };
+    };
+    expect(envelope.source).toBe("discord");
+    expect(envelope.eventKind).toBe("reaction");
+    expect(envelope.reaction).toEqual({
+      targetMessageId: "555.1",
+      emoji: "🎉",
+      op: "added",
+    });
+    expect(row.metadata?.slackMeta).toBeUndefined();
+  });
+
+  test("a Slack record writes the slackMeta envelope the Slack context reads", async () => {
+    await persistReactionRecords("conv-1", [
+      record({ channel: "slack", chatId: "C1", messageId: "1700.1" }),
+    ]);
+    const row = persisted[0]!;
+    expect(row.metadata?.providerMeta).toBeUndefined();
+    const slackMeta = JSON.parse(String(row.metadata?.slackMeta)) as {
+      source: string;
+      channelId: string;
+      channelTs: string;
+      eventKind: string;
+      reaction: { emoji: string; targetChannelTs: string; op: string };
+    };
+    expect(slackMeta.source).toBe("slack");
+    expect(slackMeta.channelId).toBe("C1");
+    expect(slackMeta.channelTs).toBe("1700.1");
+    expect(slackMeta.eventKind).toBe("reaction");
+    expect(slackMeta.reaction).toEqual({
+      emoji: "🎉",
+      targetChannelTs: "1700.1",
+      op: "added",
+    });
+  });
+
+  test("a failed write is logged, not thrown, and later records still persist", async () => {
+    failNext = true;
+    await persistReactionRecords("conv-1", [record(), record({ emoji: "👍" })]);
+    expect(persisted).toHaveLength(1);
+    const envelope = JSON.parse(
+      String(persisted[0]?.metadata?.providerMeta),
+    ) as { reaction: { emoji: string } };
+    expect(envelope.reaction.emoji).toBe("👍");
+  });
+});

--- a/assistant/src/daemon/reaction-record.ts
+++ b/assistant/src/daemon/reaction-record.ts
@@ -1,0 +1,107 @@
+/**
+ * Durable records of the assistant's own delivered reactions.
+ *
+ * A reaction happens mid-turn (the react tool fans out to the channel while
+ * the agent loop is still running), but its row must not be written then: an
+ * assistant row inserted between a `tool_use` and its `tool_result` breaks
+ * the pairing history repair enforces, and a reload would then teach the
+ * model its own reaction failed. The tool queues the record on the live
+ * conversation instead, and the agent loop drains the queue at the turn
+ * boundary, after the turn's rows are settled.
+ *
+ * Slack rows write the `slackMeta` envelope (the Slack transcript context
+ * builds provider history from rows and reads only that shape); every other
+ * channel writes the neutral `providerMeta` that `readProviderMetadata`
+ * serves to channel-agnostic readers, `Conversation.loadFromDb`'s renderer
+ * included.
+ */
+import type { ChannelId } from "../channels/types.js";
+import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
+import {
+  type SlackMessageMetadata,
+  writeSlackMetadata,
+} from "../messaging/providers/slack/message-metadata.js";
+import {
+  addMessage,
+  REACTION_MESSAGE_KIND,
+} from "../persistence/conversation-crud.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("reaction-record");
+
+export interface QueuedReactionRecord {
+  channel: ChannelId;
+  chatId: string;
+  /** Target message id, in the channel's own id space. */
+  messageId: string;
+  emoji: string;
+  op: "added" | "removed";
+  /** The turn's provenance, so actor-scoped loads keep the row. */
+  provenanceTrustClass?: string;
+}
+
+/**
+ * Persist queued reaction records as standalone assistant rows. Non-throwing:
+ * the reactions already happened on the channel, so a persistence failure
+ * loses the record, never the act, and is logged rather than raised.
+ */
+export async function persistReactionRecords(
+  conversationId: string,
+  records: readonly QueuedReactionRecord[],
+): Promise<void> {
+  for (const record of records) {
+    try {
+      const envelope =
+        record.channel === "slack"
+          ? { slackMeta: writeSlackMetadata(slackReactionMeta(record)) }
+          : { providerMeta: JSON.stringify(neutralReactionMeta(record)) };
+      await addMessage(conversationId, "assistant", "[reaction]", {
+        metadata: {
+          messageKind: REACTION_MESSAGE_KIND,
+          ...(record.provenanceTrustClass
+            ? { provenanceTrustClass: record.provenanceTrustClass }
+            : {}),
+          provenanceSourceChannel: record.channel,
+          ...envelope,
+        },
+        skipIndexing: true,
+      });
+    } catch (err) {
+      log.warn(
+        { err, conversationId, channel: record.channel, op: record.op },
+        "Failed to persist the assistant's reaction record",
+      );
+    }
+  }
+}
+
+function neutralReactionMeta(
+  record: QueuedReactionRecord,
+): ProviderMessageMetadata {
+  return {
+    source: record.channel,
+    conversationExternalId: record.chatId,
+    eventKind: "reaction",
+    reaction: {
+      targetMessageId: record.messageId,
+      emoji: record.emoji,
+      op: record.op,
+    },
+  };
+}
+
+function slackReactionMeta(record: QueuedReactionRecord): SlackMessageMetadata {
+  return {
+    source: "slack",
+    channelId: record.chatId,
+    // A reaction row stores the reacted message's ts here; it is the target,
+    // not an id of the row's own, mirroring the inbound persist shape.
+    channelTs: record.messageId,
+    eventKind: "reaction",
+    reaction: {
+      emoji: record.emoji,
+      targetChannelTs: record.messageId,
+      op: record.op,
+    },
+  };
+}

--- a/assistant/src/daemon/reaction-record.ts
+++ b/assistant/src/daemon/reaction-record.ts
@@ -16,11 +16,11 @@
  * included.
  */
 import type { ChannelId } from "../channels/types.js";
-import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
+import { writeSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import {
-  type SlackMessageMetadata,
-  writeSlackMetadata,
-} from "../messaging/providers/slack/message-metadata.js";
+  buildNeutralReactionMeta,
+  buildSlackReactionMeta,
+} from "../messaging/reaction-envelopes.js";
 import {
   addMessage,
   REACTION_MESSAGE_KIND,
@@ -51,10 +51,17 @@ export async function persistReactionRecords(
 ): Promise<void> {
   for (const record of records) {
     try {
+      const facts = {
+        channel: record.channel,
+        chatId: record.chatId,
+        targetMessageId: record.messageId,
+        emoji: record.emoji,
+        op: record.op,
+      };
       const envelope =
         record.channel === "slack"
-          ? { slackMeta: writeSlackMetadata(slackReactionMeta(record)) }
-          : { providerMeta: JSON.stringify(neutralReactionMeta(record)) };
+          ? { slackMeta: writeSlackMetadata(buildSlackReactionMeta(facts)) }
+          : { providerMeta: JSON.stringify(buildNeutralReactionMeta(facts)) };
       await addMessage(conversationId, "assistant", "[reaction]", {
         metadata: {
           messageKind: REACTION_MESSAGE_KIND,
@@ -73,35 +80,4 @@ export async function persistReactionRecords(
       );
     }
   }
-}
-
-function neutralReactionMeta(
-  record: QueuedReactionRecord,
-): ProviderMessageMetadata {
-  return {
-    source: record.channel,
-    conversationExternalId: record.chatId,
-    eventKind: "reaction",
-    reaction: {
-      targetMessageId: record.messageId,
-      emoji: record.emoji,
-      op: record.op,
-    },
-  };
-}
-
-function slackReactionMeta(record: QueuedReactionRecord): SlackMessageMetadata {
-  return {
-    source: "slack",
-    channelId: record.chatId,
-    // A reaction row stores the reacted message's ts here; it is the target,
-    // not an id of the row's own, mirroring the inbound persist shape.
-    channelTs: record.messageId,
-    eventKind: "reaction",
-    reaction: {
-      emoji: record.emoji,
-      targetChannelTs: record.messageId,
-      op: record.op,
-    },
-  };
 }

--- a/assistant/src/messaging/reaction-envelopes.ts
+++ b/assistant/src/messaging/reaction-envelopes.ts
@@ -1,0 +1,79 @@
+/**
+ * The two persisted envelope shapes of a reaction row, built from one set of
+ * facts so the inbound intercept and the assistant's own reaction records
+ * cannot drift apart.
+ *
+ * Slack keeps its own envelope because its transcript context builds
+ * provider history from rows and reads only `slackMeta`; every other channel
+ * writes the neutral shape `readProviderMetadata` serves to channel-agnostic
+ * readers.
+ */
+import type { ChannelId } from "../channels/types.js";
+import type { ProviderMessageMetadata } from "./provider-message-metadata.js";
+import type { SlackMessageMetadata } from "./providers/slack/message-metadata.js";
+
+export interface ReactionEnvelopeFacts {
+  channel: ChannelId;
+  /** Provider id of the chat the reaction belongs to. */
+  chatId: string;
+  /** Target message id, in the channel's own id space. */
+  targetMessageId: string;
+  emoji: string;
+  op: "added" | "removed";
+  /** Absent on the assistant's own reactions. */
+  actorExternalId?: string;
+  /** Absent on the assistant's own reactions. */
+  actorDisplayName?: string;
+}
+
+export function buildNeutralReactionMeta(
+  facts: ReactionEnvelopeFacts,
+): ProviderMessageMetadata {
+  return {
+    source: facts.channel,
+    conversationExternalId: facts.chatId,
+    eventKind: "reaction",
+    ...(facts.actorExternalId
+      ? { actorExternalId: facts.actorExternalId }
+      : {}),
+    ...(facts.actorDisplayName ? { displayName: facts.actorDisplayName } : {}),
+    reaction: {
+      targetMessageId: facts.targetMessageId,
+      emoji: facts.emoji,
+      op: facts.op,
+      ...(facts.actorDisplayName
+        ? { actorDisplayName: facts.actorDisplayName }
+        : {}),
+    },
+  };
+}
+
+export function buildSlackReactionMeta(
+  facts: ReactionEnvelopeFacts,
+): SlackMessageMetadata {
+  return {
+    source: "slack",
+    channelId: facts.chatId,
+    // A reaction row stores the reacted message's ts in `channelTs`, which
+    // is its target rather than an id of its own.
+    channelTs: facts.targetMessageId,
+    eventKind: "reaction",
+    // No `threadTs`: Slack sends none on a reaction, so any thread id in
+    // scope is the reacted message's own ts. It equals `channelTs`, which
+    // every reader treats as "not in a thread" anyway, and storing it makes
+    // the row false evidence that a thread belongs to this conversation
+    // (`legacySlackConversationHasThreadEvidence`).
+    ...(facts.actorExternalId
+      ? { actorExternalUserId: facts.actorExternalId }
+      : {}),
+    ...(facts.actorDisplayName ? { displayName: facts.actorDisplayName } : {}),
+    reaction: {
+      emoji: facts.emoji,
+      targetChannelTs: facts.targetMessageId,
+      op: facts.op,
+      ...(facts.actorDisplayName
+        ? { actorDisplayName: facts.actorDisplayName }
+        : {}),
+    },
+  };
+}

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -92,6 +92,7 @@ import {
   type ConversationOrigin,
   isHiddenMessageMetadata,
   isNoResponseMetadata,
+  isReactionMessageMetadata,
   isSystemCardMetadata,
   PINNED_GROUP_ID,
   SIGHT_FRAME_ATTACHMENT_IDS_KEY,
@@ -464,6 +465,7 @@ export {
   isNoResponseMetadata,
   isSystemCardMetadata,
   NO_RESPONSE_MESSAGE_KIND,
+  REACTION_MESSAGE_KIND,
   SYSTEM_CARD_MESSAGE_KIND,
 } from "./conversation-types.js";
 
@@ -507,7 +509,8 @@ export function isStandaloneAssistantMessage(
     return (
       isSystemCardMetadata(parsed) ||
       isProviderErrorMetadata(parsed) ||
-      isNoResponseMetadata(parsed)
+      isNoResponseMetadata(parsed) ||
+      isReactionMessageMetadata(parsed)
     );
   } catch {
     return false;

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -179,6 +179,24 @@ export function isNoResponseMetadata(
 }
 
 /**
+ * Marker for an assistant-authored reaction row: the assistant reacted with
+ * an emoji, and the row records it durably. The reaction fact itself lives
+ * in the row's `providerMeta.reaction` envelope, same as inbound reaction
+ * rows; this kind carries the display and grouping semantics, keeping the
+ * row a standalone turn (never merged into adjacent assistant speech, where
+ * consolidation would fold its sentinel text into a bubble and drop the
+ * envelope from the wire).
+ */
+export const REACTION_MESSAGE_KIND = "reaction";
+
+/** Shared predicate for the assistant-reaction marker. */
+export function isReactionMessageMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+): boolean {
+  return metadata?.messageKind === REACTION_MESSAGE_KIND;
+}
+
+/**
  * True when a role-`"user"` row is internal scaffolding rather than a person's
  * prompt: a daemon-injected run lifecycle notification (subagent
  * `subagentNotification`, ACP run `acpNotification`, or any wake trigger, the

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -97,6 +97,7 @@ import {
   readSlackMetadataFromMessageMetadata,
   type SlackMessageMetadata,
 } from "../../messaging/providers/slack/message-metadata.js";
+import { readProviderMetadata } from "../../messaging/read-provider-metadata.js";
 import { recordOnboardingEvent } from "../../onboarding/onboarding-events-store.js";
 import {
   classifyKind,
@@ -998,6 +999,7 @@ export async function handleListMessages({
     let backgroundToolCompletion: ConversationMessage["backgroundToolCompletion"];
     let systemCard: boolean | undefined;
     let noResponse: boolean | undefined;
+    let reaction: ConversationMessage["reaction"];
     let providerError: ConversationMessage["providerError"];
     if (msg.metadata) {
       try {
@@ -1012,6 +1014,22 @@ export async function handleListMessages({
         }
         if (isNoResponseMetadata(meta)) {
           noResponse = true;
+        }
+        // A reaction row, either direction, projects its structured fact so
+        // clients never render the stored "[reaction]" sentinel.
+        if (msg.metadata.includes("reaction")) {
+          const reactionMeta = readProviderMetadata(msg.metadata);
+          if (reactionMeta?.eventKind === "reaction" && reactionMeta.reaction) {
+            reaction = {
+              emoji: reactionMeta.reaction.emoji,
+              op: reactionMeta.reaction.op,
+              targetMessageId: reactionMeta.reaction.targetMessageId,
+              ...(reactionMeta.reaction.actorDisplayName
+                ? { actorDisplayName: reactionMeta.reaction.actorDisplayName }
+                : {}),
+              ...(msg.role === "assistant" ? { selfAuthored: true } : {}),
+            };
+          }
         }
         // Daemon-persisted provider-failure notices carry the classified
         // error code/category so clients can render a themed card instead
@@ -1066,6 +1084,7 @@ export async function handleListMessages({
       backgroundToolCompletion,
       systemCard,
       noResponse,
+      reaction,
       providerError,
       slackMessage,
       clientMessageId: msg.clientMessageId ?? undefined,
@@ -1275,6 +1294,7 @@ export async function handleListMessages({
           : {}),
         ...(m.systemCard ? { systemCard: true } : {}),
         ...(m.noResponse ? { noResponse: true } : {}),
+        ...(m.reaction ? { reaction: m.reaction } : {}),
         ...(m.providerError ? { providerError: m.providerError } : {}),
         ...(m.slackMessage ? { slackMessage: m.slackMessage } : {}),
       };

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -30,11 +30,11 @@ import { findConversation } from "../../../daemon/conversation-registry.js";
 import { getDiskPressureStatus } from "../../../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../../../daemon/disk-pressure-policy.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
-import type { ProviderMessageMetadata } from "../../../messaging/provider-message-metadata.js";
+import { writeSlackMetadata } from "../../../messaging/providers/slack/message-metadata.js";
 import {
-  type SlackMessageMetadata,
-  writeSlackMetadata,
-} from "../../../messaging/providers/slack/message-metadata.js";
+  buildNeutralReactionMeta,
+  buildSlackReactionMeta,
+} from "../../../messaging/reaction-envelopes.js";
 import {
   addMessage,
   provenanceFromTrustContext,
@@ -317,31 +317,21 @@ async function persistReactionAsMessage(params: {
   if (params.duplicate) {
     return;
   }
-  const parsed = { op: params.reaction.op, emoji: params.reaction.emoji };
+  const facts = {
+    channel: params.sourceChannel,
+    chatId: params.conversationExternalId,
+    targetMessageId: params.reactedMessageTs,
+    emoji: params.reaction.emoji,
+    op: params.reaction.op,
+    ...(params.actorExternalId
+      ? { actorExternalId: params.actorExternalId }
+      : {}),
+    ...(params.actorDisplayName
+      ? { actorDisplayName: params.actorDisplayName }
+      : {}),
+  };
 
   if (params.sourceChannel !== "slack") {
-    // Slack keeps its own envelope for its renderer; every other channel
-    // writes the neutral shape readProviderMetadata serves to
-    // channel-agnostic readers.
-    const providerMeta: ProviderMessageMetadata = {
-      source: params.sourceChannel,
-      conversationExternalId: params.conversationExternalId,
-      eventKind: "reaction",
-      ...(params.actorExternalId
-        ? { actorExternalId: params.actorExternalId }
-        : {}),
-      ...(params.actorDisplayName
-        ? { displayName: params.actorDisplayName }
-        : {}),
-      reaction: {
-        targetMessageId: params.reactedMessageTs,
-        emoji: parsed.emoji,
-        op: parsed.op,
-        ...(params.actorDisplayName
-          ? { actorDisplayName: params.actorDisplayName }
-          : {}),
-      },
-    };
     const persisted = await addMessage(
       params.conversationId,
       "user",
@@ -349,7 +339,7 @@ async function persistReactionAsMessage(params: {
       {
         metadata: {
           ...provenanceFromTrustContext(params.trustCtx),
-          providerMeta: JSON.stringify(providerMeta),
+          providerMeta: JSON.stringify(buildNeutralReactionMeta(facts)),
         },
         skipIndexing: true,
       },
@@ -359,31 +349,7 @@ async function persistReactionAsMessage(params: {
     return;
   }
 
-  const slackMeta: SlackMessageMetadata = {
-    source: "slack",
-    channelId: params.conversationExternalId,
-    channelTs: params.reactedMessageTs,
-    eventKind: "reaction",
-    // No `threadTs`: Slack sends none on a reaction, so the gateway's thread
-    // id here is the reacted message's own ts. It equals `channelTs`, which
-    // every reader treats as "not in a thread" anyway, and storing it makes
-    // the row false evidence that a thread belongs to this conversation
-    // (`legacySlackConversationHasThreadEvidence`).
-    ...(params.actorExternalId
-      ? { actorExternalUserId: params.actorExternalId }
-      : {}),
-    ...(params.actorDisplayName
-      ? { displayName: params.actorDisplayName }
-      : {}),
-    reaction: {
-      emoji: parsed.emoji,
-      targetChannelTs: params.reactedMessageTs,
-      op: parsed.op,
-      ...(params.actorDisplayName
-        ? { actorDisplayName: params.actorDisplayName }
-        : {}),
-    },
-  };
+  const slackMeta = buildSlackReactionMeta(facts);
 
   // Sentinel content — Slack transcript renderers read `slackMeta` to format
   // the reaction line; the literal text is never displayed to the model.

--- a/assistant/src/tools/channel/react-to-message.test.ts
+++ b/assistant/src/tools/channel/react-to-message.test.ts
@@ -15,6 +15,33 @@ mock.module("../../messaging/providers/index.js", () => ({
   },
 }));
 
+let persisted: Array<{
+  conversationId: string;
+  role: string;
+  content: string;
+  metadata: Record<string, unknown> | undefined;
+}> = [];
+const actualCrud = await import("../../persistence/conversation-crud.js");
+mock.module("../../persistence/conversation-crud.js", () => ({
+  ...actualCrud,
+  addMessage: async (
+    conversationId: string,
+    role: string,
+    content: string,
+    opts?: { metadata?: Record<string, unknown> },
+  ) => {
+    persisted.push({ conversationId, role, content, metadata: opts?.metadata });
+    return { id: `persisted-${persisted.length}` };
+  },
+}));
+
+let staleMarked: string[] = [];
+mock.module("../../daemon/conversation-registry.js", () => ({
+  findConversation: (id: string) => ({
+    markHistoryStale: () => staleMarked.push(id),
+  }),
+}));
+
 const { reactToMessageTool } = await import("./react-to-message.js");
 
 function channelContext(overrides: Partial<ToolContext> = {}): ToolContext {
@@ -34,6 +61,8 @@ describe("react_to_message", () => {
     reactCalls = [];
     reactResultOk = true;
     channelSupported = true;
+    persisted = [];
+    staleMarked = [];
   });
 
   test("reacts to the triggering message by default", async () => {
@@ -112,6 +141,49 @@ describe("react_to_message", () => {
       channelContext(),
     );
     expect(result.isError).toBe(true);
+  });
+
+  test("a delivered reaction persists as a standalone reaction row", async () => {
+    await reactToMessageTool.execute({ emoji: "thumbsup" }, channelContext());
+    expect(persisted).toHaveLength(1);
+    const row = persisted[0]!;
+    expect(row.conversationId).toBe("conv-1");
+    expect(row.role).toBe("assistant");
+    expect(row.content).toBe("[reaction]");
+    expect(row.metadata?.messageKind).toBe("reaction");
+    expect(row.metadata?.provenanceTrustClass).toBe("guardian");
+    expect(row.metadata?.provenanceSourceChannel).toBe("slack");
+    const envelope = JSON.parse(String(row.metadata?.providerMeta)) as {
+      source: string;
+      eventKind: string;
+      reaction: { targetMessageId: string; emoji: string; op: string };
+    };
+    expect(envelope.source).toBe("slack");
+    expect(envelope.eventKind).toBe("reaction");
+    expect(envelope.reaction).toEqual({
+      targetMessageId: "1700000000.111111",
+      emoji: "thumbsup",
+      op: "added",
+    });
+    expect(staleMarked).toEqual(["conv-1"]);
+  });
+
+  test("a removed reaction persists op removed", async () => {
+    await reactToMessageTool.execute(
+      { emoji: "thumbsup", action: "remove" },
+      channelContext(),
+    );
+    const envelope = JSON.parse(
+      String(persisted[0]?.metadata?.providerMeta),
+    ) as { reaction: { op: string } };
+    expect(envelope.reaction.op).toBe("removed");
+  });
+
+  test("a rejected reaction persists nothing", async () => {
+    reactResultOk = false;
+    await reactToMessageTool.execute({ emoji: "thumbsup" }, channelContext());
+    expect(persisted).toHaveLength(0);
+    expect(staleMarked).toHaveLength(0);
   });
 
   test("rejects input with no emoji", async () => {

--- a/assistant/src/tools/channel/react-to-message.test.ts
+++ b/assistant/src/tools/channel/react-to-message.test.ts
@@ -15,31 +15,32 @@ mock.module("../../messaging/providers/index.js", () => ({
   },
 }));
 
-let persisted: Array<{
-  conversationId: string;
-  role: string;
-  content: string;
-  metadata: Record<string, unknown> | undefined;
-}> = [];
-const actualCrud = await import("../../persistence/conversation-crud.js");
-mock.module("../../persistence/conversation-crud.js", () => ({
-  ...actualCrud,
-  addMessage: async (
-    conversationId: string,
-    role: string,
-    content: string,
-    opts?: { metadata?: Record<string, unknown> },
-  ) => {
-    persisted.push({ conversationId, role, content, metadata: opts?.metadata });
-    return { id: `persisted-${persisted.length}` };
-  },
+import type { QueuedReactionRecord } from "../../daemon/reaction-record.js";
+
+let queued: Array<{ conversationId: string; record: QueuedReactionRecord }> =
+  [];
+let conversationResident = true;
+mock.module("../../daemon/conversation-registry.js", () => ({
+  findConversationOrSubagent: (id: string) =>
+    conversationResident
+      ? {
+          queueReactionRecord: (record: QueuedReactionRecord) =>
+            queued.push({ conversationId: id, record }),
+        }
+      : undefined,
 }));
 
-let staleMarked: string[] = [];
-mock.module("../../daemon/conversation-registry.js", () => ({
-  findConversation: (id: string) => ({
-    markHistoryStale: () => staleMarked.push(id),
-  }),
+let directPersists: Array<{
+  conversationId: string;
+  records: readonly QueuedReactionRecord[];
+}> = [];
+mock.module("../../daemon/reaction-record.js", () => ({
+  persistReactionRecords: async (
+    conversationId: string,
+    records: readonly QueuedReactionRecord[],
+  ) => {
+    directPersists.push({ conversationId, records });
+  },
 }));
 
 const { reactToMessageTool } = await import("./react-to-message.js");
@@ -61,8 +62,9 @@ describe("react_to_message", () => {
     reactCalls = [];
     reactResultOk = true;
     channelSupported = true;
-    persisted = [];
-    staleMarked = [];
+    queued = [];
+    directPersists = [];
+    conversationResident = true;
   });
 
   test("reacts to the triggering message by default", async () => {
@@ -143,47 +145,44 @@ describe("react_to_message", () => {
     expect(result.isError).toBe(true);
   });
 
-  test("a delivered reaction persists as a standalone reaction row", async () => {
+  test("a delivered reaction queues its durable record on the conversation", async () => {
     await reactToMessageTool.execute({ emoji: "thumbsup" }, channelContext());
-    expect(persisted).toHaveLength(1);
-    const row = persisted[0]!;
-    expect(row.conversationId).toBe("conv-1");
-    expect(row.role).toBe("assistant");
-    expect(row.content).toBe("[reaction]");
-    expect(row.metadata?.messageKind).toBe("reaction");
-    expect(row.metadata?.provenanceTrustClass).toBe("guardian");
-    expect(row.metadata?.provenanceSourceChannel).toBe("slack");
-    const envelope = JSON.parse(String(row.metadata?.providerMeta)) as {
-      source: string;
-      eventKind: string;
-      reaction: { targetMessageId: string; emoji: string; op: string };
-    };
-    expect(envelope.source).toBe("slack");
-    expect(envelope.eventKind).toBe("reaction");
-    expect(envelope.reaction).toEqual({
-      targetMessageId: "1700000000.111111",
-      emoji: "thumbsup",
-      op: "added",
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toEqual({
+      conversationId: "conv-1",
+      record: {
+        channel: "slack",
+        chatId: "C123",
+        messageId: "1700000000.111111",
+        emoji: "thumbsup",
+        op: "added",
+        provenanceTrustClass: "guardian",
+      },
     });
-    expect(staleMarked).toEqual(["conv-1"]);
+    expect(directPersists).toHaveLength(0);
   });
 
-  test("a removed reaction persists op removed", async () => {
+  test("a removed reaction queues op removed", async () => {
     await reactToMessageTool.execute(
       { emoji: "thumbsup", action: "remove" },
       channelContext(),
     );
-    const envelope = JSON.parse(
-      String(persisted[0]?.metadata?.providerMeta),
-    ) as { reaction: { op: string } };
-    expect(envelope.reaction.op).toBe("removed");
+    expect(queued[0]?.record.op).toBe("removed");
   });
 
-  test("a rejected reaction persists nothing", async () => {
+  test("with no resident conversation the record persists directly", async () => {
+    conversationResident = false;
+    await reactToMessageTool.execute({ emoji: "thumbsup" }, channelContext());
+    expect(queued).toHaveLength(0);
+    expect(directPersists).toHaveLength(1);
+    expect(directPersists[0]?.records[0]?.emoji).toBe("thumbsup");
+  });
+
+  test("a rejected reaction records nothing", async () => {
     reactResultOk = false;
     await reactToMessageTool.execute({ emoji: "thumbsup" }, channelContext());
-    expect(persisted).toHaveLength(0);
-    expect(staleMarked).toHaveLength(0);
+    expect(queued).toHaveLength(0);
+    expect(directPersists).toHaveLength(0);
   });
 
   test("rejects input with no emoji", async () => {

--- a/assistant/src/tools/channel/react-to-message.ts
+++ b/assistant/src/tools/channel/react-to-message.ts
@@ -15,17 +15,13 @@
 import { z } from "zod";
 
 import { parseChannelId } from "../../channels/types.js";
-import { findConversation } from "../../daemon/conversation-registry.js";
-import type { ProviderMessageMetadata } from "../../messaging/provider-message-metadata.js";
+import { findConversationOrSubagent } from "../../daemon/conversation-registry.js";
+import { persistReactionRecords } from "../../daemon/reaction-record.js";
 import {
   sendChannelReaction,
   supportsChannelReaction,
 } from "../../messaging/providers/index.js";
 import { RiskLevel } from "../../permissions/types.js";
-import {
-  addMessage,
-  REACTION_MESSAGE_KIND,
-} from "../../persistence/conversation-crud.js";
 import {
   invalidToolInputResult,
   toToolInputSchema,
@@ -124,41 +120,32 @@ export const reactToMessageTool = {
       };
     }
 
-    // The delivered reaction persists as a row, the same canonical fact
-    // inbound reactions store, so it survives eviction, renders in agent
-    // history, and stays a standalone turn under the reaction message kind.
-    // Provenance mirrors the turn's, keeping the row visible to the same
-    // actor-scoped loads; failure to persist never fails the tool, since
-    // the reaction itself already happened.
+    // The delivered reaction becomes a durable row, the same canonical
+    // fact inbound reactions store. Queued on the live conversation and
+    // drained by the agent loop at the turn boundary, never written here:
+    // an assistant row inserted between this call's tool_use and its
+    // tool_result would break the pairing history repair enforces, and a
+    // reload would read the reaction as having failed. The rare turn with
+    // no resident conversation persists directly, trading perfect row
+    // ordering for durability.
     const sourceChannel = parseChannelId(channel);
-    try {
-      if (!sourceChannel) {
-        throw new Error(`unrecognized channel id: ${channel}`);
-      }
-      const providerMeta: ProviderMessageMetadata = {
-        source: sourceChannel,
-        conversationExternalId: chatId,
-        eventKind: "reaction",
-        reaction: {
-          targetMessageId: messageId,
-          emoji: parsed.data.emoji,
-          op: action === "remove" ? "removed" : "added",
-        },
+    if (sourceChannel) {
+      const record = {
+        channel: sourceChannel,
+        chatId,
+        messageId,
+        emoji: parsed.data.emoji,
+        op: action === "remove" ? ("removed" as const) : ("added" as const),
+        ...(context.trustClass
+          ? { provenanceTrustClass: context.trustClass }
+          : {}),
       };
-      await addMessage(context.conversationId, "assistant", "[reaction]", {
-        metadata: {
-          messageKind: REACTION_MESSAGE_KIND,
-          ...(context.trustClass
-            ? { provenanceTrustClass: context.trustClass }
-            : {}),
-          provenanceSourceChannel: channel,
-          providerMeta: JSON.stringify(providerMeta),
-        },
-        skipIndexing: true,
-      });
-      findConversation(context.conversationId)?.markHistoryStale();
-    } catch {
-      // Logged by persistence; the reaction was delivered either way.
+      const conversation = findConversationOrSubagent(context.conversationId);
+      if (conversation) {
+        conversation.queueReactionRecord(record);
+      } else {
+        await persistReactionRecords(context.conversationId, [record]);
+      }
     }
 
     return {

--- a/assistant/src/tools/channel/react-to-message.ts
+++ b/assistant/src/tools/channel/react-to-message.ts
@@ -14,11 +14,18 @@
  */
 import { z } from "zod";
 
+import { parseChannelId } from "../../channels/types.js";
+import { findConversation } from "../../daemon/conversation-registry.js";
+import type { ProviderMessageMetadata } from "../../messaging/provider-message-metadata.js";
 import {
   sendChannelReaction,
   supportsChannelReaction,
 } from "../../messaging/providers/index.js";
 import { RiskLevel } from "../../permissions/types.js";
+import {
+  addMessage,
+  REACTION_MESSAGE_KIND,
+} from "../../persistence/conversation-crud.js";
 import {
   invalidToolInputResult,
   toToolInputSchema,
@@ -116,6 +123,44 @@ export const reactToMessageTool = {
         isError: true,
       };
     }
+
+    // The delivered reaction persists as a row, the same canonical fact
+    // inbound reactions store, so it survives eviction, renders in agent
+    // history, and stays a standalone turn under the reaction message kind.
+    // Provenance mirrors the turn's, keeping the row visible to the same
+    // actor-scoped loads; failure to persist never fails the tool, since
+    // the reaction itself already happened.
+    const sourceChannel = parseChannelId(channel);
+    try {
+      if (!sourceChannel) {
+        throw new Error(`unrecognized channel id: ${channel}`);
+      }
+      const providerMeta: ProviderMessageMetadata = {
+        source: sourceChannel,
+        conversationExternalId: chatId,
+        eventKind: "reaction",
+        reaction: {
+          targetMessageId: messageId,
+          emoji: parsed.data.emoji,
+          op: action === "remove" ? "removed" : "added",
+        },
+      };
+      await addMessage(context.conversationId, "assistant", "[reaction]", {
+        metadata: {
+          messageKind: REACTION_MESSAGE_KIND,
+          ...(context.trustClass
+            ? { provenanceTrustClass: context.trustClass }
+            : {}),
+          provenanceSourceChannel: channel,
+          providerMeta: JSON.stringify(providerMeta),
+        },
+        skipIndexing: true,
+      });
+      findConversation(context.conversationId)?.markHistoryStale();
+    } catch {
+      // Logged by persistence; the reaction was delivered either way.
+    }
+
     return {
       content:
         action === "remove"

--- a/bun.lock
+++ b/bun.lock
@@ -669,8 +669,8 @@
     "@playwright/browser-chromium",
   ],
   "patchedDependencies": {
-    "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch",
     "app-builder-lib@26.8.1": "patches/app-builder-lib@26.8.1.patch",
+    "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch",
     "storybook@10.4.0": "patches/storybook@10.4.0.patch",
   },
   "overrides": {

--- a/bun.lock
+++ b/bun.lock
@@ -669,8 +669,8 @@
     "@playwright/browser-chromium",
   ],
   "patchedDependencies": {
-    "app-builder-lib@26.8.1": "patches/app-builder-lib@26.8.1.patch",
     "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch",
+    "app-builder-lib@26.8.1": "patches/app-builder-lib@26.8.1.patch",
     "storybook@10.4.0": "patches/storybook@10.4.0.patch",
   },
   "overrides": {

--- a/clients/web/src/domains/chat/transcript/reaction-line-row.tsx
+++ b/clients/web/src/domains/chat/transcript/reaction-line-row.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from "@/i18n";
+import type { DisplayMessage } from "@/domains/chat/types/types";
+
+/**
+ * Quiet line for a reaction row, either direction, rendered from the
+ * projected reaction fact rather than the row's stored sentinel text.
+ * Slack-shaped rows keep their richer Slack transcript line; this covers
+ * every other channel and the assistant's own reactions, until the
+ * reaction-pill UI replaces both.
+ */
+export function ReactionLineRow({ message }: { message: DisplayMessage }) {
+  const { t } = useTranslation("chat");
+  const reaction = message.reaction;
+  if (!reaction) {
+    return null;
+  }
+  const key = reaction.selfAuthored
+    ? reaction.op === "removed"
+      ? "transcript.reactionRemovedSelf"
+      : "transcript.reactionAddedSelf"
+    : reaction.op === "removed"
+      ? "transcript.reactionRemoved"
+      : "transcript.reactionAdded";
+  return (
+    <div
+      data-testid="reaction-line-row"
+      className="text-body-small-default text-[var(--content-tertiary)] italic"
+    >
+      {t(key, {
+        emoji: reaction.emoji,
+        name: reaction.actorDisplayName ?? t("transcript.reactionSomeone"),
+      })}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.test.tsx
@@ -44,6 +44,32 @@ const PROACTIVE_ITEM: CreditsUpsellItem = {
   key: "credits-upsell-proactive",
 };
 
+describe("TranscriptRow reaction dispatch", () => {
+  test("a neutral reaction row renders the reaction line in the shell, never the sentinel", () => {
+    const message: DisplayMessage = {
+      id: "m-react",
+      role: "assistant",
+      ...textBody("[reaction]"),
+      reaction: {
+        emoji: "🎉",
+        op: "added",
+        targetMessageId: "555.1",
+        selfAuthored: true,
+      },
+    };
+    const { getByTestId, queryByText, container } = render(
+      <TranscriptRow
+        item={{ kind: "message", key: "m-react", message }}
+        onSurfaceAction={() => {}}
+      />,
+    );
+    expect(getByTestId("reaction-line-row")).toBeTruthy();
+    expect(getByTestId("reaction-line-row").textContent).toContain("🎉");
+    expect(queryByText("[reaction]")).toBeNull();
+    expect(container.querySelector("#msg-m-react")).toBeTruthy();
+  });
+});
+
 describe("TranscriptRow deliberate-silence dispatch", () => {
   test("an isNoResponse message renders the quiet marker in the message shell", () => {
     // The wire shape: the route strips sentinel text from projected content,

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -17,6 +17,7 @@ import { PendingContactRecordRequestRow } from "@/domains/chat/transcript/pendin
 import { PendingContactRequestRow } from "@/domains/chat/transcript/pending-contact-request-row";
 import { PendingSecretRow } from "@/domains/chat/transcript/pending-secret-row";
 import { NoResponseRow } from "@/domains/chat/transcript/no-response-row";
+import { ReactionLineRow } from "@/domains/chat/transcript/reaction-line-row";
 import { SystemCardRow } from "@/domains/chat/transcript/system-card-row";
 import { TranscriptMessageBody } from "@/domains/chat/transcript/transcript-message-body";
 import { isInteractiveClickTarget } from "@/domains/chat/transcript/transcript-message-body-shared";
@@ -234,6 +235,20 @@ export const TranscriptRow = memo(function TranscriptRow({
       // A deliberate-silence turn renders as a quiet marker with fixed copy
       // inside the standard message shell, so deep links, scrolling, and
       // Inspect still address the row; its stored content never shows.
+      // A reaction row renders as a quiet line from its projected fact,
+      // never the stored sentinel text. Slack-shaped rows keep their richer
+      // Slack transcript line inside the ordinary body path.
+      if (item.message.reaction && !item.message.slackMessage) {
+        return (
+          <SubstitutedMessageShell
+            message={item.message}
+            conversationId={conversationId}
+            onInspectMessage={onInspectMessage}
+          >
+            <ReactionLineRow message={item.message} />
+          </SubstitutedMessageShell>
+        );
+      }
       if (item.message.isNoResponse) {
         return (
           <SubstitutedMessageShell

--- a/clients/web/src/domains/chat/types/types.ts
+++ b/clients/web/src/domains/chat/types/types.ts
@@ -167,6 +167,15 @@ export interface DisplayMessage {
    *  Mirrors `ConversationMessage["noResponse"]`; renders as a quiet marker
    *  and counts as the turn's reply. */
   isNoResponse?: boolean;
+  /** Reaction row, either direction. Mirrors `ConversationMessage["reaction"]`;
+   *  renders as a reaction line, never the stored sentinel text. */
+  reaction?: {
+    emoji: string;
+    op: "added" | "removed";
+    targetMessageId: string;
+    actorDisplayName?: string;
+    selfAuthored?: boolean;
+  };
   /** Provider-failure notice metadata, carried from the wire
    *  `ConversationMessage["providerError"]`. `code` is the stable classified
    *  error code (e.g. `"PROVIDER_BILLING"`), `category` the classified

--- a/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.test.ts
@@ -184,6 +184,25 @@ describe("mapRuntimeToDisplayMessage", () => {
     expect(mapRuntimeToDisplayMessage(m).isNoResponse).toBe(true);
   });
 
+  test("carries the reaction fact onto the display message", () => {
+    const m = makeMessage({
+      id: "m-react",
+      role: "assistant",
+      reaction: {
+        emoji: "🎉",
+        op: "added",
+        targetMessageId: "555.1",
+        selfAuthored: true,
+      },
+    });
+    expect(mapRuntimeToDisplayMessage(m).reaction).toEqual({
+      emoji: "🎉",
+      op: "added",
+      targetMessageId: "555.1",
+      selfAuthored: true,
+    });
+  });
+
   test("carries providerError code and category onto the display message", () => {
     const plain = makeMessage({ id: "m-plain", role: "assistant" });
     expect(mapRuntimeToDisplayMessage(plain).providerError).toBeUndefined();

--- a/clients/web/src/domains/chat/utils/map-runtime-message.ts
+++ b/clients/web/src/domains/chat/utils/map-runtime-message.ts
@@ -189,6 +189,9 @@ export function mapRuntimeToDisplayMessage(
   if (m.noResponse) {
     msg.isNoResponse = true;
   }
+  if (m.reaction) {
+    msg.reaction = m.reaction;
+  }
   if (m.providerError) {
     msg.providerError = {
       code: m.providerError.code,

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1763,6 +1763,11 @@
     "openTitle": "Open {path}"
   },
   "transcript": {
-    "noResponse": "Chose not to respond"
+    "noResponse": "Chose not to respond",
+    "reactionAddedSelf": "Reacted with {emoji}",
+    "reactionRemovedSelf": "Removed the {emoji} reaction",
+    "reactionAdded": "{name} reacted with {emoji}",
+    "reactionRemoved": "{name} removed their {emoji} reaction",
+    "reactionSomeone": "Someone"
   }
 }

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1752,6 +1752,11 @@
     "openTitle": "Abrir {path}"
   },
   "transcript": {
-    "noResponse": "Decidió no responder"
+    "noResponse": "Decidió no responder",
+    "reactionAddedSelf": "Reaccionó con {emoji}",
+    "reactionRemovedSelf": "Quitó la reacción {emoji}",
+    "reactionAdded": "{name} reaccionó con {emoji}",
+    "reactionRemoved": "{name} quitó su reacción {emoji}",
+    "reactionSomeone": "Alguien"
   }
 }

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -808,6 +808,11 @@
     "unmuteMicrophone": "Включить микрофон"
   },
   "transcript": {
-    "noResponse": "Решил не отвечать"
+    "noResponse": "Решил не отвечать",
+    "reactionAddedSelf": "Отреагировал(а) {emoji}",
+    "reactionRemovedSelf": "Убрал(а) реакцию {emoji}",
+    "reactionAdded": "{name} отреагировал(а) {emoji}",
+    "reactionRemoved": "{name} убрал(а) свою реакцию {emoji}",
+    "reactionSomeone": "Кто-то"
   }
 }

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -1730,6 +1730,11 @@
     "openTitle": "開啟 {path}"
   },
   "transcript": {
-    "noResponse": "決定不回覆"
+    "noResponse": "決定不回覆",
+    "reactionAddedSelf": "已用 {emoji} 回應",
+    "reactionRemovedSelf": "已移除 {emoji} 回應",
+    "reactionAdded": "{name} 用 {emoji} 回應",
+    "reactionRemoved": "{name} 移除了 {emoji} 回應",
+    "reactionSomeone": "有人"
   }
 }

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -1730,6 +1730,11 @@
     "openTitle": "打开 {path}"
   },
   "transcript": {
-    "noResponse": "决定不回复"
+    "noResponse": "决定不回复",
+    "reactionAddedSelf": "已用 {emoji} 回应",
+    "reactionRemovedSelf": "已移除 {emoji} 回应",
+    "reactionAdded": "{name} 用 {emoji} 回应",
+    "reactionRemoved": "{name} 移除了 {emoji} 回应",
+    "reactionSomeone": "有人"
   }
 }


### PR DESCRIPTION
# The assistant's own reactions persist as rows

Third slice of the reactions arc, and the daemon half of the agreed end state: reactions are message-level state, with the persisted row as the single source of truth for every producer.

## TL;DR

Until now a delivered assistant reaction survived only in the turn's tool-call record: after eviction the assistant forgot it had reacted, no other surface could ever learn of it, and the symmetric model (inbound reactions persist, outbound vanish) had a hole. The react tool now persists the same canonical fact inbound reactions store, immediately after a successful channel fan-out.

## The row

An assistant-role row with the `providerMeta.reaction` envelope (target message, emoji, add/remove op, in the channel's own id space), plus three things the envelope alone would not give it:

- **The `reaction` message kind**, joining the standalone family (`system_card`, `provider_error`, `no_response`): consolidation never folds the row's sentinel text into adjacent assistant speech, where the envelope would drop off the wire.
- **The turn's provenance** (trust class + source channel), so actor-scoped history loads keep the row for the same viewers who saw the turn.
- **A stale-mark on the resident conversation**, the established pattern from the inbound intercepts, so the next turn's history reload picks the row up.

History rendering widens to assistant-role reaction rows, rendered second-person and unfenced ("You reacted with 🎉 to the message …") since the actor and emoji are the model's own output rather than sender-authored text. Inbound rows keep their fenced third-person rendering unchanged.

## What changes for someone using it

| Before | After |
| --- | --- |
| The assistant reacts on Slack, the conversation is later evicted, and the assistant has no memory it ever reacted | The reaction is a durable row; the next turn reads "You reacted with 👍 to …" |
| Reactions are asymmetric state: inbound persists, outbound vanishes | One canonical row shape for both directions, per the message-level-state decision |

## Why it is safe

- Persistence runs only after the channel accepted the reaction, and a persistence failure never fails the tool: the reaction already happened, and the loss is the record, not the act.
- The channel id entering the envelope is validated through `parseChannelId` rather than cast; an unrecognized id (unreachable behind the capability gate) skips persistence rather than storing an invalid envelope.
- Assistant-role rows never start turns (`startsNewTurn` keys on user role), so the row cannot inflate the rehydrated turn counter the way inbound rows once did.
- Web rendering of these rows is deliberately deferred to the reaction-UI slice: today they render like neutral inbound reaction rows already do, and the UI slice replaces both with pills.

## Verification

The tool suite now asserts persistence rather than merely tolerating it: row shape (role, sentinel content, kind, provenance, envelope, op mapping), stale-marking, and that a rejected reaction persists nothing. Renderer units pin the second-person unfenced forms; a load-time test drives an assistant reaction row through `loadFromDb` and asserts the model reads "You reacted…" and never the sentinel; the turn-boundary and standalone-family suites pass with the widened predicate.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->