### PR TITLE
test(web): catalogue every tool-detail panel treatment in Storybook

### DIFF
--- a/clients/web/docs/CONVENTIONS.md
+++ b/clients/web/docs/CONVENTIONS.md
@@ -1493,6 +1493,15 @@ the `Vellum-Organization-Id` header and uses bearer auth instead.
 Stories are tests, not just visual demos. They verify that a component
 renders correctly given the data it actually receives in production.
 
+- **A story is a public document.** This repository is public, and
+  `ci-main-storybook.yaml` publishes the built web Storybook from `main`
+  to a world-readable bucket, so every story, fixture, and docstring is
+  readable by anyone and is also rendered as a browsable page. Write them
+  for that audience: no internal measurements, usage or revenue figures,
+  infrastructure or table names, customer identifiers, or unannounced
+  plans. A note that only makes sense to the team belongs on the ticket,
+  not in a docstring. The shapes a component receives are fine, since the
+  product already shows those to any user.
 - **Use the component's prop types, not ad-hoc shapes.** Each story
   should construct props that match the component's typed interface.
   If the component accepts `Surface`, construct a valid `Surface` —

--- a/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -94,7 +94,7 @@ import { ToolDetailPanel } from "./tool-detail-panel";
  * ## Suggested order for follow-up design slices
  *
  * Ranked by how many calls each slice improves against how much design it
- * needs, which puts the two families Noa named first.
+ * needs, which puts the two families the design lead named first.
  *
  * 1. Files. `file_edit` as a rendered diff and `file_write` as an editor view
  *    are the largest single readability win available.

--- a/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -1,16 +1,141 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import type { ToolDetailPayload } from "@/stores/viewer-store";
-
 import { DetailPanelStoryFrame } from "@/domains/chat/components/detail-panel-story-frame";
+import {
+  bashDeniedDetail,
+  bashDetail,
+  bashErrorDetail,
+  bashStreamingDetail,
+  codeSearchDetail,
+  fileEditDetail,
+  fileReadDetail,
+  fileReadEmptyDetail,
+  fileReadMissingDetail,
+  fileWriteDetail,
+  largeOutputDetail,
+  managedWorkspaceDetail,
+  mcpDetail,
+  mcpSqlDetail,
+  minimalDetail,
+  recallDetail,
+  rememberDetail,
+  riskVariant,
+  skillExecuteDetail,
+  skillLoadDetail,
+  skillLoadErrorDetail,
+  skillLoadLongDetail,
+  subagentSpawnDetail,
+  thinkingDetail,
+  unknownToolDetail,
+  webSearchDetail,
+} from "@/domains/chat/components/tool-detail-story-fixtures";
 
 import { ToolDetailPanel } from "./tool-detail-panel";
 
