### PR TITLE
feat(assistant): shrink aged camera frames to thumbnail scale

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -814,6 +814,7 @@ describe("AssistantConfigSchema", () => {
   test("applies sight defaults", () => {
     expect(AssistantConfigSchema.parse({}).sight).toEqual({
       keepLatestFrames: 2,
+      sweepAfterDays: 7,
     });
   });
 
@@ -841,6 +842,34 @@ describe("AssistantConfigSchema", () => {
     ).toBe(false);
     expect(
       AssistantConfigSchema.safeParse({ sight: { keepLatestFrames: "two" } })
+        .success,
+    ).toBe(false);
+  });
+
+  test("accepts a custom sight.sweepAfterDays", () => {
+    const result = AssistantConfigSchema.parse({
+      sight: { sweepAfterDays: 30 },
+    });
+    expect(result.sight.sweepAfterDays).toBe(30);
+  });
+
+  test("keeps an out-of-range sight.sweepAfterDays for the reader to clamp", () => {
+    // Same policy as keepLatestFrames: the clamp lives at read
+    // (`resolveSightSweepAfterDays`), so an out-of-range window is honored as
+    // far as the guardrail allows instead of silently reverting to the default.
+    const result = AssistantConfigSchema.parse({
+      sight: { sweepAfterDays: 0 },
+    });
+    expect(result.sight.sweepAfterDays).toBe(0);
+  });
+
+  test("rejects a non-integer sight.sweepAfterDays", () => {
+    expect(
+      AssistantConfigSchema.safeParse({ sight: { sweepAfterDays: 1.5 } })
+        .success,
+    ).toBe(false);
+    expect(
+      AssistantConfigSchema.safeParse({ sight: { sweepAfterDays: "a week" } })
         .success,
     ).toBe(false);
   });

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -20,7 +20,7 @@
 import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import { setDbMigrating, setDbReady } from "../daemon/daemon-readiness.js";
@@ -35,6 +35,7 @@ import {
   getAttachmentContent,
   getAttachmentMetadataForMessage,
   getFilePathForAttachment,
+  SWEEP_BACKUP_SUFFIX,
   uploadAttachment,
   uploadFileBackedAttachment,
 } from "../persistence/attachments-store.js";
@@ -232,6 +233,50 @@ function storedSizeBytes(attachmentId: string): number {
   return row!.sizeBytes;
 }
 
+/** A pass that found nothing to do and nothing to reclaim. */
+const NOTHING_HAPPENED = {
+  shrunk: 0,
+  freedBytes: 0,
+  skipped: 0,
+  examined: 0,
+  rowsRead: 0,
+  reclaimedBackups: 0,
+};
+
+/**
+ * Attachments the prefilter admits and the tag check rejects: each is linked to
+ * a message that mentions the sight key while naming some other attachment.
+ * They cost a page slot and a metadata lookup apiece and produce no candidate,
+ * which is the population the row budget exists for.
+ */
+async function plantPrefilterNearMisses(count: number): Promise<void> {
+  const conversation = createConversation("Call");
+  const message = await addMessage(conversation.id, "user", "(camera frame)", {
+    skipIndexing: true,
+  });
+  const filePath = join(
+    getConversationsDir(),
+    "2026-01-01T00-00-00.000Z_near-miss",
+    "attachments",
+    "near-miss.jpg",
+  );
+  const createdAt = Date.now() - 30 * DAY_MS;
+  for (let i = 0; i < count; i++) {
+    const id = `near-miss-${String(i).padStart(4, "0")}`;
+    rawRun(
+      "test:plantNearMiss",
+      `INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, file_path, created_at)
+       VALUES (?, 'near-miss.jpg', 'image/jpeg', ?, 'image', '', ?, ?)`,
+      id,
+      2 * 1024 * 1024,
+      filePath,
+      createdAt + i,
+    );
+    linkAttachmentWithoutScoping(message.id, id);
+  }
+  tagMessageFrames(message.id, ["names-nobody-here"]);
+}
+
 describe("sweepAgedSightFrames", () => {
   beforeEach(() => {
     resetTables();
@@ -383,12 +428,7 @@ describe("sweepAgedSightFrames", () => {
 
     const result = await sweepAgedSightFrames();
 
-    expect(result).toEqual({
-      shrunk: 0,
-      freedBytes: 0,
-      skipped: 0,
-      examined: 0,
-    });
+    expect(result).toEqual(NOTHING_HAPPENED);
     expect(storedSizeBytes(frame.attachmentId)).toBe(frame.sizeBytes);
   });
 
@@ -404,12 +444,7 @@ describe("sweepAgedSightFrames", () => {
 
     // Nothing is even a candidate the second time: the swept size is what the
     // query bounds on, so an already-shrunk frame is not re-read or re-encoded.
-    expect(second).toEqual({
-      shrunk: 0,
-      freedBytes: 0,
-      skipped: 0,
-      examined: 0,
-    });
+    expect(second).toEqual(NOTHING_HAPPENED);
     expect(storedSizeBytes(frame.attachmentId)).toBe(sweptSize);
     expect(readFileSync(frame.filePath).equals(sweptBytes)).toBe(true);
   });
@@ -509,5 +544,133 @@ describe("sweepAgedSightFrames", () => {
       readFileSync(frame.filePath).length,
     );
     expect(storedSizeBytes(frame.attachmentId)).toBeLessThan(frame.sizeBytes);
+  });
+
+  test("sweeps a frame only its second linked message tags", async () => {
+    // An attachment can hang off several messages, and only one of them need
+    // name it. A page that ended on one of the others used to advance the cursor
+    // past the attachment on that row's say-so, and the next page's strict `>`
+    // then excluded the link that would have qualified it, permanently. The page
+    // is one row per ATTACHMENT now, so no page boundary can fall between an
+    // attachment's own links.
+    const conversation = createConversation("Call");
+    const untagging = await addMessage(
+      conversation.id,
+      "user",
+      "(camera frame)",
+      { skipIndexing: true },
+    );
+    const stored = await attachInlineAttachmentToMessage(
+      untagging.id,
+      0,
+      "sight-frame.jpg",
+      "image/jpeg",
+      await makeFrameJpegBase64(),
+    );
+    // Mentions the key, names somebody else. Linked first, so a page of one
+    // taken from the old join would land on this row.
+    tagMessageFrames(untagging.id, ["names-nobody-here"]);
+
+    const tagging = await addMessage(
+      conversation.id,
+      "user",
+      "(camera frame)",
+      {
+        skipIndexing: true,
+      },
+    );
+    linkAttachmentWithoutScoping(tagging.id, stored.id);
+    tagMessageFrames(tagging.id, [stored.id]);
+    backdateAttachment(stored.id, 30);
+
+    const result = await sweepAgedSightFrames({ pageSize: 1 });
+
+    expect(result.shrunk).toBe(1);
+    expect(storedSizeBytes(stored.id)).toBeLessThan(stored.sizeBytes);
+  });
+
+  test("spends its row budget on prefilter near-misses and stops", async () => {
+    await plantPrefilterNearMisses(60);
+
+    const result = await sweepAgedSightFrames({
+      pageSize: 10,
+      maxRowsRead: 20,
+    });
+
+    // Not one of them is a candidate, so a budget counted in candidates would
+    // never bind and the pass would page the whole backlog every hour.
+    expect(result.examined).toBe(0);
+    expect(result.rowsRead).toBeGreaterThanOrEqual(20);
+    expect(result.rowsRead).toBeLessThan(60);
+    // Stopped part way, with somewhere to resume from rather than a wrap.
+    expect(getSightFrameSweepCursorForTest()).not.toBeNull();
+  });
+
+  test("reclaims a backup whose row already describes the file in place", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    await sweepAgedSightFrames();
+    const thumbnail = readFileSync(frame.filePath);
+
+    // What a process killed between the row update and the unlink leaves. The
+    // row reports the thumbnail now, so it never selects again and this pass is
+    // the last one that would ever have looked at it.
+    const orphaned = `${frame.filePath}${SWEEP_BACKUP_SUFFIX}`;
+    writeFileSync(orphaned, Buffer.alloc(frame.sizeBytes, 7));
+
+    // And one whose row is gone entirely, which no row-driven probe would find.
+    const strandedBase = join(
+      getConversationsDir(),
+      "2026-01-01T00-00-00.000Z_stranded",
+      "attachments",
+      "stranded.jpg",
+    );
+    mkdirSync(dirname(strandedBase), { recursive: true });
+    writeFileSync(strandedBase, Buffer.alloc(1024, 3));
+    const stranded = `${strandedBase}${SWEEP_BACKUP_SUFFIX}`;
+    writeFileSync(stranded, Buffer.alloc(4096, 9));
+
+    const result = await sweepAgedSightFrames({ maxBackupDirs: 1000 });
+
+    expect(result.reclaimedBackups).toBe(2);
+    expect(existsSync(orphaned)).toBe(false);
+    expect(existsSync(stranded)).toBe(false);
+    // The frame itself is untouched by the reclaim.
+    expect(readFileSync(frame.filePath).equals(thumbnail)).toBe(true);
+  });
+
+  test("keeps a backup whose row still overstates what is on disk", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    await sweepAgedSightFrames();
+    const original = Buffer.alloc(frame.sizeBytes, 7);
+
+    // The other crash window: the rename landed, the row update did not. The
+    // backup is the only full copy left, and the row still selects, so the next
+    // shrink attempt is what reclaims it.
+    const backup = `${frame.filePath}${SWEEP_BACKUP_SUFFIX}`;
+    writeFileSync(backup, original);
+    rawRun(
+      "test:restoreStaleSize",
+      "UPDATE attachments SET size_bytes = ? WHERE id = ?",
+      frame.sizeBytes,
+      frame.attachmentId,
+    );
+
+    // Encode nothing, so the reclaim is the only thing this pass does.
+    const reclaimOnly = await sweepAgedSightFrames({
+      maxEncodeAttempts: 0,
+      maxBackupDirs: 1000,
+    });
+
+    expect(reclaimOnly.reclaimedBackups).toBe(0);
+    expect(existsSync(backup)).toBe(true);
+    expect(readFileSync(backup).equals(original)).toBe(true);
+
+    // Convergence still happens, and takes the backup with it.
+    const converged = await sweepAgedSightFrames({ maxBackupDirs: 1000 });
+    expect(converged.shrunk).toBe(1);
+    expect(storedSizeBytes(frame.attachmentId)).toBe(
+      readFileSync(frame.filePath).length,
+    );
+    expect(existsSync(backup)).toBe(false);
   });
 });

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -23,6 +23,8 @@ import {
   getAttachmentById,
   getAttachmentContent,
   getAttachmentMetadataForMessage,
+  getFilePathForAttachment,
+  uploadAttachment,
   uploadFileBackedAttachment,
 } from "../persistence/attachments-store.js";
 import {
@@ -73,6 +75,25 @@ function backdateAttachment(attachmentId: string, ageDays: number): void {
     "UPDATE attachments SET created_at = ? WHERE id = ?",
     Date.now() - ageDays * DAY_MS,
     attachmentId,
+  );
+}
+
+/**
+ * Link an attachment to a message without scoping it into the conversation.
+ * `linkAttachmentToMessage` materializes as it links, which is exactly what the
+ * degraded shapes below need to skip.
+ */
+function linkAttachmentWithoutScoping(
+  messageId: string,
+  attachmentId: string,
+): void {
+  rawRun(
+    "test:linkAttachmentWithoutScoping",
+    "INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at) VALUES (?, ?, ?, 0, ?)",
+    `link-${attachmentId}`,
+    messageId,
+    attachmentId,
+    Date.now(),
   );
 }
 
