### PR TITLE
feat(live-voice): require a voice, not just loudness, to barge in (JARVIS-1694)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -941,6 +941,7 @@ describe("AssistantConfigSchema", () => {
         silenceThresholdMs: 1200,
         maxTurnDurationMs: 30000,
         bargeInMinSpeechMs: 250,
+        bargeInMinVoicedRatio: 0.25,
         echoBargeInMargin: 1.5,
         echoEmaHalfLifeMs: 400,
         echoDrainSlackMs: 300,

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -44,6 +44,7 @@ describe("LiveVoiceVadConfigSchema", () => {
       silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
       bargeInMinSpeechMs: 250,
+      bargeInMinVoicedRatio: 0.25,
       echoBargeInMargin: 1.5,
       echoEmaHalfLifeMs: 400,
       echoDrainSlackMs: 300,
@@ -71,6 +72,22 @@ describe("LiveVoiceVadConfigSchema", () => {
   test("rejects a negative noiseFloorMargin", () => {
     expect(() =>
       LiveVoiceVadConfigSchema.parse({ noiseFloorMargin: -1 }),
+    ).toThrow();
+  });
+
+  test("accepts a bargeInMinVoicedRatio of 0 (voicing test disabled)", () => {
+    const parsed = LiveVoiceVadConfigSchema.parse({ bargeInMinVoicedRatio: 0 });
+    expect(parsed.bargeInMinVoicedRatio).toBe(0);
+  });
+
+  test("rejects a bargeInMinVoicedRatio outside 0..1", () => {
+    // It is a fraction of the run, so above 1 is unsatisfiable (barge-in would
+    // become impossible) and below 0 is meaningless.
+    expect(() =>
+      LiveVoiceVadConfigSchema.parse({ bargeInMinVoicedRatio: 1.5 }),
+    ).toThrow();
+    expect(() =>
+      LiveVoiceVadConfigSchema.parse({ bargeInMinVoicedRatio: -0.1 }),
     ).toThrow();
   });
 
@@ -333,6 +350,7 @@ describe("LiveVoiceConfigSchema", () => {
         silenceThresholdMs: 1200,
         maxTurnDurationMs: 30_000,
         bargeInMinSpeechMs: 250,
+        bargeInMinVoicedRatio: 0.25,
         echoBargeInMargin: 1.5,
         echoEmaHalfLifeMs: 400,
         echoDrainSlackMs: 300,

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -49,6 +49,16 @@ export const LiveVoiceVadConfigSchema = z
       .describe(
         "Sustained speech (ms) required before speech during assistant playback interrupts it — the default 'interrupt sensitivity' (higher = harder to interrupt). 0 disables the guard. Clients may override it per-session via the start frame. Raised from 60 so brief TTS bleed through imperfect echo cancellation no longer self-interrupts the assistant.",
       ),
+    bargeInMinVoicedRatio: z
+      .number({
+        error: "liveVoice.vad.bargeInMinVoicedRatio must be a number",
+      })
+      .min(0, "liveVoice.vad.bargeInMinVoicedRatio must be between 0 and 1")
+      .max(1, "liveVoice.vad.bargeInMinVoicedRatio must be between 0 and 1")
+      .default(0.25)
+      .describe(
+        "Fraction of a barge-in's most recent above-gate audio that must look like voiced speech (a waveform repeating at a pitch period) before it may interrupt the assistant. Keeps sustained aperiodic noise (typing, rustling, running water, fans) from cancelling a reply. Only ever withholds an interruption, never causes one. 0 disables the test.",
+      ),
     echoBargeInMargin: z
       .number({ error: "liveVoice.vad.echoBargeInMargin must be a number" })
       .gt(1, "liveVoice.vad.echoBargeInMargin must be greater than 1")

--- a/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-vad.test.ts
@@ -97,6 +97,54 @@ function tonePcm(
   return new Uint8Array(buffer);
 }
 
+// A vowel-shaped 50 ms frame: a fundamental plus a decaying harmonic stack,
+// the waveform vocal folds driving a vocal tract actually produce. Periodic,
+// so the barge-in voicing test reads it as a voice.
+function vowelPcm(
+  amplitude: number,
+  fundamentalHz = 120,
+  sampleCount = 1_200,
+): Uint8Array {
+  const harmonics = [1, 0.7, 0.5, 0.35, 0.22, 0.14, 0.08];
+  const buffer = Buffer.alloc(sampleCount * 2);
+  for (let index = 0; index < sampleCount; index += 1) {
+    let value = 0;
+    for (let harmonic = 0; harmonic < harmonics.length; harmonic += 1) {
+      value +=
+        harmonics[harmonic]! *
+        Math.sin(
+          (2 * Math.PI * fundamentalHz * (harmonic + 1) * index) / SAMPLE_RATE,
+        );
+    }
+    buffer.writeInt16LE(Math.round((amplitude * value) / 2), index * 2);
+  }
+  return new Uint8Array(buffer);
+}
+
+// A broadband 50 ms frame with no repeating structure: a stand-in for the
+// sustained non-speech that clears the energy gate (typing, rustling, a tap
+// running, a fan). Deterministic so a threshold assertion cannot flake.
+function noisePcm(amplitude: number, sampleCount = 1_200): Uint8Array {
+  let state = 1_234_567;
+  const buffer = Buffer.alloc(sampleCount * 2);
+  for (let index = 0; index < sampleCount; index += 1) {
+    state = (state * 1_103_515_245 + 12_345) & 0x7fffffff;
+    const uniform = (state / 0x7fffffff) * 2 - 1;
+    buffer.writeInt16LE(Math.round(amplitude * uniform), index * 2);
+  }
+  return new Uint8Array(buffer);
+}
+
+function meanAmplitude(chunk: Uint8Array): number {
+  const buffer = Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+  const count = Math.floor(buffer.length / 2);
+  let total = 0;
+  for (let index = 0; index < count; index += 1) {
+    total += Math.abs(buffer.readInt16LE(index * 2));
+  }
+  return total / count;
+}
+
 // 10 ms of speech at 24 kHz.
 const LOUD_CHUNK = pcm(8_000);
 // 300 ms of speech at 24 kHz — comfortably exceeds the default sustained-speech
@@ -179,6 +227,7 @@ function createHarness(options: {
   speechEnergyThreshold?: number;
   noiseFloorMargin?: number;
   bargeInMinSpeechMs?: number;
+  bargeInMinVoicedRatio?: number;
   echoBargeInMargin?: number;
   echoEmaHalfLifeMs?: number;
   echoDrainSlackMs?: number;
@@ -264,6 +313,12 @@ function createHarness(options: {
     noiseFloorMargin:
       options.noiseFloorMargin ?? (options.viaFactory ? undefined : 0),
     bargeInMinSpeechMs: options.bargeInMinSpeechMs,
+    // Like echoBargeInMargin and noiseFloorMargin: a directly-constructed
+    // session judges barge-in on energy alone unless a test asks for the
+    // voicing test, so a case about the guard's time accounting is not also a
+    // case about the shape of its synthetic audio.
+    bargeInMinVoicedRatio:
+      options.bargeInMinVoicedRatio ?? (options.viaFactory ? undefined : 0),
     echoBargeInMargin:
       options.echoBargeInMargin ?? (options.viaFactory ? undefined : 1),
     echoEmaHalfLifeMs: options.echoEmaHalfLifeMs,
@@ -3344,6 +3399,7 @@ describe("LiveVoiceSession VAD threshold configuration", () => {
       silenceThresholdMs: 1200,
       maxTurnDurationMs: 30_000,
       bargeInMinSpeechMs: 250,
+      bargeInMinVoicedRatio: 0.25,
       echoBargeInMargin: 1.5,
       echoEmaHalfLifeMs: 400,
       echoDrainSlackMs: 300,
@@ -3460,6 +3516,7 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
   // detector timers stay out of the guard's audio-duration accounting.
   function createSpeakingTurnHarness(options: {
     bargeInMinSpeechMs: number;
+    bargeInMinVoicedRatio?: number;
     echoEmaHalfLifeMs?: number;
     echoBargeInMargin?: number;
     echoDrainSlackMs?: number;
@@ -3486,6 +3543,9 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       startVoiceTurn,
       streamTtsAudio,
       bargeInMinSpeechMs: options.bargeInMinSpeechMs,
+      ...(options.bargeInMinVoicedRatio !== undefined
+        ? { bargeInMinVoicedRatio: options.bargeInMinVoicedRatio }
+        : {}),
       echoEmaHalfLifeMs: options.echoEmaHalfLifeMs ?? 4,
       echoBargeInMargin: options.echoBargeInMargin ?? 1,
       echoDrainSlackMs: options.echoDrainSlackMs ?? 60_000,
@@ -4031,6 +4091,134 @@ describe("LiveVoiceSession sustained-speech barge-in guard", () => {
       }
 
       await waitFor(() => countType(frames, "turn_cancelled") === 1);
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+  });
+
+  describe("voiced-speech requirement", () => {
+    // 50 ms frames, the size the web client batches microphone PCM into, at
+    // matched loudness. Everything the energy gate and the noise floor can see
+    // is identical between them; only the shape of the waveform differs.
+    const VOWEL_FRAME = vowelPcm(7_500);
+    const NOISE_FRAME = noisePcm(5_800);
+
+    test("the two probe frames really are the same loudness", () => {
+      // If this drifts, the pair below stops being a controlled comparison and
+      // starts being a test about energy again.
+      const vowel = meanAmplitude(VOWEL_FRAME);
+      const noise = meanAmplitude(NOISE_FRAME);
+      expect(vowel).toBeGreaterThan(800);
+      expect(Math.abs(vowel - noise) / vowel).toBeLessThan(0.05);
+    });
+
+    test("sustained noise loud enough to barge in does not cancel the turn", async () => {
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 250,
+          bargeInMinVoicedRatio: 0.25,
+        });
+      await speakFirstReply();
+
+      // 500 ms of above-gate broadband noise: twice the guard duration, with no
+      // gap for the duty-cycle ceiling to catch. Energy alone would have fired
+      // at 250 ms.
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(NOISE_FRAME);
+      }
+      await flushAsyncCallbacks();
+
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+      expect(abort).not.toHaveBeenCalled();
+    });
+
+    test("a voice at that same loudness cancels the turn", async () => {
+      // The control: same harness, same energy, same durations, periodic
+      // waveform. A failure here means the test is rejecting real speech.
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 250,
+          bargeInMinVoicedRatio: 0.25,
+        });
+      await speakFirstReply();
+
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(VOWEL_FRAME);
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("the same noise cancels the turn with the requirement disabled", async () => {
+      // Proof the noise clears every other gate on the way in, so the case
+      // above is the voicing test doing the work and not the audio being quiet.
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 250,
+          bargeInMinVoicedRatio: 0,
+        });
+      await speakFirstReply();
+
+      for (let index = 0; index < 10; index += 1) {
+        await session.handleBinaryAudio(NOISE_FRAME);
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("speaking over noise that never stops still interrupts", async () => {
+      // The failure this must not have: a tap left running holds the gate open
+      // indefinitely, and if its unvoiced time accumulated without limit the
+      // user would be unable to interrupt at all. The window only remembers the
+      // recent stretch, so their voice fires the run it is already standing in.
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 250,
+          bargeInMinVoicedRatio: 0.25,
+        });
+      await speakFirstReply();
+
+      // Two full seconds of noise: forty frames of unvoiced above-gate audio.
+      for (let index = 0; index < 40; index += 1) {
+        await session.handleBinaryAudio(NOISE_FRAME);
+      }
+      await flushAsyncCallbacks();
+      expect(countType(frames, "turn_cancelled")).toBe(0);
+
+      // 100 ms of voice is a quarter of the 250 ms window, so the run fires
+      // without the user having to out-talk the noise's whole history.
+      for (let index = 0; index < 2; index += 1) {
+        await session.handleBinaryAudio(VOWEL_FRAME);
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
+      await waitFor(() => abort.mock.calls.length === 1);
+    });
+
+    test("a word that opens on an unvoiced consonant still interrupts", async () => {
+      // "stop": 100 ms of fricative, then the vowel. The fricative is
+      // acoustically noise and scores like noise, so a per-chunk verdict would
+      // throw away the front of the word; the run is judged as a stretch.
+      const { frames, session, abort, speakFirstReply } =
+        createSpeakingTurnHarness({
+          bargeInMinSpeechMs: 250,
+          bargeInMinVoicedRatio: 0.25,
+        });
+      await speakFirstReply();
+
+      for (let index = 0; index < 2; index += 1) {
+        await session.handleBinaryAudio(NOISE_FRAME);
+      }
+      for (let index = 0; index < 3; index += 1) {
+        await session.handleBinaryAudio(VOWEL_FRAME);
+      }
+      await waitFor(() =>
+        frames.some((frame) => frame.type === "turn_cancelled"),
+      );
       await waitFor(() => abort.mock.calls.length === 1);
     });
   });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -70,6 +70,10 @@ import {
   pcm16MaxNormalizedCorrelation,
   pcm16MeanAmplitude,
 } from "../stt/speech-energy.js";
+import {
+  isPcm16Voiced,
+  VoicedSpeechWindow,
+} from "../stt/speech-periodicity.js";
 import type {
   StreamingTranscriber,
   SttProviderId,
@@ -240,6 +244,23 @@ const BARGE_IN_GAP_TOLERANCE_MS = 200;
 // (1 / (1 + ratio) ≈ 20%): once the run is mostly silence it resets, so genuine
 // choppy speech still lands but periodic noise cannot accumulate into one.
 const BARGE_IN_MAX_TOLERATED_SILENCE_RATIO = 4;
+// Fraction of a barge-in run's most recent above-gate audio that has to look
+// like voiced speech before the run may cancel the assistant. The energy gate
+// and the noise floor together only ever ask how loud a sound is, so sustained
+// aperiodic noise (typing, rustling, running water, a fan) still clears them
+// for the full guard duration and kills a reply. Requiring a voice somewhere in
+// the run costs nothing a real interruption has to pay: a quarter is far below
+// the voiced share of any spoken word, which leaves room for the unvoiced
+// consonants a word opens with and for chunks too degraded by the client's echo
+// canceller to measure. Mirrors the liveVoice.vad.bargeInMinVoicedRatio default.
+const DEFAULT_BARGE_IN_MIN_VOICED_RATIO = 0.25;
+// Floor on the span of audio the voiced fraction is measured over, whatever
+// interrupt sensitivity the client asks for. A word is not a chunk: with the
+// web client's 50 ms framing, a window shorter than a syllable would ask each
+// frame to look like a voice on its own, and the fricative a word opens with
+// never does. The floor only binds once a run outlives it, so a run still fires
+// as soon as it has the speech it needs.
+const BARGE_IN_VOICING_WINDOW_MIN_MS = 200;
 // Slack added to the configured end-of-turn timeout before the session stops
 // waiting for an event that is not coming and falls the utterance back onto
 // the silence-boundary path. A turn-detecting provider force-ends its own turn
@@ -362,6 +383,14 @@ export interface LiveVoiceSessionOptions {
    * defaults to `DEFAULT_BARGE_IN_MIN_SPEECH_MS`.
    */
   bargeInMinSpeechMs?: number;
+  /**
+   * Voiced fraction a barge-in run's recent above-gate audio must reach before
+   * it may interrupt. The production factory seeds this from
+   * `liveVoice.vad.bargeInMinVoicedRatio` config when unset; defaults to
+   * `DEFAULT_BARGE_IN_MIN_VOICED_RATIO`. Values at or below 0 disable the test
+   * (used by tests that are about the energy accounting alone).
+   */
+  bargeInMinVoicedRatio?: number;
   /**
    * Multiplier over the learned playback echo level that input must exceed
    * to count as speech while assistant audio is playing. Values at or below
@@ -1239,6 +1268,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // Mutable so a mid-session `update_config` frame can retune "interrupt
   // sensitivity" live (see applyConfigUpdate).
   private bargeInMinSpeechMs: number;
+  private readonly bargeInMinVoicedRatio: number;
   // Sustained-speech barge-in guard, armed at speech onset while the
   // assistant turn is audibly speaking: above-gate speech-chunk duration
   // accumulates until it reaches bargeInMinSpeechMs, then the deferred
@@ -1259,6 +1289,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // chunks); resets speechMs once it exceeds the duty-cycle ceiling so sparse
     // periodic blips cannot sum into a barge-in.
     toleratedSilenceMs: number;
+    // Voiced share of the run's most recent bargeInMinSpeechMs of above-gate
+    // audio, which the run must clear alongside speechMs to fire.
+    voicing: VoicedSpeechWindow;
   } | null = null;
   // Estimated wall-clock ms until the client finishes draining the
   // assistant audio sent so far. The server clears the turn right after
@@ -1442,6 +1475,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       context.startFrame.bargeInMinSpeechMs ??
       options.bargeInMinSpeechMs ??
       DEFAULT_BARGE_IN_MIN_SPEECH_MS;
+    this.bargeInMinVoicedRatio =
+      options.bargeInMinVoicedRatio ?? DEFAULT_BARGE_IN_MIN_VOICED_RATIO;
     this.echoBargeInMargin =
       options.echoBargeInMargin ?? DEFAULT_ECHO_BARGE_IN_MARGIN;
     this.echoEmaHalfLifeMs =
@@ -2684,6 +2719,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         speechMs: 0,
         silenceMs: 0,
         toleratedSilenceMs: 0,
+        voicing: new VoicedSpeechWindow(
+          Math.max(this.bargeInMinSpeechMs, BARGE_IN_VOICING_WINDOW_MIN_MS),
+        ),
       };
       return;
     }
@@ -2736,7 +2774,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     guard.silenceMs = 0;
     guard.speechMs += chunkMs;
+    guard.voicing.observe(chunkMs, this.chunkSoundsVoiced(chunk));
     if (guard.speechMs < this.bargeInMinSpeechMs) {
+      return;
+    }
+    // Loud for long enough, but nothing in it repeats at a pitch period: a
+    // sound, not a voice. Hold rather than reset, so the run is still standing
+    // the moment the user does speak over the noise and can fire on that
+    // chunk instead of restarting from zero.
+    if (guard.voicing.voicedFraction < this.bargeInMinVoicedRatio) {
       return;
     }
     this.pendingBargeIn = null;
@@ -2756,11 +2802,25 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     guard.speechMs = 0;
     guard.silenceMs = 0;
     guard.toleratedSilenceMs = 0;
+    guard.voicing.reset();
     if (this.echoWindowGuardCarryover) {
       this.echoWindowGuardCarryover = false;
       this.echoEnergyEma = 0;
       this.echoProbeChunks = [];
     }
+  }
+
+  // Whether an above-gate chunk carries a repeating waveform. Only reached
+  // while a barge-in guard is armed, so the correlation search runs on the
+  // handful of chunks that are about to cancel a reply rather than on every
+  // chunk of the call. A chunk too short or too flat to measure counts as a
+  // voice: this test may only withhold an interruption, so it must never be
+  // the thing that decides one on evidence it does not have.
+  private chunkSoundsVoiced(chunk: Buffer): boolean {
+    if (this.bargeInMinVoicedRatio <= 0) {
+      return true;
+    }
+    return isPcm16Voiced(chunk, this.context.startFrame.audio.sampleRate);
   }
 
   private bargeIn(turn: ActiveAssistantTurn): void {
@@ -6897,6 +6957,8 @@ export function createLiveVoiceSession(
     noiseFloorMargin: options.noiseFloorMargin ?? vadConfig?.noiseFloorMargin,
     bargeInMinSpeechMs:
       options.bargeInMinSpeechMs ?? vadConfig?.bargeInMinSpeechMs,
+    bargeInMinVoicedRatio:
+      options.bargeInMinVoicedRatio ?? vadConfig?.bargeInMinVoicedRatio,
     echoBargeInMargin:
       options.echoBargeInMargin ?? vadConfig?.echoBargeInMargin,
     echoEmaHalfLifeMs:

--- a/assistant/src/stt/__tests__/speech-periodicity.test.ts
+++ b/assistant/src/stt/__tests__/speech-periodicity.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_VOICED_PERIODICITY,
+  isPcm16Voiced,
+  pcm16Periodicity,
+  VoicedSpeechWindow,
+} from "../speech-periodicity.js";
+
+const SAMPLE_RATE = 24_000;
+/** The web client batches microphone PCM into 50 ms frames. */
+const FRAME_MS = 50;
+
+function pcmFrom(samples: number[]): Buffer {
+  const buffer = Buffer.alloc(samples.length * 2);
+  for (let index = 0; index < samples.length; index += 1) {
+    const clamped = Math.max(
+      -32_768,
+      Math.min(32_767, Math.round(samples[index]!)),
+    );
+    buffer.writeInt16LE(clamped, index * 2);
+  }
+  return buffer;
+}
+
+function sampleCount(ms: number, sampleRate = SAMPLE_RATE): number {
+  return Math.round((sampleRate * ms) / 1_000);
+}
+
+/**
+ * A vowel-shaped waveform: a fundamental plus a decaying harmonic stack, which
+ * is what vocal folds driving a vocal tract actually produce.
+ */
+function vowelPcm(
+  ms: number,
+  fundamentalHz = 120,
+  amplitude = 6_000,
+  sampleRate = SAMPLE_RATE,
+): Buffer {
+  const harmonics = [1, 0.7, 0.5, 0.35, 0.22, 0.14, 0.08];
+  const count = sampleCount(ms, sampleRate);
+  const samples: number[] = [];
+  for (let index = 0; index < count; index += 1) {
+    let value = 0;
+    for (let harmonic = 0; harmonic < harmonics.length; harmonic += 1) {
+      value +=
+        harmonics[harmonic]! *
+        Math.sin(
+          (2 * Math.PI * fundamentalHz * (harmonic + 1) * index) / sampleRate,
+        );
+    }
+    samples.push((amplitude * value) / 2);
+  }
+  return pcmFrom(samples);
+}
+
+/** Deterministic uniform noise, so a threshold assertion cannot flake. */
+function makeRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state * 1_103_515_245 + 12_345) & 0x7fffffff;
+    return (state / 0x7fffffff) * 2 - 1;
+  };
+}
+
+function noisePcm(ms: number, amplitude = 6_000, seed = 7): Buffer {
+  const random = makeRandom(seed);
+  const count = sampleCount(ms);
+  return pcmFrom(Array.from({ length: count }, () => amplitude * random()));
+}
+
+/** A single broadband transient followed by silence, i.e. a click. */
+function impulsePcm(ms: number, amplitude = 28_000): Buffer {
+  const count = sampleCount(ms);
+  const samples = new Array<number>(count).fill(0);
+  for (let index = 0; index < sampleCount(1); index += 1) {
+    samples[index] = amplitude * Math.exp(-index / sampleCount(0.2));
+  }
+  return pcmFrom(samples);
+}
+
+/** Key clicks: short broadband bursts, repeated far apart. */
+function keyboardPcm(ms: number): Buffer {
+  const random = makeRandom(31);
+  const count = sampleCount(ms);
+  const samples = new Array<number>(count).fill(0);
+  const stride = sampleCount(30);
+  const burst = sampleCount(4);
+  for (let start = 0; start < count; start += stride) {
+    for (let index = 0; index < burst && start + index < count; index += 1) {
+      samples[start + index] =
+        20_000 * Math.exp(-index / sampleCount(1)) * random();
+    }
+  }
+  return pcmFrom(samples);
+}
+
+function mixPcm(...buffers: Buffer[]): Buffer {
+  const count = Math.min(...buffers.map((buffer) => buffer.length / 2));
+  const samples: number[] = [];
+  for (let index = 0; index < count; index += 1) {
+    let value = 0;
+    for (const buffer of buffers) {
+      value += buffer.readInt16LE(index * 2);
+    }
+    samples.push(value);
+  }
+  return pcmFrom(samples);
+}
+
+function meanAmplitude(chunk: Buffer): number {
+  let total = 0;
+  const count = chunk.length / 2;
+  for (let index = 0; index < count; index += 1) {
+    total += Math.abs(chunk.readInt16LE(index * 2));
+  }
+  return total / count;
+}
+
+describe("pcm16Periodicity", () => {
+  test("a vowel scores near 1 at any pitch in the searched band", () => {
+    for (const fundamentalHz of [80, 120, 200, 300]) {
+      const periodicity = pcm16Periodicity(
+        vowelPcm(FRAME_MS, fundamentalHz),
+        SAMPLE_RATE,
+      );
+      expect(periodicity).not.toBeNull();
+      expect(periodicity!).toBeGreaterThan(0.9);
+    }
+  });
+
+  test("level does not move the score", () => {
+    // Normalization is what lets a barge-in through the client's echo
+    // canceller, which attenuates the near-end voice without reshaping it.
+    const loud = pcm16Periodicity(vowelPcm(FRAME_MS, 120, 8_000), SAMPLE_RATE);
+    const ducked = pcm16Periodicity(vowelPcm(FRAME_MS, 120, 400), SAMPLE_RATE);
+    expect(loud).not.toBeNull();
+    expect(ducked).not.toBeNull();
+    expect(ducked!).toBeCloseTo(loud!, 2);
+  });
+
+  test("broadband noise scores far below a voice at the same loudness", () => {
+    const noise = noisePcm(FRAME_MS);
+    const vowel = vowelPcm(FRAME_MS, 120, 8_000);
+    // The paired control the whole change rests on: same energy, different
+    // shape. If these two ever converge the discriminator is doing nothing.
+    expect(meanAmplitude(noise)).toBeGreaterThan(meanAmplitude(vowel) * 0.8);
+    expect(pcm16Periodicity(noise, SAMPLE_RATE)!).toBeLessThan(
+      DEFAULT_VOICED_PERIODICITY,
+    );
+    expect(pcm16Periodicity(vowel, SAMPLE_RATE)!).toBeGreaterThan(
+      DEFAULT_VOICED_PERIODICITY,
+    );
+  });
+
+  test("an impulse and a run of key clicks score near zero", () => {
+    expect(pcm16Periodicity(impulsePcm(FRAME_MS), SAMPLE_RATE)!).toBeLessThan(
+      0.3,
+    );
+    expect(pcm16Periodicity(keyboardPcm(200), SAMPLE_RATE)!).toBeLessThan(0.1);
+  });
+
+  test("a voice buried in equal-power noise still reads as a voice", () => {
+    // The borderline case, and the one that decides whether someone can
+    // interrupt from a noisy room.
+    const buried = mixPcm(
+      vowelPcm(FRAME_MS, 120, 4_000),
+      noisePcm(FRAME_MS, 4_000),
+    );
+    expect(pcm16Periodicity(buried, SAMPLE_RATE)!).toBeGreaterThan(
+      DEFAULT_VOICED_PERIODICITY,
+    );
+  });
+
+  test("silence and a DC-constant buffer are unmeasurable, not unvoiced", () => {
+    const count = sampleCount(FRAME_MS);
+    expect(
+      pcm16Periodicity(pcmFrom(new Array<number>(count).fill(0)), SAMPLE_RATE),
+    ).toBeNull();
+    expect(
+      pcm16Periodicity(
+        pcmFrom(new Array<number>(count).fill(8_000)),
+        SAMPLE_RATE,
+      ),
+    ).toBeNull();
+  });
+
+  test("a chunk too short for two pitch periods is unmeasurable", () => {
+    // 10 ms cannot hold two cycles of a 70 Hz voice, so there is no repetition
+    // to look for and the honest answer is "no opinion".
+    expect(pcm16Periodicity(vowelPcm(10), SAMPLE_RATE)).toBeNull();
+    expect(pcm16Periodicity(vowelPcm(40), SAMPLE_RATE)).not.toBeNull();
+  });
+
+  test("an unusable sample rate is unmeasurable", () => {
+    expect(pcm16Periodicity(vowelPcm(FRAME_MS), 0)).toBeNull();
+    expect(pcm16Periodicity(vowelPcm(FRAME_MS), Number.NaN)).toBeNull();
+  });
+
+  test("the separation holds at every sample rate a client sends", () => {
+    for (const sampleRate of [16_000, 24_000, 48_000]) {
+      const vowel = vowelPcm(FRAME_MS, 120, 6_000, sampleRate);
+      expect(pcm16Periodicity(vowel, sampleRate)!).toBeGreaterThan(0.9);
+    }
+  });
+});
+
+describe("isPcm16Voiced", () => {
+  test("classifies a vowel voiced and noise unvoiced", () => {
+    expect(isPcm16Voiced(vowelPcm(FRAME_MS), SAMPLE_RATE)).toBe(true);
+    expect(isPcm16Voiced(noisePcm(FRAME_MS), SAMPLE_RATE)).toBe(false);
+  });
+
+  test("an unmeasurable chunk counts as voiced", () => {
+    // The bias that keeps this from ever costing someone an interruption:
+    // no evidence is not evidence of noise.
+    expect(isPcm16Voiced(vowelPcm(10), SAMPLE_RATE)).toBe(true);
+    expect(isPcm16Voiced(noisePcm(10), SAMPLE_RATE)).toBe(true);
+    expect(isPcm16Voiced(Buffer.alloc(0), SAMPLE_RATE)).toBe(true);
+  });
+});
+
+describe("VoicedSpeechWindow", () => {
+  test("an empty window has nothing to hold against anyone", () => {
+    expect(new VoicedSpeechWindow(250).voicedFraction).toBe(1);
+  });
+
+  test("reports the voiced share of the retained audio", () => {
+    const window = new VoicedSpeechWindow(200);
+    window.observe(50, true);
+    window.observe(50, false);
+    window.observe(50, false);
+    window.observe(50, false);
+    expect(window.voicedFraction).toBeCloseTo(0.25, 5);
+  });
+
+  test("a word's unvoiced opening does not sink the word", () => {
+    // "stop": a long /s/, then the vowel. Judged chunk by chunk the /s/ is
+    // noise; judged as a stretch of sound, the word contains a voice.
+    const window = new VoicedSpeechWindow(250);
+    window.observe(50, false);
+    window.observe(50, false);
+    window.observe(50, true);
+    window.observe(50, true);
+    expect(window.voicedFraction).toBeCloseTo(0.5, 5);
+  });
+
+  test("noise that never stops cannot dilute the voice that follows it", () => {
+    // Ten seconds of a running tap, then someone speaking over it. Measured
+    // over the whole run the speech would be a rounding error and the user
+    // could never interrupt; the window only remembers the recent stretch.
+    const window = new VoicedSpeechWindow(250);
+    for (let elapsed = 0; elapsed < 10_000; elapsed += 50) {
+      window.observe(50, false);
+    }
+    expect(window.voicedFraction).toBe(0);
+
+    for (let elapsed = 0; elapsed < 250; elapsed += 50) {
+      window.observe(50, true);
+    }
+    expect(window.voicedFraction).toBe(1);
+  });
+
+  test("the oldest entry is split rather than dropped whole", () => {
+    // Chunk boundaries are the client's business, so the window must be the
+    // length it says it is regardless of how audio is framed.
+    const window = new VoicedSpeechWindow(100);
+    window.observe(80, true);
+    window.observe(60, false);
+    // 40 ms of the voiced entry survives against 60 ms of the unvoiced one.
+    expect(window.voicedFraction).toBeCloseTo(0.4, 5);
+  });
+
+  test("reset forgets the run", () => {
+    const window = new VoicedSpeechWindow(250);
+    window.observe(100, false);
+    expect(window.voicedFraction).toBe(0);
+    window.reset();
+    expect(window.voicedFraction).toBe(1);
+  });
+
+  test("nonsense durations are ignored", () => {
+    const window = new VoicedSpeechWindow(250);
+    window.observe(0, false);
+    window.observe(-10, false);
+    window.observe(Number.NaN, false);
+    expect(window.voicedFraction).toBe(1);
+  });
+});

--- a/assistant/src/stt/speech-periodicity.ts
+++ b/assistant/src/stt/speech-periodicity.ts
@@ -1,0 +1,295 @@
+/**
+ * Cheap voiced-speech test for linear PCM16 audio: is this waveform repeating
+ * at a pitch period, or is it just loud?
+ *
+ * ## Why energy alone is not enough
+ *
+ * `speech-energy.ts` answers "is this louder than the gate", and
+ * `room-noise-floor.ts` moves that gate up in a room whose background is
+ * loud. Neither asks what the sound *is*. A door slam, a keyboard clack, a
+ * bark, a bag dropped on a desk: all clear any gate an ordinary talking voice
+ * also clears, because they are as loud as speech. The noise floor cannot help
+ * here, because it measures the *continuous* part of a room and these are
+ * transients: brief, loud, and gone before a floor could rise to meet them.
+ *
+ * ## Why periodicity, and not brightness
+ *
+ * The property that separates a voice from a thud is not level and not
+ * spectral tilt. It is repetition. Voiced speech is produced by the vocal
+ * folds opening and closing 70-350 times a second, so the waveform repeats
+ * itself at the pitch period, and a copy of it delayed by one period lines up
+ * with the original almost exactly. Nothing else in a room does that: an
+ * impulse has no second copy of itself to line up with, and broadband noise
+ * lines up with a delayed copy of itself no better than chance.
+ *
+ * Zero-crossing rate and band-energy ratio were the cheaper candidates, and
+ * both fail on the specific noises being complained about. Each is really a
+ * measure of *brightness*, and impulsive room noise is not bright: a door
+ * slam, a footstep, and a desk thump are all low-frequency dominated, so they
+ * score exactly like a vowel on either test. Spectral flatness does capture
+ * the right idea, but reaching it honestly means a spectrum, and a spectrum
+ * means an FFT on every chunk of a live call.
+ *
+ * ## What this deliberately does not separate
+ *
+ * Periodicity is a test for "something is vibrating at a steady rate", not for
+ * "a person is talking". A dog's bark, a smoke alarm, a musical note, a
+ * television, and a resonant thud that rings inside the searched pitch band
+ * all repeat, and all read as voiced here. Sustained *aperiodic* noise is the
+ * class this rules out: typing, rustling, running water, fans, chair scrapes,
+ * road noise. That is the class the energy gate is worst at and that a noise
+ * floor cannot reach, so it is the useful half to take.
+ *
+ * A chunk also has to be long enough to contain two pitch periods before there
+ * is anything to measure, roughly 30 ms. Shorter framing is reported as
+ * unmeasurable rather than guessed at.
+ *
+ * ## Cost
+ *
+ * The signal is block-averaged down to about 4 kHz first, which is both the
+ * anti-alias filter and the reason the search is cheap: pitch lives far below
+ * 4 kHz, so nothing that matters is thrown away, and the correlation then runs
+ * over ~47 candidate lags of a few hundred samples each, on the order of
+ * 15k multiply-adds for a 100 ms chunk. Low-passing also helps the measurement
+ * itself, by taking the fricative-band energy that muddies the correlation out
+ * of it before the search.
+ *
+ * Pure and transport-neutral: a buffer in, a number out, no session state.
+ */
+
+/**
+ * Lowest and highest fundamental frequency searched. The range spans a deep
+ * male voice to a child's, with margin at both ends: a pitch outside the
+ * searched band reads as unvoiced, so the band errs wide.
+ */
+export const PERIODICITY_MIN_PITCH_HZ = 70;
+export const PERIODICITY_MAX_PITCH_HZ = 350;
+
+/**
+ * Rate the signal is decimated to before the lag search. Above this there is
+ * no pitch information to find, only cost.
+ */
+export const PERIODICITY_ANALYSIS_RATE_HZ = 4_000;
+
+/**
+ * Normalized-autocorrelation peak at or above which a chunk counts as voiced.
+ *
+ * On synthetic 50 ms frames a harmonic vowel scores 0.99 whatever its pitch or
+ * level, the same vowel under equal-power broadband noise about 0.8, white
+ * noise 0.1-0.25, a shaped fricative 0.13, and a run of key clicks 0.01. The
+ * cutoff sits in the gap, nearer the noise end than the middle: reading noise
+ * as voiced only leaves today's behaviour in place, while reading a voice as
+ * noise takes the user's interruption away from them.
+ */
+export const DEFAULT_VOICED_PERIODICITY = 0.4;
+
+/**
+ * Peak normalized autocorrelation over the pitch lag range, in `[0, 1]`, or
+ * `null` when the chunk cannot be judged.
+ *
+ * `null` means "too short to contain two pitch periods", or "no waveform at
+ * all" (silence, or a DC-constant buffer). It is a distinct answer from a low
+ * score, and callers must not read it as evidence of noise: a chunk that
+ * could not be measured has said nothing about itself.
+ *
+ * Only positive correlation counts. A voice lines up *in phase* with itself
+ * one period later; a strong negative correlation is a half-period alignment,
+ * which is not evidence of a period at that lag.
+ */
+export function pcm16Periodicity(
+  chunk: Buffer,
+  sampleRate: number,
+): number | null {
+  if (!Number.isFinite(sampleRate) || sampleRate <= 0) {
+    return null;
+  }
+  const decimation = Math.max(
+    1,
+    Math.floor(sampleRate / PERIODICITY_ANALYSIS_RATE_HZ),
+  );
+  const analysisRate = sampleRate / decimation;
+  const minLag = Math.max(
+    1,
+    Math.floor(analysisRate / PERIODICITY_MAX_PITCH_HZ),
+  );
+  const maxLag = Math.ceil(analysisRate / PERIODICITY_MIN_PITCH_HZ);
+  if (minLag >= maxLag) {
+    return null;
+  }
+
+  const samples = decimatePcm16(chunk, decimation);
+  // Two periods at the lowest searched pitch. One period is a coincidence;
+  // two is the shortest window in which "this repeats" means anything.
+  if (samples.length < maxLag * 2) {
+    return null;
+  }
+
+  let sum = 0;
+  for (let index = 0; index < samples.length; index += 1) {
+    sum += samples[index]!;
+  }
+  const mean = sum / samples.length;
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] = samples[index]! - mean;
+  }
+
+  // Running energy from the tail, so each lag's two window energies come out
+  // of a lookup rather than a second pass over the samples.
+  const suffixEnergy = new Float64Array(samples.length + 1);
+  for (let index = samples.length - 1; index >= 0; index -= 1) {
+    const sample = samples[index]!;
+    suffixEnergy[index] = suffixEnergy[index + 1]! + sample * sample;
+  }
+  if (suffixEnergy[0]! <= 0) {
+    return null;
+  }
+
+  let best = 0;
+  const searchMaxLag = Math.min(maxLag, samples.length - minLag);
+  for (let lag = minLag; lag <= searchMaxLag; lag += 1) {
+    const overlap = samples.length - lag;
+    let dotProduct = 0;
+    for (let index = 0; index < overlap; index += 1) {
+      dotProduct += samples[index]! * samples[index + lag]!;
+    }
+    if (dotProduct <= 0) {
+      continue;
+    }
+    const headEnergy = suffixEnergy[0]! - suffixEnergy[overlap]!;
+    const tailEnergy = suffixEnergy[lag]!;
+    if (headEnergy <= 0 || tailEnergy <= 0) {
+      continue;
+    }
+    const correlation = dotProduct / Math.sqrt(headEnergy * tailEnergy);
+    if (correlation > best) {
+      best = correlation;
+    }
+  }
+  return Math.min(best, 1);
+}
+
+/**
+ * Whether a chunk looks like voiced speech.
+ *
+ * A chunk that cannot be measured counts as voiced. Every caller here is
+ * deciding whether to *withhold* something the user asked for, so an
+ * unmeasurable chunk must not be the reason it is withheld.
+ */
+export function isPcm16Voiced(
+  chunk: Buffer,
+  sampleRate: number,
+  threshold: number = DEFAULT_VOICED_PERIODICITY,
+): boolean {
+  const periodicity = pcm16Periodicity(chunk, sampleRate);
+  return periodicity === null || periodicity >= threshold;
+}
+
+/** Block-average `chunk` down by `decimation`, as centered Float64 samples. */
+function decimatePcm16(chunk: Buffer, decimation: number): Float64Array {
+  const sampleCount = Math.floor(chunk.length / 2);
+  const blockCount = Math.floor(sampleCount / decimation);
+  const result = new Float64Array(blockCount);
+  for (let block = 0; block < blockCount; block += 1) {
+    let sum = 0;
+    const firstSample = block * decimation;
+    for (let offset = 0; offset < decimation; offset += 1) {
+      sum += chunk.readInt16LE((firstSample + offset) * 2);
+    }
+    result[block] = sum / decimation;
+  }
+  return result;
+}
+
+/**
+ * What fraction of the most recent stretch of speech looked voiced.
+ *
+ * ## Why a fraction rather than a verdict per chunk
+ *
+ * Real words contain unvoiced stretches. The `s` in "stop", the `sh` in
+ * "shush", the burst of a `t`: these are turbulence, not vibration, and they
+ * score like noise because acoustically they *are* noise. Judging chunk by
+ * chunk would throw away the front of a word to save the middle of it. So the
+ * question asked is not "was this chunk voiced" but "did this stretch of sound
+ * contain a voice at all", which every word does and no thud does.
+ *
+ * ## Why a trailing window rather than the whole run
+ *
+ * Some noises do not stop. A blender, a hand dryer, a passing truck can hold
+ * the microphone above the gate for seconds at a time. Measured over the whole
+ * run, such a noise accumulates unvoiced time without limit, and by the time
+ * the user speaks over it their voice is a rounding error against a denominator
+ * that has been growing since the noise started: they would be unable to
+ * interrupt at all, which is a worse bug than the one being fixed. A window
+ * that only remembers the last stretch of speech cannot be poisoned this way.
+ * It answers about the sound happening *now*.
+ */
+export class VoicedSpeechWindow {
+  private readonly windowMs: number;
+  /** Retained observations, oldest first. */
+  private readonly entries: { ms: number; voiced: boolean }[] = [];
+  private totalMs = 0;
+  private voicedMs = 0;
+
+  constructor(windowMs: number) {
+    this.windowMs = windowMs;
+  }
+
+  /** Record one chunk of above-gate audio and its voiced verdict. */
+  observe(durationMs: number, voiced: boolean): void {
+    if (!(durationMs > 0) || !Number.isFinite(durationMs)) {
+      return;
+    }
+    this.entries.push({ ms: durationMs, voiced });
+    this.totalMs += durationMs;
+    if (voiced) {
+      this.voicedMs += durationMs;
+    }
+    this.trim();
+  }
+
+  /**
+   * Voiced share of the retained window, in `[0, 1]`.
+   *
+   * An empty window reports 1: nothing has been measured, so nothing has been
+   * measured against the user.
+   */
+  get voicedFraction(): number {
+    if (this.totalMs <= 0) {
+      return 1;
+    }
+    return this.voicedMs / this.totalMs;
+  }
+
+  /** Forget everything, e.g. when the run it was measuring resets. */
+  reset(): void {
+    this.entries.length = 0;
+    this.totalMs = 0;
+    this.voicedMs = 0;
+  }
+
+  /**
+   * Drop audio that has aged out of the window, splitting the oldest entry
+   * rather than discarding it whole. Chunk boundaries are the client's
+   * business, so a window that could only end on one would be as long as the
+   * client's framing happened to make it.
+   */
+  private trim(): void {
+    while (this.totalMs > this.windowMs && this.entries.length > 0) {
+      const oldest = this.entries[0]!;
+      const excess = this.totalMs - this.windowMs;
+      if (oldest.ms > excess) {
+        oldest.ms -= excess;
+        this.totalMs -= excess;
+        if (oldest.voiced) {
+          this.voicedMs -= excess;
+        }
+        return;
+      }
+      this.entries.shift();
+      this.totalMs -= oldest.ms;
+      if (oldest.voiced) {
+        this.voicedMs -= oldest.ms;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## The problem

Barge-in is decided purely on **energy**. `stt/speech-energy.ts` computes the mean absolute amplitude of a chunk and compares it to a threshold; `stt/room-noise-floor.ts` (#41790) raises that threshold in a loud room. Nothing anywhere asks whether the sound is *speech-shaped*.

So anything that holds the microphone above the gate for `bargeInMinSpeechMs` (250 ms, with gap tolerance and a duty-cycle cap) cancels the assistant's reply: a tap running, an extractor fan, paper being shuffled, someone typing on the desk next to the phone. Users report this as "echo", because the reply cuts off mid-sentence for no reason they can see.

The noise floor cannot reach this class. It measures the *continuous* part of a room by taking the minimum over one-second blocks, which is the right instrument for a steady hiss and the wrong one for a sound that starts, lasts three seconds and stops. Something has to ask what the sound *is*.

## The measure, and why

**Peak normalized autocorrelation over the pitch lag range (70-350 Hz).** New pure module `assistant/src/stt/speech-periodicity.ts`, factored like `speech-energy.ts` and `room-noise-floor.ts`: buffers in, numbers out, no session state, independently unit-tested.

Voiced speech is produced by the vocal folds opening and closing 70-350 times a second. The waveform therefore *repeats*, and a copy of it delayed by one pitch period lines up with the original almost exactly. That is the defining property, and it is one that nothing else in an ordinary room has: an impulse has no second copy of itself to line up with, and broadband noise lines up with a delayed copy of itself no better than chance.

Rejected alternatives, from the signal rather than from a list:

- **Zero-crossing rate** and **band-energy ratio** are both really measures of *brightness*, and the impulsive noise being complained about is not bright. A door slam, a footstep and a desk thump are all low-frequency dominated, so they score exactly like a vowel on either test. Cheapest, and wrong on the target class.
- **Spectral flatness** does capture the right idea, but reaching it honestly means a spectrum, and a spectrum means an FFT on every chunk of a live call.

**Cost.** The signal is block-averaged down to about 4 kHz first, which is both the anti-alias filter (pitch lives far below 4 kHz, so nothing that matters is discarded) and the reason the search is cheap. The lag search then runs over ~47 candidate lags of a few hundred samples each, roughly **15k multiply-adds for a 100 ms chunk**, with running energy sums so each lag's normalization is a lookup. It runs **only on above-gate chunks while a barge-in guard is armed**, not on every chunk of the call: the handful of chunks that are about to cancel a reply.

Measured on synthetic 50 ms frames (all at comparable loudness):

| signal | periodicity |
| --- | --- |
| harmonic vowel, F0 80-300 Hz | 0.99 |
| vowel attenuated 20x (AEC ducking) | 0.99 |
| vowel under equal-power broadband noise | 0.80 |
| vowel under 2x-power noise | 0.52 |
| white noise | 0.10-0.25 |
| shaped fricative | 0.13 |
| run of key clicks | 0.01 |
| impulse / click | ~0.0 |
| silence, DC constant | unmeasurable |

The per-chunk cutoff is 0.4, in the gap and nearer the noise end.

## How this is biased against rejecting real speech

Priority one is that this must never cost someone an interruption. Four separate things enforce that:

1. **It only ever withholds.** The test sits on the barge-in guard's fire condition in `trackBargeInGuard`, not on classification. It cannot make a chunk `speech`, cannot reach the echo path or the "user-first" rule, cannot change transcription, pre-roll or turn detection, and cannot cause a barge-in that would not otherwise have happened. Same one-directional shape as #41790: strictly stricter, never looser, so it cannot introduce new self-interruption.
2. **Unmeasurable means voiced.** A chunk too short to hold two pitch periods (~30 ms), a flat or DC buffer, a nonsense sample rate: all return `null` from `pcm16Periodicity` and count as a voice. `null` is a distinct answer from a low score and is never read as evidence of noise.
3. **A chunk is not the unit of judgment.** Words open on unvoiced consonants. The `s` in "stop", the `sh` in "shush", the burst of a `t` are turbulence, not vibration, and score like noise because acoustically they *are* noise. So the run keeps a `VoicedSpeechWindow` and the question asked is "did this stretch of sound contain a voice at all", at a **0.25** threshold, far below the voiced share of any spoken word. The window is floored at 200 ms so it always spans a syllable no matter how the client sets interrupt sensitivity.
4. **The window is trailing, not cumulative.** A blender, a hand dryer or a passing truck can hold the gate open for seconds. Measured over the whole run, such a noise accumulates unvoiced time without limit, and by the time the user speaks their voice is a rounding error against a denominator that has been growing since the noise started: they would be **unable to interrupt at all**, which is worse than the bug being fixed. The window only remembers the last 250 ms of above-gate audio, so it answers about the sound happening now. There is a session-level test for exactly this.

A failing run also **holds rather than resets**, so the accumulated run is still standing the moment the user does speak over the noise, and fires on that chunk instead of restarting from zero.

## Configurable and disableable

`liveVoice.vad.bargeInMinVoicedRatio`, default **0.25**, range 0..1, **0 disables the test entirely** (and skips the DSP). Wired through `LiveVoiceSessionOptions` and the production factory like the other `liveVoice.vad` knobs. Default snapshots updated in `src/__tests__/config-schema.test.ts` and `src/config/schemas/__tests__/live-voice.test.ts`.

Following the harness precedent set by `echoBargeInMargin: 1` / `noiseFloorMargin: 0`, directly-constructed sessions in `live-voice-vad.test.ts` default the knob to **0** so unrelated cases do not drift.

## Testing

**Unit (`src/stt/__tests__/speech-periodicity.test.ts`, 18 tests)** against synthetic signals: harmonic vowels at four pitches, white noise, an impulse, a run of key clicks, silence, a DC constant, a vowel buried in equal-power noise, a 20x-attenuated vowel (level-invariance, which is what lets a barge-in through the client's echo canceller), sub-30 ms chunks, unusable sample rates, and the same separation at 16/24/48 kHz. Plus the window's own behaviour: fractional accounting, unvoiced word openings, the never-stopping-noise case, partial trimming of the oldest entry, reset.

**Session (`live-voice-vad.test.ts`, 6 new tests)** on a speaking-turn harness, with a **paired control**: 500 ms of broadband noise and 500 ms of a harmonic vowel, generated at mean amplitudes within 5% of each other (asserted, so the pair cannot silently stop being controlled). The noise produces no `turn_cancelled`; the vowel cancels. A third case feeds the *same noise* with `bargeInMinVoicedRatio: 0` and asserts it *does* cancel, proving the noise clears every other gate on the way in and that the voicing test is doing the work. Plus: speaking over two seconds of continuous noise still interrupts, and a word that opens on 100 ms of unvoiced consonant still interrupts.

`bun run typecheck`, `eslint`, and every `src/live-voice/__tests__/*.test.ts` file plus the config suites pass locally.

## Coverage gaps I am leaving, knowingly

- **Periodic non-speech passes.** A dog's bark, a smoke alarm, a musical note, a television, and a resonant thud that rings inside the searched pitch band all repeat and all read as voiced. This rules out sustained *aperiodic* noise (typing, rustling, running water, fans, chair scrapes, road noise), which is the class the energy gate is worst at and a noise floor cannot reach. It is half the problem, taken because it is the half that can be taken safely. The audit framing calls the target class "broadband"; a synthetic door slam built with a 90 Hz decaying ring scores **0.95** here, so low-frequency resonant transients are not covered. Isolated ones are already handled by the existing 250 ms sustained requirement.
- **Clients framing finer than ~30 ms get no filtering**, because chunks that short are unmeasurable and count as voiced. The web client batches PCM into 50 ms frames, which is above the bar, but nothing enforces that.
- **Single-chunk variance at 50 ms.** White noise scores 0.10-0.25 depending on the realization, occasionally nearer the 0.4 cutoff. Combined with the 0.25 window threshold that leaves a small leak rate: some noise runs will still barge in. The leak is in the permissive direction by construction, which is the correct bias.
- **Every number here comes from synthetic signals.** No recorded speech and no recorded room noise was used.

## What needs verifying acoustically

1. **Real barge-in through a real echo canceller**, on iOS especially. Post-AEC near-end voice is attenuated (harmless: the measure is level-invariant) but also nonlinearly processed, and I do not know what that does to periodicity. This is the highest-risk item, because barge-in during playback is the primary use case and the audio there is the most degraded. If it turns out AEC output scores below 0.4, the fix is to lower `DEFAULT_VOICED_PERIODICITY`, not to raise the ratio.
2. **Whether 0.25 is the right ratio for real words**, particularly short fricative-heavy interruptions ("shh", "stop", "excuse me").
3. **How much of the reported "echo" this actually removes** in the field. The measure is aimed at a specific class; if the complaints are mostly TVs and barking, this will not move them.

Part of the iOS voice barge-in work alongside #41788 (dropped `autoGainControl`) and #41790 (room noise floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ka16Yh3FfZEuWnuTirQpZ3
