### PR TITLE
refactor(web): remove Teach from the companion idle row

### DIFF
--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -189,6 +189,24 @@ const pinSurface = async (
   return found;
 };
 
+/** The control a running session puts on the row, which is where it is read. */
+const stopOf = (container: HTMLElement): HTMLButtonElement | null =>
+  container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Stop teaching"]',
+  );
+
+/** The row drawn with a session running behind it, which cases wait on. */
+const runningStop = async (
+  container: HTMLElement,
+): Promise<HTMLButtonElement> =>
+  await waitFor(() => {
+    const found = stopOf(container);
+    if (!found) {
+      throw new Error("Expected the stop control to render");
+    }
+    return found;
+  });
+
 /**
  * The surface is a union of rects, and this is the one nothing draws into.
  *
@@ -798,23 +816,11 @@ describe("the working ring on the page", () => {
  * sentence and by a call, and the indicator is not.
  */
 describe("the watch session on the companion surface", () => {
-  const watchOf = (container: HTMLElement): HTMLButtonElement => {
-    const found = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Teach"]',
-    );
-    if (!found) {
-      throw new Error("Expected Watch to render");
-    }
-    return found;
-  };
-
   test("hands the press back to the window holding the session", async () => {
+    STATE.watching = true;
     const { container } = render(<CompanionSurfacePage />);
-    await pinSurface(container);
-    const canvas = canvasOf(container);
-    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
 
-    fireEvent.click(watchOf(container));
+    fireEvent.click(await runningStop(container));
 
     expect(toggleWatchMock).toHaveBeenCalledTimes(1);
   });
@@ -832,9 +838,8 @@ describe("the watch session on the companion surface", () => {
     STATE.watching = true;
     const { container } = render(<CompanionSurfacePage />);
 
-    await waitFor(() => {
-      expect(watchOf(container).getAttribute("aria-pressed")).toBe("true");
-    });
+    await runningStop(container);
+    expect(container.querySelector(".companion-working-ring")).not.toBeNull();
   });
 
   /**
@@ -846,9 +851,7 @@ describe("the watch session on the companion surface", () => {
     STATE.watching = true;
     STATE.captureCount = 3;
     const { container } = render(<CompanionSurfacePage />);
-    await waitFor(() => {
-      expect(watchOf(container).getAttribute("aria-pressed")).toBe("true");
-    });
+    await runningStop(container);
 
     pushState({ ...STATE, captureCount: 4 });
 
@@ -865,9 +868,7 @@ describe("the watch session on the companion surface", () => {
     STATE.watching = true;
     STATE.captureCount = 3;
     const { container } = render(<CompanionSurfacePage />);
-    await waitFor(() => {
-      expect(watchOf(container).getAttribute("aria-pressed")).toBe("true");
-    });
+    await runningStop(container);
 
     expect(container.querySelector(".companion-capture-pulse")).toBeNull();
   });
@@ -879,9 +880,7 @@ describe("the watch session on the companion surface", () => {
   test("reads a state that says nothing about captures as none", async () => {
     STATE.watching = true;
     const { container } = render(<CompanionSurfacePage />);
-    await waitFor(() => {
-      expect(watchOf(container).getAttribute("aria-pressed")).toBe("true");
-    });
+    await runningStop(container);
 
     expect(container.querySelector(".companion-capture-pulse")).toBeNull();
   });
@@ -897,8 +896,11 @@ describe("the watch session on the companion surface", () => {
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
 
     await waitFor(() => {
-      expect(watchOf(container).getAttribute("aria-pressed")).toBe("false");
+      expect(
+        container.querySelector('button[aria-label="Talk"]'),
+      ).not.toBeNull();
     });
+    expect(stopOf(container)).toBeNull();
   });
 
   /**
@@ -923,16 +925,7 @@ describe("the watch session on the companion surface", () => {
       }),
     );
 
-    const stop = await waitFor(() => {
-      const found = container.querySelector<HTMLButtonElement>(
-        'button[aria-label="Stop teaching"]',
-      );
-      if (!found) {
-        throw new Error("Expected the stop control to render");
-      }
-      return found;
-    });
-    fireEvent.click(stop);
+    fireEvent.click(await runningStop(container));
 
     expect(toggleWatchMock).toHaveBeenCalledTimes(1);
   });
@@ -1125,14 +1118,15 @@ describe("the companion's introduction", () => {
  *
  * The route is standalone: no auth, no `RootLayout`, and so no flag store that
  * ever settles. Main reads the evaluation the app's window wrote into settings
- * and pushes it here, and this page's whole job is to believe only a positive
- * answer.
+ * and pushes it here, and the page passes it on. No control the surface draws
+ * turns on it: the row is Talk and Type under every answer, and the way out of
+ * a running session is drawn from the session itself.
  */
 describe("the Watch flag on the companion surface", () => {
   const watchButton = (container: HTMLElement): HTMLButtonElement | null =>
     container.querySelector<HTMLButtonElement>('button[aria-label="Teach"]');
 
-  /** Open the pill, which is where the way into a session would be drawn. */
+  /** Open the pill, which is where a way into a session would be drawn. */
   const openPill = async (container: HTMLElement): Promise<void> => {
     await pinSurface(container);
     await open(container);
@@ -1154,36 +1148,29 @@ describe("the Watch flag on the companion surface", () => {
     expect(watchButton(container)).toBeNull();
   });
 
-  test("draws the way in when the pushed state says yes", async () => {
+  test("draws none when the pushed state says yes either", async () => {
     STATE.watchEnabled = true;
     const { container } = render(<CompanionSurfacePage />);
     await openPill(container);
 
-    expect(watchButton(container)).not.toBeNull();
+    expect(watchButton(container)).toBeNull();
+    expect(container.querySelector('button[aria-label="Talk"]')).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Type"]')).not.toBeNull();
   });
 
   /**
-   * The flag hides the door and never the exit. A session that outlives the
-   * answer is still reading the screen, and a capture the user cannot end is
-   * the one thing this surface exists to prevent.
+   * The exit is not the flag's to take away. A session running under a
+   * negative answer is still reading the screen, and a capture the user cannot
+   * end is the one thing this surface exists to prevent.
    */
-  test("keeps a way out of a session the flag no longer offers", async () => {
+  test("keeps a way out of a session the flag would not have offered", async () => {
     STATE.watchEnabled = false;
     STATE.watching = true;
     const { container } = render(<CompanionSurfacePage />);
     await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
 
-    const stop = await waitFor(() => {
-      const found = container.querySelector<HTMLButtonElement>(
-        'button[aria-label="Stop teaching"]',
-      );
-      if (!found) {
-        throw new Error("Expected the stop control to render");
-      }
-      return found;
-    });
-    fireEvent.click(stop);
+    fireEvent.click(await runningStop(container));
 
     expect(toggleWatchMock).toHaveBeenCalledTimes(1);
   });

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -148,7 +148,6 @@ const meta: Meta<StoryArgs> = {
     },
     accentHex: { control: "color" },
     watching: { control: "boolean" },
-    watchEnabled: { control: "boolean" },
     introBeat: {
       control: "inline-radio",
       options: COMPANION_INTRO_BEATS,
@@ -156,11 +155,6 @@ const meta: Meta<StoryArgs> = {
   },
   args: {
     phase: "resting",
-    // On here, off everywhere a real user meets it until the flag says
-    // otherwise. Design stories are for looking at what the surface can draw,
-    // and a control the stories hid would be one nobody could review. Turn it
-    // off to see the two-control row a user without the flag gets.
-    watchEnabled: true,
     backdrop: "dark",
     avatarSrc: EXAMPLE_AVATAR,
     character: EXAMPLE_CHARACTER,
@@ -345,18 +339,15 @@ export const Hover: Story = {
  * A session reading the screen, with the pointer nowhere near the surface.
  *
  * `hovered` is off on purpose: this is the state the phase exists for. The pill
- * stays open with no hand on it, Watch is held down, and the ring burns amber
- * rather than the assistant's own colour, so the running session is legible
- * from across the desk.
+ * stays open with no hand on it, the row carries the stop that ends the
+ * session, and the ring burns amber rather than the assistant's own colour, so
+ * the running session is legible from across the desk.
  *
- * The phase and the flag are both set because they answer different questions.
- * Turn `watching` off and the pill stays open on a row nothing is running
- * behind, which is what the phase alone means.
- *
- * Watch is the one control on this surface that is genuinely on or off, so it
- * is the one that reports a pressed state. Everything else the surface says
- * about a running session is a colour, and a colour reaches nobody who is
- * reading the page rather than looking at it.
+ * The phase and the session are both set because they answer different
+ * questions. Turn `watching` off and the pill stays open on a row nothing is
+ * running behind, which is what the phase alone means, and the stop goes with
+ * it: a control offering to end the reading is drawn only while there is
+ * reading to end.
  */
 export const Watching: Story = {
   args: { phase: "watching", watching: true, hovered: false },
@@ -403,7 +394,7 @@ export const SummaryReady: Story = {
  * that is not a pill.
  *
  * The way out survives with it, in the composer's own trailing controls: the
- * idle row that carries Watch is not drawn here, and a ring the user can see
+ * idle row that carries the stop is not drawn here, and a ring the user can see
  * and cannot act on is a worse bargain than no ring at all. It sits on this row
  * rather than a row of its own because the card is already within ten points of
  * the height main sized the canvas for.

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -66,6 +66,21 @@ const bobOf = (container: HTMLElement): HTMLElement | null =>
 const glowOf = (container: HTMLElement): HTMLElement | null =>
   container.querySelector<HTMLElement>(".companion-glow");
 
+/** The control that ends a watch session, wherever the surface has drawn it. */
+const stopOf = (container: HTMLElement): HTMLButtonElement | null =>
+  container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Stop teaching"]',
+  );
+
+/** The same control, for the cases that mean to press it. */
+const requiredStop = (container: HTMLElement): HTMLButtonElement => {
+  const found = stopOf(container);
+  if (!found) {
+    throw new Error("Expected the stop control to render");
+  }
+  return found;
+};
+
 describe("the companion surface's working ring", () => {
   test("is absent while nothing is running", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
@@ -782,10 +797,8 @@ describe("the companion surface's revealed labels", () => {
     );
 
   test("rests as icons, with no verb spelled out", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" watchEnabled />,
-    );
-    for (const name of ["Talk", "Type", "Teach"]) {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    for (const name of ["Talk", "Type"]) {
       const label = labelOf(container, name);
       expect(label?.getAttribute("data-label")).toBe("hover");
       expect(label?.className).toContain("hidden");
@@ -827,21 +840,6 @@ describe("the companion surface's revealed labels", () => {
   });
 
   /**
-   * A running session is the one thing on this row the user has to be able to
-   * find without hunting, so its name stays on the surface rather than under
-   * the pointer.
-   */
-  test("keeps the running session's name drawn", () => {
-    const { container } = render(
-      <CompanionSurface phase="watching" watching watchEnabled />,
-    );
-    expect(labelOf(container, "Teach")?.getAttribute("data-label")).toBe(
-      "pinned",
-    );
-    expect(labelOf(container, "Teach")?.className).not.toContain("hidden");
-  });
-
-  /**
    * The summary is a question waiting on an answer rather than a set of ways
    * in, so its two answers are not the pointer's to reveal.
    */
@@ -859,169 +857,51 @@ describe("the companion surface's revealed labels", () => {
 });
 
 /**
- * Watch, the third way in, and the session it toggles.
+ * The idle row, and the exit a running session puts on it.
  *
- * One control for both edges: the surface draws a single button and the side
- * holding the session decides which edge a press is, so what a test can hold is
- * that the press is reported and that a running session is drawn as one.
+ * The row is two input modalities and nothing else: Talk and Type say how the
+ * user is about to speak, and nothing on it starts a session that reads the
+ * screen. What a case can hold is that composition, and that a session running
+ * behind the row is one the user can still end from it.
  */
-describe("the companion surface's Watch action", () => {
-  const watchOf = (container: HTMLElement): HTMLButtonElement => {
-    const found = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Teach"]',
+describe("the companion surface's idle row", () => {
+  const labelsOf = (container: HTMLElement): (string | null)[] =>
+    [...container.querySelectorAll("button")].map((button) =>
+      button.getAttribute("aria-label"),
     );
-    if (!found) {
-      throw new Error("Expected Watch to render");
-    }
-    return found;
-  };
 
-  test("sits on the idle pill beside Talk and Type", () => {
+  test("is Talk and Type", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(labelsOf(container)).toEqual(["Talk", "Type"]);
+  });
+
+  test("is the same row with Watch offered", () => {
     const { container } = render(
       <CompanionSurface phase="hover" watchEnabled />,
     );
-    // Third of the three, since this is the row's own ordering and the one a
-    // hand travelling out from the mascot crosses last.
-    expect(
-      [...container.querySelectorAll("button")].map((button) =>
-        button.getAttribute("aria-label"),
-      ),
-    ).toEqual(["Talk", "Type", "Teach"]);
-  });
-
-  test("reports the press", () => {
-    let presses = 0;
-    const { container } = render(
-      <CompanionSurface
-        phase="hover"
-        watchEnabled
-        onWatch={() => {
-          presses += 1;
-        }}
-      />,
-    );
-    fireEvent.click(watchOf(container));
-    expect(presses).toBe(1);
+    expect(labelsOf(container)).toEqual(["Talk", "Type"]);
   });
 
   /**
-   * A reader gets none of what this PR spends on the state: not the amber ring,
-   * not the held-down background. The pressed state is the whole of what
-   * reaches them, so it is what says a session is running and that the press
-   * they are on will end it.
+   * The stop is drawn from the session and nothing else, so a session running
+   * for a user the flag says no to is still one they can end. A capture with
+   * nothing that ends it is the failure this surface exists to prevent.
    */
-  test("reports its pressed state while the session runs", () => {
+  test("carries the stop while a session runs, whatever the flag says", () => {
     const { container } = render(
-      <CompanionSurface phase="hover" watching watchEnabled />,
+      <CompanionSurface phase="watching" watching watchEnabled={false} />,
     );
-    expect(watchOf(container).getAttribute("aria-pressed")).toBe("true");
+    expect(stopOf(container)).not.toBeNull();
   });
 
-  test("reports the state it is actually in while nothing runs", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" watchEnabled />,
-    );
-    expect(watchOf(container).getAttribute("aria-pressed")).toBe("false");
-  });
-
-  /**
-   * `classList` rather than a substring, because every control carries
-   * `hover:bg-white/15` and a substring match would pass on the hover rule
-   * alone.
-   */
-  test("reads as held down while the session runs", () => {
+  test("puts it after the two ways in, with the flag on", () => {
     const { container } = render(
       <CompanionSurface phase="watching" watching watchEnabled />,
     );
-    expect(watchOf(container).classList.contains("bg-white/15")).toBe(true);
+    expect(labelsOf(container)).toEqual(["Talk", "Type", "Stop teaching"]);
   });
 
-  test("reads as idle while no session runs", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" watchEnabled />,
-    );
-    expect(watchOf(container).classList.contains("bg-white/15")).toBe(false);
-  });
-
-  /**
-   * The flag, not the phase, the same input the ring reads. The two are drawn
-   * in different places and must never be able to disagree about whether a
-   * session is running.
-   */
-  test("reads as held down on the idle pill while the session runs", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" watching watchEnabled />,
-    );
-    expect(watchOf(container).classList.contains("bg-white/15")).toBe(true);
-  });
-});
-
-/**
- * The flag Watch is behind, as the surface draws it.
- *
- * The surface has no way of evaluating it: the window it lives in never
- * hydrates a flag store, so the answer arrives on the pushed state and this
- * prop is where it lands. What a case can hold is that the way into a session
- * is absent without a positive answer, and that a session already running is
- * still drawn and still stoppable when the answer goes away, because a capture
- * the user can neither see nor end is the failure this surface exists to
- * prevent.
- */
-describe("the companion surface's Watch flag", () => {
-  const watchButton = (container: HTMLElement): HTMLButtonElement | null =>
-    container.querySelector<HTMLButtonElement>('button[aria-label="Teach"]');
-
-  test("draws no way in when the answer has not arrived", () => {
-    const { container } = render(<CompanionSurface phase="hover" />);
-    expect(watchButton(container)).toBeNull();
-  });
-
-  test("draws no way in when the answer is no", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" watchEnabled={false} />,
-    );
-    expect(watchButton(container)).toBeNull();
-  });
-
-  test("leaves Talk and Type where they were", () => {
-    const { container } = render(<CompanionSurface phase="hover" />);
-    expect(container.querySelector('button[aria-label="Talk"]')).not.toBeNull();
-    expect(container.querySelector('button[aria-label="Type"]')).not.toBeNull();
-  });
-
-  /**
-   * The flag hides the door, never the exit. A session that outlives the
-   * answer is one the user has to be able to see and to end.
-   */
-  test("still draws the running session's ring", () => {
-    const { container } = render(
-      <CompanionSurface phase="watching" watching />,
-    );
-    expect(container.querySelector(".companion-working-ring")).not.toBeNull();
-  });
-
-  test("still draws the stop control on the card", () => {
-    const { container } = render(<CompanionSurface phase="typing" watching />);
-    expect(
-      container.querySelector('button[aria-label="Stop teaching"]'),
-    ).not.toBeNull();
-  });
-
-  /**
-   * The idle row is where Watch itself is the stop, so hiding Watch there would
-   * leave a running session with nothing that ends it. The stop takes its
-   * place instead.
-   */
-  test("puts the stop where the way in would have been", () => {
-    const { container } = render(
-      <CompanionSurface phase="watching" watching />,
-    );
-    expect(
-      container.querySelector('button[aria-label="Stop teaching"]'),
-    ).not.toBeNull();
-  });
-
-  test("reports that press as the toggle it is", () => {
+  test("ends the session from the row", () => {
     let presses = 0;
     const { container } = render(
       <CompanionSurface
@@ -1032,21 +912,60 @@ describe("the companion surface's Watch flag", () => {
         }}
       />,
     );
-    const stop = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Stop teaching"]',
-    );
-    if (!stop) {
-      throw new Error("Expected the stop control to render");
-    }
-    fireEvent.click(stop);
+    fireEvent.click(requiredStop(container));
     expect(presses).toBe(1);
   });
 
-  test("draws no stop while nothing is running", () => {
+  test("carries no stop while nothing runs", () => {
     const { container } = render(<CompanionSurface phase="hover" />);
-    expect(
-      container.querySelector('button[aria-label="Stop teaching"]'),
-    ).toBeNull();
+    expect(stopOf(container)).toBeNull();
+  });
+});
+
+/**
+ * The Watch flag, as the surface draws it.
+ *
+ * The surface has no way of evaluating it: the window it lives in never
+ * hydrates a flag store, so the answer arrives on the pushed state and this
+ * prop is where it lands. No control the surface draws is gated on it, and
+ * these hold both halves of that: the row is the same row whatever the answer
+ * is, and a session already running is drawn and stoppable whatever the answer
+ * is, because a capture the user can neither see nor end is the failure this
+ * surface exists to prevent.
+ */
+describe("the companion surface's Watch flag", () => {
+  const watchButton = (container: HTMLElement): HTMLButtonElement | null =>
+    container.querySelector<HTMLButtonElement>('button[aria-label="Teach"]');
+
+  test("puts no way into a session on the row when the answer is yes", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" watchEnabled />,
+    );
+    expect(watchButton(container)).toBeNull();
+  });
+
+  test("puts none there when the answer is no", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" watchEnabled={false} />,
+    );
+    expect(watchButton(container)).toBeNull();
+  });
+
+  test("puts none there when no answer has arrived", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(watchButton(container)).toBeNull();
+  });
+
+  test("still draws the running session's ring", () => {
+    const { container } = render(
+      <CompanionSurface phase="watching" watching />,
+    );
+    expect(container.querySelector(".companion-working-ring")).not.toBeNull();
+  });
+
+  test("still draws the stop control on the card", () => {
+    const { container } = render(<CompanionSurface phase="typing" watching />);
+    expect(stopOf(container)).not.toBeNull();
   });
 });
 
@@ -1056,18 +975,25 @@ describe("the companion surface's Watch flag", () => {
  * The rendering cases above hold what a user sees; this holds the list they see
  * it from, which is the thing a contributed entrypoint will later be appended
  * to. Reading the composition here rather than off the DOM is what keeps the
- * order and the flag's effect stated once, in the place they are decided.
+ * order stated once, in the place it is decided.
  */
 describe("the companion surface's idle row items", () => {
-  const keysOf = (watchEnabled: boolean): string[] =>
-    buildIdleRowItems({ t, watchEnabled }).map((item) => item.key);
-
-  test("is Talk, Type, then Teach when Watch is offered", () => {
-    expect(keysOf(true)).toEqual(["talk", "type", "teach"]);
+  test("is Talk, then Type", () => {
+    expect(buildIdleRowItems({ t }).map((item) => item.key)).toEqual([
+      "talk",
+      "type",
+    ]);
   });
 
-  test("is Talk and Type alone when it is not", () => {
-    expect(keysOf(false)).toEqual(["talk", "type"]);
+  /**
+   * The session a stop would end is not one of these. The stop is drawn beside
+   * the row from `watching` alone, so an item list that carried it would be a
+   * second answer to a question the row already answers.
+   */
+  test("carries nothing about a watch session", () => {
+    expect(
+      buildIdleRowItems({ t, watching: true }).map((item) => item.key),
+    ).toEqual(["talk", "type"]);
   });
 });
 
@@ -1096,27 +1022,14 @@ describe("the pill a watch session holds open", () => {
 /**
  * The way out of a session, which has to reach as far as the indicator does.
  *
- * `watching` ranks below `typing` and `call`, so the idle row that carries
- * Watch is not drawn in either of them while the ring still is. An indicator
+ * `watching` ranks below `typing` and `call`, so the idle row that carries the
+ * stop is not drawn in either of them while the ring still is. An indicator
  * the user can see and cannot act on is a worse bargain than no indicator at
  * all: it names something happening to them and withholds the means to end it.
  * So both of those phases carry a stop control of their own, on the same
  * `onWatch` the idle row presses.
  */
 describe("the companion surface's stop control", () => {
-  const stopOf = (container: HTMLElement): HTMLButtonElement | null =>
-    container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Stop teaching"]',
-    );
-
-  const required = (container: HTMLElement): HTMLButtonElement => {
-    const found = stopOf(container);
-    if (!found) {
-      throw new Error("Expected the stop control to render");
-    }
-    return found;
-  };
-
   test("rides the composer while the user types", () => {
     const { container } = render(<CompanionSurface phase="typing" watching />);
     expect(stopOf(container)).not.toBeNull();
@@ -1133,7 +1046,7 @@ describe("the companion surface's stop control", () => {
         }}
       />,
     );
-    fireEvent.click(required(container));
+    fireEvent.click(requiredStop(container));
     expect(presses).toBe(1);
   });
 
@@ -1156,7 +1069,7 @@ describe("the companion surface's stop control", () => {
         }}
       />,
     );
-    fireEvent.click(required(container));
+    fireEvent.click(requiredStop(container));
     expect(presses).toBe(1);
   });
 
@@ -1269,12 +1182,9 @@ describe("the summary a finished watch session leaves on the surface", () => {
   // The phase without the state behind it is the ordinary row, not an empty
   // one: nothing on this surface should draw a question with no answer in it.
   test("draws the ordinary controls when there is no summary", () => {
-    // `watchEnabled` because this asserts the ordinary controls, and the flag
-    // is what decides whether Teach is among them.
-    const { container } = render(
-      <CompanionSurface phase="summary" watchEnabled />,
-    );
-    expect(buttonOf(container, "Teach")).not.toBeNull();
+    const { container } = render(<CompanionSurface phase="summary" />);
+    expect(buttonOf(container, "Talk")).not.toBeNull();
+    expect(buttonOf(container, "Type")).not.toBeNull();
   });
 });
 
@@ -1435,13 +1345,14 @@ describe("the companion surface growing leftward", () => {
 });
 
 /**
- * What the surface claims to be a toggle, which is one control.
+ * What the surface claims to be a toggle, which is nothing.
  *
- * `active` draws a control as though a pointer were on it, which the demo reel
- * stages on Talk and Type to show a hand reaching for one. That is a look, and
- * a look reported as a pressed state would tell a reader that Talk is switched
- * on because a clip wanted it lit. Watch is the only control here that is
- * genuinely on or off, so it is the only one that says so.
+ * Every control here goes one way when it is pressed, so none of them says it
+ * is on or off. `active` is the closest thing to a counterexample and is not
+ * one: it draws a control as though a pointer were on it, which the demo reel
+ * stages on Talk and Type to show a hand reaching for one, and a look reported
+ * as a pressed state would tell a reader that Talk is switched on because a
+ * clip wanted it lit.
  */
 describe("the companion surface's pressed states", () => {
   const buttonsOf = (container: HTMLElement): HTMLButtonElement[] =>
@@ -1755,9 +1666,7 @@ describe("the avatar's resting collapse", () => {
    * circling the empty box the capsule sits in.
    */
   test("rides the ring on the shape, not on the box", () => {
-    const { container } = render(
-      <CompanionSurface phase="resting" working />,
-    );
+    const { container } = render(<CompanionSurface phase="resting" working />);
 
     expect(ringOf(container)?.parentElement).toBe(shapeOf(container));
   });
@@ -1810,9 +1719,7 @@ describe("the avatar's resting collapse", () => {
 
   /** The creature fades with it rather than being cut, and comes back whole. */
   test("fades the creature out at rest and back in expanded", () => {
-    const { container: resting } = render(
-      <CompanionSurface phase="resting" />,
-    );
+    const { container: resting } = render(<CompanionSurface phase="resting" />);
     expect(bobOf(resting)?.parentElement?.style.opacity).toBe("0");
 
     const { container: hovered } = render(<CompanionSurface phase="hover" />);

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -2,7 +2,6 @@ import {
   ArrowUp,
   AudioLines,
   Check,
-  Eye,
   EyeOff,
   Keyboard,
   Mic,
@@ -307,14 +306,14 @@ export const FALLBACK_WIDTHS: Record<
   Exclude<CompanionSurfacePhase, "resting" | "typing">,
   number
 > = {
-  // Three icon-only controls, which is the row as it is first drawn: the labels
+  // Two icon-only controls, which is the row as it is first drawn: the labels
   // are revealed one at a time under the pointer, and on the first frame there
-  // is no pointer on any of them yet.
-  hover: 112,
-  // The same row of controls hover draws, since the session is run from it
-  // rather than from a row of its own, plus the one word the running session
-  // pins open on the control holding it.
-  watching: 151,
+  // is no pointer on either of them yet.
+  hover: 76,
+  // The idle row plus the stop a running session puts on it, which is a third
+  // icon-only control: the stop carries its name to a reader and a tooltip to
+  // a pointer, and takes no room on the row for either.
+  watching: 112,
   // Two labelled controls, both drawn: this row is a question waiting on an
   // answer rather than a set of ways in, so its words are not the pointer's to
   // reveal. That is what makes it wider than the idle row it stands in for.
@@ -591,17 +590,16 @@ export interface CompanionSurfaceProps {
    * Whether Watch is offered at all, which is the feature flag rather than any
    * fact about a session.
    *
-   * Separate from {@link CompanionSurfaceProps.watching} because the two answer
-   * questions that can disagree in the one direction that matters: a session
-   * left running when the flag is turned off still has to draw its indicator
-   * and its stop control, since a capture the user cannot see or end is the
-   * failure this surface exists to prevent. So this hides the way in and
-   * nothing else.
+   * It gates no control this surface draws. The idle row is Talk and Type, and
+   * everything the surface says about a session, its indicator and the stop
+   * that ends it, is drawn from {@link CompanionSurfaceProps.watching} alone,
+   * since a capture the user can neither see nor end is the failure this
+   * surface exists to prevent. What the flag answers is whether a session may
+   * be started at all, which is settled where the session is owned.
    *
-   * Absence is not permission. Defaulted off rather than on for the reason
-   * `CompanionSurfaceState.watchEnabled` is read that way: every caller with no
-   * evaluation in hand is a caller that does not know, and a control that reads
-   * the user's screen is not offered on a guess.
+   * Absence is not permission, the way `CompanionSurfaceState.watchEnabled` is
+   * read: every caller with no evaluation in hand is a caller that does not
+   * know, and screen reading is not offered on a guess.
    */
   watchEnabled?: boolean;
   /**
@@ -709,7 +707,6 @@ export function CompanionSurface({
   watchRetro,
   onWatchRetro,
   captureCount = 0,
-  watchEnabled = false,
   call,
   onControl,
   intro,
@@ -994,7 +991,6 @@ export function CompanionSurface({
                 <IdleBody
                   spotlight={spotlight}
                   watching={watching}
-                  watchEnabled={watchEnabled}
                   onTalk={onTalk}
                   onType={onType}
                   onWatch={onWatch}
@@ -1551,8 +1547,6 @@ type IdleRowItem = {
   label: string;
   /** Drawn as though the pointer were on it. A look, not a state. See PillButton. */
   active?: boolean;
-  /** Pins the label open and reports on/off to a reader. See PillButton. */
-  pressed?: boolean;
   onClick?: () => void;
 };
 
@@ -1562,10 +1556,8 @@ type IdleRowItem = {
  */
 type IdleRowInputs = {
   spotlight?: "talk" | "type";
-  /** Whether the session Watch starts is already running. */
+  /** Whether a session is reading the screen, which is what puts a stop in the row. */
   watching?: boolean;
-  /** Whether Watch is offered at all. See `CompanionSurfaceProps`. */
-  watchEnabled?: boolean;
   onTalk?: () => void;
   onType?: () => void;
   onWatch?: () => void;
@@ -1582,13 +1574,10 @@ type IdleRowInputs = {
 export function buildIdleRowItems({
   t,
   spotlight,
-  watching = false,
-  watchEnabled = false,
   onTalk,
   onType,
-  onWatch,
 }: IdleRowInputs & { t: TFunction<"common"> }): IdleRowItem[] {
-  const items: IdleRowItem[] = [
+  return [
     {
       key: "talk",
       icon: <AudioLines className="size-4" />,
@@ -1604,32 +1593,6 @@ export function buildIdleRowItems({
       onClick: onType,
     },
   ];
-  // Held down for as long as the session runs, so the row says which control
-  // is holding the pill open and which press ends it. `pressed` rather than
-  // `active`, because this one is a state and not a look: a reader is told a
-  // session is running, where everything else this surface does about it is a
-  // colour they never receive.
-  //
-  // It is also what keeps this control's word on the surface while the rest of
-  // the row is icons: a running session is the one thing here the user has to
-  // be able to find without hunting, and a name revealed only under the
-  // pointer is one they would have to go looking for. `pressed` pins it open,
-  // so the session names itself for as long as it runs.
-  //
-  // Absent entirely when Watch is not offered, rather than disabled: a user
-  // who cannot have the feature is not owed a control that explains itself by
-  // refusing them. The pill measures its own contents, so the row simply comes
-  // out narrower.
-  if (watchEnabled) {
-    items.push({
-      key: "teach",
-      icon: <Eye className="size-4" />,
-      label: t("companionSurface.teach"),
-      pressed: watching,
-      onClick: onWatch,
-    });
-  }
-  return items;
 }
 
 /**
@@ -1637,27 +1600,24 @@ export function buildIdleRowItems({
  *
  * Verbs throughout. "Talk" and "Type" rather than "Talk" and "Ask", because
  * they are two halves of one choice about how to say something, and a verb pair
- * reads as that where a verb and a question word do not. "Teach" is the third,
- * and the one where the assistant does the looking rather than the user the
- * saying. It is also the one that comes and goes: it is behind a flag of its
- * own, so the row is Talk and Type alone for anyone who does not have it.
+ * reads as that where a verb and a question word do not. Both are input
+ * modalities and nothing more: pressing either says how the user is about to
+ * speak, never what the assistant is to do with it.
  *
  * **The words are drawn one at a time, under the pointer** (`revealLabel`).
  * This is the row a user meets by resting a hand near the mascot, so it is
- * drawn far more often than it is acted on, and three verbs spelled out at once
- * read as a sentence aimed at someone doing something else. Teach is the
- * loudest of the three for being the least wanted: the flagged, occasional way
- * in, at the same weight as the two the row exists for.
+ * drawn far more often than it is acted on, and a row of verbs spelled out at
+ * once reads as a sentence aimed at someone doing something else.
  *
  * Resting as icons keeps the pill to a third of the width its labels want, and
  * revealing one at a time is what keeps the reveal legible: exactly one word is
  * ever on the surface, and it is the one the hand is on.
  *
- * `aria-label` carries the name in every state, so a reader gets all three
+ * `aria-label` carries the name in every state, so a reader gets every control
  * regardless of where the pointer is.
  */
 function IdleBody(props: IdleRowInputs) {
-  const { watching = false, watchEnabled = false, onWatch } = props;
+  const { watching = false, onWatch } = props;
   const { t } = useTranslation();
   return (
     <>
@@ -1668,17 +1628,16 @@ function IdleBody(props: IdleRowInputs) {
           label={item.label}
           revealLabel
           active={item.active}
-          pressed={item.pressed}
           onClick={item.onClick}
         />
       ))}
-      {/* **The exit outlives the door.** A session running under a flag that
-          has since been turned off still reads the screen, so the row that
-          would have carried Watch carries the stop instead, the same control
-          the card and the call row draw. Hiding the way in is the whole of what
-          the flag does; leaving a capture with nothing that ends it is not
-          something a flag is allowed to cause. */}
-      {!watchEnabled && watching && <StopWatchingButton onWatch={onWatch} />}
+      {/* **The door is gone, the exit is not.** The row offers no way into a
+          watch session, and a session is started elsewhere, but one that is
+          running is reading the screen right now. So the row carries the stop
+          for as long as it runs, the same control the card and the call row
+          draw: leaving a capture with nothing that ends it is not something
+          this surface is allowed to cause. */}
+      {watching && <StopWatchingButton onWatch={onWatch} />}
     </>
   );
 }
@@ -1946,15 +1905,11 @@ function StopWatchingButton({ onWatch }: { onWatch?: () => void }) {
  * room for words, which is why the call's controls are icon-only without being
  * unlabelled.
  *
- * **`active` and `pressed` are two props because they are two different
- * claims.** `active` is a look: the demo reel draws a control as though a
- * pointer were on it, and a highlight staged for a recording is not a state the
- * control is in. `pressed` is the control's own on or off, which is a state,
- * and reporting a highlight as one would tell a reader that Talk is switched on
- * because a clip wanted it lit.
- *
- * `pressed` draws the same held-down look, so the state a looking user reads
- * off the background and the state a reader is told cannot come apart.
+ * **Nothing here claims a pressed state.** Every control on this surface goes
+ * one way when it is pressed, so none of them carries `aria-pressed`: a button
+ * reporting an on or off it does not have is one assistive technology describes
+ * wrongly. `active` is a look rather than such a state, which is why it draws
+ * the held-down background and says nothing to a reader.
  */
 function PillButton({
   icon,
@@ -1963,7 +1918,6 @@ function PillButton({
   showLabel = false,
   revealLabel = false,
   active = false,
-  pressed,
   onClick,
 }: {
   icon: ReactNode;
@@ -1988,36 +1942,21 @@ function PillButton({
    * wide the word is.
    */
   revealLabel?: boolean;
-  /** Drawn as though the pointer were on it. A look, not a state. */
-  active?: boolean;
   /**
-   * On or off, for a control that genuinely toggles.
+   * Drawn as though the pointer were on it, label and all.
    *
-   * Undefined for everything that does not, which is most of this surface: a
-   * button reporting a state it does not have is one assistive technology
-   * describes wrongly. Where it is set it carries the whole of that state to a
-   * reader, since the ring and the held-down background are both things only a
-   * looking user gets.
+   * A look and not a state, so it says nothing to a reader. It is the demo reel
+   * pointing at a control, and a control pointed at in a recording nobody can
+   * hover is one whose name has to be on the surface rather than under a hand
+   * that is never coming.
    */
-  pressed?: boolean;
+  active?: boolean;
   onClick?: () => void;
 }) {
-  /**
-   * A revealed label held open with no pointer in the room.
-   *
-   * Both cases are ones where the word has to be readable without a hand on the
-   * control. `active` is the demo reel pointing at a control, and a control
-   * pointed at in a recording nobody can hover is one whose name has to be
-   * drawn. `pressed` is a control holding a session open, and the row's job
-   * then is to say which press ends it, which it cannot do as an icon the user
-   * would have to go looking under.
-   */
-  const pinned = active || pressed === true;
   return (
     <button
       type="button"
       aria-label={label}
-      aria-pressed={pressed}
       // Only where the word is nowhere else. A tooltip over a control that
       // reveals its own label on the same hover is the same word twice, a
       // second later and a few pixels away.
@@ -2029,7 +1968,7 @@ function PillButton({
         event.stopPropagation();
       }}
       className={`group flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] transition-colors hover:bg-white/15 ${
-        pinned ? "bg-white/15" : ""
+        active ? "bg-white/15" : ""
       } ${
         tone === "negative"
           ? "text-[#ff6b6b]"
@@ -2046,8 +1985,8 @@ function PillButton({
         // sees a span either way, so the attribute is the only honest way to
         // hold that this word is hidden until the pointer arrives.
         <span
-          data-label={pinned ? "pinned" : "hover"}
-          className={pinned ? "" : "hidden group-hover:inline"}
+          data-label={active ? "pinned" : "hover"}
+          className={active ? "" : "hidden group-hover:inline"}
         >
           {label}
         </span>

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -160,7 +160,6 @@
     "stopTeaching": "Stop teaching",
     "summarizing": "Summarizing",
     "talk": "Talk",
-    "teach": "Teach",
     "type": "Type",
     "unmuteAssistant": "Unmute assistant",
     "unmuteMicrophone": "Unmute microphone"

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -160,7 +160,6 @@
     "stopTeaching": "Dejar de enseñar",
     "summarizing": "Resumiendo",
     "talk": "Hablar",
-    "teach": "Enseñar",
     "type": "Escribir",
     "unmuteAssistant": "Activar sonido del asistente",
     "unmuteMicrophone": "Activar micrófono"

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -160,7 +160,6 @@
     "stopTeaching": "停止教學",
     "summarizing": "正在摘要",
     "talk": "交談",
-    "teach": "教學",
     "type": "輸入",
     "unmuteAssistant": "解除助理靜音",
     "unmuteMicrophone": "解除麥克風靜音"

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -160,7 +160,6 @@
     "stopTeaching": "停止教学",
     "summarizing": "正在摘要",
     "talk": "交谈",
-    "teach": "教学",
     "type": "输入",
     "unmuteAssistant": "取消助手静音",
     "unmuteMicrophone": "取消麦克风静音"


### PR DESCRIPTION
## Summary

- The companion idle row is Talk and Type. Teach leaves `buildIdleRowItems`: it is a commitment (it writes durably to the assistant) rather than an input modality, and the row's reveal-one-label-at-a-time design only holds at small item counts.
- The stop control is drawn whenever a session is running, not only when the flag is off. The door is gone, the exit is not, so a capture always has something that ends it.
- `watchEnabled` stays on `CompanionSurfaceProps` and the state contract (it still gates whether a session may be started elsewhere) but gates nothing this surface draws. Teach was the surface's only toggle, so `PillButton`'s unused `pressed` / `aria-pressed` machinery goes with it. The `companionSurface.teach` catalog key stays for wherever Teach lands next.

Part of plan: companion-plugin-entrypoints.md (PR 4 of 9)