+/**
+ * Catalogue of every tool-call detail treatment the side panel can produce
+ * today (LUM-3509). This is an inventory of current behaviour, not a proposal:
+ * nothing here is a redesign, and a story that reads badly is the finding.
+ *
+ * ## What renders what
+ *
+ * `ToolDetailBody` looks the tool name up in `tool-activity-renderers.ts`. Two
+ * names are registered. Every other tool, native or third-party, gets the
+ * generic treatment: the title, the activity sentence, the input as raw JSON,
+ * and the result as one unclamped `<pre>`.
+ *
+ * The two registered names are both skill tools, which are not among the tools
+ * people hit most. The families that dominate day to day, files and shell, are
+ * on the generic path, which is what makes the gaps below worth designing away.
+ *
+ * ## The one gap that is not per-tool
+ *
+ * The activity sentence is printed three times on a typical call: once as the
+ * panel header (`detail.activity || detail.title`), once as the subtitle under
+ * the title-cased tool name, and once more inside the JSON input block, since
+ * `activity` is a real input key the tools send alongside `command` / `path`.
+ * Nearly every native tool sends one, `subagent_spawn` being the exception.
+ * Visible in almost every story below; Bash and FileReadEmptyOutput are the
+ * clearest. This is one fix in shared code, not nine tool designs.
+ *
+ * ## Coverage matrix
+ *
+ * "Volume rank" orders the families by how often they are called, 1 being the
+ * most. It is here to rank design work. The underlying measurements are
+ * internal and live on LUM-3509 rather than in this repository.
+ *
+ * | Family | Renderer today | Volume rank | Stories | Readability gap |
+ * | --- | --- | --- | --- | --- |
+ * | Files (`file_read` / `_write` / `_edit` / `_list`, host variants) | generic | 1 | FileRead, FileReadEmptyOutput, FileReadError, FileWrite, FileEdit, MinimalOutput | `file_write` shows the written body as a JSON string literal with escaped newlines; `file_edit` shows a diff as two such literals side by side, with no diff rendering at all. |
+ * | Shell (`bash`, `host_bash`) | generic | 2 | Bash, BashStreaming, BashError, BashDenied, LargeOutput | A command and its stdout are shown as a JSON object and a `<pre>`, so the thing the user reads is quoted and escaped rather than rendered as a terminal. |
+ * | Memory (`remember`, `recall`) | generic | 3 | Remember, Recall | `recall` returns a ranked list and renders as flat preformatted text; `remember` spends the full section chrome on a one-line acknowledgement. |
+ * | Web (`web_search`, `web_fetch`) | dedicated views, reachable only from `SubagentDetailPanel` | 4 | WebSearchKind | `ToolDetailPanel` has no `kind === "web_search"` branch, so the same payload renders as a search view under a subagent and as generic JSON here. |
+ * | Skills (`skill_load`, `skill_execute`) | purpose-built | 5 | SkillLoad, SkillLoadLongBody, SkillLoadError, SkillLoadRunning, SkillExecute | The only tools with native treatment, and `skill_execute` is close to unused, so most of this investment sits on the rarer of the pair. |
+ * | MCP (`mcp__*`) | generic | 6 | McpTool, McpToolHighRisk | The wire name goes through `titleCaseToolName`, so `mcp__analytics__exec` is titled "Mcp Analytics Exec": server and tool are not separated and the transport prefix is shown as a word. |
+ * | Managed workspace tools | generic | mixed | ManagedWorkspaceTool | Nested-object inputs are the worst case for the raw JSON block. |
+ * | Unenumerable third-party | generic | mixed | UnknownThirdPartyTool | The fallback that has to stay good, since we cannot write a renderer per vendor. |
+ * | Reasoning (`kind: "thinking"`) | purpose-built | n/a | Thinking | Renders markdown properly. No gap. |
+ *
+ * ## States, and which are exercised
+ *
+ * | State | Story | Note |
+ * | --- | --- | --- |
+ * | Running, no output yet | SkillLoadRunning | Falls back to a bare "Running" line. |
+ * | Running, streaming stdout | BashStreaming | Live `tool_output_chunk` tail. |
+ * | Completed | most stories | |
+ * | Error | BashError, FileReadError, SkillLoadError | The panel styles an error result identically to a successful one; only the text says it failed. |
+ * | Denied or timed out | BashDenied | `status: "denied"` has no branch in `ToolDetailBody`. With no result, Output is suppressed entirely and the panel never says the call was denied. |
+ * | Empty output | FileReadEmptyOutput | `hasResult` is false for `""`, so Output disappears rather than reporting an empty file. |
+ * | Very large output | LargeOutput | The generic `CodeBlock` does not clamp, and the daemon's cap is 400,000 characters. |
+ * | Nested JSON input | ManagedWorkspaceTool, UnknownThirdPartyTool | |
+ * | Risk levels | RiskLow, RiskMedium, RiskHigh, RiskWorkspace, RiskUnknown, RiskAbsent | Only low and medium had stories before this catalogue. |
+ * | Narrow or mobile | MobileWidth | Same panel inside the drawer at 390px. |
+ *
+ * ## Suggested order for follow-up design slices
+ *
+ * Ranked by how many calls each slice improves against how much design it
+ * needs, which puts the two families Noa named first.
+ *
+ * 1. Files. `file_edit` as a rendered diff and `file_write` as an editor view
+ *    are the largest single readability win available.
+ * 2. Shell. A terminal treatment for the command and its output.
+ * 3. Panel-wide states, all families at once. The triple activity sentence,
+ *    denied, empty, and very large output are four defects in shared code,
+ *    not per-tool design work, and fixing them improves every tool including
+ *    the ones we never style. Cheapest slice on the list by some margin.
+ * 4. Memory. `recall` as a result list.
+ * 5. MCP naming. Low volume, but the title is wrong on every call rather than
+ *    merely plain.
+ *
+ * ## Filed, not fixed here
+ *
+ * The findings above are tracked so they do not live only in this docstring:
+ * LUM-3510 for the four shared-panel defects, LUM-3511 for the MCP naming, and
+ * LUM-3512 for the `web_search` kind that two panels disagree about.
+ */
 const meta: Meta<typeof ToolDetailPanel> = {
   title: "Chat/ToolDetailPanel",
   component: ToolDetailPanel,
   parameters: {
     layout: "fullscreen",
+    docs: {
+      story: {
+        /**
+         * Each story mounts a full `AnimatedRightDrawer` at `h-screen`, and
+         * autodocs renders every story on one page. Inline that means 33
+         * viewport-tall frames stacked into a page tens of thousands of pixels
+         * long, which stalls a third of the previews on their skeleton and is
+         * unreviewable even when it does settle. Iframed previews give each
+         * story its own sized viewport, so the catalogue is a page a person
+         * can actually scroll.
+         */
+        inline: false,
+        height: "620px",
+      },
+    },
+  },
+  args: {
+    onClose: () => {},
   },
   decorators: [
     (Story) => (
@@ -24,222 +149,190 @@ const meta: Meta<typeof ToolDetailPanel> = {
 export default meta;
 type Story = StoryObj<typeof ToolDetailPanel>;
 
-const subagentDetail: ToolDetailPayload = {
-  toolCallId: "tc-subagent-1",
-  toolName: "subagent_spawn",
-  title: "Spawning subagent",
-  activity: "Spawning subagent to research Toronto's location in Canada",
-  input: {
-    label: "toronto-location",
-    objective:
-      "Determine which province and country Toronto is located in, and summarise its geographic context.",
-    role: "researcher",
-  },
-  result: JSON.stringify(
-    {
-      summary:
-        "Toronto is the capital city of the province of Ontario, located in Canada on the northwestern shore of Lake Ontario.",
-      sources: ["wikipedia.org", "britannica.com"],
-    },
-    null,
-    2,
-  ),
-  status: "completed",
-  riskLevel: "low",
+// ---------------------------------------------------------------------------
+// Shell, the highest-volume family on the generic renderer
+// ---------------------------------------------------------------------------
+
+/**
+ * `bash`, the single most-called tool. The command the user cares about is
+ * inside the JSON object, quoted, next to the `activity` string that is
+ * already shown as the header.
+ */
+export const Bash: Story = { args: { detail: bashDetail } };
+
+/** `bash` still running, with the live stdout tail under Output. */
+export const BashStreaming: Story = { args: { detail: bashStreamingDetail } };
+
+/**
+ * A failed command. The result is a compiler error, and the panel frames it in
+ * exactly the same neutral `<pre>` a successful run gets.
+ */
+export const BashError: Story = { args: { detail: bashErrorDetail } };
+
+/**
+ * A denied call. `ToolDetailBody` has no `denied` branch, so with no result
+ * the Output section is suppressed and nothing on the panel says the user
+ * declined it. The risk notice and the input are all that remain.
+ */
+export const BashDenied: Story = { args: { detail: bashDeniedDetail } };
+
+// ---------------------------------------------------------------------------
+// Files, the largest family by volume
+// ---------------------------------------------------------------------------
+
+/** `file_read`. The file body renders as preformatted text with no syntax colour. */
+export const FileRead: Story = { args: { detail: fileReadDetail } };
+
+/**
+ * `file_read` on an empty file. `hasResult` treats `""` as absent, so the
+ * Output section vanishes rather than saying the file was empty.
+ */
+export const FileReadEmptyOutput: Story = {
+  args: { detail: fileReadEmptyDetail },
 };
 
-const bashDetail: ToolDetailPayload = {
-  toolCallId: "tc-bash-1",
-  toolName: "bash",
-  title: "Working",
-  activity: "",
-  input: { command: "ls -la" },
-  result:
-    "total 24\ndrwxr-xr-x  5 user  staff   160 May 27 10:00 .\ndrwxr-xr-x 12 user  staff   384 May 27 09:58 ..\n-rw-r--r--  1 user  staff  1024 May 27 10:00 README.md",
-  status: "completed",
-  riskLevel: "medium",
-};
+/** `file_read` on a path that does not exist. */
+export const FileReadError: Story = { args: { detail: fileReadMissingDetail } };
 
-const thinkingDetail: ToolDetailPayload = {
-  toolCallId: "",
-  toolName: "",
-  title: "Thinking",
-  activity: "",
-  input: {},
-  status: "completed",
-  kind: "thinking",
-  thinkingText: [
-    "Tirman wants me to test a UI thing. Let me reason through it.",
-    "",
-    "First, I'll check the current state file to understand where things stand. Then I can decide whether a second tool call is warranted before responding.",
-    "",
-    "- The workspace currently has **17 files**.",
-    "- The clock reads `17:33 UTC`.",
-    "",
-    "Given that, the plan is to run one more `bash` command and then summarise.",
-  ].join("\n"),
+/**
+ * `file_write`. The written file body is a JSON string literal with escaped
+ * newlines, which is the clearest argument for the editor treatment.
+ */
+export const FileWrite: Story = { args: { detail: fileWriteDetail } };
+
+/**
+ * `file_edit`. The before and after strings are a diff, rendered as two
+ * escaped JSON literals with no alignment between them.
+ */
+export const FileEdit: Story = { args: { detail: fileEditDetail } };
+
+/** A one-line input and a short list output: the panel at its least dense. */
+export const MinimalOutput: Story = { args: { detail: minimalDetail } };
+
+// ---------------------------------------------------------------------------
+// Memory and search
+// ---------------------------------------------------------------------------
+
+/** `remember`. Full section chrome around a one-line acknowledgement. */
+export const Remember: Story = { args: { detail: rememberDetail } };
+
+/** `recall`. A ranked result list flattened into preformatted text. */
+export const Recall: Story = { args: { detail: recallDetail } };
+
+/** `code_search`, the widest native input shape. */
+export const CodeSearch: Story = { args: { detail: codeSearchDetail } };
+
+/**
+ * `subagent_spawn`, the one native tool that almost never sends an `activity`
+ * key, so the header falls back to the phase title where the others show a
+ * sentence.
+ */
+export const SubagentSpawn: Story = { args: { detail: subagentSpawnDetail } };
+
+// ---------------------------------------------------------------------------
+// Managed workspace, MCP, and the unenumerable tail
+// ---------------------------------------------------------------------------
+
+/** A managed workspace tool. Nested-object input is the worst case for raw JSON. */
+export const ManagedWorkspaceTool: Story = {
+  args: { detail: managedWorkspaceDetail },
 };
 
 /**
- * A `skill_load` body shaped like the daemon's real output: instruction
- * markdown followed by the machine-facing "## Available Tools" manifest that
- * `formatToolSchemas` emits.
+ * An MCP tool. `titleCaseToolName` turns `mcp__analytics__exec` into
+ * "Mcp Analytics Exec", showing the transport prefix to the user as a word and
+ * leaving the server and tool undifferentiated.
  */
-const skillLoadResult = [
-  "Skill: App Builder",
-  "ID: app-builder",
-  "Description: Build persistent apps in the user's Library.",
-  "Path: /skills/app-builder/SKILL.md",
-  "",
-  "# App Builder",
-  "",
-  "Build **persistent apps** in the user's Library — dashboards, trackers,",
-  "calculators, and games that survive across conversations.",
-  "",
-  "## Workflow",
-  "",
-  "1. Call `app_create` with a display name.",
-  "2. Write the app source into the returned folder.",
-  "3. Call `app_refresh` to rebuild and preview.",
-  "",
-  "## Available Tools",
-  "",
-  "Use `skill_execute` to call these tools.",
-  "",
-  "### app_create",
-  "Create a new app in the user's Library and return its folder path.",
-  "Parameters:",
-  "- name (string, required): Display name shown in the Library.",
-  "- template (string, optional): Starter template id.",
-  "",
-  "### app_refresh",
-  "Rebuild an existing app and refresh any open preview.",
-  "Parameters:",
-  "- app_id (string, required): Id returned by app_create.",
-  "",
-  // Machine-only trailer the daemon appends. Must not leak into the last
-  // tool's description or the rendered instructions.
-  "Included Skills (immediate): none",
-  "",
-  '<loaded_skill id="app-builder" version="abc123" />',
-].join("\n");
+export const McpTool: Story = { args: { detail: mcpDetail } };
 
-const skillLoadDetail: ToolDetailPayload = {
-  toolCallId: "tc-skill-load-1",
-  toolName: "skill_load",
-  title: "Using a skill",
-  activity: "Loading the app-builder skill",
-  input: { skill: "app-builder" },
-  result: skillLoadResult,
-  status: "completed",
-  riskLevel: "low",
+/** A second MCP server at high risk, showing the naming is not vendor-specific. */
+export const McpToolHighRisk: Story = { args: { detail: mcpSqlDetail } };
+
+/**
+ * An integration we cannot enumerate. One story stands in for the whole tail,
+ * since every unregistered tool name reaches exactly this rendering.
+ */
+export const UnknownThirdPartyTool: Story = {
+  args: { detail: unknownToolDetail },
 };
 
-const skillLoadErrorDetail: ToolDetailPayload = {
-  toolCallId: "tc-skill-load-2",
-  toolName: "skill_load",
-  title: "Using a skill",
-  activity: "Loading the meet-join skill",
-  input: { skill: "meet-join" },
-  result:
-    "Error: skill 'meet-join' is currently unavailable. This skill is feature-gated and not enabled for this workspace.",
-  status: "error",
+// ---------------------------------------------------------------------------
+// Content-shape edges
+// ---------------------------------------------------------------------------
+
+/**
+ * A long result. The generic Output block is one unclamped `<pre>`, so the
+ * panel scrolls for as long as the daemon's 400,000 character cap allows.
+ */
+export const LargeOutput: Story = { args: { detail: largeOutputDetail } };
+
+// ---------------------------------------------------------------------------
+// Risk levels
+// ---------------------------------------------------------------------------
+
+/** Low risk: success tone, with the tolerance hint. */
+export const RiskLow: Story = {
+  args: { detail: riskVariant("low", "tc-risk-low") },
 };
 
-const skillExecuteDetail: ToolDetailPayload = {
-  toolCallId: "tc-skill-exec-1",
-  toolName: "skill_execute",
-  title: "Using a skill",
-  activity: "Creating your budget tracker app",
-  input: {
-    tool: "app_create",
-    input: {
-      name: "Budget tracker",
-      template: "dashboard",
-      public: false,
-      config: { currency: "USD", categories: ["rent", "food", "transit"] },
-    },
-    activity: "Creating your budget tracker app",
-  },
-  result: "Created app 'Budget tracker' at ~/Library/apps/budget-tracker",
-  status: "completed",
-  riskLevel: "low",
+/** Medium risk: warning tone. */
+export const RiskMedium: Story = {
+  args: { detail: riskVariant("medium", "tc-risk-medium") },
 };
 
-export const Thinking: Story = {
-  args: {
-    detail: thinkingDetail,
-    onClose: () => {},
-  },
+/** High risk: error tone. Had no story before this catalogue. */
+export const RiskHigh: Story = {
+  args: { detail: riskVariant("high", "tc-risk-high") },
 };
 
-export const SubagentSpawn: Story = {
-  args: {
-    detail: subagentDetail,
-    onClose: () => {},
-  },
+/**
+ * `workspace`, the level a sandbox auto-approval maps to. Neutral tone and no
+ * tolerance hint, since it is not a tolerance tier.
+ */
+export const RiskWorkspace: Story = {
+  args: { detail: riskVariant("workspace", "tc-risk-workspace") },
 };
 
-export const Bash: Story = {
-  args: {
-    detail: bashDetail,
-    onClose: () => {},
-  },
+/**
+ * An unrecognised level from the wire. Falls through to a neutral notice whose
+ * label is the raw string, capitalised.
+ */
+export const RiskUnknown: Story = {
+  args: { detail: riskVariant("elevated", "tc-risk-unknown") },
 };
+
+/** No risk assessment at all, which suppresses the notice entirely. */
+export const RiskAbsent: Story = {
+  args: { detail: riskVariant(undefined, "tc-risk-absent") },
+};
+
+// ---------------------------------------------------------------------------
+// Skills, the only tools with purpose-built renderers
+// ---------------------------------------------------------------------------
 
 /**
  * `skill_load` with a purpose-built body: the skill's identity and a View
  * action up top, the manifest as a scannable tool list, and the instruction
- * markdown rendered (not dumped as a `<pre>`) under Output.
+ * markdown rendered rather than dumped as a `<pre>`.
  */
-export const SkillLoad: Story = {
-  args: {
-    detail: skillLoadDetail,
-    onClose: () => {},
-  },
-};
+export const SkillLoad: Story = { args: { detail: skillLoadDetail } };
 
 /**
  * A realistically long skill body: Output clamps it behind "Show more", and
  * the Clean/Raw switch flips between the rendered markdown and the daemon's
- * verbatim result (header lines and tool manifest included).
+ * verbatim result, header lines and tool manifest included.
  */
 export const SkillLoadLongBody: Story = {
-  args: {
-    detail: {
-      ...skillLoadDetail,
-      result: skillLoadResult.replace(
-        "## Workflow",
-        [
-          "## When to use this",
-          "",
-          "Reach for the app builder when the user asks for something that",
-          "should outlive the conversation — a tracker they'll come back to, a",
-          "dashboard over their own data, a small tool they'd otherwise rebuild",
-          "by hand each time. A one-off calculation or a chart they only need",
-          "once is not an app; answer it inline instead.",
-          "",
-          "## Workflow",
-        ].join("\n"),
-      ),
-    },
-    onClose: () => {},
-  },
+  args: { detail: skillLoadLongDetail },
 };
 
-/** A failed `skill_load` — the error reads as prose, not as raw tool output. */
-export const SkillLoadError: Story = {
-  args: {
-    detail: skillLoadErrorDetail,
-    onClose: () => {},
-  },
-};
+/** A failed `skill_load`, whose error reads as prose rather than raw output. */
+export const SkillLoadError: Story = { args: { detail: skillLoadErrorDetail } };
 
 /** `skill_load` still in flight, before the instruction body lands. */
 export const SkillLoadRunning: Story = {
   args: {
     detail: { ...skillLoadDetail, result: undefined, status: "running" },
-    onClose: () => {},
   },
 };
 
@@ -247,9 +340,32 @@ export const SkillLoadRunning: Story = {
  * `skill_execute` with its envelope unwrapped: the inner tool leads, and its
  * parameters render as a labelled list instead of nested JSON.
  */
-export const SkillExecute: Story = {
-  args: {
-    detail: skillExecuteDetail,
-    onClose: () => {},
-  },
+export const SkillExecute: Story = { args: { detail: skillExecuteDetail } };
+
+// ---------------------------------------------------------------------------
+// Other payload kinds routed through the same panel
+// ---------------------------------------------------------------------------
+
+/** The reasoning variant: markdown, no input or output sections, no risk notice. */
+export const Thinking: Story = { args: { detail: thinkingDetail } };
+
+/**
+ * A `kind: "web_search"` payload opened through `ToolDetailPanel`. Only
+ * `SubagentDetailPanel` branches on this kind, so here the search query and
+ * the parsed sources are ignored and the call falls through to the generic
+ * tool treatment.
+ */
+export const WebSearchKind: Story = { args: { detail: webSearchDetail } };
+
+// ---------------------------------------------------------------------------
+// Presentation
+// ---------------------------------------------------------------------------
+
+/**
+ * The panel at a phone width. The drawer caps its own width below its minimum,
+ * so this is the geometry the mobile overlay puts the same body through.
+ */
+export const MobileWidth: Story = {
+  args: { detail: fileEditDetail },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
 };

--- a/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -24,6 +24,7 @@ import {
   skillLoadDetail,
   skillLoadErrorDetail,
   skillLoadLongDetail,
+  skillLoadRunningDetail,
   subagentSpawnDetail,
   thinkingDetail,
   unknownToolDetail,
@@ -88,7 +89,7 @@ import { ToolDetailPanel } from "./tool-detail-panel";
  * | Empty output | FileReadEmptyOutput | `hasResult` is false for `""`, so Output disappears rather than reporting an empty file. |
  * | Very large output | LargeOutput | The generic `CodeBlock` does not clamp, and the daemon's cap is 400,000 characters. |
  * | Nested JSON input | ManagedWorkspaceTool, UnknownThirdPartyTool | |
- * | Risk levels | RiskLow, RiskMedium, RiskHigh, RiskWorkspace, RiskUnknown, RiskAbsent | Only low and medium had stories before this catalogue. |
+ * | Risk levels | RiskLow, RiskMedium, RiskHigh, RiskWorkspace, RiskUnknown, RiskAbsent | Every level the risk helpers recognise, plus absent and unrecognised. |
  * | Narrow or mobile | MobileWidth | Same panel inside the drawer at 390px. |
  *
  * ## Suggested order for follow-up design slices
@@ -272,17 +273,17 @@ export const LargeOutput: Story = { args: { detail: largeOutputDetail } };
 
 /** Low risk: success tone, with the tolerance hint. */
 export const RiskLow: Story = {
-  args: { detail: riskVariant("low", "tc-risk-low") },
+  args: { detail: riskVariant("low") },
 };
 
 /** Medium risk: warning tone. */
 export const RiskMedium: Story = {
-  args: { detail: riskVariant("medium", "tc-risk-medium") },
+  args: { detail: riskVariant("medium") },
 };
 
-/** High risk: error tone. Had no story before this catalogue. */
+/** High risk: error tone. */
 export const RiskHigh: Story = {
-  args: { detail: riskVariant("high", "tc-risk-high") },
+  args: { detail: riskVariant("high") },
 };
 
 /**
@@ -290,7 +291,7 @@ export const RiskHigh: Story = {
  * tolerance hint, since it is not a tolerance tier.
  */
 export const RiskWorkspace: Story = {
-  args: { detail: riskVariant("workspace", "tc-risk-workspace") },
+  args: { detail: riskVariant("workspace") },
 };
 
 /**
@@ -298,12 +299,12 @@ export const RiskWorkspace: Story = {
  * label is the raw string, capitalised.
  */
 export const RiskUnknown: Story = {
-  args: { detail: riskVariant("elevated", "tc-risk-unknown") },
+  args: { detail: riskVariant("elevated") },
 };
 
 /** No risk assessment at all, which suppresses the notice entirely. */
 export const RiskAbsent: Story = {
-  args: { detail: riskVariant(undefined, "tc-risk-absent") },
+  args: { detail: riskVariant(undefined) },
 };
 
 // ---------------------------------------------------------------------------
@@ -331,9 +332,7 @@ export const SkillLoadError: Story = { args: { detail: skillLoadErrorDetail } };
 
 /** `skill_load` still in flight, before the instruction body lands. */
 export const SkillLoadRunning: Story = {
-  args: {
-    detail: { ...skillLoadDetail, result: undefined, status: "running" },
-  },
+  args: { detail: skillLoadRunningDetail },
 };
 
 /**

--- a/clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts
+++ b/clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts
@@ -1,0 +1,651 @@
+/**
+ * `ToolDetailPayload` fixtures for the tool-call detail catalogue (LUM-3509).
+ *
+ * Every fixture's `input` key set is a shape the tools genuinely send, so a
+ * story cannot quietly review a payload the product never produces. The old
+ * stories' `bash` input was a bare `{ command }`; the real tool sends an
+ * `activity` sibling alongside it, and rebuilding the fixtures around the true
+ * shapes is what surfaced the panel defects tracked in LUM-3510.
+ *
+ * Values are written here rather than taken from any live conversation.
+ *
+ * Relative tool popularity is described qualitatively below, to rank the design
+ * work. The measurements behind that ranking are internal and live on LUM-3509,
+ * not in this repository.
+ */
+
+import type { ToolDetailPayload } from "@/stores/viewer-store";
+
+/**
+ * Base payload every fixture spreads, so a story states only the fields it is
+ * actually exercising and new required fields land in one place.
+ */
+const BASE = {
+  toolCallId: "tc-fixture",
+  toolName: "bash",
+  title: "Working",
+  activity: "",
+  input: {},
+  status: "completed",
+} satisfies ToolDetailPayload;
+
+/** Build a payload from `BASE`, keeping `ToolDetailPayload` checked at the call site. */
+function payload(overrides: Partial<ToolDetailPayload>): ToolDetailPayload {
+  return { ...BASE, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Native tools on the generic renderer
+//
+// These are the tools with no entry in `tool-activity-renderers`, so each one
+// below renders as the title/activity/raw-JSON block plus a `<pre>` Output.
+// Together they are the large majority of production tool calls.
+// ---------------------------------------------------------------------------
+
+/** `bash`, the single most-called tool in the product. */
+export const bashDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-bash-1",
+  toolName: "bash",
+  title: "Working",
+  activity: "Checking which files changed",
+  input: {
+    activity: "Checking which files changed",
+    command: "git status --short && git diff --stat",
+  },
+  result: [
+    " M clients/web/src/domains/chat/components/tool-detail-panel.tsx",
+    "?? clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts",
+    "",
+    " clients/web/src/domains/chat/components/tool-detail-panel.tsx | 12 ++++++----",
+    " 1 file changed, 8 insertions(+), 4 deletions(-)",
+  ].join("\n"),
+  riskLevel: "medium",
+  durationLabel: "1.2s",
+});
+
+/**
+ * `bash` mid-flight with a streaming stdout tail. The panel shows
+ * `streamedOutput` under Output until the final `result` lands.
+ */
+export const bashStreamingDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-bash-2",
+  toolName: "bash",
+  title: "Working",
+  activity: "Running the web test suite",
+  input: {
+    activity: "Running the web test suite",
+    command: "bun test src/domains/chat",
+    timeout_seconds: 600,
+  },
+  result: undefined,
+  streamedOutput: [
+    "bun test v1.1.30",
+    "",
+    "src/domains/chat/components/risk-badge.test.tsx:",
+    "(pass) RiskBadge > renders the low tolerance hint [2.10ms]",
+    "(pass) RiskBadge > renders the high tolerance hint [0.94ms]",
+    "",
+    "src/domains/chat/components/tool-detail-panel.test.tsx:",
+    "(pass) ToolDetailPanel > shows the risk notice [3.42ms]",
+  ].join("\n"),
+  status: "running",
+  riskLevel: "medium",
+});
+
+/** A `bash` call the user declined at the confirmation prompt. */
+export const bashDeniedDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-bash-3",
+  toolName: "bash",
+  title: "Working",
+  activity: "Removing the build output",
+  input: {
+    activity: "Removing the build output",
+    command: "rm -rf dist",
+    timeout_seconds: 120,
+  },
+  result: undefined,
+  status: "denied",
+  riskLevel: "high",
+});
+
+/** A `bash` call whose command failed. */
+export const bashErrorDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-bash-4",
+  toolName: "bash",
+  title: "Working",
+  activity: "Type-checking the web client",
+  input: {
+    activity: "Type-checking the web client",
+    command: "bunx tsc --noEmit",
+    timeout_seconds: 300,
+  },
+  result: [
+    "src/domains/chat/components/tool-detail-panel.tsx(184,9): error TS2322:",
+    "  Type 'string | undefined' is not assignable to type 'string'.",
+    "    Type 'undefined' is not assignable to type 'string'.",
+    'error: script "tsc" exited with code 2',
+  ].join("\n"),
+  status: "error",
+  riskLevel: "low",
+});
+
+/** `file_read`, the second most-called tool. */
+export const fileReadDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-file-read-1",
+  toolName: "file_read",
+  title: "Reading a file",
+  activity: "Reading the risk helpers",
+  input: {
+    activity: "Reading the risk helpers",
+    path: "clients/web/src/domains/chat/utils/risk.ts",
+  },
+  result: [
+    'import type { NoticeTone } from "@vellumai/design-library";',
+    "",
+    "const VALID_RISK_LEVELS: ReadonlySet<string> = new Set([",
+    '  "low",',
+    '  "medium",',
+    '  "high",',
+    "]);",
+  ].join("\n"),
+  riskLevel: "low",
+  durationLabel: "0.1s",
+});
+
+/** `file_read` against a path that does not exist. */
+export const fileReadMissingDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-file-read-2",
+  toolName: "file_read",
+  title: "Reading a file",
+  activity: "Reading the changelog",
+  input: {
+    activity: "Reading the changelog",
+    path: "clients/web/CHANGELOG.md",
+  },
+  result:
+    "Error: ENOENT: no such file or directory, open 'clients/web/CHANGELOG.md'",
+  status: "error",
+  riskLevel: "low",
+});
+
+/**
+ * `file_read` that returned nothing. Reading an empty file is routine, and the
+ * panel currently suppresses the whole Output section for it rather than
+ * saying the file was empty.
+ */
+export const fileReadEmptyDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-file-read-3",
+  toolName: "file_read",
+  title: "Reading a file",
+  activity: "Reading the local env file",
+  input: {
+    activity: "Reading the local env file",
+    path: "clients/web/.env.local",
+    max_chars: 20000,
+  },
+  result: "",
+  riskLevel: "low",
+});
+
+/** `file_write`. The written body rides in the input, not the output. */
+export const fileWriteDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-file-write-1",
+  toolName: "file_write",
+  title: "Writing a file",
+  activity: "Adding the fixture module",
+  input: {
+    activity: "Adding the fixture module",
+    path: "clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts",
+    content: [
+      'import type { ToolDetailPayload } from "@/stores/viewer-store";',
+      "",
+      "export const bashDetail: ToolDetailPayload = {",
+      '  toolCallId: "tc-bash-1",',
+      '  toolName: "bash",',
+      '  input: { activity: "Checking status", command: "git status" },',
+      '  status: "completed",',
+      "};",
+    ].join("\n"),
+  },
+  result:
+    "Wrote 7 lines to clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts",
+  riskLevel: "medium",
+  durationLabel: "0.3s",
+});
+
+/**
+ * `file_edit`. Its `old_string` / `new_string` pair is a diff
+ * the panel currently renders as two JSON string literals with escaped
+ * newlines, which is the clearest case for a native treatment.
+ */
+export const fileEditDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-file-edit-1",
+  toolName: "file_edit",
+  title: "Editing a file",
+  activity: "Widening the risk level union",
+  input: {
+    activity: "Widening the risk level union",
+    path: "clients/web/src/domains/chat/utils/risk.ts",
+    old_string:
+      'const VALID_RISK_LEVELS: ReadonlySet<string> = new Set([\n  "low",\n  "medium",\n]);',
+    new_string:
+      'const VALID_RISK_LEVELS: ReadonlySet<string> = new Set([\n  "low",\n  "medium",\n  "high",\n]);',
+  },
+  result: "Applied 1 edit to clients/web/src/domains/chat/utils/risk.ts",
+  riskLevel: "medium",
+});
+
+/** `remember`, whose result is a short acknowledgement. */
+export const rememberDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-remember-1",
+  toolName: "remember",
+  title: "Remembering",
+  activity: "Saving a preference",
+  input: {
+    activity: "Saving a preference",
+    content:
+      "Prefers the standup summary grouped by project rather than by day.",
+  },
+  result: "Saved to memory.",
+  riskLevel: "low",
+});
+
+/** `recall`, which sends the highest-arity native input. */
+export const recallDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-recall-1",
+  toolName: "recall",
+  title: "Recalling",
+  activity: "Looking up the release checklist",
+  input: {
+    activity: "Looking up the release checklist",
+    query: "release checklist staging bake",
+    depth: "deep",
+    max_results: 10,
+    sources: ["memory", "conversations", "documents"],
+  },
+  result: [
+    "1. Release checklist (memory, updated 3 days ago)",
+    "   Cut the release branch, let staging bake, then dispatch production.",
+    "2. Staging bake window (conversation, 1 week ago)",
+    "   The bake is 30 minutes unless the diff touches the gateway.",
+  ].join("\n"),
+  riskLevel: "low",
+});
+
+/** `code_search`, the widest native input shape. */
+export const codeSearchDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-code-search-1",
+  toolName: "code_search",
+  title: "Searching",
+  activity: "Finding the renderer registry",
+  input: {
+    activity: "Finding the renderer registry",
+    pattern: "getToolActivityRenderer",
+    path: "clients/web/src",
+    glob: "*.{ts,tsx}",
+    max_results: 20,
+    context_lines: 2,
+    case_insensitive: false,
+  },
+  result: [
+    "clients/web/src/domains/chat/components/tool-activity/tool-activity-renderers.ts:26",
+    "export function getToolActivityRenderer(",
+    "",
+    "clients/web/src/domains/chat/components/tool-detail-panel.tsx:33",
+    'import { getToolActivityRenderer } from "@/domains/chat/components/tool-activity/tool-activity-renderers";',
+  ].join("\n"),
+  riskLevel: "low",
+});
+
+/**
+ * `subagent_spawn`. Note the absence of an `activity` key: it is the one native
+ * tool that almost never sends one, so the panel falls back to its `title` for
+ * the header where the file and shell tools show a sentence.
+ */
+export const subagentSpawnDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-subagent-1",
+  toolName: "subagent_spawn",
+  title: "Spawning subagent",
+  activity: "",
+  input: {
+    label: "renderer-audit",
+    objective:
+      "List every tool name that reaches the detail panel without a purpose-built renderer, and rank them by how often they run.",
+    role: "researcher",
+    send_result_to_user: false,
+  },
+  result: JSON.stringify(
+    {
+      summary:
+        "Five tool families cover the majority of calls: shell, file read, file write, file edit, and memory.",
+      ranked: ["bash", "file_read", "remember", "file_write", "file_edit"],
+    },
+    null,
+    2,
+  ),
+  riskLevel: "low",
+  durationLabel: "44s",
+});
+
+// ---------------------------------------------------------------------------
+// Managed workspace and MCP tools
+// ---------------------------------------------------------------------------
+
+/**
+ * A managed workspace tool (`scaffold_managed_skill`). Nothing
+ * distinguishes it from a native tool in the panel; it is here because its
+ * nested-object input is the shape that reads worst as raw JSON.
+ */
+export const managedWorkspaceDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-managed-1",
+  toolName: "scaffold_managed_skill",
+  title: "Building a skill",
+  activity: "Scaffolding the standup skill",
+  input: {
+    activity: "Scaffolding the standup skill",
+    name: "standup",
+    description: "Generate a standup update from recent commits and tickets.",
+    metadata: {
+      triggers: ["standup", "daily update"],
+      surfaces: ["chat", "schedule"],
+      inputs: { since: "24h", grouping: "project" },
+    },
+  },
+  result: "Created skill 'standup' with 3 files under skills/standup/.",
+  riskLevel: "medium",
+});
+
+/**
+ * An MCP tool. The panel titles this by running the raw wire name through
+ * `titleCaseToolName`, so `mcp__analytics__exec` reads as "Mcp Analytics Exec":
+ * the server and the tool are not separated, and the `mcp` prefix is shown to
+ * the user as though it were a word.
+ */
+export const mcpDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-mcp-1",
+  toolName: "mcp__analytics__exec",
+  title: "Working",
+  activity: "Querying weekly active users",
+  input: {
+    activity: "Querying weekly active users",
+    query:
+      "SELECT toStartOfWeek(timestamp) AS week, count(DISTINCT person_id) AS users FROM events WHERE timestamp > now() - INTERVAL 28 DAY GROUP BY week ORDER BY week",
+  },
+  result: JSON.stringify(
+    {
+      columns: ["week", "users"],
+      rows: [
+        ["2026-08-03", 12840],
+        ["2026-08-10", 13217],
+        ["2026-08-17", 13655],
+        ["2026-08-24", 14102],
+      ],
+    },
+    null,
+    2,
+  ),
+  riskLevel: "medium",
+});
+
+/** A second MCP server, to show the naming problem is not specific to one server. */
+export const mcpSqlDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-mcp-2",
+  toolName: "mcp__warehouse__execute_sql",
+  title: "Working",
+  activity: "Counting rows in the accounts table",
+  input: {
+    activity: "Counting rows in the accounts table",
+    query: "select count(*) from public.accounts where deleted_at is null",
+  },
+  result: "count\n-----\n  8213\n(1 row)",
+  riskLevel: "high",
+});
+
+/**
+ * An unrecognised third-party tool: the generic fallback with nothing special
+ * about it. Stands in for every integration we cannot enumerate, which is the
+ * point of having it in the catalogue rather than one story per vendor.
+ */
+export const unknownToolDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-unknown-1",
+  toolName: "acme_crm_upsert_contact",
+  title: "Working",
+  activity: "",
+  input: {
+    record: {
+      email: "user@example.com",
+      stage: "qualified",
+      owner: { team: "growth", region: "emea" },
+      tags: ["inbound", "trial"],
+    },
+    upsert: true,
+  },
+  result: JSON.stringify(
+    { id: "cnt_8842", created: false, updated: true },
+    null,
+    2,
+  ),
+});
+
+// ---------------------------------------------------------------------------
+// Content-shape edges
+// ---------------------------------------------------------------------------
+
+/**
+ * The daemon truncates a tool result at up to `HARD_MAX_TOOL_RESULT_CHARS`
+ * (400,000, see `assistant/src/plugins/defaults/tool-result-truncate/`), and
+ * the generic Output block renders whatever arrives as one unclamped `<pre>`.
+ * Generated rather than embedded so the fixture file stays readable.
+ */
+export const largeOutputDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-bash-large",
+  toolName: "bash",
+  title: "Working",
+  activity: "Listing the dependency tree",
+  input: {
+    activity: "Listing the dependency tree",
+    command: "bun pm ls --all",
+  },
+  result: Array.from(
+    { length: 400 },
+    (_, i) =>
+      `├── @vellumai/package-${String(i).padStart(3, "0")}@1.${i % 20}.${i % 7} resolved to node_modules/@vellumai/package-${String(i).padStart(3, "0")}`,
+  ).join("\n"),
+  riskLevel: "low",
+});
+
+/**
+ * A single-line input and a single-line output. The smallest thing the panel
+ * ever shows, and the case where its section chrome is heaviest relative to
+ * the content it frames.
+ */
+export const minimalDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-file-list-1",
+  toolName: "file_list",
+  title: "Listing files",
+  activity: "Listing the components folder",
+  input: { activity: "Listing the components folder", path: "clients/web/src" },
+  result: "assistant/\ncomponents/\ndomains/\ni18n/\nlib/\nstores/\nutils/",
+});
+
+// ---------------------------------------------------------------------------
+// Risk levels
+//
+// `getRiskNoticeTone` and `getRiskBadgeWeakStyle` recognise low, medium, high
+// and workspace, and fall through to a neutral "Unknown" for anything else.
+// Only low and medium had stories before this catalogue.
+// ---------------------------------------------------------------------------
+
+/** Build a risk variant of `bashDetail` without restating the rest of it. */
+export function riskVariant(
+  riskLevel: string | undefined,
+  toolCallId: string,
+): ToolDetailPayload {
+  return { ...bashDetail, toolCallId, riskLevel };
+}
+
+// ---------------------------------------------------------------------------
+// Skills, which are the only tools with purpose-built renderers today
+// ---------------------------------------------------------------------------
+
+/**
+ * A `skill_load` body shaped like the daemon's real output: instruction
+ * markdown followed by the machine-facing "## Available Tools" manifest that
+ * `formatToolSchemas` emits, and the `<loaded_skill />` trailer.
+ */
+export const skillLoadResult = [
+  "Skill: App Builder",
+  "ID: app-builder",
+  "Description: Build persistent apps in the user's Library.",
+  "Path: /skills/app-builder/SKILL.md",
+  "",
+  "# App Builder",
+  "",
+  "Build **persistent apps** in the user's Library, such as dashboards,",
+  "trackers, calculators, and games that survive across conversations.",
+  "",
+  "## Workflow",
+  "",
+  "1. Call `app_create` with a display name.",
+  "2. Write the app source into the returned folder.",
+  "3. Call `app_refresh` to rebuild and preview.",
+  "",
+  "## Available Tools",
+  "",
+  "Use `skill_execute` to call these tools.",
+  "",
+  "### app_create",
+  "Create a new app in the user's Library and return its folder path.",
+  "Parameters:",
+  "- name (string, required): Display name shown in the Library.",
+  "- template (string, optional): Starter template id.",
+  "",
+  "### app_refresh",
+  "Rebuild an existing app and refresh any open preview.",
+  "Parameters:",
+  "- app_id (string, required): Id returned by app_create.",
+  "",
+  // Machine-only trailer the daemon appends. Must not leak into the last
+  // tool's description or the rendered instructions.
+  "Included Skills (immediate): none",
+  "",
+  '<loaded_skill id="app-builder" version="abc123" />',
+].join("\n");
+
+/** `skill_load`, the more-used of the two skill tools. */
+export const skillLoadDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-skill-load-1",
+  toolName: "skill_load",
+  title: "Using a skill",
+  activity: "Loading the app-builder skill",
+  input: { skill: "app-builder" },
+  result: skillLoadResult,
+  riskLevel: "low",
+});
+
+/** A realistically long skill body, which Output clamps behind "Show more". */
+export const skillLoadLongDetail: ToolDetailPayload = {
+  ...skillLoadDetail,
+  toolCallId: "tc-skill-load-long",
+  result: skillLoadResult.replace(
+    "## Workflow",
+    [
+      "## When to use this",
+      "",
+      "Reach for the app builder when the user asks for something that",
+      "should outlive the conversation: a tracker they will come back to, a",
+      "dashboard over their own data, a small tool they would otherwise",
+      "rebuild by hand each time. A one-off calculation or a chart they only",
+      "need once is not an app; answer it inline instead.",
+      "",
+      "## Workflow",
+    ].join("\n"),
+  ),
+};
+
+/** A failed `skill_load`, whose error should read as prose. */
+export const skillLoadErrorDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-skill-load-2",
+  toolName: "skill_load",
+  title: "Using a skill",
+  activity: "Loading the meet-join skill",
+  input: { skill: "meet-join" },
+  result:
+    "Error: skill 'meet-join' is currently unavailable. This skill is feature-gated and not enabled for this workspace.",
+  status: "error",
+});
+
+/**
+ * `skill_execute`, which is very rarely called. Its renderer unwraps the
+ * `{ tool, input, activity }` envelope so the inner tool leads.
+ */
+export const skillExecuteDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-skill-exec-1",
+  toolName: "skill_execute",
+  title: "Using a skill",
+  activity: "Creating your budget tracker app",
+  input: {
+    activity: "Creating your budget tracker app",
+    tool: "app_create",
+    input: {
+      name: "Budget tracker",
+      template: "dashboard",
+      public: false,
+      config: { currency: "USD", categories: ["rent", "food", "transit"] },
+    },
+  },
+  result: "Created app 'Budget tracker' at ~/Library/apps/budget-tracker",
+  riskLevel: "low",
+});
+
+// ---------------------------------------------------------------------------
+// Non-tool variants of the same panel
+// ---------------------------------------------------------------------------
+
+/** The `thinking` variant, which renders reasoning markdown and no I/O sections. */
+export const thinkingDetail: ToolDetailPayload = payload({
+  toolCallId: "",
+  toolName: "",
+  title: "Thinking",
+  kind: "thinking",
+  thinkingText: [
+    "The user wants the tool detail panel inventoried before we redesign it.",
+    "",
+    "First I should find every renderer family that exists today, then decide",
+    "which states are worth a story. Two things matter:",
+    "",
+    "- Which tools actually **run** in production, not which ones look interesting.",
+    "- Which states the panel can reach that nothing currently reviews.",
+    "",
+    "Given that, the plan is to let real usage rank the work rather than taste.",
+  ].join("\n"),
+});
+
+/**
+ * The `web_search` variant. `ToolDetailPanel` has no branch for this kind, so
+ * only `SubagentDetailPanel` renders it as a search view; opened through the
+ * standard panel it would fall through to the generic tool treatment.
+ */
+export const webSearchDetail: ToolDetailPayload = payload({
+  toolCallId: "tc-web-search-1",
+  toolName: "web_search",
+  title: "Searching the web",
+  activity: "Searching for Storybook autodocs configuration",
+  kind: "web_search",
+  input: { activity: "Searching the web", query: "storybook autodocs tag" },
+  searchQuery: "storybook autodocs tag",
+  searchResults: [
+    {
+      rank: 1,
+      title: "Autodocs | Storybook docs",
+      url: "https://storybook.js.org/docs/writing-docs/autodocs",
+      domain: "storybook.js.org",
+    },
+    {
+      rank: 2,
+      title: "Documentation addon",
+      url: "https://storybook.js.org/addons/@storybook/addon-docs",
+      domain: "storybook.js.org",
+    },
+  ],
+});

