### PR TITLE
fix(cli): detect ngrok processes on Windows

### DIFF
--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -49,6 +49,7 @@ import {
   executableName,
   isProcessAlive,
   pathListDelimiter,
+  readProcessCommandLine,
   resolveProcessState,
   stopProcess,
   stopProcessByPidFile,
@@ -1965,13 +1966,8 @@ export async function startGateway(
 /** Check whether a PID belongs to an ngrok process via its command line. */
 function isNgrokProcess(pid: number): boolean {
   try {
-    const output = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
-      encoding: "utf-8",
-      timeout: 3000,
-      stdio: ["ignore", "pipe", "ignore"],
-      windowsHide: true,
-    }).trim();
-    return /ngrok/.test(output);
+    const output = readProcessCommandLine(pid);
+    return /ngrok/i.test(output);
   } catch {
     return false;
   }

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -76,13 +76,22 @@ export function windowsCommandLineLookupArgs(pid: number): string[] {
   ];
 }
 
-function readWindowsCommandLine(pid: number): string {
-  return execFileSync("powershell.exe", windowsCommandLineLookupArgs(pid), {
+/** Read a process command line using the platform's process inspection tool. */
+export function readProcessCommandLine(
+  pid: number,
+  hostPlatform: NodeJS.Platform = platform(),
+): string {
+  const command = hostPlatform === "win32" ? "powershell.exe" : "ps";
+  const args =
+    hostPlatform === "win32"
+      ? windowsCommandLineLookupArgs(pid)
+      : ["-p", String(pid), "-o", "command="];
+  return execFileSync(command, args, {
     windowsHide: true,
     encoding: "utf8",
     timeout: 3000,
     stdio: ["ignore", "pipe", "ignore"],
-  });
+  }).trim();
 }
 
 export function isVellumWindowsProcess(
@@ -111,12 +120,7 @@ export function isVellumWindowsProcess(
  */
 export function readPosixCommandLine(pid: number): string | null {
   try {
-    return execFileSync("ps", ["-p", String(pid), "-o", "command="], {
-      encoding: "utf-8",
-      timeout: 3000,
-      stdio: ["ignore", "pipe", "ignore"],
-      windowsHide: true,
-    }).trim();
+    return readProcessCommandLine(pid, platform());
   } catch {
     return null;
   }
@@ -130,16 +134,11 @@ export function isVellumProcess(
     if (hostPlatform === "win32") {
       const imageName = readWindowsProcesses(pid)[0]?.imageName ?? "";
       const commandLine = /^(?:bun|qdrant)\.exe$/i.test(imageName)
-        ? readWindowsCommandLine(pid)
+        ? readProcessCommandLine(pid, hostPlatform)
         : "";
       return isVellumWindowsProcess(imageName, commandLine);
     }
-    const output = execFileSync("ps", ["-p", String(pid), "-o", "command="], {
-      encoding: "utf-8",
-      timeout: 3000,
-      stdio: ["ignore", "pipe", "ignore"],
-      windowsHide: true,
-    }).trim();
+    const output = readProcessCommandLine(pid, hostPlatform);
     return isVellumCommandLine(output);
   } catch {
     return false;

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -489,7 +489,7 @@ export async function stopOrphanedDaemonProcesses(
               (/^vellum-daemon\.exe$/i.test(imageName) ||
                 (/^bun\.exe$/i.test(imageName) &&
                   /vellum-daemon|[\\/]assistant[\\/]src[\\/](?:index|daemon[\\/]main)\.ts/i.test(
-                    readWindowsCommandLine(pid),
+                    readProcessCommandLine(pid, hostPlatform),
                   ))),
           )
           .map(({ pid }) =>


### PR DESCRIPTION
## Summary

- reuse the shared platform-aware process command-line lookup for ngrok PID verification
- use the existing Windows CIM lookup so ngrok processes can be safely stopped on win32
- keep POSIX ps behavior and fail-closed ownership checks intact

## Original prompt

Fix B15c in the Windows client lifecycle path, where isNgrokProcess only invoked ps and therefore never recognized ngrok PIDs on win32. Reuse the existing CIM-based Windows process lookup while preserving PID-reuse safety.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41816" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->