### PR TITLE
chore(skills): regenerate the stale catalog.json on main

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-01T17:18:02.000Z"
+      "updatedAt": "2026-09-01T17:54:05.000Z"
     },
     {
       "id": "doordash",
@@ -392,7 +392,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-01T16:05:56.000Z"
+      "updatedAt": "2026-09-01T17:54:05.000Z"
     },
     {
       "id": "headless-claude-code",
@@ -512,7 +512,7 @@
           "display-name": "LLM Cost Optimizer"
         }
       },
-      "updatedAt": "2026-09-01T16:52:34.000Z"
+      "updatedAt": "2026-09-01T18:32:50.000Z"
     },
     {
       "id": "llm-provider-setup",


### PR DESCRIPTION
## TL;DR

`skills/catalog.json` on `main` does not match what its own generator produces. Regenerated. The diff is three `updatedAt` timestamps and nothing else.

Every branch cut from `main` inherits the mismatch and fails `Check catalog.json is up to date` for a change it did not make. That is how it surfaced: on the v0.11.8 cherry-pick PR (#41844), whose commits touch no skills at all.

## Why it drifted

The catalog carries an `updatedAt` per skill, derived from the skill's source files. Three merged PRs edited skills without regenerating it:

- #41853 — `llm-cost-optimizer`
- #41856 — `discord-app-setup`, `guardian-verify-setup`
- #41750 — `inbox-management`

Verified by running `node scripts/skills/generate-catalog.mjs` against `main` at `3c3f17157b`: it produces `17:54:05`, `17:54:05`, and `18:32:50` for those three, exactly the values CI asked for on #41844.

## Why this is safe

Generated file only. No skill content, no code, no schema, no behavior. The generator is the one CI runs to validate.

## This is the recurrence LUM-3105 describes

LUM-3105 ("skills/catalog.json goes stale on main, and only an unrelated PR notices") is the standing ticket for this exact shape: a generated artifact whose regeneration is not enforced where the change happens, so the failure lands on an unrelated PR later. This PR clears the current drift; it does not prevent the next one.

The prevention worth considering there: have CI regenerate and fail the PR that edits a skill, rather than the next PR to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41898" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->