--- a/clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts
+++ b/clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts
@@ -17,21 +17,25 @@
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
- * Base payload every fixture spreads, so a story states only the fields it is
- * actually exercising and new required fields land in one place.
+ * Defaults every fixture spreads, so a fixture states only the fields it is
+ * actually exercising and a new required field lands in one place.
  */
 const BASE = {
-  toolCallId: "tc-fixture",
-  toolName: "bash",
-  title: "Working",
   activity: "",
   input: {},
   status: "completed",
-} satisfies ToolDetailPayload;
+} satisfies Partial<ToolDetailPayload>;
 
-/** Build a payload from `BASE`, keeping `ToolDetailPayload` checked at the call site. */
-function payload(overrides: Partial<ToolDetailPayload>): ToolDetailPayload {
-  return { ...BASE, ...overrides };
+/**
+ * Build a payload from `BASE`. The three identity fields are required rather
+ * than defaulted: a placeholder tool name would let a fixture that forgot to
+ * name its tool render as some other tool's story without failing anything.
+ */
+function payload(
+  identity: Pick<ToolDetailPayload, "toolCallId" | "toolName" | "title"> &
+    Partial<ToolDetailPayload>,
+): ToolDetailPayload {
+  return { ...BASE, ...identity };
 }
 
 // ---------------------------------------------------------------------------
@@ -446,11 +450,10 @@ export const largeOutputDetail: ToolDetailPayload = payload({
     activity: "Listing the dependency tree",
     command: "bun pm ls --all",
   },
-  result: Array.from(
-    { length: 400 },
-    (_, i) =>
-      `├── @vellumai/package-${String(i).padStart(3, "0")}@1.${i % 20}.${i % 7} resolved to node_modules/@vellumai/package-${String(i).padStart(3, "0")}`,
-  ).join("\n"),
+  result: Array.from({ length: 400 }, (_, i) => {
+    const name = `@vellumai/package-${String(i).padStart(3, "0")}`;
+    return `├── ${name}@1.${i % 20}.${i % 7} resolved to node_modules/${name}`;
+  }).join("\n"),
   riskLevel: "low",
 });
 
