### PR TITLE
feat(mac-helper): detect holds of a configured modifier set

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperCore/ModifierHoldDetector.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperCore/ModifierHoldDetector.swift
@@ -28,20 +28,28 @@ public struct ModifierHoldDetector {
     private var open = false
     /// Whether this press of the set is spent.
     ///
-    /// A hold that ends for any reason other than the set being released stays
-    /// ended: the user is holding modifiers they have already spent on
-    /// something else, and reopening the moment the extra key lifts would open
-    /// a microphone in the middle of their shortcut. Cleared only by the set
-    /// being fully released, so it takes a fresh press to start another hold.
+    /// A hold that ends while any of the set is still down stays ended: the
+    /// user is holding modifiers they have already spent on something else,
+    /// and reopening the moment the extra key lifts would open a microphone in
+    /// the middle of their shortcut.
+    ///
+    /// Cleared only once the whole set is up, which for a set of more than one
+    /// is a stricter test than the set no longer being held: Ctrl+Option stops
+    /// being held the moment either of them lifts, and clearing there would let
+    /// a press of the one that lifted reopen a hold the other is still
+    /// mid-shortcut on.
     private var spent = false
 
     public init() {}
 
     /// Feed a modifier-flags change. Returns the edges to report, in order.
     ///
-    /// `targetHeld` is whether every modifier of the configured set is down.
-    /// `extraModifiersHeld` is whether any modifier outside it is. Both are the
-    /// caller's to mask, so this type never learns which modifiers it watches.
+    /// `targetHeld` is whether every modifier of the configured set is down and
+    /// `anyTargetHeld` whether any of it is, which differ for a set of more
+    /// than one and are the difference between a hold ending and the set being
+    /// released. `extraModifiersHeld` is whether any modifier outside the set
+    /// is down. All three are the caller's to mask, so this type never learns
+    /// which modifiers it watches.
     ///
     /// `ordinaryKeyHeld` answers whether any non-modifier key is down right
     /// now, and is consulted only when a hold would open: a key pressed before
@@ -50,6 +58,7 @@ public struct ModifierHoldDetector {
     /// Deliberately a closure so the caller's poll runs only then.
     public mutating func flagsChanged(
         targetHeld: Bool,
+        anyTargetHeld: Bool,
         extraModifiersHeld: Bool,
         ordinaryKeyHeld: () -> Bool = { false }
     ) -> [Edge] {
@@ -58,17 +67,16 @@ public struct ModifierHoldDetector {
         if open {
             guard qualifies else {
                 open = false
-                spent = targetHeld
+                spent = anyTargetHeld
                 return [.up]
             }
             return []
         }
 
-        guard targetHeld else {
+        if !anyTargetHeld {
             spent = false
-            return []
         }
-        guard !spent else {
+        guard targetHeld, !spent else {
             return []
         }
         guard qualifies && !ordinaryKeyHeld() else {

--- a/clients/macos/native/mac-helper/Sources/MacHelperCore/ModifierHoldDetector.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperCore/ModifierHoldDetector.swift
@@ -1,0 +1,107 @@
+/// Distills the raw keyboard stream into holds of one configured set of
+/// modifiers, with nothing else involved.
+///
+/// A hold begins when every modifier in the set is down, no modifier outside it
+/// is, and no ordinary key is; it ends when any of those stops being true. The
+/// verdict is known at press, which is what separates this from
+/// `FnTapDetector`: a tap is only a tap once it has been released, but a hold
+/// is a hold while it is being held, and the caller needs the opening edge to
+/// open a microphone with.
+///
+/// A hold disqualified mid-way ends rather than pausing. Holding the set and
+/// then pressing a key is someone else's shortcut passing through (Ctrl+Option
+/// is VoiceOver's own modifier, and macOS claims Ctrl+Option+F and friends), so
+/// the hold closes and does not reopen when the extra key lifts. Only a fresh
+/// press of the set can start another one.
+///
+/// Pure state machine, fed by the caller with pre-masked booleans. Latched
+/// modifier state (Caps Lock, Num Lock) must not be included in
+/// `extraModifiersHeld`: it stays set for whole sessions and would permanently
+/// disqualify every hold.
+public struct ModifierHoldDetector {
+    public enum Edge: String, Equatable, Sendable {
+        case down
+        case up
+    }
+
+    /// Whether a hold is open, which is what an `up` is owed to.
+    private var open = false
+    /// Whether this press of the set is spent.
+    ///
+    /// A hold that ends for any reason other than the set being released stays
+    /// ended: the user is holding modifiers they have already spent on
+    /// something else, and reopening the moment the extra key lifts would open
+    /// a microphone in the middle of their shortcut. Cleared only by the set
+    /// being fully released, so it takes a fresh press to start another hold.
+    private var spent = false
+
+    public init() {}
+
+    /// Feed a modifier-flags change. Returns the edges to report, in order.
+    ///
+    /// `targetHeld` is whether every modifier of the configured set is down.
+    /// `extraModifiersHeld` is whether any modifier outside it is. Both are the
+    /// caller's to mask, so this type never learns which modifiers it watches.
+    ///
+    /// `ordinaryKeyHeld` answers whether any non-modifier key is down right
+    /// now, and is consulted only when a hold would open: a key pressed before
+    /// the modifiers (Delete held, then Ctrl+Option) is invisible both to the
+    /// flags and to the key-down events that follow, so the opening has to ask.
+    /// Deliberately a closure so the caller's poll runs only then.
+    public mutating func flagsChanged(
+        targetHeld: Bool,
+        extraModifiersHeld: Bool,
+        ordinaryKeyHeld: () -> Bool = { false }
+    ) -> [Edge] {
+        let qualifies = targetHeld && !extraModifiersHeld
+
+        if open {
+            guard qualifies else {
+                open = false
+                spent = targetHeld
+                return [.up]
+            }
+            return []
+        }
+
+        guard targetHeld else {
+            spent = false
+            return []
+        }
+        guard !spent else {
+            return []
+        }
+        guard qualifies && !ordinaryKeyHeld() else {
+            spent = true
+            return []
+        }
+        open = true
+        return [.down]
+    }
+
+    /// Feed a non-modifier key press. A key pressed during a hold makes it a
+    /// chord, which belongs to whatever the user is actually working in.
+    public mutating func keyDown() -> [Edge] {
+        guard open else {
+            return []
+        }
+        open = false
+        spent = true
+        return [.up]
+    }
+
+    /// Close an open hold because the world changed underneath it: the helper
+    /// is shutting down, the binding was cleared, or the monitor stopped
+    /// delivering. Silent when nothing is open, so it is safe to call anywhere.
+    public mutating func cancel() -> [Edge] {
+        guard open else {
+            return []
+        }
+        open = false
+        // The set may still be physically down, and the reason this hold ended
+        // has not gone away with it, so it takes a fresh press to start
+        // another. Cancelling nothing changes nothing.
+        spent = true
+        return [.up]
+    }
+}

--- a/clients/macos/native/mac-helper/Tests/MacHelperCoreTests/ModifierHoldDetectorTests.swift
+++ b/clients/macos/native/mac-helper/Tests/MacHelperCoreTests/ModifierHoldDetectorTests.swift
@@ -1,0 +1,175 @@
+import Testing
+
+@testable import MacHelperCore
+
+private typealias Edge = ModifierHoldDetector.Edge
+
+/// The opening edge arrives at press, which is the whole difference from a tap:
+/// a microphone that opened on release would record nothing.
+@Test func holdOpensAtPressAndClosesAtRelease() {
+    var detector = ModifierHoldDetector()
+
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+            == [Edge.down]
+    )
+    #expect(
+        detector.flagsChanged(targetHeld: false, extraModifiersHeld: false)
+            == [Edge.up]
+    )
+}
+
+/// Repeated flag events during one hold are the common case, since every
+/// modifier press and release delivers one.
+@Test func holdReportsNothingWhileItIsMerelyContinuing() {
+    var detector = ModifierHoldDetector()
+
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+            == [Edge.down]
+    )
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false) == []
+    )
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false) == []
+    )
+}
+
+/// A modifier outside the set joining makes the press a chord on its way
+/// somewhere else.
+@Test func extraModifierJoiningEndsTheHold() {
+    var detector = ModifierHoldDetector()
+
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+            == [Edge.down]
+    )
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: true)
+            == [Edge.up]
+    )
+}
+
+/// And it stays disqualified: releasing the extra modifier leaves the user
+/// holding a set they already spent, so nothing reopens until they press again.
+@Test func aDisqualifiedHoldDoesNotReopenWhenTheExtraModifierLifts() {
+    var detector = ModifierHoldDetector()
+
+    _ = detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+    _ = detector.flagsChanged(targetHeld: true, extraModifiersHeld: true)
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false) == []
+    )
+    #expect(
+        detector.flagsChanged(targetHeld: false, extraModifiersHeld: false)
+            == []
+    )
+}
+
+/// Starting inside a chord never opens one either.
+@Test func targetHeldInsideAChordNeverOpens() {
+    var detector = ModifierHoldDetector()
+
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: true) == []
+    )
+    #expect(
+        detector.flagsChanged(targetHeld: false, extraModifiersHeld: true) == []
+    )
+}
+
+/// An ordinary key pressed during the hold is the shortcut the user is actually
+/// reaching for, which is the case that has to stay theirs.
+@Test func anOrdinaryKeyDuringTheHoldEndsIt() {
+    var detector = ModifierHoldDetector()
+
+    #expect(
+        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+            == [Edge.down]
+    )
+    #expect(detector.keyDown() == [Edge.up])
+    // The release that follows is owed nothing: the hold is already closed.
+    #expect(
+        detector.flagsChanged(targetHeld: false, extraModifiersHeld: false)
+            == []
+    )
+}
+
+/// A key already down when the modifiers arrive is invisible to the flags and
+/// to every key-down that follows, so the opening has to poll for it.
+@Test func anOrdinaryKeyAlreadyDownNeverOpensAHold() {
+    var detector = ModifierHoldDetector()
+
+    #expect(
+        detector.flagsChanged(
+            targetHeld: true,
+            extraModifiersHeld: false,
+            ordinaryKeyHeld: { true }
+        ) == []
+    )
+}
+
+/// The poll runs only where it can change the answer, since it walks the whole
+/// keyboard.
+@Test func theOrdinaryKeyPollIsNotConsultedOnEveryEvent() {
+    var detector = ModifierHoldDetector()
+    var polls = 0
+    let poll = {
+        polls += 1
+        return false
+    }
+
+    _ = detector.flagsChanged(
+        targetHeld: true, extraModifiersHeld: false, ordinaryKeyHeld: poll)
+    _ = detector.flagsChanged(
+        targetHeld: true, extraModifiersHeld: false, ordinaryKeyHeld: poll)
+    _ = detector.flagsChanged(
+        targetHeld: false, extraModifiersHeld: false, ordinaryKeyHeld: poll)
+
+    #expect(polls == 1)
+}
+
+/// Keys pressed while nothing is open are somebody else's business entirely.
+@Test func keyDownOutsideAHoldReportsNothing() {
+    var detector = ModifierHoldDetector()
+
+    #expect(detector.keyDown() == [])
+}
+
+/// Teardown owes an open hold its closing edge, or the consumer is left with a
+/// microphone nobody is going to close.
+@Test func cancelClosesAnOpenHoldAndIsSilentOtherwise() {
+    var detector = ModifierHoldDetector()
+
+    #expect(detector.cancel() == [])
+    _ = detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+    #expect(detector.cancel() == [Edge.up])
+    #expect(detector.cancel() == [])
+}
+
+/// Every hold that opens is closed exactly once, whichever way it ends. The
+/// consumer's bookkeeping is a microphone, so an unmatched edge either strands
+/// it open or closes one that was never opened.
+@Test func everyOpenIsClosedExactlyOnce() {
+    var detector = ModifierHoldDetector()
+    var depth = 0
+
+    let apply = { (edges: [Edge]) in
+        for edge in edges {
+            depth += edge == .down ? 1 : -1
+            #expect(depth == 0 || depth == 1)
+        }
+    }
+
+    apply(detector.flagsChanged(targetHeld: true, extraModifiersHeld: false))
+    apply(detector.keyDown())
+    apply(detector.flagsChanged(targetHeld: false, extraModifiersHeld: false))
+    apply(detector.flagsChanged(targetHeld: true, extraModifiersHeld: false))
+    apply(detector.flagsChanged(targetHeld: true, extraModifiersHeld: true))
+    apply(detector.flagsChanged(targetHeld: false, extraModifiersHeld: false))
+    apply(detector.flagsChanged(targetHeld: true, extraModifiersHeld: false))
+    apply(detector.cancel())
+
+    #expect(depth == 0)
+}

