### PR TITLE
chore(skills): regenerate catalog.json for the v0.11.8 cherry-picks

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-01T17:18:02.000Z"
+      "updatedAt": "2026-09-01T17:54:05.000Z"
     },
     {
       "id": "doordash",
@@ -392,7 +392,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-01T16:05:56.000Z"
+      "updatedAt": "2026-09-01T17:54:05.000Z"
     },
     {
       "id": "headless-claude-code",
@@ -512,7 +512,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-09-01T16:52:34.000Z"
+      "updatedAt": "2026-09-01T18:32:50.000Z"
     },
     {
       "id": "llm-provider-setup",


### PR DESCRIPTION
## TL;DR

`Check catalog.json is up to date` fails on #41844, blocking the v0.11.8 cherry-pick PR. This regenerates the catalog so the check passes. The diff is three `updatedAt` timestamps and nothing else.

## Why it drifted

`skills/catalog.json` carries an `updatedAt` per skill derived from the skill's source files. Three commits cherry-picked onto `cherry-pick/release/v0.11.8` edited skills:

- #41853 — `llm-cost-optimizer`
- #41856 — `discord-app-setup`, `guardian-verify-setup`
- #41750 — `inbox-management`

Each carried the catalog as it stood on `main`, but the timestamps the generator produces on this branch differ, so the checked-in file no longer matches its own generator.

Verified the fix locally: `node scripts/skills/generate-catalog.mjs` on this branch produces exactly the three values CI asked for (`17:54:05`, `17:54:05`, `18:32:50`).

## Why this is safe

Generated file only. No skill content, no code, no schema. The generator is the same one CI runs to validate.

## Not caused by the guardian cherry-picks

#41820, #41854, and #41861 (the guardian work also on this branch) touch zero files under `skills/`. Confirmed per commit.

## Root cause is already tracked

LUM-3105, "skills/catalog.json goes stale, and only an unrelated PR notices," is the standing ticket for this shape: a generated file whose regeneration is not enforced at the point of change, so the failure surfaces on whichever unrelated PR runs next. This PR unblocks the release; it does not fix that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->