### PR TITLE
feat(web): avatar-tinted treatment and empty state for the assistant section

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-section-empty-state.tsx
+++ b/clients/web/src/domains/chat/components/assistant-section-empty-state.tsx
@@ -1,0 +1,55 @@
+/**
+ * The assistant-initiated section with nothing in it yet.
+ *
+ * Every other sidebar section renders only once it has rows, so none of them
+ * needs an empty state. This one renders at zero on purpose: it is a section
+ * the user never files anything into, so without a word here it reads as
+ * broken rather than as waiting. The copy's whole job is to say what will
+ * eventually arrive and who puts it there.
+ *
+ * Written in the assistant's own voice, first person, because the section is
+ * the assistant's rather than a category of the user's. That is also why the
+ * hero is the assistant's own eyes instead of the section header's glyph:
+ * `AssistantEyesMark` renders `null` for a custom-image or still-loading
+ * avatar, so the scene degrades to copy alone without a guard here.
+ *
+ * Deliberately smaller than `EmptyStateScene`: this sits inside a sidebar
+ * card a couple of hundred pixels wide, where that component's icon well and
+ * recipe grid do not fit.
+ */
+
+import { AssistantEyesMark } from "@/domains/chat/components/assistant-eyes-mark";
+import { useTranslation } from "@/i18n";
+import { Typography } from "@vellumai/design-library";
+
+export interface AssistantSectionEmptyStateProps {
+  assistantId: string | null;
+}
+
+export function AssistantSectionEmptyState({
+  assistantId,
+}: AssistantSectionEmptyStateProps) {
+  const { t } = useTranslation("chat");
+
+  return (
+    <div className="flex flex-col items-center gap-[var(--app-spacing-sm)] px-[var(--app-spacing-md)] pt-[var(--app-spacing-sm)] pb-[var(--app-spacing-md)] text-center">
+      <AssistantEyesMark
+        assistantId={assistantId}
+        width={28}
+        className="opacity-80"
+      />
+      <Typography
+        variant="body-small-default"
+        className="text-[var(--content-secondary)]"
+      >
+        {t("assistantSection.emptyTitle")}
+      </Typography>
+      <Typography
+        variant="body-small-lighter"
+        className="text-balance text-[var(--content-tertiary)]"
+      >
+        {t("assistantSection.emptyBody")}
+      </Typography>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.stories.tsx
@@ -14,6 +14,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { CollapsibleNavSection } from "@/components/collapsible-nav-section";
+import { AssistantSectionEmptyState } from "@/domains/chat/components/assistant-section-empty-state";
 import { GroupIndicatorDot } from "@/domains/chat/components/collapsed-group-icon";
 import { ConversationListProvider } from "@/domains/chat/components/conversation-list-context";
 import {
@@ -260,6 +261,80 @@ export const Composed: Story = {
         groupMenu={CHATS_MENU}
         trailing={<GroupActionsMenu label="Chats" {...CHATS_MENU} />}
       />
+    </CollapsibleNavSection.Root>
+  ),
+};
+
+/**
+ * The assistant-initiated section: the one card painted in the assistant's
+ * own color, and the one that renders at zero.
+ *
+ * The tint reads `--avatar-accent`, which the real app publishes on `<html>`
+ * from the active avatar. Storybook has no assistant, so these stories set it
+ * on the card's own wrapper — same variable, same `color-mix`, so what shows
+ * here is what the sidebar paints. Change the hex below to check a different
+ * avatar color; the light end of the palette is the one worth looking at,
+ * since a 7% mix has to stay distinguishable from a plain card without
+ * turning into a highlight.
+ *
+ * The empty state's eyes are absent here for the same reason: the mark reads
+ * the real avatar and renders `null` without one, which is exactly what a
+ * custom-image avatar gets in the app.
+ */
+const ASSISTANT_TINT_CLASS =
+  "bg-[color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_7%,var(--surface-lift))]";
+
+const ASSISTANT_THREADS: Conversation[] = [
+  conversation("a1", "Your Tuesday reviews keep slipping past 6pm", {
+    hasUnseenLatestAssistantMessage: true,
+  }),
+  conversation("a2", "That contractor never sent the revised quote"),
+  conversation("a3", "You've rewritten the same paragraph four times"),
+];
+
+export const AssistantInitiated: Story = {
+  args: {
+    value: "assistant",
+    label: "From Ada",
+    items: ASSISTANT_THREADS,
+    cardClassName: ASSISTANT_TINT_CLASS,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ ["--avatar-accent" as string]: "#C4436A" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <CollapsibleNavSection.Root type="multiple" defaultValue={["assistant"]}>
+      <SidebarSectionCard {...args} />
+    </CollapsibleNavSection.Root>
+  ),
+};
+
+/**
+ * Nothing yet — the state the section spends its first days in, and the only
+ * reason it renders at zero at all.
+ */
+export const AssistantInitiatedEmpty: Story = {
+  args: {
+    value: "assistant",
+    label: "From Ada",
+    items: [],
+    cardClassName: ASSISTANT_TINT_CLASS,
+    children: <AssistantSectionEmptyState assistantId={null} />,
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ ["--avatar-accent" as string]: "#C4436A" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <CollapsibleNavSection.Root type="multiple" defaultValue={["assistant"]}>
+      <SidebarSectionCard {...args} />
     </CollapsibleNavSection.Root>
   ),
 };

--- a/clients/web/src/domains/chat/components/sidebar-section-item.test.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * The two things `SidebarSectionItem` does only for the assistant-initiated
+ * section: name its header after the assistant, and put an empty state in
+ * place of its row list.
+ *
+ * The empty state is the risky one, which is why it is covered here rather
+ * than left to Storybook. `ConversationNavSection` resolves its body as
+ * `children ?? <ConversationRowList/>`, so a `children` that is anything other
+ * than `undefined` for the other sections would silently replace their rows
+ * with nothing. The assertions below pin both directions of that.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import type * as SectionConversations from "@/domains/chat/use-section-conversations";
+import type { SidebarSection } from "@/domains/chat/use-sidebar-state";
+import type { Conversation } from "@/types/conversation-types";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+
+/** What the section query answers with, per test. */
+let sectionRows: Conversation[] = [];
+
+mock.module(
+  "@/domains/chat/use-section-conversations",
+  (): Partial<typeof SectionConversations> => ({
+    useSectionConversations: () => ({
+      conversations: sectionRows,
+      hasMore: false,
+      loadMore: () => {},
+      getAllRows: () => Promise.resolve(sectionRows),
+      isPending: false,
+    }),
+  }),
+);
+
+const { SidebarSectionItem } =
+  await import("@/domains/chat/components/sidebar-section-item");
+const { ConversationListProvider } =
+  await import("@/domains/chat/components/conversation-list-context");
+const { CollapsibleNavSection } =
+  await import("@/components/collapsible-nav-section");
+
+function conv(conversationId: string, title: string): Conversation {
+  return {
+    conversationId,
+    title,
+    hasUnseenLatestAssistantMessage: false,
+  };
+}
+
+function assistantSection(): SidebarSection {
+  return { type: "assistant", key: "assistant", label: "On My Mind", all: [] };
+}
+
+function chatsSection(): SidebarSection {
+  return {
+    type: "recents",
+    key: "recents",
+    label: "Chats",
+    all: [],
+    holdsChannels: true,
+  };
+}
+
+function renderSection(section: SidebarSection) {
+  /* The empty state's eyes read the avatar through a query, so the tree needs
+     a client even though nothing here asserts on the avatar. */
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ConversationListProvider
+        value={{
+          overlayCards: false,
+          processingConversationIds: new Set<string>(),
+          attentionConversationIds: new Set<string>(),
+          onSelect: () => {},
+        }}
+      >
+        <CollapsibleNavSection.Root
+          type="multiple"
+          defaultValue={[section.key]}
+        >
+          <SidebarSectionItem
+            section={section}
+            assistantId="asst-1"
+            groupMenu={() => ({})}
+          />
+        </CollapsibleNavSection.Root>
+      </ConversationListProvider>
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  sectionRows = [];
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+describe("SidebarSectionItem — the assistant-initiated section", () => {
+  test("names the header after the assistant once it has a name", () => {
+    useAssistantIdentityStore.getState().setIdentity("Ada", "0.12.0", "asst-1");
+    renderSection(assistantSection());
+
+    expect(screen.getByText("From Ada")).toBeTruthy();
+  });
+
+  test("falls back to the neutral header while the assistant is unnamed", () => {
+    // "From Your Assistant" reads as a settings row rather than a byline.
+    renderSection(assistantSection());
+
+    expect(screen.getByText("On My Mind")).toBeTruthy();
+    expect(screen.queryByText(/^From /)).toBeNull();
+  });
+
+  test("shows the empty state in place of the rows when it has none", () => {
+    renderSection(assistantSection());
+
+    expect(screen.getByText("Nothing on my mind yet.")).toBeTruthy();
+  });
+
+  test("shows its rows, not the empty state, once it has any", () => {
+    sectionRows = [conv("a1", "Your Tuesday reviews keep slipping")];
+    renderSection(assistantSection());
+
+    expect(
+      screen.getAllByText("Your Tuesday reviews keep slipping").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("Nothing on my mind yet.")).toBeNull();
+  });
+});
+
+describe("SidebarSectionItem — every other section", () => {
+  test("keeps its rows, so the empty-state branch cannot blank them", () => {
+    // The regression this guards: `children` is resolved with `??`, so a
+    // non-undefined value here would replace the row list for every section.
+    sectionRows = [conv("c1", "Lease renewal")];
+    renderSection(chatsSection());
+
+    expect(screen.getAllByText("Lease renewal").length).toBeGreaterThan(0);
+  });
+
+  test("gets no empty state and no assistant header when it is empty", () => {
+    renderSection(chatsSection());
+
+    expect(screen.queryByText("Nothing on my mind yet.")).toBeNull();
+    expect(screen.getByText("Chats")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/sidebar-section-item.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.tsx
@@ -22,6 +22,7 @@
 import type { ReactNode } from "react";
 
 import type { CollapsibleNavSectionDrag } from "@/components/collapsible-nav-section";
+import { AssistantSectionEmptyState } from "@/domains/chat/components/assistant-section-empty-state";
 import { SidebarSectionCard } from "@/domains/chat/components/sidebar-section-card";
 import {
   GroupActionsMenu,
@@ -29,7 +30,11 @@ import {
 } from "@/domains/chat/components/group-actions-menu";
 import type { SidebarSection } from "@/domains/chat/use-sidebar-state";
 import { useSectionConversations } from "@/domains/chat/use-section-conversations";
-import { sectionIcon } from "@/domains/chat/utils/sidebar-section-icon";
+import {
+  assistantSectionLabel,
+  sectionIcon,
+} from "@/domains/chat/utils/sidebar-section-icon";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import type { Conversation } from "@/types/conversation-types";
 
 export interface SidebarSectionItemProps {
@@ -76,6 +81,10 @@ export function SidebarSectionItem({
 }: SidebarSectionItemProps) {
   const { conversations, hasMore, loadMore, getAllRows } =
     useSectionConversations(assistantId, section);
+  /* Read here rather than threaded down from the side menu: only one section
+     wants the name, and the same store is what the layout above reads. */
+  const assistantName = useAssistantIdentityStore.use.name();
+  const isAssistantSection = section.type === "assistant";
 
   /* Every section handed to this component renders. Whether a section exists
      at all is `use-sidebar-state`'s answer, and it has to stay the only one:
@@ -86,11 +95,28 @@ export function SidebarSectionItem({
      One predicate for membership and visibility, or the two drift and this
      recurs at the next section type. */
   const groupMenu = buildGroupMenu(conversations, getAllRows);
+  const label = isAssistantSection
+    ? assistantSectionLabel(assistantName)
+    : section.label;
   return (
     <SidebarSectionCard
       value={section.key}
       icon={sectionIcon(section)}
-      label={section.label}
+      label={label}
+      /* The one section painted in the assistant's own color, so it reads as
+         coming from someone rather than as another bucket. `--avatar-accent`
+         is published on `<html>` by `useAvatarAccentVar` and is *absent* for
+         custom-image and still-loading avatars, so the fallback has to be the
+         surface itself: mixing a percentage of `--surface-lift` into
+         `--surface-lift` is exactly `--surface-lift`, which is what every
+         other card paints. A `transparent` fallback would instead punch a
+         hole in the card. Kept low (7%) because this sits behind
+         conversation rows that still have to read as ordinary rows. */
+      cardClassName={
+        isAssistantSection
+          ? "bg-[color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_7%,var(--surface-lift))]"
+          : undefined
+      }
       /* The "…" button and the header's right-click menu both render from
          `groupMenu`. Every section carries it: a section's actions should not
          depend on which kind it is, and Chats and the channels have their own
@@ -107,6 +133,17 @@ export function SidebarSectionItem({
       isLast={isLast}
       items={conversations}
       onEndReached={hasMore ? loadMore : undefined}
+      /* The only section that renders at zero, so the only one with anything
+         to say there. `ConversationNavSection` resolves this as
+         `children ?? <ConversationRowList/>`, so it has to be exactly
+         `undefined` in every other case or a section would lose its rows to
+         an empty node. Passed as a prop rather than as a JSX child for that
+         reason: it keeps the absent case unambiguous. */
+      children={
+        isAssistantSection && conversations.length === 0 ? (
+          <AssistantSectionEmptyState assistantId={assistantId} />
+        ) : undefined
+      }
     />
   );
 }

--- a/clients/web/src/domains/chat/utils/sidebar-section-icon.test.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-section-icon.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The assistant-initiated section's header, which is the one section label
+ * that is not a constant.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ASSISTANT_SECTION_LABEL,
+  assistantSectionLabel,
+} from "@/domains/chat/utils/sidebar-section-icon";
+
+describe("assistantSectionLabel", () => {
+  test("names the section after the assistant", () => {
+    expect(assistantSectionLabel("Ada")).toBe("From Ada");
+  });
+
+  test("falls back before the assistant has a name", () => {
+    // Either absence: never set, or cleared.
+    expect(assistantSectionLabel(null)).toBe(ASSISTANT_SECTION_LABEL);
+    expect(assistantSectionLabel(undefined)).toBe(ASSISTANT_SECTION_LABEL);
+    expect(assistantSectionLabel("")).toBe(ASSISTANT_SECTION_LABEL);
+  });
+
+  test("falls back on a whitespace-only name", () => {
+    // The name is user-entered, and "From " with nothing after it is worse
+    // than either real option.
+    expect(assistantSectionLabel("   ")).toBe(ASSISTANT_SECTION_LABEL);
+  });
+
+  test("trims a padded name rather than rendering the padding", () => {
+    expect(assistantSectionLabel("  Ada  ")).toBe("From Ada");
+  });
+});

--- a/clients/web/src/domains/chat/utils/sidebar-section-icon.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-section-icon.ts
@@ -38,6 +38,26 @@ export const RECENTS_SECTION_ICON: LucideIcon = MessageSquare;
  */
 export const ASSISTANT_SECTION_LABEL = "On My Mind";
 
+/**
+ * Header for the assistant-initiated section: `"From <name>"` once the
+ * assistant has a name, {@link ASSISTANT_SECTION_LABEL} before it does.
+ *
+ * The named form is the point — it makes the section a person rather than a
+ * category, which is the whole reason these threads are worth separating from
+ * Chats. The fallback exists because the unnamed placeholder the switcher pill
+ * shows ("Your Assistant") reads as a settings row rather than a byline, so an
+ * unnamed assistant gets a neutral header instead of "From Your Assistant".
+ *
+ * Whitespace-only names fall back too: the name is user-entered, and `"From "`
+ * with nothing after it is worse than either real option.
+ */
+export function assistantSectionLabel(
+  assistantName: string | null | undefined,
+): string {
+  const trimmed = assistantName?.trim();
+  return trimmed ? `From ${trimmed}` : ASSISTANT_SECTION_LABEL;
+}
+
 export function sectionIcon(section: SidebarSection): LucideIcon {
   switch (section.type) {
     case "pinned":

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -90,6 +90,10 @@
   "assistantNavItem": {
     "newChat": "New Chat"
   },
+  "assistantSection": {
+    "emptyTitle": "Nothing on my mind yet.",
+    "emptyBody": "I keep thinking between our conversations. When something's worth your time, I'll start a thread here."
+  },
   "assistantSideMenu": {
     "bulkActionMembersFailed": "Couldn't load every conversation in this section. Try again.",
     "closeNavAria": "Close navigation",


### PR DESCRIPTION
## Summary

- **Tint.** The section card mixes 7% of `--avatar-accent` into `--surface-lift`. The var is published on `<html>` by `useAvatarAccentVar` and is *absent* for custom-image and still-loading avatars, so the fallback is `--surface-lift` itself — mixing a percentage of a color into itself is that color, which is what every other card paints. A `transparent` fallback would instead punch a hole in the card.
- **Header.** `From <name>` once the assistant is named, `On My Mind` before that. "From Your Assistant" (the unnamed placeholder the switcher pill shows) reads as a settings row rather than a byline, so the unnamed case gets a neutral header instead. Whitespace-only names fall back too.
- **Empty state.** `AssistantEyesMark` plus two lines in the assistant's voice — *"Nothing on my mind yet." / "I keep thinking between our conversations. When something's worth your time, I'll start a thread here."* The mark renders `null` without a character avatar, so the scene degrades to copy alone with no guard.
- Two Storybook stories (filled + empty) that set `--avatar-accent` on their own wrapper, so the treatment can be reviewed without a running assistant.
- 10 new tests.

## One thing I dropped from the plan

I proposed recoloring the section's unread dot to the avatar accent. I did not build it, deliberately:

`GroupIndicatorDot` is shared by every section and its colors are semantic (`--system-mid-strong` for unread, `--primary-base` for processing). Recoloring one section's dot would make the same signal mean the same thing in two different colors, and an arbitrary avatar hue has no contrast guarantee — a light avatar (the yellow end of the palette) would put a near-invisible dot on an already-tinted card. The tint, the eyes, and the named header carry the branding without touching a state signal. Worth a second opinion if you disagree.

## Notes

- The empty state is passed as an explicit `children` **prop**, not a JSX child. `ConversationNavSection` resolves its body as `children ?? <ConversationRowList/>`, so anything other than `undefined` for the other sections would silently replace their rows with nothing. A test pins both directions.
- English copy only. The other four catalogs already lag (`ru` is missing 157 keys in this namespace) and there is no CI parity check, so this matches existing practice; i18n fallback covers it.

## Original prompt

PR 3 of 3 in the notifications split. The bell keeps the transactional items (approvals, credential alerts); the threads the assistant starts get their own sidebar section, feature-gated. PRs 1 and 2 built the server split and the sidebar plumbing and are invisible with the flag off — this is the part you can actually see.