### PR TITLE
chore(web): guardian row stories carry the real projection

### DIFF
--- a/clients/web/src/domains/home/home-recap-row.stories.tsx
+++ b/clients/web/src/domains/home/home-recap-row.stories.tsx
@@ -105,17 +105,63 @@ export const ScheduledReminder: Story = {
   },
 };
 
-/** A guardian request: `security` category, high urgency. */
-export const SecurityRequest: Story = {
+/**
+ * A pending guardian request as it lands in the bell: the canonical
+ * "Needs attention" item, carrying the `guardianRequest` projection that
+ * pins it first, labels it "Guardian action needed", and withholds the
+ * dismiss affordance until the request resolves.
+ */
+export const GuardianRequestPending: Story = {
   args: {
     item: feedItem({
-      id: "feed-guardian",
-      title: "Approval needed",
+      id: "guardian:req-approval",
+      title: "Alice asked the assistant to look up ticket ABC-123",
       summary:
-        "A tool wants to send an email on your behalf to the finance team.",
+        "Alice asked the assistant to look up ticket ABC-123 before replying in the thread.",
       category: "security",
       urgency: "high",
+      detailPanel: { kind: "permissionChat" },
       conversationId: FIXTURE_CONVERSATION_ID,
+      guardianRequest: {
+        requestId: "req-approval",
+        kind: "tool_approval",
+        intent: "approval",
+        status: "pending",
+        requesterLabel: "Alice",
+        toolName: "linear_graphql",
+        sourceChannel: "slack",
+        sourceContextLabel: "#user-feedback",
+      },
+    }),
+  },
+};
+
+/**
+ * The same item after resolution: an ordinary clearable notification
+ * whose detail shows the receipt in place of the action buttons.
+ */
+export const GuardianRequestResolved: Story = {
+  args: {
+    item: feedItem({
+      id: "guardian:req-resolved",
+      title: "Alice asked the assistant to look up ticket ABC-123",
+      summary:
+        "Alice asked the assistant to look up ticket ABC-123 before replying in the thread.",
+      category: "security",
+      urgency: "medium",
+      detailPanel: { kind: "permissionChat" },
+      conversationId: FIXTURE_CONVERSATION_ID,
+      guardianRequest: {
+        requestId: "req-resolved",
+        kind: "tool_approval",
+        intent: "approval",
+        status: "approved",
+        requesterLabel: "Alice",
+        toolName: "linear_graphql",
+        sourceContextLabel: "#user-feedback",
+        decidedByLabel: "Bob",
+        decidedAt: "2026-09-01T13:00:00.000Z",
+      },
     }),
   },
 };


### PR DESCRIPTION
## TL;DR
The bell-row Storybook story predated the guardian projection and showed a generic security item. It now renders what actually lands in the bell: the pending canonical item (pinned first, labeled Guardian action needed, dismiss withheld) and its resolved receipt counterpart. Story-only change; production data shapes, per the Storybook rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->