--- a/clients/macos/native/mac-helper/Tests/MacHelperCoreTests/ModifierHoldDetectorTests.swift
+++ b/clients/macos/native/mac-helper/Tests/MacHelperCoreTests/ModifierHoldDetectorTests.swift
@@ -10,11 +10,15 @@ private typealias Edge = ModifierHoldDetector.Edge
     var detector = ModifierHoldDetector()
 
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false)
             == [Edge.down]
     )
     #expect(
-        detector.flagsChanged(targetHeld: false, extraModifiersHeld: false)
+        detector.flagsChanged(
+        targetHeld: false,
+        anyTargetHeld: false, extraModifiersHeld: false)
             == [Edge.up]
     )
 }
@@ -25,14 +29,20 @@ private typealias Edge = ModifierHoldDetector.Edge
     var detector = ModifierHoldDetector()
 
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false)
             == [Edge.down]
     )
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false) == []
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false) == []
     )
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false) == []
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false) == []
     )
 }
 
@@ -42,11 +52,15 @@ private typealias Edge = ModifierHoldDetector.Edge
     var detector = ModifierHoldDetector()
 
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false)
             == [Edge.down]
     )
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: true)
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: true)
             == [Edge.up]
     )
 }
@@ -56,13 +70,21 @@ private typealias Edge = ModifierHoldDetector.Edge
 @Test func aDisqualifiedHoldDoesNotReopenWhenTheExtraModifierLifts() {
     var detector = ModifierHoldDetector()
 
-    _ = detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
-    _ = detector.flagsChanged(targetHeld: true, extraModifiersHeld: true)
+    _ = detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false)
+    _ = detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: true)
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false) == []
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false) == []
     )
     #expect(
