### PR TITLE
Render the dev and staging thumbnail grounds in display-p3

### DIFF
--- a/clients/web/src/components/avatar/app-icon-preview.test.tsx
+++ b/clients/web/src/components/avatar/app-icon-preview.test.tsx
@@ -452,7 +452,7 @@ describe("AppIconPreview", () => {
         components={BUNDLED_COMPONENTS}
         eyeStyle={WIDE_EYE_STYLE}
         color="green"
-        fieldColorHex="#123456"
+        fieldColor="#123456"
         size={SIZE}
       />,
     );

--- a/clients/web/src/components/avatar/app-icon-preview.tsx
+++ b/clients/web/src/components/avatar/app-icon-preview.tsx
@@ -69,11 +69,13 @@ export interface AppIconPreviewProps {
    */
   primary?: boolean;
   /**
-   * Paint the field this exact color rather than the one `color` resolves to,
-   * for a depiction whose field is not a catalog color at all. The shells that
-   * ship a primary icon on their own field use it; alternates leave it off.
+   * Paint the field this exact CSS color rather than the one `color` resolves
+   * to, for a depiction whose field is not a catalog color at all. Any color
+   * syntax the renderer parses works, wide-gamut `color()` included. The shells
+   * that ship a primary icon on their own field use it; alternates leave it
+   * off.
    */
-  fieldColorHex?: string;
+  fieldColor?: string;
   /** Rendered width and height in px. */
   size?: number;
   className?: string;
@@ -131,7 +133,7 @@ export function AppIconPreview({
   eyeStyle,
   color,
   primary = false,
-  fieldColorHex,
+  fieldColor,
   size = DEFAULT_SIZE,
   className,
 }: AppIconPreviewProps) {
@@ -142,7 +144,7 @@ export function AppIconPreview({
   const catalogHex = components?.colors.find(
     (entry) => entry.id === color,
   )?.hex;
-  const fieldHex = fieldColorHex ?? catalogHex;
+  const fieldFill = fieldColor ?? catalogHex;
   const radius = size * CORNER_RADIUS_FRACTION;
 
   return (
@@ -161,7 +163,7 @@ export function AppIconPreview({
         height={size}
         rx={radius}
         ry={radius}
-        fill={fieldHex ?? UNKNOWN_FIELD_FILL}
+        fill={fieldFill ?? UNKNOWN_FIELD_FILL}
       />
       {art ? (
         <g data-testid="app-icon-preview-eyes" transform={art.transform}>

--- a/clients/web/src/domains/settings/components/app-icon-row.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.test.tsx
@@ -5,6 +5,9 @@
  * it through the real hook against a stand-in shell, so what they pin is the
  * round trip, from a press to a re-read of the home screen.
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   act,
@@ -25,13 +28,50 @@ import type { AvatarState } from "@/types/avatar";
 const TRAITS = { bodyShape: "blob", eyeStyle: "goofy", color: "teal" };
 const AVATAR_ICON = "avatar-eyes-goofy-teal";
 
+/** Where the Icon Composer bundles the shells ship live. */
+const ICON_BUNDLE_DIR = join(import.meta.dir, "../../../../../ios/App/App");
+
+/** One entry of a bundle's root `fill-specializations` array. */
+interface FillSpecialization {
+  appearance?: string;
+  value?: { solid?: string };
+}
+
 /**
- * The fills the Dev and Staging Icon Composer bundles declare, verbatim.
- * Literals rather than a read off the row, so a coordinate drifting from
- * `clients/ios/App/App/AppIcon-Dev.icon` or `AppIcon-Staging.icon` fails here.
+ * The `color(display-p3 ...)` a bundle's own ground reads as, taken off the
+ * bundle rather than named here, so a fill edited in Icon Composer fails this
+ * file instead of leaving the thumbnail depicting a color no shell installs.
+ * The entry carrying no `appearance` is the default one; every appearance in
+ * these bundles pins the same fill.
  */
-const DEV_GROUND_P3 = "color(display-p3 1 0.53333 0.78824)";
-const STAGING_GROUND_P3 = "color(display-p3 0.91373 0.78824 0.10196)";
+function bundleGroundP3(bundle: string): string {
+  const path = join(ICON_BUNDLE_DIR, bundle, "icon.json");
+  const specializations: FillSpecialization[] =
+    JSON.parse(readFileSync(path, "utf8"))["fill-specializations"] ?? [];
+  const solid = specializations.find(
+    (entry) => entry.appearance === undefined,
+  )?.value?.solid;
+  if (typeof solid !== "string") {
+    throw new Error(`${bundle} declares no default solid fill`);
+  }
+  const coordinates = solid.startsWith("display-p3:")
+    ? solid.slice("display-p3:".length).split(",")
+    : [];
+  if (coordinates.length !== 4) {
+    throw new Error(`${bundle} fill is not display-p3 R,G,B,A: ${solid}`);
+  }
+  const channels = coordinates.slice(0, 3).map((coordinate) => {
+    const channel = Number(coordinate);
+    if (!Number.isFinite(channel)) {
+      throw new Error(`${bundle} fill has a non-numeric channel: ${solid}`);
+    }
+    return channel;
+  });
+  return `color(display-p3 ${channels.join(" ")})`;
+}
+
+const DEV_GROUND_P3 = bundleGroundP3("AppIcon-Dev.icon");
+const STAGING_GROUND_P3 = bundleGroundP3("AppIcon-Staging.icon");
 
 const CHARACTER: AvatarState = {
   kind: "character",

--- a/clients/web/src/domains/settings/components/app-icon-row.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.test.tsx
@@ -25,6 +25,14 @@ import type { AvatarState } from "@/types/avatar";
 const TRAITS = { bodyShape: "blob", eyeStyle: "goofy", color: "teal" };
 const AVATAR_ICON = "avatar-eyes-goofy-teal";
 
+/**
+ * The fills the Dev and Staging Icon Composer bundles declare, verbatim.
+ * Literals rather than a read off the row, so a coordinate drifting from
+ * `clients/ios/App/App/AppIcon-Dev.icon` or `AppIcon-Staging.icon` fails here.
+ */
+const DEV_GROUND_P3 = "color(display-p3 1 0.53333 0.78824)";
+const STAGING_GROUND_P3 = "color(display-p3 0.91373 0.78824 0.10196)";
+
 const CHARACTER: AvatarState = {
   kind: "character",
   traits: TRAITS,
@@ -200,6 +208,26 @@ function previewEyeWidth(): number {
 const buildEnv = import.meta.env as Record<string, string | undefined>;
 let previousBuildEnv: string | undefined;
 
+/**
+ * happy-dom answers every `CSS.supports` with true and hands back a fresh `CSS`
+ * on each read of the global, so a renderer with no `color(display-p3 ...)` is
+ * stood in for by swapping the whole global out.
+ */
+const cssDescriptor = Object.getOwnPropertyDescriptor(globalThis, "CSS");
+
+function dropDisplayP3Support() {
+  Object.defineProperty(globalThis, "CSS", {
+    configurable: true,
+    value: { supports: () => false },
+  });
+}
+
+function restoreDisplayP3Support() {
+  if (cssDescriptor) {
+    Object.defineProperty(globalThis, "CSS", cssDescriptor);
+  }
+}
+
 function catalogPaths(eyeStyleId: string): (string | null)[] {
   const eyeStyle = BUNDLED_COMPONENTS.eyeStyles.find(
     (entry) => entry.id === eyeStyleId,
@@ -232,6 +260,7 @@ beforeEach(() => {
 
 afterEach(() => {
   buildEnv.VITE_SENTRY_ENVIRONMENT = previousBuildEnv;
+  restoreDisplayP3Support();
   cleanup();
   getAppIconState.mockClear();
   setAppIcon.mockClear();
@@ -303,7 +332,7 @@ describe("AppIconRow", () => {
       await renderRow();
 
       await waitFor(() => {
-        expect(previewFill()).toBe(APP_ICON_GROUNDS.dev);
+        expect(previewFill()).toBe(DEV_GROUND_P3);
       });
       expect(previewEyePaths()).toEqual(catalogPaths("quirky"));
     });
@@ -314,7 +343,7 @@ describe("AppIconRow", () => {
       await renderRow();
 
       await waitFor(() => {
-        expect(previewFill()).toBe(APP_ICON_GROUNDS.staging);
+        expect(previewFill()).toBe(STAGING_GROUND_P3);
       });
       expect(previewEyePaths()).toEqual(catalogPaths("quirky"));
     });
@@ -325,7 +354,7 @@ describe("AppIconRow", () => {
       await renderRow();
 
       await waitFor(() => {
-        expect(previewFill()).toBe(APP_ICON_GROUNDS.dev);
+        expect(previewFill()).toBe(DEV_GROUND_P3);
       });
     });
 
@@ -347,7 +376,7 @@ describe("AppIconRow", () => {
       await renderRow();
 
       await waitFor(() => {
-        expect(previewFill()).toBe(APP_ICON_GROUNDS.staging);
+        expect(previewFill()).toBe(STAGING_GROUND_P3);
       });
     });
 
@@ -358,7 +387,33 @@ describe("AppIconRow", () => {
       await renderRow();
 
       await waitFor(() => {
+        expect(previewFill()).toBe(DEV_GROUND_P3);
+      });
+    });
+
+    // The two bundles hold sRGB channels in a display-p3 fill, so the readings
+    // are visibly different colors rather than rounding of each other. sRGB is
+    // the closest a renderer that cannot parse `color()` can get.
+    test("paints the sRGB ground where color() will not parse", async () => {
+      dropDisplayP3Support();
+      shellAppId = "ai.vocify-inc.vellum-assistant-ios.dev";
+
+      await renderRow();
+
+      await waitFor(() => {
         expect(previewFill()).toBe(APP_ICON_GROUNDS.dev);
+      });
+    });
+
+    test("paints the sRGB ground off a build environment too", async () => {
+      dropDisplayP3Support();
+      buildEnv.VITE_SENTRY_ENVIRONMENT = "staging";
+      shellAppId = "com.example.some-other-shell";
+
+      await renderRow();
+
+      await waitFor(() => {
+        expect(previewFill()).toBe(APP_ICON_GROUNDS.staging);
       });
     });
 

--- a/clients/web/src/domains/settings/components/app-icon-row.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.tsx
@@ -33,26 +33,50 @@ import { Button } from "@vellumai/design-library/components/button";
 /** Size of the row's thumbnail, sitting beside a single-line control. */
 const ROW_PREVIEW_SIZE = 32;
 
+/** A shell's icon ground, in both gamuts a renderer might take it in. */
+interface IconGround {
+  /** The fill the shell's Icon Composer bundle declares. */
+  displayP3: string;
+  /** sRGB stand-in, for a renderer that cannot parse `color()`. */
+  srgb: string;
+}
+
+/**
+ * Vellum Dev draws its icon on pink, `clients/ios/App/App/AppIcon-Dev.icon`.
+ *
+ * That bundle declares its fill in display-p3 and holds sRGB channels there
+ * rather than the conversion `clients/ios/README.md` asks for, so the installed
+ * icon is the more saturated of the two on a wide-gamut screen. Naming the same
+ * coordinates keeps the thumbnail from undershooting the icon it depicts;
+ * {@link APP_ICON_GROUNDS} carries only the sRGB reading.
+ */
+const DEV_GROUND: IconGround = {
+  displayP3: "color(display-p3 1 0.53333 0.78824)",
+  srgb: APP_ICON_GROUNDS.dev,
+};
+
+/** Vellum Staging's yellow, read the same way off `AppIcon-Staging.icon`. */
+const STAGING_GROUND: IconGround = {
+  displayP3: "color(display-p3 0.91373 0.78824 0.10196)",
+  srgb: APP_ICON_GROUNDS.staging,
+};
+
 /**
  * Ground the primary icon is drawn on in the shells that do not ship the
  * production one, keyed by the shell's own environment.
  *
- * Vellum Dev draws its icon on pink and Vellum Staging on yellow
- * (`clients/ios/App/App/AppIcon-Dev.icon` and `AppIcon-Staging.icon`), so a
- * thumbnail standing in for "no alternate applied" follows the shell it is
- * running in or it depicts an icon that is on nobody's home screen. The
- * grounds themselves are the ones {@link APP_ICON_GROUNDS} already carries for
- * the widget previews, which is where the Icon Composer fills are converted.
- *
- * It is the shell that is asked and not `VITE_SENTRY_ENVIRONMENT`, because the
- * icon belongs to the installed build while that variable names the web
- * deploy: a Staging shell loading a dev server would otherwise draw pink under
- * a yellow icon. Production is absent: the catalog green
- * {@link DEFAULT_APP_ICON_TRAITS} names is already that shell's ground.
+ * A thumbnail standing in for "no alternate applied" follows the shell it is
+ * running in or it depicts an icon that is on nobody's home screen. It is the
+ * shell that is asked and not `VITE_SENTRY_ENVIRONMENT`, because the icon
+ * belongs to the installed build while that variable names the web deploy: a
+ * Staging shell loading a dev server would otherwise draw pink under a yellow
+ * icon. Production is absent: the catalog green
+ * {@link DEFAULT_APP_ICON_TRAITS} names is already that shell's ground, and its
+ * bundle carries a true conversion of it.
  */
-const PRIMARY_ICON_GROUND: Partial<Record<ShellEnvironment, string>> = {
-  dev: APP_ICON_GROUNDS.dev,
-  staging: APP_ICON_GROUNDS.staging,
+const PRIMARY_ICON_GROUND: Partial<Record<ShellEnvironment, IconGround>> = {
+  dev: DEV_GROUND,
+  staging: STAGING_GROUND,
 };
 
 /**
@@ -61,11 +85,27 @@ const PRIMARY_ICON_GROUND: Partial<Record<ShellEnvironment, string>> = {
  * `clients/ios/README.md` runs on the App Dev scheme, so it takes the same
  * pink.
  */
-const WEB_ENV_PRIMARY_ICON_GROUND: Record<string, string> = {
-  local: APP_ICON_GROUNDS.dev,
-  dev: APP_ICON_GROUNDS.dev,
-  staging: APP_ICON_GROUNDS.staging,
+const WEB_ENV_PRIMARY_ICON_GROUND: Record<string, IconGround> = {
+  local: DEV_GROUND,
+  dev: DEV_GROUND,
+  staging: STAGING_GROUND,
 };
+
+/** Whether the renderer parses a CSS Color 4 `color()` at all. */
+function supportsDisplayP3(): boolean {
+  if (typeof CSS === "undefined" || typeof CSS.supports !== "function") {
+    return false;
+  }
+  return CSS.supports("color", "color(display-p3 1 1 1)");
+}
+
+/** A ground in the widest gamut the renderer can take it in. */
+function groundFill(ground: IconGround | undefined): string | undefined {
+  if (!ground) {
+    return undefined;
+  }
+  return supportsDisplayP3() ? ground.displayP3 : ground.srgb;
+}
 
 /**
  * Ground the running shell's primary icon carries, undefined on production and
@@ -76,12 +116,14 @@ function primaryIconGround(
   shell: ShellEnvironment | null | undefined,
 ): string | undefined {
   if (shell) {
-    return PRIMARY_ICON_GROUND[shell];
+    return groundFill(PRIMARY_ICON_GROUND[shell]);
   }
   if (shell === null) {
-    return WEB_ENV_PRIMARY_ICON_GROUND[
-      import.meta.env.VITE_SENTRY_ENVIRONMENT ?? "local"
-    ];
+    return groundFill(
+      WEB_ENV_PRIMARY_ICON_GROUND[
+        import.meta.env.VITE_SENTRY_ENVIRONMENT ?? "local"
+      ],
+    );
   }
   return undefined;
 }
@@ -140,7 +182,7 @@ function AppIconRowContent({ assistantId, sync }: AppIconRowContentProps) {
             eyeStyle={traits.eyeStyle}
             color={traits.color}
             primary={isPrimary}
-            fieldColorHex={
+            fieldColor={
               isPrimary ? primaryIconGround(shellEnvironment) : undefined
             }
             size={ROW_PREVIEW_SIZE}


### PR DESCRIPTION
Follow-up to #41849, which shipped the environment-aware default thumbnail.

## The mismatch

The App icon row's primary thumbnail took its dev and staging grounds from the sRGB hexes in `APP_ICON_GROUNDS` (`#FF88C9`, `#E7C91A`). The native Icon Composer bundles declare those same fields as **display-p3** coordinates:

| Bundle | `fill.solid` |
| --- | --- |
| `AppIcon-Dev.icon` | `display-p3:1.00000,0.53333,0.78824` |
| `AppIcon-Staging.icon` | `display-p3:0.91373,0.78824,0.10196` |

Those coordinates are the sRGB channels pasted straight into P3 fields, which `clients/ios/README.md` calls out as the thing to avoid ("Pasting the raw sRGB components straight through renders noticeably more saturated than the hex you started from"). So on a P3-capable iPhone the installed icon is the more saturated of the two, and the thumbnail depicting it visibly undershot.

Production needs no change: its bundle value (`display-p3:0.37749,0.60064,0.34581`) is a proper P3 conversion of the catalog green, so the existing sRGB reading already matches.

## The change

- The row's ground map now carries both readings per environment: the bundle's `color(display-p3 ...)` fill and the sRGB hex.
- `groundFill()` picks the P3 string when `CSS.supports("color", "color(display-p3 1 1 1)")` is true, and the sRGB hex otherwise, so a renderer that cannot parse CSS Color 4 paints the nearest thing rather than falling back to black.
- The shared `APP_ICON_GROUNDS` constant is untouched. The iOS widget previews that read it carry the same sRGB approximation; that is out of scope here and left as is.
- `AppIconPreview`'s `fieldColorHex` prop is renamed to `fieldColor`, since it now takes any CSS color string rather than a hex. The prop was introduced on #41849 and has one caller, so the rename is free.

## Tests

`app-icon-row.test.tsx` pins the two P3 strings as literals, so a coordinate drifting from the bundles fails here. Two new cases swap the `CSS` global for one that reports no support and assert the sRGB hex is painted instead. All the existing shell-identity cases are intact.

## Verification

- `bun run test:ci -- src/domains/settings/components/app-icon-row.test.tsx src/components/avatar/app-icon-preview.test.tsx` — 2 files passed
- `bunx tsc --noEmit` — clean
- `bunx eslint` on the four changed files — clean
- Negative check: reverting `groundFill()` to always return the P3 string fails exactly the two new fallback cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
