### PR TITLE
fix: gate set below API 26 and scope alias enumeration to avatar icons

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -126,7 +126,10 @@ toggle lands, `getState` reports the recorded target as `current`, so the web
 layer's re-read after an apply sees the icon it asked for. An apply enables the
 target before disabling the others and clears the record last, so no launcher
 sees the app with every launcher component off, and an interrupted pass is
-retried rather than half kept.
+retried rather than half kept. It reads its alias set off the manifest and takes
+`.icon.primary` plus the `.icon.avatar_eyes_*` alternates only, so an activity
+that lands in the `.icon.` namespace for anything else is neither offered in
+`available` nor toggled by an apply.
 
 `load()` runs that same apply before the activity resumes, so a process death
 between `set` and the next background never strands a recorded target. It then
@@ -146,7 +149,9 @@ on every run.
 
 `getState` reports `supported: true` only on API 26 or newer with at least one
 alternate present. `minSdkVersion` is 24, so an API 24 or 25 device answers
-`supported: false` and the picker draws nothing.
+`supported: false` and the picker draws nothing. `set` applies the same version
+check and resolves `{ok: false, error}` below it, so a caller that skipped
+`supported` cannot leave a target behind for the next background to toggle.
 
 Alternates read at the size of the default launcher icon sitting next to them in
 the picker. Each pair is fitted by the longer edge of its measured artwork

--- a/clients/android/app/src/main/java/ai/vellum/assistant/AppIconPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/AppIconPlugin.java
@@ -27,13 +27,15 @@ import java.util.Map;
  * and {@code set} resolves {@code {ok}} plus an {@code error} when it refuses.
  *
  * Android reads the launcher icon off whichever launcher component is enabled,
- * so an icon swap enables one generated {@code ai.vellum.assistant.icon.*}
- * {@code <activity-alias>} and disables the rest. Only aliases are ever
- * toggled: {@code MainActivity} carries the deep links and the shortcuts
- * source, and stays enabled so shortcuts, the voice notification, and the Quick
- * Settings tile resolve in every icon state. The primary alias is the default
- * artwork rather than a pickable icon, so it is absent from {@code available}
- * and reads back as a null {@code current}.
+ * so an icon swap enables one {@code <activity-alias>} and disables the rest.
+ * The only components ever toggled are the primary alias and the generated
+ * {@code ai.vellum.assistant.icon.avatar_eyes_*} alternates:
+ * {@code MainActivity} carries the deep links and the shortcuts source, and
+ * stays enabled so shortcuts, the voice notification, and the Quick Settings
+ * tile resolve in every icon state, and any other activity that lands in the
+ * {@code ai.vellum.assistant.icon.} namespace is left alone. The primary alias
+ * is the default artwork rather than a pickable icon, so it is absent from
+ * {@code available} and reads back as a null {@code current}.
  *
  * Enabled-state scheme: the primary alias sits at
  * {@code COMPONENT_ENABLED_STATE_DEFAULT}, which the manifest defines as
@@ -60,7 +62,8 @@ import java.util.Map;
  * Per the skew rule in {@code clients/web/docs/CAPACITOR.md}, one result shape
  * encodes every state and neither method rejects: a device or build with no
  * alternates resolves {@code supported: false} with an empty {@code available},