-        detector.flagsChanged(targetHeld: false, extraModifiersHeld: false)
+        detector.flagsChanged(
+        targetHeld: false,
+        anyTargetHeld: false, extraModifiersHeld: false)
             == []
     )
 }
@@ -72,10 +94,14 @@ private typealias Edge = ModifierHoldDetector.Edge
     var detector = ModifierHoldDetector()
 
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: true) == []
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: true) == []
     )
     #expect(
-        detector.flagsChanged(targetHeld: false, extraModifiersHeld: true) == []
+        detector.flagsChanged(
+        targetHeld: false,
+        anyTargetHeld: false, extraModifiersHeld: true) == []
     )
 }
 
@@ -85,13 +111,17 @@ private typealias Edge = ModifierHoldDetector.Edge
     var detector = ModifierHoldDetector()
 
     #expect(
-        detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+        detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false)
             == [Edge.down]
     )
     #expect(detector.keyDown() == [Edge.up])
     // The release that follows is owed nothing: the hold is already closed.
     #expect(
-        detector.flagsChanged(targetHeld: false, extraModifiersHeld: false)
+        detector.flagsChanged(
+        targetHeld: false,
+        anyTargetHeld: false, extraModifiersHeld: false)
             == []
     )
 }
@@ -103,7 +133,8 @@ private typealias Edge = ModifierHoldDetector.Edge
 
     #expect(
         detector.flagsChanged(
-            targetHeld: true,
+        targetHeld: true,
+        anyTargetHeld: true,
             extraModifiersHeld: false,
             ordinaryKeyHeld: { true }
         ) == []
