### PR TITLE
fix(web): let iOS dismiss the voice first-run card

### DIFF
--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -71,12 +71,13 @@ The general rule is to test the feature itself — see [MDN: Implementing featur
 
 ### OS permission requests on iOS
 
-Any UI that gates a browser API which triggers an OS permission alert (`getUserMedia`, `Notification.requestPermission`, geolocation, etc.) must, on Capacitor iOS, either:
+Any UI that gates a browser API which triggers an OS permission alert (`getUserMedia`, `Notification.requestPermission`, geolocation, etc.) must, on Capacitor iOS, have **exactly one path that reaches the gated API, and it must lead straight to the system alert**. A pre-prompt may not stand between the user and the alert: no "Allow"/"Deny" of its own, no third choice that fakes the OS decision, no re-asking after a denial.
 
-- **skip rendering** so the API call fires directly into the system alert, OR
-- **render with zero exit affordances** — no Cancel button, no auto-rendered close-X, no backdrop dismiss, no Escape key.
+Cancelling is not such a path, so **pre-permission UI keeps its ordinary exit affordances** — ✕, backdrop dismiss, Escape. Those abandon the flow rather than route around the alert. Do not lock a pre-prompt to a single forward action: a modal with no way out strands anyone who opened the feature just to look at it, and reads closer to *forcing* consent, which is what [Guideline 5.1.1(iv)](https://developer.apple.com/app-store/review/guidelines/#5.1.1) actually targets. Apple's [HIG — Requesting permission](https://developer.apple.com/design/human-interface-guidelines/requesting-permission) asks you to explain *why* before the alert; it does not ask you to trap the user.
 
-Apple's [HIG — Requesting permission](https://developer.apple.com/design/human-interface-guidelines/requesting-permission) and [App Store Review Guideline 5.1.1(iv)](https://developer.apple.com/app-store/review/guidelines/#5.1.1) require any pre-prompt screen to lead directly to the alert. Pair `isXSupported()` capability checks with `useIsNativePlatform()` for any pre-permission UI: capability detection alone is not sufficient.
+The voice-mode first-run card ([`voice-first-run-card.tsx`](../src/domains/chat/voice/voice-room/voice-first-run-card.tsx)) is the worked example: "Start talking" goes straight to `getUserMedia`, and every other exit cancels without touching it.
+
+Pair `isXSupported()` capability checks with `useIsNativePlatform()` for any pre-permission UI: capability detection alone is not sufficient.
 
 ### Keyboard-only affordances on touch devices
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -169,13 +169,8 @@ mock.module("@/domains/chat/voice/voice-room/voice-first-run-card", () => ({
   VoiceFirstRunCard: (props: {
     onStart: () => void;
     onDismiss?: () => void;
-    nonDismissible?: boolean;
   }) => (
-    <div
-      data-testid="first-run-card"
-      // Surface the lock so a test can assert the composer passes it on iOS.
-      data-non-dismissible={String(props.nonDismissible ?? false)}
-    >
+    <div data-testid="first-run-card">
       <button type="button" onClick={props.onStart}>
         first-run-start
       </button>
@@ -2642,12 +2637,8 @@ describe("ChatComposer — live-voice integration", () => {
     const { getByLabelText, getByTestId } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN the prefs card appears (dismissible on web) and the session has NOT
-    // started yet
+    // THEN the prefs card appears and the session has NOT started yet
     expect(getByTestId("first-run-card")).toBeTruthy();
-    expect(
-      getByTestId("first-run-card").getAttribute("data-non-dismissible"),
-    ).toBe("false");
     expect(liveStarterSpy).not.toHaveBeenCalled();
     expect(livePrewarmSpy).not.toHaveBeenCalled();
   });
@@ -2695,10 +2686,8 @@ describe("ChatComposer — live-voice integration", () => {
 
   test("Capacitor iOS: first-ever entry shows the prefs card too (web↔iOS parity)", () => {
     // GIVEN the native iOS shell, the flag on, no session, and a first-ever
-    // entry. The card is intentionally shown on every platform — a deliberate
-    // deviation from CAPACITOR.md's "no dismissible pre-prompt before
-    // getUserMedia" rule, chosen for parity with web (see the composer's
-    // handleLiveVoiceStart note) — so the iOS shell must get it too.
+    // entry. The card is shown on every platform (see the composer's
+    // handleLiveVoiceStart note), so the iOS shell must get it too.
     useTurnStore.setState(INITIAL_TURN_STATE);
     mockIsNativeIOS = true;
     useVoicePrefsStore.setState({ firstRunSeen: false });
@@ -2707,15 +2696,29 @@ describe("ChatComposer — live-voice integration", () => {
     const { getByLabelText, getByTestId } = renderVoiceComposer();
     fireEvent.click(getByLabelText("Start voice mode"));
 
-    // THEN the same prefs card appears and the session has NOT started yet —
-    // like web, but locked (non-dismissible) so it leads straight to the mic
-    // alert per CAPACITOR.md.
+    // THEN the same prefs card appears and the session has NOT started yet.
     expect(getByTestId("first-run-card")).toBeTruthy();
-    expect(
-      getByTestId("first-run-card").getAttribute("data-non-dismissible"),
-    ).toBe("true");
     expect(liveStarterSpy).not.toHaveBeenCalled();
     expect(livePrewarmSpy).not.toHaveBeenCalled();
+  });
+
+  test("Capacitor iOS: dismissing the prefs card cancels without touching the mic", () => {
+    // The card carries the same ✕ / backdrop dismiss as web. Cancelling is a
+    // path that never reaches `getUserMedia`, so it keeps the CAPACITOR.md
+    // rule satisfied: the only route to the OS alert is still "Start talking".
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockIsNativeIOS = true;
+    useVoicePrefsStore.setState({ firstRunSeen: false });
+
+    const { getByLabelText, getByText, queryByTestId } = renderVoiceComposer();
+    fireEvent.click(getByLabelText("Start voice mode"));
+    fireEvent.click(getByText("first-run-dismiss"));
+
+    expect(queryByTestId("first-run-card")).toBeNull();
+    expect(liveStarterSpy).not.toHaveBeenCalled();
+    expect(livePrewarmSpy).not.toHaveBeenCalled();
+    // Un-consumed: the card returns on the next entry.
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
   });
 
   test("Capacitor iOS: returning-user entry prewarms and starts after preflight", async () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -87,7 +87,6 @@ import { isElectron } from "@/runtime/is-electron";
 import { isPopoutWindowLifetime } from "@/runtime/popout-window";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import {
-  isNativeIOS,
   useIsNativeAndroid,
   useIsNativeMobile,
 } from "@/runtime/platform-detection";
@@ -670,12 +669,11 @@ export function ChatComposer({
       }
       // First-run preferences card — shown on the first-ever voice entry on
       // EVERY platform, the Capacitor iOS shell included (web↔iOS parity for the
-      // welcome card). On iOS the card renders locked (`nonDismissible`, see its
-      // render below), which keeps it compliant with `docs/CAPACITOR.md` § OS
-      // permission requests: the card precedes the live-voice `getUserMedia`
-      // alert, and a locked pre-prompt whose only action leads straight to that
-      // alert is the sanctioned pattern (Apple HIG / App Store Review 5.1.1(iv))
-      // — a *dismissible* pre-prompt is the disallowed one.
+      // welcome card), and dismissible on all of them. The card precedes the
+      // live-voice `getUserMedia` alert, so `docs/CAPACITOR.md` § OS permission
+      // requests governs it: dismissing cancels outright and never reaches
+      // `getUserMedia`, so the only path that *does* reach the alert is still
+      // the direct one ("Start talking").
       if (firstRunCardIntercepts()) {
         return;
       }
@@ -1523,19 +1521,16 @@ export function ChatComposer({
       {firstRunCardOpen && (
         // First voice-mode entry only — the card commits prefs + starts via
         // `handleFirstRunStart`; a plain dismiss cancels without consuming the
-        // first run, so it returns on the next entry. On Capacitor iOS the card
-        // is locked (no ✕ / backdrop / Escape): it precedes the live-voice
-        // `getUserMedia` alert, so per `docs/CAPACITOR.md` § OS permission
-        // requests the pre-prompt must lead straight to that alert — its only
-        // action is "Start talking", and there is no card-level cancel (backing
-        // out means denying the OS mic prompt, or ✕ once the room opens).
+        // first run, so it returns on the next entry. Dismissible on every
+        // platform, Capacitor iOS included: the card precedes the live-voice
+        // `getUserMedia` alert, and `docs/CAPACITOR.md` § OS permission requests
+        // allows a pre-prompt whose decline path never reaches the gated API.
         <VoiceFirstRunCard
           assistantId={assistantId}
           onStart={handleFirstRunStart}
           onDismiss={() =>
             useLiveVoiceStore.getState().setFirstRunCardOpen(false)
           }
-          nonDismissible={isNativeIOS()}
         />
       )}
       {/* Every banner that stands over the card, in one watched box. While

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.test.tsx
@@ -194,26 +194,78 @@ describe("VoiceFirstRunCard", () => {
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
   });
 
-  test("dismissible by default (web): renders the ✕ close affordance", () => {
+  test("renders the ✕ close affordance — on every platform, iOS included", () => {
+    // The card takes no platform prop: there is no build in which it renders
+    // without a way out. An iOS-only lock once removed the ✕ and the backdrop
+    // dismiss, stranding first-time users in voice mode.
     const { getByLabelText } = render(
       <VoiceFirstRunCard assistantId="asst_test" onStart={() => {}} />,
     );
     expect(getByLabelText("Close")).toBeTruthy();
   });
 
-  test("nonDismissible (iOS lock): no ✕, only Start talking leads forward", () => {
-    // The lock strips the close affordance so the pre-permission card leads
-    // straight to the mic alert (CAPACITOR.md § OS permission requests); there
-    // is intentionally no card-level cancel.
-    const { queryByLabelText, getByText } = render(
+  test("✕ cancels without starting or consuming the first run", () => {
+    const onStart = mock(() => {});
+    const onDismiss = mock(() => {});
+    const { getByLabelText } = render(
+      <VoiceFirstRunCard
+        assistantId="asst_test"
+        onStart={onStart}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    fireEvent.click(getByLabelText("Close"));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onStart).not.toHaveBeenCalled();
+    // Un-consumed, so the card returns on the next voice entry.
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
+  });
+
+  test("a backdrop tap cancels the intro the same way", () => {
+    // The overlay carries its own onClick (design-library `modal.tsx`) rather
+    // than leaning on Radix's document-level listener, which is what makes the
+    // tap register in the iOS WKWebView — see CAPACITOR.md § Click events
+    // require interactive elements on iOS.
+    const onStart = mock(() => {});
+    const onDismiss = mock(() => {});
+    const { baseElement } = render(
+      <VoiceFirstRunCard
+        assistantId="asst_test"
+        onStart={onStart}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const overlay = baseElement.querySelector('[data-slot="modal-overlay"]');
+    expect(overlay).toBeTruthy();
+    fireEvent.click(overlay!);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onStart).not.toHaveBeenCalled();
+    expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
+  });
+
+  test("a backdrop tap in a sub-view returns to the intro, never cancels", () => {
+    // `onOpenChange` is the authoritative guard, so the backdrop routes the
+    // same way Escape does: back out of the sub-view, don't discard the card.
+    const onDismiss = mock(() => {});
+    const { getByText, baseElement } = render(
       <VoiceFirstRunCard
         assistantId="asst_test"
         onStart={() => {}}
-        nonDismissible
+        onDismiss={onDismiss}
       />,
     );
-    expect(queryByLabelText("Close")).toBeNull();
+
+    fireEvent.click(getByText(SETTINGS_LINK));
+    expect(dialogTitle()).toBe("Voice settings");
+
+    fireEvent.click(baseElement.querySelector('[data-slot="modal-overlay"]')!);
+
     expect(getByText("Start talking")).toBeTruthy();
+    expect(onDismiss).not.toHaveBeenCalled();
   });
 
   describe("voice settings view", () => {
@@ -251,14 +303,15 @@ describe("VoiceFirstRunCard", () => {
       expect(useVoicePrefsStore.getState().firstRunSeen).toBe(false);
     });
 
-    test("the link is reachable under the iOS lock too", () => {
-      // The lock removes cancels, not in-modal navigation — a locked card
-      // still has to let a user reach voice settings before the mic prompt.
+    test("the back arrow is in-modal navigation, distinct from the ✕", () => {
+      // Both affordances sit in a sub-view: Back returns to the intro while ✕
+      // cancels the card outright. Neither may be mistaken for the other.
+      const onDismiss = mock(() => {});
       const { getByText, getByLabelText } = render(
         <VoiceFirstRunCard
           assistantId="asst_test"
           onStart={() => {}}
-          nonDismissible
+          onDismiss={onDismiss}
         />,
       );
 
@@ -266,6 +319,7 @@ describe("VoiceFirstRunCard", () => {
       expect(dialogTitle()).toBe("Voice settings");
       fireEvent.click(getByLabelText("Back"));
       expect(getByText("Start talking")).toBeTruthy();
+      expect(onDismiss).not.toHaveBeenCalled();
     });
   });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-first-run-card.tsx
@@ -74,14 +74,14 @@ import { useTranslation } from "@/i18n";
  * navigates back to the intro rather than cancelling, so a stray keypress
  * can't discard a half-entered API key.
  *
- * `nonDismissible` locks the card to a single forward action — no ✕, backdrop,
- * or Escape. The composer sets it on Capacitor iOS, where the card precedes the
- * live-voice `getUserMedia` alert: per `docs/CAPACITOR.md` § OS permission
- * requests (Apple HIG / App Store Review 5.1.1(iv)) such a pre-prompt must lead
- * straight to the system alert, so a dismissible one is disallowed. Locked,
- * there is no card-level cancel by design — backing out means denying the OS
- * mic prompt (or ✕ once the room opens). The sub-view back arrow is in-modal
- * navigation, not a cancel, so it stays available under the lock.
+ * Dismissible on every platform, Capacitor iOS included. The card precedes the
+ * live-voice `getUserMedia` alert, so `docs/CAPACITOR.md` § OS permission
+ * requests governs it: what that rule forbids is a pre-prompt that stands
+ * between the user and the system alert, and cancelling here never reaches
+ * `getUserMedia` at all — the one path that does ("Start talking") still leads
+ * straight to it. An iOS build once locked the card instead (no ✕ / backdrop /
+ * Escape), which left first-time users with no way out of voice mode short of
+ * answering the OS mic prompt; don't reintroduce it.
  */
 
 /** Mini idle avatar diameter — a quiet, in-context echo of the room avatar. */
@@ -101,19 +101,12 @@ export interface VoiceFirstRunCardProps {
   onStart: () => void;
   /** Cancel: dismissed without starting (does not consume the first run). */
   onDismiss?: () => void;
-  /**
-   * Lock the card: no ✕ / backdrop / Escape, only "Start talking". Set on
-   * Capacitor iOS so the pre-permission card leads straight to the mic alert
-   * (see the module docstring). Defaults to dismissible (web).
-   */
-  nonDismissible?: boolean;
 }
 
 export function VoiceFirstRunCard({
   assistantId,
   onStart,
   onDismiss,
-  nonDismissible = false,
 }: VoiceFirstRunCardProps) {
   const { t } = useTranslation("chat");
   const { components, traits, customImageUrl } =
@@ -186,9 +179,7 @@ export function VoiceFirstRunCard({
           return;
         }
         // On the intro a close is a plain cancel: the first run stays
-        // un-consumed. Inert when locked (those affordances are removed /
-        // prevented below), so `onDismiss` only fires on the dismissible
-        // (web) path.
+        // un-consumed, so the card returns on the next voice entry.
         onDismiss?.();
       }}
     >
@@ -197,22 +188,16 @@ export function VoiceFirstRunCard({
         // Held constant across views: a sub-view that resized the dialog would
         // shift the back arrow and ✕ out from under the pointer.
         className="max-w-[520px]"
-        // iOS lock: strip the ✕, the backdrop-tap dismiss, and Escape so the
-        // only way forward is "Start talking" → the mic alert.
-        hideCloseButton={nonDismissible}
-        dismissOnOverlayClick={!nonDismissible}
         onEscapeKeyDown={
           // Inside a sub-view Escape is "go back", never "cancel" — it must not
           // discard a half-entered key. On the intro it keeps its normal
-          // meaning (cancel), or is swallowed entirely under the lock.
+          // meaning (cancel).
           view !== "intro"
             ? (event) => {
                 event.preventDefault();
                 leaveCurrentView();
               }
-            : nonDismissible
-              ? (event) => event.preventDefault()
-              : undefined
+            : undefined
         }
         onKeyDown={
           // Belt to `onEscapeKeyDown`'s suspenders: Radix delivers Escape via
@@ -234,9 +219,6 @@ export function VoiceFirstRunCard({
                 }
               }
             : undefined
-        }
-        onInteractOutside={
-          nonDismissible ? (event) => event.preventDefault() : undefined
         }
       >
         {view === "intro" && (


### PR DESCRIPTION
## The bug

Reported from iOS: the Voice mode welcome card has no ✕ and ignores taps outside it, so there is no way to close it. Android shows the ✕ and closes normally.

Anyone who opened voice mode just to look — the reporter was on their way to switching models — is stuck. The only forward action is **Start talking**, so backing out means answering the OS mic prompt first.

## Cause

`chat-composer.tsx` passed `nonDismissible={isNativeIOS()}`, which made the card:

- hide the ✕ (`hideCloseButton`)
- ignore backdrop taps (`dismissOnOverlayClick={false}`)
- swallow Escape (`onEscapeKeyDown` → `preventDefault`)
- cancel outside interaction (`onInteractOutside` → `preventDefault`)

That was deliberate, not an oversight. It read `docs/CAPACITOR.md` § OS permission requests as banning any dismissible pre-prompt ahead of `getUserMedia`.

## Why that reading changes

The rule's real requirement is that exactly one path *reaches* the gated API and that it leads straight to the system alert. Cancelling is not such a path — it abandons the flow without touching `getUserMedia` — so **Start talking** remains the only route to the alert either way.

Meanwhile [Guideline 5.1.1(iv)](https://developer.apple.com/app-store/review/guidelines/#5.1.1) targets *forcing* consent, and a modal whose only exit is the permission alert sits closer to that than a dismissible one. The [HIG](https://developer.apple.com/design/human-interface-guidelines/requesting-permission) asks you to explain why before the alert; it does not ask you to trap the user.

## Changes

- **`chat-composer.tsx`** — drop the `nonDismissible` prop and the now-unused `isNativeIOS` import. No platform branch: there is no build where the card renders without a way out.
- **`voice-first-run-card.tsx`** — remove the prop and all four lock branches.
- **`CAPACITOR.md`** — rewrite § OS permission requests to say what it means: one path to the gated API leading straight to the alert, ordinary exit affordances kept, never lock a pre-prompt to a single forward action. Without this the code just reads as a violation and gets reverted later.

Outside-click needs nothing extra on iOS: the design-library overlay already carries its own `onClick` (added in f5b9ab9dd6) rather than relying on the document-level listener WKWebView won't fire on non-interactive elements — the workaround `CAPACITOR.md` § Click events already prescribes.

Sub-views are unchanged: a backdrop tap in Voice settings or the language picker still routes to "back to intro" via `onOpenChange`, so it can't discard a half-entered API key. There's a new test pinning that.

## Testing

- 29 first-run card tests, 159 composer tests, all passing
- typecheck clean; lint 0 errors (15 pre-existing warnings, untouched files)
- new coverage: ✕ present on every platform, ✕ cancels without consuming the first run, backdrop tap cancels the intro, backdrop tap in a sub-view returns instead of cancelling, and iOS dismiss never reaches the mic

Run tests with `bun run test:ci <paths>` from `clients/web` — a single `bun test` over both files together produces phantom failures from cross-file mock leakage.

## Review notes

The compliance call is the part worth a careful look. This reverses a rule someone wrote deliberately, and I could not tell from the code whether it traced to real App Store review feedback or to a conservative reading. If it was an actual rejection, the alternative that still fixes the trap is skipping the card on iOS entirely — `CAPACITOR.md`'s other sanctioned branch — at the cost of the welcome card, pre-session voice picker, and listening-language row on iOS.

Symptom is iOS-only, so this wants QA on a device build rather than in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
