### PR TITLE
fix(gateway): a re-added reaction is a new event, not a duplicate

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -70,7 +70,6 @@ mock.module("../../../contacts/contact-store.js", () => ({
 // ---------------------------------------------------------------------------
 
 let recordInboundCalls: Array<{ conversationId?: string }> = [];
-let recordedEvent: { eventId: string; conversationId: string } | null = null;
 // Keyed the way the real `channel_inbound_events` row is keyed, so a test can
 // replay a sequence of events and see which of them the daemon treats as new.
 const inboundStore = new Map<
@@ -79,6 +78,13 @@ const inboundStore = new Map<
 >();
 const inboundKey = (channel: string, chat: string, id: string) =>
   `${channel}\u0000${chat}\u0000${id}`;
+/** Seed a row so the next delivery of `externalMessageId` reads as a redelivery. */
+function seedRecordedEvent(externalMessageId: string, eventId: string): void {
+  inboundStore.set(inboundKey("slack", SLACK_CHANNEL_ID, externalMessageId), {
+    eventId,
+    conversationId: "conv-target",
+  });
+}
 let outboundTargetConversationId: string | null = null;
 let outboundLookupChannels: string[] = [];
 let storedTarget: { messageId: string; conversationId: string } | null = null;
@@ -116,10 +122,7 @@ mock.module("../../../persistence/delivery-crud.js", () => ({
     channel: string,
     chat: string,
     externalMessageId: string,
-  ) =>
-    recordedEvent ??
-    inboundStore.get(inboundKey(channel, chat, externalMessageId)) ??
-    null,
+  ) => inboundStore.get(inboundKey(channel, chat, externalMessageId)) ?? null,
   clearPayload: () => {},
   storePayload: (eventId: string, payload: Record<string, unknown>) => {
     storedPayloads.push({ eventId, payload });
@@ -287,32 +290,33 @@ function expectDropped(result: Record<string, unknown>): void {
   expect(guardianReplyCalls.length).toBe(0);
 }
 
+function resetHarness(): void {
+  ipcCalls = [];
+  guardianDeliveryReads = 0;
+  setMemberVerdictCalls = 0;
+  contactLookups = 0;
+  recordInboundCalls = [];
+  inboundStore.clear();
+  outboundTargetConversationId = null;
+  outboundLookupChannels = [];
+  addMessageCalls = 0;
+  guardianReplyCalls = [];
+  guardianReplyResponse = undefined;
+  storedTarget = { messageId: "msg-target", conversationId: "conv-target" };
+  // Default target: a user-authored row, so reactions stay passive unless
+  // a test makes the target the assistant's own post.
+  targetRow = {
+    role: "user",
+    content: [{ type: "text", text: "the reacted-to message" }],
+  };
+  dispatchedTurns = [];
+  dispatchThrows = false;
+  storedPayloads.length = 0;
+  markProcessedCalls = 0;
+}
+
 describe("reaction intercept consumes the stamped verdict directly", () => {
-  beforeEach(() => {
-    ipcCalls = [];
-    guardianDeliveryReads = 0;
-    setMemberVerdictCalls = 0;
-    contactLookups = 0;
-    recordInboundCalls = [];
-    recordedEvent = null;
-    inboundStore.clear();
-    outboundTargetConversationId = null;
-    outboundLookupChannels = [];
-    addMessageCalls = 0;
-    guardianReplyCalls = [];
-    guardianReplyResponse = undefined;
-    storedTarget = { messageId: "msg-target", conversationId: "conv-target" };
-    // Default target: a user-authored row, so reactions stay passive unless
-    // a test makes the target the assistant's own post.
-    targetRow = {
-      role: "user",
-      content: [{ type: "text", text: "the reacted-to message" }],
-    };
-    dispatchedTurns = [];
-    dispatchThrows = false;
-    storedPayloads.length = 0;
-    markProcessedCalls = 0;
-  });
+  beforeEach(resetHarness);
 
   test("guardian verdict routes the reaction into the approval decision pipeline", async () => {
     guardianReplyResponse = { accepted: true, canonicalRouter: "applied" };
@@ -610,12 +614,14 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
   });
 
   test("a redelivered reaction never reaches the guardian rail twice", async () => {
-    recordedEvent = { eventId: "evt-1", conversationId: "conv-target" };
+    const externalMessageId = `${SLACK_CHANNEL_ID}:1700000000.1:redelivered`;
+    seedRecordedEvent(externalMessageId, "evt-1");
 
     const result = await handleReactionIntercept(
       buildParams({
         rawSenderId: GUARDIAN_USER_ID,
         trustVerdict: GUARDIAN_VERDICT,
+        externalMessageId,
       }),
     );
 
@@ -726,24 +732,7 @@ describe("a re-added reaction records again", () => {
     `1700000000.1:reaction:\u2705:${MEMBER_USER_ID}:dispatch-2`,
   ];
 
-  beforeEach(() => {
-    recordInboundCalls = [];
-    recordedEvent = null;
-    inboundStore.clear();
-    outboundTargetConversationId = null;
-    addMessageCalls = 0;
-    guardianReplyCalls = [];
-    guardianReplyResponse = undefined;
-    storedTarget = { messageId: "msg-target", conversationId: "conv-target" };
-    targetRow = {
-      role: "user",
-      content: [{ type: "text", text: "the reacted-to message" }],
-    };
-    dispatchedTurns = [];
-    dispatchThrows = false;
-    storedPayloads.length = 0;
-    markProcessedCalls = 0;
-  });
+  beforeEach(resetHarness);
 
   async function replay(
     externalMessageIds: string[],

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -713,11 +713,10 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
 /**
  * Add, remove, re-add: the sequence whose third event must survive dedup.
  *
- * The dedup id is what decides whether the third event exists at all: the
- * intercept returns before `persistPassively` on a duplicate, so a re-add
- * that collides with the first add writes no transcript row, leaving the
- * removal as the last recorded state. The ids here are the shapes the
- * gateway normalizers build (`slack/reaction-normalizer.ts`,
+ * The intercept returns before `persistPassively` on a duplicate, so an id
+ * that repeats across occurrences costs the re-add its transcript row and
+ * leaves the removal as the last recorded state. The ids here are the shapes
+ * the gateway normalizers build (`slack/reaction-normalizer.ts`,
  * `discord/normalize.ts`), whose per-event component is the trailing segment.
  */
 describe("a re-added reaction records again", () => {
@@ -785,9 +784,8 @@ describe("a re-added reaction records again", () => {
   });
 
   test("a genuine redelivery of one event still collapses to one", async () => {
-    // What the dedup id is for, and what the fix must not cost: the gateway
-    // retries a forward with the same payload, so the same id arrives twice
-    // and the second arrival must write nothing.
+    // What the dedup id is for: the gateway retries a forward with the same
+    // payload, so the same id arrives twice and the second writes nothing.
     const [first, second] = await replay(
       [SLACK_IDS[0]!, SLACK_IDS[0]!],
       ["added", "added"],

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -71,23 +71,36 @@ mock.module("../../../contacts/contact-store.js", () => ({
 
 let recordInboundCalls: Array<{ conversationId?: string }> = [];
 let recordedEvent: { eventId: string; conversationId: string } | null = null;
+// Keyed the way the real `channel_inbound_events` row is keyed, so a test can
+// replay a sequence of events and see which of them the daemon treats as new.
+const inboundStore = new Map<
+  string,
+  { eventId: string; conversationId: string }
+>();
+const inboundKey = (channel: string, chat: string, id: string) =>
+  `${channel}\u0000${chat}\u0000${id}`;
 let outboundTargetConversationId: string | null = null;
 let outboundLookupChannels: string[] = [];
 let storedTarget: { messageId: string; conversationId: string } | null = null;
 mock.module("../../../persistence/delivery-crud.js", () => ({
   recordInbound: (
-    _channel: string,
-    _chat: string,
-    _externalMessageId: string,
+    channel: string,
+    chat: string,
+    externalMessageId: string,
     options?: { conversationId?: string },
   ) => {
     recordInboundCalls.push({ conversationId: options?.conversationId });
-    return {
-      eventId: "evt-1",
+    const key = inboundKey(channel, chat, externalMessageId);
+    const existing = inboundStore.get(key);
+    if (existing) {
+      return { ...existing, accepted: true, duplicate: true };
+    }
+    const row = {
+      eventId: `evt-${inboundStore.size + 1}`,
       conversationId: options?.conversationId ?? "conv-minted",
-      accepted: true,
-      duplicate: false,
     };
+    inboundStore.set(key, row);
+    return { ...row, accepted: true, duplicate: false };
   },
   findMessageBySourceId: () => storedTarget,
   findMessageByProviderMessageId: (sourceChannel: string) => {
@@ -99,7 +112,14 @@ mock.module("../../../persistence/delivery-crud.js", () => ({
         }
       : null;
   },
-  findInboundEvent: () => recordedEvent,
+  findInboundEvent: (
+    channel: string,
+    chat: string,
+    externalMessageId: string,
+  ) =>
+    recordedEvent ??
+    inboundStore.get(inboundKey(channel, chat, externalMessageId)) ??
+    null,
   clearPayload: () => {},
   storePayload: (eventId: string, payload: Record<string, unknown>) => {
     storedPayloads.push({ eventId, payload });
@@ -222,18 +242,23 @@ function buildParams(overrides: {
   rawSenderId: string;
   trustVerdict?: TrustVerdict;
   op?: "added" | "removed";
+  externalMessageId?: string;
+  sourceChannel?: "slack" | "discord";
 }) {
   msgCounter++;
+  const sourceChannel = overrides.sourceChannel ?? ("slack" as const);
   return {
     reaction: {
       op: overrides.op ?? ("added" as const),
       emoji: "white_check_mark",
       targetMessageId: "1700000000.1",
     },
-    sourceChannel: "slack" as const,
-    sourceInterface: "slack" as const,
+    sourceChannel,
+    sourceInterface: sourceChannel,
     conversationExternalId: SLACK_CHANNEL_ID,
-    externalMessageId: `${SLACK_CHANNEL_ID}:1700000000.1:${msgCounter}`,
+    externalMessageId:
+      overrides.externalMessageId ??
+      `${SLACK_CHANNEL_ID}:1700000000.1:${msgCounter}`,
     rawSenderId: overrides.rawSenderId,
     canonicalSenderId: overrides.rawSenderId,
     actorDisplayName: "Reactor",
@@ -270,6 +295,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     contactLookups = 0;
     recordInboundCalls = [];
     recordedEvent = null;
+    inboundStore.clear();
     outboundTargetConversationId = null;
     outboundLookupChannels = [];
     addMessageCalls = 0;
@@ -675,5 +701,114 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
     expect(guardianDeliveryReads).toBe(0);
     expect(setMemberVerdictCalls).toBe(0);
     expect(contactLookups).toBe(0);
+  });
+});
+
+/**
+ * Add, remove, re-add: the sequence that used to end with the reaction
+ * permanently invisible.
+ *
+ * The dedup id is what decides whether the third event exists at all: the
+ * intercept returns before `persistPassively` on a duplicate, so a re-add
+ * that collides with the first add writes no transcript row, leaving the
+ * removal as the last recorded state. The ids here are the shapes the
+ * gateway normalizers build (`slack/reaction-normalizer.ts`,
+ * `discord/normalize.ts`), whose per-event component is the trailing segment.
+ */
+describe("a re-added reaction records again", () => {
+  const SLACK_IDS = [
+    `${SLACK_CHANNEL_ID}:1700000000.1:white_check_mark:${MEMBER_USER_ID}:Ev001`,
+    `${SLACK_CHANNEL_ID}:1700000000.1:white_check_mark:${MEMBER_USER_ID}:removed:Ev002`,
+    `${SLACK_CHANNEL_ID}:1700000000.1:white_check_mark:${MEMBER_USER_ID}:Ev003`,
+  ];
+  const DISCORD_IDS = [
+    `1700000000.1:reaction:\u2705:${MEMBER_USER_ID}:dispatch-0`,
+    `1700000000.1:reaction:\u2705:${MEMBER_USER_ID}:removed:dispatch-1`,
+    `1700000000.1:reaction:\u2705:${MEMBER_USER_ID}:dispatch-2`,
+  ];
+
+  beforeEach(() => {
+    recordInboundCalls = [];
+    recordedEvent = null;
+    inboundStore.clear();
+    outboundTargetConversationId = null;
+    addMessageCalls = 0;
+    guardianReplyCalls = [];
+    guardianReplyResponse = undefined;
+    storedTarget = { messageId: "msg-target", conversationId: "conv-target" };
+    targetRow = {
+      role: "user",
+      content: [{ type: "text", text: "the reacted-to message" }],
+    };
+    dispatchedTurns = [];
+    dispatchThrows = false;
+    storedPayloads.length = 0;
+    markProcessedCalls = 0;
+  });
+
+  async function replay(
+    externalMessageIds: string[],
+    ops: Array<"added" | "removed">,
+    sourceChannel: "slack" | "discord" = "slack",
+  ) {
+    const results: Array<Record<string, unknown>> = [];
+    for (const [index, externalMessageId] of externalMessageIds.entries()) {
+      results.push(
+        await handleReactionIntercept(
+          buildParams({
+            rawSenderId: MEMBER_USER_ID,
+            trustVerdict: MEMBER_VERDICT,
+            op: ops[index],
+            externalMessageId,
+            sourceChannel,
+          }),
+        ),
+      );
+    }
+    return results;
+  }
+
+  test("Slack: three events, three transcript rows, none deduped away", async () => {
+    const results = await replay(SLACK_IDS, ["added", "removed", "added"]);
+
+    expect(results.map((result) => result.duplicate)).toEqual([
+      false,
+      false,
+      false,
+    ]);
+    expect(inboundStore.size).toBe(3);
+    expect(addMessageCalls).toBe(3);
+  });
+
+  test("Discord: three events, three transcript rows, none deduped away", async () => {
+    const results = await replay(
+      DISCORD_IDS,
+      ["added", "removed", "added"],
+      "discord",
+    );
+
+    expect(results.map((result) => result.duplicate)).toEqual([
+      false,
+      false,
+      false,
+    ]);
+    expect(inboundStore.size).toBe(3);
+    expect(addMessageCalls).toBe(3);
+  });
+
+  test("a genuine redelivery of one event still collapses to one", async () => {
+    // What the dedup id is for, and what the fix must not cost: the gateway
+    // retries a forward with the same payload, so the same id arrives twice
+    // and the second arrival must write nothing.
+    const [first, second] = await replay(
+      [SLACK_IDS[0]!, SLACK_IDS[0]!],
+      ["added", "added"],
+    );
+
+    expect(first!.duplicate).toBe(false);
+    expect(second!.duplicate).toBe(true);
+    expect(second!.eventId).toBe(first!.eventId);
+    expect(inboundStore.size).toBe(1);
+    expect(addMessageCalls).toBe(1);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts
@@ -705,8 +705,7 @@ describe("reaction intercept consumes the stamped verdict directly", () => {
 });
 
 /**
- * Add, remove, re-add: the sequence that used to end with the reaction
- * permanently invisible.
+ * Add, remove, re-add: the sequence whose third event must survive dedup.
  *
  * The dedup id is what decides whether the third event exists at all: the
  * intercept returns before `persistPassively` on a duplicate, so a re-add

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -83,6 +83,7 @@ Gateway inbound events use a channel-discriminated union model (`GatewayInboundE
 
 - **`conversationExternalId`**: Delivery/conversation address (e.g., Telegram chat ID, phone number). Used for conversation binding and message routing. **Not** used for trust classification.
 - **`actorExternalId`**: Sender identity (e.g., Telegram user ID, WhatsApp phone number). Used for trust classification, guardian binding, and ACL enforcement. **Required** for all public channel ingress.
+- **`externalMessageId`**: Dedup identity. It must name one OCCURRENCE of an event, not one kind of event: two distinct acts by the same actor differ here, and the same act delivered twice repeats here. Both halves are load-bearing, because the gateway claims a delivery on `(sourceChannel, externalChatId, externalMessageId)` (`db/inbound-dedup-store.ts`) and the daemon records the permanent event row on the same triple. Prefer the provider's own per-event id (Telegram `update_id`, Slack `event_id`, a Discord snowflake, an email `Message-ID`). Where a provider names only the thing acted on and not the act, as both reaction families do, addressing fields alone (room, target message, actor, verb) repeat byte for byte on the second occurrence and silently dedup it away, so the normalizer must carry a per-event component of its own.
 - **"conversation"** is canonical vocabulary for delivery addresses. "thread" is reserved for provider-specific fields (Slack `thread_ts`, email thread IDs).
 - **"actor"** is canonical vocabulary for sender identity.
 

--- a/gateway/src/__tests__/slack-reaction-normalize.test.ts
+++ b/gateway/src/__tests__/slack-reaction-normalize.test.ts
@@ -128,7 +128,7 @@ describe("normalizeSlackReactionAdded", () => {
 
     expect(result).not.toBeNull();
     expect(result!.event.message.externalMessageId).toBe(
-      "C123:1234567890.123456:alarm_clock:U001",
+      "C123:1234567890.123456:alarm_clock:U001:ev-7",
     );
   });
 
@@ -140,8 +140,11 @@ describe("normalizeSlackReactionAdded", () => {
     });
     const event1 = makeReactionEvent({ user: "U001" });
     const event2 = makeReactionEvent({ user: "U002" });
-    const result1 = normalizeSlackReactionAdded(event1, "ev-8a", config);
-    const result2 = normalizeSlackReactionAdded(event2, "ev-8b", config);
+    // One event id across both, so the reactor is the only thing that can
+    // separate the two ids. Distinct event ids would separate them on their
+    // own and the assertion would hold even if the reactor were dropped.
+    const result1 = normalizeSlackReactionAdded(event1, "ev-8", config);
+    const result2 = normalizeSlackReactionAdded(event2, "ev-8", config);
 
     expect(result1).not.toBeNull();
     expect(result2).not.toBeNull();

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -52,7 +52,8 @@ interface InboundEventBase<C extends InboundChannelId> {
      * only the thing acted on and not the act, addressing fields alone
      * (room, target message, actor, verb) repeat byte for byte on the second
      * occurrence and silently dedup it away. Reactions are that case on both
-     * Slack and Discord, and were exactly that bug.
+     * Slack and Discord: each carries a per-event component for exactly this
+     * reason.
      */
     externalMessageId: string;
     /** The named event family. Producers stamp it on every event; the

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -35,6 +35,25 @@ interface InboundEventBase<C extends InboundChannelId> {
   message: {
     content: string;
     conversationExternalId: string;
+    /**
+     * Dedup identity, and the invariant every normalizer owes its channel:
+     * this must name one OCCURRENCE of an event, not one kind of event. Two
+     * distinct acts by the same person differ here; the same act delivered
+     * twice repeats here. Both halves are load-bearing, on both sides of the
+     * handoff: the gateway claims the delivery on
+     * `(sourceChannel, externalChatId, externalMessageId)`
+     * (`db/inbound-dedup-store.ts`) and the daemon records the permanent
+     * event row on the same triple (`recordInbound`), which drops a repeat
+     * before it can write a transcript row or wake a turn.
+     *
+     * Prefer the provider's own per-event id, which is what most channels
+     * have: Telegram `update_id`, Slack `event_id`, a Discord message or
+     * interaction snowflake, an email `Message-ID`. Where the provider names
+     * only the thing acted on and not the act, addressing fields alone
+     * (room, target message, actor, verb) repeat byte for byte on the second
+     * occurrence and silently dedup it away. Reactions are that case on both
+     * Slack and Discord, and were exactly that bug.
+     */
     externalMessageId: string;
     /** The named event family. Producers stamp it on every event; the
      *  flag and sentinel fields below carry each family's payload and

--- a/gateway/src/channels/inbound-event.ts
+++ b/gateway/src/channels/inbound-event.ts
@@ -49,11 +49,10 @@ interface InboundEventBase<C extends InboundChannelId> {
      * Prefer the provider's own per-event id, which is what most channels
      * have: Telegram `update_id`, Slack `event_id`, a Discord message or
      * interaction snowflake, an email `Message-ID`. Where the provider names
-     * only the thing acted on and not the act, addressing fields alone
-     * (room, target message, actor, verb) repeat byte for byte on the second
-     * occurrence and silently dedup it away. Reactions are that case on both
-     * Slack and Discord: each carries a per-event component for exactly this
-     * reason.
+     * only the thing acted on and not the act, addressing fields alone (room,
+     * target message, actor, verb) repeat byte for byte on the second
+     * occurrence and dedup it away, so the normalizer supplies a per-event
+     * component of its own. Both reaction families are that case.
      */
     externalMessageId: string;
     /** The named event family. Producers stamp it on every event; the

--- a/gateway/src/discord/gateway-socket.test.ts
+++ b/gateway/src/discord/gateway-socket.test.ts
@@ -512,6 +512,23 @@ describe("reaction dispatch", () => {
     expect(h.events).toHaveLength(0);
   });
 
+  test("add, remove and re-add forward as three distinct events", async () => {
+    // End to end through the socket: the same person reacting, un-reacting
+    // and re-reacting sends three byte-identical dispatch payloads. The id
+    // the socket stamps at receipt is the only thing keeping the third one
+    // from reading as a redelivery of the first, which the daemon would
+    // discard, leaving the removal as the last recorded state forever.
+    const h = harness();
+    const ws = await connectAndReady(h);
+    ws.message(reactionAdd());
+    ws.message({ ...reactionAdd(), t: "MESSAGE_REACTION_REMOVE" });
+    ws.message(reactionAdd());
+
+    expect(h.events).toHaveLength(3);
+    const ids = h.events.map((event) => event.message.externalMessageId);
+    expect(new Set(ids).size).toBe(3);
+  });
+
   test("a thread reaction resolves its parent conversation", async () => {
     const h = harness();
     const ws = await connectAndReady(h);

--- a/gateway/src/discord/gateway-socket.test.ts
+++ b/gateway/src/discord/gateway-socket.test.ts
@@ -513,11 +513,9 @@ describe("reaction dispatch", () => {
   });
 
   test("add, remove and re-add forward as three distinct events", async () => {
-    // End to end through the socket: the same person reacting, un-reacting
-    // and re-reacting sends three byte-identical dispatch payloads. The id
-    // the socket stamps at receipt is the only thing keeping the third one
-    // from reading as a redelivery of the first, which the daemon would
-    // discard, leaving the removal as the last recorded state forever.
+    // End to end through the socket: three byte-identical dispatch payloads,
+    // three distinct ids. The socket's stamp at receipt is what separates
+    // them, so this covers the minting the pure normalizer tests cannot.
     const h = harness();
     const ws = await connectAndReady(h);
     ws.message(reactionAdd());

--- a/gateway/src/discord/gateway-socket.ts
+++ b/gateway/src/discord/gateway-socket.ts
@@ -895,8 +895,16 @@ export class DiscordGatewayClient {
     // event still rides the full forward path, where the kill switch and
     // per-family stages apply.
     const parentChannelId = this.threadParents.parentOf(reaction.channel_id);
+    // Stamped here, once per received dispatch, because Discord names the
+    // reaction and not the act of reacting: the same person re-adding the
+    // same emoji sends a byte-identical payload, and without a per-dispatch
+    // component the daemon reads the second one as a redelivery of the first.
+    // Receipt is the only place that can tell them apart, and the id it mints
+    // rides inside the forwarded event, so a forward retried against the
+    // daemon still carries the one id and still dedups.
     const normalized = normalizeDiscordMessageReaction(reaction, {
       op,
+      ingestId: crypto.randomUUID(),
       ...(parentChannelId !== undefined ? { parentChannelId } : {}),
       raw: (data ?? {}) as Record<string, unknown>,
     });

--- a/gateway/src/discord/gateway-socket.ts
+++ b/gateway/src/discord/gateway-socket.ts
@@ -895,13 +895,10 @@ export class DiscordGatewayClient {
     // event still rides the full forward path, where the kill switch and
     // per-family stages apply.
     const parentChannelId = this.threadParents.parentOf(reaction.channel_id);
-    // Stamped here, once per received dispatch, because Discord names the
-    // reaction and not the act of reacting: the same person re-adding the
-    // same emoji sends a byte-identical payload, and without a per-dispatch
-    // component the daemon reads the second one as a redelivery of the first.
-    // Receipt is the only place that can tell them apart, and the id it mints
-    // rides inside the forwarded event, so a forward retried against the
-    // daemon still carries the one id and still dedups.
+    // Receipt is the only place that can tell one occurrence of a reaction
+    // from the next, because Discord's payload cannot (see the dedup id in
+    // `normalize.ts`). Minting per dispatch is what makes the ids differ;
+    // minting outside the retry path is what keeps a redelivery's identical.
     const normalized = normalizeDiscordMessageReaction(reaction, {
       op,
       ingestId: crypto.randomUUID(),

--- a/gateway/src/discord/normalize.test.ts
+++ b/gateway/src/discord/normalize.test.ts
@@ -607,10 +607,8 @@ describe("normalizeDiscordMessageReaction", () => {
   });
 
   test("add, remove and re-add are three events, not two", () => {
-    // The bug this shape exists to catch: with no per-dispatch component the
-    // re-add is byte-identical to the first add, `recordInbound` calls it a
-    // duplicate, and the removal stays the last recorded state forever: the
-    // reaction is invisible in the transcript from then on, permanently.
+    // Three acts, three ids. The dispatch payload is byte-identical across
+    // all three, so `ingestId` is the only thing separating them.
     const ids = (["added", "removed", "added"] as const).map(
       (op, index) =>
         normalizeDiscordMessageReaction(thumbsUp(), {
@@ -625,8 +623,8 @@ describe("normalizeDiscordMessageReaction", () => {
 
   test("one dispatch forwarded twice keeps its id, so redelivery still dedups", () => {
     // The other half of the contract: the id is stamped once per received
-    // dispatch and rides inside the forwarded payload, so a forward the
-    // gateway retries against the daemon must present the same id.
+    // dispatch and rides in the forwarded payload, so a retried forward
+    // presents the same id.
     const first = normalizeDiscordMessageReaction(thumbsUp(), {
       op: "added",
       ingestId: "dispatch-0",

--- a/gateway/src/discord/normalize.test.ts
+++ b/gateway/src/discord/normalize.test.ts
@@ -487,6 +487,10 @@ describe("normalizeDiscordMessageDelete", () => {
   });
 });
 describe("normalizeDiscordMessageReaction", () => {
+  // Stand-in for the id `gateway-socket.ts` mints per received dispatch. It
+  // is a parameter precisely so the normalizer stays deterministic here.
+  const INGEST_ID = "ingest-1";
+
   function parseReaction(payload: Record<string, unknown>) {
     const parsed = DiscordMessageReactionSchema.safeParse(payload);
     if (!parsed.success) {
@@ -494,6 +498,16 @@ describe("normalizeDiscordMessageReaction", () => {
     }
     return parsed.data;
   }
+
+  const thumbsUp = (overrides: Record<string, unknown> = {}) =>
+    parseReaction({
+      user_id: "user-1",
+      channel_id: "channel-1",
+      message_id: "msg-1",
+      guild_id: "guild-1",
+      emoji: { id: null, name: "\u{1F44D}" },
+      ...overrides,
+    });
 
   test("a unicode reaction carries the structured payload", () => {
     const event = normalizeDiscordMessageReaction(
@@ -504,7 +518,7 @@ describe("normalizeDiscordMessageReaction", () => {
         guild_id: "guild-1",
         emoji: { id: null, name: "\u{1F44D}" },
       }),
-      { op: "added", raw: {} },
+      { op: "added", ingestId: INGEST_ID, raw: {} },
     );
 
     expect(event).not.toBeNull();
@@ -516,7 +530,7 @@ describe("normalizeDiscordMessageReaction", () => {
       targetMessageId: "msg-1",
     });
     expect(event!.message.externalMessageId).toBe(
-      "msg-1:reaction:\u{1F44D}:user-1",
+      `msg-1:reaction:\u{1F44D}:user-1:${INGEST_ID}`,
     );
     expect(event!.source.messageId).toBe("msg-1");
     expect(event!.actor.actorExternalId).toBe("user-1");
@@ -532,12 +546,12 @@ describe("normalizeDiscordMessageReaction", () => {
         guild_id: "guild-1",
         emoji: { id: null, name: "\u{1F44D}" },
       }),
-      { op: "removed", raw: {} },
+      { op: "removed", ingestId: INGEST_ID, raw: {} },
     );
 
     expect(event!.message.reaction!.op).toBe("removed");
     expect(event!.message.externalMessageId).toBe(
-      "msg-1:reaction:\u{1F44D}:user-1:removed",
+      `msg-1:reaction:\u{1F44D}:user-1:removed:${INGEST_ID}`,
     );
   });
 
@@ -550,7 +564,7 @@ describe("normalizeDiscordMessageReaction", () => {
         guild_id: "guild-1",
         emoji: { id: "111222333", name: "party_blob" },
       }),
-      { op: "added", raw: {} },
+      { op: "added", ingestId: INGEST_ID, raw: {} },
     );
 
     expect(event!.message.reaction!.emoji).toBe("<:party_blob:111222333>");
@@ -567,7 +581,7 @@ describe("normalizeDiscordMessageReaction", () => {
         guild_id: "guild-1",
         emoji: { id: "999888777", name: "white_check_mark" },
       }),
-      { op: "added", raw: {} },
+      { op: "added", ingestId: INGEST_ID, raw: {} },
     );
 
     expect(event!.message.reaction!.emoji).toBe(
@@ -584,7 +598,7 @@ describe("normalizeDiscordMessageReaction", () => {
         guild_id: "guild-1",
         emoji: { id: "111222333", name: null },
       }),
-      { op: "removed", raw: {} },
+      { op: "removed", ingestId: INGEST_ID, raw: {} },
     );
 
     expect(event).toBeNull();
@@ -598,7 +612,7 @@ describe("normalizeDiscordMessageReaction", () => {
         message_id: "msg-2",
         emoji: { id: null, name: "\u2705" },
       }),
-      { op: "added", raw: {} },
+      { op: "added", ingestId: INGEST_ID, raw: {} },
     );
 
     expect(event!.source.isDirectMessage).toBe(true);
@@ -614,11 +628,53 @@ describe("normalizeDiscordMessageReaction", () => {
         guild_id: "guild-1",
         emoji: { id: null, name: "\u{1F44D}" },
       }),
-      { op: "added", parentChannelId: "channel-1", raw: {} },
+      {
+        op: "added",
+        ingestId: INGEST_ID,
+        parentChannelId: "channel-1",
+        raw: {},
+      },
     );
 
     expect(event!.message.conversationExternalId).toBe("channel-1");
     expect(event!.source.threadId).toBe("thread-1");
+  });
+
+  test("add, remove and re-add are three events, not two", () => {
+    // The bug this shape exists to catch: with no per-dispatch component the
+    // re-add is byte-identical to the first add, `recordInbound` calls it a
+    // duplicate, and the removal stays the last recorded state forever: the
+    // reaction is invisible in the transcript from then on, permanently.
+    const ids = (["added", "removed", "added"] as const).map(
+      (op, index) =>
+        normalizeDiscordMessageReaction(thumbsUp(), {
+          op,
+          ingestId: `dispatch-${index}`,
+          raw: {},
+        })!.message.externalMessageId,
+    );
+
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  test("one dispatch forwarded twice keeps its id, so redelivery still dedups", () => {
+    // The other half of the contract: the id is stamped once per received
+    // dispatch and rides inside the forwarded payload, so a forward the
+    // gateway retries against the daemon must present the same id.
+    const first = normalizeDiscordMessageReaction(thumbsUp(), {
+      op: "added",
+      ingestId: "dispatch-0",
+      raw: {},
+    });
+    const redelivered = normalizeDiscordMessageReaction(thumbsUp(), {
+      op: "added",
+      ingestId: "dispatch-0",
+      raw: {},
+    });
+
+    expect(redelivered!.message.externalMessageId).toBe(
+      first!.message.externalMessageId,
+    );
   });
 });
 describe("normalizeDiscordInteraction", () => {

--- a/gateway/src/discord/normalize.test.ts
+++ b/gateway/src/discord/normalize.test.ts
@@ -510,16 +510,11 @@ describe("normalizeDiscordMessageReaction", () => {
     });
 
   test("a unicode reaction carries the structured payload", () => {
-    const event = normalizeDiscordMessageReaction(
-      parseReaction({
-        user_id: "user-1",
-        channel_id: "channel-1",
-        message_id: "msg-1",
-        guild_id: "guild-1",
-        emoji: { id: null, name: "\u{1F44D}" },
-      }),
-      { op: "added", ingestId: INGEST_ID, raw: {} },
-    );
+    const event = normalizeDiscordMessageReaction(thumbsUp(), {
+      op: "added",
+      ingestId: INGEST_ID,
+      raw: {},
+    });
 
     expect(event).not.toBeNull();
     expect(event!.message.eventKind).toBe("reaction");
@@ -538,16 +533,11 @@ describe("normalizeDiscordMessageReaction", () => {
   });
 
   test("a removal appends the op suffix so it never dedups against the add", () => {
-    const event = normalizeDiscordMessageReaction(
-      parseReaction({
-        user_id: "user-1",
-        channel_id: "channel-1",
-        message_id: "msg-1",
-        guild_id: "guild-1",
-        emoji: { id: null, name: "\u{1F44D}" },
-      }),
-      { op: "removed", ingestId: INGEST_ID, raw: {} },
-    );
+    const event = normalizeDiscordMessageReaction(thumbsUp(), {
+      op: "removed",
+      ingestId: INGEST_ID,
+      raw: {},
+    });
 
     expect(event!.message.reaction!.op).toBe("removed");
     expect(event!.message.externalMessageId).toBe(
@@ -557,13 +547,7 @@ describe("normalizeDiscordMessageReaction", () => {
 
   test("a custom emoji forwards its mention form, never its bare name", () => {
     const event = normalizeDiscordMessageReaction(
-      parseReaction({
-        user_id: "user-1",
-        channel_id: "channel-1",
-        message_id: "msg-1",
-        guild_id: "guild-1",
-        emoji: { id: "111222333", name: "party_blob" },
-      }),
+      thumbsUp({ emoji: { id: "111222333", name: "party_blob" } }),
       { op: "added", ingestId: INGEST_ID, raw: {} },
     );
 
@@ -574,13 +558,7 @@ describe("normalizeDiscordMessageReaction", () => {
     // A guild can name a custom emoji anything, including a Slack decision
     // name. The mention form is what keeps it out of the approval map.
     const event = normalizeDiscordMessageReaction(
-      parseReaction({
-        user_id: "user-1",
-        channel_id: "channel-1",
-        message_id: "msg-1",
-        guild_id: "guild-1",
-        emoji: { id: "999888777", name: "white_check_mark" },
-      }),
+      thumbsUp({ emoji: { id: "999888777", name: "white_check_mark" } }),
       { op: "added", ingestId: INGEST_ID, raw: {} },
     );
 
@@ -591,13 +569,7 @@ describe("normalizeDiscordMessageReaction", () => {
 
   test("an emoji with no name cannot be expressed and drops", () => {
     const event = normalizeDiscordMessageReaction(
-      parseReaction({
-        user_id: "user-1",
-        channel_id: "channel-1",
-        message_id: "msg-1",
-        guild_id: "guild-1",
-        emoji: { id: "111222333", name: null },
-      }),
+      thumbsUp({ emoji: { id: "111222333", name: null } }),
       { op: "removed", ingestId: INGEST_ID, raw: {} },
     );
 
@@ -621,13 +593,7 @@ describe("normalizeDiscordMessageReaction", () => {
 
   test("a thread reaction addresses the parent conversation and names the thread", () => {
     const event = normalizeDiscordMessageReaction(
-      parseReaction({
-        user_id: "user-1",
-        channel_id: "thread-1",
-        message_id: "msg-3",
-        guild_id: "guild-1",
-        emoji: { id: null, name: "\u{1F44D}" },
-      }),
+      thumbsUp({ channel_id: "thread-1", message_id: "msg-3" }),
       {
         op: "added",
         ingestId: INGEST_ID,

--- a/gateway/src/discord/normalize.ts
+++ b/gateway/src/discord/normalize.ts
@@ -196,9 +196,7 @@ export function normalizeDiscordMessageReaction(
     op: "added" | "removed";
     /**
      * Identity of the dispatch that carried this reaction, minted by the
-     * caller at receipt. Discord assigns reactions no id of their own, so the
-     * caller is the only place that can tell one occurrence from the next;
-     * see the `externalMessageId` note below.
+     * caller at receipt. See the `externalMessageId` note below.
      */
     ingestId: string;
     parentChannelId?: string;
@@ -227,28 +225,18 @@ export function normalizeDiscordMessageReaction(
   const inThread = options.parentChannelId !== undefined;
   const isDirectMessage = reaction.guild_id === undefined;
   // The addressing parts (message, emoji, reactor, op) name a reaction, not
-  // an occurrence of one: they repeat byte for byte every time the same person
-  // re-adds the same emoji, so on their own a re-add after a removal dedups
-  // into the original add and never reaches a transcript row. `ingestId` is
-  // what separates the occurrences.
+  // one occurrence of one: they repeat byte for byte each time the same person
+  // re-adds the same emoji. `ingestId` separates the occurrences.
   //
-  // It has to be minted rather than read off the wire. Discord models a
+  // It is minted rather than read off the wire because Discord models a
   // reaction as membership in a set on the message, not as a document: the
   // MESSAGE_REACTION_ADD / _REMOVE dispatch carries user_id, channel_id,
   // message_id, guild_id, emoji, burst and type, with no event id and no
-  // timestamp (`GatewayMessageReactionAddDispatchData` in
-  // `discord-api-types`, cross-checked in `message-schemas.ts`). The gateway
-  // dispatch sequence is no substitute: it is session-scoped and restarts at a
-  // fresh IDENTIFY, so it collides across sessions.
-  //
-  // Minting is still correct for what dedup defends against here. The id is
-  // stamped once per received dispatch and travels inside the forwarded
-  // payload, so every retry of that forward (`runtime/client.ts` retries the
-  // same body) repeats it and still collapses to one event. The other
-  // direction, Discord sending a dispatch twice, is not a case Discord
-  // creates: a RESUME replays only the events after the sequence the client
-  // recorded, and `gateway-socket.ts` records it on receipt of every frame,
-  // before dispatching.
+  // timestamp (`GatewayMessageReactionAddDispatchData` in `discord-api-types`,
+  // cross-checked in `message-schemas.ts`). The dispatch sequence is no
+  // substitute: it is session-scoped and restarts at a fresh IDENTIFY. Minting
+  // once per received dispatch, into the forwarded payload, is what keeps a
+  // retried forward on one id.
   const externalMessageId =
     options.op === "added"
       ? `${reaction.message_id}:reaction:${emoji}:${reaction.user_id}:${options.ingestId}`

--- a/gateway/src/discord/normalize.ts
+++ b/gateway/src/discord/normalize.ts
@@ -194,6 +194,13 @@ export function normalizeDiscordMessageReaction(
   reaction: DiscordMessageReaction,
   options: {
     op: "added" | "removed";
+    /**
+     * Identity of the dispatch that carried this reaction, minted by the
+     * caller at receipt. Discord assigns reactions no id of their own, so the
+     * caller is the only place that can tell one occurrence from the next;
+     * see the `externalMessageId` note below.
+     */
+    ingestId: string;
     parentChannelId?: string;
     raw: Record<string, unknown>;
   },
@@ -219,14 +226,33 @@ export function normalizeDiscordMessageReaction(
     customEmojiId != null ? `<:${emojiName}:${customEmojiId}>` : emojiName;
   const inThread = options.parentChannelId !== undefined;
   const isDirectMessage = reaction.guild_id === undefined;
-  // The reactor joins the dedup id so two users reacting with the same emoji
-  // on one message stay distinct events, and the op suffix keeps an add and
-  // its removal distinct. A re-add after a removal repeats the add's id and
-  // dedups away downstream, matching the Slack reaction id shape.
+  // The addressing parts (message, emoji, reactor, op) name a reaction, not
+  // an occurrence of one: they repeat byte for byte every time the same person
+  // re-adds the same emoji, so on their own a re-add after a removal dedups
+  // into the original add and never reaches a transcript row. `ingestId` is
+  // what separates the occurrences.
+  //
+  // It has to be minted rather than read off the wire. Discord models a
+  // reaction as membership in a set on the message, not as a document: the
+  // MESSAGE_REACTION_ADD / _REMOVE dispatch carries user_id, channel_id,
+  // message_id, guild_id, emoji, burst and type, with no event id and no
+  // timestamp (`GatewayMessageReactionAddDispatchData` in
+  // `discord-api-types`, cross-checked in `message-schemas.ts`). The gateway
+  // dispatch sequence is no substitute: it is session-scoped and restarts at a
+  // fresh IDENTIFY, so it collides across sessions.
+  //
+  // Minting is still correct for what dedup defends against here. The id is
+  // stamped once per received dispatch and travels inside the forwarded
+  // payload, so every retry of that forward (`runtime/client.ts` retries the
+  // same body) repeats it and still collapses to one event. The other
+  // direction, Discord sending a dispatch twice, is not a case Discord
+  // creates: a RESUME replays only the events after the sequence the client
+  // recorded, and `gateway-socket.ts` records it on receipt of every frame,
+  // before dispatching.
   const externalMessageId =
     options.op === "added"
-      ? `${reaction.message_id}:reaction:${emoji}:${reaction.user_id}`
-      : `${reaction.message_id}:reaction:${emoji}:${reaction.user_id}:removed`;
+      ? `${reaction.message_id}:reaction:${emoji}:${reaction.user_id}:${options.ingestId}`
+      : `${reaction.message_id}:reaction:${emoji}:${reaction.user_id}:removed:${options.ingestId}`;
   return {
     version: "v1",
     sourceChannel: "discord",

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -631,11 +631,8 @@ describe("normalizeSlackReactionRemoved", () => {
   });
 
   it("add, remove and re-add are three events, not two", () => {
-    // The bug this shape exists to catch: the addressing parts repeat byte
-    // for byte on the re-add, so without Slack's `event_id` the daemon reads
-    // it as a redelivery of the first add and records nothing. The removal
-    // then stays the last recorded state forever and the reaction is
-    // invisible in the transcript from then on, permanently.
+    // Three acts, three ids. The addressing parts are identical across all
+    // three, so `event_id` is the only thing separating them.
     const config = makeConfig();
     const ids = [
       normalizeSlackReactionAdded(makeReactionAddedEvent(), "Ev001", config),
@@ -651,9 +648,8 @@ describe("normalizeSlackReactionRemoved", () => {
   });
 
   it("a redelivered event keeps its id, so redelivery still dedups", () => {
-    // The other half of the contract. Slack re-sends the same event payload,
-    // `event_id` and all, so the two normalize to one id and the daemon
-    // collapses them, which is what the dedup id is for.
+    // The other half of the contract: Slack re-sends the same event payload,
+    // `event_id` and all, so the two normalize to one id.
     const config = makeConfig();
     const first = normalizeSlackReactionAdded(
       makeReactionAddedEvent(),

--- a/gateway/src/slack/normalize.test.ts
+++ b/gateway/src/slack/normalize.test.ts
@@ -387,7 +387,7 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result!.event.message.content).toBe("");
     expect(result!.event.message.conversationExternalId).toBe("C456");
     expect(result!.event.message.externalMessageId).toBe(
-      "C456:1234567890.123456:thumbsup:U123",
+      "C456:1234567890.123456:thumbsup:U123:evt-1",
     );
     expect(result!.event.actor.actorExternalId).toBe("U123");
     expect(result!.event.source.messageId).toBe("1234567890.123456");
@@ -464,7 +464,7 @@ describe("normalizeSlackReactionAdded", () => {
     expect(result!.threadTs).toBe("1700000000.999999");
     expect(result!.routing.assistantId).toBe("ast-1");
     expect(result!.event.message.externalMessageId).toBe(
-      "C500:1700000000.999999:thumbsup:U123",
+      "C500:1700000000.999999:thumbsup:U123:evt-expand",
     );
   });
 });
@@ -483,7 +483,7 @@ describe("normalizeSlackReactionRemoved", () => {
     expect(result!.event.message.reaction?.op).toBe("removed");
     expect(result!.event.message.conversationExternalId).toBe("C456");
     expect(result!.event.message.externalMessageId).toBe(
-      "C456:1234567890.123456:thumbsup:U123:removed",
+      "C456:1234567890.123456:thumbsup:U123:removed:evt-r-1",
     );
     expect(result!.event.actor.actorExternalId).toBe("U123");
     expect(result!.event.source.messageId).toBe("1234567890.123456");
@@ -558,7 +558,7 @@ describe("normalizeSlackReactionRemoved", () => {
     expect(result).not.toBeNull();
     expect(result!.channel).toBe("D999");
     expect(result!.event.message.externalMessageId).toBe(
-      "D999:111.222:thumbsup:U123:removed",
+      "D999:111.222:thumbsup:U123:removed:evt-r-8",
     );
   });
 
@@ -575,7 +575,7 @@ describe("normalizeSlackReactionRemoved", () => {
     expect(result!.event.message.reaction?.emoji).toBe("thumbsup");
     expect(result!.event.message.reaction?.op).toBe("removed");
     expect(result!.event.message.externalMessageId).toBe(
-      "D789:1700000000.000001:thumbsup:U123:removed",
+      "D789:1700000000.000001:thumbsup:U123:removed:evt-r-9",
     );
   });
 
@@ -597,7 +597,7 @@ describe("normalizeSlackReactionRemoved", () => {
     expect(result).not.toBeNull();
     expect(result!.routing.assistantId).toBe("ast-1");
     expect(result!.event.message.externalMessageId).toBe(
-      "C500:1700000000.999999:thumbsup:U123:removed",
+      "C500:1700000000.999999:thumbsup:U123:removed:evt-r-10",
     );
   });
 
@@ -613,10 +613,13 @@ describe("normalizeSlackReactionRemoved", () => {
       reaction: "fire",
       messageTs: "111.222",
     });
-    const addResult = normalizeSlackReactionAdded(addEvent, "evt-add", config);
+    // One event id across both, so the op suffix is the only thing that can
+    // separate the two ids. Distinct event ids would separate them on their
+    // own and the assertion would hold even if the suffix were dropped.
+    const addResult = normalizeSlackReactionAdded(addEvent, "evt-op", config);
     const removeResult = normalizeSlackReactionRemoved(
       removeEvent,
-      "evt-remove",
+      "evt-op",
       config,
     );
 
@@ -624,6 +627,47 @@ describe("normalizeSlackReactionRemoved", () => {
     expect(removeResult).not.toBeNull();
     expect(addResult!.event.message.externalMessageId).not.toBe(
       removeResult!.event.message.externalMessageId,
+    );
+  });
+
+  it("add, remove and re-add are three events, not two", () => {
+    // The bug this shape exists to catch: the addressing parts repeat byte
+    // for byte on the re-add, so without Slack's `event_id` the daemon reads
+    // it as a redelivery of the first add and records nothing. The removal
+    // then stays the last recorded state forever and the reaction is
+    // invisible in the transcript from then on, permanently.
+    const config = makeConfig();
+    const ids = [
+      normalizeSlackReactionAdded(makeReactionAddedEvent(), "Ev001", config),
+      normalizeSlackReactionRemoved(
+        makeReactionRemovedEvent(),
+        "Ev002",
+        config,
+      ),
+      normalizeSlackReactionAdded(makeReactionAddedEvent(), "Ev003", config),
+    ].map((result) => result!.event.message.externalMessageId);
+
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it("a redelivered event keeps its id, so redelivery still dedups", () => {
+    // The other half of the contract. Slack re-sends the same event payload,
+    // `event_id` and all, so the two normalize to one id and the daemon
+    // collapses them, which is what the dedup id is for.
+    const config = makeConfig();
+    const first = normalizeSlackReactionAdded(
+      makeReactionAddedEvent(),
+      "Ev001",
+      config,
+    );
+    const redelivered = normalizeSlackReactionAdded(
+      makeReactionAddedEvent(),
+      "Ev001",
+      config,
+    );
+
+    expect(redelivered!.event.message.externalMessageId).toBe(
+      first!.event.message.externalMessageId,
     );
   });
 });

--- a/gateway/src/slack/reaction-normalizer.ts
+++ b/gateway/src/slack/reaction-normalizer.ts
@@ -37,14 +37,21 @@ function normalizeSlackReaction(
   const routing = resolveAssistant(config, channel, event.user);
   if (isRejection(routing)) return null;
 
-  // Include reactor user ID to prevent dedup collisions when multiple
-  // users react with the same emoji on the same message. Append the op
-  // suffix so an add and a subsequent remove of the same emoji by the
-  // same user produce distinct externalMessageIds.
+  // Slack's `event_id` is what makes this id name one event rather than one
+  // kind of event. The addressing parts (channel, message ts, emoji, reactor,
+  // op) are stable across every occurrence of the same person re-adding the
+  // same emoji, so on their own they collapse a re-add into the first add:
+  // `recordInbound` answers `duplicate`, the intercept returns before writing
+  // a transcript row, and the removal stays the last recorded state forever.
+  // The event id is the one component that differs per occurrence while still
+  // repeating on a genuine redelivery. Slack calls it "a unique identifier
+  // for this specific event, globally unique across all workspaces", and a
+  // re-sent envelope carries the same one, which is why `socket-mode.ts`
+  // already keys its own in-process dedup on it.
   const externalMessageId =
     op === "added"
-      ? `${channel}:${event.item.ts}:${event.reaction}:${event.user}`
-      : `${channel}:${event.item.ts}:${event.reaction}:${event.user}:removed`;
+      ? `${channel}:${event.item.ts}:${event.reaction}:${event.user}:${eventId}`
+      : `${channel}:${event.item.ts}:${event.reaction}:${event.user}:removed:${eventId}`;
 
   return {
     event: {

--- a/gateway/src/slack/reaction-normalizer.ts
+++ b/gateway/src/slack/reaction-normalizer.ts
@@ -37,17 +37,11 @@ function normalizeSlackReaction(
   const routing = resolveAssistant(config, channel, event.user);
   if (isRejection(routing)) return null;
 
-  // Slack's `event_id` is what makes this id name one event rather than one
-  // kind of event. The addressing parts (channel, message ts, emoji, reactor,
-  // op) are stable across every occurrence of the same person re-adding the
-  // same emoji, so on their own they collapse a re-add into the first add:
-  // `recordInbound` answers `duplicate`, the intercept returns before writing
-  // a transcript row, and the removal stays the last recorded state forever.
-  // The event id is the one component that differs per occurrence while still
-  // repeating on a genuine redelivery. Slack calls it "a unique identifier
-  // for this specific event, globally unique across all workspaces", and a
-  // re-sent envelope carries the same one, which is why `socket-mode.ts`
-  // already keys its own in-process dedup on it.
+  // The addressing parts (channel, message ts, emoji, reactor, op) name a
+  // reaction, not one occurrence of one: they repeat byte for byte each time
+  // the same person re-adds the same emoji. `event_id` is the component that
+  // separates the occurrences and still repeats on a redelivery, which is why
+  // `socket-mode.ts` keys its own dedup on it too.
   const externalMessageId =
     op === "added"
       ? `${channel}:${event.item.ts}:${event.reaction}:${event.user}:${eventId}`


### PR DESCRIPTION
## TL;DR

Removing a reaction and re-adding it was silently dropped, and stayed dropped
forever. The dedup id had no per-event component, so the second add was
byte-identical to the first. Both Slack and Discord had it. The fix is in the
id, not in the intercept: dedup still collapses a genuine redelivery.

## What was happening

The Slack normalizer, run on one message:

```
add1  : C1:1700000000.000100:+1:U1
remove: C1:1700000000.000100:+1:U1:removed
add2  : C1:1700000000.000100:+1:U1      <- identical to add1
```

`recordInbound` (`assistant/src/persistence/delivery-crud.ts`) finds the
existing `channel_inbound_events` row and answers `duplicate: true`, so
`reaction-intercept.ts` returns before `persistPassively` and before the wake
dispatch. No transcript row, no discretion turn. Both renderers show a line
per recorded event (`daemon/reaction-history-render.ts` for model history,
`transcript-message-body-shared.tsx` for the web), so the last thing the user
and the model see is the removal, permanently. Every later re-add is dropped
the same way.

The duplicate probe also sits *above* the guardian rail, so the drop is not
only cosmetic: a guardian who removes and re-adds a decision emoji, which is
the natural retry gesture when the first one appeared to do nothing, is
answered as a duplicate before `handleGuardianReplyIntercept` ever runs. The
retry silently cannot work.

## The fix

The addressing parts (room, target message, emoji, reactor, op) name a *kind*
of event. They repeat byte for byte on every occurrence, so the id needs a
component that differs per occurrence while still repeating on a redelivery.

**Slack** already had one and was throwing it away: the normalizer receives
Slack's `event_id`, uses it for `source.updateId`, and dropped it from the
dedup id. It is now appended. Slack calls it "a unique identifier for this
specific event, globally unique across all workspaces", a re-sent envelope
carries the same one, and `socket-mode.ts` already keys its own in-process
dedup on it.

**Discord** has nothing to append. `MESSAGE_REACTION_ADD` / `_REMOVE` carries
`user_id, channel_id, message_id, guild_id, emoji, burst, type` and nothing
else: no event id, no timestamp. Checked against
`GatewayMessageReactionAddDispatchData` in the vendored `discord-api-types`,
the same types `message-schemas.ts` cross-checks. Discord models a reaction as
membership in a set on the message rather than as a document, so there is no
per-occurrence identity to read.

Considered and rejected: the gateway dispatch sequence number. Bare, it
restarts at a fresh IDENTIFY and collides across sessions. Paired with the
session id it would be collision-free, but it buys nothing over the option
below and would persist Discord session ids into the daemon's database
permanently.

Shipped: the socket stamps one id per received dispatch and passes it to the
normalizer as an explicit `ingestId`, so `normalize.ts` stays a pure,
deterministic function. The id lives inside the forwarded payload, so the
gateway's retry loop (`runtime/client.ts` re-POSTs the same body) presents one
id and still collapses to one event.

## Why this is safe

The dedup id keeps doing the one job it exists for. Both new formats are
stable across every redelivery path that exists:

- The gateway's retry of a forward re-sends the same payload, so the same id.
- Slack re-sends the same event, `event_id` and all.
- Slack's reconnect catch-up never synthesizes reaction events (see
  `computeMessageDedupKey`), so a reaction always carries a real `event_id`.

The one behavior this gives up on Discord is collapsing a Discord-side
redelivery of an already-received dispatch. Discord does not create that case:
a RESUME replays only the events after the sequence the client recorded, and
`gateway-socket.ts` records the sequence on receipt of every frame, before
dispatching. The remaining case is two gateway processes on one bot token,
an unsupported topology that already doubles everything else.

Nothing parses `externalMessageId`. The one place that reads it as a value
(`slack/approval-source.ts`) guards with `isSlackTs`, which a reaction id has
never satisfied.

**Upgrade boundary** (flagged per root `AGENTS.md` "Backwards Compatibility").
This changes the format of a persisted value: reaction rows already in
`channel_inbound_events` carry ids in the old format. No migration is possible
or warranted, because the per-event component of a past event cannot be
reconstructed after the fact. The exposure is one case: a reaction event whose
first delivery lands before the upgrade and whose redelivery lands after would
not match its own old row and would be recorded a second time. That needs a
Slack retry to straddle the restart (Discord cannot, since its retry loop is
in-process and a socket reconnect replays nothing already received), and the
worst outcome is one duplicate reaction line in a transcript. Every id written
after the upgrade is internally consistent.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| React, un-react, react again | The re-add vanishes. No transcript line, no turn, and the removal stays the last thing the assistant sees. Permanent. | The re-add lands: transcript line, and a discretion turn if it is on the assistant's own message. |
| Guardian re-adds a decision emoji to retry it | Dropped above the guardian rail. The retry cannot work. | Routed into the decision pipeline like any first reaction. |
| Two people, same emoji | Distinct events | Unchanged |
| Add then remove | Distinct events | Unchanged |
| The same event delivered twice | Collapsed to one | Unchanged |

## Tests

Run per-file. Deliberate pin change: `discord/normalize.test.ts` pinned these
ids byte for byte, and the format moved, so those pins moved with it.

- `gateway/src/slack/normalize.test.ts`, `gateway/src/discord/normalize.test.ts`:
  add, remove, re-add produces three distinct ids; one event normalized twice
  keeps one id.
- `gateway/src/discord/gateway-socket.test.ts`: end to end through the socket,
  three identical dispatch payloads forward as three distinct events. This is
  the one that covers the minting itself.
- `assistant/src/runtime/routes/inbound-stages/reaction-intercept.test.ts`:
  the `recordInbound` / `findInboundEvent` stubs are now stateful and keyed
  like the real row, so the suite can replay a sequence. Add, remove, re-add
  records three events and three transcript rows on Slack and on Discord; the
  same id twice records one.

Every new test was sensitivity-checked by reverting the id change: each one
fails without the fix. Two existing tests ("two users reacting same emoji",
"add differs from remove") had been made vacuous by the new component, since
distinct event ids separated the ids on their own; both now pass one event id
to both calls so the reactor and the op suffix stay load-bearing.

## Prevention

`externalMessageId` carried an unwritten invariant, and the two channels that
violated it are exactly the two with no provider event id to lean on, so the
id got hand-built out of addressing. The Discord comment then cited Slack's
shape as justification, which is how the defect propagated. The invariant is
now written on the field itself in `gateway/src/channels/inbound-event.ts`,
where the next channel's normalizer author reads it.

Deferred deliberately: a per-channel contract test asserting the invariant
directly across all normalizers. Eleven of the thirteen id constructions in
the gateway already key on a provider-assigned event id (Telegram `update_id`,
Slack `event_id`, Discord snowflakes and `edited_timestamp`, an email
`Message-ID`), so such a test would mostly pin ids that cannot drift. Its
value is in forcing the next channel author to add a row, which is worth
having when the next channel lands rather than now.
