### PR TITLE
feat(design-library): add asChild to Typography via an ElementType slot

### DIFF
--- a/packages/design-library/src/components/typography.render.test.tsx
+++ b/packages/design-library/src/components/typography.render.test.tsx
@@ -110,3 +110,24 @@ describe("Typography asChild", () => {
     expect(html).toContain('data-slot="typography"');
   });
 });
+
+describe("Typography asChild prop precedence", () => {
+  test("a child's own data-slot wins, and the variant class still merges", () => {
+    // Radix Slot gives the child precedence on ordinary props, so composing
+    // Typography around something that already identifies itself keeps the
+    // child's identity. Styling does not depend on the marker: the variant
+    // class merges either way, so only a `[data-slot="typography"]` selector
+    // stops matching. Button and Card compose the same way.
+    const html = renderToStaticMarkup(
+      <Typography asChild variant="body-small-default">
+        <button data-slot="button" className="px-2">
+          Go
+        </button>
+      </Typography>,
+    );
+    expect(html).toContain('data-slot="button"');
+    expect(html).not.toContain('data-slot="typography"');
+    expect(html).toContain("text-body-small-default");
+    expect(html).toContain("px-2");
+  });
+});

--- a/packages/design-library/src/components/typography.render.test.tsx
+++ b/packages/design-library/src/components/typography.render.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Rendering behaviour for the Typography primitive.
+ *
+ * No DOM environment, so these assert the emitted HTML via
+ * `renderToStaticMarkup`, matching `button.test.tsx`.
+ *
+ * `Comp` is annotated `ElementType` rather than left to inference. With a
+ * union of intrinsic tags, JSX intersects the props of every member, so `ref`
+ * resolves to `RefObject<HTMLParagraphElement> & RefObject<HTMLDivElement> &
+ * ...`, which nothing satisfies. `ElementType` is React's type for a
+ * polymorphic slot and does not force that intersection. These tests pin the
+ * runtime behaviour that annotation has to keep correct.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { Typography } from "./typography";
+
+describe("Typography rendering", () => {
+  test("defaults to <span> and carries the variant class and data-slot", () => {
+    const html = renderToStaticMarkup(
+      <Typography variant="body-medium-default">Hello</Typography>,
+    );
+    expect(html).toContain("<span");
+    expect(html).toContain("text-body-medium-default");
+    expect(html).toContain('data-slot="typography"');
+    expect(html).toContain(">Hello</span>");
+  });
+
+  test("renders the tag given by `as`", () => {
+    const html = renderToStaticMarkup(
+      <Typography as="h1" variant="title-large">
+        Page title
+      </Typography>,
+    );
+    expect(html).toContain("<h1");
+    expect(html).toContain("text-title-large");
+  });
+
+  test("composes caller className after the variant class", () => {
+    const html = renderToStaticMarkup(
+      <Typography variant="title-small" className="mt-2">
+        x
+      </Typography>,
+    );
+    const variantAt = html.indexOf("text-title-small");
+    const callerAt = html.indexOf("mt-2");
+    expect(variantAt).toBeGreaterThan(-1);
+    expect(callerAt).toBeGreaterThan(variantAt);
+  });
+
+  test("emits `for` when used as a label with htmlFor", () => {
+    const html = renderToStaticMarkup(
+      <Typography as="label" variant="label-small-default" htmlFor="field">
+        Name
+      </Typography>,
+    );
+    expect(html).toContain("<label");
+    expect(html).toContain('for="field"');
+  });
+});
+
+describe("Typography asChild", () => {
+  test("renders the child element rather than `as`", () => {
+    // The reason asChild exists: <th> is outside TypographyAs, and widening
+    // that union would mean bolting element-specific props onto
+    // TypographyProps one at a time.
+    const html = renderToStaticMarkup(
+      <Typography asChild variant="label-small-default">
+        <th className="px-4 py-2">Source</th>
+      </Typography>,
+    );
+    expect(html.startsWith("<th")).toBe(true);
+    expect(html).toContain("text-label-small-default");
+    expect(html).toContain("px-4 py-2");
+    expect(html).toContain(">Source</th>");
+  });
+
+  test("keeps element-specific child props the props type does not declare", () => {
+    // `href` is not on HTMLAttributes<HTMLElement>; the child keeps its own.
+    const html = renderToStaticMarkup(
+      <Typography asChild variant="body-small-lighter">
+        <a href="/roadmap">Roadmap</a>
+      </Typography>,
+    );
+    expect(html.startsWith("<a")).toBe(true);
+    expect(html).toContain('href="/roadmap"');
+    expect(html).toContain("text-body-small-lighter");
+  });
+
+  test("asChild wins over `as`", () => {
+    const html = renderToStaticMarkup(
+      <Typography asChild as="h1" variant="title-small">
+        <td>cell</td>
+      </Typography>,
+    );
+    expect(html.startsWith("<td")).toBe(true);
+    expect(html).not.toContain("<h1");
+  });
+
+  test("still marks the slotted element with data-slot", () => {
+    const html = renderToStaticMarkup(
+      <Typography asChild variant="body-small-default">
+        <button type="submit">Go</button>
+      </Typography>,
+    );
+    expect(html.startsWith("<button")).toBe(true);
+    expect(html).toContain('type="submit"');
+    expect(html).toContain('data-slot="typography"');
+  });
+});

