### PR TITLE
fix(assistant): name the camera frame a sight_frame rejection refused

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-sight-frame.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-sight-frame.test.ts
@@ -9,7 +9,9 @@
  * The two neighbouring contracts are pinned by their own suites: a deliberate
  * snap persists standalone and untagged (`live-voice-attach-image.test.ts`), a
  * parked frame persists nothing and rides the next turn
- * (`live-voice-attach-frame.test.ts`).
+ * (`live-voice-attach-frame.test.ts`). One photo case does live here, because
+ * it pins the edge of something this suite owns: the refusal's attachment
+ * echo, which is the keep stream's alone.
  */
 
 import { describe, expect, mock, test } from "bun:test";
@@ -276,11 +278,78 @@ describe("live-voice camera frames kept mid-call", () => {
       ).toMatchObject({
         type: "error",
         frameType: "sight_frame",
+        // The id it refused, so the client retires that keep rather than
+        // guessing among the sends it has not heard back on.
+        attachmentId: "att-missing",
         recoverable: true,
       });
       // Nothing landed and the call carries on.
       expect(getMessages(harness.conversationId)).toHaveLength(0);
       expect(harness.startVoiceTurn).not.toHaveBeenCalled();
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("each refused keep names its own attachment", async () => {
+    // The point of the echo: keeps overlap, so a shared `frameType` cannot
+    // tell two outstanding sends apart.
+    const harness = createSessionHarness("Sight keep two refusals");
+    try {
+      await harness.session.start();
+      const before = harness.frames.length;
+
+      await harness.session.handleClientFrame({
+        type: "sight_frame",
+        attachmentId: "att-missing-1",
+      });
+      await harness.session.handleClientFrame({
+        type: "sight_frame",
+        attachmentId: "att-missing-2",
+      });
+      await waitFor(
+        () =>
+          harness.frames.slice(before).filter((frame) => frame.type === "error")
+            .length === 2,
+        { message: "Timed out waiting for both refusals" },
+      );
+
+      const refused = harness.frames
+        .slice(before)
+        .filter((frame) => frame.type === "error")
+        .map((frame) => frame.attachmentId);
+      expect(refused.sort()).toEqual(["att-missing-1", "att-missing-2"]);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  test("a photo that cannot be stored names no attachment", async () => {
+    // Scope pin: the echo is the keep stream's, where sends overlap. A photo
+    // is one deliberate snap at a time, and its receipt strip already knows
+    // which one it is waiting on.
+    const harness = createSessionHarness("Sight keep photo scope");
+    try {
+      await harness.session.start();
+      const before = harness.frames.length;
+
+      await harness.session.handleClientFrame({
+        type: "attach_image",
+        attachmentId: "att-missing",
+      });
+      await waitFor(() => harness.frames.length > before, {
+        message: "Timed out waiting for the rejected photo's error",
+      });
+
+      const error = harness.frames
+        .slice(before)
+        .find((frame) => frame.type === "error");
+      expect(error).toMatchObject({
+        type: "error",
+        frameType: "attach_image",
+        recoverable: true,
+      });
+      expect(error?.attachmentId).toBeUndefined();
     } finally {
       harness.dispose();
     }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1707,6 +1707,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           // preview it already showed, rather than filing this with the
           // transient transcriber and TTS blips that share `recoverable`.
           frameType: "sight_frame",
+          // Which keep, not just which stream: several can be outstanding
+          // while a persist waits out a turn.
+          attachmentId: frame.attachmentId,
           // The session is fine; only this frame failed.
           recoverable: true,
         });

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -272,7 +272,9 @@ export interface LiveVoiceClientAttachFrameFrame {
  * "sight_frame"` and `recoverable: true`: the session is fine and only this
  * frame failed. Attributing it is what lets the client retract the preview it
  * already showed instead of filing the error with the transient transcriber
- * and TTS blips that share `recoverable`.
+ * and TTS blips that share `recoverable`. The refusal echoes the frame's
+ * `attachmentId` too, because keeps overlap: see that field on
+ * {@link LiveVoiceErrorServerFrame}.
  */
 export interface LiveVoiceClientSightFrameFrame {
   readonly type: "sight_frame";
@@ -602,6 +604,24 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
    * from older daemons) means the error is terminal for the session.
    */
   readonly recoverable?: boolean;
+  /**
+   * The attachment the refused frame named, present on `sight_frame`
+   * rejections so the client can retire the exact keep that failed.
+   *
+   * `frameType` alone only narrows a rejection to the keep stream, and that
+   * stream is the one place several sends are routinely outstanding at once:
+   * the camera keeps shooting while a persist waits out a running turn, so a
+   * client holding three unacknowledged keeps cannot tell which of them this
+   * error is about. Naming the id is what turns "a frame failed" into "this
+   * preview comes down".
+   *
+   * Optional, and no other error path populates it: a parse failure has no
+   * id to name, and the other frames carrying an attachment have at most one
+   * in flight, which `frameType` already identifies. Daemons predating the
+   * field never send it either, so a client reading it absent falls back to
+   * whatever it did before and nothing gates on its presence.
+   */
+  readonly attachmentId?: string;
 }
 
 export type LiveVoiceServerFrame =

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -617,9 +617,8 @@ export interface LiveVoiceErrorServerFrame extends LiveVoiceServerFrameBase {
    *
    * Optional, and no other error path populates it: a parse failure has no
    * id to name, and the other frames carrying an attachment have at most one
-   * in flight, which `frameType` already identifies. Daemons predating the
-   * field never send it either, so a client reading it absent falls back to
-   * whatever it did before and nothing gates on its presence.
+   * in flight, which `frameType` already identifies. Clients must tolerate
+   * an absent id and must not gate any behavior on its presence.
    */
   readonly attachmentId?: string;
 }


### PR DESCRIPTION
## Summary
- The live-voice `sight_frame` rejection error now carries an optional `attachmentId` naming the exact refused keep, so a client holding several unacknowledged sends can retire the right one instead of guessing (several keeps can be outstanding while a persist waits out a turn).
- One optional wire field on `LiveVoiceErrorServerFrame`, populated only at the sight_frame rejection site; attach_image and other error paths are pinned unchanged by a scope test. Old webs ignore the extra field and old daemons simply omit it, so no gating is needed.
- Follow-up to #41765; unblocks exact pulse retraction in the web keep-stream PR (#41833).

🤖 Generated with [Claude Code](https://claude.com/claude-code)