### PR TITLE
Payment modal: single skeleton loading state

### DIFF
--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
@@ -87,12 +87,16 @@ import * as platformDetection from "@/runtime/platform-detection";
 import * as runtimeBrowser from "@/runtime/browser";
 
 let setupIntentCalls = 0;
+let setupIntentFails = false;
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
   organizationsBillingAutoTopUpSetupIntentCreate: () => {
     setupIntentCalls += 1;
+    if (setupIntentFails) {
+      return Promise.reject(new Error("setup intent unavailable"));
+    }
     return Promise.resolve({
-      data: { client_secret: "seti_123_secret_456" },
+      data: { client_secret: `seti_123_secret_${setupIntentCalls}` },
       response: { ok: true },
     });
   },
@@ -232,6 +236,7 @@ beforeEach(() => {
   confirmSetupCalls = [];
   confirmSetupResult = Promise.resolve({});
   setupIntentCalls = 0;
+  setupIntentFails = false;
   nativeAndroid = false;
   openedUrl = null;
   useAuthStore.setState(initialAuthState, true);
@@ -387,18 +392,14 @@ describe("AutoTopUpPaymentMethodModal completeness gate", () => {
     expect(saveButton(result).disabled).toBe(true);
   });
 
-  test("surfaces an error when an element fails to load", async () => {
-    const { getByTestId } = await renderModalWithForm();
+  test("re-disables the primary action when an element fails to load", async () => {
+    const result = await renderReadyForm();
+    expect(saveButton(result).disabled).toBe(false);
 
-    fireOnLoadError(paymentElementProps);
-    expect(
-      getByTestId("auto-top-up-pm-modal-confirm-error").textContent,
-    ).toContain("Failed to load the payment form");
-
+    // The form unmounts with the failed element, so it cannot report its own
+    // completeness back down; the error branch has to do it.
     fireOnLoadError(addressElementProps);
-    expect(
-      getByTestId("auto-top-up-pm-modal-confirm-error").textContent,
-    ).toContain("Failed to load the billing address form");
+    expect(saveButton(result).disabled).toBe(true);
   });
 });
 
@@ -457,7 +458,7 @@ describe("AutoTopUpPaymentMethodModal submit", () => {
         throw new Error("onSavedOptimistic not called");
       }
     });
-    // The mocked client_secret is `seti_123_secret_456`.
+    // The mocked client_secret is `seti_123_secret_<call number>`.
     expect(savedArgs[0]).toEqual({ setupIntentId: "seti_123" });
   });
 
@@ -645,6 +646,181 @@ describe("AutoTopUpPaymentMethodModal submit", () => {
   });
 });
 
