### PR TITLE
feat(approvals): guardian source labels use the captured channel name

### DIFF
--- a/assistant/src/__tests__/access-request-seed-content-blocks.test.ts
+++ b/assistant/src/__tests__/access-request-seed-content-blocks.test.ts
@@ -90,7 +90,7 @@ describe("buildAccessRequestSeedContentBlocks", () => {
     });
     expect(data.metadata).toContainEqual({
       label: "Source",
-      value: "Slack — #C01ABC",
+      value: "Slack · #C01ABC",
     });
   });
 
@@ -101,7 +101,7 @@ describe("buildAccessRequestSeedContentBlocks", () => {
     });
     expect(surfaceOf(blocks).data.metadata).toContainEqual({
       label: "Source",
-      value: "Slack — Direct message",
+      value: "Slack · Direct message",
     });
   });
 

--- a/assistant/src/__tests__/latest-external-conversation-name.test.ts
+++ b/assistant/src/__tests__/latest-external-conversation-name.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { getLatestExternalConversationName } from "../persistence/delivery-crud.js";
+
+await initializeDb();
+
+function slackMetaFor(channelName?: string): Record<string, unknown> {
+  return {
+    slackMeta: JSON.stringify({
+      source: "slack",
+      channelId: "C0123CHANNEL",
+      channelTs: `170000000${Math.floor(Math.random() * 10)}.000100`,
+      eventKind: "message",
+      ...(channelName ? { channelName } : {}),
+    }),
+  };
+}
+
+describe("getLatestExternalConversationName", () => {
+  test("returns the newest row's captured channel name", async () => {
+    const conversation = await createConversation({ title: "t" });
+    await addMessage(conversation.id, "user", "hello", {
+      metadata: slackMetaFor("old-name"),
+    });
+    await addMessage(conversation.id, "user", "hello again", {
+      metadata: slackMetaFor("user-feedback"),
+    });
+
+    expect(getLatestExternalConversationName(conversation.id, "slack")).toBe(
+      "user-feedback",
+    );
+  });
+
+  test("skips rows without a name and other channels", async () => {
+    const conversation = await createConversation({ title: "t" });
+    await addMessage(conversation.id, "user", "unnamed", {
+      metadata: slackMetaFor(),
+    });
+
+    expect(
+      getLatestExternalConversationName(conversation.id, "slack"),
+    ).toBeNull();
+    expect(
+      getLatestExternalConversationName(conversation.id, "telegram"),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/__tests__/latest-external-conversation-name.test.ts
+++ b/assistant/src/__tests__/latest-external-conversation-name.test.ts
@@ -49,4 +49,22 @@ describe("getLatestExternalConversationName", () => {
       getLatestExternalConversationName(conversation.id, "telegram"),
     ).toBeNull();
   });
+
+  test("never lends a name from a different external chat", async () => {
+    const conversation = await createConversation({ title: "t" });
+    await addMessage(conversation.id, "user", "hello", {
+      metadata: slackMetaFor("user-feedback"),
+    });
+
+    expect(
+      getLatestExternalConversationName(
+        conversation.id,
+        "slack",
+        "C0123CHANNEL",
+      ),
+    ).toBe("user-feedback");
+    expect(
+      getLatestExternalConversationName(conversation.id, "slack", "C0OTHER"),
+    ).toBeNull();
+  });
 });

--- a/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
+++ b/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
@@ -236,6 +236,19 @@ describe("buildToolApprovalSeedContentBlocks", () => {
     });
   });
 
