### PR TITLE
fix(web): stop reporting expired-session 401/403s as telemetry contract rejections

### DIFF
--- a/clients/web/src/lib/telemetry/client-perf.test.ts
+++ b/clients/web/src/lib/telemetry/client-perf.test.ts
@@ -222,6 +222,24 @@ describe("sendClientWatchdogEvent", () => {
     expect(captureErrorMock).not.toHaveBeenCalled();
   });
 
+  test.each([401, 403])(
+    "stays quiet on %i: the auth layer refusing the caller is expected",
+    async (status) => {
+      telemetryIngestPostMock.mockImplementation(() =>
+        Promise.resolve({ response: { ok: false, status } }),
+      );
+
+      sendClientWatchdogEvent({
+        checkName: "client_boot",
+        value: 1,
+        detail: {},
+      });
+      await Bun.sleep(0);
+
+      expect(captureErrorMock).not.toHaveBeenCalled();
+    },
+  );
+
   test("stays quiet on 5xx: an unreachable daemon is transport, not contract", async () => {
     telemetryIngestPostMock.mockImplementation(() =>
       Promise.resolve({ response: { ok: false, status: 503 } }),

--- a/clients/web/src/lib/telemetry/client-perf.ts
+++ b/clients/web/src/lib/telemetry/client-perf.ts
@@ -81,9 +81,11 @@ export type ClientPerfCheckName =
  * Posts one `client_*` watchdog event through the daemon relay. Fire and
  * forget: never throws into the caller, so a probe can sit on a hot render
  * or navigation path without adding a failure mode. Transport failures
- * (network, unreachable daemon) are swallowed; a 4xx rejection other than
- * 404 is reported to Sentry once per status per page load, because a batch
- * the daemon refuses is silent data loss otherwise.
+ * (network, unreachable daemon) are swallowed; a contract-class 4xx
+ * rejection (400/422, the wire refusing the event) is reported to Sentry
+ * once per status per page load, because a batch the daemon refuses is
+ * silent data loss otherwise. Auth-layer answers (401/403) and pre-relay
+ * daemons (404) stay quiet, expected states rather than contract breaks.
  *
  * Precision is the caller's: durations arrive already rounded to whole
  * milliseconds, scores keep their decimals, and `value` is null when the
@@ -135,10 +137,20 @@ export function sendClientWatchdogEvent(event: {
     })
       .then(({ response }) => {
         const status = response?.status ?? 0;
-        // 404 is not a reportable condition: a daemon predating the relay
-        // route answers it per event, expected and quiet, and telemetry from
-        // it is simply absent.
-        if (status < 400 || status >= 500 || status === 404) {
+        // Only contract-class rejections are reportable. Not reportable:
+        // 404, a daemon predating the relay route answers it per event, and
+        // telemetry from it is simply absent; 401/403, an auth layer refusing
+        // the caller rather than the wire refusing the event (on the cloud
+        // proxy path an expired or absent platform session answers 403), the
+        // app surfaces signed-out state on its own and every expired-session
+        // page load would otherwise report once, forever.
+        if (
+          status < 400 ||
+          status >= 500 ||
+          status === 401 ||
+          status === 403 ||
+          status === 404
+        ) {
           return;
         }
         if (claimUnreportedConditions([`relay:${status}`]).length === 0) {

--- a/clients/web/src/lib/telemetry/ingest.test.ts
+++ b/clients/web/src/lib/telemetry/ingest.test.ts
@@ -186,6 +186,18 @@ describe("postTelemetryEvents", () => {
     expect(reportedMessages()[0]).toContain("503");
   });
 
+  test.each([401, 403])(
+    "stays quiet on %i: the auth layer refusing the caller is expected",
+    async (status) => {
+      result = { response: { ok: false, status } };
+
+      postTelemetryEvents([{ type: "watchdog" }]);
+      await flush();
+
+      expect(captureErrorMock).not.toHaveBeenCalled();
+    },
+  );
+
   test("swallows a transport failure without reporting it", async () => {
     transportError = new Error("network down");
 

--- a/clients/web/src/lib/telemetry/ingest.ts
+++ b/clients/web/src/lib/telemetry/ingest.ts
@@ -59,6 +59,13 @@ export function postTelemetryEvents(events: readonly object[]): void {
     .then(({ data, response }) => {
       if (!response?.ok) {
         const status = response?.status ?? null;
+        // 401/403 are the auth layer refusing the caller (an expired or
+        // absent platform session), not the contract refusing the batch. The
+        // app surfaces signed-out state on its own, and every expired-session
+        // page load would otherwise report once, forever.
+        if (status === 401 || status === 403) {
+          return;
+        }
         if (
           claimUnreportedConditions([`rejected:${status ?? "no-response"}`])
             .length


### PR DESCRIPTION
## TL;DR

An expired or signed-out platform session answers the web client's telemetry POSTs with 403, and both telemetry senders treated that as a contract rejection and reported it to Sentry, once per page load, forever. This PR keeps 401/403 quiet on both paths while contract-class rejections (400/422, the wire refusing the event) stay loud.

## Why this is needed

The first `client_boot` relay rejection on staging (Sep 1, 14:22 UTC) traced server-side to `Authentication failed during organization resolution` with `has_session_cookie: false`: the tab's Django session had expired, and DRF renders `NotAuthenticated` as 403 under session auth. The same user's other platform calls were 403ing at the same moment, and requests from live sessions on the same assistant succeeded seconds earlier.

So a 401/403 on these paths is the auth layer refusing the caller, not the daemon or platform refusing the event's shape:

- The event is legitimately undeliverable, and the app already surfaces signed-out state through its own auth handling.
- Every expired-session tab reports once per page load, a steady drip at production scale that trains everyone to ignore exactly the warning class #41761 created to be load-bearing.
- The daemon's own route policy cannot 403 a real web caller on scopes: every actor-facing token mints `actor_client_v1`, which carries `settings.write` (`gateway/src/auth/scopes.ts`), so quieting 403 hides no daemon-side contract signal.

## What changes for the user

Nothing in the product. Operator visibility only:

| Situation | Before | After |
| --- | --- | --- |
| Wire-schema rejection (400/422) | Sentry warning, once per status per page load | Unchanged |
| Expired/absent session (401/403) | Sentry warning, once per page load, on both the relay and session-ingest paths | Silent (expected auth state) |
| Pre-relay daemon (404, relay path) | Silent | Unchanged |
| 5xx / transport failure | Per-path behavior (relay quiet, session ingest loud) | Unchanged |

## Why it is safe

- No request, payload, or flush behavior changes; only which statuses the response handlers report.
- The silent-loss class #41761 and #41785 exist to end is contract rejection of a healthy session's events. 400/422 still report on both paths; accepted-but-dropped reporting is untouched.
- Tests cover the new quiet pair on both senders and still pin 400 loud, 404 quiet (relay), and 503 loud (session ingest).

## Deferred, and why

- Django answering 403 rather than 401 for an unauthenticated session is DRF's documented behavior for session auth and belongs to the platform; no change proposed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->