- * and a name this build cannot draw resolves {@code {ok: false, error}}.
+ * and a platform below API 26 or a name this build cannot draw resolves
+ * {@code {ok: false, error}}.
  */
 @CapacitorPlugin(name = "AppIcon")
 public class AppIconPlugin extends Plugin {
@@ -70,7 +73,16 @@ public class AppIconPlugin extends Plugin {
     /** The launcher entry drawn with the default artwork. Not a wire icon. */
     static final String PRIMARY_ALIAS = ALIAS_PREFIX + "primary";
 
+    /**
+     * Class-name prefix every pickable alternate carries. The namespace is
+     * wider than the icon set, so matching the generated prefix rather than the
+     * namespace keeps an alias added for anything else out of
+     * {@code available} and out of the toggles an apply performs.
+     */
+    static final String ALTERNATE_PREFIX = ALIAS_PREFIX + "avatar_eyes_";
+
     private static final String UNKNOWN_ICON_ERROR = "unknown app icon";
+    private static final String UNSUPPORTED_ERROR = "app icons need API 26";
     private static final String PREFERENCES = "app_icon";
     private static final String PENDING_ALIAS_KEY = "pending_alias";
     private static final String FAILURE_CODE = "APP_ICON_FAILED";
@@ -91,7 +103,7 @@ public class AppIconPlugin extends Plugin {
             List<String> available = wireNames(aliases);
             call.resolve(
                 statePayload(
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !available.isEmpty(),
+                    supportsAlternateIcons(Build.VERSION.SDK_INT) && !available.isEmpty(),
                     currentWireName(pendingAlias(), enabledAlternateAlias(aliases)),
                     available
                 )
@@ -103,8 +115,9 @@ public class AppIconPlugin extends Plugin {
     public void set(PluginCall call) {
         NativeFailureGuard.call(call, FAILURE_MESSAGE, FAILURE_CODE, () -> {
             String target = targetAlias(call.getString("name"), aliasClassNames());
-            if (target == null) {
-                call.resolve(new JSObject().put("ok", false).put("error", UNKNOWN_ICON_ERROR));
+            String refusal = setRefusal(Build.VERSION.SDK_INT, target);
+            if (refusal != null) {
+                call.resolve(new JSObject().put("ok", false).put("error", refusal));
                 return;
             }
             preferences().edit().putString(PENDING_ALIAS_KEY, target).apply();
@@ -118,15 +131,39 @@ public class AppIconPlugin extends Plugin {
     }
 
     /**
+     * Whether the platform is offered the icon picker at all. The picker is
+     * API 26 and newer while {@code minSdkVersion} is 24, so both methods give
+     * the API 24 and 25 devices a build admits the same answer.
+     */
+    static boolean supportsAlternateIcons(int sdkInt) {
+        return sdkInt >= Build.VERSION_CODES.O;
+    }
+
+    /**
+     * Why {@code set} refuses to record an alias target, or null when it takes
+     * it. The platform check comes first, so a caller that skipped
+     * {@code supported} is refused rather than leaving a target behind that the
+     * next background would toggle onto an API 24 or 25 launcher.
+     */
+    static String setRefusal(int sdkInt, String target) {
+        if (!supportsAlternateIcons(sdkInt)) {
+            return UNSUPPORTED_ERROR;
+        }
+        return target == null ? UNKNOWN_ICON_ERROR : null;
+    }
+
+    /**
      * The wire name an alias class name stands for, or null when the class is
-     * not an alternate icon alias. The suffix is the wire name with every dash
+     * not an alternate icon alias. Only the generated {@code avatar_eyes_}
+     * aliases are alternates, so the primary alias and anything else sharing
+     * the namespace read as null. The suffix is the wire name with every dash
      * replaced by an underscore, so the reverse is a whole-string swap.
      */
     static String wireNameForAlias(String aliasClassName) {
         if (
             aliasClassName == null ||
-            !aliasClassName.startsWith(ALIAS_PREFIX) ||
-            PRIMARY_ALIAS.equals(aliasClassName)
+            !aliasClassName.startsWith(ALTERNATE_PREFIX) ||
+            aliasClassName.length() == ALTERNATE_PREFIX.length()
         ) {
             return null;
         }
@@ -135,14 +172,25 @@ public class AppIconPlugin extends Plugin {
 
     /**
      * The alias class name a wire name stands for, or null when the name cannot
-     * name an alternate. The primary alias is not addressable this way.
+     * name an alternate. The result is put back through
+     * {@link #wireNameForAlias(String)}, so the two are exact inverses and the
+     * primary alias stays unaddressable this way.
      */
     static String aliasForWireName(String wireName) {
         if (wireName == null || wireName.isEmpty()) {
             return null;
         }
         String alias = ALIAS_PREFIX + wireName.replace('-', '_');
-        return PRIMARY_ALIAS.equals(alias) ? null : alias;
+        return wireNameForAlias(alias) == null ? null : alias;
+    }
+
+    /**
+     * Whether a declared activity is a launcher alias this plugin owns, which
+     * is the primary alias or one of the generated alternates. Every other
+     * activity is invisible to the plugin, so an apply never toggles it.
+     */
+    static boolean isIconAlias(String activityName) {
+        return PRIMARY_ALIAS.equals(activityName) || wireNameForAlias(activityName) != null;
     }
 
     /** Sorted wire names of the alternates present, primary excluded. */
@@ -224,7 +272,9 @@ public class AppIconPlugin extends Plugin {
 
     /**
      * Every icon alias this build declares, enabled or not, so the disabled
-     * alternates the manifest ships are still discoverable.
+     * alternates the manifest ships are still discoverable. Activities that are
+     * not icon aliases are skipped, which is what keeps them out of
+     * {@code available} and out of the toggles an apply performs.
      */
     private List<String> aliasClassNames() {
         List<String> aliases = new ArrayList<>();
@@ -245,7 +295,7 @@ public class AppIconPlugin extends Plugin {
             return aliases;
         }
         for (ActivityInfo activity : info.activities) {
-            if (activity.name != null && activity.name.startsWith(ALIAS_PREFIX)) {
+            if (isIconAlias(activity.name)) {
                 aliases.add(activity.name);
             }
         }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AppIconPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AppIconPluginTest.java
@@ -8,11 +8,6 @@ import static org.junit.Assert.assertTrue;
 
 import android.content.pm.PackageManager;
 import com.getcapacitor.JSObject;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -37,15 +32,8 @@ public class AppIconPluginTest {
         GOOFY_TEAL_ALIAS
     );
 
-    /**
-     * Candidate locations of the plugin source, so the guard test below finds it
-     * whether the runner starts in the module, the Android project, or the repo.
-     */
-    private static final List<String> SOURCE_PATHS = Arrays.asList(
-        "src/main/java/ai/vellum/assistant/AppIconPlugin.java",
-        "app/src/main/java/ai/vellum/assistant/AppIconPlugin.java",
-        "clients/android/app/src/main/java/ai/vellum/assistant/AppIconPlugin.java"
-    );
+    /** An activity sharing the alias namespace without being an icon alias. */
+    private static final String FOREIGN_ICON_ACTIVITY = "ai.vellum.assistant.icon.IconPickerShim";
 
     @Test
     public void translatesBetweenWireNamesAndAliasClassNames() {
@@ -88,6 +76,26 @@ public class AppIconPluginTest {
         assertEquals(Collections.singletonList(GRUMPY_GREEN), available);
     }
 
+    /**
+     * The alias namespace is wider than the icon set, so an activity that lands
+     * in it without being a generated alternate is neither offered as a
+     * pickable icon nor collected into the set an apply toggles.
+     */
+    @Test
+    public void ignoresActivitiesInTheNamespaceThatAreNotAvatarAliases() {
+        List<String> available = AppIconPlugin.wireNames(
+            Arrays.asList(PRIMARY_ALIAS, FOREIGN_ICON_ACTIVITY, GRUMPY_GREEN_ALIAS)
+        );
+
+        assertEquals(Collections.singletonList(GRUMPY_GREEN), available);
+        assertNull(AppIconPlugin.wireNameForAlias(FOREIGN_ICON_ACTIVITY));
+        assertFalse(AppIconPlugin.isIconAlias(FOREIGN_ICON_ACTIVITY));
+        assertFalse(AppIconPlugin.isIconAlias("ai.vellum.assistant.icon.avatar_eyes_"));
+        assertFalse(AppIconPlugin.isIconAlias(null));
+        assertTrue(AppIconPlugin.isIconAlias(PRIMARY_ALIAS));
+        assertTrue(AppIconPlugin.isIconAlias(GRUMPY_GREEN_ALIAS));
+    }
+
     @Test
     public void aRecordedTargetOutranksTheAliasStillEnabled() {
         assertEquals(GOOFY_TEAL, AppIconPlugin.currentWireName(GOOFY_TEAL_ALIAS, GRUMPY_GREEN_ALIAS));
@@ -110,7 +118,30 @@ public class AppIconPluginTest {
         assertEquals(GRUMPY_GREEN_ALIAS, AppIconPlugin.targetAlias(GRUMPY_GREEN, ALIASES));
         assertNull(AppIconPlugin.targetAlias("avatar-eyes-smitten-chartreuse", ALIASES));
         assertNull(AppIconPlugin.targetAlias("primary", ALIASES));
+        assertNull(AppIconPlugin.targetAlias("IconPickerShim", ALIASES));
         assertNull(AppIconPlugin.targetAlias("", ALIASES));
+    }
+
+    /**
+     * The picker is hidden below API 26, but nothing stops a caller from
+     * skipping that check, so {@code set} refuses instead of recording a target
+     * the next background would toggle onto an API 24 or 25 launcher.
+     */
+    @Test
+    public void refusesToRecordATargetBelowApi26() {
+        assertFalse(AppIconPlugin.supportsAlternateIcons(25));
+        assertEquals("app icons need API 26", AppIconPlugin.setRefusal(25, GRUMPY_GREEN_ALIAS));
+        assertEquals("app icons need API 26", AppIconPlugin.setRefusal(24, PRIMARY_ALIAS));
+        // The platform refusal outranks an unrecognized name.
+        assertEquals("app icons need API 26", AppIconPlugin.setRefusal(25, null));
+    }
+
+    @Test
+    public void refusesNamesNothingInstalledCanDraw() {
+        assertTrue(AppIconPlugin.supportsAlternateIcons(26));
+        assertEquals("unknown app icon", AppIconPlugin.setRefusal(26, null));
+        assertNull(AppIconPlugin.setRefusal(26, GRUMPY_GREEN_ALIAS));
+        assertNull(AppIconPlugin.setRefusal(34, PRIMARY_ALIAS));
     }
 
     @Test
@@ -196,30 +227,20 @@ public class AppIconPluginTest {
 
     /**
      * The launcher icon is swapped by toggling aliases only. Toggling the
-     * activity itself would take the deep links, shortcuts, voice notification,
-     * and Quick Settings tile down with it, so the plugin's code never names it.
+     * activity behind them would take the deep links, the shortcuts, the voice
+     * notification, and the Quick Settings tile down with it, so it is not an
+     * icon alias and never reaches the set an apply toggles.
      */
     @Test
-    public void neverTogglesTheActivityBehindTheAliases() throws IOException {
-        String code = stripComments(readPluginSource());
+    public void theActivityBehindTheAliasesIsNeverAnIconAlias() {
+        String mainActivity = "ai.vellum.assistant.MainActivity";
 
-        assertTrue(code.contains("setComponentEnabledSetting"));
-        assertFalse(code.contains("MainActivity"));
-    }
-
-    private static String readPluginSource() throws IOException {
-        for (String candidate : SOURCE_PATHS) {
-            Path path = Paths.get(candidate);
-            if (Files.exists(path)) {
-                return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
-            }
-        }
-        throw new AssertionError(
-            "Unable to find AppIconPlugin.java from " + Paths.get("").toAbsolutePath()
+        assertFalse(AppIconPlugin.isIconAlias(mainActivity));
+        assertNull(AppIconPlugin.wireNameForAlias(mainActivity));
+        assertNull(AppIconPlugin.aliasForWireName("MainActivity"));
+        assertEquals(
+            Collections.singletonList(GRUMPY_GREEN),
+            AppIconPlugin.wireNames(Arrays.asList(mainActivity, GRUMPY_GREEN_ALIAS))
         );
-    }
-
-    private static String stripComments(String source) {
-        return source.replaceAll("(?s)/\\*.*?\\*/", "").replaceAll("//[^\\n]*", "");
     }
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for android-avatar-app-icons.md.

**Gap:** set was not SDK-gated and the alias enumeration accepted any .icon. activity; the source-grep guard test was the weakest encoding of the never-toggle invariant
**Fix:** set rejects below API 26, enumeration is scoped to the avatar_eyes_ suffix pattern, and the invariant is enforced behaviorally with the source-grep test removed