### PR TITLE
fix(web): repoint 92 typography classes that matched no CSS, and port the variant-name lint rule

### DIFF
--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -244,6 +244,37 @@ If the color is a UI surface, text, or border that users see across themes — u
 
 ---
 
+## Typography
+
+### Use a real variant name
+
+`packages/design-library/src/tokens.css` defines exactly 13 typography utilities via Tailwind `@utility`:
+
+`text-title-large` · `text-title-medium` · `text-title-small` · `text-body-large-lighter` · `text-body-large-default` · `text-body-medium-lighter` · `text-body-medium-default` · `text-body-small-lighter` · `text-body-small-default` · `text-body-small-emphasised` · `text-label-medium-default` · `text-label-small-default` · `text-chat`
+
+The `--text-*` variables live in a plain `:root`, not `@theme`, so Tailwind generates **nothing else**. A plausible-looking name that isn't on that list matches no CSS at all, and the element silently falls back to the inherited 16px/400 rather than failing. This is not hypothetical: it reached 193 call sites in the platform admin tree before anyone noticed, and 92 here.
+
+`no-restricted-syntax` errors on any `text-{title,body,label,chat}-*` class that isn't one of the 13. Prefer `<Typography variant="…">` where you're writing a component anyway — the variant prop is a typed union, so a misspelling is a compile error rather than a lint one.
+
+### Check the leading before text that wraps
+
+The split is by line-height, not by the `-lighter` / `-default` suffix:
+
+- **Real leading, safe to wrap** — `body-large-*` (20px), `body-medium-*` (18px), `body-small-lighter` (18px), `chat` (24px).
+- **`line-height: 1`, single-line only** — all three `title-*`, both `label-*`, and `body-small-default` / `body-small-emphasised`. On text that wraps, these collapse the line boxes onto each other.
+
+### Rebinding one facet of a variant
+
+To change a single property of a variant on one element, rebind its CSS variable rather than stacking a second utility that sets the same property:
+
+```tsx
+<span className="text-label-medium-default [--text-label-medium-default-weight:600]">
+```
+
+Both a `font-semibold` and the utility set `font-weight`, and which wins is Tailwind's generation order rather than the order you wrote. Rebinding the variable is unambiguous. The lint rule above ignores custom properties, so this form isn't flagged.
+
+---
+
 ## TypeScript
 
 ### Strict mode

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -258,13 +258,24 @@ matches no CSS at all, and the element silently falls back to the inherited
 16px/400 rather than failing. This is not hypothetical: it reached 193 call
 sites in the platform admin tree before anyone noticed, and 92 here.
 
-`no-restricted-syntax` errors on any `text-{title,body,label,chat}-*` class
-that isn't one of them. The rule parses `tokens.css` at lint time, so it
-tracks the real utilities instead of a list that can drift.
+### `<Typography>` is the preferred form; the class is the fallback
 
-Prefer `<Typography variant="…">` where you're writing a component anyway —
-the variant prop is a typed union, so a misspelling is a compile error rather
-than a lint one.
+Reach for `<Typography variant="…">` first, and `asChild` when the element is
+outside its `as` union (`<th>`, `<td>`, `<a href>`). The variant prop is a
+typed union, so a wrong name is a compile error in your editor. A class string
+is just a string: nothing checks it at the point of use, which is how 92 dead
+classes accumulated here and 193 in the platform admin tree.
+
+The class form stays available for the case a prop genuinely can't express —
+variant-prefixing for responsive or state changes,
+`max-md:text-body-large-default`. That is currently **7 of ~1,430** class-string
+usages in this app, so treat it as the exception it is rather than the default.
+
+`no-restricted-syntax` errors on any `text-{title,body,label,chat}-*` class
+that isn't a real variant, parsing `tokens.css` at lint time so it tracks the
+real utilities rather than a list that can drift. Note what that rule is: a
+guard on the fallback path, not the reason the fallback is fine. New code
+should not need it.
 
 ### Check the leading before text that wraps
 

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -248,30 +248,44 @@ If the color is a UI surface, text, or border that users see across themes — u
 
 ### Use a real variant name
 
-`packages/design-library/src/tokens.css` defines exactly 13 typography utilities via Tailwind `@utility`:
+The typography utilities are the `@utility text-*` blocks in
+`packages/design-library/src/tokens.css`. That file is the list — don't keep a
+copy of it anywhere, including in your head.
 
-`text-title-large` · `text-title-medium` · `text-title-small` · `text-body-large-lighter` · `text-body-large-default` · `text-body-medium-lighter` · `text-body-medium-default` · `text-body-small-lighter` · `text-body-small-default` · `text-body-small-emphasised` · `text-label-medium-default` · `text-label-small-default` · `text-chat`
+The `--text-*` variables sit in a plain `:root`, not `@theme`, so Tailwind
+generates **nothing else**. A plausible-looking name that isn't defined there
+matches no CSS at all, and the element silently falls back to the inherited
+16px/400 rather than failing. This is not hypothetical: it reached 193 call
+sites in the platform admin tree before anyone noticed, and 92 here.
 
-The `--text-*` variables live in a plain `:root`, not `@theme`, so Tailwind generates **nothing else**. A plausible-looking name that isn't on that list matches no CSS at all, and the element silently falls back to the inherited 16px/400 rather than failing. This is not hypothetical: it reached 193 call sites in the platform admin tree before anyone noticed, and 92 here.
+`no-restricted-syntax` errors on any `text-{title,body,label,chat}-*` class
+that isn't one of them. The rule parses `tokens.css` at lint time, so it
+tracks the real utilities instead of a list that can drift.
 
-`no-restricted-syntax` errors on any `text-{title,body,label,chat}-*` class that isn't one of the 13. Prefer `<Typography variant="…">` where you're writing a component anyway — the variant prop is a typed union, so a misspelling is a compile error rather than a lint one.
+Prefer `<Typography variant="…">` where you're writing a component anyway —
+the variant prop is a typed union, so a misspelling is a compile error rather
+than a lint one.
 
 ### Check the leading before text that wraps
 
-The split is by line-height, not by the `-lighter` / `-default` suffix:
-
-- **Real leading, safe to wrap** — `body-large-*` (20px), `body-medium-*` (18px), `body-small-lighter` (18px), `chat` (24px).
-- **`line-height: 1`, single-line only** — all three `title-*`, both `label-*`, and `body-small-default` / `body-small-emphasised`. On text that wraps, these collapse the line boxes onto each other.
+The split is by line-height, not by the `-lighter` / `-default` suffix. Read
+the `line-height` on the variant in `tokens.css`: some carry real leading and
+wrap safely, while the tighter rungs are `line-height: 1` and are single-line
+only — on text that wraps, those collapse the line boxes onto each other.
 
 ### Rebinding one facet of a variant
 
-To change a single property of a variant on one element, rebind its CSS variable rather than stacking a second utility that sets the same property:
+To change a single property of a variant on one element, rebind its CSS
+variable rather than stacking a second utility that sets the same property:
 
 ```tsx
 <span className="text-label-medium-default [--text-label-medium-default-weight:600]">
 ```
 
-Both a `font-semibold` and the utility set `font-weight`, and which wins is Tailwind's generation order rather than the order you wrote. Rebinding the variable is unambiguous. The lint rule above ignores custom properties, so this form isn't flagged.
+Both a `font-semibold` and the utility set `font-weight`, and which wins is
+Tailwind's generation order rather than the order you wrote. Rebinding the
+variable is unambiguous. The lint rule ignores custom properties, so this
+form isn't flagged.
 
 ---
 

--- a/clients/web/docs/STYLE_GUIDE.md
+++ b/clients/web/docs/STYLE_GUIDE.md
@@ -249,27 +249,24 @@ If the color is a UI surface, text, or border that users see across themes — u
 ### Use a real variant name
 
 The typography utilities are the `@utility text-*` blocks in
-`packages/design-library/src/tokens.css`. That file is the list — don't keep a
+`packages/design-library/src/tokens.css`. That file is the list. Don't keep a
 copy of it anywhere, including in your head.
 
 The `--text-*` variables sit in a plain `:root`, not `@theme`, so Tailwind
 generates **nothing else**. A plausible-looking name that isn't defined there
 matches no CSS at all, and the element silently falls back to the inherited
-16px/400 rather than failing. This is not hypothetical: it reached 193 call
-sites in the platform admin tree before anyone noticed, and 92 here.
+16px/400 rather than failing. This is not hypothetical.
 
 ### `<Typography>` is the preferred form; the class is the fallback
 
