### PR TITLE
feat(assistant): expose plugin companion entrypoints on the plugins list

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24842,8 +24842,8 @@ paths:
                               id:
                                 type: string
                                 description:
-                                  Globally unique entrypoint id, namespaced as `<pluginId>:<entrypointId>`. Already composed by the daemon,
-                                  so a client never has to build it.
+                                  Globally unique entrypoint id, namespaced as `<pluginId>:<entrypointId>`. Already composed by the
+                                  assistant, so a client never has to build it.
                               label:
                                 type: string
                                 description: Short control label the client draws.

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24750,7 +24750,10 @@ paths:
         and description. Each entry carries a `category` (marketplace slug from the Skills taxonomy, or `null` for
         non-marketplace installs); the response also reports `categoryCounts` (per-category totals, computed before the
         category filter) and `totalCount`. `?category=<slug>` filters the returned plugins by category server-side while
-        leaving the counts unfiltered. A marketplace outage degrades `category` to `null` without failing the list.
+        leaving the counts unfiltered. A marketplace outage degrades `category` to `null` without failing the list. An
+        enabled plugin that declares `companionEntrypoints` in its `package.json` also carries `entrypoints`, each id
+        already namespaced as `<pluginId>:<entrypointId>`; the field is omitted for a plugin that declares none and for
+        a disabled plugin.
       tags:
         - plugins
       parameters:
@@ -24828,6 +24831,33 @@ paths:
                             Content hash of the validated `icon.png`; present only when `hasIcon` is true. Use it as a cache-buster for
                             the bundled-icon endpoint.
                           type: string
+                        entrypoints:
+                          description:
+                            Companion-surface controls the plugin contributes, from its `package.json` `companionEntrypoints`. Omitted
+                            entirely when the plugin declares none, and never returned for a disabled plugin.
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                                description:
+                                  Globally unique entrypoint id, namespaced as `<pluginId>:<entrypointId>`. Already composed by the daemon,
+                                  so a client never has to build it.
+                              label:
+                                type: string
+                                description: Short control label the client draws.
+                              icon:
+                                description: Author-declared icon name; absent when the plugin declares none.
+                                type: string
+                              prompt:
+                                type: string
+                                description: Message text to submit when the control is pressed.
+                            required:
+                              - id
+                              - label
+                              - prompt
+                            additionalProperties: false
                       required:
                         - id
                         - name

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24834,7 +24834,9 @@ paths:
                         entrypoints:
                           description:
                             Companion-surface controls the plugin contributes, from its `package.json` `companionEntrypoints`. Omitted
-                            entirely when the plugin declares none, and never returned for a disabled plugin.
+                            entirely when the plugin declares none, and never returned for a disabled plugin. An
+                            individual control whose namespaced id would exceed the companion surface's id bound is left
+                            out; the rest still come through.
                           type: array
                           items:
                             type: object

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -12,6 +12,9 @@
  *   - `categoryCounts` / `totalCount` computed before the `?category=` filter
  *   - `?category=` filters the list while counts stay unfiltered
  *   - A catalog fetch failure degrades `category` to null without erroring
+ *   - `entrypoints` read from the plugin's `companionEntrypoints`, ids
+ *     namespaced `<pluginId>:<entrypointId>`; omitted for a plugin declaring
+ *     none and for a disabled plugin
  *
  * GET /v1/plugins/search (catalog search):
  *   - Resolves the catalog for `?ref=` and filters it by `?q=`