+  test("Slack channel source prefers the captured channel name", () => {
+    const payload = {
+      ...toolApprovalPayload,
+      sourceChatId: "C01ABC",
+      sourceChatName: "user-feedback",
+    };
+    const surface = surfaceBlock(buildToolApprovalSeedContentBlocks(payload)!);
+    expect(surface.data.metadata).toContainEqual({
+      label: "Source",
+      value: "Slack · #user-feedback",
+    });
+  });
+
   test("Slack source falls back to requesterChatId and omits the link without one", () => {
     const payload = {
       ...toolApprovalPayload,

--- a/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
+++ b/assistant/src/__tests__/tool-approval-seed-content-blocks.test.ts
@@ -214,7 +214,7 @@ describe("buildToolApprovalSeedContentBlocks", () => {
     );
     expect(surface.data.metadata).toContainEqual({
       label: "Source",
-      value: "Slack — Direct message",
+      value: "Slack · Direct message",
     });
   });
 
@@ -232,7 +232,7 @@ describe("buildToolApprovalSeedContentBlocks", () => {
     );
     expect(surface.data.metadata).toContainEqual({
       label: "Source",
-      value: "Slack — #C01ABC",
+      value: "Slack · #C01ABC",
     });
   });
 
@@ -258,7 +258,7 @@ describe("buildToolApprovalSeedContentBlocks", () => {
     expect(surface.data.body).not.toContain("[View message]");
     expect(surface.data.metadata).toContainEqual({
       label: "Source",
-      value: "Slack — Direct message",
+      value: "Slack · Direct message",
     });
   });
 

--- a/assistant/src/messaging/provider-message-metadata.ts
+++ b/assistant/src/messaging/provider-message-metadata.ts
@@ -55,6 +55,13 @@ export const providerMessageMetadataSchema = z
      */
     conversationExternalId: z.string(),
     /**
+     * Display name of the external chat, when the provider reported one at
+     * ingress (e.g. a Slack channel's name, without the `#`). Absent for
+     * DMs and for providers that never report one; never synthesized from
+     * `conversationExternalId`.
+     */
+    conversationName: z.string().optional(),
+    /**
      * Provider id of this row itself. Absent on a reaction, which no channel
      * gives an id of its own: a reaction event names the chat, the message it
      * was attached to, the actor and the emoji, and nothing identifies the

--- a/assistant/src/messaging/providers/slack/approval-source.ts
+++ b/assistant/src/messaging/providers/slack/approval-source.ts
@@ -15,7 +15,10 @@
  * directly.
  */
 
-import { getLatestInboundEventReference } from "../../../persistence/delivery-crud.js";
+import {
+  getLatestExternalConversationName,
+  getLatestInboundEventReference,
+} from "../../../persistence/delivery-crud.js";
 import { getBindingByConversation } from "../../../persistence/external-conversation-store.js";
 import type {
   ApprovalSourceHint,
@@ -26,16 +29,19 @@ import { isSlackTs } from "./message-metadata.js";
 
 function toReference(
   chatId: string,
+  chatName: string | null,
   messageTs: string | undefined,
   threadTs: string | undefined,
 ): ApprovalSourceReference {
+  const named = chatName ? { sourceChatName: chatName } : {};
   // Without a message ts, the thread root is still a valid anchor.
   const anchorTs = messageTs ?? threadTs;
   if (!anchorTs) {
-    return { sourceChatId: chatId };
+    return { sourceChatId: chatId, ...named };
   }
   return {
     sourceChatId: chatId,
+    ...named,
     sourceLink: {
       webUrl: buildSlackPermalink({
         channelId: chatId,
@@ -56,6 +62,7 @@ export function resolveSlackApprovalSource(
   if (hint?.requesterChatId && isSlackTs(hint.sourceMessageId)) {
     return toReference(
       hint.requesterChatId,
+      getLatestExternalConversationName(conversationId, "slack"),
       hint.sourceMessageId,
       isSlackTs(hint.sourceThreadId) ? hint.sourceThreadId : undefined,
     );
@@ -83,5 +90,10 @@ export function resolveSlackApprovalSource(
     ? binding.externalThreadId
     : undefined;
 
-  return toReference(chatId, messageTs, threadTs);
+  return toReference(
+    chatId,
+    getLatestExternalConversationName(conversationId, "slack"),
+    messageTs,
+    threadTs,
+  );
 }

--- a/assistant/src/messaging/providers/slack/approval-source.ts
+++ b/assistant/src/messaging/providers/slack/approval-source.ts
@@ -62,7 +62,11 @@ export function resolveSlackApprovalSource(
   if (hint?.requesterChatId && isSlackTs(hint.sourceMessageId)) {
     return toReference(
       hint.requesterChatId,
-      getLatestExternalConversationName(conversationId, "slack"),
+      getLatestExternalConversationName(
+        conversationId,
+        "slack",
+        hint.requesterChatId,
+      ),
       hint.sourceMessageId,
       isSlackTs(hint.sourceThreadId) ? hint.sourceThreadId : undefined,
     );
@@ -92,7 +96,7 @@ export function resolveSlackApprovalSource(
 
   return toReference(
     chatId,
-    getLatestExternalConversationName(conversationId, "slack"),
+    getLatestExternalConversationName(conversationId, "slack", chatId),
     messageTs,
     threadTs,
   );

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -315,6 +315,7 @@ export function slackMetadataAsProviderMetadata(
       : {}),
     ...(meta.threadTs ? { threadId: meta.threadTs } : {}),
     ...(meta.displayName ? { displayName: meta.displayName } : {}),
+    ...(meta.channelName ? { conversationName: meta.channelName } : {}),
     eventKind: meta.eventKind,
     ...(meta.reaction
       ? {

--- a/assistant/src/messaging/read-provider-metadata.test.ts
+++ b/assistant/src/messaging/read-provider-metadata.test.ts
@@ -53,6 +53,16 @@ describe("readProviderMetadata", () => {
     expect(meta?.displayName).toBe("Jason");
   });
 
+  it("maps slackMeta.channelName to the neutral conversationName", () => {
+    const metadata = JSON.stringify({
+      slackMeta: JSON.stringify(slackRow({ channelName: "user-feedback" })),
+    });
+
+    expect(readProviderMetadata(metadata)?.conversationName).toBe(
+      "user-feedback",
+    );
+  });
+
   it("maps a reaction's target onto the neutral name", () => {
     const metadata = JSON.stringify({
       slackMeta: JSON.stringify(

--- a/assistant/src/notifications/__tests__/guardian-feed-projection.test.ts
+++ b/assistant/src/notifications/__tests__/guardian-feed-projection.test.ts
@@ -115,7 +115,7 @@ describe("buildPendingGuardianProjection", () => {
       requesterLabel: "Alice",
       toolName: "linear_graphql",
       sourceChannel: "slack",
-      sourceContextLabel: "Slack #C0123456789",
+      sourceContextLabel: "#C0123456789",
     });
   });
 

--- a/assistant/src/notifications/__tests__/guardian-feed-projection.test.ts
+++ b/assistant/src/notifications/__tests__/guardian-feed-projection.test.ts
@@ -130,6 +130,14 @@ describe("buildPendingGuardianProjection", () => {
     expect(projection?.status).toBe("pending");
   });
 
+  test("a captured channel name becomes the source context label", () => {
+    const projection = buildPendingGuardianProjection({
+      ...toolApprovalPayload,
+      sourceChatName: "user-feedback",
+    });
+    expect(projection?.sourceContextLabel).toBe("#user-feedback");
+  });
+
   test("a sent Slack delivery yields the card deep link", () => {
     const projection = buildPendingGuardianProjection(toolApprovalPayload, {
       channel: "slack",

--- a/assistant/src/notifications/approval-card-data.ts
+++ b/assistant/src/notifications/approval-card-data.ts
@@ -151,7 +151,11 @@ function sourceMetadataRow(
   channel: string | undefined,
   slackChatId: string | undefined,
   isSlackDm: boolean,
+  chatName?: string,
 ): { label: string; value: string } | undefined {
+  if (channel === "slack" && !isSlackDm && chatName) {
+    return { label: "Source", value: `Slack · #${chatName}` };
+  }
   if (channel === "slack" && slackChatId) {
     return {
       label: "Source",
@@ -298,6 +302,7 @@ function extractToolApprovalCard(
     nonEmpty(p.sourceChannel),
     sourceView?.chatId,
     sourceView?.isSlackDm ?? false,
+    sourceView?.chatName,
   );
   if (sourceRow) {
     metadata.push(sourceRow);
@@ -364,6 +369,7 @@ function extractQuestionCard(
     nonEmpty(p.sourceChannel),
     sourceView?.chatId,
     sourceView?.isSlackDm ?? false,
+    sourceView?.chatName,
   );
   if (sourceRow) {
     metadata.push(sourceRow);

--- a/assistant/src/notifications/approval-card-data.ts
+++ b/assistant/src/notifications/approval-card-data.ts
@@ -31,6 +31,7 @@ import {
   buildGuardianRequestCodeInstruction,
   buildQuestionDeliveryText,
   buildToolApprovalSourceView,
+  describeSlackChatLabel,
   type GuardianQuestionPayload,
   type LenientToolApprovalPayload,
   LenientToolApprovalPayloadSchema,
@@ -153,14 +154,15 @@ function sourceMetadataRow(
   isSlackDm: boolean,
   chatName?: string,
 ): { label: string; value: string } | undefined {
-  if (channel === "slack" && !isSlackDm && chatName) {
-    return { label: "Source", value: `Slack · #${chatName}` };
-  }
-  if (channel === "slack" && slackChatId) {
-    return {
-      label: "Source",
-      value: isSlackDm ? "Slack — Direct message" : `Slack — #${slackChatId}`,
-    };
+  if (channel === "slack") {
+    const chat = describeSlackChatLabel({
+      chatId: slackChatId,
+      chatName,
+      isSlackDm,
+    });
+    if (chat) {
+      return { label: "Source", value: `Slack · ${chat}` };
+    }
   }
   if (channel) {
     return { label: "Source", value: channel };

--- a/assistant/src/notifications/guardian-feed-projection.ts
+++ b/assistant/src/notifications/guardian-feed-projection.ts
@@ -185,10 +185,17 @@ function intentFromInstructionMode(
 function describeApprovalSourceContext(view: {
   channel: string;
   chatId?: string | null;
+  chatName?: string | null;
   isSlackDm: boolean;
 }): string {
+  if (view.channel === "slack" && view.isSlackDm) {
+    return "Slack direct message";
+  }
+  if (view.channel === "slack" && view.chatName) {
+    return `#${view.chatName}`;
+  }
   if (view.channel === "slack" && view.chatId) {
-    return view.isSlackDm ? "Slack direct message" : `Slack #${view.chatId}`;
+    return `Slack #${view.chatId}`;
   }
   return view.channel;
 }

--- a/assistant/src/notifications/guardian-feed-projection.ts
+++ b/assistant/src/notifications/guardian-feed-projection.ts
@@ -177,10 +177,12 @@ function intentFromInstructionMode(
 }
 
 /**
- * Display label for the originating chat, mirroring the wording the
- * in-app approval card's source row uses (`sourceMetadataRow` in
- * `approval-card-data.ts`): Slack chats are named, other channels fall
- * back to the channel id.
+ * Display label for the originating chat. A named Slack channel renders
+ * as the bare `#name` (the bell's context line joins it with the tool,
+ * so the channel word would be noise); unnamed chats keep the id-based
+ * wording the in-app card's source row uses (`sourceMetadataRow` in
+ * `approval-card-data.ts`), and other channels fall back to the channel
+ * id.
  */
 function describeApprovalSourceContext(view: {
   channel: string;

--- a/assistant/src/notifications/guardian-feed-projection.ts
+++ b/assistant/src/notifications/guardian-feed-projection.ts
@@ -42,10 +42,12 @@ import {
 import { getLogger } from "../util/logger.js";
 import {
   buildToolApprovalSourceView,
+  describeSlackChatLabel,
   type GuardianQuestionRequestKind,
   LenientToolApprovalPayloadSchema,
   resolveGuardianInstructionModeFromFields,
   resolveGuardianQuestionInstructionMode,
+  type ToolApprovalSourceView,
 } from "./guardian-question-mode.js";
 import { readPayloadString } from "./notification-utils.js";
 import type { NotificationDeliveryResult } from "./types.js";
@@ -177,27 +179,14 @@ function intentFromInstructionMode(
 }
 
 /**
- * Display label for the originating chat. A named Slack channel renders
- * as the bare `#name` (the bell's context line joins it with the tool,
- * so the channel word would be noise); unnamed chats keep the id-based
- * wording the in-app card's source row uses (`sourceMetadataRow` in
- * `approval-card-data.ts`), and other channels fall back to the channel
- * id.
+ * Display label for the originating chat: the bare chat label from the
+ * shared derivation (the bell's context line joins it with the tool, so
+ * the channel word would be noise), or the channel id for channels the
+ * view carries no chat facts for.
  */
-function describeApprovalSourceContext(view: {
-  channel: string;
-  chatId?: string | null;
-  chatName?: string | null;
-  isSlackDm: boolean;
-}): string {
-  if (view.channel === "slack" && view.isSlackDm) {
-    return "Slack direct message";
-  }
-  if (view.channel === "slack" && view.chatName) {
-    return `#${view.chatName}`;
-  }
-  if (view.channel === "slack" && view.chatId) {
-    return `Slack #${view.chatId}`;
+function describeApprovalSourceContext(view: ToolApprovalSourceView): string {
+  if (view.channel === "slack") {
+    return describeSlackChatLabel(view) || view.channel;
   }
   return view.channel;
 }

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -99,6 +99,8 @@ export const PendingQuestionPayloadSchema =
 const sourceReferenceFields = {
   /** Channel-native chat/conversation id the request originated from. */
   sourceChatId: z.string().optional(),
+  /** Display name of the originating chat, when ingress captured one. */
+  sourceChatName: z.string().optional(),
   /** Deep link to the originating message/thread, when derivable. */
   sourceLink: externalSourceLinkSchema.optional(),
 };
@@ -162,6 +164,7 @@ export const LenientToolApprovalPayloadSchema = z.object({
   riskLevel: z.string().nullable().optional(),
   commandPreview: z.string().nullable().optional(),
   sourceChatId: z.string().nullable().optional(),
+  sourceChatName: z.string().nullable().optional(),
   sourceLink: sourceReferenceFields.sourceLink.nullable(),
 });
 
@@ -190,6 +193,8 @@ export const ToolApprovalSourceViewSchema = z.object({
   channel: z.string(),
   /** Channel-native chat id, when the payload carries one. */
   chatId: z.string().optional(),
+  /** Display name of the originating chat, when ingress captured one. */
+  chatName: z.string().optional(),
   /** Whether the source chat is a Slack direct message (`false` for other channels). */
   isSlackDm: z.boolean(),
   /** Link to the originating message/thread, when derivable. */
@@ -208,7 +213,11 @@ export type ToolApprovalSourceView = z.infer<
 export function buildToolApprovalSourceView(
   p: Pick<
     LenientToolApprovalPayload,
-    "sourceChannel" | "sourceChatId" | "sourceLink" | "requesterChatId"
+    | "sourceChannel"
+    | "sourceChatId"
+    | "sourceChatName"
+    | "sourceLink"
+    | "requesterChatId"
   >,
 ): ToolApprovalSourceView | undefined {
   const channel = nonEmpty(p.sourceChannel);
@@ -225,6 +234,7 @@ export function buildToolApprovalSourceView(
   return {
     channel,
     chatId,
+    chatName: nonEmpty(p.sourceChatName),
     isSlackDm:
       channel === "slack" && chatId != null && isSlackDmConversation(chatId),
     permalink,

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -210,6 +210,28 @@ export type ToolApprovalSourceView = z.infer<
  * facts. Returns `undefined` when the payload names no chat and carries no
  * link — renderers then fall back to the plain channel label.
  */
+/**
+ * Bare display label for the source chat, derived once for every
+ * renderer: `Direct message` for a DM, `#name` for a named channel,
+ * `#<id>` when only the id is known, empty when the view names no chat.
+ * Slack-scoped like the facts it reads; surfaces add their own framing
+ * (the card prefixes the channel word, the bell uses it bare).
+ */
+export function describeSlackChatLabel(
+  view: Pick<ToolApprovalSourceView, "chatId" | "chatName" | "isSlackDm">,
+): string {
+  if (view.isSlackDm) {
+    return "Direct message";
+  }
+  if (view.chatName) {
+    return `#${view.chatName}`;
+  }
+  if (view.chatId) {
+    return `#${view.chatId}`;
+  }
+  return "";
+}
+
 export function buildToolApprovalSourceView(
   p: Pick<
     LenientToolApprovalPayload,

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -544,6 +544,7 @@ const CONVERSATION_NAME_SCAN_WINDOW = 50;
 export function getLatestExternalConversationName(
   conversationId: string,
   sourceChannel: string,
+  externalChatId?: string,
 ): string | null {
   const db = getDb();
   const rows = db
@@ -561,6 +562,12 @@ export function getLatestExternalConversationName(
   for (const row of rows) {
     const meta = readProviderMetadata(row.metadata, { allowFlatLegacy: true });
     if (meta?.source !== sourceChannel) {
+      continue;
+    }
+    // A conversation's rows normally all belong to one external chat, but
+    // the name must never come from a different chat than the caller is
+    // labeling (e.g. rows written before a rebind).
+    if (externalChatId && meta.conversationExternalId !== externalChatId) {
       continue;
     }
     const name = meta.conversationName?.trim();

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -524,6 +524,50 @@ export interface LatestInboundEventReference {
 }
 
 /**
+ * Display name of the external chat a conversation's channel rows report,
+ * from the newest row that carries one. The name is frozen at ingress into
+ * each row's provider metadata, so this is a pure local read: no provider
+ * API call, and a rename converges on the next inbound message. Null when
+ * no row names the chat (DMs, providers without names, pre-capture rows).
+ *
+ * The `LIKE` is an indexable prefilter only (same contract as
+ * `selectProviderMetaCandidateMetadata`); every candidate is parsed and
+ * source-checked before its name is trusted.
+ */
+export function getLatestExternalConversationName(
+  conversationId: string,
+  sourceChannel: string,
+): string | null {
+  const db = getDb();
+  const rows = db
+    .select({ metadata: messages.metadata })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.conversationId, conversationId),
+        or(
+          like(messages.metadata, '%"conversationName"%'),
+          like(messages.metadata, '%"channelName"%'),
+        ),
+      ),
+    )
+    .orderBy(desc(sql`rowid`))
+    .limit(20)
+    .all();
+  for (const row of rows) {
+    const meta = readProviderMetadata(row.metadata, { allowFlatLegacy: true });
+    if (meta?.source !== sourceChannel) {
+      continue;
+    }
+    const name = meta.conversationName?.trim();
+    if (name) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/**
  * Find the most recent inbound event for a conversation on a channel.
  * Used to anchor guardian-facing approval cards to the channel message
  * that triggered the request.

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -530,13 +530,17 @@ export interface LatestInboundEventReference {
  * API call, and a rename converges on the next inbound message. Null when
  * no row names the chat (DMs, providers without names, pre-capture rows).
  *
- * The `LIKE` is an indexable prefilter only (same contract as
- * `selectProviderMetaCandidateMetadata`); every candidate is parsed and
- * source-checked before its name is trusted. The patterns are unquoted
- * on purpose: `slackMeta` is stored as a JSON string inside the outer
- * metadata, so its inner keys appear with escaped quotes on disk, which
- * a quoted pattern would never match.
+ * Reads a fixed window of the conversation's newest rows through the
+ * conversation index (backward index scan supplies the rowid order, the
+ * same trick `getLatestInboundEventReference` documents), then parses in
+ * code: no LIKE against the serialized metadata, whose nested escaping
+ * a substring pattern is easy to get wrong. Every channel inbound row
+ * carries the name, so a name deeper than the window only hides behind
+ * a tail of pure assistant/local traffic and reads as absent, which
+ * degrades to the raw-id label.
  */
+const CONVERSATION_NAME_SCAN_WINDOW = 50;
+
 export function getLatestExternalConversationName(
   conversationId: string,
   sourceChannel: string,
@@ -548,14 +552,11 @@ export function getLatestExternalConversationName(
     .where(
       and(
         eq(messages.conversationId, conversationId),
-        or(
-          like(messages.metadata, "%conversationName%"),
-          like(messages.metadata, "%channelName%"),
-        ),
+        isNotNull(messages.metadata),
       ),
     )
     .orderBy(desc(sql`rowid`))
-    .limit(20)
+    .limit(CONVERSATION_NAME_SCAN_WINDOW)
     .all();
   for (const row of rows) {
     const meta = readProviderMetadata(row.metadata, { allowFlatLegacy: true });

--- a/assistant/src/persistence/delivery-crud.ts
+++ b/assistant/src/persistence/delivery-crud.ts
@@ -532,7 +532,10 @@ export interface LatestInboundEventReference {
  *
  * The `LIKE` is an indexable prefilter only (same contract as
  * `selectProviderMetaCandidateMetadata`); every candidate is parsed and
- * source-checked before its name is trusted.
+ * source-checked before its name is trusted. The patterns are unquoted
+ * on purpose: `slackMeta` is stored as a JSON string inside the outer
+ * metadata, so its inner keys appear with escaped quotes on disk, which
+ * a quoted pattern would never match.
  */
 export function getLatestExternalConversationName(
   conversationId: string,
@@ -546,8 +549,8 @@ export function getLatestExternalConversationName(
       and(
         eq(messages.conversationId, conversationId),
         or(
-          like(messages.metadata, '%"conversationName"%'),
-          like(messages.metadata, '%"channelName"%'),
+          like(messages.metadata, "%conversationName%"),
+          like(messages.metadata, "%channelName%"),
         ),
       ),
     )

--- a/assistant/src/runtime/approval-source-link.ts
+++ b/assistant/src/runtime/approval-source-link.ts
@@ -45,6 +45,12 @@ const log = getLogger("approval-source-link");
 export interface ApprovalSourceReference {
   /** Channel-native chat/conversation id the request originated from. */
   sourceChatId: string;
+  /**
+   * Display name of the originating chat, when ingress captured one (a
+   * Slack channel's name, without the `#`). Renderers prefer it over the
+   * raw chat id and fall back when absent (DMs, pre-capture rows).
+   */
+  sourceChatName?: string;
   /** Deep link to the originating message/thread, when derivable. */
   sourceLink?: ExternalSourceLink;
 }


### PR DESCRIPTION
## TL;DR

Guardian source labels now show the real channel name instead of a raw Slack id, closing the last copy-contract gap from the guardian attention plan. The name is a pure local read: ingress already freezes `channelName` into each Slack row's metadata, so no provider API call is added anywhere.

## What the guardian experiences

| Surface | Before | After |
| --- | --- | --- |
| Bell item context line | `linear_graphql · Slack #C0123ABC` | `linear_graphql · #user-feedback` |
| In-app approval card, Source row | `Slack — #C0123ABC` | `Slack · #user-feedback` |
| In-app card for DMs or unnamed chats | `Slack — Direct message` / `Slack — #C0123ABC` | Same content, unified as `Slack · Direct message` / `Slack · #C0123ABC` |
| Slack-side card | Already shows the real name (mrkdwn channel reference) | Unchanged |

## Design

- `providerMeta` gains a neutral optional `conversationName` (per the metadata vocabulary's rule that channel-neutral keys belong there), mapped on read from `slackMeta.channelName`, which ingress has captured per row all along.
- `getLatestExternalConversationName` in `delivery-crud` returns the newest row's name for a conversation and channel: a bounded, indexed local query, so a channel rename converges on the next inbound message and offline emit paths never stall on an API call.
- The Slack approval-source resolver attaches `sourceChatName` to the source reference on both its paths (stamped provenance and row reconstruction); the reference flows through the existing payload fields, `buildToolApprovalSourceView` (`chatName`), the in-app card's Source row, and the bell item's `sourceContextLabel`.
- One derivation: `describeSlackChatLabel` in the view layer is the single place chat facts become a label; the card row and the bell context label consume it and keep only their own framing, so no renderer re-branches on channel facts.

## Why this is safe

- Additive optional fields end to end; absent names hit the untouched fallback branches, and the two seed-content tests pinning the fallback copy pass unchanged.
- No API calls, no caching, no new routes; one indexed read at emit time on the same tables the resolver already consults.
- New coverage: the neutral mapping, the delivery-crud reader (newest-first, channel-scoped, null without a name), the card's named Source row, and the bell label. `bunx tsc --noEmit` and lint clean; per standing instructions no tests were run locally (exact-HEAD CI is the authority).

## Deliberately unchanged

- Access-request cards keep their id-based source row: they predate the source-reference registry (documented legacy in the notifications AGENTS.md) and converging them is the registry's existing follow-up, not this change.
- Question and voice producers don't spread the source reference today; their cards keep current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
