### PR TITLE
fix(slack): extract markdown and attachment-nested blocks; dedupe bot lookups per batch

### DIFF
--- a/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/adapter-mention-rendering.test.ts
@@ -166,6 +166,29 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
       };
     }
 
+    if (parsed.searchParams.get("channel") === "C_FLAKY_BOT_HISTORY") {
+      return {
+        ok: true,
+        has_more: false,
+        messages: [
+          {
+            type: "message",
+            subtype: "bot_message",
+            ts: "1700000004.000100",
+            bot_id: "B_FLAKY",
+            text: "first alert",
+          },
+          {
+            type: "message",
+            subtype: "bot_message",
+            ts: "1700000004.000200",
+            bot_id: "B_FLAKY",
+            text: "second alert",
+          },
+        ],
+      };
+    }
+
     if (parsed.searchParams.get("channel") === "C_BOT_HISTORY") {
       return {
         ok: true,
@@ -282,6 +305,11 @@ function fakeSlackResponse(url: string): Record<string, unknown> {
     botsInfoCalls.push(botId);
     if (botId === "B_ASSISTANT") {
       return { ok: true, bot: { id: "B_ASSISTANT", name: "CI Notifier" } };
+    }
+    // An unmapped transient failure: thrown immediately (no in-transport
+    // retry, unlike rate limits) and evicted from the cross-batch cache.
+    if (botId === "B_FLAKY") {
+      return { ok: false, error: "fatal_error" };
     }
     return { ok: false, error: "bot_not_found" };
   }
@@ -480,6 +508,25 @@ describe("Slack adapter mention rendering", () => {
     expect(
       botsInfoCalls.filter((botId) => botId === "B_ASSISTANT"),
     ).toHaveLength(1);
+  });
+
+  test("a transient bots.info failure is attempted once per batch and falls back to the bot id", async () => {
+    const messages = await slackProvider.getHistory(
+      undefined,
+      "C_FLAKY_BOT_HISTORY",
+    );
+
+    expect(messages).toHaveLength(2);
+    expect(messages.map((message) => message.sender)).toEqual([
+      { id: "B_FLAKY", name: "B_FLAKY" },
+      { id: "B_FLAKY", name: "B_FLAKY" },
+    ]);
+    // The transient failure is evicted from the cross-batch cache (so a later
+    // page retries), but within one page the batch memo pins the first
+    // attempt: two rows from the same bot cost one bots.info call.
+    expect(botsInfoCalls.filter((botId) => botId === "B_FLAKY")).toHaveLength(
+      1,
+    );
   });
 
   test("getHistory caches Slack user info and maps timezone metadata", async () => {

--- a/assistant/src/messaging/providers/slack/__tests__/message-content.test.ts
+++ b/assistant/src/messaging/providers/slack/__tests__/message-content.test.ts
@@ -111,6 +111,35 @@ describe("slackMessageRawText", () => {
     );
   });
 
+  test("extracts markdown block text", () => {
+    expect(
+      slackMessageRawText({
+        text: "",
+        blocks: [
+          { type: "markdown", text: "**Deploy failed** on `main`" },
+          { type: "divider" },
+        ],
+      }),
+    ).toBe("**Deploy failed** on `main`");
+  });
+
+  test("extracts blocks nested inside an attachment", () => {
+    expect(
+      slackMessageRawText({
+        text: "",
+        attachments: [
+          {
+            fallback: "plain summary",
+            blocks: [
+              { type: "section", text: { type: "mrkdwn", text: "Run #7 red" } },
+              { type: "markdown", text: "3 tests failing" },
+            ],
+          },
+        ],
+      }),
+    ).toBe("Run #7 red\n3 tests failing");
+  });
+
   test("returns empty string when nothing carries text", () => {
     expect(
       slackMessageRawText({

--- a/assistant/src/messaging/providers/slack/adapter.ts
+++ b/assistant/src/messaging/providers/slack/adapter.ts
@@ -341,10 +341,41 @@ function slackUserInfoCacheKey(
 }
 
 /**
+ * Shared resolve-once discipline for the Slack directory name caches
+ * (channel and bot names): concurrent callers share the in-flight promise,
+ * successes and provably-permanent failures stay cached, and transient
+ * failures are evicted so a later batch retries.
+ */
+async function resolveCachedSlackName(
+  cache: Map<string, Promise<string | undefined>>,
+  cacheKey: string,
+  lookup: () => Promise<string | undefined>,
+  isPermanentFailure: (err: unknown) => boolean,
+): Promise<string | undefined> {
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const resolved = lookup().then(
+    (name) => name,
+    (err: unknown) => {
+      // Cache the definitive "this auth cannot resolve it" answers; drop
+      // everything else so transient failures retry on the next batch.
+      if (!isPermanentFailure(err)) {
+        cache.delete(cacheKey);
+      }
+      return undefined;
+    },
+  );
+  cache.set(cacheKey, resolved);
+  return resolved;
+}
+
+/**
  * Resolve a channel's display name for inline mention rendering, cached per
  * auth scope. Returns undefined when the channel has no name (DMs) or this
- * auth cannot see it; transient failures are not cached so a later batch
- * retries.
+ * auth cannot see it.
  */
 async function resolveChannelName(
   auth: OAuthConnection | string,
@@ -353,61 +384,35 @@ async function resolveChannelName(
   if (!channelId) {
     return undefined;
   }
-  const cacheKey = `${slackAuthCacheScope(auth)}:channel:${channelId}`;
-  const cached = channelNameCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-
-  const resolved = slack.conversationInfo(auth, channelId).then(
-    (resp) => trimNonEmpty(resp.channel.name),
-    (err: unknown) => {
-      // Cache the definitive "this auth cannot resolve it" answers; drop
-      // everything else so transient failures retry on the next batch.
-      const permanent =
-        err instanceof SlackApiError &&
-        (err.category === "channel_not_found" || err.category === "permission");
-      if (!permanent) {
-        channelNameCache.delete(cacheKey);
-      }
-      return undefined;
-    },
+  return resolveCachedSlackName(
+    channelNameCache,
+    `${slackAuthCacheScope(auth)}:channel:${channelId}`,
+    async () =>
+      trimNonEmpty(
+        (await slack.conversationInfo(auth, channelId)).channel.name,
+      ),
+    (err) =>
+      err instanceof SlackApiError &&
+      (err.category === "channel_not_found" || err.category === "permission"),
   );
-  channelNameCache.set(cacheKey, resolved);
-  return resolved;
 }
 
 /**
  * Resolve a bot's display name via `bots.info`, cached per auth scope.
- * Returns undefined when this auth cannot resolve it; transient failures are
- * not cached so a later batch retries.
+ * Returns undefined when this auth cannot resolve it.
  */
 async function resolveBotName(
   auth: OAuthConnection | string,
   botId: string,
 ): Promise<string | undefined> {
-  const cacheKey = `${slackAuthCacheScope(auth)}:bot:${botId}`;
-  const cached = botNameCache.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-
-  const resolved = slack.botsInfo(auth, botId).then(
-    (resp) => trimNonEmpty(resp.bot.name),
-    (err: unknown) => {
-      // Cache the definitive "this auth cannot resolve it" answers; drop
-      // everything else so transient failures retry on the next batch.
-      const permanent =
-        err instanceof SlackApiError &&
-        (err.slackError === "bot_not_found" || err.category === "permission");
-      if (!permanent) {
-        botNameCache.delete(cacheKey);
-      }
-      return undefined;
-    },
+  return resolveCachedSlackName(
+    botNameCache,
+    `${slackAuthCacheScope(auth)}:bot:${botId}`,
+    async () => trimNonEmpty((await slack.botsInfo(auth, botId)).bot.name),
+    (err) =>
+      err instanceof SlackApiError &&
+      (err.slackError === "bot_not_found" || err.category === "permission"),
   );
-  botNameCache.set(cacheKey, resolved);
-  return resolved;
 }
 
 /**
@@ -415,10 +420,16 @@ async function resolveBotName(
  * own `username` (bot_message subtype) or `bot_profile.name` answers without
  * I/O; `bots.info` covers rows carrying only a `bot_id`, with the id itself
  * as the last resort so the sender is at least attributable.
+ *
+ * `batchBotNames` pins the first lookup attempt per bot id for the caller's
+ * batch: the module cache evicts transient failures (so a later batch
+ * retries), and without the pin a history page full of one webhook's rows
+ * would re-fire a doomed `bots.info` cycle per row during a Slack outage.
  */
 async function resolveBotSenderInfo(
   auth: OAuthConnection | string,
   msg: SlackMessage,
+  batchBotNames: Map<string, Promise<string | undefined>>,
 ): Promise<NormalizedSlackUserInfo> {
   const fromMessage =
     trimNonEmpty(msg.username) ?? trimNonEmpty(msg.bot_profile?.name);
@@ -429,7 +440,12 @@ async function resolveBotSenderInfo(
   if (!botId) {
     return { displayName: "unknown" };
   }
-  return { displayName: (await resolveBotName(auth, botId)) ?? botId };
+  let pending = batchBotNames.get(botId);
+  if (pending === undefined) {
+    pending = resolveBotName(auth, botId);
+    batchBotNames.set(botId, pending);
+  }
+  return { displayName: (await pending) ?? botId };
 }
 
 function normalizeSlackUserInfo(
@@ -599,11 +615,12 @@ async function mapSlackMessages(
   // mention labels are built from the same derived strings that get rendered.
   const rawTexts = slackMessages.map((msg) => slackMessageRawText(msg));
   const labels = await buildMentionLabels(auth, rawTexts);
+  const batchBotNames = new Map<string, Promise<string | undefined>>();
   const messages: Message[] = [];
   for (const [i, msg] of slackMessages.entries()) {
     const senderInfo = msg.user
       ? await resolveUserInfo(auth, msg.user)
-      : await resolveBotSenderInfo(auth, msg);
+      : await resolveBotSenderInfo(auth, msg, batchBotNames);
     messages.push(
       mapMessage(
         msg,

--- a/assistant/src/messaging/providers/slack/message-content.ts
+++ b/assistant/src/messaging/providers/slack/message-content.ts
@@ -16,6 +16,7 @@ import type {
   AnyBlock,
   ContextBlock,
   HeaderBlock,
+  MarkdownBlock,
   MessageAttachment,
   SectionBlock,
 } from "@slack/types";
@@ -41,6 +42,9 @@ export function slackMessageRawText(
 }
 
 function slackAttachmentText(attachment: MessageAttachment): string {
+  // An attachment carrying Block Kit blocks renders them as its body, so
+  // they lead; the legacy fields still contribute when both are present.
+  const blockParts = slackBlocksText(attachment.blocks);
   const title = trimmed(attachment.title);
   const titleLink = trimmed(attachment.title_link);
   const fieldLines = (attachment.fields ?? []).map((field) => {
@@ -52,6 +56,7 @@ function slackAttachmentText(attachment: MessageAttachment): string {
     return fieldTitle ?? fieldValue ?? "";
   });
   const structured = [
+    ...blockParts,
     trimmed(attachment.pretext),
     trimmed(attachment.author_name),
     title && titleLink ? `${title} (${titleLink})` : title,
@@ -75,6 +80,10 @@ function isHeaderBlock(block: AnyBlock): block is HeaderBlock {
 
 function isContextBlock(block: AnyBlock): block is ContextBlock {
   return block.type === "context";
+}
+
+function isMarkdownBlock(block: AnyBlock): block is MarkdownBlock {
+  return block.type === "markdown";
 }
 
 /**
@@ -111,6 +120,11 @@ function slackBlocksText(blocks: readonly AnyBlock[] | undefined): string[] {
         .join(" ");
       if (contextText) {
         parts.push(contextText);
+      }
+    } else if (isMarkdownBlock(block)) {
+      const text = trimmed(block.text);
+      if (text) {
+        parts.push(text);
       }
     }
   }


### PR DESCRIPTION
Related to LUM-3496. Follow-up to #41811, addressing both of its review findings (the PR merged before the fixes landed, so they ship here).

## TL;DR

Two review findings on the Slack bot-message content fix, both addressed:

1. **Devin: some webhook blocks still extracted empty.** Fallback text extraction now covers `markdown` blocks and Block Kit blocks nested inside legacy attachments (an attachment carrying blocks renders them as its body, so they lead its text). The types were already canonical (`@slack/types` models both shapes); only the extractor and tests changed.
2. **Codex (P1): transient `bots.info` failures could re-fire per row.** Bot-name resolution now shares one resolve-once helper with the channel-name cache (the duplicated cache/fetch discipline Codex flagged), and a per-batch memo pins the first `bots.info` attempt per bot id: transient failures are still evicted from the cross-batch cache so a later page retries, but a history page full of one webhook's rows costs one lookup instead of one per row during a Slack outage.

## Why it's safe

- Extraction changes are additive: messages whose text resolved before resolve identically; only previously-empty shapes gain text.
- The resolver refactor is behavior-preserving for channels (same cache, same permanence classification) and strictly reduces API calls for bots.
- New tests pin the markdown-block, attachment-nested-blocks, and once-per-batch transient-failure cases; typecheck, lint, and both suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41823" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->