### PR TITLE
fix: consolidate catalog lookups in the core and right-size the drift pins

### DIFF
--- a/clients/ios/scripts/__tests__/android-avatar-icons.test.ts
+++ b/clients/ios/scripts/__tests__/android-avatar-icons.test.ts
@@ -30,9 +30,10 @@ import {
 } from "../../../../packages/avatar-catalog/src/index.js";
 import {
   androidResourceNameForTraits,
+  assertUnderscoreSafeIds,
   eyeArtworkBounds,
+  requireEyeStyle,
   traitCombinations,
-  type EyeStyle,
   type IconSetScope,
 } from "../avatar-icon-core.js";
 import {
@@ -84,9 +85,6 @@ const EXPECTED_ICON_ALIAS_COUNT = 54;
 /** The launcher entry at rest, drawn with the default launcher artwork. */
 const PRIMARY_ALIAS_NAME = ".icon.primary";
 
-/** Deep-link filters `.MainActivity` is the sole receiver of. */
-const EXPECTED_DEEP_LINK_FILTER_COUNT = 6;
-
 const LAUNCHER_ACTION = '<action android:name="android.intent.action.MAIN" />';
 const LAUNCHER_CATEGORY =
   '<category android:name="android.intent.category.LAUNCHER" />';
@@ -103,16 +101,6 @@ afterAll(() => {
 
 function readCommitted(relativePath: string): string {
   return readFileSync(join(ANDROID_RES_DIR, relativePath), "utf8");
-}
-
-function requireEyeStyle(eyeStyleId: string): EyeStyle {
-  const eyeStyle = getCharacterComponents().eyeStyles.find(
-    (eye) => eye.id === eyeStyleId,
-  );
-  if (!eyeStyle) {
-    throw new Error(`Eye style "${eyeStyleId}" missing from the catalog`);
-  }
-  return eyeStyle;
 }
 
 /**
@@ -300,6 +288,28 @@ function generateFresh(): FreshGeneration {
   freshGeneration = { resDir, manifestPath };
   return freshGeneration;
 }
+
+describe("androidResourceNameForTraits", () => {
+  /**
+   * Android resource names admit underscores rather than dashes, so this is the
+   * wire name with every separator swapped. The literal is pinned because a
+   * drawable that changes name stops resolving from the manifest entry that
+   * references it.
+   */
+  test("builds the avatar_eyes_<eye>_<color> resource name", () => {
+    expect(
+      androidResourceNameForTraits({
+        eyeStyle: "grumpy",
+        color: "green",
+      }),
+    ).toBe("avatar_eyes_grumpy_green");
+  });
+
+  /** Whole-string dash to underscore translation only round-trips while this holds. */
+  test("accepts every id in the current library", () => {
+    expect(() => assertUnderscoreSafeIds()).not.toThrow();
+  });
+});
 
 describe("committed Android avatar icons", () => {
   test(
@@ -618,11 +628,6 @@ describe("MainActivity", () => {
   test("stays the always-enabled target the generator never touches", () => {
     expect(attribute(mainActivity, "name")).toBe(".MainActivity");
     expect(attribute(mainActivity, "exported")).toBe("true");
-    expect(attribute(mainActivity, "launchMode")).toBe("singleTask");
-    expect(attribute(mainActivity, "label")).toBe("@string/app_name");
-    expect(attribute(mainActivity, "theme")).toBe(
-      "@style/AppTheme.NoActionBarLaunch",
-    );
     expect(openingTagOf(mainActivity)).not.toContain("android:enabled");
   });
 
@@ -637,12 +642,18 @@ describe("MainActivity", () => {
     ).toHaveLength(0);
   });
 
-  test("keeps every deep-link filter", () => {
+  /**
+   * The aliases carry no VIEW filter, so deep links resolve through
+   * `.MainActivity` alone and it has to keep at least one. How many it declares
+   * is a deep-link concern rather than an icon one, and the generator itself
+   * only enforces that they are still there.
+   */
+  test("keeps its deep-link filters", () => {
     expect(
       intentFiltersOf(mainActivity).filter((filter) =>
         filter.includes(VIEW_ACTION),
-      ),
-    ).toHaveLength(EXPECTED_DEEP_LINK_FILTER_COUNT);
+      ).length,
+    ).toBeGreaterThan(0);
   });
 
   test("keeps the static shortcuts meta-data", () => {

--- a/clients/ios/scripts/__tests__/generate-avatar-icons.test.ts
+++ b/clients/ios/scripts/__tests__/generate-avatar-icons.test.ts
@@ -26,16 +26,14 @@ import { join } from "node:path";
 import { inflateSync } from "node:zlib";
 
 import {
-  androidResourceNameForTraits,
-  assertUnderscoreSafeIds,
+  iconNameForTraits,
+  traitCombinations,
+  type IconSetScope,
 } from "../avatar-icon-core.js";
 import {
   AVATAR_ICONS_DIR,
   AVATAR_ICONS_XCCONFIG_PATH,
   generateAvatarIcons,
-  iconNameForTraits,
-  traitCombinations,
-  type IconSetScope,
 } from "../generate-avatar-icons.js";
 
 /** Scope of the catalog checked into the repo. Narrowing it is a code change. */
@@ -297,28 +295,6 @@ describe("iconNameForTraits", () => {
     },
     GENERATION_TIMEOUT_MS,
   );
-});
-
-describe("androidResourceNameForTraits", () => {
-  /**
-   * Android resource names admit underscores rather than dashes, so this is the
-   * wire name with every separator swapped. The literal is pinned because a
-   * drawable that changes name stops resolving from the manifest entry that
-   * references it.
-   */
-  test("builds the avatar_eyes_<eye>_<color> resource name", () => {
-    expect(
-      androidResourceNameForTraits({
-        eyeStyle: "grumpy",
-        color: "green",
-      }),
-    ).toBe("avatar_eyes_grumpy_green");
-  });
-
-  /** Whole-string dash to underscore translation only round-trips while this holds. */
-  test("accepts every id in the current library", () => {
-    expect(() => assertUnderscoreSafeIds()).not.toThrow();
-  });
 });
 
 describe("generateAvatarIcons", () => {

--- a/clients/ios/scripts/avatar-icon-core.ts
+++ b/clients/ios/scripts/avatar-icon-core.ts
@@ -44,6 +44,9 @@ const EYE_BOUNDS_PROBE_PX = 2048;
  */
 const PILOT_EYE_STYLES = ["grumpy", "gentle"];
 
+/** Every color in the palette is a 6-digit sRGB hex, and goes straight to markup. */
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
 export type IconSetScope = "pilot" | "full";
 
 export interface AvatarIconTraits {
@@ -144,6 +147,48 @@ function assertKnownIds(
     }
   }
   return requested;
+}
+
+/** The eye style an id names, or a throw listing the ids the library defines. */
+export function requireEyeStyle(eyeStyleId: string): EyeStyle {
+  const components = getCharacterComponents();
+  const eyeStyle = components.eyeStyles.find((eye) => eye.id === eyeStyleId);
+  if (!eyeStyle) {
+    throw new Error(
+      `Unknown eye style: "${eyeStyleId}". Valid IDs: ${components.eyeStyles
+        .map((eye) => eye.id)
+        .join(", ")}`,
+    );
+  }
+  return eyeStyle;
+}
+
+/** Color id to hex, for the field every platform draws its icons on. */
+export function colorHexIndex(): Map<string, string> {
+  return new Map(
+    getCharacterComponents().colors.map((color) => [color.id, color.hex]),
+  );
+}
+
+/**
+ * The hex a color id names. Every platform interpolates it straight into markup
+ * it emits, so anything that is not a 6-digit hex is rejected here rather than
+ * written into an icon.
+ */
+export function requireColorHex(
+  index: Map<string, string>,
+  colorId: string,
+): string {
+  const hex = index.get(colorId);
+  if (!hex) {
+    throw new Error(`Unknown color id: "${colorId}"`);
+  }
+  if (!HEX_COLOR_PATTERN.test(hex)) {
+    throw new Error(
+      `Expected a 6-digit hex color for "${colorId}", got "${hex}"`,
+    );
+  }
+  return hex;
 }
 
 /** An eye style's paths, verbatim, under one shared affine transform. */

--- a/clients/ios/scripts/generate-android-avatar-icons.ts
+++ b/clients/ios/scripts/generate-android-avatar-icons.ts
@@ -66,8 +66,11 @@ import {
 } from "../../../packages/avatar-catalog/src/index.js";
 import {
   androidResourceNameForTraits,
+  colorHexIndex,
   eyeArtworkBounds,
   eyeSpanFraction,
+  requireColorHex,
+  requireEyeStyle,
   traitCombinations,
   type AvatarIconTraits,
   type EyeStyle,
@@ -252,33 +255,6 @@ export function generateAndroidAvatarIcons(
 
 function uniqueEyeStyleIds(combinations: AvatarIconTraits[]): string[] {
   return [...new Set(combinations.map((traits) => traits.eyeStyle))];
-}
-
-function colorHexIndex(): Map<string, string> {
-  return new Map(
-    getCharacterComponents().colors.map((color) => [color.id, color.hex]),
-  );
-}
-
-function requireColorHex(index: Map<string, string>, colorId: string): string {
-  const hex = index.get(colorId);
-  if (!hex) {
-    throw new Error(`Unknown color id: "${colorId}"`);
-  }
-  return hex;
-}
-
-function requireEyeStyle(eyeStyleId: string): EyeStyle {
-  const components = getCharacterComponents();
-  const eyeStyle = components.eyeStyles.find((eye) => eye.id === eyeStyleId);
-  if (!eyeStyle) {
-    throw new Error(
-      `Unknown eye style: "${eyeStyleId}". Valid IDs: ${components.eyeStyles
-        .map((eye) => eye.id)
-        .join(", ")}`,
-    );
-  }
-  return eyeStyle;
 }
 
 /**

--- a/clients/ios/scripts/generate-avatar-icons.ts
+++ b/clients/ios/scripts/generate-avatar-icons.ts
@@ -37,19 +37,14 @@ import { deflateSync } from "node:zlib";
 
 import { getCharacterComponents } from "../../../packages/avatar-catalog/src/index.js";
 import {
+  colorHexIndex,
   eyeArtworkBounds,
   eyePathsSvg,
   eyeSpanFraction,
   iconNameForTraits,
   renderSvg,
-  traitCombinations,
-  type AvatarIconTraits,
-  type EyeStyle,
-  type IconSetScope,
-} from "./avatar-icon-core.js";
-
-export {
-  iconNameForTraits,
+  requireColorHex,
+  requireEyeStyle,
   traitCombinations,
   type AvatarIconTraits,
   type IconSetScope,
@@ -107,9 +102,6 @@ const CATALOG_INFO = { author: "xcode", version: 1 };
  */
 const CONTACT_SHEET_CELL_PX = 180;
 
-/** Every color in the palette is a 6-digit sRGB hex, and goes straight to SVG. */
-const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
-
 export interface GenerateAvatarIconsOptions {
   iconsDir: string;
   xcconfigPath: string;
@@ -145,38 +137,6 @@ export function generateAvatarIcons(
   writeFileSync(options.xcconfigPath, buildXcconfig());
 
   return names;
-}
-
-function colorHexIndex(): Map<string, string> {
-  return new Map(
-    getCharacterComponents().colors.map((color) => [color.id, color.hex]),
-  );
-}
-
-function requireColorHex(index: Map<string, string>, colorId: string): string {
-  const hex = index.get(colorId);
-  if (!hex) {
-    throw new Error(`Unknown color id: "${colorId}"`);
-  }
-  if (!HEX_COLOR_PATTERN.test(hex)) {
-    throw new Error(
-      `Expected a 6-digit hex color for "${colorId}", got "${hex}"`,
-    );
-  }
-  return hex;
-}
-
-function requireEyeStyle(eyeStyleId: string): EyeStyle {
-  const components = getCharacterComponents();
-  const eyeStyle = components.eyeStyles.find((eye) => eye.id === eyeStyleId);
-  if (!eyeStyle) {
-    throw new Error(
-      `Unknown eye style: "${eyeStyleId}". Valid IDs: ${components.eyeStyles
-        .map((eye) => eye.id)
-        .join(", ")}`,
-    );
-  }
-  return eyeStyle;
 }
 
 /** Catalog root marker, matching what Xcode writes for `Assets.xcassets`. */


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for android-avatar-app-icons.md.

**Gap:** requireEyeStyle/colorHexIndex/requireColorHex duplicated across both generators with hex validation only on iOS; a redundant re-export block; icon drift tests pinning non-icon MainActivity facts; core naming tests in the wrong file
**Fix:** helpers live once in avatar-icon-core with validation for both platforms, the re-export block is gone, the drift test pins only icon-relevant invariants, and the naming tests moved next to the Android suite