### PR TITLE
feat(channels): inbound message rows persist the neutral providerMeta envelope

### DIFF
--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -170,6 +170,48 @@ describe("channel-delivery-store", () => {
     ).toBeNull();
   });
 
+  test("linked inbound rows are excluded from the provider-id scan; crash-window rows resolve", () => {
+    const chatId = "chat-scan-budget";
+    const minted = recordInbound("telegram", chatId, "evt-linked", {
+      sourceMessageId: "tg-linked-1",
+    });
+    const envelope = (messageId: string) =>
+      JSON.stringify({
+        providerMeta: JSON.stringify({
+          source: "telegram",
+          conversationExternalId: chatId,
+          messageId,
+          eventKind: "message",
+        }),
+      });
+
+    // A normally-ingested inbound row: linked to its event, so the
+    // inbound-event index owns its resolution and the fallback scan must
+    // not spend budget on it.
+    insertMessage("linked-user-row", minted.conversationId, {});
+    getDb()
+      .update(messages)
+      .set({ metadata: envelope("tg-linked-1") })
+      .where(eq(messages.id, "linked-user-row"))
+      .run();
+    linkMessage(minted.eventId, "linked-user-row");
+    expect(
+      findConversationByProviderMessageId("telegram", chatId, "tg-linked-1"),
+    ).toBeNull();
+
+    // A crash-window row: persisted with its envelope but its event link
+    // never landed. The fallback is the only path that can resolve it.
+    insertMessage("orphan-user-row", minted.conversationId, {});
+    getDb()
+      .update(messages)
+      .set({ metadata: envelope("tg-orphan-1") })
+      .where(eq(messages.id, "orphan-user-row"))
+      .run();
+    expect(
+      findConversationByProviderMessageId("telegram", chatId, "tg-orphan-1"),
+    ).toBe(minted.conversationId);
+  });
+
   test("same chat on same channel reuses the same conversation", () => {
     const r1 = recordInbound("telegram", "chat-1", "msg-1");
     const r2 = recordInbound("telegram", "chat-1", "msg-2");

--- a/assistant/src/__tests__/channel-delivery-store.test.ts
+++ b/assistant/src/__tests__/channel-delivery-store.test.ts
@@ -210,6 +210,21 @@ describe("channel-delivery-store", () => {
     expect(
       findConversationByProviderMessageId("telegram", chatId, "tg-orphan-1"),
     ).toBe(minted.conversationId);
+
+    // A legacy linked row whose event carries no source_message_id:
+    // findMessageBySourceId matches only that column, so the fallback must
+    // still admit the row or reactions to it become unresolvable.
+    const legacy = recordInbound("telegram", chatId, "evt-legacy");
+    insertMessage("legacy-user-row", legacy.conversationId, {});
+    getDb()
+      .update(messages)
+      .set({ metadata: envelope("tg-legacy-1") })
+      .where(eq(messages.id, "legacy-user-row"))
+      .run();
+    linkMessage(legacy.eventId, "legacy-user-row");
+    expect(
+      findConversationByProviderMessageId("telegram", chatId, "tg-legacy-1"),
+    ).toBe(legacy.conversationId);
   });
 
   test("same chat on same channel reuses the same conversation", () => {

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -236,6 +236,52 @@ function seedFailedSlackEvent(opts: {
   return inbound.eventId;
 }
 
+function seedFailedTelegramEvent(opts: {
+  content: string;
+  externalChatId: string;
+  messageId: string;
+  threadId?: string;
+  /** Stands in for the `channelInbound` the live path captures onto the payload. */
+  channelInbound?: Record<string, unknown>;
+}): string {
+  const inbound = deliveryCrud.recordInbound(
+    "telegram",
+    opts.externalChatId,
+    opts.messageId,
+  );
+  deliveryCrud.storePayload(inbound.eventId, {
+    content: opts.content,
+    sourceChannel: "telegram",
+    interface: "telegram",
+    externalChatId: opts.externalChatId,
+    externalMessageId: opts.messageId,
+    sourceMetadata: {
+      messageId: opts.messageId,
+      ...(opts.threadId ? { threadId: opts.threadId } : {}),
+    },
+    ...(opts.channelInbound ? { channelInbound: opts.channelInbound } : {}),
+    trustCtx: {
+      trustClass: "guardian",
+      sourceChannel: "telegram",
+      requesterExternalUserId: "user-1",
+      requesterChatId: opts.externalChatId,
+      guardianPrincipalId: "principal-1",
+    },
+  });
+
+  getDb()
+    .update(channelInboundEvents)
+    .set({
+      processingStatus: "failed",
+      processingAttempts: 1,
+      retryAfter: Date.now() - 1,
+    })
+    .where(eq(channelInboundEvents.id, inbound.eventId))
+    .run();
+
+  return inbound.eventId;
+}
+
 describe("channel-retry-sweep", () => {
   beforeEach(() => {
     resetTables();
@@ -440,6 +486,119 @@ describe("channel-retry-sweep", () => {
     expect(capturedOptions?.displayContent).toBeUndefined();
     // The idempotency key is still reconstructed so guardian replays dedup too.
     expect(capturedOptions?.slackInbound?.channelTs).toBe("1700000000.000200");
+  });
+
+  test("replays a captured channelInbound envelope verbatim", async () => {
+    const captured = {
+      source: "telegram",
+      conversationExternalId: "chat-500",
+      messageId: "tg-msg-1",
+      threadId: "topic-3",
+      actorExternalId: "user-77",
+      displayName: "Alice",
+      eventKind: "message",
+    };
+    seedFailedTelegramEvent({
+      content: "retry me",
+      externalChatId: "chat-500",
+      messageId: "tg-msg-1",
+      channelInbound: captured,
+    });
+
+    let capturedOptions:
+      | { channelInbound?: Record<string, unknown> }
+      | undefined;
+    await sweepFailedEvents(async (conversationId, content, options) => {
+      capturedOptions = options as {
+        channelInbound?: Record<string, unknown>;
+      };
+      const messageId = "message-tg-captured";
+      getDb()
+        .insert(messages)
+        .values({
+          id: messageId,
+          conversationId,
+          role: "user",
+          content: JSON.stringify([{ type: "text", text: content }]),
+          createdAt: Date.now(),
+        })
+        .run();
+      return { messageId };
+    });
+
+    // The captured envelope is the EXACT object the live turn used, so the
+    // replayed row persists an identical providerMeta.
+    expect(capturedOptions?.channelInbound).toEqual(captured);
+  });
+
+  test("reconstructs channelInbound from the stored payload when no capture exists", async () => {
+    seedFailedTelegramEvent({
+      content: "retry me",
+      externalChatId: "chat-501",
+      messageId: "tg-msg-2",
+      threadId: "topic-9",
+    });
+
+    let capturedOptions:
+      | { channelInbound?: Record<string, unknown> }
+      | undefined;
+    await sweepFailedEvents(async (conversationId, content, options) => {
+      capturedOptions = options as {
+        channelInbound?: Record<string, unknown>;
+      };
+      const messageId = "message-tg-fallback";
+      getDb()
+        .insert(messages)
+        .values({
+          id: messageId,
+          conversationId,
+          role: "user",
+          content: JSON.stringify([{ type: "text", text: content }]),
+          createdAt: Date.now(),
+        })
+        .run();
+      return { messageId };
+    });
+
+    expect(capturedOptions?.channelInbound).toEqual({
+      source: "telegram",
+      conversationExternalId: "chat-501",
+      messageId: "tg-msg-2",
+      threadId: "topic-9",
+      eventKind: "message",
+    });
+  });
+
+  test("a Slack replay carries no channelInbound (Slack keeps slackMeta)", async () => {
+    seedFailedSlackEvent({
+      trustClass: "guardian",
+      content: "hello",
+      externalChatId: "C0000001",
+      channelTs: "1700000001.000100",
+    });
+
+    let capturedOptions:
+      | { channelInbound?: Record<string, unknown> }
+      | undefined;
+    await sweepFailedEvents(async (conversationId, content, options) => {
+      capturedOptions = options as {
+        channelInbound?: Record<string, unknown>;
+      };
+      const messageId = "message-slack-no-neutral";
+      getDb()
+        .insert(messages)
+        .values({
+          id: messageId,
+          conversationId,
+          role: "user",
+          content: JSON.stringify([{ type: "text", text: content }]),
+          createdAt: Date.now(),
+        })
+        .run();
+      return { messageId };
+    });
+
+    expect(capturedOptions?.channelInbound).toBeUndefined();
   });
 
   test("replays the sender's Slack app context from the captured slackInbound", async () => {

--- a/assistant/src/__tests__/channel-retry-sweep.test.ts
+++ b/assistant/src/__tests__/channel-retry-sweep.test.ts
@@ -241,6 +241,8 @@ function seedFailedTelegramEvent(opts: {
   externalChatId: string;
   messageId: string;
   threadId?: string;
+  /** Sender display name as `storePayload` records it at ingress. */
+  senderName?: string;
   /** Stands in for the `channelInbound` the live path captures onto the payload. */
   channelInbound?: Record<string, unknown>;
 }): string {
@@ -259,6 +261,7 @@ function seedFailedTelegramEvent(opts: {
       messageId: opts.messageId,
       ...(opts.threadId ? { threadId: opts.threadId } : {}),
     },
+    ...(opts.senderName ? { senderName: opts.senderName } : {}),
     ...(opts.channelInbound ? { channelInbound: opts.channelInbound } : {}),
     trustCtx: {
       trustClass: "guardian",
@@ -532,11 +535,15 @@ describe("channel-retry-sweep", () => {
   });
 
   test("reconstructs channelInbound from the stored payload when no capture exists", async () => {
+    // The crash window: `storePayload` ran at ingress but the daemon died
+    // before `storeInboundChannelMetadata`. Recovery must rebuild the same
+    // envelope the live turn would have persisted, sender fields included.
     seedFailedTelegramEvent({
       content: "retry me",
       externalChatId: "chat-501",
       messageId: "tg-msg-2",
       threadId: "topic-9",
+      senderName: "Alice",
     });
 
     let capturedOptions:
@@ -565,6 +572,8 @@ describe("channel-retry-sweep", () => {
       conversationExternalId: "chat-501",
       messageId: "tg-msg-2",
       threadId: "topic-9",
+      displayName: "Alice",
+      actorExternalId: "user-1",
       eventKind: "message",
     });
   });

--- a/assistant/src/__tests__/provider-meta-persistence.test.ts
+++ b/assistant/src/__tests__/provider-meta-persistence.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildProviderMetaForPersistence } from "../daemon/conversation-messaging.js";
+import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
+import { readProviderMetadata } from "../messaging/read-provider-metadata.js";
+
+const telegramInbound: ProviderMessageMetadata = {
+  source: "telegram",
+  conversationExternalId: "chat-42",
+  messageId: "msg-100",
+  threadId: "topic-7",
+  actorExternalId: "user-9",
+  displayName: "Alice",
+  eventKind: "message",
+};
+
+describe("buildProviderMetaForPersistence", () => {
+  test("a matching non-Slack turn persists an envelope the neutral reader round-trips", () => {
+    const serialized = buildProviderMetaForPersistence({
+      channelInbound: telegramInbound,
+      turnChannel: "telegram",
+    });
+    expect(serialized).not.toBeNull();
+
+    // The stored row's metadata JSON carries the envelope under the
+    // `providerMeta` key; the canonical reader must resolve it.
+    const rowMetadata = JSON.stringify({
+      userMessageChannel: "telegram",
+      providerMeta: serialized,
+    });
+    const read = readProviderMetadata(rowMetadata);
+    expect(read).toEqual(telegramInbound);
+  });
+
+  test("a Slack turn never gains a providerMeta key", () => {
+    expect(
+      buildProviderMetaForPersistence({
+        channelInbound: { ...telegramInbound, source: "slack" },
+        turnChannel: "slack",
+      }),
+    ).toBeNull();
+  });
+
+  test("a turn channel that does not match the envelope's source is refused", () => {
+    expect(
+      buildProviderMetaForPersistence({
+        channelInbound: telegramInbound,
+        turnChannel: "discord",
+      }),
+    ).toBeNull();
+    expect(
+      buildProviderMetaForPersistence({
+        channelInbound: telegramInbound,
+        turnChannel: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  test("an absent envelope persists nothing", () => {
+    expect(
+      buildProviderMetaForPersistence({
+        channelInbound: undefined,
+        turnChannel: "telegram",
+      }),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -557,9 +557,15 @@ export function buildSlackMetaForPersistence(params: {
  * {@link buildSlackMetaForPersistence}. Returns `null` (do not include the
  * key) when the turn channel does not match the envelope's own `source`, so
  * a stale plumbing field can never tag a row with another channel's
- * identity. Slack turns also return `null`: Slack keeps writing `slackMeta`,
+ * identity. Slack turns also return `null`: Slack still writes `slackMeta`,
  * which `readProviderMetadata` maps onto the neutral shape on read, and a
  * `providerMeta` key on a Slack row would shadow that richer envelope.
+ *
+ * TRANSITIONAL: the Slack exclusion exists only while Slack writes its own
+ * envelope. The end state is Slack writing `providerMeta` like every other
+ * channel (its extra fields ride the schema's passthrough), at which point
+ * this guard reduces to the source match and `slackMeta` remains only as
+ * the read-compat arm for historical rows. Do not extend the exclusion.
  */
 export function buildProviderMetaForPersistence(params: {
   channelInbound: ProviderMessageMetadata | undefined;

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -28,6 +28,10 @@ import {
 } from "../channels/types.js";
 import { parseImageDimensions } from "../context/image-dimensions.js";
 import {
+  type ProviderMessageMetadata,
+  providerMessageMetadataSchema,
+} from "../messaging/provider-message-metadata.js";
+import {
   buildSlackTimezoneMetadata,
   type SlackMessageMetadata,
   writeSlackMetadata,
@@ -547,6 +551,38 @@ export function buildSlackMetaForPersistence(params: {
   return writeSlackMetadata(slackMeta);
 }
 
+/**
+ * Build the neutral channel envelope persisted under the `providerMeta` key
+ * on a user message's `metadata` JSON, the non-Slack counterpart of
+ * {@link buildSlackMetaForPersistence}. Returns `null` (do not include the
+ * key) when the turn channel does not match the envelope's own `source`, so
+ * a stale plumbing field can never tag a row with another channel's
+ * identity. Slack turns also return `null`: Slack keeps writing `slackMeta`,
+ * which `readProviderMetadata` maps onto the neutral shape on read, and a
+ * `providerMeta` key on a Slack row would shadow that richer envelope.
+ */
+export function buildProviderMetaForPersistence(params: {
+  channelInbound: ProviderMessageMetadata | undefined;
+  turnChannel: string | undefined;
+}): string | null {
+  const inbound = params.channelInbound;
+  if (!inbound) {
+    return null;
+  }
+  if (
+    params.turnChannel === undefined ||
+    params.turnChannel === "slack" ||
+    params.turnChannel !== inbound.source
+  ) {
+    return null;
+  }
+  const parsed = providerMessageMetadataSchema.safeParse(inbound);
+  if (!parsed.success) {
+    return null;
+  }
+  return JSON.stringify(parsed.data);
+}
+
 // ── EnqueueMessageOptions ────────────────────────────────────────────
 
 /** Options for `enqueueMessage`. Only `content` is required; everything
@@ -887,16 +923,22 @@ export async function persistQueuedMessageBody(
     // never reported.
     const {
       slackInbound: rawSlackInbound,
+      channelInbound: rawChannelInbound,
       scripted: rawScriptedFromMetadata,
       clientOsFromRequest: _rawClientOsFromRequest,
       ...metadataWithoutSlackInbound
     } = (metadata ?? {}) as Record<string, unknown> & {
       slackInbound?: SlackInboundMessageMetadata;
+      channelInbound?: ProviderMessageMetadata;
       scripted?: unknown;
       clientOsFromRequest?: unknown;
     };
     const slackMeta = buildSlackMetaForPersistence({
       slackInbound: rawSlackInbound,
+      turnChannel: turnCtx?.userMessageChannel,
+    });
+    const providerMeta = buildProviderMetaForPersistence({
+      channelInbound: rawChannelInbound,
       turnChannel: turnCtx?.userMessageChannel,
     });
 
@@ -978,6 +1020,7 @@ export async function persistQueuedMessageBody(
       ...(clientOsFromRequest ? { clientOsFromRequest: true } : {}),
       ...(imageSourcePaths ? { imageSourcePaths } : {}),
       ...(slackMeta ? { slackMeta } : {}),
+      ...(providerMeta ? { providerMeta } : {}),
       // Scripted-turn marker, forwarded by `turn-events-store` onto
       // `TurnTelemetryEvent.scripted`. Written LAST so it cannot be
       // half-overwritten by the raw metadata spread above.

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -562,10 +562,7 @@ export function buildSlackMetaForPersistence(params: {
  * `providerMeta` key on a Slack row would shadow that richer envelope.
  *
  * TRANSITIONAL: the Slack exclusion exists only while Slack writes its own
- * envelope. The end state is Slack writing `providerMeta` like every other
- * channel (its extra fields ride the schema's passthrough), at which point
- * this guard reduces to the source match and `slackMeta` remains only as
- * the read-compat arm for historical rows. Do not extend the exclusion.
+ * envelope; do not extend it.
  */
 export function buildProviderMetaForPersistence(params: {
   channelInbound: ProviderMessageMetadata | undefined;

--- a/assistant/src/daemon/conversation-messaging.ts
+++ b/assistant/src/daemon/conversation-messaging.ts
@@ -569,11 +569,7 @@ export function buildProviderMetaForPersistence(params: {
   if (!inbound) {
     return null;
   }
-  if (
-    params.turnChannel === undefined ||
-    params.turnChannel === "slack" ||
-    params.turnChannel !== inbound.source
-  ) {
+  if (params.turnChannel !== inbound.source || inbound.source === "slack") {
     return null;
   }
   const parsed = providerMessageMetadataSchema.safeParse(inbound);

--- a/assistant/src/daemon/handlers/shared.ts
+++ b/assistant/src/daemon/handlers/shared.ts
@@ -15,6 +15,7 @@ import { ConfirmationDecisionSchema } from "../../api/responses/conversation-mes
 import { getConfig } from "../../config/loader.js";
 import type { LLMCallSite, Speed } from "../../config/schemas/llm.js";
 import { ipcCall as gatewayIpcCall } from "../../ipc/gateway-client.js";
+import type { ProviderMessageMetadata } from "../../messaging/provider-message-metadata.js";
 import type { SecretPromptResult } from "../../permissions/secret-prompt-types.js";
 import type { ConversationCreateType } from "../../persistence/conversation-types.js";
 import { resolveMediaSourceData } from "../../providers/media-resolve.js";
@@ -223,6 +224,14 @@ export interface ConversationCreateOptions {
    * chronological renderer to consume.
    */
   slackInbound?: SlackInboundMessageMetadata;
+  /**
+   * Neutral per-row channel envelope captured at the channel ingress
+   * boundary, the non-Slack counterpart of `slackInbound`. When present (and
+   * the turn channel matches its `source`), persistence writes it as the
+   * message's `providerMeta` metadata key so the stored row can say which
+   * external message it is, in which thread, from whom.
+   */
+  channelInbound?: ProviderMessageMetadata;
   /**
    * Conversation type for newly created conversations. When omitted,
    * defaults to `"standard"` (visible in the sidebar). Set to

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -149,6 +149,43 @@ export function deriveIngressIdempotencyKey(options?: {
   return undefined;
 }
 
+/**
+ * The transient carrier bag `persistUserMessage` strips back out of the
+ * metadata: the channel ingress envelopes threaded through options.
+ * Undefined when the turn carries neither, so non-channel turns persist no
+ * extra keys.
+ */
+function buildIngressCarrierMetadata(
+  options?: ProcessMessageOptions,
+): Record<string, unknown> | undefined {
+  if (!options?.slackInbound && !options?.channelInbound) {
+    return undefined;
+  }
+  return {
+    ...(options.slackInbound ? { slackInbound: options.slackInbound } : {}),
+    ...(options.channelInbound
+      ? { channelInbound: options.channelInbound }
+      : {}),
+  };
+}
+
+/**
+ * Layer the turn's persisted channel envelopes onto a metadata object:
+ * `slackMeta` for Slack turns, `providerMeta` for every other channel.
+ * At most one is non-null per turn.
+ */
+function withChannelEnvelopes(
+  base: Record<string, unknown>,
+  slackMeta: string | null,
+  providerMeta: string | null,
+): Record<string, unknown> {
+  return {
+    ...base,
+    ...(slackMeta ? { slackMeta } : {}),
+    ...(providerMeta ? { providerMeta } : {}),
+  };
+}
+
 function buildEventEmitter(
   observer?: (msg: AssistantEvent) => void,
 ): (msg: AssistantEvent) => void {
@@ -433,13 +470,14 @@ export async function processMessage(
   });
   const slashResult = await resolveSlash(content, slashContext);
 
+  const turnChannel = conversation.getTurnChannelContext()?.userMessageChannel;
   const slackMeta = buildSlackMetaForPersistence({
     slackInbound: options?.slackInbound,
-    turnChannel: conversation.getTurnChannelContext()?.userMessageChannel,
+    turnChannel,
   });
   const providerMeta = buildProviderMetaForPersistence({
     channelInbound: options?.channelInbound,
-    turnChannel: conversation.getTurnChannelContext()?.userMessageChannel,
+    turnChannel,
   });
 
   if (slashResult.kind === "unknown") {
@@ -474,11 +512,11 @@ export async function processMessage(
         : {}),
       ...(Object.keys(imageSourcePaths).length > 0 ? { imageSourcePaths } : {}),
     };
-    const userMetaWithSlack = {
-      ...serverChannelMeta,
-      ...(slackMeta ? { slackMeta } : {}),
-      ...(providerMeta ? { providerMeta } : {}),
-    };
+    const userMetaWithSlack = withChannelEnvelopes(
+      serverChannelMeta,
+      slackMeta,
+      providerMeta,
+    );
     const cleanMsg = await createUserMessage(content, attachments);
     const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
     const persisted = await addMessage(
@@ -573,11 +611,11 @@ export async function processMessage(
           }
         : {}),
     };
-    const compactUserMeta = {
-      ...compactChannelMeta,
-      ...(slackMeta ? { slackMeta } : {}),
-      ...(providerMeta ? { providerMeta } : {}),
-    };
+    const compactUserMeta = withChannelEnvelopes(
+      compactChannelMeta,
+      slackMeta,
+      providerMeta,
+    );
     const cleanMsg = await createUserMessage(content, attachments);
     const persisted = await addMessage(
       conversationId,
@@ -633,11 +671,11 @@ export async function processMessage(
           }
         : {}),
     };
-    const cleanUserMeta = {
-      ...cleanChannelMeta,
-      ...(slackMeta ? { slackMeta } : {}),
-      ...(providerMeta ? { providerMeta } : {}),
-    };
+    const cleanUserMeta = withChannelEnvelopes(
+      cleanChannelMeta,
+      slackMeta,
+      providerMeta,
+    );
     const cleanMsg = await createUserMessage(content, attachments);
     const persisted = await addMessage(
       conversationId,
@@ -671,17 +709,7 @@ export async function processMessage(
   const resolvedContent = slashResult.content;
 
   const requestId = uuidv7();
-  const persistMetadata =
-    options?.slackInbound || options?.channelInbound
-      ? {
-          ...(options.slackInbound
-            ? { slackInbound: options.slackInbound }
-            : {}),
-          ...(options.channelInbound
-            ? { channelInbound: options.channelInbound }
-            : {}),
-        }
-      : undefined;
+  const persistMetadata = buildIngressCarrierMetadata(options);
   const ingressKey = deriveIngressIdempotencyKey(options);
   const { id: messageId, deduplicated } = await conversation.persistUserMessage(
     {
@@ -762,17 +790,7 @@ export async function processMessageInBackground(
   const emitEvent = buildEventEmitter(options?.onEvent);
 
   const requestId = uuidv7();
-  const persistMetadata =
-    options?.slackInbound || options?.channelInbound
-      ? {
-          ...(options.slackInbound
-            ? { slackInbound: options.slackInbound }
-            : {}),
-          ...(options.channelInbound
-            ? { channelInbound: options.channelInbound }
-            : {}),
-        }
-      : undefined;
+  const persistMetadata = buildIngressCarrierMetadata(options);
   const ingressKey = deriveIngressIdempotencyKey(options);
   const { id: messageId, deduplicated } = await conversation.persistUserMessage(
     {

--- a/assistant/src/daemon/process-message.ts
+++ b/assistant/src/daemon/process-message.ts
@@ -38,6 +38,7 @@ import {
 import { getLogger } from "../util/logger.js";
 import type { Conversation } from "./conversation.js";
 import {
+  buildProviderMetaForPersistence,
   buildSlackMetaForPersistence,
   CONVERSATION_BUSY_MESSAGE,
   serializePersistedUserMessageContent,
@@ -436,6 +437,10 @@ export async function processMessage(
     slackInbound: options?.slackInbound,
     turnChannel: conversation.getTurnChannelContext()?.userMessageChannel,
   });
+  const providerMeta = buildProviderMetaForPersistence({
+    channelInbound: options?.channelInbound,
+    turnChannel: conversation.getTurnChannelContext()?.userMessageChannel,
+  });
 
   if (slashResult.kind === "unknown") {
     const serverTurnCtx = conversation.getTurnChannelContext();
@@ -469,9 +474,11 @@ export async function processMessage(
         : {}),
       ...(Object.keys(imageSourcePaths).length > 0 ? { imageSourcePaths } : {}),
     };
-    const userMetaWithSlack = slackMeta
-      ? { ...serverChannelMeta, slackMeta }
-      : serverChannelMeta;
+    const userMetaWithSlack = {
+      ...serverChannelMeta,
+      ...(slackMeta ? { slackMeta } : {}),
+      ...(providerMeta ? { providerMeta } : {}),
+    };
     const cleanMsg = await createUserMessage(content, attachments);
     const llmMsg = enrichMessageWithSourcePaths(cleanMsg, attachments);
     const persisted = await addMessage(
@@ -566,9 +573,11 @@ export async function processMessage(
           }
         : {}),
     };
-    const compactUserMeta = slackMeta
-      ? { ...compactChannelMeta, slackMeta }
-      : compactChannelMeta;
+    const compactUserMeta = {
+      ...compactChannelMeta,
+      ...(slackMeta ? { slackMeta } : {}),
+      ...(providerMeta ? { providerMeta } : {}),
+    };
     const cleanMsg = await createUserMessage(content, attachments);
     const persisted = await addMessage(
       conversationId,
@@ -624,9 +633,11 @@ export async function processMessage(
           }
         : {}),
     };
-    const cleanUserMeta = slackMeta
-      ? { ...cleanChannelMeta, slackMeta }
-      : cleanChannelMeta;
+    const cleanUserMeta = {
+      ...cleanChannelMeta,
+      ...(slackMeta ? { slackMeta } : {}),
+      ...(providerMeta ? { providerMeta } : {}),
+    };
     const cleanMsg = await createUserMessage(content, attachments);
     const persisted = await addMessage(
       conversationId,
@@ -660,9 +671,17 @@ export async function processMessage(
   const resolvedContent = slashResult.content;
 
   const requestId = uuidv7();
-  const persistMetadata = options?.slackInbound
-    ? { slackInbound: options.slackInbound }
-    : undefined;
+  const persistMetadata =
+    options?.slackInbound || options?.channelInbound
+      ? {
+          ...(options.slackInbound
+            ? { slackInbound: options.slackInbound }
+            : {}),
+          ...(options.channelInbound
+            ? { channelInbound: options.channelInbound }
+            : {}),
+        }
+      : undefined;
   const ingressKey = deriveIngressIdempotencyKey(options);
   const { id: messageId, deduplicated } = await conversation.persistUserMessage(
     {
@@ -743,9 +762,17 @@ export async function processMessageInBackground(
   const emitEvent = buildEventEmitter(options?.onEvent);
 
   const requestId = uuidv7();
-  const persistMetadata = options?.slackInbound
-    ? { slackInbound: options.slackInbound }
-    : undefined;
+  const persistMetadata =
+    options?.slackInbound || options?.channelInbound
+      ? {
+          ...(options.slackInbound
+            ? { slackInbound: options.slackInbound }
+            : {}),
+          ...(options.channelInbound
+            ? { channelInbound: options.channelInbound }
+            : {}),
+        }
+      : undefined;
   const ingressKey = deriveIngressIdempotencyKey(options);
   const { id: messageId, deduplicated } = await conversation.persistUserMessage(
     {

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -354,15 +354,23 @@ export function findConversationByProviderMessageId(
           like(messages.metadata, '%"slackMeta"%'),
         ),
         // Rows the inbound-event index resolves are not candidates: this
-        // lookup exists for messages with no inbound event (the assistant's
-        // own posts, plus a crash-window inbound row whose link never
-        // landed), and admitting linked rows would burn the scan budget on
-        // messages `findMessageBySourceId` already answers.
+        // lookup exists for messages `findMessageBySourceId` cannot answer
+        // (the assistant's own posts, a crash-window inbound row whose link
+        // never landed, and legacy linked rows whose event carries no
+        // source_message_id to match on), and admitting resolvable rows
+        // would burn the scan budget on messages the primary path already
+        // answers. The source-id predicate mirrors findMessageBySourceId's
+        // own match column.
         notExists(
           db
             .select({ id: channelInboundEvents.id })
             .from(channelInboundEvents)
-            .where(eq(channelInboundEvents.messageId, messages.id)),
+            .where(
+              and(
+                eq(channelInboundEvents.messageId, messages.id),
+                isNotNull(channelInboundEvents.sourceMessageId),
+              ),
+            ),
         ),
       ),
     )

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -9,6 +9,7 @@ import { and, desc, eq, isNotNull, like, ne, or, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { ChannelId } from "../channels/types.js";
+import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
 import { readProviderMetadata } from "../messaging/read-provider-metadata.js";
 import type { SlackInboundMessageMetadata } from "../runtime/http-types.js";
 import { parseJsonSafe } from "../util/json.js";
@@ -55,8 +56,15 @@ const SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN = 500;
  * Bounded on purpose: the scan runs on the inbound path while the gateway
  * waits for its ack, and reactions land on recent messages, so a cap costs
  * almost no recall and keeps the cost flat as the database grows.
+ *
+ * Sized for the candidate density the `providerMeta`/`slackMeta` prefilter
+ * admits: inbound user rows carry `providerMeta` too, so in a busy room
+ * roughly half the candidates are inbound rows the primary
+ * `findMessageBySourceId` path already resolves. The cap is doubled from the
+ * 400 that sufficed when only assistant-authored and reaction rows matched,
+ * keeping the same reachable window of assistant posts.
  */
-const OUTBOUND_MESSAGE_ID_MAX_SCAN = 400;
+const OUTBOUND_MESSAGE_ID_MAX_SCAN = 800;
 
 /**
  * Channels where an inbound thread id scopes the conversation: a Slack thread
@@ -650,6 +658,21 @@ export function storeInboundSlackMetadata(
   slackInbound: SlackInboundMessageMetadata,
 ): void {
   mergeRawPayload(eventId, { slackInbound });
+}
+
+/**
+ * Persist the neutral channel inbound envelope captured at ingress onto the
+ * stored payload, the non-Slack counterpart of
+ * {@link storeInboundSlackMetadata}: the retry sweep replays the turn with
+ * the SAME `channelInbound` the live path used, so the replayed row carries
+ * an identical `providerMeta` envelope. No-ops when the payload was cleared
+ * (e.g. a secret-bearing ingress), so cleared secrets are never resurrected.
+ */
+export function storeInboundChannelMetadata(
+  eventId: string,
+  channelInbound: ProviderMessageMetadata,
+): void {
+  mergeRawPayload(eventId, { channelInbound });
 }
 
 /**

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -5,7 +5,17 @@
  * finding messages by source identifiers, and managing raw payload storage.
  */
 
-import { and, desc, eq, isNotNull, like, ne, or, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  isNotNull,
+  like,
+  ne,
+  notExists,
+  or,
+  sql,
+} from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 
 import type { ChannelId } from "../channels/types.js";
@@ -57,14 +67,12 @@ const SLACK_LEGACY_THREAD_EVIDENCE_MAX_SCAN = 500;
  * waits for its ack, and reactions land on recent messages, so a cap costs
  * almost no recall and keeps the cost flat as the database grows.
  *
- * Sized for the candidate density the `providerMeta`/`slackMeta` prefilter
- * admits: inbound user rows carry `providerMeta` too, so in a busy room
- * roughly half the candidates are inbound rows the primary
- * `findMessageBySourceId` path already resolves. The cap is doubled from the
- * 400 that sufficed when only assistant-authored and reaction rows matched,
- * keeping the same reachable window of assistant posts.
+ * The candidate set is provenance-bearing rows with no inbound-event link
+ * (the NOT EXISTS in the query): inbound user rows carry `providerMeta` too,
+ * but the inbound-event index already resolves them, so admitting them here
+ * would only shrink the window of assistant posts the cap can reach.
  */
-const OUTBOUND_MESSAGE_ID_MAX_SCAN = 800;
+const OUTBOUND_MESSAGE_ID_MAX_SCAN = 400;
 
 /**
  * Channels where an inbound thread id scopes the conversation: a Slack thread
@@ -344,6 +352,17 @@ export function findConversationByProviderMessageId(
         or(
           like(messages.metadata, '%"providerMeta"%'),
           like(messages.metadata, '%"slackMeta"%'),
+        ),
+        // Rows the inbound-event index resolves are not candidates: this
+        // lookup exists for messages with no inbound event (the assistant's
+        // own posts, plus a crash-window inbound row whose link never
+        // landed), and admitting linked rows would burn the scan budget on
+        // messages `findMessageBySourceId` already answers.
+        notExists(
+          db
+            .select({ id: channelInboundEvents.id })
+            .from(channelInboundEvents)
+            .where(eq(channelInboundEvents.messageId, messages.id)),
         ),
       ),
     )

--- a/assistant/src/persistence/migrations/374-channel-inbound-message-id-index.ts
+++ b/assistant/src/persistence/migrations/374-channel-inbound-message-id-index.ts
@@ -1,0 +1,26 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const INDEX = "idx_channel_inbound_events_message_id";
+
+/**
+ * Index the inbound-event to message link.
+ *
+ * Three queries filter on `message_id`: the sibling lookups on the
+ * redelivery path (`getSiblingStreamedReplyTs`,
+ * `isDeduplicatedDeliveryOwnedBySibling`) and the NOT EXISTS prefilter in
+ * `findConversationByProviderMessageId` that skips rows the inbound-event
+ * index already resolves. Without this index each is a full table scan.
+ *
+ * Partial, on linked rows only: unlinked events (crash-window orphans,
+ * reactions before linking) contribute nothing to it.
+ *
+ * Idempotent via IF NOT EXISTS.
+ */
+export function migrateChannelInboundMessageIdIndex(database: DrizzleDb): void {
+  getSqliteFrom(database).exec(
+    `CREATE INDEX IF NOT EXISTS ${INDEX}
+       ON channel_inbound_events (message_id)
+       WHERE message_id IS NOT NULL`,
+  );
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -481,6 +481,7 @@ import { migrateAcpSessionHistoryAuthErrorCode } from "./migrations/370-acp-sess
 import { migrateAcpSessionHistoryAuthErrorCredential } from "./migrations/371-acp-session-history-auth-error-credential.js";
 import { migrateCreateAcpRefusedCredentials } from "./migrations/372-create-acp-refused-credentials.js";
 import { migrateAcpAuthMarkerIndex } from "./migrations/373-acp-auth-marker-index.js";
+import { migrateChannelInboundMessageIdIndex } from "./migrations/374-channel-inbound-message-id-index.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1596,4 +1597,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateAcpSessionHistoryAuthErrorCredential,
   migrateCreateAcpRefusedCredentials,
   migrateAcpAuthMarkerIndex,
+  migrateChannelInboundMessageIdIndex,
 ];

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -494,6 +494,16 @@ export async function sweepFailedEvents(
         sourceMetadata,
         externalMessageId,
       });
+    // Empty strings fall through to the username, mirroring the live
+    // `actorDisplayName ?? actorUsername` derivation (`"" ?? x` would not).
+    const storedSenderName =
+      typeof payload.senderName === "string" && payload.senderName
+        ? payload.senderName
+        : undefined;
+    const storedSenderUsername =
+      typeof payload.senderUsername === "string" && payload.senderUsername
+        ? payload.senderUsername
+        : undefined;
     const replayChannelInbound =
       parseStoredChannelInbound(payload.channelInbound) ??
       buildReplayChannelInbound({
@@ -501,13 +511,7 @@ export async function sweepFailedEvents(
         externalChatId,
         sourceMetadata,
         externalMessageId,
-        senderDisplayName:
-          (typeof payload.senderName === "string" && payload.senderName
-            ? payload.senderName
-            : undefined) ??
-          (typeof payload.senderUsername === "string" && payload.senderUsername
-            ? payload.senderUsername
-            : undefined),
+        senderDisplayName: storedSenderName ?? storedSenderUsername,
         actorExternalId: trustContext.requesterExternalUserId,
       });
     // The captured `slackInbound` carries the sender's Slack `app_context`, so

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -220,17 +220,21 @@ function parseStoredChannelInbound(
 /**
  * Fallback when the payload carries no captured `channelInbound`, the
  * non-Slack counterpart of {@link buildReplaySlackInbound}: reconstruct the
- * turn-shaping identity fields from what the payload has always carried
- * (`messageId` mirrors the live `sourceMessageId ?? externalMessageId`
- * derivation). Actor fields (`displayName`, `actorExternalId`) stay absent:
- * no envelope reader keys on them, matching the Slack fallback's
- * partial-slackMeta stance.
+ * envelope from what the payload has always carried, so a crash between
+ * `storePayload` and `storeInboundChannelMetadata` recovers the same row a
+ * live turn would have persisted. `messageId` mirrors the live
+ * `sourceMessageId ?? externalMessageId` derivation; `displayName` mirrors
+ * the live `actorDisplayName ?? actorUsername` (stored as the payload's
+ * `senderName` / `senderUsername`); `actorExternalId` comes from the same
+ * trust context the live envelope read.
  */
 function buildReplayChannelInbound(params: {
   sourceChannel: ChannelId;
   externalChatId: string | undefined;
   sourceMetadata: import("@vellumai/gateway-client").SourceMetadata | undefined;
   externalMessageId: string | undefined;
+  senderDisplayName: string | undefined;
+  actorExternalId: string | undefined;
 }): ProviderMessageMetadata | undefined {
   if (params.sourceChannel === "slack" || !params.externalChatId) {
     return undefined;
@@ -253,6 +257,12 @@ function buildReplayChannelInbound(params: {
     messageId,
     eventKind: "message",
     ...(threadId ? { threadId } : {}),
+    ...(params.senderDisplayName
+      ? { displayName: params.senderDisplayName }
+      : {}),
+    ...(params.actorExternalId
+      ? { actorExternalId: params.actorExternalId }
+      : {}),
   };
 }
 
@@ -491,6 +501,14 @@ export async function sweepFailedEvents(
         externalChatId,
         sourceMetadata,
         externalMessageId,
+        senderDisplayName:
+          (typeof payload.senderName === "string" && payload.senderName
+            ? payload.senderName
+            : undefined) ??
+          (typeof payload.senderUsername === "string" && payload.senderUsername
+            ? payload.senderUsername
+            : undefined),
+        actorExternalId: trustContext.requesterExternalUserId,
       });
     // The captured `slackInbound` carries the sender's Slack `app_context`, so
     // the replayed turn is prepared with the same context block the live turn

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -15,6 +15,10 @@ import { findConversation } from "../daemon/conversation-registry.js";
 import { getDiskPressureStatus } from "../daemon/disk-pressure-guard.js";
 import { classifyDiskPressureTurnPolicy } from "../daemon/disk-pressure-policy.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import {
+  type ProviderMessageMetadata,
+  providerMessageMetadataSchema,
+} from "../messaging/provider-message-metadata.js";
 import { updateDeliveredSegmentCount } from "../persistence/delivery-channels.js";
 import {
   clearPayload,
@@ -197,6 +201,58 @@ function buildReplaySlackInbound(params: {
     ...(Array.isArray(appContext?.entities) && appContext.entities.length > 0
       ? { appContext }
       : {}),
+  };
+}
+
+/**
+ * Read the neutral `channelInbound` envelope the live path captured onto the
+ * payload (via `storeInboundChannelMetadata`), the non-Slack counterpart of
+ * {@link parseStoredSlackInbound}: the EXACT envelope the live turn used, so
+ * the replayed row carries an identical `providerMeta`.
+ */
+function parseStoredChannelInbound(
+  value: unknown,
+): ProviderMessageMetadata | undefined {
+  const parsed = providerMessageMetadataSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+/**
+ * Fallback when the payload carries no captured `channelInbound`, the
+ * non-Slack counterpart of {@link buildReplaySlackInbound}: reconstruct the
+ * turn-shaping identity fields from what the payload has always carried
+ * (`messageId` mirrors the live `sourceMessageId ?? externalMessageId`
+ * derivation). Actor fields (`displayName`, `actorExternalId`) stay absent:
+ * no envelope reader keys on them, matching the Slack fallback's
+ * partial-slackMeta stance.
+ */
+function buildReplayChannelInbound(params: {
+  sourceChannel: ChannelId;
+  externalChatId: string | undefined;
+  sourceMetadata: import("@vellumai/gateway-client").SourceMetadata | undefined;
+  externalMessageId: string | undefined;
+}): ProviderMessageMetadata | undefined {
+  if (params.sourceChannel === "slack" || !params.externalChatId) {
+    return undefined;
+  }
+  const messageId =
+    (typeof params.sourceMetadata?.messageId === "string"
+      ? params.sourceMetadata.messageId
+      : undefined) ?? params.externalMessageId;
+  if (!messageId) {
+    return undefined;
+  }
+  const threadId =
+    typeof params.sourceMetadata?.threadId === "string" &&
+    params.sourceMetadata.threadId.trim().length > 0
+      ? params.sourceMetadata.threadId.trim()
+      : undefined;
+  return {
+    source: params.sourceChannel,
+    conversationExternalId: params.externalChatId,
+    messageId,
+    eventKind: "message",
+    ...(threadId ? { threadId } : {}),
   };
 }
 
@@ -428,6 +484,14 @@ export async function sweepFailedEvents(
         sourceMetadata,
         externalMessageId,
       });
+    const replayChannelInbound =
+      parseStoredChannelInbound(payload.channelInbound) ??
+      buildReplayChannelInbound({
+        sourceChannel,
+        externalChatId,
+        sourceMetadata,
+        externalMessageId,
+      });
     // The captured `slackInbound` carries the sender's Slack `app_context`, so
     // the replayed turn is prepared with the same context block the live turn
     // rendered. Payloads predating the capture simply have none.
@@ -462,6 +526,10 @@ export async function sweepFailedEvents(
       ...(prepared.displayContent !== undefined
         ? { displayContent: prepared.displayContent }
         : {}),
+      // Not idempotency-bearing (the derived key reads only `slackInbound`),
+      // so it is shared with the incomplete-turn re-run below: the completing
+      // row should carry the same `providerMeta` a live turn would.
+      ...(replayChannelInbound ? { channelInbound: replayChannelInbound } : {}),
     };
 
     let userMessageId: string | undefined;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -46,6 +46,7 @@ import { classifyDiskPressureTurnPolicy } from "../../daemon/disk-pressure-polic
 import { processMessage } from "../../daemon/process-message.js";
 import type { TrustContext } from "../../daemon/trust-context-types.js";
 import { HeartbeatService } from "../../heartbeat/heartbeat-service.js";
+import type { ProviderMessageMetadata } from "../../messaging/provider-message-metadata.js";
 import type { Message as ProviderMessage } from "../../messaging/provider-types.js";
 import { editChannelMessage } from "../../messaging/providers/index.js";
 import {
@@ -1417,6 +1418,30 @@ export async function handleChannelInbound({
             }
           : undefined;
 
+      // Neutral per-row envelope for every non-Slack channel, mirroring the
+      // Slack capture above field for field: it is persisted as the row's
+      // `providerMeta` so the row can say which external message it is, in
+      // which thread, from whom. Slack keeps its own `slackMeta` envelope
+      // (mapped to the neutral shape on read), so nothing is stored twice.
+      const inboundActorDisplayName =
+        body.actorDisplayName ?? body.actorUsername;
+      const channelInbound: ProviderMessageMetadata | undefined =
+        sourceChannel !== "slack"
+          ? {
+              source: sourceChannel,
+              conversationExternalId,
+              messageId: sourceMessageId ?? externalMessageId,
+              eventKind: "message",
+              ...(channelThreadId ? { threadId: channelThreadId } : {}),
+              ...(inboundActorDisplayName
+                ? { displayName: inboundActorDisplayName }
+                : {}),
+              ...(trustCtx.requesterExternalUserId
+                ? { actorExternalId: trustCtx.requesterExternalUserId }
+                : {}),
+            }
+          : undefined;
+
       // Account identifier threaded into backfill so `resolveConnection()`
       // can pick the right workspace in multi-account setups. Best-effort:
       // the gateway forwards `sourceMetadata.account` when it knows which
@@ -1524,6 +1549,7 @@ export async function handleChannelInbound({
         clientTimezone: inboundClientTimezone,
         slackBotMentioned,
         slackInbound,
+        channelInbound,
       });
     }
   }

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../contacts/guardian-delivery-reader.js";
 import { isConversationBusyError } from "../../../daemon/conversation-messaging.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
+import type { ProviderMessageMetadata } from "../../../messaging/provider-message-metadata.js";
 import {
   channelActivityRefreshMs,
   setChannelActivity,
@@ -27,6 +28,7 @@ import {
 import {
   getSiblingStreamedReplyTs,
   linkMessage,
+  storeInboundChannelMetadata,
   storeInboundSlackMetadata,
   storeReplyMessageId,
   storeStreamedReplyTs,
@@ -110,6 +112,12 @@ export interface BackgroundProcessingParams {
    * `slackMeta` envelope for the chronological renderer.
    */
   slackInbound?: SlackInboundMessageMetadata;
+  /**
+   * Neutral per-row channel envelope for non-Slack channels, the counterpart
+   * of `slackInbound`: threaded through to `persistUserMessage` so the row
+   * is tagged with `providerMeta` and can say which external message it is.
+   */
+  channelInbound?: ProviderMessageMetadata;
 }
 
 /**
@@ -141,15 +149,21 @@ export function processChannelMessageInBackground(
     clientTimezone,
     slackBotMentioned,
     slackInbound,
+    channelInbound,
   } = params;
 
-  // Capture the Slack ingress metadata onto the stored payload up front — before
-  // the admission wait or any processing — so if the daemon dies mid-wait or
-  // mid-turn, the retry sweep replays with the SAME `slackInbound` this turn
-  // used. That keeps the derived idempotency key identical (the replay dedups
-  // against a turn this attempt already persisted) and carries full slackMeta.
+  // Capture the channel ingress metadata onto the stored payload up front,
+  // before the admission wait or any processing, so if the daemon dies
+  // mid-wait or mid-turn, the retry sweep replays with the SAME envelope this
+  // turn used. For Slack that keeps the derived idempotency key identical
+  // (the replay dedups against a turn this attempt already persisted) and
+  // carries full slackMeta; for every other channel it carries the same
+  // `providerMeta` onto the replayed row.
   if (slackInbound) {
     storeInboundSlackMetadata(eventId, slackInbound);
+  }
+  if (channelInbound) {
+    storeInboundChannelMetadata(eventId, channelInbound);
   }
 
   // Defer the whole turn + delivery until the conversation's processing lock is
@@ -252,6 +266,7 @@ export function processChannelMessageInBackground(
           ...(displayContent !== undefined ? { displayContent } : {}),
           ...(cmdIntent ? { commandIntent: cmdIntent } : {}),
           ...(slackInbound ? { slackInbound } : {}),
+          ...(channelInbound ? { channelInbound } : {}),
           onEvent: observeAgentEvent,
           sourceChannel,
           sourceInterface,


### PR DESCRIPTION
Related to LUM-3496

## TL;DR

Plain inbound Telegram/Discord message rows persist the neutral per-row channel envelope (`providerMeta`) that reactions, edits, deletes, and outbound assistant replies already write. This is step 1 of making channel provenance channel-generic: a stored row can now say which external message it is, in which thread, from whom, on any channel — which is what the wire projection and the web's channel-reference surface (follow-up PRs) will read.

## Why

The per-row provenance machinery was built Slack-first: Slack rows carry `slackMeta`, and the neutral `providerMeta` seam that was designed to generalize it (see the docstring in `messaging/read-provider-metadata.ts`: "the conversation route … then work[s] for a channel nobody here has heard of") was only ever written by reaction/edit/delete/outbound paths — never by ordinary inbound messages. So a Telegram or Discord conversation's rows were unattributable, and everything downstream (transcript reaction quoting, the future neutral wire projection, channel references) had nothing to read.

Design per the Channel Capability Map's North Star tests: the fact goes on the row once, in the vocabulary no channel owns; plugin channels validate (`"plugin"` is in `CHANNEL_IDS`); Slack keeps `slackMeta` for now (mapped on read, so nothing is stored twice and a `providerMeta` key can never shadow the richer Slack envelope) — a transitional state; see step 4 of the sequence.

## What changes for the user

| Before | After |
| --- | --- |
| A reaction to a Telegram/Discord message renders for the assistant as "Someone reacted with :x: to an earlier message" | It renders with the quoted target text, like Slack reactions already do |
| Telegram/Discord rows carry no external message identity | Rows self-describe (channel, chat id, message id, thread, sender), enabling the neutral wire projection and channel references for these channels in the follow-up PRs |
| A reaction on an assistant post resolves via a scan whose budget inbound rows would now dilute | The scan is scoped to rows without an inbound-event link (its actual purpose), keeping the 400 cap's original semantics; migration 374 indexes `channel_inbound_events.message_id`, which the scan and the existing redelivery sibling lookups all filter on |

## Why it's safe

- **Reader audit first.** Every consumer of `readProviderMetadata` / the raw schema was enumerated before changing the writers. Result: one desired flip (reaction-target text index now covers inbound rows, quote is fenced via `wrapUntrustedContent`), one reader whose candidate set changed (`findConversationByProviderMessageId`, root-fixed here by scoping its scan to unlinked rows plus an index migration), and no other reader changes behavior — the reaction/turn-count/wire-serializer readers all key on `eventKind === "reaction"`, which a message envelope fails; the Slack thread-evidence reader is hard-gated to Slack.
- **Slack is untouched.** `buildProviderMetaForPersistence` refuses Slack turns and any turn whose channel doesn't match the envelope's `source`, so a stale plumbing field can never tag a row with another channel's identity.
- **Faithful replay preserved.** The envelope is captured onto the stored inbound payload before admission (`storeInboundChannelMetadata`, mirroring `storeInboundSlackMetadata`), and the retry sweep replays the byte-identical envelope, with a reconstruction fallback from `sourceMetadata` for payloads predating the capture — same two-source pattern as the Slack replay. The envelope is not idempotency-bearing (`deriveIngressIdempotencyKey` reads only `slackInbound`), so it is also carried on the incomplete-turn re-run.
- Typecheck clean; new unit tests pin the builder guards and the stored-format round-trip through `readProviderMetadata`; new sweep tests pin captured-verbatim, reconstructed-fallback, and Slack-carries-nothing; adjacent suites (background-dispatch, reaction-intercept, channel-delivery-store, secret-ingress, disk-pressure, persist-callsite) all pass.

## Sequence

1. **This PR**: inbound rows write the neutral envelope (no user-visible wire change beyond the reaction quote). Includes migration 374 (index on `channel_inbound_events.message_id`; idempotent, append-only).
2. **Next**: project the envelope onto the client wire (`ConversationMessage`) and converge the web channel-sidecar/reference surface onto one neutral reader — Telegram/Discord conversations gain drawer lanes and channel references.
3. **Then**: converge the remaining `slackMessage` consumers (transcript sender attribution, links, reaction lines) onto the neutral envelope and delete `slackMessage` plus the per-channel reader registry.
4. **End state**: Slack writes `providerMeta` like every other channel (its extra fields ride the schema's passthrough, per the schema's own docstring), `slackMeta` remains only as the read-compat arm for historical rows, and the Slack-exclusion guards in this PR (marked TRANSITIONAL in code) are deleted. Until then the dual write is a sequencing state, not the design.

## Deferred

- Historical rows predating this PR never gain envelopes (no backfill migration; consumers already render only what is present).
- Idempotency keys for non-Slack channel turns (`deriveIngressIdempotencyKey` still derives only from `slackInbound`) — separate claim, unchanged here.
- Ordinary inbound rows don't carry a chat display name in the envelope; the conversation binding provides it to clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