@@ -121,11 +152,14 @@ private typealias Edge = ModifierHoldDetector.Edge
     }
 
     _ = detector.flagsChanged(
-        targetHeld: true, extraModifiersHeld: false, ordinaryKeyHeld: poll)
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false, ordinaryKeyHeld: poll)
     _ = detector.flagsChanged(
-        targetHeld: true, extraModifiersHeld: false, ordinaryKeyHeld: poll)
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false, ordinaryKeyHeld: poll)
     _ = detector.flagsChanged(
-        targetHeld: false, extraModifiersHeld: false, ordinaryKeyHeld: poll)
+        targetHeld: false,
+        anyTargetHeld: false, extraModifiersHeld: false, ordinaryKeyHeld: poll)
 
     #expect(polls == 1)
 }
@@ -143,7 +177,9 @@ private typealias Edge = ModifierHoldDetector.Edge
     var detector = ModifierHoldDetector()
 
     #expect(detector.cancel() == [])
-    _ = detector.flagsChanged(targetHeld: true, extraModifiersHeld: false)
+    _ = detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false)
     #expect(detector.cancel() == [Edge.up])
     #expect(detector.cancel() == [])
 }
@@ -162,14 +198,91 @@ private typealias Edge = ModifierHoldDetector.Edge
         }
     }
 
-    apply(detector.flagsChanged(targetHeld: true, extraModifiersHeld: false))
+    apply(detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false))
     apply(detector.keyDown())
