### PR TITLE
feat(companion): show the words while they are being said (JARVIS-1701)

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -1285,6 +1285,25 @@ describe("the watch flag when the app's window goes away", () => {
 
     expect(pushes.length).toBe(before);
   });
+
+  /**
+   * A held key's recording lives in the same window, and goes down with it
+   * the same way. Left standing, the pill would go on listening to a
+   * microphone that is no longer open, with the last words it heard in it.
+   */
+  test("gives up a dictation the same way", () => {
+    send(
+      "vellum:companion:setContext",
+      context({ dictating: "listening", dictationText: "the quick brown" }),
+    );
+    expect(state().dictating).toBe("listening");
+
+    mainWindowOpen = false;
+    fireVisibilityChange();
+
+    expect(state().dictating).toBeUndefined();
+    expect(state().dictationText).toBeUndefined();
+  });
 });
 
 /**

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -379,6 +379,9 @@ const currentState = (): CompanionSurfaceState => {
     // Passed through as it arrived, for the reason `watchRetro` is: every value
     // it can hold claims a microphone is doing something.
     dictating: context.dictating,
+    // Passed through as it arrived. Bounded by the publisher and again by the
+    // schema, so nothing here has to decide how much of it is too much.
+    dictationText: context.dictationText,
     // Read on every rebuild rather than captured once, because the evaluation
     // lands after launch: the app's window has to sign in and fetch it first,
     // and a targeting change can move it again while the app runs.

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1072,15 +1072,26 @@ export const installCompanionWindow = (): void => {
    * leaves the renderer alive and its session running, and must not clear
    * anything.
    *
-   * Only the watch flag. The name and the tail are a record of what was said
-   * and this surface is still where it is read, the same bargain `working` is
-   * given by `clearCompanionWorking`.
+   * The watch flag and the dictation, which are the two things in the context
+   * that claim a microphone or a socket is open in that window. The name and
+   * the tail are a record of what was said and this surface is still where it
+   * is read, the same bargain `working` is given by `clearCompanionWorking`.
    */
   onMainWindowVisibilityChange(() => {
-    if (currentMainWindow() !== null || context.watching !== true) {
+    if (currentMainWindow() !== null) {
       return;
     }
-    context = { ...context, watching: false };
+    const claiming =
+      context.watching === true || context.dictating !== undefined;
+    if (!claiming) {
+      return;
+    }
+    context = {
+      ...context,
+      watching: false,
+      dictating: undefined,
+      dictationText: undefined,
+    };
     pushState();
   });
 

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -89,6 +89,7 @@ export function CompanionSurfacePage() {
   const [dictating, setDictating] = useState<CompanionDictating | undefined>(
     undefined,
   );
+  const [dictationText, setDictationText] = useState("");
   const [turns, setTurns] = useState<CompanionTurn[]>([]);
   // Empty until the app's window publishes one, which the surface covers with
   // the component's own fallback wording rather than drawing a blank name.
@@ -178,6 +179,7 @@ export function CompanionSurfacePage() {
       // indicator over a machine nobody is reading.
       setWatching(state.watching === true);
       setDictating(state.dictating);
+      setDictationText(state.dictationText ?? "");
       setWatchRetro(state.watchRetro);
       // Absence is no reads, for the same reason absence is no session: a
       // state that cannot say how much of the screen was taken has not
@@ -508,6 +510,7 @@ export function CompanionSurfacePage() {
         assistantName={assistantName === "" ? undefined : assistantName}
         call={call ?? undefined}
         dictating={dictating}
+        dictationText={dictationText}
         // Unlike the turns, this is drawn whether or not the exchange on the
         // card is this surface's own: the question it answers is whether the
         // assistant is busy, and it is busy on someone else's conversation just

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -122,7 +122,7 @@ const meta: Meta<StoryArgs> = {
   argTypes: {
     phase: {
       control: "inline-radio",
-      options: ["resting", "hover", "watching", "call", "typing"],
+      options: ["resting", "hover", "dictating", "watching", "call", "typing"],
     },
     backdrop: {
       control: "inline-radio",
@@ -263,6 +263,41 @@ export const RestingPeeks: Story = {
       })}
     </div>
   ),
+};
+
+/**
+ * Mid-dictation, with the words arriving.
+ *
+ * The state the surface spends a hold in: the user is talking into another
+ * application and this is the only thing on screen telling them anything is
+ * being heard.
+ */
+export const Dictating: Story = {
+  args: {
+    phase: "dictating",
+    dictating: "listening",
+    dictationText: "the quick brown fox jumps over the lazy dog",
+  },
+};
+
+/** Long enough to run past the pill, so the front of it is clipped away. */
+export const DictatingLongSentence: Story = {
+  args: {
+    phase: "dictating",
+    dictating: "listening",
+    dictationText:
+      "I was thinking we could take the whole thing apart and start again from the shape of the problem rather than the code",
+  },
+};
+
+/** Before the recogniser has produced anything to show. */
+export const DictatingSilent: Story = {
+  args: { phase: "dictating", dictating: "listening" },
+};
+
+/** The keys are up and the last of it is still being transcribed. */
+export const DictatingTranscribing: Story = {
+  args: { phase: "dictating", dictating: "transcribing" },
 };
 
 /**

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1785,6 +1785,80 @@ describe("the avatar's resting collapse", () => {
     expect(bobOf(container)?.parentElement?.style.opacity).toBe("1");
   });
 
+  /**
+   * The words are the point of the state. A speaker dictating into another
+   * application cannot see what landed there yet, and this is the only surface
+   * telling them anything.
+   */
+  test("draws the words once there are any", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="dictating"
+        dictating="listening"
+        dictationText="the quick brown fox"
+      />,
+    );
+
+    expect(container.textContent).toContain("the quick brown fox");
+  });
+
+  /** Until then the status word stands in, rather than an empty line. */
+  test("falls back to the status word with nothing recognised yet", () => {
+    const { container } = render(
+      <CompanionSurface phase="dictating" dictating="listening" />,
+    );
+
+    expect(container.textContent).toContain("Listening");
+  });
+
+  test("says it is thinking once the keys are up", () => {
+    const { container } = render(
+      <CompanionSurface phase="dictating" dictating="transcribing" />,
+    );
+
+    expect(container.textContent).toContain("Thinking");
+  });
+
+  /**
+   * A line that filled from the left would freeze on the opening words and
+   * leave the speaker watching the part they are least unsure of. Laid out
+   * right to left so the overflow is at the beginning, with the run isolated
+   * so the words keep their own order.
+   */
+  test("clips the words from the front, not the end", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="dictating"
+        dictating="listening"
+        dictationText="a sentence long enough to run past the end of the pill"
+      />,
+    );
+
+    const words = container.querySelector<HTMLElement>("bdi");
+    expect(words).not.toBeNull();
+    const box = words?.parentElement;
+    expect(box?.style.direction).toBe("rtl");
+    expect(box?.className).toContain("overflow-hidden");
+  });
+
+  /**
+   * Every other body here is as wide as its content, and a sentence has no
+   * width to be as wide as. A stated ceiling is what keeps the pill inside the
+   * canvas main sized for it.
+   */
+  test("bounds the words rather than measuring them", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="dictating"
+        dictating="listening"
+        dictationText={"x".repeat(400)}
+      />,
+    );
+
+    const box = container.querySelector<HTMLElement>("bdi")?.parentElement;
+    expect(box?.style.maxWidth).toBe("244px");
+  });
+
   /** The creature fades with it rather than being cut, and comes back whole. */
   test("fades the creature out at rest and back in expanded", () => {
     const { container: resting } = render(<CompanionSurface phase="resting" />);

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1785,9 +1785,9 @@ describe("the avatar's resting collapse", () => {
     expect(bobOf(container)?.parentElement?.style.opacity).toBe("1");
   });
 
-  /** The box the words are drawn in, which is the one with a live region. */
+  /** The box the words are drawn in, the one that takes its direction from them. */
   const transcriptBox = (container: HTMLElement) =>
-    container.querySelector<HTMLElement>("[aria-live][dir]");
+    container.querySelector<HTMLElement>("[dir=auto]");
 
   /**
    * The words are the point of the state. A speaker dictating into another
@@ -1846,6 +1846,8 @@ describe("the avatar's resting collapse", () => {
     expect(box?.className).toContain("overflow-hidden");
     expect(box?.getAttribute("dir")).toBe("auto");
     expect(box?.style.direction).toBe("");
+    // Revised several times a second; a live region would read every guess.
+    expect(box?.getAttribute("aria-live")).toBeNull();
   });
 
   /**

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1843,20 +1843,30 @@ describe("the avatar's resting collapse", () => {
 
   /**
    * Every other body here is as wide as its content, and a sentence has no
-   * width to be as wide as. A stated ceiling is what keeps the pill inside the
-   * canvas main sized for it.
+   * width to be as wide as. A stated width is what keeps the pill inside the
+   * canvas main sized for it, and what keeps it still: the box is the same
+   * size with three words as with three hundred, and the same size as the
+   * status word's box before there were any, so the pill grows to its
+   * dictating width once rather than on every partial.
    */
-  test("bounds the words rather than measuring them", () => {
-    const { container } = render(
-      <CompanionSurface
-        phase="dictating"
-        dictating="listening"
-        dictationText={"x".repeat(400)}
-      />,
-    );
+  test("gives the words a fixed box rather than measuring them", () => {
+    const widthOf = (text?: string) => {
+      const { container } = render(
+        <CompanionSurface
+          phase="dictating"
+          dictating="listening"
+          dictationText={text}
+        />,
+      );
+      const box =
+        container.querySelector<HTMLElement>("bdi")?.parentElement ??
+        container.querySelector<HTMLElement>(".truncate");
+      return box?.style.width;
+    };
 
-    const box = container.querySelector<HTMLElement>("bdi")?.parentElement;
-    expect(box?.style.maxWidth).toBe("244px");
+    expect(widthOf("x".repeat(400))).toBe("244px");
+    expect(widthOf("three words here")).toBe("244px");
+    expect(widthOf(undefined)).toBe("244px");
   });
 
   /** The creature fades with it rather than being cut, and comes back whole. */

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1785,6 +1785,10 @@ describe("the avatar's resting collapse", () => {
     expect(bobOf(container)?.parentElement?.style.opacity).toBe("1");
   });
 
+  /** The box the words are drawn in, which is the one with a live region. */
+  const transcriptBox = (container: HTMLElement) =>
+    container.querySelector<HTMLElement>("[aria-live][dir]");
+
   /**
    * The words are the point of the state. A speaker dictating into another
    * application cannot see what landed there yet, and this is the only surface
@@ -1820,10 +1824,12 @@ describe("the avatar's resting collapse", () => {
   });
 
   /**
-   * A line that filled from the left would freeze on the opening words and
-   * leave the speaker watching the part they are least unsure of. Laid out
-   * right to left so the overflow is at the beginning, with the run isolated
-   * so the words keep their own order.
+   * A line that filled from the start would freeze on the opening words and
+   * leave the speaker watching the part they are least unsure of. The words
+   * sit at the end of their box, so a run longer than the box overflows at
+   * the start, where the clipping is. The end is the words' own: the box
+   * takes its direction from them rather than forcing one, so a right-to-left
+   * transcript keeps its last words in view the same way.
    */
   test("clips the words from the front, not the end", () => {
     const { container } = render(
@@ -1834,11 +1840,12 @@ describe("the avatar's resting collapse", () => {
       />,
     );
 
-    const words = container.querySelector<HTMLElement>("bdi");
-    expect(words).not.toBeNull();
-    const box = words?.parentElement;
-    expect(box?.style.direction).toBe("rtl");
+    const box = transcriptBox(container);
+    expect(box).not.toBeNull();
+    expect(box?.className).toContain("justify-end");
     expect(box?.className).toContain("overflow-hidden");
+    expect(box?.getAttribute("dir")).toBe("auto");
+    expect(box?.style.direction).toBe("");
   });
 
   /**
@@ -1859,7 +1866,7 @@ describe("the avatar's resting collapse", () => {
         />,
       );
       const box =
-        container.querySelector<HTMLElement>("bdi")?.parentElement ??
+        transcriptBox(container) ??
         container.querySelector<HTMLElement>(".truncate");
       return box?.style.width;
     };

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -1639,12 +1639,16 @@ function DictatingBody({
            there were any, so the pill takes its dictating width once and
            holds it while the words change underneath. A box that grew with
            its words would be re-measured on every partial, and the pill's
-           width transition would run for as long as the speaker talked. */
+           width transition would run for as long as the speaker talked.
+ 
+           Not a live region. A recogniser revises its guess several times a
+           second, and a screen reader that announced each revision would be
+           reading the whole line over and over behind a user who is already
+           saying it. */
         <span
           dir="auto"
           className="flex justify-end overflow-hidden text-[12px] whitespace-nowrap text-white/85"
           style={{ width: TRANSCRIPT_WIDTH }}
-          aria-live="polite"
         >
           <span className="shrink-0">{words}</span>
         </span>

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -1624,11 +1624,13 @@ function DictatingBody({
       {words ? (
         /* The end of the sentence, not the start of it.
  
-           A line that filled from the left would freeze on the opening words
+           A line that filled from the start would freeze on the opening words
            and leave the speaker watching the part they are least unsure of. So
-           the box is laid out right to left, which puts the overflow at the
-           beginning, and the run inside is isolated so the words themselves
-           keep their own order and their punctuation stays where it was said.
+           the words sit at the end of their box, and a run longer than the
+           box overflows at the start, where the clipping is. The end is the
+           words' own: the box takes its direction from them, so a transcript
+           in a right-to-left language ends on the left and is clipped on the
+           right, and its last words stay in view the same way.
  
            A stated width rather than a measured one: every other state on
            this surface is as wide as its content, and a sentence has no width
@@ -1639,11 +1641,12 @@ function DictatingBody({
            its words would be re-measured on every partial, and the pill's
            width transition would run for as long as the speaker talked. */
         <span
-          className="overflow-hidden text-left text-[12px] whitespace-nowrap text-white/85"
-          style={{ width: TRANSCRIPT_WIDTH, direction: "rtl" }}
+          dir="auto"
+          className="flex justify-end overflow-hidden text-[12px] whitespace-nowrap text-white/85"
+          style={{ width: TRANSCRIPT_WIDTH }}
           aria-live="polite"
         >
-          <bdi>{words}</bdi>
+          <span className="shrink-0">{words}</span>
         </span>
       ) : (
         <span

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -341,9 +341,9 @@ export const FALLBACK_WIDTHS: Record<
   // answer rather than a set of ways in, so its words are not the pointer's to
   // reveal. That is what makes it wider than the idle row it stands in for.
   summary: 220,
-  // The transcript at its widest, beside the icon and the row's own clearance.
-  // The words are drawn in a box of a stated width rather than measured, so
-  // this is the state's actual width rather than a guess at one.
+  // The transcript box beside the icon and the row's own clearance. The box
+  // has a stated width whatever is in it, so this is the state's actual width
+  // rather than a guess at one.
   dictating: TRANSCRIPT_WIDTH + 32,
   // The row with the stop control on it, which is the widest a call draws: a
   // watch session adds a fifth control to the four the call already has.
@@ -1630,19 +1630,26 @@ function DictatingBody({
            beginning, and the run inside is isolated so the words themselves
            keep their own order and their punctuation stays where it was said.
  
-           Bounded rather than measured: every other state on this surface is
-           as wide as its content, and a sentence has no width to be as wide
-           as. The ceiling is what keeps the pill inside the canvas main sized
-           for it. */
+           A stated width rather than a measured one: every other state on
+           this surface is as wide as its content, and a sentence has no width
+           to be as wide as. The box is the same size with three words in it
+           as with thirty, and the same size as the status word's box before
+           there were any, so the pill takes its dictating width once and
+           holds it while the words change underneath. A box that grew with
+           its words would be re-measured on every partial, and the pill's
+           width transition would run for as long as the speaker talked. */
         <span
           className="overflow-hidden text-left text-[12px] whitespace-nowrap text-white/85"
-          style={{ maxWidth: TRANSCRIPT_WIDTH, direction: "rtl" }}
+          style={{ width: TRANSCRIPT_WIDTH, direction: "rtl" }}
           aria-live="polite"
         >
           <bdi>{words}</bdi>
         </span>
       ) : (
-        <span className="truncate text-[12px] text-white/85">
+        <span
+          className="truncate text-[12px] text-white/85"
+          style={{ width: TRANSCRIPT_WIDTH }}
+        >
           {dictating === "listening"
             ? t("companionSurface.dictating")
             : t("companionSurface.dictatingTranscribing")}

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -286,6 +286,21 @@ const RESTING_BOX = {
 export const INNER_GAP = 8;
 
 /**
+ * How wide the running dictation's words are allowed to draw.
+ *
+ * Stated rather than measured, unlike every other body on this surface. Those
+ * are rows of controls with a natural width; a sentence has none, and one
+ * allowed to ask for what it wants would run past the canvas main sized for
+ * the pill. What does not fit is clipped from the front, so the line stays
+ * full of the most recent words.
+ *
+ * Sized so the row it sits in lands inside
+ * {@link COMPANION_BASE_MAX_PILL_WIDTH}: the icon and its gap take 24, and the
+ * row's own clearance takes {@link INNER_GAP} at either end.
+ */
+const TRANSCRIPT_WIDTH = 244;
+
+/**
  * Body widths to use until the content has been measured.
  *
  * The body alone, since the avatar is a sibling of the pill rather than
@@ -326,9 +341,10 @@ export const FALLBACK_WIDTHS: Record<
   // answer rather than a set of ways in, so its words are not the pointer's to
   // reveal. That is what makes it wider than the idle row it stands in for.
   summary: 220,
-  // One status word beside the creature, which is all this state has to say:
-  // the gesture is the control, and it is already under the user's hand.
-  dictating: 132,
+  // The transcript at its widest, beside the icon and the row's own clearance.
+  // The words are drawn in a box of a stated width rather than measured, so
+  // this is the state's actual width rather than a guess at one.
+  dictating: TRANSCRIPT_WIDTH + 32,
   // The row with the stop control on it, which is the widest a call draws: a
   // watch session adds a fifth control to the four the call already has.
   call: 288,
@@ -648,6 +664,11 @@ export interface CompanionSurfaceProps {
    * {@link CompanionDictating}.
    */
   dictating?: CompanionDictating;
+  /**
+   * The words recognised so far in that dictation. See
+   * {@link CompanionContext.dictationText}.
+   */
+  dictationText?: string;
 }
 
 /**
@@ -726,6 +747,7 @@ export function CompanionSurface({
   captureCount = 0,
   watchEnabled = false,
   dictating,
+  dictationText = "",
   call,
   onControl,
   intro,
@@ -1005,7 +1027,10 @@ export function CompanionSurface({
                   onWatch={onWatch}
                 />
               ) : phase === "dictating" && dictating !== undefined ? (
-                <DictatingBody dictating={dictating} />
+                <DictatingBody
+                  dictating={dictating}
+                  dictationText={dictationText}
+                />
               ) : phase === "summary" && watchRetro !== undefined ? (
                 <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
               ) : (
@@ -1584,16 +1609,45 @@ function Avatar({
  * microphone open for dictation and one open for a conversation do not read as
  * different machines.
  */
-function DictatingBody({ dictating }: { dictating: CompanionDictating }) {
+function DictatingBody({
+  dictating,
+  dictationText,
+}: {
+  dictating: CompanionDictating;
+  dictationText: string;
+}) {
   const { t } = useTranslation();
+  const words = dictationText.trim();
   return (
     <div className="flex h-7 shrink-0 items-center gap-2 px-1">
       <AudioLines className="size-4 shrink-0" aria-hidden />
-      <span className="truncate text-[12px] text-white/85">
-        {dictating === "listening"
-          ? t("companionSurface.dictating")
-          : t("companionSurface.dictatingTranscribing")}
-      </span>
+      {words ? (
+        /* The end of the sentence, not the start of it.
+ 
+           A line that filled from the left would freeze on the opening words
+           and leave the speaker watching the part they are least unsure of. So
+           the box is laid out right to left, which puts the overflow at the
+           beginning, and the run inside is isolated so the words themselves
+           keep their own order and their punctuation stays where it was said.
+ 
+           Bounded rather than measured: every other state on this surface is
+           as wide as its content, and a sentence has no width to be as wide
+           as. The ceiling is what keeps the pill inside the canvas main sized
+           for it. */
+        <span
+          className="overflow-hidden text-left text-[12px] whitespace-nowrap text-white/85"
+          style={{ maxWidth: TRANSCRIPT_WIDTH, direction: "rtl" }}
+          aria-live="polite"
+        >
+          <bdi>{words}</bdi>
+        </span>
+      ) : (
+        <span className="truncate text-[12px] text-white/85">
+          {dictating === "listening"
+            ? t("companionSurface.dictating")
+            : t("companionSurface.dictatingTranscribing")}
+        </span>
+      )}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -747,6 +747,9 @@ describe("VoiceInputButton: a hold takes the stream's final", () => {
     markHoldDictation(true);
     const onTranscript = mock(async (_text: string) => {});
     await startSession(onTranscript);
+    // The store carries which microphone this is, for the surfaces that only
+    // hear about the recording once the key is already up again.
+    expect(useVoiceRecordingStore.getState().hold).toBe(true);
 
     fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
     await waitFor(() => expect(onTranscript).toHaveBeenCalled());

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -1064,7 +1064,10 @@ export const VoiceInputButton = forwardRef<
       // timeslice should come back paired with that consumer.
       recorder.start();
       sessionStartedAtRef.current = Date.now();
-      vsStartRecording();
+      // Carried on the store because the key may be up again by now: the
+      // flag was read before the awaits above, and the surface that draws
+      // this recording reads the store, not the flag.
+      vsStartRecording({ hold: holdSession });
       onError?.(null);
     } catch (err) {
       mediaRecorderRef.current = null;

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
@@ -91,6 +91,10 @@ const { useChatSessionStore } = await import(
 const { beginWatchRetro, clearWatchRetro, settleWatchRetro } = await import(
   "@/domains/chat/watch/watch-retro"
 );
+const { useVoiceRecordingStore } = await import(
+  "@/domains/chat/voice/voice-recording-store"
+);
+const { markHoldDictation } = await import("@/utils/hold-to-dictate");
 const { useCompanionMirror } = await import("./use-companion-mirror");
 
 function Mirror() {
@@ -111,6 +115,8 @@ afterEach(() => {
   useTurnStore.getState().resetTurn();
   useConversationStore.setState({ processingConversationIds: new Set() });
   useChatSessionStore.setState({ snapshot: null } as never);
+  markHoldDictation(false);
+  useVoiceRecordingStore.getState().reset();
 });
 
 /** The most recent push, which is what the surface would be drawing. */
@@ -500,6 +506,71 @@ describe("the watch session at teardown", () => {
     view.unmount();
 
     expect(published.length).toBe(count);
+  });
+});
+
+/**
+ * The dictation, which is the surface's business only when a held key started
+ * it. The recording store is the real one and is shared with the composer's
+ * microphone, so which recording is running is decided at its start.
+ */
+describe("dictating", () => {
+  const recording = useVoiceRecordingStore.getState;
+
+  /**
+   * A recording begun from the composer is already visible where it was
+   * begun; the surface saying so too would be the same fact drawn twice.
+   */
+  test("says nothing for a recording the composer started", () => {
+    render(<Mirror />);
+    recording().startRecording();
+    recording().setInterimTranscript("typed into the composer");
+
+    expect(latest().dictating).toBeUndefined();
+    expect(latest().dictationText ?? "").toBe("");
+  });
+
+  test("draws a hold's words as they arrive", () => {
+    render(<Mirror />);
+    markHoldDictation(true);
+    recording().startRecording();
+    recording().setInterimTranscript("the quick brown");
+
+    expect(latest().dictating).toBe("listening");
+    expect(latest().dictationText).toBe("the quick brown");
+  });
+
+  /**
+   * The keys come up before the recording is over, and the wait after them is
+   * the stretch with nothing else on screen to explain it. The hold flag has
+   * already dropped by then, so the surface has to remember whose recording
+   * this was.
+   */
+  test("stays with the hold through the wait after the keys come up", () => {
+    render(<Mirror />);
+    markHoldDictation(true);
+    recording().startRecording();
+    markHoldDictation(false);
+    recording().stopRecording();
+
+    expect(latest().dictating).toBe("transcribing");
+
+    recording().reset();
+
+    expect(latest().dictating).toBeUndefined();
+  });
+
+  /** And having remembered one hold, it does not mistake the next composer recording for another. */
+  test("forgets the hold once its recording is over", () => {
+    render(<Mirror />);
+    markHoldDictation(true);
+    recording().startRecording();
+    markHoldDictation(false);
+    recording().reset();
+
+    recording().startRecording();
+
+    expect(latest().dictating).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
@@ -15,6 +15,19 @@ mock.module("@/runtime/companion-surface", () => ({
     published.push(context);
   },
   clearCompanionWorking: clearWorkingMock,
+  // The targeted path the running dictation's words take, which reuses the
+  // last context rather than rebuilding one. Recorded the same way, since what
+  // matters to these cases is what reached the surface.
+  setCompanionDictation: (
+    dictating: CompanionContext["dictating"],
+    dictationText: string,
+  ) => {
+    const last = published[published.length - 1];
+    if (last === undefined) {
+      return;
+    }
+    published.push({ ...last, dictating, dictationText });
+  },
 }));
 
 let isPopout = false;
@@ -488,4 +501,21 @@ describe("the watch session at teardown", () => {
 
     expect(published.length).toBe(count);
   });
+});
+
+/**
+ * The mount itself, with nothing arranged around it.
+ *
+ * The effect publishes once before wiring any subscription, so anything the
+ * first publish reads has to exist by then. A binding declared later in the
+ * effect body is in its dead zone at that point and throws, which takes the
+ * mirror down and the layout with it, and no case about what gets published
+ * would notice because nothing gets published at all.
+ */
+test("mounts and publishes without throwing", () => {
+  expect(() => {
+    render(<Mirror />);
+  }).not.toThrow();
+
+  expect(published.length).toBeGreaterThan(0);
 });

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
@@ -94,7 +94,6 @@ const { beginWatchRetro, clearWatchRetro, settleWatchRetro } = await import(
 const { useVoiceRecordingStore } = await import(
   "@/domains/chat/voice/voice-recording-store"
 );
-const { markHoldDictation } = await import("@/utils/hold-to-dictate");
 const { useCompanionMirror } = await import("./use-companion-mirror");
 
 function Mirror() {
@@ -115,7 +114,6 @@ afterEach(() => {
   useTurnStore.getState().resetTurn();
   useConversationStore.setState({ processingConversationIds: new Set() });
   useChatSessionStore.setState({ snapshot: null } as never);
-  markHoldDictation(false);
   useVoiceRecordingStore.getState().reset();
 });
 
@@ -512,7 +510,7 @@ describe("the watch session at teardown", () => {
 /**
  * The dictation, which is the surface's business only when a held key started
  * it. The recording store is the real one and is shared with the composer's
- * microphone, so which recording is running is decided at its start.
+ * microphone; it carries which of the two opened it.
  */
 describe("dictating", () => {
   const recording = useVoiceRecordingStore.getState;
@@ -532,8 +530,7 @@ describe("dictating", () => {
 
   test("draws a hold's words as they arrive", () => {
     render(<Mirror />);
-    markHoldDictation(true);
-    recording().startRecording();
+    recording().startRecording({ hold: true });
     recording().setInterimTranscript("the quick brown");
 
     expect(latest().dictating).toBe("listening");
@@ -542,33 +539,16 @@ describe("dictating", () => {
 
   /**
    * The keys come up before the recording is over, and the wait after them is
-   * the stretch with nothing else on screen to explain it. The hold flag has
-   * already dropped by then, so the surface has to remember whose recording
-   * this was.
+   * the stretch with nothing else on screen to explain it.
    */
   test("stays with the hold through the wait after the keys come up", () => {
     render(<Mirror />);
-    markHoldDictation(true);
-    recording().startRecording();
-    markHoldDictation(false);
+    recording().startRecording({ hold: true });
     recording().stopRecording();
 
     expect(latest().dictating).toBe("transcribing");
 
     recording().reset();
-
-    expect(latest().dictating).toBeUndefined();
-  });
-
-  /** And having remembered one hold, it does not mistake the next composer recording for another. */
-  test("forgets the hold once its recording is over", () => {
-    render(<Mirror />);
-    markHoldDictation(true);
-    recording().startRecording();
-    markHoldDictation(false);
-    recording().reset();
-
-    recording().startRecording();
 
     expect(latest().dictating).toBeUndefined();
   });

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
@@ -43,7 +43,6 @@ import {
 } from "@/domains/chat/watch/watch-controller";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useWatchRetroStore } from "@/domains/chat/watch/watch-retro";
-import { isHoldDictation } from "@/utils/hold-to-dictate";
 import { COMPANION_DICTATION_TAIL } from "@vellumai/ipc-contract";
 import type {
   CompanionContext,
@@ -169,34 +168,27 @@ function currentContext(): CompanionContext {
 }
 
 /**
- * Whether the recording in the store is one a held key started.
- *
- * The store does not say who opened the microphone, and the hold flag says so
- * only while the keys are down, which ends before the recording does. So the
- * answer is taken as the recording starts, while the flag still stands, and
- * kept until the recording is over.
- */
-let holdRecording = false;
-
-/**
  * The dictation the surface should be drawing, or nothing.
  *
  * Only a dictation the keyboard started: one begun from a control in the app is
  * already visible where it was begun, and the surface saying so as well would
- * be the same fact drawn twice. `processing` is the wait after the keys come
- * up, which is the stretch with nothing else on screen to explain it.
+ * be the same fact drawn twice. The store says which it was for as long as the
+ * recording runs, which matters because the key itself is up again before a
+ * short recording has finished starting. `processing` is the wait after the
+ * keys come up, which is the stretch with nothing else on screen to explain
+ * it.
  */
 function dictatingPhase(): CompanionDictating | undefined {
-  switch (useVoiceRecordingStore.getState().phase) {
+  const { phase, hold } = useVoiceRecordingStore.getState();
+  if (!hold) {
+    return undefined;
+  }
+  switch (phase) {
     case "recording":
-      if (isHoldDictation()) {
-        holdRecording = true;
-      }
-      return holdRecording ? "listening" : undefined;
+      return "listening";
     case "processing":
-      return holdRecording ? "transcribing" : undefined;
+      return "transcribing";
     default:
-      holdRecording = false;
       return undefined;
   }
 }

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
@@ -43,10 +43,8 @@ import {
 } from "@/domains/chat/watch/watch-controller";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useWatchRetroStore } from "@/domains/chat/watch/watch-retro";
-import { readHoldToDictateEnabled } from "@/utils/hold-to-dictate";
-import {
-  COMPANION_DICTATION_TAIL,
-} from "@vellumai/ipc-contract";
+import { isHoldDictation } from "@/utils/hold-to-dictate";
+import { COMPANION_DICTATION_TAIL } from "@vellumai/ipc-contract";
 import type {
   CompanionContext,
   CompanionDictating,
@@ -171,6 +169,16 @@ function currentContext(): CompanionContext {
 }
 
 /**
+ * Whether the recording in the store is one a held key started.
+ *
+ * The store does not say who opened the microphone, and the hold flag says so
+ * only while the keys are down, which ends before the recording does. So the
+ * answer is taken as the recording starts, while the flag still stands, and
+ * kept until the recording is over.
+ */
+let holdRecording = false;
+
+/**
  * The dictation the surface should be drawing, or nothing.
  *
  * Only a dictation the keyboard started: one begun from a control in the app is
@@ -179,15 +187,16 @@ function currentContext(): CompanionContext {
  * up, which is the stretch with nothing else on screen to explain it.
  */
 function dictatingPhase(): CompanionDictating | undefined {
-  if (!readHoldToDictateEnabled()) {
-    return undefined;
-  }
   switch (useVoiceRecordingStore.getState().phase) {
     case "recording":
-      return "listening";
+      if (isHoldDictation()) {
+        holdRecording = true;
+      }
+      return holdRecording ? "listening" : undefined;
     case "processing":
-      return "transcribing";
+      return holdRecording ? "transcribing" : undefined;
     default:
+      holdRecording = false;
       return undefined;
   }
 }

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
@@ -31,6 +31,7 @@ import { selectTranscriptMessages } from "@/domains/chat/transcript/select-trans
 import {
   clearCompanionWorking,
   setCompanionContext,
+  setCompanionDictation,
 } from "@/runtime/companion-surface";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
@@ -43,6 +44,9 @@ import {
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useWatchRetroStore } from "@/domains/chat/watch/watch-retro";
 import { readHoldToDictateEnabled } from "@/utils/hold-to-dictate";
+import {
+  COMPANION_DICTATION_TAIL,
+} from "@vellumai/ipc-contract";
 import type {
   CompanionContext,
   CompanionDictating,
@@ -154,6 +158,7 @@ function currentContext(): CompanionContext {
     // `watching` is: the recording runs in this window, and while it runs the
     // surface is the only thing on screen to say so.
     dictating: dictatingPhase(),
+    dictationText: dictationTail(),
     turns: messages
       .filter(isSpeech)
       .slice(-TAIL)
@@ -187,6 +192,21 @@ function dictatingPhase(): CompanionDictating | undefined {
   }
 }
 
+/**
+ * The end of what the running dictation has recognised, bounded.
+ *
+ * The end rather than the start: the surface draws one line, and the words a
+ * speaker wants to check are the ones they just said. Empty when nothing is
+ * being dictated, so the field says nothing rather than something stale.
+ */
+function dictationTail(): string {
+  if (dictatingPhase() === undefined) {
+    return "";
+  }
+  const interim = useVoiceRecordingStore.getState().interimTranscript;
+  return interim.slice(-COMPANION_DICTATION_TAIL);
+}
+
 /** Whether two payloads would draw the same card. */
 function sameContext(a: CompanionContext, b: CompanionContext): boolean {
   return (
@@ -196,6 +216,7 @@ function sameContext(a: CompanionContext, b: CompanionContext): boolean {
     a.watchRetro === b.watchRetro &&
     a.captureCount === b.captureCount &&
     a.dictating === b.dictating &&
+    a.dictationText === b.dictationText &&
     a.turns.length === b.turns.length &&
     a.turns.every(
       (turn, index) =>
@@ -230,6 +251,7 @@ export function useCompanionMirror(): void {
       const context = currentContext();
       working = context.working;
       dictating = context.dictating;
+      dictationText = context.dictationText ?? "";
       if (pushed !== null && sameContext(pushed, context)) {
         return;
       }
@@ -286,11 +308,24 @@ export function useCompanionMirror(): void {
     // carries the live audio level and the interim transcript, so it moves
     // continuously through a recording, and `sync` reselects and remaps the
     // whole tail on every call.
+    let dictationText = dictationTail();
     const onDictationMaybeFlipped = (): void => {
-      if (dictatingPhase() === dictating) {
+      if (dictatingPhase() !== dictating) {
+        sync();
         return;
       }
-      sync();
+      // The words moved but nothing else did. Corrected in place rather than
+      // rebuilt: `sync` reselects and remaps the whole tail, and a recogniser
+      // revises its guess several times a second.
+      const nextText = dictationTail();
+      if (nextText === dictationText) {
+        return;
+      }
+      dictationText = nextText;
+      if (pushed !== null) {
+        pushed = { ...pushed, dictationText: nextText };
+      }
+      setCompanionDictation(dictating, nextText);
     };
     const unsubscribeDictation = useVoiceRecordingStore.subscribe(
       onDictationMaybeFlipped,

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
@@ -246,6 +246,9 @@ export function useCompanionMirror(): void {
     // while a microphone is open, and only two of those writes change what the
     // surface draws.
     let dictating = dictatingPhase();
+    // The words that came with it. Declared beside the phase because `sync`
+    // writes both, and `sync` runs before the subscriptions are set up.
+    let dictationText = dictationTail();
 
     const sync = (): void => {
       const context = currentContext();
@@ -308,7 +311,6 @@ export function useCompanionMirror(): void {
     // carries the live audio level and the interim transcript, so it moves
     // continuously through a recording, and `sync` reselects and remaps the
     // whole tail on every call.
-    let dictationText = dictationTail();
     const onDictationMaybeFlipped = (): void => {
       if (dictatingPhase() !== dictating) {
         sync();

--- a/clients/web/src/domains/chat/voice/voice-recording-store.ts
+++ b/clients/web/src/domains/chat/voice/voice-recording-store.ts
@@ -60,10 +60,18 @@ export interface VoiceRecordingState {
    * success check. Cleared on the next `startRecording`.
    */
   dictationInsertionError: string | null;
+  /**
+   * Whether a held key opened this microphone rather than a control in the
+   * app. Set as the recording starts and kept for as long as it runs, so a
+   * consumer that only hears about the recording once it is under way can
+   * still tell the two apart: the key itself is up again before a short
+   * recording has finished starting.
+   */
+  hold: boolean;
 }
 
 export interface VoiceRecordingActions {
-  startRecording: () => void;
+  startRecording: (options?: { hold?: boolean }) => void;
   stopRecording: () => void;
   finalize: () => void;
   fail: (code: string) => void;
@@ -108,8 +116,9 @@ const useVoiceRecordingStoreBase = create<VoiceRecordingStore>()((set) => ({
   interimTranscript: "",
   audioLevel: 0,
   dictationInsertionError: null,
+  hold: false,
 
-  startRecording: () => {
+  startRecording: (options) => {
     clearDismissTimer();
     set({
       phase: "recording",
@@ -117,6 +126,7 @@ const useVoiceRecordingStoreBase = create<VoiceRecordingStore>()((set) => ({
       interimTranscript: "",
       audioLevel: 0,
       dictationInsertionError: null,
+      hold: options?.hold ?? false,
     });
   },
 
@@ -156,6 +166,7 @@ const useVoiceRecordingStoreBase = create<VoiceRecordingStore>()((set) => ({
       interimTranscript: "",
       audioLevel: 0,
       dictationInsertionError: null,
+      hold: false,
     });
   },
 

--- a/clients/web/src/runtime/companion-surface.test.ts
+++ b/clients/web/src/runtime/companion-surface.test.ts
@@ -6,9 +6,8 @@ mock.module("@/runtime/is-electron", () => ({
   isElectron: () => true,
 }));
 
-const { setCompanionContext, clearCompanionWorking } = await import(
-  "./companion-surface"
-);
+const { setCompanionContext, clearCompanionWorking, setCompanionDictation } =
+  await import("./companion-surface");
 
 const sent: CompanionContext[] = [];
 
@@ -102,5 +101,73 @@ describe("clearCompanionWorking", () => {
     clearCompanionWorking();
 
     expect(sent.at(-1)?.working).toBe(false);
+  });
+});
+
+describe("setCompanionDictation", () => {
+  /**
+   * A recogniser revises its guess several times a second, and each revision
+   * is a fact about the microphone rather than about the conversation. The
+   * tail the card draws must survive being corrected in place.
+   */
+  test("keeps the conversation it was published beside", () => {
+    setCompanionContext({
+      assistantName: "Ziggy",
+      turns: [{ role: "user", text: "hello" }],
+      working: true,
+    });
+    sent.length = 0;
+
+    setCompanionDictation("listening", "the quick brown");
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.dictationText).toBe("the quick brown");
+    expect(sent[0]?.dictating).toBe("listening");
+    expect(sent[0]?.turns).toEqual([{ role: "user", text: "hello" }]);
+    expect(sent[0]?.working).toBe(true);
+  });
+
+  /** Words that did not move are not news, and this runs per recognition. */
+  test("says nothing when neither the phase nor the words moved", () => {
+    setCompanionDictation("listening", "the quick brown");
+    sent.length = 0;
+
+    setCompanionDictation("listening", "the quick brown");
+
+    expect(sent).toHaveLength(0);
+  });
+
+  test("publishes the end of the dictation", () => {
+    setCompanionDictation("listening", "the quick brown");
+    sent.length = 0;
+
+    setCompanionDictation(undefined, "");
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.dictating).toBeUndefined();
+    expect(sent[0]?.dictationText).toBe("");
+  });
+
+  /**
+   * There is nothing to correct before a context exists, and a dictation with
+   * no assistant beside it is not a card the surface draws.
+   */
+  test("stays silent before any context has been published", async () => {
+    delete (window as { vellum?: unknown }).vellum;
+    const fresh = await import(`./companion-surface?fresh=${Date.now()}`);
+    const seen: CompanionContext[] = [];
+    window.vellum = {
+      companion: {
+        getState: async () => null,
+        onState: () => () => undefined,
+        setContext: (context: CompanionContext) => {
+          seen.push(context);
+        },
+      },
+    } as unknown as Window["vellum"];
+
+    fresh.setCompanionDictation("listening", "hello");
+
+    expect(seen).toHaveLength(0);
   });
 });

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -11,6 +11,7 @@
 import { isElectron } from "@/runtime/is-electron";
 import type {
   CompanionContext,
+  CompanionDictating,
   CompanionIntroAction,
   CompanionSurfaceState,
 } from "@vellumai/ipc-contract";
@@ -186,6 +187,34 @@ let lastContext: CompanionContext | null = null;
  * path, so no React cleanup runs. Same reason `setAssistantName("")` is called
  * there.
  */
+/**
+ * Correct what the running dictation is doing and saying, and nothing else.
+ *
+ * A recogniser revises its guess several times a second, and each revision is
+ * a fact about the microphone rather than about the conversation. Rebuilding
+ * the whole context for one would reselect and remap the conversation's tail
+ * on every word, so this reuses the last one and replaces the two fields that
+ * moved, the way {@link clearCompanionWorking} does for the turn.
+ *
+ * Silent until a context has been published, since there is nothing to correct
+ * and a dictation with no assistant beside it is not a card the surface draws.
+ */
+export function setCompanionDictation(
+  dictating: CompanionDictating | undefined,
+  dictationText: string,
+): void {
+  if (lastContext === null) {
+    return;
+  }
+  if (
+    lastContext.dictating === dictating &&
+    (lastContext.dictationText ?? "") === dictationText
+  ) {
+    return;
+  }
+  setCompanionContext({ ...lastContext, dictating, dictationText });
+}
+
 export function clearCompanionWorking(): void {
   if (lastContext === null || !lastContext.working) {
     return;

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 
 import {
   ASSISTANT_STATUSES,
+  COMPANION_DICTATION_TAIL,
   NOTIFICATION_CATEGORIES,
   VOICE_ACTIVITY_CONTROL_ACTIONS,
   VOICE_ACTIVITY_PHASES,
@@ -126,6 +127,11 @@ export const companionContextSchema = z.object({
   // claim a microphone is doing something, and absence is the only way to say
   // none is.
   dictating: z.enum(["listening", "transcribing"]).optional(),
+  // Defaulted rather than optional: a publisher with nothing recognised yet is
+  // reporting no words, and empty is the truthful reading of that. Bounded at
+  // the boundary as well as at the publisher, since the surface draws one line
+  // and the length is the only part of this a sender controls.
+  dictationText: z.string().max(COMPANION_DICTATION_TAIL).catch("").default(""),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -1197,7 +1197,29 @@ export interface CompanionContext {
    * reading of a publisher that never mentions it.
    */
   dictating?: CompanionDictating;
+  /**
+   * The words recognised so far in that dictation, or empty before any are.
+   *
+   * The tail of them rather than all of them: this crosses a process boundary
+   * on every recognition result, and the surface draws one line of it, so the
+   * end is the part worth sending. {@link COMPANION_DICTATION_TAIL} is where
+   * that is cut.
+   *
+   * Revised as it arrives, since a recogniser rewrites its own guesses, which
+   * is why it is shown and not what gets inserted anywhere.
+   */
+  dictationText?: string;
 }
+
+/**
+ * How much of a running dictation the surface is given, in characters.
+ *
+ * The pill draws one line and clips what will not fit, so this is a bound on
+ * what crosses rather than on what is seen: enough that the line is always
+ * full, little enough that a long dictation does not grow the payload with
+ * every word.
+ */
+export const COMPANION_DICTATION_TAIL = 120;
 
 /**
  * How far a keyboard dictation has got, in the two states the user can act on.
@@ -1270,6 +1292,8 @@ export type CompanionIntroAction = (typeof COMPANION_INTRO_ACTIONS)[number];
 export interface CompanionSurfaceState {
   /** See {@link CompanionContext.dictating}. */
   dictating?: CompanionDictating;
+  /** See {@link CompanionContext.dictationText}. */
+  dictationText?: string;
   growth: CompanionGrowth;
   /**
    * Which way the typing card unfurls, and with it where the avatar sits inside


### PR DESCRIPTION
## Summary

- While a hold-to-dictate recording runs, the companion draws the words as they are recognised instead of the bare status word. Falls back to Listening and Thinking before anything has been heard.
- The words are whatever is feeding `useVoiceRecordingStore.interimTranscript`: Deepgram's stream partials since #41920, the on-device recogniser's when the stream is not available. Published on the existing `dictating` channel; no new transport.

## Three decisions worth a look

**The end of the sentence, not the start.** A line filling from the left freezes on the opening words and leaves the speaker watching the part they are least unsure of. The box is laid out right to left so the overflow lands at the beginning, with the run isolated in a `<bdi>` so the words keep their own order and their punctuation stays where it was said.

**Bounded rather than measured.** Every other body on this surface is as wide as its content, and a sentence has no width to be as wide as. `TRANSCRIPT_WIDTH` is a stated ceiling; the row lands at 292 against the 316 the canvas is sized for. The tail is cut again at the publisher (`COMPANION_DICTATION_TAIL`) and once more in the schema, so a long dictation does not grow the payload with every word.

**Corrected in place rather than republished.** This was the design problem. A recogniser revises itself several times a second, and `use-companion-mirror`'s sync reselects and remaps the whole conversation tail on every call, which is why its recording-store subscription was gated on the phase alone. Rather than widen that gate, the words take a targeted path (`setCompanionDictation`) that reuses the last context and replaces two fields, the way `clearCompanionWorking` already does for the turn. A phase change still goes through the full sync.

## Testing

126 surface tests including the render, the fallback, the front-clipping and the width ceiling; 10 on the runtime publisher including that it keeps the conversation it was published beside and stays quiet when nothing moved. Typecheck and lint across web and macOS.

Verified in Storybook: `Dictating`, `DictatingLongSentence` (the clipping case), `DictatingSilent`, `DictatingTranscribing`.

Verified on a live microphone against the earlier revision of this branch (the words on the pill during a hold). This revision is the same two commits rebased onto main after #41920; the recogniser experiments that sat between them were superseded by that PR and dropped.

## Original prompt

Hold-to-dictate shipped in JARVIS-1692, and using it surfaced that the surface says nothing about what it is hearing: you hold, talk, and wait for text to appear in another app. The ask was to show the words as they are recognised so you can see what you just said. This is the cheap half of a larger idea (JARVIS-1702) to stream dictation in at the cursor rather than pasting it at the end; it needs none of that work because the local partials already flow.

Closes JARVIS-1701
