### PR TITLE
feat(macos): carry companion entrypoints through to surface state

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -1327,3 +1327,44 @@ describe("the Watch flag on the pushed state", () => {
     expect(pushes.at(-1)?.watchEnabled).toBe(false);
   });
 });
+
+/**
+ * The controls installed plugins contribute, which the surface draws and main
+ * only carries.
+ *
+ * The plugin registry lives with the session, and this surface has neither, so
+ * the entrypoints arrive the way the tail does: published by the window that
+ * can read them and pushed back down with the rest of the state.
+ */
+describe("the plugin entrypoints main relays", () => {
+  const ENTRYPOINT = {
+    id: "notes:capture",
+    label: "Capture",
+    icon: "pencil",
+    prompt: "Capture a note about what I am looking at.",
+  };
+
+  beforeEach(() => {
+    send("vellum:companion:setContext", context());
+    pushes.length = 0;
+  });
+
+  test("carries the published entrypoints into pushed state", () => {
+    send("vellum:companion:setContext", context({ entrypoints: [ENTRYPOINT] }));
+
+    expect(pushes.at(-1)?.entrypoints).toEqual([ENTRYPOINT]);
+    expect(state().entrypoints).toEqual([ENTRYPOINT]);
+  });
+
+  /**
+   * A publisher with no plugins loaded, or one that predates the field,
+   * contributes no controls. The surface reads an empty row, never an absent
+   * one.
+   */
+  test("reads a context with no entrypoints as none contributed", () => {
+    send("vellum:companion:setContext", context({ entrypoints: [ENTRYPOINT] }));
+    send("vellum:companion:setContext", context());
+
+    expect(state().entrypoints).toEqual([]);
+  });
+});

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -340,6 +340,7 @@ let context: CompanionContext = {
   working: false,
   watching: false,
   captureCount: 0,
+  entrypoints: [],
 };
 
 /**
@@ -376,6 +377,10 @@ const currentState = (): CompanionSurfaceState => {
     // a publisher that reports no count has taken no reads this surface can
     // vouch for.
     captureCount: context.captureCount ?? 0,
+    // Settled to an array for the same reason: a publisher with no plugins
+    // loaded, or one that predates the field, contributes no controls, and the
+    // surface should read one shape whatever arrived.
+    entrypoints: context.entrypoints ?? [],
     // Read on every rebuild rather than captured once, because the evaluation
     // lands after launch: the app's window has to sign in and fetch it first,
     // and a targeting change can move it again while the app runs.


### PR DESCRIPTION
## Summary

- `currentState()` now carries `entrypoints` from the published `CompanionContext` onto `CompanionSurfaceState`, settled to an array the way `watching` and `captureCount` are, so the surface reads one shape whatever arrived.
- The initial context literal seeds `entrypoints: []`, so a surface drawn before any window publishes gets an empty row rather than an undefined one.
- Adds cases covering both directions: published entrypoints reach the pushed and pulled state, and a context that omits them settles back to `[]`.

Part of plan: companion-plugin-entrypoints.md (PR 6 of 9)