### PR TITLE
fix(web): recover rejected personal API keys in chat

### DIFF
--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -39,6 +39,7 @@ import { useTranscriptData } from "@/domains/chat/hooks/use-transcript-data";
 import { useTranscriptMessages } from "@/domains/chat/transcript/use-transcript-messages";
 import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
 import { useComposerSubmit } from "@/domains/chat/hooks/use-composer-submit";
+import { useInvalidApiKeyRecovery } from "@/domains/chat/hooks/use-invalid-api-key-recovery";
 import { useDraftSecretDetection } from "@/domains/chat/hooks/use-draft-secret-detection";
 import type { SendChatMessageOptions } from "@/domains/chat/hooks/use-send-message";
 import {
@@ -120,7 +121,9 @@ import { Button } from "@vellumai/design-library";
 import { Link, useLocation, useNavigate, useParams } from "react-router";
 import {
   getChatBillingBannerDecision,
+  isInvalidApiKeyChatError,
   isManagedCredentialChatError,
+  isMissingApiKeyChatError,
   resolveComposerBillingBanner,
   shouldShowGenericChatErrorNotice,
 } from "@/domains/chat/utils/error-classification";
@@ -401,6 +404,13 @@ export function ChatMainPanel({
   // do it.
   const rawIsLoadingHistory = useChatSessionStore.use.isLoadingHistory();
   const draftConversationIds = useConversationStore.use.draftConversationIds();
+  const invalidApiKeyRecovery = useInvalidApiKeyRecovery({
+    assistantId,
+    conversationId: activeConversationId,
+    isDraft: !!(
+      activeConversationId && draftConversationIds.has(activeConversationId)
+    ),
+  });
   const { conversationId: urlConversationId } = useParams<{
     conversationId: string;
   }>();
@@ -1461,9 +1471,23 @@ export function ChatMainPanel({
             // dismissible, so disk always wins there; a dismissed or
             // suppressed warning hands the space to the resource banner.
             resourcePressureBanner={resourcePressureBannerSlot}
-            showMissingApiKeyBanner={error?.code === "PROVIDER_NOT_CONFIGURED"}
+            apiKeyBanner={
+              isMissingApiKeyChatError(error)
+                ? "missing"
+                : isInvalidApiKeyChatError(error)
+                  ? "invalid"
+                  : null
+            }
             onOpenAiSettings={pushToAiSettings}
             onDismissApiKeyError={handleDismissApiKeyError}
+            onUseDefaultModel={
+              invalidApiKeyRecovery.canUseDefaultModel
+                ? () => {
+                    void invalidApiKeyRecovery.useDefaultModel();
+                  }
+                : undefined
+            }
+            useDefaultModelPending={invalidApiKeyRecovery.pending}
             compactionCircuitOpenUntil={compactionCircuitOpenUntil}
             onCompactionCircuitExpired={handleCompactionCircuitExpired}
             showMaintenanceBanner={

--- a/clients/web/src/domains/chat/components/composer-notices.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-notices.test.tsx
@@ -15,7 +15,7 @@ function QuietSlot() {
 }
 
 const REQUIRED = {
-  showMissingApiKeyBanner: false,
+  apiKeyBanner: null,
   onOpenAiSettings: () => {},
   onDismissApiKeyError: () => {},
   showMaintenanceBanner: false,
@@ -34,6 +34,29 @@ describe("ComposerNotices", () => {
     // left by a quiet slot would take the settings pills and the avatar peek
     // down with it for the whole session.
     expect(container.childElementCount).toBe(0);
+  });
+
+  test("an invalid API key banner reaches the stack", () => {
+    const { container } = render(
+      <ComposerNotices {...REQUIRED} apiKeyBanner="invalid" />,
+    );
+
+    expect(container.querySelector('[data-testid="invalid-api-key-banner"]')).not.toBe(
+      null,
+    );
+    expect(container.querySelector('[data-testid="missing-api-key-banner"]')).toBe(
+      null,
+    );
+  });
+
+  test("a missing API key banner reaches the stack", () => {
+    const { container } = render(
+      <ComposerNotices {...REQUIRED} apiKeyBanner="missing" />,
+    );
+
+    expect(container.querySelector('[data-testid="missing-api-key-banner"]')).not.toBe(
+      null,
+    );
   });
 
   test("a slot with a banner in it still renders", () => {

--- a/clients/web/src/domains/chat/components/composer-notices.tsx
+++ b/clients/web/src/domains/chat/components/composer-notices.tsx
@@ -62,12 +62,21 @@ export interface ComposerNoticesProps {
    */
   billingBannerSlot?: ReactNode;
 
-  /** True when the assistant returned `PROVIDER_NOT_CONFIGURED`. */
-  showMissingApiKeyBanner: boolean;
-  /** Handler invoked when the user clicks "Open settings" on the missing-API-key banner. */
+  /**
+   * Dedicated API-key recovery banner. `missing` is `PROVIDER_NOT_CONFIGURED`;
+   * `invalid` is a rejected personal key (`PROVIDER_INVALID_KEY`).
+   */
+  apiKeyBanner?: "missing" | "invalid" | null;
+  /** Handler invoked when the user clicks "Open settings" on the API-key banner. */
   onOpenAiSettings: () => void;
-  /** Handler invoked when the user dismisses the missing-API-key banner. */
+  /** Handler invoked when the user dismisses the API-key banner. */
   onDismissApiKeyError: () => void;
+  /**
+   * Pins the conversation (and, when needed, the workspace default) to a
+   * managed profile. Only offered for `invalid` when a managed profile exists.
+   */
+  onUseDefaultModel?: () => void;
+  useDefaultModelPending?: boolean;
 
   /**
    * When non-null and in the future, the compaction circuit is open and a
@@ -96,9 +105,11 @@ export function ComposerNotices({
   diskPressureBanner,
   resourcePressureBanner,
   billingBannerSlot,
-  showMissingApiKeyBanner,
+  apiKeyBanner = null,
   onOpenAiSettings,
   onDismissApiKeyError,
+  onUseDefaultModel,
+  useDefaultModelPending = false,
   compactionCircuitOpenUntil,
   onCompactionCircuitExpired,
   showMaintenanceBanner,
@@ -158,11 +169,16 @@ export function ComposerNotices({
       {diskPressureBanner}
       {resourcePressureBanner}
       {billingBannerSlot}
-      {showMissingApiKeyBanner && (
+      {apiKeyBanner && (
         <div className="mb-2">
           <MissingApiKeyBanner
+            variant={apiKeyBanner}
             onOpenSettings={onOpenAiSettings}
             onDismiss={onDismissApiKeyError}
+            onUseDefaultModel={
+              apiKeyBanner === "invalid" ? onUseDefaultModel : undefined
+            }
+            useDefaultModelPending={useDefaultModelPending}
           />
         </div>
       )}

--- a/clients/web/src/domains/chat/components/missing-api-key-banner.test.tsx
+++ b/clients/web/src/domains/chat/components/missing-api-key-banner.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+import { MissingApiKeyBanner } from "@/domains/chat/components/missing-api-key-banner";
+
+afterEach(cleanup);
+
+describe("MissingApiKeyBanner", () => {
+  test("missing-key variant offers Settings and no default-model action", () => {
+    const onOpenSettings = mock(() => {});
+    const onUseDefaultModel = mock(() => {});
+
+    render(
+      <MissingApiKeyBanner
+        onOpenSettings={onOpenSettings}
+        onDismiss={() => {}}
+        onUseDefaultModel={onUseDefaultModel}
+      />,
+    );
+
+    expect(screen.getByTestId("missing-api-key-banner")).toBeTruthy();
+    expect(screen.queryByTestId("invalid-api-key-banner")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Open Settings" }));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Use default model" })).toBe(
+      null,
+    );
+    expect(onUseDefaultModel).not.toHaveBeenCalled();
+  });
+
+  test("invalid-key variant offers Settings and Use default model", () => {
+    const onOpenSettings = mock(() => {});
+    const onUseDefaultModel = mock(() => {});
+
+    render(
+      <MissingApiKeyBanner
+        variant="invalid"
+        onOpenSettings={onOpenSettings}
+        onDismiss={() => {}}
+        onUseDefaultModel={onUseDefaultModel}
+      />,
+    );
+
+    expect(screen.getByTestId("invalid-api-key-banner")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open Settings" }));
+    fireEvent.click(screen.getByRole("button", { name: "Use default model" }));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(onUseDefaultModel).toHaveBeenCalledTimes(1);
+  });
+
+  test("invalid-key variant hides Use default model when no handler is provided", () => {
+    render(
+      <MissingApiKeyBanner
+        variant="invalid"
+        onOpenSettings={() => {}}
+        onDismiss={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("invalid-api-key-banner")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Use default model" })).toBe(
+      null,
+    );
+  });
+});

--- a/clients/web/src/domains/chat/components/missing-api-key-banner.tsx
+++ b/clients/web/src/domains/chat/components/missing-api-key-banner.tsx
@@ -4,47 +4,89 @@ import { Button } from "@vellumai/design-library";
 
 import { useTranslation } from "@/i18n";
 
+export type ApiKeyBannerVariant = "missing" | "invalid";
+
 export interface MissingApiKeyBannerProps {
+  variant?: ApiKeyBannerVariant;
   onOpenSettings: () => void;
   onDismiss: () => void;
+  onUseDefaultModel?: () => void;
+  useDefaultModelPending?: boolean;
 }
 
 export function MissingApiKeyBanner({
+  variant = "missing",
   onOpenSettings,
   onDismiss,
+  onUseDefaultModel,
+  useDefaultModelPending = false,
 }: MissingApiKeyBannerProps) {
   const { t } = useTranslation("chat");
+  const invalid = variant === "invalid";
+  const showUseDefault = invalid && typeof onUseDefaultModel === "function";
+
   return (
     <div
       className="relative flex flex-col gap-3 bg-[var(--surface-active)] p-4"
       style={{ borderRadius: "10px 10px 0 0" }}
       role="status"
-      aria-label={t("missingApiKeyBanner.ariaLabel")}
-      data-testid="missing-api-key-banner"
+      aria-label={
+        invalid
+          ? t("invalidApiKeyBanner.ariaLabel")
+          : t("missingApiKeyBanner.ariaLabel")
+      }
+      data-testid={
+        invalid ? "invalid-api-key-banner" : "missing-api-key-banner"
+      }
     >
       <div className="absolute right-2 top-2">
         <Button
           variant="ghost"
           size="compact"
           iconOnly={<X />}
-          tooltip={t("missingApiKeyBanner.dismiss")}
-          aria-label={t("missingApiKeyBanner.dismissAria")}
+          tooltip={
+            invalid
+              ? t("invalidApiKeyBanner.dismiss")
+              : t("missingApiKeyBanner.dismiss")
+          }
+          aria-label={
+            invalid
+              ? t("invalidApiKeyBanner.dismissAria")
+              : t("missingApiKeyBanner.dismissAria")
+          }
           onClick={onDismiss}
         />
       </div>
 
       <div className="flex flex-col gap-2 pr-8">
         <p className="text-body-small-emphasised text-[var(--content-default)]">
-          {t("missingApiKeyBanner.title")}
+          {invalid
+            ? t("invalidApiKeyBanner.title")
+            : t("missingApiKeyBanner.title")}
         </p>
         <p className="text-body-medium-default text-[var(--content-tertiary)]">
-          {t("missingApiKeyBanner.body")}
+          {invalid
+            ? t("invalidApiKeyBanner.body")
+            : t("missingApiKeyBanner.body")}
         </p>
       </div>
 
-      <Button variant="primary" onClick={onOpenSettings}>
-        {t("missingApiKeyBanner.openSettings")}
-      </Button>
+      <div className="flex flex-col gap-2">
+        <Button variant="primary" onClick={onOpenSettings}>
+          {invalid
+            ? t("invalidApiKeyBanner.openSettings")
+            : t("missingApiKeyBanner.openSettings")}
+        </Button>
+        {showUseDefault && (
+          <Button
+            variant="outlined"
+            onClick={onUseDefaultModel}
+            disabled={useDefaultModelPending}
+          >
+            {t("invalidApiKeyBanner.useDefaultModel")}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/clients/web/src/domains/chat/hooks/use-invalid-api-key-recovery.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-invalid-api-key-recovery.test.ts
@@ -1,0 +1,163 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactNode } from "react";
+
+const inferenceprofilePut = mock(async () => ({ data: {} }));
+const activeprofilePut = mock(async () => ({ data: {} }));
+const toastSuccess = mock((_msg: string) => {});
+const toastError = mock((_msg: string) => {});
+const setError = mock((_error: unknown) => {});
+const setPendingDraftProfile = mock((_id: string, _name: string) => {});
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  conversationsByIdInferenceprofilePut: inferenceprofilePut,
+  inferenceActiveprofilePut: activeprofilePut,
+}));
+
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: mock(() => {}),
+}));
+
+mock.module("@/lib/backwards-compat/complete-profile-snapshots", () => ({
+  useSupportsCompleteProfileSnapshots: () => true,
+}));
+
+mock.module("@/lib/backwards-compat/use-supports-active-profile-route", () => ({
+  useSupportsActiveProfileRoute: () => true,
+}));
+
+mock.module("@/domains/chat/chat-session-store", () => ({
+  useChatSessionStore: {
+    getState: () => ({ setError }),
+  },
+}));
+
+mock.module("@/stores/conversation-store", () => ({
+  useConversationStore: {
+    getState: () => ({ setPendingDraftProfile }),
+  },
+}));
+
+const configData = {
+  llm: {
+    activeProfile: "glm-5-2",
+    profileOrder: ["balanced", "glm-5-2"],
+    profiles: {
+      balanced: {
+        source: "managed",
+        provider: "fireworks",
+        model: "accounts/fireworks/models/glm-5p2",
+        label: "Balanced",
+      },
+      "glm-5-2": {
+        source: "user",
+        provider: "openai-compatible",
+        model: "glm-5-2",
+        label: "GLM",
+      },
+    },
+  },
+};
+
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  configGetOptions: () => ({
+    queryKey: ["config"],
+    queryFn: async () => configData,
+  }),
+  configGetQueryKey: () => ["config"],
+  conversationsByIdGetOptions: () => ({
+    queryKey: ["conversation"],
+    queryFn: async () => ({
+      conversation: { inferenceProfile: "glm-5-2" },
+    }),
+  }),
+  conversationsByIdGetQueryKey: () => ["conversation"],
+  inferenceProfilesGetQueryKey: () => ["inference-profiles"],
+}));
+
+import { useInvalidApiKeyRecovery } from "@/domains/chat/hooks/use-invalid-api-key-recovery";
+
+function wrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe("useInvalidApiKeyRecovery", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    inferenceprofilePut.mockClear();
+    activeprofilePut.mockClear();
+    toastSuccess.mockClear();
+    toastError.mockClear();
+    setError.mockClear();
+    setPendingDraftProfile.mockClear();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  test("pins the conversation and workspace default to a managed profile", async () => {
+    const { result } = renderHook(
+      () =>
+        useInvalidApiKeyRecovery({
+          assistantId: "asst-1",
+          conversationId: "conv-xyz",
+          isDraft: false,
+        }),
+      { wrapper: wrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.canUseDefaultModel).toBe(true);
+    });
+
+    await result.current.useDefaultModel();
+
+    expect(inferenceprofilePut).toHaveBeenCalledWith({
+      path: { assistant_id: "asst-1", id: "conv-xyz" },
+      body: { profile: "balanced" },
+      throwOnError: true,
+    });
+    expect(activeprofilePut).toHaveBeenCalledWith({
+      path: { assistant_id: "asst-1" },
+      body: { name: "balanced" },
+      throwOnError: true,
+    });
+    expect(setError).toHaveBeenCalledWith(null);
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  test("stashes a draft profile instead of writing the conversation override", async () => {
+    const { result } = renderHook(
+      () =>
+        useInvalidApiKeyRecovery({
+          assistantId: "asst-1",
+          conversationId: "draft-xyz",
+          isDraft: true,
+        }),
+      { wrapper: wrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.canUseDefaultModel).toBe(true);
+    });
+
+    await result.current.useDefaultModel();
+
+    expect(inferenceprofilePut).not.toHaveBeenCalled();
+    expect(setPendingDraftProfile).toHaveBeenCalledWith("draft-xyz", "balanced");
+    expect(activeprofilePut).toHaveBeenCalled();
+    expect(setError).toHaveBeenCalledWith(null);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-invalid-api-key-recovery.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-invalid-api-key-recovery.test.ts
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createElement, type ReactNode } from "react";
 
@@ -122,7 +122,9 @@ describe("useInvalidApiKeyRecovery", () => {
       expect(result.current.canUseDefaultModel).toBe(true);
     });
 
-    await result.current.useDefaultModel();
+    await act(async () => {
+      await result.current.useDefaultModel();
+    });
 
     expect(inferenceprofilePut).toHaveBeenCalledWith({
       path: { assistant_id: "asst-1", id: "conv-xyz" },
@@ -153,7 +155,9 @@ describe("useInvalidApiKeyRecovery", () => {
       expect(result.current.canUseDefaultModel).toBe(true);
     });
 
-    await result.current.useDefaultModel();
+    await act(async () => {
+      await result.current.useDefaultModel();
+    });
 
     expect(inferenceprofilePut).not.toHaveBeenCalled();
     expect(setPendingDraftProfile).toHaveBeenCalledWith("draft-xyz", "balanced");

--- a/clients/web/src/domains/chat/hooks/use-invalid-api-key-recovery.ts
+++ b/clients/web/src/domains/chat/hooks/use-invalid-api-key-recovery.ts
@@ -28,8 +28,8 @@ import { badRequestMessage } from "@/utils/api-errors";
 import { toast } from "@vellumai/design-library/components/toast";
 
 export interface UseInvalidApiKeyRecoveryArgs {
-  assistantId: string | null;
-  conversationId: string | undefined;
+  assistantId: string | null | undefined;
+  conversationId: string | null | undefined;
   isDraft: boolean;
 }
 

--- a/clients/web/src/domains/chat/hooks/use-invalid-api-key-recovery.ts
+++ b/clients/web/src/domains/chat/hooks/use-invalid-api-key-recovery.ts
@@ -1,0 +1,189 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
+
+import { useStickyProfiles } from "@/assistant/use-sticky-profiles";
+import { useChatSessionStore } from "@/domains/chat/chat-session-store";
+import {
+  orderedProfileEntries,
+  pickManagedRecoveryProfile,
+  type RecoveryProfileEntry,
+} from "@/domains/chat/utils/managed-recovery-profile";
+import {
+  configGetOptions,
+  configGetQueryKey,
+  conversationsByIdGetOptions,
+  conversationsByIdGetQueryKey,
+  inferenceProfilesGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  conversationsByIdInferenceprofilePut,
+  inferenceActiveprofilePut,
+} from "@/generated/daemon/sdk.gen";
+import { t } from "@/i18n";
+import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
+import { useSupportsActiveProfileRoute } from "@/lib/backwards-compat/use-supports-active-profile-route";
+import { captureError } from "@/lib/sentry/capture-error";
+import { useConversationStore } from "@/stores/conversation-store";
+import { badRequestMessage } from "@/utils/api-errors";
+import { toast } from "@vellumai/design-library/components/toast";
+
+export interface UseInvalidApiKeyRecoveryArgs {
+  assistantId: string | null;
+  conversationId: string | undefined;
+  isDraft: boolean;
+}
+
+export interface InvalidApiKeyRecovery {
+  canUseDefaultModel: boolean;
+  useDefaultModel: () => Promise<void>;
+  pending: boolean;
+}
+
+/**
+ * Recovers a chat turn that failed on a rejected personal API key by
+ * switching to a Vellum-managed profile. Conversation pin always; workspace
+ * `activeProfile` only when the current default is a user-owned profile.
+ */
+export function useInvalidApiKeyRecovery({
+  assistantId,
+  conversationId,
+  isDraft,
+}: UseInvalidApiKeyRecoveryArgs): InvalidApiKeyRecovery {
+  const queryClient = useQueryClient();
+  const [pending, setPending] = useState(false);
+  const requireOwnProviderAndModel = useSupportsCompleteProfileSnapshots();
+  const supportsActiveProfileRoute =
+    useSupportsActiveProfileRoute(assistantId);
+
+  const configQuery = useQuery({
+    ...configGetOptions({ path: { assistant_id: assistantId ?? "" } }),
+    enabled: !!assistantId,
+    staleTime: 30_000,
+  });
+  const conversationQuery = useQuery({
+    ...conversationsByIdGetOptions({
+      path: { assistant_id: assistantId ?? "", id: conversationId ?? "" },
+    }),
+    enabled: !!assistantId && !!conversationId && !isDraft,
+  });
+
+  const { profiles, profileOrder } = useStickyProfiles(
+    configQuery.data?.llm,
+    assistantId ?? undefined,
+  );
+  const globalActiveProfile = configQuery.data?.llm?.activeProfile ?? null;
+  const conversationProfileOverride =
+    conversationQuery.data?.conversation.inferenceProfile ?? null;
+
+  const entries = useMemo(
+    () =>
+      orderedProfileEntries(
+        profiles as Record<string, Omit<RecoveryProfileEntry, "name">>,
+        profileOrder,
+      ),
+    [profiles, profileOrder],
+  );
+
+  const excludeName =
+    conversationProfileOverride ?? globalActiveProfile ?? null;
+  const recoveryProfile = useMemo(
+    () =>
+      pickManagedRecoveryProfile(
+        entries,
+        { requireOwnProviderAndModel },
+        excludeName,
+      ),
+    [entries, excludeName, requireOwnProviderAndModel],
+  );
+
+  const activeEntry = globalActiveProfile
+    ? entries.find((entry) => entry.name === globalActiveProfile)
+    : undefined;
+  const shouldSwitchWorkspaceDefault = activeEntry?.source === "user";
+
+  const canUseDefaultModel =
+    !!assistantId &&
+    !!recoveryProfile &&
+    (!!conversationId || shouldSwitchWorkspaceDefault);
+
+  const useDefaultModel = useCallback(async () => {
+    if (!assistantId || !recoveryProfile) {
+      return;
+    }
+
+    setPending(true);
+    try {
+      if (conversationId && isDraft) {
+        useConversationStore
+          .getState()
+          .setPendingDraftProfile(conversationId, recoveryProfile);
+      } else if (conversationId) {
+        await conversationsByIdInferenceprofilePut({
+          path: { assistant_id: assistantId, id: conversationId },
+          body: { profile: recoveryProfile },
+          throwOnError: true,
+        });
+        void queryClient.invalidateQueries({
+          queryKey: conversationsByIdGetQueryKey({
+            path: { assistant_id: assistantId, id: conversationId },
+          }),
+        });
+      }
+
+      if (shouldSwitchWorkspaceDefault && supportsActiveProfileRoute) {
+        try {
+          await inferenceActiveprofilePut({
+            path: { assistant_id: assistantId },
+            body: { name: recoveryProfile },
+            throwOnError: true,
+          });
+        } catch (error) {
+          // Conversation pin is enough to unblock this chat. A workspace
+          // default that cannot be rewritten is not a failed recovery.
+          captureError(error, {
+            context: "invalid-api-key-recovery-active-profile",
+          });
+        }
+      }
+
+      void queryClient.invalidateQueries({
+        queryKey: configGetQueryKey({
+          path: { assistant_id: assistantId },
+        }),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: inferenceProfilesGetQueryKey({
+          path: { assistant_id: assistantId },
+        }),
+      });
+
+      useChatSessionStore.getState().setError(null);
+      const label =
+        entries.find((entry) => entry.name === recoveryProfile)?.label ??
+        recoveryProfile;
+      toast.success(
+        t("chat:invalidApiKeyBanner.switchedToDefault", { profile: label }),
+      );
+    } catch (error) {
+      toast.error(
+        badRequestMessage(error) ?? t("chat:invalidApiKeyBanner.switchFailed"),
+      );
+      if (!badRequestMessage(error)) {
+        captureError(error, { context: "invalid-api-key-recovery" });
+      }
+    } finally {
+      setPending(false);
+    }
+  }, [
+    assistantId,
+    conversationId,
+    entries,
+    isDraft,
+    queryClient,
+    recoveryProfile,
+    shouldSwitchWorkspaceDefault,
+    supportsActiveProfileRoute,
+  ]);
+
+  return { canUseDefaultModel, useDefaultModel, pending };
+}

--- a/clients/web/src/domains/chat/utils/error-classification.test.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getChatBillingBannerDecision,
+  isApiKeyRecoveryChatError,
   isCreditsExhaustedProviderError,
+  isInvalidApiKeyChatError,
   isManagedCredentialChatError,
+  isMissingApiKeyChatError,
   resolveComposerBillingBanner,
   shouldShowGenericChatErrorNotice,
   shouldSuppressGenericChatErrorNotice,
@@ -74,6 +77,28 @@ describe("chat error classification", () => {
     expect(getChatBillingBannerDecision(error)).toBeNull();
     expect(shouldSuppressGenericChatErrorNotice(error)).toBe(false);
     expect(shouldShowGenericChatErrorNotice(error)).toBe(true);
+  });
+
+  test("routes a missing API key through the dedicated recovery banner", () => {
+    const error = { code: "PROVIDER_NOT_CONFIGURED" };
+
+    expect(isMissingApiKeyChatError(error)).toBe(true);
+    expect(isApiKeyRecoveryChatError(error)).toBe(true);
+    expect(shouldSuppressGenericChatErrorNotice(error)).toBe(true);
+    expect(shouldShowGenericChatErrorNotice(error)).toBe(false);
+  });
+
+  test("routes a rejected personal API key through the dedicated recovery banner", () => {
+    // PROVIDER_INVALID_KEY is distinct from a missing key: the user already
+    // chose a profile, and Doctor is the wrong next step. The composer
+    // banner owns Settings / switch-to-default recovery.
+    const error = { code: "PROVIDER_INVALID_KEY" };
+
+    expect(isInvalidApiKeyChatError(error)).toBe(true);
+    expect(isApiKeyRecoveryChatError(error)).toBe(true);
+    expect(isMissingApiKeyChatError(error)).toBe(false);
+    expect(shouldSuppressGenericChatErrorNotice(error)).toBe(true);
+    expect(shouldShowGenericChatErrorNotice(error)).toBe(false);
   });
 
   test("routes managed key failures through the generic Doctor-capable notice", () => {

--- a/clients/web/src/domains/chat/utils/error-classification.ts
+++ b/clients/web/src/domains/chat/utils/error-classification.ts
@@ -13,6 +13,7 @@ export type ChatBillingBannerDecision =
 
 const PROVIDER_BILLING_CODE = "PROVIDER_BILLING";
 const PROVIDER_NOT_CONFIGURED_CODE = "PROVIDER_NOT_CONFIGURED";
+const PROVIDER_INVALID_KEY_CODE = "PROVIDER_INVALID_KEY";
 const MANAGED_KEY_INVALID_CODE = "MANAGED_KEY_INVALID";
 const MANAGED_CREDITS_EXHAUSTED_CATEGORY = "credits_exhausted";
 const PROVIDER_BILLING_CATEGORY = "provider_billing";
@@ -159,12 +160,35 @@ export function resolveComposerBillingBanner(args: {
   return args.isLowBalance && !args.dismissed ? "low_balance" : null;
 }
 
+export function isMissingApiKeyChatError(
+  error: ChatErrorLike | null | undefined,
+): boolean {
+  return error?.code === PROVIDER_NOT_CONFIGURED_CODE;
+}
+
+export function isInvalidApiKeyChatError(
+  error: ChatErrorLike | null | undefined,
+): boolean {
+  return error?.code === PROVIDER_INVALID_KEY_CODE;
+}
+
+/**
+ * Errors whose dedicated composer banner owns recovery (Open Settings,
+ * and for a rejected personal key, switch to a managed default). The
+ * generic notice must stay hidden so Doctor is not the default action.
+ */
+export function isApiKeyRecoveryChatError(
+  error: ChatErrorLike | null | undefined,
+): boolean {
+  return isMissingApiKeyChatError(error) || isInvalidApiKeyChatError(error);
+}
+
 export function shouldSuppressGenericChatErrorNotice(
   error: ChatErrorLike | null | undefined,
 ): boolean {
   return (
     getChatBillingBannerDecision(error) !== null ||
-    error?.code === PROVIDER_NOT_CONFIGURED_CODE ||
+    isApiKeyRecoveryChatError(error) ||
     error?.displayAs === "modal"
   );
 }

--- a/clients/web/src/domains/chat/utils/managed-recovery-profile.test.ts
+++ b/clients/web/src/domains/chat/utils/managed-recovery-profile.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  orderedProfileEntries,
+  pickManagedRecoveryProfile,
+} from "@/domains/chat/utils/managed-recovery-profile";
+
+const DISPATCHABLE = { requireOwnProviderAndModel: true } as const;
+
+describe("orderedProfileEntries", () => {
+  test("follows profileOrder then appends extras", () => {
+    expect(
+      orderedProfileEntries(
+        {
+          quality: { source: "managed" },
+          balanced: { source: "managed" },
+          custom: { source: "user" },
+        },
+        ["balanced", "quality"],
+      ).map((entry) => entry.name),
+    ).toEqual(["balanced", "quality", "custom"]);
+  });
+});
+
+describe("pickManagedRecoveryProfile", () => {
+  test("prefers the shipped balanced profile when it can dispatch", () => {
+    const entries = orderedProfileEntries(
+      {
+        quality: {
+          source: "managed",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+        balanced: {
+          source: "managed",
+          provider: "fireworks",
+          model: "accounts/fireworks/models/glm-5p2",
+        },
+        custom: {
+          source: "user",
+          provider: "openai-compatible",
+          model: "glm-5-2",
+        },
+      },
+      ["quality", "custom", "balanced"],
+    );
+
+    expect(pickManagedRecoveryProfile(entries, DISPATCHABLE, "custom")).toBe(
+      "balanced",
+    );
+  });
+
+  test("skips the excluded profile and user-owned keys", () => {
+    const entries = orderedProfileEntries(
+      {
+        balanced: {
+          source: "user",
+          provider: "openai-compatible",
+          model: "glm-5-2",
+        },
+        quality: {
+          source: "managed",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+      },
+      ["balanced", "quality"],
+    );
+
+    expect(pickManagedRecoveryProfile(entries, DISPATCHABLE, "balanced")).toBe(
+      "quality",
+    );
+  });
+
+  test("returns null when no managed profile can dispatch", () => {
+    const entries = orderedProfileEntries(
+      {
+        custom: {
+          source: "user",
+          provider: "openai-compatible",
+          model: "glm-5-2",
+        },
+        broken: { source: "managed" },
+      },
+      ["custom", "broken"],
+    );
+
+    expect(pickManagedRecoveryProfile(entries, DISPATCHABLE)).toBeNull();
+  });
+
+  test("returns the first dispatchable managed profile when balanced is absent", () => {
+    const entries = orderedProfileEntries(
+      {
+        quality: {
+          source: "managed",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+        fast: {
+          source: "managed",
+          provider: "openai",
+          model: "gpt-5.4-mini",
+        },
+      },
+      ["quality", "fast"],
+    );
+
+    expect(pickManagedRecoveryProfile(entries, DISPATCHABLE)).toBe("quality");
+  });
+});

--- a/clients/web/src/domains/chat/utils/managed-recovery-profile.ts
+++ b/clients/web/src/domains/chat/utils/managed-recovery-profile.ts
@@ -1,0 +1,57 @@
+/**
+ * Picks a Vellum-managed profile the invalid-key banner can switch to.
+ *
+ * A rejected personal (BYOK) key must stay on the selected custom profile so
+ * the user can fix the credential. Recovery is an explicit switch to a
+ * managed profile that can dispatch, not a silent provider fallback.
+ */
+
+import {
+  isDispatchableProfile,
+  type ProfileDispatchOptions,
+  type ProfilePickerEntry,
+} from "@/assistant/profile-pickers";
+
+const PREFERRED_MANAGED_PROFILE = "balanced";
+
+export type RecoveryProfileEntry = ProfilePickerEntry & {
+  readonly source?: "managed" | "user" | null;
+};
+
+export function orderedProfileEntries(
+  profiles: Record<string, Omit<RecoveryProfileEntry, "name">>,
+  profileOrder: readonly string[],
+): RecoveryProfileEntry[] {
+  const ordered = profileOrder
+    .filter((name) => name in profiles)
+    .map((name) => ({ name, ...profiles[name]! }));
+  const extras = Object.keys(profiles)
+    .filter((name) => !profileOrder.includes(name))
+    .map((name) => ({ name, ...profiles[name]! }));
+  return [...ordered, ...extras];
+}
+
+/**
+ * First dispatchable managed profile, preferring the shipped `balanced`
+ * default when that entry is usable. `excludeName` drops the profile the
+ * failed turn already used so recovery cannot reselect the broken key.
+ */
+export function pickManagedRecoveryProfile(
+  entries: ReadonlyArray<RecoveryProfileEntry>,
+  options: ProfileDispatchOptions,
+  excludeName?: string | null,
+): string | null {
+  const candidates = entries.filter(
+    (entry) =>
+      entry.source === "managed" &&
+      entry.name !== excludeName &&
+      isDispatchableProfile(entry, entries, options),
+  );
+  if (candidates.length === 0) {
+    return null;
+  }
+  const preferred = candidates.find(
+    (entry) => entry.name === PREFERRED_MANAGED_PROFILE,
+  );
+  return (preferred ?? candidates[0])?.name ?? null;
+}

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx
@@ -270,6 +270,9 @@ describe("useVoiceRoomSight: parking a keep", () => {
 
   test("the newest keep replaces the one before it, and gives its preview back", async () => {
     const revoke = spyOn(URL, "revokeObjectURL");
+    // Two keeps can share a Date.now() millisecond in CI. Capture order,
+    // not wall clock, decides which frame stays parked.
+    const now = spyOn(Date, "now").mockImplementation(() => 1_700_000_000_000);
     const { view } = renderSight();
 
     await keepFrame();
@@ -281,6 +284,7 @@ describe("useVoiceRoomSight: parking a keep", () => {
     expect(controls.attachFrame).toHaveBeenNthCalledWith(2, "att-2");
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-2");
     expect(revoke).toHaveBeenCalledWith(first!.previewUrl);
+    now.mockRestore();
     revoke.mockRestore();
   });
 

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
@@ -107,6 +107,11 @@ export interface VoiceRoomSightOptions {
 interface HeldFrame extends VoiceRoomSightFrame {
   /** Session generation at capture. A frame never crosses sessions. */
   readonly sessionGeneration: number;
+  /**
+   * Capture order for this hook instance. `Date.now()` can stamp two keeps
+   * with the same millisecond, and `>=` would then drop the newer one.
+   */
+  readonly captureSeq: number;
 }
 
 export function useVoiceRoomSight(
@@ -123,6 +128,7 @@ export function useVoiceRoomSight(
   const heldRef = useRef<HeldFrame | null>(null);
   const gateRef = useRef<FrameGate | null>(null);
   const frameCountRef = useRef(0);
+  const captureSeqRef = useRef(0);
   /**
    * Which camera and transport this capture chain feeds. Bumped when sampling
    * stops, when the camera flips, and when the transport drops into a
@@ -167,6 +173,7 @@ export function useVoiceRoomSight(
       // neither can be re-read afterwards without describing the wrong one.
       const sessionGeneration = useLiveVoiceStore.getState().sessionGeneration;
       const captureEpoch = captureEpochRef.current;
+      const captureSeq = ++captureSeqRef.current;
       const atMs = Date.now();
       try {
         frameCountRef.current += 1;
@@ -218,11 +225,13 @@ export function useVoiceRoomSight(
           abandonUpload();
           return;
         }
-        // Latest wins by CAPTURE time, not by resolve order: two uploads can be
-        // in flight and the slower one is not the newer view. Losing here is
-        // the whole cost of a superseded frame, so it is simply dropped.
+        // Latest wins by CAPTURE order, not by resolve order: two uploads can
+        // be in flight and the slower one is not the newer view. Losing here
+        // is the whole cost of a superseded frame, so it is simply dropped.
+        // Sequence, not wall clock: two keeps in the same millisecond are
+        // still ordered.
         const held = heldRef.current;
-        if (held && held.atMs >= atMs) {
+        if (held && held.captureSeq >= captureSeq) {
           abandonUpload();
           return;
         }
@@ -240,6 +249,7 @@ export function useVoiceRoomSight(
           atMs,
           previewUrl: URL.createObjectURL(frame),
           sessionGeneration,
+          captureSeq,
         });
       } catch (cause) {
         // Best effort by design: nobody asked for this frame, so a failure

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1079,6 +1079,17 @@
     "description": "Voice input requires microphone access. Audio is transcribed by your configured speech-to-text provider, or by your device's built-in dictation when no provider is set.",
     "title": "Microphone Access"
   },
+  "invalidApiKeyBanner": {
+    "ariaLabel": "Invalid API key",
+    "body": "This model's personal API key was rejected. Update it in Settings → Models & Services, or switch to a default model to keep chatting.",
+    "dismiss": "Dismiss",
+    "dismissAria": "Dismiss invalid API key alert",
+    "openSettings": "Open Settings",
+    "switchFailed": "Couldn't switch to a default model. Try Settings → Models & Services.",
+    "switchedToDefault": "Switched to {profile}. You can send again.",
+    "title": "Invalid API key",
+    "useDefaultModel": "Use default model"
+  },
   "missingApiKeyBanner": {
     "ariaLabel": "API key required",
     "body": "Add an API key in Settings → Models & Services to start chatting.",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1079,6 +1079,17 @@
     "description": "La entrada de voz requiere acceso al micrófono. El audio lo transcribe tu proveedor de voz a texto configurado, o el dictado integrado del dispositivo cuando no hay proveedor.",
     "title": "Acceso al micrófono"
   },
+  "invalidApiKeyBanner": {
+    "ariaLabel": "Clave API no válida",
+    "body": "La clave API personal de este modelo fue rechazada. Actualízala en Ajustes → Modelos y servicios, o cambia a un modelo predeterminado para seguir chateando.",
+    "dismiss": "Descartar",
+    "dismissAria": "Descartar la alerta de clave API no válida",
+    "openSettings": "Abrir ajustes",
+    "switchFailed": "No se pudo cambiar al modelo predeterminado. Prueba en Ajustes → Modelos y servicios.",
+    "switchedToDefault": "Cambiado a {profile}. Ya puedes enviar de nuevo.",
+    "title": "Clave API no válida",
+    "useDefaultModel": "Usar modelo predeterminado"
+  },
   "missingApiKeyBanner": {
     "ariaLabel": "Se requiere una clave API",
     "body": "Añade una clave API en Ajustes → Modelos y servicios para empezar a chatear.",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -617,6 +617,17 @@
     "v3SourceNeedle": "needle",
     "yes": "Да"
   },
+  "invalidApiKeyBanner": {
+    "ariaLabel": "Недействительный API-ключ",
+    "body": "Персональный API-ключ этой модели отклонён. Обновите его в Настройки → Модели и сервисы или переключитесь на модель по умолчанию, чтобы продолжить.",
+    "dismiss": "Закрыть",
+    "dismissAria": "Закрыть предупреждение о недействительном API-ключе",
+    "openSettings": "Открыть настройки",
+    "switchFailed": "Не удалось переключиться на модель по умолчанию. Откройте Настройки → Модели и сервисы.",
+    "switchedToDefault": "Переключено на {profile}. Можно отправить снова.",
+    "title": "Недействительный API-ключ",
+    "useDefaultModel": "Использовать модель по умолчанию"
+  },
   "mobileCallSelector": {
     "callOfTotal": "Вызов {number} из {total}",
     "llmCallCount": "{count, plural, one {1 вызов LLM} few {# вызова LLM} many {# вызовов LLM} other {# вызова LLM}}",

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -1057,6 +1057,17 @@
     "description": "語音輸入需要麥克風存取權限。音訊將由您設定的語音轉文字供應商轉錄，如果未設定供應商，則由您裝置的內建聽寫功能轉錄。",
     "title": "麥克風存取權限"
   },
+  "invalidApiKeyBanner": {
+    "ariaLabel": "API 金鑰無效",
+    "body": "此模型的個人 API 金鑰被拒絕。請在設定 → 模型與服務中更新該金鑰，或切換到預設模型以繼續聊天。",
+    "dismiss": "關閉",
+    "dismissAria": "關閉 API 金鑰無效的提示",
+    "openSettings": "開啟設定",
+    "switchFailed": "無法切換到預設模型。請前往設定 → 模型與服務。",
+    "switchedToDefault": "已切換到 {profile}。可以重新傳送。",
+    "title": "API 金鑰無效",
+    "useDefaultModel": "使用預設模型"
+  },
   "missingApiKeyBanner": {
     "ariaLabel": "需要 API 金鑰",
     "body": "請在「設定」→「模型與服務」中新增 API 金鑰以開始聊天。",

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -1057,6 +1057,17 @@
     "description": "语音输入需要麦克风访问权限。音频将由您配置的语音转文本提供商转录，如果未设置提供商，则由您设备的内置听写功能转录。",
     "title": "麦克风访问权限"
   },
+  "invalidApiKeyBanner": {
+    "ariaLabel": "API 密钥无效",
+    "body": "此模型的个人 API 密钥被拒绝。请在设置 → 模型与服务中更新该密钥，或切换到默认模型以继续聊天。",
+    "dismiss": "忽略",
+    "dismissAria": "忽略 API 密钥无效的提醒",
+    "openSettings": "打开设置",
+    "switchFailed": "无法切换到默认模型。请前往设置 → 模型与服务。",
+    "switchedToDefault": "已切换到 {profile}。可以重新发送。",
+    "title": "API 密钥无效",
+    "useDefaultModel": "使用默认模型"
+  },
   "missingApiKeyBanner": {
     "ariaLabel": "需要 API 密钥",
     "body": "请在“设置”→“模型与服务”中添加 API 密钥以开始聊天。",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Deep-usage dropoff investigation for 2026-08-31 (ET). A user sent one real standard message that failed immediately with `PROVIDER_INVALID_KEY` on a custom OpenAI-compatible profile. Managed Fireworks call sites (`homeGreeting`, `conversationStarters`, `replySuggestion`) succeeded in the same minute. The product intentionally does not auto-fallback a rejected personal (BYOK) key, because that would silently reroute onto a differently billed path. The chat UI still treated the failure as a generic error whose default action is Doctor, not Settings, so recovery was a dead end on iOS.

This PR does **not** add silent BYOK fallback. It wires the recovery surface the daemon classification already describes: a dedicated invalid-key banner, suppress the generic Doctor notice, Open Settings, and an explicit "Use default model" action when a Vellum-managed profile can dispatch.

## Summary
- Treat `PROVIDER_INVALID_KEY` like `PROVIDER_NOT_CONFIGURED` for generic-notice suppression.
- Show a composer banner with "Invalid API key" copy, Open Settings, and (when a managed profile exists) Use default model.
- Use default model pins the conversation to a managed profile (preferring `balanced`) and, if the workspace default is a user-owned profile, also updates `llm.activeProfile`.
- Daemon retry / no-BYOK-fallback policy is unchanged.
- Unrelated CI flake: voice sight kept frames in the same `Date.now()` millisecond dropped the newer keep. Capture order is now a per-hook sequence.

## Test plan
- Focused web tests (256 pass / 0 fail):
  - `clients/web` `bun test src/domains/chat/utils/error-classification.test.ts src/domains/chat/utils/managed-recovery-profile.test.ts src/domains/chat/components/missing-api-key-banner.test.tsx src/domains/chat/components/composer-notices.test.tsx src/domains/chat/hooks/use-invalid-api-key-recovery.test.ts src/i18n/catalogs.test.ts`
- `cd clients/web && bunx tsc --noEmit` (pass after widening hook args to accept `string | null`)
- `cd clients/web && bun test src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx` (pass, including same-millisecond replacement)

## Risk
- Low: UI-only recovery path. A rejected personal key still surfaces; switching models is an explicit user action.
- Workspace `activeProfile` is updated only when the current default is `source: "user"`, so a managed default is left alone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ba2e879-d436-4e0d-a482-7feffa9b14b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ba2e879-d436-4e0d-a482-7feffa9b14b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

