### PR TITLE
feat(dictation): a hold takes Deepgram's final over the stream

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/DictationPartials.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/DictationPartials.swift
@@ -147,6 +147,12 @@ final class DictationPartialsSession: @unchecked Sendable {
         }
 
         request.shouldReportPartialResults = true
+        // Punctuation and capitalisation from the recogniser itself, which
+        // costs nothing: without it the transcript is a run of lowercase words
+        // that reads as unfinished wherever it lands.
+        if #available(macOS 13.0, *) {
+            request.addsPunctuation = true
+        }
         // Pin recognition on-device when the locale has a local model:
         // dictation audio shouldn't leave the machine, and it keeps the
         // transcript working offline. Locales without an on-device model

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -722,7 +722,7 @@ describe("VoiceInputButton: mobile composer row chrome", () => {
  * promised, or it finds no handle, takes that for no transcript, and the
  * flush goes to nobody.
  */
-describe("VoiceInputButton — a hold takes the stream's final", () => {
+describe("VoiceInputButton: a hold takes the stream's final", () => {
   beforeEach(() => {
     postSttTranscribeSpy.mockClear();
     useVoiceRecordingStore.getState().reset();

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -28,6 +28,7 @@ import {
   MOBILE_CONTROL_CLASS,
   MOBILE_GLYPH_CLASS,
 } from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
+import { markHoldDictation } from "@/utils/hold-to-dictate";
 
 const addBreadcrumbSpy = mock((_breadcrumb: unknown) => {});
 mock.module("@sentry/react", () => ({
@@ -62,7 +63,10 @@ interface FakeDictationStreamArgs {
 }
 let dictationStreamImpl: (
   args: FakeDictationStreamArgs,
-) => { isLive: () => boolean; stop: () => void } | null = () => null;
+) => {
+  isLive: () => boolean;
+  stop: () => Promise<string | null>;
+} | null = () => null;
 mock.module("@/domains/chat/voice/dictation-stream", () => ({
   startDictationStream: (args: FakeDictationStreamArgs) =>
     dictationStreamImpl(args),
@@ -708,5 +712,51 @@ describe("VoiceInputButton: mobile composer row chrome", () => {
         screen.getByRole("button", { name: "Start voice input" }),
       ),
     ).toBe(true);
+  });
+});
+
+/**
+ * A hold takes the stream's flushed final. The imperative stop runs before
+ * the recorder's own stop event, and the first of the two is the one that
+ * asks the provider to flush; the second has to be handed what the first was
+ * promised, or it finds no handle, takes that for no transcript, and the
+ * flush goes to nobody.
+ */
+describe("VoiceInputButton — a hold takes the stream's final", () => {
+  beforeEach(() => {
+    postSttTranscribeSpy.mockClear();
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    dictationStreamImpl = () => null;
+    markHoldDictation(false);
+    useVoiceRecordingStore.getState().reset();
+  });
+
+  test("inserts the flushed final from the stop that asked for it", async () => {
+    let stops = 0;
+    dictationStreamImpl = () => ({
+      isLive: () => true,
+      stop: () => {
+        stops += 1;
+        return Promise.resolve("the whole sentence, from the provider.");
+      },
+    });
+    markHoldDictation(true);
+    const onTranscript = mock(async (_text: string) => {});
+    await startSession(onTranscript);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop recording" }));
+    await waitFor(() => expect(onTranscript).toHaveBeenCalled());
+
+    expect(onTranscript).toHaveBeenCalledWith(
+      "the whole sentence, from the provider.",
+    );
+    // Asked once. A second stop would be the flush requested twice.
+    expect(stops).toBe(1);
+    // And never the upload: a hold has no use for a second round trip.
+    expect(postSttTranscribeSpy).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/components/voice-input-button.test.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.test.tsx
@@ -137,7 +137,7 @@ class FakeMediaRecorder {
 (globalThis as Record<string, unknown>).MediaRecorder = FakeMediaRecorder;
 
 const fakeStream = {
-  getTracks: () => [{ stop: () => {} }],
+  getTracks: () => [{ stop: () => Promise.resolve(null) }],
 } as unknown as MediaStream;
 Object.defineProperty(navigator, "mediaDevices", {
   configurable: true,
@@ -498,7 +498,7 @@ describe("VoiceInputButton — native partials fallback", () => {
       streamOnPartial = args.onPartial;
       // A stream whose daemon is reachable (localhost) but whose provider
       // is not: the handle exists, never goes live, never errors.
-      return { isLive: () => false, stop: () => {} };
+      return { isLive: () => false, stop: () => Promise.resolve(null) };
     };
     nativePartialsImpl = async (onPartial) => {
       onPartial("offline transcript");
@@ -533,7 +533,7 @@ describe("VoiceInputButton — native partials fallback", () => {
     let streamOnPartial: ((text: string) => void) | undefined;
     dictationStreamImpl = (args) => {
       streamOnPartial = args.onPartial;
-      return { isLive: () => false, stop: () => {} };
+      return { isLive: () => false, stop: () => Promise.resolve(null) };
     };
     postSttTranscribeSpy.mockImplementationOnce(async () => ({
       status: "error",
@@ -574,7 +574,7 @@ describe("VoiceInputButton — forced native provider (macOS Native Dictation)",
     let streamStarted = false;
     dictationStreamImpl = () => {
       streamStarted = true;
-      return { isLive: () => true, stop: () => {} };
+      return { isLive: () => true, stop: () => Promise.resolve(null) };
     };
     transcribeBlobImpl = async () => "spoken natively";
 

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -841,12 +841,16 @@ export const VoiceInputButton = forwardRef<
       chunksRef.current = [];
       const fallbackText = speechAccumulatorRef.current;
       speechAccumulatorRef.current = "";
+      // A hold is never empty yet: its stream final is still on its way,
+      // and a recording short enough to leave the recorder without a chunk
+      // is exactly the one whose only transcript is that final.
       if (
         chunks.length === 0 &&
         !fallbackText &&
         !nativePartialText &&
         !streamText &&
-        !pendingNativeFinal
+        !pendingNativeFinal &&
+        !holdSession
       ) {
         addDictationSessionBreadcrumb("empty", durationMs, 0);
         vsReset();

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -36,8 +36,7 @@ import { getVoiceInputMediaStream } from "@/utils/voice-input-device";
 import { isHoldDictation } from "@/utils/hold-to-dictate";
 import { Button, cn } from "@vellumai/design-library";
 
-const RECORDING_GLYPH_CLASS =
-  "[&_svg]:size-5 touch-mobile:[&_svg]:size-5";
+const RECORDING_GLYPH_CLASS = "[&_svg]:size-5 touch-mobile:[&_svg]:size-5";
 
 // ---------------------------------------------------------------------------
 // MIME type selection
@@ -404,9 +403,17 @@ export const VoiceInputButton = forwardRef<
     }
   }, []);
 
-  const stopDictationStream = useCallback(() => {
-    dictationStreamRef.current?.stop();
+  /**
+   * Stop the stream and keep what it has left to say.
+   *
+   * The provider flushes its remaining finals after the stop, so the promise
+   * is the complete transcript of the recording, ready about as soon as the
+   * keys come up. `null` where there was no live stream to ask.
+   */
+  const stopDictationStream = useCallback((): Promise<string | null> => {
+    const handle = dictationStreamRef.current;
     dictationStreamRef.current = null;
+    return handle?.stop() ?? Promise.resolve(null);
   }, []);
 
   const stopNativePartials = useCallback(() => {
@@ -509,7 +516,7 @@ export const VoiceInputButton = forwardRef<
   const stopRecording = useCallback(() => {
     cancelledStartRef.current = true;
     stopSpeechRecognition();
-    stopDictationStream();
+    void stopDictationStream();
     stopNativePartials();
     const recorder = mediaRecorderRef.current;
     if (!recorder) {
@@ -542,7 +549,7 @@ export const VoiceInputButton = forwardRef<
     }
     discardedRef.current = true;
     stopSpeechRecognition();
-    stopDictationStream();
+    void stopDictationStream();
     stopNativePartials();
     if (recorder.state !== "inactive") {
       try {
@@ -609,7 +616,7 @@ export const VoiceInputButton = forwardRef<
     return () => {
       transcribeAbortRef.current?.abort();
       stopSpeechRecognition();
-      stopDictationStream();
+      void stopDictationStream();
       stopNativePartials();
       const recorder = mediaRecorderRef.current;
       if (recorder && recorder.state !== "inactive") {
@@ -640,15 +647,14 @@ export const VoiceInputButton = forwardRef<
     // whole session: no daemon stream, no batch upload — the helper's
     // recognizer (already running for every session) is the authority.
     const nativeSttForced = prefersMacosNativeStt();
-    // The same bargain, reached a different way. A hold is aimed at a cursor
-    // in another application and has been showing its words on the companion
-    // the whole time it ran, so what it owes is the sentence the user just
-    // read, the moment they stop. Waiting on a round trip to replace text they
-    // have already checked is a wait with nothing at the end of it.
+    // Whether this dictation was started from the keyboard. A hold is aimed
+    // at a cursor in another application, and the wait between the keys
+    // coming up and the words landing is the whole experience, so it takes
+    // the stream's flushed final instead of uploading the recording again.
     //
     // Captured at the start, like the provider choice above, so a session
     // cannot change what it owes halfway through.
-    const localTranscriptWins = nativeSttForced || isHoldDictation();
+    const holdSession = isHoldDictation();
 
     if (onBeforeStart) {
       let proceed: boolean;
@@ -791,7 +797,7 @@ export const VoiceInputButton = forwardRef<
       }
       releaseStream();
       stopSpeechRecognition();
-      stopDictationStream();
+      const pendingStreamFinal = stopDictationStream();
       const streamText = streamTranscriptRef.current;
       const nativePartialText = nativePartialsTextRef.current;
       stopNativePartials();
@@ -850,8 +856,42 @@ export const VoiceInputButton = forwardRef<
 
         let text = "";
         let daemonFailure: SttFailureReason | null = null;
+
+        // A dictation started from the keyboard takes the stream's own
+        // final. The audio was already with the provider while the user
+        // spoke, so the transcript is complete about as soon as they stop,
+        // and it is one transcript of the whole recording from a model that
+        // hears the whole recording. Uploading the recording again to get the
+        // same answer a second later is the wait this gesture exists to
+        // remove.
+        //
+        // The local recognizer is not the authority here even though it is
+        // faster still: it transcribes one utterance at a time and starts
+        // over at each pause, so a dictation with a breath in it comes back
+        // as its last sentence.
+        const finalizeStartedAt = Date.now();
+        if (holdSession) {
+          const streamFinal = (await pendingStreamFinal)?.trim() ?? "";
+          console.info(
+            `dictation: stream final chars=${streamFinal.length} waited=${Date.now() - finalizeStartedAt}ms`,
+          );
+          if (streamFinal) {
+            text = streamFinal;
+          }
+        }
+
+        // Never the upload for a hold. Where the stream produced nothing the
+        // local passes below are the fallback, not a second round trip: the
+        // upload is the wait this gesture exists to remove, and on a provider
+        // that fails slowly it is a wait with nothing at the end of it.
         try {
-          if (audioBlob && assistantId && !localTranscriptWins) {
+          if (
+            audioBlob &&
+            assistantId &&
+            !text &&
+            !nativeSttForced &&
+            !holdSession
+          ) {
             if (
               typeof navigator !== "undefined" &&
               navigator.onLine === false
@@ -861,10 +901,17 @@ export const VoiceInputButton = forwardRef<
               console.info("dictation: skipping batch STT (offline)");
               daemonFailure = "network";
             } else {
+              const batchStartedAt = Date.now();
               const result = await postSttTranscribe(
                 audioBlob,
                 assistantId,
                 abortCtrl.signal,
+              );
+              // The batch upload is the one leg of this with a network in it,
+              // and a provider that fails slowly reads exactly like one that
+              // succeeds slowly without this.
+              console.info(
+                `dictation: batch ${result.status} ${result.status === "ok" ? `chars=${result.text.length}` : `reason=${result.reason}${result.httpStatus ? ` http=${result.httpStatus}` : ""}`} took=${Date.now() - batchStartedAt}ms bytes=${audioBlob.size}`,
               );
               if (result.status === "ok") {
                 text = result.text.trim();
@@ -904,7 +951,7 @@ export const VoiceInputButton = forwardRef<
         // What the pill drew, when the pill is what the user was reading. The
         // whole-recording pass below is a second slower for a handful of
         // characters, and a second is most of the wait this gesture has left.
-        if (!text && localTranscriptWins && nativeText) {
+        if (!text && holdSession && nativeText) {
           text = nativeText;
         }
 
@@ -915,7 +962,7 @@ export const VoiceInputButton = forwardRef<
 
         // Character counts only — transcript content must never be logged.
         console.info(
-          `dictation: finalize batchChars=${text.length} blobChars=${blobText.length} nativeChars=${nativeText.length} streamChars=${streamText.length} webChars=${fallbackText.length} failure=${daemonFailure ?? "none"} forcedNative=${nativeSttForced} localWins=${localTranscriptWins}`,
+          `dictation: finalize chars=${text.length} blobChars=${blobText.length} nativeChars=${nativeText.length} streamChars=${streamText.length} webChars=${fallbackText.length} failure=${daemonFailure ?? "none"} forcedNative=${nativeSttForced} hold=${holdSession}`,
         );
 
         if (!text && blobText) {
@@ -982,7 +1029,7 @@ export const VoiceInputButton = forwardRef<
       mediaRecorderRef.current = null;
       releaseStream();
       stopSpeechRecognition();
-      stopDictationStream();
+      void stopDictationStream();
       stopNativePartials();
       onError?.("audio-capture");
       vsFail("audio-capture");
@@ -1017,10 +1064,13 @@ export const VoiceInputButton = forwardRef<
     // source; the recorder above is untouched either way. A forced-native
     // session never opens the stream: the helper recognizer below is its
     // only transcript source.
-    stopDictationStream();
+    void stopDictationStream();
     stopNativePartials();
-    if (!nativeSttForced) {
+    // No assistant is no session to mint a token against or an ingress to
+    // dial, so there is no stream; the recorder above is unaffected.
+    if (!nativeSttForced && assistantId) {
       dictationStreamRef.current = startDictationStream({
+        assistantId,
         onPartial: (text) => {
           streamTranscriptRef.current = text;
           publishInterim(text);

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -33,6 +33,7 @@ import {
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useVellumCommands } from "@/runtime/vellum-commands";
 import { getVoiceInputMediaStream } from "@/utils/voice-input-device";
+import { isHoldDictation } from "@/utils/hold-to-dictate";
 import { Button, cn } from "@vellumai/design-library";
 
 const RECORDING_GLYPH_CLASS =
@@ -639,6 +640,15 @@ export const VoiceInputButton = forwardRef<
     // whole session: no daemon stream, no batch upload — the helper's
     // recognizer (already running for every session) is the authority.
     const nativeSttForced = prefersMacosNativeStt();
+    // The same bargain, reached a different way. A hold is aimed at a cursor
+    // in another application and has been showing its words on the companion
+    // the whole time it ran, so what it owes is the sentence the user just
+    // read, the moment they stop. Waiting on a round trip to replace text they
+    // have already checked is a wait with nothing at the end of it.
+    //
+    // Captured at the start, like the provider choice above, so a session
+    // cannot change what it owes halfway through.
+    const localTranscriptWins = nativeSttForced || isHoldDictation();
 
     if (onBeforeStart) {
       let proceed: boolean;
@@ -841,7 +851,7 @@ export const VoiceInputButton = forwardRef<
         let text = "";
         let daemonFailure: SttFailureReason | null = null;
         try {
-          if (audioBlob && assistantId && !nativeSttForced) {
+          if (audioBlob && assistantId && !localTranscriptWins) {
             if (
               typeof navigator !== "undefined" &&
               navigator.onLine === false
@@ -891,6 +901,13 @@ export const VoiceInputButton = forwardRef<
         // the fallback's fallback. The Web Speech accumulator only matters
         // in plain browsers — inside Electron the API ships without a
         // speech service, so it stays empty.
+        // What the pill drew, when the pill is what the user was reading. The
+        // whole-recording pass below is a second slower for a handful of
+        // characters, and a second is most of the wait this gesture has left.
+        if (!text && localTranscriptWins && nativeText) {
+          text = nativeText;
+        }
+
         let blobText = "";
         if (!text) {
           blobText = (await blobTextPromise) ?? "";
@@ -898,7 +915,7 @@ export const VoiceInputButton = forwardRef<
 
         // Character counts only — transcript content must never be logged.
         console.info(
-          `dictation: finalize batchChars=${text.length} blobChars=${blobText.length} nativeChars=${nativeText.length} streamChars=${streamText.length} webChars=${fallbackText.length} failure=${daemonFailure ?? "none"} forcedNative=${nativeSttForced}`,
+          `dictation: finalize batchChars=${text.length} blobChars=${blobText.length} nativeChars=${nativeText.length} streamChars=${streamText.length} webChars=${fallbackText.length} failure=${daemonFailure ?? "none"} forcedNative=${nativeSttForced} localWins=${localTranscriptWins}`,
         );
 
         if (!text && blobText) {

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -359,6 +359,8 @@ export const VoiceInputButton = forwardRef<
   // after stopNativePartials — short dictations end before the first
   // partial, so this is the only reliable native text source.
   const nativeFinalPromiseRef = useRef<Promise<NativeFinalResult> | null>(null);
+  /** The stream's flushed final, from the stop that asked for it. See {@link stopDictationStream}. */
+  const streamFinalPromiseRef = useRef<Promise<string | null> | null>(null);
 
   // Latest running transcript from the daemon stream — kept through
   // teardown so it can serve as the final-transcript fallback when batch
@@ -413,7 +415,16 @@ export const VoiceInputButton = forwardRef<
   const stopDictationStream = useCallback((): Promise<string | null> => {
     const handle = dictationStreamRef.current;
     dictationStreamRef.current = null;
-    return handle?.stop() ?? Promise.resolve(null);
+    if (!handle) {
+      return streamFinalPromiseRef.current ?? Promise.resolve(null);
+    }
+    // Kept where `onstop` can find it. The imperative stop runs first and the
+    // recorder's own stop event later, and the second caller would otherwise
+    // find no handle and take that for no transcript: the flush the first
+    // caller asked for, handed to nobody.
+    const final = handle.stop();
+    streamFinalPromiseRef.current = final;
+    return final;
   }, []);
 
   const stopNativePartials = useCallback(() => {
@@ -682,6 +693,7 @@ export const VoiceInputButton = forwardRef<
     nativePartialsStartRef.current = null;
     nativePartialsTextRef.current = "";
     nativeFinalPromiseRef.current = null;
+    streamFinalPromiseRef.current = null;
     streamTranscriptRef.current = "";
     const Ctor = getSpeechRecognitionCtor();
     if (Ctor) {
@@ -798,6 +810,7 @@ export const VoiceInputButton = forwardRef<
       releaseStream();
       stopSpeechRecognition();
       const pendingStreamFinal = stopDictationStream();
+      streamFinalPromiseRef.current = null;
       const streamText = streamTranscriptRef.current;
       const nativePartialText = nativePartialsTextRef.current;
       stopNativePartials();

--- a/clients/web/src/domains/chat/voice/dictation-stream.test.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.test.ts
@@ -105,14 +105,18 @@ function createCaptureFake({
   };
 }
 
-function startWithFakes(
+async function startWithFakes(
   onPartial: (text: string) => void = () => undefined,
   captureFake = createCaptureFake(),
+  {
+    resolveWsUrl = () => Promise.resolve("ws://gateway.test/v1/stt/stream"),
+  }: { resolveWsUrl?: (assistantId: string) => Promise<string> } = {},
 ) {
   let ws: FakeWebSocket | null = null;
   const handle = startDictationStream(
-    { onPartial },
+    { assistantId: "a1", onPartial },
     {
+      resolveWsUrl,
       webSocketFactory: (url) => {
         ws = new FakeWebSocket(url);
         return ws as unknown as WebSocket;
@@ -120,8 +124,14 @@ function startWithFakes(
       captureFactory: captureFake.factory,
     },
   );
-  if (!handle || !ws) {
-    throw new Error("expected stream to start");
+  if (!handle) {
+    throw new Error("expected a stream handle");
+  }
+  // The URL is a promise away, and the socket is dialled once it settles.
+  await flushMicrotasks();
+  await flushMicrotasks();
+  if (!ws) {
+    throw new Error("expected the socket to be dialled once the URL resolved");
   }
   return { handle, ws: ws as FakeWebSocket, captureFake };
 }
@@ -177,44 +187,39 @@ describe("buildSttStreamWsUrl", () => {
 // ---------------------------------------------------------------------------
 
 describe("startDictationStream", () => {
-  test("returns null without a self-hosted ingress, token, or worklet support", () => {
-    ingressUrl = null;
-    expect(startDictationStream({ onPartial: () => undefined })).toBeNull();
-
-    ingressUrl = "http://localhost:8500";
-    actorToken = null;
-    expect(startDictationStream({ onPartial: () => undefined })).toBeNull();
-
-    actorToken = "actor-jwt";
+  test("returns null only where PCM capture is impossible", () => {
     pcmSupported = false;
-    expect(startDictationStream({ onPartial: () => undefined })).toBeNull();
+    expect(
+      startDictationStream({ assistantId: "a1", onPartial: () => undefined }),
+    ).toBeNull();
   });
 
-  test("returns null for a paired-assistant ingress without dialling a socket", () => {
-    // The paired __gateway-paired proxy is HTTP-only, so streaming partials
-    // must skip deterministically; batch dictation is unaffected.
-    ingressUrl = "http://localhost:3000/assistant/__gateway-paired/asst-1";
-    let dialled = 0;
-    const handle = startDictationStream(
-      { onPartial: () => undefined },
-      {
-        webSocketFactory: () => {
-          dialled += 1;
-          throw new Error("unexpected socket dial for a paired ingress");
-        },
-      },
-    );
-    expect(handle).toBeNull();
-    expect(dialled).toBe(0);
-  });
+  /**
+   * The socket is a token mint away for a managed assistant, and the speaker
+   * is not waiting for it. Capture starts at once and what it hears is held,
+   * then released the moment the socket opens, so a dictation that begins the
+   * instant a key goes down keeps its opening words.
+   */
+  test("captures from the start and releases held audio when the socket opens", async () => {
+    const { ws, captureFake } = await startWithFakes();
+    const early = new ArrayBuffer(4);
+    const late = new ArrayBuffer(8);
 
-  test("starts capture on open and composes partial/final transcripts", async () => {
-    const partials: string[] = [];
-    const { handle, ws, captureFake } = startWithFakes((t) => partials.push(t));
+    expect(captureFake.calls.started).toBe(1);
+    captureFake.pushChunk(early);
+    expect(ws.sent).toHaveLength(0);
 
     ws.serverOpen();
-    await flushMicrotasks();
-    expect(captureFake.calls.started).toBe(1);
+    expect(ws.sent).toEqual([early]);
+
+    captureFake.pushChunk(late);
+    expect(ws.sent).toEqual([early, late]);
+  });
+
+  test("composes partial and final transcripts as they arrive", async () => {
+    const partials: string[] = [];
+    const { handle, ws } = await startWithFakes((t) => partials.push(t));
+    ws.serverOpen();
 
     expect(handle.isLive()).toBe(false);
     ws.serverMessage({ type: "ready", provider: "deepgram" });
@@ -233,26 +238,67 @@ describe("startDictationStream", () => {
     ]);
   });
 
-  test("forwards PCM chunks only while the socket is open", () => {
-    const { handle, ws, captureFake } = startWithFakes();
-    const chunk = new ArrayBuffer(4);
-
-    captureFake.pushChunk(chunk);
-    expect(ws.sent).toHaveLength(0);
-
+  /**
+   * The provider flushes what it has left after the stop and the session
+   * closes behind it. What the stop resolves with is everything committed by
+   * then, which is a complete transcript of the recording.
+   */
+  test("stop() flushes, waits for the close, and resolves the committed transcript", async () => {
+    const { handle, ws } = await startWithFakes();
     ws.serverOpen();
-    captureFake.pushChunk(chunk);
-    expect(ws.sent).toEqual([chunk]);
+    ws.serverMessage({ type: "ready" });
+    ws.serverMessage({ type: "final", text: "first sentence.", seq: 0 });
 
-    handle.stop();
-    captureFake.pushChunk(chunk);
-    expect(ws.sent.filter((s) => s === chunk)).toHaveLength(1);
+    const stopped = handle.stop();
+    const stopFrames = ws.sent.filter(
+      (frame) => typeof frame === "string" && frame.includes('"stop"'),
+    );
+    expect(stopFrames).toHaveLength(1);
+    // Not yet: the provider is still flushing.
+    expect(ws.closeCalls).toHaveLength(0);
+
+    ws.serverMessage({ type: "final", text: "and the last.", seq: 1 });
+    ws.serverMessage({ type: "closed" });
+
+    expect(await stopped).toBe("first sentence. and the last.");
+    expect(handle.isLive()).toBe(false);
   });
 
-  test("a structured error (e.g. provider without streaming) tears down silently", () => {
-    const partials: string[] = [];
-    const { handle, ws, captureFake } = startWithFakes((t) => partials.push(t));
+  test("stop() is idempotent and both calls settle on the same transcript", async () => {
+    const { handle, ws } = await startWithFakes();
+    ws.serverOpen();
+    ws.serverMessage({ type: "ready" });
+    ws.serverMessage({ type: "final", text: "words.", seq: 0 });
 
+    const first = handle.stop();
+    const second = handle.stop();
+    ws.serverMessage({ type: "closed" });
+
+    expect(await first).toBe("words.");
+    expect(await second).toBe("words.");
+    const stopFrames = ws.sent.filter(
+      (frame) => typeof frame === "string" && frame.includes('"stop"'),
+    );
+    expect(stopFrames).toHaveLength(1);
+  });
+
+  /**
+   * `null` is "nothing was heard", which a caller must be able to tell from
+   * an empty transcript: a session that never went live has no opinion about
+   * what was said, and the recording is transcribed some other way.
+   */
+  test("stop() resolves null when the session never went live", async () => {
+    const { handle, ws } = await startWithFakes();
+    ws.serverOpen();
+
+    expect(await handle.stop()).toBeNull();
+  });
+
+  test("a structured error (e.g. provider without streaming) tears down silently", async () => {
+    const partials: string[] = [];
+    const { handle, ws, captureFake } = await startWithFakes((t) =>
+      partials.push(t),
+    );
     ws.serverOpen();
     ws.serverMessage({
       type: "error",
@@ -263,36 +309,66 @@ describe("startDictationStream", () => {
 
     expect(handle.isLive()).toBe(false);
     expect(captureFake.calls.shutdown).toBe(1);
+    expect(await handle.stop()).toBeNull();
 
     ws.serverMessage({ type: "partial", text: "late", seq: 1 });
     expect(partials).toEqual([]);
   });
 
-  test("stop() sends the stop frame once and closes; idempotent", () => {
-    const { handle, ws } = startWithFakes();
-    ws.serverOpen();
-
-    handle.stop();
-    handle.stop();
-
-    const stopFrames = ws.sent.filter(
-      (frame) => typeof frame === "string" && frame.includes('"stop"'),
+  /**
+   * A paired ingress, a token the platform refused, an assistant with no way
+   * in: each is a reason there is no stream rather than a fault. The handle
+   * still exists, it just resolves to nothing, and batch dictation is
+   * unaffected.
+   */
+  test("a URL that cannot be resolved tears down without dialling", async () => {
+    let dialled = 0;
+    const captureFake = createCaptureFake();
+    const handle = startDictationStream(
+      { assistantId: "a1", onPartial: () => undefined },
+      {
+        resolveWsUrl: () => Promise.reject(new Error("paired ingress")),
+        webSocketFactory: () => {
+          dialled += 1;
+          throw new Error("unexpected dial");
+        },
+        captureFactory: captureFake.factory,
+      },
     );
-    expect(stopFrames).toHaveLength(1);
-    expect(ws.closeCalls).toHaveLength(1);
-    expect(handle.isLive()).toBe(false);
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(dialled).toBe(0);
+    expect(captureFake.calls.shutdown).toBe(1);
+    expect(await handle!.stop()).toBeNull();
   });
 
+  /**
+   * Capture fails before the URL has even resolved here, so the socket is
+   * never dialled at all: a session already torn down has nothing to connect.
+   */
   test("capture failure tears the session down without throwing", async () => {
     const captureFake = createCaptureFake({
       startResult: { ok: false, error: "permission-denied" },
     });
-    const { handle, ws } = startWithFakes(() => undefined, captureFake);
-
-    ws.serverOpen();
+    let dialled = 0;
+    const handle = startDictationStream(
+      { assistantId: "a1", onPartial: () => undefined },
+      {
+        resolveWsUrl: () => Promise.resolve("ws://gateway.test/v1/stt/stream"),
+        webSocketFactory: () => {
+          dialled += 1;
+          throw new Error("unexpected dial");
+        },
+        captureFactory: captureFake.factory,
+      },
+    );
+    await flushMicrotasks();
     await flushMicrotasks();
 
-    expect(handle.isLive()).toBe(false);
+    expect(handle!.isLive()).toBe(false);
     expect(captureFake.calls.shutdown).toBe(1);
+    expect(dialled).toBe(0);
+    expect(await handle!.stop()).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/dictation-stream.test.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.test.ts
@@ -450,4 +450,53 @@ describe("startDictationStream", () => {
     ws.serverMessage({ type: "closed" });
     expect(await stopped).toBe("brief.");
   });
+
+  /**
+   * Shorter still: the hold ends while the token is still being minted, so
+   * there is no socket to send anything on. The dial goes ahead anyway, and
+   * the stop follows the held audio out once the runtime is ready.
+   */
+  test("a stop before the socket is dialled still reaches the runtime", async () => {
+    let resolveUrl: (url: string) => void = () => undefined;
+    const captureFake = createCaptureFake();
+    let ws: FakeWebSocket | null = null;
+    const handle = startDictationStream(
+      { assistantId: "a1", onPartial: () => undefined },
+      {
+        resolveWsUrl: () =>
+          new Promise<string>((resolve) => {
+            resolveUrl = resolve;
+          }),
+        webSocketFactory: (url) => {
+          ws = new FakeWebSocket(url);
+          return ws as unknown as WebSocket;
+        },
+        captureFactory: captureFake.factory,
+      },
+    );
+    await flushMicrotasks();
+    const early = new ArrayBuffer(4);
+    captureFake.pushChunk(early);
+
+    const stopped = handle!.stop();
+    expect(ws).toBeNull();
+    expect(captureFake.calls.shutdown).toBe(0);
+
+    resolveUrl("ws://gateway.test/v1/stt/stream");
+    await flushMicrotasks();
+    await flushMicrotasks();
+    const socket = ws as FakeWebSocket | null;
+    if (!socket) {
+      throw new Error("expected the socket to be dialled after the stop");
+    }
+    socket.serverOpen();
+    expect(socket.sent).toHaveLength(0);
+    socket.serverMessage({ type: "ready" });
+    expect(socket.sent[0]).toBe(early);
+    expect(socket.sent[1]).toContain('"stop"');
+
+    socket.serverMessage({ type: "final", text: "hi.", seq: 0 });
+    socket.serverMessage({ type: "closed" });
+    expect(await stopped).toBe("hi.");
+  });
 });

--- a/clients/web/src/domains/chat/voice/dictation-stream.test.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.test.ts
@@ -426,4 +426,28 @@ describe("startDictationStream", () => {
     expect(dialled).toBe(0);
     expect(await handle!.stop()).toBeNull();
   });
+
+  /**
+   * A hold short enough to end before the runtime is ready has its audio
+   * still held and a runtime that ignores a stop. The stop goes out from the
+   * ready handler, right behind the audio it asks the runtime to finish,
+   * rather than being lost and the hold waiting out the flush timeout.
+   */
+  test("a stop before ready is sent once ready arrives, after the held audio", async () => {
+    const { handle, ws, captureFake } = await startWithFakes();
+    const early = new ArrayBuffer(4);
+    ws.serverOpen();
+    captureFake.pushChunk(early);
+
+    const stopped = handle.stop();
+    expect(ws.sent).toHaveLength(0);
+
+    ws.serverMessage({ type: "ready" });
+    expect(ws.sent[0]).toBe(early);
+    expect(ws.sent[1]).toContain('"stop"');
+
+    ws.serverMessage({ type: "final", text: "brief.", seq: 0 });
+    ws.serverMessage({ type: "closed" });
+    expect(await stopped).toBe("brief.");
+  });
 });

--- a/clients/web/src/domains/chat/voice/dictation-stream.test.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.test.ts
@@ -196,13 +196,18 @@ describe("startDictationStream", () => {
 
   /**
    * The socket is a token mint away for a managed assistant, and the speaker
-   * is not waiting for it. Capture starts at once and what it hears is held,
-   * then released the moment the socket opens, so a dictation that begins the
-   * instant a key goes down keeps its opening words.
+   * is not waiting for it. Capture starts at once and what it hears is held
+   * until the runtime says `ready`, so a dictation that begins the instant a
+   * key goes down keeps its opening words.
+   *
+   * `ready` and not the socket opening: the runtime discards audio that
+   * arrives before its transcriber is up, and that is the same moment it
+   * sends `ready`. A frame released on `open` lands in that gap.
    */
-  test("captures from the start and releases held audio when the socket opens", async () => {
+  test("captures from the start and releases held audio on ready, not open", async () => {
     const { ws, captureFake } = await startWithFakes();
     const early = new ArrayBuffer(4);
+    const between = new ArrayBuffer(6);
     const late = new ArrayBuffer(8);
 
     expect(captureFake.calls.started).toBe(1);
@@ -210,10 +215,60 @@ describe("startDictationStream", () => {
     expect(ws.sent).toHaveLength(0);
 
     ws.serverOpen();
-    expect(ws.sent).toEqual([early]);
+    captureFake.pushChunk(between);
+    expect(ws.sent).toHaveLength(0);
+
+    ws.serverMessage({ type: "ready" });
+    expect(ws.sent).toEqual([early, between]);
 
     captureFake.pushChunk(late);
-    expect(ws.sent).toEqual([early, late]);
+    expect(ws.sent).toEqual([early, between, late]);
+  });
+
+  /**
+   * A session that dropped mid-way has a prefix of a transcript, and a prefix
+   * handed over as the whole is inserted as the whole. The caller cannot tell
+   * the two apart, so the stop resolves null for anything but a flush the
+   * runtime finished, and the recording is transcribed some other way.
+   */
+  test("an unprompted close after finals resolves null, not the prefix", async () => {
+    const { handle, ws } = await startWithFakes();
+    ws.serverOpen();
+    ws.serverMessage({ type: "ready" });
+    ws.serverMessage({ type: "final", text: "the first half", seq: 0 });
+
+    // The runtime went away on its own: nobody asked it to stop.
+    ws.serverMessage({ type: "closed" });
+
+    expect(await handle.stop()).toBeNull();
+  });
+
+  test("an error after finals resolves null, not the prefix", async () => {
+    const { handle, ws } = await startWithFakes();
+    ws.serverOpen();
+    ws.serverMessage({ type: "ready" });
+    ws.serverMessage({ type: "final", text: "the first half", seq: 0 });
+
+    ws.serverMessage({
+      type: "error",
+      category: "provider-error",
+      message: "gone",
+    });
+
+    expect(await handle.stop()).toBeNull();
+  });
+
+  /** And a socket that drops after a stop was sent is a failed flush, not a finished one. */
+  test("a socket dropping after the stop resolves null", async () => {
+    const { handle, ws } = await startWithFakes();
+    ws.serverOpen();
+    ws.serverMessage({ type: "ready" });
+    ws.serverMessage({ type: "final", text: "words.", seq: 0 });
+
+    const stopped = handle.stop();
+    ws.close(1006);
+
+    expect(await stopped).toBeNull();
   });
 
   test("composes partial and final transcripts as they arrive", async () => {

--- a/clients/web/src/domains/chat/voice/dictation-stream.test.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.test.ts
@@ -480,7 +480,10 @@ describe("startDictationStream", () => {
 
     const stopped = handle!.stop();
     expect(ws).toBeNull();
-    expect(captureFake.calls.shutdown).toBe(0);
+    // The mic is released at the stop, and audio arriving after it stays out
+    // of the transcript, however long the dial takes to catch up.
+    expect(captureFake.calls.shutdown).toBe(1);
+    captureFake.pushChunk(new ArrayBuffer(4));
 
     resolveUrl("ws://gateway.test/v1/stt/stream");
     await flushMicrotasks();
@@ -492,6 +495,7 @@ describe("startDictationStream", () => {
     socket.serverOpen();
     expect(socket.sent).toHaveLength(0);
     socket.serverMessage({ type: "ready" });
+    expect(socket.sent).toHaveLength(2);
     expect(socket.sent[0]).toBe(early);
     expect(socket.sent[1]).toContain('"stop"');
 

--- a/clients/web/src/domains/chat/voice/dictation-stream.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.ts
@@ -201,6 +201,16 @@ export function startDictationStream(
   // saying the flush is done. Any other way out is a failure, whatever text
   // had been committed by then.
   let closedByServer = false;
+  // A stop asked for before the runtime was ready to hear it.
+  let stopPending = false;
+
+  const sendStop = (socket: WebSocket): void => {
+    try {
+      socket.send(JSON.stringify({ type: "stop" }));
+    } catch {
+      // Socket raced shut. The flush timeout finishes the session.
+    }
+  };
   // Settled by `teardown`, which every way out of the session runs through.
   let settleStop: ((text: string | null) => void) | null = null;
   const stopped = new Promise<string | null>((resolve) => {
@@ -288,6 +298,10 @@ export function startDictationStream(
             socket.send(buf);
           }
           held = [];
+          if (stopPending) {
+            stopPending = false;
+            sendStop(socket);
+          }
           return;
         case "partial":
           if (typeof message.text === "string") {
@@ -301,7 +315,7 @@ export function startDictationStream(
           }
           return;
         // Includes the structured "streaming not supported for provider"
-        // error — the session degrades to batch-only.
+        // error, and the session degrades to batch-only.
         case "error":
           console.warn(
             "dictation-stream: server error event",
@@ -323,7 +337,7 @@ export function startDictationStream(
     });
 
     socket.addEventListener("close", (event) => {
-      // A close before `ready` means the session never delivered a partial —
+      // A close before `ready` means the session never delivered a partial;
       // surface why (CSP-blocked sockets land here with code 1006, and a
       // gateway that could not reach the assistant with 1014).
       if (!live && !closed) {
@@ -391,10 +405,14 @@ export function startDictationStream(
         // to flush finals.
         capture.flush?.();
         stopRequestedAt = Date.now();
-        try {
-          ws.send(JSON.stringify({ type: "stop" }));
-        } catch {
-          // Socket raced shut — the timeout below finishes it.
+        // A hold short enough to end before `ready` has its audio still held
+        // and a runtime still initialising, which ignores a stop. The stop
+        // goes out from the `ready` handler in that case, right behind the
+        // audio it is asking the runtime to finish.
+        if (live) {
+          sendStop(ws);
+        } else {
+          stopPending = true;
         }
         // The provider flushes what it has left and the session closes
         // behind it, which is what settles `stopped` through `teardown`.

--- a/clients/web/src/domains/chat/voice/dictation-stream.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.ts
@@ -223,7 +223,10 @@ export function startDictationStream(
       new LiveVoiceAudioCapture(captureOptions))
   )({
     onChunk: (buf) => {
-      if (closed) {
+      // Nothing after the stop is part of the dictation. The mic is on its
+      // way down by then, and a quantum that beats the disconnect would
+      // otherwise go out ahead of a stop still waiting on `ready`.
+      if (closed || stopRequestedAt !== null) {
         return;
       }
       // Until `ready`, not until the socket opens. The runtime discards audio
@@ -404,6 +407,9 @@ export function startDictationStream(
       // to flush finals.
       capture.flush?.();
       stopRequestedAt = Date.now();
+      // The key is up, so the mic goes now. The session stays up for the
+      // runtime to finish what it was already sent.
+      capture.shutdown();
       // A hold short enough to end before `ready` has its audio still held,
       // and possibly no socket yet: the token mint is a round trip and the
       // socket a handshake behind it. The runtime ignores a stop it is not

--- a/clients/web/src/domains/chat/voice/dictation-stream.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.ts
@@ -197,6 +197,10 @@ export function startDictationStream(
   let held: ArrayBuffer[] = [];
   // When the caller asked for the flush, so the close can say how long it took.
   let stopRequestedAt: number | null = null;
+  // Whether the runtime ended the session itself, which after a stop is it
+  // saying the flush is done. Any other way out is a failure, whatever text
+  // had been committed by then.
+  let closedByServer = false;
   // Settled by `teardown`, which every way out of the session runs through.
   let settleStop: ((text: string | null) => void) | null = null;
   const stopped = new Promise<string | null>((resolve) => {
@@ -212,7 +216,11 @@ export function startDictationStream(
       if (closed) {
         return;
       }
-      if (ws !== null && ws.readyState === WebSocket.OPEN) {
+      // Until `ready`, not until the socket opens. The runtime discards audio
+      // that arrives before its transcriber is up, and that is the same
+      // moment it sends `ready`, so a frame sent on `open` lands in the gap
+      // and is the opening words gone for a second reason.
+      if (live && ws !== null && ws.readyState === WebSocket.OPEN) {
         ws.send(buf);
         return;
       }
@@ -225,7 +233,11 @@ export function startDictationStream(
       return;
     }
     closed = true;
-    const wasLive = live;
+    // Only a session that was asked to stop and then closed of its own accord
+    // has finished its transcript. One that errored or dropped mid-way has a
+    // prefix of one, and a prefix handed over as the whole would be inserted
+    // as the whole: the caller cannot tell the two apart, so this has to.
+    const finished = live && stopRequestedAt !== null && closedByServer;
     live = false;
     held = [];
     capture.shutdown();
@@ -240,23 +252,14 @@ export function startDictationStream(
         // Already closing — nothing to clean up.
       }
     }
-    settleStop?.(wasLive ? committedText : null);
+    settleStop?.(finished ? committedText : null);
   };
 
   const attach = (socket: WebSocket): void => {
     ws = socket;
 
     socket.addEventListener("open", () => {
-      if (closed) {
-        return;
-      }
-      console.info(
-        `dictation-stream: open after ${Date.now() - startedAt}ms, releasing ${held.length} held chunks`,
-      );
-      for (const buf of held) {
-        socket.send(buf);
-      }
-      held = [];
+      console.info(`dictation-stream: open after ${Date.now() - startedAt}ms`);
     });
 
     socket.addEventListener("message", (event) => {
@@ -279,8 +282,12 @@ export function startDictationStream(
         case "ready":
           live = true;
           console.info(
-            `dictation-stream: ready after ${Date.now() - startedAt}ms`,
+            `dictation-stream: ready after ${Date.now() - startedAt}ms, releasing ${held.length} held chunks`,
           );
+          for (const buf of held) {
+            socket.send(buf);
+          }
+          held = [];
           return;
         case "partial":
           if (typeof message.text === "string") {
@@ -307,6 +314,7 @@ export function startDictationStream(
           console.info(
             `dictation-stream: closed by server ${stopRequestedAt === null ? "unprompted" : `${Date.now() - stopRequestedAt}ms after stop`}, committedChars=${committedText.length}`,
           );
+          closedByServer = true;
           teardown();
           return;
         default:

--- a/clients/web/src/domains/chat/voice/dictation-stream.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.ts
@@ -399,29 +399,28 @@ export function startDictationStream(
       if (closed || stopRequestedAt !== null) {
         return stopped;
       }
-      if (ws !== null && ws.readyState === WebSocket.OPEN) {
-        // The last <50ms may still sit in the capture's batch accumulator;
-        // drain it (synchronously, via onChunk) before asking the provider
-        // to flush finals.
-        capture.flush?.();
-        stopRequestedAt = Date.now();
-        // A hold short enough to end before `ready` has its audio still held
-        // and a runtime still initialising, which ignores a stop. The stop
-        // goes out from the `ready` handler in that case, right behind the
-        // audio it is asking the runtime to finish.
-        if (live) {
-          sendStop(ws);
-        } else {
-          stopPending = true;
-        }
-        // The provider flushes what it has left and the session closes
-        // behind it, which is what settles `stopped` through `teardown`.
-        // A provider that has gone quiet is given this long and no more.
-        setTimeout(teardown, STOP_FLUSH_TIMEOUT_MS);
-        return stopped;
+      // The last <50ms may still sit in the capture's batch accumulator;
+      // drain it (synchronously, via onChunk) before asking the provider
+      // to flush finals.
+      capture.flush?.();
+      stopRequestedAt = Date.now();
+      // A hold short enough to end before `ready` has its audio still held,
+      // and possibly no socket yet: the token mint is a round trip and the
+      // socket a handshake behind it. The runtime ignores a stop it is not
+      // ready for, so the stop waits for `ready` and goes out from that
+      // handler, right behind the audio it is asking the runtime to finish.
+      // A session that never gets there closes some other way, and each of
+      // those settles the stop through `teardown`.
+      if (live && ws !== null && ws.readyState === WebSocket.OPEN) {
+        sendStop(ws);
+      } else {
+        stopPending = true;
       }
-      // No open socket: nothing to flush, and nothing was ever heard.
-      teardown();
+      // The provider flushes what it has left and the session closes
+      // behind it, which is what settles `stopped` through `teardown`.
+      // A provider that has gone quiet, or a dial that never completes, is
+      // given this long and no more.
+      setTimeout(teardown, STOP_FLUSH_TIMEOUT_MS);
       return stopped;
     },
   };

--- a/clients/web/src/domains/chat/voice/dictation-stream.ts
+++ b/clients/web/src/domains/chat/voice/dictation-stream.ts
@@ -6,19 +6,24 @@
  * no live transcript on its own. This module streams mic audio to the
  * daemon's STT stream session and renders its `partial` events.
  *
- * Scope: **interim display only.** The session runs alongside the existing
- * `MediaRecorder` → batch `/v1/stt/transcribe` flow in
- * `voice-input-button.tsx`, which remains the sole authority for the final
- * inserted text. If the stream can't start (no self-hosted gateway ingress,
- * provider without streaming support, capture failure), dictation simply
- * proceeds without live partials — exactly today's behavior.
+ * The session runs alongside the `MediaRecorder` → batch `/v1/stt/transcribe`
+ * flow in `voice-input-button.tsx` and serves two things. Its partials are the
+ * live transcript. Its finals, flushed by the provider when the session is
+ * stopped, are a complete transcript of the recording that exists the moment
+ * the user stops speaking, since the audio was already there: the button
+ * prefers that over uploading the recording again for a dictation that was
+ * started from the keyboard, where the wait is the whole experience. If the
+ * stream can't start (no ingress, provider without streaming support, capture
+ * failure), dictation proceeds on the batch path alone.
  *
- * Transport mirrors `live-voice/connection.ts`'s self-hosted path: connect
- * straight to the user's gateway ingress with the actor edge JWT in
- * `?token=` (browser WebSockets can't set an `Authorization` header). The
- * cloud/velay path is deliberately not wired — the Electron shell (this
- * feature's target) always talks to a local/self-hosted gateway, matching
- * the legacy native client.
+ * Transport follows `live-voice/connection.ts` and the watch stream. A
+ * self-hosted assistant is dialled straight at its gateway ingress with the
+ * actor edge JWT in `?token=` (browser WebSockets can't set an `Authorization`
+ * header); a managed one is reached through the platform's velay ingress with
+ * a minted short-lived token. The mint is a round trip, so the socket is
+ * resolved asynchronously and audio captured meanwhile is held until it opens,
+ * which is what keeps the opening words of a dictation that begins the
+ * instant a key goes down.
  *
  * Audio is the live-voice capture pipeline's 16 kHz mono PCM16LE
  * (`LiveVoiceAudioCapture`), sent as binary frames; the runtime session
@@ -35,7 +40,11 @@ import {
 } from "@/domains/chat/voice/live-voice/pcm-capture";
 import {
   buildSelfHostedGatewayWsUrl,
+  buildVelayWsUrl,
   isPairedGatewayIngress,
+  mintVelayWsToken,
+  PairedVoiceUnavailableError,
+  VelayWsTokenError,
 } from "@/domains/chat/voice/live-voice/connection";
 import { LIVE_VOICE_AUDIO_FORMAT_PARAMS } from "@/domains/chat/voice/live-voice/protocol";
 import {
@@ -51,13 +60,18 @@ export interface DictationStreamHandle {
    */
   isLive(): boolean;
   /**
-   * Stop capture, ask the provider to flush, and close the session.
-   * Idempotent.
+   * Stop capture, ask the provider to flush, and close the session once it
+   * has. Resolves with the committed transcript, which is complete: every
+   * final the provider had left to say arrives before it closes. `null` when
+   * the session never went live, so a caller can tell "nothing was said" from
+   * "nothing was heard". Idempotent, and never rejects.
    */
-  stop(): void;
+  stop(): Promise<string | null>;
 }
 
 export interface StartDictationStreamArgs {
+  /** Whose assistant the session is for, which is what a velay token is minted against. */
+  assistantId: string;
   /**
    * Receives the running transcript (committed finals + current interim)
    * on every partial/final event.
@@ -65,9 +79,54 @@ export interface StartDictationStreamArgs {
   onPartial: (text: string) => void;
 }
 
+/**
+ * How long a stop waits for the provider to flush and close before the
+ * transcript is taken as it stands. A provider that has gone quiet is not
+ * worth more than this: the recording is still uploaded on the batch path.
+ */
+const STOP_FLUSH_TIMEOUT_MS = 4000;
+
+/**
+ * Where the session's socket is, for a given assistant.
+ *
+ * The same shape as the watch stream's resolver and live voice's, since all
+ * three are gateway WebSocket routes with the same two ways in. Throws the
+ * same errors they do for the same reasons; see `resolveWatchStreamWsUrl`.
+ */
+export async function resolveDictationStreamWsUrl(
+  assistantId: string,
+): Promise<string> {
+  const ingressUrl = getSelfHostedIngressUrl();
+  if (ingressUrl) {
+    if (isPairedGatewayIngress(ingressUrl)) {
+      throw new PairedVoiceUnavailableError();
+    }
+    const token = getSelfHostedActorToken();
+    if (!token) {
+      throw new VelayWsTokenError(
+        0,
+        "Self-hosted dictation has no actor token yet; the gateway isn't ready.",
+      );
+    }
+    return buildSttStreamWsUrl({ ingressUrl, token });
+  }
+
+  const { token } = await mintVelayWsToken(assistantId);
+  return buildVelayWsUrl({
+    assistantId,
+    routePath: STT_STREAM_ROUTE,
+    token,
+    params: LIVE_VOICE_AUDIO_FORMAT_PARAMS,
+  });
+}
+
+const STT_STREAM_ROUTE = "/v1/stt/stream";
+
 /** Injection seams for tests. */
 export interface DictationStreamOptions {
   webSocketFactory?: (url: string) => WebSocket;
+  /** Where the socket is, resolved asynchronously. See {@link resolveDictationStreamWsUrl}. */
+  resolveWsUrl?: (assistantId: string) => Promise<string>;
   captureFactory?: (options: LiveVoiceAudioCaptureOptions) => {
     start(): Promise<LiveVoiceCaptureResult>;
     shutdown(): void;
@@ -94,7 +153,7 @@ export function buildSttStreamWsUrl({
 }): string {
   return buildSelfHostedGatewayWsUrl({
     ingressUrl,
-    routePath: "/v1/stt/stream",
+    routePath: STT_STREAM_ROUTE,
     token,
     params: LIVE_VOICE_AUDIO_FORMAT_PARAMS,
   });
@@ -115,41 +174,34 @@ function joinTranscript(a: string, b: string): string {
  * session down silently; the batch recording path is unaffected.
  */
 export function startDictationStream(
-  { onPartial }: StartDictationStreamArgs,
+  { assistantId, onPartial }: StartDictationStreamArgs,
   options: DictationStreamOptions = {},
 ): DictationStreamHandle | null {
-  const ingressUrl = getSelfHostedIngressUrl();
-  const token = getSelfHostedActorToken();
-  if (!ingressUrl || !token || !isPcmCaptureSupported()) {
-    // Expected on cloud-hosted assistants and plain browsers — log once
-    // per session attempt so a missing-partials report is diagnosable.
-    console.info(
-      "dictation-stream: skipping (no self-hosted ingress/token or no AudioWorklet)",
-    );
-    return null;
-  }
-  if (isPairedGatewayIngress(ingressUrl)) {
-    // The paired gateway proxy is HTTP-only, so no STT stream WS exists;
-    // batch dictation over HTTP still works, only live partials are skipped.
-    console.info(
-      "dictation-stream: skipping (voice streaming isn't available for paired assistants yet)",
-    );
+  if (!isPcmCaptureSupported()) {
+    // Plain browsers without an AudioWorklet. Logged once per attempt so a
+    // missing-partials report is diagnosable.
+    console.info("dictation-stream: skipping (no AudioWorklet)");
     return null;
   }
 
   const webSocketFactory =
     options.webSocketFactory ?? ((url: string) => new WebSocket(url));
 
-  let ws: WebSocket;
-  try {
-    ws = webSocketFactory(buildSttStreamWsUrl({ ingressUrl, token }));
-  } catch {
-    return null;
-  }
-
+  let ws: WebSocket | null = null;
   let live = false;
   let closed = false;
   let committedText = "";
+  // Audio captured before the socket is open. The token mint is a round trip
+  // and a dictation started from a key begins the instant it goes down, so
+  // dropping what arrives meanwhile would drop the opening words.
+  let held: ArrayBuffer[] = [];
+  // When the caller asked for the flush, so the close can say how long it took.
+  let stopRequestedAt: number | null = null;
+  // Settled by `teardown`, which every way out of the session runs through.
+  let settleStop: ((text: string | null) => void) | null = null;
+  const stopped = new Promise<string | null>((resolve) => {
+    settleStop = resolve;
+  });
 
   const capture = (
     options.captureFactory ??
@@ -157,9 +209,14 @@ export function startDictationStream(
       new LiveVoiceAudioCapture(captureOptions))
   )({
     onChunk: (buf) => {
-      if (!closed && ws.readyState === WebSocket.OPEN) {
-        ws.send(buf);
+      if (closed) {
+        return;
       }
+      if (ws !== null && ws.readyState === WebSocket.OPEN) {
+        ws.send(buf);
+        return;
+      }
+      held.push(buf);
     },
   });
 
@@ -168,11 +225,14 @@ export function startDictationStream(
       return;
     }
     closed = true;
+    const wasLive = live;
     live = false;
+    held = [];
     capture.shutdown();
     if (
-      ws.readyState === WebSocket.OPEN ||
-      ws.readyState === WebSocket.CONNECTING
+      ws !== null &&
+      (ws.readyState === WebSocket.OPEN ||
+        ws.readyState === WebSocket.CONNECTING)
     ) {
       try {
         ws.close(1000);
@@ -180,96 +240,163 @@ export function startDictationStream(
         // Already closing — nothing to clean up.
       }
     }
+    settleStop?.(wasLive ? committedText : null);
   };
 
-  ws.addEventListener("open", () => {
-    if (closed) {
-      return;
-    }
-    void capture.start().then((result) => {
-      // Mic denied / device busy: no partials, batch capture unaffected.
-      if (!result.ok) {
-        console.warn("dictation-stream: PCM capture failed", result.error);
-        teardown();
+  const attach = (socket: WebSocket): void => {
+    ws = socket;
+
+    socket.addEventListener("open", () => {
+      if (closed) {
+        return;
+      }
+      console.info(
+        `dictation-stream: open after ${Date.now() - startedAt}ms, releasing ${held.length} held chunks`,
+      );
+      for (const buf of held) {
+        socket.send(buf);
+      }
+      held = [];
+    });
+
+    socket.addEventListener("message", (event) => {
+      if (closed || typeof event.data !== "string") {
+        return;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      if (!parsed || typeof parsed !== "object") {
+        return;
+      }
+
+      const message = parsed as { type?: string; text?: string };
+      switch (message.type) {
+        case "ready":
+          live = true;
+          console.info(
+            `dictation-stream: ready after ${Date.now() - startedAt}ms`,
+          );
+          return;
+        case "partial":
+          if (typeof message.text === "string") {
+            onPartial(joinTranscript(committedText, message.text));
+          }
+          return;
+        case "final":
+          if (typeof message.text === "string") {
+            committedText = joinTranscript(committedText, message.text);
+            onPartial(committedText);
+          }
+          return;
+        // Includes the structured "streaming not supported for provider"
+        // error — the session degrades to batch-only.
+        case "error":
+          console.warn(
+            "dictation-stream: server error event",
+            (parsed as { message?: string; category?: string }).category ?? "",
+            (parsed as { message?: string }).message ?? event.data,
+          );
+          teardown();
+          return;
+        case "closed":
+          console.info(
+            `dictation-stream: closed by server ${stopRequestedAt === null ? "unprompted" : `${Date.now() - stopRequestedAt}ms after stop`}, committedChars=${committedText.length}`,
+          );
+          teardown();
+          return;
+        default:
+          return;
       }
     });
-  });
 
-  ws.addEventListener("message", (event) => {
-    if (closed || typeof event.data !== "string") {
-      return;
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(event.data);
-    } catch {
-      return;
-    }
-    if (!parsed || typeof parsed !== "object") {
-      return;
-    }
-
-    const message = parsed as { type?: string; text?: string };
-    switch (message.type) {
-      case "ready":
-        live = true;
-        return;
-      case "partial":
-        if (typeof message.text === "string") {
-          onPartial(joinTranscript(committedText, message.text));
-        }
-        return;
-      case "final":
-        if (typeof message.text === "string") {
-          committedText = joinTranscript(committedText, message.text);
-          onPartial(committedText);
-        }
-        return;
-      // Includes the structured "streaming not supported for provider"
-      // error — the session degrades to batch-only.
-      case "error":
+    socket.addEventListener("close", (event) => {
+      // A close before `ready` means the session never delivered a partial —
+      // surface why (CSP-blocked sockets land here with code 1006, and a
+      // gateway that could not reach the assistant with 1014).
+      if (!live && !closed) {
         console.warn(
-          "dictation-stream: server error event",
-          (parsed as { message?: string }).message ?? event.data,
+          `dictation-stream: socket closed before ready (code ${event.code}${event.reason ? `, ${event.reason}` : ""}) after ${Date.now() - startedAt}ms`,
         );
-        teardown();
-        return;
-      case "closed":
-        teardown();
-        return;
-      default:
-        return;
+      }
+      teardown();
+    });
+    socket.addEventListener("error", teardown);
+  };
+
+  // Capture starts now rather than on the socket opening, since the socket
+  // may be a token mint away and the speaker is not waiting for it.
+  void capture.start().then((result) => {
+    // Mic denied / device busy: no partials, batch capture unaffected.
+    if (!result.ok) {
+      console.warn("dictation-stream: PCM capture failed", result.error);
+      teardown();
     }
   });
 
-  ws.addEventListener("close", (event) => {
-    // A close before `ready` means the session never delivered a partial —
-    // surface why (CSP-blocked sockets land here with code 1006).
-    if (!live && !closed) {
-      console.warn(
-        `dictation-stream: socket closed before ready (code ${event.code})`,
+  const startedAt = Date.now();
+  const resolveWsUrl = options.resolveWsUrl ?? resolveDictationStreamWsUrl;
+  void resolveWsUrl(assistantId).then(
+    (url) => {
+      if (closed) {
+        return;
+      }
+      // Which way in, and how long the token took, without the token.
+      console.info(
+        `dictation-stream: dialling ${new URL(url).host} (${getSelfHostedIngressUrl() ? "self-hosted" : "velay"}) after ${Date.now() - startedAt}ms`,
       );
-    }
-    teardown();
-  });
-  ws.addEventListener("error", teardown);
+      try {
+        attach(webSocketFactory(url));
+      } catch (err) {
+        console.warn("dictation-stream: could not open socket", err);
+        teardown();
+      }
+    },
+    (err: unknown) => {
+      // A paired ingress, a token not yet provisioned, or a mint the platform
+      // refused. Each is a reason there is no stream, not a fault: batch
+      // dictation still works, and only the live half is missing.
+      console.info(
+        "dictation-stream: skipping",
+        err instanceof Error ? err.message : String(err),
+      );
+      teardown();
+    },
+  );
 
   return {
     isLive: () => live && !closed,
     stop: () => {
-      if (!closed && ws.readyState === WebSocket.OPEN) {
+      // Asked already, or nothing left to ask: the same promise either way,
+      // so a second caller waits on the same flush rather than sending a
+      // second stop.
+      if (closed || stopRequestedAt !== null) {
+        return stopped;
+      }
+      if (ws !== null && ws.readyState === WebSocket.OPEN) {
         // The last <50ms may still sit in the capture's batch accumulator;
         // drain it (synchronously, via onChunk) before asking the provider
         // to flush finals.
         capture.flush?.();
+        stopRequestedAt = Date.now();
         try {
           ws.send(JSON.stringify({ type: "stop" }));
         } catch {
-          // Socket raced shut — teardown below handles it.
+          // Socket raced shut — the timeout below finishes it.
         }
+        // The provider flushes what it has left and the session closes
+        // behind it, which is what settles `stopped` through `teardown`.
+        // A provider that has gone quiet is given this long and no more.
+        setTimeout(teardown, STOP_FLUSH_TIMEOUT_MS);
+        return stopped;
       }
+      // No open socket: nothing to flush, and nothing was ever heard.
       teardown();
+      return stopped;
     },
   };
 }

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -41,6 +41,20 @@ mock.module("@/domains/chat/components/voice-input-button", () => ({
   }),
 }));
 
+let holdHandlers: {
+  onHoldStart: () => void;
+  onHoldEnd: () => void;
+} | null = null;
+mock.module("@/domains/chat/voice/use-hold-to-dictate", () => ({
+  HOLD_ARMING_MS: 220,
+  useHoldToDictate: (options: {
+    onHoldStart: () => void;
+    onHoldEnd: () => void;
+  }) => {
+    holdHandlers = options;
+  },
+}));
+
 mock.module("@/domains/chat/hooks/use-dictation-overlay-sync", () => ({
   useDictationOverlaySync: () => undefined,
 }));
@@ -248,4 +262,39 @@ describe("GlobalPushToTalkBridge", () => {
 
     expect(voiceStopMock).not.toHaveBeenCalled();
   });
+});
+
+/**
+ * A hold is aimed at a cursor in another application, and its words belong
+ * there. The composer's microphone registers itself as the global dictation
+ * target whenever a chat route is mounted, and routing a hold through that one
+ * splices the transcript into the composer and sends it as a turn: the words
+ * never reach the cursor, and a turn is spent that nobody asked for.
+ */
+test("drives its own recorder, not whatever claimed dictation last", async () => {
+  const { registerPushToTalkTarget } = await import(
+    "@/domains/chat/voice/push-to-talk-target"
+  );
+  const composerStart = mock(() => undefined);
+  const composerStop = mock(() => undefined);
+  const release = registerPushToTalkTarget({
+    start: composerStart,
+    stop: composerStop,
+  });
+
+  renderBridge("a1");
+
+  act(() => {
+    holdHandlers?.onHoldStart();
+  });
+  useVoiceRecordingStore.setState({ phase: "recording" });
+  act(() => {
+    holdHandlers?.onHoldEnd();
+  });
+
+  expect(composerStart).not.toHaveBeenCalled();
+  expect(composerStop).not.toHaveBeenCalled();
+  expect(voiceStopMock).toHaveBeenCalled();
+
+  release();
 });

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -31,11 +31,10 @@ interface GlobalPushToTalkBridgeProps {
 /**
  * How long a hold gives the cleanup pass before inserting the words as heard.
  *
- * Generous for a healthy call, which is a small model answering a sentence,
- * and far short of the route's own five second timeout, which is the wait
- * the pass has been measured costing when the daemon is not answering.
+ * The route's own timeout, so the pass gets every chance to answer while its
+ * cost is being measured. The log line below carries what each hold paid.
  */
-const CLEANUP_DEADLINE_MS = 1500;
+const CLEANUP_DEADLINE_MS = 5000;
 
 function appendTranscript(current: string, text: string): string {
   const trimmed = text.trim();
@@ -166,11 +165,8 @@ export function GlobalPushToTalkBridge({
       // nothing else on its path is worth waiting for; what it costs is
       // measured rather than assumed. Character counts and timings only.
       //
-      // Raced against a deadline rather than awaited. The pass is worth a few
-      // hundred milliseconds and no more: a daemon that is not answering has
-      // been measured stalling for the route's own five second timeout and
-      // then returning the words untouched, and a hold that waited for that
-      // would be paying the whole wait for nothing. Past the deadline the raw
+      // Raced against a deadline rather than awaited, so a daemon that is not
+      // answering costs the hold the deadline and no more. Past it the raw
       // words go down and the late answer is dropped.
       const cleanupStartedAt = Date.now();
       const cleanupAbort = new AbortController();

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -75,12 +75,6 @@ export function GlobalPushToTalkBridge({
   });
   const setVoiceAudioLevel = useVoiceRecordingStore.use.setAudioLevel();
   const holdToDictateEnabled = useHoldToDictateEnabled();
-  /**
-   * Whether the dictation in flight was started by the hold rather than by a
-   * press. A ref because the transcript arrives after the keys are back up, so
-   * a state read at that point would already describe the next silence.
-   */
-  const holdRef = useRef(false);
 
   useEffect(() => {
     if (!voiceStream) {
@@ -148,7 +142,6 @@ export function GlobalPushToTalkBridge({
       if (useVoiceRecordingStore.getState().phase === "recording") {
         return;
       }
-      holdRef.current = true;
       // Read by the recording session as it starts, which decides there
       // whether the local transcript is the authority.
       markHoldDictation(true);
@@ -157,7 +150,6 @@ export function GlobalPushToTalkBridge({
     onHoldEnd: () => {
       markHoldDictation(false);
       if (useVoiceRecordingStore.getState().phase !== "recording") {
-        holdRef.current = false;
         return;
       }
       holdTarget()?.stop();
@@ -235,8 +227,6 @@ export function GlobalPushToTalkBridge({
             useConversationStore.getState().activeConversationId,
           );
       }
-
-      holdRef.current = false;
 
       const conversationKey = ensureConversationKey();
       const composer = useComposerStore.getState();

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -12,7 +12,10 @@ import { getPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
 import { supportsKeyboardActivation } from "@/domains/chat/voice/keyboard-activation-host";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { useHoldToDictate } from "@/domains/chat/voice/use-hold-to-dictate";
-import { useHoldToDictateEnabled } from "@/utils/hold-to-dictate";
+import {
+  markHoldDictation,
+  useHoldToDictateEnabled,
+} from "@/utils/hold-to-dictate";
 import { useVoiceModeHotkey } from "@/domains/chat/voice/use-voice-mode-hotkey";
 import { mintVoiceDraftConversation } from "@/domains/chat/voice/voice-draft-conversation";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
@@ -119,9 +122,13 @@ export function GlobalPushToTalkBridge({
         return;
       }
       holdRef.current = true;
+      // Read by the recording session as it starts, which decides there
+      // whether the local transcript is the authority.
+      markHoldDictation(true);
       resolveTarget()?.start();
     },
     onHoldEnd: () => {
+      markHoldDictation(false);
       if (useVoiceRecordingStore.getState().phase !== "recording") {
         holdRef.current = false;
         return;

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -90,6 +90,24 @@ export function GlobalPushToTalkBridge({
   // saying it separately.
   useDictationOverlaySync({ suppressed: holdToDictateEnabled });
 
+  /**
+   * The recorder a held key drives, which is always this bridge's own.
+   *
+   * Never {@link resolveTarget}. That answers with whatever most recently
+   * claimed dictation, and on a chat route that is the composer's microphone,
+   * whose transcript is spliced into the composer and sent as a turn. A hold
+   * is aimed at a cursor in another application: its words belong there, and
+   * routing them into a conversation instead both loses them and spends a turn
+   * the user did not ask for.
+   *
+   * The composer's own microphone is unaffected; this only decides where the
+   * keys go.
+   */
+  const holdTarget = useCallback(
+    () => (assistantId ? fallbackVoiceInputRef.current : null),
+    [assistantId],
+  );
+
   const resolveTarget = useCallback(
     () =>
       getPushToTalkTarget() ??
@@ -125,7 +143,7 @@ export function GlobalPushToTalkBridge({
       // Read by the recording session as it starts, which decides there
       // whether the local transcript is the authority.
       markHoldDictation(true);
-      resolveTarget()?.start();
+      holdTarget()?.start();
     },
     onHoldEnd: () => {
       markHoldDictation(false);
@@ -133,7 +151,7 @@ export function GlobalPushToTalkBridge({
         holdRef.current = false;
         return;
       }
-      resolveTarget()?.stop();
+      holdTarget()?.stop();
     },
   });
 

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -28,6 +28,15 @@ interface GlobalPushToTalkBridgeProps {
   assistantId: string | null;
 }
 
+/**
+ * How long a hold gives the cleanup pass before inserting the words as heard.
+ *
+ * Generous for a healthy call, which is a small model answering a sentence,
+ * and far short of the route's own five second timeout, which is the wait
+ * the pass has been measured costing when the daemon is not answering.
+ */
+const CLEANUP_DEADLINE_MS = 1500;
+
 function appendTranscript(current: string, text: string): string {
   const trimmed = text.trim();
   if (!trimmed) {
@@ -164,11 +173,32 @@ export function GlobalPushToTalkBridge({
       // list, and the only leg of this that can. A hold takes it too, now that
       // nothing else on its path is worth waiting for; what it costs is
       // measured rather than assumed. Character counts and timings only.
+      //
+      // Raced against a deadline rather than awaited. The pass is worth a few
+      // hundred milliseconds and no more: a daemon that is not answering has
+      // been measured stalling for the route's own five second timeout and
+      // then returning the words untouched, and a hold that waited for that
+      // would be paying the whole wait for nothing. Past the deadline the raw
+      // words go down and the late answer is dropped.
       const cleanupStartedAt = Date.now();
+      const cleanupAbort = new AbortController();
       const dictationResult = assistantId
-        ? await postDictation(rawText, assistantId, {
-            cursorInTextField: true,
-          })
+        ? await Promise.race([
+            postDictation(
+              rawText,
+              assistantId,
+              {
+                cursorInTextField: true,
+              },
+              cleanupAbort.signal,
+            ),
+            new Promise<null>((resolve) => {
+              setTimeout(() => {
+                cleanupAbort.abort();
+                resolve(null);
+              }, CLEANUP_DEADLINE_MS);
+            }),
+          ])
         : null;
       if (dictationResult?.mode === "dictation" && dictationResult.text) {
         insertText = dictationResult.text;

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -158,21 +158,29 @@ export function GlobalPushToTalkBridge({
   const handleTranscript = useCallback(
     async (rawText: string): Promise<void> => {
       let insertText = rawText;
-      // The cleanup pass is a daemon round-trip that runs a model, and it sits
-      // between letting go of the keys and seeing the words. A hold is aimed at
-      // a cursor in another app, where the wait is the whole experience and the
-      // intent needs no classifying, so those words go straight down and the
-      // pass is spent only where something is waiting on it anyway.
-      const dictationResult =
-        assistantId && !holdRef.current
-          ? await postDictation(rawText, assistantId, {
-              cursorInTextField: true,
-            })
-          : null;
+      // The cleanup pass: one model call that punctuates, drops the fillers,
+      // adapts the tone to the application in front and applies the user's
+      // own style. It is what turns "grocery list, onions, tomatoes" into a
+      // list, and the only leg of this that can. A hold takes it too, now that
+      // nothing else on its path is worth waiting for; what it costs is
+      // measured rather than assumed. Character counts and timings only.
+      const cleanupStartedAt = Date.now();
+      const dictationResult = assistantId
+        ? await postDictation(rawText, assistantId, {
+            cursorInTextField: true,
+          })
+        : null;
       if (dictationResult?.mode === "dictation" && dictationResult.text) {
         insertText = dictationResult.text;
       }
+      console.info(
+        `dictation: cleanup ${dictationResult ? dictationResult.mode : "skipped"} inChars=${rawText.length} outChars=${insertText.length} ms=${Date.now() - cleanupStartedAt}`,
+      );
+      const insertStartedAt = Date.now();
       const frontAppInsertion = await insertTextIntoFrontApp(insertText);
+      console.info(
+        `dictation: inserted chars=${insertText.length} status=${frontAppInsertion.status} ms=${Date.now() - insertStartedAt}`,
+      );
       if (frontAppInsertion.status === "inserted") {
         return;
       }

--- a/clients/web/src/utils/hold-to-dictate.test.ts
+++ b/clients/web/src/utils/hold-to-dictate.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  isHoldDictation,
+  markHoldDictation,
+} from "@/utils/hold-to-dictate";
+
+afterEach(() => {
+  markHoldDictation(false);
+});
+
+describe("the hold dictation marker", () => {
+  test("is off until a hold marks it", () => {
+    expect(isHoldDictation()).toBe(false);
+
+    markHoldDictation(true);
+    expect(isHoldDictation()).toBe(true);
+  });
+
+  /**
+   * The recording is started through an imperative handle on whichever button
+   * owns dictation, so the marker is how the session learns what it was begun
+   * for. It is read once at the start; clearing it later must not reach back
+   * into a session already running.
+   */
+  test("clears when the hold ends", () => {
+    markHoldDictation(true);
+    markHoldDictation(false);
+
+    expect(isHoldDictation()).toBe(false);
+  });
+});

--- a/clients/web/src/utils/hold-to-dictate.ts
+++ b/clients/web/src/utils/hold-to-dictate.ts
@@ -39,3 +39,28 @@ export function useHoldToDictateEnabled(): boolean {
   );
   return enabled;
 }
+
+/**
+ * Whether the dictation being recorded was started by the held keys.
+ *
+ * A hold is aimed at a cursor in another application and shows its words on
+ * the companion while they are said, so what it owes the user is the sentence
+ * they just read, as soon as they stop. That is a different bargain from the
+ * composer's microphone, which can afford to wait for the best answer because
+ * nobody is standing in another app watching for it.
+ *
+ * A flag rather than a parameter because the recording is started through an
+ * imperative handle on whichever `VoiceInputButton` currently owns dictation,
+ * which is the composer's on a chat route and a headless one everywhere else.
+ * Read once when a session starts, so what it says later cannot change the
+ * bargain a session was begun under.
+ */
+let holdDictation = false;
+
+export function markHoldDictation(active: boolean): void {
+  holdDictation = active;
+}
+
+export function isHoldDictation(): boolean {
+  return holdDictation;
+}

--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock } from "bun:test";
+import { afterEach, describe, test, expect, mock } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { initSigningKey, mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
@@ -19,6 +19,7 @@ mock.module("../auth/guardian-bootstrap.js", () => ({
 const { createSttStreamWebsocketHandler, getSttStreamWebsocketHandlers } =
   await import("../http/routes/stt-stream-websocket.js");
 import type { SttStreamSocketData } from "../http/routes/stt-stream-websocket.js";
+import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
 initSigningKey(TEST_SIGNING_KEY);
@@ -451,5 +452,98 @@ describe("dictation is not a guardian-only surface", () => {
     const result = handler(req, makeFakeServer());
 
     expect(result).not.toBeInstanceOf(Promise);
+  });
+});
+
+/**
+ * The managed path, where velay validated the browser's own token and
+ * attested the caller to the bridge. There is no edge JWT on it, so requiring
+ * one rejected every managed caller: the socket opened at velay and closed at
+ * the loopback with an open failure, which the browser saw as a 1014.
+ *
+ * No guardian cross-check, unlike live voice and watch. Dictation admits any
+ * valid actor, and velay only mints a token for a user with access to this
+ * assistant, which is the same standing an actor token proves.
+ */
+describe("createSttStreamWebsocketHandler: velay-attested managed auth", () => {
+  const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
+  const VELAY_ORG_ID = "22222222-2222-2222-2222-222222222222";
+
+  afterEach(() => {
+    delete process.env.IS_PLATFORM;
+  });
+
+  const managedUpgrade = ({
+    bridgeProof = true,
+    orgId = VELAY_ORG_ID as string | null,
+    token,
+    managed = true,
+  }: {
+    bridgeProof?: boolean;
+    orgId?: string | null;
+    token?: string;
+    managed?: boolean;
+  }) => {
+    if (managed) {
+      process.env.IS_PLATFORM = "true";
+    } else {
+      delete process.env.IS_PLATFORM;
+    }
+    const headers = new Headers({
+      upgrade: "websocket",
+      "x-velay-user-id": VELAY_USER_ID,
+      "x-velay-actor": "user",
+    });
+    if (orgId !== null) {
+      headers.set("x-velay-org-id", orgId);
+    }
+    if (bridgeProof) {
+      setVelayBridgeAuthHeader(headers);
+    }
+    const handler = createSttStreamWebsocketHandler(makeConfig());
+    const query = token ? `&token=${token}` : "";
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?mimeType=audio/pcm${query}`,
+      { headers },
+    );
+    const server = makeFakeServer();
+    return { res: handler(req, server), server };
+  };
+
+  test("admits an attested caller with the bridge proof and no token", () => {
+    const { res, server } = managedUpgrade({});
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * A direct request to a reachable gateway can spoof the header names. It
+   * cannot know the process-local bridge proof, which is what says the request
+   * really arrived through this gateway's own loopback bridge.
+   */
+  test("ignores spoofed velay headers with no bridge proof", () => {
+    const { res, server } = managedUpgrade({ bridgeProof: false });
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("falls through to the token path on an incomplete attestation", () => {
+    const { res, server } = managedUpgrade({
+      orgId: null,
+      token: mintEdgeToken(),
+    });
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  /** The attestation means nothing off the platform: only the token does. */
+  test("ignores velay headers on a self-hosted gateway", () => {
+    const { res, server } = managedUpgrade({ managed: false });
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
   });
 });

--- a/gateway/src/http/routes/stt-stream-websocket.ts
+++ b/gateway/src/http/routes/stt-stream-websocket.ts
@@ -9,6 +9,13 @@
  * the binding, and dictation takes any valid actor, which is why that pin is a
  * route opt-in rather than part of the shared gate.
  *
+ * A managed assistant is reached through velay, which validates the browser's
+ * own token and attests the caller to the bridge; there is no edge JWT on that
+ * path to validate. So a velay-attested caller with the bridge proof is
+ * admitted here the way live voice and watch admit one, minus their guardian
+ * check: velay only mints a token for a user with access to this assistant,
+ * which is the same standing an actor token proves.
+ *
  * The rest of what is this route's own is the query it accepts and carries
  * upstream.
  */
@@ -18,8 +25,13 @@ import {
   createRuntimeAudioStreamHandlers,
   type RuntimeAudioStreamState,
 } from "./runtime-audio-stream.js";
+import {
+  extractVelayAttestedContext,
+  isPlatformManaged,
+} from "./guardian-pin.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
+import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
 
 const log = getLogger("stt-stream-ws");
 
@@ -59,9 +71,33 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
     // to a transcriber and back; it is not a guardian-only surface, and the
     // watch stream's `guardian-pin` check is exactly what this route does not
     // want.
-    const auth = authorizeRuntimeAudioStream(req, config, log);
-    if (!auth.ok) {
-      return auth.response;
+    //
+    // The managed path first, as live voice and watch take it. A direct
+    // request to a reachable gateway can spoof the X-Velay-* names but cannot
+    // know the bridge proof, and an attestation without the proof falls
+    // through to the token gate rather than being trusted.
+    let managedCaller = false;
+    if (isPlatformManaged() && config.runtimeProxyRequireAuth) {
+      const velayContext = extractVelayAttestedContext(req);
+      if (velayContext) {
+        if (requestHasVelayBridgeAuth(req)) {
+          log.info(
+            { userId: velayContext.userId, orgId: velayContext.orgId },
+            "STT stream WS: authenticated via velay-attested managed context",
+          );
+          managedCaller = true;
+        } else {
+          log.warn(
+            "STT stream WS: ignoring velay context without bridge proof",
+          );
+        }
+      }
+    }
+    if (!managedCaller) {
+      const auth = authorizeRuntimeAudioStream(req, config, log);
+      if (!auth.ok) {
+        return auth.response;
+      }
     }
 
     // ── Query parameters ──


### PR DESCRIPTION
## Summary

A hold-to-dictate now takes Deepgram's transcript instead of the local recogniser's, and gets it about as fast as the local one.

- **The stream reaches a managed assistant.** It dialled a self-hosted ingress only; it now goes through velay with a minted token, the way the watch stream does. The gateway's STT route also had to admit velay-attested callers, which it never did: it demanded an edge JWT that does not exist on that path, refused every managed caller at the loopback, and the browser saw velay close with 1014. That is why the client's cloud path was "deliberately not wired".
- **The stream's final is kept.** Stopping used to tear the socket down the instant the stop was sent, before the provider had flushed, which is why the stream could only ever be interim display. It now waits for the flush and resolves with the committed transcript.
- **A hold takes that final, and never the batch upload.** Where the stream produced nothing, the local passes are the fallback. On a provider that fails slowly the upload was a five second wait with nothing at the end of it.
- **The local recogniser asks for punctuation**, which has been built into macOS since 13 and was never requested.
- Two fixes carried from #41909 that this depends on: a hold drives the bridge's own recorder rather than whatever claimed dictation last (a chat route was swallowing holds into the composer and sending them as turns), and the hold marker the recorder reads at session start.

## Why the local recogniser is not the authority

It transcribes one utterance at a time and starts over at each pause, re-transcribing the overlapping audio differently each time ("Weren't" / "Were"). No text-level merge fixes a source that contradicts itself; #41909 has two commits' worth of trying. Deepgram hears the whole recording and returns one transcript of it, with `smart_format` and `punctuate` already on by default in the daemon's adapter, so the formatting comes with it at no cost.

## Measured, from the desk

Before, from key release to the text being handed over: **460ms to 1.4s** against a local daemon, **6.65s** on dev. Of the dev figure, 5.3s was the batch upload *failing* with `provider-error` before the fallback ran. The local recogniser's result was ready 25 to 340ms after release every time.

## Testing

26 gateway tests including four for the velay-attested path (admitted with proof, spoofed headers refused, incomplete attestation falls through, ignored off-platform). 11 on the stream including the held-audio release, the awaited stop, stop idempotence (which caught a second stop frame being sent), and a null final for a session that never went live. 28 Swift. Typecheck across web, macOS and gateway.

**Not verified end to end**: the velay path needs the gateway fix deployed, so on a managed assistant the stream still closes with 1014 until then and the hold uses the local fallback. Verified by hand that the fallback path is fast and now punctuated.

## Open

This branch does not make the local fallback robust to pauses; that is a limitation of `SFSpeechAudioBufferRecognitionRequest`, and once the stream connects it is only a fallback. If it needs to be better on its own, the honest fix is recognising the recorded audio as a file (`SFSpeechURLRecognitionRequest`), which yields one transcript rather than one per utterance.

Part of JARVIS-1702: this is the transport and the authority. Progressive insertion at the cursor remains.