### PR TITLE
refactor(persistence): use drizzle's text enum for the status columns

### DIFF
--- a/assistant/src/persistence/delivery-status.ts
+++ b/assistant/src/persistence/delivery-status.ts
@@ -14,7 +14,26 @@ import {
   RETRY_MAX_ATTEMPTS,
   retryDelayForAttempt,
 } from "./job-utils.js";
+import type { ChannelDeliveryStatus } from "./schema.js";
 import { channelInboundEvents } from "./schema.js";
+
+/**
+ * Whether a delivery status means the row owes no further delivery.
+ *
+ * A total map over the union rather than a `!== "pending"` comparison: adding
+ * a status is then a compile error until its terminality is decided, and that
+ * decision is load-bearing. `isDeduplicatedDeliveryOwnedBySibling` reads it to
+ * decide whether a sibling event already owns this turn's reply, and the
+ * stranded-delivery recovery step treats a non-terminal row as a reply still
+ * owed. A new status silently defaulting to one side or the other either
+ * double-posts a reply or drops one.
+ */
+const DELIVERY_STATUS_IS_TERMINAL: Record<ChannelDeliveryStatus, boolean> = {
+  pending: false,
+  delivered: true,
+  failed: true,
+  dead_letter: true,
+};
 
 /**
  * How long {@link deferRetryUntilIdle} pushes `retryAfter` forward. Shorter than
@@ -327,7 +346,7 @@ export function getRetryableDeliveryEvents(limit = 20): Array<{
 export function getSiblingEventDeliveryStatuses(
   messageId: string,
   excludeEventId: string,
-): string[] {
+): ChannelDeliveryStatus[] {
   const db = getDb();
   return db
     .select({ deliveryStatus: channelInboundEvents.deliveryStatus })
@@ -355,7 +374,7 @@ export function isDeduplicatedDeliveryOwnedBySibling(
   excludeEventId: string,
 ): boolean {
   return getSiblingEventDeliveryStatuses(messageId, excludeEventId).some(
-    (status) => status !== "pending",
+    (status) => DELIVERY_STATUS_IS_TERMINAL[status],
   );
 }
 

--- a/assistant/src/persistence/schema/conversations.ts
+++ b/assistant/src/persistence/schema/conversations.ts
@@ -289,18 +289,23 @@ export const conversationCompactionEvents = sqliteTable(
  * off it, including the paths that finish WITHOUT delivering: recovery reads a
  * lingering `pending` as a reply still owed. See `runtime/AGENTS.md`.
  */
-export type ChannelDeliveryStatus =
-  | "pending"
-  | "delivered"
-  | "failed"
-  | "dead_letter";
+export const CHANNEL_DELIVERY_STATUSES = [
+  "pending",
+  "delivered",
+  "failed",
+  "dead_letter",
+] as const;
+export type ChannelDeliveryStatus = (typeof CHANNEL_DELIVERY_STATUSES)[number];
 
 /** Lifecycle of a channel inbound event's agent-turn processing. */
+export const CHANNEL_PROCESSING_STATUSES = [
+  "pending",
+  "processed",
+  "failed",
+  "dead_letter",
+] as const;
 export type ChannelProcessingStatus =
-  | "pending"
-  | "processed"
-  | "failed"
-  | "dead_letter";
+  (typeof CHANNEL_PROCESSING_STATUSES)[number];
 
 export const channelInboundEvents = sqliteTable("channel_inbound_events", {
   id: text("id").primaryKey(),
@@ -314,12 +319,12 @@ export const channelInboundEvents = sqliteTable("channel_inbound_events", {
   messageId: text("message_id").references(() => messages.id, {
     onDelete: "cascade",
   }),
-  deliveryStatus: text("delivery_status")
-    .$type<ChannelDeliveryStatus>()
+  deliveryStatus: text("delivery_status", { enum: CHANNEL_DELIVERY_STATUSES })
     .notNull()
     .default("pending"),
-  processingStatus: text("processing_status")
-    .$type<ChannelProcessingStatus>()
+  processingStatus: text("processing_status", {
+    enum: CHANNEL_PROCESSING_STATUSES,
+  })
     .notNull()
     .default("pending"),
   processingAttempts: integer("processing_attempts").notNull().default(0),


### PR DESCRIPTION
Follow-up to #41877, which merged before its review was addressed. Two things: it used the wrong drizzle mechanism, and it left a Codex P2 unanswered.

## 1. Wrong mechanism

#41877 narrowed the status columns with `$type<>()`. That is the escape hatch, not the tool for this job.

Drizzle documents `{ enum: [...] }` as the way to restrict a text column to a fixed set of values, and `$type<>()` for serialized or branded shapes (its examples are `blob().$type<Data>()`). This schema already had a precedent doing it the documented way, `contacts.contact_type`, which I missed because I grepped for `$type<` (the mechanism I had already picked) instead of for the problem.

Both columns now use `{ enum: [...] }`. The values live in exported `as const` arrays with the unions derived from them, so the column and its type cannot drift.

## 2. The unanswered review

Codex's P2 on #41877: a union catches misspellings, but adding a member does not force existing readers to handle it.

That half is correct and is now closed. `DELIVERY_STATUS_IS_TERMINAL` is a total `Record` over the union, so a new status fails to compile until its terminality is decided. It is live, not decorative: `isDeduplicatedDeliveryOwnedBySibling` reads it instead of comparing against the `"pending"` literal, which is what that comparison always meant. Getting that decision wrong for a new status either double-posts a reply or drops one, so forcing it is worth the map.

**I am not adopting the other half.** Codex proposed making `processed` + `pending` unrepresentable. That would be wrong: it is the normal in-flight state of every channel turn between persisting its reply and delivering it, not an illegal combination to design out. What it actually lacked was a recovery path after a crash, which is #41873, not a type.

## Why it is safe

- No behavior change and no migration. `enum` and `$type` are both compile-time narrowings over the same `text()` column; stored values, defaults, and reads are byte-identical. The one runtime-visible edit swaps `status !== "pending"` for a map lookup that returns the same boolean for all four values.
- `tsc` passes with zero errors, so every existing call site already conformed.
- Both guards sensitivity-checked rather than trusted:
  - a typo'd `"deliverd"` fails with `TS2820 ... Did you mean '"delivered"'?`
  - adding an `"abandoned"` status fails with `TS2741: Property 'abandoned' is missing ... but required in type 'Record<...>'`

A green typecheck on an unenforced type would look identical to a real one, which is why both were checked by breaking them on purpose.

## What changes for the user

Nothing at runtime. Both changes are compile-time guards over the same stored values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41883" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->