### PR TITLE
fix: round-4 mechanical cleanup

### DIFF
--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -591,12 +591,12 @@ describe("BillingTab lifecycle loading", () => {
     expect(stack.getAttribute("role")).toBe("status");
     expect(stack.querySelectorAll('[role="status"]').length).toBe(0);
     expect(stack.getAttribute("aria-label")).toBe("Loading billing");
-    // Each card is hidden from assistive tech: the card skeletons paint real
-    // heading text, which this live region would otherwise read out.
-    expect(stack.children.length).toBe(3);
-    for (const child of Array.from(stack.children)) {
-      expect(child.getAttribute("aria-hidden")).toBe("true");
-    }
+    // The cards sit behind one hidden wrapper: they paint real heading text,
+    // which this live region would otherwise read out.
+    expect(stack.children.length).toBe(1);
+    const hidden = stack.children[0];
+    expect(hidden?.getAttribute("aria-hidden")).toBe("true");
+    expect(hidden?.children.length).toBe(3);
     // The loading copy exists only as the aria-label above, never as visible text.
     expect(queryByText("Loading billing")).toBeNull();
     expect(queryByTestId("plan-card-tier-upgraded")).toBeNull();

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -157,8 +157,8 @@ function FinishProSetupNotice({
  * Stand-in for the whole Billing tab while it cannot render yet: each card's
  * own exported skeleton, so the stack's geometry and its responsive stacking
  * cannot drift from the cards it stands in for. The stack carries the one
- * announcement and each card is hidden from assistive tech, so the live
- * region does not read out the real headings the card skeletons paint.
+ * announcement and hides the cards behind it, so the live region does not
+ * read out the real headings the card skeletons paint.
  */
 function BillingTabSkeleton() {
   const { t } = useTranslation("settings");
@@ -166,16 +166,11 @@ function BillingTabSkeleton() {
     <div
       role="status"
       aria-label={t("billingPage.loadingLabel")}
-      className="space-y-4"
       data-testid="billing-tab-skeleton"
     >
-      <div aria-hidden>
+      <div aria-hidden className="space-y-4">
         <PlanCardSkeleton />
-      </div>
-      <div aria-hidden>
         <PaymentMethodsCardSkeleton />
-      </div>
-      <div aria-hidden>
         <BillingPanelSkeleton />
       </div>
     </div>

--- a/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
@@ -30,6 +30,7 @@ import {
   makeProPackage,
   makeSuperPackage,
 } from "@/domains/settings/billing/plans/pro-package-test-fixtures";
+import { PlanTileRow } from "@/domains/settings/components/plan-tile-row";
 import {
   formatDollars,
   priceLabelFromCents,
@@ -47,8 +48,8 @@ const SUPER = makeSuperPackage();
 
 /** The width the settings row gives a single tile (roughly half a card). */
 const TILE_WIDTH_PX = 420;
-/** Two tiles plus the row's `gap-2`. */
-const ROW_WIDTH_PX = TILE_WIDTH_PX * 2 + 8;
+/** Two tiles plus the row's `gap-4`. */
+const ROW_WIDTH_PX = TILE_WIDTH_PX * 2 + 16;
 
 /** The upgrade CTA quotes the price difference, as `plan-card.tsx` composes it. */
 const UPGRADE_LABEL = `Power Up for +${formatDollars(
@@ -265,14 +266,14 @@ export const NextPlanPending: Story = {
 };
 
 /**
- * The real pairing, in the row `plan-card.tsx` renders: the current tile
- * inherits the app theme while the next-plan tile inverts it, exactly as
- * `RecommendedUpgrade` does. `useDocumentTheme()` reads the `data-theme`
- * attribute the themes addon stamps on the preview document, so toggling the
- * Storybook theme flips the next tile the way the app does. The row stacks
- * below the `lg` breakpoint: select `Mobile` in the viewport toolbar to see
- * that treatment, since the Canvas holds a desktop width regardless of window
- * size.
+ * The real pairing, inside the shared `PlanTileRow` that `plan-card.tsx` wraps
+ * both tiles in: the current tile inherits the app theme while the next-plan
+ * tile inverts it, exactly as `RecommendedUpgrade` does. `useDocumentTheme()`
+ * reads the `data-theme` attribute the themes addon stamps on the preview
+ * document, so toggling the Storybook theme flips the next tile the way the
+ * app does. The row stacks below the `lg` breakpoint: select `Mobile` in the
+ * viewport toolbar to see that treatment, since the Canvas holds a desktop
+ * width regardless of window size.
  */
 export const SideBySide: Story = {
   parameters: {
@@ -282,7 +283,7 @@ export const SideBySide: Story = {
   render: function SideBySideRender() {
     const inverted = useDocumentTheme() === "light" ? "dark" : "light";
     return (
-      <div className="flex flex-col gap-2 lg:flex-row lg:items-stretch">
+      <PlanTileRow>
         <PlanTile
           testId="plan-tile-current"
           tierKey={MIGHTY.key}
@@ -305,7 +306,7 @@ export const SideBySide: Story = {
           })}
           footer={upgradeCta()}
         />
-      </div>
+      </PlanTileRow>
     );
   },
 };

--- a/clients/web/src/domains/settings/components/billing-panel-balance-skeleton.test.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-balance-skeleton.test.tsx
@@ -16,6 +16,18 @@ describe("BillingPanelBalanceSkeleton", () => {
     expect(container.querySelectorAll('[data-slot="skeleton"]').length).toBe(3);
   });
 
+  test("stands each slot in with phrasing content the tile can hold", () => {
+    const { container } = render(<BillingPanelBalanceSkeleton />);
+
+    const placeholders = Array.from(
+      container.querySelectorAll('[data-slot="skeleton"]'),
+    );
+    expect(placeholders.length).toBe(3);
+    for (const placeholder of placeholders) {
+      expect(placeholder.tagName).toBe("SPAN");
+    }
+  });
+
   test("announces only when it is given a label", () => {
     const { container, rerender } = render(<BillingPanelBalanceSkeleton />);
     expect(container.querySelector('[role="status"]')).toBeNull();

--- a/clients/web/src/domains/settings/components/billing-panel-balance-skeleton.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-balance-skeleton.tsx
@@ -25,9 +25,21 @@ export function BillingPanelBalanceSkeleton({
       data-testid="billing-panel-balance-skeleton"
     >
       <StatSquare
-        icon={<Skeleton aria-hidden className="h-4 w-4 rounded-sm" />}
-        value={<Skeleton aria-hidden className="h-5 w-28 rounded-md" />}
-        label={<Skeleton aria-hidden className="h-4 w-24 rounded-md" />}
+        icon={<Skeleton as="span" aria-hidden className="h-4 w-4 rounded-sm" />}
+        value={
+          <Skeleton
+            as="span"
+            aria-hidden
+            className="block h-5 w-28 rounded-md"
+          />
+        }
+        label={
+          <Skeleton
+            as="span"
+            aria-hidden
+            className="block h-4 w-24 rounded-md"
+          />
+        }
       />
     </div>
   );

--- a/clients/web/src/domains/settings/components/billing-panel-skeleton.test.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-skeleton.test.tsx
@@ -18,11 +18,13 @@ describe("BillingPanelSkeleton", () => {
     // body below it is ever stood in for.
     expect(container.textContent).toContain("Extra Usage Credits");
 
-    // Balance tile, then the auto-reload, daily-limit and low-balance rows,
-    // the last two behind the panel's own dividers.
-    const body = getByTestId("billing-panel-skeleton-body");
-    expect(body.children.length).toBe(4);
-    expect(body.querySelectorAll(".border-t").length).toBe(2);
+    // The header, then the balance tile and the auto-reload, daily-limit and
+    // low-balance rows, the last two behind the panel's own dividers. The
+    // card's own body is the only wrapper the skeleton sits inside.
+    const card = getByTestId("billing-panel-skeleton");
+    const body = card.querySelector('[data-slot="card-body"]');
+    expect(body?.children.length).toBe(5);
+    expect(card.querySelectorAll(".border-t").length).toBe(2);
   });
 
   test("stays silent so the stack around it announces once", () => {

--- a/clients/web/src/domains/settings/components/billing-panel-skeleton.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel-skeleton.tsx
@@ -23,16 +23,14 @@ export function BillingPanelSkeleton() {
           </>
         }
       />
-      <div data-testid="billing-panel-skeleton-body">
-        <BillingPanelBalanceSkeleton />
-        <SkeletonLines lines={2} lineClassName="h-6" className="mt-6" />
-        <BillingPanelRowGroup>
-          <SkeletonLines lines={2} lineClassName="h-6" />
-        </BillingPanelRowGroup>
-        <BillingPanelRowGroup>
-          <SkeletonLines lines={1} lineClassName="h-6" />
-        </BillingPanelRowGroup>
-      </div>
+      <BillingPanelBalanceSkeleton />
+      <SkeletonLines lines={2} lineClassName="h-6" className="mt-6" />
+      <BillingPanelRowGroup>
+        <SkeletonLines lines={2} lineClassName="h-6" />
+      </BillingPanelRowGroup>
+      <BillingPanelRowGroup>
+        <SkeletonLines lines={1} lineClassName="h-6" />
+      </BillingPanelRowGroup>
     </Card>
   );
 }

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -147,8 +147,8 @@ export function PaymentMethodsCard() {
   return (
     <>
       {configPending ? (
-        // It carries the loading announcement: in the settled tree no outer
-        // region announces this wait.
+        // The skeleton carries the loading announcement: in the settled tree
+        // no outer region announces this wait.
         <PaymentMethodsCardSkeleton
           label={t("paymentMethodsCard.loadingLabel")}
         />

--- a/clients/web/src/domains/settings/components/plan-tile-row.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-tile-row.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * The stacking contract both the resolved plan card and its skeleton lean on:
+ * the tiles stack below `lg` and sit side by side at equal height above it.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { PlanTileRow } from "./plan-tile-row";
+
+afterEach(cleanup);
+
+describe("PlanTileRow", () => {
+  test("stacks the tiles below lg and rows them side by side above it", () => {
+    const { getByTestId } = render(
+      <PlanTileRow>
+        <div data-testid="first-tile" />
+        <div data-testid="second-tile" />
+      </PlanTileRow>,
+    );
+
+    const row = getByTestId("first-tile").parentElement;
+    expect(getByTestId("second-tile").parentElement).toBe(row);
+    expect(row?.className).toContain("flex-col");
+    expect(row?.className).toContain("lg:flex-row");
+    expect(row?.className).toContain("lg:items-stretch");
+  });
+});


### PR DESCRIPTION
## Summary
Final self-review residue: balance skeleton uses span placeholders inside StatSquare's phrasing slots, the bare skeleton-body wrapper is gone, the tab stack hides its composed skeletons behind one aria-hidden wrapper, the tile-row stacking contract has a test again, and the plan-tile story renders the shared PlanTileRow.

Part of plan: billing-skeleton-loading.md (self-review round 4)