### PR TITLE
fix(windows): shrink installer by cutting duplicate packaged content

### DIFF
--- a/clients/macos/electron-builder.config.cjs
+++ b/clients/macos/electron-builder.config.cjs
@@ -42,6 +42,12 @@ module.exports = {
   directories: {
     output: "dist",
   },
+  // Only the electron-vite output belongs in app.asar. Without this allowlist
+  // electron-builder packs the whole project dir, shipping resources/ (a
+  // second bun binary included) again inside the asar. Production
+  // node_modules are collected from the dependency tree regardless of these
+  // patterns.
+  files: ["out/main/**", "out/preload/**", "package.json"],
   extraResources: [
     { from: "resources/bun", to: "bun" },
     {

--- a/clients/macos/electron-builder.config.cjs
+++ b/clients/macos/electron-builder.config.cjs
@@ -43,10 +43,11 @@ module.exports = {
     output: "dist",
   },
   // Only the electron-vite output belongs in app.asar. Without this allowlist
-  // electron-builder packs the whole project dir, shipping resources/ (a
-  // second bun binary included) again inside the asar. Production
-  // node_modules are collected from the dependency tree regardless of these
-  // patterns.
+  // electron-builder packs the whole project dir: the Swift helper build tree,
+  // a second copy of web-dist, src/, scripts/, and whatever else sits in
+  // clients/macos at pack time (a local pack once shipped a 12GB asar this
+  // way). Production node_modules are collected from the dependency tree
+  // regardless of these patterns.
   files: ["out/main/**", "out/preload/**", "package.json"],
   extraResources: [
     { from: "resources/bun", to: "bun" },

--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -3,7 +3,7 @@
 The Windows desktop client. Like `clients/macos`, this is an Electron shell
 around the `clients/web` renderer: in dev it loads the Vite dev server (or
 vel's edge proxy when `vel up` is running), and in packaged builds it serves a
-bundled `resources/web-dist` over a privileged `app://` protocol.
+bundled `resources/cli-runtime/web-dist` over a privileged `app://` protocol.
 
 ## Layout
 

--- a/clients/windows/electron-builder.config.cjs
+++ b/clients/windows/electron-builder.config.cjs
@@ -139,12 +139,18 @@ module.exports = {
   directories: {
     output: "dist",
   },
+  // Only the electron-vite output belongs in app.asar. Without this allowlist
+  // electron-builder packs the whole project dir, shipping resources/ (the
+  // ~1GB cli-runtime included) a second time inside the asar. Production
+  // node_modules are collected from the dependency tree regardless of these
+  // patterns.
+  files: ["out/main/**", "out/preload/**", "package.json"],
   // Requires `bun run build:web` (resources/web-dist), `bun run build:runtime`
   // (resources/cli-runtime), `bun run build:native-helper` (resources/
   // native-helper/<arch>), and `bun run build:preview-handler` (native COM
-  // build output) to exist before packing.
+  // build output) to exist before packing. The renderer bundle ships once,
+  // inside cli-runtime/web-dist.
   extraResources: [
-    { from: "resources/web-dist", to: "web-dist" },
     {
       from: `resources/native-helper/${targetArch}`,
       to: `native-helper/${targetArch}`,

--- a/clients/windows/scripts/package-runtime.ts
+++ b/clients/windows/scripts/package-runtime.ts
@@ -45,7 +45,9 @@ const calculateRuntimeBuildId = (runtimeDir: string): string => {
     );
     for (const entry of entries) {
       const absolute = path.join(dir, entry.name);
-      const relative = path.relative(runtimeDir, absolute).replaceAll("\\", "/");
+      const relative = path
+        .relative(runtimeDir, absolute)
+        .replaceAll("\\", "/");
       const stat = lstatSync(absolute);
       if (stat.isSymbolicLink()) {
         hash.update(relative);
@@ -278,12 +280,35 @@ if (cliVersionCheck.status !== 0 || cliVersionOutput !== expectedCliVersion) {
     `Packaged CLI version check failed: expected ${expectedCliVersion}, got ${cliVersionOutput || "no output"} (${diagnostics}).`,
   );
 }
+// Copies only git-tracked files so gitignored residue (skill node_modules
+// can run to hundreds of MB on a dev checkout) never ships in the runtime.
+const copyTrackedFiles = (source: string, destination: string): void => {
+  const listing = spawnSync(
+    "git",
+    ["-C", repoRoot, "ls-files", "-z", "--", source],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, windowsHide: true },
+  );
+  if (listing.status !== 0) {
+    throw new Error(
+      `git ls-files failed for ${source} (exit ${listing.status}).`,
+    );
+  }
+  const files = listing.stdout.split("\0").filter(Boolean);
+  if (files.length === 0) {
+    throw new Error(`No tracked files found under ${source}.`);
+  }
+  for (const file of files) {
+    const target = path.join(destination, path.relative(source, file));
+    mkdirSync(path.dirname(target), { recursive: true });
+    copyFileSync(path.join(repoRoot, file), target);
+  }
+};
+copyTrackedFiles("skills", path.join(outputDir, "first-party-skills"));
 for (const [source, name] of [
   ["assistant/src/prompts/templates", "templates"],
   ["assistant/src/config/bundled-skills", "bundled-skills"],
   ["assistant/src/runtime/routes/brain-graph", "brain-graph"],
   ["assistant/src/plugins/defaults", "default-plugins"],
-  ["skills", "first-party-skills"],
   ["clients/windows/resources/web-dist", "web-dist"],
 ] as const) {
   cpSync(path.join(repoRoot, source), path.join(outputDir, name), {

--- a/clients/windows/scripts/package-smoke.ts
+++ b/clients/windows/scripts/package-smoke.ts
@@ -132,7 +132,7 @@ const main = async (): Promise<void> => {
     );
   }
   for (const [relative, label] of [
-    ["web-dist/index.html", "Web renderer bundle"],
+    ["cli-runtime/web-dist/index.html", "Web renderer bundle"],
     ["cli-runtime/runtime.json", "Runtime manifest"],
     [`native-helper/${arch}/Vellum.WindowsHelper.exe`, "Native helper"],
     ["preview-handler/Vellum.PreviewHandler.dll", "Preview handler DLL"],

--- a/clients/windows/src/main/app-config.ts
+++ b/clients/windows/src/main/app-config.ts
@@ -3,7 +3,7 @@
  *
  * `APP_PROTOCOL` and `APP_HOST` define the custom scheme the packaged
  * renderer is served from; `index.ts` registers it privileged and serves
- * `resources/web-dist` through it, and `main-window.ts` derives the
+ * `resources/cli-runtime/web-dist` through it, and `main-window.ts` derives the
  * BrowserWindow load URL and the same-origin navigation guard from it.
  *
  * The renderer-base URLs are derived: `RENDERER_BASE_PROD` is the

--- a/clients/windows/src/main/index.ts
+++ b/clients/windows/src/main/index.ts
@@ -53,10 +53,10 @@ import { installWebContentsSecurity } from "./windows.client";
 /**
  * Windows shell for the Vellum Assistant: a hardened BrowserWindow loading
  * the clients/web renderer (Vite dev server in dev, `app://` static serving
- * of `resources/web-dist` in packaged builds). Every desktop capability is a
- * module under `./features/`, composed through the capability registry once
- * the app is ready; `docs/parity-matrix.md` maps them to their macOS
- * counterparts.
+ * of `resources/cli-runtime/web-dist` in packaged builds). Every desktop
+ * capability is a module under `./features/`, composed through the capability
+ * registry once the app is ready; `docs/parity-matrix.md` maps them to their
+ * macOS counterparts.
  */
 
 // Dev-only: override the package `name` (`@vellumai/windows`) so
@@ -134,7 +134,10 @@ const RENDERER_MOUNT = "/assistant";
 
 const resolveRendererRoot = (): string => {
   if (app.isPackaged) {
-    return path.join(process.resourcesPath, "web-dist");
+    // The renderer bundle ships once, inside the CLI runtime (see
+    // scripts/package-runtime.ts); the installed copy under userData is a
+    // clone of this directory.
+    return path.join(process.resourcesPath, "cli-runtime", "web-dist");
   }
   // Dev source tree: clients/web/dist. Requires `bun run build` in clients/web/.
   const repoRoot = path.resolve(app.getAppPath(), "..", "..");


### PR DESCRIPTION
## Summary
- Add a `files` allowlist (`out/main/**`, `out/preload/**`, `package.json`) to the Windows and macOS electron-builder configs so the whole project dir (notably the ~1.1GB `resources/cli-runtime` on Windows; on macOS the Swift helper build tree, a duplicate web-dist, src/ and scripts/, and a June local pack even swept in a 12GB apple-containers runtime) stops being packed into app.asar on top of the extraResources copies. Production node_modules are collected from the dependency tree independently of `files` patterns, so externalized deps still ship.
- Ship the renderer bundle once: drop the top-level `web-dist` extraResource on Windows and serve `app://` from `resources/cli-runtime/web-dist` (the userData runtime install already clones that directory); the package smoke asserts the new path.
- Copy only git-tracked files into `cli-runtime/first-party-skills` so gitignored residue (297MB of `node_modules` under `skills/meet-join` on a dev checkout) can never be swept into a pack.

Expected effect: installed footprint drops from ~4GB to roughly 1.5GB and the installer shrinks accordingly. The remaining big-ticket item (eight `bun build --compile` exes each embedding a 110MB Bun runtime) is intentionally left for a separate effort.

## Original prompt
Investigated why the Windows setup exe is ~1GB and installs to ~4GB. Root causes: electron-builder packing the entire project dir into app.asar (duplicating the CLI runtime), web-dist shipped multiple times, and the CLI runtime embedding nine copies of the Bun runtime. The user asked to ship the safe subset of fixes (asar allowlist for both desktop clients, web-dist dedupe, tracked-only skills copy) and to explicitly exclude the compiled-exe consolidation as too risky for this PR. Validation is via the clients/windows test suite and the windows-package-smoke workflow, since packing only runs on Windows CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJmMyLVPwttqj9gSvFnHEm
