### PR TITLE
fix: BillingPanel parallel queries + finished single-sourcing

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -591,6 +591,12 @@ describe("BillingTab lifecycle loading", () => {
     expect(stack.getAttribute("role")).toBe("status");
     expect(stack.querySelectorAll('[role="status"]').length).toBe(0);
     expect(stack.getAttribute("aria-label")).toBe("Loading billing");
+    // Each card is hidden from assistive tech: the card skeletons paint real
+    // heading text, which this live region would otherwise read out.
+    expect(stack.children.length).toBe(3);
+    for (const child of Array.from(stack.children)) {
+      expect(child.getAttribute("aria-hidden")).toBe("true");
+    }
     // The loading copy exists only as the aria-label above, never as visible text.
     expect(queryByText("Loading billing")).toBeNull();
     expect(queryByTestId("plan-card-tier-upgraded")).toBeNull();
@@ -598,22 +604,6 @@ describe("BillingTab lifecycle loading", () => {
     // never needs the page-level stand-in.
     expect(queryByTestId("billing-page-skeleton")).toBeNull();
     expect(stack.closest('[data-slot="tabs-panel"]')).toBeTruthy();
-  });
-
-  test("stands the credits card in with its own nested row groups", () => {
-    lifecycleIsLoading = true;
-    const { getByTestId } = renderPage();
-
-    // The header the real panel paints from its first frame, so settling only
-    // swaps the body below it.
-    expect(getByTestId("billing-panel-skeleton").textContent).toContain(
-      "Extra Usage Credits",
-    );
-    // Balance tile, then the auto-reload, daily-limit and low-balance rows the
-    // real panel nests inside the card, the last two behind its dividers.
-    const body = getByTestId("billing-panel-skeleton-body");
-    expect(body.children.length).toBe(4);
-    expect(body.querySelectorAll(".border-t").length).toBe(2);
   });
 });
 

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -156,9 +156,9 @@ function FinishProSetupNotice({
 /**
  * Stand-in for the whole Billing tab while it cannot render yet: each card's
  * own exported skeleton, so the stack's geometry and its responsive stacking
- * cannot drift from the cards it stands in for. The cards are mounted without
- * labels here and the stack carries the one announcement, so a screen reader
- * hears the wait once rather than once per card.
+ * cannot drift from the cards it stands in for. The stack carries the one
+ * announcement and each card is hidden from assistive tech, so the live
+ * region does not read out the real headings the card skeletons paint.
  */
 function BillingTabSkeleton() {
   const { t } = useTranslation("settings");
@@ -169,9 +169,15 @@ function BillingTabSkeleton() {
       className="space-y-4"
       data-testid="billing-tab-skeleton"
     >
-      <PlanCardSkeleton />
-      <PaymentMethodsCardSkeleton />
-      <BillingPanelSkeleton />
+      <div aria-hidden>
+        <PlanCardSkeleton />
+      </div>
+      <div aria-hidden>
+        <PaymentMethodsCardSkeleton />
+      </div>
+      <div aria-hidden>
+        <BillingPanelSkeleton />
+      </div>
     </div>
   );
 }
@@ -437,11 +443,10 @@ export function BillingPage() {
   // skeletons and then get torn down when the probe lands. The gate bounds
   // its own pending state, so this cannot hold forever.
   //
-  // A `"gated"` gate is decided without the session (local mode with the
-  // platform API off), and `shouldShowBillingTab` never shows Billing for it,
-  // so those viewers skip the hold and mount Usage on the first paint.
-  const holdForPlatformSession =
-    platformSessionPending && !wantsUsageTab && billingGate !== "gated";
+  // A pending probe reads as `"disabled"` above, so a viewer the gate decided
+  // without the session (`"gated"`: local mode with the platform API off) is
+  // already settled here and mounts Usage on the first paint.
+  const holdForPlatformSession = platformSessionPending && !wantsUsageTab;
 
   // Keep the active tab explicit in the URL so both tabs are symmetric and
   // the address bar always names what's shown: a bare `/settings/usage` — or

--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -338,7 +338,6 @@ describe("AutoTopUpCard loading state", () => {
     );
 
     const card = getByTestId("auto-top-up-card");
-    expect(card.hasAttribute("aria-hidden")).toBe(false);
     const announced = card.querySelectorAll('[role="status"]');
     expect(announced.length).toBe(1);
     expect(announced[0]?.getAttribute("aria-label")).toBe(

--- a/clients/web/src/domains/settings/components/billing-panel-balance-skeleton.test.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-balance-skeleton.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * The stand-in for the Credits balance tile: the label contract every card
+ * skeleton shares, and the tile shape the resolved `StatSquare` replaces.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { BillingPanelBalanceSkeleton } from "./billing-panel-balance-skeleton";
+
+afterEach(cleanup);
+
+describe("BillingPanelBalanceSkeleton", () => {
+  test("stands the tile in with its icon, value and label placeholders", () => {
+    const { container } = render(<BillingPanelBalanceSkeleton />);
+
+    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBe(3);
+  });
+
+  test("announces only when it is given a label", () => {
+    const { container, rerender } = render(<BillingPanelBalanceSkeleton />);
+    expect(container.querySelector('[role="status"]')).toBeNull();
+
+    rerender(<BillingPanelBalanceSkeleton label="Loading credit balance" />);
+    const announced = container.querySelector('[role="status"]');
+    expect(announced?.getAttribute("aria-label")).toBe(
+      "Loading credit balance",
+    );
+  });
+});

--- a/clients/web/src/domains/settings/components/billing-panel-balance-skeleton.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-balance-skeleton.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
+import { StatSquare } from "@vellumai/design-library/components/stat-square";
+
+export interface BillingPanelBalanceSkeletonProps {
+  /**
+   * Announces the wait. `BillingPanel` passes it while its summary is pending;
+   * the billing tab's skeleton stack leaves it off and announces the whole
+   * stack once instead of once per card.
+   */
+  label?: string;
+}
+
+/**
+ * Stand-in for the Credits balance tile, shaped like the `StatSquare` that
+ * replaces it so the panel holds its height across the swap.
+ */
+export function BillingPanelBalanceSkeleton({
+  label,
+}: BillingPanelBalanceSkeletonProps) {
+  return (
+    <div
+      role={label == null ? undefined : "status"}
+      aria-label={label}
+      className="mt-4"
+      data-testid="billing-panel-balance-skeleton"
+    >
+      <StatSquare
+        icon={<Skeleton aria-hidden className="h-4 w-4 rounded-sm" />}
+        value={<Skeleton aria-hidden className="h-5 w-28 rounded-md" />}
+        label={<Skeleton aria-hidden className="h-4 w-24 rounded-md" />}
+      />
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/components/billing-panel-header.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-header.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
+import { useTranslation } from "@/i18n";
+
+export interface BillingPanelHeaderProps {
+  /** The resolved panel passes its buttons; the skeleton passes placeholders. */
+  actions: ReactNode;
+}
+
+/**
+ * The Credits section's title and subtitle, shared by `BillingPanel` and its
+ * skeleton so the header reads the same from the first paint.
+ */
+export function BillingPanelHeader({ actions }: BillingPanelHeaderProps) {
+  const { t } = useTranslation("settings");
+  return (
+    <BillingSectionHeader
+      title={t("billingPanel.title")}
+      subtitle={t("billingPanel.subtitle")}
+      actions={actions}
+    />
+  );
+}

--- a/clients/web/src/domains/settings/components/billing-panel-row-group.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-row-group.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@vellumai/design-library";
+
+export interface BillingPanelRowGroupProps {
+  children: ReactNode;
+  /** Deep-link target; only the daily-limit group is anchored. */
+  id?: string;
+  className?: string;
+}
+
+/**
+ * One of the divided row groups below the Credits balance, shared by
+ * `BillingPanel` and its skeleton: the rule above the group plus the spacing
+ * on either side of it.
+ */
+export function BillingPanelRowGroup({
+  children,
+  id,
+  className,
+}: BillingPanelRowGroupProps) {
+  return (
+    <div
+      id={id}
+      className={cn(
+        "mt-6 border-t border-[var(--border-subtle)] pt-6",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/components/billing-panel-skeleton.test.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-skeleton.test.tsx
@@ -1,7 +1,7 @@
 /**
- * The stand-in for the Credits card: the label contract shared by every card
- * skeleton, plus the nested row groups the real panel lays out below its
- * balance tile.
+ * The stand-in for the whole Credits card, which only the billing tab's
+ * skeleton stack mounts: the panel's own header and the nested row groups it
+ * lays out below its balance tile.
  */
 import { afterEach, describe, expect, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
@@ -14,8 +14,8 @@ describe("BillingPanelSkeleton", () => {
   test("keeps the panel's own header and nests its three row groups", () => {
     const { container, getByTestId } = render(<BillingPanelSkeleton />);
 
-    // The real panel paints this header from its first frame, so the swap
-    // only replaces the body below it.
+    // The real panel paints this header from the first frame, so only the
+    // body below it is ever stood in for.
     expect(container.textContent).toContain("Extra Usage Credits");
 
     // Balance tile, then the auto-reload, daily-limit and low-balance rows,
@@ -25,14 +25,9 @@ describe("BillingPanelSkeleton", () => {
     expect(body.querySelectorAll(".border-t").length).toBe(2);
   });
 
-  test("announces only when it is given a label", () => {
-    const { container, rerender } = render(<BillingPanelSkeleton />);
-    expect(container.querySelector('[role="status"]')).toBeNull();
+  test("stays silent so the stack around it announces once", () => {
+    const { container } = render(<BillingPanelSkeleton />);
 
-    rerender(<BillingPanelSkeleton label="Loading credit balance" />);
-    const announced = container.querySelector('[role="status"]');
-    expect(announced?.getAttribute("aria-label")).toBe(
-      "Loading credit balance",
-    );
+    expect(container.querySelector('[role="status"]')).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/components/billing-panel-skeleton.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-skeleton.tsx
@@ -1,33 +1,21 @@
 import { Card } from "@vellumai/design-library/components/card";
 import { Skeleton } from "@vellumai/design-library/components/skeleton";
-import { StatSquare } from "@vellumai/design-library/components/stat-square";
 
-import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
+import { BillingPanelBalanceSkeleton } from "@/domains/settings/components/billing-panel-balance-skeleton";
+import { BillingPanelHeader } from "@/domains/settings/components/billing-panel-header";
+import { BillingPanelRowGroup } from "@/domains/settings/components/billing-panel-row-group";
 import { SkeletonLines } from "@/domains/settings/components/skeleton-lines";
-import { useTranslation } from "@/i18n";
-
-export interface BillingPanelSkeletonProps {
-  /**
-   * Announces the wait. `BillingPanel` passes it whenever it loads on its own;
-   * the billing tab's skeleton stack leaves it off and announces the whole
-   * stack once instead of once per card.
-   */
-  label?: string;
-}
 
 /**
- * Stand-in for `BillingPanel` as it first mounts: the header the real panel
- * renders from the first paint, the balance tile, and the three nested row
- * groups (auto-reload, daily limit, low-balance toggle) behind the dividers
- * the panel lays them out with.
+ * Stand-in for `BillingPanel` in the billing tab's skeleton stack, which is
+ * the only place the whole card is stood in for: the panel itself keeps its
+ * chrome mounted and swaps only its balance body. The stack announces the wait
+ * once for all three cards, so nothing here is labeled.
  */
-export function BillingPanelSkeleton({ label }: BillingPanelSkeletonProps) {
-  const { t } = useTranslation("settings");
+export function BillingPanelSkeleton() {
   return (
     <Card padding="md" data-testid="billing-panel-skeleton">
-      <BillingSectionHeader
-        title={t("billingPanel.title")}
-        subtitle={t("billingPanel.subtitle")}
+      <BillingPanelHeader
         actions={
           <>
             <Skeleton aria-hidden className="h-8 w-36 rounded-md" />
@@ -35,25 +23,15 @@ export function BillingPanelSkeleton({ label }: BillingPanelSkeletonProps) {
           </>
         }
       />
-      <div
-        role={label == null ? undefined : "status"}
-        aria-label={label}
-        data-testid="billing-panel-skeleton-body"
-      >
-        <div className="mt-4">
-          <StatSquare
-            icon={<Skeleton aria-hidden className="h-4 w-4 rounded-sm" />}
-            value={<Skeleton aria-hidden className="h-5 w-28 rounded-md" />}
-            label={<Skeleton aria-hidden className="h-4 w-24 rounded-md" />}
-          />
-        </div>
+      <div data-testid="billing-panel-skeleton-body">
+        <BillingPanelBalanceSkeleton />
         <SkeletonLines lines={2} lineClassName="h-6" className="mt-6" />
-        <div className="mt-6 border-t border-[var(--border-subtle)] pt-6">
+        <BillingPanelRowGroup>
           <SkeletonLines lines={2} lineClassName="h-6" />
-        </div>
-        <div className="mt-6 border-t border-[var(--border-subtle)] pt-6">
+        </BillingPanelRowGroup>
+        <BillingPanelRowGroup>
           <SkeletonLines lines={1} lineClassName="h-6" />
-        </div>
+        </BillingPanelRowGroup>
       </div>
     </Card>
   );

--- a/clients/web/src/domains/settings/components/billing-panel.test.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.test.tsx
@@ -8,7 +8,8 @@
  * moving part.
  *
  * The unseeded case covers the loading branch: a shimmer tile the same height
- * as the resolved one, with no spinner and no "Loading" copy.
+ * as the resolved one, with no spinner and no "Loading" copy, and the rest of
+ * the card still mounted around it.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -29,13 +30,16 @@ mock.module("@/generated/api/sdk.gen", () => ({
 }));
 
 // The siblings below the tile each pull their own billing reads and Stripe
-// wiring; none of them is what this suite is about.
+// wiring; none of them is what this suite is about. They render a marker so
+// the loading case can prove they are mounted alongside the pending summary.
 mock.module("@/domains/settings/components/auto-top-up-card", () => ({
-  AutoTopUpCard: () => null,
+  AutoTopUpCard: () => <div data-testid="auto-top-up-card-stub" />,
 }));
 mock.module("@/domains/settings/components/daily-credit-limit-card", () => ({
   DAILY_CREDIT_LIMIT_ANCHOR_ID: "daily-credit-limit",
-  DailyCreditLimitCard: () => null,
+  DailyCreditLimitCard: () => (
+    <div data-testid="daily-credit-limit-card-stub" />
+  ),
 }));
 mock.module("@/domains/settings/components/low-balance-alert-card", () => ({
   LowBalanceAlertCard: () => null,
@@ -113,26 +117,39 @@ afterEach(() => {
 });
 
 describe("BillingPanel while loading", () => {
-  test("stands the whole card in with shimmer, no spinner or loading copy", () => {
+  test("swaps only the balance for shimmer, with no spinner or loading copy", () => {
     const { container, getByTestId, queryByTestId } = renderPanel();
 
-    const skeleton = getByTestId("billing-panel-skeleton");
-    // The header the real panel paints from the first frame, so the swap
-    // keeps its title and subtitle in place.
-    expect(skeleton.textContent).toContain("Extra Usage Credits");
+    expect(getByTestId("billing-panel-balance-skeleton")).not.toBeNull();
     expect(queryByTestId("effective-balance")).toBeNull();
     expect(container.textContent).not.toContain("Loading");
+    // The header the real panel paints from the first frame, so the swap
+    // keeps its title and subtitle in place.
+    expect(container.textContent).toContain("Extra Usage Credits");
+  });
 
-    // Balance tile, then the auto-reload, daily-limit and low-balance rows.
-    const body = getByTestId("billing-panel-skeleton-body");
-    expect(body.children.length).toBe(4);
-    expect(body.querySelectorAll(".border-t").length).toBe(2);
+  test("keeps the rest of the card mounted while the summary is pending", () => {
+    // The nested cards each run their own read, so they have to mount now
+    // rather than behind this one; the deep-link anchor they hang under has
+    // to be in the document for the same reason.
+    const { container, getByTestId, queryByTestId } = renderPanel();
+
+    expect(queryByTestId("auto-top-up-card-stub")).not.toBeNull();
+    expect(queryByTestId("daily-credit-limit-card-stub")).not.toBeNull();
+    expect(container.querySelector("#daily-credit-limit")).not.toBeNull();
+    expect(container.textContent).toContain("Custom Low Balance Alert");
+    // Earning credits asks nothing of the summary, so it stays usable; adding
+    // them needs the top-up bounds it carries.
+    const earn = getByTestId("earn-credits-button") as HTMLButtonElement;
+    expect(earn.disabled).toBe(false);
+    const add = getByTestId("add-credits-button") as HTMLButtonElement;
+    expect(add.disabled).toBe(true);
   });
 
   test("announces the wait it is standing in for", () => {
     // The panel loads on its own inside the settled tab, where nothing else
-    // announces the wait. The tab's own skeleton stack mounts it without a
-    // label and announces the whole stack once instead.
+    // announces the wait. The tab's own skeleton stack mounts the whole-card
+    // stand-in instead and announces that once.
     const { container } = renderPanel();
 
     const announced = container.querySelectorAll('[role="status"]');

--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -6,7 +6,9 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AddCreditsModal } from "@/components/add-credits-modal";
 import { ContentReveal } from "@/components/content-reveal";
 import { AutoTopUpCard } from "@/domains/settings/components/auto-top-up-card";
-import { BillingPanelSkeleton } from "@/domains/settings/components/billing-panel-skeleton";
+import { BillingPanelBalanceSkeleton } from "@/domains/settings/components/billing-panel-balance-skeleton";
+import { BillingPanelHeader } from "@/domains/settings/components/billing-panel-header";
+import { BillingPanelRowGroup } from "@/domains/settings/components/billing-panel-row-group";
 import {
   organizationsBillingSummaryRetrieveOptions,
   organizationsBillingSummaryRetrieveQueryKey,
@@ -20,7 +22,6 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { StatSquare } from "@vellumai/design-library/components/stat-square";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 import { useTranslation } from "@/i18n";
-import { BillingSectionHeader } from "./billing-section-header";
 import {
   DAILY_CREDIT_LIMIT_ANCHOR_ID,
   DailyCreditLimitCard,
@@ -112,9 +113,7 @@ export function BillingPanel() {
   ]);
 
   const creditsHeader = (
-    <BillingSectionHeader
-      title={t("billingPanel.title")}
-      subtitle={t("billingPanel.subtitle")}
+    <BillingPanelHeader
       actions={
         <>
           <Button
@@ -128,7 +127,7 @@ export function BillingPanel() {
           <Button
             variant="primary"
             onClick={() => setAddCreditsOpen(true)}
-            disabled={!summary}
+            disabled={isLoading || !summary}
             data-testid="add-credits-button"
           >
             {t("billingPanel.addCreditsButton")}
@@ -167,6 +166,14 @@ export function BillingPanel() {
   };
 
   const renderBalanceBody = (): ReactNode => {
+    // Only the balance swaps to a placeholder: the header, the nested cards and
+    // the daily-limit anchor stay mounted, so those cards' own queries start
+    // alongside this one instead of behind it.
+    if (isLoading) {
+      return (
+        <BillingPanelBalanceSkeleton label={t("billingPanel.loadingLabel")} />
+      );
+    }
     if (isError) {
       return (
         <div className="mt-4">
@@ -195,36 +202,29 @@ export function BillingPanel() {
 
   return (
     <>
-      {isLoading ? (
-        // The panel's own skeleton, so the tab-level stack and this branch
-        // cannot drift apart. It carries the loading announcement: in the
-        // settled tree no outer region announces this wait.
-        <BillingPanelSkeleton label={t("billingPanel.loadingLabel")} />
-      ) : (
-        <Card padding="md">
-          {creditsHeader}
-          {renderBalanceBody()}
-          <div className="mt-6">
-            <AutoTopUpCard />
+      <Card padding="md">
+        {creditsHeader}
+        {renderBalanceBody()}
+        <div className="mt-6">
+          <AutoTopUpCard />
+        </div>
+        <BillingPanelRowGroup
+          id={DAILY_CREDIT_LIMIT_ANCHOR_ID}
+          className="scroll-mt-4"
+        >
+          <DailyCreditLimitCard />
+        </BillingPanelRowGroup>
+        <BillingPanelRowGroup>
+          <div className="flex flex-col gap-4">
+            <Toggle
+              checked={lowBalanceExpanded}
+              onChange={setLowBalanceExpanded}
+              label={t("billingPanel.lowBalanceToggle")}
+            />
+            {lowBalanceExpanded && <LowBalanceAlertCard />}
           </div>
-          <div
-            id={DAILY_CREDIT_LIMIT_ANCHOR_ID}
-            className="mt-6 scroll-mt-4 border-t border-[var(--border-subtle)] pt-6"
-          >
-            <DailyCreditLimitCard />
-          </div>
-          <div className="mt-6 border-t border-[var(--border-subtle)] pt-6">
-            <div className="flex flex-col gap-4">
-              <Toggle
-                checked={lowBalanceExpanded}
-                onChange={setLowBalanceExpanded}
-                label={t("billingPanel.lowBalanceToggle")}
-              />
-              {lowBalanceExpanded && <LowBalanceAlertCard />}
-            </div>
-          </div>
-        </Card>
-      )}
+        </BillingPanelRowGroup>
+      </Card>
 
       <AddCreditsModal open={addCreditsOpen} onOpenChange={setAddCreditsOpen} />
       <ReferralModal open={referralOpen} onOpenChange={setReferralOpen} />

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
@@ -662,7 +662,6 @@ describe("DailyCreditLimitCard loading state", () => {
     const { getByTestId } = renderAtAnchor(newClient());
 
     const card = getByTestId("daily-credit-limit-card");
-    expect(card.getAttribute("aria-hidden")).toBeNull();
     expect(
       card.querySelector('[role="status"]')?.getAttribute("aria-label"),
     ).toBe("Loading daily credit limit settings");

--- a/clients/web/src/domains/settings/components/low-balance-alert-card.test.tsx
+++ b/clients/web/src/domains/settings/components/low-balance-alert-card.test.tsx
@@ -126,7 +126,6 @@ describe("LowBalanceAlertCard", () => {
     const { getByTestId } = renderCard(null);
 
     const card = getByTestId("low-balance-alert-card");
-    expect(card.hasAttribute("aria-hidden")).toBe(false);
     const announced = card.querySelectorAll('[role="status"]');
     expect(announced.length).toBe(1);
     expect(announced[0]?.getAttribute("aria-label")).toBe(

--- a/clients/web/src/domains/settings/components/payment-methods-action-slot.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-action-slot.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+export interface PaymentMethodsActionSlotProps {
+  children?: ReactNode;
+}
+
+/**
+ * The Payment Methods header's action slot, shared by the resolved card and
+ * its skeleton. It is mounted at button height whether or not it holds an
+ * action: a slot that appeared only when it had something to show would take
+ * its whole row back out of the header (about 44px, stacked below `sm`) as
+ * soon as a card-on-file config landed.
+ */
+export function PaymentMethodsActionSlot({
+  children,
+}: PaymentMethodsActionSlotProps) {
+  return (
+    <div
+      className="flex h-8 items-center"
+      data-testid="payment-methods-action-slot"
+    >
+      {children}
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/components/payment-methods-card-skeleton.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card-skeleton.test.tsx
@@ -22,6 +22,15 @@ describe("PaymentMethodsCardSkeleton", () => {
     expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBe(3);
   });
 
+  test("stands the title in with phrasing content the heading can hold", () => {
+    const { container } = render(<PaymentMethodsCardSkeleton />);
+
+    const title = container.querySelector('h2 > [data-slot="skeleton"]');
+    expect(title?.tagName).toBe("SPAN");
+    // The 20px line the resolved title renders at.
+    expect(title?.className).toContain("h-5");
+  });
+
   test("announces only when it is given a label", () => {
     const { container, rerender } = render(<PaymentMethodsCardSkeleton />);
     expect(container.querySelector('[role="status"]')).toBeNull();

--- a/clients/web/src/domains/settings/components/payment-methods-card-skeleton.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card-skeleton.tsx
@@ -2,6 +2,7 @@ import { Card } from "@vellumai/design-library/components/card";
 import { Skeleton } from "@vellumai/design-library/components/skeleton";
 
 import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
+import { PaymentMethodsActionSlot } from "@/domains/settings/components/payment-methods-action-slot";
 import { SkeletonLines } from "@/domains/settings/components/skeleton-lines";
 
 export interface PaymentMethodsCardSkeletonProps {
@@ -24,21 +25,21 @@ export function PaymentMethodsCardSkeleton({
   return (
     <Card padding="md" data-testid="payment-methods-card-skeleton">
       <BillingSectionHeader
-        title={<Skeleton aria-hidden className="h-6 w-40 rounded-md" />}
+        title={
+          <Skeleton
+            as="span"
+            aria-hidden
+            className="block h-5 w-40 rounded-md"
+          />
+        }
         actions={
-          // The same button-tall slot the resolved header keeps mounted, so
-          // the header row holds its height (a whole stacked row below `sm`)
-          // across the swap.
-          <div
-            className="flex h-8 items-center"
-            data-testid="payment-methods-action-slot"
-          >
+          <PaymentMethodsActionSlot>
             <Skeleton
               aria-hidden
               className="h-8 w-24 rounded-md"
               data-testid="payment-methods-add-skeleton"
             />
-          </div>
+          </PaymentMethodsActionSlot>
         }
       />
       <SkeletonLines

--- a/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -361,23 +361,22 @@ describe("PaymentMethodsCard org readiness", () => {
 });
 
 describe("PaymentMethodsCard loading skeleton", () => {
-  test("mirrors the card row and reserves the header action slot while pending", () => {
+  test("mounts the card's own skeleton, labeled, while the config is pending", () => {
     holdRetrieve();
     const { container } = render(wrap());
 
-    // The card loads on its own inside the settled tab, where nothing else
-    // announces the wait. The tab's own skeleton stack mounts it without a
-    // label and announces the whole stack once instead.
+    // Geometry is the skeleton's own contract; what belongs here is that this
+    // card reaches for it and labels it. The card loads on its own inside the
+    // settled tab, where nothing else announces the wait; the tab's skeleton
+    // stack mounts it without a label and announces the stack once instead.
+    expect(
+      container.querySelector('[data-testid="payment-methods-card-skeleton"]'),
+    ).not.toBeNull();
     const announced = container.querySelectorAll('[role="status"]');
     expect(announced.length).toBe(1);
     expect(announced[0]?.getAttribute("aria-label")).toBe(
       "Loading payment method",
     );
-    // The title and action placeholders plus the one card-row line.
-    expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBe(3);
-    expect(
-      container.querySelector('[data-testid="payment-methods-add-skeleton"]'),
-    ).not.toBeNull();
     expect(
       container.querySelector('[data-testid="payment-methods-add"]'),
     ).toBeNull();
@@ -392,10 +391,6 @@ describe("PaymentMethodsCard loading skeleton", () => {
     const client = makeClient();
     const { container } = render(wrapWith(client));
 
-    const slot = container.querySelector(
-      '[data-testid="payment-methods-action-slot"]',
-    );
-    expect(slot?.className).toContain("h-8");
     expect(
       container.querySelector('[data-testid="payment-methods-add-skeleton"]'),
     ).not.toBeNull();
@@ -411,13 +406,11 @@ describe("PaymentMethodsCard loading skeleton", () => {
       }
     });
     // The skeleton hands the slot over to the resolved header, which keeps it
-    // button-tall while holding nothing.
+    // mounted while holding nothing.
     const resolvedSlot = container.querySelector(
       '[data-testid="payment-methods-action-slot"]',
     );
     expect(resolvedSlot).not.toBeNull();
-    expect(resolvedSlot?.className).toBe(slot?.className);
-    expect(resolvedSlot?.className).toContain("h-8");
     expect(resolvedSlot?.children.length).toBe(0);
     expect(
       container.querySelector('[data-testid="payment-methods-add"]'),

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -9,6 +9,7 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
 import { ContentReveal } from "@/components/content-reveal";
+import { PaymentMethodsActionSlot } from "@/domains/settings/components/payment-methods-action-slot";
 import { PaymentMethodsCardSkeleton } from "@/domains/settings/components/payment-methods-card-skeleton";
 import {
   modalSnapshotFor,
@@ -115,24 +116,6 @@ export function PaymentMethodsCard() {
     });
   }, [outcome, queryClient]);
 
-  // Contents of the always-mounted action slot below: the Add button, or
-  // nothing when a card is already on file.
-  const renderHeaderAction = () => {
-    if (!showAddButton) {
-      return null;
-    }
-    return (
-      <Button
-        variant="outlined"
-        onClick={openPaymentModal}
-        disabled={returnPending}
-        data-testid="payment-methods-add"
-      >
-        {t("paymentMethodsCard.addButton")}
-      </Button>
-    );
-  };
-
   const renderBody = () => {
     if (configQuery.isError || config == null) {
       return <Notice tone="error">{t("paymentMethodsCard.loadError")}</Notice>;
@@ -164,9 +147,8 @@ export function PaymentMethodsCard() {
   return (
     <>
       {configPending ? (
-        // The card's own skeleton, so the tab-level stack and this branch
-        // cannot drift apart. It carries the loading announcement: in the
-        // settled tree no outer region announces this wait.
+        // It carries the loading announcement: in the settled tree no outer
+        // region announces this wait.
         <PaymentMethodsCardSkeleton
           label={t("paymentMethodsCard.loadingLabel")}
         />
@@ -175,17 +157,20 @@ export function PaymentMethodsCard() {
           <BillingSectionHeader
             title={t("paymentMethodsCard.title")}
             actions={
-              // The slot is mounted at button height whether or not it holds
-              // an action, matching the one the skeleton reserves: a slot that
-              // appeared only when it had something to show would take its
-              // whole row back out of the header (about 44px, stacked below
-              // `sm`) as soon as a card-on-file config landed.
-              <div
-                className="flex h-8 items-center"
-                data-testid="payment-methods-action-slot"
-              >
-                {renderHeaderAction()}
-              </div>
+              // The slot holds the Add button, or nothing once a card is on
+              // file; either way it keeps its height.
+              <PaymentMethodsActionSlot>
+                {showAddButton && (
+                  <Button
+                    variant="outlined"
+                    onClick={openPaymentModal}
+                    disabled={returnPending}
+                    data-testid="payment-methods-add"
+                  >
+                    {t("paymentMethodsCard.addButton")}
+                  </Button>
+                )}
+              </PaymentMethodsActionSlot>
             }
           />
 

--- a/clients/web/src/domains/settings/components/plan-card-skeleton.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-skeleton.tsx
@@ -2,6 +2,7 @@ import { Card } from "@vellumai/design-library/components/card";
 import { Skeleton } from "@vellumai/design-library/components/skeleton";
 
 import { PlanHeading } from "@/domains/settings/components/plan-heading";
+import { PlanTileRow } from "@/domains/settings/components/plan-tile-row";
 
 export interface PlanCardSkeletonProps {
   /**
@@ -31,13 +32,12 @@ export function PlanCardSkeleton({ label }: PlanCardSkeletonProps) {
           <Skeleton aria-hidden className="h-4 w-56 rounded-md" />
         </div>
         <Skeleton aria-hidden className="h-3 w-full rounded-full" />
-        {/* Same container as the resolved tile row, so the placeholders stack
-            below `lg` exactly as the tiles do. The height is a real tile's:
-            tag, avatar row, three spec chips and a footer row. */}
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
+        {/* The height is a real tile's: tag, avatar row, three spec chips and
+            a footer row. */}
+        <PlanTileRow>
           <Skeleton aria-hidden className="h-84 rounded-xl lg:flex-1" />
           <Skeleton aria-hidden className="h-84 rounded-xl lg:flex-1" />
-        </div>
+        </PlanTileRow>
       </div>
     </Card>
   );

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1530,34 +1530,20 @@ describe("PlanCard with obscure-credits on", () => {
 });
 
 describe("PlanCard loading state", () => {
-  test("keeps the card chrome and stands the layout in with shimmer", () => {
+  test("mounts the card's own skeleton, labeled, with no spinner", () => {
+    // Geometry is the skeleton's own contract; what belongs here is that this
+    // card reaches for it and labels it. It loads on its own inside the
+    // settled tab, where nothing else announces the wait; the tab's skeleton
+    // stack mounts it without a label and announces the stack once instead.
     const host = renderLoadingCardDom();
-    expect(host.querySelector("h2")?.textContent).toBe("Plan");
-    // Plan name, renewal line, usage bar, and one per plan tile.
-    expect(host.querySelectorAll('[data-slot="skeleton"]').length).toBe(5);
+    expect(
+      host.querySelector('[data-testid="plan-card-skeleton"]'),
+    ).not.toBeNull();
     expect(host.querySelectorAll(".animate-spin").length).toBe(0);
-    expect(host.textContent).not.toContain("Loading plan");
-  });
-
-  test("stacks the tile placeholders the way the resolved tiles stack", () => {
-    const host = renderLoadingCardDom();
-    const tiles = Array.from(
-      host.querySelectorAll('[data-slot="skeleton"]'),
-    ).slice(-2);
-    const row = tiles[0]?.parentElement;
-    expect(tiles[1]?.parentElement).toBe(row);
-    expect(row?.className).toContain("flex-col");
-    expect(row?.className).toContain("lg:flex-row");
-  });
-
-  test("announces the wait it is standing in for", () => {
-    // The card loads on its own inside the settled tab, where nothing else
-    // announces the wait. The tab's own skeleton stack mounts this card
-    // without a label and announces the whole stack once instead.
-    const host = renderLoadingCardDom();
     const announced = host.querySelectorAll('[role="status"]');
     expect(announced.length).toBe(1);
     expect(announced[0]?.getAttribute("aria-label")).toBe("Loading plan");
+    // The loading copy exists only as that label, never as visible text.
     expect(host.textContent).not.toContain("Loading plan");
   });
 

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -60,6 +60,7 @@ import { Typography } from "@vellumai/design-library/components/typography";
 import { ContentReveal } from "@/components/content-reveal";
 import { PlanCardSkeleton } from "@/domains/settings/components/plan-card-skeleton";
 import { PlanHeading } from "@/domains/settings/components/plan-heading";
+import { PlanTileRow } from "@/domains/settings/components/plan-tile-row";
 import {
   formatDollars,
   priceLabelFromCents,
@@ -566,7 +567,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
               : t("planCard.manageSubscription")}
           </Button>
         </div>
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
+        <PlanTileRow>
           <PlanTile
             testId="plan-tile-current"
             tierKey={currentTier}
@@ -588,7 +589,7 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
             onManage={onManage}
             onTierUpgraded={onTierUpgraded}
           />
-        </div>
+        </PlanTileRow>
       </ContentReveal>
       <AddCreditsModal open={addCreditsOpen} onOpenChange={setAddCreditsOpen} />
     </Card>

--- a/clients/web/src/domains/settings/components/plan-tile-row.tsx
+++ b/clients/web/src/domains/settings/components/plan-tile-row.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+export interface PlanTileRowProps {
+  children: ReactNode;
+}
+
+/**
+ * The plan card's tile row, shared by the resolved card and its skeleton: the
+ * tiles sit side by side from `lg` and stack below it.
+ */
+export function PlanTileRow({ children }: PlanTileRowProps) {
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Round-3 fixes: BillingPanel skeletons only its balance body so the nested cards' queries fire in parallel and the referral action stays usable; the action slot, panel header, and plan tile row become shared components (drift-guard tests removed); skeleton geometry contracts live in the skeleton test files; composed card skeletons are aria-hidden inside the tab stack's live region.

Part of plan: billing-skeleton-loading.md (self-review round 3)