### PR TITLE
feat(tools): raise the file-read window to 100k chars and exempt file reads from result-time spooling

### DIFF
--- a/assistant/src/__tests__/file-ops-service.test.ts
+++ b/assistant/src/__tests__/file-ops-service.test.ts
@@ -10,7 +10,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { THRESHOLD_CHARS } from "../context/post-turn-tool-result-truncation.js";
+import { FILE_READ_TOOL_NAMES } from "../context/post-turn-tool-result-truncation.js";
+import { RESULT_TIME_SPOOL_EXEMPT_TOOLS } from "../context/tool-result-spool.js";
 import {
   FileSystemOps,
   type PathPolicy,
@@ -330,8 +331,12 @@ describe("FileSystemOps.readFileSafe", () => {
     expect(body).toBe("abcd");
   });
 
-  test("the read budget stays under the tool-result spool threshold", () => {
-    expect(READ_CHAR_BUDGET).toBeLessThan(THRESHOLD_CHARS);
+  test("file reads are result-time spool-exempt so a full window survives its turn", () => {
+    // The budget exceeds the spool threshold, so without the exemption a
+    // default read of a large file would be stubbed before the model saw it.
+    for (const name of FILE_READ_TOOL_NAMES) {
+      expect(RESULT_TIME_SPOOL_EXEMPT_TOOLS.has(name)).toBe(true);
+    }
   });
 });
 

--- a/assistant/src/__tests__/tool-result-spool.test.ts
+++ b/assistant/src/__tests__/tool-result-spool.test.ts
@@ -140,11 +140,12 @@ describe("spoolAndStubOversizedToolResults", () => {
     expect(existsSync(join(convDir, TOOL_RESULT_DIR))).toBe(false);
   });
 
-  test("spools an oversized file read of an ordinary path", () => {
+  test("leaves an oversized file read of an ordinary path inline (explicit self-sized read)", () => {
     const blocks = [
       makeToolResult(LONG, "tu_read"),
       makeToolResult(LONG, "tu_host_read"),
     ];
+    const originals = blocks.map((b) => b);
 
     const count = spoolAndStubOversizedToolResults(blocks, {
       conversationDir: convDir,
@@ -154,13 +155,9 @@ describe("spoolAndStubOversizedToolResults", () => {
           : { name: "host_file_read", input: { path: "/Users/me/notes.md" } },
     });
 
-    expect(count).toBe(2);
-    expect((blocks[0] as { content: string }).content).toContain(
-      TRUNCATION_MARKER,
-    );
-    expect((blocks[1] as { content: string }).content).toContain(
-      TRUNCATION_MARKER,
-    );
+    expect(count).toBe(0);
+    expect(blocks).toEqual(originals);
+    expect(existsSync(join(convDir, TOOL_RESULT_DIR))).toBe(false);
   });
 
   test("leaves a file read of a spooled .tool-results path inline", () => {

--- a/assistant/src/context/tool-result-spool.ts
+++ b/assistant/src/context/tool-result-spool.ts
@@ -20,15 +20,22 @@ const AX_TREE_TAG = "<ax-tree>";
 
 /**
  * Tools whose results are explicit, self-sized reads the model paginates
- * itself: `web_fetch` takes `max_chars`/`start_index` and reports a
- * "Character Window: X-Y of Z", so the model pages by character index against
- * the window it requested. Stubbing such a result at result time hands the
- * model ~a tenth of the window it just sized — and it keeps paging blind
- * against content it never saw. Like the file-read tools, these explicit
- * reads are honored in full for the turn that made them; the post-turn pass
- * still truncates them at turn end, after the model has consumed the content.
+ * itself: each takes `max_chars`/`start_index` and reports where its window
+ * ended (`web_fetch`'s "Character Window: X-Y of Z", the file-read tools'
+ * "[Truncated: characters X-Y of Z]" notice), so the model pages by character
+ * index against the window it requested. Stubbing such a result at result
+ * time would hand the model a fraction of the window it just sized — and it
+ * keeps paging blind against content it never saw. These reads are honored in
+ * full for the turn that made them; the post-turn pass still truncates them
+ * at turn end, after the model has consumed the content. This exemption is
+ * also what lets `READ_CHAR_BUDGET` exceed `THRESHOLD_CHARS` without a fresh
+ * read being stubbed before the model sees it.
  */
-export const RESULT_TIME_SPOOL_EXEMPT_TOOLS = new Set<string>(["web_fetch"]);
+export const RESULT_TIME_SPOOL_EXEMPT_TOOLS = new Set<string>([
+  "web_fetch",
+  "file_read",
+  "host_file_read",
+]);
 
 /**
  * Whether a tool result is eligible for the result-time spool/stub pass: the
@@ -39,12 +46,12 @@ export const RESULT_TIME_SPOOL_EXEMPT_TOOLS = new Set<string>(["web_fetch"]);
  * The spooled-read exemption is what keeps paging possible: a file read is the
  * model's only way to pull spooled content back into context, so stubbing a
  * read of a `.tool-results/` file would write a fresh copy and hand back
- * another stub, putting that content out of reach for good. It is scoped by
- * target path rather than by tool name, because a file read aimed anywhere
- * else is ordinary oversized output with no such circularity, and exempting it
- * keeps a whole file inline on every LLM call for the rest of the turn.
- * Explicit self-sized reads are honored in full; the post-turn pass still
- * truncates them at turn end, after the model has consumed the content.
+ * another stub, putting that content out of reach for good. The file-read
+ * tools are also name-exempt as explicit self-sized reads, but this
+ * path-scoped guarantee stands on its own so spooled content stays reachable
+ * regardless of how the exempt-tools set evolves. Explicit self-sized reads
+ * are honored in full; the post-turn pass still truncates them at turn end,
+ * after the model has consumed the content.
  */
 function isSpoolEligible(
   tr: ToolResultContent,

--- a/assistant/src/tools/filesystem/read.ts
+++ b/assistant/src/tools/filesystem/read.ts
@@ -45,7 +45,7 @@ export const fileReadInputSchema = z.looseObject({
   max_chars: z
     .number()
     .describe(
-      "Maximum number of characters to read. Defaults to 20000, which is also the ceiling. Text files only.",
+      "Maximum number of characters to read. Defaults to 100000, which is also the ceiling. Text files only.",
     )
     .optional()
     .catch(undefined),
@@ -61,7 +61,7 @@ export const fileReadInputSchema = z.looseObject({
 export const fileReadTool = {
   name: "file_read",
   description:
-    "Read the contents of a file on your own machine. Text reads return the first 20000 characters unless you pass `max_chars`; when a read stops short the result says so, and `start_index` pages on from there. To find where something is in a large file, code_search is cheaper than paging through it. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis. For audio files (MP3, WAV, OGG, FLAC, AAC, M4A), returns the audio for listening. Use host_file_read for files on your guardian's device instead.",
+    "Read the contents of a file on your own machine. Text reads return the first 100000 characters unless you pass `max_chars`; when a read stops short the result says so, and `start_index` pages on from there. To find where something is in a large file, code_search is cheaper than paging through it. For image files (JPEG, PNG, GIF, WebP), returns the image for visual analysis. For audio files (MP3, WAV, OGG, FLAC, AAC, M4A), returns the audio for listening. Use host_file_read for files on your guardian's device instead.",
   category: "filesystem",
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,

--- a/assistant/src/tools/host-filesystem/read.ts
+++ b/assistant/src/tools/host-filesystem/read.ts
@@ -53,7 +53,7 @@ export const hostFileReadInputSchema = z.looseObject({
   max_chars: z
     .number()
     .describe(
-      "Maximum number of characters to read. Defaults to 20000, which is also the ceiling. Text files only.",
+      "Maximum number of characters to read. Defaults to 100000, which is also the ceiling. Text files only.",
     )
     .optional()
     .catch(undefined),
@@ -69,7 +69,7 @@ export const hostFileReadInputSchema = z.looseObject({
 export const hostFileReadTool = {
   name: "host_file_read",
   description:
-    "Read the contents of a file on your guardian's device, including images (JPEG, PNG, GIF, WebP) and audio (MP3, WAV, OGG, FLAC, AAC, M4A). Text reads return the first 20000 characters unless you pass `max_chars`; when a read stops short the result says so, and `start_index` pages on from there. For files on your own machine, use file_read instead.",
+    "Read the contents of a file on your guardian's device, including images (JPEG, PNG, GIF, WebP) and audio (MP3, WAV, OGG, FLAC, AAC, M4A). Text reads return the first 100000 characters unless you pass `max_chars`; when a read stops short the result says so, and `start_index` pages on from there. For files on your own machine, use file_read instead.",
   category: "host-filesystem",
   executionTarget: "host",
   defaultRiskLevel: RiskLevel.Medium,

--- a/assistant/src/tools/shared/filesystem/file-ops-service.ts
+++ b/assistant/src/tools/shared/filesystem/file-ops-service.ts
@@ -78,12 +78,15 @@ function pathError(
 }
 
 /**
- * Characters returned by a read that names no `max_chars`. Stays under
- * `THRESHOLD_CHARS` in `context/post-turn-tool-result-truncation.ts`, which
- * spools any larger tool result to disk and replaces it inline with a short
- * stub, so a default read returns content rather than a stub.
+ * Characters returned by a read that names no `max_chars`, and the ceiling for
+ * one that does. File reads are exempt from the result-time spool pass
+ * (`RESULT_TIME_SPOOL_EXEMPT_TOOLS` in `context/tool-result-spool.ts`), so the
+ * full window reaches the model for the turn that read it; the post-turn pass
+ * compacts oversized results to recoverable stubs at turn end, and the
+ * `tool-result-truncate` plugin bounds any single result against the model's
+ * context window.
  */
-export const READ_CHAR_BUDGET = 20_000;
+export const READ_CHAR_BUDGET = 100_000;
 
 /**
  * Trailing marker appended when a read stops short of the end of the file. A
@@ -169,8 +172,8 @@ export class FileSystemOps {
     try {
       const raw = await readFile(filePath, "utf-8");
 
-      // A ceiling, not just a default: a larger window would be spooled to
-      // disk and replaced with a stub, returning less than this.
+      // A ceiling, not just a default: an uncapped `max_chars` would put an
+      // arbitrarily large file inline in a single result.
       const maxChars = Math.min(
         READ_CHAR_BUDGET,
         Math.max(0, input.maxChars ?? READ_CHAR_BUDGET),

--- a/bun.lock
+++ b/bun.lock
@@ -669,8 +669,8 @@
     "@playwright/browser-chromium",
   ],
   "patchedDependencies": {
-    "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch",
     "app-builder-lib@26.8.1": "patches/app-builder-lib@26.8.1.patch",
+    "@capacitor-community/camera-preview@8.0.1": "patches/@capacitor-community%2Fcamera-preview@8.0.1.patch",
     "storybook@10.4.0": "patches/storybook@10.4.0.patch",
   },
   "overrides": {

--- a/packages/electron-desktop/src/host-proxy/executors/host-file-executor.test.ts
+++ b/packages/electron-desktop/src/host-proxy/executors/host-file-executor.test.ts
@@ -183,28 +183,28 @@ describe("host-file-executor", () => {
     test("caps an unbounded read at the character budget and says so", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "big.txt");
-      const total = 20_500;
+      const total = 100_500;
       fs.writeFileSync(filePath, "x".repeat(total));
 
       const result = __testing.executeRead({ path: filePath });
       const [body] = result.content!.split("\n\n[Truncated:");
-      expect(body).toHaveLength(20_000);
+      expect(body).toHaveLength(100_000);
       expect(result.content).toContain(
-        `[Truncated: characters 0-20000 of ${total}. Read on with start_index=20000.]`,
+        `[Truncated: characters 0-100000 of ${total}. Read on with start_index=100000.]`,
       );
     });
 
     test("a maxChars above the budget is clamped to it", () => {
       const dir = freshTmpDir();
       const filePath = path.join(dir, "big.txt");
-      fs.writeFileSync(filePath, "x".repeat(20_500));
+      fs.writeFileSync(filePath, "x".repeat(100_500));
 
       const result = __testing.executeRead({
         path: filePath,
-        maxChars: 20_500,
+        maxChars: 100_500,
       });
       const [body] = result.content!.split("\n\n[Truncated:");
-      expect(body).toHaveLength(20_000);
+      expect(body).toHaveLength(100_000);
     });
 
     test("reads text file and returns content", () => {

--- a/packages/electron-desktop/src/host-proxy/executors/host-file-executor.ts
+++ b/packages/electron-desktop/src/host-proxy/executors/host-file-executor.ts
@@ -29,7 +29,7 @@ const DENIED_BASENAMES = new Set([".backup.key", "backup.key"]);
  * `tools/shared/filesystem/file-ops-service.ts`, which owns the value and the
  * wording of the notice below.
  */
-const READ_CHAR_BUDGET = 20_000;
+const READ_CHAR_BUDGET = 100_000;
 
 const isHighSurrogate = (code: number): boolean =>
   code >= 0xd800 && code <= 0xdbff;


### PR DESCRIPTION
## Summary
- Raises READ_CHAR_BUDGET from 20k to 100k characters in the shared file-ops service, updates the documented mirror constant in the Electron host-file executor, and updates both tool descriptions and schemas to match.
- Adds file_read and host_file_read to RESULT_TIME_SPOOL_EXEMPT_TOOLS. These reads are explicit self-sized windows, and the raised budget exceeds THRESHOLD_CHARS (25k), so without the exemption a fresh read would be stubbed at result time before the model consumed it. The post-turn pass still compacts oversized results at turn end.
- All touched suites pass (47 assistant + 45 electron-desktop tests); assistant and electron-desktop typechecks are clean. The bun.lock hunk is a no-op key reordering.

## Original prompt
The working tree on a machine hosting a live assistant instance carried these uncommitted changes; the user asked to merge them to main so the instance can be restarted on clean, current main as part of aligning a mixed-version daemon/worker deployment.