### PR TITLE
fix: payment modal self-review sweep (tests, comments, stories, unknown brand)

### DIFF
--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
@@ -317,6 +317,9 @@ describe("AutoTopUpPaymentMethodModal Stripe element options", () => {
       billingDetails: { name: "never", address: "never", email: "never" },
     });
     expect(paymentElementProps?.options?.paymentMethodOrder).toBeUndefined();
+    // A Link member's default email would mount an OTP takeover ahead of the
+    // card fields.
+    expect(paymentElementProps?.options?.defaultValues).toBeUndefined();
   });
 
   test("asks for the email when the account does not know it", async () => {
@@ -872,45 +875,25 @@ describe("AutoTopUpPaymentMethodModal redirect return", () => {
   });
 });
 
+/**
+ * The shell owns the subtitle sentences and is tested on them directly, so
+ * these cases cover only what the modal decides: which mode it opens in, and
+ * that `cardOnFile` reaches the shell in replace mode.
+ */
 describe("AutoTopUpPaymentMethodModal modes", () => {
-  test("defaults to add mode and names no card on file", async () => {
-    const { getByText, queryByTestId } = await renderModalWithForm();
+  test("defaults to add mode", async () => {
+    const { getByText } = await renderModalWithForm();
 
     expect(getByText("Add a card")).not.toBeNull();
-    expect(
-      getByText("Kept on file for auto-reload and your Pro plan."),
-    ).not.toBeNull();
-    expect(queryByTestId("payment-method-modal-card-on-file")).toBeNull();
   });
 
-  test("replace mode names the card being replaced in the subtitle", async () => {
-    const { getByText, queryByTestId } = await renderModalWithForm({
+  test("replace mode hands the card on file to the shell", async () => {
+    const { getByText } = await renderModalWithForm({
       mode: "replace",
       cardOnFile: { brand: "visa", last4: "4242", expMonth: 4, expYear: 2042 },
     });
 
     expect(getByText("Replace your card")).not.toBeNull();
-    expect(
-      getByText(
-        "Replacing Visa •••• 4242 · 04 / 42. The new card takes over immediately.",
-      ),
-    ).not.toBeNull();
-    expect(queryByTestId("payment-method-modal-card-on-file")).toBeNull();
-  });
-
-  test("ignores a card on file in add mode", async () => {
-    const { getByText, queryByTestId } = await renderModalWithForm({
-      cardOnFile: {
-        brand: "visa",
-        last4: "4242",
-        expMonth: null,
-        expYear: null,
-      },
-    });
-
-    expect(
-      getByText("Kept on file for auto-reload and your Pro plan."),
-    ).not.toBeNull();
-    expect(queryByTestId("payment-method-modal-card-on-file")).toBeNull();
+    expect(getByText(/Replacing Visa •••• 4242/)).not.toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -64,7 +64,7 @@ export interface AutoTopUpPaymentMethodModalProps {
   open: boolean;
   onClose: () => void;
   mode?: PaymentMethodModalMode;
-  /** The card being replaced; rendered only in `replace` mode. */
+  /** The card being replaced; named in the subtitle only in `replace` mode. */
   cardOnFile?: CardOnFile | null;
   /** Seeds the Address Element so a known billing address is not retyped. */
   billingAddress?: BillingAddress | null;
@@ -568,11 +568,9 @@ function SetupCardForm({
           wallets: { link: "auto", applePay: "never", googlePay: "never" },
           // The Address Element below owns the billing address (the saved PM
           // needs it for tax) and always collects a name, so both are
-          // suppressed here. Email is asked for only when the account does
-          // not already know it, since Link's banner carries its own email
-          // entry; `defaultValues` is deliberately not passed, because a
-          // member email there would mount an OTP takeover ahead of the card
-          // fields (revisit separately).
+          // suppressed here. `defaultValues` is deliberately not passed: a
+          // Link member's email there would mount an OTP takeover ahead of the
+          // card fields.
           fields: {
             billingDetails: {
               name: "never",

--- a/clients/web/src/domains/settings/components/field-skeletons.tsx
+++ b/clients/web/src/domains/settings/components/field-skeletons.tsx
@@ -2,12 +2,13 @@ import { Skeleton } from "@vellumai/design-library/components/skeleton";
 
 import { useTranslation } from "@/i18n";
 
-/** Row height of a mounted Stripe input, so the swap does not move the modal. */
+/** Row height copied from a mounted Stripe input. */
 const FIELD_ROW_CLASS = "h-[42px] w-full rounded-lg";
 
 /**
- * Vertical rhythm of the field stack. The skeleton and the mounted form share
- * it so they stay the same height and the reveal does not move the modal.
+ * Vertical rhythm of the field stack, shared with the mounted form. The five
+ * rows match the manual-entry baseline; the reveal grows past it whenever Link
+ * renders its banner or, for a signed-in member, its saved-card panel.
  */
 export const FIELD_STACK_CLASS = "flex flex-col gap-[10px]";
 

--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.stories.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.stories.tsx
@@ -2,11 +2,13 @@
  * The payment-method modal chrome in each of its states.
  *
  * The real modal mounts Stripe Elements as `children`, and those iframes
- * cannot load in Storybook, so the stories pass grey blocks the same height as
- * the Stripe inputs. That keeps the header, state slot, and footer laid out at
- * the real proportions while the shell stays reviewable without a publishable
- * key. The two loading stories are the exception: the skeleton that covers that
- * boot is our own component, so they render the real one.
+ * cannot load in Storybook, so the stories pass grey blocks at the height of
+ * the manual-entry fields. That keeps the header, state slot, and footer laid
+ * out at the manual-entry proportions while the shell stays reviewable without
+ * a publishable key; the live form runs taller whenever Link renders its banner
+ * or its signed-in panel. The two loading stories are the exception: the
+ * skeleton that covers that boot is our own component, so they render the real
+ * one.
  *
  * Light, dark, and velvet all come from the theme toolbar, so there is no
  * per-theme story.
@@ -58,6 +60,28 @@ export const ReplaceIdle: Story = {
   args: {
     mode: "replace",
     cardOnFile: { brand: "visa", last4: "4242", expMonth: 4, expYear: 2042 },
+  },
+};
+
+/**
+ * A card the platform has digits but no brand for: the subtitle names the
+ * ending instead of the network.
+ */
+export const ReplaceCardWithoutBrand: Story = {
+  args: {
+    mode: "replace",
+    cardOnFile: { brand: null, last4: "4242", expMonth: 4, expYear: 2042 },
+  },
+};
+
+/**
+ * The mirror case, a brand with no digits: the subtitle names the network on
+ * its own rather than trailing four empty dots.
+ */
+export const ReplaceCardWithoutLast4: Story = {
+  args: {
+    mode: "replace",
+    cardOnFile: { brand: "visa", last4: null, expMonth: 4, expYear: 2042 },
   },
 };
 

--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.test.tsx
@@ -32,7 +32,7 @@ const VISA_ON_FILE = {
 
 describe("PaymentMethodModalShell", () => {
   test("add mode titles the modal and the primary action", () => {
-    const { getByText, getByTestId, queryByTestId } = renderShell();
+    const { getByText, getByTestId } = renderShell();
     expect(getByText("Add a card")).not.toBeNull();
     expect(
       getByText("Kept on file for auto-reload and your Pro plan."),
@@ -40,11 +40,10 @@ describe("PaymentMethodModalShell", () => {
     expect(getByTestId("auto-top-up-pm-save-button").textContent).toBe(
       "Save card",
     );
-    expect(queryByTestId("payment-method-modal-card-on-file")).toBeNull();
   });
 
   test("replace mode folds the card being replaced into the subtitle", () => {
-    const { getByText, getByTestId, queryByTestId } = renderShell({
+    const { getByText, getByTestId } = renderShell({
       mode: "replace",
       cardOnFile: VISA_ON_FILE,
     });
@@ -57,7 +56,6 @@ describe("PaymentMethodModalShell", () => {
         "Replacing Visa •••• 4242 · 04 / 42. The new card takes over immediately.",
       ),
     ).not.toBeNull();
-    expect(queryByTestId("payment-method-modal-card-on-file")).toBeNull();
   });
 
   test("a card on file with no last4 reads its own sentence", () => {
@@ -76,6 +74,18 @@ describe("PaymentMethodModalShell", () => {
     const { getByText } = renderShell({
       mode: "replace",
       cardOnFile: { ...VISA_ON_FILE, brand: null },
+    });
+    expect(
+      getByText(
+        "Replacing the card ending in 4242 · 04 / 42. The new card takes over immediately.",
+      ),
+    ).not.toBeNull();
+  });
+
+  test("a card on file Stripe could not name reads as having no brand", () => {
+    const { getByText } = renderShell({
+      mode: "replace",
+      cardOnFile: { ...VISA_ON_FILE, brand: "unknown" },
     });
     expect(
       getByText(
@@ -110,13 +120,10 @@ describe("PaymentMethodModalShell", () => {
   });
 
   test("add mode ignores a card on file in the subtitle", () => {
-    const { getByText, queryByTestId } = renderShell({
-      cardOnFile: VISA_ON_FILE,
-    });
+    const { getByText } = renderShell({ cardOnFile: VISA_ON_FILE });
     expect(
       getByText("Kept on file for auto-reload and your Pro plan."),
     ).not.toBeNull();
-    expect(queryByTestId("payment-method-modal-card-on-file")).toBeNull();
   });
 
   test("showTerms toggles the terms line", () => {
@@ -231,6 +238,16 @@ describe("PaymentMethodModalShell", () => {
     const panel = getByTestId("payment-method-modal-saved");
     expect(panel.textContent).toContain("Card saved");
     expect(panel.textContent).not.toContain("Auto-reload is active again");
+  });
+
+  test("saved falls back to the generic title for a brand Stripe could not name", () => {
+    const { getByTestId } = renderShell({
+      state: "saved",
+      savedCard: { brand: "unknown", last4: "1881" },
+    });
+    const panel = getByTestId("payment-method-modal-saved");
+    expect(panel.textContent).toContain("Card saved");
+    expect(panel.textContent).not.toContain("unknown");
   });
 
   test("error renders the message beside a dot", () => {

--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.tsx
@@ -270,35 +270,38 @@ function replaceSubtitle(
   t: TFunction<"settings">,
   card: CardOnFile | null,
 ): string {
-  const brand = card?.brand ? brandLabel(card.brand) : null;
-  const last4 = card?.last4 ?? null;
+  const brand = brandLabel(card?.brand ?? null);
+  const last4 = card?.last4;
+  if (!brand && !last4) {
+    return t("autoTopUpPaymentMethodModal.replaceSubtitle");
+  }
+
   // `cardExpiryLabel` carries its own leading separator, so the sentences take
   // it behind a single space, or take nothing at all.
-  const expiryLabel = card
-    ? cardExpiryLabel(t, card.expMonth, card.expYear)
-    : null;
+  const expiryLabel = cardExpiryLabel(
+    t,
+    card?.expMonth ?? null,
+    card?.expYear ?? null,
+  );
   const expiry = expiryLabel ? ` ${expiryLabel}` : "";
 
-  if (brand && last4) {
-    return t("autoTopUpPaymentMethodModal.replaceSubtitleCard", {
-      brand,
-      last4,
-      expiry,
-    });
-  }
-  if (last4) {
-    return t("autoTopUpPaymentMethodModal.replaceSubtitleCardNoBrand", {
-      last4,
-      expiry,
-    });
-  }
-  if (brand) {
+  if (!last4) {
     return t("autoTopUpPaymentMethodModal.replaceSubtitleCardNoLast4", {
       brand,
       expiry,
     });
   }
-  return t("autoTopUpPaymentMethodModal.replaceSubtitle");
+  if (!brand) {
+    return t("autoTopUpPaymentMethodModal.replaceSubtitleCardNoBrand", {
+      last4,
+      expiry,
+    });
+  }
+  return t("autoTopUpPaymentMethodModal.replaceSubtitleCard", {
+    brand,
+    last4,
+    expiry,
+  });
 }
 
 /** Titles the success panel, and the screen-reader title above it. */
@@ -306,9 +309,10 @@ function savedPanelTitle(
   t: TFunction<"settings">,
   card: SavedCard | null,
 ): string {
-  return card?.brand && card.last4
+  const brand = brandLabel(card?.brand ?? null);
+  return brand && card?.last4
     ? t("autoTopUpPaymentMethodModal.savedTitle", {
-        brand: brandLabel(card.brand),
+        brand,
         last4: card.last4,
       })
     : t("autoTopUpPaymentMethodModal.savedTitleGeneric");

--- a/clients/web/src/domains/settings/components/payment-method-row.stories.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.stories.tsx
@@ -33,7 +33,7 @@ export const Default: Story = {};
 
 /**
  * The platform knows the card's expiry, so it trails the last four digits in
- * the same `MM / YY` form the modal's card-on-file row uses.
+ * the same `MM / YY` form the modal's replace subtitle uses.
  */
 export const WithExpiry: Story = {
   args: { expMonth: 4, expYear: 2042 },

--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -34,6 +34,15 @@ describe("PaymentMethodRow", () => {
     expect(row.textContent).not.toContain("null");
   });
 
+  test("falls back to the generic label when Stripe could not name the brand", () => {
+    const { getByTestId } = render(
+      <PaymentMethodRow brand="unknown" last4="4242" onUpdateCard={() => {}} />,
+    );
+    const row = getByTestId("payment-method-row");
+    expect(row.textContent).toContain("Saved card");
+    expect(row.textContent).not.toContain("unknown");
+  });
+
   test("renders the expiry after the ending line when both parts are known", () => {
     const { getByTestId } = render(
       <PaymentMethodRow

--- a/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -30,9 +30,9 @@
  *    the mode the saved card calls for. The failure waits for the config query
  *    to settle, so it cannot be pinned to add mode by a still-pending one.
  *  - The card expiry and the saved billing address come from the platform
- *    config: the row and the modal's card on file show the expiry, the modal
- *    is seeded with the address, and a platform deployment that omits the
- *    keys renders with nulls instead.
+ *    config: the row and the modal's replace subtitle show the expiry, the
+ *    modal is seeded with the address, and a platform deployment that omits
+ *    the keys renders with nulls instead.
  *  - The config query is gated on org readiness: before the org store
  *    hydrates the card shows the loading state, never the Add button or the
  *    error notice, so a headerless request can't mislabel the org as having

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -75,7 +75,8 @@ export function PaymentMethodsCard() {
   // That mode comes from the config query, so a failed outcome waits for it to
   // settle. Snapshotting while it is still pending would read no cards, and
   // the updater below preserves that snapshot: the replacement would replay
-  // under the Add title with no card-on-file row for the rest of the visit.
+  // under the Add title with no card named in the subtitle for the rest of
+  // the visit.
   const configSettled = configQuery.isSuccess || configQuery.isError;
   useEffect(() => {
     if (outcome == null) {

--- a/clients/web/src/domains/settings/utils/payment-method-brand.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-brand.ts
@@ -14,8 +14,18 @@ const BRAND_LABELS: Record<string, string> = {
   unionpay: "UnionPay",
 };
 
-export function brandLabel(brand: string): string {
-  return BRAND_LABELS[brand.toLowerCase()] ?? brand;
+/**
+ * The display label, or null when there is no brand to name. Stripe's own
+ * `"unknown"`, for a card whose network it could not identify, counts as no
+ * brand: passed through it reads as a word mid sentence, as in "Replacing
+ * unknown •••• 4242".
+ */
+export function brandLabel(brand: string | null): string | null {
+  const key = brand?.toLowerCase();
+  if (key == null || key === "unknown") {
+    return null;
+  }
+  return BRAND_LABELS[key] ?? brand;
 }
 
 /** The brand label, or the one fallback for a card Stripe gave no brand for. */
@@ -23,7 +33,7 @@ export function brandDisplayLabel(
   t: TFunction<"settings">,
   brand: string | null,
 ): string {
-  return brand ? brandLabel(brand) : t("paymentMethodRow.savedCard");
+  return brandLabel(brand) ?? t("paymentMethodRow.savedCard");
 }
 
 /** Carries its own leading separator, so callers render it as-is. */

--- a/clients/web/src/domains/settings/utils/payment-method-cards.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-cards.ts
@@ -40,7 +40,7 @@ export function paymentMethodCards(
  * What the payment modal was opened with. Captured on the click that opens it,
  * because a successful save writes the new card into the config query cache
  * before the modal closes: derived props would flip an in-flight add into
- * replace mode and swap the card-on-file row for the card that was just saved.
+ * replace mode and name the card that was just saved in the subtitle.
  */
 export interface PaymentModalSnapshot {
   mode: PaymentMethodModalMode;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for payment-modal-link-passthrough.md: vacuous testid assertions removed, duplicated sentence assertions reduced, defaultValues regression guard added, stale card-on-file-row comments repointed, two missing subtitle-shape stories, unknown Stripe brand now degrades to the no-brand sentence, comment and no-op cleanup, honest skeleton height comments.