### PR TITLE
feat(assistant): parse companionEntrypoints from a plugin's package.json

### DIFF
--- a/assistant/src/__tests__/external-plugin-loader.test.ts
+++ b/assistant/src/__tests__/external-plugin-loader.test.ts
@@ -277,6 +277,14 @@ describe("companionEntrypoints manifest field", () => {
       ],
     ],
     ["a missing prompt", [{ id: "start-run", label: "Run" }]],
+    [
+      "a whitespace-only label",
+      [{ id: "start-run", label: "   ", prompt: "Start a new run" }],
+    ],
+    [
+      "a whitespace-only prompt",
+      [{ id: "start-run", label: "Run", prompt: " \n\t " }],
+    ],
   ])(
     "malformed declaration (%s) degrades to undefined without blocking load",
     async (_desc, malformed) => {

--- a/assistant/src/__tests__/external-plugin-loader.test.ts
+++ b/assistant/src/__tests__/external-plugin-loader.test.ts
@@ -196,6 +196,157 @@ describe("credentialKeyPatterns manifest field", () => {
   );
 });
 
+describe("companionEntrypoints manifest field", () => {
+  const validEntrypoints = [
+    { id: "start-run", label: "Run", icon: "play", prompt: "Start a new run" },
+    { id: "summarize", label: "Summary", prompt: "Summarize today" },
+  ];
+
+  test("a valid declaration round-trips onto the manifest", async () => {
+    const dir = freshPluginDir("entrypoints-valid");
+    writePackageJson(dir, {
+      name: "entrypoints-valid",
+      version: "0.1.0",
+      companionEntrypoints: validEntrypoints,
+    });
+
+    await loadExternalPlugin(dir);
+    const manifest = await parsePluginManifest(dir);
+
+    const registered = getRegisteredPlugins().find(
+      (p) => p.manifest.name === "entrypoints-valid",
+    );
+    expect(registered?.manifest.companionEntrypoints).toEqual(validEntrypoints);
+    expect(manifest?.companionEntrypoints).toEqual(validEntrypoints);
+  });
+
+  test("absent field parses to undefined on both paths", async () => {
+    const dir = freshPluginDir("entrypoints-absent");
+    writePackageJson(dir, { name: "entrypoints-absent", version: "0.1.0" });
+
+    await loadExternalPlugin(dir);
+    const manifest = await parsePluginManifest(dir);
+
+    const registered = getRegisteredPlugins().find(
+      (p) => p.manifest.name === "entrypoints-absent",
+    );
+    expect(registered).toBeDefined();
+    expect(registered?.manifest.companionEntrypoints).toBeUndefined();
+    expect(manifest?.companionEntrypoints).toBeUndefined();
+  });
+
+  test.each([
+    ["a string instead of an array", "not-an-array"],
+    [
+      "more than 4 entries",
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `entry-${i}`,
+        label: `Entry ${i}`,
+        prompt: `Do thing ${i}`,
+      })),
+    ],
+    [
+      "an id that is not kebab-case",
+      [{ id: "Start_Run", label: "Run", prompt: "Start a new run" }],
+    ],
+    [
+      "an id with a leading dash",
+      [{ id: "-start", label: "Run", prompt: "Start a new run" }],
+    ],
+    [
+      "an over-long id",
+      [{ id: "a".repeat(41), label: "Run", prompt: "Start a new run" }],
+    ],
+    [
+      "an over-long label",
+      [{ id: "start-run", label: "x".repeat(25), prompt: "Start a new run" }],
+    ],
+    [
+      "an over-long prompt",
+      [{ id: "start-run", label: "Run", prompt: "x".repeat(2001) }],
+    ],
+    [
+      "an over-long icon",
+      [
+        {
+          id: "start-run",
+          label: "Run",
+          icon: "i".repeat(41),
+          prompt: "Start a new run",
+        },
+      ],
+    ],
+    ["a missing prompt", [{ id: "start-run", label: "Run" }]],
+  ])(
+    "malformed declaration (%s) degrades to undefined without blocking load",
+    async (_desc, malformed) => {
+      const dir = freshPluginDir("entrypoints-malformed");
+      writePackageJson(dir, {
+        name: "entrypoints-malformed",
+        version: "0.1.0",
+        companionEntrypoints: malformed,
+      });
+
+      await loadExternalPlugin(dir);
+      const manifest = await parsePluginManifest(dir);
+
+      const registered = getRegisteredPlugins().find(
+        (p) => p.manifest.name === "entrypoints-malformed",
+      );
+      expect(registered).toBeDefined();
+      expect(registered?.manifest.companionEntrypoints).toBeUndefined();
+      expect(manifest).toEqual({
+        name: "entrypoints-malformed",
+        version: "0.1.0",
+      });
+    },
+  );
+
+  test("exactly 4 entries is accepted", async () => {
+    const dir = freshPluginDir("entrypoints-at-cap");
+    const atCap = Array.from({ length: 4 }, (_, i) => ({
+      id: `entry-${i}`,
+      label: `Entry ${i}`,
+      prompt: `Do thing ${i}`,
+    }));
+    writePackageJson(dir, {
+      name: "entrypoints-at-cap",
+      version: "0.1.0",
+      companionEntrypoints: atCap,
+    });
+
+    await loadExternalPlugin(dir);
+
+    const registered = getRegisteredPlugins().find(
+      (p) => p.manifest.name === "entrypoints-at-cap",
+    );
+    expect(registered?.manifest.companionEntrypoints).toEqual(atCap);
+  });
+
+  test("a duplicate id collapses to the first declaration", async () => {
+    const dir = freshPluginDir("entrypoints-duplicate");
+    writePackageJson(dir, {
+      name: "entrypoints-duplicate",
+      version: "0.1.0",
+      companionEntrypoints: [
+        { id: "start-run", label: "First", prompt: "First prompt" },
+        { id: "start-run", label: "Second", prompt: "Second prompt" },
+        { id: "summarize", label: "Summary", prompt: "Summarize today" },
+      ],
+    });
+
+    await loadExternalPlugin(dir);
+
+    const registered = getRegisteredPlugins().find(
+      (p) => p.manifest.name === "entrypoints-duplicate",
+    );
+    expect(registered?.manifest.companionEntrypoints).toEqual([
+      { id: "start-run", label: "First", prompt: "First prompt" },
+      { id: "summarize", label: "Summary", prompt: "Summarize today" },
+    ]);
+  });
+});
+
 describe("loadExternalPlugin — plugin-api peerDependency", () => {
   // Tests anchor against assistantPkg.version (read from the assistant's
   // own package.json) so the matrix below stays correct across version

--- a/assistant/src/__tests__/plugin-types.test.ts
+++ b/assistant/src/__tests__/plugin-types.test.ts
@@ -42,6 +42,14 @@ describe("plugin core types", () => {
       credentialKeyPatterns: [
         { label: "Example API token", pattern: "^ex_tkn_[A-Za-z0-9]{24}$" },
       ],
+      companionEntrypoints: [
+        {
+          id: "start-run",
+          label: "Run",
+          icon: "play",
+          prompt: "Start a new run",
+        },
+      ],
     };
 
     const sampleTool: Tool = {

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -170,6 +170,13 @@ const COMPANION_ENTRYPOINT_LIMITS = {
 /** Stable kebab-case: lowercase alphanumeric groups joined by single dashes. */
 const COMPANION_ENTRYPOINT_ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
+/**
+ * At least one non-whitespace character. A label of only spaces draws a blank
+ * control and a prompt of only spaces submits no message, so both are
+ * malformed rather than merely nonempty.
+ */
+const COMPANION_ENTRYPOINT_NON_BLANK_PATTERN = /\S/;
+
 const CompanionEntrypointsSchema = z
   .array(
     z.object({
@@ -177,7 +184,10 @@ const CompanionEntrypointsSchema = z
         .string()
         .max(COMPANION_ENTRYPOINT_LIMITS.maxIdLength)
         .regex(COMPANION_ENTRYPOINT_ID_PATTERN),
-      label: z.string().min(1).max(COMPANION_ENTRYPOINT_LIMITS.maxLabelLength),
+      label: z
+        .string()
+        .max(COMPANION_ENTRYPOINT_LIMITS.maxLabelLength)
+        .regex(COMPANION_ENTRYPOINT_NON_BLANK_PATTERN),
       icon: z
         .string()
         .min(1)
@@ -185,15 +195,15 @@ const CompanionEntrypointsSchema = z
         .optional(),
       prompt: z
         .string()
-        .min(1)
-        .max(COMPANION_ENTRYPOINT_LIMITS.maxPromptLength),
+        .max(COMPANION_ENTRYPOINT_LIMITS.maxPromptLength)
+        .regex(COMPANION_ENTRYPOINT_NON_BLANK_PATTERN),
     }),
   )
   .max(COMPANION_ENTRYPOINT_LIMITS.maxEntrypointsPerPlugin);
 
 /**
  * Shape-validate a raw `companionEntrypoints` value from a plugin
- * `package.json`. Ids must be unique within the plugin — a repeat is dropped
+ * `package.json`. Ids must be unique within the plugin: a repeat is dropped
  * rather than rejected, since the first declaration is unambiguous and the
  * plugin is otherwise well-formed. A malformed value degrades to `undefined`
  * with a logged warning and must never fail plugin load (daemon startup
@@ -210,7 +220,7 @@ function parseCompanionEntrypoints(
   if (!parsed.success) {
     log.warn(
       { pluginDir, err: parsed.error },
-      `package.json at ${pluginDir} has a malformed companionEntrypoints field — ignoring it`,
+      `package.json at ${pluginDir} has a malformed companionEntrypoints field, ignoring it`,
     );
     return undefined;
   }
@@ -597,7 +607,7 @@ export async function parsePluginPresentation(
 
 /**
  * The manifest fields {@link parsePluginManifest} can read from a
- * `package.json` alone — everything else on {@link PluginManifest} comes from
+ * `package.json` alone. Everything else on {@link PluginManifest} comes from
  * surface files the full loader imports.
  */
 export type ParsedPluginManifest = Pick<

--- a/assistant/src/plugins/external-plugin-loader.ts
+++ b/assistant/src/plugins/external-plugin-loader.ts
@@ -57,6 +57,7 @@ import { registerPlugin } from "./registry.js";
 import type {
   HookFunction,
   Plugin,
+  PluginCompanionEntrypoint,
   PluginCredentialKeyPattern,
   PluginHooks,
   PluginManifest,
@@ -82,6 +83,8 @@ const DEFAULT_IMPORT_TIMEOUT_MS = 10_000;
  *   separately ({@link parseCredentialKeyPatterns}) so a malformed
  *   declaration degrades to `undefined` instead of failing the whole
  *   `safeParse` and blocking plugin load.
+ * - `companionEntrypoints` is typed `unknown` for the same reason and
+ *   shape-validated by {@link parseCompanionEntrypoints}.
  * - Unknown fields pass through (`passthrough`) so the loader does not
  *   destructively reshape the file when the rest of the npm ecosystem
  *   writes to it.
@@ -92,6 +95,7 @@ const PluginPackageJsonSchema = z
     version: z.string().optional(),
     peerDependencies: z.record(z.string(), z.string()).optional(),
     credentialKeyPatterns: z.unknown().optional(),
+    companionEntrypoints: z.unknown().optional(),
     /** Human title, when the package name is not one ("@vellumai/imessage"). */
     displayName: z.string().min(1).optional(),
     /** Standard npm field, reused as the one-line description clients show. */
@@ -147,6 +151,77 @@ function parseCredentialKeyPatterns(
     return undefined;
   }
   return parsed.data;
+}
+
+/**
+ * Shape-level caps for the `companionEntrypoints` manifest field. These bound
+ * what a plugin may *declare* so a manifest cannot smuggle in unbounded data;
+ * how many of those entries a client actually draws is the client's own
+ * decision, taken well below this cap.
+ */
+const COMPANION_ENTRYPOINT_LIMITS = {
+  maxEntrypointsPerPlugin: 4,
+  maxIdLength: 40,
+  maxLabelLength: 24,
+  maxIconLength: 40,
+  maxPromptLength: 2000,
+} as const;
+
+/** Stable kebab-case: lowercase alphanumeric groups joined by single dashes. */
+const COMPANION_ENTRYPOINT_ID_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const CompanionEntrypointsSchema = z
+  .array(
+    z.object({
+      id: z
+        .string()
+        .max(COMPANION_ENTRYPOINT_LIMITS.maxIdLength)
+        .regex(COMPANION_ENTRYPOINT_ID_PATTERN),
+      label: z.string().min(1).max(COMPANION_ENTRYPOINT_LIMITS.maxLabelLength),
+      icon: z
+        .string()
+        .min(1)
+        .max(COMPANION_ENTRYPOINT_LIMITS.maxIconLength)
+        .optional(),
+      prompt: z
+        .string()
+        .min(1)
+        .max(COMPANION_ENTRYPOINT_LIMITS.maxPromptLength),
+    }),
+  )
+  .max(COMPANION_ENTRYPOINT_LIMITS.maxEntrypointsPerPlugin);
+
+/**
+ * Shape-validate a raw `companionEntrypoints` value from a plugin
+ * `package.json`. Ids must be unique within the plugin — a repeat is dropped
+ * rather than rejected, since the first declaration is unambiguous and the
+ * plugin is otherwise well-formed. A malformed value degrades to `undefined`
+ * with a logged warning and must never fail plugin load (daemon startup
+ * philosophy: subsystem failures never block).
+ */
+function parseCompanionEntrypoints(
+  raw: unknown,
+  pluginDir: string,
+): PluginCompanionEntrypoint[] | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const parsed = CompanionEntrypointsSchema.safeParse(raw);
+  if (!parsed.success) {
+    log.warn(
+      { pluginDir, err: parsed.error },
+      `package.json at ${pluginDir} has a malformed companionEntrypoints field — ignoring it`,
+    );
+    return undefined;
+  }
+  const seen = new Set<string>();
+  return parsed.data.filter((entry) => {
+    if (seen.has(entry.id)) {
+      return false;
+    }
+    seen.add(entry.id);
+    return true;
+  });
 }
 
 export interface LoadExternalPluginOptions {
@@ -348,6 +423,13 @@ async function buildPluginFromDir(pluginDir: string): Promise<Plugin> {
   if (credentialKeyPatterns !== undefined) {
     manifest.credentialKeyPatterns = credentialKeyPatterns;
   }
+  const companionEntrypoints = parseCompanionEntrypoints(
+    pkg.companionEntrypoints,
+    pluginDir,
+  );
+  if (companionEntrypoints !== undefined) {
+    manifest.companionEntrypoints = companionEntrypoints;
+  }
   const plugin: Plugin = { manifest };
 
   const hooks = await loadHooks(pluginDir, name);
@@ -513,12 +595,20 @@ export async function parsePluginPresentation(
   return { displayName, description, icon };
 }
 
+/**
+ * The manifest fields {@link parsePluginManifest} can read from a
+ * `package.json` alone — everything else on {@link PluginManifest} comes from
+ * surface files the full loader imports.
+ */
+export type ParsedPluginManifest = Pick<
+  PluginManifest,
+  "name" | "version" | "credentialKeyPatterns" | "companionEntrypoints"
+>;
+
 export async function parsePluginManifest(
   pluginDir: string,
   opts: { quiet?: boolean } = {},
-): Promise<
-  Pick<PluginManifest, "name" | "version" | "credentialKeyPatterns"> | undefined
-> {
+): Promise<ParsedPluginManifest | undefined> {
   const pkgPath = join(pluginDir, "package.json");
   let rawPkg: unknown;
   try {
@@ -546,12 +636,20 @@ export async function parsePluginManifest(
   const pkg: PluginPackageJson = parsed.data;
   const name = basename(pluginDir);
   const version = pkg.version && pkg.version.length > 0 ? pkg.version : "0.0.0";
+  const manifest: ParsedPluginManifest = { name, version };
   const credentialKeyPatterns = parseCredentialKeyPatterns(
     pkg.credentialKeyPatterns,
     pluginDir,
   );
   if (credentialKeyPatterns !== undefined) {
-    return { name, version, credentialKeyPatterns };
+    manifest.credentialKeyPatterns = credentialKeyPatterns;
   }
-  return { name, version };
+  const companionEntrypoints = parseCompanionEntrypoints(
+    pkg.companionEntrypoints,
+    pluginDir,
+  );
+  if (companionEntrypoints !== undefined) {
+    manifest.companionEntrypoints = companionEntrypoints;
+  }
+  return manifest;
 }

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -90,7 +90,7 @@ export interface PluginCredentialKeyPattern {
  *
  * Data rather than code. Clients resolve `icon` against their own fixed set of
  * names and fall back when it is unknown, so a plugin never chooses what is
- * drawn — only which of the host's icons is picked.
+ * drawn, only which of the host's icons is picked.
  */
 export interface PluginCompanionEntrypoint {
   /** Stable kebab-case id, unique within the plugin. */

--- a/assistant/src/plugins/types.ts
+++ b/assistant/src/plugins/types.ts
@@ -64,6 +64,13 @@ export interface PluginManifest {
    * never blocks plugin load).
    */
   credentialKeyPatterns?: PluginCredentialKeyPattern[];
+  /**
+   * Entrypoints the plugin contributes to a client surface, parsed from the
+   * plugin's `package.json` `companionEntrypoints` field. The loader only
+   * enforces shape (entry count, id grammar, field lengths); a malformed
+   * declaration degrades to `undefined` and never blocks plugin load.
+   */
+  companionEntrypoints?: PluginCompanionEntrypoint[];
 }
 
 /**
@@ -75,6 +82,25 @@ export interface PluginCredentialKeyPattern {
   label: string;
   /** Regex source string matching the service's credential format. */
   pattern: string;
+}
+
+/**
+ * One entrypoint a plugin contributes to a client surface: a labelled control
+ * that, when pressed, sends `prompt` as a message.
+ *
+ * Data rather than code. Clients resolve `icon` against their own fixed set of
+ * names and fall back when it is unknown, so a plugin never chooses what is
+ * drawn — only which of the host's icons is picked.
+ */
+export interface PluginCompanionEntrypoint {
+  /** Stable kebab-case id, unique within the plugin. */
+  id: string;
+  /** Short label. One or two words: it is drawn inside a floating pill. */
+  label: string;
+  /** Icon name resolved against the client's allowlist; unknown falls back. */
+  icon?: string;
+  /** The message submitted when the entrypoint is pressed. */
+  prompt: string;
 }
 
 // ─── Public plugin-API types ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `PluginCompanionEntrypoint` and an optional `companionEntrypoints` field to `PluginManifest` — a labelled, icon-named control a plugin declares as data, whose `prompt` a client submits when pressed.
- The external plugin loader shape-validates `companionEntrypoints` from `package.json` exactly the way `credentialKeyPatterns` is handled: caps at 4 entries per plugin, a kebab-case `id` (<= 40 chars), `label` <= 24, `icon` <= 40, `prompt` <= 2000, and duplicate ids collapsed to the first. A malformed declaration logs one warning, degrades to `undefined`, and never blocks plugin load.
- Loader tests cover the round-trip onto the manifest (both `loadExternalPlugin` and `parsePluginManifest`), every cap, the id grammar, and duplicate collapsing.

Part of plan: companion-plugin-entrypoints.md (PR 2 of 9)