### PR TITLE
fix(channels): email badge reads inbox registration from the platform, not a dead config key

### DIFF
--- a/assistant/src/__tests__/channel-availability-routes.test.ts
+++ b/assistant/src/__tests__/channel-availability-routes.test.ts
@@ -13,6 +13,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { CHANNEL_METADATA } from "../channels/types.js";
+import { credentialKey } from "../security/credential-key.js";
 
 // ---------------------------------------------------------------------------
 // Mock state — flipped per-test
@@ -29,6 +30,11 @@ let mockEmailAddressesResponse: {
   body: { count: 0, results: [] },
 };
 let mockFetchThrows = false;
+let mockSecureKeys: Record<string, string> = {};
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
+}));
 
 mock.module("../platform/client.js", () => ({
   VellumPlatformClient: {
@@ -83,6 +89,7 @@ describe("channels/available", () => {
       body: { count: 0, results: [] },
     };
     mockFetchThrows = false;
+    mockSecureKeys = {};
   });
 
   test("base list only when no email address registered", async () => {
@@ -120,6 +127,14 @@ describe("channels/available", () => {
       status: 200,
       body: { results: [{ id: "addr-1", address: "hi@bot" }] },
     };
+
+    const result = (await handler({})) as HandlerResult;
+
+    expect(result.channels.map((c) => c.id)).toContain("email");
+  });
+
+  test("appends email when a your-own provider credential is stored", async () => {
+    mockSecureKeys[credentialKey("resend", "api_key")] = "stored";
 
     const result = (await handler({})) as HandlerResult;
 

--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -174,6 +174,33 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       );
     });
 
+    test("a your-own provider credential passes the inbox check", async () => {
+      setConfig("ingress", {
+        publicBaseUrl: "https://example.com",
+        enabled: true,
+      });
+      mockRegisteredInbox = { status: "none" };
+      mockSecureKeys[credentialKey("resend", "api_key")] = "stored";
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email", true);
+
+      expect(snapshot.ready).toBe(true);
+      expect(snapshot.reasons).toHaveLength(0);
+    });
+
+    test("a your-own credential decides even when the platform is unreachable", async () => {
+      setConfig("ingress", {
+        publicBaseUrl: "https://example.com",
+        enabled: true,
+      });
+      mockRegisteredInbox = { status: "unavailable", detail: "HTTP 503" };
+      mockSecureKeys[credentialKey("mailgun", "api_key")] = "stored";
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email", true);
+
+      expect(snapshot.ready).toBe(true);
+    });
+
     test("unreachable platform is indeterminate, not a fault", async () => {
       setConfig("ingress", {
         publicBaseUrl: "https://example.com",

--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -128,8 +128,8 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
 
     test("platform registration decides the check; local config cannot", async () => {
       // Registration lives on the platform. A stray local `email.address`
-      // (the key the probe used to read, which nothing writes) must not make
-      // an unregistered inbox pass.
+      // config value (a key nothing writes) must not make an unregistered
+      // inbox pass.
       setConfig("ingress", {
         publicBaseUrl: "https://example.com",
         enabled: true,

--- a/assistant/src/__tests__/channel-readiness-routes.test.ts
+++ b/assistant/src/__tests__/channel-readiness-routes.test.ts
@@ -10,9 +10,11 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing the service
 // ---------------------------------------------------------------------------
+import type { RegisteredInboxState } from "../email/registered-inbox.js";
 
 let mockSecureKeys: Record<string, string>;
 let mockHasTwilioCredentials: boolean;
+let mockRegisteredInbox: RegisteredInboxState;
 
 mock.module("../calls/twilio-rest.js", () => ({
   hasTwilioCredentials: () => mockHasTwilioCredentials,
@@ -23,6 +25,11 @@ mock.module("../config/env.js", () => ({}));
 
 mock.module("../security/secure-keys.js", () => ({
   getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
+}));
+
+mock.module("../email/registered-inbox.js", () => ({
+  resolveRegisteredInbox: async () => mockRegisteredInbox,
+  invalidateRegisteredInboxCache: () => {},
 }));
 
 // ---------------------------------------------------------------------------
@@ -45,6 +52,7 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
     setConfig("email", {});
     mockSecureKeys = {};
     mockHasTwilioCredentials = false;
+    mockRegisteredInbox = { status: "none" };
   });
 
   // -------------------------------------------------------------------------
@@ -102,12 +110,15 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       expect(ingressCheck!.passed).toBe(false);
     });
 
-    test("ready when all prerequisites are met (including inbox)", async () => {
+    test("ready when the platform reports a registered inbox", async () => {
       setConfig("ingress", {
         publicBaseUrl: "https://example.com",
         enabled: true,
       });
-      setConfig("email", { address: "user@example.com" });
+      mockRegisteredInbox = {
+        status: "registered",
+        address: "assistant@example.com",
+      };
       const service = createReadinessService();
       const [snapshot] = await service.getReadiness("email", true);
 
@@ -115,7 +126,26 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       expect(snapshot.reasons).toHaveLength(0);
     });
 
-    test("not ready when inbox is missing (remote check)", async () => {
+    test("platform registration decides the check; local config cannot", async () => {
+      // Registration lives on the platform. A stray local `email.address`
+      // (the key the probe used to read, which nothing writes) must not make
+      // an unregistered inbox pass.
+      setConfig("ingress", {
+        publicBaseUrl: "https://example.com",
+        enabled: true,
+      });
+      setConfig("email", { address: "stale@example.com" });
+      mockRegisteredInbox = { status: "none" };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email", true);
+
+      expect(snapshot.ready).toBe(false);
+      expect(snapshot.reasons.some((r) => r.code === "inbox_configured")).toBe(
+        true,
+      );
+    });
+
+    test("not ready when the platform reports no inbox (remote check)", async () => {
       setConfig("ingress", {
         publicBaseUrl: "https://example.com",
         enabled: true,
@@ -127,6 +157,42 @@ describe("channel readiness routes — email and WhatsApp probes", () => {
       expect(snapshot.reasons.some((r) => r.code === "inbox_configured")).toBe(
         true,
       );
+    });
+
+    test("missing platform credentials fail the inbox check", async () => {
+      setConfig("ingress", {
+        publicBaseUrl: "https://example.com",
+        enabled: true,
+      });
+      mockRegisteredInbox = { status: "no_platform" };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email", true);
+
+      expect(snapshot.ready).toBe(false);
+      expect(snapshot.reasons.some((r) => r.code === "inbox_configured")).toBe(
+        true,
+      );
+    });
+
+    test("unreachable platform is indeterminate, not a fault", async () => {
+      setConfig("ingress", {
+        publicBaseUrl: "https://example.com",
+        enabled: true,
+      });
+      mockRegisteredInbox = { status: "unavailable", detail: "HTTP 503" };
+      const service = createReadinessService();
+      const [snapshot] = await service.getReadiness("email", true);
+
+      // No positive confirmation, so the channel cannot report ready, but an
+      // unanswerable question is not a fault and must not be listed as one.
+      expect(snapshot.ready).toBe(false);
+      expect(snapshot.reasons.some((r) => r.code === "inbox_configured")).toBe(
+        false,
+      );
+      const remoteCheck = snapshot.remoteChecks?.find(
+        (c) => c.name === "inbox_configured",
+      );
+      expect(remoteCheck?.indeterminate).toBe(true);
     });
 
     test("local-only readiness still passes without inbox check", async () => {

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -369,9 +369,11 @@ describe("ChannelReadinessService", () => {
     });
   });
 
-  test("email readiness ignores platform connectivity", async () => {
-    // Email passes `allowManagedCallbacks: false`, so the managed tiers are
-    // not offered to it and only a real ingress URL counts.
+  test("email readiness accepts a platform-connected assistant with no ingress", async () => {
+    // Inbound email arrives through the platform callback route the gateway
+    // registers (`registerEmailCallbackRoute`, the same pattern as Telegram),
+    // so a platform-connected assistant with no public ingress URL still
+    // receives email and must not report missing ingress.
     mockPlatformConnected = true;
 
     const readiness = createReadinessService();
@@ -379,8 +381,21 @@ describe("ChannelReadinessService", () => {
 
     expect(snapshot.localChecks).toContainEqual({
       name: "ingress",
+      passed: true,
+      message: "Managed platform callback routing is configured",
+    });
+  });
+
+  test("email readiness reports missing ingress when nothing can route inbound", async () => {
+    mockPlatformConnected = false;
+
+    const readiness = createReadinessService();
+    const [snapshot] = await readiness.getReadiness("email");
+
+    expect(snapshot.localChecks).toContainEqual({
+      name: "ingress",
       passed: false,
-      message: "Public ingress URL is not configured or disabled",
+      message: "No public ingress URL or managed callback route is configured",
     });
   });
 

--- a/assistant/src/__tests__/credential-security-invariants.test.ts
+++ b/assistant/src/__tests__/credential-security-invariants.test.ts
@@ -238,6 +238,7 @@ describe("Invariant 2: no generic plaintext secret read API", () => {
       "providers/inference/connection-availability.ts", // shared (provider, connection) availability status (credential presence check only; value never leaves the helper)
       "plugin-api/resolve-credential.ts", // plugin-facing resolveCredential: reveal-equivalent plaintext read, scoped to the in-context plugin's own service
       "tools/credentials/store.ts", // shared credential write path (setSecureKeyAsync only; no reads) behind credentials/set and plugin-facing storeCredential
+      "email/byo-email-credential.ts", // BYO email provider configuration check (credential presence only; value never leaves the helper)
     ]);
 
     const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -485,7 +486,6 @@ describe("Invariant 4: credentials only used for allowed purpose", () => {
     expect(result.reason).toContain("No tools are currently allowed");
   });
 });
-
 
 // ---------------------------------------------------------------------------
 // Invariant 6 — oauth2ClientSecret never in plaintext metadata

--- a/assistant/src/__tests__/email-invite-adapter.test.ts
+++ b/assistant/src/__tests__/email-invite-adapter.test.ts
@@ -1,11 +1,27 @@
 /**
  * Tests for the email invite adapter.
  *
- * Verifies that the email adapter resolves the assistant's email address
- * from workspace config and falls back to `undefined` when no address
- * is configured.
+ * Verifies that the email adapter resolves the assistant's address from the
+ * shared registered-inbox reader (the platform is the only writer of managed
+ * inbox registrations) and falls back to `undefined` when no address is
+ * registered or the platform cannot be asked.
  */
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { RegisteredInboxState } from "../email/registered-inbox.js";
+
+let mockInboxState: RegisteredInboxState;
+let mockResolveThrows: boolean;
+
+mock.module("../email/registered-inbox.js", () => ({
+  resolveRegisteredInbox: async () => {
+    if (mockResolveThrows) {
+      throw new Error("resolver unavailable");
+    }
+    return mockInboxState;
+  },
+  invalidateRegisteredInboxCache: () => {},
+}));
 
 import { resolveAdapterHandle } from "../runtime/channel-invite-transport.js";
 import { emailInviteAdapter } from "../runtime/channel-invite-transports/email.js";
@@ -17,28 +33,53 @@ import { setConfig } from "./helpers/set-config.js";
 
 describe("emailInviteAdapter", () => {
   beforeEach(() => {
-    // The adapter reads the raw workspace config; reset the `email` key so
-    // each test starts without a configured address.
-    setConfig("email", {});
+    mockInboxState = { status: "none" };
+    mockResolveThrows = false;
   });
 
-  test("returns configured email address via resolveChannelHandleAsync", async () => {
-    setConfig("email", { address: "user@example.com" });
+  test("returns the registered address via resolveChannelHandleAsync", async () => {
+    mockInboxState = { status: "registered", address: "user@example.com" };
 
     const handle = await resolveAdapterHandle(emailInviteAdapter);
     expect(handle).toBe("user@example.com");
   });
 
-  test("returns undefined when no address is configured", async () => {
+  test("returns undefined when no inbox is registered", async () => {
     const handle = await resolveAdapterHandle(emailInviteAdapter);
     expect(handle).toBeUndefined();
   });
 
-  test("returns undefined when email.address is empty string", async () => {
-    setConfig("email", { address: "" });
+  test("returns undefined when the platform is not connected", async () => {
+    mockInboxState = { status: "no_platform" };
 
     const handle = await resolveAdapterHandle(emailInviteAdapter);
     expect(handle).toBeUndefined();
+  });
+
+  test("returns undefined when the platform cannot be asked", async () => {
+    mockInboxState = { status: "unavailable", detail: "HTTP 503" };
+
+    const handle = await resolveAdapterHandle(emailInviteAdapter);
+    expect(handle).toBeUndefined();
+  });
+
+  test("returns undefined when the resolver throws", async () => {
+    mockResolveThrows = true;
+
+    const handle = await resolveAdapterHandle(emailInviteAdapter);
+    expect(handle).toBeUndefined();
+  });
+
+  test("a local email.address config value cannot supply the handle", async () => {
+    // Registration lives on the platform; a stray config value (a key
+    // nothing writes) must not surface as the assistant's address.
+    setConfig("email", { address: "stale@example.com" });
+    mockInboxState = { status: "none" };
+
+    const handle = await resolveAdapterHandle(emailInviteAdapter);
+    expect(handle).toBeUndefined();
+
+    setConfig("email", {});
   });
 
   test("adapter channel is email", () => {

--- a/assistant/src/email/byo-email-credential.test.ts
+++ b/assistant/src/email/byo-email-credential.test.ts
@@ -8,7 +8,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let invalidatedChannels: string[];
 
-mock.module("../../daemon/handlers/config-channels.js", () => ({
+mock.module("../daemon/handlers/config-channels.js", () => ({
   getReadinessService: () => ({
     invalidateChannel: (channel: string) => {
       invalidatedChannels.push(channel);
@@ -16,7 +16,7 @@ mock.module("../../daemon/handlers/config-channels.js", () => ({
   }),
 }));
 
-import { invalidateEmailReadinessForByoCredential } from "./store.js";
+import { invalidateEmailReadinessForByoCredential } from "./byo-email-credential.js";
 
 describe("invalidateEmailReadinessForByoCredential", () => {
   beforeEach(() => {

--- a/assistant/src/email/byo-email-credential.ts
+++ b/assistant/src/email/byo-email-credential.ts
@@ -1,0 +1,37 @@
+/**
+ * "Your own" (BYO) email providers: the assistant sends and receives email
+ * through the user's own provider account instead of a platform-managed
+ * inbox. Configuration is the provider's stored `api_key` credential;
+ * inbound arrives through the gateway's per-provider webhook routes
+ * (`gateway/src/http/routes/resend-webhook.ts`, `mailgun-webhook.ts`).
+ *
+ * The service ids here are the credential-store service names those webhook
+ * routes and the web client's BYO setup read (`EMAIL_BYO_PROVIDERS` in
+ * `clients/web/src/lib/provider-catalogs.ts` mirrors this list). Adding a
+ * provider means a new gateway webhook route and a web catalog entry, so
+ * extend all three together.
+ */
+
+import { credentialKey } from "../security/credential-key.js";
+import { getSecureKeyAsync } from "../security/secure-keys.js";
+
+export const BYO_EMAIL_CREDENTIAL_SERVICES = ["resend", "mailgun"] as const;
+
+export type ByoEmailCredentialService =
+  (typeof BYO_EMAIL_CREDENTIAL_SERVICES)[number];
+
+/**
+ * The first BYO email provider whose API key is stored, or `undefined` when
+ * none is configured. Credential presence is the configuration claim, the
+ * same standard the other channels' readiness checks apply to their tokens.
+ */
+export async function resolveConfiguredByoEmailService(): Promise<
+  ByoEmailCredentialService | undefined
+> {
+  for (const service of BYO_EMAIL_CREDENTIAL_SERVICES) {
+    if (await getSecureKeyAsync(credentialKey(service, "api_key"))) {
+      return service;
+    }
+  }
+  return undefined;
+}

--- a/assistant/src/email/byo-email-credential.ts
+++ b/assistant/src/email/byo-email-credential.ts
@@ -14,11 +14,20 @@
 
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("byo-email-credential");
 
 export const BYO_EMAIL_CREDENTIAL_SERVICES = ["resend", "mailgun"] as const;
 
 export type ByoEmailCredentialService =
   (typeof BYO_EMAIL_CREDENTIAL_SERVICES)[number];
+
+export function isByoEmailCredentialService(
+  service: string,
+): service is ByoEmailCredentialService {
+  return BYO_EMAIL_CREDENTIAL_SERVICES.some((s) => s === service);
+}
 
 /**
  * The first BYO email provider whose API key is stored, or `undefined` when
@@ -34,4 +43,34 @@ export async function resolveConfiguredByoEmailService(): Promise<
     }
   }
   return undefined;
+}
+
+/**
+ * A stored or deleted BYO email provider key changes the email channel's
+ * readiness verdict, and that check lives in the readiness service's
+ * TTL-cached remote bucket; drop the cached snapshot so the next readiness
+ * read re-evaluates instead of serving the pre-write answer for the rest of
+ * the TTL. Called from the credential write and delete paths. Best-effort:
+ * the credential change already succeeded, and a missed invalidation
+ * self-heals when the TTL lapses.
+ */
+export async function invalidateEmailReadinessForByoCredential(
+  service: string,
+): Promise<void> {
+  if (!isByoEmailCredentialService(service)) {
+    return;
+  }
+  try {
+    // Lazily imported: the readiness service sits in the daemon handler
+    // graph, which credential writers (CLI, plugin API) should not load
+    // unless a BYO email key actually changed.
+    const { getReadinessService } =
+      await import("../daemon/handlers/config-channels.js");
+    getReadinessService().invalidateChannel("email");
+  } catch (err) {
+    log.warn(
+      { err, service },
+      "Credential change succeeded, but email readiness invalidation failed",
+    );
+  }
 }

--- a/assistant/src/email/registered-inbox.test.ts
+++ b/assistant/src/email/registered-inbox.test.ts
@@ -37,10 +37,20 @@ mock.module("../platform/client.js", () => ({
 // Import after mocks
 // ---------------------------------------------------------------------------
 
+import { VellumPlatformClient } from "../platform/client.js";
 import {
   invalidateRegisteredInboxCache,
+  listEmailAddresses,
   resolveRegisteredInbox,
 } from "./registered-inbox.js";
+
+async function testClient(): Promise<VellumPlatformClient> {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    throw new Error("mocked create returned null");
+  }
+  return client;
+}
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -59,7 +69,10 @@ describe("resolveRegisteredInbox", () => {
     mockResponse = {
       ok: true,
       status: 200,
-      body: { count: 1, results: [{ address: "assistant@example.com" }] },
+      body: {
+        count: 1,
+        results: [{ id: "addr-1", address: "assistant@example.com" }],
+      },
     };
 
     const state = await resolveRegisteredInbox();
@@ -118,7 +131,7 @@ describe("resolveRegisteredInbox", () => {
     mockResponse = {
       ok: true,
       status: 200,
-      body: { count: 1, results: [{ address: "hi@bot" }] },
+      body: { count: 1, results: [{ id: "addr-1", address: "hi@bot" }] },
     };
     await resolveRegisteredInbox();
 
@@ -135,7 +148,7 @@ describe("resolveRegisteredInbox", () => {
     mockResponse = {
       ok: true,
       status: 200,
-      body: { count: 1, results: [{ address: "hi@bot" }] },
+      body: { count: 1, results: [{ id: "addr-1", address: "hi@bot" }] },
     };
 
     const fresh = await resolveRegisteredInbox({ fresh: true });
@@ -162,10 +175,58 @@ describe("resolveRegisteredInbox", () => {
     mockResponse = {
       ok: true,
       status: 200,
-      body: { count: 1, results: [{ address: "hi@bot" }] },
+      body: { count: 1, results: [{ id: "addr-1", address: "hi@bot" }] },
     };
     const state = await resolveRegisteredInbox();
 
     expect(state).toEqual({ status: "registered", address: "hi@bot" });
+  });
+});
+
+describe("listEmailAddresses", () => {
+  beforeEach(() => {
+    mockPlatformAssistantId = "assistant-test-id";
+    mockResponse = { ok: true, status: 200, body: { count: 0, results: [] } };
+    mockFetchThrows = false;
+    fetchCallCount = 0;
+  });
+
+  test("returns the platform's rows with ids", async () => {
+    mockResponse = {
+      ok: true,
+      status: 200,
+      body: { results: [{ id: "addr-1", address: "user@example.com" }] },
+    };
+
+    const list = await listEmailAddresses(await testClient());
+
+    expect(list).toEqual({
+      ok: true,
+      addresses: [{ id: "addr-1", address: "user@example.com" }],
+    });
+  });
+
+  test("carries the platform's status on a non-ok response", async () => {
+    mockResponse = { ok: false, status: 503, body: { detail: "boom" } };
+
+    const list = await listEmailAddresses(await testClient());
+
+    expect(list).toEqual({ ok: false, status: 503, detail: "HTTP 503" });
+  });
+
+  test("fails without a status when the fetch throws", async () => {
+    mockFetchThrows = true;
+
+    const list = await listEmailAddresses(await testClient());
+
+    expect(list).toEqual({ ok: false, detail: "platform unreachable" });
+  });
+
+  test("fails on an unexpected response shape", async () => {
+    mockResponse = { ok: true, status: 200, body: { results: [{ id: 7 }] } };
+
+    const list = await listEmailAddresses(await testClient());
+
+    expect(list).toEqual({ ok: false, detail: "unexpected response shape" });
   });
 });

--- a/assistant/src/email/registered-inbox.test.ts
+++ b/assistant/src/email/registered-inbox.test.ts
@@ -12,26 +12,34 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 let mockPlatformAssistantId: string | null;
 let mockResponse: { ok: boolean; status: number; body: unknown };
 let mockFetchThrows: boolean;
+let mockCreateThrows: boolean;
 let fetchCallCount: number;
 
 mock.module("../platform/client.js", () => ({
   VellumPlatformClient: {
-    create: async () => ({
-      platformAssistantId: mockPlatformAssistantId,
-      fetch: async (_path: string) => {
-        fetchCallCount += 1;
-        if (mockFetchThrows) {
-          throw new Error("platform unreachable");
-        }
-        return {
-          ok: mockResponse.ok,
-          status: mockResponse.status,
-          json: async () => mockResponse.body,
-        };
-      },
-    }),
+    create: async () => {
+      if (mockCreateThrows) {
+        throw new Error("credential store unavailable");
+      }
+      return clientStub();
+    },
   },
 }));
+
+const clientStub = () => ({
+  platformAssistantId: mockPlatformAssistantId,
+  fetch: async (_path: string) => {
+    fetchCallCount += 1;
+    if (mockFetchThrows) {
+      throw new Error("platform unreachable");
+    }
+    return {
+      ok: mockResponse.ok,
+      status: mockResponse.status,
+      json: async () => mockResponse.body,
+    };
+  },
+});
 
 // ---------------------------------------------------------------------------
 // Import after mocks
@@ -61,8 +69,20 @@ describe("resolveRegisteredInbox", () => {
     mockPlatformAssistantId = "assistant-test-id";
     mockResponse = { ok: true, status: 200, body: { count: 0, results: [] } };
     mockFetchThrows = false;
+    mockCreateThrows = false;
     fetchCallCount = 0;
     invalidateRegisteredInboxCache();
+  });
+
+  test("unavailable when client creation itself throws", async () => {
+    mockCreateThrows = true;
+
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({
+      status: "unavailable",
+      detail: "credential store unavailable",
+    });
   });
 
   test("registered when the platform lists an address", async () => {
@@ -188,7 +208,27 @@ describe("listEmailAddresses", () => {
     mockPlatformAssistantId = "assistant-test-id";
     mockResponse = { ok: true, status: 200, body: { count: 0, results: [] } };
     mockFetchThrows = false;
+    mockCreateThrows = false;
     fetchCallCount = 0;
+  });
+
+  test("a 200 without results is a failed listing, not an empty one", async () => {
+    mockResponse = { ok: true, status: 200, body: {} };
+
+    const list = await listEmailAddresses(await testClient());
+
+    expect(list).toEqual({ ok: false, detail: "unexpected response shape" });
+  });
+
+  test("a positive count with no rows is a failed listing", async () => {
+    mockResponse = { ok: true, status: 200, body: { count: 2, results: [] } };
+
+    const list = await listEmailAddresses(await testClient());
+
+    expect(list).toEqual({
+      ok: false,
+      detail: "listing reported 2 addresses but returned none",
+    });
   });
 
   test("returns the platform's rows with ids", async () => {

--- a/assistant/src/email/registered-inbox.test.ts
+++ b/assistant/src/email/registered-inbox.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for the shared registered-inbox reader: the single answer to "does
+ * this assistant have a managed inbox?", read from the platform
+ * email-addresses API (the only writer of managed registrations).
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Mocks, set up before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockPlatformAssistantId: string | null;
+let mockResponse: { ok: boolean; status: number; body: unknown };
+let mockFetchThrows: boolean;
+let fetchCallCount: number;
+
+mock.module("../platform/client.js", () => ({
+  VellumPlatformClient: {
+    create: async () => ({
+      platformAssistantId: mockPlatformAssistantId,
+      fetch: async (_path: string) => {
+        fetchCallCount += 1;
+        if (mockFetchThrows) {
+          throw new Error("platform unreachable");
+        }
+        return {
+          ok: mockResponse.ok,
+          status: mockResponse.status,
+          json: async () => mockResponse.body,
+        };
+      },
+    }),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import {
+  invalidateRegisteredInboxCache,
+  resolveRegisteredInbox,
+} from "./registered-inbox.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("resolveRegisteredInbox", () => {
+  beforeEach(() => {
+    mockPlatformAssistantId = "assistant-test-id";
+    mockResponse = { ok: true, status: 200, body: { count: 0, results: [] } };
+    mockFetchThrows = false;
+    fetchCallCount = 0;
+    invalidateRegisteredInboxCache();
+  });
+
+  test("registered when the platform lists an address", async () => {
+    mockResponse = {
+      ok: true,
+      status: 200,
+      body: { count: 1, results: [{ address: "assistant@example.com" }] },
+    };
+
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({
+      status: "registered",
+      address: "assistant@example.com",
+    });
+  });
+
+  test("none when the platform lists no addresses", async () => {
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({ status: "none" });
+  });
+
+  test("no_platform when platform credentials are missing", async () => {
+    mockPlatformAssistantId = null;
+
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({ status: "no_platform" });
+  });
+
+  test("unavailable on a non-ok platform response", async () => {
+    mockResponse = { ok: false, status: 503, body: { detail: "boom" } };
+
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({ status: "unavailable", detail: "HTTP 503" });
+  });
+
+  test("unavailable when the platform fetch throws", async () => {
+    mockFetchThrows = true;
+
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({
+      status: "unavailable",
+      detail: "platform unreachable",
+    });
+  });
+
+  test("unavailable on an unexpected response shape", async () => {
+    mockResponse = { ok: true, status: 200, body: { results: "not-a-list" } };
+
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({
+      status: "unavailable",
+      detail: "unexpected response shape",
+    });
+  });
+
+  test("serves the cached answer within the TTL", async () => {
+    mockResponse = {
+      ok: true,
+      status: 200,
+      body: { count: 1, results: [{ address: "hi@bot" }] },
+    };
+    await resolveRegisteredInbox();
+
+    // A changed platform answer is not observed until the cache is dropped.
+    mockResponse = { ok: true, status: 200, body: { count: 0, results: [] } };
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({ status: "registered", address: "hi@bot" });
+    expect(fetchCallCount).toBe(1);
+  });
+
+  test("fresh bypasses the cache and updates it", async () => {
+    await resolveRegisteredInbox();
+    mockResponse = {
+      ok: true,
+      status: 200,
+      body: { count: 1, results: [{ address: "hi@bot" }] },
+    };
+
+    const fresh = await resolveRegisteredInbox({ fresh: true });
+    const cached = await resolveRegisteredInbox();
+
+    expect(fresh).toEqual({ status: "registered", address: "hi@bot" });
+    expect(cached).toEqual({ status: "registered", address: "hi@bot" });
+    expect(fetchCallCount).toBe(2);
+  });
+
+  test("invalidate drops the cached answer", async () => {
+    await resolveRegisteredInbox();
+    invalidateRegisteredInboxCache();
+    await resolveRegisteredInbox();
+
+    expect(fetchCallCount).toBe(2);
+  });
+
+  test("unavailable is not cached, so the next call retries", async () => {
+    mockFetchThrows = true;
+    await resolveRegisteredInbox();
+
+    mockFetchThrows = false;
+    mockResponse = {
+      ok: true,
+      status: 200,
+      body: { count: 1, results: [{ address: "hi@bot" }] },
+    };
+    const state = await resolveRegisteredInbox();
+
+    expect(state).toEqual({ status: "registered", address: "hi@bot" });
+  });
+});

--- a/assistant/src/email/registered-inbox.ts
+++ b/assistant/src/email/registered-inbox.ts
@@ -1,0 +1,111 @@
+/**
+ * The one place that answers "does this assistant have a managed inbox?".
+ *
+ * Managed email registration lives on the Vellum platform: the
+ * `/v1/assistants/:id/email-addresses/` API is the only writer and the only
+ * source of truth. Nothing about a registration lands in workspace config, so
+ * any reader that wants the inbox address has to ask the platform. The three
+ * consumers (the email readiness probe, the email invite adapter, and the
+ * channel-availability route) all resolve through here so they cannot drift
+ * onto different answers.
+ *
+ * `unavailable` is distinct from `none` for the same reason the readiness
+ * service separates "failed" from "indeterminate": an unreachable platform is
+ * not evidence that no inbox exists, and reporting it as one turns every
+ * platform blip into a "set up email" prompt.
+ */
+
+import { z } from "zod";
+
+import { VellumPlatformClient } from "../platform/client.js";
+
+export type RegisteredInboxState =
+  /** The platform holds a registered inbox address for this assistant. */
+  | { status: "registered"; address: string }
+  /** The platform answered: no inbox is registered. */
+  | { status: "none" }
+  /** No platform credentials, so no managed inbox can exist. */
+  | { status: "no_platform" }
+  /** The platform could not be asked; nothing is known either way. */
+  | { status: "unavailable"; detail: string };
+
+/**
+ * Validated rather than cast: the response crosses a runtime boundary, and a
+ * shape drift should read as `unavailable` (nothing established), not as a
+ * confidently wrong answer. Unknown keys are ignored, since the platform adds
+ * fields over time.
+ */
+const EmailAddressListSchema = z.object({
+  count: z.number().optional(),
+  results: z.array(z.object({ address: z.string() })).optional(),
+});
+
+/**
+ * Matches the readiness service's remote-check TTL: the cache exists so the
+ * invite-adapter enrichment on the readiness poll (every 15s per client) does
+ * not turn into a platform request per poll, and registration changes made
+ * through the daemon invalidate it explicitly.
+ */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let cache: { state: RegisteredInboxState; fetchedAt: number } | null = null;
+
+/** Drop the cached answer; call after registering or releasing an inbox. */
+export function invalidateRegisteredInboxCache(): void {
+  cache = null;
+}
+
+/**
+ * Resolve the managed inbox state, serving a cached answer within
+ * {@link CACHE_TTL_MS} unless `fresh` demands a live read. `unavailable` is
+ * never cached: a platform blip should heal on the next call, not pin the
+ * unknown state for the TTL.
+ */
+export async function resolveRegisteredInbox(
+  options: { fresh?: boolean } = {},
+): Promise<RegisteredInboxState> {
+  if (!options.fresh && cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
+    return cache.state;
+  }
+
+  const state = await fetchRegisteredInbox();
+  if (state.status === "unavailable") {
+    return state;
+  }
+  cache = { state, fetchedAt: Date.now() };
+  return state;
+}
+
+async function fetchRegisteredInbox(): Promise<RegisteredInboxState> {
+  const client = await VellumPlatformClient.create();
+  if (!client?.platformAssistantId) {
+    return { status: "no_platform" };
+  }
+
+  let response: Response;
+  try {
+    response = await client.fetch(
+      `/v1/assistants/${client.platformAssistantId}/email-addresses/`,
+    );
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { status: "unavailable", detail };
+  }
+
+  if (!response.ok) {
+    return { status: "unavailable", detail: `HTTP ${response.status}` };
+  }
+
+  const parsed = EmailAddressListSchema.safeParse(
+    await response.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return { status: "unavailable", detail: "unexpected response shape" };
+  }
+
+  const address = parsed.data.results?.[0]?.address;
+  if (typeof address === "string" && address.length > 0) {
+    return { status: "registered", address };
+  }
+  return { status: "none" };
+}

--- a/assistant/src/email/registered-inbox.ts
+++ b/assistant/src/email/registered-inbox.ts
@@ -4,10 +4,11 @@
  * Managed email registration lives on the Vellum platform: the
  * `/v1/assistants/:id/email-addresses/` API is the only writer and the only
  * source of truth. Nothing about a registration lands in workspace config, so
- * any reader that wants the inbox address has to ask the platform. The three
- * consumers (the email readiness probe, the email invite adapter, and the
- * channel-availability route) all resolve through here so they cannot drift
- * onto different answers.
+ * any reader that wants the inbox address has to ask the platform. Every
+ * consumer of the listing (the email readiness probe, the email invite
+ * adapter, the channel-availability route, the email management routes, and
+ * verification email delivery) reads through this module so they cannot
+ * drift onto different answers.
  *
  * `unavailable` is distinct from `none` for the same reason the readiness
  * service separates "failed" from "indeterminate": an unreachable platform is
@@ -48,9 +49,10 @@ export type EmailAddressListResult =
  */
 const EmailAddressListSchema = z.object({
   count: z.number().optional(),
-  results: z
-    .array(z.object({ id: z.string(), address: z.string() }))
-    .optional(),
+  // Required: the platform's paginated listing always carries `results`, so
+  // a 200 without it is shape drift and must read as a failed listing, never
+  // as "no inbox".
+  results: z.array(z.object({ id: z.string(), address: z.string() })),
 });
 
 /**
@@ -90,7 +92,17 @@ export async function listEmailAddresses(
     return { ok: false, detail: "unexpected response shape" };
   }
 
-  return { ok: true, addresses: parsed.data.results ?? [] };
+  const { count, results: addresses } = parsed.data;
+  if (addresses.length === 0 && (count ?? 0) > 0) {
+    // A positive count with no rows is drift, not an empty listing: treating
+    // it as "no inbox" would recreate the false Not connected verdict.
+    return {
+      ok: false,
+      detail: `listing reported ${count} addresses but returned none`,
+    };
+  }
+
+  return { ok: true, addresses };
 }
 
 /**
@@ -130,7 +142,16 @@ export async function resolveRegisteredInbox(
 }
 
 async function fetchRegisteredInbox(): Promise<RegisteredInboxState> {
-  const client = await VellumPlatformClient.create();
+  // Creation resolves the managed-proxy context and the credential store,
+  // either of which can reject; a backend blip there is "could not ask",
+  // not an error the caller should surface as a failed request.
+  let client: VellumPlatformClient | null;
+  try {
+    client = await VellumPlatformClient.create();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { status: "unavailable", detail };
+  }
   if (!client?.platformAssistantId) {
     return { status: "no_platform" };
   }

--- a/assistant/src/email/registered-inbox.ts
+++ b/assistant/src/email/registered-inbox.ts
@@ -29,16 +29,69 @@ export type RegisteredInboxState =
   /** The platform could not be asked; nothing is known either way. */
   | { status: "unavailable"; detail: string };
 
+/** One row of the platform's email-address listing. */
+export interface RegisteredEmailAddress {
+  id: string;
+  address: string;
+}
+
+export type EmailAddressListResult =
+  | { ok: true; addresses: RegisteredEmailAddress[] }
+  /** The platform could not be asked or answered unusably. */
+  | { ok: false; status?: number; detail: string };
+
 /**
  * Validated rather than cast: the response crosses a runtime boundary, and a
- * shape drift should read as `unavailable` (nothing established), not as a
+ * shape drift should read as a failed listing (nothing established), not as a
  * confidently wrong answer. Unknown keys are ignored, since the platform adds
  * fields over time.
  */
 const EmailAddressListSchema = z.object({
   count: z.number().optional(),
-  results: z.array(z.object({ address: z.string() })).optional(),
+  results: z
+    .array(z.object({ id: z.string(), address: z.string() }))
+    .optional(),
 });
+
+/**
+ * Fetch the platform's email-address listing for the caller's own client.
+ *
+ * The seam every consumer of the listing shares: the readiness resolver
+ * below, the email register/unregister/status/send routes, and verification
+ * email delivery. Takes the caller's client rather than creating one so a
+ * route that already authenticated (and already knows how to report a
+ * missing platform connection) keeps its own error semantics.
+ */
+export async function listEmailAddresses(
+  client: VellumPlatformClient,
+): Promise<EmailAddressListResult> {
+  let response: Response;
+  try {
+    response = await client.fetch(
+      `/v1/assistants/${client.platformAssistantId}/email-addresses/`,
+    );
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, detail };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      detail: `HTTP ${response.status}`,
+    };
+  }
+
+  const parsed = EmailAddressListSchema.safeParse(
+    await response.json().catch(() => null),
+  );
+  if (!parsed.success) {
+    return { ok: false, detail: "unexpected response shape" };
+  }
+
+  return { ok: true, addresses: parsed.data.results ?? [] };
+}
 
 /**
  * Matches the readiness service's remote-check TTL: the cache exists so the
@@ -82,28 +135,12 @@ async function fetchRegisteredInbox(): Promise<RegisteredInboxState> {
     return { status: "no_platform" };
   }
 
-  let response: Response;
-  try {
-    response = await client.fetch(
-      `/v1/assistants/${client.platformAssistantId}/email-addresses/`,
-    );
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    return { status: "unavailable", detail };
+  const list = await listEmailAddresses(client);
+  if (!list.ok) {
+    return { status: "unavailable", detail: list.detail };
   }
 
-  if (!response.ok) {
-    return { status: "unavailable", detail: `HTTP ${response.status}` };
-  }
-
-  const parsed = EmailAddressListSchema.safeParse(
-    await response.json().catch(() => null),
-  );
-  if (!parsed.success) {
-    return { status: "unavailable", detail: "unexpected response shape" };
-  }
-
-  const address = parsed.data.results?.[0]?.address;
+  const address = list.addresses[0]?.address;
   if (typeof address === "string" && address.length > 0) {
     return { status: "registered", address };
   }

--- a/assistant/src/runtime/channel-invite-transports/email.ts
+++ b/assistant/src/runtime/channel-invite-transports/email.ts
@@ -2,16 +2,18 @@
  * Email channel invite adapter.
  *
  * Resolves the assistant's email address for use in invite instructions.
- * Reads the address from workspace config (`email.address`). Returns
- * `undefined` when no address is configured, which causes the invite
+ * The address is a managed inbox registration, which lives on the platform
+ * (nothing about one lands in workspace config), so it resolves through the
+ * shared registered-inbox reader. Returns `undefined` when no address is
+ * registered or the platform cannot be asked, which causes the invite
  * instruction generator to emit generic "on Email" wording.
  *
  * Email invites use the universal 6-digit code path for redemption, so
- * this adapter only implements `resolveChannelHandleAsync` — no
+ * this adapter only implements `resolveChannelHandleAsync`, with no
  * `buildShareLink` or `extractInboundToken` needed.
  */
 
-import { getNestedValue, loadRawConfig } from "../../config/loader.js";
+import { resolveRegisteredInbox } from "../../email/registered-inbox.js";
 import type { ChannelInviteAdapter } from "../channel-invite-types.js";
 
 // ---------------------------------------------------------------------------
@@ -23,13 +25,12 @@ export const emailInviteAdapter: ChannelInviteAdapter = {
 
   async resolveChannelHandleAsync(): Promise<string | undefined> {
     try {
-      const raw = loadRawConfig();
-      const address = getNestedValue(raw, "email.address");
-      if (typeof address === "string" && address.length > 0) {
-        return address;
+      const inbox = await resolveRegisteredInbox();
+      if (inbox.status === "registered") {
+        return inbox.address;
       }
     } catch {
-      // Config unavailable
+      // Platform unavailable; fall through to generic wording
     }
     return undefined;
   },

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -291,14 +291,17 @@ const emailProbe: ChannelProbe = {
     ];
   },
   /**
-   * Ask the platform whether an inbox address is registered. The platform's
-   * email-addresses API is the only writer of managed inbox registrations
-   * (nothing about one lands in workspace config), so it is the only source
-   * this check may read.
+   * Ask the platform whether an inbox address is registered, falling back to
+   * a "your own" provider credential. The platform's email-addresses API is
+   * the only writer of managed inbox registrations (nothing about one lands
+   * in workspace config), and a BYO deployment's configuration claim is its
+   * stored provider API key, so those are the only sources this check may
+   * read.
    *
-   * Three outcomes, matching the Telegram probe: a platform answer passes or
-   * fails the check outright, and an unreachable platform is indeterminate,
-   * which is not evidence of a fault and must not report the channel broken.
+   * Three outcomes, matching the Telegram probe: an answer passes or fails
+   * the check outright, and an unreachable platform (with no BYO credential
+   * to fall back to) is indeterminate, which is not evidence of a fault and
+   * must not report the channel broken.
    */
   async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
     // Imported here rather than at module scope, matching the other probes:
@@ -314,6 +317,22 @@ const emailProbe: ChannelProbe = {
     // Published identifier (see the Telegram probe's `webhook_delivery` note):
     // external clients search readiness responses for this name.
     const name = "inbox_configured";
+
+    if (inbox.status !== "registered") {
+      const { resolveConfiguredByoEmailService } =
+        await import("../email/byo-email-credential.js");
+      const byoService = await resolveConfiguredByoEmailService();
+      if (byoService) {
+        return [
+          {
+            name,
+            passed: true,
+            message: `Email is configured through your own provider (${byoService} API key is stored)`,
+          },
+        ];
+      }
+    }
+
     switch (inbox.status) {
       case "registered":
         return [

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -283,32 +283,73 @@ const emailProbe: ChannelProbe = {
         "Email invite code redemption is enabled",
         "Email invite code redemption is disabled",
       ),
-      await checkIngress(),
+      // Managed callbacks allowed: inbound email arrives through the platform
+      // callback route the gateway registers (`registerEmailCallbackRoute`,
+      // the same pattern as Telegram's webhook route), so a platform-connected
+      // deployment with no public ingress URL still receives email.
+      await checkIngress(true),
     ];
   },
+  /**
+   * Ask the platform whether an inbox address is registered. The platform's
+   * email-addresses API is the only writer of managed inbox registrations
+   * (nothing about one lands in workspace config), so it is the only source
+   * this check may read.
+   *
+   * Three outcomes, matching the Telegram probe: a platform answer passes or
+   * fails the check outright, and an unreachable platform is indeterminate,
+   * which is not evidence of a fault and must not report the channel broken.
+   */
   async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
-    try {
-      const raw = loadRawConfig();
-      const address = getNestedValue(raw, "email.address");
-      const hasInbox = typeof address === "string" && address.length > 0;
-      return [
-        {
-          name: "inbox_configured",
-          passed: hasInbox,
-          message: hasInbox
-            ? `Inbox address is configured (${address})`
-            : "No inbox address configured — register one with: assistant email register <username>",
-        },
-      ];
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return [
-        {
-          name: "inbox_configured",
-          passed: false,
-          message: `Failed to check inbox configuration: ${message}`,
-        },
-      ];
+    // Imported here rather than at module scope, matching the other probes:
+    // the platform client pulls in a module graph that unrelated consumers of
+    // this service should not have to mock.
+    const { resolveRegisteredInbox } =
+      await import("../email/registered-inbox.js");
+    // Fresh, because this service already caches remote checks for
+    // REMOTE_TTL_MS; layering the resolver's own cache under that would make
+    // an explicit readiness refresh serve a stale answer anyway.
+    const inbox = await resolveRegisteredInbox({ fresh: true });
+
+    // Published identifier (see the Telegram probe's `webhook_delivery` note):
+    // external clients search readiness responses for this name.
+    const name = "inbox_configured";
+    switch (inbox.status) {
+      case "registered":
+        return [
+          {
+            name,
+            passed: true,
+            message: `Inbox address is registered (${inbox.address})`,
+          },
+        ];
+      case "none":
+        return [
+          {
+            name,
+            passed: false,
+            message:
+              "No inbox address registered. Register one with: assistant email register <username>",
+          },
+        ];
+      case "no_platform":
+        return [
+          {
+            name,
+            passed: false,
+            message:
+              "Platform credentials are not configured, so no managed inbox can be registered. Run: assistant platform connect",
+          },
+        ];
+      case "unavailable":
+        return [
+          {
+            name,
+            passed: true,
+            indeterminate: true,
+            message: `Could not reach the platform to check inbox registration (${inbox.detail})`,
+          },
+        ];
     }
   },
 };

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -348,7 +348,7 @@ const emailProbe: ChannelProbe = {
             name,
             passed: false,
             message:
-              "No inbox address registered. Register one with: assistant email register <username>",
+              "No inbox address registered. Register one with: assistant email register <username>, or configure your own provider (Resend or Mailgun)",
           },
         ];
       case "no_platform":
@@ -357,7 +357,7 @@ const emailProbe: ChannelProbe = {
             name,
             passed: false,
             message:
-              "Platform credentials are not configured, so no managed inbox can be registered. Run: assistant platform connect",
+              "Email is not configured. Connect the platform for a managed inbox (assistant platform connect), or configure your own provider (Resend or Mailgun)",
           },
         ];
       case "unavailable":

--- a/assistant/src/runtime/routes/channel-availability-routes.ts
+++ b/assistant/src/runtime/routes/channel-availability-routes.ts
@@ -26,6 +26,7 @@ import {
   type ChannelInfo,
 } from "../../channels/types.js";
 import { getConfig } from "../../config/loader.js";
+import { resolveConfiguredByoEmailService } from "../../email/byo-email-credential.js";
 import { resolveRegisteredInbox } from "../../email/registered-inbox.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
@@ -40,25 +41,30 @@ const BASE_AVAILABLE_CHANNELS: readonly ChannelId[] = [
 ] as const;
 
 /**
- * Best-effort check that an inbox address is registered for this
- * assistant, through the shared registered-inbox reader. An unavailable
- * platform is treated as "no inbox": we prefer to under-report than block
- * the entire Contacts page when the platform is briefly unreachable.
+ * Best-effort check that email is configured for this assistant: a managed
+ * inbox registered on the platform, or a "your own" provider credential
+ * (whose gateway webhook routes carry inbound just as the managed pipeline
+ * does). An unavailable platform is treated as "no inbox": we prefer to
+ * under-report than block the entire Contacts page when the platform is
+ * briefly unreachable.
  *
  * Fresh, preserving this route's long-standing live-read-per-request
  * behavior: availability is fetched on surface loads, not on a poll, so it
  * does not need the resolver's cache and should not inherit its staleness.
  */
-async function hasRegisteredInbox(): Promise<boolean> {
+async function hasConfiguredEmail(): Promise<boolean> {
   const inbox = await resolveRegisteredInbox({ fresh: true });
-  return inbox.status === "registered";
+  if (inbox.status === "registered") {
+    return true;
+  }
+  return (await resolveConfiguredByoEmailService()) !== undefined;
 }
 
 async function handleGetChannelAvailability(
   _args: RouteHandlerArgs,
 ): Promise<{ channels: AvailableChannel[] }> {
   const ids: ChannelId[] = [...BASE_AVAILABLE_CHANNELS];
-  if (await hasRegisteredInbox()) {
+  if (await hasConfiguredEmail()) {
     ids.push("email");
   }
   if (isA2AEnabled(getConfig())) {

--- a/assistant/src/runtime/routes/channel-availability-routes.ts
+++ b/assistant/src/runtime/routes/channel-availability-routes.ts
@@ -26,7 +26,7 @@ import {
   type ChannelInfo,
 } from "../../channels/types.js";
 import { getConfig } from "../../config/loader.js";
-import { VellumPlatformClient } from "../../platform/client.js";
+import { resolveRegisteredInbox } from "../../email/registered-inbox.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
@@ -39,38 +39,19 @@ const BASE_AVAILABLE_CHANNELS: readonly ChannelId[] = [
   "phone",
 ] as const;
 
-interface EmailAddressListResponse {
-  count?: number;
-  results?: Array<{ id: string; address: string }>;
-}
-
 /**
  * Best-effort check that an inbox address is registered for this
- * assistant. A platform fetch failure is treated as "no inbox" — we
- * prefer to under-report than block the entire Contacts page when the
- * platform is briefly unreachable.
+ * assistant, through the shared registered-inbox reader. An unavailable
+ * platform is treated as "no inbox": we prefer to under-report than block
+ * the entire Contacts page when the platform is briefly unreachable.
+ *
+ * Fresh, preserving this route's long-standing live-read-per-request
+ * behavior: availability is fetched on surface loads, not on a poll, so it
+ * does not need the resolver's cache and should not inherit its staleness.
  */
 async function hasRegisteredInbox(): Promise<boolean> {
-  const client = await VellumPlatformClient.create();
-  if (!client?.platformAssistantId) {
-    return false;
-  }
-
-  try {
-    const response = await client.fetch(
-      `/v1/assistants/${client.platformAssistantId}/email-addresses/`,
-    );
-    if (!response.ok) {
-      return false;
-    }
-    const data = (await response.json()) as EmailAddressListResponse;
-    if (typeof data.count === "number") {
-      return data.count > 0;
-    }
-    return Array.isArray(data.results) && data.results.length > 0;
-  } catch {
-    return false;
-  }
+  const inbox = await resolveRegisteredInbox({ fresh: true });
+  return inbox.status === "registered";
 }
 
 async function handleGetChannelAvailability(

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -23,6 +23,7 @@ import {
   type ManagedCredentialDescriptor,
 } from "../../credential-execution/managed-catalog.js";
 import { buildForChatSentinel } from "../../daemon/chat-credential-redaction.js";
+import { invalidateEmailReadinessForByoCredential } from "../../email/byo-email-credential.js";
 import {
   disconnectOAuthProvider,
   getConnectionByProvider,
@@ -47,7 +48,6 @@ import {
 import type { CredentialInjectionTemplate } from "../../tools/credentials/policy-types.js";
 import {
   CredentialStorageError,
-  invalidateEmailReadinessForByoCredential,
   InvalidCredentialInputError,
   storeCredentialValue,
 } from "../../tools/credentials/store.js";

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -47,6 +47,7 @@ import {
 import type { CredentialInjectionTemplate } from "../../tools/credentials/policy-types.js";
 import {
   CredentialStorageError,
+  invalidateEmailReadinessForByoCredential,
   InvalidCredentialInputError,
   storeCredentialValue,
 } from "../../tools/credentials/store.js";
@@ -550,6 +551,8 @@ async function handleCredentialsDelete({ body }: RouteHandlerArgs) {
   }
 
   invalidateConnectionsAfterCredentialDelete(affectedConnections);
+
+  await invalidateEmailReadinessForByoCredential(service);
 
   return { service, field, affectedConnections };
 }

--- a/assistant/src/runtime/routes/email-routes.ts
+++ b/assistant/src/runtime/routes/email-routes.ts
@@ -7,7 +7,9 @@
 
 import { z } from "zod";
 
+import { getReadinessService } from "../../daemon/handlers/config-channels.js";
 import { markdownToEmailHtml } from "../../email/html-renderer.js";
+import { invalidateRegisteredInboxCache } from "../../email/registered-inbox.js";
 import { VellumPlatformClient } from "../../platform/client.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -70,7 +72,18 @@ async function handleEmailRegister({ body = {} }: RouteHandlerArgs) {
     address: string;
     created_at: string;
   };
+  invalidateEmailReadinessState();
   return data;
+}
+
+/**
+ * A registration change must be visible on the next readiness read: both the
+ * registered-inbox cache and the readiness service's cached email snapshot
+ * would otherwise keep answering with the pre-change state for their TTL.
+ */
+function invalidateEmailReadinessState(): void {
+  invalidateRegisteredInboxCache();
+  getReadinessService().invalidateChannel("email");
 }
 
 async function handleEmailUnregister(_args: RouteHandlerArgs) {
@@ -117,6 +130,7 @@ async function handleEmailUnregister(_args: RouteHandlerArgs) {
     );
   }
 
+  invalidateEmailReadinessState();
   return { unregistered: target.address };
 }
 

--- a/assistant/src/runtime/routes/email-routes.ts
+++ b/assistant/src/runtime/routes/email-routes.ts
@@ -9,7 +9,11 @@ import { z } from "zod";
 
 import { getReadinessService } from "../../daemon/handlers/config-channels.js";
 import { markdownToEmailHtml } from "../../email/html-renderer.js";
-import { invalidateRegisteredInboxCache } from "../../email/registered-inbox.js";
+import {
+  invalidateRegisteredInboxCache,
+  listEmailAddresses,
+  type RegisteredEmailAddress,
+} from "../../email/registered-inbox.js";
 import { VellumPlatformClient } from "../../platform/client.js";
 import { LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import {
@@ -86,26 +90,28 @@ function invalidateEmailReadinessState(): void {
   getReadinessService().invalidateChannel("email");
 }
 
+/**
+ * The registered addresses, or the route-appropriate error: a listing
+ * failure maps to LIST_FAILED with the platform's status when it sent one.
+ */
+async function requireEmailAddressList(
+  client: VellumPlatformClient,
+): Promise<RegisteredEmailAddress[]> {
+  const list = await listEmailAddresses(client);
+  if (!list.ok) {
+    throw new RouteError(
+      `Failed to list email addresses: ${list.detail}`,
+      "LIST_FAILED",
+      list.status ?? 502,
+    );
+  }
+  return list.addresses;
+}
+
 async function handleEmailUnregister(_args: RouteHandlerArgs) {
   const client = await requireClient();
 
-  const listResponse = await client.fetch(
-    `/v1/assistants/${client.platformAssistantId}/email-addresses/`,
-  );
-
-  if (!listResponse.ok) {
-    throw new RouteError(
-      `Failed to list email addresses: HTTP ${listResponse.status}`,
-      "LIST_FAILED",
-      listResponse.status,
-    );
-  }
-
-  const listData = (await listResponse.json()) as {
-    results: { id: string; address: string }[];
-  };
-
-  const addresses = listData.results ?? [];
+  const addresses = await requireEmailAddressList(client);
   if (addresses.length === 0) {
     throw new NotFoundError("No email address registered for this assistant.");
   }
@@ -137,23 +143,7 @@ async function handleEmailUnregister(_args: RouteHandlerArgs) {
 async function handleEmailStatus(_args: RouteHandlerArgs) {
   const client = await requireClient();
 
-  const listResponse = await client.fetch(
-    `/v1/assistants/${client.platformAssistantId}/email-addresses/`,
-  );
-
-  if (!listResponse.ok) {
-    throw new RouteError(
-      `Failed to list email addresses: HTTP ${listResponse.status}`,
-      "LIST_FAILED",
-      listResponse.status,
-    );
-  }
-
-  const listData = (await listResponse.json()) as {
-    results: { id: string; address: string }[];
-  };
-
-  const addresses = listData.results ?? [];
+  const addresses = await requireEmailAddressList(client);
   if (addresses.length === 0) {
     throw new NotFoundError(
       "No email address registered for this assistant. Run: assistant email register <username>",
@@ -272,23 +262,7 @@ async function handleEmailSend({ body = {} }: RouteHandlerArgs) {
   const client = await requireClient();
 
   // Resolve "from" address
-  const listResponse = await client.fetch(
-    `/v1/assistants/${client.platformAssistantId}/email-addresses/`,
-  );
-
-  if (!listResponse.ok) {
-    throw new RouteError(
-      `Failed to list email addresses: HTTP ${listResponse.status}`,
-      "LIST_FAILED",
-      listResponse.status,
-    );
-  }
-
-  const listData = (await listResponse.json()) as {
-    results: { id: string; address: string }[];
-  };
-
-  const addresses = listData.results ?? [];
+  const addresses = await requireEmailAddressList(client);
   if (addresses.length === 0) {
     throw new NotFoundError(
       "No email address registered for this assistant. Run: assistant email register <username>",

--- a/assistant/src/runtime/verification-outbound-actions.ts
+++ b/assistant/src/runtime/verification-outbound-actions.ts
@@ -575,27 +575,23 @@ export function deliverVerificationEmail(
         return;
       }
 
-      const listResponse = await client.fetch(
-        `/v1/assistants/${client.platformAssistantId}/email-addresses/`,
-      );
-      if (!listResponse.ok) {
+      const { listEmailAddresses } =
+        await import("../email/registered-inbox.js");
+      const list = await listEmailAddresses(client);
+      if (!list.ok) {
         log.error(
-          { status: listResponse.status },
+          { status: list.status, detail: list.detail },
           "Failed to list email addresses for verification",
         );
         return;
       }
-      const listData = (await listResponse.json()) as {
-        results: { address: string }[];
-      };
-      const addresses = listData.results ?? [];
-      if (addresses.length === 0) {
+      const fromAddress = list.addresses[0]?.address;
+      if (!fromAddress) {
         log.error(
-          "No email address registered — cannot deliver verification email",
+          "No email address registered; cannot deliver verification email",
         );
         return;
       }
-      const fromAddress = addresses[0].address;
 
       const { markdownToEmailHtml } = await import("../email/html-renderer.js");
       const html = markdownToEmailHtml(text);

--- a/assistant/src/tools/credentials/store-byo-invalidation.test.ts
+++ b/assistant/src/tools/credentials/store-byo-invalidation.test.ts
@@ -1,0 +1,39 @@
+/**
+ * A stored or deleted BYO email provider credential must drop the readiness
+ * service's cached email snapshot: the BYO check lives in the TTL-cached
+ * remote bucket, so without the invalidation the channel badge serves the
+ * pre-write verdict for the rest of the TTL.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let invalidatedChannels: string[];
+
+mock.module("../../daemon/handlers/config-channels.js", () => ({
+  getReadinessService: () => ({
+    invalidateChannel: (channel: string) => {
+      invalidatedChannels.push(channel);
+    },
+  }),
+}));
+
+import { invalidateEmailReadinessForByoCredential } from "./store.js";
+
+describe("invalidateEmailReadinessForByoCredential", () => {
+  beforeEach(() => {
+    invalidatedChannels = [];
+  });
+
+  test("invalidates the email channel for each BYO provider", async () => {
+    await invalidateEmailReadinessForByoCredential("resend");
+    await invalidateEmailReadinessForByoCredential("mailgun");
+
+    expect(invalidatedChannels).toEqual(["email", "email"]);
+  });
+
+  test("leaves other services' credentials alone", async () => {
+    await invalidateEmailReadinessForByoCredential("telegram");
+    await invalidateEmailReadinessForByoCredential("slack_channel");
+
+    expect(invalidatedChannels).toEqual([]);
+  });
+});

--- a/assistant/src/tools/credentials/store.ts
+++ b/assistant/src/tools/credentials/store.ts
@@ -28,6 +28,7 @@ import {
   ACP_SERVICE,
   assertAcpCredentialFormat,
 } from "../../acp/acp-credentials.js";
+import { BYO_EMAIL_CREDENTIAL_SERVICES } from "../../email/byo-email-credential.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { normalizeSecretValue } from "../../security/secret-normalize.js";
 import {
@@ -176,5 +177,33 @@ export async function storeCredentialValue(
     );
   }
 
+  await invalidateEmailReadinessForByoCredential(service);
+
   return { credentialId: metadata.credentialId, service, field };
+}
+
+/**
+ * A stored or deleted "your own" email provider key changes the email
+ * channel's readiness verdict, and that check lives in the readiness
+ * service's TTL-cached remote bucket; drop the cached snapshot so the next
+ * readiness read re-evaluates instead of serving the pre-write answer for
+ * the rest of the TTL. Best-effort: the credential write already succeeded,
+ * and a missed invalidation self-heals when the TTL lapses.
+ */
+export async function invalidateEmailReadinessForByoCredential(
+  service: string,
+): Promise<void> {
+  if (!(BYO_EMAIL_CREDENTIAL_SERVICES as readonly string[]).includes(service)) {
+    return;
+  }
+  try {
+    const { getReadinessService } =
+      await import("../../daemon/handlers/config-channels.js");
+    getReadinessService().invalidateChannel("email");
+  } catch (err) {
+    log.warn(
+      { err, service },
+      "Credential write succeeded, but email readiness invalidation failed",
+    );
+  }
 }

--- a/assistant/src/tools/credentials/store.ts
+++ b/assistant/src/tools/credentials/store.ts
@@ -28,7 +28,7 @@ import {
   ACP_SERVICE,
   assertAcpCredentialFormat,
 } from "../../acp/acp-credentials.js";
-import { BYO_EMAIL_CREDENTIAL_SERVICES } from "../../email/byo-email-credential.js";
+import { invalidateEmailReadinessForByoCredential } from "../../email/byo-email-credential.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { normalizeSecretValue } from "../../security/secret-normalize.js";
 import {
@@ -180,30 +180,4 @@ export async function storeCredentialValue(
   await invalidateEmailReadinessForByoCredential(service);
 
   return { credentialId: metadata.credentialId, service, field };
-}
-
-/**
- * A stored or deleted "your own" email provider key changes the email
- * channel's readiness verdict, and that check lives in the readiness
- * service's TTL-cached remote bucket; drop the cached snapshot so the next
- * readiness read re-evaluates instead of serving the pre-write answer for
- * the rest of the TTL. Best-effort: the credential write already succeeded,
- * and a missed invalidation self-heals when the TTL lapses.
- */
-export async function invalidateEmailReadinessForByoCredential(
-  service: string,
-): Promise<void> {
-  if (!(BYO_EMAIL_CREDENTIAL_SERVICES as readonly string[]).includes(service)) {
-    return;
-  }
-  try {
-    const { getReadinessService } =
-      await import("../../daemon/handlers/config-channels.js");
-    getReadinessService().invalidateChannel("email");
-  } catch (err) {
-    log.warn(
-      { err, service },
-      "Credential write succeeded, but email readiness invalidation failed",
-    );
-  }
 }

--- a/clients/web/src/domains/channels/components/email-managed-content.tsx
+++ b/clients/web/src/domains/channels/components/email-managed-content.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DomainField } from "@/domains/channels/components/domain-field";
 import {
   assistantsDomainsCreateMutation,
@@ -190,10 +191,15 @@ export function EmailManagedContent({
   // readiness snapshot, whose inbox check the daemon caches for minutes.
   // Address changes here go straight to the platform, so the daemon must be
   // told to re-check or the badge keeps the pre-change answer for the TTL.
+  // Keyed on the ACTIVE assistant id, not this component's `assistantId`
+  // prop: the prop is the platform UUID the platform routes need, while the
+  // daemon readiness query in `useAssistantChannels` is cached under the
+  // active id (a local slug on self-hosted assistants).
+  const activeAssistantId = useActiveAssistantId();
   const refreshReadinessMutateAsync = refreshReadiness.mutateAsync;
   const refreshChannelReadiness = useCallback(() => {
     void refreshReadinessMutateAsync({
-      path: { assistant_id: assistantId },
+      path: { assistant_id: activeAssistantId },
       body: { channel: "email" },
     })
       .catch(() => {
@@ -202,11 +208,11 @@ export function EmailManagedContent({
       .finally(() => {
         void queryClient.invalidateQueries({
           queryKey: channelsReadinessGetQueryKey({
-            path: { assistant_id: assistantId },
+            path: { assistant_id: activeAssistantId },
           }),
         });
       });
-  }, [assistantId, queryClient, refreshReadinessMutateAsync]);
+  }, [activeAssistantId, queryClient, refreshReadinessMutateAsync]);
 
   // -- Handlers --------------------------------------------------------------
   const handleRegisterDomain = useCallback(async () => {

--- a/clients/web/src/domains/channels/components/email-managed-content.tsx
+++ b/clients/web/src/domains/channels/components/email-managed-content.tsx
@@ -20,6 +20,10 @@ import {
   assistantsListQueryKey,
   organizationsBillingSubscriptionRetrieveOptions,
 } from "@/generated/api/@tanstack/react-query.gen";
+import {
+  channelsReadinessGetQueryKey,
+  channelsReadinessRefreshPostMutation,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 import { extractErrorMessage } from "@/utils/api-errors";
 import { routes } from "@/utils/routes";
@@ -158,6 +162,7 @@ export function EmailManagedContent({
   const deleteDomain = useMutation(assistantsDomainsDestroyMutation());
   const registerAddress = useMutation(assistantsEmailAddressesCreateMutation());
   const deleteAddress = useMutation(assistantsEmailAddressesDestroyMutation());
+  const refreshReadiness = useMutation(channelsReadinessRefreshPostMutation());
 
   const invalidateEmailQueries = useCallback(() => {
     const path = { assistant_id: assistantId };
@@ -180,6 +185,28 @@ export function EmailManagedContent({
       queryKey: assistantsListQueryKey(),
     });
   }, [address?.id, assistantId, queryClient]);
+
+  // The channel list's Connected / Not connected badge reads the daemon's
+  // readiness snapshot, whose inbox check the daemon caches for minutes.
+  // Address changes here go straight to the platform, so the daemon must be
+  // told to re-check or the badge keeps the pre-change answer for the TTL.
+  const refreshReadinessMutateAsync = refreshReadiness.mutateAsync;
+  const refreshChannelReadiness = useCallback(() => {
+    void refreshReadinessMutateAsync({
+      path: { assistant_id: assistantId },
+      body: { channel: "email" },
+    })
+      .catch(() => {
+        // Best-effort: the readiness poll converges after the daemon TTL.
+      })
+      .finally(() => {
+        void queryClient.invalidateQueries({
+          queryKey: channelsReadinessGetQueryKey({
+            path: { assistant_id: assistantId },
+          }),
+        });
+      });
+  }, [assistantId, queryClient, refreshReadinessMutateAsync]);
 
   // -- Handlers --------------------------------------------------------------
   const handleRegisterDomain = useCallback(async () => {
@@ -234,6 +261,7 @@ export function EmailManagedContent({
       setUsernameDraft("");
       setUsernameError(null);
       invalidateEmailQueries();
+      refreshChannelReadiness();
       toast.success(t("emailManagedContent.emailCreatedToast"));
     } catch (err) {
       setUsernameError(
@@ -244,7 +272,14 @@ export function EmailManagedContent({
         ),
       );
     }
-  }, [assistantId, invalidateEmailQueries, registerAddress, usernameDraft, t]);
+  }, [
+    assistantId,
+    invalidateEmailQueries,
+    refreshChannelReadiness,
+    registerAddress,
+    usernameDraft,
+    t,
+  ]);
 
   const handleDeleteAddress = useCallback(async () => {
     if (!address?.id) {
@@ -256,12 +291,20 @@ export function EmailManagedContent({
         path: { assistant_id: assistantId, id: address.id },
       });
       invalidateEmailQueries();
+      refreshChannelReadiness();
       toast.success(t("emailManagedContent.emailRemovedToast"));
     } catch (err) {
       captureError(err, { context: "email_address_delete" });
       toast.error(t("emailManagedContent.emailRemoveFailedToast"));
     }
-  }, [address?.id, assistantId, deleteAddress, invalidateEmailQueries, t]);
+  }, [
+    address?.id,
+    assistantId,
+    deleteAddress,
+    invalidateEmailQueries,
+    refreshChannelReadiness,
+    t,
+  ]);
 
   const handleDeleteDomain = useCallback(async () => {
     if (!domain?.id) {


### PR DESCRIPTION
## TL;DR

The Channels page showed Email as "Not connected" on deployments where a managed inbox is registered and verified (reported on Credence). The daemon's email readiness probe checked "inbox configured" against the workspace config key `email.address`, which **no code anywhere writes**: managed inbox registration lives entirely on the platform email-addresses API. The probe has been false-negativing since it was added; moving email onto the Channels page (#41478) correctly wired the badge to the readiness endpoint, which is what made the lie visible.

This PR makes the platform API the single source the daemon reads for the managed inbox, fixes two more defects found in the same probe (it required self-hosted public ingress even though inbound email is delivered via the platform's managed callback route, and it did not recognize "your own" provider deployments at all), and deletes every duplicated copy of the platform email-address list-fetch.

Fixes LUM-3501

## What changes for the user

| Surface | Before | After |
| --- | --- | --- |
| Channels page email badge (managed) | Always "Not connected", even with a registered, domain-verified address | "Connected" when the platform holds a registered inbox (and ingress/invite checks pass) |
| Channels page email badge (your-own Resend/Mailgun) | Always "Not connected", contradicting the BYO tab's own configured state | "Connected" when a BYO provider API key is stored |
| `assistant channels get email --remote` | `ready=false`, reason `inbox_configured: "No inbox address configured"` despite an active address | `ready=true`, `inbox_configured` reports the registered address (or the BYO provider) |
| Managed-callback deployments (no public ingress URL) | Email readiness failed the `ingress` check | Passes via "Managed platform callback routing is configured", matching how inbound email actually arrives |
| Contacts "available channels" email row | Only shown for managed inboxes | Also shown for BYO deployments, whose gateway webhook routes carry inbound |
| Invite instructions for email | Always generic "on Email" wording (`channelHandle` was resolved from the same dead key) | Include the assistant's managed address |
| Registering/removing an address in the web UI | (Badge was always wrong) | Badge updates promptly: the UI busts the daemon's readiness cache instead of waiting out the 5-minute remote-check TTL |
| Platform briefly unreachable (or credential backend down) | Readiness reported email as broken, or the request failed outright | Indeterminate: not ready, but not listed as a fault, and never a failed request |
| Email trust-floor card on the Channels page | Effectively never shown (the connected gate could not be reached while readiness always failed) | Shown for connected email, as the panel's connected-only gate was designed to do |
| Email register/unregister/status/send CLI+API errors on a drifted or unreachable platform listing | Unhandled cast over the response: a generic 500 or wrong data | A clean LIST_FAILED error naming the failure |

## Design

One module, `assistant/src/email/registered-inbox.ts`, owns the platform email-address listing:

- `listEmailAddresses(client)` is the single validated fetch of `/v1/assistants/{id}/email-addresses/`. Every consumer reads through it: the readiness resolver, the email unregister/status/send routes, and verification email delivery. A 200 without `results` is shape drift and reads as a failed listing (never as "no inbox"), as does a positive `count` carrying no rows.
- `resolveRegisteredInbox()` distinguishes `registered` / `none` / `no_platform` / `unavailable`, mapping `unavailable` (unreachable platform, credential-backend failure during client creation, drifted response) to the readiness service's documented indeterminate semantics: no positive confirmation, so not ready, but no false fault reason and never a thrown request.
- The resolver caches for 5 minutes so the invite-adapter enrichment on the 15-second readiness poll does not become a platform request per poll; the probe and the availability route bypass the cache (`fresh: true`), and the daemon's register/unregister routes, the web UI's address flows, and BYO credential writes (via the shared credential store path) invalidate the cached readiness state.

"Your own" email is a first-class configuration: `assistant/src/email/byo-email-credential.ts` recognizes a stored `resend`/`mailgun` API key (the credential the gateway's `resend-webhook.ts` / `mailgun-webhook.ts` inbound routes and the web BYO tab already key on), and both the probe's `inbox_configured` check and the availability route accept it when no managed inbox is registered.

The web address register/remove flows call the readiness refresh endpoint keyed on the **active** assistant id (distinct from the platform UUID the platform routes need), so the daemon's cached snapshot and the client's cached query both update immediately.

## Why this is safe

- `inbox_configured` keeps its name (it is a published identifier external clients search readiness responses for); only what it reads changed.
- The platform read is the exact call `assistant email status` and the web detail pane already make; this PR moves the readiness probe onto that same source rather than inventing a new one.
- An unreachable platform can no longer mark the channel broken or fail the readiness/availability request, so this cannot introduce a new class of false "email is down" alerts.
- The newly non-null email `channelHandle` reaches no unknown surface: the web maps it onto `AssistantChannelState.address`, and the email branch of the channel panel renders its own section without consuming that field (only Slack/Telegram/Discord/Phone do), so its only consumers are the invite instruction generator and readiness API output.
- The `inbox_configured` failure-message prose changed (it now names both the managed and BYO paths); external clients key on the published check name, never on message text.
- Credential writes for non-email services are untouched: the readiness invalidation no-ops for any service outside the BYO email list.
- The BYO recognition applies the same standard the other channels' readiness checks use (credential presence is the configuration claim) and matches the state the web BYO tab already displays.
- Covered by unit tests for the resolver (state mapping, caching, invalidation, creation-failure and shape-drift handling), the shared listing, BYO recognition in both the probe and availability, and a sensitivity test proving a stray local `email.address` value can no longer decide the check or supply the invite handle (the pre-existing invite-adapter test that pinned the config-key read was rewritten against the resolver). The test asserting email ignores managed callbacks was inverted deliberately: it pinned the wrong assumption, disproven by the gateway's email callback registration.

## Noted while auditing all channel probes (not in this PR)

Per-channel audit: Slack (credentials + socket delivery + remote `auth.test` + scope grants), Telegram (credentials + ingress + remote webhook-delivery health), Discord (credential + socket, no remote by documented design), and Phone (Twilio credentials + number + Twilio ingress) all read state their setup flows actually write. Email was the only channel whose probe read a source nothing writes.

The WhatsApp probe shares the old ingress-flag choice (`allowManagedCallbacks: false`); it is left untouched deliberately: WhatsApp is not surfaced in any client and sits outside the current channels arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
