### PR TITLE
Extract the avatar icon naming, span, and bounds core into a shared module

### DIFF
--- a/clients/ios/scripts/__tests__/generate-avatar-icons.test.ts
+++ b/clients/ios/scripts/__tests__/generate-avatar-icons.test.ts
@@ -26,6 +26,10 @@ import { join } from "node:path";
 import { inflateSync } from "node:zlib";
 
 import {
+  androidResourceNameForTraits,
+  assertUnderscoreSafeIds,
+} from "../avatar-icon-core.js";
+import {
   AVATAR_ICONS_DIR,
   AVATAR_ICONS_XCCONFIG_PATH,
   generateAvatarIcons,
@@ -293,6 +297,28 @@ describe("iconNameForTraits", () => {
     },
     GENERATION_TIMEOUT_MS,
   );
+});
+
+describe("androidResourceNameForTraits", () => {
+  /**
+   * Android resource names admit underscores rather than dashes, so this is the
+   * wire name with every separator swapped. The literal is pinned because a
+   * drawable that changes name stops resolving from the manifest entry that
+   * references it.
+   */
+  test("builds the avatar_eyes_<eye>_<color> resource name", () => {
+    expect(
+      androidResourceNameForTraits({
+        eyeStyle: "grumpy",
+        color: "green",
+      }),
+    ).toBe("avatar_eyes_grumpy_green");
+  });
+
+  /** Whole-string dash to underscore translation only round-trips while this holds. */
+  test("accepts every id in the current library", () => {
+    expect(() => assertUnderscoreSafeIds()).not.toThrow();
+  });
 });
 
 describe("generateAvatarIcons", () => {

--- a/clients/ios/scripts/avatar-icon-core.ts
+++ b/clients/ios/scripts/avatar-icon-core.ts
@@ -84,7 +84,7 @@ export function iconNameForTraits(traits: AvatarIconTraits): string {
  * swapped, and {@link assertUnderscoreSafeIds} keeps that swap reversible.
  */
 export function androidResourceNameForTraits(traits: AvatarIconTraits): string {
-  return `avatar_eyes_${traits.eyeStyle}_${traits.color}`;
+  return iconNameForTraits(traits).replace(/-/g, "_");
 }
 
 /**

--- a/clients/ios/scripts/avatar-icon-core.ts
+++ b/clients/ios/scripts/avatar-icon-core.ts
@@ -1,0 +1,235 @@
+/**
+ * Naming, framing, and eye-artwork measurement behind the avatar app icons.
+ *
+ * Every platform generator draws the same artwork at the same size, so the
+ * pieces that decide *which* icons exist and *how big* the eyes are drawn live
+ * here rather than in any one platform's script. Rasterizing needs the native
+ * `@resvg/resvg-js` binding, so the assistant package's dependencies have to be
+ * installed first: `bun install --filter=@vellumai/assistant`.
+ */
+
+import { getCharacterComponents } from "../../../packages/avatar-catalog/src/index.js";
+import { getResvg } from "../../../assistant/src/avatar/resvg-lazy.js";
+
+/**
+ * Fraction of the icon an eye pair's tight bounds span, for every style the
+ * table below does not name.
+ *
+ * `clients/web/src/components/avatar/app-icon-preview.tsx` mirrors both this
+ * number and the table, so its on-screen preview frames a pair the way the
+ * shipped PNG does. Each side pins the numbers in its own tests, since a web
+ * bundle cannot import a build script that rasterizes SVG. A span moves here
+ * only alongside that file, and the catalog is regenerated with it.
+ */
+const DEFAULT_EYE_SPAN_FRACTION = 0.5;
+
+/** Eye styles framed wider or narrower than {@link DEFAULT_EYE_SPAN_FRACTION}. */
+const EYE_SPAN_FRACTION_OVERRIDES: Record<string, number> = {
+  dazed: 0.55,
+  bashful: 0.4,
+};
+
+/**
+ * Canvas the eye bounds below are measured on, in px. The scan reports whole
+ * probe pixels, so each edge carries up to one of them as slack; this size
+ * keeps that under a thousandth of the artwork.
+ */
+const EYE_BOUNDS_PROBE_PX = 2048;
+
+/**
+ * `--pilot` narrows a local run to a 12-set slice, which rasterizes in a couple
+ * of seconds. `grumpy` is the widest, flattest eye pair in the library and
+ * `gentle` the closest to square, so between them they cover both ends of what
+ * the placement has to fit.
+ */
+const PILOT_EYE_STYLES = ["grumpy", "gentle"];
+
+export type IconSetScope = "pilot" | "full";
+
+export interface AvatarIconTraits {
+  eyeStyle: string;
+  color: string;
+}
+
+export type EyeStyle = ReturnType<
+  typeof getCharacterComponents
+>["eyeStyles"][number];
+
+/** Tight bounds of an eye style's artwork, in its own source viewBox units. */
+export interface EyeBounds {
+  minX: number;
+  minY: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Icon set name for an eye style and color. The web layer derives the same name
+ * when it asks iOS to switch icons, so this format is a wire contract: changing
+ * it breaks every already-installed app until both sides ship together. Body
+ * shape is deliberately absent, since the icons draw eyes on a color field and
+ * no body.
+ *
+ * The name is also a cache key: iOS caches an alternate icon's artwork under
+ * it, so each name permanently identifies one artwork version. Changed art
+ * goes out under a new versioned name, never behind an existing one.
+ */
+export function iconNameForTraits(traits: AvatarIconTraits): string {
+  return `avatar-eyes-${traits.eyeStyle}-${traits.color}`;
+}
+
+/**
+ * Android resource name for the same pair. Resource names admit underscores
+ * rather than dashes, so this is {@link iconNameForTraits} with every separator
+ * swapped, and {@link assertUnderscoreSafeIds} keeps that swap reversible.
+ */
+export function androidResourceNameForTraits(traits: AvatarIconTraits): string {
+  return `avatar_eyes_${traits.eyeStyle}_${traits.color}`;
+}
+
+/**
+ * Rejects any library id carrying an underscore.
+ *
+ * Translating between the wire name and the Android resource name swaps every
+ * dash for an underscore across the whole string, which only round-trips while
+ * no id contains a separator of its own.
+ */
+export function assertUnderscoreSafeIds(): void {
+  const components = getCharacterComponents();
+  const ids = [
+    ...components.eyeStyles.map((eye) => eye.id),
+    ...components.colors.map((color) => color.id),
+  ];
+  for (const id of ids) {
+    if (id.includes("_")) {
+      throw new Error(
+        `Avatar component id "${id}" contains an underscore, which would not ` +
+          `survive the dash to underscore translation into an Android resource name.`,
+      );
+    }
+  }
+}
+
+/** Trait pairs in scope, in a stable eye, color order. */
+export function traitCombinations(scope: IconSetScope): AvatarIconTraits[] {
+  assertUnderscoreSafeIds();
+
+  const components = getCharacterComponents();
+  const allEyeStyles = components.eyeStyles.map((eye) => eye.id);
+
+  const eyeStyles =
+    scope === "full"
+      ? allEyeStyles
+      : assertKnownIds(PILOT_EYE_STYLES, allEyeStyles, "eye style");
+
+  const combinations: AvatarIconTraits[] = [];
+  for (const eyeStyle of eyeStyles) {
+    for (const color of components.colors) {
+      combinations.push({ eyeStyle, color: color.id });
+    }
+  }
+  return combinations;
+}
+
+function assertKnownIds(
+  requested: string[],
+  known: string[],
+  label: string,
+): string[] {
+  for (const id of requested) {
+    if (!known.includes(id)) {
+      throw new Error(
+        `Unknown ${label}: "${id}". Valid IDs: ${known.join(", ")}`,
+      );
+    }
+  }
+  return requested;
+}
+
+/** An eye style's paths, verbatim, under one shared affine transform. */
+export function eyePathsSvg(eyeStyle: EyeStyle, transform: string): string {
+  return eyeStyle.paths
+    .map(
+      (path) =>
+        `<path d="${path.svgPath}" fill="${path.color}" transform="${transform}"/>`,
+    )
+    .join("");
+}
+
+export function renderSvg(body: string, width: number, height: number) {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" ` +
+    `width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">${body}</svg>`;
+  const Resvg = getResvg();
+  return new Resvg(svg, { fitTo: { mode: "width", value: width } }).render();
+}
+
+const eyeBoundsCache = new Map<string, EyeBounds>();
+
+/**
+ * Tight bounds of an eye style's artwork, measured by rasterizing it on its own
+ * and scanning for covered pixels. Measuring through the same rasterizer that
+ * writes the icons puts the bounds where the artwork is drawn rather than where
+ * its path data nominally reaches, and the result is a pure function of the
+ * path data, so the placement it feeds stays byte-reproducible.
+ */
+export function eyeArtworkBounds(eyeStyle: EyeStyle): EyeBounds {
+  const cached = eyeBoundsCache.get(eyeStyle.id);
+  if (cached) {
+    return cached;
+  }
+
+  const viewBox = eyeStyle.sourceViewBox;
+  const probeScale =
+    EYE_BOUNDS_PROBE_PX / Math.max(viewBox.width, viewBox.height);
+  const rendered = renderSvg(
+    eyePathsSvg(eyeStyle, `matrix(${probeScale},0,0,${probeScale},0,0)`),
+    Math.round(viewBox.width * probeScale),
+    Math.round(viewBox.height * probeScale),
+  );
+
+  // `pixels` materializes a fresh buffer per read, so it is read exactly once.
+  const pixels = rendered.pixels;
+  const width = rendered.width;
+  const height = rendered.height;
+  let minX = width;
+  let minY = height;
+  let maxX = -1;
+  let maxY = -1;
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (pixels[(y * width + x) * 4 + 3] === 0) {
+        continue;
+      }
+      if (x < minX) {
+        minX = x;
+      }
+      if (x > maxX) {
+        maxX = x;
+      }
+      if (y < minY) {
+        minY = y;
+      }
+      if (y > maxY) {
+        maxY = y;
+      }
+    }
+  }
+  if (maxX < minX || maxY < minY) {
+    throw new Error(`Eye style "${eyeStyle.id}" rasterized to nothing.`);
+  }
+
+  const bounds: EyeBounds = {
+    minX: minX / probeScale,
+    minY: minY / probeScale,
+    width: (maxX + 1 - minX) / probeScale,
+    height: (maxY + 1 - minY) / probeScale,
+  };
+  eyeBoundsCache.set(eyeStyle.id, bounds);
+  return bounds;
+}
+
+/** Fraction of the icon one style's pair spans. */
+export function eyeSpanFraction(eyeStyleId: string): number {
+  return EYE_SPAN_FRACTION_OVERRIDES[eyeStyleId] ?? DEFAULT_EYE_SPAN_FRACTION;
+}

--- a/clients/ios/scripts/generate-avatar-icons.ts
+++ b/clients/ios/scripts/generate-avatar-icons.ts
@@ -36,7 +36,24 @@ import { dirname, join, resolve, sep } from "node:path";
 import { deflateSync } from "node:zlib";
 
 import { getCharacterComponents } from "../../../packages/avatar-catalog/src/index.js";
-import { getResvg } from "../../../assistant/src/avatar/resvg-lazy.js";
+import {
+  eyeArtworkBounds,
+  eyePathsSvg,
+  eyeSpanFraction,
+  iconNameForTraits,
+  renderSvg,
+  traitCombinations,
+  type AvatarIconTraits,
+  type EyeStyle,
+  type IconSetScope,
+} from "./avatar-icon-core.js";
+
+export {
+  iconNameForTraits,
+  traitCombinations,
+  type AvatarIconTraits,
+  type IconSetScope,
+} from "./avatar-icon-core.js";
 
 const REPO_ROOT = resolve(import.meta.dir, "..", "..", "..");
 
@@ -64,31 +81,6 @@ const GENERATOR_COMMAND = "bun clients/ios/scripts/generate-avatar-icons.ts";
 /** Width and height of each rendered icon, in px. */
 const ICON_PX = 1024;
 
-/**
- * Fraction of the icon an eye pair's tight bounds span, for every style the
- * table below does not name.
- *
- * `clients/web/src/components/avatar/app-icon-preview.tsx` mirrors both this
- * number and the table, so its on-screen preview frames a pair the way the
- * shipped PNG does. Each side pins the numbers in its own tests, since a web
- * bundle cannot import a build script that rasterizes SVG. A span moves here
- * only alongside that file, and the catalog is regenerated with it.
- */
-const DEFAULT_EYE_SPAN_FRACTION = 0.5;
-
-/** Eye styles framed wider or narrower than {@link DEFAULT_EYE_SPAN_FRACTION}. */
-const EYE_SPAN_FRACTION_OVERRIDES: Record<string, number> = {
-  dazed: 0.55,
-  bashful: 0.4,
-};
-
-/**
- * Canvas the eye bounds below are measured on, in px. The scan reports whole
- * probe pixels, so each edge carries up to one of them as slack; this size
- * keeps that under a thousandth of the artwork.
- */
-const EYE_BOUNDS_PROBE_PX = 2048;
-
 const ICON_IMAGE_NAME = "icon.png";
 
 /** Bytes every PNG opens with. */
@@ -110,14 +102,6 @@ const PNG_DEFLATE_LEVEL = 9;
 const CATALOG_INFO = { author: "xcode", version: 1 };
 
 /**
- * `--pilot` narrows a local run to a 12-set slice, which rasterizes in a couple
- * of seconds. `grumpy` is the widest, flattest eye pair in the library and
- * `gentle` the closest to square, so between them they cover both ends of what
- * the placement below has to fit.
- */
-const PILOT_EYE_STYLES = ["grumpy", "gentle"];
-
-/**
  * Contact sheet cell size, in px. 180 is the largest size iOS ever draws an app
  * icon at, so the preview shows the artwork at the size it is read.
  */
@@ -126,61 +110,10 @@ const CONTACT_SHEET_CELL_PX = 180;
 /** Every color in the palette is a 6-digit sRGB hex, and goes straight to SVG. */
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 
-export type IconSetScope = "pilot" | "full";
-
-export interface AvatarIconTraits {
-  eyeStyle: string;
-  color: string;
-}
-
-type EyeStyle = ReturnType<typeof getCharacterComponents>["eyeStyles"][number];
-
-/** Tight bounds of an eye style's artwork, in its own source viewBox units. */
-interface EyeBounds {
-  minX: number;
-  minY: number;
-  width: number;
-  height: number;
-}
-
 export interface GenerateAvatarIconsOptions {
   iconsDir: string;
   xcconfigPath: string;
   scope: IconSetScope;
-}
-
-/**
- * Icon set name for an eye style and color. The web layer derives the same name
- * when it asks iOS to switch icons, so this format is a wire contract: changing
- * it breaks every already-installed app until both sides ship together. Body
- * shape is deliberately absent, since the icons draw eyes on a color field and
- * no body.
- *
- * The name is also a cache key: iOS caches an alternate icon's artwork under
- * it, so each name permanently identifies one artwork version. Changed art
- * goes out under a new versioned name, never behind an existing one.
- */
-export function iconNameForTraits(traits: AvatarIconTraits): string {
-  return `avatar-eyes-${traits.eyeStyle}-${traits.color}`;
-}
-
-/** Trait pairs in scope, in a stable eye, color order. */
-export function traitCombinations(scope: IconSetScope): AvatarIconTraits[] {
-  const components = getCharacterComponents();
-  const allEyeStyles = components.eyeStyles.map((eye) => eye.id);
-
-  const eyeStyles =
-    scope === "full"
-      ? allEyeStyles
-      : assertKnownIds(PILOT_EYE_STYLES, allEyeStyles, "eye style");
-
-  const combinations: AvatarIconTraits[] = [];
-  for (const eyeStyle of eyeStyles) {
-    for (const color of components.colors) {
-      combinations.push({ eyeStyle, color: color.id });
-    }
-  }
-  return combinations;
 }
 
 /**
@@ -212,21 +145,6 @@ export function generateAvatarIcons(
   writeFileSync(options.xcconfigPath, buildXcconfig());
 
   return names;
-}
-
-function assertKnownIds(
-  requested: string[],
-  known: string[],
-  label: string,
-): string[] {
-  for (const id of requested) {
-    if (!known.includes(id)) {
-      throw new Error(
-        `Unknown ${label}: "${id}". Valid IDs: ${known.join(", ")}`,
-      );
-    }
-  }
-  return requested;
 }
 
 function colorHexIndex(): Map<string, string> {
@@ -302,86 +220,6 @@ function buildXcconfig(): string {
   ].join("\n");
 }
 
-/** An eye style's paths, verbatim, under one shared affine transform. */
-function eyePathsSvg(eyeStyle: EyeStyle, transform: string): string {
-  return eyeStyle.paths
-    .map(
-      (path) =>
-        `<path d="${path.svgPath}" fill="${path.color}" transform="${transform}"/>`,
-    )
-    .join("");
-}
-
-const eyeBoundsCache = new Map<string, EyeBounds>();
-
-/**
- * Tight bounds of an eye style's artwork, measured by rasterizing it on its own
- * and scanning for covered pixels. Measuring through the same rasterizer that
- * writes the icons puts the bounds where the artwork is drawn rather than where
- * its path data nominally reaches, and the result is a pure function of the
- * path data, so the placement it feeds stays byte-reproducible.
- */
-function eyeArtworkBounds(eyeStyle: EyeStyle): EyeBounds {
-  const cached = eyeBoundsCache.get(eyeStyle.id);
-  if (cached) {
-    return cached;
-  }
-
-  const viewBox = eyeStyle.sourceViewBox;
-  const probeScale =
-    EYE_BOUNDS_PROBE_PX / Math.max(viewBox.width, viewBox.height);
-  const rendered = renderSvg(
-    eyePathsSvg(eyeStyle, `matrix(${probeScale},0,0,${probeScale},0,0)`),
-    Math.round(viewBox.width * probeScale),
-    Math.round(viewBox.height * probeScale),
-  );
-
-  // `pixels` materializes a fresh buffer per read, so it is read exactly once.
-  const pixels = rendered.pixels;
-  const width = rendered.width;
-  const height = rendered.height;
-  let minX = width;
-  let minY = height;
-  let maxX = -1;
-  let maxY = -1;
-  for (let y = 0; y < height; y += 1) {
-    for (let x = 0; x < width; x += 1) {
-      if (pixels[(y * width + x) * 4 + 3] === 0) {
-        continue;
-      }
-      if (x < minX) {
-        minX = x;
-      }
-      if (x > maxX) {
-        maxX = x;
-      }
-      if (y < minY) {
-        minY = y;
-      }
-      if (y > maxY) {
-        maxY = y;
-      }
-    }
-  }
-  if (maxX < minX || maxY < minY) {
-    throw new Error(`Eye style "${eyeStyle.id}" rasterized to nothing.`);
-  }
-
-  const bounds: EyeBounds = {
-    minX: minX / probeScale,
-    minY: minY / probeScale,
-    width: (maxX + 1 - minX) / probeScale,
-    height: (maxY + 1 - minY) / probeScale,
-  };
-  eyeBoundsCache.set(eyeStyle.id, bounds);
-  return bounds;
-}
-
-/** Fraction of the icon one style's pair spans. */
-function eyeSpanFraction(eyeStyleId: string): number {
-  return EYE_SPAN_FRACTION_OVERRIDES[eyeStyleId] ?? DEFAULT_EYE_SPAN_FRACTION;
-}
-
 /**
  * One solid trait-color square with the eye pair centered on it, as SVG markup.
  * Shared by the icons themselves and by the contact sheet, so the preview shows
@@ -413,14 +251,6 @@ function iconCellSvg(
       `matrix(${scale},0,0,${scale},${translateX},${translateY})`,
     )
   );
-}
-
-function renderSvg(body: string, width: number, height: number) {
-  const svg =
-    `<svg xmlns="http://www.w3.org/2000/svg" ` +
-    `width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">${body}</svg>`;
-  const Resvg = getResvg();
-  return new Resvg(svg, { fitTo: { mode: "width", value: width } }).render();
 }
 
 function rasterize(body: string, width: number, height: number): Buffer {


### PR DESCRIPTION
## Summary
- Moves iconNameForTraits, traitCombinations, eye bounds measurement, and the span table into clients/ios/scripts/avatar-icon-core.ts, re-exported by the iOS generator
- Adds androidResourceNameForTraits (underscore form) plus an underscore-safety guard over the library ids

Part of plan: android-avatar-app-icons.md (PR 1 of 8)