### PR TITLE
fix(web): drive the sight-frame reclaimer's wait on real timers

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -5,7 +5,15 @@
  * layout-mounted controller — plus the session-ownership predicates.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import { makeControlsSpies } from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
 import {
@@ -45,6 +53,24 @@ beforeEach(() => {
     .getState()
     .takeDueSightFrameReclaims(Number.MAX_SAFE_INTEGER);
 });
+
+afterEach(() => {
+  setSystemTime();
+});
+
+/**
+ * Park the clock and hand back the instant it now reads.
+ *
+ * The deadlines below are derived from a `Date.now()` the store reads for
+ * itself, so a case that asserts one exactly has to agree with the store on
+ * what "now" is. Parking the clock is that agreement: without it the two reads
+ * straddle a millisecond boundary often enough to fail.
+ */
+function atAParkedClock(): number {
+  const at = Date.now();
+  setSystemTime(new Date(at));
+  return at;
+}
 
 function makeStarter() {
   return {
@@ -843,7 +869,7 @@ describe("sight frame refusals", () => {
     attachLiveVoiceImage("photo-2", generation);
     attachLiveVoiceImage("photo-3", generation);
     sendLiveVoiceSightFrame("att-1", generation);
-    const at = Date.now();
+    const at = atAParkedClock();
 
     useLiveVoiceStore.getState().reset();
 
@@ -855,7 +881,7 @@ describe("sight frame refusals", () => {
   test("a shorter queue yields a shorter deadline", () => {
     const { generation } = sightSession();
     sendLiveVoiceSightFrame("att-1", generation);
-    const at = Date.now();
+    const at = atAParkedClock();
 
     useLiveVoiceStore.getState().reset();
 
@@ -873,7 +899,7 @@ describe("sight frame refusals", () => {
       attachLiveVoiceImage(`photo-${i}`, generation);
     }
     sendLiveVoiceSightFrame("att-1", generation);
-    const at = Date.now();
+    const at = atAParkedClock();
 
     useLiveVoiceStore.getState().reset();
 
@@ -962,7 +988,7 @@ describe("sight frame refusals", () => {
     attachLiveVoiceImage("photo-1", generation);
     useLiveVoiceStore.getState().notePhotoRejected("failed");
     sendLiveVoiceSightFrame("att-1", generation);
-    const at = Date.now();
+    const at = atAParkedClock();
 
     useLiveVoiceStore.getState().reset();
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-sight-frame-reclaimer.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-sight-frame-reclaimer.test.tsx
@@ -11,13 +11,12 @@ import {
   beforeEach,
   describe,
   expect,
-  jest,
   mock,
   setSystemTime,
   test,
 } from "bun:test";
 import { useEffect } from "react";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 
 const deleteChatAttachment = mock(
   async (_assistantId: string, _attachmentId: string) => true,
@@ -35,6 +34,11 @@ const ASSISTANT_ID = "asst_sight";
 // Comfortably past every deadline these tests derive, which queue at most a
 // handful of jobs ahead.
 const PAST_EVERY_DEADLINE_MS = 10 * PER_JOB_CEILING_MS;
+
+// How far short of a deadline {@link holdShortOfTheDeadline} parks the clock,
+// and so how long the hook's own `setTimeout` waits: short enough to spend on
+// a real clock, long enough not to spin.
+const SHORT_OF_THE_DEADLINE_MS = 25;
 
 /** Put a running session on the store, bound to an assistant. */
 function startSession() {
@@ -58,33 +62,32 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   setSystemTime();
-  jest.useRealTimers();
 });
 
 /**
- * Run `body` on a clock this test owns.
+ * Queue reclaims and let the hook arm against a clock parked just short of the
+ * deadline they derive. Returns that deadline, for the caller to step past.
  *
- * Scoped rather than global: fake timers freeze the ordinary `setTimeout(0)`
- * settles the other cases wait on, so only the cases about the delay take
- * them, and those settle with microtasks alone.
+ * The wait under test is tens of seconds long, so something has to give. What
+ * gives is `Date.now()` rather than the timers: the hook keeps the ordinary
+ * `setTimeout` it ships with, and its arm comes out a few real milliseconds
+ * instead. Replacing the timers instead would take React's own scheduling with
+ * them, since a faked timer that writes to the store leaves work `act` can no
+ * longer settle.
+ *
+ * The clock is parked rather than merely set, so an arm that fires while the
+ * caller is asserting the wait finds nothing due and simply arms again.
  */
-async function onAFakeClock(
-  body: (advanceBy: (ms: number) => void) => Promise<void>,
-): Promise<void> {
-  const base = new Date("2026-09-01T00:00:00Z");
-  setSystemTime(base);
-  jest.useFakeTimers();
-  let elapsed = 0;
-  try {
-    await body((ms) => {
-      elapsed += ms;
-      setSystemTime(new Date(base.getTime() + elapsed));
-      jest.advanceTimersByTime(ms);
-    });
-  } finally {
-    jest.useRealTimers();
-    setSystemTime();
-  }
+async function holdShortOfTheDeadline(queue: () => void): Promise<number> {
+  let deadline = 0;
+  await act(async () => {
+    queue();
+    const pending = useLiveVoiceStore.getState().sightFramesToReclaim;
+    deadline = Math.max(...pending.map((entry) => entry.notBefore ?? 0));
+    setSystemTime(new Date(deadline - SHORT_OF_THE_DEADLINE_MS));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+  return deadline;
 }
 
 describe("useSightFrameReclaimer", () => {
@@ -189,97 +192,85 @@ describe("useSightFrameReclaimer", () => {
     // still be queued behind another when the socket closes. Deleting straight
     // away would make its persist find nothing and drop a frame that was going
     // to land, with no open socket left to say so.
-    await onAFakeClock(async (advanceBy) => {
-      const generation = startSession();
-      renderHook(() => useSightFrameReclaimer());
-      sendLiveVoiceSightFrame("att-1", generation);
-      sendLiveVoiceSightFrame("att-2", generation);
+    const generation = startSession();
+    renderHook(() => useSightFrameReclaimer());
+    sendLiveVoiceSightFrame("att-1", generation);
+    sendLiveVoiceSightFrame("att-2", generation);
 
-      await act(async () => {
-        useLiveVoiceStore.getState().reset({ sessionContinues: true });
-        await Promise.resolve();
-      });
+    const deadline = await holdShortOfTheDeadline(() => {
+      useLiveVoiceStore.getState().reset({ sessionContinues: true });
+    });
 
-      expect(deleteChatAttachment).not.toHaveBeenCalled();
-      expect(useLiveVoiceStore.getState().sightFramesToReclaim).toHaveLength(2);
+    expect(deleteChatAttachment).not.toHaveBeenCalled();
+    expect(useLiveVoiceStore.getState().sightFramesToReclaim).toHaveLength(2);
 
-      // Once the daemon has had its time, the link-aware delete decides: a
-      // frame that persisted meanwhile is refused, one that was lost is
-      // collected.
-      await act(async () => {
-        advanceBy(PAST_EVERY_DEADLINE_MS);
-        await Promise.resolve();
-      });
-
-      expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-1");
-      expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-2");
+    // Once the daemon has had its time, the link-aware delete decides: a frame
+    // that persisted meanwhile is refused, one that was lost is collected.
+    setSystemTime(new Date(deadline + 1));
+    await waitFor(() => {
       expect(useLiveVoiceStore.getState().sightFramesToReclaim).toEqual([]);
     });
+
+    expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-1");
+    expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-2");
   });
 
   test("holds a terminal reset's the same way", async () => {
-    await onAFakeClock(async (advanceBy) => {
-      const generation = startSession();
-      renderHook(() => useSightFrameReclaimer());
-      sendLiveVoiceSightFrame("att-1", generation);
+    const generation = startSession();
+    renderHook(() => useSightFrameReclaimer());
+    sendLiveVoiceSightFrame("att-1", generation);
 
-      await act(async () => {
-        useLiveVoiceStore.getState().reset();
-        await Promise.resolve();
-      });
-      expect(deleteChatAttachment).not.toHaveBeenCalled();
+    const deadline = await holdShortOfTheDeadline(() => {
+      useLiveVoiceStore.getState().reset();
+    });
+    expect(deleteChatAttachment).not.toHaveBeenCalled();
 
-      await act(async () => {
-        advanceBy(PAST_EVERY_DEADLINE_MS);
-        await Promise.resolve();
-      });
-
+    setSystemTime(new Date(deadline + 1));
+    await waitFor(() => {
       expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-1");
     });
   });
 
   test("stops arming once the queue is empty", async () => {
-    await onAFakeClock(async (advanceBy) => {
-      const generation = startSession();
-      renderHook(() => useSightFrameReclaimer());
-      sendLiveVoiceSightFrame("att-1", generation);
-      await act(async () => {
-        useLiveVoiceStore.getState().reset();
-        await Promise.resolve();
-      });
+    const generation = startSession();
+    renderHook(() => useSightFrameReclaimer());
+    sendLiveVoiceSightFrame("att-1", generation);
 
-      await act(async () => {
-        advanceBy(PAST_EVERY_DEADLINE_MS);
-        await Promise.resolve();
-      });
-      expect(deleteChatAttachment).toHaveBeenCalledTimes(1);
+    const deadline = await holdShortOfTheDeadline(() => {
+      useLiveVoiceStore.getState().reset();
+    });
 
-      // Nothing is queued, so nothing is waiting to fire: running the clock on
-      // must not re-issue the delete this already made.
-      await act(async () => {
-        advanceBy(PAST_EVERY_DEADLINE_MS * 4);
-        await Promise.resolve();
-      });
-
+    setSystemTime(new Date(deadline + 1));
+    await waitFor(() => {
       expect(deleteChatAttachment).toHaveBeenCalledTimes(1);
     });
+
+    // Nothing is queued, so nothing is waiting to fire: running the clock on
+    // must not re-issue the delete this already made.
+    setSystemTime(new Date(deadline + PAST_EVERY_DEADLINE_MS));
+    await act(async () => {
+      await new Promise((resolve) =>
+        setTimeout(resolve, SHORT_OF_THE_DEADLINE_MS * 4),
+      );
+    });
+
+    expect(deleteChatAttachment).toHaveBeenCalledTimes(1);
   });
 
   test("a refusal-routed reclaim does not wait", async () => {
     // The assistant answered for these and reclaimed its own side, so there is
     // nothing left to settle and no reason to hold them.
-    await onAFakeClock(async () => {
-      const generation = startSession();
-      renderHook(() => useSightFrameReclaimer());
-      sendLiveVoiceSightFrame("att-1", generation);
+    const generation = startSession();
+    renderHook(() => useSightFrameReclaimer());
+    sendLiveVoiceSightFrame("att-1", generation);
 
-      await act(async () => {
-        useLiveVoiceStore.getState().noteSightFrameRefused(true);
-        await Promise.resolve();
-      });
-
-      expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-1");
+    await act(async () => {
+      useLiveVoiceStore.getState().noteSightFrameRefused(true);
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
+
+    expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-1");
+    expect(useLiveVoiceStore.getState().sightFramesToReclaim).toEqual([]);
   });
 
   test("a routine refusal queues nothing to delete", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-sight-frame-reclaimer.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-sight-frame-reclaimer.ts
@@ -18,7 +18,7 @@
  * (see `PER_JOB_CEILING_MS`, and `queueUnacknowledgedSightFrames` for how the
  * deadline is derived from what can still be queued on the daemon), so this
  * runs on a timer as well as on new work. The timer is armed for the earliest
- * waiting entry, re-armed by the drain it triggers, and left unarmed once
+ * waiting entry, re-arms itself for whatever is left, and is left unarmed once
  * nothing is queued.
  *
  * Deletion failures are logged and dropped. Nobody asked for these uploads and
@@ -67,20 +67,27 @@ export function useSightFrameReclaimer(): void {
     if (queued.length === 0) {
       return;
     }
-    drainDue();
+    let timer: ReturnType<typeof setTimeout> | undefined;
     // Whatever is left is waiting on its own clock, and no store change is
-    // coming to wake this. Arm for the earliest of them: the drain that
-    // follows re-runs this effect, which re-arms only while something is still
-    // pending and arms nothing once the queue is empty.
-    const pending = useLiveVoiceStore.getState().sightFramesToReclaim;
-    if (pending.length === 0) {
-      return;
-    }
-    const now = Date.now();
-    const earliest = Math.min(
-      ...pending.map((entry) => entry.notBefore ?? now),
-    );
-    const timer = setTimeout(drainDue, Math.max(0, earliest - now));
+    // coming to wake this, so the wait re-arms itself rather than relying on a
+    // render. A timer that wakes a hair short of its entry's deadline takes
+    // nothing, and a take that took nothing leaves the queue untouched, so an
+    // arm made only where the queue changes would strand that entry for good.
+    // Each arm is for the earliest waiting entry, and the queue emptying ends
+    // the chain.
+    const drainAndArm = (): void => {
+      drainDue();
+      const pending = useLiveVoiceStore.getState().sightFramesToReclaim;
+      if (pending.length === 0) {
+        return;
+      }
+      const now = Date.now();
+      const earliest = Math.min(
+        ...pending.map((entry) => entry.notBefore ?? now),
+      );
+      timer = setTimeout(drainAndArm, Math.max(0, earliest - now));
+    };
+    drainAndArm();
     return () => clearTimeout(timer);
   }, [drainDue, queued]);
 }


### PR DESCRIPTION
`main` is red: `clients/web/src/domains/chat/voice/live-voice/use-sight-frame-reclaimer.test.tsx` fails on every CI run since #41833 (`1159 passed, 1 failed`).

## Root cause

The suite drove the reclaimer's re-arm timer with `jest.useFakeTimers()` + `jest.advanceTimersByTime`. On a GitHub runner, a faked timer callback that writes to the live-voice store leaves React holding work that `act` can no longer settle, so the very next `await act(...)` never resolves and the test dies on Bun's 5000 ms timeout. `onAFakeClock` restored the real timers in a `finally` that only runs when that abandoned continuation resumes, so the restore landed in the middle of the *following* test. That is why one hung case produced six failures, four "Unhandled error between tests" reports, and the `Fake timers are not active` errors: those were all downstream of the first hang.

The hang was not flakiness and not CPU starvation. It reproduces 10/10 on `ubuntu-latest` and 0/10 anywhere else I could build (macOS arm64, Linux arm64 and amd64 containers, the exact CI install shape, and down to `--cpus=0.3`), so I bisected it on a runner with a temporary workflow. Isolated variants, each in its own process:

| variant | result |
| --- | --- |
| fake timers, `advanceTimersByTime` fires the hook's armed timer **inside** `act` | hangs |
| fake timers, `advanceTimersByTime` fires it **outside** `act`, plain `act` afterwards | hangs |
| fake timers, timer armed but never fired | passes |
| fake timers, drain runs but nothing was ever armed | passes |
| real timers, same drain | passes |

So the poison is precisely "a faked timer fires the hook's drain", and neither `setSystemTime` nor `act` nor the mocked delete on their own.

Two smaller true findings fell out of the same investigation:

- `setSystemTime` is ignored while Bun's fake timers are active, so `onAFakeClock`'s base date never applied. The suite's clock was only ever moving because `advanceTimersByTime` moves Bun's own clock.
- `live-voice-store.test.ts` also failed on CI (`Expected: 1788282518506, Received: 1788282518507`). Four deadline cases read a `Date.now()` of their own and compared it exactly against one the store reads for itself.

## What changed

**`use-sight-frame-reclaimer.ts` (product).** Reworking the test exposed a real leak. The effect armed a single `setTimeout`, and re-arming depended on the drain changing the queue. A timer that wakes a hair short of its entry's deadline takes nothing, a take that took nothing leaves the queue untouched, and so no render is coming to arm again: the entry is stranded for good, which is exactly the orphaned upload this hook exists to collect. The drain now re-arms itself and stops only once the queue is empty. It cannot spin, because a zero delay only arises for an entry that is already due, and a due entry is taken.

**`use-sight-frame-reclaimer.test.tsx`.** No fake timers. `holdShortOfTheDeadline` parks `Date.now()` just short of the deadline the queue derived, so the hook's own `setTimeout` has a few real milliseconds to run and the wait is exercised on the timers it ships with. The caller then steps the clock past the deadline and uses `waitFor`. Parking rather than merely setting the clock is what makes it deterministic: an arm that fires while the "it holds" assertions are running finds nothing due and simply arms again. `a refusal-routed reclaim does not wait` needed no clock control at all and no longer takes any.

**`live-voice-store.test.ts`.** `atAParkedClock()` freezes the clock for the four cases that assert a derived deadline exactly, with an `afterEach` restore.

## Verification

- Runner (`ubuntu-latest`, the environment that fails): both suites 10 times each, `10 pass / 0 fail` and `97 pass / 0 fail` on every attempt. Before the fix the same job gave `4 pass / 6 fail` on all 10 attempts.
- Runner: the whole `live-voice/` directory through `run-tests.ts`, `16 passed, 0 failed`.
- Local: both files 8 times each, 0 failures; `live-voice/` directory `16 passed, 0 failed`; `bunx tsc --noEmit` clean; `bun run lint` 0 errors.

The failure was **deterministic on GitHub runners** and unreproducible elsewhere, so the fix was validated where it actually fails rather than only locally.

## Not fixed here

- Running `bun test src/domains/chat/voice/live-voice/` as one process fails on unrelated files (`live-activity-push-registration`, `live-voice-session`). That is pre-existing `mock.module` leakage between files; CI runs one process per file and is unaffected.
- No attempt to make Bun's fake timers work with React's `act` in general. Other suites that use fake timers without driving a store write from a timer callback are fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1GzJ38vHL3WSCqUkrgyQc

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->