### PR TITLE
fix(web): deflake the voice-sight newest-keep test with a stepped clock

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx
@@ -269,6 +269,12 @@ describe("useVoiceRoomSight: parking a keep", () => {
   });
 
   test("the newest keep replaces the one before it, and gives its preview back", async () => {
+    // Real keeps sit a rate floor apart; these two can land in the same
+    // `Date.now()` millisecond, where latest-wins reads the second as a tie
+    // and refuses it. Step the clock so capture order is visible to it.
+    const base = Date.now();
+    let tick = 0;
+    const clock = spyOn(Date, "now").mockImplementation(() => base + ++tick);
     const revoke = spyOn(URL, "revokeObjectURL");
     const { view } = renderSight();
 
@@ -281,6 +287,7 @@ describe("useVoiceRoomSight: parking a keep", () => {
     expect(controls.attachFrame).toHaveBeenNthCalledWith(2, "att-2");
     expect(view.result.current.heldFrame?.attachmentId).toBe("att-2");
     expect(revoke).toHaveBeenCalledWith(first!.previewUrl);
+    clock.mockRestore();
     revoke.mockRestore();
   });
 


### PR DESCRIPTION
## Summary
- Deflakes the `useVoiceRoomSight` test "the newest keep replaces the one before it, and gives its preview back", which broke CI Main Web on `main` (run 33496562026): two back-to-back keeps can stamp the same `Date.now()` millisecond, and the hook's latest-wins guard (`held.atMs >= atMs` in `use-voice-room-sight.ts`) reads the tie as "not newer" and abandons the second frame, so the expected second `attachFrame` call never happens.
- The `>=` in the hook is intentional (a same-ms tie must not let a late-resolving older upload displace a newer frame, pinned by the "an upload that resolves late" test), so the fix is test-side only: a strictly increasing `Date.now` spy makes capture order visible to the comparison.
- Verified by reproducing first: freezing the clock forces the tie and fails with exactly the CI error ("called 1 time, but call 2 was requested"); with the stepped clock the file passes 5/5 consecutive runs.

## Original prompt
Invoked via `/do` with auto-merge to fix only the failure in this CI job: https://github.com/vellum-ai/vellum-assistant/actions/runs/33496562026/job/99820004808 (CI Main Web, `Test` job on `main`). The failure was a single flaky web test, not a regression from the run's head commit, so the scoped fix is deflaking that test.