@@ -925,6 +928,95 @@ describe("GET /v1/plugins", () => {
     // The plugin is still counted (under "system"), just not reachable as
     // "memory" — counts match visible rows.
     expect(result.categoryCounts).toEqual({ system: 1 });
+  });
+
+  describe("companion entrypoints", () => {
+    const created: string[] = [];
+
+    afterEach(() => {
+      for (const dir of created.splice(0)) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    /**
+     * Materialize `<workspacePlugins>/<name>/package.json` and return an
+     * `InstalledPluginInfo` pointing at it, so the route's real
+     * `parsePluginManifest` read is exercised rather than mocked.
+     */
+    function pluginWithManifest(
+      name: string,
+      pkg: Record<string, unknown>,
+    ): InstalledPluginInfo {
+      const dir = join(getWorkspacePluginsDir(), name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name, ...pkg }),
+      );
+      created.push(dir);
+      return pluginEntry({
+        name,
+        target: dir,
+        packageJson: { name, version: "1.0.0" },
+      });
+    }
+
+    test("returns declared entrypoints with ids namespaced by plugin id", async () => {
+      installedFixture = [
+        pluginWithManifest("notes", {
+          companionEntrypoints: [
+            {
+              id: "new-note",
+              label: "New note",
+              icon: "pencil",
+              prompt: "Start a new note",
+            },
+            { id: "daily", label: "Daily", prompt: "Show me today's notes" },
+          ],
+        }),
+      ];
+
+      const [entry] = (await invoke()).plugins;
+      expect(entry?.entrypoints).toEqual([
+        {
+          id: "notes:new-note",
+          label: "New note",
+          icon: "pencil",
+          prompt: "Start a new note",
+        },
+        // No `icon` declared → omitted from the wire object, not null.
+        { id: "notes:daily", label: "Daily", prompt: "Show me today's notes" },
+      ]);
+    });
+
+    test("omits the field for a plugin that declares none", async () => {
+      installedFixture = [
+        pluginWithManifest("plain", {}),
+        // An explicitly empty declaration is "none contributed" too: absence is
+        // the contract, so no plugin ever carries an empty array.
+        pluginWithManifest("empty", { companionEntrypoints: [] }),
+      ];
+
+      const byId = new Map((await invoke()).plugins.map((p) => [p.id, p]));
+      expect("entrypoints" in byId.get("plain")!).toBe(false);
+      expect("entrypoints" in byId.get("empty")!).toBe(false);
+    });
+
+    test("contributes nothing for a disabled plugin", async () => {
+      installedFixture = [
+        pluginWithManifest("notes", {
+          companionEntrypoints: [
+            { id: "new-note", label: "New note", prompt: "Start a new note" },
+          ],
+        }),
+      ];
+      disabledFixture.add("notes");
+
+      const [entry] = (await invoke()).plugins;
+      expect(entry?.enabled).toBe(false);
+      expect("entrypoints" in entry!).toBe(false);
+    });
   });
 });
 