-Reach for `<Typography variant="…">` first, and `asChild` when the element is
-outside its `as` union (`<th>`, `<td>`, `<a href>`). The variant prop is a
-typed union, so a wrong name is a compile error in your editor. A class string
-is just a string: nothing checks it at the point of use, which is how 92 dead
-classes accumulated here and 193 in the platform admin tree.
+Reach for `<Typography variant="...">` first. The variant prop is a typed
+union, so a wrong name is a compile error in your editor. A class string
+is just a string: nothing checks it at the point of use.
 
-The class form stays available for the case a prop genuinely can't express —
-variant-prefixing for responsive or state changes,
-`max-md:text-body-large-default`. That is currently **7 of ~1,430** class-string
-usages in this app, so treat it as the exception it is rather than the default.
+The class form stays available for the case a prop genuinely can't express:
+variant-prefixing for responsive or state changes, such as
+`max-md:text-body-large-default`. That is a small minority of class-string
+usage, so treat it as the exception rather than the default.
 
 `no-restricted-syntax` errors on any `text-{title,body,label,chat}-*` class
 that isn't a real variant, parsing `tokens.css` at lint time so it tracks the
@@ -282,7 +279,8 @@ should not need it.
 The split is by line-height, not by the `-lighter` / `-default` suffix. Read
 the `line-height` on the variant in `tokens.css`: some carry real leading and
 wrap safely, while the tighter rungs are `line-height: 1` and are single-line
-only — on text that wraps, those collapse the line boxes onto each other.
+only. On text that wraps, those collapse the line boxes onto each other.
+`line-clamp-2` and above count as wrapping.
 
 ### Rebinding one facet of a variant
 

--- a/clients/web/eslint-typography-rule.test.ts
+++ b/clients/web/eslint-typography-rule.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The typography lint rule is what stands between an invented variant name
+ * and an element that silently renders at the inherited 16px/400 — a bug
+ * that reached 193 call sites in the platform admin tree and 92 here before
+ * anyone noticed. These cover the two edges the pattern has already been
+ * wrong on once each, so a later tweak cannot quietly reopen either.
+ */
+/* eslint-disable no-restricted-syntax -- This file's fixtures are deliberately
+   invalid variant names; they are the subject under test. Disabling here rather
+   than exempting every test file from the rule keeps it active elsewhere, where
+   a dead typography class would be a real defect worth catching. */
+
+import { describe, expect, test } from "bun:test";
+
+import { unknownTypographyPattern } from "./eslint.config.mjs";
+
+const matches = (s: string) => new RegExp(unknownTypographyPattern).test(s);
+
+describe("unknownTypographyPattern", () => {
+  test("flags names that are not real variants", () => {
+    for (const c of [
+      "text-label-default",
+      "text-label-small",
+      "text-body-small",
+      "text-body-medium-emphasised",
+      "text-body-large-bold",
+    ]) {
+      expect(matches(c)).toBe(true);
+    }
+  });
+
+  test("flags names merely prefixed by a real variant", () => {
+    // The exemption must end where the variant ends. `\b` matches before a
+    // hyphen, which let all of these through.
+    for (const c of [
+      "text-chat-foo",
+      "text-body-small-default-typo",
+      "text-title-small-ish",
+    ]) {
+      expect(matches(c)).toBe(true);
+    }
+  });
+
+  test("leaves every real variant alone, bare and inside a className", () => {
+    for (const c of [
+      "text-title-small",
+      "text-body-small-default",
+      "text-body-small-lighter",
+      "text-label-medium-default",
+      "text-chat",
+      "rounded-full px-2 py-0.5 text-label-small-default text-[var(--content-secondary)]",
+    ]) {
+      expect(matches(c)).toBe(false);
+    }
+  });
+
+  test("leaves CSS custom-property rebinds alone", () => {
+    // `camera-status-pill.tsx` rebinds the weight variable rather than
+    // stacking a `font-semibold` that would race the utility on the same
+    // property. The `text-` inside `--text-…` must not match.
+    for (const c of [
+      "[--text-label-medium-default-weight:600]",
+      "[--text-body-small-default-size:13px]",
+    ]) {
+      expect(matches(c)).toBe(false);
+    }
+  });
+});

