### PR TITLE
fix(web): keep the drawer's conversation list clear of the action pills

### DIFF
--- a/clients/web/src/domains/chat/components/sidebar-list-context-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-list-context-menu.test.tsx
@@ -112,6 +112,27 @@ describe("SidebarListContextMenu", () => {
     }
   });
 
+  test("the target forwards the scrollport's bounded height", () => {
+    // `flex-1` alone leaves the wrapper an `auto` minimum, so it sizes to its
+    // content and the last section's flex-fill has nothing left to fill: the
+    // list then runs past the overlay drawer's floating action pills.
+    const { container } = render(
+      createElement(SidebarListContextMenu, {
+        onCreateGroup: () => {},
+        children: createElement("div", { "data-testid": "sections" }, "sections"),
+      }),
+    );
+    try {
+      const target = container.querySelector(
+        '[data-slot="sidebar-list-context-target"]',
+      );
+      expect(target?.className).toContain("min-h-0");
+      expect(target?.className).toContain("flex-1");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("renders children unwrapped when group creation isn't available", () => {
     const { container } = render(
       createElement(SidebarListContextMenu, {

--- a/clients/web/src/domains/chat/components/sidebar-list-context-menu.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-list-context-menu.tsx
@@ -13,7 +13,12 @@
  *   innermost trigger wins and a right-click on a row opens the row's menu
  *   only. This wrapper is what that behavior exists for.
  * - The wrapper stretches (`flex-1`) to fill the scrollport, so the empty area
- *   under the sections is part of the target rather than dead space.
+ *   under the sections is part of the target rather than dead space. It pairs
+ *   that with `min-h-0` so it also forwards the scrollport's bounded height:
+ *   without it the wrapper's `auto` minimum sizes it to its content, the last
+ *   section's flex-fill has nothing to fill, and the list runs past the
+ *   overlay drawer's floating action pills instead of scrolling inside its
+ *   own card.
  *
  * Desktop-only for now: on touch, Radix arms this on long-press, the same
  * gesture the conversation rows and section headers already use for their
@@ -52,7 +57,7 @@ export function SidebarListContextMenu({
             on has to be reproduced here. */}
         <div
           data-slot="sidebar-list-context-target"
-          className="flex flex-1 flex-col gap-4"
+          className="flex min-h-0 flex-1 flex-col gap-4"
         >
           {children}
         </div>


### PR DESCRIPTION
## Summary

On a mobile-width window the drawer's Chats card grew past the floating Preferences / New Chat pills, so conversation rows sat underneath them instead of scrolling inside the card.

The sidebar's right-click target (`SidebarListContextMenu`) wraps the whole conversation list in a flex column stretched with `flex-1`, but without `min-h-0` its flex minimum stayed `auto`: it sized to its content rather than to the scrollport. That broke the height chain the last section's flex-fill depends on, so the card resolved to full content height (952px inside a 774px scrollport) and the body scrolled as a whole.

The wrapper only renders on a fine pointer (`isPointerCoarse()` returns early on touch), which is why a phone looked correct and a mobile-width browser window did not.

## Changes

- Pair `min-h-0` with the existing `flex-1` on the list's context-menu target so it forwards the scrollport's bounded height.
- Note in the file's doc comment what that class is load-bearing for, next to the existing note on the stretch.
- Add a regression test asserting the target keeps both classes.

## Verification

`bun run test:ci` passes for `sidebar-list-context-menu` and `assistant-side-menu`; lint is clean on the changed file.

Measured in the running app with the drawer open:

| | before | after |
| --- | --- | --- |
| Chats card bottom @412x830 | y=1076 (past the pills) | y=734, pills start y=770 |
| body scrollHeight / clientHeight | 1116 / 774 | 774 / 774 |
| @390x600 | overlapping | card ends y=504, pills y=540 |

Desktop (1400x900) also lands where the `collapsible-nav-section` comments say it should: the card ends above the Preferences footer and scrolls internally.

## QA

- [ ] Drawer at mobile width: rows never sit under the pills, and the last card scrolls internally.
- [ ] Real touch device (wrapper absent there) is unchanged.
- [ ] Desktop rail with many conversations: the bottom-most open section still fills the leftover height.