### PR TITLE
refactor(persistence): type the channel inbound event status columns

### DIFF
--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -283,6 +283,25 @@ export const conversationCompactionEvents = sqliteTable(
   ],
 );
 
+/**
+ * Lifecycle of a channel inbound event's reply delivery. `pending` is the only
+ * non-terminal value, so every path that finishes a turn has to move the row
+ * off it, including the paths that finish WITHOUT delivering: recovery reads a
+ * lingering `pending` as a reply still owed. See `runtime/AGENTS.md`.
+ */
+export type ChannelDeliveryStatus =
+  | "pending"
+  | "delivered"
+  | "failed"
+  | "dead_letter";
+
+/** Lifecycle of a channel inbound event's agent-turn processing. */
+export type ChannelProcessingStatus =
+  | "pending"
+  | "processed"
+  | "failed"
+  | "dead_letter";
+
 export const channelInboundEvents = sqliteTable("channel_inbound_events", {
   id: text("id").primaryKey(),
   sourceChannel: text("source_channel").notNull(),
@@ -295,8 +314,14 @@ export const channelInboundEvents = sqliteTable("channel_inbound_events", {
   messageId: text("message_id").references(() => messages.id, {
     onDelete: "cascade",
   }),
-  deliveryStatus: text("delivery_status").notNull().default("pending"),
-  processingStatus: text("processing_status").notNull().default("pending"),
+  deliveryStatus: text("delivery_status")
+    .$type<ChannelDeliveryStatus>()
+    .notNull()
+    .default("pending"),
+  processingStatus: text("processing_status")
+    .$type<ChannelProcessingStatus>()
+    .notNull()
+    .default("pending"),
   processingAttempts: integer("processing_attempts").notNull().default(0),
   deliveryAttempts: integer("delivery_attempts").notNull().default(0),
   lastProcessingError: text("last_processing_error"),


### PR DESCRIPTION
## TL;DR

`channel_inbound_events.delivery_status` and `.processing_status` were plain `text()` columns. 33 raw string literals across the delivery module, no union type anywhere, nothing stopping a typo or a newly added state from compiling.

Narrows both with drizzle's `$type<>()`. Purely additive: every existing call site already conformed, so nothing else changes.

## Why this column, and why now

This is the failure class these two columns are most exposed to. A row whose status no query selects does not error, it just silently stops being processed. That is precisely how a channel reply ends up undelivered with no operator signal, which is the bug being fixed in #41873: a row sitting in `processed` + `pending`, a state no sweep selected.

Fixing that one instance does not stop the next one. Typing the column does, at compile time.

## What changes for the user

Nothing at runtime. No behavior change, no migration, stored values untouched. This is a compile-time guard.

| | Before | After |
| --- | --- | --- |
| Typo'd status literal (`"deliverd"`) | Compiles, silently matches no row | Compile error with a did-you-mean |
| New status added without updating readers | Compiles | Every unhandled drizzle site fails to compile |
| Existing call sites | 33 raw literals, unchecked | Same 33 literals, now checked |

## Why it is safe

- **No call site changed.** `tsc` passes with zero errors against the new unions, which is the evidence that all 33 existing literals were already correct. If any had been wrong, this PR would have surfaced it as a compile error rather than a silent runtime miss.
- **No migration.** `$type<>()` is a compile-time narrowing over the same `text()` column. Stored values, defaults, and reads are byte-identical.
- **The guard is not vacuous.** Verified by deliberately introducing `deliveryStatus: "deliverd"`, which now fails with `TS2820 ... Did you mean '"delivered"'?` at both call sites. A green `tsc` on an unenforced type would have looked identical without that check.

## Note on precedent

This is the first `$type<>()` in `persistence/schema`, so it introduces a pattern. It is drizzle's documented mechanism for narrowing a text column to a union, and the alternative (hand-annotating function signatures) leaves the drizzle `.set()` and `eq()` call sites unchecked, which is where the risk actually lives.

Scoped deliberately to these two columns rather than swept across every status-like column in the schema. Other columns can adopt it where the same argument holds, but that is a separate judgment per column, not a mechanical sweep.

## Provenance

Surfaced by a `/simplify` pass over #41873. Independent of that PR and mergeable in either order: the recovery step added there uses raw SQL strings, which a TypeScript union cannot check either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->