### PR TITLE
Implement the Android AppIcon plugin with deferred alias switching

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/AppIconPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AppIconPlugin.java
@@ -15,7 +15,9 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Exposes the alternate launcher icons this build ships, mirroring
@@ -38,6 +40,13 @@ import java.util.List;
  * enabled, except while an alternate is active, when it is explicitly disabled.
  * Alternates are explicitly enabled or disabled, so an alternate reading back
  * as {@code COMPONENT_ENABLED_STATE_ENABLED} is the applied icon.
+ *
+ * An enabled-state override outlives the install that wrote it, so exactly one
+ * declared alias drawing the app is an invariant {@link #load()} enforces on
+ * every start: when none of them draws it, the primary alias goes back to
+ * {@code COMPONENT_ENABLED_STATE_DEFAULT}. That is the shape of a device
+ * holding an explicit disable on the primary and an applied alternate this
+ * build does not declare, which otherwise leaves no launcher entry at all.
  *
  * Toggling a launcher component makes the launcher re-resolve the app, which
  * some launchers answer by dropping the running task. So {@code set} only
@@ -69,7 +78,10 @@ public class AppIconPlugin extends Plugin {
 
     @Override
     public void load() {
-        NativeFailureGuard.run("Unable to reconcile the Android app icon", this::applyPendingAlias);
+        NativeFailureGuard.run(
+            "Unable to reconcile the Android app icon",
+            this::reconcileLauncherAliases
+        );
     }
 
     @PluginMethod
@@ -168,6 +180,40 @@ public class AppIconPlugin extends Plugin {
         return alias != null && aliasClassNames.contains(alias) ? alias : null;
     }
 
+    /**
+     * Whether the primary alias has to go back to the manifest default, given
+     * the enabled setting each alias this build declares reads back as: it does
+     * when the build declares a primary alias and none of the declared aliases
+     * is drawing the app, which is the state an applied alternate that the
+     * build does not declare leaves behind.
+     */
+    static boolean restoresPrimaryAlias(Map<String, Integer> enabledSettings) {
+        if (!enabledSettings.containsKey(PRIMARY_ALIAS)) {
+            return false;
+        }
+        for (Map.Entry<String, Integer> entry : enabledSettings.entrySet()) {
+            if (drawsLauncherIcon(entry.getKey(), entry.getValue())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Whether an alias is drawing the app in the launcher. An explicit enable
+     * always draws, and the manifest default draws only for the primary alias,
+     * the one alias the manifest declares enabled.
+     */
+    private static boolean drawsLauncherIcon(String aliasClassName, int enabledSetting) {
+        if (enabledSetting == PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
+            return true;
+        }
+        return (
+            enabledSetting == PackageManager.COMPONENT_ENABLED_STATE_DEFAULT &&
+            PRIMARY_ALIAS.equals(aliasClassName)
+        );
+    }
+
     static JSObject statePayload(boolean supported, String current, List<String> available) {
         JSObject payload = new JSObject();
         payload.put("supported", supported);
@@ -219,6 +265,40 @@ public class AppIconPlugin extends Plugin {
             }
         }
         return null;
+    }
+
+    /**
+     * Apply whatever {@code set} last recorded, then hold the launcher to
+     * exactly one enabled alias whether or not anything was recorded.
+     */
+    private void reconcileLauncherAliases() {
+        applyPendingAlias();
+        restoreLauncherIfOrphaned();
+    }
+
+    /**
+     * Put the primary alias back on the launcher when no alias this build
+     * declares is drawing the app, which is where an applied alternate that
+     * this build does not declare leaves a device: the enabled-state overrides
+     * survive the install, so the alternate is gone and the primary stays
+     * explicitly disabled with nothing left to launch.
+     */
+    private void restoreLauncherIfOrphaned() {
+        PackageManager packageManager = getContext().getPackageManager();
+        Map<String, Integer> enabledSettings = new LinkedHashMap<>();
+        for (String aliasClassName : aliasClassNames()) {
+            enabledSettings.put(
+                aliasClassName,
+                packageManager.getComponentEnabledSetting(component(aliasClassName))
+            );
+        }
+        if (restoresPrimaryAlias(enabledSettings)) {
+            setEnabledState(
+                packageManager,
+                PRIMARY_ALIAS,
+                PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+            );
+        }
     }
 
     /**

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AppIconPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AppIconPlugin.java
@@ -1,0 +1,277 @@
+package ai.vellum.assistant;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import com.getcapacitor.JSArray;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Exposes the alternate launcher icons this build ships, mirroring
+ * {@code clients/ios/App/App/AppIconPlugin.swift} so
+ * {@code clients/web/src/runtime/app-icon.ts} drives both shells through one
+ * contract: {@code getState} resolves {@code {supported, current, available}}
+ * and {@code set} resolves {@code {ok}} plus an {@code error} when it refuses.
+ *
+ * Android reads the launcher icon off whichever launcher component is enabled,
+ * so an icon swap enables one generated {@code ai.vellum.assistant.icon.*}
+ * {@code <activity-alias>} and disables the rest. Only aliases are ever
+ * toggled: {@code MainActivity} carries the deep links and the shortcuts
+ * source, and stays enabled so shortcuts, the voice notification, and the Quick
+ * Settings tile resolve in every icon state. The primary alias is the default
+ * artwork rather than a pickable icon, so it is absent from {@code available}
+ * and reads back as a null {@code current}.
+ *
+ * Enabled-state scheme: the primary alias sits at
+ * {@code COMPONENT_ENABLED_STATE_DEFAULT}, which the manifest defines as
+ * enabled, except while an alternate is active, when it is explicitly disabled.
+ * Alternates are explicitly enabled or disabled, so an alternate reading back
+ * as {@code COMPONENT_ENABLED_STATE_ENABLED} is the applied icon.
+ *
+ * Toggling a launcher component makes the launcher re-resolve the app, which
+ * some launchers answer by dropping the running task. So {@code set} only
+ * records the target and {@link #handleOnStop()} applies it once the activity
+ * has left the screen. {@link #load()} runs the same reconcile, so a process
+ * death between the two never strands a recorded target, and it runs before the
+ * activity is resumed. Until the toggle lands, {@code getState} reports the
+ * recorded target as {@code current}, so the web layer's post-apply re-read
+ * sees the icon it asked for.
+ *
+ * Per the skew rule in {@code clients/web/docs/CAPACITOR.md}, one result shape
+ * encodes every state and neither method rejects: a device or build with no
+ * alternates resolves {@code supported: false} with an empty {@code available},
+ * and a name this build cannot draw resolves {@code {ok: false, error}}.
+ */
+@CapacitorPlugin(name = "AppIcon")
+public class AppIconPlugin extends Plugin {
+    /** Java namespace the generated aliases sit under, flavor independent. */
+    static final String ALIAS_PREFIX = "ai.vellum.assistant.icon.";
+
+    /** The launcher entry drawn with the default artwork. Not a wire icon. */
+    static final String PRIMARY_ALIAS = ALIAS_PREFIX + "primary";
+
+    private static final String UNKNOWN_ICON_ERROR = "unknown app icon";
+    private static final String PREFERENCES = "app_icon";
+    private static final String PENDING_ALIAS_KEY = "pending_alias";
+    private static final String FAILURE_CODE = "APP_ICON_FAILED";
+    private static final String FAILURE_MESSAGE = "The Android app icon is unavailable";
+
+    @Override
+    public void load() {
+        NativeFailureGuard.run("Unable to reconcile the Android app icon", this::applyPendingAlias);
+    }
+
+    @PluginMethod
+    public void getState(PluginCall call) {
+        NativeFailureGuard.call(call, FAILURE_MESSAGE, FAILURE_CODE, () -> {
+            List<String> aliases = aliasClassNames();
+            List<String> available = wireNames(aliases);
+            call.resolve(
+                statePayload(
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !available.isEmpty(),
+                    currentWireName(pendingAlias(), enabledAlternateAlias(aliases)),
+                    available
+                )
+            );
+        });
+    }
+
+    @PluginMethod
+    public void set(PluginCall call) {
+        NativeFailureGuard.call(call, FAILURE_MESSAGE, FAILURE_CODE, () -> {
+            String target = targetAlias(call.getString("name"), aliasClassNames());
+            if (target == null) {
+                call.resolve(new JSObject().put("ok", false).put("error", UNKNOWN_ICON_ERROR));
+                return;
+            }
+            preferences().edit().putString(PENDING_ALIAS_KEY, target).apply();
+            call.resolve(new JSObject().put("ok", true));
+        });
+    }
+
+    @Override
+    protected void handleOnStop() {
+        NativeFailureGuard.run("Unable to apply the Android app icon", this::applyPendingAlias);
+    }
+
+    /**
+     * The wire name an alias class name stands for, or null when the class is
+     * not an alternate icon alias. The suffix is the wire name with every dash
+     * replaced by an underscore, so the reverse is a whole-string swap.
+     */
+    static String wireNameForAlias(String aliasClassName) {
+        if (
+            aliasClassName == null ||
+            !aliasClassName.startsWith(ALIAS_PREFIX) ||
+            PRIMARY_ALIAS.equals(aliasClassName)
+        ) {
+            return null;
+        }
+        return aliasClassName.substring(ALIAS_PREFIX.length()).replace('_', '-');
+    }
+
+    /**
+     * The alias class name a wire name stands for, or null when the name cannot
+     * name an alternate. The primary alias is not addressable this way.
+     */
+    static String aliasForWireName(String wireName) {
+        if (wireName == null || wireName.isEmpty()) {
+            return null;
+        }
+        String alias = ALIAS_PREFIX + wireName.replace('-', '_');
+        return PRIMARY_ALIAS.equals(alias) ? null : alias;
+    }
+
+    /** Sorted wire names of the alternates present, primary excluded. */
+    static List<String> wireNames(List<String> aliasClassNames) {
+        List<String> names = new ArrayList<>();
+        for (String aliasClassName : aliasClassNames) {
+            String wireName = wireNameForAlias(aliasClassName);
+            if (wireName != null) {
+                names.add(wireName);
+            }
+        }
+        Collections.sort(names);
+        return names;
+    }
+
+    /**
+     * The icon the home screen is heading for: a recorded target that has not
+     * been applied yet wins over the alias currently enabled, and the primary
+     * alias reads as null because it is the default icon, not an alternate.
+     */
+    static String currentWireName(String pendingAlias, String enabledAlias) {
+        return wireNameForAlias(pendingAlias == null ? enabledAlias : pendingAlias);
+    }
+
+    /**
+     * The alias {@link #set} should record for a requested name: the primary
+     * alias for a null reset, the matching alternate when this build ships one,
+     * or null when nothing installed can draw the name.
+     */
+    static String targetAlias(String name, List<String> aliasClassNames) {
+        if (name == null) {
+            return PRIMARY_ALIAS;
+        }
+        String alias = aliasForWireName(name);
+        return alias != null && aliasClassNames.contains(alias) ? alias : null;
+    }
+
+    static JSObject statePayload(boolean supported, String current, List<String> available) {
+        JSObject payload = new JSObject();
+        payload.put("supported", supported);
+        payload.put("current", current == null ? JSObject.NULL : current);
+        payload.put("available", new JSArray(available));
+        return payload;
+    }
+
+    /**
+     * Every icon alias this build declares, enabled or not, so the disabled
+     * alternates the manifest ships are still discoverable.
+     */
+    private List<String> aliasClassNames() {
+        List<String> aliases = new ArrayList<>();
+        Context context = getContext();
+        PackageInfo info;
+        try {
+            info = context
+                .getPackageManager()
+                .getPackageInfo(
+                    context.getPackageName(),
+                    PackageManager.GET_ACTIVITIES | PackageManager.MATCH_DISABLED_COMPONENTS
+                );
+        } catch (PackageManager.NameNotFoundException exception) {
+            NativeFailureGuard.record("Unable to read the Android app icon aliases", exception);
+            return aliases;
+        }
+        if (info.activities == null) {
+            return aliases;
+        }
+        for (ActivityInfo activity : info.activities) {
+            if (activity.name != null && activity.name.startsWith(ALIAS_PREFIX)) {
+                aliases.add(activity.name);
+            }
+        }
+        return aliases;
+    }
+
+    /** The one alternate alias explicitly enabled, or null when none is. */
+    private String enabledAlternateAlias(List<String> aliasClassNames) {
+        PackageManager packageManager = getContext().getPackageManager();
+        for (String aliasClassName : aliasClassNames) {
+            if (wireNameForAlias(aliasClassName) == null) {
+                continue;
+            }
+            int setting = packageManager.getComponentEnabledSetting(component(aliasClassName));
+            if (setting == PackageManager.COMPONENT_ENABLED_STATE_ENABLED) {
+                return aliasClassName;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Put the recorded target on the home screen, if there is one. The target is
+     * enabled before the others are disabled, so no launcher ever sees the app
+     * with every launcher component off, and the record is cleared last so an
+     * interrupted pass is retried rather than half kept.
+     */
+    private void applyPendingAlias() {
+        String target = pendingAlias();
+        if (target == null) {
+            return;
+        }
+        List<String> aliases = aliasClassNames();
+        if (aliases.contains(target)) {
+            PackageManager packageManager = getContext().getPackageManager();
+            setEnabledState(
+                packageManager,
+                target,
+                PRIMARY_ALIAS.equals(target)
+                    ? PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
+                    : PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            );
+            for (String aliasClassName : aliases) {
+                if (!aliasClassName.equals(target)) {
+                    setEnabledState(
+                        packageManager,
+                        aliasClassName,
+                        PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+                    );
+                }
+            }
+        }
+        preferences().edit().remove(PENDING_ALIAS_KEY).apply();
+    }
+
+    private void setEnabledState(PackageManager packageManager, String aliasClassName, int state) {
+        packageManager.setComponentEnabledSetting(
+            component(aliasClassName),
+            state,
+            PackageManager.DONT_KILL_APP
+        );
+    }
+
+    private ComponentName component(String aliasClassName) {
+        return new ComponentName(getContext().getPackageName(), aliasClassName);
+    }
+
+    private String pendingAlias() {
+        return preferences().getString(PENDING_ALIAS_KEY, null);
+    }
+
+    private SharedPreferences preferences() {
+        return getContext().getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -137,6 +137,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(AndroidNotificationChannelsPlugin.class);
         registerPlugin(AndroidNotificationSettingsPlugin.class);
         registerPlugin(AndroidPushRegistrationPlugin.class);
+        registerPlugin(AppIconPlugin.class);
         registerPlugin(InstallReferrerPlugin.class);
         registerPlugin(VoiceAudioSessionPlugin.class);
         registerPlugin(VoiceLiveActivityPlugin.class);

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AppIconPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AppIconPluginTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import android.content.pm.PackageManager;
 import com.getcapacitor.JSObject;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -14,7 +15,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -135,6 +138,60 @@ public class AppIconPluginTest {
         assertEquals(2, available.length());
         assertEquals(GOOFY_TEAL, available.getString(0));
         assertEquals(GRUMPY_GREEN, available.getString(1));
+    }
+
+    /**
+     * A device that applied an alternate holds an explicit disable on the
+     * primary alias, and that override survives an install that no longer
+     * declares the alternate: the applied alias drops out of the build's
+     * aliases and nothing is left to launch, so the primary goes back on.
+     */
+    @Test
+    public void restoresThePrimaryWhenNoDeclaredAliasDrawsTheApp() {
+        Map<String, Integer> enabledSettings = new LinkedHashMap<>();
+        enabledSettings.put(PRIMARY_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+        enabledSettings.put(GRUMPY_GREEN_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+        // An alternate left at the manifest default is disabled, not drawing.
+        enabledSettings.put(GOOFY_TEAL_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DEFAULT);
+
+        assertTrue(AppIconPlugin.restoresPrimaryAlias(enabledSettings));
+    }
+
+    @Test
+    public void leavesTheLauncherAloneWhileAnAlternateIsEnabled() {
+        Map<String, Integer> enabledSettings = new LinkedHashMap<>();
+        enabledSettings.put(PRIMARY_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+        enabledSettings.put(GRUMPY_GREEN_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_ENABLED);
+        enabledSettings.put(GOOFY_TEAL_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+
+        assertFalse(AppIconPlugin.restoresPrimaryAlias(enabledSettings));
+    }
+
+    /**
+     * A recorded target is applied before the invariant is checked, so the
+     * restore only ever reads the state that pass left: the primary back at the
+     * manifest default for a reset, or the target alternate enabled. Neither
+     * needs a second write.
+     */
+    @Test
+    public void anAppliedTargetNeedsNoRestore() {
+        Map<String, Integer> afterReset = new LinkedHashMap<>();
+        afterReset.put(PRIMARY_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DEFAULT);
+        afterReset.put(GRUMPY_GREEN_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+        afterReset.put(GOOFY_TEAL_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+
+        Map<String, Integer> afterAlternate = new LinkedHashMap<>();
+        afterAlternate.put(PRIMARY_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+        afterAlternate.put(GRUMPY_GREEN_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+        afterAlternate.put(GOOFY_TEAL_ALIAS, PackageManager.COMPONENT_ENABLED_STATE_ENABLED);
+
+        assertFalse(AppIconPlugin.restoresPrimaryAlias(afterReset));
+        assertFalse(AppIconPlugin.restoresPrimaryAlias(afterAlternate));
+    }
+
+    @Test
+    public void restoresNothingWhenTheBuildDeclaresNoPrimaryAlias() {
+        assertFalse(AppIconPlugin.restoresPrimaryAlias(Collections.emptyMap()));
     }
 
     /**

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AppIconPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AppIconPluginTest.java
@@ -1,0 +1,168 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.getcapacitor.JSObject;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class AppIconPluginTest {
+    private static final String PRIMARY_ALIAS = "ai.vellum.assistant.icon.primary";
+    private static final String GRUMPY_GREEN = "avatar-eyes-grumpy-green";
+    private static final String GRUMPY_GREEN_ALIAS = "ai.vellum.assistant.icon.avatar_eyes_grumpy_green";
+    private static final String GOOFY_TEAL = "avatar-eyes-goofy-teal";
+    private static final String GOOFY_TEAL_ALIAS = "ai.vellum.assistant.icon.avatar_eyes_goofy_teal";
+
+    /** A build's aliases as {@code PackageInfo} reports them, primary first. */
+    private static final List<String> ALIASES = Arrays.asList(
+        PRIMARY_ALIAS,
+        GRUMPY_GREEN_ALIAS,
+        GOOFY_TEAL_ALIAS
+    );
+
+    /**
+     * Candidate locations of the plugin source, so the guard test below finds it
+     * whether the runner starts in the module, the Android project, or the repo.
+     */
+    private static final List<String> SOURCE_PATHS = Arrays.asList(
+        "src/main/java/ai/vellum/assistant/AppIconPlugin.java",
+        "app/src/main/java/ai/vellum/assistant/AppIconPlugin.java",
+        "clients/android/app/src/main/java/ai/vellum/assistant/AppIconPlugin.java"
+    );
+
+    @Test
+    public void translatesBetweenWireNamesAndAliasClassNames() {
+        assertEquals(GRUMPY_GREEN, AppIconPlugin.wireNameForAlias(GRUMPY_GREEN_ALIAS));
+        assertEquals(GRUMPY_GREEN_ALIAS, AppIconPlugin.aliasForWireName(GRUMPY_GREEN));
+        // Colors can carry their own dash, so the swap is whole-string.
+        assertEquals(
+            "ai.vellum.assistant.icon.avatar_eyes_curious_cosmic_purple",
+            AppIconPlugin.aliasForWireName("avatar-eyes-curious-cosmic-purple")
+        );
+        assertEquals(
+            "avatar-eyes-curious-cosmic-purple",
+            AppIconPlugin.wireNameForAlias("ai.vellum.assistant.icon.avatar_eyes_curious_cosmic_purple")
+        );
+    }
+
+    @Test
+    public void refusesNamesAndClassesThatAreNotAlternateAliases() {
+        assertNull(AppIconPlugin.wireNameForAlias(null));
+        assertNull(AppIconPlugin.wireNameForAlias("ai.vellum.assistant.SomeOtherActivity"));
+        assertNull(AppIconPlugin.aliasForWireName(null));
+        assertNull(AppIconPlugin.aliasForWireName(""));
+    }
+
+    @Test
+    public void excludesThePrimaryAliasFromAvailableAndSortsWhatIsLeft() {
+        List<String> available = AppIconPlugin.wireNames(ALIASES);
+
+        assertEquals(Arrays.asList(GOOFY_TEAL, GRUMPY_GREEN), available);
+        assertNull(AppIconPlugin.wireNameForAlias(PRIMARY_ALIAS));
+        assertNull(AppIconPlugin.aliasForWireName("primary"));
+    }
+
+    @Test
+    public void ignoresActivitiesOutsideTheAliasNamespace() {
+        List<String> available = AppIconPlugin.wireNames(
+            Arrays.asList("ai.vellum.assistant.SomeOtherActivity", GRUMPY_GREEN_ALIAS)
+        );
+
+        assertEquals(Collections.singletonList(GRUMPY_GREEN), available);
+    }
+
+    @Test
+    public void aRecordedTargetOutranksTheAliasStillEnabled() {
+        assertEquals(GOOFY_TEAL, AppIconPlugin.currentWireName(GOOFY_TEAL_ALIAS, GRUMPY_GREEN_ALIAS));
+        assertEquals(GRUMPY_GREEN, AppIconPlugin.currentWireName(null, GRUMPY_GREEN_ALIAS));
+    }
+
+    @Test
+    public void thePrimaryAliasReadsBackAsTheDefaultIcon() {
+        assertNull(AppIconPlugin.currentWireName(null, null));
+        assertNull(AppIconPlugin.currentWireName(PRIMARY_ALIAS, GRUMPY_GREEN_ALIAS));
+    }
+
+    @Test
+    public void anAbsentNameTargetsThePrimaryAlias() {
+        assertEquals(PRIMARY_ALIAS, AppIconPlugin.targetAlias(null, ALIASES));
+    }
+
+    @Test
+    public void onlyBundledAlternatesAreTargetable() {
+        assertEquals(GRUMPY_GREEN_ALIAS, AppIconPlugin.targetAlias(GRUMPY_GREEN, ALIASES));
+        assertNull(AppIconPlugin.targetAlias("avatar-eyes-smitten-chartreuse", ALIASES));
+        assertNull(AppIconPlugin.targetAlias("primary", ALIASES));
+        assertNull(AppIconPlugin.targetAlias("", ALIASES));
+    }
+
+    @Test
+    public void theDefaultIconResolvesAJsonNullCurrent() throws JSONException {
+        JSObject payload = AppIconPlugin.statePayload(true, null, Collections.emptyList());
+
+        assertTrue(payload.getBoolean("supported"));
+        assertTrue(payload.has("current"));
+        assertTrue(payload.isNull("current"));
+        assertSame(JSONObject.NULL, payload.get("current"));
+        assertEquals(0, payload.getJSONArray("available").length());
+    }
+
+    @Test
+    public void anAppliedIconResolvesItsWireName() throws JSONException {
+        JSObject payload = AppIconPlugin.statePayload(
+            false,
+            GRUMPY_GREEN,
+            Arrays.asList(GOOFY_TEAL, GRUMPY_GREEN)
+        );
+
+        assertFalse(payload.getBoolean("supported"));
+        assertEquals(GRUMPY_GREEN, payload.getString("current"));
+        JSONArray available = payload.getJSONArray("available");
+        assertEquals(2, available.length());
+        assertEquals(GOOFY_TEAL, available.getString(0));
+        assertEquals(GRUMPY_GREEN, available.getString(1));
+    }
+
+    /**
+     * The launcher icon is swapped by toggling aliases only. Toggling the
+     * activity itself would take the deep links, shortcuts, voice notification,
+     * and Quick Settings tile down with it, so the plugin's code never names it.
+     */
+    @Test
+    public void neverTogglesTheActivityBehindTheAliases() throws IOException {
+        String code = stripComments(readPluginSource());
+
+        assertTrue(code.contains("setComponentEnabledSetting"));
+        assertFalse(code.contains("MainActivity"));
+    }
+
+    private static String readPluginSource() throws IOException {
+        for (String candidate : SOURCE_PATHS) {
+            Path path = Paths.get(candidate);
+            if (Files.exists(path)) {
+                return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+            }
+        }
+        throw new AssertionError(
+            "Unable to find AppIconPlugin.java from " + Paths.get("").toAbsolutePath()
+        );
+    }
+
+    private static String stripComments(String source) {
+        return source.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("//[^\\n]*", "");
+    }
+}


### PR DESCRIPTION
## Summary
- AppIconPlugin (Android) implements the AppIcon Capacitor contract: getState reports supported/current/available with the pending target as current, set persists the target and defers the alias toggle to handleOnStop with a load-time reconcile
- Aliases only: MainActivity is never toggled, keeping shortcuts, voice notification, and Quick Settings entry points live in every icon state
- JVM unit tests cover translation, primary exclusion, pending precedence, and a source guard against MainActivity toggling

Part of plan: android-avatar-app-icons.md (PR 5 of 8)