### PR TITLE
fix(design-library): let a Tag label truncate

### DIFF
--- a/packages/design-library/src/components/tag.stories.tsx
+++ b/packages/design-library/src/components/tag.stories.tsx
@@ -27,6 +27,30 @@ type Story = StoryObj<typeof Tag>;
 /** Arg-driven: edit the label and flip the tone from the Controls panel. */
 export const Default: Story = {};
 
+/**
+ * A label longer than the space the tag is given.
+ *
+ * Arg-driven like `Default`, with a decorator supplying the constraint: a tag
+ * only truncates when something bounds it, and a story rendering it at its
+ * natural width would show nothing. The label ellipsizes inside the box
+ * instead of pushing the tag past it and being clipped mid-word by whatever
+ * is doing the bounding.
+ */
+export const TruncatedLabel: Story = {
+  args: {
+    tone: "warning",
+    leftIcon: <Circle />,
+    children: "A label longer than the space this tag has to render it in",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ display: "flex", width: 220, overflow: "hidden" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
 /** Every tone at a glance. */
 export const Tones: Story = {
   render: () => (

--- a/packages/design-library/src/components/tag.tsx
+++ b/packages/design-library/src/components/tag.tsx
@@ -99,14 +99,20 @@ export function Tag({
       className={cn(tagVariants({ tone }), className)}
     >
       {leftIcon != null ? (
-        <span
-          aria-hidden="true"
-          style={{ ...iconStyle, color: iconColor }}
-        >
+        <span aria-hidden="true" style={{ ...iconStyle, color: iconColor }}>
           {leftIcon}
         </span>
       ) : null}
-      {children}
+      {/*
+        The label carries its own truncation. The root is `inline-flex` and
+        `whitespace-nowrap`, so a bare text node here cannot ellipsize: it has
+        no width to overflow and pushes the tag past its container instead,
+        leaving the parent to clip it mid-word. Its own slot can shrink
+        (`min-w-0`) and ellipsize, and consumers can target it by slot.
+      */}
+      <span data-slot="tag-label" className="min-w-0 truncate">
+        {children}
+      </span>
       {rightIcon != null && onRemove == null ? (
         <span
           aria-hidden="true"


### PR DESCRIPTION
## TL;DR

A `Tag` whose label is longer than the space it is given does not truncate. It overflows and gets clipped mid-word by whatever is bounding it.

`Tag`'s root is `inline-flex` with `whitespace-nowrap`, and `children` renders as a bare text node inside it. A consumer that bounds the tag and asks for an ellipsis gets neither: the text has no box of its own to overflow, so `text-overflow` has nothing to act on and the label simply pushes the tag past its container.

This gives the label its own slot that can shrink (`min-w-0`) and ellipsize.

## Before / after

| Before | After |
| --- | --- |
| A long label pushes the tag past its container and is clipped mid-word by the parent | The label ellipsizes inside the tag |
| `className="truncate"` on a `Tag` does nothing | Works, because there is now an element it can apply to |
| No way to style the label from CSS | Addressable as `[data-slot="tag-label"]` |

## Why it is safe

Additive and inherited by every consumer. `min-w-0 truncate` only bites when something bounds the tag, so an unbounded tag renders exactly as it does today: there is nothing to truncate against. Verified against a real consumer (the profile row's "Default" tag) as well as the component's own stories.

Per rule 2 in `packages/design-library/AGENTS.md`, a multi-part component adds a slot per part, so the new label span carries `data-slot="tag-label"` and is stylable from CSS without touching the component.

## Screenshots

`Components/Tag` → `TruncatedLabel` shows it. The story is arg-driven like `Default`, with a decorator supplying the width constraint, since a tag rendered at its natural width has nothing to truncate and would show nothing.

## Context

Found while a long notification title ran under the status controls in the notifications bell, in vellum-ai/vellum-assistant#41906. Split out because it changes behavior for every `Tag` consumer and deserves review on its own terms rather than inside a credential-recovery change. That PR does not depend on this one; its titles are short enough not to need truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41913" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->