@@ -231,14 +252,7 @@ describe("sweepAgedSightFrames", () => {
       outsidePath,
       bytes.length,
     );
-    rawRun(
-      "test:linkOutsideAttachment",
-      "INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at) VALUES (?, ?, ?, 0, ?)",
-      `link-${stored.id}`,
-      message.id,
-      stored.id,
-      Date.now(),
-    );
+    linkAttachmentWithoutScoping(message.id, stored.id);
     tagMessageFrames(message.id, [stored.id]);
     backdateAttachment(stored.id, 30);
 
@@ -248,6 +262,43 @@ describe("sweepAgedSightFrames", () => {
     expect(result.skipped).toBe(1);
     expect(existsSync(outsidePath)).toBe(true);
     expect(readFileSync(outsidePath).length).toBe(bytes.length);
+  });
+
+  test("re-encodes a frame whose bytes are still inline in the row", async () => {
+    // The shape materialization leaves when it finds nothing readable to copy:
+    // a linked row still holding its payload in the database, which is the last
+    // place a frame nobody chose to send should grow.
+    const conversation = createConversation("Call");
+    const message = await addMessage(
+      conversation.id,
+      "user",
+      "(camera frame)",
+      {
+        skipIndexing: true,
+      },
+    );
+    const stored = await uploadAttachment(
+      "sight-frame.jpg",
+      "image/jpeg",
+      await makeFrameJpegBase64(),
+    );
+    linkAttachmentWithoutScoping(message.id, stored.id);
+    tagMessageFrames(message.id, [stored.id]);
+    backdateAttachment(stored.id, 30);
+    expect(getFilePathForAttachment(stored.id)).toBeNull();
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result.shrunk).toBe(1);
+    const swept = getAttachmentById(stored.id);
+    expect(swept!.dataBase64.length).toBeGreaterThan(0);
+    expect(Buffer.from(swept!.dataBase64, "base64").length).toBe(
+      swept!.sizeBytes,
+    );
+    expect(swept!.sizeBytes).toBeLessThan(stored.sizeBytes);
+    // Still inline: the sweep re-encodes what is there rather than changing how
+    // the row stores it.
+    expect(getFilePathForAttachment(stored.id)).toBeNull();
   });
 
   test("skips every cycle while DB migrations are unready", async () => {

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -34,7 +34,9 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { setDbMigrating, setDbReady } from "../daemon/daemon-readiness.js";
 import {
+  getSightFrameSweepBackupCursorForTest,
   getSightFrameSweepCursorForTest,
+  getSightFrameSweepDirEnumerationsForTest,
   resetSightFrameSweepCursorForTest,
   sweepAgedSightFrames,
 } from "../daemon/sight-frame-storage-sweep.js";
@@ -270,8 +272,40 @@ function plantCanonicalFile(
   return { id, path, bytes };
 }
 
-/** The prefilter pattern the candidate query binds, so the plans are read with real arguments. */
-const TAGGED_MESSAGE_LIKE = '%"sightFrameAttachmentIds"%';
+/**
+ * Aged, large, image attachments that carry no sight tag at all: the shape of an
+ * ordinary photo library sitting in the index range the sweep pages through.
+ * They are what the page has to walk past, and what a `LIMIT` that bounded
+ * matches rather than visits would let it walk past for free.
+ */
+async function plantUntaggedImages(count: number): Promise<void> {
+  const conversation = createConversation("Album");
+  const message = await addMessage(conversation.id, "user", "photos", {
+    skipIndexing: true,
+  });
+  const filePath = join(
+    getConversationsDir(),
+    "2026-01-01T00-00-00.000Z_album",
+    "attachments",
+    "photo.jpg",
+  );
+  const createdAt = Date.now() - 30 * DAY_MS;
+  for (let i = 0; i < count; i++) {
+    rawRun(
+      "test:plantUntaggedImage",
+      `INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, file_path, created_at)
+       VALUES (?, 'photo.jpg', 'image/jpeg', ?, 'image', '', ?, ?)`,
+      `untagged-${String(i).padStart(4, "0")}`,
+      2 * 1024 * 1024,
+      filePath,
+      createdAt + i,
+    );
+    linkAttachmentWithoutScoping(
+      message.id,
+      `untagged-${String(i).padStart(4, "0")}`,
+    );
+  }
+}
 
 /** Every step SQLite reports for a query, joined so a test can assert over the whole plan. */
 function queryPlanFor(sql: string, binds: Array<string | number>): string {
@@ -490,9 +524,14 @@ describe("sweepAgedSightFrames", () => {
 
     const second = await sweepAgedSightFrames();
 
-    // Nothing is even a candidate the second time: the swept size is what the
-    // query bounds on, so an already-shrunk frame is not re-read or re-encoded.
-    expect(second).toEqual(NOTHING_HAPPENED);
+    // The row is still walked, because the page is a plain index range over age
+    // and the size threshold is applied to what it returns. What matters is that
+    // it stops being a CANDIDATE, so nothing re-reads or re-encodes its bytes.
+    expect(second.shrunk).toBe(0);
+    expect(second.examined).toBe(0);
+    expect(second.skipped).toBe(0);
+    expect(second.freedBytes).toBe(0);
+    expect(second.rowsRead).toBe(1);
     expect(storedSizeBytes(frame.attachmentId)).toBe(sweptSize);
     expect(readFileSync(frame.filePath).equals(sweptBytes)).toBe(true);
   });
@@ -816,8 +855,6 @@ describe("sweepAgedSightFrames", () => {
     // per page.
     const detail = queryPlanFor(SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL, [
       Date.now(),
-      128 * 1024,
-      TAGGED_MESSAGE_LIKE,
       200,
     ]);
 
@@ -829,6 +866,41 @@ describe("sweepAgedSightFrames", () => {
     expect(detail).not.toMatch(/\bSCAN a\b/);
   });
 
+  test("visits no more rows than its budget through an untagged backlog", async () => {
+    // The population that used to be invisible. Every one of these is aged,
+    // large, and an image, so the only thing that disqualifies it is the sight
+    // tag. With the tag test in SQL, one page would walk all 60 index entries
+    // probing message_attachments for each and return nothing, none of it
+    // charged. The page is a plain index range now, so a visit is a returned
+    // row and the budget is a real bound.
+    await plantUntaggedImages(60);
+
+    const result = await sweepAgedSightFrames({
+      pageSize: 10,
+      maxRowsRead: 20,
+    });
+
+    expect(result.shrunk).toBe(0);
+    expect(result.examined).toBe(0);
+    // Two pages of ten. Every visited row is counted, and no metadata probe
+    // happens at all, because nothing survives the kind and size checks that a
+    // probe would follow.
+    expect(result.rowsRead).toBe(20);
+    // Stopped part way with somewhere to resume from, not a wrap.
+    expect(getSightFrameSweepCursorForTest()).not.toBeNull();
+  });
+
+  test("charges every visited row when the range holds no candidates", async () => {
+    await plantUntaggedImages(12);
+
+    const result = await sweepAgedSightFrames({ pageSize: 100 });
+
+    // One page covering all twelve, each visited and each counted.
+    expect(result.rowsRead).toBe(12);
+    expect(result.examined).toBe(0);
+    expect(getSightFrameSweepCursorForTest()).toBeNull();
+  });
+
   test("seeks a continuation page straight to the cursor", () => {
     // The lower bound is the half that makes paging linear. A cursor predicate
     // SQLite cannot fold into the index range still SEARCHes, but from the
@@ -836,10 +908,8 @@ describe("sweepAgedSightFrames", () => {
     // quadratic in the pages walked. The tuple has to reach the constraint.
     const detail = queryPlanFor(SIGHT_FRAME_SWEEP_CONTINUATION_SQL, [
       Date.now(),
-      128 * 1024,
       Date.now() - DAY_MS,
       "att-cursor",
-      TAGGED_MESSAGE_LIKE,
       200,
     ]);
 
@@ -847,6 +917,39 @@ describe("sweepAgedSightFrames", () => {
     expect(detail).toContain("(created_at,id)>(?,?)");
     expect(detail).not.toContain("USE TEMP B-TREE");
     expect(detail).not.toMatch(/\bSCAN a\b/);
+  });
+
+  test("lists the conversations directory once per cycle, not once per pass", async () => {
+    // Discovery is O(all conversations). Doing it every pass would leave the
+    // advertised bound covering the child scans while the listing that feeds
+    // them grew with the workspace.
+    for (const suffix of ["aaa", "bbb", "ccc"]) {
+      mkdirSync(
+        join(
+          getConversationsDir(),
+          `2026-02-01T00-00-00.000Z_${suffix}`,
+          "attachments",
+        ),
+        { recursive: true },
+      );
+    }
+
+    await sweepAgedSightFrames({ maxBackupDirs: 1 });
+    expect(getSightFrameSweepDirEnumerationsForTest()).toBe(1);
+    expect(getSightFrameSweepBackupCursorForTest()).not.toBeNull();
+
+    await sweepAgedSightFrames({ maxBackupDirs: 1 });
+    await sweepAgedSightFrames({ maxBackupDirs: 1 });
+    expect(getSightFrameSweepDirEnumerationsForTest()).toBe(1);
+
+    // Finishing the cycle is what earns a fresh listing, which is also how a
+    // conversation created since the cycle began gets picked up.
+    await sweepAgedSightFrames({ maxBackupDirs: 10_000 });
+    expect(getSightFrameSweepBackupCursorForTest()).toBeNull();
+    expect(getSightFrameSweepDirEnumerationsForTest()).toBe(1);
+
+    await sweepAgedSightFrames({ maxBackupDirs: 1 });
+    expect(getSightFrameSweepDirEnumerationsForTest()).toBe(2);
   });
 
   test("deletes a backup whose base is missing and whose row is gone", async () => {

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -44,6 +44,7 @@ import {
   getAttachmentContent,
   getAttachmentMetadataForMessage,
   getFilePathForAttachment,
+  SIGHT_FRAME_SWEEP_CANDIDATE_SQL,
   SWEEP_BACKUP_SUFFIX,
   SWEEP_TEMP_SUFFIX,
   uploadAttachment,
@@ -53,7 +54,7 @@ import {
   addMessage,
   createConversation,
 } from "../persistence/conversation-crud.js";
-import { getDb } from "../persistence/db-connection.js";
+import { getDb, getSqlite } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { rawRun } from "../persistence/raw-query.js";
 import { isCompleteJpeg } from "../util/image-conversion.js";
@@ -794,6 +795,35 @@ describe("sweepAgedSightFrames", () => {
     expect(storedSizeBytes(frame.attachmentId)).toBe(
       readFileSync(frame.filePath).length,
     );
+  });
+
+  test("reads each candidate page as an index range, not a scan and a sort", () => {
+    // Paging is what makes this load-bearing. The row budget bounds rows
+    // RETURNED, so without an index every page would re-scan the whole
+    // attachments table and re-sort it, and a large install's hourly pass would
+    // pay for that once per page. With `idx_attachments_created_at_id` the age
+    // bound, the keyset continuation, and the ordering are the same index seek,
+    // so a page resumes where the last one stopped.
+    const plan = getSqlite()
+      .prepare(`EXPLAIN QUERY PLAN ${SIGHT_FRAME_SWEEP_CANDIDATE_SQL}`)
+      .all(
+        Date.now(),
+        128 * 1024,
+        1,
+        0,
+        "",
+        '%"sightFrameAttachmentIds"%',
+        200,
+      );
+    const detail = (plan as Array<{ detail: string }>)
+      .map((step) => step.detail)
+      .join("\n");
+
+    expect(detail).toContain("USING INDEX idx_attachments_created_at_id");
+    expect(detail).not.toContain("USE TEMP B-TREE");
+    // `SCAN a` is the whole-table read the index replaces. The subquery's own
+    // steps are SEARCHes on indexes that already existed.
+    expect(detail).not.toMatch(/\bSCAN a\b/);
   });
 
   test("deletes a backup whose base is missing and whose row is gone", async () => {

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -9,18 +9,27 @@
  * does: an untagged attachment, a frame inside the window, and a file more than
  * one row names.
  *
- * Two properties are about the pass rather than the frame, and both are failures
- * of the shape where nothing looks broken. A pass has to walk PAST the frames it
- * cannot rewrite, or a wall of them at the oldest end starves every frame behind
- * it and storage grows again. And a row update that throws after the new bytes
- * landed has to put the original back, or the row overstates a size the content
- * route serves as `Content-Length`.
+ * The rest are about the pass rather than the frame, and all of them are
+ * failures of the shape where nothing looks broken. A pass has to walk PAST the
+ * frames it cannot rewrite, or a wall of them at the oldest end starves every
+ * frame behind it and storage grows again. A row update that throws after the
+ * new bytes landed has to put the original back, or the row overstates a size
+ * the content route serves as `Content-Length`. And the files a killed process
+ * leaves mid-shrink have to be judged by the rows that point at them rather than
+ * by their names, which are derived from an attachment's own path and can
+ * therefore belong to a real attachment.
  */
 
 import { randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import { setDbMigrating, setDbReady } from "../daemon/daemon-readiness.js";
@@ -36,6 +45,7 @@ import {
   getAttachmentMetadataForMessage,
   getFilePathForAttachment,
   SWEEP_BACKUP_SUFFIX,
+  SWEEP_TEMP_SUFFIX,
   uploadAttachment,
   uploadFileBackedAttachment,
 } from "../persistence/attachments-store.js";
@@ -233,6 +243,31 @@ function storedSizeBytes(attachmentId: string): number {
   return row!.sizeBytes;
 }
 
+/**
+ * A real file with a row naming it as its canonical bytes, for names that
+ * collide with the sweep's own sidecar suffixes.
+ */
+function plantCanonicalFile(
+  dir: string,
+  filename: string,
+): { id: string; path: string; bytes: Buffer } {
+  const path = join(dir, filename);
+  const bytes = Buffer.alloc(2048, 5);
+  writeFileSync(path, bytes);
+  const id = `canonical-${filename}`;
+  rawRun(
+    "test:plantCanonicalFile",
+    `INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, file_path, created_at)
+     VALUES (?, ?, 'image/jpeg', ?, 'image', '', ?, ?)`,
+    id,
+    filename,
+    bytes.length,
+    path,
+    Date.now(),
+  );
+  return { id, path, bytes };
+}
+
 /** A pass that found nothing to do and nothing to reclaim. */
 const NOTHING_HAPPENED = {
   shrunk: 0,
@@ -240,7 +275,7 @@ const NOTHING_HAPPENED = {
   skipped: 0,
   examined: 0,
   rowsRead: 0,
-  reclaimedBackups: 0,
+  leftovers: { deleted: 0, restored: 0, skipped: 0 },
 };
 
 /**
@@ -631,7 +666,7 @@ describe("sweepAgedSightFrames", () => {
 
     const result = await sweepAgedSightFrames({ maxBackupDirs: 1000 });
 
-    expect(result.reclaimedBackups).toBe(2);
+    expect(result.leftovers.deleted).toBe(2);
     expect(existsSync(orphaned)).toBe(false);
     expect(existsSync(stranded)).toBe(false);
     // The frame itself is untouched by the reclaim.
@@ -661,7 +696,8 @@ describe("sweepAgedSightFrames", () => {
       maxBackupDirs: 1000,
     });
 
-    expect(reclaimOnly.reclaimedBackups).toBe(0);
+    expect(reclaimOnly.leftovers.deleted).toBe(0);
+    expect(reclaimOnly.leftovers.skipped).toBeGreaterThanOrEqual(1);
     expect(existsSync(backup)).toBe(true);
     expect(readFileSync(backup).equals(original)).toBe(true);
 
@@ -671,6 +707,109 @@ describe("sweepAgedSightFrames", () => {
     expect(storedSizeBytes(frame.attachmentId)).toBe(
       readFileSync(frame.filePath).length,
     );
+    expect(existsSync(backup)).toBe(false);
+  });
+
+  test("leaves alone a stored file whose own name ends in a sweep suffix", async () => {
+    // The suffixes are derived from an attachment's path, not reserved. A user
+    // can pick a file called `holiday.jpg.sweep-tmp`, the store keeps the name,
+    // and it lands in a directory the reclaim scans. Deleting it on the strength
+    // of its name destroys canonical bytes a row and a transcript still point at.
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    const dir = dirname(frame.filePath);
+    const namedLikeTemp = plantCanonicalFile(
+      dir,
+      `holiday.jpg${SWEEP_TEMP_SUFFIX}`,
+    );
+    const namedLikeBackup = plantCanonicalFile(
+      dir,
+      `holiday.jpg${SWEEP_BACKUP_SUFFIX}`,
+    );
+
+    const result = await sweepAgedSightFrames({ maxBackupDirs: 1000 });
+
+    expect(result.leftovers.deleted).toBe(0);
+    expect(result.leftovers.skipped).toBe(2);
+    expect(readFileSync(namedLikeTemp.path).equals(namedLikeTemp.bytes)).toBe(
+      true,
+    );
+    expect(
+      readFileSync(namedLikeBackup.path).equals(namedLikeBackup.bytes),
+    ).toBe(true);
+    expect(getAttachmentContent(namedLikeTemp.id)?.length).toBe(
+      namedLikeTemp.bytes.length,
+    );
+  });
+
+  test("refuses to shrink a frame whose sidecar names are already taken", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    const original = readFileSync(frame.filePath);
+    // Another row's canonical bytes sitting exactly where this frame's backup
+    // would go. Writing there would take that attachment's only copy.
+    const squatter = plantCanonicalFile(
+      dirname(frame.filePath),
+      `${basename(frame.filePath)}${SWEEP_BACKUP_SUFFIX}`,
+    );
+
+    const result = await sweepAgedSightFrames({ maxBackupDirs: 1000 });
+
+    expect(result.shrunk).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(readFileSync(frame.filePath).equals(original)).toBe(true);
+    expect(readFileSync(squatter.path).equals(squatter.bytes)).toBe(true);
+  });
+
+  test("restores a base file a crash left missing between the two renames", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    const original = readFileSync(frame.filePath);
+
+    // The window between the renames: the original is aside under the backup
+    // name, the replacement is written but not promoted, and the row points at
+    // nothing at all.
+    const backup = `${frame.filePath}${SWEEP_BACKUP_SUFFIX}`;
+    const temp = `${frame.filePath}${SWEEP_TEMP_SUFFIX}`;
+    renameSync(frame.filePath, backup);
+    writeFileSync(temp, Buffer.alloc(4096, 1));
+    expect(getAttachmentContent(frame.attachmentId)).toBeNull();
+
+    const reclaimOnly = await sweepAgedSightFrames({
+      maxEncodeAttempts: 0,
+      maxBackupDirs: 1000,
+    });
+
+    // Keeping the backup where it lay would have left the frame unreadable for
+    // as long as the row survived, since nothing else ever puts it back.
+    expect(reclaimOnly.leftovers.restored).toBe(1);
+    expect(readFileSync(frame.filePath).equals(original)).toBe(true);
+    expect(existsSync(backup)).toBe(false);
+    // The temp beside it is debris once the base it would have replaced is back.
+    expect(existsSync(temp)).toBe(false);
+    expect(getAttachmentContent(frame.attachmentId)?.length).toBe(
+      original.length,
+    );
+
+    // Readable again and still over the threshold, so the sweep finishes it.
+    const converged = await sweepAgedSightFrames({ maxBackupDirs: 1000 });
+    expect(converged.shrunk).toBe(1);
+    expect(storedSizeBytes(frame.attachmentId)).toBe(
+      readFileSync(frame.filePath).length,
+    );
+  });
+
+  test("deletes a backup whose base is missing and whose row is gone", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    const backup = `${frame.filePath}${SWEEP_BACKUP_SUFFIX}`;
+    renameSync(frame.filePath, backup);
+    rawRun(
+      "test:dropAttachmentRow",
+      "DELETE FROM attachments WHERE id = ?",
+      frame.attachmentId,
+    );
+
+    const result = await sweepAgedSightFrames({ maxBackupDirs: 1000 });
+
+    expect(result.leftovers.restored).toBe(0);
+    expect(result.leftovers.deleted).toBe(1);
     expect(existsSync(backup)).toBe(false);
   });
 });

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -34,11 +34,14 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { setDbMigrating, setDbReady } from "../daemon/daemon-readiness.js";
 import {
+  CATCH_UP_SWEEP_DELAY_MS,
   getSightFrameSweepBackupCursorForTest,
   getSightFrameSweepCursorForTest,
   getSightFrameSweepDirEnumerationsForTest,
   resetSightFrameSweepCursorForTest,
+  SWEEP_INTERVAL_MS,
   sweepAgedSightFrames,
+  sweepDelayAfter,
 } from "../daemon/sight-frame-storage-sweep.js";
 import {
   attachInlineAttachmentToMessage,
@@ -48,6 +51,7 @@ import {
   getFilePathForAttachment,
   SIGHT_FRAME_SWEEP_CONTINUATION_SQL,
   SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL,
+  SIGHT_FRAME_TAG_PROBE_LIMIT,
   SWEEP_BACKUP_SUFFIX,
   SWEEP_TEMP_SUFFIX,
   uploadAttachment,
@@ -323,6 +327,7 @@ const NOTHING_HAPPENED = {
   examined: 0,
   rowsRead: 0,
   leftovers: { deleted: 0, restored: 0, skipped: 0 },
+  stoppedOnBudget: false,
 };
 
 /**
@@ -882,9 +887,8 @@ describe("sweepAgedSightFrames", () => {
 
     expect(result.shrunk).toBe(0);
     expect(result.examined).toBe(0);
-    // Two pages of ten. Every visited row is counted, and no metadata probe
-    // happens at all, because nothing survives the kind and size checks that a
-    // probe would follow.
+    // One page of ten rows plus the ten links its tag checks read, which spends
+    // the budget exactly. Every visit is counted, the probe's included.
     expect(result.rowsRead).toBe(20);
     // Stopped part way with somewhere to resume from, not a wrap.
     expect(getSightFrameSweepCursorForTest()).not.toBeNull();
@@ -895,10 +899,63 @@ describe("sweepAgedSightFrames", () => {
 
     const result = await sweepAgedSightFrames({ pageSize: 100 });
 
-    // One page covering all twelve, each visited and each counted.
-    expect(result.rowsRead).toBe(12);
+    // One page covering all twelve, plus the one linked message each of them
+    // costs the tag check. Every visit is charged, the probe's included.
+    expect(result.rowsRead).toBe(24);
     expect(result.examined).toBe(0);
     expect(getSightFrameSweepCursorForTest()).toBeNull();
+  });
+
+  test("caps the links one candidate's tag check reads", async () => {
+    // A frame hangs off one message by construction, so the cap costs a real
+    // one nothing. What it stops is an attachment with an unusual link count
+    // turning a single candidate into an unbounded read, invisible to the
+    // budget because only the survivors used to be counted.
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    const extraLinks = SIGHT_FRAME_TAG_PROBE_LIMIT * 3;
+    for (let i = 0; i < extraLinks; i++) {
+      const extra = await addMessage(frame.conversationId, "user", "turn", {
+        skipIndexing: true,
+      });
+      rawRun(
+        "test:extraSightLink",
+        "INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at) VALUES (?, ?, ?, 0, ?)",
+        `extra-link-${i}`,
+        extra.id,
+        frame.attachmentId,
+        Date.now(),
+      );
+      tagMessageFrames(extra.id, [frame.attachmentId]);
+    }
+
+    const result = await sweepAgedSightFrames();
+
+    // Still verified, and still swept.
+    expect(result.shrunk).toBe(1);
+    // One page row plus the capped probe, not one row per link.
+    expect(result.rowsRead).toBe(1 + SIGHT_FRAME_TAG_PROBE_LIMIT);
+  });
+
+  test("comes back on the catch-up cadence only while work is left", async () => {
+    // The gate will not keep two frames inside five seconds, so a call with the
+    // camera up all hour persists at most 720. A pass attempts 200, so at the
+    // resting cadence the backlog would grow faster than it drains; the
+    // catch-up cadence turns that into 2400 an hour against a ceiling of 720.
+    const frames = [
+      await plantFrame({ ageDays: 30, tagged: true }),
+      await plantFrame({ ageDays: 20, tagged: true }),
+    ];
+    expect(frames).toHaveLength(2);
+
+    const spent = await sweepAgedSightFrames({ maxEncodeAttempts: 1 });
+    expect(spent.stoppedOnBudget).toBe(true);
+    expect(sweepDelayAfter(spent)).toBe(CATCH_UP_SWEEP_DELAY_MS);
+
+    // Draining the rest leaves nothing behind, so the sweep goes back to
+    // resting rather than spinning at the short delay forever.
+    const drained = await sweepAgedSightFrames();
+    expect(drained.stoppedOnBudget).toBe(false);
+    expect(sweepDelayAfter(drained)).toBe(SWEEP_INTERVAL_MS);
   });
 
   test("seeks a continuation page straight to the cursor", () => {

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -51,6 +51,9 @@ import {
 } from "../daemon/sight-frame-storage-sweep.js";
 import {
   attachInlineAttachmentToMessage,
+  ATTACHMENT_FILE_PATH_REFERENCE_SQL,
+  ATTACHMENT_SIDECARS_CLAIMED_SQL,
+  ATTACHMENT_SWEEP_BACKUP_OWNERS_SQL,
   getAttachmentById,
   getAttachmentContent,
   getAttachmentMetadataForMessage,
@@ -671,11 +674,9 @@ describe("sweepAgedSightFrames", () => {
 
   test("sweeps a frame only its second linked message tags", async () => {
     // An attachment can hang off several messages, and only one of them need
-    // name it. A page that ended on one of the others used to advance the cursor
-    // past the attachment on that row's say-so, and the next page's strict `>`
-    // then excluded the link that would have qualified it, permanently. The page
-    // is one row per ATTACHMENT now, so no page boundary can fall between an
-    // attachment's own links.
+    // name it. A page is one row per ATTACHMENT, so no page boundary falls
+    // between an attachment's own links and the cursor can never step past it on
+    // the say-so of a link that does not name it.
     const conversation = createConversation("Call");
     const untagging = await addMessage(
       conversation.id,
@@ -903,12 +904,12 @@ describe("sweepAgedSightFrames", () => {
   });
 
   test("visits no more rows than its budget through an untagged backlog", async () => {
-    // The population that used to be invisible. Every one of these is aged,
-    // large, and an image, so the only thing that disqualifies it is the sight
-    // tag. With the tag test in SQL, one page would walk all 60 index entries
-    // probing message_attachments for each and return nothing, none of it
-    // charged. The page is a plain index range now, so a visit is a returned
-    // row and the budget is a real bound.
+    // Every one of these is aged, large, and an image, so the only thing that
+    // disqualifies it is the sight tag. The page is a plain index range and the
+    // tag test happens over what it returns, so a visit IS a returned row and
+    // the budget bounds the walk. A tag test inside the query would instead let
+    // one page walk all 60 index entries, probing message_attachments for each,
+    // return nothing, and charge nothing.
     await plantUntaggedImages(60);
 
     const result = await sweepAgedSightFrames({
@@ -940,8 +941,7 @@ describe("sweepAgedSightFrames", () => {
   test("caps the links one candidate's tag check reads", async () => {
     // A frame hangs off one message by construction, so the cap costs a real
     // one nothing. What it stops is an attachment with an unusual link count
-    // turning a single candidate into an unbounded read, invisible to the
-    // budget because only the survivors used to be counted.
+    // turning a single candidate into a read the budget cannot see the size of.
     const frame = await plantFrame({ ageDays: 30, tagged: true });
     const extraLinks = SIGHT_FRAME_TAG_PROBE_LIMIT * 3;
     for (let i = 0; i < extraLinks; i++) {
@@ -987,6 +987,26 @@ describe("sweepAgedSightFrames", () => {
     const drained = await sweepAgedSightFrames();
     expect(drained.stoppedOnBudget).toBe(false);
     expect(sweepDelayAfter(drained)).toBe(SWEEP_INTERVAL_MS);
+  });
+
+  test("answers its file_path guards from an index", () => {
+    // The refusal check asks two of these per candidate, for up to two hundred
+    // candidates a pass, so a scan here is a scan of the whole table hundreds of
+    // times an hour. The reclaim asks the third per sidecar it finds.
+    const shapes: Array<[string, Array<string | number>]> = [
+      [ATTACHMENT_FILE_PATH_REFERENCE_SQL, ["/some/attachment.jpg"]],
+      [
+        ATTACHMENT_SIDECARS_CLAIMED_SQL,
+        ["/a.jpg.sweep-tmp", "/a.jpg.sweep-bak"],
+      ],
+      [ATTACHMENT_SWEEP_BACKUP_OWNERS_SQL, [1024, "/some/attachment.jpg"]],
+    ];
+
+    for (const [sql, binds] of shapes) {
+      const detail = queryPlanFor(sql, binds);
+      expect(detail).toContain("INDEX idx_attachments_file_path");
+      expect(detail).not.toMatch(/\bSCAN attachments\b/);
+    }
   });
 
   test("seeks a continuation page straight to the cursor", () => {
@@ -1078,7 +1098,7 @@ describe("sweepAgedSightFrames", () => {
 
     // Every store call throws once the table it reads is not there. The
     // candidate read is guarded and ends the pass quietly; the leftover scan's
-    // is not, and is what used to escape.
+    // is not, so it is the one that reaches the boundary catch.
     getDb().run("ALTER TABLE attachments RENAME TO attachments_hidden");
     startSightFrameStorageSweep();
     try {

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -8,6 +8,13 @@
  * growing, and everything it must NOT touch is asserted here alongside what it
  * does: an untagged attachment, a frame inside the window, and a file more than
  * one row names.
+ *
+ * Two properties are about the pass rather than the frame, and both are failures
+ * of the shape where nothing looks broken. A pass has to walk PAST the frames it
+ * cannot rewrite, or a wall of them at the oldest end starves every frame behind
+ * it and storage grows again. And a row update that throws after the new bytes
+ * landed has to put the original back, or the row overstates a size the content
+ * route serves as `Content-Length`.
  */
 
 import { randomBytes } from "node:crypto";
@@ -17,7 +24,11 @@ import { join } from "node:path";
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import { setDbMigrating, setDbReady } from "../daemon/daemon-readiness.js";
-import { sweepAgedSightFrames } from "../daemon/sight-frame-storage-sweep.js";
+import {
+  getSightFrameSweepCursorForTest,
+  resetSightFrameSweepCursorForTest,
+  sweepAgedSightFrames,
+} from "../daemon/sight-frame-storage-sweep.js";
 import {
   attachInlineAttachmentToMessage,
   getAttachmentById,
@@ -35,6 +46,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import { rawRun } from "../persistence/raw-query.js";
 import { isCompleteJpeg } from "../util/image-conversion.js";
+import { getConversationsDir } from "../util/platform.js";
 import { setConfig } from "./helpers/set-config.js";
 
 setConfig("memory", { enabled: false });
@@ -63,10 +75,29 @@ async function makeFrameJpegBase64(): Promise<string> {
 
 function resetTables() {
   const db = getDb();
+  db.run("DROP TRIGGER IF EXISTS test_block_shrink");
   db.run("DELETE FROM message_attachments");
   db.run("DELETE FROM attachments");
   db.run("DELETE FROM messages");
   db.run("DELETE FROM conversations");
+}
+
+/**
+ * Make the row update inside `shrinkAttachmentBytes` throw for one attachment,
+ * at the real seam rather than through a module mock, so the recovery path runs
+ * against the same statement production uses. The id is interpolated because
+ * `CREATE TRIGGER` takes no bind parameters; it is a uuid this file just minted.
+ */
+function failNextRowUpdate(attachmentId: string): void {
+  getDb().run(
+    `CREATE TRIGGER test_block_shrink BEFORE UPDATE ON attachments
+     FOR EACH ROW WHEN NEW.id = '${attachmentId}'
+     BEGIN SELECT RAISE(ABORT, 'forced row update failure'); END`,
+  );
+}
+
+function clearRowUpdateFailure(): void {
+  getDb().run("DROP TRIGGER IF EXISTS test_block_shrink");
 }
 
 function backdateAttachment(attachmentId: string, ageDays: number): void {
@@ -119,6 +150,50 @@ interface PlantedFrame {
 }
 
 /**
+ * A wall of aged frames the sweep can never rewrite, all naming one file so each
+ * is refused as shared. Written by hand rather than through the store because no
+ * bytes are ever read: the point is a candidate set larger than one page that
+ * yields nothing, which is the shape that starves everything behind it.
+ *
+ * They share one tagged message, the way a spoken turn carrying several parked
+ * frames does.
+ */
+async function plantRefusedFrames(
+  count: number,
+  ageDays: number,
+): Promise<void> {
+  const conversation = createConversation("Call");
+  const message = await addMessage(conversation.id, "user", "(camera frame)", {
+    skipIndexing: true,
+  });
+  // Inside the store's own tree, so the rows are refused as SHARED rather than
+  // as foreign. The file itself never has to exist: nothing reads it.
+  const sharedPath = join(
+    getConversationsDir(),
+    "2026-01-01T00-00-00.000Z_shared",
+    "attachments",
+    "shared-frame.jpg",
+  );
+  const createdAt = Date.now() - ageDays * DAY_MS;
+  const ids: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const id = `refused-${String(i).padStart(4, "0")}`;
+    ids.push(id);
+    rawRun(
+      "test:plantRefusedFrame",
+      `INSERT INTO attachments (id, original_filename, mime_type, size_bytes, kind, data_base64, file_path, created_at)
+       VALUES (?, 'shared-frame.jpg', 'image/jpeg', ?, 'image', '', ?, ?)`,
+      id,
+      2 * 1024 * 1024,
+      sharedPath,
+      createdAt + i,
+    );
+    linkAttachmentWithoutScoping(message.id, id);
+  }
+  tagMessageFrames(message.id, ids);
+}
+
+/**
  * Persist one image as an attachment on a fresh conversation, tagging the row
  * as a camera frame unless `tagged` says otherwise, and backdate the attachment
  * so the sweep sees it as `ageDays` old.
@@ -161,6 +236,7 @@ describe("sweepAgedSightFrames", () => {
   beforeEach(() => {
     resetTables();
     setDbReady(true);
+    resetSightFrameSweepCursorForTest();
   });
 
   test("shrinks an aged camera frame while the transcript keeps resolving it", async () => {
@@ -307,7 +383,12 @@ describe("sweepAgedSightFrames", () => {
 
     const result = await sweepAgedSightFrames();
 
-    expect(result).toEqual({ shrunk: 0, freedBytes: 0, skipped: 0 });
+    expect(result).toEqual({
+      shrunk: 0,
+      freedBytes: 0,
+      skipped: 0,
+      examined: 0,
+    });
     expect(storedSizeBytes(frame.attachmentId)).toBe(frame.sizeBytes);
   });
 
@@ -323,8 +404,110 @@ describe("sweepAgedSightFrames", () => {
 
     // Nothing is even a candidate the second time: the swept size is what the
     // query bounds on, so an already-shrunk frame is not re-read or re-encoded.
-    expect(second).toEqual({ shrunk: 0, freedBytes: 0, skipped: 0 });
+    expect(second).toEqual({
+      shrunk: 0,
+      freedBytes: 0,
+      skipped: 0,
+      examined: 0,
+    });
     expect(storedSizeBytes(frame.attachmentId)).toBe(sweptSize);
     expect(readFileSync(frame.filePath).equals(sweptBytes)).toBe(true);
+  });
+
+  test("reaches a younger frame behind more refusals than one page holds", async () => {
+    // Older than the frame below, so an ascending scan meets them first, and
+    // more of them than a page, so a pass that could not step past them would
+    // hand back the same wall every time and never see what is behind it.
+    await plantRefusedFrames(250, 30);
+    const frame = await plantFrame({ ageDays: 8, tagged: true });
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result.shrunk).toBe(1);
+    expect(result.skipped).toBe(250);
+    expect(result.examined).toBe(251);
+    expect(storedSizeBytes(frame.attachmentId)).toBeLessThan(frame.sizeBytes);
+  });
+
+  test("a pass that stops on its bound resumes where it left off", async () => {
+    const oldest = await plantFrame({ ageDays: 30, tagged: true });
+    const middle = await plantFrame({ ageDays: 20, tagged: true });
+    const newest = await plantFrame({ ageDays: 10, tagged: true });
+
+    const first = await sweepAgedSightFrames({ maxEncodeAttempts: 1 });
+    expect(first.shrunk).toBe(1);
+    expect(getSightFrameSweepCursorForTest()?.id).toBe(oldest.attachmentId);
+    expect(storedSizeBytes(oldest.attachmentId)).toBeLessThan(oldest.sizeBytes);
+    expect(storedSizeBytes(middle.attachmentId)).toBe(middle.sizeBytes);
+
+    const second = await sweepAgedSightFrames({ maxEncodeAttempts: 1 });
+    expect(second.shrunk).toBe(1);
+    expect(getSightFrameSweepCursorForTest()?.id).toBe(middle.attachmentId);
+    expect(storedSizeBytes(middle.attachmentId)).toBeLessThan(middle.sizeBytes);
+    expect(storedSizeBytes(newest.attachmentId)).toBe(newest.sizeBytes);
+
+    // The pass that runs out of rows wraps, so newly aged frames are seen again.
+    await sweepAgedSightFrames({ maxEncodeAttempts: 1 });
+    await sweepAgedSightFrames({ maxEncodeAttempts: 1 });
+    expect(getSightFrameSweepCursorForTest()).toBeNull();
+    expect(storedSizeBytes(newest.attachmentId)).toBeLessThan(newest.sizeBytes);
+  });
+
+  test("puts the original bytes back when recording the new size throws", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    const original = readFileSync(frame.filePath);
+
+    failNextRowUpdate(frame.attachmentId);
+    try {
+      const failed = await sweepAgedSightFrames();
+      expect(failed.shrunk).toBe(0);
+      expect(failed.skipped).toBe(1);
+    } finally {
+      clearRowUpdateFailure();
+    }
+
+    // The row and the file still agree, which is the whole point: a thumbnail
+    // left under a row claiming the original size is served with a
+    // Content-Length no reader can satisfy.
+    expect(readFileSync(frame.filePath).equals(original)).toBe(true);
+    expect(storedSizeBytes(frame.attachmentId)).toBe(frame.sizeBytes);
+    expect(existsSync(`${frame.filePath}.sweep-bak`)).toBe(false);
+    expect(existsSync(`${frame.filePath}.sweep-tmp`)).toBe(false);
+
+    // Still a candidate, so the next pass finishes what this one could not.
+    const recovered = await sweepAgedSightFrames();
+    expect(recovered.shrunk).toBe(1);
+    expect(readFileSync(frame.filePath).length).toBeLessThan(original.length);
+    expect(storedSizeBytes(frame.attachmentId)).toBe(
+      readFileSync(frame.filePath).length,
+    );
+  });
+
+  test("converges on a row a killed process left overstating its size", async () => {
+    // What a crash between the file rename and the row update leaves: the
+    // thumbnail is on disk, the row still claims the original size. That is the
+    // reason the file is written FIRST. An overstated size keeps the row above
+    // the sweep's threshold, so it is still a candidate and the next pass
+    // finishes the job; a DB-first order would understate it instead, drop the
+    // row below the threshold, and strand the full-size file forever.
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    await sweepAgedSightFrames();
+    const onDisk = readFileSync(frame.filePath).length;
+    expect(onDisk).toBeLessThan(frame.sizeBytes);
+
+    rawRun(
+      "test:restoreStaleSize",
+      "UPDATE attachments SET size_bytes = ? WHERE id = ?",
+      frame.sizeBytes,
+      frame.attachmentId,
+    );
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result.shrunk).toBe(1);
+    expect(storedSizeBytes(frame.attachmentId)).toBe(
+      readFileSync(frame.filePath).length,
+    );
+    expect(storedSizeBytes(frame.attachmentId)).toBeLessThan(frame.sizeBytes);
   });
 });

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -44,7 +44,8 @@ import {
   getAttachmentContent,
   getAttachmentMetadataForMessage,
   getFilePathForAttachment,
-  SIGHT_FRAME_SWEEP_CANDIDATE_SQL,
+  SIGHT_FRAME_SWEEP_CONTINUATION_SQL,
+  SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL,
   SWEEP_BACKUP_SUFFIX,
   SWEEP_TEMP_SUFFIX,
   uploadAttachment,
@@ -267,6 +268,17 @@ function plantCanonicalFile(
     Date.now(),
   );
   return { id, path, bytes };
+}
+
+/** The prefilter pattern the candidate query binds, so the plans are read with real arguments. */
+const TAGGED_MESSAGE_LIKE = '%"sightFrameAttachmentIds"%';
+
+/** Every step SQLite reports for a query, joined so a test can assert over the whole plan. */
+function queryPlanFor(sql: string, binds: Array<string | number>): string {
+  const plan = getSqlite()
+    .prepare(`EXPLAIN QUERY PLAN ${sql}`)
+    .all(...binds) as Array<{ detail: string }>;
+  return plan.map((step) => step.detail).join("\n");
 }
 
 /** A pass that found nothing to do and nothing to reclaim. */
@@ -797,32 +809,43 @@ describe("sweepAgedSightFrames", () => {
     );
   });
 
-  test("reads each candidate page as an index range, not a scan and a sort", () => {
-    // Paging is what makes this load-bearing. The row budget bounds rows
-    // RETURNED, so without an index every page would re-scan the whole
-    // attachments table and re-sort it, and a large install's hourly pass would
-    // pay for that once per page. With `idx_attachments_created_at_id` the age
-    // bound, the keyset continuation, and the ordering are the same index seek,
-    // so a page resumes where the last one stopped.
-    const plan = getSqlite()
-      .prepare(`EXPLAIN QUERY PLAN ${SIGHT_FRAME_SWEEP_CANDIDATE_SQL}`)
-      .all(
-        Date.now(),
-        128 * 1024,
-        1,
-        0,
-        "",
-        '%"sightFrameAttachmentIds"%',
-        200,
-      );
-    const detail = (plan as Array<{ detail: string }>)
-      .map((step) => step.detail)
-      .join("\n");
+  test("opens on an index range rather than a scan and a sort", () => {
+    // Without `idx_attachments_created_at_id` every page would re-scan the whole
+    // attachments table and re-sort it, and the row budget bounds rows RETURNED,
+    // not rows visited, so a large install's hourly pass would pay for that once
+    // per page.
+    const detail = queryPlanFor(SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL, [
+      Date.now(),
+      128 * 1024,
+      TAGGED_MESSAGE_LIKE,
+      200,
+    ]);
 
     expect(detail).toContain("USING INDEX idx_attachments_created_at_id");
+    expect(detail).toContain("created_at<?");
     expect(detail).not.toContain("USE TEMP B-TREE");
     // `SCAN a` is the whole-table read the index replaces. The subquery's own
     // steps are SEARCHes on indexes that already existed.
+    expect(detail).not.toMatch(/\bSCAN a\b/);
+  });
+
+  test("seeks a continuation page straight to the cursor", () => {
+    // The lower bound is the half that makes paging linear. A cursor predicate
+    // SQLite cannot fold into the index range still SEARCHes, but from the
+    // oldest eligible entry every time, so walking a backlog costs index visits
+    // quadratic in the pages walked. The tuple has to reach the constraint.
+    const detail = queryPlanFor(SIGHT_FRAME_SWEEP_CONTINUATION_SQL, [
+      Date.now(),
+      128 * 1024,
+      Date.now() - DAY_MS,
+      "att-cursor",
+      TAGGED_MESSAGE_LIKE,
+      200,
+    ]);
+
+    expect(detail).toContain("USING INDEX idx_attachments_created_at_id");
+    expect(detail).toContain("(created_at,id)>(?,?)");
+    expect(detail).not.toContain("USE TEMP B-TREE");
     expect(detail).not.toMatch(/\bSCAN a\b/);
   });
 

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -26,6 +26,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -38,7 +39,12 @@ import {
   getSightFrameSweepBackupCursorForTest,
   getSightFrameSweepCursorForTest,
   getSightFrameSweepDirEnumerationsForTest,
+  getSightFrameSweepLastFailureForTest,
+  getSightFrameSweepScheduledDelayForTest,
   resetSightFrameSweepCursorForTest,
+  runSightFrameSweepPassForTest,
+  startSightFrameStorageSweep,
+  stopSightFrameStorageSweep,
   SWEEP_INTERVAL_MS,
   sweepAgedSightFrames,
   sweepDelayAfter,
@@ -319,6 +325,31 @@ function queryPlanFor(sql: string, binds: Array<string | number>): string {
   return plan.map((step) => step.detail).join("\n");
 }
 
+/**
+ * A conversation attachments directory holding `fileCount` ordinary files, the
+ * shape a call that kept the camera up all day leaves behind.
+ */
+function plantCrowdedAttachmentsDir(
+  dirName: string,
+  fileCount: number,
+): string {
+  const dir = join(getConversationsDir(), dirName, "attachments");
+  mkdirSync(dir, { recursive: true });
+  for (let i = 0; i < fileCount; i++) {
+    writeFileSync(join(dir, `frame-${String(i).padStart(4, "0")}.jpg`), "x");
+  }
+  return dir;
+}
+
+/** A base file and an unowned backup beside it: debris the reclaim should collect. */
+function plantOrphanBackup(dir: string): string {
+  const base = join(dir, "orphan.jpg");
+  writeFileSync(base, "base");
+  const backup = `${base}${SWEEP_BACKUP_SUFFIX}`;
+  writeFileSync(backup, "backup");
+  return backup;
+}
+
 /** A pass that found nothing to do and nothing to reclaim. */
 const NOTHING_HAPPENED = {
   shrunk: 0,
@@ -326,7 +357,7 @@ const NOTHING_HAPPENED = {
   skipped: 0,
   examined: 0,
   rowsRead: 0,
-  leftovers: { deleted: 0, restored: 0, skipped: 0 },
+  leftovers: { deleted: 0, restored: 0, skipped: 0, entriesScanned: 0 },
   stoppedOnBudget: false,
 };
 
@@ -1007,6 +1038,61 @@ describe("sweepAgedSightFrames", () => {
 
     await sweepAgedSightFrames({ maxBackupDirs: 1 });
     expect(getSightFrameSweepDirEnumerationsForTest()).toBe(2);
+  });
+
+  test("spreads a crowded attachments directory across passes", async () => {
+    // A directory cap bounds directories, not work. One conversation's
+    // attachments dir holds a file per frame, so a day of camera leaves tens of
+    // thousands in it, and catch-up mode would re-read them every few minutes.
+    // Names chosen to sort ahead of every other conversation this file creates,
+    // so the pass reaches them first.
+    plantCrowdedAttachmentsDir("0000-crowded-a", 30);
+    const second = plantCrowdedAttachmentsDir("0000-crowded-b", 30);
+    const backup = plantOrphanBackup(second);
+
+    const first = await sweepAgedSightFrames({ maxLeftoverEntries: 10 });
+
+    // The first directory is finished, then the pass stops rather than paying
+    // for the next one. Finishing beats resuming mid-directory: entry order is
+    // filesystem-defined and reshuffles on writes, so an offset could skip a
+    // sidecar.
+    expect(first.leftovers.entriesScanned).toBeGreaterThanOrEqual(30);
+    expect(first.leftovers.entriesScanned).toBeLessThan(60);
+    expect(existsSync(backup)).toBe(true);
+
+    const next = await sweepAgedSightFrames({ maxLeftoverEntries: 10 });
+
+    // Resumed at the directory the last pass stopped before, and reclaimed what
+    // was waiting there.
+    expect(next.leftovers.deleted).toBe(1);
+    expect(existsSync(backup)).toBe(false);
+  });
+
+  test("survives a failure inside a pass and stays scheduled", async () => {
+    // The timer fires a pass with `void`, so a throw anywhere inside it would
+    // surface as an unhandled rejection, and shutdown-handlers routes those into
+    // handleFatalError: a background sweep hiccup would take the assistant down
+    // and no further pass would ever be scheduled.
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    const stranded = plantOrphanBackup(dirname(frame.filePath));
+
+    // Every store call throws once the table it reads is not there. The
+    // candidate read is guarded and ends the pass quietly; the leftover scan's
+    // is not, and is what used to escape.
+    getDb().run("ALTER TABLE attachments RENAME TO attachments_hidden");
+    startSightFrameStorageSweep();
+    try {
+      await expect(runSightFrameSweepPassForTest()).resolves.toBeUndefined();
+      expect(getSightFrameSweepLastFailureForTest()).toBeInstanceOf(Error);
+      // Resting, never catch-up: a fault that recurs must not hot-loop.
+      expect(getSightFrameSweepScheduledDelayForTest()).toBe(SWEEP_INTERVAL_MS);
+    } finally {
+      stopSightFrameStorageSweep();
+      getDb().run("ALTER TABLE attachments_hidden RENAME TO attachments");
+      // The pass threw before reclaiming it, and directories outlive the row
+      // resets between tests, so clear it rather than leaving it for a later one.
+      rmSync(stranded, { force: true });
+    }
   });
 
   test("deletes a backup whose base is missing and whose row is gone", async () => {

--- a/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
+++ b/assistant/src/__tests__/sight-frame-storage-sweep.test.ts
@@ -1,0 +1,279 @@
+/**
+ * The camera-frame storage sweep.
+ *
+ * Frames are the one attachment nobody chose to send: the camera samples them
+ * every few seconds for as long as a call keeps it up, and each one is a
+ * full-resolution image that outlives the call. The sweep shrinks the aged ones
+ * to thumbnail scale so the transcript keeps rendering while the disk stops
+ * growing, and everything it must NOT touch is asserted here alongside what it
+ * does: an untagged attachment, a frame inside the window, and a file more than
+ * one row names.
+ */
+
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { setDbMigrating, setDbReady } from "../daemon/daemon-readiness.js";
+import { sweepAgedSightFrames } from "../daemon/sight-frame-storage-sweep.js";
+import {
+  attachInlineAttachmentToMessage,
+  getAttachmentById,
+  getAttachmentContent,
+  getAttachmentMetadataForMessage,
+  uploadFileBackedAttachment,
+} from "../persistence/attachments-store.js";
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { rawRun } from "../persistence/raw-query.js";
+import { isCompleteJpeg } from "../util/image-conversion.js";
+import { setConfig } from "./helpers/set-config.js";
+
+setConfig("memory", { enabled: false });
+
+await initializeDb();
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Comfortably over the sweep's 128 KB threshold, and small enough to encode fast. */
+const FRAME_WIDTH = 1200;
+const FRAME_HEIGHT = 900;
+
+/**
+ * A camera-frame-sized JPEG of random noise. Noise is what makes it big: a flat
+ * image would encode under the threshold and never become a candidate.
+ */
+async function makeFrameJpegBase64(): Promise<string> {
+  const { default: sharp } = await import("sharp");
+  const bytes = await sharp(randomBytes(FRAME_WIDTH * FRAME_HEIGHT * 3), {
+    raw: { width: FRAME_WIDTH, height: FRAME_HEIGHT, channels: 3 },
+  })
+    .jpeg({ quality: 90 })
+    .toBuffer();
+  return bytes.toString("base64");
+}
+
+function resetTables() {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+function backdateAttachment(attachmentId: string, ageDays: number): void {
+  rawRun(
+    "test:backdateAttachment",
+    "UPDATE attachments SET created_at = ? WHERE id = ?",
+    Date.now() - ageDays * DAY_MS,
+    attachmentId,
+  );
+}
+
+/** Tag an already-persisted row as carrying the given camera frames. */
+function tagMessageFrames(messageId: string, attachmentIds: string[]): void {
+  rawRun(
+    "test:tagMessageFrames",
+    "UPDATE messages SET metadata = ? WHERE id = ?",
+    JSON.stringify({
+      voiceSessionTurn: true,
+      sightFrameAttachmentIds: attachmentIds,
+    }),
+    messageId,
+  );
+}
+
+interface PlantedFrame {
+  conversationId: string;
+  messageId: string;
+  attachmentId: string;
+  filePath: string;
+  sizeBytes: number;
+}
+
+/**
+ * Persist one image as an attachment on a fresh conversation, tagging the row
+ * as a camera frame unless `tagged` says otherwise, and backdate the attachment
+ * so the sweep sees it as `ageDays` old.
+ */
+async function plantFrame(options: {
+  ageDays: number;
+  tagged: boolean;
+}): Promise<PlantedFrame> {
+  const conversation = createConversation("Call");
+  const message = await addMessage(conversation.id, "user", "(camera frame)", {
+    skipIndexing: true,
+  });
+  const stored = await attachInlineAttachmentToMessage(
+    message.id,
+    0,
+    "sight-frame.jpg",
+    "image/jpeg",
+    await makeFrameJpegBase64(),
+  );
+  if (options.tagged) {
+    tagMessageFrames(message.id, [stored.id]);
+  }
+  backdateAttachment(stored.id, options.ageDays);
+  return {
+    conversationId: conversation.id,
+    messageId: message.id,
+    attachmentId: stored.id,
+    filePath: stored.filePath,
+    sizeBytes: stored.sizeBytes,
+  };
+}
+
+function storedSizeBytes(attachmentId: string): number {
+  const row = getAttachmentById(attachmentId);
+  expect(row).not.toBeNull();
+  return row!.sizeBytes;
+}
+
+describe("sweepAgedSightFrames", () => {
+  beforeEach(() => {
+    resetTables();
+    setDbReady(true);
+  });
+
+  test("shrinks an aged camera frame while the transcript keeps resolving it", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    expect(frame.sizeBytes).toBeGreaterThan(128 * 1024);
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result.shrunk).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(result.freedBytes).toBeGreaterThan(0);
+
+    // The bytes on disk are a smaller, complete JPEG.
+    const onDisk = readFileSync(frame.filePath);
+    expect(onDisk.length).toBeLessThan(frame.sizeBytes);
+    expect(isCompleteJpeg(onDisk)).toBe(true);
+
+    // The row still describes what it actually stores. `/attachments/:id/content`
+    // serves `sizeBytes` as Content-Length, so a stale size truncates the image
+    // the transcript is trying to draw.
+    expect(storedSizeBytes(frame.attachmentId)).toBe(onDisk.length);
+
+    // The row, its link, and its content all survive: the sweep deletes nothing.
+    const linked = getAttachmentMetadataForMessage(frame.messageId);
+    expect(linked.map((a) => a.id)).toEqual([frame.attachmentId]);
+    expect(getAttachmentContent(frame.attachmentId)?.length).toBe(
+      onDisk.length,
+    );
+  });
+
+  test("leaves an untagged attachment of the same age alone", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: false });
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result.shrunk).toBe(0);
+    expect(storedSizeBytes(frame.attachmentId)).toBe(frame.sizeBytes);
+    expect(readFileSync(frame.filePath).length).toBe(frame.sizeBytes);
+  });
+
+  test("leaves a tagged frame inside the retention window alone", async () => {
+    const frame = await plantFrame({ ageDays: 1, tagged: true });
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result.shrunk).toBe(0);
+    expect(storedSizeBytes(frame.attachmentId)).toBe(frame.sizeBytes);
+    expect(readFileSync(frame.filePath).length).toBe(frame.sizeBytes);
+  });
+
+  test("refuses a file a second attachment row still names", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+
+    // The shape a clone leaves behind when materialization could not repoint it:
+    // two rows, one file. Rewriting it would rewrite the other row's image too.
+    const alias = uploadFileBackedAttachment(
+      "sight-frame.jpg",
+      "image/jpeg",
+      frame.filePath,
+      frame.sizeBytes,
+    );
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result.shrunk).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(readFileSync(frame.filePath).length).toBe(frame.sizeBytes);
+    expect(storedSizeBytes(frame.attachmentId)).toBe(frame.sizeBytes);
+    expect(storedSizeBytes(alias.id)).toBe(frame.sizeBytes);
+  });
+
+  test("refuses a file outside the attachment store's own directories", async () => {
+    const conversation = createConversation("Call");
+    const message = await addMessage(
+      conversation.id,
+      "user",
+      "(camera frame)",
+      { skipIndexing: true },
+    );
+    const outsideDir = join(tmpdir(), `vellum-sight-sweep-${Date.now()}`);
+    mkdirSync(outsideDir, { recursive: true });
+    const outsidePath = join(outsideDir, "user-owned.jpg");
+    const bytes = Buffer.from(await makeFrameJpegBase64(), "base64");
+    writeFileSync(outsidePath, bytes);
+
+    const stored = uploadFileBackedAttachment(
+      "user-owned.jpg",
+      "image/jpeg",
+      outsidePath,
+      bytes.length,
+    );
+    rawRun(
+      "test:linkOutsideAttachment",
+      "INSERT INTO message_attachments (id, message_id, attachment_id, position, created_at) VALUES (?, ?, ?, 0, ?)",
+      `link-${stored.id}`,
+      message.id,
+      stored.id,
+      Date.now(),
+    );
+    tagMessageFrames(message.id, [stored.id]);
+    backdateAttachment(stored.id, 30);
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result.shrunk).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(existsSync(outsidePath)).toBe(true);
+    expect(readFileSync(outsidePath).length).toBe(bytes.length);
+  });
+
+  test("skips every cycle while DB migrations are unready", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+    setDbMigrating();
+
+    const result = await sweepAgedSightFrames();
+
+    expect(result).toEqual({ shrunk: 0, freedBytes: 0, skipped: 0 });
+    expect(storedSizeBytes(frame.attachmentId)).toBe(frame.sizeBytes);
+  });
+
+  test("re-running finds nothing once a frame has been swept", async () => {
+    const frame = await plantFrame({ ageDays: 30, tagged: true });
+
+    const first = await sweepAgedSightFrames();
+    expect(first.shrunk).toBe(1);
+    const sweptSize = storedSizeBytes(frame.attachmentId);
+    const sweptBytes = readFileSync(frame.filePath);
+
+    const second = await sweepAgedSightFrames();
+
+    // Nothing is even a candidate the second time: the swept size is what the
+    // query bounds on, so an already-shrunk frame is not re-read or re-encoded.
+    expect(second).toEqual({ shrunk: 0, freedBytes: 0, skipped: 0 });
+    expect(storedSizeBytes(frame.attachmentId)).toBe(sweptSize);
+    expect(readFileSync(frame.filePath).equals(sweptBytes)).toBe(true);
+  });
+});

--- a/assistant/src/config/schemas/sight.ts
+++ b/assistant/src/config/schemas/sight.ts
@@ -30,6 +30,33 @@ export const MIN_SIGHT_KEEP_LATEST_FRAMES = 1;
  */
 export const MAX_SIGHT_KEEP_LATEST_FRAMES = 6;
 
+/**
+ * How old a camera frame has to be before the storage sweep shrinks its stored
+ * bytes to thumbnail scale (`daemon/sight-frame-storage-sweep.ts`).
+ *
+ * Answers a different question from {@link KEEP_LATEST_SIGHT_FRAMES}, which
+ * bounds what one request costs and is counted in frames. This bounds what the
+ * disk holds forever and is counted in days: a call samples frames for as long
+ * as the camera is up, and every one of them is a file that outlives the call.
+ * A week is long enough that a frame is still full resolution while anyone
+ * might scroll back to the call it came from.
+ */
+export const SWEEP_SIGHT_FRAMES_AFTER_DAYS = 7;
+
+/**
+ * Floor for `sight.sweepAfterDays`. A frame captured today belongs to a call
+ * that may still be running, and shrinking it under a live camera would swap
+ * the view out from under the transcript the user is watching.
+ */
+export const MIN_SIGHT_SWEEP_AFTER_DAYS = 1;
+
+/**
+ * Ceiling for `sight.sweepAfterDays`. Past a year the setting stops bounding
+ * anything: frames accumulate at a few per second of camera time, so a window
+ * no install ever reaches is the same as no sweep at all.
+ */
+export const MAX_SIGHT_SWEEP_AFTER_DAYS = 365;
+
 export const SightConfigSchema = z
   .object({
     keepLatestFrames: z
@@ -38,6 +65,13 @@ export const SightConfigSchema = z
       .default(KEEP_LATEST_SIGHT_FRAMES)
       .describe(
         `How many of the newest camera frames a live-voice call keeps in the model's context as images; older frames become timestamped text stubs. Clamped to ${MIN_SIGHT_KEEP_LATEST_FRAMES}..${MAX_SIGHT_KEEP_LATEST_FRAMES} when read.`,
+      ),
+    sweepAfterDays: z
+      .number({ error: "sight.sweepAfterDays must be a number" })
+      .int("sight.sweepAfterDays must be an integer")
+      .default(SWEEP_SIGHT_FRAMES_AFTER_DAYS)
+      .describe(
+        `How many days a stored camera frame keeps its full-resolution bytes before a background sweep re-encodes it to a thumbnail. The frame stays in the transcript either way. Clamped to ${MIN_SIGHT_SWEEP_AFTER_DAYS}..${MAX_SIGHT_SWEEP_AFTER_DAYS} when read.`,
       ),
   })
   .describe("Ambient camera frames sampled during a live-voice call");

--- a/assistant/src/daemon/sight-frame-storage-sweep.ts
+++ b/assistant/src/daemon/sight-frame-storage-sweep.ts
@@ -21,7 +21,7 @@
  * what the model receives is always what is actually on disk.
  */
 
-import { readdirSync } from "node:fs";
+import { type Dir, opendirSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
@@ -139,6 +139,22 @@ let sweepCursor: SightFrameSweepCursor | null = null;
  */
 const MAX_BACKUP_DIRS_PER_PASS = 40;
 
+/**
+ * Directory entries a pass reads before it stops opening more directories.
+ *
+ * The directory cap alone bounds nothing: one conversation's `attachments/`
+ * holds a file per frame, so a call that kept the camera up all day leaves tens
+ * of thousands in a single directory, and catch-up mode would re-read them every
+ * few minutes. Charged across the whole pass, so a slice of ordinary
+ * conversations costs almost nothing and one enormous conversation ends the
+ * pass rather than being paid for alongside 39 others.
+ *
+ * The directory in progress is always finished, so the real bound is this plus
+ * one directory's tail. Matching {@link MAX_ROWS_READ_PER_PASS} keeps the two
+ * halves of a pass in the same order of magnitude.
+ */
+const MAX_LEFTOVER_ENTRIES_PER_PASS = 5_000;
+
 let backupScanCursor: string | null = null;
 
 /**
@@ -208,6 +224,10 @@ let sweepTimer: ReturnType<typeof setTimeout> | null = null;
 let sweepScheduled = false;
 let sweepInProgress = false;
 
+/** The delay the last scheduling decision used, and the last failure it caught. */
+let lastScheduledDelayMs: number | null = null;
+let lastSweepFailure: unknown = null;
+
 /**
  * The workspace's `sight.sweepAfterDays`, clamped to
  * [{@link MIN_SIGHT_SWEEP_AFTER_DAYS}, {@link MAX_SIGHT_SWEEP_AFTER_DAYS}].
@@ -260,6 +280,11 @@ export interface SweepLeftoverTally {
   restored: number;
   /** Files left alone: a row still needs them, or one claims them outright. */
   skipped: number;
+  /**
+   * Directory entries the scan read. What the entry budget is charged against,
+   * because a directory count says nothing about the size of the directories.
+   */
+  entriesScanned: number;
 }
 
 function emptyResult(): SightFrameSweepResult {
@@ -269,7 +294,7 @@ function emptyResult(): SightFrameSweepResult {
     skipped: 0,
     examined: 0,
     rowsRead: 0,
-    leftovers: { deleted: 0, restored: 0, skipped: 0 },
+    leftovers: { deleted: 0, restored: 0, skipped: 0, entriesScanned: 0 },
     stoppedOnBudget: false,
   };
 }
@@ -278,6 +303,7 @@ export interface SightFrameSweepBounds {
   maxEncodeAttempts?: number;
   maxRowsRead?: number;
   maxBackupDirs?: number;
+  maxLeftoverEntries?: number;
   pageSize?: number;
 }
 
@@ -285,7 +311,12 @@ export interface SightFrameSweepBounds {
  * Shrink aged camera frames, walking the candidate set from where the last pass
  * stopped until it runs out of rows or spends this pass's bounds.
  *
- * Never throws: a sweep that cannot run is a sweep that runs next hour.
+ * Best effort rather than infallible. Reading candidates is guarded, so a
+ * database that cannot answer ends the pass quietly, but the per-candidate store
+ * calls and the leftover scan can still throw. {@link runSweepPass} is where
+ * that is caught, because it is the boundary a timer calls and the only place
+ * that can promise the schedule survives; guarding each inner call instead would
+ * be a list nobody can keep complete.
  *
  * The bounds are parameters only so tests can make a pass stop early. Production
  * callers take the defaults.
@@ -388,6 +419,7 @@ export async function sweepAgedSightFrames(
   sweepCursor = cursor;
   result.leftovers = reclaimSweepLeftovers(
     bounds.maxBackupDirs ?? MAX_BACKUP_DIRS_PER_PASS,
+    bounds.maxLeftoverEntries ?? MAX_LEFTOVER_ENTRIES_PER_PASS,
   );
   if (
     result.shrunk > 0 ||
@@ -432,20 +464,44 @@ async function shrinkOneFrame(attachmentId: string): Promise<number | null> {
  * of the store's own attachment directories.
  *
  * The staging directory is checked every pass, being one directory; conversation
- * directories are taken `maxDirs` at a time, resuming by name from where the
+ * directories are taken from the cached listing, resuming by name from where the
  * last pass stopped and wrapping when the list runs out. Names are stable, so a
  * conversation created or deleted between passes cannot make the scan skip its
  * neighbours.
+ *
+ * Two bounds, because a directory count alone does not bound work: a call that
+ * kept the camera up all day leaves tens of thousands of files in one
+ * conversation's `attachments/`, and in catch-up mode this runs every few
+ * minutes. `maxDirs` caps how many directories a pass opens, and
+ * `maxEntries` stops it opening more once that many directory entries have been
+ * read. The directory it has already started is always finished, so the bound is
+ * `maxEntries` plus the tail of one directory, and no directory is ever left
+ * half read.
+ *
+ * Finishing rather than resuming mid-directory is deliberate. Resuming would
+ * need a stable position inside a directory, and iteration order there is
+ * filesystem-defined and reshuffles when files are added or removed, so an
+ * offset could silently skip a sidecar. Finishing costs one directory's tail and
+ * needs no such assumption.
  *
  * What happens to a file is never decided by its name. The suffixes are derived
  * from an attachment's own path, not reserved, so a file the user picked can
  * carry one; every deletion goes through the store, which refuses any path a row
  * claims as its canonical bytes.
  *
- * Never throws. Returns what it deleted, restored, and left alone.
+ * Best effort: a directory it cannot read contributes nothing. A store call that
+ * throws propagates to the pass boundary, which logs it and keeps the schedule.
  */
-function reclaimSweepLeftovers(maxDirs: number): SweepLeftoverTally {
-  const tally: SweepLeftoverTally = { deleted: 0, restored: 0, skipped: 0 };
+function reclaimSweepLeftovers(
+  maxDirs: number,
+  maxEntries: number,
+): SweepLeftoverTally {
+  const tally: SweepLeftoverTally = {
+    deleted: 0,
+    restored: 0,
+    skipped: 0,
+    entriesScanned: 0,
+  };
   reclaimLeftoversIn(join(getWorkspaceDir(), "data", "attachments"), tally);
 
   const conversationsDir = getConversationsDir();
@@ -469,32 +525,70 @@ function reclaimSweepLeftovers(maxDirs: number): SweepLeftoverTally {
   }
 
   const slice = dirNames.slice(resumeAt, resumeAt + maxDirs);
+  let lastVisited: string | null = null;
   for (const name of slice) {
     reclaimLeftoversIn(join(conversationsDir, name, "attachments"), tally);
+    lastVisited = name;
+    if (tally.entriesScanned >= maxEntries) {
+      break;
+    }
   }
+  // A pass that stopped on the entry budget has more of this slice left, so the
+  // cursor holds where it actually got to. Only running the slice out means the
+  // listing is spent, and only then does reaching its end wrap the cycle.
+  const finishedSlice = lastVisited === slice[slice.length - 1];
   backupScanCursor =
-    resumeAt + maxDirs >= dirNames.length
-      ? null
-      : (slice[slice.length - 1] ?? null);
+    finishedSlice && resumeAt + maxDirs >= dirNames.length ? null : lastVisited;
   return tally;
 }
 
-/** One directory's leftovers. Never throws; a directory that is not there has none. */
+/**
+ * One directory's leftovers, read as a stream.
+ *
+ * A conversation that kept the camera up accumulates a file per frame, so this
+ * reads the directory rather than materializing its listing: `opendir` hands
+ * back entries a buffer at a time, and only the two sidecar suffixes are
+ * collected. What it holds is therefore the sidecars, of which a healthy install
+ * has none, instead of every filename in the directory.
+ *
+ * Collecting before acting is what preserves the order the two kinds need.
+ * Backups go first, because one of them may put a missing base file back, and a
+ * temp beside that base is only debris once the base it would have replaced is
+ * there to compare against.
+ *
+ * A directory it cannot read contributes nothing, and a conversation that never
+ * had an attachment has no such directory at all. Opening is lazy, so the read
+ * is where a missing one surfaces and both share one guard.
+ */
 function reclaimLeftoversIn(dir: string, tally: SweepLeftoverTally): void {
-  let entries: string[];
+  const backups: string[] = [];
+  const temps: string[] = [];
+  let handle: Dir | null = null;
   try {
-    entries = readdirSync(dir);
+    handle = opendirSync(dir);
+    for (
+      let entry = handle.readSync();
+      entry !== null;
+      entry = handle.readSync()
+    ) {
+      tally.entriesScanned += 1;
+      if (entry.name.endsWith(SWEEP_BACKUP_SUFFIX)) {
+        backups.push(entry.name);
+      } else if (entry.name.endsWith(SWEEP_TEMP_SUFFIX)) {
+        temps.push(entry.name);
+      }
+    }
   } catch {
     return;
+  } finally {
+    try {
+      handle?.closeSync();
+    } catch {
+      /* already closed by whatever ended the read */
+    }
   }
 
-  // Backups first. One of them may put a missing base file back, and a temp
-  // beside that base is only debris once the base it was going to replace is
-  // there to compare it against.
-  for (const entry of entries) {
-    if (!entry.endsWith(SWEEP_BACKUP_SUFFIX)) {
-      continue;
-    }
+  for (const entry of backups) {
     recordLeftoverOutcome(
       reclaimAttachmentSweepBackup(join(dir, entry)),
       tally,
@@ -504,10 +598,7 @@ function reclaimLeftoversIn(dir: string, tally: SweepLeftoverTally): void {
   // A temp is a replacement that never reached its rename, so nothing wants it,
   // and this never runs while a shrink is in flight. The store still refuses to
   // unlink one that is some row's canonical file.
-  for (const entry of entries) {
-    if (!entry.endsWith(SWEEP_TEMP_SUFFIX)) {
-      continue;
-    }
+  for (const entry of temps) {
     recordLeftoverOutcome(deleteSweepLeftover(join(dir, entry)), tally);
   }
 }
@@ -536,6 +627,26 @@ export function resetSightFrameSweepCursorForTest(): void {
   backupScanCursor = null;
   backupScanDirNames = null;
   backupScanEnumerations = 0;
+  lastScheduledDelayMs = null;
+  lastSweepFailure = null;
+}
+
+/**
+ * Run one pass exactly as the timer does, for tests that assert what a pass
+ * leaves behind for the schedule rather than what it returns.
+ */
+export function runSightFrameSweepPassForTest(): Promise<void> {
+  return runSweepPass();
+}
+
+/** The delay the last completed pass scheduled its successor on. */
+export function getSightFrameSweepScheduledDelayForTest(): number | null {
+  return lastScheduledDelayMs;
+}
+
+/** The failure the last pass caught at its boundary, if any. */
+export function getSightFrameSweepLastFailureForTest(): unknown {
+  return lastSweepFailure;
 }
 
 /**
@@ -585,13 +696,28 @@ function scheduleNextSweep(delayMs: number): void {
   if (!sweepScheduled) {
     return;
   }
+  lastScheduledDelayMs = delayMs;
   sweepTimer = setTimeout(() => {
     sweepTimer = null;
     void runSweepPass();
   }, delayMs);
 }
 
-/** One pass, then the next is scheduled on the cadence that pass earned. */
+/**
+ * One pass, then the next is scheduled on the cadence that pass earned.
+ *
+ * The catch is the whole point of this function. A timer fires it with `void`,
+ * so nothing is awaiting the promise it returns, and a throw from anywhere
+ * inside the pass would surface as an unhandled rejection. The daemon treats
+ * those as fatal (`daemon/shutdown-handlers.ts` routes `unhandledRejection`
+ * into `handleFatalError`, which sets a failing exit code and runs `shutdown()`),
+ * so a background sweep hiccup would take the assistant down with it, and the
+ * next pass would never be scheduled either way.
+ *
+ * A failure therefore reschedules on the RESTING cadence, never catch-up. A
+ * fault that recurs (an unreadable database, a directory the process cannot
+ * open) would otherwise retry every few minutes forever.
+ */
 async function runSweepPass(): Promise<void> {
   if (sweepInProgress) {
     scheduleNextSweep(SWEEP_INTERVAL_MS);
@@ -601,6 +727,9 @@ async function runSweepPass(): Promise<void> {
   let delayMs = SWEEP_INTERVAL_MS;
   try {
     delayMs = sweepDelayAfter(await sweepAgedSightFrames());
+  } catch (err) {
+    lastSweepFailure = err;
+    log.error({ err }, "Camera frame storage sweep failed");
   } finally {
     sweepInProgress = false;
   }

--- a/assistant/src/daemon/sight-frame-storage-sweep.ts
+++ b/assistant/src/daemon/sight-frame-storage-sweep.ts
@@ -28,9 +28,11 @@ import {
   SWEEP_SIGHT_FRAMES_AFTER_DAYS,
 } from "../config/schemas/sight.js";
 import {
+  attachmentShrinkRefusal,
   getAttachmentContent,
   selectSightFrameSweepCandidates,
   shrinkAttachmentBytes,
+  type SightFrameSweepCursor,
 } from "../persistence/attachments-store.js";
 import { convertImageToJpeg } from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
@@ -62,8 +64,46 @@ const SWEPT_JPEG_QUALITY = 60;
  */
 const SWEPT_MAX_BYTES = 128 * 1024;
 
-/** Rows examined per pass, so one tick's work is bounded whatever the backlog. */
-const SWEEP_BATCH_SIZE = 200;
+/** Rows one candidate query asks for. A pass walks as many pages as its bounds allow. */
+const SWEEP_PAGE_SIZE = 200;
+
+/**
+ * Re-encodes a pass will attempt before stopping.
+ *
+ * The bound is counted in ENCODES rather than rows because that is where the
+ * cost is. A refusal the store can decide from the row alone (a shared file, a
+ * file it does not own) costs two point queries, so a pass steps over any number
+ * of those to reach work it can actually do; producing a thumbnail costs real
+ * CPU, and a frame that comes out no smaller costs it for nothing.
+ *
+ * 200 frames an hour is far more than a camera generates, so the bound only ever
+ * binds on a backlog, which is exactly when a pass should stop and let the next
+ * one continue.
+ */
+const MAX_ENCODE_ATTEMPTS_PER_PASS = 200;
+
+/**
+ * Rows a pass will examine before stopping, whatever it managed to encode.
+ *
+ * Refusals are cheap but not free, and the candidate query has no index to ride,
+ * so an install whose aged frames are all unrewritable still needs a stop. The
+ * cursor below is what makes stopping safe: the next pass resumes here rather
+ * than starting over.
+ */
+const MAX_ROWS_EXAMINED_PER_PASS = 5_000;
+
+/**
+ * Where the last pass stopped, so the next one resumes instead of re-examining
+ * rows it already refused. Reset to the head once a scan reaches the end of the
+ * candidate set, so newly aged frames and rows whose circumstances changed get
+ * looked at again.
+ *
+ * In memory on purpose. A durable marker would be a schema addition to survive
+ * a restart, and what a restart actually costs is one pass that re-examines the
+ * refusals at the head before advancing past them again, which is a handful of
+ * queries once per boot.
+ */
+let sweepCursor: SightFrameSweepCursor | null = null;
 
 /**
  * How often the sweep runs. The window it enforces is measured in days, so an
@@ -112,52 +152,117 @@ export interface SightFrameSweepResult {
   freedBytes: number;
   /** Candidates left alone: shared or foreign file, unreadable, or no smaller. */
   skipped: number;
+  /** Candidate rows this pass looked at, refusals included. */
+  examined: number;
 }
 
 function emptyResult(): SightFrameSweepResult {
-  return { shrunk: 0, freedBytes: 0, skipped: 0 };
+  return { shrunk: 0, freedBytes: 0, skipped: 0, examined: 0 };
+}
+
+export interface SightFrameSweepBounds {
+  maxEncodeAttempts?: number;
+  maxRowsExamined?: number;
 }
 
 /**
- * Shrink one batch of aged camera frames. Never throws: a sweep that cannot run
- * is a sweep that runs next hour.
+ * Shrink aged camera frames, walking the candidate set from where the last pass
+ * stopped until it runs out of rows or spends this pass's bounds.
+ *
+ * Never throws: a sweep that cannot run is a sweep that runs next hour.
+ *
+ * The bounds are parameters only so tests can make a pass stop early. Production
+ * callers take the defaults.
  */
-export async function sweepAgedSightFrames(): Promise<SightFrameSweepResult> {
+export async function sweepAgedSightFrames(
+  bounds: SightFrameSweepBounds = {},
+): Promise<SightFrameSweepResult> {
   if (!getDbMigrationReadiness().ready) {
     return emptyResult();
   }
+  const maxEncodeAttempts =
+    bounds.maxEncodeAttempts ?? MAX_ENCODE_ATTEMPTS_PER_PASS;
+  const maxRowsExamined = bounds.maxRowsExamined ?? MAX_ROWS_EXAMINED_PER_PASS;
 
-  let candidates;
-  try {
-    candidates = selectSightFrameSweepCandidates({
-      createdBefore: Date.now() - resolveSightSweepAfterDays() * MS_PER_DAY,
-      largerThanBytes: SWEPT_MAX_BYTES,
-      limit: SWEEP_BATCH_SIZE,
-    });
-  } catch (err) {
-    log.warn({ err }, "Could not read aged camera frames");
-    return emptyResult();
-  }
-
+  const createdBefore = Date.now() - resolveSightSweepAfterDays() * MS_PER_DAY;
   const result = emptyResult();
-  for (const candidate of candidates) {
+  let cursor = sweepCursor;
+  let encodeAttempts = 0;
+
+  while (encodeAttempts < maxEncodeAttempts) {
+    let page;
     try {
-      const shrunkBytes = await shrinkOneFrame(candidate.id);
-      if (shrunkBytes === null) {
-        result.skipped += 1;
-        continue;
-      }
-      result.shrunk += 1;
-      result.freedBytes += candidate.sizeBytes - shrunkBytes;
+      page = selectSightFrameSweepCandidates({
+        createdBefore,
+        largerThanBytes: SWEPT_MAX_BYTES,
+        limit: SWEEP_PAGE_SIZE,
+        after: cursor,
+      });
     } catch (err) {
-      result.skipped += 1;
-      log.warn(
-        { err, attachmentId: candidate.id },
-        "Could not shrink an aged camera frame",
-      );
+      log.warn({ err }, "Could not read aged camera frames");
+      break;
+    }
+
+    let spentOnThisPage = false;
+    for (const candidate of page.candidates) {
+      result.examined += 1;
+      // Ask before encoding. A row the store will refuse whatever it is handed
+      // costs a query here and nothing more, which is what lets a pass walk past
+      // a wall of them to the frames behind.
+      const refusal = attachmentShrinkRefusal(candidate.id);
+      if (refusal) {
+        result.skipped += 1;
+        log.debug(
+          { attachmentId: candidate.id, outcome: refusal },
+          "Left an aged camera frame alone",
+        );
+      } else {
+        encodeAttempts += 1;
+        try {
+          const shrunkBytes = await shrinkOneFrame(candidate.id);
+          if (shrunkBytes === null) {
+            result.skipped += 1;
+          } else {
+            result.shrunk += 1;
+            result.freedBytes += candidate.sizeBytes - shrunkBytes;
+          }
+        } catch (err) {
+          result.skipped += 1;
+          log.warn(
+            { err, attachmentId: candidate.id },
+            "Could not shrink an aged camera frame",
+          );
+        }
+      }
+      // Per candidate, not per page: a pass that stops on its bound part way
+      // through has to resume on the next candidate, and a cursor holding the
+      // page's last row would skip everything between.
+      cursor = { createdAt: candidate.createdAt, id: candidate.id };
+      if (encodeAttempts >= maxEncodeAttempts) {
+        spentOnThisPage = true;
+        break;
+      }
+    }
+    if (spentOnThisPage) {
+      break;
+    }
+
+    // The whole page was consumed, so step past its tail too: rows the metadata
+    // prefilter matched and the parse rejected are not candidates and would
+    // otherwise be re-read on every pass.
+    cursor = page.nextCursor ?? cursor;
+    if (!page.hasMore) {
+      // End of the candidate set. Start the next pass at the head so newly aged
+      // frames, and rows whose circumstances changed, are seen again.
+      cursor = null;
+      break;
+    }
+    if (result.examined >= maxRowsExamined) {
+      break;
     }
   }
 
+  sweepCursor = cursor;
   if (result.shrunk > 0) {
     log.info(result, "Shrank aged camera frames to thumbnail scale");
   }
@@ -190,6 +295,16 @@ async function shrinkOneFrame(attachmentId: string): Promise<number | null> {
     return null;
   }
   return thumbnail.length;
+}
+
+/** The pass cursor, for tests that assert a pass resumed rather than restarted. */
+export function getSightFrameSweepCursorForTest(): SightFrameSweepCursor | null {
+  return sweepCursor;
+}
+
+/** Send the next pass back to the head of the candidate set. */
+export function resetSightFrameSweepCursorForTest(): void {
+  sweepCursor = null;
 }
 
 /** Start the periodic sweep. Idempotent. */

--- a/assistant/src/daemon/sight-frame-storage-sweep.ts
+++ b/assistant/src/daemon/sight-frame-storage-sweep.ts
@@ -21,7 +21,7 @@
  * what the model receives is always what is actually on disk.
  */
 
-import { readdirSync, unlinkSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import { getConfig } from "../config/loader.js";
@@ -32,8 +32,10 @@ import {
 } from "../config/schemas/sight.js";
 import {
   attachmentShrinkRefusal,
+  deleteSweepLeftover,
   getAttachmentContent,
   reclaimAttachmentSweepBackup,
+  type ReclaimBackupResult,
   selectSightFrameSweepCandidates,
   shrinkAttachmentBytes,
   type SightFrameSweepCursor,
@@ -192,8 +194,17 @@ export interface SightFrameSweepResult {
    * attachment no linked message actually tags.
    */
   rowsRead: number;
-  /** Leftover sweep files this pass reclaimed. */
-  reclaimedBackups: number;
+  /** What the directory scan did with the sweep files a crash left behind. */
+  leftovers: SweepLeftoverTally;
+}
+
+export interface SweepLeftoverTally {
+  /** Files removed as debris. */
+  deleted: number;
+  /** Backups renamed over a base file a crash left missing. */
+  restored: number;
+  /** Files left alone: a row still needs them, or one claims them outright. */
+  skipped: number;
 }
 
 function emptyResult(): SightFrameSweepResult {
@@ -203,7 +214,7 @@ function emptyResult(): SightFrameSweepResult {
     skipped: 0,
     examined: 0,
     rowsRead: 0,
-    reclaimedBackups: 0,
+    leftovers: { deleted: 0, restored: 0, skipped: 0 },
   };
 }
 
@@ -317,10 +328,14 @@ export async function sweepAgedSightFrames(
   }
 
   sweepCursor = cursor;
-  result.reclaimedBackups = reclaimSweepLeftovers(
+  result.leftovers = reclaimSweepLeftovers(
     bounds.maxBackupDirs ?? MAX_BACKUP_DIRS_PER_PASS,
   );
-  if (result.shrunk > 0 || result.reclaimedBackups > 0) {
+  if (
+    result.shrunk > 0 ||
+    result.leftovers.deleted > 0 ||
+    result.leftovers.restored > 0
+  ) {
     log.info(result, "Shrank aged camera frames to thumbnail scale");
   }
   return result;
@@ -355,8 +370,8 @@ async function shrinkOneFrame(attachmentId: string): Promise<number | null> {
 }
 
 /**
- * Delete the sweep files a killed process left behind, across a bounded slice of
- * the store's own attachment directories.
+ * Deal with the sweep files a killed process left behind, across a bounded slice
+ * of the store's own attachment directories.
  *
  * The staging directory is checked every pass, being one directory; conversation
  * directories are taken `maxDirs` at a time, resuming by name from where the
@@ -364,73 +379,87 @@ async function shrinkOneFrame(attachmentId: string): Promise<number | null> {
  * conversation created or deleted between passes cannot make the scan skip its
  * neighbours.
  *
- * Whether a backup may go is never this function's call: it hands each one to
- * {@link reclaimAttachmentSweepBackup}, which keeps the ones a row still needs.
- * A leftover `.sweep-tmp` needs no such question, being a replacement that never
- * reached its rename, and this never runs while a shrink is in flight.
+ * What happens to a file is never decided by its name. The suffixes are derived
+ * from an attachment's own path, not reserved, so a file the user picked can
+ * carry one; every deletion goes through the store, which refuses any path a row
+ * claims as its canonical bytes.
  *
- * Never throws. Returns how many files it removed.
+ * Never throws. Returns what it deleted, restored, and left alone.
  */
-function reclaimSweepLeftovers(maxDirs: number): number {
-  let reclaimed = 0;
-  reclaimed += reclaimLeftoversIn(
-    join(getWorkspaceDir(), "data", "attachments"),
-  );
+function reclaimSweepLeftovers(maxDirs: number): SweepLeftoverTally {
+  const tally: SweepLeftoverTally = { deleted: 0, restored: 0, skipped: 0 };
+  reclaimLeftoversIn(join(getWorkspaceDir(), "data", "attachments"), tally);
 
   const conversationsDir = getConversationsDir();
   let dirNames: string[];
   try {
     dirNames = readdirSync(conversationsDir).sort();
   } catch {
-    return reclaimed;
+    return tally;
   }
   const resumeAfter = backupScanCursor;
   const resumeAt =
     resumeAfter === null ? 0 : dirNames.findIndex((name) => name > resumeAfter);
   if (resumeAt === -1) {
     backupScanCursor = null;
-    return reclaimed;
+    return tally;
   }
 
   const slice = dirNames.slice(resumeAt, resumeAt + maxDirs);
   for (const name of slice) {
-    reclaimed += reclaimLeftoversIn(
-      join(conversationsDir, name, "attachments"),
-    );
+    reclaimLeftoversIn(join(conversationsDir, name, "attachments"), tally);
   }
   backupScanCursor =
     resumeAt + maxDirs >= dirNames.length
       ? null
       : (slice[slice.length - 1] ?? null);
-  return reclaimed;
+  return tally;
 }
 
 /** One directory's leftovers. Never throws; a directory that is not there has none. */
-function reclaimLeftoversIn(dir: string): number {
+function reclaimLeftoversIn(dir: string, tally: SweepLeftoverTally): void {
   let entries: string[];
   try {
     entries = readdirSync(dir);
   } catch {
-    return 0;
+    return;
   }
-  let reclaimed = 0;
+
+  // Backups first. One of them may put a missing base file back, and a temp
+  // beside that base is only debris once the base it was going to replace is
+  // there to compare it against.
   for (const entry of entries) {
-    if (entry.endsWith(SWEEP_BACKUP_SUFFIX)) {
-      if (reclaimAttachmentSweepBackup(join(dir, entry)) === "deleted") {
-        reclaimed += 1;
-      }
+    if (!entry.endsWith(SWEEP_BACKUP_SUFFIX)) {
       continue;
     }
-    if (entry.endsWith(SWEEP_TEMP_SUFFIX)) {
-      try {
-        unlinkSync(join(dir, entry));
-        reclaimed += 1;
-      } catch {
-        /* gone already, or not ours to remove */
-      }
-    }
+    recordLeftoverOutcome(
+      reclaimAttachmentSweepBackup(join(dir, entry)),
+      tally,
+    );
   }
-  return reclaimed;
+
+  // A temp is a replacement that never reached its rename, so nothing wants it,
+  // and this never runs while a shrink is in flight. The store still refuses to
+  // unlink one that is some row's canonical file.
+  for (const entry of entries) {
+    if (!entry.endsWith(SWEEP_TEMP_SUFFIX)) {
+      continue;
+    }
+    recordLeftoverOutcome(deleteSweepLeftover(join(dir, entry)), tally);
+  }
+}
+
+function recordLeftoverOutcome(
+  outcome: ReclaimBackupResult,
+  tally: SweepLeftoverTally,
+): void {
+  if (outcome === "deleted") {
+    tally.deleted += 1;
+  } else if (outcome === "restored") {
+    tally.restored += 1;
+  } else if (outcome === "kept") {
+    tally.skipped += 1;
+  }
 }
 
 /** The pass cursor, for tests that assert a pass resumed rather than restarted. */

--- a/assistant/src/daemon/sight-frame-storage-sweep.ts
+++ b/assistant/src/daemon/sight-frame-storage-sweep.ts
@@ -95,11 +95,11 @@ const MAX_ENCODE_ATTEMPTS_PER_PASS = 200;
  * Rows a pass will READ before stopping, whatever it managed to encode.
  *
  * Charged against what the queries actually touched, not against the candidates
- * they yielded. A message that mentions the sight key without naming a given
- * attachment makes that attachment a prefilter near-miss: it costs a page slot
- * and a metadata lookup and produces nothing. Counting only candidates would
- * leave a backlog of those free, so a pass would page and parse the whole
- * backlog every hour and never notice.
+ * they yielded, and the page is built so those are the same thing: it visits
+ * exactly the rows it returns, so nothing a pass does is invisible here. A range
+ * full of attachments that qualify for nothing (wrong kind, already small, no
+ * sight tag) still costs page slots and lookups, and counting only candidates
+ * would leave all of it free.
  *
  * The cursor below is what makes stopping safe: the next pass resumes where this
  * one ran out rather than starting over.
@@ -138,6 +138,31 @@ let sweepCursor: SightFrameSweepCursor | null = null;
 const MAX_BACKUP_DIRS_PER_PASS = 40;
 
 let backupScanCursor: string | null = null;
+
+/**
+ * The sorted conversation directory names the current cycle is working through,
+ * enumerated once when the cycle starts rather than on every pass.
+ *
+ * Listing the conversations directory is O(all conversations), so doing it each
+ * pass would leave the advertised bound covering only the child scans while
+ * discovery stayed unbounded. Held across the passes of one cycle, the cost is
+ * one O(N) listing per full cycle and O(maxDirs) per pass.
+ *
+ * Two trades, both cheap here. Staleness: a conversation created mid-cycle is
+ * not scanned until the cursor wraps and the list is rebuilt, which for files a
+ * crash left behind is of no consequence, and a fresh conversation has had no
+ * time to leave any. Memory: one string per conversation, bounded by the size of
+ * the workspace, released and rebuilt at each wrap.
+ *
+ * A streaming `opendir` walk would avoid the list entirely, but the cursor
+ * depends on a stable total order to resume from a name, and directory
+ * iteration order is filesystem-defined rather than sorted, so streaming would
+ * need its own ordering pass and give back what it saved.
+ */
+let backupScanDirNames: string[] | null = null;
+
+/** How many times the conversations directory has been enumerated, for tests. */
+let backupScanEnumerations = 0;
 
 /**
  * How often the sweep runs. The window it enforces is measured in days, so an
@@ -391,12 +416,17 @@ function reclaimSweepLeftovers(maxDirs: number): SweepLeftoverTally {
   reclaimLeftoversIn(join(getWorkspaceDir(), "data", "attachments"), tally);
 
   const conversationsDir = getConversationsDir();
-  let dirNames: string[];
-  try {
-    dirNames = readdirSync(conversationsDir).sort();
-  } catch {
-    return tally;
+  // A null cursor means the last cycle finished, so this pass starts a new one
+  // and re-enumerates. That is also what picks up conversations created since.
+  if (backupScanCursor === null || backupScanDirNames === null) {
+    backupScanEnumerations += 1;
+    try {
+      backupScanDirNames = readdirSync(conversationsDir).sort();
+    } catch {
+      backupScanDirNames = [];
+    }
   }
+  const dirNames = backupScanDirNames;
   const resumeAfter = backupScanCursor;
   const resumeAt =
     resumeAfter === null ? 0 : dirNames.findIndex((name) => name > resumeAfter);
@@ -471,6 +501,21 @@ export function getSightFrameSweepCursorForTest(): SightFrameSweepCursor | null 
 export function resetSightFrameSweepCursorForTest(): void {
   sweepCursor = null;
   backupScanCursor = null;
+  backupScanDirNames = null;
+  backupScanEnumerations = 0;
+}
+
+/**
+ * How many times the conversations directory has been listed, for tests that
+ * assert discovery costs one listing per cycle rather than one per pass.
+ */
+export function getSightFrameSweepDirEnumerationsForTest(): number {
+  return backupScanEnumerations;
+}
+
+/** Where the directory scan stopped, for tests that assert a cycle wrapped. */
+export function getSightFrameSweepBackupCursorForTest(): string | null {
+  return backupScanCursor;
 }
 
 /** Start the periodic sweep. Idempotent. */

--- a/assistant/src/daemon/sight-frame-storage-sweep.ts
+++ b/assistant/src/daemon/sight-frame-storage-sweep.ts
@@ -21,6 +21,9 @@
  * what the model receives is always what is actually on disk.
  */
 
+import { readdirSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+
 import { getConfig } from "../config/loader.js";
 import {
   MAX_SIGHT_SWEEP_AFTER_DAYS,
@@ -30,12 +33,16 @@ import {
 import {
   attachmentShrinkRefusal,
   getAttachmentContent,
+  reclaimAttachmentSweepBackup,
   selectSightFrameSweepCandidates,
   shrinkAttachmentBytes,
   type SightFrameSweepCursor,
+  SWEEP_BACKUP_SUFFIX,
+  SWEEP_TEMP_SUFFIX,
 } from "../persistence/attachments-store.js";
 import { convertImageToJpeg } from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
+import { getConversationsDir, getWorkspaceDir } from "../util/platform.js";
 import { getDbMigrationReadiness } from "./daemon-readiness.js";
 
 const log = getLogger("sight-frame-storage-sweep");
@@ -83,14 +90,19 @@ const SWEEP_PAGE_SIZE = 200;
 const MAX_ENCODE_ATTEMPTS_PER_PASS = 200;
 
 /**
- * Rows a pass will examine before stopping, whatever it managed to encode.
+ * Rows a pass will READ before stopping, whatever it managed to encode.
  *
- * Refusals are cheap but not free, and the candidate query has no index to ride,
- * so an install whose aged frames are all unrewritable still needs a stop. The
- * cursor below is what makes stopping safe: the next pass resumes here rather
- * than starting over.
+ * Charged against what the queries actually touched, not against the candidates
+ * they yielded. A message that mentions the sight key without naming a given
+ * attachment makes that attachment a prefilter near-miss: it costs a page slot
+ * and a metadata lookup and produces nothing. Counting only candidates would
+ * leave a backlog of those free, so a pass would page and parse the whole
+ * backlog every hour and never notice.
+ *
+ * The cursor below is what makes stopping safe: the next pass resumes where this
+ * one ran out rather than starting over.
  */
-const MAX_ROWS_EXAMINED_PER_PASS = 5_000;
+const MAX_ROWS_READ_PER_PASS = 5_000;
 
 /**
  * Where the last pass stopped, so the next one resumes instead of re-examining
@@ -104,6 +116,26 @@ const MAX_ROWS_EXAMINED_PER_PASS = 5_000;
  * queries once per boot.
  */
 let sweepCursor: SightFrameSweepCursor | null = null;
+
+/**
+ * Conversation directories a pass checks for leftover sweep files.
+ *
+ * The reclaim cannot be driven off the candidate set, which is the whole
+ * problem: a row whose update landed no longer selects, so the pass that shrank
+ * it is the last one that will ever look at it, and a backup left by a process
+ * that died before the unlink would sit there forever. Directories are the only
+ * place a leftover can be found without knowing which row it belonged to, and
+ * they find the ones whose row is gone entirely, which no row-driven probe can.
+ *
+ * Bounded and staged rather than exhaustive. A full walk is a `readdir` per
+ * conversation, and what it is looking for only appears when a process dies
+ * inside a window a few microseconds wide, so 40 directories an hour clears a
+ * few thousand conversations in a couple of days and costs nothing meanwhile.
+ * The staging cursor is in memory, on the same terms as the row cursor above.
+ */
+const MAX_BACKUP_DIRS_PER_PASS = 40;
+
+let backupScanCursor: string | null = null;
 
 /**
  * How often the sweep runs. The window it enforces is measured in days, so an
@@ -152,17 +184,34 @@ export interface SightFrameSweepResult {
   freedBytes: number;
   /** Candidates left alone: shared or foreign file, unreadable, or no smaller. */
   skipped: number;
-  /** Candidate rows this pass looked at, refusals included. */
+  /** Candidates this pass looked at, refusals included. */
   examined: number;
+  /**
+   * Rows this pass's queries read, which is what the row budget is charged
+   * against. Larger than {@link examined} whenever the prefilter admitted an
+   * attachment no linked message actually tags.
+   */
+  rowsRead: number;
+  /** Leftover sweep files this pass reclaimed. */
+  reclaimedBackups: number;
 }
 
 function emptyResult(): SightFrameSweepResult {
-  return { shrunk: 0, freedBytes: 0, skipped: 0, examined: 0 };
+  return {
+    shrunk: 0,
+    freedBytes: 0,
+    skipped: 0,
+    examined: 0,
+    rowsRead: 0,
+    reclaimedBackups: 0,
+  };
 }
 
 export interface SightFrameSweepBounds {
   maxEncodeAttempts?: number;
-  maxRowsExamined?: number;
+  maxRowsRead?: number;
+  maxBackupDirs?: number;
+  pageSize?: number;
 }
 
 /**
@@ -182,7 +231,7 @@ export async function sweepAgedSightFrames(
   }
   const maxEncodeAttempts =
     bounds.maxEncodeAttempts ?? MAX_ENCODE_ATTEMPTS_PER_PASS;
-  const maxRowsExamined = bounds.maxRowsExamined ?? MAX_ROWS_EXAMINED_PER_PASS;
+  const maxRowsRead = bounds.maxRowsRead ?? MAX_ROWS_READ_PER_PASS;
 
   const createdBefore = Date.now() - resolveSightSweepAfterDays() * MS_PER_DAY;
   const result = emptyResult();
@@ -195,13 +244,14 @@ export async function sweepAgedSightFrames(
       page = selectSightFrameSweepCandidates({
         createdBefore,
         largerThanBytes: SWEPT_MAX_BYTES,
-        limit: SWEEP_PAGE_SIZE,
+        limit: bounds.pageSize ?? SWEEP_PAGE_SIZE,
         after: cursor,
       });
     } catch (err) {
       log.warn({ err }, "Could not read aged camera frames");
       break;
     }
+    result.rowsRead += page.rowsRead;
 
     let spentOnThisPage = false;
     for (const candidate of page.candidates) {
@@ -247,9 +297,9 @@ export async function sweepAgedSightFrames(
       break;
     }
 
-    // The whole page was consumed, so step past its tail too: rows the metadata
-    // prefilter matched and the parse rejected are not candidates and would
-    // otherwise be re-read on every pass.
+    // The whole page was consumed, so step past its tail too: attachments the
+    // metadata prefilter admitted and the tag check rejected are not candidates
+    // and would otherwise be re-read on every pass.
     cursor = page.nextCursor ?? cursor;
     if (!page.hasMore) {
       // End of the candidate set. Start the next pass at the head so newly aged
@@ -257,13 +307,20 @@ export async function sweepAgedSightFrames(
       cursor = null;
       break;
     }
-    if (result.examined >= maxRowsExamined) {
+    // Charged against rows READ, so a page that yielded no candidates still
+    // spends the budget it cost. The cursor already names the last attachment
+    // this page examined, so the next pass resumes behind it rather than paying
+    // for the same near-misses again.
+    if (result.rowsRead >= maxRowsRead) {
       break;
     }
   }
 
   sweepCursor = cursor;
-  if (result.shrunk > 0) {
+  result.reclaimedBackups = reclaimSweepLeftovers(
+    bounds.maxBackupDirs ?? MAX_BACKUP_DIRS_PER_PASS,
+  );
+  if (result.shrunk > 0 || result.reclaimedBackups > 0) {
     log.info(result, "Shrank aged camera frames to thumbnail scale");
   }
   return result;
@@ -297,14 +354,94 @@ async function shrinkOneFrame(attachmentId: string): Promise<number | null> {
   return thumbnail.length;
 }
 
+/**
+ * Delete the sweep files a killed process left behind, across a bounded slice of
+ * the store's own attachment directories.
+ *
+ * The staging directory is checked every pass, being one directory; conversation
+ * directories are taken `maxDirs` at a time, resuming by name from where the
+ * last pass stopped and wrapping when the list runs out. Names are stable, so a
+ * conversation created or deleted between passes cannot make the scan skip its
+ * neighbours.
+ *
+ * Whether a backup may go is never this function's call: it hands each one to
+ * {@link reclaimAttachmentSweepBackup}, which keeps the ones a row still needs.
+ * A leftover `.sweep-tmp` needs no such question, being a replacement that never
+ * reached its rename, and this never runs while a shrink is in flight.
+ *
+ * Never throws. Returns how many files it removed.
+ */
+function reclaimSweepLeftovers(maxDirs: number): number {
+  let reclaimed = 0;
+  reclaimed += reclaimLeftoversIn(
+    join(getWorkspaceDir(), "data", "attachments"),
+  );
+
+  const conversationsDir = getConversationsDir();
+  let dirNames: string[];
+  try {
+    dirNames = readdirSync(conversationsDir).sort();
+  } catch {
+    return reclaimed;
+  }
+  const resumeAfter = backupScanCursor;
+  const resumeAt =
+    resumeAfter === null ? 0 : dirNames.findIndex((name) => name > resumeAfter);
+  if (resumeAt === -1) {
+    backupScanCursor = null;
+    return reclaimed;
+  }
+
+  const slice = dirNames.slice(resumeAt, resumeAt + maxDirs);
+  for (const name of slice) {
+    reclaimed += reclaimLeftoversIn(
+      join(conversationsDir, name, "attachments"),
+    );
+  }
+  backupScanCursor =
+    resumeAt + maxDirs >= dirNames.length
+      ? null
+      : (slice[slice.length - 1] ?? null);
+  return reclaimed;
+}
+
+/** One directory's leftovers. Never throws; a directory that is not there has none. */
+function reclaimLeftoversIn(dir: string): number {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return 0;
+  }
+  let reclaimed = 0;
+  for (const entry of entries) {
+    if (entry.endsWith(SWEEP_BACKUP_SUFFIX)) {
+      if (reclaimAttachmentSweepBackup(join(dir, entry)) === "deleted") {
+        reclaimed += 1;
+      }
+      continue;
+    }
+    if (entry.endsWith(SWEEP_TEMP_SUFFIX)) {
+      try {
+        unlinkSync(join(dir, entry));
+        reclaimed += 1;
+      } catch {
+        /* gone already, or not ours to remove */
+      }
+    }
+  }
+  return reclaimed;
+}
+
 /** The pass cursor, for tests that assert a pass resumed rather than restarted. */
 export function getSightFrameSweepCursorForTest(): SightFrameSweepCursor | null {
   return sweepCursor;
 }
 
-/** Send the next pass back to the head of the candidate set. */
+/** Send the next pass back to the head of the candidate set and the directory scan. */
 export function resetSightFrameSweepCursorForTest(): void {
   sweepCursor = null;
+  backupScanCursor = null;
 }
 
 /** Start the periodic sweep. Idempotent. */

--- a/assistant/src/daemon/sight-frame-storage-sweep.ts
+++ b/assistant/src/daemon/sight-frame-storage-sweep.ts
@@ -1,0 +1,233 @@
+/**
+ * Long-term storage retention for ambient camera frames.
+ *
+ * The counterpart to `conversation-sight-frames.ts`, which bounds what a frame
+ * costs the model. That pass rewrites the copy of the history a turn is about
+ * to send and never touches what is stored. This one bounds what a frame costs
+ * the disk: a call samples a frame every few seconds for as long as the camera
+ * is up, and each one is a full-resolution image that outlives the call.
+ *
+ * Aged frames are re-encoded to a thumbnail in place, so the transcript block
+ * keeps resolving and the row, its links, and its message content are left
+ * exactly as they were. Deleting a conversation is still the only thing that
+ * removes a frame; this sweep never deletes a row.
+ *
+ * The bytes are the only thing that changes. In particular the persist-time
+ * `sizeBytes` / `width` / `height` hints on the message's own `workspace_ref`
+ * block are left alone: they are message content, which the retention pass
+ * above reads, and after a sweep they merely overstate the block, which costs
+ * the token estimator nothing but conservatism. The provider path re-reads and
+ * re-sniffs the stored bytes on every send (`providers/media-resolve.ts`), so
+ * what the model receives is always what is actually on disk.
+ */
+
+import { getConfig } from "../config/loader.js";
+import {
+  MAX_SIGHT_SWEEP_AFTER_DAYS,
+  MIN_SIGHT_SWEEP_AFTER_DAYS,
+  SWEEP_SIGHT_FRAMES_AFTER_DAYS,
+} from "../config/schemas/sight.js";
+import {
+  getAttachmentContent,
+  selectSightFrameSweepCandidates,
+  shrinkAttachmentBytes,
+} from "../persistence/attachments-store.js";
+import { convertImageToJpeg } from "../util/image-conversion.js";
+import { getLogger } from "../util/logger.js";
+import { getDbMigrationReadiness } from "./daemon-readiness.js";
+
+const log = getLogger("sight-frame-storage-sweep");
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** Longest side a swept frame keeps: enough to recognize the room, not to read it. */
+const SWEPT_MAX_DIMENSION_PX = 512;
+
+/** JPEG quality for a swept frame. Below transport quality; nothing re-reads these for detail. */
+const SWEPT_JPEG_QUALITY = 60;
+
+/**
+ * Size at or under which a frame counts as already swept.
+ *
+ * This is the sweep's idempotence signal, and it is a stored column rather than
+ * a new marker because the alternatives are worse: pixel dimensions would mean
+ * decoding every candidate on every tick just to ask whether to skip it, and a
+ * marker on the message would mean writing the metadata this sweep is otherwise
+ * careful never to touch. It doubles as the query's bounding predicate, so a
+ * pass over an install with nothing left to shrink matches no rows at all.
+ *
+ * Comfortably above what {@link SWEPT_MAX_DIMENSION_PX} at
+ * {@link SWEPT_JPEG_QUALITY} produces (tens of KB), so a swept frame lands well
+ * clear of the threshold rather than just under it.
+ */
+const SWEPT_MAX_BYTES = 128 * 1024;
+
+/** Rows examined per pass, so one tick's work is bounded whatever the backlog. */
+const SWEEP_BATCH_SIZE = 200;
+
+/**
+ * How often the sweep runs. The window it enforces is measured in days, so an
+ * hourly cadence is far finer than the guarantee needs; it is what bounds the
+ * cost of the pass, whose candidate query has no index to ride (neither
+ * `attachments.created_at` nor `messages.metadata` carries one) and therefore
+ * scans a table each time.
+ */
+const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Delay before the first pass. A desktop assistant is restarted often enough
+ * that waiting a full interval could mean never sweeping at all, and startup is
+ * already busy, so the first pass runs shortly after boot instead.
+ */
+const FIRST_SWEEP_DELAY_MS = 60_000;
+
+let firstSweepTimer: ReturnType<typeof setTimeout> | null = null;
+let sweepTimer: ReturnType<typeof setInterval> | null = null;
+let sweepInProgress = false;
+
+/**
+ * The workspace's `sight.sweepAfterDays`, clamped to
+ * [{@link MIN_SIGHT_SWEEP_AFTER_DAYS}, {@link MAX_SIGHT_SWEEP_AFTER_DAYS}].
+ *
+ * Clamped at read rather than rejected by the schema, matching
+ * `resolveSightKeepLatestFrames`: an out-of-range window states an intent the
+ * guardrail can honor part of the way, while failing validation would silently
+ * fall back to a default the config never asked for.
+ */
+export function resolveSightSweepAfterDays(): number {
+  const configured = getConfig().sight.sweepAfterDays;
+  if (!Number.isFinite(configured)) {
+    return SWEEP_SIGHT_FRAMES_AFTER_DAYS;
+  }
+  return Math.min(
+    MAX_SIGHT_SWEEP_AFTER_DAYS,
+    Math.max(MIN_SIGHT_SWEEP_AFTER_DAYS, Math.trunc(configured)),
+  );
+}
+
+export interface SightFrameSweepResult {
+  /** Frames whose stored bytes were replaced with a thumbnail. */
+  shrunk: number;
+  /** Freed bytes, counted as stored size before minus stored size after. */
+  freedBytes: number;
+  /** Candidates left alone: shared or foreign file, unreadable, or no smaller. */
+  skipped: number;
+}
+
+function emptyResult(): SightFrameSweepResult {
+  return { shrunk: 0, freedBytes: 0, skipped: 0 };
+}
+
+/**
+ * Shrink one batch of aged camera frames. Never throws: a sweep that cannot run
+ * is a sweep that runs next hour.
+ */
+export async function sweepAgedSightFrames(): Promise<SightFrameSweepResult> {
+  if (!getDbMigrationReadiness().ready) {
+    return emptyResult();
+  }
+
+  let candidates;
+  try {
+    candidates = selectSightFrameSweepCandidates({
+      createdBefore: Date.now() - resolveSightSweepAfterDays() * MS_PER_DAY,
+      largerThanBytes: SWEPT_MAX_BYTES,
+      limit: SWEEP_BATCH_SIZE,
+    });
+  } catch (err) {
+    log.warn({ err }, "Could not read aged camera frames");
+    return emptyResult();
+  }
+
+  const result = emptyResult();
+  for (const candidate of candidates) {
+    try {
+      const shrunkBytes = await shrinkOneFrame(candidate.id);
+      if (shrunkBytes === null) {
+        result.skipped += 1;
+        continue;
+      }
+      result.shrunk += 1;
+      result.freedBytes += candidate.sizeBytes - shrunkBytes;
+    } catch (err) {
+      result.skipped += 1;
+      log.warn(
+        { err, attachmentId: candidate.id },
+        "Could not shrink an aged camera frame",
+      );
+    }
+  }
+
+  if (result.shrunk > 0) {
+    log.info(result, "Shrank aged camera frames to thumbnail scale");
+  }
+  return result;
+}
+
+/**
+ * Re-encode one frame and store the result, returning its new byte length, or
+ * null when the frame was left exactly as it was.
+ */
+async function shrinkOneFrame(attachmentId: string): Promise<number | null> {
+  const bytes = getAttachmentContent(attachmentId);
+  if (!bytes) {
+    return null;
+  }
+  // The same converter attachment ingress and transport optimization use, so
+  // there is one encoder in the process and a swept frame is a JPEG every
+  // client and provider already reads.
+  const thumbnail = await convertImageToJpeg(bytes, {
+    maxDimensionPx: SWEPT_MAX_DIMENSION_PX,
+    quality: SWEPT_JPEG_QUALITY,
+  });
+  if (!thumbnail) {
+    return null;
+  }
+
+  const outcome = shrinkAttachmentBytes(attachmentId, thumbnail, "image/jpeg");
+  if (outcome !== "shrunk") {
+    log.debug({ attachmentId, outcome }, "Left an aged camera frame alone");
+    return null;
+  }
+  return thumbnail.length;
+}
+
+/** Start the periodic sweep. Idempotent. */
+export function startSightFrameStorageSweep(): void {
+  if (sweepTimer || firstSweepTimer) {
+    return;
+  }
+  firstSweepTimer = setTimeout(() => {
+    firstSweepTimer = null;
+    void runSweepPass();
+  }, FIRST_SWEEP_DELAY_MS);
+  sweepTimer = setInterval(() => {
+    void runSweepPass();
+  }, SWEEP_INTERVAL_MS);
+}
+
+/** Stop the periodic sweep. Used in tests and shutdown. */
+export function stopSightFrameStorageSweep(): void {
+  if (firstSweepTimer) {
+    clearTimeout(firstSweepTimer);
+    firstSweepTimer = null;
+  }
+  if (sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+  sweepInProgress = false;
+}
+
+/** One pass, skipped while the previous one is still re-encoding. */
+async function runSweepPass(): Promise<void> {
+  if (sweepInProgress) {
+    return;
+  }
+  sweepInProgress = true;
+  try {
+    await sweepAgedSightFrames();
+  } finally {
+    sweepInProgress = false;
+  }
+}

--- a/assistant/src/daemon/sight-frame-storage-sweep.ts
+++ b/assistant/src/daemon/sight-frame-storage-sweep.ts
@@ -64,8 +64,8 @@ const SWEPT_JPEG_QUALITY = 60;
  * a new marker because the alternatives are worse: pixel dimensions would mean
  * decoding every candidate on every tick just to ask whether to skip it, and a
  * marker on the message would mean writing the metadata this sweep is otherwise
- * careful never to touch. It doubles as the query's bounding predicate, so a
- * pass over an install with nothing left to shrink matches no rows at all.
+ * careful never to touch. A frame under it is not a candidate, so a pass over an
+ * install with nothing left to shrink walks its aged rows and encodes none.
  *
  * Comfortably above what {@link SWEPT_MAX_DIMENSION_PX} at
  * {@link SWEPT_JPEG_QUALITY} produces (tens of KB), so a swept frame lands well
@@ -85,9 +85,11 @@ const SWEEP_PAGE_SIZE = 200;
  * of those to reach work it can actually do; producing a thumbnail costs real
  * CPU, and a frame that comes out no smaller costs it for nothing.
  *
- * 200 frames an hour is far more than a camera generates, so the bound only ever
- * binds on a backlog, which is exactly when a pass should stop and let the next
- * one continue.
+ * It is a bound on ONE PASS, not on throughput. 200 is below what a call with
+ * the camera up can persist in an hour, which is why hitting it moves the sweep
+ * to {@link CATCH_UP_SWEEP_DELAY_MS} rather than raising it: keeping a single
+ * pass short is what keeps it off the event loop, and passes are cheap to
+ * repeat.
  */
 const MAX_ENCODE_ATTEMPTS_PER_PASS = 200;
 
@@ -165,13 +167,33 @@ let backupScanDirNames: string[] | null = null;
 let backupScanEnumerations = 0;
 
 /**
- * How often the sweep runs. The window it enforces is measured in days, so an
- * hourly cadence is far finer than the guarantee needs; it is what bounds the
- * cost of the pass, whose candidate query has no index to ride (neither
- * `attachments.created_at` nor `messages.metadata` carries one) and therefore
- * scans a table each time.
+ * The resting cadence, for when the last pass found everything it needed.
+ *
+ * The window being enforced is measured in days, so hourly is already far finer
+ * than the guarantee needs, and a pass that finds nothing is a handful of
+ * indexed range reads. There is no cost pressure here; this is simply how often
+ * it is worth asking.
  */
-const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+export const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * The cadence while a backlog is draining, chosen so the drain outruns the
+ * fastest the camera can fill it.
+ *
+ * The gate that keeps frames will not keep two inside five seconds
+ * (`clients/web/src/lib/camera/frame-gate.ts`), so a call with the camera up all
+ * hour persists at most 720 frames in that hour. At the resting cadence a pass
+ * attempts {@link MAX_ENCODE_ATTEMPTS_PER_PASS}, which is 200 an hour: less than
+ * the ceiling, so a sustained heavy call would grow the backlog faster than the
+ * sweep drained it and the storage bound would be one in name only. Five minutes
+ * gives 12 passes an hour, so 2400 encodes against a ceiling of 720, and the
+ * backlog shrinks under any workload the client can produce.
+ *
+ * This changes only the SCHEDULE. Per-pass bounds are untouched, because they
+ * are what keeps one pass off the event loop, and a shorter gap between bounded
+ * passes is the safe way to add throughput.
+ */
+export const CATCH_UP_SWEEP_DELAY_MS = 5 * 60 * 1000;
 
 /**
  * Delay before the first pass. A desktop assistant is restarted often enough
@@ -180,8 +202,10 @@ const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
  */
 const FIRST_SWEEP_DELAY_MS = 60_000;
 
-let firstSweepTimer: ReturnType<typeof setTimeout> | null = null;
-let sweepTimer: ReturnType<typeof setInterval> | null = null;
+// One timer at a time: each pass schedules the next when it finishes, which is
+// what lets the gap between them depend on what the last one found.
+let sweepTimer: ReturnType<typeof setTimeout> | null = null;
+let sweepScheduled = false;
 let sweepInProgress = false;
 
 /**
@@ -215,12 +239,18 @@ export interface SightFrameSweepResult {
   examined: number;
   /**
    * Rows this pass's queries read, which is what the row budget is charged
-   * against. Larger than {@link examined} whenever the prefilter admitted an
-   * attachment no linked message actually tags.
+   * against. Larger than {@link examined} because a page returns every aged
+   * attachment in its range, most of which qualify for nothing.
    */
   rowsRead: number;
   /** What the directory scan did with the sweep files a crash left behind. */
   leftovers: SweepLeftoverTally;
+  /**
+   * Whether the pass stopped on one of its bounds rather than running out of
+   * rows, which means work is left and the cursor points at it. The scheduler
+   * reads this to decide whether to come back soon or rest.
+   */
+  stoppedOnBudget: boolean;
 }
 
 export interface SweepLeftoverTally {
@@ -240,6 +270,7 @@ function emptyResult(): SightFrameSweepResult {
     examined: 0,
     rowsRead: 0,
     leftovers: { deleted: 0, restored: 0, skipped: 0 },
+    stoppedOnBudget: false,
   };
 }
 
@@ -330,12 +361,13 @@ export async function sweepAgedSightFrames(
       }
     }
     if (spentOnThisPage) {
+      result.stoppedOnBudget = true;
       break;
     }
 
-    // The whole page was consumed, so step past its tail too: attachments the
-    // metadata prefilter admitted and the tag check rejected are not candidates
-    // and would otherwise be re-read on every pass.
+    // The whole page was consumed, so step past its tail too: the aged rows that
+    // are not frames worth shrinking are not candidates, and would otherwise be
+    // re-read on every pass.
     cursor = page.nextCursor ?? cursor;
     if (!page.hasMore) {
       // End of the candidate set. Start the next pass at the head so newly aged
@@ -345,9 +377,10 @@ export async function sweepAgedSightFrames(
     }
     // Charged against rows READ, so a page that yielded no candidates still
     // spends the budget it cost. The cursor already names the last attachment
-    // this page examined, so the next pass resumes behind it rather than paying
-    // for the same near-misses again.
+    // this page visited, so the next pass resumes behind it rather than paying
+    // for the same rows again.
     if (result.rowsRead >= maxRowsRead) {
+      result.stoppedOnBudget = true;
       break;
     }
   }
@@ -518,42 +551,58 @@ export function getSightFrameSweepBackupCursorForTest(): string | null {
   return backupScanCursor;
 }
 
+/**
+ * How long to wait after a pass before running the next one.
+ *
+ * A pass that stopped on a bound left work behind and the cursor pointing at it,
+ * so the backlog is draining and the sweep leans into it. A pass that ran out of
+ * rows is caught up, and goes back to resting.
+ */
+export function sweepDelayAfter(result: SightFrameSweepResult): number {
+  return result.stoppedOnBudget ? CATCH_UP_SWEEP_DELAY_MS : SWEEP_INTERVAL_MS;
+}
+
 /** Start the periodic sweep. Idempotent. */
 export function startSightFrameStorageSweep(): void {
-  if (sweepTimer || firstSweepTimer) {
+  if (sweepScheduled) {
     return;
   }
-  firstSweepTimer = setTimeout(() => {
-    firstSweepTimer = null;
-    void runSweepPass();
-  }, FIRST_SWEEP_DELAY_MS);
-  sweepTimer = setInterval(() => {
-    void runSweepPass();
-  }, SWEEP_INTERVAL_MS);
+  sweepScheduled = true;
+  scheduleNextSweep(FIRST_SWEEP_DELAY_MS);
 }
 
 /** Stop the periodic sweep. Used in tests and shutdown. */
 export function stopSightFrameStorageSweep(): void {
-  if (firstSweepTimer) {
-    clearTimeout(firstSweepTimer);
-    firstSweepTimer = null;
-  }
+  sweepScheduled = false;
   if (sweepTimer) {
-    clearInterval(sweepTimer);
+    clearTimeout(sweepTimer);
     sweepTimer = null;
   }
   sweepInProgress = false;
 }
 
-/** One pass, skipped while the previous one is still re-encoding. */
+function scheduleNextSweep(delayMs: number): void {
+  if (!sweepScheduled) {
+    return;
+  }
+  sweepTimer = setTimeout(() => {
+    sweepTimer = null;
+    void runSweepPass();
+  }, delayMs);
+}
+
+/** One pass, then the next is scheduled on the cadence that pass earned. */
 async function runSweepPass(): Promise<void> {
   if (sweepInProgress) {
+    scheduleNextSweep(SWEEP_INTERVAL_MS);
     return;
   }
   sweepInProgress = true;
+  let delayMs = SWEEP_INTERVAL_MS;
   try {
-    await sweepAgedSightFrames();
+    delayMs = sweepDelayAfter(await sweepAgedSightFrames());
   } finally {
     sweepInProgress = false;
   }
+  scheduleNextSweep(delayMs);
 }

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1549,24 +1549,24 @@ export interface SightFrameSweepPage {
  * never reach anything behind them.
  */
 /**
- * The candidate page query, hoisted out so a test can put the exact text this
- * runs through `EXPLAIN QUERY PLAN`. A copy in the test would go stale the first
- * time the query changed shape, which is precisely when the plan needs checking.
+ * The candidate page query, with `cursorClause` the only thing that varies
+ * between the first page and a continuation. Everything else is written once,
+ * so the two shapes cannot drift in their select list, prefilter, residual
+ * filters, or ordering.
  *
- * The bound, the keyset continuation, and the ordering are all carried by
- * `idx_attachments_created_at_id` (migration 374), so a page is an index-range
- * continuation rather than a fresh scan and sort of the whole table. `kind` and
- * `size_bytes` stay residual filters over the rows that range visits.
+ * Both are hoisted out so a test can put the exact text this runs through
+ * `EXPLAIN QUERY PLAN`. A copy in the test would go stale the first time the
+ * query changed shape, which is precisely when the plan needs checking.
  */
-export const SIGHT_FRAME_SWEEP_CANDIDATE_SQL = `SELECT
+function sightFrameSweepCandidateSql(cursorClause: string): string {
+  return `SELECT
        a.id AS id,
        a.size_bytes AS sizeBytes,
        a.created_at AS createdAt
      FROM attachments a
      WHERE a.kind = 'image'
        AND a.created_at < ?
-       AND a.size_bytes > ?
-       AND (? IS NULL OR (a.created_at, a.id) > (?, ?))
+       AND a.size_bytes > ?${cursorClause}
        AND EXISTS (
          SELECT 1
          FROM message_attachments ma
@@ -1576,6 +1576,32 @@ export const SIGHT_FRAME_SWEEP_CANDIDATE_SQL = `SELECT
        )
      ORDER BY a.created_at ASC, a.id ASC
      LIMIT ?`;
+}
+
+/**
+ * Opening page: the age bound alone, which
+ * `idx_attachments_created_at_id` (migration 374) serves as an index range in
+ * cursor order, so there is no sort step.
+ */
+export const SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL = sightFrameSweepCandidateSql("");
+
+/**
+ * Continuation page: a DIRECT tuple comparison against the cursor, deliberately
+ * not wrapped in an `OR` or guarded by a nullable sentinel.
+ *
+ * The predicate has to be one SQLite can turn into the index's lower bound. A
+ * `(? IS NULL OR (a.created_at, a.id) > (?, ?))` shape reads as a plain
+ * expression it cannot, so the plan keeps only `created_at<?`, every
+ * continuation restarts at the oldest eligible entry, and walking a backlog of
+ * pages costs index visits quadratic in the pages walked. Written directly, the
+ * plan becomes `((created_at,id)>(?,?) AND created_at<?)` and a page seeks
+ * straight to where the last one stopped. Two shapes rather than one is the
+ * price of that, which is why they are built from a single fragment above.
+ */
+export const SIGHT_FRAME_SWEEP_CONTINUATION_SQL = sightFrameSweepCandidateSql(
+  `
+       AND (a.created_at, a.id) > (?, ?)`,
+);
 
 export function selectSightFrameSweepCandidates(options: {
   createdBefore: number;
@@ -1585,18 +1611,23 @@ export function selectSightFrameSweepCandidates(options: {
 }): SightFrameSweepPage {
   const after = options.after ?? null;
   const taggedMessageLike = `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`;
+  // Bind order follows clause order, and the cursor clause sits between the
+  // size filter and the prefilter, so the shared tail keeps its positions.
+  const cursorBinds = after === null ? [] : [after.createdAt, after.id];
   const rows = rawAll<{
     id: string;
     sizeBytes: number;
     createdAt: number;
   }>(
-    "attachments:selectSightFrameSweepCandidates",
-    SIGHT_FRAME_SWEEP_CANDIDATE_SQL,
+    after === null
+      ? "attachments:selectSightFrameSweepCandidates:first"
+      : "attachments:selectSightFrameSweepCandidates:continuation",
+    after === null
+      ? SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL
+      : SIGHT_FRAME_SWEEP_CONTINUATION_SQL,
     options.createdBefore,
     options.largerThanBytes,
-    after === null ? null : 1,
-    after?.createdAt ?? 0,
-    after?.id ?? "",
+    ...cursorBinds,
     taggedMessageLike,
     options.limit,
   );

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1437,12 +1437,28 @@ export function deleteOrphanAttachments(candidateIds: string[]): number {
   return deletedCount;
 }
 
+/**
+ * The `file_path` questions the shrink and reclaim guards ask, hoisted so a test
+ * can put the exact text through `EXPLAIN QUERY PLAN`. Each is an equality or
+ * `IN` against a bound parameter, which is what lets the partial index in
+ * migration 375 serve them: a null `file_path` satisfies neither.
+ */
+export const ATTACHMENT_FILE_PATH_REFERENCE_SQL = `SELECT COUNT(*) AS refCount FROM attachments WHERE file_path = ?`;
+
+export const ATTACHMENT_SIDECARS_CLAIMED_SQL = `SELECT COUNT(*) AS claimed FROM attachments WHERE file_path IN (?, ?)`;
+
+export const ATTACHMENT_SWEEP_BACKUP_OWNERS_SQL = `SELECT
+       COUNT(*) AS rows,
+       COALESCE(SUM(CASE WHEN size_bytes > ? THEN 1 ELSE 0 END), 0) AS overstating
+     FROM attachments
+     WHERE file_path = ?`;
+
 /** How many attachment rows name this file. */
 function attachmentFilePathReferenceCount(filePath: string): number {
   return (
     rawGet<{ refCount: number }>(
       "attachments:filePathReferenceCount",
-      `SELECT COUNT(*) AS refCount FROM attachments WHERE file_path = ?`,
+      ATTACHMENT_FILE_PATH_REFERENCE_SQL,
       filePath,
     )?.refCount ?? 0
   );
@@ -1795,11 +1811,7 @@ export function reclaimAttachmentSweepBackup(
 
   const owners = rawGet<{ rows: number; overstating: number }>(
     "attachments:sweepBackupOwners",
-    `SELECT
-       COUNT(*) AS rows,
-       COALESCE(SUM(CASE WHEN size_bytes > ? THEN 1 ELSE 0 END), 0) AS overstating
-     FROM attachments
-     WHERE file_path = ?`,
+    ATTACHMENT_SWEEP_BACKUP_OWNERS_SQL,
     storedBytes,
     filePath,
   );
@@ -1896,7 +1908,7 @@ function sweepSidecarsAreClaimed(filePath: string): boolean {
   return (
     (rawGet<{ claimed: number }>(
       "attachments:sweepSidecarsClaimed",
-      `SELECT COUNT(*) AS claimed FROM attachments WHERE file_path IN (?, ?)`,
+      ATTACHMENT_SIDECARS_CLAIMED_SQL,
       `${filePath}${SWEEP_TEMP_SUFFIX}`,
       `${filePath}${SWEEP_BACKUP_SUFFIX}`,
     )?.claimed ?? 0) > 0

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -31,10 +31,7 @@ import {
 import { getLogger } from "../util/logger.js";
 import { getConversationsDir, getWorkspaceDir } from "../util/platform.js";
 import { getConversationAttachmentsDirPath } from "./conversation-directories.js";
-import {
-  messageMetadataTagsSightFrame,
-  SIGHT_FRAME_ATTACHMENT_IDS_KEY,
-} from "./conversation-types.js";
+import { messageMetadataTagsSightFrame } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
 import { rawAll, rawGet, rawRun } from "./raw-query.js";
 import { attachments, messageAttachments } from "./schema.js";
@@ -1584,10 +1581,9 @@ export const SIGHT_FRAME_SWEEP_CONTINUATION_SQL = sightFrameSweepPageSql(
  * The page is an index range over `created_at`; everything that decides whether
  * a visited row is a candidate happens here, in order of what it costs. `kind`
  * and the size threshold are read off the returned row. Only what survives both
- * is worth a metadata probe, and an attachment qualifies when at least one
- * linked message parses to a tag naming it: the `LIKE` in that probe narrows,
- * the parse decides, so a message that merely mentions the key contributes
- * nothing.
+ * is worth a metadata probe, and an attachment qualifies when at least one of
+ * the linked messages that probe reads parses to a tag naming it. The parse is
+ * what decides, so a message that merely mentions the key contributes nothing.
  *
  * The population is EVERY tagged frame, standalone camera keeps and the frames
  * that rode a spoken turn alike. That is deliberately wider than
@@ -1611,6 +1607,43 @@ export const SIGHT_FRAME_SWEEP_CONTINUATION_SQL = sightFrameSweepPageSql(
  * way to make the row stop matching, so a query that always started at the
  * oldest row would hand back the same refusals forever.
  */
+/**
+ * How many of a candidate's linked messages the tag check reads.
+ *
+ * A sight frame is linked to essentially one message: the standalone keep row
+ * the camera's gate persisted, or the single spoken turn it rode. Nothing in the
+ * design produces an attachment on hundreds of messages, so a small cap costs a
+ * real frame nothing and stops an attachment with an unusual link count from
+ * turning one candidate into an unbounded read.
+ *
+ * The cap makes this a false NEGATIVE in the pathological case: an attachment
+ * whose sampled links all fail the parse is treated as untagged for this pass.
+ * That is acceptable and bounded. It can only befall a row that is not
+ * keep-shaped to begin with, since a keep's one link names it; the pass moves on
+ * rather than stalling; and the classification is stable rather than random, so
+ * a frame is never half-swept.
+ */
+export const SIGHT_FRAME_TAG_PROBE_LIMIT = 16;
+
+/**
+ * The tag check for one candidate: the messages it hangs off, capped.
+ *
+ * The `LIKE` prefilter that used to sit here is gone on purpose. As a residual
+ * it made `LIMIT` bound rows RETURNED while the walk stayed unbounded, exactly
+ * as it did on the page query: an attachment linked to many ordinary messages
+ * would have every link visited and joined in the hunt for matches to return.
+ * Without it the limit bounds the visit, and `messageMetadataTagsSightFrame` was
+ * always the authority anyway, the prefilter only ever narrowing ahead of it.
+ *
+ * Unordered, so the cap samples whichever links the index yields first. With one
+ * link in practice there is nothing to order.
+ */
+const SIGHT_FRAME_TAG_PROBE_SQL = `SELECT m.metadata AS metadata
+       FROM message_attachments ma
+       JOIN messages m ON m.id = ma.message_id
+       WHERE ma.attachment_id = ?
+       LIMIT ?`;
+
 export function selectSightFrameSweepCandidates(options: {
   createdBefore: number;
   largerThanBytes: number;
@@ -1618,7 +1651,6 @@ export function selectSightFrameSweepCandidates(options: {
   after?: SightFrameSweepCursor | null;
 }): SightFrameSweepPage {
   const after = options.after ?? null;
-  const taggedMessageLike = `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`;
   // Bind order follows clause order, and the cursor clause is the only optional
   // one, so the limit keeps its position at the tail.
   const cursorBinds = after === null ? [] : [after.createdAt, after.id];
@@ -1651,13 +1683,9 @@ export function selectSightFrameSweepCandidates(options: {
     }
     const linked = rawAll<{ metadata: string | null }>(
       "attachments:sightFrameSweepCandidateTags",
-      `SELECT m.metadata AS metadata
-       FROM message_attachments ma
-       JOIN messages m ON m.id = ma.message_id
-       WHERE ma.attachment_id = ?
-         AND m.metadata LIKE ?`,
+      SIGHT_FRAME_TAG_PROBE_SQL,
       row.id,
-      taggedMessageLike,
+      SIGHT_FRAME_TAG_PROBE_LIMIT,
     );
     rowsRead += linked.length;
     const tagged = linked.some((link) =>

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1497,93 +1497,68 @@ export interface SightFrameSweepCursor {
 export interface SightFrameSweepPage {
   candidates: SightFrameSweepCandidate[];
   /**
-   * Key of the last attachment the page EXAMINED, which is not always the last
-   * candidate: one the prefilter matched and the tag check rejected has to be
-   * stepped over too, or the next page starts on it again.
+   * Key of the last attachment the page VISITED, which is rarely the last
+   * candidate: the page returns every aged attachment in its range, and most of
+   * them are rejected here for not being an image, for already being small, or
+   * for carrying no sight tag. All of them have to be stepped over, or the next
+   * page starts on them again.
    */
   nextCursor: SightFrameSweepCursor | null;
   /** Whether the page filled its limit, so more attachments may follow. */
   hasMore: boolean;
   /**
-   * Rows the page's queries actually read: the attachments it scanned plus the
-   * linked-message metadata it had to check to tell candidates from prefilter
-   * near-misses. A caller bounding its work per pass charges this rather than
-   * the candidate count, because a backlog of near-misses costs real queries
-   * while producing no candidates at all.
+   * Rows the page's queries read: every attachment it visited, plus the
+   * linked-message metadata it checked for the ones that got that far. The page
+   * visits only what it returns, so this is the true cost of the page and a
+   * caller bounding its work per pass charges this rather than the candidate
+   * count, which says nothing about a range full of rows that qualify for
+   * nothing.
    */
   rowsRead: number;
 }
 
 /**
- * One page of sight-tagged image attachments older than `createdBefore` whose
- * stored bytes still exceed `largerThanBytes`.
+ * The page query, with `cursorClause` the only thing that varies between the
+ * opening page and a continuation. Everything else is written once, so the two
+ * shapes cannot drift in their select list, ordering, or bounds.
  *
- * The population is EVERY tagged frame, standalone camera keeps and the frames
- * that rode a spoken turn alike. That is deliberately wider than
- * `messageMetadataIsAmbientSightKeep`, which additionally requires `scripted`
- * because it answers a question about memory. Bytes on disk cost the same
- * whoever was speaking when the camera sampled them.
+ * Deliberately nothing but the index range. `kind`, the size threshold, and the
+ * sight tag are all applied in JS over the rows this returns, because a residual
+ * left in SQL makes `LIMIT` bound rows RETURNED while the walk that produces
+ * them stays unbounded: given a long run of aged rows the residual rejects,
+ * SQLite keeps reading index entries looking for matches it can return. Measured
+ * on 5000 aged non-image rows followed by one image, the residual form read
+ * 5001 index entries to return 1 row, while this form returns exactly the
+ * entries it visits. Every row a page hands back is therefore a row the caller
+ * can charge to its budget, and `LIMIT` bounds the work rather than the yield.
  *
- * Like the other metadata prefilters, the `LIKE` only narrows: each attachment
- * the prefilter admits has its linked messages parsed, and it is a candidate
- * only when one of them actually names it, so a message that merely mentions
- * the key contributes nothing.
+ * The cost is more pages on a table where sight frames are a small share of
+ * aged attachments, since a page no longer skips past what it cannot use. The
+ * cursor is what makes that safe: a pass resumes where the last one stopped, so
+ * the extra pages are spread across passes instead of paid all at once.
  *
- * The prefilter lives inside an `EXISTS` rather than a join, so the page is one
- * row per ATTACHMENT. A join emits one row per link, and an attachment carried
- * by several messages would then appear several times under a single
- * `(created_at, id)` key. A page ending on such a row advances the cursor past
- * the attachment on the strength of whichever link happened to land last, and
- * the next page's strict `>` excludes the link that would have qualified it, for
- * good. A key that names one row is what makes the cursor safe.
- *
- * Age comes from the attachment row's own `created_at`, not the message's. It
- * dates the bytes this row stores, which is what the sweep is bounding: a fork's
- * clone is a second copy written on the day of the fork, however old the frame
- * it depicts.
- *
- * `after` resumes an ascending scan past an attachment already examined. A
- * caller that cannot act on what it finds (a shared file, a rendering that came
- * out no smaller) has no way to make the row stop matching, so a query that
- * always starts at the oldest row would hand back the same refusals forever and
- * never reach anything behind them.
- */
-/**
- * The candidate page query, with `cursorClause` the only thing that varies
- * between the first page and a continuation. Everything else is written once,
- * so the two shapes cannot drift in their select list, prefilter, residual
- * filters, or ordering.
- *
- * Both are hoisted out so a test can put the exact text this runs through
+ * Both shapes are hoisted out so a test can put the exact text this runs through
  * `EXPLAIN QUERY PLAN`. A copy in the test would go stale the first time the
  * query changed shape, which is precisely when the plan needs checking.
  */
-function sightFrameSweepCandidateSql(cursorClause: string): string {
+function sightFrameSweepPageSql(cursorClause: string): string {
   return `SELECT
        a.id AS id,
        a.size_bytes AS sizeBytes,
-       a.created_at AS createdAt
+       a.created_at AS createdAt,
+       a.kind AS kind
      FROM attachments a
-     WHERE a.kind = 'image'
-       AND a.created_at < ?
-       AND a.size_bytes > ?${cursorClause}
-       AND EXISTS (
-         SELECT 1
-         FROM message_attachments ma
-         JOIN messages m ON m.id = ma.message_id
-         WHERE ma.attachment_id = a.id
-           AND m.metadata LIKE ?
-       )
+     WHERE a.created_at < ?${cursorClause}
      ORDER BY a.created_at ASC, a.id ASC
      LIMIT ?`;
 }
 
 /**
- * Opening page: the age bound alone, which
- * `idx_attachments_created_at_id` (migration 374) serves as an index range in
- * cursor order, so there is no sort step.
+ * Opening page: the age bound alone, which `idx_attachments_created_at_id`
+ * (migration 374) serves as an index range in cursor order, so there is no sort
+ * step and no row is read that is not returned.
  */
-export const SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL = sightFrameSweepCandidateSql("");
+export const SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL = sightFrameSweepPageSql("");
 
 /**
  * Continuation page: a DIRECT tuple comparison against the cursor, deliberately
@@ -1598,11 +1573,44 @@ export const SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL = sightFrameSweepCandidateSql("");
  * straight to where the last one stopped. Two shapes rather than one is the
  * price of that, which is why they are built from a single fragment above.
  */
-export const SIGHT_FRAME_SWEEP_CONTINUATION_SQL = sightFrameSweepCandidateSql(
+export const SIGHT_FRAME_SWEEP_CONTINUATION_SQL = sightFrameSweepPageSql(
   `
        AND (a.created_at, a.id) > (?, ?)`,
 );
 
+/**
+ * One page of aged attachments, with the sight frames among them picked out.
+ *
+ * The page is an index range over `created_at`; everything that decides whether
+ * a visited row is a candidate happens here, in order of what it costs. `kind`
+ * and the size threshold are read off the returned row. Only what survives both
+ * is worth a metadata probe, and an attachment qualifies when at least one
+ * linked message parses to a tag naming it: the `LIKE` in that probe narrows,
+ * the parse decides, so a message that merely mentions the key contributes
+ * nothing.
+ *
+ * The population is EVERY tagged frame, standalone camera keeps and the frames
+ * that rode a spoken turn alike. That is deliberately wider than
+ * `messageMetadataIsAmbientSightKeep`, which additionally requires `scripted`
+ * because it answers a question about memory. Bytes on disk cost the same
+ * whoever was speaking when the camera sampled them.
+ *
+ * Verification is per attachment rather than per link, which is what keeps the
+ * cursor safe. Asking it of a join would give one row per link, several under a
+ * single `(created_at, id)` key, and a page ending on one of them would advance
+ * the cursor past the attachment on the strength of whichever link landed last,
+ * leaving the link that would have qualified it excluded for good.
+ *
+ * Age comes from the attachment row's own `created_at`, not the message's. It
+ * dates the bytes this row stores, which is what the sweep is bounding: a fork's
+ * clone is a second copy written on the day of the fork, however old the frame
+ * it depicts.
+ *
+ * `after` resumes past an attachment already visited. A caller that cannot act
+ * on what it finds (a shared file, a rendering that came out no smaller) has no
+ * way to make the row stop matching, so a query that always started at the
+ * oldest row would hand back the same refusals forever.
+ */
 export function selectSightFrameSweepCandidates(options: {
   createdBefore: number;
   largerThanBytes: number;
@@ -1611,13 +1619,14 @@ export function selectSightFrameSweepCandidates(options: {
 }): SightFrameSweepPage {
   const after = options.after ?? null;
   const taggedMessageLike = `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`;
-  // Bind order follows clause order, and the cursor clause sits between the
-  // size filter and the prefilter, so the shared tail keeps its positions.
+  // Bind order follows clause order, and the cursor clause is the only optional
+  // one, so the limit keeps its position at the tail.
   const cursorBinds = after === null ? [] : [after.createdAt, after.id];
   const rows = rawAll<{
     id: string;
     sizeBytes: number;
     createdAt: number;
+    kind: string;
   }>(
     after === null
       ? "attachments:selectSightFrameSweepCandidates:first"
@@ -1626,9 +1635,7 @@ export function selectSightFrameSweepCandidates(options: {
       ? SIGHT_FRAME_SWEEP_FIRST_PAGE_SQL
       : SIGHT_FRAME_SWEEP_CONTINUATION_SQL,
     options.createdBefore,
-    options.largerThanBytes,
     ...cursorBinds,
-    taggedMessageLike,
     options.limit,
   );
 
@@ -1637,6 +1644,11 @@ export function selectSightFrameSweepCandidates(options: {
   let rowsRead = rows.length;
   for (const row of rows) {
     nextCursor = { createdAt: row.createdAt, id: row.id };
+    // Row-local rejections first, and free: they read nothing the page did not
+    // already return, so only a plausible frame ever costs a metadata probe.
+    if (row.kind !== "image" || row.sizeBytes <= options.largerThanBytes) {
+      continue;
+    }
     const linked = rawAll<{ metadata: string | null }>(
       "attachments:sightFrameSweepCandidateTags",
       `SELECT m.metadata AS metadata

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -12,6 +12,7 @@ import {
   mkdirSync,
   readFileSync,
   realpathSync,
+  renameSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -27,8 +28,12 @@ import {
   sniffImageFileMimeType,
 } from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
-import { getWorkspaceDir } from "../util/platform.js";
+import { getConversationsDir, getWorkspaceDir } from "../util/platform.js";
 import { getConversationAttachmentsDirPath } from "./conversation-directories.js";
+import {
+  SIGHT_FRAME_ATTACHMENT_IDS_KEY,
+  sightFrameAttachmentIdsFromMetadata,
+} from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
 import { rawAll, rawGet, rawRun } from "./raw-query.js";
 import { attachments, messageAttachments } from "./schema.js";
@@ -1436,11 +1441,205 @@ export function deleteOrphanAttachments(candidateIds: string[]): number {
 
 /** True while any surviving attachment row still names this file. */
 function attachmentFilePathStillReferenced(filePath: string): boolean {
+  return attachmentFilePathReferenceCount(filePath) > 0;
+}
+
+/** How many attachment rows name this file. */
+function attachmentFilePathReferenceCount(filePath: string): number {
   return (
-    rawGet<{ id: string }>(
-      "attachments:filePathStillReferenced",
-      `SELECT id FROM attachments WHERE file_path = ? LIMIT 1`,
+    rawGet<{ refCount: number }>(
+      "attachments:filePathReferenceCount",
+      `SELECT COUNT(*) AS refCount FROM attachments WHERE file_path = ?`,
       filePath,
-    ) !== null
+    )?.refCount ?? 0
   );
+}
+
+/**
+ * True when a file is one the attachment store itself wrote: either a staged
+ * upload or a conversation's own `attachments/` directory.
+ *
+ * `file_path` is not always the store's to rewrite. `uploadFileBackedAttachment`
+ * registers a file by path, and `/attachments/register` accepts any path inside
+ * the workspace, so a row can name a file the user or a tool created and still
+ * owns. Directory identity is the same test
+ * {@link materializeAttachmentIntoConversation} uses to decide whether a file is
+ * already where it belongs.
+ */
+function isStoreOwnedAttachmentFile(filePath: string): boolean {
+  const dir = dirname(filePath);
+  if (dir === join(getWorkspaceDir(), "data", "attachments")) {
+    return true;
+  }
+  return (
+    basename(dir) === "attachments" &&
+    dirname(dirname(dir)) === getConversationsDir()
+  );
+}
+
+export interface SightFrameSweepCandidate {
+  id: string;
+  /** Stored size before the sweep, so a caller can report what it freed. */
+  sizeBytes: number;
+}
+
+/**
+ * Sight-tagged image attachments older than `createdBefore` whose stored bytes
+ * still exceed `largerThanBytes`, capped at `limit` rows.
+ *
+ * The population is EVERY tagged frame, standalone camera keeps and the frames
+ * that rode a spoken turn alike. That is deliberately wider than
+ * `messageMetadataIsAmbientSightKeep`, which additionally requires `scripted`
+ * because it answers a question about memory. Bytes on disk cost the same
+ * whoever was speaking when the camera sampled them.
+ *
+ * Like the other metadata prefilters, the `LIKE` only narrows: every candidate
+ * row is parsed and has to name this attachment before it is returned, so a row
+ * that merely mentions the key contributes nothing.
+ *
+ * Age comes from the attachment row's own `created_at`, not the message's. It
+ * dates the bytes this row stores, which is what the sweep is bounding: a fork's
+ * clone is a second copy written on the day of the fork, however old the frame
+ * it depicts.
+ */
+export function selectSightFrameSweepCandidates(options: {
+  createdBefore: number;
+  largerThanBytes: number;
+  limit: number;
+}): SightFrameSweepCandidate[] {
+  const rows = rawAll<{
+    id: string;
+    sizeBytes: number;
+    metadata: string | null;
+  }>(
+    "attachments:selectSightFrameSweepCandidates",
+    `SELECT
+       a.id AS id,
+       a.size_bytes AS sizeBytes,
+       m.metadata AS metadata
+     FROM attachments a
+     JOIN message_attachments ma ON ma.attachment_id = a.id
+     JOIN messages m ON m.id = ma.message_id
+     WHERE a.kind = 'image'
+       AND a.created_at < ?
+       AND a.size_bytes > ?
+       AND m.metadata LIKE ?
+     ORDER BY a.created_at ASC
+     LIMIT ?`,
+    options.createdBefore,
+    options.largerThanBytes,
+    `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`,
+    options.limit,
+  );
+
+  const candidates: SightFrameSweepCandidate[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    if (seen.has(row.id)) {
+      continue;
+    }
+    let tagged: string[];
+    try {
+      tagged = sightFrameAttachmentIdsFromMetadata(
+        JSON.parse(row.metadata ?? "null") as Record<string, unknown> | null,
+      );
+    } catch {
+      continue;
+    }
+    if (!tagged.includes(row.id)) {
+      continue;
+    }
+    seen.add(row.id);
+    candidates.push({ id: row.id, sizeBytes: row.sizeBytes });
+  }
+  return candidates;
+}
+
+export type ShrinkAttachmentResult =
+  | "shrunk"
+  | "not_found"
+  | "no_content"
+  | "not_smaller"
+  | "shared_file"
+  | "foreign_file"
+  | "write_failed";
+
+/**
+ * Replace an attachment's stored bytes with a smaller rendering of the same
+ * image, leaving the row, its links, and its message content in place.
+ *
+ * Refuses every case where the bytes are not this row's alone to rewrite:
+ *
+ *  - a `file_path` more than one row names. A path is not private to a row (see
+ *    {@link deleteOrphanAttachments}), and rewriting a shared file would rewrite
+ *    the other row's image too. Writing a fresh file and repointing only this
+ *    row would avoid the corruption but strand the original, which nothing
+ *    unlinks until its last row is deleted, so refusing is the option that
+ *    actually bounds storage.
+ *  - a file outside the store's own directories, which may be a file the user
+ *    or a tool still owns.
+ *  - bytes that are not smaller than what is stored, so a rendering that cannot
+ *    win leaves the original alone.
+ *
+ * The file write goes through a sibling temp file and a rename, so a torn write
+ * cannot leave a truncated image where the transcript expects one.
+ */
+export function shrinkAttachmentBytes(
+  attachmentId: string,
+  bytes: Uint8Array,
+  mimeType: string,
+): ShrinkAttachmentResult {
+  const row = getAttachmentRow(attachmentId);
+  if (!row) {
+    return "not_found";
+  }
+  if (bytes.length >= row.sizeBytes) {
+    return "not_smaller";
+  }
+
+  if (row.filePath) {
+    if (!isStoreOwnedAttachmentFile(row.filePath)) {
+      return "foreign_file";
+    }
+    if (attachmentFilePathReferenceCount(row.filePath) > 1) {
+      return "shared_file";
+    }
+    const tmpPath = `${row.filePath}.${process.pid}-${uuid().slice(0, 8)}.tmp`;
+    try {
+      writeFileSync(tmpPath, bytes);
+      renameSync(tmpPath, row.filePath);
+    } catch {
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        /* nothing was written */
+      }
+      return "write_failed";
+    }
+  } else if (row.dataBase64) {
+    rawRun(
+      "attachments:shrinkAttachmentBytes:inline",
+      `UPDATE attachments SET data_base64 = ? WHERE id = ?`,
+      Buffer.from(bytes).toString("base64"),
+      attachmentId,
+    );
+  } else {
+    return "no_content";
+  }
+
+  const db = getDb();
+  db.update(attachments)
+    .set({
+      sizeBytes: bytes.length,
+      mimeType,
+      kind: classifyKind(mimeType),
+      originalFilename:
+        mimeType === "image/jpeg" && row.mimeType !== "image/jpeg"
+          ? jpegFilenameFor(row.originalFilename)
+          : row.originalFilename,
+    })
+    .where(eq(attachments.id, attachmentId))
+    .run();
+
+  return "shrunk";
 }

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -13,6 +13,7 @@ import {
   readFileSync,
   realpathSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -31,8 +32,8 @@ import { getLogger } from "../util/logger.js";
 import { getConversationsDir, getWorkspaceDir } from "../util/platform.js";
 import { getConversationAttachmentsDirPath } from "./conversation-directories.js";
 import {
+  messageMetadataTagsSightFrame,
   SIGHT_FRAME_ATTACHMENT_IDS_KEY,
-  sightFrameAttachmentIdsFromMetadata,
 } from "./conversation-types.js";
 import { getDb } from "./db-connection.js";
 import { rawAll, rawGet, rawRun } from "./raw-query.js";
@@ -1501,13 +1502,21 @@ export interface SightFrameSweepCursor {
 export interface SightFrameSweepPage {
   candidates: SightFrameSweepCandidate[];
   /**
-   * Key of the last row the query EXAMINED, which is not always the last
-   * candidate: a row the metadata prefilter matched but the parse rejected has
-   * to be stepped over too, or the next page starts on it again.
+   * Key of the last attachment the page EXAMINED, which is not always the last
+   * candidate: one the prefilter matched and the tag check rejected has to be
+   * stepped over too, or the next page starts on it again.
    */
   nextCursor: SightFrameSweepCursor | null;
-  /** Whether the query filled its page, so more rows may follow. */
+  /** Whether the page filled its limit, so more attachments may follow. */
   hasMore: boolean;
+  /**
+   * Rows the page's queries actually read: the attachments it scanned plus the
+   * linked-message metadata it had to check to tell candidates from prefilter
+   * near-misses. A caller bounding its work per pass charges this rather than
+   * the candidate count, because a backlog of near-misses costs real queries
+   * while producing no candidates at all.
+   */
+  rowsRead: number;
 }
 
 /**
@@ -1520,20 +1529,29 @@ export interface SightFrameSweepPage {
  * because it answers a question about memory. Bytes on disk cost the same
  * whoever was speaking when the camera sampled them.
  *
- * Like the other metadata prefilters, the `LIKE` only narrows: every candidate
- * row is parsed and has to name this attachment before it is returned, so a row
- * that merely mentions the key contributes nothing.
+ * Like the other metadata prefilters, the `LIKE` only narrows: each attachment
+ * the prefilter admits has its linked messages parsed, and it is a candidate
+ * only when one of them actually names it, so a message that merely mentions
+ * the key contributes nothing.
+ *
+ * The prefilter lives inside an `EXISTS` rather than a join, so the page is one
+ * row per ATTACHMENT. A join emits one row per link, and an attachment carried
+ * by several messages would then appear several times under a single
+ * `(created_at, id)` key. A page ending on such a row advances the cursor past
+ * the attachment on the strength of whichever link happened to land last, and
+ * the next page's strict `>` excludes the link that would have qualified it, for
+ * good. A key that names one row is what makes the cursor safe.
  *
  * Age comes from the attachment row's own `created_at`, not the message's. It
  * dates the bytes this row stores, which is what the sweep is bounding: a fork's
  * clone is a second copy written on the day of the fork, however old the frame
  * it depicts.
  *
- * `after` resumes an ascending scan past a row already examined. A caller that
- * cannot act on what it finds (a shared file, a rendering that came out no
- * smaller) has no way to make the row stop matching, so a query that always
- * starts at the oldest row would hand back the same refusals forever and never
- * reach anything behind them.
+ * `after` resumes an ascending scan past an attachment already examined. A
+ * caller that cannot act on what it finds (a shared file, a rendering that came
+ * out no smaller) has no way to make the row stop matching, so a query that
+ * always starts at the oldest row would hand back the same refusals forever and
+ * never reach anything behind them.
  */
 export function selectSightFrameSweepCandidates(options: {
   createdBefore: number;
@@ -1542,64 +1560,147 @@ export function selectSightFrameSweepCandidates(options: {
   after?: SightFrameSweepCursor | null;
 }): SightFrameSweepPage {
   const after = options.after ?? null;
+  const taggedMessageLike = `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`;
   const rows = rawAll<{
     id: string;
     sizeBytes: number;
     createdAt: number;
-    metadata: string | null;
   }>(
     "attachments:selectSightFrameSweepCandidates",
     `SELECT
        a.id AS id,
        a.size_bytes AS sizeBytes,
-       a.created_at AS createdAt,
-       m.metadata AS metadata
+       a.created_at AS createdAt
      FROM attachments a
-     JOIN message_attachments ma ON ma.attachment_id = a.id
-     JOIN messages m ON m.id = ma.message_id
      WHERE a.kind = 'image'
        AND a.created_at < ?
        AND a.size_bytes > ?
-       AND m.metadata LIKE ?
        AND (? IS NULL OR (a.created_at, a.id) > (?, ?))
+       AND EXISTS (
+         SELECT 1
+         FROM message_attachments ma
+         JOIN messages m ON m.id = ma.message_id
+         WHERE ma.attachment_id = a.id
+           AND m.metadata LIKE ?
+       )
      ORDER BY a.created_at ASC, a.id ASC
      LIMIT ?`,
     options.createdBefore,
     options.largerThanBytes,
-    `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`,
     after === null ? null : 1,
     after?.createdAt ?? 0,
     after?.id ?? "",
+    taggedMessageLike,
     options.limit,
   );
 
   const candidates: SightFrameSweepCandidate[] = [];
-  const seen = new Set<string>();
   let nextCursor: SightFrameSweepCursor | null = null;
+  let rowsRead = rows.length;
   for (const row of rows) {
     nextCursor = { createdAt: row.createdAt, id: row.id };
-    if (seen.has(row.id)) {
+    const linked = rawAll<{ metadata: string | null }>(
+      "attachments:sightFrameSweepCandidateTags",
+      `SELECT m.metadata AS metadata
+       FROM message_attachments ma
+       JOIN messages m ON m.id = ma.message_id
+       WHERE ma.attachment_id = ?
+         AND m.metadata LIKE ?`,
+      row.id,
+      taggedMessageLike,
+    );
+    rowsRead += linked.length;
+    const tagged = linked.some((link) =>
+      messageMetadataTagsSightFrame(link.metadata, row.id),
+    );
+    if (!tagged) {
       continue;
     }
-    let tagged: string[];
-    try {
-      tagged = sightFrameAttachmentIdsFromMetadata(
-        JSON.parse(row.metadata ?? "null") as Record<string, unknown> | null,
-      );
-    } catch {
-      continue;
-    }
-    if (!tagged.includes(row.id)) {
-      continue;
-    }
-    seen.add(row.id);
     candidates.push({
       id: row.id,
       sizeBytes: row.sizeBytes,
       createdAt: row.createdAt,
     });
   }
-  return { candidates, nextCursor, hasMore: rows.length === options.limit };
+  return {
+    candidates,
+    nextCursor,
+    hasMore: rows.length === options.limit,
+    rowsRead,
+  };
+}
+
+/**
+ * Sibling of an attachment file holding the bytes a shrink is replacing, until
+ * the row has been updated to describe the replacement. Fixed rather than
+ * random, so one a killed process left behind is reclaimed by the next attempt
+ * on that row rather than accumulating.
+ */
+export const SWEEP_BACKUP_SUFFIX = ".sweep-bak";
+
+/** Sibling a shrink writes its replacement into before renaming it into place. */
+export const SWEEP_TEMP_SUFFIX = ".sweep-tmp";
+
+export type ReclaimBackupResult = "deleted" | "kept" | "failed";
+
+/**
+ * Collect a `.sweep-bak` left behind by a process that died mid-shrink, but only
+ * once the row it belongs to no longer needs it.
+ *
+ * A backup exists exactly between the moment a shrink renames the original aside
+ * and the moment it unlinks it, so which side of the row update the process died
+ * on is what decides whether the bytes are garbage. The row answers that on its
+ * own, by whether it still overstates what is on disk:
+ *
+ *  - NO ROW names the backed-up file. Nothing can ever read it. Garbage.
+ *  - A row OVERSTATES the file in place, so the update never landed. This is the
+ *    crash-convergence state described on {@link shrinkAttachmentBytes}: the row
+ *    still selects, and the next shrink attempt renames over this backup under
+ *    its fixed name. KEEP it, because until that happens it is the only full
+ *    copy of the frame.
+ *  - A row already DESCRIBES the file in place, so the update landed and only
+ *    the unlink was lost. The backup is spent. Garbage.
+ *  - The backed-up file's own base is MISSING, so both renames of a shrink got
+ *    away from it. KEEP: the backup may be the only surviving copy, and
+ *    reclaiming disk is never worth destroying the last one.
+ *
+ * Never call this while a shrink on the same attachment is in flight; the sweep
+ * that drives both runs them in sequence.
+ */
+export function reclaimAttachmentSweepBackup(
+  backupPath: string,
+): ReclaimBackupResult {
+  if (!backupPath.endsWith(SWEEP_BACKUP_SUFFIX)) {
+    return "kept";
+  }
+  const filePath = backupPath.slice(0, -SWEEP_BACKUP_SUFFIX.length);
+  let storedBytes: number;
+  try {
+    storedBytes = statSync(filePath).size;
+  } catch {
+    return "kept";
+  }
+
+  const owners = rawGet<{ rows: number; overstating: number }>(
+    "attachments:sweepBackupOwners",
+    `SELECT
+       COUNT(*) AS rows,
+       COALESCE(SUM(CASE WHEN size_bytes > ? THEN 1 ELSE 0 END), 0) AS overstating
+     FROM attachments
+     WHERE file_path = ?`,
+    storedBytes,
+    filePath,
+  );
+  if (owners && owners.rows > 0 && owners.overstating > 0) {
+    return "kept";
+  }
+
+  try {
+    unlinkSync(backupPath);
+    return "deleted";
+  } catch {
+    return "failed";
+  }
 }
 
 /**
@@ -1698,6 +1799,10 @@ function refusalForRow(row: AttachmentRow): ShrinkAttachmentRefusal | null {
  * so the next pass re-encodes the thumbnail that is actually there, and the
  * not-smaller check compares that against the stale, larger stored size and
  * lets it through. One more pass and the row describes what it stores.
+ *
+ * A process killed in the other window, after the update and before the backup
+ * is unlinked, leaves a full-size backup beside a row that no longer selects.
+ * {@link reclaimAttachmentSweepBackup} is what collects those.
  */
 export function shrinkAttachmentBytes(
   attachmentId: string,
@@ -1739,8 +1844,8 @@ export function shrinkAttachmentBytes(
   }
 
   const filePath = row.filePath;
-  const tmpPath = `${filePath}.sweep-tmp`;
-  const bakPath = `${filePath}.sweep-bak`;
+  const tmpPath = `${filePath}${SWEEP_TEMP_SUFFIX}`;
+  const bakPath = `${filePath}${SWEEP_BACKUP_SUFFIX}`;
   try {
     writeFileSync(tmpPath, bytes);
     renameSync(filePath, bakPath);

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1628,14 +1628,15 @@ export const SIGHT_FRAME_TAG_PROBE_LIMIT = 16;
 /**
  * The tag check for one candidate: the messages it hangs off, capped.
  *
- * The `LIKE` prefilter that used to sit here is gone on purpose. As a residual
- * it made `LIMIT` bound rows RETURNED while the walk stayed unbounded, exactly
- * as it did on the page query: an attachment linked to many ordinary messages
- * would have every link visited and joined in the hunt for matches to return.
- * Without it the limit bounds the visit, and `messageMetadataTagsSightFrame` was
- * always the authority anyway, the prefilter only ever narrowing ahead of it.
+ * The link filter is the only condition, so `LIMIT` bounds what SQLite VISITS.
+ * Every entry the index yields for this attachment is a row the probe returns,
+ * and the walk stops at the cap. A metadata condition here would make the limit
+ * bound returns instead: an attachment on many ordinary messages would have
+ * every link visited and joined while SQLite hunted for rows it could hand back.
+ * `messageMetadataTagsSightFrame` reads the tag off what comes back, which is
+ * where the decision belongs.
  *
- * Unordered, so the cap samples whichever links the index yields first. With one
+ * Unordered, so the cap takes whichever links the index yields first. With one
  * link in practice there is nothing to order.
  */
 const SIGHT_FRAME_TAG_PROBE_SQL = `SELECT m.metadata AS metadata

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1583,6 +1583,13 @@ export type ShrinkAttachmentResult =
  *
  * The file write goes through a sibling temp file and a rename, so a torn write
  * cannot leave a truncated image where the transcript expects one.
+ *
+ * A row still holding its bytes inline is rewritten too, rather than skipped.
+ * That shape is degraded (materialization found nothing readable to copy and
+ * left the staged row as it was), and it is the one shape where the bytes sit in
+ * the database itself, which is the last place an image nobody chose to send
+ * should grow unbounded. Nothing aliases an inline payload the way a file path
+ * can be aliased: a clone copies the string into a row of its own.
  */
 export function shrinkAttachmentBytes(
   attachmentId: string,

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1481,11 +1481,38 @@ export interface SightFrameSweepCandidate {
   id: string;
   /** Stored size before the sweep, so a caller can report what it freed. */
   sizeBytes: number;
+  /**
+   * This row's half of the keyset key. A caller that stops part way through a
+   * page resumes from the candidate it stopped on, not from the page's end.
+   */
+  createdAt: number;
 }
 
 /**
- * Sight-tagged image attachments older than `createdBefore` whose stored bytes
- * still exceed `largerThanBytes`, capped at `limit` rows.
+ * Where a scan of the candidate set stopped. `(created_at, id)` because
+ * `created_at` alone is not unique: frames captured inside the same millisecond
+ * would be skipped or repeated by a cursor that could not tell them apart.
+ */
+export interface SightFrameSweepCursor {
+  createdAt: number;
+  id: string;
+}
+
+export interface SightFrameSweepPage {
+  candidates: SightFrameSweepCandidate[];
+  /**
+   * Key of the last row the query EXAMINED, which is not always the last
+   * candidate: a row the metadata prefilter matched but the parse rejected has
+   * to be stepped over too, or the next page starts on it again.
+   */
+  nextCursor: SightFrameSweepCursor | null;
+  /** Whether the query filled its page, so more rows may follow. */
+  hasMore: boolean;
+}
+
+/**
+ * One page of sight-tagged image attachments older than `createdBefore` whose
+ * stored bytes still exceed `largerThanBytes`.
  *
  * The population is EVERY tagged frame, standalone camera keeps and the frames
  * that rode a spoken turn alike. That is deliberately wider than
@@ -1501,21 +1528,31 @@ export interface SightFrameSweepCandidate {
  * dates the bytes this row stores, which is what the sweep is bounding: a fork's
  * clone is a second copy written on the day of the fork, however old the frame
  * it depicts.
+ *
+ * `after` resumes an ascending scan past a row already examined. A caller that
+ * cannot act on what it finds (a shared file, a rendering that came out no
+ * smaller) has no way to make the row stop matching, so a query that always
+ * starts at the oldest row would hand back the same refusals forever and never
+ * reach anything behind them.
  */
 export function selectSightFrameSweepCandidates(options: {
   createdBefore: number;
   largerThanBytes: number;
   limit: number;
-}): SightFrameSweepCandidate[] {
+  after?: SightFrameSweepCursor | null;
+}): SightFrameSweepPage {
+  const after = options.after ?? null;
   const rows = rawAll<{
     id: string;
     sizeBytes: number;
+    createdAt: number;
     metadata: string | null;
   }>(
     "attachments:selectSightFrameSweepCandidates",
     `SELECT
        a.id AS id,
        a.size_bytes AS sizeBytes,
+       a.created_at AS createdAt,
        m.metadata AS metadata
      FROM attachments a
      JOIN message_attachments ma ON ma.attachment_id = a.id
@@ -1524,17 +1561,23 @@ export function selectSightFrameSweepCandidates(options: {
        AND a.created_at < ?
        AND a.size_bytes > ?
        AND m.metadata LIKE ?
-     ORDER BY a.created_at ASC
+       AND (? IS NULL OR (a.created_at, a.id) > (?, ?))
+     ORDER BY a.created_at ASC, a.id ASC
      LIMIT ?`,
     options.createdBefore,
     options.largerThanBytes,
     `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`,
+    after === null ? null : 1,
+    after?.createdAt ?? 0,
+    after?.id ?? "",
     options.limit,
   );
 
   const candidates: SightFrameSweepCandidate[] = [];
   const seen = new Set<string>();
+  let nextCursor: SightFrameSweepCursor | null = null;
   for (const row of rows) {
+    nextCursor = { createdAt: row.createdAt, id: row.id };
     if (seen.has(row.id)) {
       continue;
     }
@@ -1550,25 +1593,35 @@ export function selectSightFrameSweepCandidates(options: {
       continue;
     }
     seen.add(row.id);
-    candidates.push({ id: row.id, sizeBytes: row.sizeBytes });
+    candidates.push({
+      id: row.id,
+      sizeBytes: row.sizeBytes,
+      createdAt: row.createdAt,
+    });
   }
-  return candidates;
+  return { candidates, nextCursor, hasMore: rows.length === options.limit };
 }
 
-export type ShrinkAttachmentResult =
-  | "shrunk"
+/**
+ * Why an attachment's bytes are not this store's to rewrite. Every one of these
+ * is decidable from the row alone, before a caller spends anything on producing
+ * a replacement.
+ */
+export type ShrinkAttachmentRefusal =
   | "not_found"
   | "no_content"
-  | "not_smaller"
   | "shared_file"
-  | "foreign_file"
+  | "foreign_file";
+
+export type ShrinkAttachmentResult =
+  | ShrinkAttachmentRefusal
+  | "shrunk"
+  | "not_smaller"
   | "write_failed";
 
 /**
- * Replace an attachment's stored bytes with a smaller rendering of the same
- * image, leaving the row, its links, and its message content in place.
- *
- * Refuses every case where the bytes are not this row's alone to rewrite:
+ * The refusals {@link shrinkAttachmentBytes} would answer with, decided without
+ * touching the bytes:
  *
  *  - a `file_path` more than one row names. A path is not private to a row (see
  *    {@link deleteOrphanAttachments}), and rewriting a shared file would rewrite
@@ -1578,18 +1631,73 @@ export type ShrinkAttachmentResult =
  *    actually bounds storage.
  *  - a file outside the store's own directories, which may be a file the user
  *    or a tool still owns.
- *  - bytes that are not smaller than what is stored, so a rendering that cannot
- *    win leaves the original alone.
+ *  - a row holding neither a file nor inline bytes.
  *
- * The file write goes through a sibling temp file and a rename, so a torn write
- * cannot leave a truncated image where the transcript expects one.
+ * Exported so a caller that has to PRODUCE the smaller rendering can ask first
+ * and skip the work. The shrink applies the same predicate itself, so the check
+ * is an optimization and never the enforcement.
+ */
+export function attachmentShrinkRefusal(
+  attachmentId: string,
+): ShrinkAttachmentRefusal | null {
+  const row = getAttachmentRow(attachmentId);
+  return row ? refusalForRow(row) : "not_found";
+}
+
+function refusalForRow(row: AttachmentRow): ShrinkAttachmentRefusal | null {
+  if (row.filePath) {
+    if (!isStoreOwnedAttachmentFile(row.filePath)) {
+      return "foreign_file";
+    }
+    if (attachmentFilePathReferenceCount(row.filePath) > 1) {
+      return "shared_file";
+    }
+    return null;
+  }
+  return row.dataBase64 ? null : "no_content";
+}
+
+/**
+ * Replace an attachment's stored bytes with a smaller rendering of the same
+ * image, leaving the row, its links, and its message content in place.
+ *
+ * Refuses everything {@link attachmentShrinkRefusal} names, plus bytes that are
+ * not smaller than what is stored, so a rendering that cannot win leaves the
+ * original alone.
  *
  * A row still holding its bytes inline is rewritten too, rather than skipped.
  * That shape is degraded (materialization found nothing readable to copy and
  * left the staged row as it was), and it is the one shape where the bytes sit in
  * the database itself, which is the last place an image nobody chose to send
  * should grow unbounded. Nothing aliases an inline payload the way a file path
- * can be aliased: a clone copies the string into a row of its own.
+ * can be aliased: a clone copies the string into a row of its own. Its bytes and
+ * their description go into one statement, so there is no window where the row
+ * can disagree with what it holds.
+ *
+ * A file-backed row has no such single statement available, so the order is
+ * chosen for what a failure leaves behind. The original is renamed aside to a
+ * `.sweep-bak` sibling, the replacement is renamed into place, and only then is
+ * the row updated; a throw from that update puts the backup back, so the file
+ * and the row still agree. The backup name is fixed rather than random so that
+ * one left by a killed process is reclaimed by the next attempt on the same row
+ * instead of accumulating. Callers must serialize their calls per attachment;
+ * the sweep that drives this runs one pass at a time.
+ *
+ * NEVER reorder this to update the row first. The window that ordering opens is
+ * the unrecoverable one: a process killed between a DB-first update and the
+ * file rename leaves the row claiming a thumbnail's size while the full-size
+ * file is still there, which puts the row UNDER the size threshold the sweep
+ * selects on, so nothing ever looks at it again and
+ * `/attachments/:id/content` serves that understated size as `Content-Length`
+ * forever.
+ *
+ * The order used here self-heals instead. A process killed after the rename but
+ * before the update leaves a thumbnail on disk under a row still claiming the
+ * original size, which is ABOVE the threshold, so the sweep re-selects the row.
+ * {@link getAttachmentContent} reads the file rather than trusting `sizeBytes`,
+ * so the next pass re-encodes the thumbnail that is actually there, and the
+ * not-smaller check compares that against the stale, larger stored size and
+ * lets it through. One more pass and the row describes what it stores.
  */
 export function shrinkAttachmentBytes(
   attachmentId: string,
@@ -1600,53 +1708,82 @@ export function shrinkAttachmentBytes(
   if (!row) {
     return "not_found";
   }
+  const refusal = refusalForRow(row);
+  if (refusal) {
+    return refusal;
+  }
   if (bytes.length >= row.sizeBytes) {
     return "not_smaller";
   }
 
-  if (row.filePath) {
-    if (!isStoreOwnedAttachmentFile(row.filePath)) {
-      return "foreign_file";
-    }
-    if (attachmentFilePathReferenceCount(row.filePath) > 1) {
-      return "shared_file";
-    }
-    const tmpPath = `${row.filePath}.${process.pid}-${uuid().slice(0, 8)}.tmp`;
-    try {
-      writeFileSync(tmpPath, bytes);
-      renameSync(tmpPath, row.filePath);
-    } catch {
-      try {
-        unlinkSync(tmpPath);
-      } catch {
-        /* nothing was written */
-      }
-      return "write_failed";
-    }
-  } else if (row.dataBase64) {
-    rawRun(
-      "attachments:shrinkAttachmentBytes:inline",
-      `UPDATE attachments SET data_base64 = ? WHERE id = ?`,
-      Buffer.from(bytes).toString("base64"),
-      attachmentId,
-    );
-  } else {
-    return "no_content";
+  const describedBy = {
+    sizeBytes: bytes.length,
+    mimeType,
+    kind: classifyKind(mimeType),
+    originalFilename:
+      mimeType === "image/jpeg" && row.mimeType !== "image/jpeg"
+        ? jpegFilenameFor(row.originalFilename)
+        : row.originalFilename,
+  };
+  const db = getDb();
+
+  if (!row.filePath) {
+    db.update(attachments)
+      .set({
+        ...describedBy,
+        dataBase64: Buffer.from(bytes).toString("base64"),
+      })
+      .where(eq(attachments.id, attachmentId))
+      .run();
+    return "shrunk";
   }
 
-  const db = getDb();
-  db.update(attachments)
-    .set({
-      sizeBytes: bytes.length,
-      mimeType,
-      kind: classifyKind(mimeType),
-      originalFilename:
-        mimeType === "image/jpeg" && row.mimeType !== "image/jpeg"
-          ? jpegFilenameFor(row.originalFilename)
-          : row.originalFilename,
-    })
-    .where(eq(attachments.id, attachmentId))
-    .run();
+  const filePath = row.filePath;
+  const tmpPath = `${filePath}.sweep-tmp`;
+  const bakPath = `${filePath}.sweep-bak`;
+  try {
+    writeFileSync(tmpPath, bytes);
+    renameSync(filePath, bakPath);
+    renameSync(tmpPath, filePath);
+  } catch {
+    if (!existsSync(filePath) && existsSync(bakPath)) {
+      try {
+        renameSync(bakPath, filePath);
+      } catch {
+        /* the backup is the original, still readable under its own name */
+      }
+    }
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* nothing was written */
+    }
+    return "write_failed";
+  }
 
+  try {
+    db.update(attachments)
+      .set(describedBy)
+      .where(eq(attachments.id, attachmentId))
+      .run();
+  } catch (err) {
+    let restoreErr: unknown;
+    try {
+      renameSync(bakPath, filePath);
+    } catch (caught) {
+      restoreErr = caught;
+    }
+    getLogger("attachments-store").warn(
+      { err, restoreErr, attachmentId },
+      "Could not record a shrunk attachment's new size; restored its original bytes",
+    );
+    return "write_failed";
+  }
+
+  try {
+    unlinkSync(bakPath);
+  } catch {
+    /* reclaimed by the next attempt on this row */
+  }
   return "shrunk";
 }

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1548,21 +1548,17 @@ export interface SightFrameSweepPage {
  * always starts at the oldest row would hand back the same refusals forever and
  * never reach anything behind them.
  */
-export function selectSightFrameSweepCandidates(options: {
-  createdBefore: number;
-  largerThanBytes: number;
-  limit: number;
-  after?: SightFrameSweepCursor | null;
-}): SightFrameSweepPage {
-  const after = options.after ?? null;
-  const taggedMessageLike = `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`;
-  const rows = rawAll<{
-    id: string;
-    sizeBytes: number;
-    createdAt: number;
-  }>(
-    "attachments:selectSightFrameSweepCandidates",
-    `SELECT
+/**
+ * The candidate page query, hoisted out so a test can put the exact text this
+ * runs through `EXPLAIN QUERY PLAN`. A copy in the test would go stale the first
+ * time the query changed shape, which is precisely when the plan needs checking.
+ *
+ * The bound, the keyset continuation, and the ordering are all carried by
+ * `idx_attachments_created_at_id` (migration 374), so a page is an index-range
+ * continuation rather than a fresh scan and sort of the whole table. `kind` and
+ * `size_bytes` stay residual filters over the rows that range visits.
+ */
+export const SIGHT_FRAME_SWEEP_CANDIDATE_SQL = `SELECT
        a.id AS id,
        a.size_bytes AS sizeBytes,
        a.created_at AS createdAt
@@ -1579,7 +1575,23 @@ export function selectSightFrameSweepCandidates(options: {
            AND m.metadata LIKE ?
        )
      ORDER BY a.created_at ASC, a.id ASC
-     LIMIT ?`,
+     LIMIT ?`;
+
+export function selectSightFrameSweepCandidates(options: {
+  createdBefore: number;
+  largerThanBytes: number;
+  limit: number;
+  after?: SightFrameSweepCursor | null;
+}): SightFrameSweepPage {
+  const after = options.after ?? null;
+  const taggedMessageLike = `%"${SIGHT_FRAME_ATTACHMENT_IDS_KEY}"%`;
+  const rows = rawAll<{
+    id: string;
+    sizeBytes: number;
+    createdAt: number;
+  }>(
+    "attachments:selectSightFrameSweepCandidates",
+    SIGHT_FRAME_SWEEP_CANDIDATE_SQL,
     options.createdBefore,
     options.largerThanBytes,
     after === null ? null : 1,

--- a/assistant/src/persistence/attachments-store.ts
+++ b/assistant/src/persistence/attachments-store.ts
@@ -1427,7 +1427,7 @@ export function deleteOrphanAttachments(candidateIds: string[]): number {
     // destroys another conversation's data, which is what the staging-dir
     // guard in `materializeAttachmentIntoConversation` avoids at the other end
     // of the same window.
-    if (attachmentFilePathStillReferenced(filePath)) {
+    if (attachmentFileIsCanonical(filePath)) {
       continue;
     }
     try {
@@ -1438,11 +1438,6 @@ export function deleteOrphanAttachments(candidateIds: string[]): number {
   }
 
   return deletedCount;
-}
-
-/** True while any surviving attachment row still names this file. */
-function attachmentFilePathStillReferenced(filePath: string): boolean {
-  return attachmentFilePathReferenceCount(filePath) > 0;
 }
 
 /** How many attachment rows name this file. */
@@ -1641,28 +1636,45 @@ export const SWEEP_BACKUP_SUFFIX = ".sweep-bak";
 /** Sibling a shrink writes its replacement into before renaming it into place. */
 export const SWEEP_TEMP_SUFFIX = ".sweep-tmp";
 
-export type ReclaimBackupResult = "deleted" | "kept" | "failed";
+export type ReclaimBackupResult = "deleted" | "restored" | "kept" | "failed";
 
 /**
- * Collect a `.sweep-bak` left behind by a process that died mid-shrink, but only
- * once the row it belongs to no longer needs it.
+ * True while some attachment row names this exact file as its canonical bytes.
  *
- * A backup exists exactly between the moment a shrink renames the original aside
- * and the moment it unlinks it, so which side of the row update the process died
- * on is what decides whether the bytes are garbage. The row answers that on its
- * own, by whether it still overstates what is on disk:
+ * The suffixes a shrink appends are not reserved. A file the user picked can be
+ * called `holiday.jpg.sweep-bak`, `resolveUniqueFilename` stores it under that
+ * name in the very directory the reclaim scans, and `/attachments/register`
+ * accepts any workspace path at all. So nothing may be deleted for looking like
+ * a sidecar: what settles it is whether a row is pointing at it.
+ */
+export function attachmentFileIsCanonical(filePath: string): boolean {
+  return attachmentFilePathReferenceCount(filePath) > 0;
+}
+
+/**
+ * Deal with a `.sweep-bak` left behind by a process that died mid-shrink.
  *
- *  - NO ROW names the backed-up file. Nothing can ever read it. Garbage.
- *  - A row OVERSTATES the file in place, so the update never landed. This is the
- *    crash-convergence state described on {@link shrinkAttachmentBytes}: the row
- *    still selects, and the next shrink attempt renames over this backup under
- *    its fixed name. KEEP it, because until that happens it is the only full
- *    copy of the frame.
- *  - A row already DESCRIBES the file in place, so the update landed and only
- *    the unlink was lost. The backup is spent. Garbage.
- *  - The backed-up file's own base is MISSING, so both renames of a shrink got
- *    away from it. KEEP: the backup may be the only surviving copy, and
- *    reclaiming disk is never worth destroying the last one.
+ * A backup exists only between the moment a shrink renames the original aside
+ * and the moment it unlinks it, so where in that window the process died is what
+ * decides the bytes' fate. The rows answer it, in five cases:
+ *
+ *  1. The backup path is ITSELF some row's canonical file, because a filename
+ *     may legitimately end in the suffix. KEEP: this is not a sidecar at all,
+ *     and deleting it would destroy an attachment the transcript still renders.
+ *  2. The base file is MISSING and a row still names it. The crash landed
+ *     between the two renames, so the row points at nothing and
+ *     {@link getAttachmentContent} returns null for good. RESTORE the backup
+ *     over the base: the frame reads again, and its size still exceeds the
+ *     sweep's threshold, so the row stays a candidate and converges normally.
+ *  3. The base file is MISSING and no row names it. The row was deleted while
+ *     its backup was out of place, so nothing can ever read either. Garbage.
+ *  4. A row OVERSTATES the file in place, so the row update never landed. This
+ *     is the crash-convergence state on {@link shrinkAttachmentBytes}: the row
+ *     still selects, and the next shrink attempt renames over this backup under
+ *     its fixed name. KEEP, because until then it is the only full copy.
+ *  5. A row already DESCRIBES the file in place (or no row names it at all), so
+ *     the update landed and only the unlink was lost. The backup is spent.
+ *     Garbage.
  *
  * Never call this while a shrink on the same attachment is in flight; the sweep
  * that drives both runs them in sequence.
@@ -1673,12 +1685,28 @@ export function reclaimAttachmentSweepBackup(
   if (!backupPath.endsWith(SWEEP_BACKUP_SUFFIX)) {
     return "kept";
   }
+  if (attachmentFileIsCanonical(backupPath)) {
+    return "kept";
+  }
   const filePath = backupPath.slice(0, -SWEEP_BACKUP_SUFFIX.length);
-  let storedBytes: number;
+
+  let storedBytes: number | null = null;
   try {
     storedBytes = statSync(filePath).size;
   } catch {
-    return "kept";
+    storedBytes = null;
+  }
+
+  if (storedBytes === null) {
+    if (!attachmentFileIsCanonical(filePath)) {
+      return deleteSweepLeftover(backupPath);
+    }
+    try {
+      renameSync(backupPath, filePath);
+      return "restored";
+    } catch {
+      return "failed";
+    }
   }
 
   const owners = rawGet<{ rows: number; overstating: number }>(
@@ -1694,9 +1722,21 @@ export function reclaimAttachmentSweepBackup(
   if (owners && owners.rows > 0 && owners.overstating > 0) {
     return "kept";
   }
+  return deleteSweepLeftover(backupPath);
+}
 
+/**
+ * Remove a file the reclaim has decided is debris, refusing any that a row
+ * claims as its canonical bytes. Callers reach it having already made that
+ * check; it repeats it because deleting an attachment's only copy is the one
+ * mistake this machinery must not be able to make.
+ */
+export function deleteSweepLeftover(path: string): ReclaimBackupResult {
+  if (attachmentFileIsCanonical(path)) {
+    return "kept";
+  }
   try {
-    unlinkSync(backupPath);
+    unlinkSync(path);
     return "deleted";
   } catch {
     return "failed";
@@ -1712,7 +1752,8 @@ export type ShrinkAttachmentRefusal =
   | "not_found"
   | "no_content"
   | "shared_file"
-  | "foreign_file";
+  | "foreign_file"
+  | "sidecar_conflict";
 
 export type ShrinkAttachmentResult =
   | ShrinkAttachmentRefusal
@@ -1732,6 +1773,11 @@ export type ShrinkAttachmentResult =
  *    actually bounds storage.
  *  - a file outside the store's own directories, which may be a file the user
  *    or a tool still owns.
+ *  - a file whose sidecar names are already some other row's canonical bytes.
+ *    The suffixes are derived, not reserved: a file called `holiday.jpg` and one
+ *    called `holiday.jpg.sweep-bak` can both be real attachments in one
+ *    directory, and shrinking the first would write over the second. Refusing
+ *    costs one frame its shrink; overwriting costs the other its only copy.
  *  - a row holding neither a file nor inline bytes.
  *
  * Exported so a caller that has to PRODUCE the smaller rendering can ask first
@@ -1753,9 +1799,24 @@ function refusalForRow(row: AttachmentRow): ShrinkAttachmentRefusal | null {
     if (attachmentFilePathReferenceCount(row.filePath) > 1) {
       return "shared_file";
     }
+    if (sweepSidecarsAreClaimed(row.filePath)) {
+      return "sidecar_conflict";
+    }
     return null;
   }
   return row.dataBase64 ? null : "no_content";
+}
+
+/** True when either sidecar name this file would use is another row's canonical file. */
+function sweepSidecarsAreClaimed(filePath: string): boolean {
+  return (
+    (rawGet<{ claimed: number }>(
+      "attachments:sweepSidecarsClaimed",
+      `SELECT COUNT(*) AS claimed FROM attachments WHERE file_path IN (?, ?)`,
+      `${filePath}${SWEEP_TEMP_SUFFIX}`,
+      `${filePath}${SWEEP_BACKUP_SUFFIX}`,
+    )?.claimed ?? 0) > 0
+  );
 }
 
 /**

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -295,6 +295,34 @@ export function sightFrameAttachmentIdsFromMetadata(
 }
 
 /**
+ * True when a stored `messages.metadata` column tags this particular
+ * attachment as an ambient camera frame.
+ *
+ * The raw-column counterpart to {@link sightFrameAttachmentIdsFromMetadata},
+ * for consumers holding the JSON string a row was written with rather than a
+ * parsed bag. The storage sweep asks it of each message linked to a candidate
+ * attachment, because the SQL prefilter it uses to find candidates can only ask
+ * whether a message mentions the key at all, never which ids it names.
+ *
+ * Unparseable metadata tags nothing. The sweep uses this to decide what it may
+ * rewrite, so a marking that cannot be read has to read as absent.
+ */
+export function messageMetadataTagsSightFrame(
+  metadata: string | null,
+  attachmentId: string,
+): boolean {
+  if (!metadata) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(metadata) as Record<string, unknown>;
+    return sightFrameAttachmentIdsFromMetadata(parsed).includes(attachmentId);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True when a stored `messages.metadata` column belongs to a standalone
  * ambient camera keep: a row the call's own gate sampled, which no one spoke.
  *

--- a/assistant/src/persistence/migrations/374-attachments-created-at-id-index.ts
+++ b/assistant/src/persistence/migrations/374-attachments-created-at-id-index.ts
@@ -14,9 +14,9 @@ const INDEX = "idx_attachments_created_at_id";
  * and a pass over a large install re-paid for both on each page.
  *
  * The two columns in cursor order serve all three at once. The bound and the
- * continuation are the same index seek, the ordering falls out of the index, and
- * the sweep's other predicates (`kind`, `size_bytes`) stay cheap residuals on
- * rows the range already visited.
+ * continuation are the same index seek, and the ordering falls out of the index.
+ * The sweep asks nothing else of SQL: it decides what is a frame worth shrinking
+ * over the rows this range returns, so a page visits only what it hands back.
  *
  * Deliberately NOT partial. A `WHERE kind = 'image'` variant is usable, since
  * the sweep's `kind` predicate is a literal SQLite can prove the implication

--- a/assistant/src/persistence/migrations/374-attachments-created-at-id-index.ts
+++ b/assistant/src/persistence/migrations/374-attachments-created-at-id-index.ts
@@ -1,0 +1,35 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const INDEX = "idx_attachments_created_at_id";
+
+/**
+ * Order attachments by age, so a scan of them can be resumed.
+ *
+ * The camera-frame storage sweep walks aged attachments a page at a time,
+ * bounding an age (`created_at < ?`), continuing from a keyset cursor
+ * (`(created_at, id) > (?, ?)`), and reading them in that same order. Nothing
+ * indexed any of it: `attachments` carried only a partial unique index on
+ * `content_hash`, so every page was a full table scan plus a temp b-tree sort,
+ * and a pass over a large install re-paid for both on each page.
+ *
+ * The two columns in cursor order serve all three at once. The bound and the
+ * continuation are the same index seek, the ordering falls out of the index, and
+ * the sweep's other predicates (`kind`, `size_bytes`) stay cheap residuals on
+ * rows the range already visited.
+ *
+ * Deliberately NOT partial. A `WHERE kind = 'image'` variant is usable, since
+ * the sweep's `kind` predicate is a literal SQLite can prove the implication
+ * from, but its usability would then hang on that literal surviving in the query
+ * text, and a size-based predicate cannot work at all because the sweep binds
+ * that threshold as a parameter. A plain composite is the one that keeps working
+ * when the query around it changes, and it is reusable by any other age-ordered
+ * question about attachments.
+ *
+ * Idempotent via IF NOT EXISTS.
+ */
+export function migrateAttachmentsCreatedAtIdIndex(database: DrizzleDb): void {
+  getSqliteFrom(database).exec(
+    `CREATE INDEX IF NOT EXISTS ${INDEX} ON attachments (created_at, id)`,
+  );
+}

--- a/assistant/src/persistence/migrations/375-attachments-file-path-index.ts
+++ b/assistant/src/persistence/migrations/375-attachments-file-path-index.ts
@@ -1,0 +1,45 @@
+import type { DrizzleDb } from "../db-connection.js";
+import { getSqliteFrom } from "../db-connection.js";
+
+const INDEX = "idx_attachments_file_path";
+
+/**
+ * Answer "which rows name this file" without reading the table.
+ *
+ * Several guards ask exactly that, all by equality on `file_path`: whether a
+ * path is shared before a shrink rewrites it, whether either of a shrink's
+ * sidecar names is some row's canonical file, which rows a leftover backup
+ * belongs to, and whether an orphaned attachment's file is still referenced
+ * before `deleteOrphanAttachments` unlinks it. Nothing indexed the column, so
+ * each was a full scan of `attachments`, and the storage sweep runs the first
+ * two once per candidate for up to two hundred candidates a pass.
+ *
+ * EXPLAIN QUERY PLAN, before:
+ *
+ *     SCAN attachments
+ *
+ * and after, for the same three shapes (`file_path = ?` counted, aggregated,
+ * and `file_path IN (?, ?)`):
+ *
+ *     SEARCH attachments USING COVERING INDEX idx_attachments_file_path (file_path=?)
+ *     SEARCH attachments USING INDEX idx_attachments_file_path (file_path=?)
+ *     SEARCH attachments USING COVERING INDEX idx_attachments_file_path (file_path=?)
+ *
+ * Partial, and here that is the safe choice rather than the fragile one. A row
+ * whose bytes are inline carries a null `file_path` and can never satisfy an
+ * equality or `IN` against a parameter, so it belongs in none of these answers
+ * and the index need not carry it. SQLite proves that implication from the
+ * SHAPE of the predicate rather than from any literal in the query text, which
+ * is what separates this from `idx_attachments_created_at_id`, where a
+ * `kind = 'image'` variant would have been usable only for as long as that
+ * literal survived. Any future `file_path = <anything>` rides this index too.
+ *
+ * Idempotent via IF NOT EXISTS.
+ */
+export function migrateAttachmentsFilePathIndex(database: DrizzleDb): void {
+  getSqliteFrom(database).exec(
+    `CREATE INDEX IF NOT EXISTS ${INDEX}
+       ON attachments (file_path)
+       WHERE file_path IS NOT NULL`,
+  );
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -482,6 +482,7 @@ import { migrateAcpSessionHistoryAuthErrorCredential } from "./migrations/371-ac
 import { migrateCreateAcpRefusedCredentials } from "./migrations/372-create-acp-refused-credentials.js";
 import { migrateAcpAuthMarkerIndex } from "./migrations/373-acp-auth-marker-index.js";
 import { migrateAttachmentsCreatedAtIdIndex } from "./migrations/374-attachments-created-at-id-index.js";
+import { migrateAttachmentsFilePathIndex } from "./migrations/375-attachments-file-path-index.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1598,4 +1599,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateCreateAcpRefusedCredentials,
   migrateAcpAuthMarkerIndex,
   migrateAttachmentsCreatedAtIdIndex,
+  migrateAttachmentsFilePathIndex,
 ];

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -481,6 +481,7 @@ import { migrateAcpSessionHistoryAuthErrorCode } from "./migrations/370-acp-sess
 import { migrateAcpSessionHistoryAuthErrorCredential } from "./migrations/371-acp-session-history-auth-error-credential.js";
 import { migrateCreateAcpRefusedCredentials } from "./migrations/372-create-acp-refused-credentials.js";
 import { migrateAcpAuthMarkerIndex } from "./migrations/373-acp-auth-marker-index.js";
+import { migrateAttachmentsCreatedAtIdIndex } from "./migrations/374-attachments-created-at-id-index.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1596,4 +1597,5 @@ export const migrationSteps: MigrationStep[] = [
   migrateAcpSessionHistoryAuthErrorCredential,
   migrateCreateAcpRefusedCredentials,
   migrateAcpAuthMarkerIndex,
+  migrateAttachmentsCreatedAtIdIndex,
 ];

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -31,6 +31,10 @@ import {
   isDbMigrationGateBypassed,
 } from "../daemon/daemon-readiness.js";
 import { processMessage } from "../daemon/process-message.js";
+import {
+  startSightFrameStorageSweep,
+  stopSightFrameStorageSweep,
+} from "../daemon/sight-frame-storage-sweep.js";
 import { makeAddrInUseError } from "../daemon/startup-error.js";
 import {
   createLiveVoiceConnection,
@@ -631,11 +635,19 @@ export class RuntimeHttpServer {
     // and its id returns intact when the plugin is re-enabled.
     startAppPinReconcileSweep();
     log.info("App pin reconcile sweep started");
+
+    // Shrink camera frames past the configured window to thumbnail scale, so a
+    // call that sampled the camera for an hour stops costing the disk its full
+    // resolution forever. Checks readiness itself as well, since its passes are
+    // spaced hours apart and outlive whatever state startup was in.
+    startSightFrameStorageSweep();
+    log.info("Camera frame storage sweep started");
   }
 
   async stop(): Promise<void> {
     stopGuardianExpirySweep();
     stopAppPinReconcileSweep();
+    stopSightFrameStorageSweep();
     stopInferenceProfileSessionReaper();
     stopTelegramWebhookHealthSweep();
     stopPluginScheduleReconcileSweep();


### PR DESCRIPTION
## Summary
- Hourly background sweep re-encodes sight-tagged image attachments older than the configurable `sight.sweepAfterDays` window (default 7, clamped 1..365) to a 512px JPEG in place, updating the row's `sizeBytes`/`mimeType` so `Content-Length` and Range reads stay correct.
- Refuses every case where the bytes are not the row's alone to rewrite: shared file paths (a scoped clone can alias its source's file), files outside the store's own directories (registered paths the user still owns), and renderings that would not shrink. Torn writes are impossible: sibling temp file plus rename.
- Sweeps ALL sight-tagged frames (standalone keeps and turn-ridden alike; disk cost is the same either way), never anything untagged or younger than the window; idempotent via the stored-size threshold; rows and message content are never touched, so transcripts keep rendering.

Part of plan: sight-keep-stream.md (PR 3 of 3, follows #41765).

🤖 Generated with [Claude Code](https://claude.com/claude-code)