### PR TITLE
fix(channels): every post of a split reply resolves back to its row

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -139,6 +139,7 @@ describe("channel-delivery-store", () => {
             source: "discord",
             conversationExternalId: chatId,
             messageId: "1234567890123456789",
+            additionalMessageIds: ["2234567890123456789"],
             eventKind: "message",
           }),
         }),
@@ -150,6 +151,15 @@ describe("channel-delivery-store", () => {
         "discord",
         chatId,
         "1234567890123456789",
+      ),
+    ).toBe(minted.conversationId);
+    // A split reply posts several provider messages from one row; any of
+    // their ids resolves it.
+    expect(
+      findConversationByProviderMessageId(
+        "discord",
+        chatId,
+        "2234567890123456789",
       ),
     ).toBe(minted.conversationId);
     // The scan is scoped to the reaction's own channel address: the same id

--- a/assistant/src/__tests__/conversation-load-history-repair.test.ts
+++ b/assistant/src/__tests__/conversation-load-history-repair.test.ts
@@ -645,6 +645,64 @@ describe("loadFromDb history repair", () => {
     expect(allText).not.toContain("secret text");
   });
 
+  test("a reaction naming a later post of a split reply still quotes it", async () => {
+    mockConversation = {
+      id: "conv-1",
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+    };
+    mockDbMessages = [
+      {
+        id: "m1",
+        role: "assistant",
+        content: [{ type: "text", text: "Deploy finished cleanly." }],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            messageId: "555.1",
+            additionalMessageIds: ["555.2"],
+            eventKind: "message",
+          }),
+        }),
+      },
+      {
+        id: "m2",
+        role: "user",
+        content: [{ type: "text", text: "[reaction]" }],
+        metadata: JSON.stringify({
+          providerMeta: JSON.stringify({
+            source: "discord",
+            conversationExternalId: "chan-1",
+            eventKind: "reaction",
+            reaction: {
+              targetMessageId: "555.2",
+              emoji: "tada",
+              op: "added",
+              actorDisplayName: "Alice",
+            },
+          }),
+        }),
+      },
+    ];
+
+    const conversation = makeConversation();
+    await conversation.loadFromDb();
+    const allText = conversation
+      .getMessages()
+      .flatMap((m) => m.content)
+      .filter((b) => b.type === "text")
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join("\n");
+    expect(allText).toContain(":tada:");
+    // The quote resolves through the split reply's later post id: the line
+    // never degrades to the unresolved "an earlier message" form.
+    expect(allText).not.toContain("an earlier message");
+  });
+
   test("the assistant's own reaction row renders second-person", async () => {
     mockConversation = {
       id: "conv-1",

--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -594,7 +594,9 @@ describe("outbound assistant Slack metadata persistence", () => {
     expect(reconciled.source).toBe("discord");
     expect(reconciled.conversationExternalId).toBe(chatId);
 
-    // A second delivery report must not overwrite the reconciled id.
+    // A later report with a NEW id is another post of the same reply (a
+    // split at a tool boundary): it lands in additionalMessageIds and the
+    // first id keeps naming the row.
     nextDeliveryTs = "8888888888888888888";
     await deliverReplyViaCallback(
       conversationId,
@@ -610,5 +612,25 @@ describe("outbound assistant Slack metadata persistence", () => {
       JSON.parse(rowAfter!.metadata!).providerMeta as string,
     ) as Record<string, unknown>;
     expect(metaAfter.messageId).toBe("1234567890123456789");
+    expect(metaAfter.additionalMessageIds).toEqual(["8888888888888888888"]);
+
+    // A redelivery reporting an already-recorded id changes nothing.
+    nextDeliveryTs = "8888888888888888888";
+    await deliverReplyViaCallback(
+      conversationId,
+      chatId,
+      "http://gateway/deliver/discord",
+      "assistant-1",
+      { messageId: persisted.id },
+    );
+    const rowRedelivered = persistedRows.find(
+      (candidate) => candidate.id === persisted.id,
+    );
+    const metaRedelivered = JSON.parse(
+      JSON.parse(rowRedelivered!.metadata!).providerMeta as string,
+    ) as Record<string, unknown>;
+    expect(metaRedelivered.additionalMessageIds).toEqual([
+      "8888888888888888888",
+    ]);
   });
 });

--- a/assistant/src/daemon/conversation.ts
+++ b/assistant/src/daemon/conversation.ts
@@ -1186,12 +1186,20 @@ export class Conversation {
           if (
             rowMeta?.eventKind === "message" &&
             rowMeta.deletedAt === undefined &&
-            rowMeta.messageId &&
-            !reactionTargetIndexMemo.has(rowMeta.messageId)
+            rowMeta.messageId
           ) {
             const text = extractTextFromStoredMessageContent(row.content);
             if (text) {
-              reactionTargetIndexMemo.set(rowMeta.messageId, text);
+              // A split reply posts several provider messages from one row;
+              // a reaction may name any of them.
+              for (const id of [
+                rowMeta.messageId,
+                ...(rowMeta.additionalMessageIds ?? []),
+              ]) {
+                if (!reactionTargetIndexMemo.has(id)) {
+                  reactionTargetIndexMemo.set(id, text);
+                }
+              }
             }
           }
         }

--- a/assistant/src/messaging/provider-message-metadata.ts
+++ b/assistant/src/messaging/provider-message-metadata.ts
@@ -65,7 +65,7 @@ export const providerMessageMetadataSchema = z
      * Provider ids of the further posts this row's delivery produced beyond
      * `messageId`: one stored reply split at tool boundaries or length
      * limits posts several provider messages, and they all belong to this
-     * one row. A reaction or delete naming any of them resolves here.
+     * one row. A reaction naming any of them resolves here.
      */
     additionalMessageIds: z.array(z.string()).optional(),
     /**

--- a/assistant/src/messaging/provider-message-metadata.ts
+++ b/assistant/src/messaging/provider-message-metadata.ts
@@ -62,6 +62,13 @@ export const providerMessageMetadataSchema = z
      */
     messageId: z.string().optional(),
     /**
+     * Provider ids of the further posts this row's delivery produced beyond
+     * `messageId`: one stored reply split at tool boundaries or length
+     * limits posts several provider messages, and they all belong to this
+     * one row. A reaction or delete naming any of them resolves here.
+     */
+    additionalMessageIds: z.array(z.string()).optional(),
+    /**
      * Provider id of the thread this row sits in, absent when it is not in one.
      * Never synthesized from `messageId`: a value here asserts that a thread
      * exists, and inventing one keys conversations on threads that never do.

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -347,7 +347,8 @@ export function findConversationByProviderMessageId(
     const meta = readProviderMetadata(row.metadata, { allowFlatLegacy: true });
     if (
       meta?.conversationExternalId === externalChatId &&
-      meta.messageId === providerMessageId
+      (meta.messageId === providerMessageId ||
+        meta.additionalMessageIds?.includes(providerMessageId))
     ) {
       return row.conversationId;
     }

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -210,9 +210,10 @@ the gateway's Channel Identity Vocabulary, which covers the wire side.
   itself through `mergeProviderMessageMetadata`
   (`inbound-stages/edit-intercept.ts`, `inbound-message-handler.ts`), and an
   outbound assistant reply is stamped with a partial envelope at reserve time
-  (`buildAssistantChannelMetadata`) whose `messageId` the post-send
+  (`buildAssistantChannelMetadata`) whose `messageId` (and, for a reply
+  split into several posts, `additionalMessageIds`) the post-send
   reconciliation in `channel-reply-delivery.ts` back-fills from the
-  transport's delivery result, which is what lets a later reaction on the
+  transport's delivery results, which is what lets a later reaction on the
   assistant's own post resolve back to its row. Slack
   keeps writing `slackMeta`, and `readProviderMetadata` maps that envelope
   onto this shape on read, so the channel-agnostic readers in

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -389,7 +389,7 @@ async function deliverPersistedAssistantMessageViaCallback(
   // The assistant row is written BEFORE the gateway POST, so its pre-send
   // envelope names no id of its own: a Slack row's partial `slackMeta` lacks
   // `channelTs` and reads as null through `readSlackMetadata`, and a
-  // neutral-envelope row lacks the `messageId` a later reaction or delete
+  // neutral-envelope row lacks the `messageId` a later reaction
   // naming it resolves by. A reply split into several segments reports one
   // id per posted provider message, all reconciled onto this one row; see
   // `makeSentMessageIdReconciler` for the per-envelope rules.
@@ -497,7 +497,7 @@ export async function deliverReplyViaCallback(
  * `slackMeta.channelTs` for a Slack row, `providerMeta.messageId` plus
  * `additionalMessageIds` for a row carrying the neutral envelope (Discord
  * today, any transport whose delivery result reports the sent id). The
- * back-filled ids are what let a later reaction or delete naming the
+ * back-filled ids are what let a later reaction naming the
  * assistant's own post resolve back to this row.
  *
  * Behavior:

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -385,15 +385,14 @@ async function deliverPersistedAssistantMessageViaCallback(
   }
 
   // Compose an `onMessageTs` that reconciles the persisted assistant row's
-  // provider message id once the transport returns the authoritative one.
-  // The assistant row was written BEFORE the gateway POST, so its pre-send
-  // envelope names no id of its own: a Slack row's partial `slackMeta` is
-  // missing `channelTs` and would otherwise be rejected by
-  // `readSlackMetadata`, dropping the row out of chronological/thread-tag
-  // rendering, and a neutral-envelope row is missing the `messageId` a later
-  // reaction on it resolves by. We only act on the FIRST ts (top-level
-  // segment); any subsequent split segments become independent provider
-  // messages with their own ids and are not represented as separate DB rows.
+  // provider message ids as the transport reports the authoritative ones.
+  // The assistant row is written BEFORE the gateway POST, so its pre-send
+  // envelope names no id of its own: a Slack row's partial `slackMeta` lacks
+  // `channelTs` and reads as null through `readSlackMetadata`, and a
+  // neutral-envelope row lacks the `messageId` a later reaction or delete
+  // naming it resolves by. A reply split into several segments reports one
+  // id per posted provider message, all reconciled onto this one row; see
+  // `makeSentMessageIdReconciler` for the per-envelope rules.
   const reconcileOnMessageTs = makeSentMessageIdReconciler(msg.id);
   const callerOnMessageTs = options?.onMessageTs;
   const composedOnMessageTs = (ts: string): void => {
@@ -493,30 +492,29 @@ export async function deliverReplyViaCallback(
 }
 
 /**
- * Build a one-shot `onMessageTs` handler that reconciles the persisted
- * assistant row's provider message id from the transport's authoritative id:
- * `slackMeta.channelTs` for a Slack row, `providerMeta.messageId` for a row
- * carrying the neutral envelope (Discord today, any transport whose delivery
- * result reports the sent id). The back-filled id is what lets a later
- * reaction on the assistant's own post resolve back to this row.
+ * Build an `onMessageTs` handler that reconciles the persisted assistant
+ * row's provider message ids from the transport's authoritative ones:
+ * `slackMeta.channelTs` for a Slack row, `providerMeta.messageId` plus
+ * `additionalMessageIds` for a row carrying the neutral envelope (Discord
+ * today, any transport whose delivery result reports the sent id). The
+ * back-filled ids are what let a later reaction or delete naming the
+ * assistant's own post resolve back to this row.
  *
  * Behavior:
- * - Acts only on the first invocation per delivery (subsequent segments
- *   correspond to independent provider messages with their own ids and are
- *   not represented as separate DB rows).
+ * - A Slack row acts on the first invocation only: `channelTs` is the one
+ *   id its envelope names, and later split segments are independent Slack
+ *   messages it cannot carry.
+ * - A neutral-envelope row records every reported id: the first as
+ *   `messageId`, the rest under `additionalMessageIds`, all naming this
+ *   same row. An id already recorded (a redelivery) is skipped.
  * - No-op when the row was persisted with neither envelope (e.g. vellum
- *   outbound), and when the row's id is already present (a prior
- *   reconciliation ran, or backfill stamped the field).
+ *   outbound).
  * - Failures are logged and swallowed so a transient DB error cannot break
  *   the outbound delivery itself.
  */
 function makeSentMessageIdReconciler(messageId: string): (ts: string) => void {
-  let applied = false;
+  let slackApplied = false;
   return (ts: string): void => {
-    if (applied) {
-      return;
-    }
-    applied = true;
     if (!ts) {
       return;
     }
@@ -544,6 +542,10 @@ function makeSentMessageIdReconciler(messageId: string): (ts: string) => void {
         reconcileProviderMessageId(messageId, envelope, ts);
         return;
       }
+      if (slackApplied) {
+        return;
+      }
+      slackApplied = true;
       // If the existing slackMeta already parses cleanly via the strict
       // reader, channelTs is already present (a prior reconciliation ran,
       // or backfill stamped the field) — nothing to do.
@@ -586,10 +588,12 @@ function makeSentMessageIdReconciler(messageId: string): (ts: string) => void {
 }
 
 /**
- * The neutral-envelope arm of the reconciliation: patch the transport's
- * sent-message id into a row's `providerMeta` when the pre-send stamp left
- * it absent. A row whose envelope already names an id, or carries no valid
- * neutral envelope at all, is left untouched.
+ * The neutral-envelope arm of the reconciliation: record the transport's
+ * sent-message id on the row's `providerMeta`. The first reported id
+ * becomes `messageId`; further ids (a reply split at tool boundaries posts
+ * several provider messages) accumulate under `additionalMessageIds`. An id
+ * the envelope already names is a redelivery and is skipped, and a row
+ * carrying no valid neutral envelope is left untouched.
  */
 function reconcileProviderMessageId(
   messageId: string,
@@ -597,10 +601,25 @@ function reconcileProviderMessageId(
   ts: string,
 ): void {
   const providerMeta = readProviderMessageMetadata(envelope.providerMeta);
-  if (providerMeta === null || providerMeta.messageId !== undefined) {
+  if (providerMeta === null) {
+    return;
+  }
+  if (providerMeta.messageId === undefined) {
+    updateMessageMetadata(messageId, {
+      providerMeta: JSON.stringify({ ...providerMeta, messageId: ts }),
+    });
+    return;
+  }
+  if (
+    providerMeta.messageId === ts ||
+    providerMeta.additionalMessageIds?.includes(ts)
+  ) {
     return;
   }
   updateMessageMetadata(messageId, {
-    providerMeta: JSON.stringify({ ...providerMeta, messageId: ts }),
+    providerMeta: JSON.stringify({
+      ...providerMeta,
+      additionalMessageIds: [...(providerMeta.additionalMessageIds ?? []), ts],
+    }),
   });
 }


### PR DESCRIPTION
**TL;DR:** One stored reply that splits into several provider posts (text before and after a tool call) now records every reported post id on its row, so a reaction on any of those posts resolves back to it. Previously only the first reported id was recorded and a reaction on any later post dropped as unknown-target.

Fast-follow to #41808: this change was pushed to that branch as its review-feedback fix (both Devin and Codex converged on the finding), but the merge caught the branch at its earlier head, so it lands here unchanged.

## What changes for the user

| Before | After |
| --- | --- |
| React to the later part of a split Discord reply: dropped, assistant never learns of it | Resolves like a reaction on any assistant post |
| The rendered reaction line degrades to "an earlier message" for later posts of a split reply | Quotes the reply's text |
| Slack | unchanged (first-ts convention kept: `channelTs` is the one id its envelope names) |

## How

- `providerMeta` gains an optional `additionalMessageIds` array in the neutral schema: the first reported id stays `messageId`, later ids of the same delivery accumulate there. A redelivered id is skipped, so retries stay idempotent.
- The reconciler in `channel-reply-delivery.ts` acts on every reported id for neutral-envelope rows (it re-reads the row per report, preserving concurrent stamps); the Slack arm keeps its one-shot behavior.
- `findConversationByProviderMessageId` and the reaction-target quote index match any of the row's ids.

## Why this is safe

- Purely additive schema field, written only by the reconciler; every reader that ignores it behaves exactly as before.
- No wire contract changes: the per-post ids already arrive today (one `onMessageTs` per posted segment) and were being discarded.
- Slack behavior is byte-for-byte unchanged.

Tests: accumulation plus redelivery idempotence, lookup through a later post id, and the quote index resolving through it; typecheck and the touched suites green.

**Known remaining slice:** intra-segment Discord length-chunking reports only the last chunk's id, because `ChannelDeliveryResult` is a wire contract carrying a single `ts`. Extending that contract is a separate reviewable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->