### PR TITLE
feat(companion): collapse the idle surface to a thin pill (JARVIS-1691)

### DIFF
--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -195,14 +195,20 @@ export default meta;
 
 type Story = StoryObj<StoryArgs>;
 
-/** The circle, as it sits when nobody is asking anything of it. */
+/**
+ * The capsule, as it sits when nobody is asking anything of it.
+ *
+ * The state this surface spends almost all of its life in, and the reason it
+ * is a capsule rather than the creature: it sits over whatever the user is
+ * working in all day. The creature is one pointer-move away.
+ */
 export const Resting: Story = {
   args: { phase: "resting" },
 };
 
 /**
- * The same circle in an assistant's own colour, which is what the desktop
- * actually shows: the glow is the character's palette hex, not the surface's
+ * The same capsule in an assistant's own colour, which is what the desktop
+ * actually shows: the dot is the character's palette hex, not the surface's
  * teal default. Here so the resting colour is reviewable without a live call.
  */
 export const RestingInItsOwnColour: Story = {
@@ -226,7 +232,8 @@ export const RestingCustomImage: Story = {
  *
  * The state the working ring exists for: the assistant is doing something and
  * nothing is open to say so. The ring has to carry that on its own, at the size
- * the surface actually spends its day.
+ * the surface actually spends its day, which is why it is drawn on the shape
+ * rather than on the box: at rest it hugs the capsule.
  */
 export const RestingWhileWorking: Story = {
   args: { phase: "resting", working: true },

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -467,6 +467,18 @@ const shapeOf = (container: HTMLElement): HTMLElement => {
   return found;
 };
 
+/**
+ * The capsule drawn at rest, which is a sibling of that box rather than a child
+ * of it: it holds its own size while the ring's box grows to the creature's.
+ */
+const capsuleOf = (container: HTMLElement): HTMLElement => {
+  const found = avatarOf(container).children[1] as HTMLElement | undefined;
+  if (found === undefined) {
+    throw new Error("Expected the resting capsule to render");
+  }
+  return found;
+};
+
 describe("the companion surface's anchor in the canvas", () => {
   test("grows up by default, which is where the surface normally lives", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
@@ -1737,13 +1749,27 @@ describe("the avatar's resting collapse", () => {
   test("wears a dark rim inside the capsule, not an outline over it", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    const capsule = shapeOf(container).querySelector<HTMLElement>(
-      "[style*='background']",
-    );
-    expect(capsule?.style.borderWidth).toBe("2px");
-    expect(capsule?.style.borderStyle).toBe("solid");
-    // Inside the box, so the ring still owns the whole annulus outside it.
-    expect(capsule?.className).toContain("inset-0");
+    const capsule = capsuleOf(container);
+    expect(capsule.style.borderWidth).toBe("2px");
+    expect(capsule.style.borderStyle).toBe("solid");
+  });
+
+  /**
+   * The capsule holds its size and fades where it stands.
+   *
+   * Sized on itself rather than filling the ring's box, which grows to the
+   * creature's: a capsule that grew with it inflated into a coloured disc and
+   * dissolved, which read as a bubble popping rather than as the creature
+   * coming out of the pill.
+   */
+  test("never grows the capsule with the box the ring rides", () => {
+    for (const phase of PHASES) {
+      const { container } = render(<CompanionSurface phase={phase} />);
+
+      const capsule = capsuleOf(container);
+      expect(capsule.style.width).toBe("32px");
+      expect(capsule.style.height).toBe("14px");
+    }
   });
 
   /**

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1653,8 +1653,8 @@ describe("the avatar's resting collapse", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
     const shape = shapeOf(container);
-    expect(shape.style.width).toBe("28px");
-    expect(shape.style.height).toBe("10px");
+    expect(shape.style.width).toBe("32px");
+    expect(shape.style.height).toBe("14px");
   });
 
   /**
@@ -1671,9 +1671,10 @@ describe("the avatar's resting collapse", () => {
 
       const shape = shapeOf(container);
       // The lengths are the same on every setting, and the transform undoes
-      // the scale this node carries, which is the avatar's box over 44.
-      expect(shape.style.width).toBe("28px");
-      expect(shape.style.height).toBe("10px");
+      // the scale this node carries, which is the avatar's box over 44. The
+      // box is the accent core (28x10) plus the dark rim on every side.
+      expect(shape.style.width).toBe("32px");
+      expect(shape.style.height).toBe("14px");
       expect(shape.style.transform).toBe(
         `translate(-50%, -50%) scale(${44 / avatarBox})`,
       );
@@ -1725,6 +1726,24 @@ describe("the avatar's resting collapse", () => {
     );
 
     expect(ringOf(container)?.parentElement).toBe(shapeOf(container));
+  });
+
+  /**
+   * The rim is what keeps the working ring legible. Drawn in the assistant's
+   * colour immediately outside the shape, a ring around a capsule painted that
+   * same colour disappears, and a turn running while nobody is looking is the
+   * one thing at rest the ring has to carry on its own.
+   */
+  test("wears a dark rim inside the capsule, not an outline over it", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const capsule = shapeOf(container).querySelector<HTMLElement>(
+      "[style*='background']",
+    );
+    expect(capsule?.style.borderWidth).toBe("2px");
+    expect(capsule?.style.borderStyle).toBe("solid");
+    // Inside the box, so the ring still owns the whole annulus outside it.
+    expect(capsule?.className).toContain("inset-0");
   });
 
   /**

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1557,11 +1557,10 @@ describe("the resting avatar's idle motion", () => {
   /**
    * The wrapper sits inside the avatar's box, which nothing else may move.
    *
-   * One node further down than it used to be: the collapse that tucks the
-   * creature into the capsule is a `transform` of its own, so it takes a
-   * wrapper rather than riding the bob and silently replacing it. Both are
-   * asserted, since the thing that must hold is the whole chain from the box
-   * the host measures down to the artwork.
+   * The collapse that tucks the creature into the capsule is a `transform` of
+   * its own, so it takes a wrapper of its own rather than riding the bob and
+   * silently replacing it. Both links are asserted, since what has to hold is
+   * the whole chain from the box the host measures down to the artwork.
    */
   test("keeps the avatar box above the wrapper, one node up", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
@@ -1758,9 +1757,8 @@ describe("the avatar's resting collapse", () => {
    * The capsule holds its size and fades where it stands.
    *
    * Sized on itself rather than filling the ring's box, which grows to the
-   * creature's: a capsule that grew with it inflated into a coloured disc and
-   * dissolved, which read as a bubble popping rather than as the creature
-   * coming out of the pill.
+   * creature's. An accent inflating to that box and dissolving reads as a
+   * bubble popping rather than as the creature coming out of the pill.
    */
   test("never grows the capsule with the box the ring rides", () => {
     for (const phase of PHASES) {

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -454,6 +454,19 @@ const avatarOf = (container: HTMLElement): HTMLElement => {
   return found;
 };
 
+/**
+ * The shape drawn inside that box: the creature's whole box while the surface
+ * is expanded, a thin capsule at rest. The box's first child, and the node the
+ * working ring is drawn around, so the ring hugs whichever of the two it is.
+ */
+const shapeOf = (container: HTMLElement): HTMLElement => {
+  const found = avatarOf(container).firstElementChild as HTMLElement | null;
+  if (found === null) {
+    throw new Error("Expected the avatar's shape to render");
+  }
+  return found;
+};
+
 describe("the companion surface's anchor in the canvas", () => {
   test("grows up by default, which is where the surface normally lives", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
@@ -700,8 +713,8 @@ describe("the companion surface at two sizes", () => {
 
   /**
    * The creature's own node carries the difference and nothing else does. It
-   * has to be that node rather than the wrapper below it, which owns the bob's
-   * `transform`: two transforms on one node leave one of them out.
+   * has to be that node rather than either wrapper below it: the collapse owns
+   * a `transform` and so does the bob, and two on one node leave one out.
    */
   test("scales the creature by the difference between the two boxes", () => {
     const { container } = render(
@@ -710,7 +723,9 @@ describe("the companion surface at two sizes", () => {
     expect(avatarOf(container).style.transform).toBe(
       "translate(-50%, -50%) scale(2.5)",
     );
-    expect(bobOf(container)?.parentElement).toBe(avatarOf(container));
+    expect(bobOf(container)?.parentElement?.parentElement).toBe(
+      avatarOf(container),
+    );
   });
 
   test("scales it down the same way beside a larger pill", () => {
@@ -1527,11 +1542,31 @@ describe("the resting avatar's idle motion", () => {
     expect(bobOf(container)?.querySelector("svg")).not.toBeNull();
   });
 
-  /** The wrapper sits inside the avatar's box, which nothing else may move. */
-  test("keeps the avatar box as the wrapper's parent", () => {
+  /**
+   * The wrapper sits inside the avatar's box, which nothing else may move.
+   *
+   * One node further down than it used to be: the collapse that tucks the
+   * creature into the capsule is a `transform` of its own, so it takes a
+   * wrapper rather than riding the bob and silently replacing it. Both are
+   * asserted, since the thing that must hold is the whole chain from the box
+   * the host measures down to the artwork.
+   */
+  test("keeps the avatar box above the wrapper, one node up", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
-    expect(bobOf(container)?.parentElement?.className).toContain("size-11");
+    const bob = bobOf(container);
+    const collapse = bob?.parentElement;
+    expect(collapse?.className).toContain("transition-[opacity,transform]");
+    expect(collapse?.parentElement?.className).toContain("size-11");
+  });
+
+  /** Each transform on a node of its own, which is the whole point of them. */
+  test("gives the collapse and the bob separate nodes", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const collapse = bobOf(container)?.parentElement;
+    expect(collapse?.style.transform).toBe("scale(0.35)");
+    expect(bobOf(container)?.style.transform).toBe("");
   });
 
   /**
@@ -1572,5 +1607,74 @@ describe("the resting avatar's idle motion", () => {
 
     expect(bobOf(container)?.style.animation).toBe("");
     expect(glowOf(container)?.style.animation).toBe("");
+  });
+});
+
+/**
+ * The resting collapse.
+ *
+ * At rest this surface is a marker rather than a mascot: it sits over whatever
+ * the user is working in all day, so the creature gives way to a thin capsule
+ * and comes back the moment anything opens the pill.
+ *
+ * What must not move with it is the box the shape is drawn in. That box is the
+ * drag handle, the point the host positions the window around, and the rect the
+ * pointer is hit-tested against, so a collapse that shrank it would move the
+ * anchor every drag and clamp is measured from.
+ */
+describe("the avatar's resting collapse", () => {
+  test("draws a capsule at rest", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const shape = shapeOf(container);
+    expect(shape.style.width).toBe("28px");
+    expect(shape.style.height).toBe("10px");
+  });
+
+  test("draws the whole box once anything opens the pill", () => {
+    for (const phase of PHASES.filter((it) => it !== "resting")) {
+      const { container } = render(<CompanionSurface phase={phase} />);
+
+      const shape = shapeOf(container);
+      expect(shape.style.width).toBe("44px");
+      expect(shape.style.height).toBe("44px");
+    }
+  });
+
+  /**
+   * The box the host measures is the same box in every phase. This is the one
+   * assertion here that is about the window rather than the drawing: shrink it
+   * and every drag, clamp and growth flip is measured from a different point.
+   */
+  test("never resizes the box the shape is drawn in", () => {
+    for (const phase of PHASES) {
+      const { container } = render(<CompanionSurface phase={phase} />);
+
+      expect(avatarOf(container).className).toContain("size-11");
+    }
+  });
+
+  /**
+   * A ring is a statement about the shape it is drawn around, so a turn
+   * running while the surface is at rest lights the capsule rather than
+   * circling the empty box the capsule sits in.
+   */
+  test("rides the ring on the shape, not on the box", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" working />,
+    );
+
+    expect(ringOf(container)?.parentElement).toBe(shapeOf(container));
+  });
+
+  /** The creature fades with it rather than being cut, and comes back whole. */
+  test("fades the creature out at rest and back in expanded", () => {
+    const { container: resting } = render(
+      <CompanionSurface phase="resting" />,
+    );
+    expect(bobOf(resting)?.parentElement?.style.opacity).toBe("0");
+
+    const { container: hovered } = render(<CompanionSurface phase="hover" />);
+    expect(bobOf(hovered)?.parentElement?.style.opacity).toBe("1");
   });
 });

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1608,6 +1608,32 @@ describe("the resting avatar's idle motion", () => {
     expect(bobOf(container)?.style.animation).toBe("");
     expect(glowOf(container)?.style.animation).toBe("");
   });
+
+  /**
+   * The collapse is motion too, and the newest of it. Hovering the capsule
+   * grows a shape and scales a creature, which is exactly the travel across
+   * the screen a reader asking for stillness is asking not to have.
+   *
+   * The shape arrives changed; the creature keeps its fade, since a cross-fade
+   * is not motion across the screen and is gentler than snapping in and out.
+   */
+  test("holds the collapse still under reduced motion", () => {
+    reducedMotion = true;
+
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    expect(shapeOf(container).style.transitionDuration).toBe("0s");
+    expect(bobOf(container)?.parentElement?.style.transitionProperty).toBe(
+      "opacity",
+    );
+  });
+
+  test("lets the collapse travel for a reader who asked for nothing", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    expect(shapeOf(container).style.transitionDuration).toBe("");
+    expect(bobOf(container)?.parentElement?.style.transitionProperty).toBe("");
+  });
 });
 
 /**
@@ -1629,6 +1655,40 @@ describe("the avatar's resting collapse", () => {
     const shape = shapeOf(container);
     expect(shape.style.width).toBe("28px");
     expect(shape.style.height).toBe("10px");
+  });
+
+  /**
+   * Sizing the creature is a statement about the creature. Someone who wants a
+   * big mascot when they look at it has not asked for a big lozenge sitting
+   * over their work all day, so the marker is the one part of this surface the
+   * setting does not reach.
+   */
+  test("draws the capsule at one size whatever the creature is sized to", () => {
+    for (const avatarBox of [44, 66, 110, 220]) {
+      const { container } = render(
+        <CompanionSurface phase="resting" avatarBox={avatarBox} />,
+      );
+
+      const shape = shapeOf(container);
+      // The lengths are the same on every setting, and the transform undoes
+      // the scale this node carries, which is the avatar's box over 44.
+      expect(shape.style.width).toBe("28px");
+      expect(shape.style.height).toBe("10px");
+      expect(shape.style.transform).toBe(
+        `translate(-50%, -50%) scale(${44 / avatarBox})`,
+      );
+    }
+  });
+
+  /** Expanded it is the creature's own box, which the setting does reach. */
+  test("still grows the expanded shape with the creature", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={220} />,
+    );
+
+    const shape = shapeOf(container);
+    expect(shape.style.width).toBe("44px");
+    expect(shape.style.transform).toBe("translate(-50%, -50%) scale(1)");
   });
 
   test("draws the whole box once anything opens the pill", () => {
@@ -1665,6 +1725,21 @@ describe("the avatar's resting collapse", () => {
     );
 
     expect(ringOf(container)?.parentElement).toBe(shapeOf(container));
+  });
+
+  /**
+   * The introduction's first beat presents the creature by name and does not
+   * open the pill, so the phase is `resting` while a card points at it. A card
+   * introducing the capsule is the one thing this collapse must not do.
+   */
+  test("keeps the creature drawn while the introduction is on screen", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" intro={<div>meet</div>} />,
+    );
+
+    const shape = shapeOf(container);
+    expect(shape.style.height).toBe("44px");
+    expect(bobOf(container)?.parentElement?.style.opacity).toBe("1");
   });
 
   /** The creature fades with it rather than being cut, and comes back whole. */

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -221,6 +221,15 @@ const AVATAR_IMAGE = COMPANION_BASE_AVATAR_IMAGE;
  * pointer is hit-tested against, so shrinking it would move the anchor the host
  * measures every drag and clamp against, and would make the surface hardest to
  * hit exactly when it is smallest. What changes is the shape drawn inside it.
+ *
+ * **Nor does the capsule grow with the sizes.** It is drawn at these numbers on
+ * every setting, countering the scale the avatar's node carries (see
+ * `restingScale` in {@link Avatar}). Sizing the creature is a statement about
+ * the creature: someone who wants a big mascot when they look at it has not
+ * asked for a big lozenge sitting over their work all day, and the marker is
+ * the one part of this surface nobody chose to be looking at. Countering the
+ * transform rather than the lengths is what keeps the border, the radius and
+ * the ring identical at every setting instead of thickening with the scale.
  */
 const RESTING_HEIGHT = 10;
 
@@ -752,6 +761,16 @@ export function CompanionSurface({
   // and direction check against is not.
   const placement = edgeAt(growth, avatarHalf + gap);
 
+  /**
+   * Whether the introduction's card is drawn beside the surface.
+   *
+   * `null` is what the host passes when there is no beat to draw and
+   * `undefined` is what a caller that never mentions it leaves behind, and both
+   * mean the same thing. Named rather than tested inline, because the one thing
+   * that reads it is deciding whether the creature is on screen at all.
+   */
+  const introDrawn = intro !== null && intro !== undefined;
+
   // The card growing downward draws its composer row first, so the row starts
   // one options box above the creature's baseline and the card falls away from
   // it; everything else hangs upward off that baseline.
@@ -972,7 +991,17 @@ export function CompanionSurface({
         // At rest the creature tucks into a capsule. The same answer the pill's
         // own width reads, so the two collapse together and the surface goes to
         // its resting shape as one thing.
-        collapsed={!expanded}
+        //
+        // Except while the introduction is on screen. Its first beat presents
+        // the creature by name and deliberately does not open the pill
+        // (`introPhase` answers null for `meet`), so the phase is `resting`
+        // with a card pointing at a creature that is not drawn. A card
+        // introducing the capsule is the one thing this collapse must not do.
+        collapsed={!expanded && !introDrawn}
+        // The capsule is drawn at one size on every setting, so it counters
+        // what this node carries. That is the avatar's box over the authored
+        // one: the options scale on the box above cancels against `avatarRel`.
+        restingScale={COMPANION_BASE_AVATAR_BOX / avatarBox}
         edge={edge}
         style={{
           left: "50%",
@@ -1289,6 +1318,7 @@ function Avatar({
   busy = false,
   attentive = false,
   collapsed = false,
+  restingScale = 1,
   edge,
   style,
   elementRef,
@@ -1306,6 +1336,13 @@ function Avatar({
    * capsule. See {@link RESTING_HEIGHT}.
    */
   collapsed?: boolean;
+  /**
+   * What the capsule scales by to undo the scale this node already carries, so
+   * it is drawn at one size whatever the creature is sized to. Applies to the
+   * capsule alone: the expanded shape is the creature's own box and grows with
+   * it, which is the whole point of the setting.
+   */
+  restingScale?: number;
   /** What the creature's edge is drawing. See `edge` in `CompanionSurface`. */
   edge?: ReactNode;
   style?: CSSProperties;
@@ -1343,13 +1380,21 @@ function Avatar({
         keeps the one-shot capture flare from remounting and replaying: see
         `edge` in `CompanionSurface`. */}
       <div
-        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-[width,height] duration-300"
+        className="absolute top-1/2 left-1/2 rounded-full transition-[width,height,transform] duration-300"
         style={{
           width: collapsed ? AVATAR_IMAGE : COMPANION_BASE_AVATAR_BOX,
           height: collapsed ? RESTING_HEIGHT : COMPANION_BASE_AVATAR_BOX,
+          // Centred on the anchor, then scaled about that centre. The scale is
+          // stated on both sides rather than only the collapsed one, so the two
+          // states are the same transform list and interpolate cleanly.
+          transform: `translate(-50%, -50%) scale(${collapsed ? restingScale : 1})`,
           // The easing the pill's own width uses, so the two halves of a
           // surface waking up settle together rather than in sequence.
           transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
+          // Nothing travels for a reader who asked for stillness. The shape
+          // still changes, it just arrives changed: the fades below are kept,
+          // since a cross-fade is not motion across the screen.
+          transitionDuration: reduce ? "0s" : undefined,
         }}
       >
         {edge}
@@ -1382,6 +1427,10 @@ function Avatar({
           opacity: collapsed ? 0 : 1,
           transform: collapsed ? "scale(0.35)" : "scale(1)",
           transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
+          // The scale is dropped for a reader who asked for stillness and the
+          // fade is kept: a cross-fade is not motion across the screen, and it
+          // is gentler than the creature snapping in and out.
+          transitionProperty: reduce ? "opacity" : undefined,
         }}
       >
         <div

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -250,6 +250,18 @@ const RESTING_HEIGHT = 10;
 const RESTING_RIM = 2;
 
 /**
+ * The capsule's box: the accent the user sees, plus that rim on every side.
+ *
+ * One statement of it, because two things are sized from it and they must not
+ * drift. The capsule is drawn at it, and the box the working ring rides matches
+ * it at rest so the ring hugs the shape rather than the air around it.
+ */
+const RESTING_BOX = {
+  width: AVATAR_IMAGE + 2 * RESTING_RIM,
+  height: RESTING_HEIGHT + 2 * RESTING_RIM,
+};
+
+/**
  * The clearance every round thing inside the pill keeps from its edge.
  *
  * One number, because the geometry only works at one value. Nested rounded
@@ -1385,25 +1397,23 @@ function Avatar({
       onContextMenu={onContextMenu}
       onClick={onClick}
     >
-      {/* The shape the surface is drawn as: the creature's whole box while it
-        is being looked at, a thin capsule at rest, and one node morphing
-        between the two rather than two shapes cross-fading, so it reads as
-        this object changing rather than as a swap.
+      {/* The box the working ring is drawn around: the creature's whole box
+        while it is being looked at, the capsule at rest.
 
-        The edge rides it. A ring is a statement about the shape it is drawn
-        around, so a working ring at rest hugs the capsule instead of circling
-        the empty box the capsule sits in. One node either way, which is what
-        keeps the one-shot capture flare from remounting and replaying: see
-        `edge` in `CompanionSurface`. */}
+        A ring is a statement about the shape it rides, so at rest it hugs the
+        capsule rather than circling the empty box the capsule sits in. It is
+        the only thing this node carries, and the node is otherwise invisible:
+        painting the capsule here instead is what made the surface inflate a
+        coloured disc on its way open, since this box grows to the creature's
+        and anything filling it grows with it.
+
+        One node either way, never remounted, which is what keeps the one-shot
+        capture flare from replaying: see `edge` in `CompanionSurface`. */}
       <div
         className="absolute top-1/2 left-1/2 rounded-full transition-[width,height,transform] duration-300"
         style={{
-          width: collapsed
-            ? AVATAR_IMAGE + 2 * RESTING_RIM
-            : COMPANION_BASE_AVATAR_BOX,
-          height: collapsed
-            ? RESTING_HEIGHT + 2 * RESTING_RIM
-            : COMPANION_BASE_AVATAR_BOX,
+          width: collapsed ? RESTING_BOX.width : COMPANION_BASE_AVATAR_BOX,
+          height: collapsed ? RESTING_BOX.height : COMPANION_BASE_AVATAR_BOX,
           // Centred on the anchor, then scaled about that centre. The scale is
           // stated on both sides rather than only the collapsed one, so the two
           // states are the same transform list and interpolate cleanly.
@@ -1418,33 +1428,42 @@ function Avatar({
         }}
       >
         {edge}
-        {/* The capsule itself, drawn whole in the assistant's own colour.
-
-          The colour is all that is left of the creature at this size, so it is
-          the shape rather than a mark on it: a dark lozenge carrying a dot is
-          chrome with a light in it, and what this wants to be is the assistant,
-          small. It is also what keeps the marker findable on a busy desktop,
-          which matters more here than anywhere else on the surface: at rest
-          this is the only thing saying the assistant is there at all.
-
-          The pill's own material is deliberately not borrowed: a white rim over
-          a saturated colour reads as a highlight on it and muddies the one
-          thing the shape is for. The rim it does wear is dark and is not
-          decoration, it is what keeps the working ring legible; see
-          {@link RESTING_RIM}. The shadow stays, since it is what holds any of
-          this against a desktop the surface does not own. */}
-        <div
-          className="absolute inset-0 rounded-full shadow-lg shadow-black/40 transition-opacity duration-200"
-          style={{
-            background: accentHex,
-            // Drawn as a border rather than an outline so it is inside the
-            // box, which is what leaves the ring the whole annulus outside.
-            border: `${RESTING_RIM}px solid #17181b`,
-            opacity: collapsed ? 1 : 0,
-          }}
-          aria-hidden
-        />
       </div>
+      {/* The capsule itself, drawn whole in the assistant's own colour.
+
+        The colour is all that is left of the creature at this size, so it is
+        the shape rather than a mark on it: a dark lozenge carrying a dot is
+        chrome with a light in it, and what this wants to be is the assistant,
+        small. It is also what keeps the marker findable on a busy desktop,
+        which matters more here than anywhere else on the surface: at rest this
+        is the only thing saying the assistant is there at all.
+
+        **It holds its size and fades where it stands.** Sized here rather than
+        filling the box above, which grows to the creature's: a capsule that
+        grew with it inflated into a coloured disc and then dissolved, which
+        read as a bubble popping rather than as the creature coming out of the
+        pill. Nothing about this shape moves; the creature does the moving.
+
+        The pill's own material is deliberately not borrowed: a white rim over a
+        saturated colour reads as a highlight on it and muddies the one thing
+        the shape is for. The rim it does wear is dark and is not decoration, it
+        is what keeps the working ring legible; see {@link RESTING_RIM}. The
+        shadow stays, since it is what holds any of this against a desktop the
+        surface does not own. */}
+      <div
+        className="absolute top-1/2 left-1/2 rounded-full shadow-lg shadow-black/40 transition-opacity duration-200"
+        style={{
+          width: RESTING_BOX.width,
+          height: RESTING_BOX.height,
+          transform: `translate(-50%, -50%) scale(${restingScale})`,
+          background: accentHex,
+          // Drawn as a border rather than an outline so it is inside the box,
+          // which is what leaves the ring the whole annulus outside.
+          border: `${RESTING_RIM}px solid #17181b`,
+          opacity: collapsed ? 1 : 0,
+        }}
+        aria-hidden
+      />
       {/* The creature, tucking into the capsule rather than blinking out of
         it. A wrapper of its own because the scale is a `transform` and the bob
         below already owns one. */}

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -234,6 +234,22 @@ const AVATAR_IMAGE = COMPANION_BASE_AVATAR_IMAGE;
 const RESTING_HEIGHT = 10;
 
 /**
+ * The dark hairline the capsule wears, and the reason it is not a detail.
+ *
+ * The working ring is drawn immediately outside whatever shape it rides, in the
+ * assistant's colour. Around a capsule painted that same colour it disappears:
+ * a turn running while nobody is looking is exactly the state the ring exists
+ * to carry, and at rest it is the only thing carrying it. The hairline is what
+ * puts a dark edge between the two so the ring reads as a ring.
+ *
+ * The box grows by it on every side rather than the colour shrinking into it,
+ * so the accent a user actually sees stays {@link AVATAR_IMAGE} by
+ * {@link RESTING_HEIGHT} and the separation is bought from the desktop instead
+ * of from the marker.
+ */
+const RESTING_RIM = 2;
+
+/**
  * The clearance every round thing inside the pill keeps from its edge.
  *
  * One number, because the geometry only works at one value. Nested rounded
@@ -1382,8 +1398,12 @@ function Avatar({
       <div
         className="absolute top-1/2 left-1/2 rounded-full transition-[width,height,transform] duration-300"
         style={{
-          width: collapsed ? AVATAR_IMAGE : COMPANION_BASE_AVATAR_BOX,
-          height: collapsed ? RESTING_HEIGHT : COMPANION_BASE_AVATAR_BOX,
+          width: collapsed
+            ? AVATAR_IMAGE + 2 * RESTING_RIM
+            : COMPANION_BASE_AVATAR_BOX,
+          height: collapsed
+            ? RESTING_HEIGHT + 2 * RESTING_RIM
+            : COMPANION_BASE_AVATAR_BOX,
           // Centred on the anchor, then scaled about that centre. The scale is
           // stated on both sides rather than only the collapsed one, so the two
           // states are the same transform list and interpolate cleanly.
@@ -1398,25 +1418,32 @@ function Avatar({
         }}
       >
         {edge}
-        {/* The capsule itself, in the pill's own material: the same border,
-          ground and shadow the expanded body paints, so at rest and expanded
-          the user is looking at one surface rather than two. Drawn only while
-          collapsed, since the creature stands on the desktop unbacked.
+        {/* The capsule itself, drawn whole in the assistant's own colour.
 
-          The dot inside it is the assistant's colour, which is all that is
-          left of the creature at this size. Dark chrome alone would be a
-          lozenge the eye slides off on a busy desktop, and this shape has to
-          stay findable: it is the only thing saying the assistant is here. */}
+          The colour is all that is left of the creature at this size, so it is
+          the shape rather than a mark on it: a dark lozenge carrying a dot is
+          chrome with a light in it, and what this wants to be is the assistant,
+          small. It is also what keeps the marker findable on a busy desktop,
+          which matters more here than anywhere else on the surface: at rest
+          this is the only thing saying the assistant is there at all.
+
+          The pill's own material is deliberately not borrowed: a white rim over
+          a saturated colour reads as a highlight on it and muddies the one
+          thing the shape is for. The rim it does wear is dark and is not
+          decoration, it is what keeps the working ring legible; see
+          {@link RESTING_RIM}. The shadow stays, since it is what holds any of
+          this against a desktop the surface does not own. */}
         <div
-          className="absolute inset-0 grid place-items-center rounded-full border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200"
-          style={{ opacity: collapsed ? 1 : 0 }}
+          className="absolute inset-0 rounded-full shadow-lg shadow-black/40 transition-opacity duration-200"
+          style={{
+            background: accentHex,
+            // Drawn as a border rather than an outline so it is inside the
+            // box, which is what leaves the ring the whole annulus outside.
+            border: `${RESTING_RIM}px solid #17181b`,
+            opacity: collapsed ? 1 : 0,
+          }}
           aria-hidden
-        >
-          <span
-            className="size-1.5 rounded-full"
-            style={{ background: accentHex }}
-          />
-        </div>
+        />
       </div>
       {/* The creature, tucking into the capsule rather than blinking out of
         it. A wrapper of its own because the scale is a `transform` and the bob

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -202,6 +202,29 @@ const WATCHING_RING_ACCENT = "#ff9f45";
 const AVATAR_IMAGE = COMPANION_BASE_AVATAR_IMAGE;
 
 /**
+ * The capsule the creature collapses into at rest.
+ *
+ * At rest this surface is a marker rather than a mascot. It sits on the desktop
+ * all day over whatever the user is actually working in, and a character
+ * standing there is a character in the way; a thin capsule says the assistant
+ * is here and reachable and asks for nothing. The creature comes back the
+ * moment the pointer arrives, which is the only time anyone is looking at it.
+ *
+ * As wide as the artwork it stands in for ({@link AVATAR_IMAGE}), so the
+ * collapse reads as the creature tucking into its own width rather than as a
+ * differently sized object taking its place. The height is the one authored
+ * number here: thin enough to read as a marker, tall enough to see against a
+ * busy desktop and to carry the working ring around.
+ *
+ * **The box it is drawn in does not shrink with it.** That box is the drag
+ * handle, the point the host positions the window around, and the rect the
+ * pointer is hit-tested against, so shrinking it would move the anchor the host
+ * measures every drag and clamp against, and would make the surface hardest to
+ * hit exactly when it is smallest. What changes is the shape drawn inside it.
+ */
+const RESTING_HEIGHT = 10;
+
+/**
  * The clearance every round thing inside the pill keeps from its edge.
  *
  * One number, because the geometry only works at one value. Nested rounded
@@ -946,6 +969,10 @@ export function CompanionSurface({
         // uses while a reply is streaming: one vocabulary for "it is working"
         // wherever the user meets it.
         busy={assistantWorking}
+        // At rest the creature tucks into a capsule. The same answer the pill's
+        // own width reads, so the two collapse together and the surface goes to
+        // its resting shape as one thing.
+        collapsed={!expanded}
         edge={edge}
         style={{
           left: "50%",
@@ -1247,8 +1274,13 @@ function Composer({
  * animation on that node would silently replace one of them. Everything that
  * belongs to the creature rides inside the wrapper, glow included, so the light
  * travels with what is casting it. The edge sits outside the wrapper: it is
- * drawn on the box rather than on the artwork, so a ring saying something is
+ * drawn on the shape rather than on the artwork, so a ring saying something is
  * running holds still while the creature breathes under it.
+ *
+ * **The collapse is a third node, for the same reason.** Fading and shrinking
+ * the creature away at rest is a `transform`, and putting it on the bob would
+ * silently drop the bob. So the collapse gets a wrapper of its own around the
+ * bob, and the two animations stay on separate nodes.
  */
 function Avatar({
   accentHex,
@@ -1256,6 +1288,7 @@ function Avatar({
   character,
   busy = false,
   attentive = false,
+  collapsed = false,
   edge,
   style,
   elementRef,
@@ -1268,6 +1301,11 @@ function Avatar({
   character?: CompanionCharacter;
   busy?: boolean;
   attentive?: boolean;
+  /**
+   * Whether the surface is at rest, where the creature gives way to the
+   * capsule. See {@link RESTING_HEIGHT}.
+   */
+  collapsed?: boolean;
   /** What the creature's edge is drawing. See `edge` in `CompanionSurface`. */
   edge?: ReactNode;
   style?: CSSProperties;
@@ -1294,57 +1332,109 @@ function Avatar({
       onContextMenu={onContextMenu}
       onClick={onClick}
     >
-      {edge}
+      {/* The shape the surface is drawn as: the creature's whole box while it
+        is being looked at, a thin capsule at rest, and one node morphing
+        between the two rather than two shapes cross-fading, so it reads as
+        this object changing rather than as a swap.
+
+        The edge rides it. A ring is a statement about the shape it is drawn
+        around, so a working ring at rest hugs the capsule instead of circling
+        the empty box the capsule sits in. One node either way, which is what
+        keeps the one-shot capture flare from remounting and replaying: see
+        `edge` in `CompanionSurface`. */}
       <div
-        className="companion-avatar-bob relative grid place-items-center"
-        style={{ animation: reduce ? "none" : undefined }}
+        className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full transition-[width,height] duration-300"
+        style={{
+          width: collapsed ? AVATAR_IMAGE : COMPANION_BASE_AVATAR_BOX,
+          height: collapsed ? RESTING_HEIGHT : COMPANION_BASE_AVATAR_BOX,
+          // The easing the pill's own width uses, so the two halves of a
+          // surface waking up settle together rather than in sequence.
+          transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
+        }}
       >
-        <span
-          className="companion-glow absolute size-10 rounded-full blur-lg"
-          style={{
-            background: accentHex,
-            animation: reduce ? "none" : undefined,
-          }}
+        {edge}
+        {/* The capsule itself, in the pill's own material: the same border,
+          ground and shadow the expanded body paints, so at rest and expanded
+          the user is looking at one surface rather than two. Drawn only while
+          collapsed, since the creature stands on the desktop unbacked.
+
+          The dot inside it is the assistant's colour, which is all that is
+          left of the creature at this size. Dark chrome alone would be a
+          lozenge the eye slides off on a busy desktop, and this shape has to
+          stay findable: it is the only thing saying the assistant is here. */}
+        <div
+          className="absolute inset-0 grid place-items-center rounded-full border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200"
+          style={{ opacity: collapsed ? 1 : 0 }}
           aria-hidden
-        />
-        {character !== undefined ? (
-          // The live creature, composed here rather than shipped as pixels. It
-          // blinks, twitches and breathes on its own, which is the whole reason
-          // the traits cross the bridge instead of a still.
-          <div className="relative drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]">
-            <AnimatedAvatar
-              components={BUNDLED_COMPONENTS}
-              traits={character}
-              size={AVATAR_IMAGE}
-              isAssistantBusy={busy}
-              attentive={attentive}
-            />
-          </div>
-        ) : avatarSrc === undefined ? (
-          // Until the avatar resolves, a disc in its colour. Same size, so
-          // nothing about the geometry moves when the image lands.
+        >
           <span
-            className="relative size-7 rounded-full drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
+            className="size-1.5 rounded-full"
             style={{ background: accentHex }}
+          />
+        </div>
+      </div>
+      {/* The creature, tucking into the capsule rather than blinking out of
+        it. A wrapper of its own because the scale is a `transform` and the bob
+        below already owns one. */}
+      <div
+        className="transition-[opacity,transform] duration-300"
+        style={{
+          opacity: collapsed ? 0 : 1,
+          transform: collapsed ? "scale(0.35)" : "scale(1)",
+          transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
+        }}
+      >
+        <div
+          className="companion-avatar-bob relative grid place-items-center"
+          style={{ animation: reduce ? "none" : undefined }}
+        >
+          <span
+            className="companion-glow absolute size-10 rounded-full blur-lg"
+            style={{
+              background: accentHex,
+              animation: reduce ? "none" : undefined,
+            }}
             aria-hidden
           />
-        ) : (
-          // A custom uploaded image, which has no traits to compose and so no
-          // eyes to animate.
-          //
-          // Undraggable, because the avatar is the surface's drag handle. An
-          // image is natively draggable, and the platform's own HTML5 image drag
-          // takes the pointer and ends the `mousemove` stream the surface's drag
-          // runs on, so pressing a custom avatar would move nothing where
-          // pressing a composed creature moves the window. WebKit honours the CSS
-          // on paths where it ignores the attribute, so both are needed.
-          <img
-            src={avatarSrc}
-            alt=""
-            draggable={false}
-            className="relative size-7 rounded-full object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)] [-webkit-user-drag:none]"
-          />
-        )}
+          {character !== undefined ? (
+            // The live creature, composed here rather than shipped as pixels. It
+            // blinks, twitches and breathes on its own, which is the whole reason
+            // the traits cross the bridge instead of a still.
+            <div className="relative drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]">
+              <AnimatedAvatar
+                components={BUNDLED_COMPONENTS}
+                traits={character}
+                size={AVATAR_IMAGE}
+                isAssistantBusy={busy}
+                attentive={attentive}
+              />
+            </div>
+          ) : avatarSrc === undefined ? (
+            // Until the avatar resolves, a disc in its colour. Same size, so
+            // nothing about the geometry moves when the image lands.
+            <span
+              className="relative size-7 rounded-full drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
+              style={{ background: accentHex }}
+              aria-hidden
+            />
+          ) : (
+            // A custom uploaded image, which has no traits to compose and so no
+            // eyes to animate.
+            //
+            // Undraggable, because the avatar is the surface's drag handle. An
+            // image is natively draggable, and the platform's own HTML5 image drag
+            // takes the pointer and ends the `mousemove` stream the surface's drag
+            // runs on, so pressing a custom avatar would move nothing where
+            // pressing a composed creature moves the window. WebKit honours the CSS
+            // on paths where it ignores the attribute, so both are needed.
+            <img
+              src={avatarSrc}
+              alt=""
+              draggable={false}
+              className="relative size-7 rounded-full object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)] [-webkit-user-drag:none]"
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -1401,11 +1401,13 @@ function Avatar({
         while it is being looked at, the capsule at rest.
 
         A ring is a statement about the shape it rides, so at rest it hugs the
-        capsule rather than circling the empty box the capsule sits in. It is
-        the only thing this node carries, and the node is otherwise invisible:
-        painting the capsule here instead is what made the surface inflate a
-        coloured disc on its way open, since this box grows to the creature's
-        and anything filling it grows with it.
+        capsule rather than circling the empty box the capsule sits in.
+
+        The ring is the only thing this node carries and the node is otherwise
+        invisible, because this box grows between the two shapes and anything
+        filling it grows with it: an accent inflating to the creature's box and
+        dissolving reads as a bubble popping rather than as the creature coming
+        out of the pill. The capsule is drawn beside it, at its own size.
 
         One node either way, never remounted, which is what keeps the one-shot
         capture flare from replaying: see `edge` in `CompanionSurface`. */}
@@ -1438,11 +1440,10 @@ function Avatar({
         which matters more here than anywhere else on the surface: at rest this
         is the only thing saying the assistant is there at all.
 
-        **It holds its size and fades where it stands.** Sized here rather than
-        filling the box above, which grows to the creature's: a capsule that
-        grew with it inflated into a coloured disc and then dissolved, which
-        read as a bubble popping rather than as the creature coming out of the
-        pill. Nothing about this shape moves; the creature does the moving.
+        **It holds its size and fades where it stands.** Sized on itself rather
+        than filling the box above, which grows to the creature's. Nothing about
+        the resting shape moves: the creature is what grows out of the pill and
+        shrinks back into it, and one thing moving is what makes that legible.
 
         The pill's own material is deliberately not borrowed: a white rim over a
         saturated colour reads as a highlight on it and muddies the one thing


### PR DESCRIPTION
## Summary

- At rest the companion now draws a thin capsule (28x10) carrying the assistant's accent, instead of the full 44pt creature. The creature comes back on hover, and for every state that already opened the pill (call, typing, watching, summary, intro), since both read the same `expanded` answer.
- The shape is one node morphing between the two rather than two shapes cross-fading, and the working / capture ring moved onto it. A ring at rest now hugs the capsule instead of circling an empty 44pt box.
- **The capsule is drawn at one size on every avatar setting.** Sizing the creature is a statement about the creature: someone who wants a big mascot when they look at it has not asked for a big lozenge sitting over their work all day. It counters the scale its own node carries, and counters the transform rather than the lengths so the border, radius and ring stay identical too. The expanded shape still grows with the setting, which is the point of the setting.
- No geometry constant changed, in either process. The 44pt box is still the drag handle, still the anchor the host positions the window around, and still the rect the pointer is hit-tested against, so drag, clamping, growth flips and click-through arming are untouched and the window canvas is unchanged.

## Notes for review

- **The hit target stays the full 44pt box** (scaled by the avatar setting) while the drawn capsule is fixed. Deliberate: a forgiving target on a small marker, and it is the rect main already measures. The consequence to weigh is that at a large avatar setting the window arms across a region well outside the visible capsule.
- **The creature stays mounted while collapsed** (opacity 0, scaled down). It already animated at rest before this change, so this is not a new cost, but it is a cost, and unmounting it would cost the cross-fade.
- **Reduced motion** drops the spatial half only: the shape arrives changed rather than travelling, and the creature keeps its fade, which is not motion across the screen.
- Verified in Storybook rather than by eye in the app: `Resting`, `RestingInItsOwnColour`, `RestingCustomImage`, `RestingWhileWorking` (the ring-on-the-capsule case) and `RestingBigAvatarSmallOptions` (the fixed size).

## Corrections to an earlier version of this description

It claimed first run was unaffected because `CompanionIntro` holds the surface open. That was wrong and Codex caught it: `introPhase("meet")` returns `null` on purpose, so the beat that presents the creature by name leaves the phase at `resting`, and the card would have been pointing at a capsule. The surface now keeps the creature drawn whenever the introduction's card is on screen, with a test for it.

## Original prompt

Three companion ideas were filed as Linear issues (JARVIS-1691/1692/1693) and then picked up serially so each can be tested as it lands. This is the first: at rest the companion is a full-size avatar circle standing on the desktop, and it should collapse to a thin pill instead, closer to what the notch does than to a mascot in the corner, growing back out on hover. The constraint carried in from the ticket was that whatever it collapses to has to stay draggable and keep the same anchor point, since the avatar is both the drag handle and the point the Electron main process positions the window around. Reviewing the first build, the request was added that the resting shape not change size when the avatar size setting is adjusted.

Closes JARVIS-1691