### PR TITLE
fix(assistant): accept the boolean form of the assistant-initiated-threads flag

### DIFF
--- a/assistant/src/config/__tests__/assistant-initiated-threads-gate.test.ts
+++ b/assistant/src/config/__tests__/assistant-initiated-threads-gate.test.ts
@@ -1,0 +1,61 @@
+/**
+ * The gate reads a string-valued flag that does not always arrive as a
+ * string.
+ *
+ * The registry and the gateway's persisted store carry the declared `"on"` /
+ * `"off"` strings. The gateway's env-override path does not: its parser
+ * (`feature-flag-env-overrides.ts`) treats `on` as a truthy *word* and
+ * coerces it to boolean `true`, then applies env overrides last — so
+ * `VELLUM_FLAG_ASSISTANT_INITIATED_THREADS=on` reaches the daemon as `true`.
+ *
+ * A strict `=== "on"` therefore read the documented env kill-switch as OFF,
+ * and did it silently: the section just never rendered. That shipped in the
+ * first cut of this gate and cost an afternoon of QA, which is why both
+ * shapes are pinned here rather than only the one the registry emits.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+let flagValue: boolean | string = "off";
+
+mock.module("../assistant-feature-flags.js", () => ({
+  getAssistantFeatureFlagValue: () => flagValue,
+}));
+
+const { isAssistantInitiatedThreadsEnabled } = await import(
+  "../assistant-initiated-threads-gate.js"
+);
+
+afterEach(() => {
+  flagValue = "off";
+});
+
+describe("isAssistantInitiatedThreadsEnabled", () => {
+  test('enabled by the declared string "on" (registry / persisted store)', () => {
+    flagValue = "on";
+    expect(isAssistantInitiatedThreadsEnabled()).toBe(true);
+  });
+
+  test("enabled by boolean true (the gateway's env-override coercion)", () => {
+    // The regression. `VELLUM_FLAG_ASSISTANT_INITIATED_THREADS=on` arrives
+    // here as `true`, never as "on".
+    flagValue = true;
+    expect(isAssistantInitiatedThreadsEnabled()).toBe(true);
+  });
+
+  test('disabled by the declared string "off"', () => {
+    flagValue = "off";
+    expect(isAssistantInitiatedThreadsEnabled()).toBe(false);
+  });
+
+  test("disabled by boolean false (env `=off` coercion)", () => {
+    flagValue = false;
+    expect(isAssistantInitiatedThreadsEnabled()).toBe(false);
+  });
+
+  test("fails closed on an unrecognized arm", () => {
+    // A future A/B value this gate has no opinion about must not read as on.
+    flagValue = "variant-b";
+    expect(isAssistantInitiatedThreadsEnabled()).toBe(false);
+  });
+});

--- a/assistant/src/config/assistant-initiated-threads-gate.ts
+++ b/assistant/src/config/assistant-initiated-threads-gate.ts
@@ -29,10 +29,22 @@ const ASSISTANT_INITIATED_THREADS_FLAG_KEY =
 export function isAssistantInitiatedThreadsEnabled(
   config?: AssistantConfig,
 ): boolean {
-  return (
-    getAssistantFeatureFlagValue(
-      ASSISTANT_INITIATED_THREADS_FLAG_KEY,
-      config,
-    ) === "on"
+  const value = getAssistantFeatureFlagValue(
+    ASSISTANT_INITIATED_THREADS_FLAG_KEY,
+    config,
   );
+  /* Both shapes are the same answer, and the on arm arrives as either one
+     depending on which layer resolved it.
+
+     The registry and the gateway's persisted store carry the declared string
+     (`"on"`). The gateway's env-override path does not: its parser treats
+     `on` as a truthy word (`TRUTHY = {"true","1","yes","on"}` in
+     `feature-flag-env-overrides.ts`) and coerces it to boolean `true`, then
+     applies env last — so `VELLUM_FLAG_ASSISTANT_INITIATED_THREADS=on`
+     reaches the daemon as `true`, not `"on"`.
+
+     A strict `=== "on"` therefore reads the env kill-switch as OFF, which is
+     the exact opposite of what an operator setting it intends, and it fails
+     silently: the section simply does not render. Accept both. */
+  return value === true || value === "on";
 }


### PR DESCRIPTION
## Summary

The gate compared strictly against the declared string `"on"`. The gateway's env-override parser treats `on` as a truthy *word* (`TRUTHY = {"true","1","yes","on"}` in `feature-flag-env-overrides.ts`) and coerces it to boolean `true`, then applies env overrides **last** in `getMergedFeatureFlags()`. So `VELLUM_FLAG_ASSISTANT_INITIATED_THREADS=on` — the documented kill switch — arrived as `true` and the gate read it as **off**.

Fails silently: the section just does not render, which is indistinguishable from the feature being broken.

The gate now accepts `true` or `"on"`, and still fails closed on any unrecognized arm. 5 regression tests pin all four shapes plus the fail-closed case.

## How it was found

Local QA, where it presented as the flag "intermittently reverting". It only ever worked while the gateway was unreachable and the daemon fell back to its own bundled registry — which *does* carry the string. Once the gateway answered, the boolean won and the section vanished.

Confirmed by asking the gateway directly, over the same IPC call the daemon makes at startup:

```
gateway returned 22 flags
assistant-initiated-threads = true
```

## Worth noting for other flags

Any string-valued flag gated with `=== "on"` has this bug the moment someone uses the env override. `use-vision-mode-flag.ts` and `use-proactive-tips-flag.ts` follow the same shape client-side — they read from a different store so this parser does not reach them today, but the pattern is worth a look if env overrides ever reach the client.

## Operability follow-up

Nothing logs which layer a flag value came from, so a wrong value is invisible. A one-line startup log (`flag X = <value> (from persisted|remote|registry|env)`) would have turned an afternoon of guessing into a two-minute answer. Not in this PR; worth doing.
