### PR TITLE
Gate the app icon picker per platform and open it on Android

### DIFF
--- a/clients/web/src/domains/settings/components/app-icon-row.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.tsx
@@ -7,8 +7,8 @@
  * an avatar switched to an uploaded image leaves the old icon in place until
  * someone resets it from the picker.
  *
- * Draws nothing at all off native iOS, with the `ios-avatar-app-icon` flag
- * off, or on a build that ships no alternate icons.
+ * Draws nothing at all outside the native mobile shells, with the running
+ * shell's own flag off, or on a build that ships no alternate icons.
  */
 import { useState } from "react";
 

--- a/clients/web/src/hooks/use-app-icon-sync.test.tsx
+++ b/clients/web/src/hooks/use-app-icon-sync.test.tsx
@@ -51,6 +51,7 @@ const NONE: AvatarState = {
 
 let avatarState: AvatarState | null = CHARACTER;
 let nativeIOS = true;
+let nativeAndroid = false;
 let iconState: AppIconState = {
   supported: true,
   current: null,
@@ -70,6 +71,7 @@ const setAppIcon = mock(async (_name: string | null) => swapSucceeds);
 mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
 mock.module("@/runtime/platform-detection", () => ({
   useIsNativeIOS: () => nativeIOS,
+  useIsNativeAndroid: () => nativeAndroid,
 }));
 mock.module("@/hooks/use-assistant-avatar", () => ({
   useAssistantAvatar: () => ({
@@ -100,17 +102,24 @@ async function renderSync() {
 beforeEach(() => {
   avatarState = CHARACTER;
   nativeIOS = true;
+  nativeAndroid = false;
   swapSucceeds = true;
   iconState = { supported: true, current: null, available: [ICON] };
   useAppIconStore.setState({ snapshot: APP_ICON_UNSUPPORTED });
-  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
+  useClientFeatureFlagStore.setState({
+    iosAvatarAppIcon: true,
+    androidAvatarAppIcon: false,
+  });
 });
 
 afterEach(() => {
   cleanup();
   getAppIconState.mockClear();
   setAppIcon.mockClear();
-  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+  useClientFeatureFlagStore.setState({
+    iosAvatarAppIcon: false,
+    androidAvatarAppIcon: false,
+  });
 });
 
 describe("useAppIconSync", () => {
@@ -137,6 +146,36 @@ describe("useAppIconSync", () => {
 
   test("stays off with the flag off", async () => {
     useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+
+    const { result } = renderHook(() => useAppIconSync("asst-1"));
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.canSyncAvatar).toBe(false);
+    expect(getAppIconState).not.toHaveBeenCalled();
+  });
+
+  test("runs on the Android shell behind its own flag", async () => {
+    nativeIOS = false;
+    nativeAndroid = true;
+    useClientFeatureFlagStore.setState({
+      iosAvatarAppIcon: false,
+      androidAvatarAppIcon: true,
+    });
+
+    const { result } = await renderSync();
+
+    await waitFor(() => {
+      expect(result.current.enabled).toBe(true);
+    });
+    expect(result.current.targetIcon).toBe(ICON);
+    expect(result.current.canSyncAvatar).toBe(true);
+  });
+
+  test("stays off on Android with only the iOS flag on", async () => {
+    // Each shell carries its own flag, so rolling the picker out on iOS must
+    // not open it on an Android handset.
+    nativeIOS = false;
+    nativeAndroid = true;
 
     const { result } = renderHook(() => useAppIconSync("asst-1"));
 

--- a/clients/web/src/hooks/use-app-icon-sync.ts
+++ b/clients/web/src/hooks/use-app-icon-sync.ts
@@ -1,5 +1,5 @@
 /**
- * Puts a bundled iOS home-screen icon on the device, on request.
+ * Puts a bundled home-screen icon on the device, on request.
  *
  * The hook only ever acts on a user gesture. iOS shows a system alert the app
  * cannot suppress on every icon swap, so `apply` and `reset` are the two
@@ -16,9 +16,11 @@
  * name is bundled and not already applied. Together they drive the one-tap
  * "match my avatar" shortcut beside the picker.
  *
- * The whole surface reports `enabled: false`, and therefore draws nothing, off
- * native iOS, with the `ios-avatar-app-icon` flag off, or when the installed
- * shell answers `supported: false` (`docs/CAPACITOR.md` § The skew rule).
+ * The whole surface reports `enabled: false`, and therefore draws nothing,
+ * outside the native mobile shells, with the running shell's own flag off
+ * (`ios-avatar-app-icon` on iOS, `android-avatar-app-icon` on Android), or when
+ * the installed shell answers `supported: false` (`docs/CAPACITOR.md` § The
+ * skew rule).
  *
  * The shell's answer is one fact about one device, so it lives in
  * {@link useAppIconStore} rather than in per-instance state: an apply from one
@@ -29,7 +31,10 @@ import { useCallback, useEffect } from "react";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { getAppIconState, setAppIcon } from "@/runtime/app-icon";
-import { useIsNativeIOS } from "@/runtime/platform-detection";
+import {
+  useIsNativeAndroid,
+  useIsNativeIOS,
+} from "@/runtime/platform-detection";
 import { APP_ICON_UNSUPPORTED, useAppIconStore } from "@/stores/app-icon-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { resolveAppIconTarget } from "@/utils/avatar-app-icon";
@@ -62,8 +67,14 @@ const NO_ICONS: string[] = [];
 
 export function useAppIconSync(assistantId: string | null): AppIconSync {
   const isNativeIOS = useIsNativeIOS();
-  const flagEnabled = useClientFeatureFlagStore.use.iosAvatarAppIcon();
-  const gateOpen = isNativeIOS && flagEnabled;
+  const isNativeAndroid = useIsNativeAndroid();
+  const iosFlagEnabled = useClientFeatureFlagStore.use.iosAvatarAppIcon();
+  const androidFlagEnabled =
+    useClientFeatureFlagStore.use.androidAvatarAppIcon();
+  // A flag per shell, so either platform can ship while the other waits, and
+  // one platform's rollout never opens the other's.
+  const gateOpen =
+    (isNativeIOS && iosFlagEnabled) || (isNativeAndroid && androidFlagEnabled);
 
   const { state } = useAssistantAvatar(assistantId);
   const iconState = useAppIconStore.use.snapshot();
@@ -85,9 +96,10 @@ export function useAppIconSync(assistantId: string | null): AppIconSync {
     void refresh();
   }, [refresh]);
 
-  // The user can put the default icon back from iOS Settings while the app is
-  // backgrounded, so the snapshot taken at mount goes stale. Re-read the
-  // shell's answer on every foreground rather than trusting it.
+  // The icon can move while the app is backgrounded: iOS Settings can put the
+  // default back, and Android applies a pending swap as the app leaves the
+  // foreground. Re-read the shell's answer on every foreground rather than
+  // trusting the snapshot taken at mount.
   useBusSubscription("app.resume", () => {
     void refresh();
   });

--- a/clients/web/src/runtime/app-icon.test.ts
+++ b/clients/web/src/runtime/app-icon.test.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for the `AppIcon` bridge.
  *
- * The contract under test is skew-safety: the iOS shell ships through App
- * Store review while this bundle deploys continuously, so an arbitrarily old
+ * The contract under test is skew-safety: each mobile shell ships through a
+ * store review while this bundle deploys continuously, so an arbitrarily old
  * shell can host it with no such plugin compiled in. Every degrade path
- * (non-iOS platform, missing plugin, a rejecting bridge) must resolve the
+ * (non-mobile platform, missing plugin, a rejecting bridge) must resolve the
  * feature-off state without throwing and without touching the bridge.
  *
  * Self-contained mocks: run this file solo (`mock.module` leaks across a
@@ -13,11 +13,11 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-let onNativeIOS = true;
+let onNativeMobile = true;
 let pluginAvailable = true;
 
 mock.module("@/runtime/platform-detection", () => ({
-  isNativeIOS: () => onNativeIOS,
+  isNativeMobile: () => onNativeMobile,
 }));
 
 interface NativeState {
@@ -65,7 +65,7 @@ const { getAppIconState, setAppIcon } = await import("@/runtime/app-icon");
 const OFF = { supported: false, current: null, available: [] };
 
 beforeEach(() => {
-  onNativeIOS = true;
+  onNativeMobile = true;
   pluginAvailable = true;
   stateResult = {
     supported: true,
@@ -95,8 +95,8 @@ describe("getAppIconState", () => {
     });
   });
 
-  test("degrades to feature-off without calling the bridge off iOS", async () => {
-    onNativeIOS = false;
+  test("degrades to feature-off without calling the bridge off native mobile", async () => {
+    onNativeMobile = false;
 
     expect(await getAppIconState()).toEqual(OFF);
     expect(getStateMock).not.toHaveBeenCalled();
@@ -149,11 +149,11 @@ describe("setAppIcon", () => {
     expect(captureErrorMock).toHaveBeenCalledTimes(1);
   });
 
-  test("resolves false without calling the bridge off iOS or with no plugin", async () => {
-    onNativeIOS = false;
+  test("resolves false without calling the bridge off native mobile or with no plugin", async () => {
+    onNativeMobile = false;
     expect(await setAppIcon("avatar-a")).toBe(false);
 
-    onNativeIOS = true;
+    onNativeMobile = true;
     pluginAvailable = false;
     expect(await setAppIcon("avatar-a")).toBe(false);
 

--- a/clients/web/src/runtime/app-icon.ts
+++ b/clients/web/src/runtime/app-icon.ts
@@ -1,16 +1,17 @@
 /**
- * Bridge to the iOS shell's `AppIcon` plugin
- * (`clients/ios/App/App/AppIconPlugin.swift`), which swaps the home-screen
- * icon between the alternates the build ships.
+ * Bridge to the native mobile shells' `AppIcon` plugin
+ * (`clients/ios/App/App/AppIconPlugin.swift` and the Android plugin of the same
+ * name), which swaps the home-screen icon between the alternates the build
+ * ships.
  *
- * iOS-only: alternate app icons are an iOS bundle feature with no Android
- * equivalent, and the web app has no home-screen icon to swap.
+ * Native mobile only: swapping the installed icon is a shell capability, and
+ * the web app has no home-screen icon to swap.
  *
  * `getState().available` is the only source of truth for which icon names
- * exist. The iOS shell loads this bundle remotely, so an arbitrarily old shell
- * can be running arbitrarily new web (see `docs/CAPACITOR.md` § The skew rule):
- * a name the web layer computes may simply not be in the installed build, and
- * only the shell can say. Every degrade path (older shell, non-iOS platform,
+ * exist. Both shells load this bundle remotely, so an arbitrarily old shell can
+ * be running arbitrarily new web (see `docs/CAPACITOR.md` § The skew rule): a
+ * name the web layer computes may simply not be in the installed build, and
+ * only the shell can say. Every degrade path (older shell, non-mobile platform,
  * bridge failure) resolves `supported: false` with an empty `available`, so
  * callers have one thing to check and no error branch to write.
  */
@@ -18,7 +19,7 @@
 import { Capacitor, registerPlugin } from "@capacitor/core";
 
 import { captureError } from "@/lib/sentry/capture-error";
-import { isNativeIOS } from "@/runtime/platform-detection";
+import { isNativeMobile } from "@/runtime/platform-detection";
 
 export interface AppIconState {
   /** Whether the device and build allow swapping the icon at all. */
@@ -52,7 +53,7 @@ function unsupported(): AppIconState {
  * any call is made and the `captureError`s below only ever see real faults.
  */
 function isAvailable(): boolean {
-  return isNativeIOS() && Capacitor.isPluginAvailable(APP_ICON_PLUGIN);
+  return isNativeMobile() && Capacitor.isPluginAvailable(APP_ICON_PLUGIN);
 }
 
 /** Reads what the installed shell can do, never throwing. */
@@ -79,8 +80,9 @@ export async function getAppIconState(): Promise<AppIconState> {
  * Swaps the home-screen icon to `name`, or back to the primary icon when
  * `name` is null. Resolves true only when the shell applied the change.
  *
- * iOS shows a system alert on every successful swap, so this must only ever
- * run from an explicit user action.
+ * iOS shows a system alert on every successful swap, and Android can reset a
+ * pinned home-screen shortcut, so this must only ever run from an explicit
+ * user action.
  */
 export async function setAppIcon(name: string | null): Promise<boolean> {
   if (!isAvailable()) {


### PR DESCRIPTION
## Summary
- app-icon.ts availability now covers both native mobile shells behind the same plugin skew guard
- useAppIconSync gates per platform: iOS behind ios-avatar-app-icon, Android behind android-avatar-app-icon

Part of plan: android-avatar-app-icons.md (PR 6 of 8)