### PR TITLE
fix(voice): capture live voice without automatic gain control (JARVIS-1694)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.test.ts
@@ -81,13 +81,19 @@ class FakeAudioContext {
 
 let getUserMediaImpl: () => Promise<FakeMediaStream> = () =>
   Promise.resolve(new FakeMediaStream());
+// Constraints handed to the last getUserMedia call, so tests can assert what
+// the capture actually asked the browser for.
+let lastGetUserMediaConstraints: MediaStreamConstraints | null = null;
 
 function installAudioGlobals(): void {
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
     value: {
       mediaDevices: {
-        getUserMedia: () => getUserMediaImpl(),
+        getUserMedia: (constraints?: MediaStreamConstraints) => {
+          lastGetUserMediaConstraints = constraints ?? null;
+          return getUserMediaImpl();
+        },
       },
     },
   });
@@ -109,6 +115,7 @@ function installAudioGlobals(): void {
 beforeEach(() => {
   lastWorklet = null;
   FakeAudioContext.lastInstance = null;
+  lastGetUserMediaConstraints = null;
   getUserMediaImpl = () => Promise.resolve(new FakeMediaStream());
   installAudioGlobals();
 });
@@ -216,6 +223,37 @@ describe("isSupported", () => {
       value: { mediaDevices: {} },
     });
     expect(isSupported()).toBe(false);
+  });
+});
+
+describe("gain control", () => {
+  test("requests auto gain by default (half-duplex consumers)", async () => {
+    const capture = new LiveVoiceAudioCapture({ onChunk: () => {} });
+
+    await capture.start();
+
+    expect(lastGetUserMediaConstraints).not.toBeNull();
+    const audio = lastGetUserMediaConstraints?.audio as MediaTrackConstraints;
+    expect(audio.autoGainControl).toBe(true);
+    await capture.shutdown();
+  });
+
+  test("drops auto gain when asked, keeping echo cancellation on", async () => {
+    const capture = new LiveVoiceAudioCapture({
+      onChunk: () => {},
+      autoGainControl: false,
+    });
+
+    await capture.start();
+
+    const audio = lastGetUserMediaConstraints?.audio as MediaTrackConstraints;
+    // A moving input gain in front of the daemon's fixed absolute barge-in
+    // threshold is what lets room noise cancel a reply (JARVIS-1694). Echo
+    // cancellation is unrelated and must survive the opt-out.
+    expect(audio.autoGainControl).toBe(false);
+    expect(audio.echoCancellation).toBe(true);
+    expect(audio.noiseSuppression).toBe(true);
+    await capture.shutdown();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/pcm-capture.ts
@@ -79,6 +79,18 @@ export interface LiveVoiceAudioCaptureOptions {
   onChunk: (buf: ArrayBuffer) => void;
   /** Receives the smoothed RMS amplitude in [0, 1] for UI / barge-in. */
   onAmplitude?: (amplitude: number) => void;
+  /**
+   * Request automatic gain control on the mic track. Defaults to `true`.
+   *
+   * Half-duplex consumers of this pipeline (streaming dictation, the watch
+   * session) want the default: nothing is playing back, so normalizing a quiet
+   * talker only helps the transcriber. Full-duplex live voice passes `false`,
+   * because a moving input gain sits between the room and the fixed absolute
+   * threshold its barge-in gate compares against. The reasoning lives on
+   * `VoiceInputConstraintOptions.autoGainControl` in
+   * `@/utils/voice-input-device`.
+   */
+  autoGainControl?: boolean;
 }
 
 /**
@@ -129,6 +141,7 @@ function classifyError(cause: unknown): LiveVoiceCaptureError {
 export class LiveVoiceAudioCapture {
   private readonly onChunk: (buf: ArrayBuffer) => void;
   private readonly onAmplitude?: (amplitude: number) => void;
+  private readonly autoGainControl: boolean;
 
   private stream: MediaStream | null = null;
   private context: AudioContext | null = null;
@@ -148,6 +161,7 @@ export class LiveVoiceAudioCapture {
   constructor(options: LiveVoiceAudioCaptureOptions) {
     this.onChunk = options.onChunk;
     this.onAmplitude = options.onAmplitude;
+    this.autoGainControl = options.autoGainControl ?? true;
   }
 
   /**
@@ -174,7 +188,9 @@ export class LiveVoiceAudioCapture {
 
     let stream: MediaStream;
     try {
-      stream = await getVoiceInputMediaStream();
+      stream = await getVoiceInputMediaStream({
+        autoGainControl: this.autoGainControl,
+      });
     } catch (cause) {
       return { ok: false, error: classifyError(cause), cause };
     }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -793,6 +793,14 @@ export function useLiveVoice(
         onChunk: (buf) => handleChunk(session, buf),
         onAmplitude: (amplitude) =>
           handleAmplitude(session, amplitude, teardown),
+        // Full-duplex capture runs without AGC. Barge-in is decided on the
+        // daemon by comparing mean absolute amplitude against a threshold on
+        // the absolute 16-bit scale, and AGC is a moving gain in front of that
+        // fixed number: it lifts a quiet room's noise floor toward the level
+        // speech reaches in a loud one, so ordinary room noise clears the gate
+        // and cancels the reply. Every other consumer of this capture pipeline
+        // is half-duplex and keeps the default (JARVIS-1694).
+        autoGainControl: false,
       });
       session.capture = capture;
       sessionRef.current = session;

--- a/clients/web/src/utils/voice-input-device.test.ts
+++ b/clients/web/src/utils/voice-input-device.test.ts
@@ -31,4 +31,22 @@ describe("voiceInputAudioConstraints", () => {
       deviceId: { exact: "mic-42" },
     });
   });
+
+  test("drops auto gain on request, keeping the rest of the processing", () => {
+    expect(voiceInputAudioConstraints({ autoGainControl: false })).toEqual({
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: false,
+    });
+  });
+
+  test("still honors the pinned device with auto gain off", () => {
+    localStorage.setItem(LS_VOICE_INPUT_DEVICE, "mic-42");
+    expect(voiceInputAudioConstraints({ autoGainControl: false })).toEqual({
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: false,
+      deviceId: { exact: "mic-42" },
+    });
+  });
 });

--- a/clients/web/src/utils/voice-input-device.ts
+++ b/clients/web/src/utils/voice-input-device.ts
@@ -6,6 +6,25 @@ import { getLocalSetting } from "@/utils/local-settings";
  */
 export const LS_VOICE_INPUT_DEVICE = "vellum:voice:inputDeviceId";
 
+/** Per-call overrides for the shared voice capture constraints. */
+export interface VoiceInputConstraintOptions {
+  /**
+   * Request automatic gain control. Defaults to `true`, which is right for
+   * every half-duplex consumer (dictation, the amplitude meter, watch): the
+   * mic is the only sound in the room and normalizing a quiet talker up to a
+   * usable level makes the transcriber's job easier.
+   *
+   * Full-duplex live voice passes `false`. Its barge-in gate compares mean
+   * absolute amplitude against a threshold on the absolute 16-bit scale
+   * (`assistant/src/stt/speech-energy.ts`), and AGC is a moving gain between
+   * the room and that fixed number: in a quiet room it lifts the noise floor
+   * toward the same absolute level that speech reaches in a loud one, so the
+   * gate's real sensitivity becomes a property of the room rather than of the
+   * sound. See JARVIS-1694.
+   */
+  autoGainControl?: boolean;
+}
+
 export function getPreferredInputDeviceId(): string {
   return getLocalSetting(LS_VOICE_INPUT_DEVICE, "");
 }
@@ -14,15 +33,18 @@ export function getPreferredInputDeviceId(): string {
  * Audio constraints for voice capture, honoring the microphone chosen on the
  * Voice settings page. Uses `exact` so Chromium 130+ actually selects the
  * device (ideal constraints are silently ignored since that version).
- * Always requests echo cancellation, noise suppression, and auto gain so the
- * mic stays usable while TTS is playing (full-duplex capture).
+ * Always requests echo cancellation and noise suppression so the mic stays
+ * usable while TTS is playing (full-duplex capture); auto gain is on by
+ * default and opt-out per {@link VoiceInputConstraintOptions.autoGainControl}.
  */
-export function voiceInputAudioConstraints(): MediaTrackConstraints {
+export function voiceInputAudioConstraints(
+  options: VoiceInputConstraintOptions = {},
+): MediaTrackConstraints {
   const deviceId = getPreferredInputDeviceId();
   return {
     echoCancellation: true,
     noiseSuppression: true,
-    autoGainControl: true,
+    autoGainControl: options.autoGainControl ?? true,
     ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
   };
 }
@@ -32,8 +54,10 @@ export function voiceInputAudioConstraints(): MediaTrackConstraints {
  * system default if the saved device is unavailable (unplugged, revoked, etc.)
  * rather than failing with an `OverconstrainedError`.
  */
-export async function getVoiceInputMediaStream(): Promise<MediaStream> {
-  const constraints = voiceInputAudioConstraints();
+export async function getVoiceInputMediaStream(
+  options: VoiceInputConstraintOptions = {},
+): Promise<MediaStream> {
+  const constraints = voiceInputAudioConstraints(options);
   try {
     return await navigator.mediaDevices.getUserMedia({ audio: constraints });
   } catch (err) {


### PR DESCRIPTION
First of the JARVIS-1694 series against "voice mode barges in on room noise". Shipping to dev one change at a time so each can be felt on a handset in isolation.

## The problem

Barge-in is decided entirely on the daemon, on energy: `pcm16MeanAmplitude(chunk) > threshold`, where the base threshold is a hardcoded `800` on the absolute 16-bit scale (`assistant/src/stt/speech-energy.ts`).

Live-voice capture requests `autoGainControl: true`. AGC's whole job is to move the input gain so that speech lands at a consistent level — which means it sits between the room and that fixed absolute number. In a quiet room it raises gain until the noise floor approaches the same absolute level speech reaches in a loud room, and the gate can no longer tell them apart. The effective sensitivity of barge-in becomes a property of the room and of AGC's current state rather than of the sound, which is also why the symptom repros constantly for some people and barely at all for others.

## The change

Drop AGC for the full-duplex live-voice path only.

Echo cancellation and noise suppression are unrelated to this and stay on. Every other consumer of `LiveVoiceAudioCapture` is half-duplex — streaming dictation, the watch session, plus the `MediaRecorder` dictation and amplitude meter that share `getVoiceInputMediaStream` — so nothing is playing back, no absolute gate reads the result, and normalizing a quiet talker only helps the transcriber. Those keep the default; the opt-out is an explicit `autoGainControl: false` at the one call site in `use-live-voice.ts`.

## Why on its own

The adaptive-threshold change is the next PR in the series. AGC changes the very signal that threshold would be calibrated against, so landing it first keeps the second change measurable instead of measuring the two through each other.

## Testing

- `voice-input-device.test.ts` — the opt-out reaches the constraints, with and without a pinned device, and leaves EC/NS on.
- `pcm-capture.test.ts` — asserts what the capture actually hands `getUserMedia`: auto gain by default, off on request.
- Ran the affected files individually (`use-live-voice`, `use-live-voice-session-controller`, `dictation-stream`, `watch-controller`, `voice-input-button`, `chat-composer`, `voice-page`), all green. Running that set in one `bun test` invocation shows unrelated failures from the known cross-file `mock.module` leak in this package.
- `bun run typecheck` and `eslint` clean.

## Verification this needs

Acoustic, on a handset — no test can tell you whether the room still cancels the reply. What to watch for: a *quiet* room is where AGC was doing the most damage, so that is where the improvement should show first. The thing to watch against is the opposite failure — a genuinely soft-spoken barge-in that no longer registers, since we have removed the gain that used to carry it over a threshold that is still fixed. If that shows up, it is an argument for the adaptive threshold landing next, not for putting AGC back.