--- a/packages/design-library/src/components/typography.stories.tsx
+++ b/packages/design-library/src/components/typography.stories.tsx
@@ -29,6 +29,10 @@ const meta: Meta<typeof Typography> = {
       control: "select",
       options: ["span", "p", "div", "label", "h1", "h2", "h3", "h4", "h5", "h6"],
     },
+    // Slot prop: toggling it against string `children` leaves Radix nothing
+    // to clone and blanks the canvas. Demonstrated by the AsChild story
+    // instead, which supplies a real element.
+    asChild: { control: false },
   },
 };
 
@@ -80,5 +84,14 @@ export const AllVariants: Story = {
         </Typography>
       ))}
     </div>
+  ),
+};
+
+export const AsChild: Story = {
+  args: { variant: "label-small-default" },
+  render: (args) => (
+    <Typography {...args} asChild>
+      <th className="px-4 py-2 text-left">Source</th>
+    </Typography>
   ),
 };

--- a/packages/design-library/src/components/typography.tsx
+++ b/packages/design-library/src/components/typography.tsx
@@ -1,5 +1,6 @@
+import { Slot } from "@radix-ui/react-slot";
 import {
-  createElement,
+  type ElementType,
   type HTMLAttributes,
   type ReactNode,
   type Ref,
@@ -57,6 +58,7 @@ export interface TypographyProps extends HTMLAttributes<HTMLElement> {
   children?: ReactNode;
   htmlFor?: string;
   ref?: Ref<HTMLElement>;
+  asChild?: boolean;
 }
 
 export function Typography({
@@ -65,16 +67,18 @@ export function Typography({
   className,
   children,
   ref,
+  asChild = false,
   ...rest
 }: TypographyProps) {
-  return createElement(
-    as,
-    {
-      ...rest,
-      ref,
-      "data-slot": "typography",
-      className: cn(VARIANT_CLASS[variant], className),
-    },
-    children,
+  const Comp: ElementType = asChild ? Slot : as;
+  return (
+    <Comp
+      {...rest}
+      ref={ref}
+      data-slot="typography"
+      className={cn(VARIANT_CLASS[variant], className)}
+    >
+      {children}
+    </Comp>
   );
 }

--- a/packages/design-library/src/components/typography.tsx
+++ b/packages/design-library/src/components/typography.tsx
@@ -58,6 +58,21 @@ export interface TypographyProps extends HTMLAttributes<HTMLElement> {
   children?: ReactNode;
   htmlFor?: string;
   ref?: Ref<HTMLElement>;
+  /**
+   * Render the single child element instead of `as`, merging the variant
+   * class onto it. For elements outside `TypographyAs`, such as `<th>`,
+   * `<td>`, `<a href>` or `<button type>`, whose own props cannot be added
+   * to `HTMLAttributes<HTMLElement>` one at a time. Uses Radix's `Slot`,
+   * matching `Button` and `Card`.
+   *
+   * `children` must be a single React element: Slot calls `Children.only`
+   * and throws on multiple children, and a plain string renders nothing.
+   *
+   * Slot gives the child precedence on ordinary props, so a child that sets
+   * its own `data-slot` keeps it and this component's marker does not apply.
+   * The variant class still merges either way, so styling is unaffected and
+   * only a `[data-slot="typography"]` selector stops matching.
+   */
   asChild?: boolean;
 }
 


### PR DESCRIPTION
Part of LUM-3507.

## What a person hits today

Styling text on a `<th>`, `<td>`, `<a href>` or `<button type>` has no typed path. `TypographyAs` covers `span`, `p`, `div`, `label` and `h1`-`h6`, so anything else means writing the class by hand:

```tsx
<th className="px-4 py-2 text-label-small-default">Source</th>
```

That string is unchecked at the point of use. Get the name slightly wrong and it matches **no CSS at all**, so the element silently inherits 16px/400 and ships looking plausible.

That is not hypothetical. It happened **285 times** across the two repos, and 64 of the platform cases were exactly this shape: a `<th>` that could not be a `<Typography>`. Users saw admin table headers rendering larger than the captions beneath them, and inspector labels at body size, on pages that had no visual hierarchy at all because every class on them was inert.

## Before and after

| | before | after |
| -- | -- | -- |
| Styling a `<th>` | hand-written class string, unchecked at the call site | `<Typography asChild variant="…">` around it |
| A wrong variant name | matches no CSS, renders at inherited 16px/400, ships | compile error in the editor |
| The child's own props (`href`, `colSpan`, `type`) | keep working, but nothing types the text style | keep working, and the text style is typed |

**211 elements** in `clients/web` sit outside `TypographyAs` today and carry a scale class: 88 `<button>`, 22 `<pre>`, 12 `<th>`, 11 `<code>`, plus `li`, `a`, `Link`, `select`, `table`. Every one of those is currently on the unchecked path. This gives all of them a checked one.

## Being straight about the scope of the win

**This PR changes nothing a user sees today.** No call site uses `asChild` yet. Its value is closing the last structural gap that let those 285 classes accumulate, so the next person styling a `<th>` has an option that fails at compile time instead of silently at runtime.

It is also **not** the only guard any more. The lint rule shipped in #10263 and #41908 already rejects unknown variant names at CI. This moves the same check earlier, into the editor and the type system, and lets the component be used consistently rather than only on the elements it happens to support. Defence in depth plus consistency, not a rescue.

Converting the 211 call sites is deliberately separate. It is 211 hand-checked JSX changes, and a scripted attempt during #41908 produced broken JSX in 4 files and missing imports in 19, so it needs its own reviewed pass.

## Why this way, and not the obvious way

`Typography` renders through `createElement(as, ...)` rather than JSX. That looked like an oddity worth tidying, so I tried, and **it is load bearing**.

With a union of intrinsic tags, JSX intersects the props of every member. `ref` resolves to `RefObject<HTMLParagraphElement> & RefObject<HTMLDivElement> & RefObject<HTMLHeadingElement> & ...`, which nothing satisfies:

> `Type 'RefObject<HTMLElement | null>' is not assignable to ...`
> `Property 'align' is missing in type 'HTMLElement' but required in type 'HTMLParagraphElement'`

`createElement`'s string tag overload does not force that intersection, so it is what makes a polymorphic `as` typecheck at all. `Button` and `Card` use JSX only because they render a **fixed** tag, so the question never arises for them. The original choice was correct and stays intact in spirit.

What blocks `asChild` specifically: adding `Slot` to the union makes TypeScript resolve `createElement`'s `SlotProps` overload, which declares no `data-slot` and has no index signature for `data-*`, so the slot marker this package requires on every root is rejected.

Annotating the slot as React's `ElementType` avoids the intersection while allowing JSX, which then accepts `data-slot`:

```tsx
const Comp: ElementType = asChild ? Slot : as;
return <Comp {...rest} ref={ref} data-slot="typography" className={cn(...)}>{children}</Comp>;
```

`ElementType` is React's own type for a polymorphic slot. It is an annotation, not a cast. `TypographyProps` is unchanged, so nothing about the public API loosens; the looseness is confined to this one render call.

Rejected alternatives: casting `Comp` (a cast is a question, not an answer), dropping `data-slot` on the `asChild` path (breaks the package's own convention), and widening `TypographyAs` (means bolting `href`, `type`, `colSpan` onto `HTMLAttributes<HTMLElement>` one prop at a time, which is how `htmlFor` already got there).

## Why it is safe

- **Additive.** `asChild` defaults to `false`, and the non-`asChild` path renders exactly what it did before, pinned by four tests.
- **All existing call sites still compile.** `packages/design-library` and `clients/web` both typecheck clean, covering **362** `<Typography>` usages.
- Lint 0 errors, 15 pre-existing warnings unchanged.
- 13 tests pass: the 4 drift tests plus 9 render tests. Sensitivity checked by pinning the slot to `as`, which fails four of them.
- **Verified in the browser, not just the type checker.** The `AsChild` story renders `<th class="text-label-small-default px-4 py-2 text-left" data-slot="typography">` at a computed 10px/500. The element survives, the variant class applies, the child's own classes are preserved, and the slot marker lands.

## Review findings, all verified before acting

- **Storybook control** (Codex): a boolean prop auto-infers a toggle, and the `Default` story passes `children` as a string, so flipping it leaves Slot nothing to clone and blanks the canvas. `AGENTS.md` rule 4 already requires `control: false` for slot props. Disabled, with an element-backed `AsChild` story instead.
- **`data-slot` precedence** (Devin): measured both ways. A child carrying its own `data-slot` keeps it, but the variant class merges regardless, so styling is unaffected and only a `[data-slot="typography"]` selector stops matching. Not "fixed" on purpose: forcing this component's marker to win would erase the child's identity, and `Button` and `Card` compose identically. Documented and pinned by a test.
- **Single-element contract** (Devin): `Button` documents it, `Typography` did not. Mirrored, since Slot calls `Children.only` and a plain string renders nothing.

## Noted, deliberately unchanged

`skeleton.tsx` carries the identical `createElement(as, ...)` construct for the same reason and is correct as it stands. It would need the same `ElementType` treatment only if it ever takes an `asChild`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
