### PR TITLE
feat(companion): show/hide the surface from the Window menu (JARVIS-1696)

### DIFF
--- a/clients/macos/src/main/command-palette-window.test.ts
+++ b/clients/macos/src/main/command-palette-window.test.ts
@@ -253,6 +253,15 @@ mock.module("./devtools", () => ({
 
 mock.module("@vellumai/electron-desktop/window-state", () => ({
   readOnboardingActive: () => false,
+  readCompanionHidden: () => false,
+  onCompanionHiddenChange: () => () => {},
+}));
+
+// Stubbed so `./menu`, imported below for `dispatchMenuCommand`, doesn't drag
+// the real companion surface into this file's module graph, along with the
+// rest of `window-state` that the mock above deliberately doesn't cover.
+mock.module("./companion-window", () => ({
+  setCompanionSurfaceVisible: () => undefined,
 }));
 
 // Full `./cli-path-installer` surface so this mock — which leaks into co-run

--- a/clients/macos/src/main/menu.test.ts
+++ b/clients/macos/src/main/menu.test.ts
@@ -12,7 +12,10 @@ type TemplateItem = {
   type?: string;
   enabled?: boolean;
   accelerator?: string;
-  click?: () => void | Promise<void>;
+  checked?: boolean;
+  // Optional argument so the no-arg call sites below still typecheck: Electron
+  // passes the item, and only the checkbox items read it.
+  click?: (item?: { checked: boolean }) => void | Promise<void>;
   submenu?: TemplateItem[];
 };
 
@@ -79,8 +82,22 @@ mock.module("@vellumai/electron-desktop/settings", () => ({
   onSettingChange: () => () => {},
 }));
 
+let companionHidden = false;
+let companionHiddenListener: ((hidden: boolean) => void) | null = null;
 mock.module("@vellumai/electron-desktop/window-state", () => ({
   readOnboardingActive: () => false,
+  readCompanionHidden: () => companionHidden,
+  onCompanionHiddenChange: (callback: (hidden: boolean) => void) => {
+    companionHiddenListener = callback;
+    return () => {
+      companionHiddenListener = null;
+    };
+  },
+}));
+
+const setCompanionSurfaceVisibleMock = mock((_visible: boolean) => undefined);
+mock.module("./companion-window", () => ({
+  setCompanionSurfaceVisible: setCompanionSurfaceVisibleMock,
 }));
 
 const getCliPathInstallStateMock = mock(
@@ -167,6 +184,8 @@ beforeEach(async () => {
   isCliPathFlowInFlightMock.mockReset();
   isCliPathFlowInFlightMock.mockImplementation(() => false);
   callOrder.length = 0;
+  companionHidden = false;
+  setCompanionSurfaceVisibleMock.mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -391,5 +410,59 @@ describe("refreshCliPathMenuState", () => {
     await refreshCliPathMenuState();
     expect(appMenuLabels()).toContain(INSTALL_LABEL);
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Window menu companion toggle", () => {
+  const COMPANION_LABEL = "Show Companion";
+
+  const windowSubmenu = (): TemplateItem[] =>
+    lastTemplate().find((item) => item.label === "Window")?.submenu ?? [];
+
+  const companionItem = (): TemplateItem | undefined =>
+    windowSubmenu().find((item) => item.label === COMPANION_LABEL);
+
+  test("offers the companion toggle as a checkbox in the Window menu", async () => {
+    await refreshCliPathMenuState();
+    expect(companionItem()?.type).toBe("checkbox");
+  });
+
+  test("checks the item while the surface is shown", async () => {
+    companionHidden = false;
+    await refreshCliPathMenuState();
+    expect(companionItem()?.checked).toBe(true);
+  });
+
+  test("unchecks the item while the surface is hidden", async () => {
+    companionHidden = true;
+    await refreshCliPathMenuState();
+    expect(companionItem()?.checked).toBe(false);
+  });
+
+  test("shows the surface when the item is ticked", async () => {
+    companionHidden = true;
+    await refreshCliPathMenuState();
+    // Electron flips `checked` before `click`, so a tick arrives as `true`.
+    await companionItem()?.click?.({ checked: true });
+    expect(setCompanionSurfaceVisibleMock).toHaveBeenCalledWith(true);
+  });
+
+  test("hides the surface when the item is unticked", async () => {
+    companionHidden = false;
+    await refreshCliPathMenuState();
+    await companionItem()?.click?.({ checked: false });
+    expect(setCompanionSurfaceVisibleMock).toHaveBeenCalledWith(false);
+  });
+
+  test("rebuilds the menu when the surface is hidden from somewhere else", () => {
+    // The tray item and the surface's own right-click "Hide" both move the
+    // stored flag without going through this menu. Unlike the tray's, this
+    // menu is built once and kept, so the subscription is the only thing that
+    // brings its checkmark back in line.
+    expect(companionHiddenListener).not.toBeNull();
+    companionHidden = true;
+    companionHiddenListener?.(true);
+    expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+    expect(companionItem()?.checked).toBe(false);
   });
 });

--- a/clients/macos/src/main/menu.ts
+++ b/clients/macos/src/main/menu.ts
@@ -1,6 +1,7 @@
 import { Menu, type MenuItemConstructorOptions, app, shell } from "electron";
 import { z } from "zod";
 
+import { companionVisibilityItem } from "@vellumai/electron-desktop/companion-menu";
 import {
   onSettingChange,
   readSetting,
@@ -253,20 +254,12 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         { type: "separator" },
         fileItem("Pop Out Conversation", { kind: "popOut" }),
         { type: "separator" },
-        {
-          // The same label and checkbox shape as the tray's item, because it
-          // is the same switch reached two ways rather than two switches. A
-          // checkbox because the surface can be hidden from three places (here,
-          // the tray, its own right-click) and the item has to say which state
-          // it is in. Electron flips `checked` before `click` runs, so the item
-          // carries the state being asked for.
-          label: "Show Companion",
-          type: "checkbox",
-          checked: !readCompanionHidden(),
-          click: (item) => {
-            setCompanionSurfaceVisible(item.checked);
-          },
-        },
+        // The show/hide checkbox the tray offers too, from the one builder both
+        // read: two doors onto a single switch, not two switches.
+        companionVisibilityItem(
+          readCompanionHidden(),
+          setCompanionSurfaceVisible,
+        ),
         { type: "separator" },
         { role: "front" },
       ],

--- a/clients/macos/src/main/menu.ts
+++ b/clients/macos/src/main/menu.ts
@@ -5,7 +5,11 @@ import {
   onSettingChange,
   readSetting,
 } from "@vellumai/electron-desktop/settings";
-import { readOnboardingActive } from "@vellumai/electron-desktop/window-state";
+import {
+  onCompanionHiddenChange,
+  readCompanionHidden,
+  readOnboardingActive,
+} from "@vellumai/electron-desktop/window-state";
 
 import { openAboutWindow } from "./about.client";
 import { checkForUpdates } from "./auto-update.client";
@@ -28,6 +32,7 @@ import {
   isCommandPaletteWindowFocused,
   openCommandPaletteWindow,
 } from "./command-palette.client";
+import { setCompanionSurfaceVisible } from "./companion-window";
 import { areChromeDevToolsEnabled } from "./devtools";
 import { handle } from "./ipc";
 import { dispatchToMain } from "./main-window";
@@ -248,6 +253,21 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         { type: "separator" },
         fileItem("Pop Out Conversation", { kind: "popOut" }),
         { type: "separator" },
+        {
+          // The same label and checkbox shape as the tray's item, because it
+          // is the same switch reached two ways rather than two switches. A
+          // checkbox because the surface can be hidden from three places (here,
+          // the tray, its own right-click) and the item has to say which state
+          // it is in. Electron flips `checked` before `click` runs, so the item
+          // carries the state being asked for.
+          label: "Show Companion",
+          type: "checkbox",
+          checked: !readCompanionHidden(),
+          click: (item) => {
+            setCompanionSurfaceVisible(item.checked);
+          },
+        },
+        { type: "separator" },
         { role: "front" },
       ],
     },
@@ -344,6 +364,14 @@ export const installApplicationMenu = (): void => {
   // Rebuild the menu when feature flags change so the Developer submenu
   // appears or disappears without requiring an app restart.
   onSettingChange("featureFlags", () => {
+    applyMenu();
+  });
+
+  // Rebuild the menu when the companion surface is shown or hidden, so this
+  // menu's checkbox agrees with the tray's. The tray builds its menu at pop
+  // time and reads the flag fresh every time; this one is built once and kept,
+  // so it is the surface that has to be told.
+  onCompanionHiddenChange(() => {
     applyMenu();
   });
 

--- a/packages/electron-desktop/src/companion-menu.test.ts
+++ b/packages/electron-desktop/src/companion-menu.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { CompanionSize, CompanionSizeAxis } from "@vellumai/ipc-contract";
 
-import { companionSizeSubmenus } from "./companion-menu";
+import {
+  companionSizeSubmenus,
+  companionVisibilityItem,
+} from "./companion-menu";
 
 /**
  * The size pickers both companion menus draw, built once.
@@ -98,5 +101,58 @@ describe("companionSizeSubmenus", () => {
     expect(
       build(undefined, { enabled: false }).items.map((item) => item.enabled),
     ).toEqual([false, false]);
+  });
+});
+
+/**
+ * The show/hide checkbox both the tray and the application menu draw.
+ *
+ * The same reasoning as the size pickers above: the two callers read one
+ * builder, so the wording, the shape and what a press carries are stated once,
+ * here, rather than argued over in two menus that would drift apart.
+ */
+describe("companionVisibilityItem", () => {
+  /** Only what a menu item is read for here. */
+  type MenuItem = {
+    label?: string;
+    type?: string;
+    checked?: boolean;
+    click?: (item: { checked: boolean }) => void;
+  };
+
+  const build = (hidden: boolean) => {
+    const asked: boolean[] = [];
+    const item = companionVisibilityItem(hidden, (visible) => {
+      asked.push(visible);
+    }) as MenuItem;
+    return { item, asked };
+  };
+
+  test("is a checkbox, so a menu that hid the surface still says so", () => {
+    expect(build(false).item.type).toBe("checkbox");
+  });
+
+  test("names the surface the same way in every menu that offers it", () => {
+    expect(build(false).item.label).toBe("Show Companion");
+  });
+
+  test("is checked while the surface is shown and unchecked while hidden", () => {
+    expect(build(false).item.checked).toBe(true);
+    expect(build(true).item.checked).toBe(false);
+  });
+
+  /**
+   * Electron flips `checked` before `click` runs, so the item is handed the
+   * state being asked for. Reading the state it was drawn in instead would
+   * make the item a no-op that re-asserts what is already true.
+   */
+  test("carries the state being asked for, not the one it was drawn in", () => {
+    const ticked = build(true);
+    ticked.item.click?.({ checked: true });
+    expect(ticked.asked).toEqual([true]);
+
+    const unticked = build(false);
+    unticked.item.click?.({ checked: false });
+    expect(unticked.asked).toEqual([false]);
   });
 });

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -72,3 +72,32 @@ export const companionSizeSubmenus = (
       },
     })),
   }));