@@ -2759,7 +2851,9 @@ describe("POST /v1/plugins/:name/disable", () => {
       toggleResult(name, "disable"),
     );
 
-    const result = await invokeDisable({ pathParams: { name: "simple-memory" } });
+    const result = await invokeDisable({
+      pathParams: { name: "simple-memory" },
+    });
 
     expect(result).toEqual({ ok: true });
     expect(disablePluginSpy.mock.calls[0]?.[0]).toBe("simple-memory");

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -16,6 +16,9 @@
  *     namespaced `<pluginId>:<entrypointId>`; omitted for a plugin declaring
  *     none, for a disabled plugin, and for a plugin directory that resolves
  *     outside the plugins root (the loader would refuse to activate it)
+ *   - A single `entrypoints` entry whose namespaced id would exceed the
+ *     companion's id cap is dropped on its own, leaving the plugin listed and
+ *     its other entrypoints intact
  *
  * GET /v1/plugins/search (catalog search):
  *   - Resolves the catalog for `?ref=` and filters it by `?q=`
@@ -63,6 +66,8 @@
 import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { COMPANION_ENTRYPOINT_ID_MAX_LENGTH } from "@vellumai/service-contracts/companion-entrypoints";
 
 import {
   type DiffPluginDeps,
@@ -1016,6 +1021,52 @@ describe("GET /v1/plugins", () => {
 
       const [entry] = (await invoke()).plugins;
       expect(entry?.enabled).toBe(false);
+      expect("entrypoints" in entry!).toBe(false);
+    });
+
+    test("drops only the entry whose namespaced id exceeds the cap", async () => {
+      // A legal 40-character entrypoint id under a directory name this long
+      // composes one character past the cap the companion validates its whole
+      // context snapshot against. Nothing bounds the directory name, so the
+      // composition is where the bound has to be enforced.
+      const overCapId = "a".repeat(40);
+      const name = "n".repeat(
+        COMPANION_ENTRYPOINT_ID_MAX_LENGTH - overCapId.length,
+      );
+      installedFixture = [
+        pluginWithManifest(name, {
+          companionEntrypoints: [
+            { id: overCapId, label: "Too long", prompt: "Never drawn" },
+            { id: "go", label: "Go", prompt: "Do the thing" },
+          ],
+        }),
+      ];
+
+      const [entry] = (await invoke()).plugins;
+      // Still listed and enabled, and the entry that fits still comes through:
+      // one over-long id must not cost the plugin its other controls.
+      expect(entry?.enabled).toBe(true);
+      expect(entry?.entrypoints).toEqual([
+        { id: `${name}:go`, label: "Go", prompt: "Do the thing" },
+      ]);
+    });
+
+    test("omits the field when every namespaced id exceeds the cap", async () => {
+      const overCapId = "a".repeat(40);
+      const name = "n".repeat(
+        COMPANION_ENTRYPOINT_ID_MAX_LENGTH - overCapId.length,
+      );
+      installedFixture = [
+        pluginWithManifest(name, {
+          companionEntrypoints: [
+            { id: overCapId, label: "Too long", prompt: "Never drawn" },
+          ],
+        }),
+      ];
+
+      const [entry] = (await invoke()).plugins;
+      expect(entry?.enabled).toBe(true);
+      // Absence, not an empty array: same shape as declaring none.
       expect("entrypoints" in entry!).toBe(false);
     });
 

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -14,7 +14,8 @@
  *   - A catalog fetch failure degrades `category` to null without erroring
  *   - `entrypoints` read from the plugin's `companionEntrypoints`, ids
  *     namespaced `<pluginId>:<entrypointId>`; omitted for a plugin declaring
- *     none and for a disabled plugin
+ *     none, for a disabled plugin, and for a plugin directory that resolves
+ *     outside the plugins root (the loader would refuse to activate it)
  *
  * GET /v1/plugins/search (catalog search):
  *   - Resolves the catalog for `?ref=` and filters it by `?q=`
@@ -59,7 +60,7 @@
  * here we mock them to isolate the route's wiring logic.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -1015,6 +1016,43 @@ describe("GET /v1/plugins", () => {
 
       const [entry] = (await invoke()).plugins;
       expect(entry?.enabled).toBe(false);
+      expect("entrypoints" in entry!).toBe(false);
+    });
+
+    test("contributes nothing for a directory resolving outside the plugin root", async () => {
+      // The listing follows a symlinked entry wherever it points, but boot
+      // discovery rejects a plugin directory that resolves outside `plugins/`.
+      // Such a plugin can never activate, so its declared controls would
+      // submit prompts into a surface nothing serves.
+      const pluginsDir = getWorkspacePluginsDir();
+      mkdirSync(pluginsDir, { recursive: true });
+      const outside = join(pluginsDir, "..", "outside-plugins");
+      mkdirSync(outside, { recursive: true });
+      writeFileSync(
+        join(outside, "package.json"),
+        JSON.stringify({
+          name: "escapee",
+          companionEntrypoints: [
+            { id: "go", label: "Go", prompt: "Do the thing" },
+          ],
+        }),
+      );
+      const link = join(pluginsDir, "escapee");
+      symlinkSync(outside, link, "dir");
+      // Remove the target before the link so neither cleanup follows it.
+      created.push(outside, link);
+
+      installedFixture = [
+        pluginEntry({
+          name: "escapee",
+          target: link,
+          packageJson: { name: "escapee", version: "1.0.0" },
+        }),
+      ];
+
+      const [entry] = (await invoke()).plugins;
+      // Still listed and enabled: only the entrypoints are withheld.
+      expect(entry?.enabled).toBe(true);
       expect("entrypoints" in entry!).toBe(false);
     });
   });

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -93,6 +93,7 @@ import { getPlatformBaseUrl } from "../../config/env.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { ensurePluginApiShim } from "../../plugins/ensure-plugin-api-shim.js";
 import { parsePluginManifest } from "../../plugins/external-plugin-loader.js";
