### PR TITLE
feat(web): teach the empty Schedules card instead of leaving a void

### DIFF
--- a/clients/web/src/domains/intelligence/components/identity-overview.stories.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.stories.tsx
@@ -1,0 +1,137 @@
+/**
+ * The Schedules card from the assistant profile's bento grid, in the two
+ * states its content can take.
+ *
+ * The bento sizes this card from the page: it starts at one Personality-row
+ * of height and grows only once three schedule tiles need more. The frame
+ * below stands in for that cell so both states can be read side by side at
+ * the size the page gives them.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+
+import type { IdentitySectionStat } from "../use-identity-section-stats";
+import { buildIdentitySections } from "./identity-sections";
+import { SectionCard } from "./identity-overview";
+
+const SCHEDULES_SECTION = buildIdentitySections().find(
+  (section) => section.key === "schedules",
+)!;
+
+const HOUR_MS = 3_600_000;
+
+const POPULATED_STAT: IdentitySectionStat = {
+  value: 3,
+  label: "active",
+  text: "3 active",
+  schedules: {
+    items: [
+      {
+        id: "sched-morning",
+        name: "Morning briefing",
+        cadence: "Every weekday at 8:00",
+        nextRunAt: Date.now() + HOUR_MS,
+      },
+      {
+        id: "sched-inbox",
+        name: "Inbox triage",
+        cadence: "Every 2 hours",
+        nextRunAt: Date.now() + 2 * HOUR_MS,
+      },
+      {
+        id: "sched-review",
+        name: "Weekly review",
+        cadence: "Fridays at 4:00 PM",
+        nextRunAt: Date.now() + 48 * HOUR_MS,
+      },
+    ],
+    more: 0,
+  },
+};
+
+const EMPTY_STAT: IdentitySectionStat = { text: "Nothing scheduled yet" };
+
+/** The bento cell the Schedules card occupies, at a desktop row height. */
+function Cell({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="grid"
+      style={{
+        width: 280,
+        gridTemplateAreas: `"schedules"`,
+        gridTemplateRows: "300px",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Bench({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-start gap-8 bg-[var(--surface-base)] p-10">
+      {children}
+    </div>
+  );
+}
+
+function SchedulesCard({ stat }: { stat: IdentitySectionStat }) {
+  return (
+    <Cell>
+      <SectionCard
+        section={SCHEDULES_SECTION}
+        stat={stat}
+        gridArea="schedules"
+        cardStyle={{ alignSelf: "start", height: "auto", minHeight: 300 }}
+        hoverFill
+      />
+    </Cell>
+  );
+}
+
+const meta = {
+  title: "Intelligence/Schedules Card",
+  component: SchedulesCard,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof SchedulesCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * No schedules: the preview column carries dashed, dimmed outlines of two
+ * example schedules, and the stat line gains an invitation. Both are
+ * decoration and copy, never controls, because the card is one big link.
+ */
+export const Empty: Story = {
+  args: { stat: EMPTY_STAT },
+  render: (args) => (
+    <Bench>
+      <SchedulesCard {...args} />
+    </Bench>
+  ),
+};
+
+/** Three schedules: solid, washed tiles with a cadence and next fire time. */
+export const Populated: Story = {
+  args: { stat: POPULATED_STAT },
+  render: (args) => (
+    <Bench>
+      <SchedulesCard {...args} />
+    </Bench>
+  ),
+};
+
+/**
+ * Both together, which is how the ghosts should be judged: a glance must
+ * never read the empty card as an assistant that owns two schedules.
+ */
+export const EmptyBesidePopulated: Story = {
+  args: { stat: EMPTY_STAT },
+  render: () => (
+    <Bench>
+      <SchedulesCard stat={EMPTY_STAT} />
+      <SchedulesCard stat={POPULATED_STAT} />
+    </Bench>
+  ),
+};

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -12,6 +12,7 @@
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  ArrowRight,
   Brain,
   Calendar,
   ChevronRight,
@@ -134,6 +135,23 @@ const CARD_HOVER_LINE_KEY: Record<
   contacts: "identityOverview.cardHoverLine.contacts",
   channels: "identityOverview.cardHoverLine.channels",
 };
+
+/**
+ * The example schedules the Schedules card outlines while the assistant has
+ * none. "Morning briefing" is the name the create-schedule form already
+ * suggests as its placeholder, so the card teases the same starting point
+ * its destination offers.
+ */
+const SCHEDULE_GHOSTS = [
+  {
+    nameKey: "identityOverview.scheduleGhosts.morningBriefingName",
+    cadenceKey: "identityOverview.scheduleGhosts.morningBriefingCadence",
+  },
+  {
+    nameKey: "identityOverview.scheduleGhosts.inboxTriageName",
+    cadenceKey: "identityOverview.scheduleGhosts.inboxTriageCadence",
+  },
+] as const;
 
 /** "14 Jul, 9:00 am" — compact next-fire time for the schedules preview. */
 function formatNextRun(nextRunAt: number): string {
@@ -373,7 +391,71 @@ export function IdentityOverview({ assistantId }: IdentityOverviewProps) {
   );
 }
 
-function SectionCard({
+/**
+ * One row of the Schedules card's preview column. The ghost variant draws
+ * the same shape as a dashed, unfilled outline at reduced opacity, so an
+ * empty card can preview what a filled one looks like without any of its
+ * rows reading as a schedule the user owns.
+ */
+function ScheduleTile({
+  name,
+  cadence,
+  fg,
+  fgMuted,
+  flooded,
+  ghost = false,
+}: {
+  name: string;
+  cadence: string;
+  /** The card's content tone, already resolved for the flood state. */
+  fg: string;
+  /** The card's muted tone, already resolved for the flood state. */
+  fgMuted: string;
+  flooded: boolean;
+  ghost?: boolean;
+}) {
+  return (
+    <span
+      className={`flex flex-col gap-0.5 rounded-xl px-3 py-2 transition-colors duration-300 ${
+        ghost ? "border border-dashed opacity-60" : ""
+      }`}
+      style={
+        ghost
+          ? {
+              borderColor: flooded
+                ? "color-mix(in srgb, var(--card-flood-fg) 45%, transparent)"
+                : "var(--border-base)",
+            }
+          : {
+              // A content-tinted wash (not a surface token) so the tile
+              // visibly lifts off the card in dark themes too.
+              backgroundColor: flooded
+                ? "color-mix(in srgb, var(--card-flood-fg) 12%, transparent)"
+                : "color-mix(in srgb, var(--content-default) 5%, transparent)",
+            }
+      }
+    >
+      <span
+        className={`truncate text-[13px] font-medium transition-colors duration-300 ${
+          ghost ? fgMuted : fg
+        }`}
+      >
+        {name}
+      </span>
+      <span
+        className={`truncate text-[12px] transition-colors duration-300 ${fgMuted}`}
+      >
+        {cadence}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * One bento tile. Exported for the Storybook fixture that reviews the
+ * Schedules card in both its populated and its empty state.
+ */
+export function SectionCard({
   section,
   stat,
   gridArea,
@@ -519,6 +601,16 @@ function SectionCard({
   const isFeatureCard =
     section.key === "personality" || section.key === "schedules";
 
+  // An assistant with no schedules has a stat but no preview list, which
+  // leaves the tall card's whole middle empty. It spends that space on
+  // ghosts of the example schedules instead. `stat === undefined` is the
+  // still-loading card, which stays blank rather than teasing.
+  const showsScheduleGhosts =
+    Boolean(gridArea) &&
+    section.key === "schedules" &&
+    stat !== undefined &&
+    !stat.schedules;
+
   return (
     // The feature cards sit flat on the page (no shadow) with a hairline
     // theme border; the other tiles keep the standard raised card chrome.
@@ -632,31 +724,17 @@ function SectionCard({
         {gridArea && stat?.schedules && stat.schedules.items.length > 0 && (
           <span className="relative flex min-h-0 flex-1 flex-col justify-start gap-2 overflow-hidden py-2">
             {stat.schedules.items.map((schedule) => (
-              <span
+              <ScheduleTile
                 key={schedule.id}
-                className="flex flex-col gap-0.5 rounded-xl px-3 py-2 transition-colors duration-300"
-                style={{
-                  // A content-tinted wash (not a surface token) so the tile
-                  // visibly lifts off the card in dark themes too.
-                  backgroundColor: flooded
-                    ? "color-mix(in srgb, var(--card-flood-fg) 12%, transparent)"
-                    : "color-mix(in srgb, var(--content-default) 5%, transparent)",
-                }}
-              >
-                <span
-                  className={`truncate text-[13px] font-medium transition-colors duration-300 ${fg}`}
-                >
-                  {schedule.name}
-                </span>
-                <span
-                  className={`truncate text-[12px] transition-colors duration-300 ${fgMuted}`}
-                >
-                  {t("identityOverview.scheduleCadence", {
-                    cadence: schedule.cadence,
-                    nextRun: formatNextRun(schedule.nextRunAt),
-                  })}
-                </span>
-              </span>
+                name={schedule.name}
+                cadence={t("identityOverview.scheduleCadence", {
+                  cadence: schedule.cadence,
+                  nextRun: formatNextRun(schedule.nextRunAt),
+                })}
+                fg={fg}
+                fgMuted={fgMuted}
+                flooded={flooded}
+              />
             ))}
             {stat.schedules.more > 0 && (
               <span
@@ -667,6 +745,28 @@ function SectionCard({
                 })}
               </span>
             )}
+          </span>
+        )}
+        {/* With nothing scheduled the same column carries outlines of two
+            example schedules. They are decoration, not data, so the group
+            is hidden from assistive technology and the card's own link
+            stays the only action: a button cannot nest inside an anchor. */}
+        {showsScheduleGhosts && (
+          <span
+            aria-hidden
+            className="relative flex min-h-0 flex-1 flex-col justify-start gap-2 overflow-hidden py-2"
+          >
+            {SCHEDULE_GHOSTS.map((ghost) => (
+              <ScheduleTile
+                key={ghost.nameKey}
+                name={t(ghost.nameKey)}
+                cadence={t(ghost.cadenceKey)}
+                fg={fg}
+                fgMuted={fgMuted}
+                flooded={flooded}
+                ghost
+              />
+            ))}
           </span>
         )}
         {stat?.value !== undefined ? (
@@ -684,10 +784,23 @@ function SectionCard({
             </span>
           </span>
         ) : stat?.text ? (
-          <span
-            className={`relative text-[14px] font-medium italic transition-colors duration-300 ${fg}`}
-          >
-            {stat.text}
+          <span className="relative flex flex-col gap-1">
+            <span
+              className={`text-[14px] font-medium italic transition-colors duration-300 ${fg}`}
+            >
+              {stat.text}
+            </span>
+            {/* An invitation, not a control. The card already links to
+                Schedules, so this names the destination and lets the whole
+                surface remain the click target. */}
+            {showsScheduleGhosts && (
+              <span
+                className={`flex items-center gap-1 text-[13px] font-medium transition-colors duration-300 ${fg}`}
+              >
+                {t("identityOverview.setUpSchedule")}
+                <ArrowRight size={13} aria-hidden />
+              </span>
+            )}
           </span>
         ) : null}
       </Link>

--- a/clients/web/src/i18n/locales/en/intelligence.json
+++ b/clients/web/src/i18n/locales/en/intelligence.json
@@ -101,6 +101,13 @@
     "renameErrorToast": "The rename didn't go through. Please try again.",
     "renameSuccessToast": "Say hi to {newName}!",
     "scheduleCadence": "{cadence} · next {nextRun}",
+    "scheduleGhosts": {
+      "inboxTriageCadence": "Every 2 hours",
+      "inboxTriageName": "Inbox triage",
+      "morningBriefingCadence": "Every weekday at 8:00",
+      "morningBriefingName": "Morning briefing"
+    },
+    "setUpSchedule": "Set one up",
     "updateAvatarAndName": "Update avatar and name",
     "viewMoreSchedules": "{count, plural, one {View # more…} other {View # more…}}"
   },

--- a/clients/web/src/i18n/locales/es/intelligence.json
+++ b/clients/web/src/i18n/locales/es/intelligence.json
@@ -101,6 +101,13 @@
     "renameErrorToast": "El cambio de nombre no se completó. Vuelve a intentarlo.",
     "renameSuccessToast": "¡Saluda a {newName}!",
     "scheduleCadence": "{cadence} · próxima {nextRun}",
+    "scheduleGhosts": {
+      "inboxTriageCadence": "Cada 2 horas",
+      "inboxTriageName": "Revisión del buzón",
+      "morningBriefingCadence": "Cada día laborable a las 8:00",
+      "morningBriefingName": "Resumen matutino"
+    },
+    "setUpSchedule": "Crear una",
     "updateAvatarAndName": "Actualizar avatar y nombre",
     "viewMoreSchedules": "{count, plural, one {Ver # más…} other {Ver # más…}}"
   },

--- a/clients/web/src/i18n/locales/ru/intelligence.json
+++ b/clients/web/src/i18n/locales/ru/intelligence.json
@@ -101,6 +101,13 @@
     "renameErrorToast": "Имя не сменилось. Повторите попытку.",
     "renameSuccessToast": "Знакомься, это {newName}!",
     "scheduleCadence": "{cadence} · следующее {nextRun}",
+    "scheduleGhosts": {
+      "inboxTriageCadence": "Каждые 2 часа",
+      "inboxTriageName": "Разбор входящих",
+      "morningBriefingCadence": "По будням в 8:00",
+      "morningBriefingName": "Утренняя сводка"
+    },
+    "setUpSchedule": "Создать расписание",
     "updateAvatarAndName": "Изменить аватар и имя",
     "viewMoreSchedules": "{count, plural, one {Показать ещё #…} few {Показать ещё #…} many {Показать ещё #…} other {Показать ещё #…}}"
   },

--- a/clients/web/src/i18n/locales/zh-TW/intelligence.json
+++ b/clients/web/src/i18n/locales/zh-TW/intelligence.json
@@ -101,6 +101,13 @@
     "renameErrorToast": "重新命名未成功。請再試一次。",
     "renameSuccessToast": "向 {newName} 問好！",
     "scheduleCadence": "{cadence} · 下次 {nextRun}",
+    "scheduleGhosts": {
+      "inboxTriageCadence": "每 2 小時",
+      "inboxTriageName": "收件匣整理",
+      "morningBriefingCadence": "每個工作日 8:00",
+      "morningBriefingName": "晨間簡報"
+    },
+    "setUpSchedule": "建立排程",
     "updateAvatarAndName": "更新頭像和名稱",
     "viewMoreSchedules": "{count, plural, other {檢視 {count} 個更多…}}"
   },

--- a/clients/web/src/i18n/locales/zh/intelligence.json
+++ b/clients/web/src/i18n/locales/zh/intelligence.json
@@ -101,6 +101,13 @@
     "renameErrorToast": "重命名未成功。请重试。",
     "renameSuccessToast": "向 {newName} 问好！",
     "scheduleCadence": "{cadence} · 下次 {nextRun}",
+    "scheduleGhosts": {
+      "inboxTriageCadence": "每 2 小时",
+      "inboxTriageName": "收件箱整理",
+      "morningBriefingCadence": "每个工作日 8:00",
+      "morningBriefingName": "早间简报"
+    },
+    "setUpSchedule": "创建定时任务",
     "updateAvatarAndName": "更新头像和名称",
     "viewMoreSchedules": "{count, plural, other {查看 {count} 个更多…}}"
   },


### PR DESCRIPTION
## The bug

The tall **Schedules** card on the assistant profile page previews up to three
schedules as tiles. When the assistant has none, that whole preview block is
skipped, so the card renders a header, several hundred pixels of nothing, and
one italic "Nothing scheduled yet" pinned to the bottom. Every new assistant
sees that card first.

## Before / after (light)

![Empty Schedules card, before and after, light theme](https://raw.githubusercontent.com/vellum-ai/vellum-assistant/assets/schedules-card-empty-state/before-after-light.png)

## Before / after (dark)

![Empty Schedules card, before and after, dark theme](https://raw.githubusercontent.com/vellum-ai/vellum-assistant/assets/schedules-card-empty-state/before-after-dark.png)

## Why it teaches instead of offering a button

The card wraps its entire body in a `<Link to="/assistant/schedules">`. A button
cannot nest inside an anchor, so an empty state here cannot carry a CTA control
without breaking the card's one contract: glance, then go. The negative space is
therefore spent on teaching what a schedule is, and the bottom line is turned
from a dead stat into a door.

Two pieces:

1. **Ghost tiles.** The same tile shape the populated card draws, rendered as
   placeholders: dashed hairline border, no fill, 60% opacity, muted text. The
   group is `aria-hidden` because it is decoration, not data. Getting this wrong
   was the main risk, so the reference render below puts the empty card next to
   a populated one: a glance must never read the empty card as two schedules the
   user owns.
2. **An invitation.** "Set one up" with a right arrow, in the card's content
   color, under the unchanged "Nothing scheduled yet" line. It is a label, not a
   control. The whole card is still the click target.

The two ghost names are the ones the product already suggests: "Morning
briefing" is the create-schedule form's own name placeholder
(`settings:createScheduleModal.namePlaceholder`), so the card teases the exact
starting point its destination hands over.

## Empty beside populated

Light:

![Empty card beside the populated card, light theme](https://raw.githubusercontent.com/vellum-ai/vellum-assistant/assets/schedules-card-empty-state/side-by-side-light.png)

Dark:

![Empty card beside the populated card, dark theme](https://raw.githubusercontent.com/vellum-ai/vellum-assistant/assets/schedules-card-empty-state/side-by-side-dark.png)

## Implementation notes

- Real rows and ghost rows are drawn by one new `ScheduleTile`, so the ghost
  shape cannot drift from the shape it imitates. The populated path keeps its
  existing tokens (the `color-mix` content wash, `rounded-xl`, 13px/12px type)
  and renders byte-identically.
- The ghosts show only in the bento layout (`gridArea`), where the card is tall,
  and only once the stat has resolved. A still-loading card stays blank rather
  than teasing schedules that may exist.
- Copy is in `i18n/locales/*/intelligence.json` under `identityOverview`,
  alongside `useIdentitySectionStats.noSchedulesText`, in all five locales.
- `SectionCard` is exported for a new Storybook story
  (`Intelligence/Schedules Card`) covering the empty state, the populated state,
  and the two side by side, so the ghosts can be judged against real data
  without running the app.

## Verification

From `clients/web`:

- `bunx tsc --noEmit` clean.
- `bun run lint` 0 errors (14 pre-existing `react-hooks/exhaustive-deps`
  warnings, none in touched files).
- `bun test src/i18n/catalogs.test.ts` 210 pass, 0 fail.
- `bun test src/domains/intelligence` 328 pass, 13 fail, identical to the same
  command on `origin/main` (a pre-existing `SkillDetailMobile` /
  `SuperpowersTab` isolation failure, untouched by this change).
- Rendered in Chromium via Storybook in both light and dark themes; the
  screenshots above are those renders.

Screenshots are hosted on the throwaway `assets/schedules-card-empty-state`
branch, which is not for merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRyE6m6PYynVB8vnbKhsuv

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41837" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->