### PR TITLE
fix(web): drop the stray commit-message fragment from the shell script

### DIFF
--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -135,7 +135,7 @@
     // `src/shell-metadata.test.ts` fails if the two drift.
     (function () {
       var SUPPORTED_LOCALES = ["en", "es", "ru", "zh", "zh-TW"];
-      var LABELS = { es: "Cargando", zh: "正在加载", "zh-TW": "正在載入" };: add Traditional Chinese (zh-TW) localization catalog)
+      var LABELS = { es: "Cargando", zh: "正在加载", "zh-TW": "正在載入" };
 
       function resolveLocale() {
         var findCanonical = function (candidate) {


### PR DESCRIPTION
The inline boot script in `clients/web/index.html` had a fragment of a commit message (`: add Traditional Chinese (zh-TW) localization catalog)`) pasted after the `LABELS` declaration. It is a syntax error, so the browser executed none of that script.

Two things silently stopped working:
- the stored theme was never stamped on the document before first paint, so users saw a flash of the wrong theme;
- the boot splash label was never localized, which was the feature the fragment came in with.

The fragment came from #41653. This supersedes the closed #41825, which was scoped down to just this line on review feedback: one line, no test.

Verified: the inline script now parses (`Bun.Transpiler.transformSync` throws on the old file, not on the new one), `bunx tsc --noEmit` clean, `bun run lint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRyE6m6PYynVB8vnbKhsuv
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41850" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->