### PR TITLE
fix(web): repair the shell init script broken by a stray commit fragment

### DIFF
--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -135,7 +135,7 @@
     // `src/shell-metadata.test.ts` fails if the two drift.
     (function () {
       var SUPPORTED_LOCALES = ["en", "es", "ru", "zh", "zh-TW"];
-      var LABELS = { es: "Cargando", zh: "正在加载", "zh-TW": "正在載入" };: add Traditional Chinese (zh-TW) localization catalog)
+      var LABELS = { es: "Cargando", zh: "正在加载", "zh-TW": "正在載入" };
 
       function resolveLocale() {
         var findCanonical = function (candidate) {

--- a/clients/web/src/shell-metadata.test.ts
+++ b/clients/web/src/shell-metadata.test.ts
@@ -36,6 +36,20 @@ const SHELL_INIT = (() => {
   return inline[0]?.textContent ?? "";
 })();
 
+/**
+ * Parses `source` under the Script grammar, the parse goal a `<script>`
+ * element uses, and throws its `SyntaxError` when it does not parse.
+ *
+ * Indirect `eval` is the entry point that supplies that goal, so a top-level
+ * `return` or `new.target` fails here exactly as it does in a browser. The
+ * `if (false)` wrapper makes every statement unreachable, so the source is
+ * parsed and never run: no theme is stamped and no observer is installed.
+ */
+function parseAsScript(source: string): void {
+  const indirectEval = eval;
+  indirectEval(`if (false) {\n${source}\n}`);
+}
+
 function ogTag(property: string): string | null {
   return (
     doc
@@ -145,14 +159,13 @@ describe("SPA shell: boot splash", () => {
     expect(doc.querySelector('script[src*="theme-init"]')).toBeNull();
   });
 
-  // Every other assertion here is a substring check, which a syntactically
-  // broken script still satisfies: a stray fragment pasted into the source
-  // (a commit-message tail, a bad conflict resolution) leaves every expected
-  // string present while the browser throws on load and the whole shell init
-  // never runs. Parsing it is the only assertion that catches that, and the
-  // failure is silent in production because nothing else reads the console.
-  test("the shell init parses as JavaScript", () => {
-    expect(() => new Function(SHELL_INIT)).not.toThrow();
+  // Every other assertion here is a substring check, and a script that does
+  // not parse still contains all of them. The browser answers a syntax error
+  // by running none of the script, which costs the stored theme its stamp
+  // before first paint and the splash its localized label. Both fail
+  // silently, so this assertion is the only one that reports the loss.
+  test("the shell init parses as a browser would parse it", () => {
+    expect(() => parseAsScript(SHELL_INIT)).not.toThrow();
   });
 
   test("its static label is the same string the app's own spinner uses", () => {

--- a/clients/web/src/shell-metadata.test.ts
+++ b/clients/web/src/shell-metadata.test.ts
@@ -145,6 +145,16 @@ describe("SPA shell: boot splash", () => {
     expect(doc.querySelector('script[src*="theme-init"]')).toBeNull();
   });
 
+  // Every other assertion here is a substring check, which a syntactically
+  // broken script still satisfies: a stray fragment pasted into the source
+  // (a commit-message tail, a bad conflict resolution) leaves every expected
+  // string present while the browser throws on load and the whole shell init
+  // never runs. Parsing it is the only assertion that catches that, and the
+  // failure is silent in production because nothing else reads the console.
+  test("the shell init parses as JavaScript", () => {
+    expect(() => new Function(SHELL_INIT)).not.toThrow();
+  });
+
   test("its static label is the same string the app's own spinner uses", () => {
     expect(splash?.getAttribute("aria-label")).toBe(
       loadingLabel(DEFAULT_LOCALE),

--- a/clients/web/src/shell-metadata.test.ts
+++ b/clients/web/src/shell-metadata.test.ts
@@ -37,17 +37,21 @@ const SHELL_INIT = (() => {
 })();
 
 /**
- * Parses `source` under the Script grammar, the parse goal a `<script>`
- * element uses, and throws its `SyntaxError` when it does not parse.
+ * Parses `source` as JavaScript and throws when it does not parse.
  *
- * Indirect `eval` is the entry point that supplies that goal, so a top-level
- * `return` or `new.target` fails here exactly as it does in a browser. The
- * `if (false)` wrapper makes every statement unreachable, so the source is
- * parsed and never run: no theme is stamped and no observer is installed.
+ * The transpiler parses without evaluating, which is the property that
+ * matters here: the input is a file this suite treats as possibly corrupt, and
+ * anything that runs it to check it can run the corruption. Every wrapper
+ * trick built on `eval` fails that test, because a source with unbalanced
+ * braces closes the wrapper and executes what follows.
+ *
+ * It parses a module body rather than the Script goal a `<script>` element
+ * uses, so a top-level `return` is accepted here and rejected by a browser.
+ * That gap is narrower than the risk it removes: a stray paste is the
+ * corruption this file has to catch, and it is caught.
  */
 function parseAsScript(source: string): void {
-  const indirectEval = eval;
-  indirectEval(`if (false) {\n${source}\n}`);
+  new Bun.Transpiler({ loader: "js" }).transformSync(source);
 }
 
 function ogTag(property: string): string | null {
@@ -164,7 +168,7 @@ describe("SPA shell: boot splash", () => {
   // by running none of the script, which costs the stored theme its stamp
   // before first paint and the splash its localized label. Both fail
   // silently, so this assertion is the only one that reports the loss.
-  test("the shell init parses as a browser would parse it", () => {
+  test("the shell init parses as JavaScript", () => {
     expect(() => parseAsScript(SHELL_INIT)).not.toThrow();
   });
 


### PR DESCRIPTION
## The bug

`clients/web/index.html` line 138, inside the inline shell-init script:

```js
var LABELS = { es: "Cargando", zh: "正在加载", "zh-TW": "正在載入" };: add Traditional Chinese (zh-TW) localization catalog)
```

A commit-message tail from #41653 (`feat(i18n): add Traditional Chinese (zh-TW) localization catalog`) was pasted into the file. It has been on `main` since Aug 26.

## What it breaks

The inline script is one `<script>` block, so a syntax error anywhere in it means **none of it runs**. Both of its jobs are lost on every route, in every build:

1. **Theme stamping.** The stored `device:theme` is not applied to `<html>` before first paint, so the boot splash paints in the default theme and flips when React mounts.
2. **Boot splash localization.** The splash's `aria-label` stays English for `es`, `zh`, and `zh-TW` users, which is exactly what #41653 was adding.

Every page load throws `SyntaxError: Unexpected token ':'` into the console. I hit it while verifying an unrelated change on the dev server:

```
[EXCEPTION] (http://localhost:3111/assistant/identity:144:67)
SyntaxError: Unexpected token ':'
```

It reproduces on `/assistant/`, `/assistant/identity`, and every other route, because nginx serves this one file for all of them.

Both failure modes are silent. Nothing surfaces the console, and a splash label reading English is not something anyone reports.

## Why the existing test missed it

`src/shell-metadata.test.ts` already extracts the inline script into `SHELL_INIT` and asserts against it, but every assertion is a `toContain` substring check. A script with garbage appended still contains all the expected strings, so all 14 tests passed on the broken file.

This adds the one assertion that catches it:

```ts
test("the shell init parses as JavaScript", () => {
  expect(() => new Function(SHELL_INIT)).not.toThrow();
});
```

## Verification

With the fix:

```
$ bun test src/shell-metadata.test.ts
 15 pass
 0 fail
```

With the fix to `index.html` reverted and only the new test applied, to confirm the guard actually bites:

```
✗ SPA shell: boot splash > the shell init parses as JavaScript
 14 pass
 1 fail
```

`bun run lint` reports 0 errors and no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRyE6m6PYynVB8vnbKhsuv

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41825" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->