### PR TITLE
fix(live-voice): make a wrong barge-in recoverable (JARVIS-1694)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -281,8 +281,9 @@ export class FakePlayer {
   }
   /**
    * Flush while retaining the unplayed audio. A flush that finds nothing
-   * playing leaves an existing hold alone, mirroring the real player: the
-   * second flush of a barge-in pair must not clear what the first kept.
+   * playing captures nothing, mirroring the real player on both counts: a
+   * drained reply has nothing left to keep, and the second flush of a barge-in
+   * pair must not clear what the first kept.
    */
   holdPlayback(): void {
     this.holdCount++;

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -219,6 +219,18 @@ export class FakePlayer {
   /** Route the fake reports, and how many times it was asked to re-render it. */
   outputRoute: TtsOutputRoute = "unsupported";
   restartOutputRouteCount = 0;
+  /**
+   * Chunks a `holdPlayback()` flush retained, or null when nothing is held.
+   * The real player keeps the audio scheduled but not yet sounded; the fake
+   * stands in for it with whatever had been enqueued, which is enough for the
+   * controller specs (they assert what is held, resumed, and dropped, not how
+   * the audio is re-scheduled). Buffer-level behavior is covered against the
+   * real player in `tts-playback.test.ts`.
+   */
+  heldAudio: unknown[] | null = null;
+  holdCount = 0;
+  resumeHeldCount = 0;
+  discardHeldCount = 0;
   private drainResolvers: Array<() => void> = [];
 
   prewarm(): void {
@@ -256,13 +268,44 @@ export class FakePlayer {
     this.outputMuted = muted;
   }
   enqueue(chunk: unknown): void {
+    // New audio supersedes a hold, exactly as it does on the real player.
+    this.heldAudio = null;
     this.enqueued.push(chunk);
     this.isPlaying = true;
   }
   stop(): void {
+    this.heldAudio = null;
     this.stopCount++;
     this.isPlaying = false;
     this.resolveDrain();
+  }
+  /**
+   * Flush while retaining the unplayed audio. A flush that finds nothing
+   * playing leaves an existing hold alone, mirroring the real player: the
+   * second flush of a barge-in pair must not clear what the first kept.
+   */
+  holdPlayback(): void {
+    this.holdCount++;
+    const held = this.isPlaying ? [...this.enqueued] : this.heldAudio;
+    this.stop();
+    this.heldAudio = held;
+  }
+  hasHeldPlayback(): boolean {
+    return this.heldAudio !== null;
+  }
+  discardHeldPlayback(): void {
+    this.discardHeldCount++;
+    this.heldAudio = null;
+  }
+  resumeHeldPlayback(): boolean {
+    const held = this.heldAudio;
+    this.heldAudio = null;
+    if (!held) {
+      return false;
+    }
+    this.resumeHeldCount++;
+    this.isPlaying = true;
+    return true;
   }
   async dispose(): Promise<void> {
     this.disposeCount++;

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -1255,4 +1255,72 @@ describe("LiveVoiceAudioPlayer held playback", () => {
 
     expect(player.hasHeldPlayback()).toBe(false);
   });
+
+  test("holds nothing when the reply finished inside the rewind window", () => {
+    const { player, ctx } = makePlayer();
+    player.enqueue(chunk(new Array(24000).fill(100))); // 0 -> 1.0s
+
+    // Noise landing a fifth of a second after the assistant stopped talking.
+    // The rewind window still covers the reply's last syllables, but none of
+    // it is unplayed, so holding would mean replaying the end of a finished
+    // reply on the retraction. Deliberately without firing `onended`: the rule
+    // is the audio clock, not when the ended event happens to be delivered.
+    ctx.currentTime = 1.2;
+
+    player.holdPlayback();
+
+    expect(player.hasHeldPlayback()).toBe(false);
+    expect(player.resumeHeldPlayback()).toBe(false);
+  });
+
+  test("control: the same flush one moment earlier is still mid-sentence", () => {
+    const { player, ctx } = makePlayer();
+    player.enqueue(chunk(new Array(24000).fill(100))); // 0 -> 1.0s
+
+    // Identical setup, clock 0.4s earlier, so 0.2s of the reply has yet to
+    // sound. That one is worth keeping.
+    ctx.currentTime = 0.8;
+
+    player.holdPlayback();
+
+    expect(player.hasHeldPlayback()).toBe(true);
+    expect(player.resumeHeldPlayback()).toBe(true);
+  });
+
+  test("retained history shrinks as playback advances", () => {
+    const { player, ctx } = makePlayer();
+    // Ten 1.0s frames delivered up front: the whole reply decoded and
+    // scheduled before any of it has played.
+    for (let i = 0; i < 10; i++) {
+      player.enqueue(chunk(new Array(24000).fill(100)));
+    }
+    expect(player.retainedSegmentCount).toBe(10);
+
+    // Play eight of them out. Nothing further is ever scheduled, so pruning
+    // has to come off the audio clock or every decoded buffer stays pinned for
+    // the length of the reply.
+    for (let i = 0; i < 8; i++) {
+      ctx.currentTime = i + 1;
+      ctx.sources[i]!.finish();
+    }
+
+    // What is left is the two unplayed frames plus the rewind window.
+    expect(player.retainedSegmentCount).toBe(3);
+  });
+
+  test("a drained reply retains nothing between turns", () => {
+    const { player, ctx } = makePlayer();
+    player.enqueue(chunk(new Array(24000).fill(100)));
+    player.enqueue(chunk(new Array(24000).fill(200)));
+
+    ctx.currentTime = 2;
+    ctx.sources[0]!.finish();
+    ctx.sources[1]!.finish();
+
+    // A hands-free session sits idle between turns, and a drained timeline can
+    // never produce a hold, so nothing decoded for the finished reply should
+    // still be referenced.
+    expect(player.isPlaying).toBe(false);
+    expect(player.retainedSegmentCount).toBe(0);
+  });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -18,6 +18,8 @@ interface MockSource {
   buffer: AudioBuffer | null;
   connectedTo: AudioNode | null;
   startedAt: number | null;
+  /** Offset into the buffer playback began at; non-zero only on a resume. */
+  startedOffset: number;
   stopped: boolean;
   disconnected: boolean;
   onended: (() => void) | null;
@@ -89,6 +91,7 @@ class MockAudioContext {
       buffer: null,
       connectedTo: null,
       startedAt: null,
+      startedOffset: 0,
       stopped: false,
       disconnected: false,
       onended: null,
@@ -116,8 +119,9 @@ class MockAudioContext {
       disconnect() {
         source.disconnected = true;
       },
-      start(when?: number) {
+      start(when?: number, offset?: number) {
         source.startedAt = when ?? getCurrentTime();
+        source.startedOffset = offset ?? 0;
       },
       stop() {
         source.stopped = true;
@@ -1057,5 +1061,198 @@ describe("LiveVoiceAudioPlayer output mute", () => {
 
     expect(() => player.setOutputMuted(true)).not.toThrow();
     expect(player.isOutputMuted()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reversible barge-in (hold / resume)
+// ---------------------------------------------------------------------------
+
+describe("LiveVoiceAudioPlayer held playback", () => {
+  /** Mirrors RESUME_REWIND_SECONDS in tts-playback.ts. */
+  const REWIND_SECONDS = 0.35;
+
+  /**
+   * Three gapless 1.0s buffers (t = 0, 1, 2) with the clock parked halfway
+   * through the second one, i.e. the shape of a barge-in landing mid-reply.
+   */
+  function enqueueThreeSecondsAndAdvance(
+    player: LiveVoiceAudioPlayer,
+    ctx: MockAudioContext,
+  ): void {
+    player.enqueue(chunk(new Array(24000).fill(100)));
+    player.enqueue(chunk(new Array(24000).fill(200)));
+    player.enqueue(chunk(new Array(24000).fill(300)));
+    ctx.currentTime = 1.5;
+  }
+
+  test("a hold retains the unplayed audio and resume re-schedules it", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    player.holdPlayback();
+
+    // The flush itself is indistinguishable from stop(): everything scheduled
+    // is stopped, and nothing is playing.
+    expect(ctx.sources.every((s) => s.stopped)).toBe(true);
+    expect(player.isPlaying).toBe(false);
+    expect(player.hasHeldPlayback()).toBe(true);
+
+    expect(player.resumeHeldPlayback()).toBe(true);
+
+    // Source nodes are single-use, so the retained buffers come back through
+    // fresh ones: the interrupted buffer and the one queued behind it.
+    expect(ctx.sources.length).toBe(5);
+    expect(ctx.sources[3]!.buffer).toBe(ctx.sources[1]!.buffer);
+    expect(ctx.sources[4]!.buffer).toBe(ctx.sources[2]!.buffer);
+    expect(player.isPlaying).toBe(true);
+    expect(player.hasHeldPlayback()).toBe(false);
+  });
+
+  test("stop() is the control: the same barge-in destroys the audio", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    player.stop();
+
+    expect(player.hasHeldPlayback()).toBe(false);
+    expect(player.resumeHeldPlayback()).toBe(false);
+    expect(ctx.sources.length).toBe(3);
+    expect(player.isPlaying).toBe(false);
+  });
+
+  test("resume rewinds into the interrupted buffer so the word is whole", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    player.holdPlayback();
+    player.resumeHeldPlayback();
+
+    // Playback was 0.5s into the second buffer; the resume enters it at
+    // 0.5 - REWIND_SECONDS so the syllable the flush cut is spoken again.
+    expect(ctx.sources[3]!.startedAt).toBe(1.5);
+    expect(ctx.sources[3]!.startedOffset).toBeCloseTo(0.5 - REWIND_SECONDS, 6);
+    // Everything behind it is still whole, and still gapless: the resumed
+    // remainder of buffer two is 1 - (0.5 - REWIND_SECONDS) long.
+    expect(ctx.sources[4]!.startedOffset).toBe(0);
+    expect(ctx.sources[4]!.startedAt).toBeCloseTo(
+      1.5 + 0.5 + REWIND_SECONDS,
+      6,
+    );
+  });
+
+  test("audio that already sounded is not resumed", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    player.holdPlayback();
+    player.resumeHeldPlayback();
+
+    // The first buffer finished 0.5s ago, well past the rewind window.
+    const resumedBuffers = ctx.sources.slice(3).map((s) => s.buffer);
+    expect(resumedBuffers).not.toContain(ctx.sources[0]!.buffer);
+  });
+
+  test("playback progress continues across the resume, rewound to match", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    const beforeFlush = player.getPlaybackProgress();
+    expect(beforeFlush).toEqual({ playedSeconds: 1.5, totalSeconds: 3 });
+
+    player.holdPlayback();
+    player.resumeHeldPlayback();
+
+    // The spoken-word cursor has to survive the round trip, or the caption
+    // would snap back to the first word of the reply as it resumes. Total is
+    // unchanged and played rewinds by exactly what the audio rewound.
+    const afterResume = player.getPlaybackProgress();
+    expect(afterResume?.totalSeconds).toBeCloseTo(3, 6);
+    expect(afterResume?.playedSeconds).toBeCloseTo(1.5 - REWIND_SECONDS, 6);
+  });
+
+  test("a real barge-in behind the first one discards the held audio", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    player.holdPlayback();
+    expect(player.hasHeldPlayback()).toBe(true);
+
+    // The controller drops the hold explicitly on a second speech onset; a
+    // stop() from any deliberate interrupt does the same thing here.
+    player.stop();
+
+    expect(player.hasHeldPlayback()).toBe(false);
+    expect(player.resumeHeldPlayback()).toBe(false);
+    expect(ctx.sources.length).toBe(3);
+  });
+
+  test("a second flush with nothing scheduled keeps the first flush's hold", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    // A server barge-in flushes twice: `speech_started`, then the
+    // `turn_cancelled` that follows once the daemon aborts the turn. The
+    // second one arrives with the queue already empty and must not be read as
+    // "there was nothing to keep".
+    player.holdPlayback();
+    player.holdPlayback();
+
+    expect(player.hasHeldPlayback()).toBe(true);
+    expect(player.resumeHeldPlayback()).toBe(true);
+    expect(ctx.sources.length).toBe(5);
+  });
+
+  test("audio arriving after the flush supersedes the hold", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    player.holdPlayback();
+    player.enqueue(chunk(new Array(24000).fill(400)));
+
+    // Held audio resumes at the front of an empty queue, so it cannot be
+    // spliced behind a frame that has already been scheduled.
+    expect(player.hasHeldPlayback()).toBe(false);
+    expect(player.resumeHeldPlayback()).toBe(false);
+    expect(ctx.sources.length).toBe(4);
+  });
+
+  test("a hold does not survive disposal of its context", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+
+    player.holdPlayback();
+    void player.dispose();
+
+    // The retained buffers belong to a graph that no longer plays.
+    expect(player.resumeHeldPlayback()).toBe(false);
+    expect(ctx.closed).toBe(true);
+  });
+
+  test("resuming onto a muted output stays muted", () => {
+    const { player, ctx } = makePlayer();
+    enqueueThreeSecondsAndAdvance(player, ctx);
+    player.setOutputMuted(true);
+
+    player.holdPlayback();
+    player.resumeHeldPlayback();
+
+    // The mute rides the graph, not the queue, so a resume cannot un-silence
+    // an assistant the user muted.
+    expect(ctx.gain?.gain.value).toBe(0);
+    expect(ctx.sources[3]!.connectedTo).toBe(ctx.gain as unknown as AudioNode);
+    expect(player.isOutputMuted()).toBe(true);
+  });
+
+  test("holds nothing when the reply had already finished playing", () => {
+    const { player, ctx } = makePlayer();
+    player.enqueue(chunk(new Array(24000).fill(100)));
+    ctx.sources[0]!.finish();
+    // Well past the rewind window: there is no undelivered audio to keep.
+    ctx.currentTime = 5;
+
+    player.holdPlayback();
+
+    expect(player.hasHeldPlayback()).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -110,7 +110,8 @@ const RAW_PCM_MIME_TYPE = "audio/pcm";
  *
  * It also sets how much already-sounded audio {@link LiveVoiceAudioPlayer}
  * retains: the schedule log keeps this much history behind the playhead and
- * nothing more.
+ * nothing more, pruned as the audio clock advances and released outright once
+ * the timeline drains.
  */
 const RESUME_REWIND_SECONDS = 0.35;
 
@@ -485,6 +486,18 @@ export class LiveVoiceAudioPlayer {
   }
 
   /**
+   * How many buffers the schedule log currently retains.
+   *
+   * Retained history is bounded to {@link RESUME_REWIND_SECONDS} behind the
+   * playhead and released entirely once the timeline drains, so a long reply
+   * cannot pin its whole decoded PCM in a mobile WebView. Exposed so that
+   * bound is assertable; nothing in the app reads it.
+   */
+  get retainedSegmentCount(): number {
+    return this.scheduleLog.length;
+  }
+
+  /**
    * Decode a TTS frame and schedule it to play immediately after whatever is
    * already queued. The decode path is selected on `chunk.mimeType`:
    *
@@ -717,10 +730,23 @@ export class LiveVoiceAudioPlayer {
    * The undelivered tail of the scheduled timeline, from
    * {@link RESUME_REWIND_SECONDS} before now, or null when nothing is left to
    * keep. Read-only: capturing does not disturb playback.
+   *
+   * There has to be audio that has not sounded yet, not merely audio inside
+   * the rewind window. Noise arriving in the moment just after a reply ends is
+   * an ordinary event, and the window still covers the reply's last syllables
+   * then: without this gate a hold would form over a finished reply and a
+   * later retraction would replay its last words for no reason, which is
+   * exactly what users report as the assistant echoing.
    */
   private captureHeldPlayback(): HeldPlayback | null {
     const context = this.context;
     if (!context) {
+      return null;
+    }
+    // Entries are appended in schedule order and each starts no earlier than
+    // the previous one ends, so the last entry is the tail of the timeline.
+    const tail = this.scheduleLog[this.scheduleLog.length - 1];
+    if (!tail || tail.startAt + tail.durationSeconds <= context.currentTime) {
       return null;
     }
     const resumeAt = Math.max(0, context.currentTime - RESUME_REWIND_SECONDS);
@@ -1169,6 +1195,13 @@ export class LiveVoiceAudioPlayer {
       return;
     }
     source.disconnect();
+    // Retained history has to shrink with the audio clock, not only when the
+    // next buffer is scheduled. A response whose frames all arrive before any
+    // of it plays schedules nothing further, so pruning here is the only thing
+    // keeping its decoded buffers from being pinned for the whole reply.
+    if (this.context) {
+      this.pruneScheduleLog(this.context.currentTime);
+    }
     this.settleIfIdle();
   }
 
@@ -1176,6 +1209,11 @@ export class LiveVoiceAudioPlayer {
    * Mark playback finished and resolve drain waiters once nothing is left to
    * play — neither a scheduled source nor an in-flight container decode that
    * could still schedule one. Called whenever either count reaches zero.
+   *
+   * Retained history goes with it. A drained timeline can never produce a hold
+   * (see {@link captureHeldPlayback}), so keeping the rewind window past that
+   * point buys nothing and pins decoded audio through the idle stretch between
+   * turns of a hands-free session.
    */
   private settleIfIdle(): void {
     if (this.activeSources.size > 0 || this.pendingContainerDecodes > 0) {
@@ -1183,6 +1221,7 @@ export class LiveVoiceAudioPlayer {
     }
     this.playheadTime = 0;
     this.playingState = false;
+    this.scheduleLog = [];
     this.resolveDrain();
   }
 

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -34,6 +34,16 @@
  * barge-in/interrupt: it stops every scheduled source, drops queued chunks, and
  * resets the playhead so the next `enqueue` starts fresh.
  *
+ * {@link LiveVoiceAudioPlayer.holdPlayback} is the recoverable form of that
+ * flush. Server VAD can mistake a door slam or a keyboard for speech, and the
+ * daemon only discovers otherwise once the utterance closes with an empty
+ * transcript, by which point a plain `stop()` has already destroyed the reply.
+ * A hold flushes exactly as `stop()` does but keeps the audio that had been
+ * scheduled and not yet sounded, so
+ * {@link LiveVoiceAudioPlayer.resumeHeldPlayback} can put it back. Web Audio
+ * source nodes are single-use, so a resume re-schedules fresh sources over the
+ * retained `AudioBuffer`s rather than un-stopping the old ones.
+ *
  * No audio playback infrastructure exists elsewhere in `clients/web`; this module
  * owns its own `AudioContext` lifecycle.
  */
@@ -87,6 +97,56 @@ const CONTAINER_MIME_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 const RAW_PCM_MIME_TYPE = "audio/pcm";
+
+/**
+ * How far back a resume rewinds from the point the flush cut playback off.
+ *
+ * Resuming from the exact interruption sample splits a word across the gap the
+ * barge-in opened ("the weather tomor" ... "row will be sunny"), which reads as
+ * a glitch rather than as the reply continuing. Re-speaking the fraction of a
+ * second before the cut carries the last syllable or two into the resumed
+ * audio, so the sentence is intelligible again. Short enough that the repeat
+ * sounds like a stutter rather than the assistant saying something twice.
+ *
+ * It also sets how much already-sounded audio {@link LiveVoiceAudioPlayer}
+ * retains: the schedule log keeps this much history behind the playhead and
+ * nothing more.
+ */
+const RESUME_REWIND_SECONDS = 0.35;
+
+/** One buffer as placed on the scheduled timeline. */
+interface ScheduledSegment {
+  buffer: AudioBuffer;
+  /** Offset into `buffer` at which this placement starts sounding. */
+  offsetSeconds: number;
+  /** Absolute `AudioContext.currentTime` at which it starts sounding. */
+  startAt: number;
+  /** Sounding length, i.e. `buffer.duration - offsetSeconds`. */
+  durationSeconds: number;
+}
+
+/** A retained buffer plus where in it a resume should pick up. */
+interface HeldSegment {
+  buffer: AudioBuffer;
+  offsetSeconds: number;
+}
+
+/** Audio flushed by a hold, kept so a resume can re-schedule it. */
+interface HeldPlayback {
+  /**
+   * The context the buffers belong to. An `AudioBuffer` cannot be played by a
+   * different context, so a hold that outlives its context is unusable.
+   */
+  context: AudioContextLike;
+  /** Undelivered audio in play order, from the rewound resume point. */
+  segments: HeldSegment[];
+  /**
+   * `totalScheduledSeconds` as it will read the instant the resume starts, so
+   * playback progress (the spoken-word cursor) continues from where the flush
+   * cut it off instead of restarting at the tail.
+   */
+  priorSeconds: number;
+}
 
 /**
  * Output-amplitude metering tuning for the assistant's own band
@@ -308,6 +368,25 @@ export class LiveVoiceAudioPlayer {
   private activeSources = new Set<AudioBufferSourceNode>();
 
   /**
+   * Every buffer placed on the scheduled timeline that a hold could still need,
+   * in play order: everything not yet finished, plus the last
+   * {@link RESUME_REWIND_SECONDS} of already-sounded audio so a resume has
+   * something to rewind into. Pruned on each schedule, so it retains no more
+   * history than that. It is not an alternative to {@link activeSources}, which
+   * holds the nodes a flush has to stop; this holds the buffers a flush has to
+   * keep.
+   */
+  private scheduleLog: ScheduledSegment[] = [];
+
+  /**
+   * Audio a {@link holdPlayback} flush retained, or null when nothing is held.
+   * Dropped by {@link stop}, {@link discardHeldPlayback}, and by any new
+   * `enqueue`, which supersedes it: audio arriving after the flush cannot be
+   * spliced behind audio the hold would resume.
+   */
+  private heldPlayback: HeldPlayback | null = null;
+
+  /**
    * Absolute `AudioContext.currentTime` at which the next buffer should begin.
    * Tracks the tail of the scheduled timeline for gapless chaining.
    */
@@ -418,6 +497,10 @@ export class LiveVoiceAudioPlayer {
    * Empty/malformed PCM chunks (zero samples) are dropped.
    */
   enqueue(chunk: TtsAudioChunk): void {
+    // New audio supersedes a hold. Held audio resumes at the front of an empty
+    // queue, so keeping it across an enqueue would eventually play the
+    // interrupted reply's tail after the frames that arrived since.
+    this.heldPlayback = null;
     const mimeType = normalizeMimeType(chunk.mimeType);
 
     if (mimeType === RAW_PCM_MIME_TYPE) {
@@ -513,8 +596,17 @@ export class LiveVoiceAudioPlayer {
     });
   }
 
-  /** Connect a decoded buffer to the destination and start it gaplessly. */
-  private scheduleBuffer(context: AudioContextLike, buffer: AudioBuffer): void {
+  /**
+   * Connect a decoded buffer to the destination and start it gaplessly.
+   *
+   * `offsetSeconds` skips into the buffer, which only a resume uses: it picks
+   * up part-way through the buffer the flush interrupted.
+   */
+  private scheduleBuffer(
+    context: AudioContextLike,
+    buffer: AudioBuffer,
+    offsetSeconds = 0,
+  ): void {
     const source = context.createBufferSource();
     source.buffer = buffer;
 
@@ -531,9 +623,13 @@ export class LiveVoiceAudioPlayer {
     // Chain start time from the running playhead. Never schedule in the past:
     // if the queue drained the playhead may lag behind currentTime.
     const startAt = Math.max(this.playheadTime, context.currentTime);
-    source.start(startAt);
-    this.playheadTime = startAt + buffer.duration;
-    this.totalScheduledSeconds += buffer.duration;
+    const durationSeconds = Math.max(0, buffer.duration - offsetSeconds);
+    source.start(startAt, offsetSeconds);
+    this.playheadTime = startAt + durationSeconds;
+    this.totalScheduledSeconds += durationSeconds;
+
+    this.pruneScheduleLog(context.currentTime);
+    this.scheduleLog.push({ buffer, offsetSeconds, startAt, durationSeconds });
 
     this.activeSources.add(source);
     source.onended = () => {
@@ -554,8 +650,132 @@ export class LiveVoiceAudioPlayer {
    * interrupted utterance after the flush. Those decodes are also treated as
    * drained immediately (counter zeroed) so `waitUntilDrained()` resolves now
    * rather than waiting on the abandoned decode to settle.
+   *
+   * This is the unrecoverable flush: any audio held for a resume goes with it.
+   * {@link holdPlayback} is the form that keeps it.
    */
   stop(): void {
+    this.heldPlayback = null;
+    this.stopScheduledAudio();
+  }
+
+  /**
+   * Flush playback but keep the audio that has not sounded yet, so a barge-in
+   * the daemon later reports as noise (`utterance_discarded`) can be undone by
+   * {@link resumeHeldPlayback}.
+   *
+   * A flush that finds nothing scheduled leaves any existing hold alone rather
+   * than clearing it. A barge-in flushes twice in quick succession (the
+   * `speech_started` frame, then the `turn_cancelled` that follows when the
+   * turn was still in flight), and the second one arrives with the queue
+   * already empty: an empty capture is that second flush, not evidence that
+   * there was never a reply to keep.
+   */
+  holdPlayback(): void {
+    const held = this.captureHeldPlayback() ?? this.heldPlayback;
+    this.stopScheduledAudio();
+    this.heldPlayback = held;
+  }
+
+  /** Whether a {@link holdPlayback} flush has audio a resume could restore. */
+  hasHeldPlayback(): boolean {
+    return this.heldPlayback !== null;
+  }
+
+  /** Drop held audio for good (a real barge-in, a new turn, teardown). */
+  discardHeldPlayback(): void {
+    this.heldPlayback = null;
+  }
+
+  /**
+   * Re-schedule the audio a {@link holdPlayback} flush kept, rewound by
+   * {@link RESUME_REWIND_SECONDS} so the interrupted word is spoken whole.
+   * Returns whether anything resumed.
+   *
+   * The retained `AudioBuffer`s are re-played through fresh source nodes (Web
+   * Audio sources are single-use). Playback progress is restored to what it
+   * read at the flush, so the spoken-word cursor continues through the reply
+   * rather than restarting at the resumed tail. The mute stage is part of the
+   * graph, not of the queue, so a resume onto a muted output stays muted.
+   */
+  resumeHeldPlayback(): boolean {
+    const held = this.heldPlayback;
+    this.heldPlayback = null;
+    // A hold whose context has been closed or replaced is unusable: its
+    // buffers belong to a graph that no longer plays.
+    if (!held || this.context === null || this.context !== held.context) {
+      return false;
+    }
+    this.totalScheduledSeconds = held.priorSeconds;
+    for (const segment of held.segments) {
+      this.scheduleBuffer(held.context, segment.buffer, segment.offsetSeconds);
+    }
+    return true;
+  }
+
+  /**
+   * The undelivered tail of the scheduled timeline, from
+   * {@link RESUME_REWIND_SECONDS} before now, or null when nothing is left to
+   * keep. Read-only: capturing does not disturb playback.
+   */
+  private captureHeldPlayback(): HeldPlayback | null {
+    const context = this.context;
+    if (!context) {
+      return null;
+    }
+    const resumeAt = Math.max(0, context.currentTime - RESUME_REWIND_SECONDS);
+    const segments: HeldSegment[] = [];
+    let heldSeconds = 0;
+    for (const scheduled of this.scheduleLog) {
+      const endAt = scheduled.startAt + scheduled.durationSeconds;
+      if (endAt <= resumeAt) {
+        continue;
+      }
+      // Only the segment straddling the resume point is entered part-way; every
+      // later one is still whole.
+      const skipped = Math.max(0, resumeAt - scheduled.startAt);
+      const remaining = scheduled.durationSeconds - skipped;
+      if (remaining <= 0) {
+        continue;
+      }
+      segments.push({
+        buffer: scheduled.buffer,
+        offsetSeconds: scheduled.offsetSeconds + skipped,
+      });
+      heldSeconds += remaining;
+    }
+    if (segments.length === 0) {
+      return null;
+    }
+    return {
+      context,
+      segments,
+      priorSeconds: Math.max(0, this.totalScheduledSeconds - heldSeconds),
+    };
+  }
+
+  /**
+   * Drop schedule-log entries that finished more than
+   * {@link RESUME_REWIND_SECONDS} ago. The log is in start order and gaplessly
+   * chained, so the expired entries are always a prefix.
+   */
+  private pruneScheduleLog(now: number): void {
+    const cutoff = now - RESUME_REWIND_SECONDS;
+    let expired = 0;
+    while (expired < this.scheduleLog.length) {
+      const scheduled = this.scheduleLog[expired]!;
+      if (scheduled.startAt + scheduled.durationSeconds > cutoff) {
+        break;
+      }
+      expired += 1;
+    }
+    if (expired > 0) {
+      this.scheduleLog.splice(0, expired);
+    }
+  }
+
+  /** The queue-flushing half of {@link stop}, shared with {@link holdPlayback}. */
+  private stopScheduledAudio(): void {
     this.generation += 1;
     for (const source of this.activeSources) {
       // Detach the handler first so stop() doesn't re-enter handleSourceEnded
@@ -569,6 +789,7 @@ export class LiveVoiceAudioPlayer {
       source.disconnect();
     }
     this.activeSources.clear();
+    this.scheduleLog = [];
     this.pendingContainerDecodes = 0;
     this.totalScheduledSeconds = 0;
     // Reset the decode chain so the next response's container frames don't queue
@@ -640,6 +861,7 @@ export class LiveVoiceAudioPlayer {
       this.context = context;
       this.playheadTime = 0;
       this.totalScheduledSeconds = 0;
+      this.scheduleLog = [];
       const destinationNode = this.createOutputNode(context);
       // Mute stage, closest to the destination so everything upstream (the
       // metering tap included) still sees the real signal.

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -71,6 +71,7 @@ function renderController(
   extraOptions: {
     observeAudioState?: boolean;
     reconnectBackoffMs?: number[];
+    heldPlaybackTimeoutMs?: number;
     /**
      * Configure each FakeCapture at creation — before the controller calls
      * `capture.start()`, which happens synchronously at connect time (so
@@ -3548,5 +3549,266 @@ describe("speak first (seed turn)", () => {
     await emitReady(h, "s2");
 
     expect(h.client.sentText).toEqual([SEED, SEED]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reversible barge-in (JARVIS-1694)
+// ---------------------------------------------------------------------------
+
+describe("reversible barge-in", () => {
+  /**
+   * Drive a hands-free session to `speaking`, i.e. the assistant mid-reply
+   * with audio queued, which is the state a barge-in interrupts.
+   */
+  async function speakingSession(options?: { heldPlaybackTimeoutMs?: number }) {
+    const h = renderController(options);
+    await startListening(h, { handsFree: true });
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq: 2 });
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 3,
+        reason: "silence",
+      });
+      h.client.emit("sttFinal", { type: "stt_final", seq: 4, text: "hello" });
+      h.client.emit("thinking", { type: "thinking", seq: 5, turnId: "t1" });
+      h.client.emit("ttsAudio", {
+        type: "tts_audio",
+        seq: 6,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      });
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    return h;
+  }
+
+  /** A noise onset: server VAD fires, the client flushes and holds. */
+  function bargeIn(h: ReturnType<typeof renderController>, seq: number) {
+    act(() => {
+      h.client.emit("speechStarted", { type: "speech_started", seq });
+    });
+  }
+
+  test("a discarded utterance puts the flushed reply back", async () => {
+    const h = await speakingSession();
+
+    bargeIn(h, 10);
+    // The flush is what today's bug is: the reply's audio is gone and the
+    // room is listening to a noise that was never speech.
+    expect(h.player.stopCount).toBeGreaterThan(0);
+    expect(h.player.hasHeldPlayback()).toBe(true);
+    expect(h.view.result.current.state).toBe("listening");
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 11,
+        reason: "silence",
+      });
+    });
+    expect(h.view.result.current.state).toBe("transcribing");
+
+    await act(async () => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 12,
+      });
+      await Promise.resolve();
+    });
+
+    expect(h.player.resumeHeldCount).toBe(1);
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
+  });
+
+  test("control: an utterance that transcribes keeps the reply destroyed", async () => {
+    const h = await speakingSession();
+
+    // Same barge-in, same flush. The only difference is that this utterance
+    // carried real speech, so the daemon starts a turn instead of retracting.
+    bargeIn(h, 10);
+    expect(h.player.hasHeldPlayback()).toBe(true);
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 11,
+        reason: "silence",
+      });
+      h.client.emit("sttFinal", {
+        type: "stt_final",
+        seq: 12,
+        text: "actually wait",
+      });
+      h.client.emit("thinking", { type: "thinking", seq: 13, turnId: "t2" });
+    });
+
+    expect(h.player.hasHeldPlayback()).toBe(false);
+    expect(h.player.resumeHeldCount).toBe(0);
+    expect(h.view.result.current.state).toBe("thinking");
+  });
+
+  test("a second speech onset drops the audio the first one held", async () => {
+    const h = await speakingSession();
+
+    bargeIn(h, 10);
+    expect(h.player.hasHeldPlayback()).toBe(true);
+
+    // The user really is talking over the reply. Even if this utterance is
+    // itself discarded, the reply is a whole speech onset stale by now.
+    bargeIn(h, 11);
+    expect(h.player.hasHeldPlayback()).toBe(false);
+
+    await act(async () => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 12,
+      });
+      await Promise.resolve();
+    });
+
+    expect(h.player.resumeHeldCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("the hold expires on its deadline", async () => {
+    const h = await speakingSession({ heldPlaybackTimeoutMs: 20 });
+
+    bargeIn(h, 10);
+    expect(h.player.hasHeldPlayback()).toBe(true);
+
+    await act(async () => {
+      await sleep(40);
+    });
+
+    // A reply resumed long after the room went quiet is a non-sequitur, so
+    // the deadline drops it and a late retraction finds nothing to restore.
+    expect(h.player.hasHeldPlayback()).toBe(false);
+    await act(async () => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 11,
+      });
+      await Promise.resolve();
+    });
+    expect(h.player.resumeHeldCount).toBe(0);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("control: the same wait inside the deadline still resumes", async () => {
+    const h = await speakingSession({ heldPlaybackTimeoutMs: 400 });
+
+    bargeIn(h, 10);
+    await act(async () => {
+      await sleep(40);
+    });
+
+    await act(async () => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 11,
+      });
+      await Promise.resolve();
+    });
+
+    expect(h.player.resumeHeldCount).toBe(1);
+    expect(h.view.result.current.state).toBe("speaking");
+  });
+
+  test("turn_cancelled behind the onset keeps the hold rather than clearing it", async () => {
+    const h = await speakingSession();
+
+    // The daemon cancels a still-generating turn on barge-in, so the client
+    // sees a second flush a frame later with the queue already empty.
+    bargeIn(h, 10);
+    act(() => {
+      h.client.emit("turnCancelled", {
+        type: "turn_cancelled",
+        seq: 11,
+        turnId: "t1",
+      });
+    });
+    expect(h.player.hasHeldPlayback()).toBe(true);
+
+    await act(async () => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 12,
+      });
+      await Promise.resolve();
+    });
+
+    expect(h.player.resumeHeldCount).toBe(1);
+  });
+
+  test("the user's own interrupt is not recoverable", async () => {
+    const h = await speakingSession();
+
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+
+    // Stopping the assistant deliberately means it stays stopped, whatever
+    // the daemon later says about the utterance.
+    expect(h.client.interruptCount).toBe(1);
+    expect(h.player.hasHeldPlayback()).toBe(false);
+    expect(h.view.result.current.state).toBe("listening");
+
+    await act(async () => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 11,
+      });
+      await Promise.resolve();
+    });
+    expect(h.player.resumeHeldCount).toBe(0);
+  });
+
+  test("a resumed turn still ends when its audio drains", async () => {
+    const h = await speakingSession();
+
+    // The turn's own drain waiter resolved when the flush emptied the queue,
+    // so without a fresh one the session would sit in `speaking` for good.
+    await act(async () => {
+      h.client.emit("ttsDone", { type: "tts_done", seq: 10, turnId: "t1" });
+      await Promise.resolve();
+    });
+    bargeIn(h, 11);
+    await act(async () => {
+      h.client.emit("utteranceDiscarded", {
+        type: "utterance_discarded",
+        seq: 12,
+      });
+      await Promise.resolve();
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+
+    await act(async () => {
+      h.player.finishPlayback();
+      await Promise.resolve();
+    });
+
+    expect(h.view.result.current.state).toBe("listening");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(false);
+  });
+
+  test("teardown drops the hold and its deadline", async () => {
+    const h = await speakingSession({ heldPlaybackTimeoutMs: 20 });
+
+    bargeIn(h, 10);
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+
+    // The player is disposed with the session, so nothing survives to be
+    // resumed onto a later one, and the expiry timer has nothing to fire at.
+    expect(h.player.hasHeldPlayback()).toBe(false);
+    await act(async () => {
+      await sleep(40);
+    });
+    expect(h.view.result.current.state).toBe("idle");
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -29,7 +29,10 @@
  * (full duplex; echo cancellation is requested on capture) and the *server*
  * owns utterance boundaries and barge-in: `speech_started` flushes local TTS
  * playback and opens the next utterance, `utterance_end` marks transcription,
- * and `turn_cancelled` drops a barged-in turn's playback. The client-local
+ * and `turn_cancelled` drops a barged-in turn's playback. That flush is
+ * reversible (see {@link HELD_PLAYBACK_TIMEOUT_MS}): server VAD fires on room
+ * noise as well as on speech, and a barge-in it later retracts with
+ * `utterance_discarded` puts the flushed audio back. The client-local
  * silence auto-release and amplitude barge-in below are disabled in this mode.
  * The session ends only on user toggle-off, `busy`, a terminal `error`, or
  * socket close — errors the daemon marks `recoverable` (transient transcriber
@@ -121,6 +124,22 @@ const SILENCE_DURATION_BEFORE_RELEASE_MS = 1000;
 
 /** Minimum speech (ms) required before a silence window can trigger release. */
 const MINIMUM_SPEECH_DURATION_BEFORE_RELEASE_MS = 120;
+
+/**
+ * How long a barge-in's flushed playback is held before it is dropped for good.
+ *
+ * The daemon retracts a wrong barge-in by closing the utterance with an empty
+ * transcript, which takes the VAD's trailing-silence threshold (800ms by
+ * default) plus the transcriber's finalize grace (up to 1s) plus a network hop.
+ * This covers that with headroom while staying short enough that a resume still
+ * lands as the same reply continuing: audio put back long after the room went
+ * quiet is a non-sequitur, and losing it is the better failure.
+ *
+ * The deadline is the backstop, not the usual path. A hold is normally released
+ * by whatever happens next (the resume itself, a real barge-in, the next turn),
+ * and every teardown path drops it with the player.
+ */
+const HELD_PLAYBACK_TIMEOUT_MS = 6_000;
 
 // ---------------------------------------------------------------------------
 // Reconnect (hands-free only)
@@ -223,6 +242,12 @@ export interface UseLiveVoiceOptions {
    * seconds; production uses {@link RECONNECT_BACKOFF_MS}.
    */
   reconnectBackoffMs?: number[];
+  /**
+   * Override how long a barge-in's flushed playback is held before it is
+   * dropped. Primarily a test seam so specs don't wait real seconds; production
+   * uses {@link HELD_PLAYBACK_TIMEOUT_MS}.
+   */
+  heldPlaybackTimeoutMs?: number;
 }
 
 /**
@@ -323,6 +348,14 @@ interface SessionContext {
    * Cleared on teardown/flush.
    */
   assistantAudioIdleTimer: ReturnType<typeof setTimeout> | null;
+  /**
+   * Deadline after which a barge-in's held playback is dropped rather than
+   * resumed. Armed by each flush that leaves audio held, cleared when the hold
+   * is released for any other reason.
+   */
+  heldPlaybackTimer: ReturnType<typeof setTimeout> | null;
+  /** Resolved {@link HELD_PLAYBACK_TIMEOUT_MS} for this session. */
+  heldPlaybackTimeoutMs: number;
 }
 
 /** Number of bytes per Int16 PCM sample. */
@@ -785,6 +818,9 @@ export function useLiveVoice(
         turnHeardStampMs: null,
         clientHeardLatencyMs: null,
         assistantAudioIdleTimer: null,
+        heldPlaybackTimer: null,
+        heldPlaybackTimeoutMs:
+          opts.heldPlaybackTimeoutMs ?? HELD_PLAYBACK_TIMEOUT_MS,
       };
 
       const capture = (
@@ -909,7 +945,13 @@ export function useLiveVoice(
           }
           session.utteranceOpen = true;
           s.setUtteranceOpen(true);
-          flushPlaybackToListening(session);
+          // Server VAD fires on room noise as well as on speech, so hold the
+          // flushed audio instead of destroying it: `utterance_discarded`
+          // retracts a wrong barge-in and puts the reply back. A second onset
+          // arriving on top of an unresolved hold drops it first, because by
+          // then the user is demonstrably talking over the reply.
+          clearHeldPlayback(session);
+          flushPlaybackToListening(session, { holdAudio: true });
         }),
         client.on("utteranceEnd", () => {
           if (!live() || !session.handsFree) {
@@ -936,6 +978,12 @@ export function useLiveVoice(
           // The discarded utterance never becomes a turn: drop its
           // end-of-speech stamp so it can't pair with a later turn's audio.
           session.speechEndedAtMs = null;
+          // The utterance the barge-in opened held no speech, so the barge-in
+          // was wrong: put the flushed reply back rather than leaving silence
+          // where the answer was. Resuming sets `speaking` itself.
+          if (resumeHeldPlayback(session, teardown)) {
+            return;
+          }
           // The closed utterance had no usable speech (noise/cough); return
           // to listening. A discarded utterance never reaches `thinking`
           // (empty finals stay in `transcribing`), so any other state belongs
@@ -1012,6 +1060,9 @@ export function useLiveVoice(
           // list.
           //
           // New response: reset the per-response transcript and barge-in flags.
+          // A turn starting is the definitive answer that the barge-in before
+          // it was real, so the previous reply's held audio is spent.
+          clearHeldPlayback(session);
           session.responseEpoch += 1;
           session.responseAudioStarted = false;
           session.interruptSent = false;
@@ -1128,7 +1179,10 @@ export function useLiveVoice(
           // own `thinking` will bind it.
           session.turnHeardStampMs = null;
           // Barge-in aborted the turn; no tts_done follows a cancelled turn.
-          flushPlaybackToListening(session);
+          // This lands right behind the `speech_started` that already flushed,
+          // so it keeps that flush's hold rather than replacing it: the
+          // barge-in can still turn out to have been noise.
+          flushPlaybackToListening(session, { holdAudio: true });
         }),
         client.on("metrics", (frame) => {
           if (!live()) {
@@ -1448,6 +1502,7 @@ function disposeSessionPrimitives(
 ): void {
   session.generation += 1;
   clearAssistantAudioActive(session);
+  clearHeldPlaybackTimer(session);
   for (const unsubscribe of session.unsubscribes) {
     unsubscribe();
   }
@@ -1810,12 +1865,78 @@ function clearAssistantAudioActive(session: SessionContext): void {
 /**
  * Hands-free: flush local TTS playback immediately, drop expectations for the
  * in-flight response, and keep the session live in `listening`.
+ *
+ * `holdAudio` makes the flush reversible: the unplayed audio is retained so
+ * {@link resumeHeldPlayback} can put it back if the daemon retracts the
+ * barge-in. Only the server-barge-in frames pass it. A deliberate stop (the
+ * user's own interrupt, teardown, reconnect) flushes without it, which also
+ * discards anything already held.
  */
-function flushPlaybackToListening(session: SessionContext): void {
-  session.player.stop();
+function flushPlaybackToListening(
+  session: SessionContext,
+  options?: { holdAudio?: boolean },
+): void {
+  if (options?.holdAudio) {
+    holdPlaybackForResume(session);
+  } else {
+    clearHeldPlayback(session);
+    session.player.stop();
+  }
   session.responseAudioStarted = false;
   clearAssistantAudioActive(session);
   useLiveVoiceStore.getState().setState("listening");
+}
+
+/** Flush playback keeping the unplayed audio, and arm the hold's deadline. */
+function holdPlaybackForResume(session: SessionContext): void {
+  session.player.holdPlayback();
+  clearHeldPlaybackTimer(session);
+  if (!session.player.hasHeldPlayback()) {
+    return;
+  }
+  session.heldPlaybackTimer = setTimeout(() => {
+    session.heldPlaybackTimer = null;
+    session.player.discardHeldPlayback();
+  }, session.heldPlaybackTimeoutMs);
+}
+
+/**
+ * Put a wrongly flushed reply back and resume the turn around it. Returns
+ * whether anything actually resumed.
+ *
+ * A flush resolves the drain waiter armed by this turn's `tts_done`, so a
+ * resumed turn needs a fresh one or the session would sit in `speaking` once
+ * the audio finishes. `responseEpoch` is bumped to hand state ownership to the
+ * resumed turn: the superseded waiter must not settle onto audio that is
+ * playing again (the guard only checks inequality, so the bump is safe even
+ * though this is the same response).
+ */
+function resumeHeldPlayback(
+  session: SessionContext,
+  teardown: () => void,
+): boolean {
+  clearHeldPlaybackTimer(session);
+  if (!session.player.resumeHeldPlayback()) {
+    return false;
+  }
+  session.responseEpoch += 1;
+  markAssistantAudioActive(session);
+  useLiveVoiceStore.getState().setState("speaking");
+  void finishResponseAfterPlayback(session, teardown);
+  return true;
+}
+
+/** Drop held audio and its deadline (a real barge-in, a new turn, teardown). */
+function clearHeldPlayback(session: SessionContext): void {
+  clearHeldPlaybackTimer(session);
+  session.player.discardHeldPlayback();
+}
+
+function clearHeldPlaybackTimer(session: SessionContext): void {
+  if (session.heldPlaybackTimer !== null) {
+    clearTimeout(session.heldPlaybackTimer);
+    session.heldPlaybackTimer = null;
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Users report "echo" on iOS voice mode. The audit behind JARVIS-1694 found the real defect is that barge-in fires on environmental noise (door slams, keyboards, TVs), not on speech. Two fixes have already landed: #41788 dropped `autoGainControl` for full-duplex capture, and #41790 raised the daemon's speech gate to 3x the room's measured noise floor. Both make a wrong barge-in *rarer*. Neither makes one survivable.

At the client, barge-in is irreversible. `speech_started` calls `flushPlaybackToListening()`, which calls `LiveVoiceAudioPlayer.stop()`, which stops every scheduled source and drops the queue **before any transcript exists**. The daemon does eventually discover the "speech" was noise: it closes the utterance with an empty transcript and sends `utterance_discarded`, which this client already handles (it returns the UI to `listening`). By then the reply's audio is gone forever, so a cough permanently destroys the assistant's answer.

This PR makes the flush reversible: hold the audio briefly, and put it back on `utterance_discarded`. A wrong barge-in degrades from "reply destroyed" to "brief stutter".

## Design

Web Audio `AudioBufferSourceNode`s are single-use, so "resume" cannot mean un-stopping the nodes `stop()` halted. What can be retained is the `AudioBuffer`s and the position on the scheduled timeline, and a resume re-schedules fresh sources over them.

**`LiveVoiceAudioPlayer`** gains a schedule log: every buffer placed on the timeline that a hold could still need, i.e. everything not yet sounded plus the last `RESUME_REWIND_SECONDS` of what has. It is pruned on every schedule, so it retains no more history than the rewind window, and the pending part was already retained by the scheduled source nodes anyway. On top of that:

- `holdPlayback()` flushes exactly as `stop()` does (same source stops, same generation bump invalidating in-flight container decodes, same drain resolution) but captures the undelivered tail first.
- `resumeHeldPlayback()` re-schedules that tail and returns whether anything resumed.
- `discardHeldPlayback()` / `hasHeldPlayback()` for the release paths.
- `stop()` is unchanged in behavior and is still the unrecoverable flush: it drops any hold.

**Rewind, not exact resume.** Resuming from the exact interruption sample splits a word across the gap the barge-in opened ("the weather tomor" ... "row will be sunny"), which reads as a glitch rather than as the reply continuing. The resume rewinds 350ms, so the last syllable or two is re-spoken and the sentence is intelligible again. Short enough to sound like a stutter rather than the assistant repeating itself.

**Playback progress rides along.** `getPlaybackProgress()` drives the voice room's spoken-word cursor. A naive resume would restore only the tail's duration and snap the caption back to the reply's first word. The hold records what `totalScheduledSeconds` will read at the instant the resume starts, so total is unchanged across the round trip and played rewinds by exactly what the audio rewound.

**Release paths.** The hold is dropped by everything except the retraction:

| Path | Behavior |
|---|---|
| `speech_started` | Drops any outstanding hold, then holds the current audio. A second onset means the user really is talking, so the earlier reply is spent. |
| `turn_cancelled` | Flushes *keeping* the hold. It lands a frame behind the `speech_started` that already flushed, with the queue empty; an empty capture is that second flush, not evidence there was nothing to keep. |
| `thinking` | Drops it. A turn starting is the definitive answer that the barge-in was real. |
| any `player.enqueue()` | Drops it. Held audio resumes at the front of an empty queue, so it cannot be spliced behind frames that arrived since. This is the backstop against a straggler `tts_audio` racing the flush. |
| user's own `interrupt()` | Drops it (goes through the non-holding flush). A deliberate stop stays stopped. |
| teardown / reconnect / dispose | Drops it with `player.stop()` / `player.dispose()`. |
| 6s deadline | Drops it. |

**Deadline.** `HELD_PLAYBACK_TIMEOUT_MS = 6s`, sized against the daemon's actual retraction path: the VAD's trailing-silence threshold (800ms default) plus the transcriber's finalize grace (up to 1s) plus a network hop, with headroom. Long enough that the ordinary case lands well inside it, short enough that a resume still reads as the same reply. Audio put back long after the room went quiet is a non-sequitur, and losing it is the better failure.

**`responseEpoch`.** A resume bumps it. The flush resolves the drain waiter armed by this turn's `tts_done`, and that superseded waiter must not settle the session back to `listening` onto audio that is playing again. The resume arms a fresh waiter, so a resumed turn still ends when its audio drains. (The guard only checks inequality, so bumping within the same response is safe, matching the existing hands-free `stt_final` double-bump.)

**Mute.** `outputMuted` rides the gain stage, which is part of the graph rather than the queue, so a resume onto a muted output stays muted. Covered by a test rather than left to inspection.

## What resuming does and does not restore

Read `assistant/src/live-voice/live-voice-session.ts` (read only; a fourth fix is being written there in parallel). The daemon sends `speech_started` in two situations, and they differ in what survives:

1. **The turn was already finalized server-side** and the client was draining its buffered playback tail (`isAssistantPlaybackEchoPossible()`, no bargeable turn). No `turn_cancelled` follows. Here the resume restores the **entire rest of the reply**: the server had already sent all of it.
2. **A turn was still in flight**, so `bargeIn()` aborts it synchronously, sends `turn_cancelled`, and detaches the interrupted work to a background continuation. Here the resume restores **only the audio already delivered to the client at the moment of the flush**. The remainder was never generated and will not be; the continuation delivers it later on its own path. `utterance_discarded` does not un-cancel a cancelled turn.

So this PR does not claim to undo a barge-in. It claims the user hears the buffered tail instead of silence, which is the difference between an answer that vanished and one that stuttered. I did not attempt to make case 2 whole; doing that means a daemon or protocol change (a retraction the server acts on), which is out of scope here and would collide with the parallel work in `assistant/`.

**Also not restored:** frames still in flight on the network, and container-format frames (wav/mp3/opus from providers without raw-PCM streaming) that were still inside `decodeAudioData` when the flush landed. The hold retains audio that had been *scheduled*; a mid-decode frame was never scheduled and is dropped by the generation guard exactly as it is today. Raw-PCM providers, which is the common path, decode synchronously and are unaffected.

## Alternatives rejected

- **Delaying the flush** (wait for `utterance_discarded` before stopping). Barge-in has to feel instant; a few hundred ms of the assistant talking over the user is the complaint this whole workstream exists to fix.
- **Ducking instead of stopping** (drop the gain, restore it on discard). Keeps the timeline running, so a real barge-in resumes into audio that has silently advanced several seconds, and the user's own voice competes with an assistant that never actually stopped.
- **Bounding the hold by an age check at resume only, with no timer.** Handles staleness but leaves the retained buffers alive until the next flush.
- **Rewinding across an unbounded history.** Would need every buffer of the response retained. The schedule log keeps exactly the rewind window instead.
- **A daemon-side retraction that replays the audio.** The right long-term fix for case 2 above, and out of scope: the information needed here is already on the wire, and `assistant/` is being edited in parallel.

## Testing

`bunx tsc --noEmit` and `eslint` clean. Suites run individually (`mock.module` leaks across files in this package).

`tts-playback.test.ts` (59 pass), 11 new, against the real player:
- a hold retains the unplayed audio and resume re-schedules it, **paired against** the same barge-in with `stop()`, which destroys it;
- resume rewinds into the interrupted buffer and stays gapless behind it;
- audio that already sounded is not resumed;
- playback progress continues across the resume, rewound to match;
- a second flush with nothing scheduled keeps the first flush's hold;
- audio arriving after the flush supersedes the hold;
- a hold does not survive disposal of its context;
- resuming onto a muted output stays muted;
- nothing is held when the reply had already finished playing.

`use-live-voice.test.ts` (123 pass), 9 new, against the controller:
- a discarded utterance puts the flushed reply back;
- **control:** an utterance that transcribes keeps the reply destroyed (same inputs, real transcript instead of empty);
- a second speech onset drops the audio the first one held;
- the hold expires on its deadline, **paired with** the control that the same wait inside the deadline still resumes;
- `turn_cancelled` behind the onset keeps the hold;
- the user's own interrupt is not recoverable;
- a resumed turn still ends when its audio drains;
- teardown drops the hold and its deadline.

`use-live-voice-session-controller.test.tsx` (29 pass) and `live-voice-store.test.ts` (67 pass) unchanged and green.

`live-voice-fakes.test-helper.ts`'s `FakePlayer` gained the hold surface. It stands in for the real player with whatever had been enqueued, which is enough for the controller specs (they assert *what* is held, resumed, and dropped, not how it is re-scheduled); buffer-level behavior is covered against the real player.

## Coverage gaps I knowingly left

- **No test drives a container-format (wav) reply through a hold.** The behavior is inherited from the existing generation guard rather than added here, but it is asserted only for `stop()`.
- **No test covers a hold surviving a reconnect**, because it deliberately does not: `disposeSessionPrimitives({ keepPlayerAlive })` calls `player.stop()`, which drops it. That is intentional (a reply resumed across a socket blip is stale) but it is asserted only indirectly, via the teardown test.
- **No end-to-end test against the real daemon.** The frame ordering this relies on (`speech_started` then `turn_cancelled`, and `utterance_discarded` only for an empty transcript) is read out of `live-voice-session.ts`, not exercised.
- **Nothing measures how often the retraction actually arrives inside 6s in the field.** The deadline is reasoned from the daemon's configured thresholds, not from telemetry.

## Needs verifying on a device

The Simulator exposes a mock audio device with no mic, speaker, or acoustic path, so it cannot answer any of the below (`docs/CAPACITOR.md`). On a physical handset, in a hands-free session:

1. **The MediaStream output route survives a hold/resume.** This is the load-bearing one. Resumed sources connect through the same analyser and gain stages to the same `MediaStreamAudioDestinationNode`, and nothing pauses or re-creates the `HTMLAudioElement`, so the route should be untouched. Confirm `getOutputRouteDiagnostics().route` still reads `media-stream` after a resume, and that echo cancellation still works on the turn *after* one (a resumed reply that WebKit is no longer given as far-end reference audio would reintroduce exactly the echo this workstream is fixing).
2. **The rewind sounds like a stutter, not a repeat.** 350ms is a judgement call made against how TTS is chunked, not against a recording. Slam a door mid-reply and listen to where it picks up.
3. **A real barge-in still feels instant**, and the reply does not come back after it.
4. **The 6s deadline is not routinely hit.** Cough mid-reply a few times and check the reply resumes rather than staying dead.
5. **Muted resume stays silent** on the device's actual output route, not just through the gain node in a mock.

Part of the JARVIS-1694 barge-in work, after #41788 and #41790.
