### PR TITLE
refactor(recovery): share the boot fence across the recovery steps

### DIFF
--- a/assistant/src/monitoring/recovery/db.ts
+++ b/assistant/src/monitoring/recovery/db.ts
@@ -12,6 +12,7 @@ import { Database } from "bun:sqlite";
 
 import { getLogger } from "../../util/logger.js";
 import { getDbPath } from "../../util/platform.js";
+import { readDaemonBootTime } from "../daemon-boot-time.js";
 
 const log = getLogger("recovery-db");
 
@@ -35,5 +36,39 @@ export function openRecoveryDb(): Database | null {
   } catch (err) {
     log.debug({ err }, "recovery: could not open database");
     return null;
+  }
+}
+
+/**
+ * Run one recovery step against a boot-fenced database handle.
+ *
+ * Every step reconciles rows a dead process left behind, so every step needs
+ * the same two guards first: a daemon boot time to fence against (without it
+ * a live daemon's in-flight row is indistinguishable from a dead process's
+ * orphan) and an openable database. `run` is invoked only when both hold, and
+ * the handle is closed however it returns.
+ *
+ * Steps keep their own logger and their own result logging: this owns the
+ * preconditions and the handle's lifetime, not what a step does or says.
+ * A throw propagates to the orchestrator, which treats it as "schema not
+ * ready yet" and retries on the next monitor run.
+ */
+export function withBootFencedRecoveryDb(
+  step: string,
+  run: (db: Database, bootTime: number) => void,
+): void {
+  const bootTime = readDaemonBootTime();
+  if (bootTime == null) {
+    log.warn({ step }, "Skipping recovery step: daemon boot time unavailable");
+    return;
+  }
+  const db = openRecoveryDb();
+  if (db == null) {
+    return;
+  }
+  try {
+    run(db, bootTime);
+  } finally {
+    db.close();
   }
 }

--- a/assistant/src/monitoring/recovery/orphaned-channel-events.ts
+++ b/assistant/src/monitoring/recovery/orphaned-channel-events.ts
@@ -25,30 +25,13 @@
  */
 
 import { getLogger } from "../../util/logger.js";
-import { readDaemonBootTime } from "../daemon-boot-time.js";
-import { openRecoveryDb } from "./db.js";
+import { withBootFencedRecoveryDb } from "./db.js";
 
 const log = getLogger("recovery-orphaned-channel-events");
 
 export function recoverOrphanedChannelEvents(): void {
-  const bootTime = readDaemonBootTime();
-  if (bootTime == null) {
-    // Without the fence we cannot tell a dead process's orphan from a live
-    // daemon's just-arrived pending row, so skip; the next restart reconciles.
-    log.warn(
-      "Skipping orphaned-channel-event recovery — daemon boot time unavailable",
-    );
-    return;
-  }
-
-  const db = openRecoveryDb();
-  if (db == null) {
-    return;
-  }
-  try {
+  withBootFencedRecoveryDb("orphaned-channel-events", (db, bootTime) => {
     const now = Date.now();
-    // Throws here (missing column) propagate to the orchestrator as "schema not
-    // ready yet" and retry on the next monitor run.
     const result = db
       .query(
         `UPDATE channel_inbound_events
@@ -66,7 +49,5 @@ export function recoverOrphanedChannelEvents(): void {
         "Promoted orphaned pending channel events onto the retry sweep",
       );
     }
-  } finally {
-    db.close();
-  }
+  });
 }

--- a/assistant/src/monitoring/recovery/run-recovery.ts
+++ b/assistant/src/monitoring/recovery/run-recovery.ts
@@ -5,9 +5,11 @@
  * path runs here instead, in the resource-monitor process, off the daemon's
  * event loop. It lists a set of recovery steps and runs each ONCE, shortly
  * after the monitor starts — this is crash recovery, not a periodic sweep.
- * Each step owns the database file it needs and its own logging; the
+ * Each step owns its own reconciliation query and its own logging; the
  * orchestrator only sequences them and isolates one step's failure from the
- * next.
+ * next. The preconditions every step shares, a daemon boot time to fence
+ * against and an openable handle to close afterwards, live in
+ * `withBootFencedRecoveryDb`.
  *
  * Steps run in order; new reconciliations plug in by adding a
  * {@link RecoveryStep} to `RECOVERY_STEPS`. `clear-stale-processing` runs

--- a/assistant/src/monitoring/recovery/stale-processing.ts
+++ b/assistant/src/monitoring/recovery/stale-processing.ts
@@ -24,27 +24,12 @@
  */
 
 import { getLogger } from "../../util/logger.js";
-import { readDaemonBootTime } from "../daemon-boot-time.js";
-import { openRecoveryDb } from "./db.js";
+import { withBootFencedRecoveryDb } from "./db.js";
 
 const log = getLogger("recovery-stale-processing");
 
 export function clearStaleProcessing(): void {
-  const bootTime = readDaemonBootTime();
-  if (bootTime == null) {
-    // Without the boot-time fence we can't distinguish a dead process's flag
-    // from a live turn's, so skip; the next daemon restart reconciles.
-    log.warn("Skipping stale-processing clear — daemon boot time unavailable");
-    return;
-  }
-
-  const db = openRecoveryDb();
-  if (db == null) {
-    return;
-  }
-  try {
-    // Throws here (missing `processing_started_at` column) propagate to the
-    // orchestrator as "schema not ready yet" and retry on the next monitor run.
+  withBootFencedRecoveryDb("stale-processing", (db, bootTime) => {
     const result = db
       .query(
         `UPDATE conversations
@@ -59,7 +44,5 @@ export function clearStaleProcessing(): void {
         "Cleared stale conversation processing flags from a previous process",
       );
     }
-  } finally {
-    db.close();
-  }
+  });
 }

