### PR TITLE
fix: Link connect-src hosts and a CSP drift-guard test

### DIFF
--- a/packages/electron-desktop/src/csp.test.ts
+++ b/packages/electron-desktop/src/csp.test.ts
@@ -1,10 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import { CSP_POLICY } from "./csp";
 
-/** Extract the value for a single CSP directive from the policy string. */
-function directiveValue(directive: string): string | undefined {
-  const match = CSP_POLICY.match(new RegExp(`(?:^|;\\s*)${directive}\\s+([^;]+)`));
+/** Extract the value for a single CSP directive from a policy string. */
+function directiveValue(
+  directive: string,
+  policy: string = CSP_POLICY,
+): string | undefined {
+  const match = policy.match(new RegExp(`(?:^|;\\s*)${directive}\\s+([^;]+)`));
   return match?.[1]?.trim();
 }
 
@@ -117,13 +123,36 @@ describe("CSP_POLICY", () => {
     expect(frameSrc).toContain("https://js.stripe.com");
     expect(frameSrc).toContain("https://*.js.stripe.com");
     expect(frameSrc).toContain("https://hooks.stripe.com");
-    // Link wallet frames. clients/web/index.html lists them too, but CSP
-    // intersects, so dropping them here blocks Link in the packaged app only.
+    // Link wallet frames: see the frame-src note in csp.ts.
     expect(frameSrc).toContain("https://link.com");
     expect(frameSrc).toContain("https://*.link.com");
 
     const connectSrc = directiveValue("connect-src")!;
     expect(connectSrc).toContain("https://api.stripe.com");
+    expect(connectSrc).toContain("https://link.com");
+    expect(connectSrc).toContain("https://*.link.com");
+  });
+
+  test("frame-src is a superset of the web bundle's frame-src meta", () => {
+    // The packaged app serves clients/web over app:// and applies both
+    // policies, and CSP intersects: a host the meta allows but this policy
+    // omits is blocked in the desktop app. Link drifted exactly that way.
+    const indexHtml = readFileSync(
+      join(import.meta.dir, "../../../clients/web/index.html"),
+      "utf8",
+    );
+    const metaContent = indexHtml.match(
+      /<meta\s+http-equiv="Content-Security-Policy"[^>]*?content="([^"]*)"/,
+    )?.[1];
+    expect(metaContent).toBeDefined();
+    const metaFrameSrc = directiveValue("frame-src", metaContent!);
+    expect(metaFrameSrc).toBeDefined();
+
+    const policySources = directiveValue("frame-src")!.split(/\s+/);
+    const missing = metaFrameSrc!
+      .split(/\s+/)
+      .filter((source) => !policySources.includes(source));
+    expect(missing).toEqual([]);
   });
 
   test("connect-src allows loopback gateway WebSockets but not broad ws:", () => {

--- a/packages/electron-desktop/src/csp.ts
+++ b/packages/electron-desktop/src/csp.ts
@@ -45,11 +45,13 @@ const WILDCARD_HOST = `*${ROOT_HOSTNAME}`;
 // and confirms SetupIntents against api.stripe.com (connect-src).
 // hooks.stripe.com hosts the 3D Secure challenge frame. link.com /
 // *.link.com host the Link wallet frames the payment element mounts while
-// `wallets.link` is enabled: the banner, the OTP sheet, and the saved-card
-// panel. This is Stripe's
-// documented CSP set for Stripe.js: https://docs.stripe.com/security/guide
-// (minus maps.googleapis.com, which only applies when supplying your own
-// Google Maps key to the Address Element).
+// `wallets.link` is enabled (the banner, the OTP sheet, the saved-card panel)
+// and the requests those frames issue, so they appear in frame-src and
+// connect-src alike. Together that covers the frame and connection halves of
+// Stripe's documented CSP set for Stripe.js
+// (https://docs.stripe.com/security/guide); its img-src hosts already fall
+// under the broad `https:` in img-src below, and maps.googleapis.com applies
+// only when supplying your own Google Maps key to the Address Element.
 // frame-src is the only directive that names Stripe hosts alongside 'self';
 // without it frames fall back to `default-src 'self'`, which blocks the
 // Element iframes. Keeping the list to 'self' + Stripe hosts costs the
@@ -73,7 +75,7 @@ export const CSP_POLICY = [
   "default-src 'self'",
   `script-src 'self' 'unsafe-inline' https://${WILDCARD_HOST} https://js.stripe.com https://*.js.stripe.com`,
   "style-src 'self' 'unsafe-inline'",
-  `connect-src 'self' blob: data: https://${WILDCARD_HOST} wss://${WILDCARD_HOST} https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com https://storage.googleapis.com https://*.storage.googleapis.com https://api.stripe.com ws://localhost:* ws://127.0.0.1:*`,
+  `connect-src 'self' blob: data: https://${WILDCARD_HOST} wss://${WILDCARD_HOST} https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.elevenlabs.io https://api.deepgram.com https://storage.googleapis.com https://*.storage.googleapis.com https://api.stripe.com https://link.com https://*.link.com ws://localhost:* ws://127.0.0.1:*`,
   "frame-src 'self' https://js.stripe.com https://*.js.stripe.com https://hooks.stripe.com https://link.com https://*.link.com",
   "img-src 'self' https: data: blob:",
   // Hosted voice-preview samples: ElevenLabs premades live in the


### PR DESCRIPTION
## Summary
Round-2 self-review fixes for payment-modal-link-passthrough.md: connect-src gains https://link.com and https://*.link.com per Stripe's documented Link CSP set, comments reflowed to match reality, and a drift-guard test now reads clients/web/index.html's frame-src meta and asserts the Electron policy stays a superset (the exact drift direction that originally broke Link in the packaged app).