-    apply(detector.flagsChanged(targetHeld: false, extraModifiersHeld: false))
-    apply(detector.flagsChanged(targetHeld: true, extraModifiersHeld: false))
-    apply(detector.flagsChanged(targetHeld: true, extraModifiersHeld: true))
-    apply(detector.flagsChanged(targetHeld: false, extraModifiersHeld: false))
-    apply(detector.flagsChanged(targetHeld: true, extraModifiersHeld: false))
+    apply(detector.flagsChanged(
+        targetHeld: false,
+        anyTargetHeld: false, extraModifiersHeld: false))
+    apply(detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false))
+    apply(detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: true))
+    apply(detector.flagsChanged(
+        targetHeld: false,
+        anyTargetHeld: false, extraModifiersHeld: false))
+    apply(detector.flagsChanged(
+        targetHeld: true,
+        anyTargetHeld: true, extraModifiersHeld: false))
     apply(detector.cancel())
 
     #expect(depth == 0)
+}
+
+/// A set of more than one stops being *held* the moment either modifier lifts,
+/// which is not the same as the set being *released*. The latch has to survive
+/// the difference, or half a chord is enough to rearm it.
+@Test func aSpentPressSurvivesOneModifierOfTheSetLifting() {
+    var detector = ModifierHoldDetector()
+
+    // Ctrl+Option down, then a key: the hold is someone else's shortcut now.
+    #expect(
+        detector.flagsChanged(
+            targetHeld: true, anyTargetHeld: true, extraModifiersHeld: false)
+            == [Edge.down]
+    )
+    #expect(detector.keyDown() == [Edge.up])
+
+    // Option lifts, Ctrl stays down. The set is no longer held, but it is not
+    // released either, and the user is still mid-shortcut on the one that is.
+    #expect(
+        detector.flagsChanged(
+            targetHeld: false, anyTargetHeld: true, extraModifiersHeld: false)
+            == []
+    )
+    // Pressing it again must not reopen a microphone under their shortcut.
+    #expect(
+        detector.flagsChanged(
+            targetHeld: true, anyTargetHeld: true, extraModifiersHeld: false)
+            == []
+    )
+
+    // Everything up: the press is finally spent, and the next one is fresh.
+    #expect(
+        detector.flagsChanged(
+            targetHeld: false, anyTargetHeld: false, extraModifiersHeld: false)
+            == []
+    )
+    #expect(
+        detector.flagsChanged(
+            targetHeld: true, anyTargetHeld: true, extraModifiersHeld: false)
+            == [Edge.down]
+    )
+}
+
+/// The same, for a hold ended by an extra modifier rather than by a key.
+@Test func aChordDisqualifiedHoldStaysSpentAcrossAPartialRelease() {
+    var detector = ModifierHoldDetector()
+
+    _ = detector.flagsChanged(
+        targetHeld: true, anyTargetHeld: true, extraModifiersHeld: false)
+    #expect(
+        detector.flagsChanged(
+            targetHeld: true, anyTargetHeld: true, extraModifiersHeld: true)
+            == [Edge.up]
+    )
+    // Shift lifts and Option lifts; Ctrl is still down.
+    #expect(
+        detector.flagsChanged(
+            targetHeld: false, anyTargetHeld: true, extraModifiersHeld: false)
+            == []
+    )
+    #expect(
+        detector.flagsChanged(
+            targetHeld: true, anyTargetHeld: true, extraModifiersHeld: false)
+            == []
+    )
 }


### PR DESCRIPTION
## Summary

- Adds `ModifierHoldDetector`: a pure state machine that distills the raw keyboard stream into holds of one configured set of modifiers.
- **Nothing reads it yet.** This is the first of a stack; the binding, the transport and the consumer land on top.

## Why a second detector rather than generalizing the first

`FnTapDetector` answers a different question, and the difference is not the modifier it watches. A tap is only known to be a tap once it has been released, so it emits `down` and `up` together at release. A microphone needs the opening edge while the key is still down, so a hold has to report at press and close later.

Keeping them apart means Fn keeps behaving exactly as it does, which matters because the single existing consumer treats the `down` edge as a toggle and discards the `up`.

## The rule worth reviewing

A hold that ends for any reason other than the set being released **stays ended**, and only a fresh press starts another. Holding the set and then pressing a key is someone else's shortcut passing through, and reopening the moment that key lifts would open a microphone in the middle of it.

This matters more than it would for Fn: Ctrl+Option is VoiceOver's own modifier, and macOS claims Ctrl+Option+F and friends, so the disqualified path is the common one rather than the edge case.

## Testing

`cd clients/macos/native/mac-helper && swift test` — 26 tests, no app build. Two of the eleven new ones are there because they failed first: the disqualified-hold latch was documented but not implemented, so the hold re-opened when the extra modifier lifted; and `cancel()` on an idle detector poisoned the next press. There is also a property test asserting every open is closed exactly once across all four exit paths, since the consumer's bookkeeping is a live microphone and an unmatched edge either strands it open or closes one that never opened.