### PR TITLE
docs(hosting): add macOS/Linux toggles to install steps

### DIFF
--- a/clients/docs/src/app/docs/_components/code-tabs.tsx
+++ b/clients/docs/src/app/docs/_components/code-tabs.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useId, useRef, useState } from "react";
+import type { ReactNode } from "react";
+
+/**
+ * A segmented control that swaps between alternate versions of a step, such as
+ * the same install command for macOS and Linux.
+ *
+ * Every panel stays mounted and is hidden with the `hidden` attribute rather
+ * than being conditionally rendered. `code-block-copy` reparents each `<pre>`
+ * into a wrapper element React does not know about, so unmounting a panel
+ * would leave React removing a child from a stale parent.
+ */
+
+export interface CodeTab {
+  id: string;
+  label: string;
+  content: ReactNode;
+}
+
+interface CodeTabsProps {
+  tabs: CodeTab[];
+  /** Describes the choice for screen readers, e.g. "Operating system". */
+  label: string;
+}
+
+export function CodeTabs({ tabs, label }: CodeTabsProps) {
+  const baseId = useId();
+  const [activeId, setActiveId] = useState(tabs[0]?.id);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const select = (index: number): void => {
+    const tab = tabs[index];
+    if (!tab) {
+      return;
+    }
+    setActiveId(tab.id);
+    tabRefs.current[index]?.focus();
+  };
+
+  const handleKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ): void => {
+    if (event.key === "ArrowRight") {
+      event.preventDefault();
+      select((index + 1) % tabs.length);
+    } else if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      select((index - 1 + tabs.length) % tabs.length);
+    } else if (event.key === "Home") {
+      event.preventDefault();
+      select(0);
+    } else if (event.key === "End") {
+      event.preventDefault();
+      select(tabs.length - 1);
+    }
+  };
+
+  return (
+    <div className="docs-code-tabs">
+      <div className="docs-code-tabs-list" role="tablist" aria-label={label}>
+        {tabs.map((tab, index) => {
+          const isActive = tab.id === activeId;
+          return (
+            <button
+              key={tab.id}
+              ref={(node) => {
+                tabRefs.current[index] = node;
+              }}
+              type="button"
+              role="tab"
+              id={`${baseId}-tab-${tab.id}`}
+              aria-selected={isActive}
+              aria-controls={`${baseId}-panel-${tab.id}`}
+              tabIndex={isActive ? 0 : -1}
+              className={`docs-code-tabs-tab${isActive ? " is-active" : ""}`}
+              onClick={() => setActiveId(tab.id)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+      {tabs.map((tab) => (
+        <div
+          key={tab.id}
+          role="tabpanel"
+          id={`${baseId}-panel-${tab.id}`}
+          aria-labelledby={`${baseId}-tab-${tab.id}`}
+          className="docs-code-tabs-panel"
+          hidden={tab.id !== activeId}
+        >
+          {tab.content}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/clients/docs/src/app/docs/_components/hosting-options-gcp-content.tsx
+++ b/clients/docs/src/app/docs/_components/hosting-options-gcp-content.tsx
@@ -143,9 +143,9 @@ gcloud services enable compute.googleapis.com`}</code>
               <strong>Install Vellum and its dependencies.</strong>
               <div className="mt-3 overflow-x-auto">
                 <pre className={preClass}>
-<code>{`# Install nginx in case you want to set up remote access to your assistant later
+<code>{`# Bun's installer needs curl and unzip
 sudo apt-get update
-sudo apt-get install -y curl unzip git nginx
+sudo apt-get install -y curl unzip git
 
 # Vellum ships as a Bun package, so Bun needs to be installed
 curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"

--- a/clients/docs/src/app/docs/_components/hosting-options-pair-a-device-content.tsx
+++ b/clients/docs/src/app/docs/_components/hosting-options-pair-a-device-content.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 
+import { CodeTabs } from "@/app/docs/_components/code-tabs";
 import { DocsContent } from "@/app/docs/_components/docs-content";
 import { SectionHeading } from "@/app/docs/_components/section-heading";
 import { TableOfContents } from "@/app/docs/_components/table-of-contents";
@@ -9,6 +10,7 @@ import { TableOfContents } from "@/app/docs/_components/table-of-contents";
 const TOC_ITEMS = [
   { id: "overview", label: "Overview", level: 2 },
   { id: "before-you-start", label: "Before you start", level: 2 },
+  { id: "install-nginx", label: "Install nginx", level: 2 },
   { id: "set-up-a-tunnel", label: "Set up a tunnel provider", level: 2 },
   { id: "ngrok", label: "ngrok", level: 3 },
   { id: "tailscale", label: "Tailscale", level: 3 },
@@ -77,26 +79,58 @@ export function HostingOptionsPairADeviceContent() {
           <SectionHeading id="before-you-start" level={2}>
             Before you start
           </SectionHeading>
-          <p className={paraClass}>On the computer that hosts your assistant:</p>
-          <ul className="mb-0 list-disc space-y-2 pl-6 text-stone-600 dark:text-stone-400">
-            <li>
-              <strong>Make sure it&apos;s running.</strong>{" "}
-              <code className={codeClass}>vellum ps</code> to check,{" "}
-              <code className={codeClass}>vellum wake</code> to start it. No
-              assistant yet? See{" "}
-              <Link href="/docs/hosting-options/local-hosting" className={linkClass}>
-                Local hosting
-              </Link>
-              .
-            </li>
-            <li>
-              <strong>Install nginx.</strong>{" "}
-              Tunnels run through it, and Vellum starts it for you but
-              won&apos;t install it:{" "}
-              <code className={codeClass}>brew install nginx</code> on macOS,{" "}
-              <code className={codeClass}>sudo apt install nginx</code> on Linux.
-            </li>
-          </ul>
+          <p className={lastParaClass}>
+            Your assistant has to be running on the computer that hosts it.{" "}
+            <code className={codeClass}>vellum ps</code> to check,{" "}
+            <code className={codeClass}>vellum wake</code> to start it. No
+            assistant yet? See{" "}
+            <Link href="/docs/hosting-options/local-hosting" className={linkClass}>
+              Local hosting
+            </Link>
+            .
+          </p>
+        </section>
+
+        <section id="install-nginx" className="mt-12">
+          <SectionHeading id="install-nginx" level={2}>
+            Install nginx
+          </SectionHeading>
+          <p className={paraClass}>
+            Tunnels run through nginx. Vellum starts it for you, but
+            won&apos;t install it. Run this on the computer hosting your
+            assistant.
+          </p>
+          <CodeTabs
+            label="Operating system"
+            tabs={[
+              {
+                id: "macos",
+                label: "macOS",
+                content: (
+                  <div className="overflow-x-auto">
+                    <pre className={preClass}>
+<code>{`brew install nginx`}</code>
+                    </pre>
+                  </div>
+                ),
+              },
+              {
+                id: "linux",
+                label: "Linux",
+                content: (
+                  <div className="overflow-x-auto">
+                    <pre className={preClass}>
+<code>{`sudo apt-get update
+sudo apt-get install -y nginx
+
+# nginx lands in /usr/sbin, which isn't on PATH for non-root users
+echo 'export PATH="$PATH:/usr/sbin"' >> ~/.bashrc && source ~/.bashrc`}</code>
+                    </pre>
+                  </div>
+                ),
+              },
+            ]}
+          />
         </section>
 
         <section id="set-up-a-tunnel" className="mt-12">
@@ -137,16 +171,63 @@ export function HostingOptionsPairADeviceContent() {
                 .
               </li>
               <li>
-                <strong>Install the agent.</strong>{" "}
-                <code className={codeClass}>brew install ngrok/ngrok/ngrok</code>{" "}
-                on macOS, or{" "}
-                <code className={codeClass}>sudo snap install ngrok</code> on
-                Linux.
+                <strong className="block">Install the agent.</strong>
+                <CodeTabs
+                  label="Operating system"
+                  tabs={[
+                    {
+                      id: "macos",
+                      label: "macOS",
+                      content: (
+                        <div className="overflow-x-auto">
+                          <pre className={preClass}>
+<code>{`# Install ngrok
+brew install ngrok/ngrok/ngrok
+
+# Confirm it's there
+ngrok --version`}</code>
+                          </pre>
+                        </div>
+                      ),
+                    },
+                    {
+                      id: "linux",
+                      label: "Linux",
+                      content: (
+                        <div className="overflow-x-auto">
+                          <pre className={preClass}>
+<code>{`# ngrok ships as a snap. Ubuntu Desktop has snapd already, but
+# Debian and most server images don't.
+sudo apt update
+sudo apt install -y snapd
+
+# Install ngrok
+sudo snap install ngrok
+
+# snap links binaries into /snap/bin, which isn't on PATH by default
+echo 'export PATH="$PATH:/snap/bin"' >> ~/.bashrc && source ~/.bashrc
+
+# Confirm it's there
+ngrok --version`}</code>
+                          </pre>
+                        </div>
+                      ),
+                    },
+                  ]}
+                />
               </li>
               <li>
                 <strong>Add your authtoken</strong>{" "}
-                from the <span className={uiClass}>Your Authtoken</span> page in
-                the dashboard:
+                from the{" "}
+                <Link
+                  href="https://dashboard.ngrok.com/get-started/your-authtoken"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkClass}
+                >
+                  Your Authtoken
+                </Link>{" "}
+                page in the dashboard:
                 <div className="mt-3 overflow-x-auto">
                   <pre className={preClass}>
 <code>{`ngrok config add-authtoken <your-token>`}</code>
@@ -154,14 +235,22 @@ export function HostingOptionsPairADeviceContent() {
                 </div>
               </li>
               <li>
-                <strong>Claim a static domain.</strong>{" "}
-                Optional, but it saves re-pairing later. Without one, ngrok
-                issues a new URL each time the tunnel restarts, and paired
-                devices keep pointing at the old one. A reboot, a Ctrl+C, or a{" "}
-                <code className={codeClass}>vellum wake</code>{" "}
-                all restart it.
-                Note the domain you pick; you&apos;ll pass it to Vellum in the
-                next section.
+                <strong>(Optional) Claim a static domain.</strong>{" "}
+                Without one, ngrok issues a new URL every time the tunnel
+                restarts, and your paired devices keep pointing at the old one.
+                Restarts are easy to trigger: a reboot, a Ctrl+C, or a{" "}
+                <code className={codeClass}>vellum wake</code>. Reserving a
+                domain on the{" "}
+                <Link
+                  href="https://dashboard.ngrok.com/domains"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={linkClass}
+                >
+                  Domains
+                </Link>{" "}
+                page saves you re-pairing each time. Note the one you pick;
+                you&apos;ll pass it to Vellum in the next section.
               </li>
             </ol>
           </div>
@@ -210,43 +299,41 @@ export function HostingOptionsPairADeviceContent() {
             Start the tunnel
           </SectionHeading>
           <p className={paraClass}>
-            Run this on the computer hosting the assistant. For ngrok, pass the
-            domain you reserved:
+            Run this on the computer hosting the assistant. For ngrok, pass{" "}
+            <Link
+              href="https://dashboard.ngrok.com/domains"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={linkClass}
+            >
+              the domain
+            </Link>{" "}
+            you reserved:
           </p>
           <div className={blockClass}>
             <pre className={preClass}>
-<code>{`vellum tunnel --provider ngrok --domain your-assistant.ngrok.app`}</code>
+<code>{`vellum tunnel --provider ngrok --domain your-assistant.ngrok.app -d`}</code>
             </pre>
           </div>
           <p className={paraClass}>For Tailscale:</p>
           <div className={blockClass}>
             <pre className={preClass}>
-<code>{`vellum tunnel --provider tailscale`}</code>
+<code>{`vellum tunnel --provider tailscale -d`}</code>
             </pre>
           </div>
           <p className={paraClass}>
-            Either way the command prints{" "}
-            <code className={codeClass}>Tunnel established:</code> followed by
-            the address your devices will use, and saves that address so the
-            pairing steps below fill it in for you.
+            <code className={codeClass}>-d</code>{" "}
+            runs the tunnel in the background, so it survives closing the
+            terminal. It has to stay up for as long as you want remote access.
           </p>
-          <p className={paraClass}>
-            The tunnel has to stay up for as long as you want remote access. To
-            keep it running without leaving a terminal open, add{" "}
-            <code className={codeClass}>-d</code>:
-          </p>
-          <div className={blockClass}>
-            <pre className={preClass}>
-<code>{`vellum tunnel --provider ngrok -d`}</code>
-            </pre>
-          </div>
           <p className={lastParaClass}>
-            It waits for the tunnel to come up, then prints the address, where
-            it is logging, and the{" "}
+            Either way the command waits for the tunnel to come up, then prints{" "}
+            <code className={codeClass}>Tunnel established:</code> with the
+            address your devices will use, where it is logging, and the{" "}
             <code className={codeClass}>kill</code>{" "}
-            command that stops it again.
-            Vellum remembers your ngrok domain after the first run, which is why
-            this one doesn&apos;t repeat{" "}
+            command that stops it again. Vellum saves that address so the
+            pairing steps below fill it in for you, and remembers your ngrok
+            domain so later runs don&apos;t need{" "}
             <code className={codeClass}>--domain</code>.
           </p>
         </section>

--- a/clients/docs/src/app/docs/docs-theme.css
+++ b/clients/docs/src/app/docs/docs-theme.css
@@ -253,6 +253,65 @@ html:has(.docs-shell) {
   border-radius: 0;
 }
 
+/* Segmented control for alternate versions of a step, e.g. macOS vs Linux. */
+.docs-shell .docs-code-tabs {
+  margin-top: 0.75rem;
+}
+
+.docs-shell .docs-code-tabs-list {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  margin-bottom: 0.5rem;
+  padding: 3px;
+  border: 1px solid var(--docs-border);
+  border-radius: 10px;
+  background: var(--docs-sidebar-bg);
+}
+
+.docs-shell .docs-code-tabs-list:hover {
+  border-color: var(--docs-border-strong);
+}
+
+.docs-shell .docs-code-tabs-tab {
+  padding: 0.25rem 0.7rem;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--docs-text-subtle);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+  transition:
+    color 0.18s ease,
+    background 0.18s ease;
+}
+
+.docs-shell .docs-code-tabs-tab:hover {
+  color: var(--docs-text-muted);
+}
+
+.docs-shell .docs-code-tabs-tab.is-active {
+  background: var(--docs-surface);
+  color: var(--docs-accent);
+}
+
+.docs-shell .docs-code-tabs-tab:focus-visible {
+  outline: 2px solid var(--docs-accent);
+  outline-offset: -1px;
+}
+
+.docs-shell .docs-code-tabs-panel[hidden] {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-shell .docs-code-tabs-tab {
+    transition: none;
+  }
+}
+
 /* Copy-to-clipboard button, injected by CodeBlockCopy. The wrapper sits
    around the scroll container so the button stays put on wide blocks. */
 .docs-shell .docs-codeblock {


### PR DESCRIPTION
## Summary

- **New `CodeTabs` component** (`clients/docs/src/app/docs/_components/code-tabs.tsx`): a segmented control for alternate versions of a step, with a proper `role="tablist"`, roving tabindex, and arrow/Home/End keyboard nav. Styled on the existing `--docs-*` tokens to match the theme picker's idiom, light and dark.
- **Applied to the nginx and ngrok install steps** on Pair a device, which previously squeezed both platforms into one sentence. Splitting them made room for the per-platform setup each actually needs: `/snap/bin` on PATH after ngrok's snap install, `/usr/sbin` after nginx's, and a `ngrok --version` check.
- **"Install nginx" promoted to its own section** (with a TOC entry). It was a bullet in "Before you start"; with a code block under it, it had outgrown the list, and the remaining one-item list collapsed to a paragraph.
- **ngrok dashboard links** for the authtoken and domains pages, opening in new tabs (`target="_blank" rel="noopener noreferrer"`, matching the convention in 13 other docs files).
- **`-d` on the tunnel commands.** This made the "to keep it running without leaving a terminal open, add `-d`:" block below contradict itself, so that explainer is folded into the surrounding prose and its now-redundant third code block removed. No facts were dropped, including the `--domain` memory behavior.
- **GCP page**: `nginx` removed from its install block, now that the prerequisite lives on the page that sets up tunnels. `curl unzip git` stay there, since that page really is bootstrapping a bare VM before Bun exists.

## Original prompt

Add a macOS/Linux toggle to the ngrok install step on the hosting-options Pair a device page, so each platform gets its own code block instead of two inline code chips in a prose sentence. This grew through review into fleshing out the Linux install paths (both need a PATH fixup that the one-line form had no room for), giving nginx its own section, linking the ngrok dashboard pages, and moving the nginx prerequisite off the GCP page onto the page where tunnels are actually configured.

## Implementation note

`CodeTabs` keeps every panel mounted and hides inactive ones with the `hidden` attribute instead of rendering conditionally. `CodeBlockCopy` enhances each `<pre>` by reparenting it into a wrapper `<div>` that React does not know about, so unmounting a panel would leave React calling `removeChild` on a stale parent and throwing. Keeping panels mounted sidesteps that, and has the side benefit that both blocks get their copy buttons up front.

## Verification

`bun run typecheck`, `bun run lint`, and `bun test` (120 tests) pass in `clients/docs/`. Checked in the browser on the local dev server: both toggles switch correctly, arrow keys move between tabs, copy buttons attach inside both panels, a fresh load defaults to macOS, light and dark both render correctly, and the console is clean (no hydration or `removeChild` errors). Both ngrok links were clicked to confirm they open a new tab and land on the real pages; `dashboard.ngrok.com/domains` was verified canonical (`/cloud-edge/domains` 301s to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)