### PR TITLE
Payment modal: enable Stripe Link autofill in add and replace

### DIFF
--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
@@ -305,11 +305,11 @@ describe("AutoTopUpPaymentMethodModal Stripe element options", () => {
     });
   });
 
-  test("suppresses every wallet and asks for no email when the account has one", async () => {
+  test("offers Link, suppresses the other wallets, and asks for no email when the account has one", async () => {
     await renderModalWithForm();
 
     expect(paymentElementProps?.options?.wallets).toEqual({
-      link: "never",
+      link: "auto",
       applePay: "never",
       googlePay: "never",
     });

--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -562,12 +562,17 @@ function SetupCardForm({
         }
         options={{
           layout: { type: "tabs", defaultCollapsed: false },
-          wallets: { link: "never", applePay: "never", googlePay: "never" },
-          // The Address Element below owns the billing address (so the saved
-          // PM carries billing_details.address for tax) and unconditionally
-          // collects a name; suppress the Payment Element's own name and
-          // address inputs to avoid duplicate fields. Email stays here, and
-          // only when the account does not already know it.
+          // Link rides in the card form as a wallet; the SetupIntent stays
+          // card-only, so saved PaymentMethods keep a `card` type with a real
+          // brand and last4.
+          wallets: { link: "auto", applePay: "never", googlePay: "never" },
+          // The Address Element below owns the billing address (the saved PM
+          // needs it for tax) and always collects a name, so both are
+          // suppressed here. Email is asked for only when the account does
+          // not already know it, since Link's banner carries its own email
+          // entry; `defaultValues` is deliberately not passed, because a
+          // member email there would mount an OTP takeover ahead of the card
+          // fields (revisit separately).
           fields: {
             billingDetails: {
               name: "never",


### PR DESCRIPTION
## Summary
- Flips the payment element wallet config to link: auto (Apple/Google Pay stay suppressed) in both add and replace flows
- SetupIntent stays card-only; email handling and the skeleton loading contract are untouched

Part of plan: payment-modal-link-passthrough.md (PR 2 of 2)