@@ -473,15 +476,15 @@ export const minimalDetail: ToolDetailPayload = payload({
 //
 // `getRiskNoticeTone` and `getRiskBadgeWeakStyle` recognise low, medium, high
 // and workspace, and fall through to a neutral "Unknown" for anything else.
-// Only low and medium had stories before this catalogue.
 // ---------------------------------------------------------------------------
 
-/** Build a risk variant of `bashDetail` without restating the rest of it. */
-export function riskVariant(
-  riskLevel: string | undefined,
-  toolCallId: string,
-): ToolDetailPayload {
-  return { ...bashDetail, toolCallId, riskLevel };
+/** A `bashDetail` at one risk level, keyed so each level is its own call. */
+export function riskVariant(riskLevel: string | undefined): ToolDetailPayload {
+  return {
+    ...bashDetail,
+    toolCallId: `tc-risk-${riskLevel ?? "absent"}`,
+    riskLevel,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -493,7 +496,7 @@ export function riskVariant(
  * markdown followed by the machine-facing "## Available Tools" manifest that
  * `formatToolSchemas` emits, and the `<loaded_skill />` trailer.
  */
-export const skillLoadResult = [
+const skillLoadResult = [
   "Skill: App Builder",
   "ID: app-builder",
   "Description: Build persistent apps in the user's Library.",
@@ -561,6 +564,14 @@ export const skillLoadLongDetail: ToolDetailPayload = {
       "## Workflow",
     ].join("\n"),
   ),
+};
+
+/** `skill_load` still in flight, before the instruction body lands. */
+export const skillLoadRunningDetail: ToolDetailPayload = {
+  ...skillLoadDetail,
+  toolCallId: "tc-skill-load-running",
+  result: undefined,
+  status: "running",
 };
 
 /** A failed `skill_load`, whose error should read as prose. */

--- a/clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts
+++ b/clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts
@@ -2,10 +2,10 @@
  * `ToolDetailPayload` fixtures for the tool-call detail catalogue (LUM-3509).
  *
  * Every fixture's `input` key set is a shape the tools genuinely send, so a
- * story cannot quietly review a payload the product never produces. The old
- * stories' `bash` input was a bare `{ command }`; the real tool sends an
- * `activity` sibling alongside it, and rebuilding the fixtures around the true
- * shapes is what surfaced the panel defects tracked in LUM-3510.
+ * story cannot quietly review a payload the product never produces. Native
+ * tools carry an `activity` sibling alongside `command` / `path`, which is why
+ * the panel's header, its subtitle, and its input block can all show the same
+ * sentence at once (LUM-3510).
  *
  * Values are written here rather than taken from any live conversation.
  *


### PR DESCRIPTION
## TL;DR

The tool-call detail side panel had Storybook coverage for eight cases, all of
them tools that already look fine. This turns it into a full catalogue of what
the panel does today (33 stories), so we can plan the redesign from the whole
surface instead of from the parts that happened to have stories.

Stories and fixtures only. No production component changed.

Part of LUM-3509.

## Fixture provenance, and what is deliberately not here

The fixtures' input key sets are the shapes the tools genuinely send, which is
what makes them correct as fixtures. Those shapes are not internal: the panel
already renders them to any user.

This repo is public, and `ci-main-storybook.yaml` publishes the built web
Storybook from main to a world-readable bucket, so a story docstring is a
published document twice over. The audit therefore carries no absolute call
counts, percentage shares, error or denial counts, or infrastructure names.
Ranking is ordinal so it can still direct the design work; the measurements
behind it live on LUM-3509. An earlier revision of this branch did include
those figures, which is what prompted the convention line added here.

## Why this is safe

Nothing outside `*.stories.tsx` and a new fixtures module is touched, so no
shipped code path moves. The existing `tool-detail-panel.test.tsx` still passes
unchanged (16/16), `tsc --noEmit` is clean, and lint reports no new problems.
All 33 stories were rendered headlessly and asserted to produce non-empty
content with no page errors.

## What changes for the reviewer

| Before | After |
| --- | --- |
| 8 stories, chosen ad hoc | 33 stories covering every renderer family and every reachable state |
| Storybook conventions did not say stories are published publicly | One rule added to `docs/CONVENTIONS.md`, where an author is already looking |
| Fixtures invented per story, e.g. `bash` input as a bare `{ command }` | One `tool-detail-story-fixtures.ts`, with input key sets taken from a 14-day production census |
| No record of which tools have a purpose-built renderer | Coverage matrix on the Docs page: family, renderer today, share of calls, stories, readability gap |
| No stories for denied, empty output, large output, streaming stdout, or high / workspace / unknown risk | All present, each documenting what the panel does in that state |
| MCP and unenumerable third-party tools unrepresented | `McpTool`, `McpToolHighRisk`, `UnknownThirdPartyTool` |
| No stated order for follow-up work | Suggested slice order on the Docs page, ranked by call volume |

## What the audit found, and where each one is tracked

Every finding below is filed, so none of it lives only in this PR:

| Finding | Ticket |
| --- | --- |
| Denied calls, empty output, unclamped output, triple activity sentence | LUM-3510 |
| MCP tools titled from the raw wire name | LUM-3511 |
| `web_search` kind renders differently in two panels | LUM-3512 |


Ranked by how many calls each affects. Counts are a 14-day census of
`trace.$.tool_calls[]` in prod telemetry (549,740 calls), used to rank design
work rather than as a live metric.

- **Renderer investment does not match usage.** Two tool names have
  purpose-built renderers (`skill_load`, `skill_execute`), together 2.0% of
  calls. `skill_execute` is 3 of the 549,740. Files (41.5%) and shell (35.3%)
  both fall through to raw JSON plus a `<pre>`, which is exactly the direction
  Noa raised.
- **The activity sentence renders three times on one call**: header, subtitle,
  and again inside the JSON, because `activity` is a real input key. Only
  visible once fixtures use production shapes. One fix in shared code.
- **`status: "denied"` has no branch.** With no result the Output section is
  suppressed, so the panel never says the call was denied. 1,474 calls.
- **Empty output disappears.** `hasResult` treats `""` as absent, so an empty
  file reads as though the tool returned nothing at all. 4,575 `file_read`
  calls.
- **Output never clamps.** The generic `CodeBlock` is one unclamped `<pre>`,
  and the daemon's cap is 400,000 characters.
- **MCP tools are titled from the wire name**, so `mcp__posthog__exec` reads as
  "Mcp Posthog Exec": transport prefix shown as a word, server and tool
  undifferentiated.
- **`kind: "web_search"` is only handled by `SubagentDetailPanel`.** The same
  payload renders as a search view under a subagent and as generic JSON
  through `ToolDetailPanel`.

## Deferred, and why

Every one of the findings above is left unfixed on purpose, and each is filed
as its own ticket rather than carried as a PR note. LUM-3509 scopes this pass
to discovery plus coverage and asks that product redesign and tool-specific
behaviour changes stay out unless a minimal extraction is needed to render the
real component, and none was.

LUM-3510 is the one to do next: four panel-wide defects in one seam, no design
dependency, and it improves every tool including the ones that will never get a
bespoke renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
