### PR TITLE
feat(companion): open the surface at the bottom centre by default

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -200,6 +200,7 @@ const {
   cardGrowthFor,
   avatarOffsetFor,
   companionContextMenuTemplate,
+  defaultAvatarCentre,
   geometryFor,
   placeCanvas,
   callOnUpdate,
@@ -492,6 +493,24 @@ describe("placeCanvas", () => {
     expect(centre.y).toBe(WORK_AREA.y + DROP_BELOW);
     // Where it used to stop: the old canvas's half-height below the work area.
     expect(centre.y).toBeLessThan(WORK_AREA.y + RISE_ABOVE);
+  });
+});
+
+describe("defaultAvatarCentre", () => {
+  test("opens at the bottom centre of the work area", () => {
+    const centre = defaultAvatarCentre(WORK_AREA, GEOMETRY);
+    expect(centre.x).toBe(720);
+    expect(centre.y).toBe(25 + 875 - 24 - GEOMETRY.avatarBox / 2);
+  });
+
+  test("centres on the display it is given, not the primary one", () => {
+    const secondary = { x: 1440, y: 0, width: 2560, height: 1415 };
+    expect(defaultAvatarCentre(secondary, GEOMETRY).x).toBe(1440 + 1280);
+  });
+
+  test("lands where placeCanvas leaves it alone", () => {
+    const wanted = defaultAvatarCentre(WORK_AREA, GEOMETRY);
+    expect(centreOf(placeCanvas(wanted, WORK_AREA, GEOMETRY))).toEqual(wanted);
   });
 });
 

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -239,7 +239,7 @@ export const geometryFor = (
   };
 };
 
-/** Gap from the work area's bottom-right on the first ever launch. */
+/** Gap from the work area's bottom edge on the first ever launch. */
 const DEFAULT_MARGIN = 24;
 
 let growth: CompanionGrowth = "right";
@@ -523,9 +523,24 @@ export const placeCanvas = (
 };
 
 /**
- * Where the surface opens with no remembered position: the bottom-right of the
- * display under the cursor, near where the Dock usually is and clear of the
- * window the user is working in.
+ * Where the avatar's centre goes with no remembered position: the bottom
+ * centre of the work area, a margin up from its edge. Centred so the pill has
+ * room to grow either way, and low so it sits under the window the user is
+ * working in rather than over it.
+ *
+ * Exported for its tests and pure for the same reason as {@link placeCanvas}.
+ */
+export const defaultAvatarCentre = (
+  workArea: { x: number; y: number; width: number; height: number },
+  geometry: CompanionGeometry,
+): { x: number; y: number } => ({
+  x: workArea.x + workArea.width / 2,
+  y: workArea.y + workArea.height - DEFAULT_MARGIN - geometry.avatarBox / 2,
+});
+
+/**
+ * Where the surface opens with no remembered position: the bottom centre of
+ * the display under the cursor.
  *
  * The canvas is much larger than the visible circle, so the position is
  * computed for the avatar and then backed out to the canvas origin. Getting
@@ -534,12 +549,8 @@ export const placeCanvas = (
 const defaultCanvasOrigin = (): { x: number; y: number } => {
   const cursor = screen.getCursorScreenPoint();
   const { workArea } = screen.getDisplayNearestPoint(cursor);
-  const half = geometry.avatarBox / 2;
   const placed = placeCanvas(
-    {
-      x: workArea.x + workArea.width - DEFAULT_MARGIN - half,
-      y: workArea.y + workArea.height - DEFAULT_MARGIN - half,
-    },
+    defaultAvatarCentre(workArea, geometry),
     workArea,
     geometry,
   );


### PR DESCRIPTION
## Summary

The macOS companion surface opened in the work area's bottom-right corner on first launch. It now opens at the bottom centre, a margin up from the edge, on the display under the cursor.

- Pulls the default into `defaultAvatarCentre`, pure and exported, so it is tested against `placeCanvas` like the other placement rules.
- Remembered positions are untouched: this only changes where the surface goes when nothing has been saved yet.

## Test plan

- [x] `bun test src/main/companion-window.test.ts` in `clients/macos` (82 pass, 3 new)
- [x] `bun run typecheck` in `clients/macos`
- [ ] Clear the companion's saved position and launch: the pill appears at the bottom centre of the display under the cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKvvfL5WN5eiLMZRWRXnEr
