### PR TITLE
feat(ipc-contract): add companion entrypoints to context and surface state

### DIFF
--- a/clients/macos/scripts/run-tests.ts
+++ b/clients/macos/scripts/run-tests.ts
@@ -13,5 +13,6 @@ await runIsolatedTests({
     "../../packages/electron-desktop/src/native-auth.test.ts",
     "../../packages/electron-desktop/src/session-token-store.test.ts",
     "../../packages/electron-desktop/src/workos-pkce.test.ts",
+    "../../packages/ipc-contract/src/schemas.test.ts",
   ],
 });

--- a/packages/ipc-contract/package.json
+++ b/packages/ipc-contract/package.json
@@ -7,6 +7,10 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
   "dependencies": {
     "@vellumai/service-contracts": "workspace:*"
   },

--- a/packages/ipc-contract/src/schemas.test.ts
+++ b/packages/ipc-contract/src/schemas.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { companionContextSchema } from "./schemas";
+
+const entrypoint = (overrides: Record<string, unknown> = {}) => ({
+  id: "notes:capture",
+  label: "Capture",
+  icon: "pencil",
+  prompt: "Capture a note about what I am working on.",
+  ...overrides,
+});
+
+const context = (overrides: Record<string, unknown> = {}) => ({
+  assistantName: "Vellum",
+  turns: [],
+  ...overrides,
+});
+
+describe("companionContextSchema entrypoints", () => {
+  test("parses a contributed list and keeps its order", () => {
+    const parsed = companionContextSchema.parse(
+      context({
+        entrypoints: [
+          entrypoint(),
+          entrypoint({ id: "inbox:triage", label: "Triage", icon: undefined }),
+        ],
+      }),
+    );
+    expect(parsed.entrypoints.map((e) => e.id)).toEqual([
+      "notes:capture",
+      "inbox:triage",
+    ]);
+    expect(parsed.entrypoints[1]?.icon).toBeUndefined();
+  });
+
+  test("defaults to none contributed when the field is absent", () => {
+    expect(companionContextSchema.parse(context()).entrypoints).toEqual([]);
+  });
+
+  test("rejects more entrypoints than the aggregate cap allows", () => {
+    const nine = Array.from({ length: 9 }, (_, i) =>
+      entrypoint({ id: `plugin:${i}` }),
+    );
+    expect(
+      companionContextSchema.safeParse(context({ entrypoints: nine })).success,
+    ).toBe(false);
+    expect(
+      companionContextSchema.safeParse(
+        context({ entrypoints: nine.slice(0, 8) }),
+      ).success,
+    ).toBe(true);
+  });
+
+  test("rejects a label longer than a pill can hold", () => {
+    expect(
+      companionContextSchema.safeParse(
+        context({ entrypoints: [entrypoint({ label: "a".repeat(25) })] }),
+      ).success,
+    ).toBe(false);
+  });
+
+  test("rejects an empty label and an over-long prompt", () => {
+    expect(
+      companionContextSchema.safeParse(
+        context({ entrypoints: [entrypoint({ label: "" })] }),
+      ).success,
+    ).toBe(false);
+    expect(
+      companionContextSchema.safeParse(
+        context({ entrypoints: [entrypoint({ prompt: "a".repeat(2001) })] }),
+      ).success,
+    ).toBe(false);
+  });
+});

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -100,6 +100,21 @@ export const companionTurnSchema = z.object({
  */
 export const companionTurnsSchema = z.array(companionTurnSchema).max(40);
 
+/**
+ * See `CompanionEntrypoint`: one plugin-contributed control on the idle row.
+ *
+ * Every field is bounded, because all four originate in a plugin's manifest and
+ * end up on a window that floats over every other app. `label` is bounded to
+ * what a pill can hold, `prompt` to what a composer would accept from a person,
+ * and `icon` is a name the surface looks up rather than anything it renders.
+ */
+export const companionEntrypointSchema = z.object({
+  id: z.string().min(1).max(128),
+  label: z.string().min(1).max(24),
+  icon: z.string().max(64).optional(),
+  prompt: z.string().min(1).max(2000),
+});
+
 /** What the app's window tells main about the assistant the surface is for. */
 export const companionContextSchema = z.object({
   assistantName: z.string(),
@@ -122,6 +137,13 @@ export const companionContextSchema = z.object({
   // capture having happened, and the only shape that can say that is a whole
   // number that goes up.
   captureCount: z.number().int().nonnegative().default(0),
+  // Defaulted for the same reason `watching` is: a publisher with no plugins
+  // loaded contributes nothing, and an empty row is the truthful reading of
+  // silence. Capped in aggregate as well as per field, and deliberately looser
+  // than what the surface draws: the daemon caps what any one plugin may
+  // contribute, and this caps the total that reaches a window which cannot
+  // afford to grow.
+  entrypoints: z.array(companionEntrypointSchema).max(8).default([]),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -1088,6 +1088,26 @@ export interface CompanionTurn {
 export type CompanionWatchRetro = "pending" | "ready";
 
 /**
+ * One plugin-contributed control on the companion's idle row.
+ *
+ * The surface is a floating route with no session and no plugin registry of its
+ * own, so these arrive the way `watchEnabled` does: published by the window that
+ * can read them and pushed back down with the rest of the state.
+ *
+ * `icon` is a name, not markup. The surface resolves it against its own fixed
+ * map and falls back when unknown, because this window is always-on-top and
+ * denies every navigation: nothing a plugin supplies may become markup here.
+ */
+export interface CompanionEntrypoint {
+  /** `<pluginId>:<entrypointId>`, unique across plugins. */
+  id: string;
+  label: string;
+  icon?: string;
+  /** Submitted verbatim when pressed. */
+  prompt: string;
+}
+
+/**
  * What the app's own window knows that the surface cannot.
  *
  * The surface is a renderer with no assistant and no conversation in it, so
@@ -1154,6 +1174,19 @@ export interface CompanionContext {
    * the truthful reading of silence.
    */
   captureCount?: number;
+
+  /**
+   * The controls plugins have contributed to the idle row, in the order they
+   * should be offered. See {@link CompanionEntrypoint}.
+   *
+   * Published by the app's window for the reason the turns are: the plugin
+   * registry lives with the session, and the surface has neither.
+   *
+   * Optional for the same reason {@link CompanionContext.watching} is, and
+   * absence means none contributed. A publisher that predates the field, or one
+   * with no plugins loaded, contributes nothing rather than erroring.
+   */
+  entrypoints?: CompanionEntrypoint[];
 }
 
 /**
@@ -1335,6 +1368,21 @@ export interface CompanionSurfaceState {
    * offer while the answer is unknown.
    */
   watchEnabled?: boolean;
+  /**
+   * The controls plugins have contributed to the idle row, as the app's window
+   * last published them. See {@link CompanionEntrypoint}.
+   *
+   * Carried on the state rather than read where it is drawn, for the reason
+   * {@link CompanionSurfaceState.watchEnabled} is: the surface is a floating
+   * route with no session and no plugin registry, so a list it assembled for
+   * itself would be empty forever.
+   *
+   * Optional, and absence means none contributed. Read it that way rather than
+   * as an error: a shell that predates the field and a window whose plugins
+   * have not loaded yet are both states with nothing to offer, and an idle row
+   * with nothing extra on it is the honest drawing of either.
+   */
+  entrypoints?: CompanionEntrypoint[];
   /**
    * The character to render live, or `undefined` when there is none to
    * compose. See {@link CompanionCharacter}; `avatarBase64` is the fallback.


### PR DESCRIPTION
## Summary

- Adds `CompanionEntrypoint` (id, label, optional icon name, prompt) and carries an optional `entrypoints` list on both `CompanionContext` and `CompanionSurfaceState`. Absence means none contributed, matching how `watching` and `watchEnabled` document theirs, so a shell or publisher that predates the field contributes nothing rather than erroring.
- Adds `companionEntrypointSchema` and wires `entrypoints` into `companionContextSchema` with an aggregate cap of 8 and per-field bounds (label 24, prompt 2000). The daemon caps what any one plugin contributes; this caps the total that reaches an always-on-top window. `icon` is a name the surface resolves against its own map, never markup.
- New `packages/ipc-contract/src/schemas.test.ts` covers the valid list, the absent-field default, the aggregate cap, and the field bounds. The package gains `typecheck`/`test` scripts to match its sibling packages, and the file is listed in `clients/macos/scripts/run-tests.ts` so it runs in the CI job that already path-filters on `packages/ipc-contract/**`.

Part of plan: companion-plugin-entrypoints.md (PR 3 of 9)