+
+/**
+ * The show/hide item, as every menu that is also a way back draws it.
+ *
+ * A checkbox rather than an action, because such a menu is the only thing left
+ * saying the surface exists once it is hidden, so the item has to show which
+ * state it is in. The surface's own right-click is the deliberate exception and
+ * says "Hide Companion" instead: there is a companion in front of the user
+ * there, so that item only ever has to take it away.
+ *
+ * One builder rather than a literal per menu, for the reason
+ * {@link companionSizeSubmenus} is one. The tray and the application menu are
+ * two doors onto a single switch, and wording or click behaviour changed at one
+ * of them would otherwise leave the two describing it differently.
+ *
+ * Electron flips `checked` before `click` runs, so the item hands on the state
+ * being asked for rather than the one it was drawn in.
+ */
+export const companionVisibilityItem = (
+  hidden: boolean,
+  setVisible: (visible: boolean) => void,
+): MenuItemConstructorOptions => ({
+  label: "Show Companion",
+  type: "checkbox",
+  checked: !hidden,
+  click: (item) => {
+    setVisible(item.checked);
+  },
+});

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -29,7 +29,10 @@ import {
   type AssistantStatus,
 } from "./status";
 import { invalidateIconCache, statusFrames } from "./status-icon";
-import { companionSizeSubmenus } from "./companion-menu";
+import {
+  companionSizeSubmenus,
+  companionVisibilityItem,
+} from "./companion-menu";
 
 export type TrayMenuIcon =
   | "check"
