### PR TITLE
fix(channels): reactions on the assistant's own posts resolve on every channel

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -10,6 +10,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
   clearPayload,
+  findConversationByProviderMessageId,
   findMessageBySourceId,
   linkMessage,
   recordInbound,
@@ -120,6 +121,53 @@ describe("channel-delivery-store", () => {
       .get();
 
     expect(row!.sourceMessageId).toBe("src-42");
+  });
+
+  test("resolves an assistant post by its provider id on a non-Slack channel", () => {
+    const chatId = "999000111222333444";
+    const minted = recordInbound("discord", chatId, "evt-seed");
+    const db = getDb();
+    db.insert(messages)
+      .values({
+        id: "assistant-post-1",
+        conversationId: minted.conversationId,
+        role: "assistant",
+        content: "outbound reply",
+        createdAt: Date.now(),
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: chatId,
+            messageId: "1234567890123456789",
+            eventKind: "message",
+          }),
+        }),
+      })
+      .run();
+
+    expect(
+      findConversationByProviderMessageId(
+        "discord",
+        chatId,
+        "1234567890123456789",
+      ),
+    ).toBe(minted.conversationId);
+    // The scan is scoped to the reaction's own channel address: the same id
+    // is invisible from another channel's or another chat's key space.
+    expect(
+      findConversationByProviderMessageId(
+        "telegram",
+        chatId,
+        "1234567890123456789",
+      ),
+    ).toBeNull();
+    expect(
+      findConversationByProviderMessageId(
+        "discord",
+        "other-chat",
+        "1234567890123456789",
+      ),
+    ).toBeNull();
   });
 
   test("same chat on same channel reuses the same conversation", () => {

--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -185,7 +185,7 @@ import { setConfig } from "./helpers/set-config.js";
 function makeDeps(
   conversationId: string,
   overrides: {
-    assistantMessageChannel?: "slack" | "vellum" | "telegram";
+    assistantMessageChannel?: "slack" | "vellum" | "telegram" | "discord";
     requesterChatId?: string;
     requesterTimezoneLabel?: string;
     clientTimezone?: string;
@@ -518,7 +518,97 @@ describe("outbound assistant Slack metadata persistence", () => {
 
     const persisted = lastAssistantPersisted();
     expect(persisted.metadata).toBeDefined();
-    // Non-Slack channels must leave the existing metadata shape untouched.
+    // Non-Slack channels must leave the existing metadata shape untouched,
+    // and a vellum turn is not a provider message, so it gets no neutral
+    // envelope either.
     expect(persisted.metadata?.slackMeta).toBeUndefined();
+    expect(persisted.metadata?.providerMeta).toBeUndefined();
+  });
+
+  test("stamps a partial neutral envelope on non-Slack channel replies", async () => {
+    const conversationId = "conv-discord-stamp";
+    const deps = makeDeps(conversationId, {
+      assistantMessageChannel: "discord",
+      requesterChatId: "9990001112223334445",
+    });
+    await handleLlmCallStarted(state, deps);
+    await handleMessageComplete(
+      state,
+      deps,
+      makeMessageCompleteEvent("discord reply"),
+    );
+
+    const persisted = lastAssistantPersisted();
+    const providerMetaRaw = persisted.metadata?.providerMeta;
+    expect(typeof providerMetaRaw).toBe("string");
+    const providerMeta = JSON.parse(providerMetaRaw as string) as Record<
+      string,
+      unknown
+    >;
+    expect(providerMeta.source).toBe("discord");
+    expect(providerMeta.conversationExternalId).toBe("9990001112223334445");
+    expect(providerMeta.eventKind).toBe("message");
+    // Persistence runs BEFORE the transport posts the message, so the
+    // provider-assigned id is not yet known; the post-send reconciliation in
+    // `deliverReplyViaCallback` fills `messageId` once the transport returns
+    // it. `threadId` is never stamped: a value there asserts a thread exists.
+    expect(providerMeta.messageId).toBeUndefined();
+    expect(providerMeta.threadId).toBeUndefined();
+    expect(persisted.metadata?.slackMeta).toBeUndefined();
+  });
+
+  test("post-send reconciliation patches messageId into the neutral envelope", async () => {
+    const conversationId = "conv-discord-reconcile";
+    const chatId = "9990001112223334445";
+    const deps = makeDeps(conversationId, {
+      assistantMessageChannel: "discord",
+      requesterChatId: chatId,
+    });
+    await handleLlmCallStarted(state, deps);
+    await handleMessageComplete(
+      state,
+      deps,
+      makeMessageCompleteEvent("discord reconciliation reply"),
+    );
+
+    const persisted = lastAssistantPersisted();
+    nextDeliveryTs = "1234567890123456789";
+    await deliverReplyViaCallback(
+      conversationId,
+      chatId,
+      "http://gateway/deliver/discord",
+      "assistant-1",
+      { messageId: persisted.id },
+    );
+
+    const row = persistedRows.find(
+      (candidate) => candidate.id === persisted.id,
+    );
+    expect(typeof row?.metadata).toBe("string");
+    const envelope = JSON.parse(row!.metadata!) as Record<string, unknown>;
+    const reconciled = JSON.parse(envelope.providerMeta as string) as Record<
+      string,
+      unknown
+    >;
+    expect(reconciled.messageId).toBe("1234567890123456789");
+    expect(reconciled.source).toBe("discord");
+    expect(reconciled.conversationExternalId).toBe(chatId);
+
+    // A second delivery report must not overwrite the reconciled id.
+    nextDeliveryTs = "8888888888888888888";
+    await deliverReplyViaCallback(
+      conversationId,
+      chatId,
+      "http://gateway/deliver/discord",
+      "assistant-1",
+      { messageId: persisted.id },
+    );
+    const rowAfter = persistedRows.find(
+      (candidate) => candidate.id === persisted.id,
+    );
+    const metaAfter = JSON.parse(
+      JSON.parse(rowAfter!.metadata!).providerMeta as string,
+    ) as Record<string, unknown>;
+    expect(metaAfter.messageId).toBe("1234567890123456789");
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -22,6 +22,7 @@ import { getConfig } from "../config/loader.js";
 import { recordEstimate } from "../context/estimator-calibration.js";
 import { stripInjectionsForCompaction } from "../context/strip-injections.js";
 import { getCalibrationProviderKey } from "../context/token-estimator.js";
+import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
 import {
   formatSlackTimezoneLabel,
   isSlackTs,
@@ -1398,6 +1399,22 @@ function buildAssistantChannelMetadata(
       metadata.slackMeta = writeSlackMetadata(
         partialSlackMeta as SlackMessageMetadata,
       );
+    }
+  } else if (deps.turnChannelContext.assistantMessageChannel !== "vellum") {
+    // Every other channel row describes itself in the neutral envelope
+    // `readProviderMetadata` serves, the shape a plugin channel writes too.
+    // `messageId` stays absent here and is back-filled by the post-send
+    // reconciliation once the transport returns the sent message's id, which
+    // is what lets a later reaction on this row resolve back to it. No
+    // `threadId`: a value there asserts a thread exists, and the reply's
+    // routing thread is delivery state, not a fact about this row.
+    const chatId = turnOrRestingTrust(deps.ctx)?.requesterChatId;
+    if (chatId) {
+      metadata.providerMeta = JSON.stringify({
+        source: deps.turnChannelContext.assistantMessageChannel,
+        conversationExternalId: chatId,
+        eventKind: "message",
+      } satisfies ProviderMessageMetadata);
     }
   }
 

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -51,12 +51,12 @@ const SLACK_LEGACY_THREAD_EVIDENCE_BATCH_SIZE = 50;
 const SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN = 500;
 
 /**
- * Rows examined when locating a Slack message the assistant itself posted.
+ * Rows examined when locating a channel message the assistant itself posted.
  * Bounded on purpose: the scan runs on the inbound path while the gateway
  * waits for its ack, and reactions land on recent messages, so a cap costs
  * almost no recall and keeps the cost flat as the database grows.
  */
-const SLACK_OUTBOUND_TS_MAX_SCAN = 400;
+const OUTBOUND_MESSAGE_ID_MAX_SCAN = 400;
 
 /**
  * Channels where an inbound thread id scopes the conversation: a Slack thread
@@ -295,8 +295,8 @@ export function findInboundEvent(
 }
 
 /**
- * The conversation holding the message with this provider id, found by reading
- * the metadata the assistant's own posts carry.
+ * The conversation holding the message with this provider id, found by
+ * reading the metadata the assistant's own posts carry, on any channel.
  *
  * Reads through `readProviderMetadata`, so it matches any channel that
  * describes its rows in the neutral shape as well as Slack's own envelope.
@@ -305,16 +305,18 @@ export function findInboundEvent(
  * event. It cannot see what the assistant posted, because an outbound reply
  * opens no inbound event, so a reaction on the assistant's own message needs
  * this. The search is confined to conversations already bound to the same
- * Slack channel and to the most recent {@link SLACK_OUTBOUND_TS_MAX_SCAN}
- * rows among them; beyond that it gives up and the caller drops the
- * annotation, which is the same outcome as never finding it at all.
+ * channel address and to the most recent
+ * {@link OUTBOUND_MESSAGE_ID_MAX_SCAN} rows among them; beyond that it gives
+ * up and the caller drops the annotation, which is the same outcome as never
+ * finding it at all.
  */
-export function findSlackConversationByMessageTs(
+export function findConversationByProviderMessageId(
+  sourceChannel: string,
   externalChatId: string,
-  channelTs: string,
+  providerMessageId: string,
 ): string | null {
   const db = getDb();
-  const keyPrefix = `${CONVERSATION_KEY_SCOPE}:slack:${externalChatId}`;
+  const keyPrefix = `${CONVERSATION_KEY_SCOPE}:${sourceChannel}:${externalChatId}`;
   const rows = db
     .select({
       conversationId: messages.conversationId,
@@ -338,14 +340,14 @@ export function findSlackConversationByMessageTs(
       ),
     )
     .orderBy(desc(messages.createdAt))
-    .limit(SLACK_OUTBOUND_TS_MAX_SCAN)
+    .limit(OUTBOUND_MESSAGE_ID_MAX_SCAN)
     .all();
 
   for (const row of rows) {
     const meta = readProviderMetadata(row.metadata, { allowFlatLegacy: true });
     if (
       meta?.conversationExternalId === externalChatId &&
-      meta.messageId === channelTs
+      meta.messageId === providerMessageId
     ) {
       return row.conversationId;
     }

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -205,10 +205,15 @@ the gateway's Channel Identity Vocabulary, which covers the wire side.
   channel belongs here rather than in a sixth key of its own.
 
   Every channel except Slack writes it: a reaction row carries the whole
-  shape (`inbound-stages/reaction-intercept.ts`), and an edit or a delete
+  shape (`inbound-stages/reaction-intercept.ts`), an edit or a delete
   stamps `editedAt` / `deletedAt` onto whatever the row already said about
   itself through `mergeProviderMessageMetadata`
-  (`inbound-stages/edit-intercept.ts`, `inbound-message-handler.ts`). Slack
+  (`inbound-stages/edit-intercept.ts`, `inbound-message-handler.ts`), and an
+  outbound assistant reply is stamped with a partial envelope at reserve time
+  (`buildAssistantChannelMetadata`) whose `messageId` the post-send
+  reconciliation in `channel-reply-delivery.ts` back-fills from the
+  transport's delivery result, which is what lets a later reaction on the
+  assistant's own post resolve back to its row. Slack
   keeps writing `slackMeta`, and `readProviderMetadata` maps that envelope
   onto this shape on read, so the channel-agnostic readers in
   `persistence/delivery-crud.ts` (thread evidence, and finding the

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -3,6 +3,7 @@ import type { MessageAudience } from "@vellumai/gateway-client";
 import { stripVellumLinks } from "../daemon/assistant-attachments.js";
 import type { RenderedHistoryContent } from "../daemon/handlers/shared.js";
 import { renderHistoryContent } from "../daemon/handlers/shared.js";
+import { readProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
 import { editChannelMessage } from "../messaging/providers/index.js";
 import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { getAttachmentMetadataForMessage } from "../persistence/attachments-store.js";
@@ -383,16 +384,17 @@ async function deliverPersistedAssistantMessageViaCallback(
     return false;
   }
 
-  // Compose an `onMessageTs` that reconciles `slackMeta.channelTs` on the
-  // persisted assistant row once Slack returns the authoritative ts. The
-  // assistant row was written BEFORE the gateway POST in
-  // `handleMessageComplete`, so the partial `slackMeta` it carries is
+  // Compose an `onMessageTs` that reconciles the persisted assistant row's
+  // provider message id once the transport returns the authoritative one.
+  // The assistant row was written BEFORE the gateway POST, so its pre-send
+  // envelope names no id of its own: a Slack row's partial `slackMeta` is
   // missing `channelTs` and would otherwise be rejected by
   // `readSlackMetadata`, dropping the row out of chronological/thread-tag
-  // rendering. We only act on the FIRST ts (top-level segment); any
-  // subsequent split segments become independent Slack messages with
-  // their own ts and are not represented as separate DB rows.
-  const reconcileOnMessageTs = makeChannelTsReconciler(msg.id);
+  // rendering, and a neutral-envelope row is missing the `messageId` a later
+  // reaction on it resolves by. We only act on the FIRST ts (top-level
+  // segment); any subsequent split segments become independent provider
+  // messages with their own ids and are not represented as separate DB rows.
+  const reconcileOnMessageTs = makeSentMessageIdReconciler(msg.id);
   const callerOnMessageTs = options?.onMessageTs;
   const composedOnMessageTs = (ts: string): void => {
     reconcileOnMessageTs(ts);
@@ -492,21 +494,23 @@ export async function deliverReplyViaCallback(
 
 /**
  * Build a one-shot `onMessageTs` handler that reconciles the persisted
- * assistant message's `slackMeta.channelTs` from Slack's authoritative `ts`.
+ * assistant row's provider message id from the transport's authoritative id:
+ * `slackMeta.channelTs` for a Slack row, `providerMeta.messageId` for a row
+ * carrying the neutral envelope (Discord today, any transport whose delivery
+ * result reports the sent id). The back-filled id is what lets a later
+ * reaction on the assistant's own post resolve back to this row.
  *
  * Behavior:
  * - Acts only on the first invocation per delivery (subsequent segments
- *   correspond to independent Slack messages with their own ts and are not
- *   represented as separate DB rows).
- * - No-op when the row was not persisted with a `slackMeta` envelope (the
- *   channel was not Slack at write-time, e.g. vellum/telegram outbound).
- * - No-op when the row's existing `slackMeta` already parses cleanly via
- *   `readSlackMetadata` (channelTs already present, e.g. from a prior
- *   reconciliation).
+ *   correspond to independent provider messages with their own ids and are
+ *   not represented as separate DB rows).
+ * - No-op when the row was persisted with neither envelope (e.g. vellum
+ *   outbound), and when the row's id is already present (a prior
+ *   reconciliation ran, or backfill stamped the field).
  * - Failures are logged and swallowed so a transient DB error cannot break
  *   the outbound delivery itself.
  */
-function makeChannelTsReconciler(messageId: string): (ts: string) => void {
+function makeSentMessageIdReconciler(messageId: string): (ts: string) => void {
   let applied = false;
   return (ts: string): void => {
     if (applied) {
@@ -519,11 +523,11 @@ function makeChannelTsReconciler(messageId: string): (ts: string) => void {
     try {
       // Re-read the row's current metadata so a concurrent edit-propagation
       // write (e.g. `editedAt`) is not clobbered. `updateMessageMetadata`
-      // shallow-merges into the top-level envelope, and the slackMeta
+      // shallow-merges into the top-level envelope, and the per-channel
       // sub-object is merged manually below so we can preserve fields on
       // the partial pre-send envelope (`mergeSlackMetadata` would call
       // `readSlackMetadata` which rejects the partial form for lacking
-      // channelTs — exactly the state we are reconciling).
+      // channelTs, exactly the state we are reconciling).
       const row = getMessageById(messageId);
       if (row === null || row.metadata === null) {
         return;
@@ -537,6 +541,7 @@ function makeChannelTsReconciler(messageId: string): (ts: string) => void {
       const slackMetaRaw =
         typeof envelope.slackMeta === "string" ? envelope.slackMeta : null;
       if (slackMetaRaw === null) {
+        reconcileProviderMessageId(messageId, envelope, ts);
         return;
       }
       // If the existing slackMeta already parses cleanly via the strict
@@ -578,4 +583,24 @@ function makeChannelTsReconciler(messageId: string): (ts: string) => void {
       );
     }
   };
+}
+
+/**
+ * The neutral-envelope arm of the reconciliation: patch the transport's
+ * sent-message id into a row's `providerMeta` when the pre-send stamp left
+ * it absent. A row whose envelope already names an id, or carries no valid
+ * neutral envelope at all, is left untouched.
+ */
+function reconcileProviderMessageId(
+  messageId: string,
+  envelope: Record<string, unknown>,
+  ts: string,
+): void {
+  const providerMeta = readProviderMessageMetadata(envelope.providerMeta);
+  if (providerMeta === null || providerMeta.messageId !== undefined) {
+    return;
+  }
+  updateMessageMetadata(messageId, {
+    providerMeta: JSON.stringify({ ...providerMeta, messageId: ts }),
+  });
 }

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -72,6 +72,7 @@ mock.module("../../../contacts/contact-store.js", () => ({
 let recordInboundCalls: Array<{ conversationId?: string }> = [];
 let recordedEvent: { eventId: string; conversationId: string } | null = null;
 let outboundTargetConversationId: string | null = null;
+let outboundLookupChannels: string[] = [];
 let storedTarget: { messageId: string; conversationId: string } | null = null;
 mock.module("../../../persistence/delivery-crud.js", () => ({
   recordInbound: (
@@ -89,7 +90,10 @@ mock.module("../../../persistence/delivery-crud.js", () => ({
     };
   },
   findMessageBySourceId: () => storedTarget,
-  findSlackConversationByMessageTs: () => outboundTargetConversationId,
+  findConversationByProviderMessageId: (sourceChannel: string) => {
+    outboundLookupChannels.push(sourceChannel);
+    return outboundTargetConversationId;
+  },
   findInboundEvent: () => recordedEvent,
   clearPayload: () => {},
   linkMessage: () => {},
@@ -221,6 +225,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     recordInboundCalls = [];
     recordedEvent = null;
     outboundTargetConversationId = null;
+    outboundLookupChannels = [];
     addMessageCalls = 0;
     guardianReplyCalls = [];
     guardianReplyResponse = undefined;
@@ -265,8 +270,8 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     expect(recordInboundCalls).toEqual([{ conversationId: "conv-target" }]);
   });
 
-  test("a reaction on the assistant's own post resolves through slackMeta", async () => {
-    // Outbound posts open no inbound event, so the ts is only on the row.
+  test("a reaction on the assistant's own post resolves through its stored envelope", async () => {
+    // Outbound posts open no inbound event, so the id is only on the row.
     storedTarget = null;
     outboundTargetConversationId = "conv-assistant-post";
 
@@ -281,6 +286,30 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
       { conversationId: "conv-assistant-post" },
     ]);
     expect(addMessageCalls).toBe(1);
+    expect(result).toMatchObject({ accepted: true, duplicate: false });
+    // The outbound-row lookup is scoped to the reaction's own channel: a
+    // Slack reaction never scans another channel's conversations.
+    expect(outboundLookupChannels).toEqual(["slack"]);
+  });
+
+  test("a non-Slack reaction resolves the assistant's post on its own channel", async () => {
+    storedTarget = null;
+    outboundTargetConversationId = "conv-discord-post";
+
+    const params = {
+      ...buildParams({
+        rawSenderId: MEMBER_USER_ID,
+        trustVerdict: MEMBER_VERDICT,
+      }),
+      sourceChannel: "discord" as const,
+      sourceInterface: undefined,
+    };
+    const result = await handleReactionIntercept(params);
+
+    expect(outboundLookupChannels).toEqual(["discord"]);
+    expect(recordInboundCalls).toEqual([
+      { conversationId: "conv-discord-post" },
+    ]);
     expect(result).toMatchObject({ accepted: true, duplicate: false });
   });
 

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.ts
@@ -40,9 +40,9 @@ import {
   provenanceFromTrustContext,
 } from "../../../persistence/conversation-crud.js";
 import {
+  findConversationByProviderMessageId,
   findInboundEvent,
   findMessageBySourceId,
-  findSlackConversationByMessageTs,
   linkMessage,
   recordInbound,
 } from "../../../persistence/delivery-crud.js";
@@ -215,14 +215,16 @@ export async function handleReactionIntercept(
   // reaction is dropped rather than given a conversation of its own.
   // Inbound messages carry their provider id on the event that delivered
   // them. The assistant's own posts open no inbound event, so a reaction on
-  // one is resolved through the `slackMeta` those rows carry.
+  // one is resolved through the envelope those rows carry (`slackMeta` on
+  // Slack, the neutral `providerMeta` everywhere else).
   const targetConversationId = reactedMessageTs
     ? (findMessageBySourceId(
         sourceChannel,
         conversationExternalId,
         reactedMessageTs,
       )?.conversationId ??
-      findSlackConversationByMessageTs(
+      findConversationByProviderMessageId(
+        sourceChannel,
         conversationExternalId,
         reactedMessageTs,
       ))


### PR DESCRIPTION
**TL;DR:** A reaction on a message the assistant itself posted now resolves back to that message on every channel. It only worked on Slack: non-Slack assistant rows never recorded their sent message id, and the outbound-row lookup was hard-scoped to Slack conversation keys, so on Discord the reaction intercept dropped these reactions as `dropped_unknown_target` before writing anything.

## What changes for the user

| Before | After |
| --- | --- |
| React to the assistant's own message on Discord: nothing happens - no transcript line, and the assistant never learns of it | The reaction is recorded in the conversation like any other, renders in the transcript, and reaches the assistant's history |
| The rendered reaction line on Discord could not quote the assistant message it targeted | The target index resolves the assistant's post, so the line carries its quoted snippet |
| Slack | unchanged (already worked) |
| Telegram | unchanged (Telegram delivers no reaction events to bots - a platform limit, so there is nothing to resolve) |

## How

Mirrors the existing Slack design exactly, using the neutral envelope that already exists for this purpose:

- **Reserve-time stamp** (`buildAssistantChannelMetadata`): non-Slack, non-vellum channel replies stamp a partial `providerMeta` (`source`, `conversationExternalId`, `eventKind: "message"`) - the same pattern as the partial `slackMeta` Slack rows get, and the shape any channel, plugin channels included, describes its rows in.
- **Post-send reconciliation** (`channel-reply-delivery.ts`): `makeChannelTsReconciler` is generalized to `makeSentMessageIdReconciler`; when the transport's delivery result reports the sent id (Discord's does), the neutral arm patches `providerMeta.messageId` into the row. One-shot per delivery; an already-reconciled id is never overwritten.
- **Channel-scoped lookup** (`delivery-crud.ts`): `findSlackConversationByMessageTs` becomes `findConversationByProviderMessageId(sourceChannel, ...)`, keyed on the reaction's own channel address (`asst:self:<channel>:<chatId>`) and reading through `readProviderMetadata`, which already serves both envelopes. The reaction intercept passes its `sourceChannel` through.

## Why this is safe

- The stamp is provenance the row already implies (channel + chat id); the reader audit found every existing `readProviderMetadata` consumer either unaffected (eventKind `"message"` rows are inert to the reaction projection, summarize boundary, and delete rendering; the load-time render hook's substring guard doesn't even parse them) or positively affected (the reaction-target quote index can now resolve assistant posts).
- No `threadId` is stamped, so the thread-evidence scan can never read a synthesized thread out of these rows - the same invariant the Slack reaction envelope documents.
- The Slack reconciliation path is byte-for-byte the old behavior; the neutral arm only runs where the old code returned early.
- Wire/API surfaces unchanged; all writes are the existing `messages.metadata` envelope keys.

Tests: reserve-time stamp shape and reconciliation (including the no-overwrite pin) in `outbound-slack-persistence.test.ts`; channel-scoped lookup against a real DB in `channel-delivery-store.test.ts` (wrong-channel and wrong-chat isolation pinned); intercept channel pass-through in `reaction-intercept.test.ts`. Full typecheck and the metadata-sensitive suites (retry sweep, edit/delete propagation, thread backfill, background dispatch, disk pressure, recovery) all green.

**Deferred:** Telegram outbound ids stay unrecorded - the gateway's `sendTelegramReply` returns no message id, and Telegram delivers no reaction events to bots, so recording one would have no reader. If Telegram ever gains a reaction consumer, the transport is the one seam to extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41808" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->