--- a/assistant/src/monitoring/recovery/stranded-delivery-events.ts
+++ b/assistant/src/monitoring/recovery/stranded-delivery-events.ts
@@ -37,30 +37,13 @@
  */
 
 import { getLogger } from "../../util/logger.js";
-import { readDaemonBootTime } from "../daemon-boot-time.js";
-import { openRecoveryDb } from "./db.js";
+import { withBootFencedRecoveryDb } from "./db.js";
 
 const log = getLogger("recovery-stranded-delivery-events");
 
 export function recoverStrandedDeliveryEvents(): void {
-  const bootTime = readDaemonBootTime();
-  if (bootTime == null) {
-    // Without the fence we cannot tell a dead process's orphan from a live
-    // daemon's in-flight delivery, so skip; the next restart reconciles.
-    log.warn(
-      "Skipping stranded-delivery-event recovery: daemon boot time unavailable",
-    );
-    return;
-  }
-
-  const db = openRecoveryDb();
-  if (db == null) {
-    return;
-  }
-  try {
+  withBootFencedRecoveryDb("stranded-delivery-events", (db, bootTime) => {
     const now = Date.now();
-    // Throws here (missing column) propagate to the orchestrator as "schema not
-    // ready yet" and retry on the next monitor run.
     const result = db
       .query(
         `UPDATE channel_inbound_events
@@ -81,7 +64,5 @@ export function recoverStrandedDeliveryEvents(): void {
         "Promoted stranded processed channel events onto the delivery-retry sweep",
       );
     }
-  } finally {
-    db.close();
-  }
+  });
 }


### PR DESCRIPTION
## TL;DR

All three recovery steps opened with the same preamble: read the daemon boot time, bail if absent, open a handle, bail if absent, run one query in a `try/finally` that closes it. `withBootFencedRecoveryDb` owns that; steps keep their query and their logging.

Net 20 lines lighter. No behavior change.

## Why this is worth a PR

The duplicated part is not boilerplate in the harmless sense. It is the guard that decides whether reconciliation is safe to run at all: without a boot-time fence a step cannot tell a dead process's orphan from a live daemon's in-flight row, and reconciling the latter races the running turn.

Three copies of that guard means a fourth step inherits nothing and has to remember it. Now it inherits the fence and can only get its own query wrong.

## What changes for the user

Nothing. Same guards, same queries, same order.

The one observable difference is a log line: the "boot time unavailable" warning is now emitted once from the helper with a `step` field, rather than three per-step messages. Same condition, same level, still says which step skipped.

## Why it is safe

- **The contract the orchestrator documents is unchanged.** A step still owns its reconciliation and its logging, and still isolates its own failure. A throw inside `run` still propagates to `runRecovery`, which treats it as "schema not ready yet" and retries on the next monitor run, because the helper's `finally` closes the handle without swallowing.
- **`finally` placement is preserved**, so the handle closes however the step returns.
- **Existing per-step tests cover this three times over.** Each step's suite already asserts the pre-boot promotion, the post-boot skip, the missing-payload skip, and the missing-boot-time skip, all through the step's public function. Those exercise the extracted path unchanged, which is why no new test is added: the behavior has coverage, only its location moved.
- `tsc` clean, lint and the pinned prettier pass.

## Also

Corrects the orchestrator docstring, which claimed each step "owns the database file it needs." That sentence is what made this duplication look deliberate rather than accidental, and I cited it earlier as a reason not to do this. It describes the orchestrator's minimal role, not a prohibition on shared setup.

## Provenance

Deferred from #41873, where a third copy of the preamble was added and flagged in a `/simplify` pass. Unblocked now that #41873 has merged and `stranded-delivery-events.ts` is on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->