### PR TITLE
fix(web): attribute GLM 5.3 models to their maker (unbreak main CI)

### DIFF
--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -388,6 +388,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/glm-5p3",
       displayName: "GLM 5.3",
+      vendor: "zhipu",
       contextWindowTokens: 1_040_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,
@@ -397,6 +398,7 @@ export const MODELS_BY_PROVIDER = {
     {
       id: "accounts/fireworks/models/glm-5p3-flash",
       displayName: "GLM 5.3 Flash",
+      vendor: "zhipu",
       contextWindowTokens: 1_040_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 131_072,


### PR DESCRIPTION
## Summary
- #41762 added GLM 5.3 / GLM 5.3 Flash via Fireworks with its CI run cancelled; the web vendor map had no entry for them, so the model list grouped them under the gateway name and three model-vendor tests fail on every main run since (first red: run 33440782988)
- adds the maker attribution following the existing vendor-map pattern; no test weakened

Unbreaks CI Main Web.