### PR TITLE
fix(web): end the drawer's scrollport above the floating pills

### DIFF
--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -712,11 +712,23 @@ describe("AssistantSideMenu · overlay bottom scroll reserve", () => {
     return html.slice(open, close + 1);
   };
 
-  test("rail body reserves no bottom padding", () => {
+  test("rail body reserves nothing under its list", () => {
     const tag = sliceBodyOpeningTag(renderMenu({ conversations }));
 
+    expect(tag).not.toContain("mb-24");
+    expect(tag).not.toContain("margin-bottom");
+  });
+
+  test("the overlay reserve ends the scrollport rather than padding it", () => {
+    // A margin, not padding: padding belongs to the scrollable box, so a
+    // card taller than the drawer drew its rows through the floating
+    // column instead of being clipped above it.
+    const tag = sliceBodyOpeningTag(
+      renderMenu({ conversations, variant: "overlay" }),
+    );
+
+    expect(tag).toContain("mb-24");
     expect(tag).not.toContain("pb-24");
-    expect(tag).not.toContain("padding-bottom");
   });
 
   test("reserves the measured floating-column height once mounted", async () => {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -720,8 +720,8 @@ describe("AssistantSideMenu · overlay bottom scroll reserve", () => {
   });
 
   test("the overlay scrollport rounds its cut onto the card's corners", () => {
-    // The cut lands mid-card whenever the list outruns the drawer, so
-    // without this the card ends in two square corners.
+    // The cut lands mid-card whenever the list outruns the drawer, so it
+    // carries the card's own radius.
     const tag = sliceBodyOpeningTag(
       renderMenu({ conversations, variant: "overlay" }),
     );
@@ -734,9 +734,8 @@ describe("AssistantSideMenu · overlay bottom scroll reserve", () => {
   });
 
   test("the overlay reserve ends the scrollport rather than padding it", () => {
-    // A margin, not padding: padding belongs to the scrollable box, so a
-    // card taller than the drawer drew its rows through the floating
-    // column instead of being clipped above it.
+    // A margin, so the reserve ends the scrollport: padding belongs to the
+    // scrollable box, and a card taller than the drawer paints through it.
     const tag = sliceBodyOpeningTag(
       renderMenu({ conversations, variant: "overlay" }),
     );
@@ -807,7 +806,7 @@ describe("AssistantSideMenu · overlay bottom scroll reserve", () => {
       );
 
       // happy-dom's CSSStyleDeclaration drops values containing `env()`,
-      // so the composed `padding-bottom` calc is unobservable here; the
+      // so the composed `margin-bottom` calc is unobservable here; the
       // measured height feeding it is asserted via its custom property,
       // which happy-dom stores verbatim.
       const measuredReserve = () => {

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -719,6 +719,20 @@ describe("AssistantSideMenu · overlay bottom scroll reserve", () => {
     expect(tag).not.toContain("margin-bottom");
   });
 
+  test("the overlay scrollport rounds its cut onto the card's corners", () => {
+    // The cut lands mid-card whenever the list outruns the drawer, so
+    // without this the card ends in two square corners.
+    const tag = sliceBodyOpeningTag(
+      renderMenu({ conversations, variant: "overlay" }),
+    );
+
+    expect(tag).toContain("clip-path:inset(");
+    expect(tag).toContain("var(--radius-xl)");
+    expect(sliceBodyOpeningTag(renderMenu({ conversations }))).not.toContain(
+      "clip-path",
+    );
+  });
+
   test("the overlay reserve ends the scrollport rather than padding it", () => {
     // A margin, not padding: padding belongs to the scrollable box, so a
     // card taller than the drawer drew its rows through the floating

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -148,16 +148,15 @@ const NATIVE_MOBILE_LIST_TOP_FADE =
 /**
  * Rounds the overlay scrollport's bottom edge onto the section card's own
  * corners. The scrollport ends above the floating column (see the body's
- * margin reserve), so a list taller than the drawer is cut there rather than
- * drawn through the pills - and a straight cut left the card with two square
- * corners whenever it had more rows below the fold.
+ * margin reserve), so a list taller than the drawer is cut at that edge, and
+ * the cut carries the card's radius so the card reads as a card at any scroll
+ * position rather than as two square corners.
  *
  * The inset is the scrollport's own horizontal padding, which is exactly
  * where the card's edges sit, so the clip lands on the card and nothing else.
  * `clip-path` rather than a `border-radius`: the scrollport's box is wider
  * than the card (it cancels the sheet's padding with `-mx-3` so the scrollbar
- * rides the sheet edge), so rounding its corners would curve 12px clear of
- * the card and leave the cut looking square.
+ * rides the sheet edge), so its corners curve 12px clear of the card.
  */
 const OVERLAY_LIST_ROUNDED_CLIP =
   "[clip-path:inset(0_var(--side-menu-inset)_0_var(--side-menu-inset)_round_0_0_var(--radius-xl)_var(--radius-xl))]";
@@ -302,9 +301,9 @@ export function AssistantSideMenu({
 
   // --- Overlay bottom reserve ---
   // The overlay's floating bottom column (tip card + action pills) covers the
-  // scrollable body, so the body reserves matching bottom padding to keep the
-  // last conversation rows scrollable clear of it. Measured (not static)
-  // because the tip card appears/disappears and its copy length varies.
+  // sheet's bottom, so the body's own box stops above it and the last
+  // conversation rows scroll clear. Measured (not static) because the tip
+  // card appears/disappears and its copy length varies.
   // The scrollport the flat "All" list virtualizes against. State, not a ref,
   // because the list only mounts once the node exists and has to re-render
   // when it does.
@@ -621,13 +620,11 @@ export function AssistantSideMenu({
                      less the inset the body already has, leaves exactly the
                      second step as clearance under the last row.
 
-                     A margin rather than padding: the reserve has to end the
-                     scrollport, not sit inside it. Padding is part of the
-                     scrollable box, so a card taller than the drawer drew its
-                     rows through the column and the pills read as floating on
-                     the Chats card instead of on the sheet. Ending the
-                     scrollport above the column clips those rows at the band
-                     instead, and the last one still scrolls into view. */
+                     A margin, so the reserve ends the scrollport rather than
+                     sitting inside it: padding belongs to the scrollable box,
+                     and a card taller than the drawer paints through it. The
+                     scrollport's own edge is what keeps rows off the column,
+                     and the last row still scrolls into view above it. */
                   "--overlay-bottom-column-h": `${overlayBottomColumnHeight}px`,
                   marginBottom:
                     "calc(var(--overlay-bottom-column-h) + 2rem - var(--side-menu-inset) + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))",

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -145,6 +145,23 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
 const NATIVE_MOBILE_LIST_TOP_FADE =
   "native-mobile:[mask-image:linear-gradient(to_bottom,transparent,black_2.75rem)] native-mobile:[-webkit-mask-image:linear-gradient(to_bottom,transparent,black_2.75rem)]";
 
+/**
+ * Rounds the overlay scrollport's bottom edge onto the section card's own
+ * corners. The scrollport ends above the floating column (see the body's
+ * margin reserve), so a list taller than the drawer is cut there rather than
+ * drawn through the pills - and a straight cut left the card with two square
+ * corners whenever it had more rows below the fold.
+ *
+ * The inset is the scrollport's own horizontal padding, which is exactly
+ * where the card's edges sit, so the clip lands on the card and nothing else.
+ * `clip-path` rather than a `border-radius`: the scrollport's box is wider
+ * than the card (it cancels the sheet's padding with `-mx-3` so the scrollbar
+ * rides the sheet edge), so rounding its corners would curve 12px clear of
+ * the card and leave the cut looking square.
+ */
+const OVERLAY_LIST_ROUNDED_CLIP =
+  "[clip-path:inset(0_var(--side-menu-inset)_0_var(--side-menu-inset)_round_0_0_var(--radius-xl)_var(--radius-xl))]";
+
 function SearchButton() {
   const { t } = useTranslation("chat");
   const toggle = useCommandPaletteStore.use.toggle();
@@ -588,7 +605,7 @@ export function AssistantSideMenu({
                  mock draws. This scrollport starts one overlay inset down, so
                  2.75rem reaches the row's bottom edge, and the assistant
                  cluster's own top padding supplies the 1rem gap beneath it. */
-                `-mx-3 ${SIDEBAR_STACK_GAP} mb-24 px-3 native-mobile:pt-11 ${NATIVE_MOBILE_LIST_TOP_FADE}`
+                `-mx-3 ${SIDEBAR_STACK_GAP} mb-24 px-3 ${OVERLAY_LIST_ROUNDED_CLIP} native-mobile:pt-11 ${NATIVE_MOBILE_LIST_TOP_FADE}`
               : /* The top inset is the same stack gap: the header closes
                    with no rule, so without it the first card (or the
                    collapsed rail's first group icon) butts against the

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -580,15 +580,15 @@ export function AssistantSideMenu({
           ref={setBodyElement}
           className={
             variant === "overlay"
-              ? /* pb-24 is a coarse floating-column reserve until the measured
-                 inline padding below is applied. The native-mobile reserve is
+              ? /* mb-24 is a coarse floating-column reserve until the measured
+                 inline margin below is applied. The native-mobile reserve is
                  the glyph row's own extent: it floats 1rem below the sheet's
                  top and stands 2.5rem tall. An icon-only Button carries a
                  40px touch target on a coarse pointer, not the 32px box the
                  mock draws. This scrollport starts one overlay inset down, so
                  2.75rem reaches the row's bottom edge, and the assistant
                  cluster's own top padding supplies the 1rem gap beneath it. */
-                `-mx-3 ${SIDEBAR_STACK_GAP} px-3 pb-24 native-mobile:pt-11 ${NATIVE_MOBILE_LIST_TOP_FADE}`
+                `-mx-3 ${SIDEBAR_STACK_GAP} mb-24 px-3 native-mobile:pt-11 ${NATIVE_MOBILE_LIST_TOP_FADE}`
               : /* The top inset is the same stack gap: the header closes
                    with no rule, so without it the first card (or the
                    collapsed rail's first group icon) butts against the
@@ -602,9 +602,17 @@ export function AssistantSideMenu({
                      body's own box stops one overlay inset short of that same
                      edge. Reserving the column's height plus both 1rem steps,
                      less the inset the body already has, leaves exactly the
-                     second step as clearance under the last row. */
+                     second step as clearance under the last row.
+
+                     A margin rather than padding: the reserve has to end the
+                     scrollport, not sit inside it. Padding is part of the
+                     scrollable box, so a card taller than the drawer drew its
+                     rows through the column and the pills read as floating on
+                     the Chats card instead of on the sheet. Ending the
+                     scrollport above the column clips those rows at the band
+                     instead, and the last one still scrolls into view. */
                   "--overlay-bottom-column-h": `${overlayBottomColumnHeight}px`,
-                  paddingBottom:
+                  marginBottom:
                     "calc(var(--overlay-bottom-column-h) + 2rem - var(--side-menu-inset) + var(--safe-area-inset-bottom, env(safe-area-inset-bottom, 0px)))",
                 } as CSSProperties)
               : undefined

--- a/clients/web/src/domains/chat/components/side-menu-overlay-bottom-column.tsx
+++ b/clients/web/src/domains/chat/components/side-menu-overlay-bottom-column.tsx
@@ -10,9 +10,9 @@ export interface SideMenuOverlayBottomColumnProps {
   onStartNewConversation?: () => void;
   onClose?: () => void;
   /**
-   * Reports the column's measured height so the scrollport behind it can
-   * reserve matching bottom padding. Measured (not static) because the tip
-   * card appears/disappears and its copy length varies.
+   * Reports the column's measured height so the scrollport behind it can end
+   * above the column. Measured (not static) because the tip card
+   * appears/disappears and its copy length varies.
    */
   onHeightChange: (height: number) => void;
 }


### PR DESCRIPTION
## Summary

On the mobile drawer, conversation rows ran under Preferences and New Chat at any scroll position other than the very bottom, so the pills read as floating on the Chats card rather than on the sheet. Reported on the iOS dev build.

The overlay reserved room for the floating column as `padding-bottom` on the sidebar body. Padding is part of the scrollable box, so a card taller than the drawer draws straight through the reserve. Reserving the same extent as a **margin** ends the scrollport above the column instead: the card is clipped at that edge whatever the scroll position, and the last row still scrolls into view exactly as before.

The arithmetic is unchanged (`column height + 2rem - side-menu inset + safe-area`), so the clearance under the last row is the same as today. This keeps the single-scrollbar model #41738 gave the drawer: no nested scroller comes back, overlay lists still virtualize against the body.

Ending the scrollport there means the cut lands mid-card for any list long enough to scroll, which left the card on two square corners. So the scrollport also clips to its own horizontal padding, which is exactly where the card's edges sit, and rounds the bottom of that clip by the card's own radius.

## Changes

- Reserve the overlay's floating column with `margin-bottom` (and `mb-24` as the pre-measurement fallback) rather than `padding-bottom`.
- Round the scrollport's cut onto the card's corners with a `clip-path` inset. A border radius on the box would not do: the scrollport is wider than the card (it cancels the sheet's padding so the scrollbar rides the sheet edge), so its corners curve clear of the card.
- Reserve tests: the rail reserves nothing and carries no clip; the overlay's reserve must be a margin, never padding, and its cut must be rounded.

## Verification

Verified in the **iOS Simulator** (iPhone 17 Pro, iOS 26.3) running this branch: the Capacitor shell is `server.url`-only, so it was pointed at a local HTTPS origin fronting the dev server. Conditions were the real thing, not emulated — `data-native-platform="ios"`, `(pointer: coarse)` true, `--safe-area-inset-bottom: 34px` — and the shell reported `marginBottom` set with `paddingBottom` empty, confirming it ran this code.

| | before | after |
| --- | --- | --- |
| scrollport bottom vs pill top (393x852) | 840 vs 792, overlapping | 776 vs 792 |
| card at scroll top | rows drawn through the pills | clipped above the band, corners rounded |
| card at scroll bottom | clears the pills | unchanged, rounded bottom visible |

`bun run test:ci` passes for `assistant-side-menu` and `sidebar-list-context-menu`; lint and typecheck clean on the changed files. Desktop rail is untouched (the reserve and the clip are overlay-only) and still ends above the Preferences footer.

## QA

- [ ] iOS dev build: drawer with more chats than fit, at scroll top and mid-scroll. No title under either pill, and the card's bottom corners stay rounded.
- [ ] Scroll to the bottom: the last row still clears the pills.
- [ ] With a tip card present (taller column): the same clearance holds, since the reserve is measured.
- [ ] Landscape / small-height phone, and a device with a home indicator (safe-area term).
- [ ] Scrolling stays smooth in WKWebView with the clip applied.