### PR TITLE
fix(slack): bot and webhook messages keep their sender name and content

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -194,7 +194,10 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
             username: "Deploy Webhook",
             text: "",
             blocks: [
-              { type: "section", text: { text: "Deploy finished" } },
+              {
+                type: "section",
+                text: { type: "mrkdwn", text: "Deploy finished" },
+              },
               {
                 type: "context",
                 elements: [{ type: "mrkdwn", text: "took 42s" }],

--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -45,6 +45,7 @@ import {
 const originalFetch = globalThis.fetch;
 let userInfoCalls: string[] = [];
 let channelInfoCalls: string[] = [];
+let botsInfoCalls: string[] = [];
 
 function installFetchStub() {
   globalThis.fetch = (async (
@@ -175,6 +176,36 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
             subtype: "bot_message",
             ts: "1700000003.000400",
             bot_id: "B_ASSISTANT",
+            text: "",
+            attachments: [
+              {
+                fallback: "notify-web failure",
+                pretext: "notify-web failure by <@ULEO>",
+                title: "CI Main Web",
+                title_link: "https://example.com/actions/runs/1",
+              },
+            ],
+          },
+          {
+            type: "message",
+            subtype: "bot_message",
+            ts: "1700000003.000500",
+            bot_id: "B_WEBHOOK",
+            username: "Deploy Webhook",
+            text: "",
+            blocks: [
+              { type: "section", text: { text: "Deploy finished" } },
+              {
+                type: "context",
+                elements: [{ type: "mrkdwn", text: "took 42s" }],
+              },
+            ],
+          },
+          {
+            type: "message",
+            subtype: "bot_message",
+            ts: "1700000003.000600",
+            bot_id: "B_ASSISTANT",
             text: "Bot-authored history",
           },
         ],
@@ -241,6 +272,15 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
     const userId = parsed.searchParams.get("user") ?? "";
     userInfoCalls.push(userId);
     return fakeUserInfoResponse(userId);
+  }
+
+  if (method === "bots.info") {
+    const botId = parsed.searchParams.get("bot") ?? "";
+    botsInfoCalls.push(botId);
+    if (botId === "B_ASSISTANT") {
+      return { ok: true, bot: { id: "B_ASSISTANT", name: "CI Notifier" } };
+    }
+    return { ok: false, error: "bot_not_found" };
   }
 
   return { ok: true };
@@ -371,6 +411,7 @@ describe("Slack adapter mention rendering", () => {
     __resetSlackMentionCachesForTests();
     userInfoCalls = [];
     channelInfoCalls = [];
+    botsInfoCalls = [];
     getSecureKeyAsyncMock.mockReset();
     getSecureKeyAsyncMock.mockImplementation(async (key: string) => {
       if (key === credentialKey("slack_channel", "bot_token")) {
@@ -399,15 +440,43 @@ describe("Slack adapter mention rendering", () => {
     expect(messages[0].reactions).toEqual([{ name: "eyes", count: 1 }]);
   });
 
-  test("getHistory preserves bot ids for bot-authored Slack messages", async () => {
+  test("getHistory resolves bot sender names and attachment/block content for bot-authored Slack messages", async () => {
     const messages = await slackProvider.getHistory(undefined, "C_BOT_HISTORY");
 
-    expect(messages).toHaveLength(1);
-    expect(messages[0].sender).toEqual({ id: "B_ASSISTANT", name: "unknown" });
+    expect(messages).toHaveLength(3);
+
+    // bot_id-only row: name via bots.info, content from the attachment
+    // (mention tokens inside it render like ordinary message text).
+    expect(messages[0].sender).toEqual({
+      id: "B_ASSISTANT",
+      name: "CI Notifier",
+    });
+    expect(messages[0].text).toBe(
+      "notify-web failure by @Leo\nCI Main Web (https://example.com/actions/runs/1)",
+    );
     expect(messages[0].metadata).toEqual({
       isBot: true,
       slackBotId: "B_ASSISTANT",
     });
+
+    // username-bearing row: named without a bots.info round trip, content
+    // from Block Kit blocks.
+    expect(messages[1].sender).toEqual({
+      id: "B_WEBHOOK",
+      name: "Deploy Webhook",
+    });
+    expect(messages[1].text).toBe("Deploy finished\ntook 42s");
+    expect(botsInfoCalls).not.toContain("B_WEBHOOK");
+
+    // Plain text row from the same bot: bots.info was resolved once, cached.
+    expect(messages[2].sender).toEqual({
+      id: "B_ASSISTANT",
+      name: "CI Notifier",
+    });
+    expect(messages[2].text).toBe("Bot-authored history");
+    expect(
+      botsInfoCalls.filter((botId) => botId === "B_ASSISTANT"),
+    ).toHaveLength(1);
   });
 
   test("getHistory caches Slack user info and maps timezone metadata", async () => {

--- a/assistant/src/messaging/providers/slack/__tests__/message-content.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/message-content.test.ts
@@ -35,7 +35,7 @@ describe("slackMessageRawText", () => {
             text: "3 tests failing",
             fields: [
               { title: "Branch", value: "main" },
-              { value: "value-only" },
+              { title: "", value: "value-only" },
             ],
             footer: "workflow #12",
           },
@@ -77,11 +77,17 @@ describe("slackMessageRawText", () => {
       slackMessageRawText({
         text: "",
         blocks: [
-          { type: "header", text: { text: "Release v1.2" } },
+          {
+            type: "header",
+            text: { type: "plain_text", text: "Release v1.2" },
+          },
           {
             type: "section",
-            text: { text: "All green" },
-            fields: [{ text: "Env: prod" }, { text: "" }],
+            text: { type: "mrkdwn", text: "All green" },
+            fields: [
+              { type: "mrkdwn", text: "Env: prod" },
+              { type: "mrkdwn", text: "" },
+            ],
           },
           { type: "divider" },
           {

--- a/assistant/src/messaging/providers/slack/__tests__/message-content.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/message-content.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+
+import { slackMessageRawText } from "../message-content.js";
+
+describe("slackMessageRawText", () => {
+  test("returns top-level text untouched when present", () => {
+    expect(
+      slackMessageRawText({
+        text: "hello <@U123>",
+        attachments: [{ fallback: "ignored" }],
+      }),
+    ).toBe("hello <@U123>");
+  });
+
+  test("whitespace-only text falls through to attachments", () => {
+    expect(
+      slackMessageRawText({
+        text: "  \n ",
+        attachments: [{ fallback: "the fallback" }],
+      }),
+    ).toBe("the fallback");
+  });
+
+  test("prefers structured attachment fields over fallback", () => {
+    expect(
+      slackMessageRawText({
+        text: "",
+        attachments: [
+          {
+            fallback: "plain summary",
+            pretext: "build failed by <@U08E>",
+            author_name: "CI",
+            title: "CI Main Web",
+            title_link: "https://example.com/runs/1",
+            text: "3 tests failing",
+            fields: [
+              { title: "Branch", value: "main" },
+              { value: "value-only" },
+            ],
+            footer: "workflow #12",
+          },
+        ],
+      }),
+    ).toBe(
+      [
+        "build failed by <@U08E>",
+        "CI",
+        "CI Main Web (https://example.com/runs/1)",
+        "3 tests failing",
+        "Branch: main",
+        "value-only",
+        "workflow #12",
+      ].join("\n"),
+    );
+  });
+
+  test("uses fallback when the attachment has no structured text", () => {
+    expect(
+      slackMessageRawText({
+        text: "",
+        attachments: [{ fallback: "only the fallback" }],
+      }),
+    ).toBe("only the fallback");
+  });
+
+  test("joins multiple attachments with newlines and drops empty ones", () => {
+    expect(
+      slackMessageRawText({
+        text: "",
+        attachments: [{ text: "first" }, {}, { fallback: "second" }],
+      }),
+    ).toBe("first\nsecond");
+  });
+
+  test("extracts section, header, and context block text ahead of attachments", () => {
+    expect(
+      slackMessageRawText({
+        text: "",
+        blocks: [
+          { type: "header", text: { text: "Release v1.2" } },
+          {
+            type: "section",
+            text: { text: "All green" },
+            fields: [{ text: "Env: prod" }, { text: "" }],
+          },
+          { type: "divider" },
+          {
+            type: "context",
+            elements: [
+              { type: "mrkdwn", text: "deployed by <@U42>" },
+              { type: "plain_text", text: "just now" },
+            ],
+          },
+        ],
+        attachments: [{ fallback: "attachment tail" }],
+      }),
+    ).toBe(
+      [
+        "Release v1.2",
+        "All green",
+        "Env: prod",
+        "deployed by <@U42> just now",
+        "attachment tail",
+      ].join("\n"),
+    );
+  });
+
+  test("returns empty string when nothing carries text", () => {
+    expect(
+      slackMessageRawText({
+        text: "",
+        blocks: [{ type: "divider" }],
+        attachments: [{}],
+      }),
+    ).toBe("");
+  });
+});

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -38,6 +38,7 @@ import {
   isPrivateConversation,
   slackUserDisplayName,
 } from "./conversation-utils.js";
+import { slackMessageRawText } from "./message-content.js";
 import type {
   SlackConversation,
   SlackMessage,
@@ -78,6 +79,15 @@ const userInfoCache = new Map<string, Promise<SlackUserInfoLookupResult>>();
  * doomed lookup per message batch.
  */
 const channelNameCache = new Map<string, Promise<string | undefined>>();
+
+/**
+ * Cache resolved bot display names (`bots.info`) for bot-authored rows that
+ * carry only a `bot_id`, same lifetime and keying discipline as
+ * {@link userInfoCache}. Holds `undefined` for bots this auth provably
+ * cannot resolve so a wall of webhook history doesn't re-fire a doomed
+ * lookup per message batch.
+ */
+const botNameCache = new Map<string, Promise<string | undefined>>();
 
 /**
  * Cached auth resolved during resolveConnection(), split by direction.
@@ -367,6 +377,61 @@ async function resolveChannelName(
   return resolved;
 }
 
+/**
+ * Resolve a bot's display name via `bots.info`, cached per auth scope.
+ * Returns undefined when this auth cannot resolve it; transient failures are
+ * not cached so a later batch retries.
+ */
+async function resolveBotName(
+  auth: OAuthConnection | string,
+  botId: string,
+): Promise<string | undefined> {
+  const cacheKey = `${slackAuthCacheScope(auth)}:bot:${botId}`;
+  const cached = botNameCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const resolved = slack.botsInfo(auth, botId).then(
+    (resp) => trimNonEmpty(resp.bot.name),
+    (err: unknown) => {
+      // Cache the definitive "this auth cannot resolve it" answers; drop
+      // everything else so transient failures retry on the next batch.
+      const permanent =
+        err instanceof SlackApiError &&
+        (err.slackError === "bot_not_found" || err.category === "permission");
+      if (!permanent) {
+        botNameCache.delete(cacheKey);
+      }
+      return undefined;
+    },
+  );
+  botNameCache.set(cacheKey, resolved);
+  return resolved;
+}
+
+/**
+ * Sender info for a bot-authored row (no `user` to look up). The message's
+ * own `username` (bot_message subtype) or `bot_profile.name` answers without
+ * I/O; `bots.info` covers rows carrying only a `bot_id`, with the id itself
+ * as the last resort so the sender is at least attributable.
+ */
+async function resolveBotSenderInfo(
+  auth: OAuthConnection | string,
+  msg: SlackMessage,
+): Promise<NormalizedSlackUserInfo> {
+  const fromMessage =
+    trimNonEmpty(msg.username) ?? trimNonEmpty(msg.bot_profile?.name);
+  if (fromMessage) {
+    return { displayName: fromMessage };
+  }
+  const botId = msg.bot_id?.trim();
+  if (!botId) {
+    return { displayName: "unknown" };
+  }
+  return { displayName: (await resolveBotName(auth, botId)) ?? botId };
+}
+
 function normalizeSlackUserInfo(
   user: SlackUser,
   contactDisplayName: string | undefined,
@@ -398,6 +463,7 @@ function trimNonEmpty(value: unknown): string | undefined {
 export function __resetSlackMentionCachesForTests(): void {
   userInfoCache.clear();
   channelNameCache.clear();
+  botNameCache.clear();
 }
 
 function slackUserInfoMetadata(
@@ -529,19 +595,21 @@ async function mapSlackMessages(
   channelId: string,
   slackMessages: SlackMessage[],
 ): Promise<Message[]> {
-  const labels = await buildMentionLabels(
-    auth,
-    slackMessages.map((msg) => msg.text),
-  );
+  // Raw text may come from attachments/blocks (bot and webhook posts), so
+  // mention labels are built from the same derived strings that get rendered.
+  const rawTexts = slackMessages.map((msg) => slackMessageRawText(msg));
+  const labels = await buildMentionLabels(auth, rawTexts);
   const messages: Message[] = [];
-  for (const msg of slackMessages) {
-    const senderInfo = await resolveUserInfo(auth, msg.user ?? "");
+  for (const [i, msg] of slackMessages.entries()) {
+    const senderInfo = msg.user
+      ? await resolveUserInfo(auth, msg.user)
+      : await resolveBotSenderInfo(auth, msg);
     messages.push(
       mapMessage(
         msg,
         channelId,
         senderInfo,
-        renderSlackTextForModel(msg.text, labels),
+        renderSlackTextForModel(rawTexts[i], labels),
       ),
     );
   }

--- a/assistant/src/messaging/providers/slack/message-content.ts
+++ b/assistant/src/messaging/providers/slack/message-content.ts
@@ -1,0 +1,110 @@
+/**
+ * Fallback text extraction for Slack messages whose content lives outside
+ * the top-level `text` field.
+ *
+ * Bot and incoming-webhook posts (CI alerts, app notifications) routinely
+ * ship an empty `text` with the visible content in legacy `attachments` or
+ * Block Kit `blocks`; Slack's own clients render those. A mapping that reads
+ * only `text` turns such a message into an empty row, which downstream
+ * surfaces (transcripts, channel references) present as missing content.
+ *
+ * Output is raw Slack mrkdwn: mention/link tokens inside attachments and
+ * blocks are preserved so callers can route the result through the same
+ * `renderSlackTextForModel` pass as ordinary message text.
+ */
+import type {
+  SlackMessage,
+  SlackMessageAttachment,
+  SlackMessageBlock,
+} from "./types.js";
+
+/**
+ * The model-facing raw mrkdwn for a Slack message: `text` when present,
+ * otherwise content derived from `blocks` and `attachments` (in that order,
+ * matching how Slack renders a message body above its attachments).
+ */
+export function slackMessageRawText(
+  msg: Pick<SlackMessage, "text" | "attachments" | "blocks">,
+): string {
+  if (msg.text?.trim()) {
+    return msg.text;
+  }
+  const parts = [
+    ...slackBlocksText(msg.blocks),
+    ...(msg.attachments ?? []).map(slackAttachmentText),
+  ].filter((part) => part.length > 0);
+  return parts.join("\n");
+}
+
+function slackAttachmentText(attachment: SlackMessageAttachment): string {
+  const title = trimmed(attachment.title);
+  const titleLink = trimmed(attachment.title_link);
+  const fieldLines = (attachment.fields ?? []).map((field) => {
+    const fieldTitle = trimmed(field.title);
+    const fieldValue = trimmed(field.value);
+    if (fieldTitle && fieldValue) {
+      return `${fieldTitle}: ${fieldValue}`;
+    }
+    return fieldTitle ?? fieldValue ?? "";
+  });
+  const structured = [
+    trimmed(attachment.pretext),
+    trimmed(attachment.author_name),
+    title && titleLink ? `${title} (${titleLink})` : title,
+    trimmed(attachment.text),
+    ...fieldLines,
+    trimmed(attachment.footer),
+  ].filter((part): part is string => !!part);
+  if (structured.length > 0) {
+    return structured.join("\n");
+  }
+  return trimmed(attachment.fallback) ?? "";
+}
+
+/**
+ * Text carried by the block types that hold a message body's copy. Other
+ * block types contribute nothing: images/dividers/actions are non-textual,
+ * and `rich_text` (deeply nested; produced for user-typed messages, which
+ * carry the equivalent top-level `text`) is intentionally not walked.
+ */
+function slackBlocksText(
+  blocks: readonly SlackMessageBlock[] | undefined,
+): string[] {
+  const parts: string[] = [];
+  for (const block of blocks ?? []) {
+    switch (block.type) {
+      case "section":
+      case "header": {
+        const text = trimmed(block.text?.text);
+        if (text) {
+          parts.push(text);
+        }
+        for (const field of block.fields ?? []) {
+          const fieldText = trimmed(field.text);
+          if (fieldText) {
+            parts.push(fieldText);
+          }
+        }
+        break;
+      }
+      case "context": {
+        const contextText = (block.elements ?? [])
+          .map((element) => trimmed(element.text))
+          .filter((text): text is string => !!text)
+          .join(" ");
+        if (contextText) {
+          parts.push(contextText);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+  return parts;
+}
+
+function trimmed(value: string | undefined): string | undefined {
+  const result = value?.trim();
+  return result ? result : undefined;
+}

--- a/assistant/src/messaging/providers/slack/message-content.ts
+++ b/assistant/src/messaging/providers/slack/message-content.ts
@@ -13,10 +13,14 @@
  * `renderSlackTextForModel` pass as ordinary message text.
  */
 import type {
-  SlackMessage,
-  SlackMessageAttachment,
-  SlackMessageBlock,
-} from "./types.js";
+  AnyBlock,
+  ContextBlock,
+  HeaderBlock,
+  MessageAttachment,
+  SectionBlock,
+} from "@slack/types";
+
+import type { SlackMessage } from "./types.js";
 
 /**
  * The model-facing raw mrkdwn for a Slack message: `text` when present,
@@ -36,7 +40,7 @@ export function slackMessageRawText(
   return parts.join("\n");
 }
 
-function slackAttachmentText(attachment: SlackMessageAttachment): string {
+function slackAttachmentText(attachment: MessageAttachment): string {
   const title = trimmed(attachment.title);
   const titleLink = trimmed(attachment.title_link);
   const fieldLines = (attachment.fields ?? []).map((field) => {
@@ -61,44 +65,53 @@ function slackAttachmentText(attachment: SlackMessageAttachment): string {
   return trimmed(attachment.fallback) ?? "";
 }
 
+function isSectionBlock(block: AnyBlock): block is SectionBlock {
+  return block.type === "section";
+}
+
+function isHeaderBlock(block: AnyBlock): block is HeaderBlock {
+  return block.type === "header";
+}
+
+function isContextBlock(block: AnyBlock): block is ContextBlock {
+  return block.type === "context";
+}
+
 /**
  * Text carried by the block types that hold a message body's copy. Other
  * block types contribute nothing: images/dividers/actions are non-textual,
  * and `rich_text` (deeply nested; produced for user-typed messages, which
  * carry the equivalent top-level `text`) is intentionally not walked.
  */
-function slackBlocksText(
-  blocks: readonly SlackMessageBlock[] | undefined,
-): string[] {
+function slackBlocksText(blocks: readonly AnyBlock[] | undefined): string[] {
   const parts: string[] = [];
   for (const block of blocks ?? []) {
-    switch (block.type) {
-      case "section":
-      case "header": {
-        const text = trimmed(block.text?.text);
-        if (text) {
-          parts.push(text);
-        }
-        for (const field of block.fields ?? []) {
-          const fieldText = trimmed(field.text);
-          if (fieldText) {
-            parts.push(fieldText);
-          }
-        }
-        break;
+    if (isSectionBlock(block)) {
+      const text = trimmed(block.text?.text);
+      if (text) {
+        parts.push(text);
       }
-      case "context": {
-        const contextText = (block.elements ?? [])
-          .map((element) => trimmed(element.text))
-          .filter((text): text is string => !!text)
-          .join(" ");
-        if (contextText) {
-          parts.push(contextText);
+      for (const field of block.fields ?? []) {
+        const fieldText = trimmed(field.text);
+        if (fieldText) {
+          parts.push(fieldText);
         }
-        break;
       }
-      default:
-        break;
+    } else if (isHeaderBlock(block)) {
+      const text = trimmed(block.text.text);
+      if (text) {
+        parts.push(text);
+      }
+    } else if (isContextBlock(block)) {
+      const contextText = block.elements
+        .map((element) =>
+          "text" in element ? trimmed(element.text) : undefined,
+        )
+        .filter((text): text is string => !!text)
+        .join(" ");
+      if (contextText) {
+        parts.push(contextText);
+      }
     }
   }
   return parts;

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -1,5 +1,11 @@
 /** Slack Web API response types. */
 
+import type {
+  AnyBlock,
+  GenericMessageEvent,
+  MessageAttachment,
+} from "@slack/types";
+
 export interface SlackApiResponse {
   ok: boolean;
   error?: string;
@@ -55,35 +61,6 @@ export interface SlackConversationsListResponse extends SlackApiResponse {
   response_metadata?: { next_cursor?: string };
 }
 
-/**
- * Legacy secondary attachment carried on bot/webhook messages. Only the
- * text-bearing fields consumed by fallback-text extraction are modeled;
- * `fallback` is Slack's own plain-text summary of the attachment.
- * @see https://api.slack.com/reference/messaging/attachments
- */
-export interface SlackMessageAttachment {
-  fallback?: string;
-  pretext?: string;
-  author_name?: string;
-  title?: string;
-  title_link?: string;
-  text?: string;
-  fields?: Array<{ title?: string; value?: string }>;
-  footer?: string;
-}
-
-/**
- * Block Kit block (subset used for fallback-text extraction): `section`,
- * `header`, and `context` carry the plain/mrkdwn text a message body shows.
- * @see https://api.slack.com/reference/block-kit/blocks
- */
-export interface SlackMessageBlock {
-  type?: string;
-  text?: { text?: string };
-  fields?: Array<{ text?: string }>;
-  elements?: Array<{ type?: string; text?: string }>;
-}
-
 export interface SlackMessage {
   type: string;
   subtype?: string;
@@ -95,20 +72,17 @@ export interface SlackMessage {
    * legacy bot posts, which carry no `user` to resolve a name from).
    */
   username?: string;
-  /** Profile of the posting app, attached to bot-authored rows. */
-  bot_profile?: {
-    id?: string;
-    name?: string;
-    app_id?: string;
-    team_id?: string;
-  };
+  /** Profile of the posting app, attached to bot-authored rows. The type is
+   *  indexed off the official message event because `@slack/types` does not
+   *  export `BotProfile` from its root. */
+  bot_profile?: GenericMessageEvent["bot_profile"];
   text: string;
   /**
    * Bot/webhook posts routinely leave `text` empty and put the visible
    * content here or in `blocks`; see `slackMessageRawText`.
    */
-  attachments?: SlackMessageAttachment[];
-  blocks?: SlackMessageBlock[];
+  attachments?: MessageAttachment[];
+  blocks?: AnyBlock[];
   thread_ts?: string;
   reply_count?: number;
   reactions?: Array<{ name: string; count: number; users: string[] }>;

--- a/assistant/src/messaging/providers/slack/types.ts
+++ b/assistant/src/messaging/providers/slack/types.ts
@@ -55,13 +55,60 @@ export interface SlackConversationsListResponse extends SlackApiResponse {
   response_metadata?: { next_cursor?: string };
 }
 
+/**
+ * Legacy secondary attachment carried on bot/webhook messages. Only the
+ * text-bearing fields consumed by fallback-text extraction are modeled;
+ * `fallback` is Slack's own plain-text summary of the attachment.
+ * @see https://api.slack.com/reference/messaging/attachments
+ */
+export interface SlackMessageAttachment {
+  fallback?: string;
+  pretext?: string;
+  author_name?: string;
+  title?: string;
+  title_link?: string;
+  text?: string;
+  fields?: Array<{ title?: string; value?: string }>;
+  footer?: string;
+}
+
+/**
+ * Block Kit block (subset used for fallback-text extraction): `section`,
+ * `header`, and `context` carry the plain/mrkdwn text a message body shows.
+ * @see https://api.slack.com/reference/block-kit/blocks
+ */
+export interface SlackMessageBlock {
+  type?: string;
+  text?: { text?: string };
+  fields?: Array<{ text?: string }>;
+  elements?: Array<{ type?: string; text?: string }>;
+}
+
 export interface SlackMessage {
   type: string;
   subtype?: string;
   ts: string;
   user?: string;
   bot_id?: string;
+  /**
+   * Display name for `bot_message`-subtype rows (incoming webhooks and
+   * legacy bot posts, which carry no `user` to resolve a name from).
+   */
+  username?: string;
+  /** Profile of the posting app, attached to bot-authored rows. */
+  bot_profile?: {
+    id?: string;
+    name?: string;
+    app_id?: string;
+    team_id?: string;
+  };
   text: string;
+  /**
+   * Bot/webhook posts routinely leave `text` empty and put the visible
+   * content here or in `blocks`; see `slackMessageRawText`.
+   */
+  attachments?: SlackMessageAttachment[];
+  blocks?: SlackMessageBlock[];
   thread_ts?: string;
   reply_count?: number;
   reactions?: Array<{ name: string; count: number; users: string[] }>;


### PR DESCRIPTION
Fixes LUM-3496

## TL;DR

Bot and incoming-webhook Slack messages backfilled into a conversation lost both their sender name and their content: the sender became the literal string `unknown` and the body came through empty, so channel references and the model transcript showed `sender: unknown` / `(no text content)`. The Slack adapter now resolves bot sender names (message `username` / `bot_profile.name`, then a cached `bots.info` lookup) and derives model-facing text from legacy `attachments` and Block Kit `blocks` when the top-level `text` is empty.

## Root cause

Two independent gaps in `mapMessage` / `mapSlackMessages` (`assistant/src/messaging/providers/slack/adapter.ts`), which every history/thread-replies read (and therefore thread and DM backfill) flows through:

1. **Sender**: a bot-authored row has no `user`, and `resolveUserInfo(auth, "")` returns `{ displayName: "unknown" }`. The fields Slack actually sends for bot rows (`username`, `bot_profile`) were not modeled on `SlackMessage` at all.
2. **Content**: only `msg.text` was read. Webhook-style posts (CI alerts, app notifications) routinely ship an empty `text` with the visible content in `attachments` or `blocks`; those fields were also unmodeled.

The observed case (the CI alert in `#build-alerts`, verified against the live Slack thread) is exactly this shape: `bot_id` only, empty `text`, all content in one legacy attachment.

## What changes for the user

| Before | After |
| --- | --- |
| A referenced CI alert shows `sender: unknown` in the channel-reference block | The reference names the posting app (e.g. the CI notifier bot) |
| The referenced message body renders as `(no text content)` | The alert's actual text (pretext, title with link, body, fields) is preserved |
| The assistant's Slack transcript shows the same empty bot rows, so it has to ask what a thread is about | Bot rows in backfilled threads carry their sender and content, so follow-up questions have context |
| `<@U…>` mentions inside attachment text would render as `@unknown-user` | Mention labels are built from attachment/block text too, so they resolve to names |

## Why it's safe

- Pure mapping change in the daemon's Slack adapter; no wire, schema, or persistence-format changes. `slackMeta.displayName` simply stops being `"unknown"` for bot rows (nothing keys on that literal; the one `=== "unknown"` comparison in turn-context treats it as unusable and only benefits).
- Human-message paths are untouched: rows with `user` resolve exactly as before, and non-empty `text` is returned verbatim.
- The new `bots.info` lookup is cached per auth scope with the same permanent-failure discipline as the existing user/channel caches, and only fires for rows carrying just a `bot_id`.
- Backfill's secret-ingress gate runs on the mapped text, so attachment-derived content is scanned the same way ordinary text is.
- Typecheck clean; adapter, backfill, thread-backfill, DM-backfill, and token-routing test files all pass; new unit tests pin the extraction rules and the bots.info caching.

## Scope notes

- **Slack-only by design.** The Telegram and Discord daemon providers are send-only (no history reads, so no backfill path), Telegram's Bot API never delivers other bots' messages, and the web channel-reference surface currently reads only the Slack envelope (`PROVENANCE_READERS`). No other channel has this failure shape today.
- **Not verified against a live re-backfill** (that would mean driving the production assistant); the fix is grounded in the actual wire shape of the observed message, fetched from the live Slack thread, and reproduced in tests.

## Deferred

- `rich_text` blocks are intentionally not walked in fallback extraction (user-typed messages carrying them also carry equivalent `text`); worth revisiting only if an app posts rich_text-only bodies. Noted in the module docstring.
- Backfilled rows don't persist an `isBot` marker into `slackMeta`, so transcript renderers can't visually distinguish app senders from humans. Backlog-grade; the sender name itself is the fix the ticket needs.
- The gateway's Socket Mode catch-up path still drops all bot messages (previously tracked as LUM-2675, closed as stale). Unrelated delivery-semantics question, deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
