### PR TITLE
fix(web): say what happened when a tool call produces no output

### DIFF
--- a/clients/web/src/components/detail-primitives.tsx
+++ b/clients/web/src/components/detail-primitives.tsx
@@ -10,7 +10,7 @@
  */
 
 import { Check, Copy } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 
 import { Typography } from "@vellumai/design-library";
 
@@ -18,6 +18,16 @@ import { useTranslation } from "@/i18n";
 import { copyToClipboard } from "@/lib/copy-to-clipboard";
 
 const COPIED_RESET_MS = 1500;
+
+/**
+ * Content longer than this collapses behind "Show more". Roughly a dozen lines
+ * of prose: enough to tell what the block holds, short enough that whatever
+ * sits above it stays on screen.
+ */
+const CLAMP_CHARS = 700;
+
+/** Collapsed height of a clamped block, in px. */
+const CLAMP_HEIGHT = 260;
 
 /**
  * Small ghost button that copies `text` to the clipboard and shows a transient
@@ -71,13 +81,76 @@ export function CopyButton({ text }: { text: string }) {
   );
 }
 
-/** A `<pre>` code block with a copy button positioned in the top-right. */
+/**
+ * Collapses `children` to a readable height when `length` exceeds the clamp,
+ * with a fade over the cut and a Show more control. Callers pass the length of
+ * the text they are rendering rather than the node, because the decision is
+ * about how much there is to read, not how it is marked up.
+ *
+ * The fade is painted in `--surface-overlay`, so a clamped block has to sit on
+ * that surface for the gradient to disappear into it.
+ */
+export function ClampedContent({
+  length,
+  children,
+}: {
+  length: number;
+  children: ReactNode;
+}) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const clampable = length > CLAMP_CHARS;
+  const clamped = clampable && !expanded;
+
+  return (
+    <>
+      <div
+        className="relative overflow-hidden"
+        style={clamped ? { maxHeight: CLAMP_HEIGHT } : undefined}
+      >
+        {children}
+        {clamped && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-[var(--surface-overlay)] to-transparent"
+          />
+        )}
+      </div>
+      {clampable && (
+        <button
+          type="button"
+          onClick={() => setExpanded((open) => !open)}
+          className="mt-2 w-full border-t border-[var(--border-base)] pt-2 text-left"
+        >
+          <Typography
+            variant="body-medium-default"
+            as="span"
+            className="text-[var(--content-default)]"
+          >
+            {expanded
+              ? t("detailPrimitives.showLess")
+              : t("detailPrimitives.showMore")}
+          </Typography>
+        </button>
+      )}
+    </>
+  );
+}
+
+/**
+ * A `<pre>` code block with a copy button positioned in the top-right, clamped
+ * when the text is long. Tool results reach the panel at up to
+ * `HARD_MAX_TOOL_RESULT_CHARS` (400,000), which is not a height any panel can
+ * absorb.
+ */
 export function CodeBlock({ text }: { text: string }) {
   return (
-    <div className="relative">
-      <pre className="rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3 font-mono text-xs whitespace-pre-wrap break-words text-[var(--content-default)]">
-        {text}
-      </pre>
+    <div className="relative rounded-lg border border-[var(--border-base)] bg-[var(--surface-overlay)] p-3">
+      <ClampedContent length={text.length}>
+        <pre className="font-mono text-xs whitespace-pre-wrap break-words text-[var(--content-default)]">
+          {text}
+        </pre>
+      </ClampedContent>
       <CopyButton text={text} />
     </div>
   );

--- a/clients/web/src/domains/chat/components/activity-steps-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/activity-steps-panel.test.tsx
@@ -128,11 +128,11 @@ describe("ActivityStepsPanel — level 2 drill-in", () => {
     expect(getByText("Bash")).toBeTruthy();
     expect(getByText("On branch main")).toBeTruthy();
     // The timeline is replaced, and the header swaps to the step's title with
-    // the back chevron on its left (the run summary is gone). The activity
-    // label appears twice: the header title and the detail body's subtitle.
+    // the back chevron on its left (the run summary is gone). The header owns
+    // the activity sentence, so it renders once and the body does not echo it.
     expect(queryByTestId("phase-header")).toBeNull();
     expect(queryByText(/Worked for/)).toBeNull();
-    expect(getAllByText("Checking git status").length).toBeGreaterThan(1);
+    expect(getAllByText("Checking git status")).toHaveLength(1);
     expect(getByRole("button", { name: /back to all steps/i })).toBeTruthy();
   });
 

--- a/clients/web/src/domains/chat/components/activity-steps-panel.tsx
+++ b/clients/web/src/domains/chat/components/activity-steps-panel.tsx
@@ -38,7 +38,10 @@ import {
   PhaseGroupedStepList,
 } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { ToolStepPill } from "@/domains/chat/components/tool-progress-card/tool-step-pill";
-import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
+import {
+  ToolDetailBody,
+  toolDetailHeaderTitle,
+} from "@/domains/chat/components/tool-detail-panel";
 import {
   WebSearchErrorRow,
   WebSearchStepRow,
@@ -114,7 +117,7 @@ export function ActivityStepsPanel({
   const stepDetailTitle = stepDetail
     ? stepDetail.kind === "thinking"
       ? "Thinking"
-      : stepDetail.activity || stepDetail.title
+      : toolDetailHeaderTitle(stepDetail)
     : "";
 
   return (

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -41,7 +41,10 @@ import {
 } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import { ICON_MAP } from "@/domains/chat/components/tool-progress-card/phase-grouped-step-list";
 import { ThreeDotIndicator } from "@/domains/chat/components/tool-progress-card/three-dot-indicator";
-import { ToolDetailBody } from "@/domains/chat/components/tool-detail-panel";
+import {
+  ToolDetailBody,
+  toolDetailHeaderTitle,
+} from "@/domains/chat/components/tool-detail-panel";
 import { WebFetchDetailView } from "@/domains/chat/components/web-fetch/web-fetch-detail-view";
 import { WebSearchDetailView } from "@/domains/chat/components/web-search/web-search-detail-view";
 import { useSubagentSteps } from "@/domains/chat/subagent-step-projection";
@@ -263,9 +266,7 @@ export function SubagentDetailPanel({
   // The nested step's label — the breadcrumb tail and the header title while a
   // detail is open. Mirrors the main-chat tool detail panel's `activity ||
   // title` precedence.
-  const detailTitle = activeDetail
-    ? activeDetail.activity || activeDetail.title
-    : "";
+  const detailTitle = activeDetail ? toolDetailHeaderTitle(activeDetail) : "";
   // The header title tracks the breadcrumb's deepest crumb: the subagent at the
   // timeline, the drilled-into step once a detail is open.
   const headerTitle = activeDetail ? detailTitle : entry.label;

--- a/clients/web/src/domains/chat/components/tool-activity/skill-load-output.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-load-output.tsx
@@ -12,9 +12,13 @@
 
 import { useState } from "react";
 
-import { SegmentControl, Typography } from "@vellumai/design-library";
+import { SegmentControl } from "@vellumai/design-library";
 
-import { CopyButton, SectionLabel } from "@/components/detail-primitives";
+import {
+  ClampedContent,
+  CopyButton,
+  SectionLabel,
+} from "@/components/detail-primitives";
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
 import { useTranslation } from "@/i18n";
 
@@ -24,16 +28,6 @@ const MODES = [
   { value: "clean" as const, label: "Clean" },
   { value: "raw" as const, label: "Raw" },
 ];
-
-/**
- * Bodies longer than this collapse behind "Show more". Roughly a dozen lines of
- * prose — enough to tell what the skill does, short enough that the tools above
- * it stay on screen.
- */
-const CLAMP_CHARS = 700;
-
-/** Collapsed height of the clamped card, in px. */
-const CLAMP_HEIGHT = 260;
 
 export function SkillLoadOutput({
   /** Instruction markdown, header and tool manifest already stripped. */
@@ -48,7 +42,6 @@ export function SkillLoadOutput({
 }) {
   const { t } = useTranslation("chat");
   const [mode, setMode] = useState<OutputMode>("clean");
-  const [expanded, setExpanded] = useState(false);
 
   // A skill whose body is nothing but the header and its tool manifest parses
   // to empty instructions; Raw is then the only view worth offering, so the
@@ -61,14 +54,15 @@ export function SkillLoadOutput({
 
   const activeMode: OutputMode = hasClean ? mode : "raw";
   const body = activeMode === "clean" ? instructions : raw;
-  const clamped = body.length > CLAMP_CHARS && !expanded;
 
   return (
     <div>
       <div className="mb-2 flex items-center justify-between gap-3">
         {/* The row owns the spacing under the header, so the label drops its
             own bottom margin — otherwise it sits off-centre from the switch. */}
-        <SectionLabel className="mb-0">{t("skillLoadOutput.output")}</SectionLabel>
+        <SectionLabel className="mb-0">
+          {t("skillLoadOutput.output")}
+        </SectionLabel>
         {hasClean && hasRaw && (
           <SegmentControl
             items={MODES}
@@ -84,9 +78,12 @@ export function SkillLoadOutput({
       </div>
 
       <div className="relative rounded-xl bg-[var(--surface-overlay)] p-3">
-        <div
-          className="relative overflow-hidden"
-          style={clamped ? { maxHeight: CLAMP_HEIGHT } : undefined}
+        <ClampedContent
+          // Re-keyed per mode so switching Clean/Raw re-evaluates the clamp
+          // against the body actually on screen instead of keeping the
+          // expansion the other view was in.
+          key={activeMode}
+          length={body.length}
         >
           {activeMode === "clean" ? (
             <ChatMarkdownMessage
@@ -98,29 +95,7 @@ export function SkillLoadOutput({
               {raw}
             </pre>
           )}
-          {clamped && (
-            <div
-              aria-hidden
-              className="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-[var(--surface-overlay)] to-transparent"
-            />
-          )}
-        </div>
-
-        {body.length > CLAMP_CHARS && (
-          <button
-            type="button"
-            onClick={() => setExpanded((open) => !open)}
-            className="mt-2 w-full border-t border-[var(--border-base)] pt-2 text-left"
-          >
-            <Typography
-              variant="body-medium-default"
-              as="span"
-              className="text-[var(--content-default)]"
-            >
-              {expanded ? t("skillLoadOutput.showLess") : t("skillLoadOutput.showMore")}
-            </Typography>
-          </button>
-        )}
+        </ClampedContent>
 
         {activeMode === "raw" && <CopyButton text={raw} />}
       </div>

--- a/clients/web/src/domains/chat/components/tool-activity/skill-load-output.tsx
+++ b/clients/web/src/domains/chat/components/tool-activity/skill-load-output.tsx
@@ -78,13 +78,7 @@ export function SkillLoadOutput({
       </div>
 
       <div className="relative rounded-xl bg-[var(--surface-overlay)] p-3">
-        <ClampedContent
-          // Re-keyed per mode so switching Clean/Raw re-evaluates the clamp
-          // against the body actually on screen instead of keeping the
-          // expansion the other view was in.
-          key={activeMode}
-          length={body.length}
-        >
+        <ClampedContent length={body.length}>
           {activeMode === "clean" ? (
             <ChatMarkdownMessage
               content={instructions}

--- a/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -105,8 +105,8 @@ import { ToolDetailPanel } from "./tool-detail-panel";
  * ## Still open
  *
  * LUM-3511 for the MCP naming, and LUM-3512 for the `web_search` kind that two
- * panels disagree about. The shared-panel states (LUM-3510) are fixed, and the
- * stories for them now document the behaviour rather than the defect.
+ * panels disagree about. Every other treatment below documents behaviour the
+ * panel has, not a gap it is waiting on.
  */
 const meta: Meta<typeof ToolDetailPanel> = {
   title: "Chat/ToolDetailPanel",

--- a/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.stories.tsx
@@ -49,15 +49,13 @@ import { ToolDetailPanel } from "./tool-detail-panel";
  * people hit most. The families that dominate day to day, files and shell, are
  * on the generic path, which is what makes the gaps below worth designing away.
  *
- * ## The one gap that is not per-tool
+ * ## Where the activity sentence shows
  *
- * The activity sentence is printed three times on a typical call: once as the
- * panel header (`detail.activity || detail.title`), once as the subtitle under
- * the title-cased tool name, and once more inside the JSON input block, since
- * `activity` is a real input key the tools send alongside `command` / `path`.
- * Nearly every native tool sends one, `subagent_spawn` being the exception.
- * Visible in almost every story below; Bash and FileReadEmptyOutput are the
- * clearest. This is one fix in shared code, not nine tool designs.
+ * Every host of `ToolDetailBody` titles its header with
+ * `toolDetailHeaderTitle`, so the body does not repeat the activity under the
+ * tool name. It still appears inside the JSON input block, because `activity`
+ * is a real input key the tools send alongside `command` / `path` and that
+ * block is the raw input.
  *
  * ## Coverage matrix
  *
@@ -85,9 +83,9 @@ import { ToolDetailPanel } from "./tool-detail-panel";
  * | Running, streaming stdout | BashStreaming | Live `tool_output_chunk` tail. |
  * | Completed | most stories | |
  * | Error | BashError, FileReadError, SkillLoadError | The panel styles an error result identically to a successful one; only the text says it failed. |
- * | Denied or timed out | BashDenied | `status: "denied"` has no branch in `ToolDetailBody`. With no result, Output is suppressed entirely and the panel never says the call was denied. |
- * | Empty output | FileReadEmptyOutput | `hasResult` is false for `""`, so Output disappears rather than reporting an empty file. |
- * | Very large output | LargeOutput | The generic `CodeBlock` does not clamp, and the daemon's cap is 400,000 characters. |
+ * | Denied or timed out | BashDenied | Output says the call was not approved and did not run. Both a declined confirmation and one that timed out land here. |
+ * | Empty output | FileReadEmptyOutput | Output reports that the tool returned nothing, rather than disappearing. |
+ * | Very large output | LargeOutput | `CodeBlock` clamps behind Show more; the daemon's cap is 400,000 characters. |
  * | Nested JSON input | ManagedWorkspaceTool, UnknownThirdPartyTool | |
  * | Risk levels | RiskLow, RiskMedium, RiskHigh, RiskWorkspace, RiskUnknown, RiskAbsent | Every level the risk helpers recognise, plus absent and unrecognised. |
  * | Narrow or mobile | MobileWidth | Same panel inside the drawer at 390px. |
@@ -100,19 +98,15 @@ import { ToolDetailPanel } from "./tool-detail-panel";
  * 1. Files. `file_edit` as a rendered diff and `file_write` as an editor view
  *    are the largest single readability win available.
  * 2. Shell. A terminal treatment for the command and its output.
- * 3. Panel-wide states, all families at once. The triple activity sentence,
- *    denied, empty, and very large output are four defects in shared code,
- *    not per-tool design work, and fixing them improves every tool including
- *    the ones we never style. Cheapest slice on the list by some margin.
- * 4. Memory. `recall` as a result list.
- * 5. MCP naming. Low volume, but the title is wrong on every call rather than
+ * 3. Memory. `recall` as a result list.
+ * 4. MCP naming. Low volume, but the title is wrong on every call rather than
  *    merely plain.
  *
- * ## Filed, not fixed here
+ * ## Still open
  *
- * The findings above are tracked so they do not live only in this docstring:
- * LUM-3510 for the four shared-panel defects, LUM-3511 for the MCP naming, and
- * LUM-3512 for the `web_search` kind that two panels disagree about.
+ * LUM-3511 for the MCP naming, and LUM-3512 for the `web_search` kind that two
+ * panels disagree about. The shared-panel states (LUM-3510) are fixed, and the
+ * stories for them now document the behaviour rather than the defect.
  */
 const meta: Meta<typeof ToolDetailPanel> = {
   title: "Chat/ToolDetailPanel",
@@ -171,9 +165,9 @@ export const BashStreaming: Story = { args: { detail: bashStreamingDetail } };
 export const BashError: Story = { args: { detail: bashErrorDetail } };
 
 /**
- * A denied call. `ToolDetailBody` has no `denied` branch, so with no result
- * the Output section is suppressed and nothing on the panel says the user
- * declined it. The risk notice and the input are all that remain.
+ * A denied call. Output says the call was not approved and did not run, which
+ * is also what a confirmation that timed out shows: `deriveToolStepStatus`
+ * folds both into this status.
  */
 export const BashDenied: Story = { args: { detail: bashDeniedDetail } };
 
@@ -185,8 +179,8 @@ export const BashDenied: Story = { args: { detail: bashDeniedDetail } };
 export const FileRead: Story = { args: { detail: fileReadDetail } };
 
 /**
- * `file_read` on an empty file. `hasResult` treats `""` as absent, so the
- * Output section vanishes rather than saying the file was empty.
+ * `file_read` on an empty file. An empty string is a result, so Output reports
+ * that the tool returned nothing instead of vanishing.
  */
 export const FileReadEmptyOutput: Story = {
   args: { detail: fileReadEmptyDetail },
@@ -262,8 +256,8 @@ export const UnknownThirdPartyTool: Story = {
 // ---------------------------------------------------------------------------
 
 /**
- * A long result. The generic Output block is one unclamped `<pre>`, so the
- * panel scrolls for as long as the daemon's 400,000 character cap allows.
+ * A long result, clamped behind Show more. Tool results reach the panel at up
+ * to the daemon's 400,000 character cap, which is not a height a panel absorbs.
  */
 export const LargeOutput: Story = { args: { detail: largeOutputDetail } };
 

--- a/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -290,15 +290,18 @@ describe("ToolDetailPanel", () => {
     expect(queryByText("Show more")).toBeNull();
   });
 
-  test("hides the Output section when result is undefined", () => {
-    const { queryByText } = render(
+  test("reports no output for a call that finished without a result", () => {
+    const { getByText, getByTestId } = render(
       <ToolDetailPanel
         detail={makeDetail({ result: undefined, status: "completed" })}
         onClose={noop}
       />,
     );
 
-    expect(queryByText("Output")).toBeNull();
+    expect(getByText("Output")).toBeDefined();
+    expect(getByTestId("tool-output-notice").textContent).toBe(
+      "The tool returned no output.",
+    );
   });
 
   test("shows a Running placeholder while running with no result", () => {

--- a/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -210,6 +210,60 @@ describe("ToolDetailPanel", () => {
     );
   });
 
+  test("picks up a denial that lands while the drawer is open", () => {
+    // The payload was captured before the guardian answered, so the snapshot
+    // still says the call was running. The live tool call carries the decision.
+    seedHistory([
+      {
+        id: "m1",
+        role: "assistant",
+        toolCalls: [
+          {
+            id: "tc-1",
+            name: "subagent_spawn",
+            confirmationDecision: "denied",
+          },
+        ],
+      } as DisplayMessage,
+    ]);
+    const { getByTestId } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ result: undefined, status: "running" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByTestId("tool-output-notice").textContent).toBe(
+      "This tool call was not approved, so it did not run.",
+    );
+  });
+
+  test("treats a timed-out confirmation as not approved", () => {
+    seedHistory([
+      {
+        id: "m1",
+        role: "assistant",
+        toolCalls: [
+          {
+            id: "tc-1",
+            name: "subagent_spawn",
+            confirmationDecision: "timed_out",
+          },
+        ],
+      } as DisplayMessage,
+    ]);
+    const { getByTestId } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ result: undefined, status: "running" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByTestId("tool-output-notice").textContent).toBe(
+      "This tool call was not approved, so it did not run.",
+    );
+  });
+
   test("clamps a long result behind Show more", () => {
     const long = "a line of output\n".repeat(200);
     const { getByText, queryByText } = render(

--- a/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -116,10 +116,10 @@ describe("ToolDetailPanel", () => {
       <ToolDetailPanel detail={makeDetail()} onClose={noop} />,
     );
 
-    // Activity renders in both the header title and the body.
+    // The header owns the activity sentence, and the body does not repeat it.
     expect(
-      getAllByText("Spawning subagent to research Toronto's location").length,
-    ).toBeGreaterThan(0);
+      getAllByText("Spawning subagent to research Toronto's location"),
+    ).toHaveLength(1);
     // Friendly tool name (title-cased from snake_case).
     expect(getByText("Subagent Spawn")).toBeDefined();
     // Input JSON + output appear inside <pre> blocks.
@@ -185,12 +185,55 @@ describe("ToolDetailPanel", () => {
     expect(queryByText("Create Trust Rule")).toBeNull();
   });
 
-  test("hides the Output section when result is empty", () => {
-    const { queryByText } = render(
+  test("reports an empty result rather than dropping the Output section", () => {
+    const { getByText, getByTestId } = render(
       <ToolDetailPanel detail={makeDetail({ result: "" })} onClose={noop} />,
     );
 
-    expect(queryByText("Output")).toBeNull();
+    expect(getByText("Output")).toBeDefined();
+    expect(getByTestId("tool-output-notice").textContent).toBe(
+      "The tool returned no output.",
+    );
+  });
+
+  test("says a denied call did not run", () => {
+    const { getByText, getByTestId } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ result: undefined, status: "denied" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByText("Output")).toBeDefined();
+    expect(getByTestId("tool-output-notice").textContent).toBe(
+      "This tool call was not approved, so it did not run.",
+    );
+  });
+
+  test("clamps a long result behind Show more", () => {
+    const long = "a line of output\n".repeat(200);
+    const { getByText, queryByText } = render(
+      <ToolDetailPanel detail={makeDetail({ result: long })} onClose={noop} />,
+    );
+
+    const toggle = getByText("Show more");
+    expect(toggle).toBeDefined();
+    act(() => {
+      fireEvent.click(toggle);
+    });
+    expect(getByText("Show less")).toBeDefined();
+    expect(queryByText("Show more")).toBeNull();
+  });
+
+  test("leaves a short result unclamped", () => {
+    const { queryByText } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ result: "two words" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(queryByText("Show more")).toBeNull();
   });
 
   test("hides the Output section when result is undefined", () => {

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -46,7 +46,10 @@ import {
   getRiskNoticeTone,
   getRiskToleranceHint,
 } from "@/domains/chat/utils/risk";
-import { isToolCallRunning } from "@/domains/chat/utils/tool-call-status";
+import {
+  isToolCallDenied,
+  isToolCallRunning,
+} from "@/domains/chat/utils/tool-call-status";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 
 /**
@@ -147,9 +150,13 @@ export function ToolDetailBody({
     ? isToolCallRunning(liveTc)
     : detail.status === "running";
   const isError = liveTc?.isError ?? detail.status === "error";
-  // `deriveToolStepStatus` folds a declined confirmation and one that timed out
-  // into the same status, so the copy has to be true of both.
-  const isDenied = detail.status === "denied";
+  // Read live like the two flags above: a confirmation declined while the
+  // drawer is open has to reach it, not wait for a reopen. `isToolCallDenied`
+  // covers a prompt that expired as well as one refused, so the copy below has
+  // to be true of both.
+  const isDenied = liveTc
+    ? isToolCallDenied(liveTc)
+    : detail.status === "denied";
   const hasStreamedOutput = !!streamedOutput;
   const inputJson = JSON.stringify(detail.input, null, 2);
 
@@ -159,6 +166,15 @@ export function ToolDetailBody({
   const riskLevel = liveTc?.riskLevel ?? detail.riskLevel;
   const riskHint = getRiskToleranceHint(riskLevel);
   const riskStyle = getRiskBadgeWeakStyle(riskLevel);
+
+  // What the Output section says when it has no text to show: the call was
+  // refused, it returned nothing, or it has not finished yet.
+  const outputNoticeKey =
+    isDenied && !hasResult
+      ? "toolDetailPanel.denied"
+      : isEmptyResult
+        ? "toolDetailPanel.emptyOutput"
+        : "toolDetailPanel.running";
 
   // Tools with purpose-built activity UI replace the generic name/activity/JSON
   // block; those that also own their output suppress the shared Output section.
@@ -232,11 +248,7 @@ export function ToolDetailBody({
               className="text-[var(--content-tertiary)]"
               data-testid="tool-output-notice"
             >
-              {isDenied && !hasResult
-                ? t("toolDetailPanel.denied")
-                : isEmptyResult
-                  ? t("toolDetailPanel.emptyOutput")
-                  : t("toolDetailPanel.running")}
+              {t(outputNoticeKey)}
             </Typography>
           )}
         </div>

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -141,19 +141,17 @@ export function ToolDetailBody({
   const result = liveTc?.result ?? detail.result;
   const streamedOutput = liveTc?.streamedOutput ?? detail.streamedOutput;
 
-  // An empty string is a result: the tool ran and returned nothing. Treating
-  // it as absent made an empty file indistinguishable from a call still in
-  // flight, and dropped the Output section entirely (LUM-3510).
+  // An empty string is a result: the tool ran and returned nothing. Only an
+  // absent result means the call has not produced one yet.
   const hasResult = result !== undefined;
   const isEmptyResult = result === "";
   const isRunning = liveTc
     ? isToolCallRunning(liveTc)
     : detail.status === "running";
   const isError = liveTc?.isError ?? detail.status === "error";
-  // Read live like the two flags above: a confirmation declined while the
-  // drawer is open has to reach it, not wait for a reopen. `isToolCallDenied`
-  // covers a prompt that expired as well as one refused, so the copy below has
-  // to be true of both.
+  // Live, like the two flags above: the decision can be stamped on the
+  // transcript while this drawer is open. `isToolCallDenied` covers a prompt
+  // that expired as well as one refused, so the copy below is true of both.
   const isDenied = liveTc
     ? isToolCallDenied(liveTc)
     : detail.status === "denied";
@@ -167,14 +165,16 @@ export function ToolDetailBody({
   const riskHint = getRiskToleranceHint(riskLevel);
   const riskStyle = getRiskBadgeWeakStyle(riskLevel);
 
-  // What the Output section says when it has no text to show: the call was
-  // refused, it returned nothing, or it has not finished yet.
+  // What the Output section says when it has no text to show. Every terminal
+  // call that produced nothing lands on `emptyOutput`, including one that was
+  // force-completed with no result at all, so the section always answers "what
+  // came back" rather than disappearing.
   const outputNoticeKey =
     isDenied && !hasResult
       ? "toolDetailPanel.denied"
-      : isEmptyResult
-        ? "toolDetailPanel.emptyOutput"
-        : "toolDetailPanel.running";
+      : isRunning
+        ? "toolDetailPanel.running"
+        : "toolDetailPanel.emptyOutput";
 
   // Tools with purpose-built activity UI replace the generic name/activity/JSON
   // block; those that also own their output suppress the shared Output section.
@@ -234,7 +234,7 @@ export function ToolDetailBody({
       {/* Output — the final result once present, else the live streamed tail
           while running, else a bare running placeholder. Suppressed for tools
           whose renderer already presents the result itself. */}
-      {!renderer?.ownsOutput && (hasResult || isRunning || isDenied) && (
+      {!renderer?.ownsOutput && (
         <div className="mt-5">
           <SectionLabel>{t("toolDetailPanel.output")}</SectionLabel>
           {hasResult && !isEmptyResult ? (

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -1,4 +1,3 @@
-
 import { useTranslation } from "@/i18n";
 /**
  * Side-drawer body shown when a tool-call step pill is clicked. Mirrors the
@@ -139,11 +138,18 @@ export function ToolDetailBody({
   const result = liveTc?.result ?? detail.result;
   const streamedOutput = liveTc?.streamedOutput ?? detail.streamedOutput;
 
-  const hasResult = result !== undefined && result !== "";
+  // An empty string is a result: the tool ran and returned nothing. Treating
+  // it as absent made an empty file indistinguishable from a call still in
+  // flight, and dropped the Output section entirely (LUM-3510).
+  const hasResult = result !== undefined;
+  const isEmptyResult = result === "";
   const isRunning = liveTc
     ? isToolCallRunning(liveTc)
     : detail.status === "running";
   const isError = liveTc?.isError ?? detail.status === "error";
+  // `deriveToolStepStatus` folds a declined confirmation and one that timed out
+  // into the same status, so the copy has to be true of both.
+  const isDenied = detail.status === "denied";
   const hasStreamedOutput = !!streamedOutput;
   const inputJson = JSON.stringify(detail.input, null, 2);
 
@@ -203,15 +209,6 @@ export function ToolDetailBody({
           >
             {titleCaseToolName(detail.toolName)}
           </Typography>
-          {detail.activity && (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="mt-0.5 text-[var(--content-secondary)]"
-            >
-              {detail.activity}
-            </Typography>
-          )}
           <div className="mt-2">
             <CodeBlock text={inputJson} />
           </div>
@@ -221,10 +218,10 @@ export function ToolDetailBody({
       {/* Output — the final result once present, else the live streamed tail
           while running, else a bare running placeholder. Suppressed for tools
           whose renderer already presents the result itself. */}
-      {!renderer?.ownsOutput && (hasResult || isRunning) && (
+      {!renderer?.ownsOutput && (hasResult || isRunning || isDenied) && (
         <div className="mt-5">
           <SectionLabel>{t("toolDetailPanel.output")}</SectionLabel>
-          {hasResult ? (
+          {hasResult && !isEmptyResult ? (
             <CodeBlock text={result as string} />
           ) : hasStreamedOutput ? (
             <CodeBlock text={streamedOutput as string} />
@@ -233,14 +230,31 @@ export function ToolDetailBody({
               variant="body-small-default"
               as="p"
               className="text-[var(--content-tertiary)]"
+              data-testid="tool-output-notice"
             >
-              {t("toolDetailPanel.running")}
+              {isDenied && !hasResult
+                ? t("toolDetailPanel.denied")
+                : isEmptyResult
+                  ? t("toolDetailPanel.emptyOutput")
+                  : t("toolDetailPanel.running")}
             </Typography>
           )}
         </div>
       )}
     </>
   );
+}
+
+/**
+ * Title the panel hosting a tool detail shows for it: the activity sentence
+ * when the call carries one, else the phase title.
+ *
+ * Every host of `ToolDetailBody` renders its own header, and the body relies on
+ * all of them showing this, which is why the body itself does not repeat the
+ * activity underneath the tool name.
+ */
+export function toolDetailHeaderTitle(detail: ToolDetailPayload): string {
+  return detail.activity || detail.title;
 }
 
 export function ToolDetailPanel({
@@ -273,7 +287,7 @@ export function ToolDetailPanel({
   const { iconName } = deriveStepLabelFromName(detail.toolName, detail.input);
   const Glyph = ICON_MAP[iconName] ?? Bolt;
 
-  const title = detail.activity || detail.title;
+  const title = toolDetailHeaderTitle(detail);
 
   return (
     <DetailShell

--- a/clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts
+++ b/clients/web/src/domains/chat/components/tool-detail-story-fixtures.ts
@@ -3,9 +3,8 @@
  *
  * Every fixture's `input` key set is a shape the tools genuinely send, so a
  * story cannot quietly review a payload the product never produces. Native
- * tools carry an `activity` sibling alongside `command` / `path`, which is why
- * the panel's header, its subtitle, and its input block can all show the same
- * sentence at once (LUM-3510).
+ * tools carry an `activity` sibling alongside `command` / `path`, so the same
+ * sentence appears both as the panel's header and inside its raw input block.
  *
  * Values are written here rather than taken from any live conversation.
  *
@@ -174,8 +173,7 @@ export const fileReadMissingDetail: ToolDetailPayload = payload({
 
 /**
  * `file_read` that returned nothing. Reading an empty file is routine, and the
- * panel currently suppresses the whole Output section for it rather than
- * saying the file was empty.
+ * panel reports it rather than leaving the Output section out.
  */
 export const fileReadEmptyDetail: ToolDetailPayload = payload({
   toolCallId: "tc-file-read-3",
@@ -436,10 +434,11 @@ export const unknownToolDetail: ToolDetailPayload = payload({
 // ---------------------------------------------------------------------------
 
 /**
- * The daemon truncates a tool result at up to `HARD_MAX_TOOL_RESULT_CHARS`
- * (400,000, see `assistant/src/plugins/defaults/tool-result-truncate/`), and
- * the generic Output block renders whatever arrives as one unclamped `<pre>`.
- * Generated rather than embedded so the fixture file stays readable.
+ * Long enough to exercise the Output clamp. The daemon truncates a tool result
+ * at up to `HARD_MAX_TOOL_RESULT_CHARS` (400,000, see
+ * `assistant/src/plugins/defaults/tool-result-truncate/`), so this is well
+ * inside what the panel can be handed. Generated rather than embedded so the
+ * fixture file stays readable.
  */
 export const largeOutputDetail: ToolDetailPayload = payload({
   toolCallId: "tc-bash-large",
@@ -546,7 +545,10 @@ export const skillLoadDetail: ToolDetailPayload = payload({
   riskLevel: "low",
 });
 
-/** A realistically long skill body, which Output clamps behind "Show more". */
+/**
+ * A skill body past the Output clamp threshold, so the story shows the
+ * "Show more" control in the default Clean view rather than only in Raw.
+ */
 export const skillLoadLongDetail: ToolDetailPayload = {
   ...skillLoadDetail,
   toolCallId: "tc-skill-load-long",
@@ -560,6 +562,18 @@ export const skillLoadLongDetail: ToolDetailPayload = {
       "dashboard over their own data, a small tool they would otherwise",
       "rebuild by hand each time. A one-off calculation or a chart they only",
       "need once is not an app; answer it inline instead.",
+      "",
+      "If the request is really a report, write the report. An app earns its",
+      "place when the user will return to it with new data, change what it",
+      "shows, or share it with someone else. Those three are the signal; a",
+      "single answer, however elaborate, is not.",
+      "",
+      "## Naming",
+      "",
+      "Name the app for what the user calls the thing, not for the mechanism.",
+      "A person tracking their runs wants a Run log, not a Time Series",
+      "Dashboard. The name is the first thing they see in the Library and the",
+      "last thing they remember about it.",
       "",
       "## Workflow",
     ].join("\n"),

--- a/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-card-utils.ts
@@ -7,6 +7,7 @@
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolDetailPayload } from "@/stores/viewer-store";
 import {
+  isToolCallDenied,
   isToolCallRunning,
   perceivedStartedAt,
 } from "@/domains/chat/utils/tool-call-status";
@@ -379,10 +380,7 @@ function isFailedEmptyWebSearch(
 function deriveToolStepStatus(
   tc: ChatMessageToolCall,
 ): "running" | "completed" | "error" | "denied" {
-  if (
-    tc.confirmationDecision === "denied" ||
-    tc.confirmationDecision === "timed_out"
-  ) {
+  if (isToolCallDenied(tc)) {
     return "denied";
   }
   if (tc.isError) {

--- a/clients/web/src/domains/chat/utils/tool-call-status.ts
+++ b/clients/web/src/domains/chat/utils/tool-call-status.ts
@@ -10,6 +10,24 @@ type ToolCallTimingFields = Pick<
   "previewStartedAt" | "startedAt"
 >;
 
+type ToolCallDecisionFields = Pick<
+  ConversationMessageToolCall,
+  "confirmationDecision"
+>;
+
+/**
+ * A tool call that never ran because the guardian did not approve it: either
+ * declined outright, or a confirmation prompt that expired unanswered. The two
+ * are separate decisions but the same outcome, and no consumer has yet needed
+ * to tell them apart.
+ */
+export function isToolCallDenied(tc: ToolCallDecisionFields): boolean {
+  return (
+    tc.confirmationDecision === "denied" ||
+    tc.confirmationDecision === "timed_out"
+  );
+}
+
 /**
  * The user-perceived start of a tool call: when its first byte was recognized
  * (`previewStartedAt`), falling back to its execution start (`startedAt`) for

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1478,9 +1478,7 @@
   },
   "skillLoadOutput": {
     "output": "Output",
-    "outputFormatAria": "Output format",
-    "showLess": "Show less",
-    "showMore": "Show more"
+    "outputFormatAria": "Output format"
   },
   "skillToolList": {
     "fromSkill": "From {name}"
@@ -1594,6 +1592,8 @@
   },
   "toolDetailPanel": {
     "closeAria": "Close tool details",
+    "denied": "This tool call was not approved, so it did not run.",
+    "emptyOutput": "The tool returned no output.",
     "output": "Output",
     "riskLevel": "Risk Level",
     "running": "Running…"

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -219,7 +219,9 @@
   },
   "detailPrimitives": {
     "copied": "Copied",
-    "copy": "Copy"
+    "copy": "Copy",
+    "showLess": "Show less",
+    "showMore": "Show more"
   },
   "dictationOverlayPage": {
     "stopRecording": "Stop recording"

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1467,9 +1467,7 @@
   },
   "skillLoadOutput": {
     "output": "Salida",
-    "outputFormatAria": "Formato de salida",
-    "showLess": "Mostrar menos",
-    "showMore": "Mostrar más"
+    "outputFormatAria": "Formato de salida"
   },
   "skillToolList": {
     "fromSkill": "De {name}"
@@ -1583,6 +1581,8 @@
   },
   "toolDetailPanel": {
     "closeAria": "Cerrar detalles de la herramienta",
+    "denied": "Esta llamada a la herramienta no se aprobó, así que no se ejecutó.",
+    "emptyOutput": "La herramienta no devolvió ninguna salida.",
     "output": "Salida",
     "riskLevel": "Nivel de riesgo",
     "running": "Ejecutando…"

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -217,7 +217,9 @@
   },
   "detailPrimitives": {
     "copied": "Copiado",
-    "copy": "Copiar"
+    "copy": "Copiar",
+    "showLess": "Mostrar menos",
+    "showMore": "Mostrar más"
   },
   "dictationOverlayPage": {
     "stopRecording": "Detener grabación"

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -815,5 +815,9 @@
     "reactionAdded": "{name} отреагировал(а) {emoji}",
     "reactionRemoved": "{name} убрал(а) свою реакцию {emoji}",
     "reactionSomeone": "Кто-то"
+  },
+  "toolDetailPanel": {
+    "denied": "Этот вызов инструмента не был одобрен, поэтому он не выполнился.",
+    "emptyOutput": "Инструмент не вернул никаких данных."
   }
 }

--- a/clients/web/src/i18n/locales/ru/common.json
+++ b/clients/web/src/i18n/locales/ru/common.json
@@ -222,5 +222,9 @@
     "view": "Вид",
     "developer": "Разработчик",
     "help": "Справка"
+  },
+  "detailPrimitives": {
+    "showLess": "Показать меньше",
+    "showMore": "Показать больше"
   }
 }

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -1445,9 +1445,7 @@
   },
   "skillLoadOutput": {
     "output": "輸出",
-    "outputFormatAria": "輸出格式",
-    "showLess": "顯示較少",
-    "showMore": "顯示更多"
+    "outputFormatAria": "輸出格式"
   },
   "skillToolList": {
     "fromSkill": "來自 {name}"
@@ -1561,6 +1559,8 @@
   },
   "toolDetailPanel": {
     "closeAria": "關閉工具詳細資料",
+    "denied": "此工具呼叫未獲核准，因此沒有執行。",
+    "emptyOutput": "該工具沒有回傳任何輸出。",
     "output": "輸出",
     "riskLevel": "風險等級",
     "running": "正在執行…"

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -217,7 +217,9 @@
   },
   "detailPrimitives": {
     "copied": "已複製",
-    "copy": "複製"
+    "copy": "複製",
+    "showLess": "顯示較少",
+    "showMore": "顯示更多"
   },
   "dictationOverlayPage": {
     "stopRecording": "停止錄音"

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -1445,9 +1445,7 @@
   },
   "skillLoadOutput": {
     "output": "输出",
-    "outputFormatAria": "输出格式",
-    "showLess": "显示更少",
-    "showMore": "显示更多"
+    "outputFormatAria": "输出格式"
   },
   "skillToolList": {
     "fromSkill": "来自 {name}"
@@ -1561,6 +1559,8 @@
   },
   "toolDetailPanel": {
     "closeAria": "关闭工具详情",
+    "denied": "此工具调用未获批准，因此没有运行。",
+    "emptyOutput": "该工具没有返回任何输出。",
     "output": "输出",
     "riskLevel": "风险级别",
     "running": "正在运行…"

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -217,7 +217,9 @@
   },
   "detailPrimitives": {
     "copied": "已复制",
-    "copy": "复制"
+    "copy": "复制",
+    "showLess": "显示更少",
+    "showMore": "显示更多"
   },
   "dictationOverlayPage": {
     "stopRecording": "停止录音"


### PR DESCRIPTION
## TL;DR

Open the tool-call detail panel on a call that was declined, returned nothing,
or is still waiting, and the Output section simply was not there. No error, no
explanation, no empty state. The panel decided what to show from a truthiness
check on the result string, so any state that did not produce text produced
silence instead.

This makes the panel answer the question it exists to answer, for every call.
Plus a clamp so a large result cannot bury the page.

Fixes LUM-3510. Found by the Storybook catalogue in #41911.

## What a user was experiencing

| Situation | Before | After |
| --- | --- | --- |
| You decline a tool's confirmation prompt, then open its detail | Risk level and the input JSON, then the panel just ends. Nothing anywhere says you declined it or that the tool never ran. | Output: "This tool call was not approved, so it did not run." |
| You decline it **while the panel is open** | Panel stays on "Running…" indefinitely. It only corrects itself if you close and reopen. | Flips to the not-approved message as the decision lands. |
| A confirmation prompt times out unanswered | Same silence as a decline. | Same message. The two are different decisions with the same outcome. |
| The assistant reads a file that turns out to be empty | Output section vanishes, so an empty file looks identical to a call still in flight. | Output: "The tool returned no output." |
| A call is force-completed with no result | Output section vanishes. | Same "no output" message. |
| A tool returns a very large result | The block renders all of it. Results reach the panel at up to the daemon's 400,000 character cap, so the panel becomes a wall of text you scroll past to reach anything below it. | Clamps to a readable height with a Show more control. |
| Any call carrying an activity sentence | The sentence is printed twice: once as the panel header, then again as a subtitle directly beneath the tool name. | Once, in the header. |

## Why this is needed

Every one of these is reachable in normal use, not an edge case:

- Declines and timeouts are a routine part of the approval flow. The panel is
  the surface a user opens to ask "what happened to that?" and it was answering
  by showing nothing.
- Reading an empty file, or a command that writes nothing to stdout, is
  ordinary.
- The 400,000 character cap is the daemon's, not a hypothetical: see
  `HARD_MAX_TOOL_RESULT_CHARS` in
  `assistant/src/plugins/defaults/tool-result-truncate/terminal.ts`.

The duplicated activity sentence is smaller but it is on nearly every call,
because `activity` is a key the native tools send alongside `command` / `path`.

## Why it is right

**The silence was one bug, not four.** `ToolDetailBody` enumerated the states
that had something to show. Anything outside that list rendered nothing, which
is why fixing "denied" and "empty" separately would have left the
force-completed case behind. The Output section is now unconditional for
renderers that do not own their own output, because there is always a true
thing to say: here is the result, it is still running, it was not approved, or
it returned nothing. That removes the category rather than three of its
members.

**The denial is read live.** `isDenied` prefers the live tool call, the way the
running and error flags beside it already did. Both review bots independently
flagged the snapshot-only version, and they were right: the decision is stamped
on the transcript after the drawer opens, which is exactly when someone is
looking at it.

**The rule for "denied" has one home.** It previously lived only inside a
private helper in `tool-call-card-utils`. It is now `isToolCallDenied` in
`tool-call-status.ts`, beside the running and completed predicates, and both
callers use it instead of each deriving it from a different field.

**The clamp is lifted, not written twice.** `skill-load-output.tsx` already had
a working one. Rather than add a second, it moves to `ClampedContent` next to
`CodeBlock` and both use it. Its `showMore` / `showLess` strings move to the
`common` namespace and the now-unread chat keys are deleted, in all five
locales.

**The activity sentence removal is safe because all three hosts agree.**
`ToolDetailBody` renders inside `ToolDetailPanel`, `SubagentDetailPanel`, and
`ActivityStepsPanel`. All three already derived their header from the identical
`activity || title` expression, which is what makes dropping the body subtitle
correct in every one of them rather than just the one I was looking at. They
now share `toolDetailHeaderTitle`, so that stays true by construction.

## Why it is safe

No wire change, no store change, no data-shape change. This is presentation
plus four catalog strings.

Every host of `ToolDetailBody` was read rather than assumed, and the
empty-result path was traced end to end to confirm an empty string genuinely
reaches the client as `""` rather than being normalised to `undefined`
somewhere in ingest. If it had been, the empty branch would have been dead code
and the impact claim wrong.

Verified: `bun run typecheck` and lint clean; the affected suites pass (21 / 6 /
25 / 6), as do the five suites downstream of `deriveToolStepStatus` (23 / 25 /
25 / 17 / 25) and the 210 i18n catalog tests. Beyond the unit tests, seven
behaviours were asserted against the real rendered DOM in Storybook, including
the two negative cases: a short result and a short skill body must **not**
clamp.

The two new tests for the live denial were sensitivity-checked by reverting the
fix and confirming both fail, so they cannot pass against the bug they exist
for.

## Two tests were pinning the bugs

`tool-detail-panel.test.tsx` asserted "hides the Output section when result is
empty", and `activity-steps-panel.test.tsx` asserted the activity label
"appears twice: the header title and the detail body's subtitle". Both encoded
a defect as intended behaviour. They now assert the invariant instead of the
count that happened to hold.

## Also worth flagging

`SkillLoadLongBody` claimed its body clamped behind Show more and never did in
the default Clean view: the parsed instructions sat just under the threshold,
so the control only appeared in Raw. That story predates this branch. Its
fixture is now genuinely long enough, which also gives the extracted clamp
coverage in its second consumer.

Two follow-ups from the same audit stay open and are untouched here: LUM-3511
(MCP tools titled from the raw wire name) and LUM-3512 (`web_search` kind
rendering differently in two panels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
