### PR TITLE
fix(web): drop the bottom scroll fade on the model profile menu

### DIFF
--- a/clients/web/src/domains/chat/components/composer-settings-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.stories.tsx
@@ -122,7 +122,8 @@ export const Closed: Story = {};
 
 /**
  * A long profile list. The rows scroll inside the popover instead of growing
- * it past the top of the window, and the edge fade says there is more below.
+ * it past the top of the window, and a top fade appears once you scroll to
+ * say there is more above.
  */
 export const OpenWithManyProfiles: Story = {
   play: openProfileMenu,

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -982,11 +982,13 @@ export function ComposerSettingsMenu({
 
   // The profile list grows with the workspace and the menu has no ceiling of
   // its own, so a long one runs off the top of the composer. Cap it at about
-  // seven rows and scroll the rest, with the design library's edge fade
-  // signalling that there is more below. Radix keeps the focused row in view
-  // as the arrow keys walk past the cap.
+  // seven rows and scroll the rest, with a top fade signalling that there is
+  // more above. Only the top edge fades: the bottom row sits against the
+  // menu's own padded edge, where a fade dims the active row instead of
+  // reading as an overflow cue. Radix keeps the focused row in view as the
+  // arrow keys walk past the cap.
   const profileMenuList = (
-    <ScrollShadow className="max-h-[13rem]" size={16}>
+    <ScrollShadow className="max-h-[13rem]" size={16} fadeEdges="start">
       {profileMenuItems}
     </ScrollShadow>
   );

--- a/packages/design-library/src/components/scroll-shadow.stories.tsx
+++ b/packages/design-library/src/components/scroll-shadow.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof ScrollShadow> = {
       control: "inline-radio",
       options: ["vertical", "horizontal"],
     },
+    fadeEdges: {
+      control: "inline-radio",
+      options: ["both", "start", "end"],
+    },
     size: { control: { type: "number", min: 0, max: 80 } },
     offset: { control: { type: "number", min: 0, max: 40 } },
     hideScrollBar: { control: "boolean" },

--- a/packages/design-library/src/components/scroll-shadow.test.tsx
+++ b/packages/design-library/src/components/scroll-shadow.test.tsx
@@ -40,4 +40,26 @@ describe("ScrollShadow", () => {
     );
     expect(disabled).not.toContain("mask-image");
   });
+
+  test("fadeEdges drops the stops for the edge it opts out of", () => {
+    const both = renderToStaticMarkup(<ScrollShadow size={16}>x</ScrollShadow>);
+    expect(both).toContain("#000 16px");
+    expect(both).toContain("calc(100% - 16px)");
+
+    const startOnly = renderToStaticMarkup(
+      <ScrollShadow size={16} fadeEdges="start">
+        x
+      </ScrollShadow>,
+    );
+    expect(startOnly).toContain("#000 16px");
+    expect(startOnly).not.toContain("calc(100% - 16px)");
+
+    const endOnly = renderToStaticMarkup(
+      <ScrollShadow size={16} fadeEdges="end">
+        x
+      </ScrollShadow>,
+    );
+    expect(endOnly).not.toContain("#000 16px");
+    expect(endOnly).toContain("calc(100% - 16px)");
+  });
 });

--- a/packages/design-library/src/components/scroll-shadow.tsx
+++ b/packages/design-library/src/components/scroll-shadow.tsx
@@ -12,6 +12,9 @@ import { cn } from "../utils/cn";
 
 export type ScrollShadowOrientation = "vertical" | "horizontal";
 
+/** Which edges fade: both, only the start (top / left), or only the end. */
+export type ScrollShadowFadeEdges = "both" | "start" | "end";
+
 export interface ScrollShadowProps {
   children: ReactNode;
   /** Scroll axis the fade applies to. */
@@ -20,6 +23,8 @@ export interface ScrollShadowProps {
   size?: number;
   /** Extra scroll distance past an edge before its fade is hidden. */
   offset?: number;
+  /** Which edges fade when they have hidden content past them. */
+  fadeEdges?: ScrollShadowFadeEdges;
   /** When false, renders a plain scroll container with no fade. */
   isEnabled?: boolean;
   /** Visually hide the scrollbar (content still scrolls). */
@@ -47,6 +52,7 @@ export function ScrollShadow({
   orientation = "vertical",
   size = 24,
   offset = 0,
+  fadeEdges = "both",
   isEnabled = true,
   hideScrollBar = false,
   className,
@@ -114,7 +120,9 @@ export function ScrollShadow({
     };
   }, [recompute]);
 
-  const maskImage = isEnabled ? buildMask(orientation, size, edges) : undefined;
+  const maskImage = isEnabled
+    ? buildMask(orientation, size, edges, fadeEdges)
+    : undefined;
 
   return (
     <div
@@ -142,9 +150,20 @@ function buildMask(
   orientation: ScrollShadowOrientation,
   size: number,
   edges: EdgeState,
+  fadeEdges: ScrollShadowFadeEdges,
 ): string {
   const direction = orientation === "vertical" ? "to bottom" : "to right";
-  const startColor = edges.start ? "transparent" : "#000";
-  const endColor = edges.end ? "transparent" : "#000";
-  return `linear-gradient(${direction}, ${startColor}, #000 ${size}px, #000 calc(100% - ${size}px), ${endColor})`;
+  // An edge the caller opted out of contributes no stops, so the neighbouring
+  // stop's colour carries all the way to that end of the box.
+  const stops: string[] = [];
+  if (fadeEdges !== "end") {
+    stops.push(edges.start ? "transparent" : "#000", `#000 ${size}px`);
+  }
+  if (fadeEdges !== "start") {
+    stops.push(
+      `#000 calc(100% - ${size}px)`,
+      edges.end ? "transparent" : "#000",
+    );
+  }
+  return `linear-gradient(${direction}, ${stops.join(", ")})`;
 }

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -34,6 +34,7 @@ export {
   ScrollShadow,
   type ScrollShadowProps,
   type ScrollShadowOrientation,
+  type ScrollShadowFadeEdges,
 } from "./components/scroll-shadow";
 export {
   Tag,


### PR DESCRIPTION
## What

The model profile dropdown capped its list at about seven rows and scrolled the rest, with `ScrollShadow` fading **both** edges. The bottom row sits against the popover's own padded edge, so that fade just dimmed the row (often the active, checked one) instead of reading as an overflow cue.

## How

- `ScrollShadow` gains a `fadeEdges` prop: `"both"` (default) | `"start"` | `"end"`. An opted-out edge contributes **no** gradient stops, so the neighbouring stop's colour carries to that end of the box.
- The profile menu passes `fadeEdges="start"`, keeping the top fade that signals there is more above.
- The default is unchanged, so the staged-quotes strip (the only other consumer) renders an identical mask.

## Verification

- Drove the real `OpenWithManyProfiles` Storybook story in Chrome and read the applied mask off the DOM: `linear-gradient(#000, #000 16px)` at rest, `linear-gradient(transparent, #000 16px)` once scrolled. No end-side stop in either state, and the bottom row renders at full opacity.
- `bun test scroll-shadow.test.tsx`: 5 pass (new case asserts the opted-out edge's stops are dropped).
- `bun test composer-settings-menu.test.tsx`: 50 pass.
- `bunx tsc --noEmit` clean in `clients/web` and `packages/design-library`; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPhbY3969tsRqBLCk6iDW9

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41851" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->