### PR TITLE
fix(web): use the prose variant for descriptions and hints, not the label one

### DIFF
--- a/clients/web/src/components/lazy-boundary.tsx
+++ b/clients/web/src/components/lazy-boundary.tsx
@@ -62,7 +62,7 @@ export function LazyBoundary({
         errorFallback ?? (
           <div
             role="alert"
-            className="p-3 text-body-small-default text-[var(--content-tertiary)]"
+            className="p-3 text-body-small-lighter text-[var(--content-tertiary)]"
           >
             {t("lazyBoundary.loadError")}
           </div>

--- a/clients/web/src/components/terminal-panel.tsx
+++ b/clients/web/src/components/terminal-panel.tsx
@@ -90,7 +90,7 @@ export function TerminalPanel({
       />
 
       {isMaintenanceActive && (
-        <div className="border-b border-[var(--system-mid-strong)] bg-[var(--system-mid-weak)] px-3 py-2 text-body-small-default text-[var(--system-mid-strong)]">
+        <div className="border-b border-[var(--system-mid-strong)] bg-[var(--system-mid-weak)] px-3 py-2 text-body-small-lighter text-[var(--system-mid-strong)]">
           {t("terminalPanel.recoveryModeBanner")}
         </div>
       )}

--- a/clients/web/src/domains/channels/components/email-managed-content.tsx
+++ b/clients/web/src/domains/channels/components/email-managed-content.tsx
@@ -413,7 +413,7 @@ export function EmailManagedContent({
           )}
           error={subdomainError}
         />
-        <p className="text-body-small-default text-[var(--content-tertiary)]">
+        <p className="text-body-small-lighter text-[var(--content-tertiary)]">
           {t("emailManagedContent.subdomainHint")}
         </p>
         <Button

--- a/clients/web/src/domains/chat/components/secret-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/secret-prompt-card.tsx
@@ -150,7 +150,7 @@ export function SecretPromptCard({
             disabled={isSubmitting || saved}
             fullWidth
           />
-          <p className="text-body-small-default text-[var(--content-disabled)]">
+          <p className="text-body-small-lighter text-[var(--content-disabled)]">
             {t("secretPromptCard.storedSecurelyNote")}
           </p>
         </div>

--- a/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/form-surface.tsx
@@ -87,7 +87,7 @@ function FormFieldInput({
             placeholder={field.placeholder}
             className={cn(inputClasses, errorClasses)}
           />
-          <p className="mt-1 flex items-center gap-1 text-body-small-default text-[var(--content-faint)]">
+          <p className="mt-1 flex items-center gap-1 text-body-small-lighter text-[var(--content-faint)]">
             <Lock className="h-3 w-3" />
             {t("formSurface.secureHint")}
           </p>

--- a/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/oauth-connect-surface.tsx
@@ -255,7 +255,7 @@ export function OAuthConnectSurface({
             </p>
 
             {missingConfiguration && (
-              <div className="mt-3 flex items-center gap-2 text-body-small-default text-[var(--system-negative-strong)]">
+              <div className="mt-3 flex items-center gap-2 text-body-small-lighter text-[var(--system-negative-strong)]">
                 <XCircle className="h-4 w-4 shrink-0" />
                 {t("oauthConnectSurface.missingDetails")}
               </div>

--- a/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
+++ b/clients/web/src/domains/intelligence/components/concept-graph/concept-graph-intro-banner.tsx
@@ -45,7 +45,7 @@ export function ConceptGraphIntroBanner({
           {t("conceptGraphIntroBanner.title")}
         </p>
         <p
-          className="mt-0.5 text-body-small-default"
+          className="mt-0.5 text-body-small-lighter"
           style={{ color: "var(--content-tertiary)" }}
         >
           {t("conceptGraphIntroBanner.description")}

--- a/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
+++ b/clients/web/src/domains/intelligence/components/plugins/plugin-detail-shared.tsx
@@ -370,7 +370,7 @@ export function PluginDetailError() {
       <p className="text-body-medium-default">
         {t("pluginDetailShared.loadErrorTitle")}
       </p>
-      <p className="text-body-small-default">
+      <p className="text-body-small-lighter">
         {t("pluginDetailShared.loadErrorDetail")}
       </p>
     </div>

--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
@@ -156,7 +156,7 @@ function SuggestionList({
       {showAddHint && (
         <li
           role="presentation"
-          className="mt-0.5 border-t border-[var(--border-base)] px-2.5 pb-0.5 pt-1.5 text-body-small-default text-[var(--content-tertiary)]"
+          className="mt-0.5 border-t border-[var(--border-base)] px-2.5 pb-0.5 pt-1.5 text-body-small-lighter text-[var(--content-tertiary)]"
         >
           {t("onboardingAutocomplete.freeTextHint")}
         </li>

--- a/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -186,7 +186,7 @@ export function ApiKeyScreen() {
                   onChange={(e) => setCustomModels(e.target.value)}
                   fullWidth
                 />
-                <p className="text-body-small-default text-[var(--content-tertiary)]">
+                <p className="text-body-small-lighter text-[var(--content-tertiary)]">
                   {t("apiKeyScreen.modelsHelp")}
                 </p>
               </div>

--- a/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
+++ b/clients/web/src/domains/schedules/components/schedule-detail-panel.tsx
@@ -140,7 +140,7 @@ function ScheduleModelProfileField({
           label={t("scheduleDetail.modelProfile")}
           value={t("scheduleDetail.notUsedForWorkflow")}
         />
-        <p className="text-body-small-default text-[var(--content-tertiary)]">
+        <p className="text-body-small-lighter text-[var(--content-tertiary)]">
           {t("scheduleDetail.modelProfileWorkflowNote")}
         </p>
       </>

--- a/clients/web/src/domains/settings/ai/advisor-profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/advisor-profile-row.tsx
@@ -48,7 +48,7 @@ export function AdvisorProfileRow({
           <p className="text-body-medium-default font-medium text-[var(--content-default)]">
             {t("advisorProfileRow.title")}
           </p>
-          <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+          <p className="mt-0.5 text-body-small-lighter text-[var(--content-tertiary)]">
             {t("advisorProfileRow.description")}
           </p>
         </div>

--- a/clients/web/src/domains/settings/ai/web-fetch-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-fetch-card.tsx
@@ -238,7 +238,7 @@ export function WebFetchCard() {
               fullWidth
             />
             {defaultApiBase ? (
-              <p className="text-body-small-default text-[var(--content-tertiary)]">
+              <p className="text-body-small-lighter text-[var(--content-tertiary)]">
                 {t("webFetchCard.apiBaseHint", {
                   defaultBase: defaultApiBase,
                 })}

--- a/clients/web/src/domains/settings/ai/web-search-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.tsx
@@ -286,7 +286,7 @@ export function WebSearchCard() {
               fullWidth
             />
             {defaultApiBase ? (
-              <p className="text-body-small-default text-[var(--content-tertiary)]">
+              <p className="text-body-small-lighter text-[var(--content-tertiary)]">
                 {t("webSearchCard.apiBaseHint", {
                   defaultBase: defaultApiBase,
                 })}

--- a/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/domain-step.tsx
@@ -206,7 +206,7 @@ export function DomainStep({
             </p>
           )}
           {isLocked && (
-            <p className="text-body-small-default text-[var(--content-tertiary)]">
+            <p className="text-body-small-lighter text-[var(--content-tertiary)]">
               {t("domainStep.domainLockedMessage")}
             </p>
           )}

--- a/clients/web/src/domains/settings/components/access-consent-setting.tsx
+++ b/clients/web/src/domains/settings/components/access-consent-setting.tsx
@@ -104,11 +104,11 @@ export function AccessConsentSetting() {
           <div className="text-body-medium-default text-[var(--content-default)]">
             {t("accessConsentSetting.title")}
           </div>
-          <p className="mt-1 text-body-small-default text-[var(--content-tertiary)]">
+          <p className="mt-1 text-body-small-lighter text-[var(--content-tertiary)]">
             {t("accessConsentSetting.description")}
           </p>
           {platformGate === "full" && isError && (
-            <p className="mt-1 text-body-small-default text-[var(--system-negative-strong)]">
+            <p className="mt-1 text-body-small-lighter text-[var(--system-negative-strong)]">
               {t("accessConsentSetting.loadError")}
             </p>
           )}

--- a/clients/web/src/domains/settings/components/app-icon-modal.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-modal.tsx
@@ -207,13 +207,13 @@ export function AppIconModal({
             </Button>
           ) : null}
 
-          <p className="text-body-small-default text-[var(--content-tertiary)]">
+          <p className="text-body-small-lighter text-[var(--content-tertiary)]">
             {t("appIcon.note")}
           </p>
           {failed ? (
             <p
               role="alert"
-              className="text-body-small-default text-[color:var(--content-negative)]"
+              className="text-body-small-lighter text-[color:var(--content-negative)]"
             >
               {t("appIcon.error")}
             </p>

--- a/clients/web/src/domains/settings/components/app-icon-row.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.tsx
@@ -172,7 +172,7 @@ function AppIconRowContent({ assistantId, sync }: AppIconRowContentProps) {
           <div className="text-body-medium-lighter text-[var(--content-default)]">
             {t("appIcon.title")}
           </div>
-          <p className="text-body-small-default text-[var(--content-tertiary)]">
+          <p className="text-body-small-lighter text-[var(--content-tertiary)]">
             {t("appIcon.description")}
           </p>
         </div>

--- a/clients/web/src/domains/settings/components/assistant-sleep-policy.tsx
+++ b/clients/web/src/domains/settings/components/assistant-sleep-policy.tsx
@@ -141,7 +141,7 @@ export function AssistantSleepPolicy({
         <label className="block text-body-medium-default text-[var(--content-default)]">
           {t("assistantSleepPolicy.idleTimeout")}
         </label>
-        <p className="text-body-small-default text-[var(--content-tertiary)]">
+        <p className="text-body-small-lighter text-[var(--content-tertiary)]">
           {t("assistantSleepPolicy.idleTimeoutDescription")}
         </p>
         <div className="mt-2 flex flex-wrap gap-2">

--- a/clients/web/src/domains/settings/components/biometric-settings-card.tsx
+++ b/clients/web/src/domains/settings/components/biometric-settings-card.tsx
@@ -78,7 +78,7 @@ export function BiometricSettingsCard() {
               label: capability.label,
             })}
           </div>
-          <p className="mt-1 text-body-small-default text-[var(--content-tertiary)]">
+          <p className="mt-1 text-body-small-lighter text-[var(--content-tertiary)]">
             {isNativeIOS
               ? t("biometricSettingsCard.descriptionWithPasscode", {
                   label: capability.label,

--- a/clients/web/src/domains/settings/components/create-schedule-modal.tsx
+++ b/clients/web/src/domains/settings/components/create-schedule-modal.tsx
@@ -580,7 +580,7 @@ function ScheduleSummary({
         >
           {summary}
         </p>
-        <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+        <p className="mt-0.5 text-body-small-lighter text-[var(--content-tertiary)]">
           {t("createScheduleModal.timezoneNote", { timezone: timezoneLabel })}
         </p>
       </div>

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -236,7 +236,7 @@ export function DailyCreditLimitCard() {
 
         {requiredByAutoTopUp && (
           <p
-            className="text-body-small-default text-[var(--content-tertiary)]"
+            className="text-body-small-lighter text-[var(--content-tertiary)]"
             data-testid="daily-credit-limit-required-note"
           >
             {t("dailyCreditLimitCard.requiredNote")}

--- a/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -92,7 +92,7 @@ export function DebugControlsPanel() {
               <p className="text-body-medium-default text-[var(--content-default)]">
                 {t("debugControlsPanel.restartTitle")}
               </p>
-              <p className="text-body-small-default text-[var(--content-tertiary)]">
+              <p className="text-body-small-lighter text-[var(--content-tertiary)]">
                 {t("debugControlsPanel.restartDescription")}
               </p>
             </div>
@@ -116,7 +116,7 @@ export function DebugControlsPanel() {
                 <p className="text-body-medium-default text-[var(--content-default)]">
                   {t("debugControlsPanel.replayTitle")}
                 </p>
-                <p className="text-body-small-default text-[var(--content-tertiary)]">
+                <p className="text-body-small-lighter text-[var(--content-tertiary)]">
                   {t("debugControlsPanel.replayDescription")}
                 </p>
               </div>

--- a/clients/web/src/domains/settings/components/recovery-mode-controls.tsx
+++ b/clients/web/src/domains/settings/components/recovery-mode-controls.tsx
@@ -121,11 +121,11 @@ export function RecoveryModeControls({
               {t("recoveryModeControls.title")}
             </p>
             {isActive ? (
-              <p className="text-body-small-default text-[var(--system-mid-strong)]">
+              <p className="text-body-small-lighter text-[var(--system-mid-strong)]">
                 {t("recoveryModeControls.activeDescription")}
               </p>
             ) : (
-              <p className="text-body-small-default text-[var(--content-tertiary)]">
+              <p className="text-body-small-lighter text-[var(--content-tertiary)]">
                 {t("recoveryModeControls.inactiveDescription")}
               </p>
             )}

--- a/clients/web/src/domains/settings/components/risk-tolerance-settings.tsx
+++ b/clients/web/src/domains/settings/components/risk-tolerance-settings.tsx
@@ -162,7 +162,7 @@ export function RiskToleranceSettings() {
         {t("riskToleranceSettings.description")}
       </p>
       {loadError && (
-        <p className="mt-2 text-body-small-default text-[var(--system-negative-strong)]">
+        <p className="mt-2 text-body-small-lighter text-[var(--system-negative-strong)]">
           {t("riskToleranceSettings.loadError")}
         </p>
       )}
@@ -171,7 +171,7 @@ export function RiskToleranceSettings() {
           <div className="text-body-medium-default text-[var(--content-default)]">
             {t("riskToleranceSettings.conversationsTitle")}
           </div>
-          <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+          <p className="mt-0.5 text-body-small-lighter text-[var(--content-tertiary)]">
             {t("riskToleranceSettings.conversationsDescription")}
           </p>
           <div className="mt-2" style={{ maxWidth: 280 }}>
@@ -213,7 +213,7 @@ export function RiskToleranceSettings() {
               <div className="text-body-medium-default text-[var(--content-default)]">
                 {t("riskToleranceSettings.backgroundTitle")}
               </div>
-              <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+              <p className="mt-0.5 text-body-small-lighter text-[var(--content-tertiary)]">
                 {t("riskToleranceSettings.backgroundDescription")}
               </p>
               <div className="mt-2" style={{ maxWidth: 280 }}>
@@ -237,7 +237,7 @@ export function RiskToleranceSettings() {
               <div className="text-body-medium-default text-[var(--content-default)]">
                 {t("riskToleranceSettings.headlessTitle")}
               </div>
-              <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+              <p className="mt-0.5 text-body-small-lighter text-[var(--content-tertiary)]">
                 {t("riskToleranceSettings.headlessDescription")}
               </p>
               <div className="mt-2" style={{ maxWidth: 280 }}>

--- a/clients/web/src/domains/settings/components/show-tips-row.tsx
+++ b/clients/web/src/domains/settings/components/show-tips-row.tsx
@@ -35,7 +35,7 @@ export function ShowTipsRow() {
         <div className="text-body-medium-lighter text-[var(--content-default)]">
           {t("showTipsRow.label")}
         </div>
-        <p className="text-body-small-default text-[var(--content-tertiary)]">
+        <p className="text-body-small-lighter text-[var(--content-tertiary)]">
           {t("showTipsRow.description")}
         </p>
       </div>

--- a/clients/web/src/domains/settings/components/your-own-oauth-tab.tsx
+++ b/clients/web/src/domains/settings/components/your-own-oauth-tab.tsx
@@ -260,7 +260,7 @@ export function YourOwnTab({
                   ? t("yourOwnOauthTab.addOwnApp", { name: displayName })
                   : t("yourOwnOauthTab.addAnotherApp", { name: displayName })}
               </p>
-              <p className="text-body-small-default leading-relaxed text-[var(--content-tertiary)]">
+              <p className="text-body-small-lighter leading-relaxed text-[var(--content-tertiary)]">
                 {t("yourOwnOauthTab.credentialsNote")}
               </p>
             </div>
@@ -304,7 +304,7 @@ export function YourOwnTab({
                     }
                   />
                 </div>
-                <p className="text-body-small-default text-[var(--content-tertiary)]">
+                <p className="text-body-small-lighter text-[var(--content-tertiary)]">
                   {t("yourOwnOauthTab.redirectHint")}
                 </p>
               </div>

--- a/clients/web/src/domains/settings/mcp/mcp-add-server-modal.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-add-server-modal.tsx
@@ -300,7 +300,7 @@ export function McpAddServerModal({
                 </div>
 
                 {authType === "oauth" ? (
-                  <p className="rounded-md border border-[var(--border-element)] bg-[var(--surface-base)] px-3 py-2 text-body-small-default text-[var(--content-tertiary)]">
+                  <p className="rounded-md border border-[var(--border-element)] bg-[var(--surface-base)] px-3 py-2 text-body-small-lighter text-[var(--content-tertiary)]">
                     {t("mcpAddServerModal.oauthHint")}
                   </p>
                 ) : null}

--- a/clients/web/src/domains/settings/mcp/mcp-page.tsx
+++ b/clients/web/src/domains/settings/mcp/mcp-page.tsx
@@ -347,7 +347,7 @@ function McpPageInner() {
           <h2 className="text-title-small text-[var(--content-default)]">
             {t("mcpPage.title")}
           </h2>
-          <p className="mt-0.5 text-body-small-default text-[var(--content-tertiary)]">
+          <p className="mt-0.5 text-body-small-lighter text-[var(--content-tertiary)]">
             {t("mcpPage.subtitle")}
           </p>
         </div>
@@ -409,7 +409,7 @@ function McpPageInner() {
           <p className="text-body-medium-default text-[var(--content-default)]">
             {t("mcpPage.emptyTitle")}
           </p>
-          <p className="text-body-small-default text-[var(--content-tertiary)]">
+          <p className="text-body-small-lighter text-[var(--content-tertiary)]">
             {mcpAddServerEnabled
               ? t("mcpPage.emptyAddSubtitle")
               : t("mcpPage.emptyChatSubtitle")}

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -163,7 +163,7 @@ export function PrivacyPage() {
                 options={retentionOptions}
               />
             </div>
-            <p className="mt-2 text-body-small-default text-[var(--content-tertiary)]">
+            <p className="mt-2 text-body-small-lighter text-[var(--content-tertiary)]">
               {t("privacyPage.llmLogRetentionDescription")}
             </p>
           </div>

--- a/clients/web/src/domains/settings/pages/sounds-sections.tsx
+++ b/clients/web/src/domains/settings/pages/sounds-sections.tsx
@@ -425,7 +425,7 @@ export function SoundsSections() {
           <h3 className="text-title-small text-[var(--content-default)]">
             {t("soundsSections.soundEventsTitle")}
           </h3>
-          <p className="text-body-small-default text-[var(--content-tertiary)]">
+          <p className="text-body-small-lighter text-[var(--content-tertiary)]">
             {t("soundsSections.soundEventsDescription")}
           </p>
         </div>

--- a/clients/web/src/domains/settings/pages/turn-detection-row.tsx
+++ b/clients/web/src/domains/settings/pages/turn-detection-row.tsx
@@ -163,7 +163,7 @@ export function TurnDetectionRow() {
       <span className="text-body-medium-lighter text-[var(--content-default)]">
         {t("voicePage.turnDetectionLabel")}
       </span>
-      <p className="text-body-small-default text-[var(--content-tertiary)]">
+      <p className="text-body-small-lighter text-[var(--content-tertiary)]">
         {languageOk
           ? t("voicePage.turnDetectionDescription")
           : t("voicePage.turnDetectionLanguageUnsupported")}

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -239,7 +239,7 @@ function SpeechServicesBanner() {
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5 px-1 text-body-small-default text-[var(--content-tertiary)]">
+    <div className="flex flex-wrap items-center gap-1.5 px-1 text-body-small-lighter text-[var(--content-tertiary)]">
       <Info className="h-3.5 w-3.5 shrink-0 text-[var(--content-quiet)]" />
       <span>{t("voicePage.speechServicesBannerPrompt")}</span>
       <Link
@@ -746,7 +746,7 @@ function VoiceModeShortcutCard() {
               recommended binding, so saying nothing would leave the user
               pressing a key that cannot fire. */}
           {isFnVoiceModeActivator(activator) && fnRefused && (
-            <div className="flex items-start gap-1 pt-1 text-body-small-default text-[var(--system-negative-strong)]">
+            <div className="flex items-start gap-1 pt-1 text-body-small-lighter text-[var(--system-negative-strong)]">
               <Info className="mt-0.5 h-3 w-3 shrink-0" />
               <span>{t("voicePage.fnRefusedNote")}</span>
             </div>
@@ -830,14 +830,14 @@ function VoiceModeShortcutCard() {
             </div>
 
             {showChordHint && (
-              <div className="flex items-start gap-1 pt-1 text-body-small-default text-[var(--content-quiet)]">
+              <div className="flex items-start gap-1 pt-1 text-body-small-lighter text-[var(--content-quiet)]">
                 <Info className="mt-0.5 h-3 w-3 shrink-0" />
                 <span>{t("voicePage.shortcutChordHint")}</span>
               </div>
             )}
 
             {shortcutEnabled && (
-              <div className="flex items-start gap-1 pt-1 text-body-small-default text-[var(--content-quiet)]">
+              <div className="flex items-start gap-1 pt-1 text-body-small-lighter text-[var(--content-quiet)]">
                 <Info className="mt-0.5 h-3 w-3 shrink-0" />
                 <span>{t("voicePage.focusedTabNote")}</span>
               </div>


### PR DESCRIPTION
Part of LUM-3507.

## TL;DR

45 sites rendering descriptions, notes and hints were using the **label** half of the 12px rung instead of the **prose** half, setting 12px text in 12px line boxes. This moves them to `body-small-lighter`. No token changes.

## The two halves of the 12px rung

| variant | weight | line-height | for |
| -- | -- | -- | -- |
| `body-small-default` | 500 | **1** | single-line labels |
| `body-small-lighter` | 400 | **18px** | prose that can wrap |

Descriptions and hints were on the first one.

## The size was never wrong

Settings rows pair a 14px `body-medium-default` label with a 12px description, and that step down is correct and consistent across the app. Only the weight and leading were wrong, which is exactly what the two halves of the rung exist to distinguish.

This matters because the obvious alternative was to give `body-small-default` real leading. That would have been a token change across **532** usages with height-shift risk on chips, badges and table cells, to fix what is actually a per-site variant choice. `line-height: 1` is correct for a single-line label style, and the 478 sites using it that way are untouched here.

## Measured, not asserted

Before and after on the same story, `settings-ai-advisorprofilerow--default`, by reverting the one file and re-measuring the rendered DOM:

| | before (`main`) | after |
| -- | -- | -- |
| font-size | 12px | 12px |
| line-height | **12px** | **18px** |
| lines rendered | 2 | 2 |
| cramped | **true** | false |

The description reads as two jammed lines before and as set prose after.

## How the 45 were chosen

Semantically, not by length. Copy gets edited and translations run longer than English, so "is it currently long enough to wrap" is the wrong test. The rule is: the i18n **leaf** key names the content as a description, note, hint, help, subtitle, banner or error.

Two refinements the first pass needed:

- **Leaf key, not full key.** Matching the whole key let component prefixes like `scheduleDetail.*` match on "detail", sweeping in unrelated short values such as `scheduleDetail.conversations` and `conceptDetailPanel.updated`.
- **Check the resolved string too.** A prose-sounding key is not sufficient. Four sites are excluded because their actual copy is a one-word label or a stat line: `scheduleDetail.error` ("Error"), `recentRunsCard.error` ("Error"), `callSiteOverridesRow.pickModelError` ("Pick a model"), and `emailManagedContent.usageSummary` (`{sent} / {limit} sent today · {received} received`).

Every one of the 45 had its English copy resolved from the locale files; none were included on the key name alone.

Scope: 38 of 45 are in `domains/settings`, which is expected since every settings row is a label-plus-description pair.

## Why it's safe

- One class token per site. No structural, logic or token changes.
- `bun run lint` 0 errors (15 pre-existing warnings unchanged); `bunx tsc --noEmit` clean.
- 141 tests across the 13 colocated test files pass, run per file. Running them batched produces 3 failures that also occur per-file-clean on `main`; that is the known Bun cross-file interference, not this change.
- 7 of the changed files have stories, so the result was checked in Storybook rather than reasoned about.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->