### PR TITLE
fix(voice): raise the speech gate to the room's measured noise floor (JARVIS-1694)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -937,6 +937,7 @@ describe("AssistantConfigSchema", () => {
       mode: "open-mic",
       vad: {
         speechEnergyThreshold: 800,
+        noiseFloorMargin: 3,
         silenceThresholdMs: 1200,
         maxTurnDurationMs: 30000,
         bargeInMinSpeechMs: 250,

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -40,6 +40,7 @@ describe("LiveVoiceVadConfigSchema", () => {
     const parsed = LiveVoiceVadConfigSchema.parse({});
     expect(parsed).toEqual({
       speechEnergyThreshold: 800,
+      noiseFloorMargin: 3,
       silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
       bargeInMinSpeechMs: 250,
@@ -60,6 +61,17 @@ describe("LiveVoiceVadConfigSchema", () => {
     expect(parsed.silenceThresholdMs).toBe(500);
     expect(parsed.maxTurnDurationMs).toBe(60_000);
     expect(parsed.bargeInMinSpeechMs).toBe(120);
+  });
+
+  test("accepts a noiseFloorMargin of 0 (adaptation disabled)", () => {
+    const parsed = LiveVoiceVadConfigSchema.parse({ noiseFloorMargin: 0 });
+    expect(parsed.noiseFloorMargin).toBe(0);
+  });
+
+  test("rejects a negative noiseFloorMargin", () => {
+    expect(() =>
+      LiveVoiceVadConfigSchema.parse({ noiseFloorMargin: -1 }),
+    ).toThrow();
   });
 
   test("accepts a bargeInMinSpeechMs of 0 (guard disabled)", () => {
@@ -317,6 +329,7 @@ describe("LiveVoiceConfigSchema", () => {
       mode: "open-mic",
       vad: {
         speechEnergyThreshold: 800,
+        noiseFloorMargin: 3,
         silenceThresholdMs: 1200,
         maxTurnDurationMs: 30_000,
         bargeInMinSpeechMs: 250,

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -16,6 +16,13 @@ export const LiveVoiceVadConfigSchema = z
       .describe(
         "Mean absolute amplitude (16-bit linear scale) above which a frame counts as speech — mirrors DEFAULT_SPEECH_ENERGY_THRESHOLD in stt/speech-energy.ts",
       ),
+    noiseFloorMargin: z
+      .number({ error: "liveVoice.vad.noiseFloorMargin must be a number" })
+      .nonnegative("liveVoice.vad.noiseFloorMargin must be nonnegative")
+      .default(3)
+      .describe(
+        "Multiple of the room's measured background noise level that the speech gate is raised to, so a noisy room does not read as continuous speech. The gate never falls below speechEnergyThreshold and never exceeds 4x it. 0 disables the adaptation and pins the gate to speechEnergyThreshold.",
+      ),
     silenceThresholdMs: z
       .number({ error: "liveVoice.vad.silenceThresholdMs must be a number" })
       .int("liveVoice.vad.silenceThresholdMs must be an integer")

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -177,6 +177,7 @@ function createHarness(options: {
   archiveAudio?: LiveVoiceSessionAudioArchiver;
   turnDetectorConfig?: TurnDetectorConfig;
   speechEnergyThreshold?: number;
+  noiseFloorMargin?: number;
   bargeInMinSpeechMs?: number;
   echoBargeInMargin?: number;
   echoEmaHalfLifeMs?: number;
@@ -257,6 +258,11 @@ function createHarness(options: {
       options.turnDetectorConfig ??
       (options.viaFactory ? undefined : { silenceThresholdMs: 40 }),
     speechEnergyThreshold: options.speechEnergyThreshold,
+    // Like echoBargeInMargin below: a directly-constructed session gets the
+    // fixed gate unless a test asks for the adaptation, so a case about
+    // something else cannot drift once it feeds ten seconds of audio.
+    noiseFloorMargin:
+      options.noiseFloorMargin ?? (options.viaFactory ? undefined : 0),
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
     echoBargeInMargin:
       options.echoBargeInMargin ?? (options.viaFactory ? undefined : 1),
@@ -3227,11 +3233,114 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
     expect(countType(raisedGate.frames, "speech_started")).toBe(0);
   });
 
+  // One second of steady room tone at 24kHz, i.e. exactly one noise-floor
+  // block. Ten of these fill the estimator's window.
+  const roomSecond = (amplitude: number): Uint8Array =>
+    pcm(amplitude, SAMPLE_RATE);
+
+  async function listenToRoom(
+    session: LiveVoiceSession,
+    amplitude: number,
+    seconds = 10,
+  ): Promise<void> {
+    for (let second = 0; second < seconds; second += 1) {
+      await session.handleBinaryAudio(roomSecond(amplitude));
+    }
+  }
+
+  test("a noisy room raises the gate over a chunk that would be speech in a quiet one", async () => {
+    const { frames, session } = createHarness({ noiseFloorMargin: 3 });
+    await session.start();
+
+    // Ten seconds of a 500-level room: below the 800 gate, so none of it is
+    // speech, but loud enough that 3x it lands above the gate.
+    await listenToRoom(session, 500);
+    await flushAsyncCallbacks();
+    expect(countType(frames, "speech_started")).toBe(0);
+
+    // 1000 clears the fixed 800 gate and would be speech today. Against a
+    // measured floor of 500 the gate is now 1500, so this is still the room.
+    await session.handleBinaryAudio(pcm(1_000));
+    await flushAsyncCallbacks();
+    expect(countType(frames, "speech_started")).toBe(0);
+
+    // Someone actually speaking still gets through.
+    await session.handleBinaryAudio(pcm(1_600));
+    await waitFor(() => countType(frames, "speech_started") === 1);
+  });
+
+  test("the same room and chunk stay speech with the adaptation disabled", async () => {
+    // Control for the case above: nothing but noiseFloorMargin differs, so a
+    // failure here means the room audio moved the gate some other way.
+    const { frames, session } = createHarness({ noiseFloorMargin: 0 });
+    await session.start();
+
+    await listenToRoom(session, 500);
+    await flushAsyncCallbacks();
+    expect(countType(frames, "speech_started")).toBe(0);
+
+    await session.handleBinaryAudio(pcm(1_000));
+    await waitFor(() => countType(frames, "speech_started") === 1);
+  });
+
+  test("a quiet room leaves the configured gate exactly where it was", async () => {
+    // The adaptation is one-directional: it may raise the gate, never lower it.
+    // A room quieter than the constant must not make barge-in easier than the
+    // configured threshold, or the change could invent self-interruption.
+    const { frames, session } = createHarness({ noiseFloorMargin: 3 });
+    await session.start();
+
+    await listenToRoom(session, 20);
+    await flushAsyncCallbacks();
+
+    await session.handleBinaryAudio(pcm(800));
+    await flushAsyncCallbacks();
+    expect(countType(frames, "speech_started")).toBe(0);
+
+    await session.handleBinaryAudio(pcm(801));
+    await waitFor(() => countType(frames, "speech_started") === 1);
+  });
+
+  test("the raised gate is capped at 4x the configured threshold", async () => {
+    // An absurd margin stands in for a pathological room: whatever the floor
+    // says, the gate must stay somewhere a person can still be heard over.
+    const { frames, session } = createHarness({
+      speechEnergyThreshold: 800,
+      noiseFloorMargin: 100,
+    });
+    await session.start();
+
+    await listenToRoom(session, 300);
+    await flushAsyncCallbacks();
+
+    // Uncapped this would be 30_000, past anything 16-bit audio can reach.
+    await session.handleBinaryAudio(pcm(3_100));
+    await flushAsyncCallbacks();
+    expect(countType(frames, "speech_started")).toBe(0);
+
+    await session.handleBinaryAudio(pcm(3_300));
+    await waitFor(() => countType(frames, "speech_started") === 1);
+  });
+
+  test("a partial window has no opinion, so the gate stays configured", async () => {
+    const { frames, session } = createHarness({ noiseFloorMargin: 3 });
+    await session.start();
+
+    // Nine seconds is not yet a window, and a partial window must not report
+    // the loudest thing it has heard as the room.
+    await listenToRoom(session, 500, 9);
+    await flushAsyncCallbacks();
+
+    await session.handleBinaryAudio(pcm(1_000));
+    await waitFor(() => countType(frames, "speech_started") === 1);
+  });
+
   test("with no config set the factory defaults to 800 energy / 1200 ms silence / 30 s max turn / 250 ms barge-in", async () => {
     // The test workspace has no liveVoice config, so the factory reads the
     // schema defaults.
     expect(getConfig().liveVoice.vad).toEqual({
       speechEnergyThreshold: 800,
+      noiseFloorMargin: 3,
       silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
       bargeInMinSpeechMs: 250,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -64,6 +64,7 @@ import {
   voteDominantLanguage,
 } from "../stt/language-metadata.js";
 import { sttCatalogKeyForRole } from "../stt/roles.js";
+import { RoomNoiseFloor } from "../stt/room-noise-floor.js";
 import {
   DEFAULT_SPEECH_ENERGY_THRESHOLD,
   pcm16MaxNormalizedCorrelation,
@@ -205,6 +206,18 @@ const ECHO_ONSET_ELIGIBILITY_MS = 300;
 // Client buffering makes audible playback trail the server's send-time
 // estimate. Keep the echo window open briefly past that estimate.
 const DEFAULT_ECHO_DRAIN_SLACK_MS = 300;
+// The speech gate's base threshold is raised to this multiple of the room's
+// measured noise floor. Speech has to stand clear of the room it is spoken in,
+// and roughly 3x (about 10dB) is the separation an ordinary talking voice keeps
+// over its own background. Mirrors the liveVoice.vad.noiseFloorMargin default.
+const DEFAULT_NOISE_FLOOR_MARGIN = 3;
+// Ceiling on the adaptive base, as a multiple of the configured threshold. The
+// floor estimate is derived from the microphone, so a pathological room (or a
+// stuck input) could in principle drive it high enough that nothing counts as
+// speech and the user cannot interrupt at all. Barge-in getting harder is a
+// nuisance; barge-in becoming impossible is a broken product, so the adaptation
+// is bounded even though the bound should never be reached.
+const NOISE_FLOOR_MAX_BASE_MULTIPLE = 4;
 // Mirrors MediaTurnDetector's DEFAULT_SILENCE_THRESHOLD_MS: the session
 // tracks the effective trailing-silence threshold (the detector keeps its own
 // copy private) so the endpoint decider can report the pause length.
@@ -334,6 +347,14 @@ export interface LiveVoiceSessionOptions {
    * `DEFAULT_SPEECH_ENERGY_THRESHOLD`.
    */
   speechEnergyThreshold?: number;
+  /**
+   * Multiple of the room's measured noise floor that the speech gate's base
+   * threshold is raised to. The production factory seeds this from
+   * `liveVoice.vad.noiseFloorMargin` config when unset; defaults to
+   * `DEFAULT_NOISE_FLOOR_MARGIN`. Values at or below 0 disable the adaptation,
+   * pinning the gate to `speechEnergyThreshold` (used by fixed-gate tests).
+   */
+  noiseFloorMargin?: number;
   /**
    * Sustained speech (ms) required before speech during assistant playback
    * interrupts it (barge-in); 0 disables the guard. The production factory
@@ -1189,6 +1210,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Base energy gate for server-VAD speech classification. During estimated
   // playback, classifyVadEnergy raises this above the learned echo level.
   private readonly speechEnergyThreshold: number | undefined;
+  private readonly noiseFloorMargin: number;
+  // Quietest recent second of microphone audio, learned only while the
+  // assistant is silent (during playback the microphone hears echo, which is
+  // what echoEnergyEma is for). Raises the base gate in a noisy room so the
+  // room itself stops reading as speech.
+  private readonly roomNoiseFloor = new RoomNoiseFloor();
   private readonly echoBargeInMargin: number;
   private readonly echoEmaHalfLifeMs: number;
   private readonly echoDrainSlackMs: number;
@@ -1406,6 +1433,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ...(options.metricsClock ? { clock: options.metricsClock } : {}),
     });
     this.speechEnergyThreshold = options.speechEnergyThreshold;
+    this.noiseFloorMargin =
+      options.noiseFloorMargin ?? DEFAULT_NOISE_FLOOR_MARGIN;
     // Precedence for the two sensitivity knobs: per-session start-frame
     // override (the client's user setting) > daemon `liveVoice.vad` config
     // (seeded into `options` by the factory) > in-code default.
@@ -2284,18 +2313,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * confirmed echo while speech above the learned margin remains frozen out.
    */
   private classifyVadEnergy(chunk: Buffer): VadClassifiedChunk[] {
-    const baseThreshold =
-      this.speechEnergyThreshold ?? DEFAULT_SPEECH_ENERGY_THRESHOLD;
     const meanAmplitude = pcm16MeanAmplitude(chunk);
+    const chunkMs = pcm16DurationMs(
+      chunk.byteLength,
+      this.context.startFrame.audio.sampleRate,
+    );
+    const baseThreshold = this.effectiveBaseThreshold();
     if (
       this.echoBargeInMargin <= 1 ||
       !this.isAssistantPlaybackEchoPossible()
     ) {
       this.resetEchoReference();
+      // Only learn the room while the assistant is silent. The floor is a
+      // minimum over completed blocks, so this chunk cannot lower the
+      // threshold that is about to judge it.
+      this.roomNoiseFloor.observe(meanAmplitude, chunkMs);
       return [
         this.classifyAtFixedThreshold(chunk, baseThreshold, meanAmplitude),
       ];
     }
+    // Playback is starting or ongoing: stop measuring the room, and drop the
+    // partial block rather than let it straddle the silence and the echo.
+    this.roomNoiseFloor.interrupt();
 
     if (this.echoWindowTotalAudioMs === 0) {
       this.echoWindowGuardCarryover =
@@ -2304,10 +2343,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.echoWindowGuardCarryover = false;
     }
 
-    const chunkMs = pcm16DurationMs(
-      chunk.byteLength,
-      this.context.startFrame.audio.sampleRate,
-    );
     const onsetWasEligible =
       !this.echoOnsetLapsed &&
       this.echoWindowTotalAudioMs < ECHO_ONSET_ELIGIBILITY_MS;
@@ -2412,6 +2447,34 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const alpha = 1 - 0.5 ** (chunkMs / this.echoEmaHalfLifeMs);
     this.echoEnergyEma =
       alpha * meanAmplitude + (1 - alpha) * this.echoEnergyEma;
+  }
+
+  /**
+   * The gate a chunk is judged against before any playback-echo adjustment.
+   *
+   * The configured `speechEnergyThreshold` is a floor, never a ceiling: the
+   * adaptation can only make speech classification *stricter*. That asymmetry
+   * is deliberate. A gate that could drop below the configured value would be
+   * able to invent new self-interruption in a room quieter than the one the
+   * constant was chosen for, which is the failure this whole change exists to
+   * remove; a gate that only rises can, at worst, make a soft barge-in need
+   * repeating. The result is bounded so it can never rise far enough to make
+   * interrupting impossible.
+   */
+  private effectiveBaseThreshold(): number {
+    const configured =
+      this.speechEnergyThreshold ?? DEFAULT_SPEECH_ENERGY_THRESHOLD;
+    if (this.noiseFloorMargin <= 0) {
+      return configured;
+    }
+    const floor = this.roomNoiseFloor.floor;
+    if (floor === null) {
+      return configured;
+    }
+    return Math.min(
+      Math.max(configured, floor * this.noiseFloorMargin),
+      configured * NOISE_FLOOR_MAX_BASE_MULTIPLE,
+    );
   }
 
   private classifyAtFixedThreshold(
@@ -6831,6 +6894,7 @@ export function createLiveVoiceSession(
         : {}),
     speechEnergyThreshold:
       options.speechEnergyThreshold ?? vadConfig?.speechEnergyThreshold,
+    noiseFloorMargin: options.noiseFloorMargin ?? vadConfig?.noiseFloorMargin,
     bargeInMinSpeechMs:
       options.bargeInMinSpeechMs ?? vadConfig?.bargeInMinSpeechMs,
     echoBargeInMargin:

--- a/assistant/src/stt/__tests__/room-noise-floor.test.ts
+++ b/assistant/src/stt/__tests__/room-noise-floor.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  NOISE_FLOOR_BLOCK_COUNT,
+  NOISE_FLOOR_BLOCK_MS,
+  RoomNoiseFloor,
+} from "../room-noise-floor.js";
+
+/** Audio needed before the estimator will report anything at all. */
+const FULL_WINDOW_MS = NOISE_FLOOR_BLOCK_MS * NOISE_FLOOR_BLOCK_COUNT;
+
+/** Feed `ms` of audio at a steady amplitude, in 50ms chunks like the client. */
+function feed(floor: RoomNoiseFloor, amplitude: number, ms: number): void {
+  for (let elapsed = 0; elapsed < ms; elapsed += 50) {
+    floor.observe(amplitude, 50);
+  }
+}
+
+describe("RoomNoiseFloor", () => {
+  test("has no opinion until the window is full", () => {
+    const floor = new RoomNoiseFloor();
+    feed(floor, 300, FULL_WINDOW_MS - NOISE_FLOOR_BLOCK_MS);
+
+    // A partial window would report the loudest thing it has heard as the room.
+    expect(floor.floor).toBeNull();
+
+    feed(floor, 300, NOISE_FLOOR_BLOCK_MS);
+    expect(floor.floor).toBeCloseTo(300, 5);
+  });
+
+  test("ignores intermittent speech and keeps the quiet second", () => {
+    const floor = new RoomNoiseFloor();
+    // Someone talking over a 250-level room, with one pause in the window.
+    feed(floor, 2_400, FULL_WINDOW_MS - NOISE_FLOOR_BLOCK_MS);
+    feed(floor, 250, NOISE_FLOOR_BLOCK_MS);
+
+    // The minimum picks the second nobody spoke in, not the average of the ten.
+    expect(floor.floor).toBeCloseTo(250, 5);
+  });
+
+  test("a block averages across syllable gaps rather than latching onto one", () => {
+    const floor = new RoomNoiseFloor();
+    // Speech with brief pauses inside it: alternating loud and room-level
+    // chunks throughout. A per-chunk minimum would call this room 250.
+    for (let elapsed = 0; elapsed < FULL_WINDOW_MS; elapsed += 100) {
+      floor.observe(2_400, 50);
+      floor.observe(250, 50);
+    }
+
+    expect(floor.floor).toBeCloseTo(1_325, 5);
+  });
+
+  test("forgets a room it has left, once the window has rolled", () => {
+    const floor = new RoomNoiseFloor();
+    feed(floor, 200, FULL_WINDOW_MS);
+    expect(floor.floor).toBeCloseTo(200, 5);
+
+    // Walk somewhere loud and stay there past the retention window.
+    feed(floor, 900, FULL_WINDOW_MS);
+
+    expect(floor.floor).toBeCloseTo(900, 5);
+  });
+
+  test("weights by duration so an odd-sized tail cannot skew a block", () => {
+    const floor = new RoomNoiseFloor();
+    for (let block = 0; block < NOISE_FLOOR_BLOCK_COUNT; block += 1) {
+      floor.observe(100, NOISE_FLOOR_BLOCK_MS - 10);
+      floor.observe(10_000, 10);
+    }
+
+    // 10ms of a loud tail moves a 1s block by ~1%, not by half.
+    expect(floor.floor).toBeCloseTo(
+      (100 * (NOISE_FLOOR_BLOCK_MS - 10) + 10_000 * 10) / NOISE_FLOOR_BLOCK_MS,
+      5,
+    );
+  });
+
+  test("interrupt() drops the partial block without losing completed ones", () => {
+    const floor = new RoomNoiseFloor();
+    feed(floor, 300, FULL_WINDOW_MS);
+    // Half a block of near-silence, then playback starts and observation stops.
+    feed(floor, 10, NOISE_FLOOR_BLOCK_MS / 2);
+    floor.interrupt();
+    // Resume after playback; the two halves must not merge into one block that
+    // measures neither side of the gap.
+    feed(floor, 300, NOISE_FLOOR_BLOCK_MS);
+
+    expect(floor.floor).toBeCloseTo(300, 5);
+  });
+
+  test("ignores non-positive durations and non-finite amplitudes", () => {
+    const floor = new RoomNoiseFloor();
+    floor.observe(500, 0);
+    floor.observe(500, -50);
+    floor.observe(Number.NaN, 50);
+
+    feed(floor, 300, FULL_WINDOW_MS);
+    expect(floor.floor).toBeCloseTo(300, 5);
+  });
+
+  test("reset() clears completed blocks too", () => {
+    const floor = new RoomNoiseFloor();
+    feed(floor, 300, FULL_WINDOW_MS);
+    floor.reset();
+
+    expect(floor.floor).toBeNull();
+  });
+});

--- a/assistant/src/stt/room-noise-floor.ts
+++ b/assistant/src/stt/room-noise-floor.ts
@@ -26,9 +26,9 @@
  * continuous.** Any ten seconds of a real conversation contains at least one
  * second in which nobody is speaking, and in that second the microphone hears
  * the room and nothing else. So: average within a one-second block, then take
- * the *minimum* across the retained blocks. Block-averaging first matters —
- * a minimum taken over raw chunks would latch onto the quietest 50 ms gap
- * between two syllables, which is a pause inside speech, not the room.
+ * the *minimum* across the retained blocks. Block-averaging first matters,
+ * because a minimum taken over raw chunks would latch onto the quietest 50 ms
+ * gap between two syllables, which is a pause inside speech, not the room.
  *
  * The estimate degrades honestly rather than dangerously. Ten unbroken seconds
  * of speech (a monologue with no breath) raises the floor, because there was

--- a/assistant/src/stt/room-noise-floor.ts
+++ b/assistant/src/stt/room-noise-floor.ts
@@ -1,0 +1,140 @@
+/**
+ * Rolling estimate of a room's continuous background noise level, on the same
+ * 16-bit mean-absolute-amplitude scale as `speech-energy.ts`.
+ *
+ * ## Why an estimate is needed at all
+ *
+ * `detectPcm16SpeechActivity` compares a chunk against a fixed absolute
+ * threshold. A constant works only if every room delivers roughly the same
+ * silence, and rooms do not: a quiet home office and a cafe differ by more
+ * than the gap between silence and speech. Set the constant for the cafe and a
+ * soft talker is never heard; set it for the office and the cafe's background
+ * reads as continuous speech, which in a live-voice session means room noise
+ * repeatedly cancels the assistant mid-reply.
+ *
+ * ## Why the minimum of block means, and not an average
+ *
+ * The hard part is estimating background noise from a signal that also
+ * contains the user. Averaging fails: it folds the user's own speech into the
+ * floor, so the floor climbs while they talk and the gate goes deaf exactly
+ * when someone is using it. An envelope with a slow time constant fails the
+ * same way for the same reason, because "a person talking" and "a noisier
+ * room" both last about as long as each other, and a time constant cannot
+ * separate two things that differ only in level.
+ *
+ * What does separate them is that **speech is intermittent and room noise is
+ * continuous.** Any ten seconds of a real conversation contains at least one
+ * second in which nobody is speaking, and in that second the microphone hears
+ * the room and nothing else. So: average within a one-second block, then take
+ * the *minimum* across the retained blocks. Block-averaging first matters —
+ * a minimum taken over raw chunks would latch onto the quietest 50 ms gap
+ * between two syllables, which is a pause inside speech, not the room.
+ *
+ * The estimate degrades honestly rather than dangerously. Ten unbroken seconds
+ * of speech (a monologue with no breath) raises the floor, because there was
+ * genuinely no quiet second to measure; it recovers on the first pause. The
+ * caller bounds what a raised floor is allowed to do.
+ *
+ * Pure and transport-neutral: amplitudes in, an estimate out, no session or
+ * provider state.
+ */
+
+/** Audio duration averaged into one block before it joins the estimate. */
+export const NOISE_FLOOR_BLOCK_MS = 1_000;
+
+/**
+ * Completed blocks retained. Ten seconds is the shortest window that reliably
+ * contains a conversational pause, and short enough that walking somewhere
+ * quieter is reflected within a turn or two.
+ */
+export const NOISE_FLOOR_BLOCK_COUNT = 10;
+
+/**
+ * Tracks the quietest recent second of microphone audio.
+ *
+ * Feed it every chunk's mean amplitude while the near end is *not* playing
+ * audio back; feeding it during playback would teach it the assistant's own
+ * echo. Call {@link interrupt} when observation stops for that reason, so a
+ * block never averages across the gap.
+ */
+export class RoomNoiseFloor {
+  private readonly blockMs: number;
+  private readonly blockCount: number;
+  /** Completed block means, oldest first, at most `blockCount` of them. */
+  private readonly blocks: number[] = [];
+  /** Duration-weighted amplitude sum of the block being filled. */
+  private pendingWeightedSum = 0;
+  private pendingMs = 0;
+
+  constructor(
+    blockMs: number = NOISE_FLOOR_BLOCK_MS,
+    blockCount: number = NOISE_FLOOR_BLOCK_COUNT,
+  ) {
+    this.blockMs = blockMs;
+    this.blockCount = blockCount;
+  }
+
+  /**
+   * Fold one chunk's mean amplitude into the estimate.
+   *
+   * Weighted by duration so an irregular chunk size cannot skew a block: the
+   * client's framing is its own business, and a 10 ms tail must not count as
+   * much as the 50 ms frame before it.
+   */
+  observe(meanAmplitude: number, durationMs: number): void {
+    if (!(durationMs > 0) || !Number.isFinite(meanAmplitude)) {
+      return;
+    }
+    this.pendingWeightedSum += meanAmplitude * durationMs;
+    this.pendingMs += durationMs;
+    if (this.pendingMs < this.blockMs) {
+      return;
+    }
+    this.blocks.push(this.pendingWeightedSum / this.pendingMs);
+    if (this.blocks.length > this.blockCount) {
+      this.blocks.shift();
+    }
+    this.pendingWeightedSum = 0;
+    this.pendingMs = 0;
+  }
+
+  /**
+   * Drop the partially-filled block, keeping everything already completed.
+   *
+   * Call this when observation is about to pause (assistant playback starting)
+   * or resume after a gap. Without it a single block could average a half
+   * second of room from before the gap with a half second from after it, which
+   * is a measurement of neither.
+   */
+  interrupt(): void {
+    this.pendingWeightedSum = 0;
+    this.pendingMs = 0;
+  }
+
+  /**
+   * The quietest retained second, or `null` until the window is **full**.
+   *
+   * Waiting for a full window is what makes the minimum safe. Over ten seconds
+   * the claim "at least one of these seconds contains no speech" holds; over
+   * one second it does not, and a partial window would happily report the first
+   * second of a sentence as the room's noise floor. That over-estimate is the
+   * dangerous direction: it raises the gate against the very voice it measured.
+   *
+   * `null` means "no opinion yet" and callers must fall back to their
+   * configured constant rather than treating it as a floor of zero. Since only
+   * non-playback audio is observed, the window fills with accumulated listening
+   * time rather than wall clock, which in a real session is a turn or two.
+   */
+  get floor(): number | null {
+    if (this.blocks.length < this.blockCount) {
+      return null;
+    }
+    return Math.min(...this.blocks);
+  }
+
+  /** Forget everything, e.g. when the input route changes under the session. */
+  reset(): void {
+    this.blocks.length = 0;
+    this.interrupt();
+  }
+}


### PR DESCRIPTION
Second of the JARVIS-1694 series. Stacks conceptually on #41788 (dropping AGC) but touches a different package, so it branches from `main` and the two can land in either order.

## The problem

Server-VAD speech classification is `pcm16MeanAmplitude(chunk) > 800`, a constant on the absolute 16-bit scale. That works only if every room delivers roughly the same silence, and rooms differ by more than the gap between silence and speech does. Set the constant for a cafe and a soft talker is never heard; set it for a quiet office, which is where it is, and a noisier room reads as continuous speech. In live voice that means the room cancels the assistant mid-reply, which is the reported symptom.

Nothing anywhere in the daemon or the client currently measures the room. The echo machinery in `classifyVadEnergy` is good, but it defends against *our own voice* and only arms during playback windows.

## The change

`RoomNoiseFloor` (`assistant/src/stt/room-noise-floor.ts`): average amplitude within one-second blocks, keep ten, report the minimum.

The estimator design is the part worth reviewing:

- **Not an average or an EMA.** Both fold the user's own speech into the floor, so the gate goes deaf exactly while someone is using it. No time constant separates "a person talking" from "a noisier room" when the two last about as long as each other. What *does* separate them is that speech is intermittent and room noise is continuous, so the quietest second in the last ten is the room.
- **Block-average before taking the minimum.** A minimum over raw 50ms chunks would latch onto the gap between two syllables, which is a pause inside speech, not the room.
- **No opinion until the window is full.** Over ten seconds "at least one of these seconds contains no speech" holds; over one second it does not. A partial window would report the first second of a sentence as the room and raise the gate against the voice that just set it, which is the dangerous direction of error. Until then the configured constant stands, i.e. today's behavior.
- **Only learned while the assistant is silent**, and the partial block is dropped at each boundary so none straddles the gap. During playback the mic hears echo, which `echoEnergyEma` already owns.

The adaptation is **one-directional and bounded**: the configured threshold is a floor, never a ceiling, so a quiet room behaves exactly as today and this change cannot invent new self-interruption. The result is capped at 4x configured, so no estimate can make interrupting impossible.

New knob `liveVoice.vad.noiseFloorMargin`, default 3 (roughly the 10dB an ordinary talking voice keeps over its own background); 0 disables the adaptation and pins the gate to `speechEnergyThreshold`.

## Testing

- `room-noise-floor.test.ts` — 8 cases on the estimator: partial window, intermittent speech vs the quiet second, syllable gaps inside a block, walking to a louder room, duration weighting, `interrupt()` across a playback gap, degenerate inputs.
- `live-voice-vad.test.ts` — 5 session-level cases, including a **paired control**: the same room audio and the same borderline chunk, differing only in `noiseFloorMargin`, classify differently. Plus the quiet-room no-op, the 4x cap, and the partial window.
- Directly-constructed harness sessions now default `noiseFloorMargin: 0`, mirroring how `echoBargeInMargin` already defaults to off there, so an unrelated case cannot drift once it feeds ten seconds of audio.
- Every file in `src/live-voice/__tests__/` run individually: all green. `bun run typecheck` and `eslint` clean.

## Known coverage gap

There is no session-level test proving the floor refuses to learn *during* playback — that needs the TTS path stood up, and the guard is a one-liner inside the existing `!isAssistantPlaybackEchoPossible()` branch with `interrupt()` unit-tested on its own. Happy to add it if a reviewer wants it held to a higher bar; calling it out rather than letting the test list imply coverage it doesn't have.

## Verification this needs

On dev, in a room that reproduces the symptom. The floor needs about ten seconds of accumulated listening before it engages, so the very start of a session still behaves as today — if noise cancels a reply in the first few seconds, that is expected and not a failure of this change. The thing to watch against is a soft barge-in in a noisy room needing to be repeated: that would mean the margin of 3 is too aggressive, and it is a config value, not a code change.