### PR TITLE
test(web): the transcript's reaction lines get Storybook coverage

### DIFF
--- a/clients/web/src/domains/chat/transcript/transcript-column.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-column.tsx
@@ -12,8 +12,8 @@
  *
  * `contain: content` is layout *and paint* containment, so anything a row
  * hangs past its own edge is hard-clipped rather than overflowing visibly:
- * a reaction chip's corner overhang and the subagent row's Details label have
- * both had to reserve their space inside the row instead. Keep it here, and
+ * the subagent row's Details label has had to reserve its space inside the
+ * row instead of overhanging the row edge. Keep it here, and
  * keep stories mounting in this: a card whose chrome escapes the column is
  * meant to look broken, in Storybook exactly as it does in the app.
  */

--- a/clients/web/src/domains/chat/transcript/transcript-reactions.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-reactions.stories.tsx
@@ -1,0 +1,235 @@
+import type { ReactNode } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import { textBody } from "@/domains/chat/utils/message-test-helpers";
+
+import { Transcript } from "./transcript";
+import type { TranscriptItem } from "./types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+//
+// A reaction row arrives from the wire as a message whose stored body is the
+// "[reaction]" sentinel plus a `reaction` fact; the transcript renders the
+// fact and never the sentinel. Inbound reactions (a person reacting on the
+// channel) persist as `user` rows carrying `actorDisplayName`; the
+// assistant's own persist as `assistant` rows with `selfAuthored`. Slack
+// reaction rows additionally carry their `slackMessage` envelope with
+// `eventKind: "reaction"`, and Slack-aware rendering prefers that richer
+// line. `textBody` is the canonical single-text-block builder the ingest
+// boundary produces.
+// ---------------------------------------------------------------------------
+
+function message(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+): TranscriptItem {
+  const msg: DisplayMessage = { id, role, ...textBody(text) };
+  return { kind: "message", key: id, message: msg };
+}
+
+function reactionRow(
+  id: string,
+  role: "user" | "assistant",
+  reaction: NonNullable<DisplayMessage["reaction"]>,
+): TranscriptItem {
+  const msg: DisplayMessage = {
+    id,
+    role,
+    ...textBody("[reaction]"),
+    reaction,
+  };
+  return { kind: "message", key: id, message: msg };
+}
+
+const REACTION_LINES: TranscriptItem[] = [
+  message("m1", "user", "Shipped the release notes, take a look when you can."),
+  message(
+    "m2",
+    "assistant",
+    "Read through them. The migration section is clear, and the rollback note covers the flag flip.",
+  ),
+  reactionRow("r1", "user", {
+    emoji: "heart",
+    op: "added",
+    targetMessageId: "m2",
+    actorDisplayName: "Alice",
+  }),
+  reactionRow("r2", "assistant", {
+    emoji: "🎉",
+    op: "added",
+    targetMessageId: "m1",
+    selfAuthored: true,
+  }),
+  reactionRow("r3", "user", {
+    emoji: "+1",
+    op: "added",
+    targetMessageId: "m2",
+  }),
+  reactionRow("r4", "user", {
+    emoji: "heart",
+    op: "removed",
+    targetMessageId: "m2",
+    actorDisplayName: "Alice",
+  }),
+];
+
+// Every emoji form a channel can deliver: a unicode emoji renders as itself,
+// a shortcode resolves through the emoji catalog (":shortcode:" while it
+// lazy-loads), and a Discord custom-emoji mention renders as its bare
+// ":name:" without consulting the catalog, even when the name collides with
+// a catalog shortcode, so a guild emoji never swaps into an unrelated
+// standard emoji.
+const EMOJI_RESOLUTION: TranscriptItem[] = [
+  message("m1", "assistant", "Deployed. Watching the error rates now."),
+  reactionRow("e1", "user", {
+    emoji: "🎉",
+    op: "added",
+    targetMessageId: "m1",
+    actorDisplayName: "Unicode",
+  }),
+  reactionRow("e2", "user", {
+    emoji: "tada",
+    op: "added",
+    targetMessageId: "m1",
+    actorDisplayName: "Shortcode",
+  }),
+  reactionRow("e3", "user", {
+    emoji: "<:vex:12345>",
+    op: "added",
+    targetMessageId: "m1",
+    actorDisplayName: "Custom guild emoji",
+  }),
+  reactionRow("e4", "user", {
+    emoji: "<:heart:99>",
+    op: "added",
+    targetMessageId: "m1",
+    actorDisplayName: "Custom emoji named like a shortcode",
+  }),
+];
+
+function slackReactionRow(
+  id: string,
+  reaction: {
+    emoji: string;
+    op: "added" | "removed";
+    actorDisplayName?: string;
+    targetChannelTs: string;
+  },
+): TranscriptItem {
+  const msg: DisplayMessage = {
+    id,
+    role: "user",
+    ...textBody("[reaction]"),
+    reaction: {
+      emoji: reaction.emoji,
+      op: reaction.op,
+      targetMessageId: reaction.targetChannelTs,
+      actorDisplayName: reaction.actorDisplayName,
+    },
+    slackMessage: {
+      channelId: "C042MSGCHAN",
+      channelName: "release-crew",
+      channelTs: `${id}.000100`,
+      eventKind: "reaction",
+      reaction,
+    },
+  };
+  return { kind: "message", key: id, message: msg };
+}
+
+const SLACK_SHAPED: TranscriptItem[] = [
+  message("s1", "user", "Staging bake looks clean, cutting the release."),
+  message("s2", "assistant", "Tag is up and the production run is dispatched."),
+  slackReactionRow("sr1", {
+    emoji: "raised_hands",
+    op: "added",
+    actorDisplayName: "Ben",
+    targetChannelTs: "1725100000.000200",
+  }),
+  slackReactionRow("sr2", {
+    emoji: "raised_hands",
+    op: "removed",
+    actorDisplayName: "Ben",
+    targetChannelTs: "1725100000.000200",
+  }),
+];
+
+/** A sized chat surface; `Transcript` fills its `h-full` parent. */
+function Frame({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        height: 560,
+        width: 780,
+        overflow: "hidden",
+        borderRadius: 12,
+        border: "1px solid var(--border-base)",
+        background: "var(--surface-base)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Reaction rows in the main transcript, on every channel. A reaction row
+ * renders as a quiet italic line built from its projected fact, never the
+ * stored "[reaction]" sentinel: the assistant's own reactions read
+ * "Reacted with ...", another actor's lead with the actor's name (falling
+ * back to "Someone"), and a removal names the withdrawn emoji. Slack rows
+ * keep their richer Slack transcript line instead.
+ */
+const meta: Meta<typeof Transcript> = {
+  title: "Chat/TranscriptReactions",
+  component: Transcript,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  args: {
+    conversationId: "demo",
+    onSurfaceAction: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <Frame>
+        <Story />
+      </Frame>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof Transcript>;
+
+/**
+ * Both directions and both operations around an ordinary exchange: an
+ * inbound reaction with a named actor, the assistant's own (`selfAuthored`,
+ * no actor name), an inbound one with no actor (the "Someone" fallback,
+ * with its `+1` shortcode resolved through the catalog), and a removal.
+ */
+export const ReactionLines: Story = {
+  args: { items: REACTION_LINES },
+};
+
+/**
+ * The emoji-resolution matrix of `displayReactionEmoji`: unicode passes
+ * through, a shortcode resolves through the lazy-loaded catalog, and a
+ * Discord custom-emoji mention renders as its bare ":name:" even when the
+ * name collides with a catalog shortcode ("heart" here), keeping the guild
+ * emoji's identity instead of swapping in the standard emoji.
+ */
+export const EmojiResolution: Story = {
+  args: { items: EMOJI_RESOLUTION },
+};
+
+/**
+ * Slack reaction rows carry their `slackMessage` envelope
+ * (`eventKind: "reaction"`), so the transcript renders the richer Slack
+ * line (emoji, actor, verb) instead of the neutral italic reaction line.
+ */
+export const SlackShaped: Story = {
+  args: { items: SLACK_SHAPED },
+};

--- a/clients/web/src/domains/chat/transcript/transcript-reactions.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-reactions.stories.tsx
@@ -4,6 +4,7 @@ import type { DisplayMessage } from "@/domains/chat/types/types";
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 
 import { Transcript } from "./transcript";
+import { message } from "./transcript-story-fixtures";
 import { TranscriptStoryFrame } from "./transcript-story-frame";
 import type { TranscriptItem } from "./types";
 
@@ -20,15 +21,6 @@ import type { TranscriptItem } from "./types";
 // line. `textBody` is the canonical single-text-block builder the ingest
 // boundary produces.
 // ---------------------------------------------------------------------------
-
-function message(
-  id: string,
-  role: "user" | "assistant",
-  text: string,
-): TranscriptItem {
-  const msg: DisplayMessage = { id, role, ...textBody(text) };
-  return { kind: "message", key: id, message: msg };
-}
 
 function reactionRow(
   id: string,

--- a/clients/web/src/domains/chat/transcript/transcript-reactions.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-reactions.stories.tsx
@@ -1,11 +1,10 @@
-import type { ReactNode } from "react";
-
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 
 import { Transcript } from "./transcript";
+import { TranscriptStoryFrame } from "./transcript-story-frame";
 import type { TranscriptItem } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -78,10 +77,10 @@ const REACTION_LINES: TranscriptItem[] = [
 ];
 
 // Every emoji form a channel can deliver, one row each, distinguishable by
-// its rendered output alone: Alice's unicode emoji renders as itself, Ben's
+// its rendered output alone: Alice's unicode emoji renders as itself, Bob's
 // "heart" shortcode resolves through the emoji catalog to the heart emoji,
-// Chris's Discord custom-emoji mention renders as its bare ":vex:", and
-// Dana's custom emoji named "heart" stays ":heart:" right under Ben's
+// Carol's Discord custom-emoji mention renders as its bare ":vex:", and
+// Dave's custom emoji named "heart" stays ":heart:" right under Bob's
 // resolved heart, because a guild emoji keeps its identity and never swaps
 // into the catalog emoji its name collides with.
 const EMOJI_RESOLUTION: TranscriptItem[] = [
@@ -96,86 +95,83 @@ const EMOJI_RESOLUTION: TranscriptItem[] = [
     emoji: "heart",
     op: "added",
     targetMessageId: "m1",
-    actorDisplayName: "Ben",
+    actorDisplayName: "Bob",
   }),
   reactionRow("e3", "user", {
     emoji: "<:vex:12345>",
     op: "added",
     targetMessageId: "m1",
-    actorDisplayName: "Chris",
+    actorDisplayName: "Carol",
   }),
   reactionRow("e4", "user", {
     emoji: "<:heart:99>",
     op: "added",
     targetMessageId: "m1",
-    actorDisplayName: "Dana",
+    actorDisplayName: "Dave",
   }),
 ];
 
-function slackReactionRow(
-  id: string,
-  reaction: {
-    emoji: string;
-    op: "added" | "removed";
-    actorDisplayName?: string;
-    targetChannelTs: string;
-  },
-): TranscriptItem {
-  const msg: DisplayMessage = {
-    id,
-    role: "user",
-    ...textBody("[reaction]"),
-    reaction: {
-      emoji: reaction.emoji,
-      op: reaction.op,
-      targetMessageId: reaction.targetChannelTs,
-      actorDisplayName: reaction.actorDisplayName,
-    },
-    slackMessage: {
-      channelId: "C042MSGCHAN",
-      channelName: "release-crew",
-      channelTs: `${id}.000100`,
-      eventKind: "reaction",
-      reaction,
-    },
-  };
-  return { kind: "message", key: id, message: msg };
-}
-
+// A Slack reaction row as the wire delivers it: the neutral `reaction` fact
+// every channel projects, plus Slack's own `slackMessage` envelope with
+// `eventKind: "reaction"`, which Slack-aware rendering prefers.
 const SLACK_SHAPED: TranscriptItem[] = [
   message("s1", "user", "Staging bake looks clean, cutting the release."),
   message("s2", "assistant", "Tag is up and the production run is dispatched."),
-  slackReactionRow("sr1", {
-    emoji: "raised_hands",
-    op: "added",
-    actorDisplayName: "Ben",
-    targetChannelTs: "1725100000.000200",
-  }),
-  slackReactionRow("sr2", {
-    emoji: "raised_hands",
-    op: "removed",
-    actorDisplayName: "Ben",
-    targetChannelTs: "1725100000.000200",
-  }),
+  {
+    kind: "message",
+    key: "sr1",
+    message: {
+      id: "sr1",
+      role: "user",
+      ...textBody("[reaction]"),
+      reaction: {
+        emoji: "raised_hands",
+        op: "added",
+        targetMessageId: "1725100000.000200",
+        actorDisplayName: "Bob",
+      },
+      slackMessage: {
+        channelId: "C042MSGCHAN",
+        channelName: "release-crew",
+        channelTs: "1725100050.000300",
+        eventKind: "reaction",
+        reaction: {
+          emoji: "raised_hands",
+          op: "added",
+          actorDisplayName: "Bob",
+          targetChannelTs: "1725100000.000200",
+        },
+      },
+    },
+  },
+  {
+    kind: "message",
+    key: "sr2",
+    message: {
+      id: "sr2",
+      role: "user",
+      ...textBody("[reaction]"),
+      reaction: {
+        emoji: "raised_hands",
+        op: "removed",
+        targetMessageId: "1725100000.000200",
+        actorDisplayName: "Bob",
+      },
+      slackMessage: {
+        channelId: "C042MSGCHAN",
+        channelName: "release-crew",
+        channelTs: "1725100060.000400",
+        eventKind: "reaction",
+        reaction: {
+          emoji: "raised_hands",
+          op: "removed",
+          actorDisplayName: "Bob",
+          targetChannelTs: "1725100000.000200",
+        },
+      },
+    },
+  },
 ];
-
-/** A sized chat surface; `Transcript` fills its `h-full` parent. */
-function Frame({ children }: { children: ReactNode }) {
-  return (
-    <div
-      style={{
-        height: 560,
-        width: 780,
-        overflow: "hidden",
-        borderRadius: 12,
-        border: "1px solid var(--border-base)",
-        background: "var(--surface-base)",
-      }}
-    >
-      {children}
-    </div>
-  );
-}
 
 /**
  * Reaction rows in the main transcript, on every channel. A reaction row
@@ -196,9 +192,9 @@ const meta: Meta<typeof Transcript> = {
   },
   decorators: [
     (Story) => (
-      <Frame>
+      <TranscriptStoryFrame height={560}>
         <Story />
-      </Frame>
+      </TranscriptStoryFrame>
     ),
   ],
 };

--- a/clients/web/src/domains/chat/transcript/transcript-reactions.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-reactions.stories.tsx
@@ -77,37 +77,38 @@ const REACTION_LINES: TranscriptItem[] = [
   }),
 ];
 
-// Every emoji form a channel can deliver: a unicode emoji renders as itself,
-// a shortcode resolves through the emoji catalog (":shortcode:" while it
-// lazy-loads), and a Discord custom-emoji mention renders as its bare
-// ":name:" without consulting the catalog, even when the name collides with
-// a catalog shortcode, so a guild emoji never swaps into an unrelated
-// standard emoji.
+// Every emoji form a channel can deliver, one row each, distinguishable by
+// its rendered output alone: Alice's unicode emoji renders as itself, Ben's
+// "heart" shortcode resolves through the emoji catalog to the heart emoji,
+// Chris's Discord custom-emoji mention renders as its bare ":vex:", and
+// Dana's custom emoji named "heart" stays ":heart:" right under Ben's
+// resolved heart, because a guild emoji keeps its identity and never swaps
+// into the catalog emoji its name collides with.
 const EMOJI_RESOLUTION: TranscriptItem[] = [
   message("m1", "assistant", "Deployed. Watching the error rates now."),
   reactionRow("e1", "user", {
     emoji: "🎉",
     op: "added",
     targetMessageId: "m1",
-    actorDisplayName: "Unicode",
+    actorDisplayName: "Alice",
   }),
   reactionRow("e2", "user", {
-    emoji: "tada",
+    emoji: "heart",
     op: "added",
     targetMessageId: "m1",
-    actorDisplayName: "Shortcode",
+    actorDisplayName: "Ben",
   }),
   reactionRow("e3", "user", {
     emoji: "<:vex:12345>",
     op: "added",
     targetMessageId: "m1",
-    actorDisplayName: "Custom guild emoji",
+    actorDisplayName: "Chris",
   }),
   reactionRow("e4", "user", {
     emoji: "<:heart:99>",
     op: "added",
     targetMessageId: "m1",
-    actorDisplayName: "Custom emoji named like a shortcode",
+    actorDisplayName: "Dana",
   }),
 ];
 

--- a/clients/web/src/domains/chat/transcript/transcript-story-fixtures.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-story-fixtures.ts
@@ -1,0 +1,20 @@
+import type { DisplayMessage } from "@/domains/chat/types/types";
+import { textBody } from "@/domains/chat/utils/message-test-helpers";
+
+import type { MessageItem } from "./types";
+
+/**
+ * Build a text-row `MessageItem` for a transcript story: a `DisplayMessage`
+ * whose body is the single-text-block shape the ingest boundary materializes
+ * (`textBody` keeps `textSegments`, `contentOrder`, and `contentBlocks` in
+ * lockstep). Shared by every transcript story file so fixture rows cannot
+ * drift from the production shape.
+ */
+export function message(
+  id: string,
+  role: "user" | "assistant",
+  text: string,
+): MessageItem {
+  const msg: DisplayMessage = { id, role, ...textBody(text) };
+  return { kind: "message", key: id, message: msg };
+}

--- a/clients/web/src/domains/chat/transcript/transcript-story-frame.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-story-frame.tsx
@@ -1,0 +1,30 @@
+import type { CSSProperties, ReactNode } from "react";
+
+/**
+ * A sized chat surface for transcript stories. `Transcript` fills its
+ * `h-full` parent, so the frame gives it the bounded box the app's chat
+ * layout would. Shared by every story file that mounts a transcript, so the
+ * framing stays one treatment.
+ */
+export function TranscriptStoryFrame({
+  height = 720,
+  children,
+}: {
+  height?: CSSProperties["height"];
+  children: ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        height,
+        width: 780,
+        overflow: "hidden",
+        borderRadius: 12,
+        border: "1px solid var(--border-base)",
+        background: "var(--surface-base)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/transcript/transcript.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.stories.tsx
@@ -1,10 +1,4 @@
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
@@ -17,6 +11,7 @@ import {
   type TranscriptHandle,
   type TranscriptProps,
 } from "./transcript";
+import { TranscriptStoryFrame } from "./transcript-story-frame";
 import type { MessageItem, TranscriptItem } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -90,24 +85,6 @@ const renderAvatar = () => (
   />
 );
 
-/** A sized chat surface; `Transcript` fills its `h-full` parent. */
-function Frame({ children }: { children: ReactNode }) {
-  return (
-    <div
-      style={{
-        height: 720,
-        width: 780,
-        overflow: "hidden",
-        borderRadius: 12,
-        border: "1px solid var(--border-base)",
-        background: "var(--surface-base)",
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
 /** Renders the transcript scrolled to the latest message on mount — the resting
  *  state production lands in when a conversation opens. Isolated from the parent
  *  scroll coordinator, the bare component would otherwise open at the top. */
@@ -142,9 +119,9 @@ const meta: Meta<typeof Transcript> = {
   },
   decorators: [
     (Story) => (
-      <Frame>
+      <TranscriptStoryFrame>
         <Story />
-      </Frame>
+      </TranscriptStoryFrame>
     ),
   ],
 };

--- a/clients/web/src/domains/chat/transcript/transcript.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.stories.tsx
@@ -4,41 +4,26 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { useTurnStore } from "@/domains/chat/turn-store";
-import type { DisplayMessage } from "@/domains/chat/types/types";
 
 import {
   Transcript,
   type TranscriptHandle,
   type TranscriptProps,
 } from "./transcript";
+import { message } from "./transcript-story-fixtures";
 import { TranscriptStoryFrame } from "./transcript-story-frame";
-import type { MessageItem, TranscriptItem } from "./types";
+import type { TranscriptItem } from "./types";
 
 // ---------------------------------------------------------------------------
 // Fixtures
 //
 // `Transcript` takes a flat `TranscriptItem[]`. A text row is a `MessageItem`
-// wrapping a `DisplayMessage` whose body is three positional arrays kept in
-// lockstep — `textSegments`, `contentOrder`, `contentBlocks` — exactly the
-// shape the ingest boundary materializes for a single text block (the canonical
-// builder is `textBody` in `utils/message-test-helpers.ts`). `message()` is the
-// thin local builder for that shape; `user`/`assistant` name the role.
+// wrapping a `DisplayMessage` whose body is the single-text-block shape the
+// ingest boundary materializes; `message()` in `transcript-story-fixtures.ts`
+// builds that row for every transcript story file, and `user`/`assistant`
+// name the role.
 // ---------------------------------------------------------------------------
 
-function message(
-  id: string,
-  role: "user" | "assistant",
-  text: string,
-): MessageItem {
-  const msg: DisplayMessage = {
-    id,
-    role,
-    textSegments: [text],
-    contentOrder: [{ type: "text", id: "0" }],
-    contentBlocks: [{ type: "text", text }],
-  };
-  return { kind: "message", key: id, message: msg };
-}
 const user = (id: string, text: string) => message(id, "user", text);
 const assistant = (id: string, text: string) => message(id, "assistant", text);
 


### PR DESCRIPTION
## TL;DR

Adds Storybook coverage for the main transcript's reaction rendering (`Chat/TranscriptReactions`). Until now the only reaction story coverage lived in the flag-gated channel-sidecar experiment; the always-on path every user sees, `ReactionLineRow` and the Slack-shaped `SlackReactionLine`, had none, even though that component just carried a real rendering bug (#41803, raw emoji names instead of resolved emoji).

## What the stories cover

Three stories render the real `Transcript` with wire-shaped reaction rows (stored `[reaction]` sentinel plus the projected `reaction` fact, matching what `map-runtime-message.ts` receives):

- **Reaction Lines**: both directions and both operations: an inbound reaction with a named actor, the assistant's own (`selfAuthored`), the no-actor "Someone" fallback, and a removal.
- **Emoji Resolution**: the `displayReactionEmoji` matrix from the #41803 fix: unicode passes through, a shortcode resolves through the lazy-loaded catalog, and a Discord custom-emoji mention keeps its `:name:` identity even when the name collides with a catalog shortcode.
- **Slack Shaped**: Slack rows carry their `slackMessage` envelope (`eventKind: "reaction"`) as explicit wire-shaped literals and dispatch to the richer Slack line, never the neutral italic line.

## Shared story infrastructure

Transcript story files now share single-author fixtures and framing instead of local copies:

- `transcript-story-fixtures.ts` owns `message()`, the text-row builder (built on the canonical `textBody`), consumed by both transcript story files.
- `transcript-story-frame.tsx` owns the sized chat surface both story files mount in.

Also fixed in passing: the `transcript-column.tsx` docstring cited a reaction chip that exists only on a closed, never-merged branch (#36837); it now cites only the shipped Details-label example.

## What changes for the user

| Before | After |
| --- | --- |
| The transcript's reaction lines could only be seen by producing real channel reactions against a running assistant | Every reaction rendering variant is visible and reviewable in Storybook |
| The emoji-catalog resolution fixed in #41803 had no visual fixture | The full resolution matrix is a story, so a regression is visible on sight |
| Slack's distinct reaction treatment was undocumented visually | The Slack dispatch rule has its own story |

## Why this is safe

The only production-code change is a docstring correction; everything else is story files and story-only helper modules. Verified rendered output of all three new stories plus the existing `Chat/Transcript` stories in a live Storybook after the refactor, and the adjacent `transcript-row.test.tsx` suite passes (13/13). Lint, prettier, and tsc are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