+describe("AutoTopUpPaymentMethodModal field skeleton", () => {
+  test("opens on the field skeleton rather than a spinner", async () => {
+    const result = renderModal();
+
+    const skeleton = result.getByTestId("auto-top-up-pm-modal-skeleton");
+    // The modal is its own surface, so this skeleton keeps the labelled
+    // loading region the billing cards' presentational ones gave up.
+    expect(skeleton.getAttribute("role")).toBe("status");
+    expect(skeleton.getAttribute("aria-label")).toBe("Loading payment fields");
+    expect(result.queryByTestId("auto-top-up-pm-modal-spinner")).toBeNull();
+    expect(result.queryByTestId("stripe-address-element")).toBeNull();
+
+    await result.findByTestId("stripe-address-element");
+    // The same skeleton spans both waits, so the shimmer does not restart
+    // when the SetupIntent lands.
+    expect(result.getByTestId("auto-top-up-pm-modal-skeleton")).toBe(skeleton);
+  });
+
+  test("suppresses Stripe's own loader so ours is the only one", async () => {
+    await renderModalWithForm();
+
+    expect((elementsProps?.options as Record<string, unknown>).loader).toBe(
+      "never",
+    );
+  });
+
+  test("holds the skeleton until both elements are ready, then reveals the fields", async () => {
+    const result = await renderModalWithForm();
+    const addressElement = result.getByTestId("stripe-address-element");
+    expect(result.getByTestId("auto-top-up-pm-modal-skeleton")).not.toBeNull();
+
+    fireOnReady(paymentElementProps);
+    expect(result.getByTestId("auto-top-up-pm-modal-skeleton")).not.toBeNull();
+
+    fireOnReady(addressElementProps);
+    expect(result.queryByTestId("auto-top-up-pm-modal-skeleton")).toBeNull();
+    // The reveal must not tear the elements down and boot them again.
+    expect(result.getByTestId("stripe-address-element")).toBe(addressElement);
+  });
+
+  test("the skeleton and the mounted form share one field-stack rhythm", async () => {
+    // They stand in for each other, so the two must keep the same spacing or
+    // the reveal changes the modal's height.
+    const result = await renderModalWithForm();
+
+    const skeleton = result.getByTestId("auto-top-up-pm-modal-skeleton");
+    const form = result.getByTestId("stripe-address-element").parentElement;
+    expect(skeleton.className).toContain("gap-[10px]");
+    expect(form?.className).toContain("gap-[10px]");
+  });
+
+  test("a re-open goes back to the skeleton until the new fields are ready", async () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const tree = (open: boolean) => (
+      <QueryClientProvider client={client}>
+        <AutoTopUpPaymentMethodModal
+          open={open}
+          onClose={() => {}}
+          onSavedOptimistic={() => {}}
+        />
+      </QueryClientProvider>
+    );
+    const result = render(tree(true));
+    await result.findByTestId("stripe-address-element");
+    fireOnReady(paymentElementProps);
+    fireOnReady(addressElementProps);
+    expect(result.queryByTestId("auto-top-up-pm-modal-skeleton")).toBeNull();
+
+    result.rerender(tree(false));
+    result.rerender(tree(true));
+
+    expect(result.getByTestId("auto-top-up-pm-modal-skeleton")).not.toBeNull();
+    // The second SetupIntent lands on a new client secret with the elements
+    // still booting, so the readiness from the first open must not have
+    // carried over.
+    await result.findByTestId("stripe-address-element");
+    expect(result.getByTestId("auto-top-up-pm-modal-skeleton")).not.toBeNull();
+
+    // The re-mounted form reports readiness again, so the reset the re-open
+    // made is answered rather than left holding the skeleton forever.
+    fireOnReady(paymentElementProps);
+    fireOnReady(addressElementProps);
+    expect(result.queryByTestId("auto-top-up-pm-modal-skeleton")).toBeNull();
+  });
+
+  test("an element load failure swaps the skeleton for a retryable error", async () => {
+    const result = await renderModalWithForm();
+    expect(result.getByTestId("auto-top-up-pm-modal-skeleton")).not.toBeNull();
+
+    fireOnLoadError(paymentElementProps);
+
+    // A failed element never reports ready, so the surface has to settle
+    // here rather than wait on a readiness that is not coming.
+    expect(
+      result.getByTestId("auto-top-up-pm-modal-fields-error").textContent,
+    ).toContain("Failed to load the payment form");
+    expect(result.queryByTestId("auto-top-up-pm-modal-skeleton")).toBeNull();
+    expect(result.queryByTestId("stripe-address-element")).toBeNull();
+    // The message has one home: the shell's inline error line stays empty.
+    expect(
+      result.queryByTestId("auto-top-up-pm-modal-confirm-error"),
+    ).toBeNull();
+
+    fireEvent.click(result.getByText("Try again"));
+
+    expect(result.getByTestId("auto-top-up-pm-modal-skeleton")).not.toBeNull();
+    await result.findByTestId("stripe-address-element");
+    expect(setupIntentCalls).toBe(2);
+  });
+
+  test("an address element load failure settles the same surface", async () => {
+    const result = await renderModalWithForm();
+
+    fireOnLoadError(addressElementProps);
+
+    expect(
+      result.getByTestId("auto-top-up-pm-modal-fields-error").textContent,
+    ).toContain("Failed to load the billing address form");
+    expect(result.queryByTestId("auto-top-up-pm-modal-skeleton")).toBeNull();
+  });
+
+  test("a re-open after a load failure comes back on the skeleton", async () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const tree = (open: boolean) => (
+      <QueryClientProvider client={client}>
+        <AutoTopUpPaymentMethodModal
+          open={open}
+          onClose={() => {}}
+          onSavedOptimistic={() => {}}
+        />
+      </QueryClientProvider>
+    );
+    const result = render(tree(true));
+    await result.findByTestId("stripe-address-element");
+    fireOnLoadError(paymentElementProps);
+    expect(
+      result.getByTestId("auto-top-up-pm-modal-fields-error"),
+    ).not.toBeNull();
+
+    result.rerender(tree(false));
+    result.rerender(tree(true));
+
+    expect(
+      result.queryByTestId("auto-top-up-pm-modal-fields-error"),
+    ).toBeNull();
+    expect(result.getByTestId("auto-top-up-pm-modal-skeleton")).not.toBeNull();
+    await result.findByTestId("stripe-address-element");
+  });
+
+  test("a failed SetupIntent swaps the skeleton for the retry action", async () => {
+    setupIntentFails = true;
+    const result = renderModal();
+
+    const notice = await result.findByTestId("auto-top-up-pm-modal-error");
+    expect(notice.textContent).toContain("Failed to start card setup");
+    expect(result.queryByTestId("auto-top-up-pm-modal-skeleton")).toBeNull();
+
+    setupIntentFails = false;
+    fireEvent.click(result.getByText("Try again"));
+
+    await result.findByTestId("stripe-address-element");
+    expect(setupIntentCalls).toBe(2);
+  });
+});
+
 describe("AutoTopUpPaymentMethodModal redirect return", () => {
   test("a saved outcome renders the panel without creating a SetupIntent", async () => {
     const { getByTestId, queryByTestId } = renderModal({
@@ -661,7 +837,7 @@ describe("AutoTopUpPaymentMethodModal redirect return", () => {
     );
     expect(setupIntentCalls).toBe(0);
     expect(queryByTestId("stripe-address-element")).toBeNull();
-    expect(queryByTestId("auto-top-up-pm-modal-spinner")).toBeNull();
+    expect(queryByTestId("auto-top-up-pm-modal-skeleton")).toBeNull();
   });
 
   test("a saved outcome closes itself on the same auto-close delay", async () => {

--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -7,7 +7,6 @@ import {
 } from "@stripe/react-stripe-js";
 import type { SetupIntentResult } from "@stripe/stripe-js";
 import { useMutation } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -19,6 +18,10 @@ import {
   setupIntentIdFromClientSecret,
   STRIPE_PK,
 } from "@/domains/settings/billing/stripe-client";
+import {
+  FieldSkeletons,
+  FIELD_STACK_CLASS,
+} from "@/domains/settings/components/field-skeletons";
 import {
   PaymentMethodModalShell,
   type CardOnFile,
@@ -35,6 +38,7 @@ import { useAuthStore } from "@/stores/auth-store";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
+import { cn } from "@vellumai/design-library/utils/cn";
 
 /**
  * Our own terms sentence waits on legal sign-off; while this is false Stripe's
@@ -93,7 +97,8 @@ export interface AutoTopUpPaymentMethodModalProps {
  * Flow:
  *  1. Modal opens, fire `organizationsBillingAutoTopUpSetupIntentCreate`
  *     to fetch a `client_secret`.
- *  2. While pending, render a centered spinner.
+ *  2. While pending, and on through the Stripe iframes' own boot,
+ *     render one field-shaped skeleton.
  *  3. On error, render a `Notice tone="error"` with a "Try again" button
  *     that re-runs the mutation.
  *  4. On success, mount `<SetupCardForm />` inside `<Elements>` and let the
@@ -223,6 +228,24 @@ function AutoTopUpPaymentMethodModalContent({
 
   const clientSecret = setupIntentMutation.data?.client_secret ?? null;
 
+  // A re-open, or a new client secret, boots fresh element instances, so the
+  // skeleton takes the surface back until both report ready again.
+  const [fieldsReady, setFieldsReady] = useState(false);
+  // An element that fails to load never reports ready, so the skeleton would
+  // otherwise hold the surface forever; this settles that wait into a retry.
+  const [fieldsLoadError, setFieldsLoadError] = useState<string | null>(null);
+  useEffect(() => {
+    setFieldsReady(false);
+    setFieldsLoadError(null);
+  }, [open, clientSecret]);
+
+  const handleFieldsLoadError = useCallback((message: string) => {
+    setFieldsLoadError(message);
+    // The form unmounts with the elements it failed to boot, so no later
+    // completeness report can arrive to arm the primary action.
+    setFormComplete(false);
+  }, []);
+
   const theme = useDocumentTheme();
   // react-stripe-js forwards appearance changes to elements.update(), so a
   // theme toggle while the modal is open re-themes the iframes.
@@ -310,33 +333,78 @@ function AutoTopUpPaymentMethodModalContent({
         </div>
       );
     }
-    if (!clientSecret) {
+    if (fieldsLoadError) {
+      // Both the skeleton and the elements go away with this branch: the
+      // failed element will never paint, so nothing is left to reveal.
+      // A retry mints a new client secret, which remounts <Elements> fresh.
       return (
         <div
-          className="flex min-h-[180px] items-center justify-center"
-          data-testid="auto-top-up-pm-modal-spinner"
+          className="space-y-3"
+          data-testid="auto-top-up-pm-modal-fields-error"
         >
-          <Loader2 className="h-6 w-6 animate-spin text-[var(--content-tertiary)]" />
+          <Notice tone="error">{fieldsLoadError}</Notice>
+          <div className="flex justify-end">
+            <Button
+              variant="primary"
+              onClick={() => {
+                setFieldsLoadError(null);
+                createSetupIntent({});
+              }}
+            >
+              {t("autoTopUpPaymentMethodModal.tryAgain")}
+            </Button>
+          </div>
         </div>
       );
     }
+    // One skeleton spans the SetupIntent fetch and the iframes' boot: it
+    // stays mounted while the elements arrive underneath, so the shimmer
+    // never restarts mid-wait.
     return (
-      <Elements
-        stripe={getStripePromise()}
-        options={{
-          clientSecret,
-          appearance: stripeAppearance,
-          fonts: STRIPE_FONTS,
-        }}
-      >
-        <SetupCardForm
-          billingAddress={billingAddress}
-          onCompleteChange={setFormComplete}
-          onError={setErrorMessage}
-          onSave={handleSave}
-          onSubmitReady={registerSubmit}
-        />
-      </Elements>
+      <div className="relative">
+        {fieldsReady ? null : <FieldSkeletons />}
+        {clientSecret ? (
+          // Revealed in place: mounting this wrapper at the flip would tear
+          // <Elements> down and back up, destroying the iframes we just waited
+          // for, so `fieldsReady` drives the fade instead. `absolute` keeps the
+          // booting iframes out of the flow so the skeleton sets the height.
+          <div
+            className={cn(
+              FIELD_STACK_CLASS,
+              "transition-opacity duration-200 ease-out motion-reduce:transition-none",
+              fieldsReady
+                ? "opacity-100"
+                : "invisible absolute inset-x-0 top-0 opacity-0",
+            )}
+          >
+            <Elements
+              // A new client secret boots new element instances, and it is
+              // also when `fieldsReady` resets: keying the provider makes
+              // those the same event, so the reset can never outlive the
+              // readiness this form last reported.
+              key={clientSecret}
+              stripe={getStripePromise()}
+              options={{
+                clientSecret,
+                appearance: stripeAppearance,
+                fonts: STRIPE_FONTS,
+                // Our skeleton already covers the iframe boot; Stripe's own
+                // loader would be a second loading language on top of it.
+                loader: "never",
+              }}
+            >
+              <SetupCardForm
+                billingAddress={billingAddress}
+                onCompleteChange={setFormComplete}
+                onFieldsLoadError={handleFieldsLoadError}
+                onFieldsReady={setFieldsReady}
+                onSave={handleSave}
+                onSubmitReady={registerSubmit}
+              />
+            </Elements>
+          </div>
+        ) : null}
+      </div>
     );
   };
 
@@ -415,13 +483,21 @@ function MissingStripeKeyNotice() {
 function SetupCardForm({
   billingAddress,
   onCompleteChange,
-  onError,
+  onFieldsLoadError,
+  onFieldsReady,
   onSave,
   onSubmitReady,
 }: {
   billingAddress: BillingAddress | null;
   onCompleteChange: (complete: boolean) => void;
-  onError: (message: string) => void;
+  /**
+   * An element failed to boot, so it will never report ready. The parent owns
+   * the message: it drops this form for a retry rather than leaving the
+   * skeleton up beside an error line.
+   */
+  onFieldsLoadError: (message: string) => void;
+  /** Both elements have painted, so the parent can drop its skeleton. */
+  onFieldsReady: (ready: boolean) => void;
   onSave: (confirm: () => Promise<SetupIntentResult>) => Promise<void>;
   onSubmitReady: (submit: () => Promise<void>) => void;
 }) {
@@ -437,8 +513,15 @@ function SetupCardForm({
   const [paymentComplete, setPaymentComplete] = useState(false);
   const [addressComplete, setAddressComplete] = useState(false);
 
-  const complete =
-    paymentReady && addressReady && paymentComplete && addressComplete;
+  const ready = paymentReady && addressReady;
+  // Invariant: every mount reports readiness from scratch, so the parent's
+  // `fieldsReady` reset (keyed on [open, clientSecret]) is never left holding
+  // a report from a previous set of elements.
+  useEffect(() => {
+    onFieldsReady(ready);
+  }, [onFieldsReady, ready]);
+
+  const complete = ready && paymentComplete && addressComplete;
   useEffect(() => {
     onCompleteChange(complete);
   }, [complete, onCompleteChange]);
@@ -473,7 +556,9 @@ function SetupCardForm({
         onReady={() => setPaymentReady(true)}
         onChange={(event) => setPaymentComplete(event.complete)}
         onLoadError={() =>
-          onError(t("autoTopUpPaymentMethodModal.paymentFormLoadError"))
+          onFieldsLoadError(
+            t("autoTopUpPaymentMethodModal.paymentFormLoadError"),
+          )
         }
         options={{
           layout: { type: "tabs", defaultCollapsed: false },
@@ -503,7 +588,9 @@ function SetupCardForm({
         onReady={() => setAddressReady(true)}
         onChange={(event) => setAddressComplete(event.complete)}
         onLoadError={() =>
-          onError(t("autoTopUpPaymentMethodModal.addressFormLoadError"))
+          onFieldsLoadError(
+            t("autoTopUpPaymentMethodModal.addressFormLoadError"),
+          )
         }
         options={{
           mode: "billing",

--- a/clients/web/src/domains/settings/components/field-skeletons.test.tsx
+++ b/clients/web/src/domains/settings/components/field-skeletons.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * The stand-in for the modal's Stripe inputs. Unlike the billing cards'
+ * presentational skeletons it announces unconditionally: the modal is its own
+ * surface, so there is no stack-level region to defer the announcement to.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { FieldSkeletons, FIELD_STACK_CLASS } from "./field-skeletons";
+
+afterEach(cleanup);
+
+describe("FieldSkeletons", () => {
+  test("announces the wait with its own translated label", () => {
+    const { container } = render(<FieldSkeletons />);
+
+    const region = container.querySelector('[role="status"]');
+    expect(region?.getAttribute("aria-label")).toBe("Loading payment fields");
+    expect(region?.getAttribute("data-testid")).toBe(
+      "auto-top-up-pm-modal-skeleton",
+    );
+  });
+
+  test("stands in for every field the mounted form renders", () => {
+    const { container } = render(<FieldSkeletons />);
+
+    // Card number, the expiry/CVC pair, then name, country and street.
+    const placeholders = container.querySelectorAll('[data-slot="skeleton"]');
+    expect(placeholders.length).toBe(6);
+    for (const placeholder of placeholders) {
+      // The labelled region is the one announcement; the rows are decoration.
+      expect(placeholder.getAttribute("aria-hidden")).toBe("true");
+      expect(placeholder.className).toContain("h-[42px]");
+    }
+  });
+
+  test("carries the field-stack rhythm the mounted form is held to", () => {
+    const { container } = render(<FieldSkeletons />);
+
+    // The modal's form wrapper applies this same exported constant, so the
+    // reveal cannot change the modal's height.
+    const region = container.querySelector('[role="status"]');
+    expect(region?.className).toBe(FIELD_STACK_CLASS);
+  });
+});

--- a/clients/web/src/domains/settings/components/field-skeletons.tsx
+++ b/clients/web/src/domains/settings/components/field-skeletons.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
+
+import { useTranslation } from "@/i18n";
+
+/** Row height of a mounted Stripe input, so the swap does not move the modal. */
+const FIELD_ROW_CLASS = "h-[42px] w-full rounded-lg";
+
+/**
+ * Vertical rhythm of the field stack. The skeleton and the mounted form share
+ * it so they stay the same height and the reveal does not move the modal.
+ */
+export const FIELD_STACK_CLASS = "flex flex-col gap-[10px]";
+
+/**
+ * Stand-in for the mounted card and billing-address inputs: card number, the
+ * expiry/CVC pair, then name, country and street. It carries the whole loading
+ * story, from the SetupIntent fetch through the iframes' own boot.
+ */
+export function FieldSkeletons() {
+  const { t } = useTranslation("settings");
+  return (
+    <div
+      role="status"
+      aria-label={t("autoTopUpPaymentMethodModal.loadingLabel")}
+      data-testid="auto-top-up-pm-modal-skeleton"
+      className={FIELD_STACK_CLASS}
+    >
+      <Skeleton aria-hidden className={FIELD_ROW_CLASS} />
+      <div className="grid grid-cols-2 gap-[10px]">
+        <Skeleton aria-hidden className={FIELD_ROW_CLASS} />
+        <Skeleton aria-hidden className={FIELD_ROW_CLASS} />
+      </div>
+      <Skeleton aria-hidden className={FIELD_ROW_CLASS} />
+      <Skeleton aria-hidden className={FIELD_ROW_CLASS} />
+      <Skeleton aria-hidden className={FIELD_ROW_CLASS} />
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.stories.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.stories.tsx
@@ -5,13 +5,16 @@
  * cannot load in Storybook, so the stories pass grey blocks the same height as
  * the Stripe inputs. That keeps the header, card-on-file row, state slot, and
  * footer laid out at the real proportions while the shell stays reviewable
- * without a publishable key.
+ * without a publishable key. The two loading stories are the exception: the
+ * skeleton that covers that boot is our own component, so they render the real
+ * one.
  *
  * Light, dark, and velvet all come from the theme toolbar, so there is no
  * per-theme story.
  */
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { FieldSkeletons } from "@/domains/settings/components/field-skeletons";
 import { PaymentMethodModalShell } from "@/domains/settings/components/payment-method-modal-shell";
 
 function FieldPlaceholders() {
@@ -111,5 +114,30 @@ export const SavedFromRedirect: Story = {
     savedCard: { brand: "visa", last4: "1881" },
     autoReloadActive: true,
     headerless: true,
+  },
+};
+
+/**
+ * The wait before any of the above: `FieldSkeletons` is the real component the
+ * modal renders from open until the SetupIntent has landed and both Stripe
+ * iframes report ready, so this story shows the shipped shimmer rather than the
+ * grey stand-ins the other stories use to hold the loaded geometry.
+ */
+export const LoadingFields: Story = {
+  args: {
+    children: <FieldSkeletons />,
+  },
+};
+
+/**
+ * The same wait when a card is already on file: the card row resolves straight
+ * away from config the modal already has, so it sits above fields that are
+ * still booting.
+ */
+export const LoadingFieldsReplace: Story = {
+  args: {
+    mode: "replace",
+    cardOnFile: { brand: "visa", last4: "4242", expMonth: 4, expYear: 2042 },
+    children: <FieldSkeletons />,
   },
 };

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -273,7 +273,7 @@
   "autoTopUpPaymentMethodModal": {
     "addSubtitle": "Kept on file for auto-reload and your Pro plan.",
     "addTitle": "Add a card",
-    "addressFormLoadError": "Failed to load the billing address form. Please close and reopen this dialog.",
+    "addressFormLoadError": "Failed to load the billing address form. Please try again.",
     "cancel": "Cancel",
     "cardOnFile": "{brand} •••• {last4}",
     "cardOnFileExpiry": "· {month} / {year}",
@@ -282,7 +282,8 @@
     "confirmFailed": "Failed to save payment method.",
     "confirmingWithBank": "Confirming with your bank…",
     "declined": "Your bank declined this card. Try another, or contact them.",
-    "paymentFormLoadError": "Failed to load the payment form. Please close and reopen this dialog.",
+    "loadingLabel": "Loading payment fields",
+    "paymentFormLoadError": "Failed to load the payment form. Please try again.",
     "primaryAdd": "Save card",
     "primaryReplace": "Replace card",
     "primarySubmitting": "Saving",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -273,7 +273,7 @@
   "autoTopUpPaymentMethodModal": {
     "addSubtitle": "Se guarda para la recarga automática y tu plan Pro.",
     "addTitle": "Añadir una tarjeta",
-    "addressFormLoadError": "No se pudo cargar el formulario de dirección de facturación. Cierra y vuelve a abrir este diálogo.",
+    "addressFormLoadError": "No se pudo cargar el formulario de dirección de facturación. Inténtalo de nuevo.",
     "cancel": "Cancelar",
     "cardOnFile": "{brand} •••• {last4}",
     "cardOnFileExpiry": "· {month} / {year}",
@@ -282,7 +282,8 @@
     "confirmFailed": "No se pudo guardar el método de pago.",
     "confirmingWithBank": "Confirmando con tu banco…",
     "declined": "Tu banco rechazó esta tarjeta. Prueba con otra o comunícate con ellos.",
-    "paymentFormLoadError": "No se pudo cargar el formulario de pago. Cierra y vuelve a abrir este diálogo.",
+    "loadingLabel": "Cargando los campos de pago",
+    "paymentFormLoadError": "No se pudo cargar el formulario de pago. Inténtalo de nuevo.",
     "primaryAdd": "Guardar tarjeta",
     "primaryReplace": "Reemplazar tarjeta",
     "primarySubmitting": "Guardando",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -261,7 +261,7 @@
   "autoTopUpPaymentMethodModal": {
     "addSubtitle": "Карта сохранится для автопополнения и плана Pro.",
     "addTitle": "Добавить карту",
-    "addressFormLoadError": "Не удалось загрузить форму адреса для оплаты. Закройте окно и откройте его снова.",
+    "addressFormLoadError": "Не удалось загрузить форму адреса для оплаты. Повторите попытку.",
     "cancel": "Отмена",
     "cardOnFile": "{brand} •••• {last4}",
     "cardOnFileExpiry": "· {month} / {year}",
@@ -270,7 +270,8 @@
     "confirmFailed": "Не удалось сохранить способ оплаты.",
     "confirmingWithBank": "Подтверждение в банке…",
     "declined": "Банк отклонил эту карту. Попробуйте другую или свяжитесь с банком.",
-    "paymentFormLoadError": "Не удалось загрузить форму оплаты. Закройте окно и откройте его снова.",
+    "loadingLabel": "Загрузка полей оплаты",
+    "paymentFormLoadError": "Не удалось загрузить форму оплаты. Повторите попытку.",
     "primaryAdd": "Сохранить карту",
     "primaryReplace": "Заменить карту",
     "primarySubmitting": "Сохранение",

--- a/clients/web/src/i18n/locales/zh-TW/settings.json
+++ b/clients/web/src/i18n/locales/zh-TW/settings.json
@@ -273,7 +273,7 @@
   "autoTopUpPaymentMethodModal": {
     "addSubtitle": "將保留在檔案中，供自動加值和您的專業版方案使用。",
     "addTitle": "新增信用卡",
-    "addressFormLoadError": "無法載入帳單地址表單。請關閉並重新開啟此對話方塊。",
+    "addressFormLoadError": "無法載入帳單地址表單。請再試一次。",
     "cancel": "取消",
     "cardOnFile": "{brand} •••• {last4}",
     "cardOnFileExpiry": "· {month} / {year}",
@@ -282,7 +282,8 @@
     "confirmFailed": "無法儲存付款方式。",
     "confirmingWithBank": "正在與您的銀行確認…",
     "declined": "您的銀行拒絕了這張卡。請改用其他卡片，或與銀行聯絡。",
-    "paymentFormLoadError": "無法載入付款表單。請關閉並重新開啟此對話方塊。",
+    "loadingLabel": "正在載入付款欄位",
+    "paymentFormLoadError": "無法載入付款表單。請再試一次。",
     "primaryAdd": "儲存信用卡",
     "primaryReplace": "替換信用卡",
     "primarySubmitting": "正在儲存",

--- a/clients/web/src/i18n/locales/zh/settings.json
+++ b/clients/web/src/i18n/locales/zh/settings.json
@@ -273,7 +273,7 @@
   "autoTopUpPaymentMethodModal": {
     "addSubtitle": "保存后用于自动充值和您的专业版套餐。",
     "addTitle": "添加银行卡",
-    "addressFormLoadError": "未能加载账单地址表单。请关闭并重新打开此对话框。",
+    "addressFormLoadError": "未能加载账单地址表单。请重试。",
     "cancel": "取消",
     "cardOnFile": "{brand} •••• {last4}",
     "cardOnFileExpiry": "· {month} / {year}",
@@ -282,7 +282,8 @@
     "confirmFailed": "未能保存付款方式。",
     "confirmingWithBank": "正在与您的银行确认…",
     "declined": "您的银行拒绝了这张卡。请换一张卡，或联系银行。",
-    "paymentFormLoadError": "未能加载付款表单。请关闭并重新打开此对话框。",
+    "loadingLabel": "正在加载付款字段",
+    "paymentFormLoadError": "未能加载付款表单。请重试。",
     "primaryAdd": "保存银行卡",
     "primaryReplace": "替换银行卡",
     "primarySubmitting": "保存中",


### PR DESCRIPTION
## Summary
- one shimmer skeleton (FieldSkeletons) covers SetupIntent fetch + Stripe iframe boot; Stripe's own grey loader is suppressed (loader: never) and fields crossfade in without remounting Elements
- a failed element load settles into a retryable error (Try again mints a fresh SetupIntent) instead of loading forever
- Storybook: the modal's real loading state is browsable (--loading-fields, --loading-fields-replace)
- extracted from the billing-skeleton feature branch (#41828) so the modal fix can ship independently; loading labels in en/es/ru/zh/zh-TW

## Notes
- Manual QA with a live Stripe test key still recommended: skeleton-to-fields height parity (the 5-row geometry vs the real mounted elements) is best measured in a browser.