### PR TITLE
Fix Windows PATH handling for skill catalog installs

### DIFF
--- a/assistant/src/skills/catalog-install.ts
+++ b/assistant/src/skills/catalog-install.ts
@@ -18,7 +18,7 @@ import { getPlatformBaseUrl } from "../config/env.js";
 import { loadSkillCatalog } from "../config/skills.js";
 import { isBunVirtualPath } from "../util/bundled-asset.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceSkillsDir } from "../util/platform.js";
+import { addToPathEnv, getWorkspaceSkillsDir } from "../util/platform.js";
 import { computeSkillHash, writeInstallMeta } from "./install-meta.js";
 import {
   isSkillCompatibleWithPlatform,
@@ -416,12 +416,13 @@ export async function installSkillDependenciesIfPresent(
   if (!existsSync(join(skillDir, "package.json"))) {
     return;
   }
-  const bunPath = `${homedir()}/.bun/bin`;
+  const env = { ...process.env };
+  addToPathEnv(env, [join(homedir(), ".bun", "bin")]);
   await new Promise<void>((resolve, reject) => {
     const child = spawn("bun", ["install"], {
       cwd: skillDir,
       stdio: "inherit",
-      env: { ...process.env, PATH: `${bunPath}:${process.env.PATH}` },
+      env,
       windowsHide: true,
     });
     child.on("error", reject);


### PR DESCRIPTION
## Summary

- use the shared `addToPathEnv` helper when adding Bun to skill dependency install environments
- preserve the existing Windows `Path` key and platform-specific delimiter instead of writing a corrupt `PATH` value

## Original prompt

Address Windows client gap B13c in the skills catalog installer. The dependency install path hardcoded a POSIX separator and uppercase `PATH`; use the same cross-platform helper as the related B13 fixes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41830" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->