### PR TITLE
feat(llm): add Claude Fable 5.1 to the model catalog

### DIFF
--- a/assistant/src/__tests__/anthropic-provider.test.ts
+++ b/assistant/src/__tests__/anthropic-provider.test.ts
@@ -3602,6 +3602,8 @@ describe("AnthropicProvider — deprecated sampling params (temperature / top_p 
     "claude-sonnet-5",
     "anthropic/claude-sonnet-5",
     "claude-fable-5",
+    "claude-fable-5-1",
+    "anthropic/claude-fable-5.1",
   ]) {
     test(`strips temperature, top_p, and top_k for ${model}`, async () => {
       const provider = new AnthropicProvider("sk-ant-test", model);

--- a/assistant/src/__tests__/model-intents.test.ts
+++ b/assistant/src/__tests__/model-intents.test.ts
@@ -20,7 +20,7 @@ describe("model intents", () => {
       "claude-haiku-4-5-20251001",
     );
     expect(resolveModelIntent("anthropic", "quality-optimized")).toBe(
-      "claude-fable-5",
+      "claude-fable-5-1",
     );
     expect(resolveModelIntent("anthropic", "vision-optimized")).toBe(
       "claude-opus-4-6",
@@ -47,7 +47,7 @@ describe("model intents", () => {
       "anthropic/claude-haiku-4.5",
     );
     expect(resolveModelIntent("vercel-ai-gateway", "quality-optimized")).toBe(
-      "anthropic/claude-fable-5",
+      "anthropic/claude-fable-5.1",
     );
     expect(resolveModelIntent("vercel-ai-gateway", "vision-optimized")).toBe(
       "anthropic/claude-opus-4.6",

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -450,6 +450,19 @@ describe("resolvePricingForUsage", () => {
     expect(result.estimatedCostUsd).toBeCloseTo(57.4, 10);
   });
 
+  test("bills Fable 5.1 cache reads at the catalog rate", () => {
+    const result = resolvePricingForUsage("anthropic", "claude-fable-5-1", {
+      directInputTokens: 0,
+      outputTokens: 0,
+      cacheCreationInputTokens: 0,
+      cacheReadInputTokens: 1_000_000,
+      anthropicCacheCreation: null,
+    });
+
+    expect(result.pricingStatus).toBe("priced");
+    expect(result.estimatedCostUsd).toBeCloseTo(0.25, 10);
+  });
+
   test("returns unpriced with null cost for unknown provider", () => {
     const usage: PricingUsage = {
       directInputTokens: 10,

--- a/assistant/src/providers/anthropic/client.ts
+++ b/assistant/src/providers/anthropic/client.ts
@@ -1056,7 +1056,7 @@ export class AnthropicProvider implements Provider {
         /claude-opus-4-[78]\b/.test(effectiveModel) ||
         /claude-opus-5\b/.test(effectiveModel) ||
         /claude-sonnet-5\b/.test(effectiveModel) ||
-        effectiveModel.startsWith("claude-fable-");
+        /claude-fable-/.test(effectiveModel);
       const mergedOutputConfig = {
         ...(output_config ?? {}),
         ...(effort && effort !== "none" && supportsEffort

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -194,6 +194,24 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       {
+        id: "claude-fable-5-1",
+        displayName: "Claude Fable 5.1",
+        contextWindowTokens: 1000000,
+        maxOutputTokens: 128000,
+        longContextPricingThresholdTokens: 200000,
+        supportsThinking: true,
+        adaptiveThinkingOnly: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 10,
+          outputPer1mTokens: 50,
+          cacheWritePer1mTokens: 12.5,
+          cacheReadPer1mTokens: 0.25,
+        },
+      },
+      {
         id: "claude-fable-5",
         displayName: "Claude Fable 5",
         contextWindowTokens: 1000000,
@@ -1087,6 +1105,24 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       // prompt caching and cache TTL metadata pass through unchanged and
       // billing matches Anthropic's direct rates.
       {
+        id: "anthropic/claude-fable-5.1",
+        displayName: "Claude Fable 5.1",
+        contextWindowTokens: 1000000,
+        maxOutputTokens: 128000,
+        longContextPricingThresholdTokens: 200000,
+        supportsThinking: true,
+        adaptiveThinkingOnly: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 10,
+          outputPer1mTokens: 50,
+          cacheWritePer1mTokens: 12.5,
+          cacheReadPer1mTokens: 0.25,
+        },
+      },
+      {
         id: "anthropic/claude-fable-5",
         displayName: "Claude Fable 5",
         contextWindowTokens: 1000000,
@@ -1934,6 +1970,24 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       // The gateway proxies anthropic/* through Anthropic's Messages API, so
       // prompt caching and cache TTL metadata pass through unchanged and
       // billing matches Anthropic's direct rates.
+      {
+        id: "anthropic/claude-fable-5.1",
+        displayName: "Claude Fable 5.1",
+        contextWindowTokens: 1000000,
+        maxOutputTokens: 128000,
+        longContextPricingThresholdTokens: 200000,
+        supportsThinking: true,
+        adaptiveThinkingOnly: true,
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 10,
+          outputPer1mTokens: 50,
+          cacheWritePer1mTokens: 12.5,
+          cacheReadPer1mTokens: 0.25,
+        },
+      },
       {
         id: "anthropic/claude-fable-5",
         displayName: "Claude Fable 5",

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -20,7 +20,7 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
     balanced: "claude-sonnet-4-6",
     "cost-optimized": "claude-haiku-4-5-20251001",
     "latency-optimized": "claude-haiku-4-5-20251001",
-    "quality-optimized": "claude-fable-5",
+    "quality-optimized": "claude-fable-5-1",
     "vision-optimized": "claude-opus-4-6",
   },
   openai: {
@@ -55,14 +55,14 @@ const PROVIDER_MODEL_INTENTS: Record<string, Record<ModelIntent, string>> = {
     balanced: "anthropic/claude-sonnet-4.6",
     "cost-optimized": "deepseek/deepseek-v4-flash",
     "latency-optimized": "anthropic/claude-haiku-4.5",
-    "quality-optimized": "anthropic/claude-fable-5",
+    "quality-optimized": "anthropic/claude-fable-5.1",
     "vision-optimized": "anthropic/claude-opus-4.6",
   },
   "vercel-ai-gateway": {
     balanced: "anthropic/claude-sonnet-4.6",
     "cost-optimized": "deepseek/deepseek-v4-flash",
     "latency-optimized": "anthropic/claude-haiku-4.5",
-    "quality-optimized": "anthropic/claude-fable-5",
+    "quality-optimized": "anthropic/claude-fable-5.1",
     "vision-optimized": "anthropic/claude-opus-4.6",
   },
 };

--- a/assistant/src/util/pricing.ts
+++ b/assistant/src/util/pricing.ts
@@ -380,7 +380,8 @@ function calculateUsageCost(
     directInputCost +
     outputCost +
     calculateTokenCost(
-      effectivePricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.read,
+      effectivePricing.cacheReadPer1M ??
+        effectivePricing.inputPer1M * ANTHROPIC_PROMPT_CACHE_MULTIPLIERS.read,
       usage.cacheReadInputTokens,
     ) +
     calculateTokenCost(

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -43,8 +43,20 @@ export interface LlmCatalogModel {
 export const MODELS_BY_PROVIDER = {
   anthropic: [
     {
+      id: "claude-fable-5-1",
+      displayName: "Claude Fable 5.1",
+      family: "claude-fable",
+      contextWindowTokens: 1_000_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 128_000,
+      supportsThinking: true,
+      adaptiveThinkingOnly: true,
+      longContextPricingThresholdTokens: 200_000,
+    },
+    {
       id: "claude-fable-5",
       displayName: "Claude Fable 5",
+      family: "claude-fable",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -459,8 +471,20 @@ export const MODELS_BY_PROVIDER = {
   ],
   openrouter: [
     {
+      id: "anthropic/claude-fable-5.1",
+      displayName: "Claude Fable 5.1",
+      family: "claude-fable",
+      contextWindowTokens: 1_000_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 128_000,
+      supportsThinking: true,
+      adaptiveThinkingOnly: true,
+      longContextPricingThresholdTokens: 200_000,
+    },
+    {
       id: "anthropic/claude-fable-5",
       displayName: "Claude Fable 5",
+      family: "claude-fable",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,
@@ -900,8 +924,20 @@ export const MODELS_BY_PROVIDER = {
   ],
   "vercel-ai-gateway": [
     {
+      id: "anthropic/claude-fable-5.1",
+      displayName: "Claude Fable 5.1",
+      family: "claude-fable",
+      contextWindowTokens: 1_000_000,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 128_000,
+      supportsThinking: true,
+      adaptiveThinkingOnly: true,
+      longContextPricingThresholdTokens: 200_000,
+    },
+    {
       id: "anthropic/claude-fable-5",
       displayName: "Claude Fable 5",
+      family: "claude-fable",
       contextWindowTokens: 1_000_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 128_000,

--- a/clients/web/src/assistant/llm-model-families.test.ts
+++ b/clients/web/src/assistant/llm-model-families.test.ts
@@ -23,6 +23,7 @@ const entries = Object.entries(MODELS_BY_PROVIDER) as [
 
 /** The member that leads each line, and so the one a picker shows. */
 const NEWEST_IN_FAMILY: Record<string, string> = {
+  "claude-fable": "Claude Fable 5.1",
   "claude-opus": "Claude Opus 5",
   "claude-sonnet": "Claude Sonnet 5",
   "gpt-5": "GPT-5.5",

--- a/clients/web/src/domains/settings/ai/model-first-groups.test.ts
+++ b/clients/web/src/domains/settings/ai/model-first-groups.test.ts
@@ -144,9 +144,9 @@ describe("resolveModelFirstGroups", () => {
 
   test("keeps a section in its owner's catalog order", () => {
     expect(namesOf([], "anthropic").slice(0, 3)).toEqual([
+      "Claude Fable 5.1",
       "Claude Fable 5",
       "Claude Opus 5",
-      "Claude Opus 4.8",
     ]);
   });
 
@@ -174,7 +174,8 @@ describe("resolveModelFirstGroups", () => {
     );
     expect(byName.get("Claude Opus 5")).toBe("claude-opus");
     expect(byName.get("Claude Opus 4.8")).toBe("claude-opus");
-    expect(byName.get("Claude Fable 5")).toBeNull();
+    expect(byName.get("Claude Fable 5.1")).toBe("claude-fable");
+    expect(byName.get("Claude Fable 5")).toBe("claude-fable");
   });
 
   test("files a custom endpoint's own models under that endpoint", () => {
@@ -201,13 +202,14 @@ describe("collapseSectionRows", () => {
     const options = optionsFor("anthropic");
     const { shown, hidden } = collapseSectionRows(options);
     expect(shown.map((option) => option.displayName)).toEqual([
-      "Claude Fable 5",
+      "Claude Fable 5.1",
       "Claude Opus 5",
       "Claude Sonnet 5",
     ]);
     // The rest follows in catalog order, so revealing it reads as the section
     // carrying on rather than as a second list.
     expect(hidden.map((option) => option.displayName)).toEqual([
+      "Claude Fable 5",
       "Claude Opus 4.8",
       "Claude Opus 4.7",
       "Claude Opus 4.6",

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -468,7 +468,7 @@ describe("the model list", () => {
 
     // Three rows and the unfold row, whatever the section holds behind it.
     expect(sectionRowLabels("Anthropic")).toEqual([
-      "Claude Fable 5",
+      "Claude Fable 5.1",
       "Claude Opus 5",
       "Claude Sonnet 5",
       "See more",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -18,6 +18,26 @@
       "defaultModel": "claude-opus-4-8",
       "models": [
         {
+          "id": "claude-fable-5-1",
+          "displayName": "Claude Fable 5.1",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "adaptiveThinkingOnly": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 10,
+            "outputPer1mTokens": 50,
+            "cacheWritePer1mTokens": 12.5,
+            "cacheReadPer1mTokens": 0.25
+          }
+        },
+        {
           "id": "claude-fable-5",
           "displayName": "Claude Fable 5",
           "contextWindowTokens": 1000000,
@@ -952,6 +972,26 @@
       "defaultModel": "x-ai/grok-4.20",
       "models": [
         {
+          "id": "anthropic/claude-fable-5.1",
+          "displayName": "Claude Fable 5.1",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "adaptiveThinkingOnly": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 10,
+            "outputPer1mTokens": 50,
+            "cacheWritePer1mTokens": 12.5,
+            "cacheReadPer1mTokens": 0.25
+          }
+        },
+        {
           "id": "anthropic/claude-fable-5",
           "displayName": "Claude Fable 5",
           "contextWindowTokens": 1000000,
@@ -1853,6 +1893,26 @@
       "supportsPlatformAuth": false,
       "defaultModel": "anthropic/claude-sonnet-4.6",
       "models": [
+        {
+          "id": "anthropic/claude-fable-5.1",
+          "displayName": "Claude Fable 5.1",
+          "contextWindowTokens": 1000000,
+          "maxOutputTokens": 128000,
+          "defaultContextWindowTokens": 200000,
+          "longContextPricingThresholdTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "adaptiveThinkingOnly": true,
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 10,
+            "outputPer1mTokens": 50,
+            "cacheWritePer1mTokens": 12.5,
+            "cacheReadPer1mTokens": 0.25
+          }
+        },
         {
           "id": "anthropic/claude-fable-5",
           "displayName": "Claude Fable 5",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Add Claude Fable 5.1 (https://www.anthropic.com/claude-fable-and-mythos-5-1) to the assistant harness catalog and quality-optimized intents.

API IDs:
- Direct Anthropic / Vertex / Foundry: `claude-fable-5-1`
- OpenRouter / Vercel AI Gateway: `anthropic/claude-fable-5.1`

Pricing (same as Fable 5 except cache reads): $10 / $50 per MTok input/output, cache reads $0.25/MTok, cache writes $12.50 (5m) / $20 (1h). 1M context, 128K max output. Adaptive thinking always on.

## What changed

- Catalog entries for Anthropic, OpenRouter, and Vercel AI Gateway, newest-first
- Anthropic / OpenRouter / Vercel `quality-optimized` intents now resolve to 5.1
- Web catalog mirror plus `claude-fable` family newest pin (`Claude Fable 5.1`)
- Cache-read billing uses the catalog `cacheReadPer1M` rate so 5.1 bills at $0.25/MTok instead of the 10% input default
- Sampling-param deprecation matches `claude-fable` on prefixed OpenRouter IDs (`anthropic/claude-fable-5.1`)
- Regenerated `meta/llm-provider-catalog.json`
- Settings model-first fixtures: Anthropic section leads with Fable 5.1 and folds Fable 5 into `claude-fable`

## Intentionally unchanged

- Fable 5 stays in the catalog
- Historical workspace migrations 100/103/123 still point at Fable 5
- Platform-managed Quality default (`gpt-5.6-sol` via `vellum`) is unchanged
- Doctor tool still hardcodes `claude-fable-5`

## Merge order

**Merge the platform PR first** (https://github.com/vellum-ai/vellum-assistant-platform/pull/10255). The hosted rate card is the allowlist. Then merge this PR.

## Test plan

- `cd assistant && bun test ./src/__tests__/model-intents.test.ts` (5 pass)
- `cd assistant && bun test ./src/__tests__/anthropic-provider.test.ts` (117 pass, including `claude-fable-5-1` and `anthropic/claude-fable-5.1` sampling deprecation)
- `cd assistant && bun test ./src/__tests__/llm-catalog-parity.test.ts` (23 pass)
- `cd assistant && bun test ./src/__tests__/pricing.test.ts` (76 pass, including `bills Fable 5.1 cache reads at the catalog rate`)
- `cd clients/web && bun test ./src/assistant/llm-model-families.test.ts` (5 pass)
- `cd clients/web && bun test ./src/domains/settings/ai/model-first-groups.test.ts` (13 pass)
- `cd clients/web && bun test ./src/domains/settings/ai/profile-create-model-first.test.tsx` (28 pass)

No new IPC routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22e54788-b714-41e0-8c1e-073fa994fbec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22e54788-b714-41e0-8c1e-073fa994fbec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