+import { isInsidePluginRoot } from "../../plugins/installed-plugin-dirs.js";
 import {
   deactivatePluginForUpdate,
   reconcilePluginSourcesNow,
@@ -124,7 +125,7 @@ const pluginCompanionEntrypointSchema = z.object({
   id: z
     .string()
     .describe(
-      "Globally unique entrypoint id, namespaced as `<pluginId>:<entrypointId>`. Already composed by the daemon, so a client never has to build it.",
+      "Globally unique entrypoint id, namespaced as `<pluginId>:<entrypointId>`. Already composed by the assistant, so a client never has to build it.",
     ),
   label: z.string().describe("Short control label the client draws."),
   icon: z
@@ -850,13 +851,21 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
  * has to know the composition rule. A disabled plugin contributes nothing (its
  * prompts would submit into a surface the plugin cannot serve), and a plugin
  * declaring none keeps the field absent rather than carrying an empty array.
+ *
+ * A plugin directory the loader would refuse contributes nothing either. The
+ * listing follows a symlinked entry wherever it points, while boot discovery
+ * only activates a directory that resolves inside the plugins root, so the
+ * loader's own containment predicate ({@link isInsidePluginRoot}) runs here
+ * too: without it the companion could draw controls whose prompts have no
+ * plugin surface behind them.
  */
 async function attachCompanionEntrypoints(
   plugins: PluginView[],
 ): Promise<PluginView[]> {
+  const pluginsDir = getWorkspacePluginsDir();
   return Promise.all(
     plugins.map(async (plugin) => {
-      if (!plugin.enabled) {
+      if (!plugin.enabled || !isInsidePluginRoot(plugin.path, pluginsDir)) {
         return plugin;
       }
       // `quiet` because an unreadable or schema-invalid `package.json` is

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -26,6 +26,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { COMPANION_ENTRYPOINT_ID_MAX_LENGTH } from "@vellumai/service-contracts/companion-entrypoints";
 import { z } from "zod";
 
 import {
@@ -198,7 +199,7 @@ const pluginInfoSchema = z.object({
     .array(pluginCompanionEntrypointSchema)
     .optional()
     .describe(
-      "Companion-surface controls the plugin contributes, from its `package.json` `companionEntrypoints`. Omitted entirely when the plugin declares none, and never returned for a disabled plugin.",
+      "Companion-surface controls the plugin contributes, from its `package.json` `companionEntrypoints`. Omitted entirely when the plugin declares none, and never returned for a disabled plugin. An individual control whose namespaced id would exceed the companion surface's id bound is left out; the rest still come through.",
     ),
 });
 
@@ -858,6 +859,13 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
  * loader's own containment predicate ({@link isInsidePluginRoot}) runs here
  * too: without it the companion could draw controls whose prompts have no
  * plugin surface behind them.
+ *
+ * A composed id longer than {@link COMPANION_ENTRYPOINT_ID_MAX_LENGTH} is
+ * dropped on its own. Nothing caps a plugin's directory name, so a long enough
+ * one plus a legal 40-character entrypoint id composes past the bound the
+ * companion validates its whole context snapshot against, where a single
+ * over-long id would take every other plugin's entrypoints down with it. The
+ * plugin stays listed and keeps whichever of its entrypoints do fit.
  */
 async function attachCompanionEntrypoints(
   plugins: PluginView[],
@@ -875,15 +883,37 @@ async function attachCompanionEntrypoints(
       if (declared === undefined || declared.length === 0) {
         return plugin;
       }
-      return {
-        ...plugin,
-        entrypoints: declared.map((entry) => ({
-          id: `${plugin.id}:${entry.id}`,
-          label: entry.label,
-          prompt: entry.prompt,
-          ...(entry.icon !== undefined ? { icon: entry.icon } : {}),
-        })),
-      };
+      const entrypoints = declared.flatMap((entry) => {
+        const id = `${plugin.id}:${entry.id}`;
+        if (id.length > COMPANION_ENTRYPOINT_ID_MAX_LENGTH) {
+          // Warn rather than drop silently: the plugin is well-formed and its
+          // author cannot see the composed id, so the only clue that a control
+          // is missing from the surface is this line.
+          log.warn(
+            {
+              pluginId: plugin.id,
+              entrypointId: entry.id,
+              idLength: id.length,
+            },
+            "Namespaced companion entrypoint id exceeds the surface's cap; dropping the entrypoint",
+          );
+          return [];
+        }
+        return [
+          {
+            id,
+            label: entry.label,
+            prompt: entry.prompt,
+            ...(entry.icon !== undefined ? { icon: entry.icon } : {}),
+          },
+        ];
+      });
+      // Same shape as declaring none: an empty array would have the client
+      // reason about a plugin that contributes nothing.
+      if (entrypoints.length === 0) {
+        return plugin;
+      }
+      return { ...plugin, entrypoints };
     }),
   );
 }

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -92,6 +92,7 @@ import {
 import { getPlatformBaseUrl } from "../../config/env.js";
 import { isPluginDisabled } from "../../plugins/disabled-state.js";
 import { ensurePluginApiShim } from "../../plugins/ensure-plugin-api-shim.js";
+import { parsePluginManifest } from "../../plugins/external-plugin-loader.js";
 import {
   deactivatePluginForUpdate,
   reconcilePluginSourcesNow,
@@ -118,6 +119,24 @@ import { RouteResponse } from "./types.js";
 // ---------------------------------------------------------------------------
 // Schema
 // ---------------------------------------------------------------------------
+
+const pluginCompanionEntrypointSchema = z.object({
+  id: z
+    .string()
+    .describe(
+      "Globally unique entrypoint id, namespaced as `<pluginId>:<entrypointId>`. Already composed by the daemon, so a client never has to build it.",
+    ),
+  label: z.string().describe("Short control label the client draws."),
+  icon: z
+    .string()
+    .optional()
+    .describe(
+      "Author-declared icon name; absent when the plugin declares none.",
+    ),
+  prompt: z
+    .string()
+    .describe("Message text to submit when the control is pressed."),
+});
 
 const pluginInfoSchema = z.object({
   id: z
@@ -173,6 +192,12 @@ const pluginInfoSchema = z.object({
     .optional()
     .describe(
       "Content hash of the validated `icon.png`; present only when `hasIcon` is true. Use it as a cache-buster for the bundled-icon endpoint.",
+    ),
+  entrypoints: z
+    .array(pluginCompanionEntrypointSchema)
+    .optional()
+    .describe(
+      "Companion-surface controls the plugin contributes, from its `package.json` `companionEntrypoints`. Omitted entirely when the plugin declares none, and never returned for a disabled plugin.",
     ),
 });
 
@@ -766,6 +791,14 @@ function logPluginCatalogUnavailable(
   );
 }
 
+/** Wire shape for one contributed control. Mirrors {@link pluginCompanionEntrypointSchema}. */
+interface PluginCompanionEntrypointView {
+  id: string;
+  label: string;
+  icon?: string;
+  prompt: string;
+}
+
 interface PluginView {
   id: string;
   name: string;
@@ -778,6 +811,7 @@ interface PluginView {
   icon?: string;
   hasIcon: boolean;
   iconVersion?: string;
+  entrypoints?: PluginCompanionEntrypointView[];
 }
 
 function projectPlugin(entry: InstalledPluginInfo): PluginView {
@@ -804,6 +838,45 @@ function projectPlugin(entry: InstalledPluginInfo): PluginView {
     view.iconVersion = entry.iconVersion;
   }
   return view;
+}
+
+/**
+ * Attach each plugin's contributed companion entrypoints, read from its
+ * `package.json` through the loader's own validated parser so the route and
+ * the running plugin agree on what a well-formed declaration is.
+ *
+ * Ids are namespaced as `<pluginId>:<entrypointId>` here rather than by the
+ * client: it makes them unique across plugins by construction, and no consumer
+ * has to know the composition rule. A disabled plugin contributes nothing (its
+ * prompts would submit into a surface the plugin cannot serve), and a plugin
+ * declaring none keeps the field absent rather than carrying an empty array.
+ */
+async function attachCompanionEntrypoints(
+  plugins: PluginView[],
+): Promise<PluginView[]> {
+  return Promise.all(
+    plugins.map(async (plugin) => {
+      if (!plugin.enabled) {
+        return plugin;
+      }
+      // `quiet` because an unreadable or schema-invalid `package.json` is
+      // already surfaced on this entry's `issues`; the list must not error.
+      const manifest = await parsePluginManifest(plugin.path, { quiet: true });
+      const declared = manifest?.companionEntrypoints;
+      if (declared === undefined || declared.length === 0) {
+        return plugin;
+      }
+      return {
+        ...plugin,
+        entrypoints: declared.map((entry) => ({
+          id: `${plugin.id}:${entry.id}`,
+          label: entry.label,
+          prompt: entry.prompt,
+          ...(entry.icon !== undefined ? { icon: entry.icon } : {}),
+        })),
+      };
+    }),
+  );
 }
 
 /**
@@ -1032,7 +1105,13 @@ async function handleListPlugins({
     list = list.filter((p) => (p.category ?? UNCATEGORIZED) === category);
   }
 
-  return { plugins: list, categoryCounts, totalCount };
+  // Read the contributed entrypoints last, over the filtered list only, so a
+  // narrow query never pays a manifest read for a plugin it drops.
+  return {
+    plugins: await attachCompanionEntrypoints(list),
+    categoryCounts,
+    totalCount,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1748,7 +1827,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "List installed plugins",
     description:
-      "Return one entry per directory under `<workspaceDir>/plugins/`, sorted alphabetically. Matches the CLI's `assistant plugins list`. Supports `?q=<text>` for case-insensitive substring matching across plugin id, name, and description. Each entry carries a `category` (marketplace slug from the Skills taxonomy, or `null` for non-marketplace installs); the response also reports `categoryCounts` (per-category totals, computed before the category filter) and `totalCount`. `?category=<slug>` filters the returned plugins by category server-side while leaving the counts unfiltered. A marketplace outage degrades `category` to `null` without failing the list.",
+      "Return one entry per directory under `<workspaceDir>/plugins/`, sorted alphabetically. Matches the CLI's `assistant plugins list`. Supports `?q=<text>` for case-insensitive substring matching across plugin id, name, and description. Each entry carries a `category` (marketplace slug from the Skills taxonomy, or `null` for non-marketplace installs); the response also reports `categoryCounts` (per-category totals, computed before the category filter) and `totalCount`. `?category=<slug>` filters the returned plugins by category server-side while leaving the counts unfiltered. A marketplace outage degrades `category` to `null` without failing the list. An enabled plugin that declares `companionEntrypoints` in its `package.json` also carries `entrypoints`, each id already namespaced as `<pluginId>:<entrypointId>`; the field is omitted for a plugin that declares none and for a disabled plugin.",
     tags: ["plugins"],
     queryParams: [
       {

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -13,6 +13,7 @@
  *   - Preload / renderer: type-only imports; schemas are never bundled
  *     into the preload or renderer.
  */
+import { COMPANION_ENTRYPOINT_ID_MAX_LENGTH } from "@vellumai/service-contracts/companion-entrypoints";
 import { z } from "zod";
 
 import {
@@ -107,9 +108,14 @@ export const companionTurnsSchema = z.array(companionTurnSchema).max(40);
  * end up on a window that floats over every other app. `label` is bounded to
  * what a pill can hold, `prompt` to what a composer would accept from a person,
  * and `icon` is a name the surface looks up rather than anything it renders.
+ *
+ * The id cap comes from `@vellumai/service-contracts` rather than a literal
+ * here: the assistant composes these ids as `<pluginId>:<entrypointId>` and has
+ * to enforce the same bound, because this schema validates a whole context
+ * snapshot and one over-long id would fail every entrypoint in it.
  */
 export const companionEntrypointSchema = z.object({
-  id: z.string().min(1).max(128),
+  id: z.string().min(1).max(COMPANION_ENTRYPOINT_ID_MAX_LENGTH),
   label: z.string().min(1).max(24),
   icon: z.string().max(64).optional(),
   prompt: z.string().min(1).max(2000),

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./channels": "./src/channels.ts",
+    "./companion-entrypoints": "./src/companion-entrypoints.ts",
     "./conversation-handle": "./src/conversation-handle.ts",
     "./client-metadata": "./src/client-metadata.ts",
     "./credential-rpc": "./src/credential-rpc.ts",

--- a/packages/service-contracts/src/companion-entrypoints.ts
+++ b/packages/service-contracts/src/companion-entrypoints.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared bound on a companion-surface entrypoint id.
+ *
+ * This constant lives in the lowest shared layer because two sides that do not
+ * depend on each other have to agree on it: the assistant composes the
+ * namespaced id (`<pluginId>:<entrypointId>`) when it lists plugins, and
+ * `@vellumai/ipc-contract`'s `companionEntrypointSchema` validates the whole
+ * context snapshot against this cap before the surface is updated. Validation
+ * is all-or-nothing on that snapshot, so a single over-long id would drop
+ * every entrypoint rather than its own; the composing side has to enforce the
+ * same number the validating side checks.
+ *
+ * 128 is generous next to the ~40 characters a plugin may declare for its own
+ * half of the id: it is a bound on what crosses the boundary, not a budget the
+ * surface draws against.
+ */
+export const COMPANION_ENTRYPOINT_ID_MAX_LENGTH = 128;

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -20,6 +20,7 @@
 
 export * from "./channels.js";
 export * from "./client-metadata.js";
+export * from "./companion-entrypoints.js";
 export * from "./conversation-handle.js";
 export * from "./transport.js";
 export * from "./error.js";


### PR DESCRIPTION
## Summary

- `GET /v1/plugins` now carries an optional `entrypoints` array per installed plugin, read from its `package.json` `companionEntrypoints` through the loader's own validated parser.
- Ids are namespaced as `<pluginId>:<entrypointId>` server-side, so they are unique across plugins by construction and no client has to compose them.
- The field is omitted entirely for a plugin that declares none (never `[]`) and for a disabled plugin; `openapi.yaml` is regenerated so the generated daemon client types pick it up.

Part of plan: companion-plugin-entrypoints.md (PR 5 of 9)