### PR TITLE
Match the default thumbnail and picker copy to the Android shell

### DIFF
--- a/clients/web/src/domains/settings/components/app-icon-modal.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-modal.tsx
@@ -2,9 +2,12 @@
  * The app icon picker.
  *
  * Cycles eyes and color the way the avatar builder cycles traits, previews the
- * pair as iOS draws it on the home screen, and applies the one the user lands
- * on. Nothing is applied by cycling: iOS puts up a system alert the app cannot
- * suppress on every icon change, so the swap waits for a press on Set.
+ * pair as the home screen draws it, and applies the one the user lands on.
+ * Nothing is applied by cycling: the swap waits for a press on Set, because iOS
+ * puts up a system alert the app cannot suppress on every icon change and
+ * Android only takes the new icon once the app leaves the foreground. A press
+ * therefore does different things on the two shells, so the note under the
+ * preview and the line a refused swap puts up are written per platform.
  *
  * Prop-driven, in the shape of `AvatarManagementModal`. {@link AppIconRow}
  * owns the shell snapshot and hands down what it found, so what this modal
@@ -15,6 +18,7 @@ import { useEffect, useState } from "react";
 import { AppIconPreview } from "@/components/avatar/app-icon-preview";
 import { TraitCycleRow } from "@/components/avatar/trait-cycle-row";
 import { useTranslation } from "@/i18n";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import {
   DEFAULT_APP_ICON_TRAITS,
   appIconNameForTraits,
@@ -75,6 +79,7 @@ export function AppIconModal({
   onReset,
 }: AppIconModalProps) {
   const { t } = useTranslation("settings");
+  const isAndroidShell = useIsNativeAndroid();
   const [eyeIndex, setEyeIndex] = useState(0);
   const [colorIndex, setColorIndex] = useState(0);
   const [pending, setPending] = useState(false);
@@ -208,14 +213,14 @@ export function AppIconModal({
           ) : null}
 
           <p className="text-body-small-default text-[var(--content-tertiary)]">
-            {t("appIcon.note")}
+            {t(isAndroidShell ? "appIcon.androidApplyNote" : "appIcon.note")}
           </p>
           {failed ? (
             <p
               role="alert"
               className="text-body-small-default text-[color:var(--content-negative)]"
             >
-              {t("appIcon.error")}
+              {t(isAndroidShell ? "appIcon.androidError" : "appIcon.error")}
             </p>
           ) : null}
         </Modal.Body>

--- a/clients/web/src/domains/settings/components/app-icon-row.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.test.tsx
@@ -73,6 +73,29 @@ function bundleGroundP3(bundle: string): string {
 const DEV_GROUND_P3 = bundleGroundP3("AppIcon-Dev.icon");
 const STAGING_GROUND_P3 = bundleGroundP3("AppIcon-Staging.icon");
 
+/** Where the Android flavors keep their own resources. */
+const ANDROID_FLAVOR_DIR = join(
+  import.meta.dir,
+  "../../../../../android/app/src",
+);
+
+/**
+ * The `launcher_background` a flavor declares, read off the flavor rather than
+ * named here for the same reason the bundles above are read: an edited resource
+ * fails this file instead of leaving the thumbnail depicting a field no shell
+ * installs.
+ */
+function flavorLauncherBackground(flavor: string): string {
+  const path = join(ANDROID_FLAVOR_DIR, flavor, "res/values/colors.xml");
+  const fill = readFileSync(path, "utf8").match(
+    /name="launcher_background"\s*>\s*(#[0-9A-Fa-f]{6})\s*</,
+  )?.[1];
+  if (!fill) {
+    throw new Error(`${flavor} declares no launcher_background`);
+  }
+  return fill;
+}
+
 const CHARACTER: AvatarState = {
   kind: "character",
   traits: TRAITS,
@@ -89,6 +112,7 @@ const IMAGE: AvatarState = {
 
 let avatarState: AvatarState | null = CHARACTER;
 let nativeIOS = true;
+let nativeAndroid = false;
 let iconState: AppIconState = {
   supported: true,
   current: null,
@@ -130,6 +154,7 @@ mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
 mock.module("@/runtime/platform-detection", () => ({
   ...platformDetection,
   useIsNativeIOS: () => nativeIOS,
+  useIsNativeAndroid: () => nativeAndroid,
 }));
 mock.module("@/hooks/use-assistant-avatar", () => ({
   useAssistantAvatar: () => ({
@@ -283,6 +308,17 @@ async function renderRow() {
   return view;
 }
 
+/**
+ * Put the stand-in shell on Android, flag and all. Each shell carries its own
+ * flag, so naming the platform without opening its gate draws nothing.
+ */
+function runOnAndroidShell(appId: string) {
+  nativeIOS = false;
+  nativeAndroid = true;
+  shellAppId = appId;
+  useClientFeatureFlagStore.setState({ androidAvatarAppIcon: true });
+}
+
 beforeEach(() => {
   // The default thumbnail follows the shell it runs in, so every test that is
   // not about that runs in the one users install.
@@ -291,10 +327,14 @@ beforeEach(() => {
   shellAppId = "ai.vocify-inc.vellum-assistant-ios";
   avatarState = CHARACTER;
   nativeIOS = true;
+  nativeAndroid = false;
   swapSucceeds = true;
   iconState = { supported: true, current: null, available: ALL_ICONS };
   useAppIconStore.setState({ snapshot: APP_ICON_UNSUPPORTED });
-  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
+  useClientFeatureFlagStore.setState({
+    iosAvatarAppIcon: true,
+    androidAvatarAppIcon: false,
+  });
   useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
 });
 
@@ -305,7 +345,10 @@ afterEach(() => {
   getAppIconState.mockClear();
   setAppIcon.mockClear();
   getInfoMock.mockClear();
-  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+  useClientFeatureFlagStore.setState({
+    iosAvatarAppIcon: false,
+    androidAvatarAppIcon: false,
+  });
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
 });
 
@@ -471,6 +514,88 @@ describe("AppIconRow", () => {
         expect(buttonByText("Change")).toBeDefined();
       });
       expect(previewFill()).toBe(hexFor("teal"));
+    });
+  });
+
+  // Android draws its launcher field from per-flavor resources that share
+  // nothing with the iOS bundles, so the thumbnail standing in for the primary
+  // icon reads the shell's platform as well as its build.
+  describe("the default thumbnail follows the Android flavor", () => {
+    test("draws the dev flavor's blue field", async () => {
+      runOnAndroidShell("ai.vellum.assistant.dev");
+
+      await renderRow();
+
+      await waitFor(() => {
+        expect(previewFill()).toBe(flavorLauncherBackground("dev"));
+      });
+      expect(previewEyePaths()).toEqual(catalogPaths("quirky"));
+    });
+
+    test("draws the staging flavor's orange field", async () => {
+      runOnAndroidShell("ai.vellum.assistant.staging");
+
+      await renderRow();
+
+      await waitFor(() => {
+        expect(previewFill()).toBe(flavorLauncherBackground("staging"));
+      });
+      expect(previewEyePaths()).toEqual(catalogPaths("quirky"));
+    });
+
+    test("leaves the production flavor on the catalog green", async () => {
+      runOnAndroidShell("ai.vellum.assistant");
+
+      await renderRow();
+
+      await waitFor(() => {
+        expect(buttonByText("Change")).toBeDefined();
+      });
+      // Production is the one flavor the row names no field for, which is only
+      // honest while the flavor itself declares the catalog's own green.
+      expect(flavorLauncherBackground("production")).toBe(hexFor("green"));
+      expect(previewFill()).toBe(hexFor("green"));
+    });
+  });
+
+  // A press means something different on each shell: iOS swaps the icon behind
+  // its own alert, Android waits for the app to leave the foreground and can
+  // drop a pinned shortcut on the way.
+  describe("the picker's copy follows the shell", () => {
+    test("names the deferred apply and the pinned shortcut on Android", async () => {
+      runOnAndroidShell("ai.vellum.assistant");
+      await renderRow();
+      await waitFor(() => {
+        expect(buttonByText("Change")).toBeDefined();
+      });
+
+      await press("Change");
+
+      expect(modal()?.textContent).toContain(
+        "Android applies your choice once you leave the app",
+      );
+      expect(modal()?.textContent).not.toContain("iOS");
+    });
+
+    test("names Android as the shell that kept the old icon", async () => {
+      swapSucceeds = false;
+      runOnAndroidShell("ai.vellum.assistant");
+      await renderRow();
+      await waitFor(() => {
+        expect(buttonByText("Change")).toBeDefined();
+      });
+
+      await press("Change");
+      await press("Set app icon");
+
+      await waitFor(() => {
+        expect(
+          document.querySelector('[role="alert"]')?.textContent?.trim(),
+        ).toBe(
+          "Android did not change your home screen icon. You can try again.",
+        );
+      });
+      expect(modal()).not.toBeNull();
     });
   });
 

--- a/clients/web/src/domains/settings/components/app-icon-row.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.tsx
@@ -18,6 +18,7 @@ import { AppIconModal } from "@/domains/settings/components/app-icon-modal";
 import { useAppIconSync, type AppIconSync } from "@/hooks/use-app-icon-sync";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useTranslation } from "@/i18n";
+import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import {
   useShellEnvironment,
   type ShellEnvironment,
@@ -80,15 +81,31 @@ const PRIMARY_ICON_GROUND: Partial<Record<ShellEnvironment, IconGround>> = {
 };
 
 /**
- * Ground to draw when the shell names no environment we know, keyed by
- * `VITE_SENTRY_ENVIRONMENT`. An unset value is a local build, which
- * `clients/ios/README.md` runs on the App Dev scheme, so it takes the same
- * pink.
+ * Ground the Android shells draw their launcher icon on, keyed by the shell's
+ * own environment.
+ *
+ * These are the per-flavor `launcher_background` resources in
+ * `clients/android/app/src/<flavor>/res/values/colors.xml`, which the platform
+ * declares in plain sRGB and ships no wide-gamut variant of, so they are named
+ * once rather than paired the way the iOS bundles above are. Production is
+ * absent for the same reason it is absent there: its `launcher_background` is
+ * already the catalog green {@link DEFAULT_APP_ICON_TRAITS} names.
  */
-const WEB_ENV_PRIMARY_ICON_GROUND: Record<string, IconGround> = {
-  local: DEV_GROUND,
-  dev: DEV_GROUND,
-  staging: STAGING_GROUND,
+const ANDROID_PRIMARY_ICON_GROUND: Partial<Record<ShellEnvironment, string>> = {
+  dev: "#2457C5",
+  staging: "#C84C09",
+};
+
+/**
+ * Environment to fall back to when the shell names none, keyed by
+ * `VITE_SENTRY_ENVIRONMENT`. An unset value is a local build, which each
+ * project runs on its own dev build (the App Dev scheme in
+ * `clients/ios/README.md`, the `dev` flavor on Android), so it reads as dev.
+ */
+const WEB_ENV_SHELL_ENVIRONMENT: Record<string, ShellEnvironment> = {
+  local: "dev",
+  dev: "dev",
+  staging: "staging",
 };
 
 /** Whether the renderer parses a CSS Color 4 `color()` at all. */
@@ -108,24 +125,41 @@ function groundFill(ground: IconGround | undefined): string | undefined {
 }
 
 /**
+ * Environment whose primary icon the thumbnail stands in for: the shell's own
+ * wherever it named one, the web deploy's where it named none, and none at all
+ * while it has yet to answer.
+ */
+function primaryIconEnvironment(
+  shell: ShellEnvironment | null | undefined,
+): ShellEnvironment | undefined {
+  if (shell) {
+    return shell;
+  }
+  if (shell === null) {
+    return WEB_ENV_SHELL_ENVIRONMENT[
+      import.meta.env.VITE_SENTRY_ENVIRONMENT ?? "local"
+    ];
+  }
+  return undefined;
+}
+
+/**
  * Ground the running shell's primary icon carries, undefined on production and
  * while the shell has yet to answer, which draws the production green for the
- * frame or two that takes.
+ * frame or two that takes. The two platforms ship unrelated fields for the same
+ * environment, so the shell's OS picks the map and the shell's build keys it.
  */
 function primaryIconGround(
   shell: ShellEnvironment | null | undefined,
+  android: boolean,
 ): string | undefined {
-  if (shell) {
-    return groundFill(PRIMARY_ICON_GROUND[shell]);
+  const environment = primaryIconEnvironment(shell);
+  if (!environment) {
+    return undefined;
   }
-  if (shell === null) {
-    return groundFill(
-      WEB_ENV_PRIMARY_ICON_GROUND[
-        import.meta.env.VITE_SENTRY_ENVIRONMENT ?? "local"
-      ],
-    );
-  }
-  return undefined;
+  return android
+    ? ANDROID_PRIMARY_ICON_GROUND[environment]
+    : groundFill(PRIMARY_ICON_GROUND[environment]);
 }
 
 export function AppIconRow() {
@@ -152,6 +186,7 @@ function AppIconRowContent({ assistantId, sync }: AppIconRowContentProps) {
   const { components } = useAssistantAvatar(assistantId);
   const bundledComponents = useBundledAvatarComponents();
   const shellEnvironment = useShellEnvironment();
+  const isAndroidShell = useIsNativeAndroid();
   const [open, setOpen] = useState(false);
 
   // The daemon's catalog is what the avatar itself is drawn from, so the
@@ -183,7 +218,9 @@ function AppIconRowContent({ assistantId, sync }: AppIconRowContentProps) {
             color={traits.color}
             primary={isPrimary}
             fieldColor={
-              isPrimary ? primaryIconGround(shellEnvironment) : undefined
+              isPrimary
+                ? primaryIconGround(shellEnvironment, isAndroidShell)
+                : undefined
             }
             size={ROW_PREVIEW_SIZE}
           />

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -74,6 +74,8 @@
     "unsupportedLabel": "Unavailable"
   },
   "appIcon": {
+    "androidApplyNote": "Alternate icons ship with the app. Android applies your choice once you leave the app, and switching can reset a shortcut you pinned to your home screen.",
+    "androidError": "Android did not change your home screen icon. You can try again.",
     "apply": "Set app icon",
     "change": "Change",
     "color": "Color",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -74,6 +74,8 @@
     "unsupportedLabel": "No disponible"
   },
   "appIcon": {
+    "androidApplyNote": "Los iconos alternativos vienen incluidos en la app. Android aplica tu elección en cuanto sales de la app, y cambiarlo puede restablecer un acceso directo que hayas anclado a tu pantalla de inicio.",
+    "androidError": "Android no cambió el icono de tu pantalla de inicio. Puedes intentarlo de nuevo.",
     "apply": "Establecer icono",
     "change": "Cambiar",
     "color": "Color",

--- a/clients/web/src/i18n/locales/zh-TW/settings.json
+++ b/clients/web/src/i18n/locales/zh-TW/settings.json
@@ -74,6 +74,8 @@
     "unsupportedLabel": "無法使用"
   },
   "appIcon": {
+    "androidApplyNote": "替換圖示隨應用程式提供。Android 會在您離開應用程式後套用您的選擇，變更圖示可能會重設您釘選到主螢幕的捷徑。",
+    "androidError": "Android 未變更您的主螢幕圖示。您可以再試一次。",
     "apply": "設定應用程式圖示",
     "change": "變更",
     "color": "顏色",

--- a/clients/web/src/i18n/locales/zh/settings.json
+++ b/clients/web/src/i18n/locales/zh/settings.json
@@ -74,6 +74,8 @@
     "unsupportedLabel": "不可用"
   },
   "appIcon": {
+    "androidApplyNote": "备用图标随应用提供。Android 会在您离开应用后应用您的选择，更换图标可能会重置您固定到主屏幕的快捷方式。",
+    "androidError": "Android 未更改您的主屏幕图标。您可以再试一次。",
     "apply": "设置应用图标",
     "change": "更改",
     "color": "颜色",


### PR DESCRIPTION
## Summary
- The primary-icon thumbnail picks the Android shell's per-environment launcher background (dev blue, staging orange, production catalog green fallback), leaving the iOS grounds untouched
- Picker copy is platform-appropriate: Android explains the on-background apply and the pinned-shortcut caveat, in both locales

Part of plan: android-avatar-app-icons.md (PR 7 of 8)