### PR TITLE
fix(assistant): Qdrant sidecar provisioning on Windows arm64

### DIFF
--- a/assistant/src/__tests__/qdrant-manager.test.ts
+++ b/assistant/src/__tests__/qdrant-manager.test.ts
@@ -109,6 +109,12 @@ describe("QdrantManager", () => {
     });
   });
 
+  test("falls back to the x64 zip release on Windows arm64", () => {
+    expect(resolveQdrantReleaseAsset("win32", "arm64")).toEqual(
+      resolveQdrantReleaseAsset("win32", "x64"),
+    );
+  });
+
   // ── getUrl ───────────────────────────────────────────────────
 
   describe("getUrl", () => {

--- a/assistant/src/persistence/embeddings/qdrant-manager.ts
+++ b/assistant/src/persistence/embeddings/qdrant-manager.ts
@@ -51,7 +51,9 @@ export function resolveQdrantReleaseAsset(
     target = "x86_64-unknown-linux-musl";
   } else if (os === "linux" && cpu === "arm64") {
     target = "aarch64-unknown-linux-musl";
-  } else if (os === "win32" && cpu === "x64") {
+  } else if (os === "win32" && (cpu === "x64" || cpu === "arm64")) {
+    // Qdrant ships no arm64 Windows build; Windows 11 on ARM runs the x64
+    // binary via transparent emulation.
     return {
       binaryName: "qdrant.exe",
       filename: "qdrant-x86_64-pc-windows-msvc.zip",


### PR DESCRIPTION
## Summary
- `resolveQdrantReleaseAsset` accepts `win32`/`arm64` and returns the same pinned x86_64 zip asset as `win32`/`x64` (identical filename and sha256), instead of throwing "Unsupported platform".
- Rationale: Qdrant publishes no aarch64-pc-windows-msvc release asset (checked pinned v1.13.2 and latest v1.19.0), and every Windows arm64 target runs Windows 11, which transparently emulates x64 binaries.
- Adds one behavioral test: `win32`/`arm64` resolves identically to `win32`/`x64`.

## Original prompt
The release pipeline builds and publishes Windows ARM64 installers, but `resolveQdrantReleaseAsset` in `assistant/src/persistence/embeddings/qdrant-manager.ts` only handled `win32`/`x64`, so an ARM64 install that needs local Qdrant throws at startup unless `QDRANT_URL` is set. The fix requested: on `win32`/`arm64`, return the same x64 zip asset (Windows 11 on ARM emulates x64), with a short comment and a single behavioral test case, keeping the diff minimal and touching no release workflows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41817" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->