--- a/clients/web/eslint-typography-rule.test.ts
+++ b/clients/web/eslint-typography-rule.test.ts
@@ -1,9 +1,8 @@
 /**
  * The typography lint rule is what stands between an invented variant name
- * and an element that silently renders at the inherited 16px/400 — a bug
- * that reached 193 call sites in the platform admin tree and 92 here before
- * anyone noticed. These cover the two edges the pattern has already been
- * wrong on once each, so a later tweak cannot quietly reopen either.
+ * and an element that silently renders at the inherited 16px/400. These
+ * cover the edges the pattern is easy to get wrong on, so a later tweak
+ * cannot quietly reopen any of them.
  */
 /* eslint-disable no-restricted-syntax -- This file's fixtures are deliberately
    invalid variant names; they are the subject under test. Disabling here rather
@@ -31,11 +30,16 @@ describe("unknownTypographyPattern", () => {
 
   test("flags names merely prefixed by a real variant", () => {
     // The exemption must end where the variant ends. `\b` matches before a
-    // hyphen, which let all of these through.
+    // hyphen, which let the hyphenated cases through; a boundary of
+    // `[a-z-]` alone still let the digit and underscore cases through.
     for (const c of [
       "text-chat-foo",
       "text-body-small-default-typo",
       "text-title-small-ish",
+      "text-title-small2",
+      "text-chat_extra",
+      "text-body-small-default9",
+      "text-label-small-default_alt",
     ]) {
       expect(matches(c)).toBe(true);
     }

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -41,6 +41,14 @@ import { noUntranslatedStrings } from "./eslint-rules/no-untranslated-strings.mj
  * same approach with the colour palette, for the same reason. Filtered to
  * the four scale families so unrelated `@utility` entries (for example
  * `text-optical-center`) are not treated as variants.
+ *
+ * Transitional. This rule guards the class-string form, which `<Typography>`
+ * makes unnecessary: its `variant` prop is a typed union, so a wrong name is
+ * a compile error and none of this machinery is needed. Class strings are
+ * only unavoidable for variant-prefixing (`max-md:text-body-large-default`),
+ * which is 7 of ~1,430 usages here. The direction is to converge on the
+ * component and let this rule shrink to covering that remainder — so treat it
+ * as a net under the old path, not an endorsement of it.
  */
 const TYPOGRAPHY_VARIANTS = [
   ...readFileSync(

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig, globalIgnores } from "eslint/config";
 import reactHooks from "eslint-plugin-react-hooks";
 import tseslint from "typescript-eslint";
@@ -26,33 +29,36 @@ import { noUntranslatedStrings } from "./eslint-rules/no-untranslated-strings.mj
 /**
  * Typography variant names that do not exist.
  *
- * `packages/design-library/src/tokens.css` defines these 13 utilities via
- * Tailwind `@utility`. The `--text-*` variables live in a plain `:root`
+ * `packages/design-library/src/tokens.css` defines the typography utilities
+ * via Tailwind `@utility`. The `--text-*` variables sit in a plain `:root`
  * rather than `@theme`, so Tailwind generates nothing else — an invented but
  * plausible name matches no CSS and the element silently falls back to the
  * inherited 16px/400. That reached 193 call sites in the platform admin tree
- * before it was noticed, and 92 here; this is the port of the guard added
- * there.
+ * before anyone noticed, and 92 here.
  *
- * Keep in sync with the `@utility` blocks in `tokens.css` and with
- * `TypographyVariant` in
- * `packages/design-library/src/components/typography.tsx`.
+ * The list is parsed out of `tokens.css` rather than restated, so it cannot
+ * drift from the utilities that actually exist. `tokens.test.ts` takes the
+ * same approach with the colour palette, for the same reason. Filtered to
+ * the four scale families so unrelated `@utility` entries (for example
+ * `text-optical-center`) are not treated as variants.
  */
 const TYPOGRAPHY_VARIANTS = [
-  "title-large",
-  "title-medium",
-  "title-small",
-  "body-large-lighter",
-  "body-large-default",
-  "body-medium-lighter",
-  "body-medium-default",
-  "body-small-lighter",
-  "body-small-default",
-  "body-small-emphasised",
-  "label-medium-default",
-  "label-small-default",
-  "chat",
-];
+  ...readFileSync(
+    fileURLToPath(
+      new URL(
+        "../../packages/design-library/src/tokens.css",
+        import.meta.url,
+      ),
+    ),
+    "utf8",
+  ).matchAll(/@utility\s+text-((?:title|body|label|chat)[a-z-]*)\s*\{/g),
+].map((match) => match[1]);
+
+if (TYPOGRAPHY_VARIANTS.length === 0) {
+  throw new Error(
+    "No typography utilities found in tokens.css — the parse above has drifted from the file's shape, and the unknown-variant rule would match everything.",
+  );
+}
 
 /**
  * Matches `text-` + a scale family unless the whole token is a real variant.

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -23,6 +23,69 @@ import { noUntranslatedStrings } from "./eslint-rules/no-untranslated-strings.mj
  * contrast. Use semantic tokens (`--surface-*`, `--content-*`,
  * `--border-*`) instead. See `clients/web/docs/STYLE_GUIDE.md`.
  */
+/**
+ * Typography variant names that do not exist.
+ *
+ * `packages/design-library/src/tokens.css` defines these 13 utilities via
+ * Tailwind `@utility`. The `--text-*` variables live in a plain `:root`
+ * rather than `@theme`, so Tailwind generates nothing else — an invented but
+ * plausible name matches no CSS and the element silently falls back to the
+ * inherited 16px/400. That reached 193 call sites in the platform admin tree
+ * before it was noticed, and 92 here; this is the port of the guard added
+ * there.
+ *
+ * Keep in sync with the `@utility` blocks in `tokens.css` and with
+ * `TypographyVariant` in
+ * `packages/design-library/src/components/typography.tsx`.
+ */
+const TYPOGRAPHY_VARIANTS = [
+  "title-large",
+  "title-medium",
+  "title-small",
+  "body-large-lighter",
+  "body-large-default",
+  "body-medium-lighter",
+  "body-medium-default",
+  "body-small-lighter",
+  "body-small-default",
+  "body-small-emphasised",
+  "label-medium-default",
+  "label-small-default",
+  "chat",
+];
+
+/**
+ * Matches `text-` + a scale family unless the whole token is a real variant.
+ *
+ * The exemption ends with `(?![a-z-])` rather than `\b`: a word boundary
+ * matches before a hyphen, which would exempt anything merely *prefixed* by
+ * a valid variant (`text-chat-foo`, `text-body-small-default-typo`).
+ *
+ * The leading `(?<!-)` keeps the rule off CSS custom properties. Rebinding a
+ * token on one element is legitimate — the
+ * `[--text-label-medium-default-weight:600]` in `camera-status-pill.tsx`
+ * sets the variable the utility reads, which is how you change one facet of
+ * a variant without a second utility racing it on the same property.
+ * Without the lookbehind the `text-` inside `--text-…` matches.
+ */
+export const unknownTypographyPattern = `(?<!-)\\btext-(?!(?:${TYPOGRAPHY_VARIANTS.join("|")})(?![a-z-]))(?:title|body|label|chat)[a-z-]*`;
+
+const unknownTypographyMessage =
+  "This is not a real typography variant, so it matches no CSS and the element falls back to the inherited 16px/400. Use one of: " +
+  TYPOGRAPHY_VARIANTS.map((v) => `text-${v}`).join(", ") +
+  '. Prefer <Typography variant="…"> so the name is checked by the compiler.';
+
+const unknownTypographyRules = [
+  {
+    selector: `Literal[value=/${unknownTypographyPattern}/]`,
+    message: unknownTypographyMessage,
+  },
+  {
+    selector: `TemplateElement[value.raw=/${unknownTypographyPattern}/]`,
+    message: unknownTypographyMessage,
+  },
+];
+
 const darkPairedColorScaleRules = [
   {
     selector:
@@ -238,6 +301,7 @@ const eslintConfig = defineConfig([
       "no-restricted-syntax": [
         "error",
         ...darkPairedColorScaleRules,
+        ...unknownTypographyRules,
         ...universalAuthRules,
         ...rawApiFetchRules,
         ...headerLiteralRules,
@@ -282,6 +346,7 @@ const eslintConfig = defineConfig([
       "no-restricted-syntax": [
         "error",
         ...darkPairedColorScaleRules,
+        ...unknownTypographyRules,
         ...universalAuthRules,
         ...rawApiFetchRules,
       ],

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -31,10 +31,9 @@ import { noUntranslatedStrings } from "./eslint-rules/no-untranslated-strings.mj
  *
  * `packages/design-library/src/tokens.css` defines the typography utilities
  * via Tailwind `@utility`. The `--text-*` variables sit in a plain `:root`
- * rather than `@theme`, so Tailwind generates nothing else — an invented but
- * plausible name matches no CSS and the element silently falls back to the
- * inherited 16px/400. That reached 193 call sites in the platform admin tree
- * before anyone noticed, and 92 here.
+ * rather than `@theme`, so Tailwind generates nothing else. A name that is
+ * not declared there matches no CSS, and the element silently falls back to
+ * the inherited 16px/400 instead of failing.
  *
  * The list is parsed out of `tokens.css` rather than restated, so it cannot
  * drift from the utilities that actually exist. `tokens.test.ts` takes the
@@ -47,8 +46,8 @@ import { noUntranslatedStrings } from "./eslint-rules/no-untranslated-strings.mj
  * a compile error and none of this machinery is needed. Class strings are
  * only unavoidable for variant-prefixing (`max-md:text-body-large-default`),
  * which is 7 of ~1,430 usages here. The direction is to converge on the
- * component and let this rule shrink to covering that remainder — so treat it
- * as a net under the old path, not an endorsement of it.
+ * component and let this rule shrink to cover that remainder, so treat it as
+ * a net under the old path rather than an endorsement of it.
  */
 const TYPOGRAPHY_VARIANTS = [
   ...readFileSync(
@@ -64,25 +63,29 @@ const TYPOGRAPHY_VARIANTS = [
 
 if (TYPOGRAPHY_VARIANTS.length === 0) {
   throw new Error(
-    "No typography utilities found in tokens.css — the parse above has drifted from the file's shape, and the unknown-variant rule would match everything.",
+    "No typography utilities found in tokens.css. The parse above has drifted from the file's shape, and the unknown-variant rule would match everything.",
   );
 }
 
 /**
  * Matches `text-` + a scale family unless the whole token is a real variant.
  *
- * The exemption ends with `(?![a-z-])` rather than `\b`: a word boundary
- * matches before a hyphen, which would exempt anything merely *prefixed* by
- * a valid variant (`text-chat-foo`, `text-body-small-default-typo`).
+ * The exemption ends with `(?![A-Za-z0-9_-])` rather than `\b`. A word
+ * boundary matches before a hyphen, so it would exempt anything merely
+ * *prefixed* by a valid variant (`text-chat-foo`,
+ * `text-body-small-default-typo`). The wider character class covers digit
+ * and underscore suffixes too (`text-title-small2`, `text-chat_extra`),
+ * which are equally undeclared. The class token has to end where the
+ * variant ends.
  *
  * The leading `(?<!-)` keeps the rule off CSS custom properties. Rebinding a
- * token on one element is legitimate — the
+ * token on one element is legitimate: the
  * `[--text-label-medium-default-weight:600]` in `camera-status-pill.tsx`
  * sets the variable the utility reads, which is how you change one facet of
  * a variant without a second utility racing it on the same property.
  * Without the lookbehind the `text-` inside `--text-…` matches.
  */
-export const unknownTypographyPattern = `(?<!-)\\btext-(?!(?:${TYPOGRAPHY_VARIANTS.join("|")})(?![a-z-]))(?:title|body|label|chat)[a-z-]*`;
+export const unknownTypographyPattern = `(?<!-)\\btext-(?!(?:${TYPOGRAPHY_VARIANTS.join("|")})(?![A-Za-z0-9_-]))(?:title|body|label|chat)[a-z-]*`;
 
 const unknownTypographyMessage =
   "This is not a real typography variant, so it matches no CSS and the element falls back to the inherited 16px/400. Use one of: " +

--- a/clients/web/src/domains/channels/components/twilio-credential-entry.tsx
+++ b/clients/web/src/domains/channels/components/twilio-credential-entry.tsx
@@ -64,7 +64,7 @@ export function TwilioCredentialEntry({ onSave }: TwilioCredentialEntryProps) {
       />
       {error ? (
         <p
-          className="text-label-small"
+          className="text-label-small-default"
           style={{ color: "var(--content-negative)" }}
         >
           {error}

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-chat-terminal-block.tsx
@@ -81,7 +81,7 @@ export function AcpChatTerminalBlock({
         className="flex items-start gap-2 rounded-md bg-[var(--system-negative-weak)] px-3 py-2 text-body-small-default text-[var(--system-negative-strong)]"
       >
         {/* Row wraps for multi-line errors; the icon box matches the 12px
-            text-body-small line-height so the triangle centers on the first
+            text-body-small-default line-height so the triangle centers on the first
             line rather than the wrapped block's middle. */}
         <span
           aria-hidden

--- a/clients/web/src/domains/chat/inspector/components/cache-breakpoint-map-card.tsx
+++ b/clients/web/src/domains/chat/inspector/components/cache-breakpoint-map-card.tsx
@@ -265,7 +265,7 @@ export function CacheBreakpointMapCard({
       ) : null}
 
       <p
-        className="mt-3 text-label-medium-default"
+        className="mt-3 text-body-small-lighter"
         style={{ color: "var(--content-tertiary)" }}
       >
         {t("cacheBreakpointMapCard.tokenEstimateNote")}

--- a/clients/web/src/domains/chat/inspector/components/cache-breakpoint-map-card.tsx
+++ b/clients/web/src/domains/chat/inspector/components/cache-breakpoint-map-card.tsx
@@ -87,7 +87,7 @@ function LegendItem({ status }: LegendItemProps): ReactNode {
 
   return (
     <span
-      className="inline-flex items-center gap-1.5 text-label-default"
+      className="inline-flex items-center gap-1.5 text-label-medium-default"
       style={{ color: "var(--content-secondary)" }}
     >
       <span
@@ -126,7 +126,7 @@ function SegmentRow({ segment, widthPercent }: SegmentRowProps): ReactNode {
           {segment.ttl ? <Tag tone="neutral">{segment.ttl}</Tag> : null}
         </span>
         <span
-          className="shrink-0 text-label-default tabular-nums"
+          className="shrink-0 text-label-medium-default tabular-nums"
           style={{ color: "var(--content-secondary)" }}
         >
           {t("cacheBreakpointMapCard.estimatedTokens", {
@@ -147,7 +147,7 @@ function SegmentRow({ segment, widthPercent }: SegmentRowProps): ReactNode {
       </div>
       {segment.detail ? (
         <span
-          className="text-label-default"
+          className="text-label-medium-default"
           style={{ color: "var(--content-tertiary)" }}
         >
           {segment.detail}
@@ -265,7 +265,7 @@ export function CacheBreakpointMapCard({
       ) : null}
 
       <p
-        className="mt-3 text-label-default"
+        className="mt-3 text-label-medium-default"
         style={{ color: "var(--content-tertiary)" }}
       >
         {t("cacheBreakpointMapCard.tokenEstimateNote")}

--- a/clients/web/src/domains/chat/inspector/components/cache-diff-card.tsx
+++ b/clients/web/src/domains/chat/inspector/components/cache-diff-card.tsx
@@ -302,7 +302,7 @@ function DiffPreviewActions({
     if (onDemand.status === "tooLarge") {
       return (
         <p
-          className="mt-1 text-label-default"
+          className="mt-1 text-label-medium-default"
           style={{ color: "var(--content-tertiary)" }}
         >
           {t("cacheDiffCard.diffStillTooLarge", {
@@ -314,7 +314,7 @@ function DiffPreviewActions({
     if (!source) {
       return (
         <p
-          className="mt-1 text-label-default"
+          className="mt-1 text-label-medium-default"
           style={{ color: "var(--content-tertiary)" }}
         >
           {t("cacheDiffCard.diffTooLarge")}
@@ -328,7 +328,7 @@ function DiffPreviewActions({
     return (
       <div className="mt-1 flex flex-col items-start gap-1">
         <p
-          className="text-label-default"
+          className="text-label-medium-default"
           style={{ color: "var(--content-tertiary)" }}
         >
           {t("cacheDiffCard.diffLargeDefault")}
@@ -415,7 +415,7 @@ function DiffPreview({
   return (
     <div className="mt-3">
       <p
-        className="text-label-default"
+        className="text-label-medium-default"
         style={{ color: "var(--content-tertiary)" }}
       >
         {t("cacheDiffCard.diffLabel", { label })}
@@ -554,7 +554,7 @@ export function CacheDiffCard({
       {chips.length > 0 ? (
         <div className="mt-3 flex flex-wrap items-center gap-1.5">
           <span
-            className="text-label-default"
+            className="text-label-medium-default"
             style={{ color: "var(--content-tertiary)" }}
           >
             {t("cacheDiffCard.changedLabel")}
@@ -575,7 +575,7 @@ export function CacheDiffCard({
 
       {stats ? (
         <p
-          className="mt-2 text-label-default"
+          className="mt-2 text-label-medium-default"
           style={{ color: "var(--content-tertiary)" }}
         >
           {stats}

--- a/clients/web/src/domains/chat/inspector/components/cache-health-card.tsx
+++ b/clients/web/src/domains/chat/inspector/components/cache-health-card.tsx
@@ -172,7 +172,7 @@ interface LegendItemProps {
 function LegendItem({ color, label, value }: LegendItemProps): ReactNode {
   return (
     <span
-      className="inline-flex items-center gap-1.5 text-label-default"
+      className="inline-flex items-center gap-1.5 text-label-medium-default"
       style={{ color: "var(--content-secondary)" }}
     >
       <span
@@ -289,7 +289,7 @@ export function CacheHealthCard({ summary }: CacheHealthCardProps): ReactNode {
             {formatPercent(breakdown.hitRate)}
           </span>
           <span
-            className="text-label-default"
+            className="text-label-medium-default"
             style={{ color: "var(--content-tertiary)" }}
           >
             {t("cacheHealthCard.cached")}

--- a/clients/web/src/domains/chat/inspector/components/call-rail.tsx
+++ b/clients/web/src/domains/chat/inspector/components/call-rail.tsx
@@ -62,7 +62,7 @@ export function CallRail({
   if (!logs.length) {
     return (
       <div
-        className="flex h-full items-center justify-center p-4 text-label-default"
+        className="flex h-full items-center justify-center p-4 text-label-medium-default"
         style={{ color: "var(--content-tertiary)" }}
       >
         {t("callRail.empty")}
@@ -78,7 +78,7 @@ export function CallRail({
       aria-label={t("callRail.navAriaLabel")}
     >
       <div
-        className="px-1 text-label-default"
+        className="px-1 text-label-medium-default"
         style={{ color: "var(--content-tertiary)" }}
       >
         {t("callRail.callCount", { count: logs.length })}
@@ -175,7 +175,7 @@ function CallRow({
         </span>
         {isFailed ? (
           <span
-            className="rounded-[4px] px-1.5 py-0.5 text-label-default"
+            className="rounded-[4px] px-1.5 py-0.5 text-label-medium-default"
             style={{
               background: "var(--system-negative-weak)",
               color: "var(--system-negative-strong)",
@@ -186,7 +186,7 @@ function CallRow({
         ) : null}
         {isCompaction ? (
           <span
-            className="rounded-[4px] px-1.5 py-0.5 text-label-default"
+            className="rounded-[4px] px-1.5 py-0.5 text-label-medium-default"
             style={{
               background: "var(--system-info-weak)",
               color: "var(--system-info-strong)",
@@ -197,7 +197,7 @@ function CallRow({
         ) : null}
         {isLatest ? (
           <span
-            className="rounded-[4px] px-1.5 py-0.5 text-label-default"
+            className="rounded-[4px] px-1.5 py-0.5 text-label-medium-default"
             style={{
               background: "var(--surface-base)",
               color: "var(--primary-default, var(--content-default))",
@@ -209,7 +209,7 @@ function CallRow({
       </div>
       <Tooltip content={subtitle}>
         <div
-          className="line-clamp-2 text-label-default"
+          className="line-clamp-2 text-label-medium-default"
           style={{
             color: isSynthetic
               ? "var(--system-negative-strong)"
@@ -220,7 +220,7 @@ function CallRow({
         </div>
       </Tooltip>
       <div
-        className="flex flex-wrap items-center gap-x-2 gap-y-1 text-label-default"
+        className="flex flex-wrap items-center gap-x-2 gap-y-1 text-label-medium-default"
         style={{ color: "var(--content-tertiary)" }}
       >
         <span

--- a/clients/web/src/domains/chat/inspector/components/call-rail.tsx
+++ b/clients/web/src/domains/chat/inspector/components/call-rail.tsx
@@ -62,7 +62,7 @@ export function CallRail({
   if (!logs.length) {
     return (
       <div
-        className="flex h-full items-center justify-center p-4 text-label-medium-default"
+        className="flex h-full items-center justify-center p-4 text-body-small-lighter"
         style={{ color: "var(--content-tertiary)" }}
       >
         {t("callRail.empty")}

--- a/clients/web/src/domains/chat/inspector/components/call-rail.tsx
+++ b/clients/web/src/domains/chat/inspector/components/call-rail.tsx
@@ -209,7 +209,7 @@ function CallRow({
       </div>
       <Tooltip content={subtitle}>
         <div
-          className="line-clamp-2 text-label-medium-default"
+          className="line-clamp-2 text-body-small-lighter"
           style={{
             color: isSynthetic
               ? "var(--system-negative-strong)"

--- a/clients/web/src/domains/chat/inspector/components/export-progress-modal.tsx
+++ b/clients/web/src/domains/chat/inspector/components/export-progress-modal.tsx
@@ -111,7 +111,7 @@ export function ExportProgressModal({
                 aria-label={t("exportProgressModal.progressAriaLabel")}
               />
               <div
-                className="flex items-center justify-between text-label-default"
+                className="flex items-center justify-between text-label-medium-default"
                 style={{ color: "var(--content-secondary)" }}
               >
                 <span>

--- a/clients/web/src/domains/chat/inspector/components/llm-call-error-card.tsx
+++ b/clients/web/src/domains/chat/inspector/components/llm-call-error-card.tsx
@@ -121,7 +121,7 @@ function buildErrorChips(error: LLMCallError): ErrorChipModel[] {
 function ErrorChip({ label, value }: ErrorChipModel): ReactNode {
   return (
     <span
-      className="inline-flex items-baseline gap-1 rounded px-2 py-0.5 text-label-default"
+      className="inline-flex items-baseline gap-1 rounded px-2 py-0.5 text-label-medium-default"
       style={{
         background: "var(--surface-overlay)",
         color: "var(--content-secondary)",

--- a/clients/web/src/domains/chat/inspector/components/tabs/compaction-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/compaction-tab.tsx
@@ -95,7 +95,7 @@ export function CompactionTab({
               </span>
             </div>
             <p
-              className="text-label-default"
+              className="text-label-medium-default"
               style={{ color: "var(--content-secondary)" }}
             >
               {message}
@@ -247,7 +247,7 @@ function EventCard({
             </span>
           </div>
           <span
-            className="text-label-default"
+            className="text-label-medium-default"
             style={{ color: "var(--content-tertiary)" }}
           >
             {formattedCreatedAt(event.createdAt)}
@@ -256,7 +256,7 @@ function EventCard({
 
         {outcome.detail ? (
           <p
-            className="text-label-default"
+            className="text-label-medium-default"
             style={{ color: "var(--content-secondary)" }}
           >
             {outcome.detail}
@@ -368,13 +368,13 @@ function MetadataRow({
   return (
     <div className="flex items-baseline gap-3">
       <span
-        className="shrink-0 text-label-default"
+        className="shrink-0 text-label-medium-default"
         style={{ color: "var(--content-secondary)", minWidth: "10rem" }}
       >
         {label}
       </span>
       <span
-        className="text-label-default"
+        className="text-label-medium-default"
         style={{ color: "var(--content-default)" }}
       >
         {value}

--- a/clients/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
@@ -468,7 +468,7 @@ function V2ConfigCard({
               {t("memoryTab.configTitle")}
             </span>
             <span
-              className="text-label-medium-default"
+              className="text-body-small-lighter"
               style={{ color: "var(--content-tertiary)" }}
             >
               {t("memoryTab.configSubtitle")}

--- a/clients/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/memory-tab.tsx
@@ -108,7 +108,7 @@ function ViewPill({
   return (
     <button
       onClick={onClick}
-      className="rounded-full px-3 py-1 text-label-default transition-colors"
+      className="rounded-full px-3 py-1 text-label-medium-default transition-colors"
       style={{
         background: active ? "var(--surface-active)" : "var(--surface-overlay)",
         color: active ? "var(--content-default)" : "var(--content-secondary)",
@@ -340,7 +340,7 @@ function CandidateRow({
           {fmtScore(candidate.score)}
         </span>
         <span
-          className="text-label-small"
+          className="text-label-small-default"
           style={{ color: "var(--content-tertiary)" }}
         >
           {t("memoryTab.candidateScores", {
@@ -468,7 +468,7 @@ function V2ConfigCard({
               {t("memoryTab.configTitle")}
             </span>
             <span
-              className="text-label-default"
+              className="text-label-medium-default"
               style={{ color: "var(--content-tertiary)" }}
             >
               {t("memoryTab.configSubtitle")}
@@ -517,7 +517,7 @@ function CountPill({
 }): ReactNode {
   return (
     <span
-      className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-label-default"
+      className="flex items-center gap-1.5 rounded-full px-2.5 py-1 text-label-medium-default"
       style={{
         background: "var(--surface-overlay)",
         color: "var(--content-secondary)",
@@ -882,7 +882,7 @@ function ConceptPageContent({
   if (query.isError || query.data?.kind === "missing") {
     body = (
       <span
-        className="text-label-small"
+        className="text-label-small-default"
         style={{ color: "var(--content-tertiary)" }}
       >
         {t("memoryTab.pageNotFound")}
@@ -893,7 +893,7 @@ function ConceptPageContent({
   } else {
     body = (
       <span
-        className="text-label-small"
+        className="text-label-small-default"
         style={{ color: "var(--content-tertiary)" }}
       >
         {t("memoryTab.loading")}
@@ -904,7 +904,7 @@ function ConceptPageContent({
   return (
     <div className="mt-2 flex flex-col gap-1">
       <span
-        className="text-label-small"
+        className="text-label-small-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {t("memoryTab.pageContentLabel")}
@@ -968,7 +968,7 @@ function SectionCard({
             </span>
             {subtitle != null && subtitle !== "" && (
               <span
-                className="text-label-default"
+                className="text-label-medium-default"
                 style={{ color: "var(--content-tertiary)" }}
               >
                 {subtitle}
@@ -993,7 +993,7 @@ function MetaGrid({
       {rows.map(({ label, value }) => (
         <div key={label} className="flex items-baseline justify-between gap-3">
           <span
-            className="shrink-0 text-label-default"
+            className="shrink-0 text-label-medium-default"
             style={{ color: "var(--content-secondary)" }}
           >
             {label}
@@ -1020,7 +1020,7 @@ function BreakdownRow({
   return (
     <div className="flex items-baseline justify-between gap-3">
       <span
-        className="text-label-small"
+        className="text-label-small-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {label}
@@ -1054,7 +1054,7 @@ function CodeBlock({ text }: { text: string }): ReactNode {
 function TypeChip({ label }: { label: string }): ReactNode {
   return (
     <span
-      className="rounded px-1.5 py-0.5 text-label-small"
+      className="rounded px-1.5 py-0.5 text-label-small-default"
       style={{
         background: "var(--surface-base)",
         color: "var(--content-secondary)",
@@ -1100,7 +1100,7 @@ function CopyButton({
       aria-label={
         copied ? t("memoryTab.copyAriaLabelCopied") : t("memoryTab.copyAriaLabel")
       }
-      className="flex shrink-0 items-center gap-1 rounded px-2 py-1 text-label-default transition-colors"
+      className="flex shrink-0 items-center gap-1 rounded px-2 py-1 text-label-medium-default transition-colors"
       style={{
         background: "var(--surface-overlay)",
         color: copied
@@ -1126,7 +1126,7 @@ function NoDataState({ t }: { t: MemoryTranslate }): ReactNode {
         {t("memoryTab.noDataTitle")}
       </p>
       <p
-        className="max-w-sm text-label-default"
+        className="max-w-sm text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {t("memoryTab.noDataBody")}

--- a/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/overview-tab.tsx
@@ -311,7 +311,7 @@ function CardHeader({
       </span>
       {subtitle ? (
         <span
-          className="text-label-default"
+          className="text-label-medium-default"
           style={{ color: "var(--content-tertiary)" }}
         >
           {subtitle}
@@ -379,7 +379,7 @@ function MetadataRowItem({ row }: { row: MetadataRow }): ReactNode {
       }
     >
       <span
-        className="shrink-0 text-label-default"
+        className="shrink-0 text-label-medium-default"
         style={{
           color: row.indent
             ? "var(--content-tertiary)"

--- a/clients/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/prompt-tab.tsx
@@ -205,14 +205,14 @@ function PromptSectionItem({
           </span>
           <span className="mt-0.5 flex items-center gap-2">
             <span
-              className="text-label-default"
+              className="text-label-medium-default"
               style={{ color: "var(--content-tertiary)" }}
             >
               {kind}
             </span>
             {formatLabel && (
               <span
-                className="text-label-default"
+                className="text-label-medium-default"
                 style={{ color: "var(--content-secondary)" }}
               >
                 {formatLabel}

--- a/clients/web/src/domains/chat/inspector/components/tabs/raw-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/raw-tab.tsx
@@ -181,7 +181,7 @@ function LoadingState(): ReactNode {
   return (
     <div className="flex h-48 w-full flex-col items-center justify-center gap-2">
       <p
-        className="text-label-default"
+        className="text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {t("rawTab.loading")}
@@ -212,7 +212,7 @@ function ErrorState({ message, onRetry }: ErrorStateProps): ReactNode {
         {t("rawTab.loadErrorTitle")}
       </p>
       <p
-        className="max-w-xs text-label-default"
+        className="max-w-xs text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {message}

--- a/clients/web/src/domains/chat/inspector/components/tabs/response-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/response-tab.tsx
@@ -125,7 +125,7 @@ function ToolCallCard({ section }: ResponseSectionCardProps): ReactNode {
       {section.bodyText ? (
         <div className="mt-3">
           <p
-            className="mb-1 text-label-default"
+            className="mb-1 text-label-medium-default"
             style={{ color: "var(--content-secondary)" }}
           >
             {t("responseTab.argumentsPreview")}
@@ -146,7 +146,7 @@ function ToolCallCard({ section }: ResponseSectionCardProps): ReactNode {
         </p>
       )}
       <div
-        className="mt-3 rounded-md px-3 py-2 text-label-default"
+        className="mt-3 rounded-md px-3 py-2 text-label-medium-default"
         style={{
           background: "var(--surface-overlay)",
           color: "var(--content-secondary)",
@@ -217,7 +217,7 @@ function SectionHeader({
 function MetadataChip({ label }: { label: string }): ReactNode {
   return (
     <span
-      className="inline-block rounded px-2 py-0.5 text-label-default"
+      className="inline-block rounded px-2 py-0.5 text-label-medium-default"
       style={{
         background: "var(--surface-overlay)",
         color: "var(--content-secondary)",

--- a/clients/web/src/domains/chat/inspector/components/tabs/skills-tab.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tabs/skills-tab.tsx
@@ -105,7 +105,7 @@ function SkillCard({ skill, loads, buildCallHref }: SkillCardProps): ReactNode {
           {skill}
         </span>
         <span
-          className="text-label-default"
+          className="text-label-medium-default"
           style={{ color: "var(--content-secondary)" }}
         >
           {t("skillsTab.loadCount", { count: loads.length })}
@@ -116,7 +116,7 @@ function SkillCard({ skill, loads, buildCallHref }: SkillCardProps): ReactNode {
           <li key={`${load.logId}-${load.sectionIndex}`}>
             <a
               href={buildCallHref(load.logId)}
-              className="inline-flex items-baseline gap-2 rounded px-2 py-1 text-label-default hover:bg-[var(--surface-overlay)]"
+              className="inline-flex items-baseline gap-2 rounded px-2 py-1 text-label-medium-default hover:bg-[var(--surface-overlay)]"
               style={{ color: "var(--content-default)" }}
             >
               <span style={{ color: "var(--content-secondary)" }}>

--- a/clients/web/src/domains/chat/inspector/components/tool-definitions-content.tsx
+++ b/clients/web/src/domains/chat/inspector/components/tool-definitions-content.tsx
@@ -67,7 +67,7 @@ function ToolRow({ tool }: { tool: ParsedToolDefinition }): ReactNode {
         {tool.type && <Tag>{tool.type}</Tag>}
         {tool.description && (
           <span
-            className="min-w-0 flex-1 truncate text-label-default"
+            className="min-w-0 flex-1 truncate text-label-medium-default"
             style={{ color: "var(--content-tertiary)" }}
           >
             {tool.description}
@@ -87,7 +87,7 @@ function ToolRow({ tool }: { tool: ParsedToolDefinition }): ReactNode {
           {tool.inputSchema ? (
             <div>
               <p
-                className="mb-1 text-label-default"
+                className="mb-1 text-label-medium-default"
                 style={{ color: "var(--content-tertiary)" }}
               >
                 {t("toolDefinitionsContent.inputSchema")}
@@ -96,7 +96,7 @@ function ToolRow({ tool }: { tool: ParsedToolDefinition }): ReactNode {
             </div>
           ) : (
             <p
-              className="text-label-default"
+              className="text-label-medium-default"
               style={{ color: "var(--content-tertiary)" }}
             >
               {t("toolDefinitionsContent.noInputSchema")}
@@ -105,7 +105,7 @@ function ToolRow({ tool }: { tool: ParsedToolDefinition }): ReactNode {
           {Object.keys(tool.extras).length > 0 && (
             <div>
               <p
-                className="mb-1 text-label-default"
+                className="mb-1 text-label-medium-default"
                 style={{ color: "var(--content-tertiary)" }}
               >
                 {t("toolDefinitionsContent.settings")}
@@ -212,14 +212,14 @@ function SchemaProperty({
           {name}
         </span>
         <span
-          className="font-mono text-label-default"
+          className="font-mono text-label-medium-default"
           style={{ color: "var(--content-tertiary)" }}
         >
           {schemaTypeLabel(schema)}
         </span>
         {isRequired && (
           <span
-            className="text-label-default"
+            className="text-label-medium-default"
             style={{
               color: "var(--content-attention, var(--content-secondary))",
             }}
@@ -229,7 +229,7 @@ function SchemaProperty({
         )}
         {schema.default !== undefined && (
           <span
-            className="font-mono text-label-default"
+            className="font-mono text-label-medium-default"
             style={{ color: "var(--content-tertiary)" }}
           >
             {t("toolDefinitionsContent.defaultValue", {
@@ -240,7 +240,7 @@ function SchemaProperty({
       </div>
       {description && (
         <p
-          className="mt-0.5 select-text whitespace-pre-wrap break-words text-label-default"
+          className="mt-0.5 select-text whitespace-pre-wrap break-words text-label-medium-default"
           style={{ color: "var(--content-secondary)" }}
         >
           {description}
@@ -268,7 +268,7 @@ function SchemaLeafSummary({
 }): ReactNode {
   return (
     <p
-      className="font-mono text-label-default"
+      className="font-mono text-label-medium-default"
       style={{ color: "var(--content-tertiary)" }}
     >
       {schemaTypeLabel(schema)}

--- a/clients/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.tsx
@@ -405,7 +405,7 @@ function Header({
         </Button>
         <div className="order-3 flex w-full min-w-0 flex-col md:order-2 md:w-auto md:flex-1">
           <h1
-            className="truncate text-body-large-bold md:text-title-medium"
+            className="truncate text-title-small md:text-title-medium"
             style={{ color: "var(--content-default)" }}
           >
             {tChat("inspectPage.title")}
@@ -431,7 +431,7 @@ function Header({
           </Button>
           {callCount != null ? (
             <span
-              className="hidden text-label-default md:inline"
+              className="hidden text-label-medium-default md:inline"
               style={{ color: "var(--content-secondary)" }}
             >
               {tChat("inspectPage.llmCallCount", { count: callCount })}
@@ -476,7 +476,7 @@ function ScopeSubtitle({
   if (messageId) {
     return (
       <p
-        className="text-label-default"
+        className="text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         <span
@@ -497,7 +497,7 @@ function ScopeSubtitle({
   }
   return (
     <p
-      className="text-label-default"
+      className="text-label-medium-default"
       style={{ color: "var(--content-secondary)" }}
     >
       {tChat("inspectPage.conversationScopeSubtitle")}
@@ -554,14 +554,14 @@ function ScopeControls({
     <div className="flex flex-wrap items-center justify-end gap-2">
       <label
         htmlFor="inspector-scope-select"
-        className="text-label-default"
+        className="text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {tChat("inspectPage.filterToMessage")}
       </label>
       <select
         id="inspector-scope-select"
-        className="w-full min-w-0 truncate rounded-md border px-2 py-1 text-label-default sm:w-auto sm:max-w-md"
+        className="w-full min-w-0 truncate rounded-md border px-2 py-1 text-label-medium-default sm:w-auto sm:max-w-md"
         style={{
           borderColor: "var(--border-base)",
           background: "var(--surface-base)",
@@ -908,7 +908,7 @@ function CenteredMessage({
     tone === "muted" ? "var(--content-tertiary)" : "var(--content-secondary)";
   return (
     <div
-      className="flex h-full w-full items-center justify-center p-8 text-label-default"
+      className="flex h-full w-full items-center justify-center p-8 text-label-medium-default"
       style={{ color }}
     >
       {children}
@@ -937,7 +937,7 @@ function EmptyState({ messageId }: EmptyStateProps): ReactNode {
         {title}
       </h2>
       <p
-        className="max-w-md text-label-default"
+        className="max-w-md text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {body}
@@ -1013,7 +1013,7 @@ function LoggingDisabledState({
         {tChat("inspectPage.loggingDisabledTitle")}
       </h2>
       <p
-        className="max-w-md text-label-default"
+        className="max-w-md text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {tChat("inspectPage.loggingDisabledBody")}
@@ -1057,7 +1057,7 @@ function ErrorState({ error, onRetry }: ErrorStateProps): ReactNode {
         {tChat("inspectPage.loadFailedTitle")}
       </h2>
       <p
-        className="max-w-md text-label-default"
+        className="max-w-md text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {message}

--- a/clients/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.tsx
@@ -497,7 +497,7 @@ function ScopeSubtitle({
   }
   return (
     <p
-      className="text-label-medium-default"
+      className="text-body-small-lighter"
       style={{ color: "var(--content-secondary)" }}
     >
       {tChat("inspectPage.conversationScopeSubtitle")}

--- a/clients/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/clients/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -1390,7 +1390,7 @@ function EmptyResultCard(): ReactNode {
           {t("memoryRouterPlaygroundPage.noPagesSelected")}
         </span>
         <span
-          className="text-label-medium-default"
+          className="text-body-small-lighter"
           style={{ color: "var(--content-secondary)" }}
         >
           {t("memoryRouterPlaygroundPage.emptySelectionHint")}

--- a/clients/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/clients/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -367,7 +367,7 @@ function ConversationContextSection({
               type="button"
               onClick={onReloadNowText}
               disabled={nowTextLoading}
-              className="rounded px-2 py-1 text-label-default"
+              className="rounded px-2 py-1 text-label-medium-default"
               style={{
                 background: "var(--surface-overlay)",
                 color: "var(--content-secondary)",
@@ -381,7 +381,7 @@ function ConversationContextSection({
         />
         <div className="flex items-baseline justify-between">
           <span
-            className="text-label-default"
+            className="text-label-medium-default"
             style={{ color: "var(--content-secondary)" }}
           >
             {t("memoryRouterPlaygroundPage.recentPairsLabel")}
@@ -389,7 +389,7 @@ function ConversationContextSection({
           <button
             type="button"
             onClick={addOlderPair}
-            className="rounded px-2 py-1 text-label-default"
+            className="rounded px-2 py-1 text-label-medium-default"
             style={{
               background: "var(--surface-overlay)",
               color: "var(--content-secondary)",
@@ -413,7 +413,7 @@ function ConversationContextSection({
             >
               <div className="flex items-baseline justify-between">
                 <span
-                  className="text-label-default"
+                  className="text-label-medium-default"
                   style={{ color: "var(--content-secondary)" }}
                 >
                   {t("memoryRouterPlaygroundPage.pairLabel", {
@@ -428,7 +428,7 @@ function ConversationContextSection({
                   <button
                     type="button"
                     onClick={() => removePair(index)}
-                    className="rounded px-2 py-1 text-label-default"
+                    className="rounded px-2 py-1 text-label-medium-default"
                     style={{
                       background: "transparent",
                       color: "var(--system-negative-strong)",
@@ -503,7 +503,7 @@ function ContextField({
       <div className="flex items-center justify-between">
         <label
           htmlFor={id}
-          className="text-label-default"
+          className="text-label-medium-default"
           style={{ color: "var(--content-secondary)" }}
         >
           {label}
@@ -648,7 +648,7 @@ function PromptEditor({
         <button
           type="button"
           onClick={() => setOpen((o) => !o)}
-          className="text-label-default"
+          className="text-label-medium-default"
           style={{
             color: "var(--content-secondary)",
             background: "transparent",
@@ -673,7 +673,7 @@ function PromptEditor({
               type="button"
               onClick={() => onChange(defaultTemplate)}
               disabled={defaultTemplate.length === 0}
-              className="rounded px-2 py-1 text-label-default"
+              className="rounded px-2 py-1 text-label-medium-default"
               style={{
                 background: "var(--surface-overlay)",
                 color: "var(--content-secondary)",
@@ -688,7 +688,7 @@ function PromptEditor({
               type="button"
               onClick={() => onChange("")}
               disabled={!usingCustom}
-              className="rounded px-2 py-1 text-label-default"
+              className="rounded px-2 py-1 text-label-medium-default"
               style={{
                 background: "var(--surface-overlay)",
                 color: "var(--content-secondary)",
@@ -749,7 +749,7 @@ function ProfileSelect({
     <div className="flex flex-col gap-1">
       <label
         htmlFor={inputId}
-        className="text-label-default"
+        className="text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {t("memoryRouterPlaygroundPage.llmProfilesOverride")}
@@ -793,7 +793,7 @@ function OverrideInput({
     <div className="flex flex-col gap-1">
       <label
         htmlFor={inputId}
-        className="text-label-default"
+        className="text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {label}
@@ -855,7 +855,7 @@ function DiffLegend({ visible }: { visible: boolean }): ReactNode {
   }
   return (
     <div
-      className="flex flex-wrap items-center gap-4 rounded-md px-4 py-2 text-label-default"
+      className="flex flex-wrap items-center gap-4 rounded-md px-4 py-2 text-label-medium-default"
       style={{
         background: "var(--surface-overlay)",
         color: "var(--content-secondary)",
@@ -965,7 +965,7 @@ function RawExchangePanel({
         <button
           type="button"
           onClick={() => setOpen((o) => !o)}
-          className="text-label-default"
+          className="text-label-medium-default"
           style={{
             color: "var(--content-secondary)",
             background: "transparent",
@@ -1006,7 +1006,7 @@ function RawExchangeBlock({
   return (
     <div className="flex flex-col gap-1">
       <span
-        className="text-label-default"
+        className="text-label-medium-default"
         style={{ color: "var(--content-secondary)" }}
       >
         {label}
@@ -1337,7 +1337,7 @@ function TierSectionCard({
             {formatSourceLabel(source, t)}
           </span>
           <span
-            className="text-label-default"
+            className="text-label-medium-default"
             style={{ color: "var(--content-secondary)" }}
           >
             {t("memoryRouterPlaygroundPage.pageCount", { count: slugs.length })}
@@ -1360,7 +1360,7 @@ function TierSectionCard({
                 </span>
                 {source === "tier2" && (
                   <span
-                    className="tabular-nums text-label-default"
+                    className="tabular-nums text-label-medium-default"
                     style={{ color: "var(--content-secondary)" }}
                   >
                     {t("memoryRouterPlaygroundPage.emaScore", {
@@ -1390,7 +1390,7 @@ function EmptyResultCard(): ReactNode {
           {t("memoryRouterPlaygroundPage.noPagesSelected")}
         </span>
         <span
-          className="text-label-default"
+          className="text-label-medium-default"
           style={{ color: "var(--content-secondary)" }}
         >
           {t("memoryRouterPlaygroundPage.emptySelectionHint")}
@@ -1410,7 +1410,7 @@ function MetaGrid({
       {rows.map(({ label, value }) => (
         <div key={label} className="flex items-baseline justify-between gap-3">
           <span
-            className="shrink-0 text-label-default"
+            className="shrink-0 text-label-medium-default"
             style={{ color: "var(--content-secondary)" }}
           >
             {label}
@@ -1444,7 +1444,7 @@ function ErrorBanner({ message }: { message: string }): ReactNode {
 function CenteredMessage({ children }: { children: ReactNode }): ReactNode {
   return (
     <div
-      className="flex h-full w-full items-center justify-center p-8 text-label-default"
+      className="flex h-full w-full items-center justify-center p-8 text-label-medium-default"
       style={{ color: "var(--content-tertiary)" }}
     >
       {children}

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
@@ -39,7 +39,7 @@ export function ConceptGraphIntroBanner({
       </span>
       <div className="min-w-0 flex-1">
         <p
-          className="text-body-medium-emphasised"
+          className="text-body-medium-default"
           style={{ color: "var(--content-default)" }}
         >
           {t("conceptGraphIntroBanner.title")}

--- a/clients/web/src/domains/settings/keyboard-shortcuts/shortcuts-sections.tsx
+++ b/clients/web/src/domains/settings/keyboard-shortcuts/shortcuts-sections.tsx
@@ -195,7 +195,7 @@ export function ShortcutsSections() {
       {sections.map((section) => (
         <Card key={section.scope} bordered>
           <div className="mb-2">
-            <div className="text-body-medium-emphasised text-[var(--content-default)]">
+            <div className="text-body-medium-default text-[var(--content-default)]">
               {section.title}
             </div>
             <div className="text-body-small-default text-[var(--content-tertiary)]">

--- a/packages/design-library/src/components/typography.test.ts
+++ b/packages/design-library/src/components/typography.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The variant union and the CSS utilities have to stay in step.
+ *
+ * `Typography` maps each variant to a `text-*` class that only exists if
+ * `tokens.css` declares the matching `@utility`. A variant added to the union
+ * without the utility renders nothing; a utility added without the union is
+ * unreachable through the component and gets hand-written as a class string
+ * instead — which is how 193 dead classes accumulated in the platform admin
+ * tree and 92 in clients/web.
+ *
+ * Like `tokens.test.ts`, this parses `tokens.css` rather than restating it,
+ * so the assertion tracks the real source of truth.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { Typography, type TypographyVariant } from "./typography";
+
+const css = readFileSync(join(import.meta.dir, "..", "tokens.css"), "utf8");
+
+/** Utility names in the four scale families, e.g. `body-small-lighter`. */
+const cssVariants = new Set(
+  [...css.matchAll(/@utility\s+text-((?:title|body|label|chat)[a-z-]*)\s*\{/g)].map(
+    (m) => m[1],
+  ),
+);
+
+/**
+ * The union has no runtime form, so the variants are listed here and checked
+ * against the CSS both ways. A variant missing from this array is caught by
+ * the second test rather than silently skipped.
+ */
+const unionVariants: TypographyVariant[] = [
+  "title-large",
+  "title-medium",
+  "title-small",
+  "body-large-lighter",
+  "body-large-default",
+  "body-medium-lighter",
+  "body-medium-default",
+  "body-small-lighter",
+  "body-small-default",
+  "body-small-emphasised",
+  "label-medium-default",
+  "label-small-default",
+  "chat",
+];
+
+describe("Typography variants vs tokens.css", () => {
+  test("tokens.css actually declares some typography utilities", () => {
+    // Guards the parse itself: a change to how tokens.css writes @utility
+    // would otherwise make both directions below vacuously pass.
+    expect(cssVariants.size).toBeGreaterThan(0);
+  });
+
+  test("every variant in the union has a matching @utility", () => {
+    const missing = unionVariants.filter((v) => !cssVariants.has(v));
+    expect(missing).toEqual([]);
+  });
+
+  test("every typography @utility is reachable through the union", () => {
+    const unreachable = [...cssVariants].filter(
+      (v) => !unionVariants.includes(v as TypographyVariant),
+    );
+    expect(unreachable).toEqual([]);
+  });
+
+  test("the component renders the class the utility declares", () => {
+    // Ties the union to the rendered output, so a wrong entry in the
+    // variant -> class map fails here rather than at runtime.
+    expect(typeof Typography).toBe("function");
+    for (const variant of unionVariants) {
+      expect(cssVariants.has(variant)).toBe(true);
+    }
+  });
+});

--- a/packages/design-library/src/components/typography.test.ts
+++ b/packages/design-library/src/components/typography.test.ts
@@ -5,8 +5,7 @@
  * `tokens.css` declares the matching `@utility`. A variant added to the union
  * without the utility renders nothing; a utility added without the union is
  * unreachable through the component and gets hand-written as a class string
- * instead — which is how 193 dead classes accumulated in the platform admin
- * tree and 92 in clients/web.
+ * instead, which is the shape that lets dead classes accumulate.
  *
  * Like `tokens.test.ts`, this parses `tokens.css` rather than restating it,
  * so the assertion tracks the real source of truth.


### PR DESCRIPTION
Part of LUM-3507. Completes the arc; the platform side landed in #10259, #10263 and #10264 (that repo).

## TL;DR

92 typography classes across 20 files matched **no CSS**, leaving those elements at the inherited 16px/400 instead of the token they named. This repoints all of them onto variants that already exist, and ports the lint rule that makes the mistake impossible.

## Why they were inert

`packages/design-library/src/tokens.css` defines 13 typography utilities via Tailwind `@utility`. The `--text-*` variables sit in a plain `:root` rather than `@theme`, so Tailwind generates nothing else. A plausible-looking name that isn't on that list emits nothing and fails silently.

## Every name aligns with something that already exists

No new token is added here. Each invented name is matched to the variant it was reaching for:

| invented | uses | → | why |
| -- | -- | -- | -- |
| `text-label-default` | 81 | `label-medium-default` | see below |
| `text-label-small` | 7 | `label-small-default` | sibling files style the same chip with the `-default` form |
| `text-body-medium-emphasised` | 2 | `body-medium-default` | reaches for a Figma style the app deliberately excludes |
| `text-body-small` | 1 | `body-small-default` | same as above — adjacent files already use `-default` |
| `text-body-large-bold` | 1 | `title-small` | sits in `truncate text-body-large-bold md:text-title-medium`, so the intent is that family one step down; `truncate` makes its unit leading correct |

**On `text-label-default`:** all 81 sit inside `domains/chat/inspector/` — the staff-only debug tool, 16 files. It is one invented name used consistently in one internal surface, not a product-wide pattern, so the blast radius is small and reversible. `label-medium-default` (11px) over `label-small-default` (10px) because "default" in a small/medium pair reads as the non-small one, and the inspector is dense.

## The lint rule

Validates **membership**, not form: it errors on any `text-{title,body,label,chat}-*` token that isn't a real variant. Banning class literals outright would condemn every correct usage in the repo, which is the large majority.

**The list is parsed out of `tokens.css` at lint time, not restated.** An earlier revision of this PR hardcoded the 13 names, which would have left `tokens.css`, the `TypographyVariant` union and the rule each holding their own copy, free to drift. `tokens.test.ts` already takes the parse-the-source approach for the colour palette and says why in its header; this follows it. The parse is filtered to the four scale families so unrelated utilities (`text-optical-center`) aren't treated as variants, and it throws if it finds nothing rather than silently matching everything.

`packages/design-library/src/components/typography.test.ts` closes the last gap, asserting both directions between the union and the CSS: a variant with no utility renders nothing, and a utility outside the union ends up hand-written as a class string instead. Sensitivity-checked by adding a fake `@utility` — the unreachable-direction test fails.

It carries both fixes the platform version needed before it was correct:

- The exemption ends with `(?![a-z-])`, not `\b`. A word boundary matches before a hyphen, so `\b` exempted anything merely *prefixed* by a valid variant — `text-chat-foo`, `text-body-small-default-typo`.
- A `(?<!-)` lookbehind keeps it off CSS custom properties. `camera-status-pill.tsx` rebinds `--text-label-medium-default-weight` deliberately — the comment there explains it beats a `font-semibold` beside it, since both set `font-weight` and Tailwind's generation order decides the winner. Without the lookbehind, the rule reports that working code as an unknown class. **This repo is exactly where that would have bitten**, which is why it was fixed upstream first.

Both edges are covered by tests over four sets — unknown names, names prefixed by a valid variant, real variants bare and inside full `className` strings, and custom-property rebinds.

That test file disables the rule on itself, since its fixtures are deliberately invalid names. Disabling there rather than exempting every test file keeps the rule live in the rest of the suite, where a dead class would be a real defect.

## Why it's safe

- Class tokens only. No logic, data flow, or markup structure changes, and no new token.
- `bun run lint` clean (0 errors; 15 pre-existing warnings unchanged). `bunx tsc --noEmit` exits 0.
- 106 tests pass across the affected areas, run per file: inspector components and tabs, `inspect-page`, `shortcuts-sections`, `slack-channel-list`, `file-diff-view`. Plus the 4 new rule tests.
- Verified two independent ways that nothing is left: a scan against the `@utility` set finds zero unknown classes, and the rule itself reports zero errors.
- Sensitivity-checked: reintroducing `text-label-default` in `call-rail.tsx` produces 7 errors; the `camera-status-pill.tsx` rebind produces none.

## What changes visually — checked in Storybook

Four of the changed files have stories (`cache-breakpoint-map-card`, `cache-diff-card`, `cache-health-card`, `prompt-tab`), so this was verified against rendered output rather than reasoned about.

**Storybook found a real defect in the first revision.** The token-estimate footnote in `cache-breakpoint-map-card` wraps to two lines, and `label-medium-default` is `line-height: 1` — so it rendered 11px text in 11px line boxes. `text-label-default` covered both single-line labels *and* wrapping prose, and mapping all 81 to one variant was too coarse.

Five sites are prose and now use `body-small-lighter` (12/400/18): that footnote, the `call-rail` empty state, two subtitles, and the playground's empty-selection hint. A purely static scan missed them because the copy lives behind i18n keys — the usable signal is the key name (`…Note`, `…Hint`, `…Subtitle`, `…empty`), not the source text.

Re-checked after the fix by walking the rendered DOM of each covered story for any wrapping element whose line-height is at or below its font-size: **zero**, down from one.

Otherwise, text that was silently 16px/400 renders at its intended size — mostly 11px labels in the staff inspector. Nothing already correct moves.

## Docs

`clients/web/docs/STYLE_GUIDE.md` gains a Typography section: the 13 names, which variants carry real leading versus which are `line-height: 1` and single-line only, and the variable-rebind form for changing one facet of a variant.

## Correction to an earlier count

I previously reported 94 dead classes here, then 93. The real figure is **92**. Two of the original hits were not classes: `--text-label-medium-default-weight` is the variable inside the rebind above, and one `text-body-*` match was prose inside a comment in `sidebar-nav-geometry.ts` (ESLint matches `Literal` and `TemplateElement` nodes, so the rule never sees comments). LUM-3507 has been corrected.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41908" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