@@ -361,19 +364,12 @@ const buildTrayMenu = (
     // that mentions it exists.
     ...(trayRuntime.companionSupported()
       ? [
-          {
-            // A checkbox rather than a toggle-action item: once the surface is
-            // hidden, this menu is the only place left to bring it back from,
-            // so the item has to show which state it is in. Electron flips
-            // `checked` before `click` runs, so the item carries the state
-            // being asked for.
-            label: "Show Companion",
-            type: "checkbox" as const,
-            checked: !trayRuntime.companionHidden(),
-            click: (item: Electron.MenuItem) => {
-              trayRuntime.setCompanionVisible(item.checked);
-            },
-          },
+          // The show/hide checkbox the application menu offers too, from the one
+          // builder both read.
+          companionVisibilityItem(
+            trayRuntime.companionHidden(),
+            trayRuntime.setCompanionVisible,
+          ),
           // The size pickers the surface's own right-click offers too, from the
           // one builder both read. Disabled rather than hidden while the
           // surface is: items that came and went with the checkbox above them

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -126,6 +126,25 @@ export const writeCompanionHidden = (hidden: boolean): void => {
   store().set("companionHidden", hidden);
 };
 
+/**
+ * Observe the companion-surface opt-out, returning an unsubscribe function.
+ *
+ * For menus that are built once and kept, rather than built fresh each time
+ * they open. The tray menu is the latter and needs nothing here; the
+ * application menu is the former, and without this its "Show Companion" item
+ * would keep showing the state the surface used to be in after the tray item
+ * or the surface's own right-click "Hide" moved it.
+ *
+ * Absent reads as shown, matching `readCompanionHidden`, so a subscriber never
+ * has to interpret the store's optionality for itself.
+ */
+export const onCompanionHiddenChange = (
+  callback: (hidden: boolean) => void,
+): (() => void) =>
+  store().onDidChange("companionHidden", (hidden) => {
+    callback(hidden ?? false);
+  });
+
 /** Where each axis keeps its own chosen size. */
 const COMPANION_SIZE_KEYS: Record<
   CompanionSizeAxis,


### PR DESCRIPTION
Closes JARVIS-1696.

The companion surface could only be shown or hidden from the menu-bar tray. This adds the same control to the macOS app's Window menu, so reaching it doesn't mean going to the menu bar.

### One switch, reached two ways

Both items carry the same label (`Show Companion`) and the same checkbox shape, read the same stored flag, and click through `setCompanionSurfaceVisible` — the funnel the surface's own right-click "Hide" already used. It's one setting with a second door, not a second setting.

### Keeping the two in agreement

This needed a subscription, and that's the only non-obvious part of the change. The tray builds its menu at pop time, so it reads the flag fresh every time and needs nothing. The application menu is built once and kept, so without a nudge it would go on showing the state the surface *used* to be in after the tray item or the right-click moved it.

`onCompanionHiddenChange` in `window-state.ts` is that seam, and `menu.ts` subscribes to it alongside the existing `onSettingChange` rebuild triggers.

### A note on the test change

`menu.ts` now imports `companion-window.ts`. That costs nothing in production — `index.ts` already loads it via `tray.client.ts` — but it widens the module graph for `command-palette-window.test.ts`, which lazily imports `./menu` for `dispatchMenuCommand` and mocks `window-state` with a partial surface. I stubbed the companion module in that file rather than enumerating all of `window-state`, since the palette test doesn't care about the companion either way.

### Verification

- `bun scripts/run-tests.ts` (clients/macos, isolating runner): **31/31**
- `bun run --filter=@vellumai/electron-desktop test`: **59/59**
- `bunx tsc --noEmit` clean on both `clients/macos` and `clients/windows` (shared package touched)

Six new tests cover the checkbox's presence and shape, both checked states, both click directions, and the rebuild-on-external-change path.

Windows has its own `menu.ts` and is untouched; `window-state.ts` only gained an export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bfa7WixVDd4Q1EwMz4HMug
