### PR TITLE
fix: brand label normalization and subtitle test/story dedupe

### DIFF
--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.stories.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.stories.tsx
@@ -63,30 +63,8 @@ export const ReplaceIdle: Story = {
   },
 };
 
-/**
- * A card the platform has digits but no brand for: the subtitle names the
- * ending instead of the network.
- */
-export const ReplaceCardWithoutBrand: Story = {
-  args: {
-    mode: "replace",
-    cardOnFile: { brand: null, last4: "4242", expMonth: 4, expYear: 2042 },
-  },
-};
-
-/**
- * The mirror case, a brand with no digits: the subtitle names the network on
- * its own rather than trailing four empty dots.
- */
-export const ReplaceCardWithoutLast4: Story = {
-  args: {
-    mode: "replace",
-    cardOnFile: { brand: "visa", last4: null, expMonth: 4, expYear: 2042 },
-  },
-};
-
-/** Replacing a card we know nothing about: the subtitle names none of it. */
-export const ReplaceUnknownCard: Story = {
+/** Replacing a card we hold no details for: the subtitle names none of it. */
+export const ReplaceNoCardDetails: Story = {
   args: {
     mode: "replace",
     cardOnFile: null,

--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.test.tsx
@@ -82,26 +82,6 @@ describe("PaymentMethodModalShell", () => {
     ).not.toBeNull();
   });
 
-  test("a card on file Stripe could not name reads as having no brand", () => {
-    const { getByText } = renderShell({
-      mode: "replace",
-      cardOnFile: { ...VISA_ON_FILE, brand: "unknown" },
-    });
-    expect(
-      getByText(
-        "Replacing the card ending in 4242 · 04 / 42. The new card takes over immediately.",
-      ),
-    ).not.toBeNull();
-  });
-
-  test("a card on file with no brand or last4 falls back to the plain subtitle", () => {
-    const { getByText } = renderShell({
-      mode: "replace",
-      cardOnFile: { ...VISA_ON_FILE, brand: null, last4: null },
-    });
-    expect(getByText("The new card takes over immediately.")).not.toBeNull();
-  });
-
   test("omits the expiry when either half is missing", () => {
     const { getByText } = renderShell({
       mode: "replace",

--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.tsx
@@ -270,19 +270,15 @@ function replaceSubtitle(
   t: TFunction<"settings">,
   card: CardOnFile | null,
 ): string {
-  const brand = brandLabel(card?.brand ?? null);
+  const brand = brandLabel(card?.brand);
   const last4 = card?.last4;
   if (!brand && !last4) {
     return t("autoTopUpPaymentMethodModal.replaceSubtitle");
   }
 
-  // `cardExpiryLabel` carries its own leading separator, so the sentences take
-  // it behind a single space, or take nothing at all.
-  const expiryLabel = cardExpiryLabel(
-    t,
-    card?.expMonth ?? null,
-    card?.expYear ?? null,
-  );
+  // The single space is composed here rather than sitting in the sentences, so
+  // a card with no expiry leaves no double space behind.
+  const expiryLabel = cardExpiryLabel(t, card?.expMonth, card?.expYear);
   const expiry = expiryLabel ? ` ${expiryLabel}` : "";
 
   if (!last4) {
@@ -309,7 +305,7 @@ function savedPanelTitle(
   t: TFunction<"settings">,
   card: SavedCard | null,
 ): string {
-  const brand = brandLabel(card?.brand ?? null);
+  const brand = brandLabel(card?.brand);
   return brand && card?.last4
     ? t("autoTopUpPaymentMethodModal.savedTitle", {
         brand,

--- a/clients/web/src/domains/settings/components/payment-method-row.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.test.tsx
@@ -34,15 +34,6 @@ describe("PaymentMethodRow", () => {
     expect(row.textContent).not.toContain("null");
   });
 
-  test("falls back to the generic label when Stripe could not name the brand", () => {
-    const { getByTestId } = render(
-      <PaymentMethodRow brand="unknown" last4="4242" onUpdateCard={() => {}} />,
-    );
-    const row = getByTestId("payment-method-row");
-    expect(row.textContent).toContain("Saved card");
-    expect(row.textContent).not.toContain("unknown");
-  });
-
   test("renders the expiry after the ending line when both parts are known", () => {
     const { getByTestId } = render(
       <PaymentMethodRow
@@ -93,18 +84,6 @@ describe("PaymentMethodRow", () => {
     expect(getByTestId("payment-method-row").textContent).not.toContain(
       "\u00b7",
     );
-  });
-
-  test("renders a long unmapped brand verbatim", () => {
-    const { getByTestId } = render(
-      <PaymentMethodRow
-        brand="internationalmaestro"
-        last4="0005"
-        onUpdateCard={() => {}}
-      />,
-    );
-    const row = getByTestId("payment-method-row");
-    expect(row.textContent).toContain("internationalmaestro");
   });
 
   test("fires onUpdateCard when Replace card is clicked", () => {

--- a/clients/web/src/domains/settings/utils/payment-method-brand.test.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-brand.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Brand labelling is the one place a raw Stripe enum could reach the screen:
+ * the platform passes `card.brand` through untouched, and Stripe sends values
+ * with no label of ours, so this pins that every one of them resolves to the
+ * generic copy instead.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { fixedT } from "@/i18n";
+
+import { brandDisplayLabel, brandLabel } from "./payment-method-brand";
+
+const t = fixedT("settings");
+
+const UNLABELLED_BRANDS = [
+  ["Stripe's own no-network value", "unknown"],
+  ["a network we hold no label for", "eftpos_au"],
+  ["an empty brand", ""],
+  ["a null brand", null],
+  ["an absent brand", undefined],
+] as const;
+
+describe("brandLabel", () => {
+  test.each([
+    ["a lowercase brand", "visa", "Visa"],
+    ["a brand Stripe already cased", "Visa", "Visa"],
+    ["a two-word brand", "diners", "Diners Club"],
+  ] as const)("names %s", (_label, brand, expected) => {
+    expect(brandLabel(brand)).toBe(expected);
+  });
+
+  test.each(UNLABELLED_BRANDS)("reads %s as no brand", (_label, brand) => {
+    expect(brandLabel(brand)).toBeNull();
+  });
+});
+
+describe("brandDisplayLabel", () => {
+  test("names a brand the map knows", () => {
+    expect(brandDisplayLabel(t, "visa")).toBe("Visa");
+  });
+
+  // The literal, not the catalog lookup: comparing `t()` against itself would
+  // pass just as well with the key missing from the catalog.
+  test.each(UNLABELLED_BRANDS)(
+    "falls back to the saved-card label for %s",
+    (_label, brand) => {
+      expect(brandDisplayLabel(t, brand)).toBe("Saved card");
+    },
+  );
+});

--- a/clients/web/src/domains/settings/utils/payment-method-brand.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-brand.ts
@@ -15,23 +15,25 @@ const BRAND_LABELS: Record<string, string> = {
 };
 
 /**
- * The display label, or null when there is no brand to name. Stripe's own
- * `"unknown"`, for a card whose network it could not identify, counts as no
- * brand: passed through it reads as a word mid sentence, as in "Replacing
- * unknown •••• 4242".
+ * The display label, or null when there is no brand to name. Anything the map
+ * has no label for counts as no brand rather than reaching the screen raw:
+ * Stripe sends `"unknown"` for a card whose network it could not identify, and
+ * values such as `"eftpos_au"` and `"link"` for networks we name nothing for,
+ * and the platform passes all of them through untouched. Rendered as-is they
+ * read as an enum mid sentence, as in "Replacing eftpos_au •••• 4242".
  */
-export function brandLabel(brand: string | null): string | null {
+export function brandLabel(brand: string | null | undefined): string | null {
   const key = brand?.toLowerCase();
-  if (key == null || key === "unknown") {
+  if (!key || key === "unknown") {
     return null;
   }
-  return BRAND_LABELS[key] ?? brand;
+  return BRAND_LABELS[key] ?? null;
 }
 
-/** The brand label, or the one fallback for a card Stripe gave no brand for. */
+/** The brand label, or the one fallback for a card we can name no brand for. */
 export function brandDisplayLabel(
   t: TFunction<"settings">,
-  brand: string | null,
+  brand: string | null | undefined,
 ): string {
   return brandLabel(brand) ?? t("paymentMethodRow.savedCard");
 }
@@ -39,8 +41,8 @@ export function brandDisplayLabel(
 /** Carries its own leading separator, so callers render it as-is. */
 export function cardExpiryLabel(
   t: TFunction<"settings">,
-  expMonth: number | null,
-  expYear: number | null,
+  expMonth: number | null | undefined,
+  expYear: number | null | undefined,
 ): string | null {
   if (expMonth == null || expYear == null) {
     return null;


### PR DESCRIPTION
## Summary
Round-2 self-review fixes for payment-modal-link-passthrough.md: brandLabel returns null for any unmapped or empty Stripe brand (raw enum strings like eftpos_au no longer render mid-sentence; PaymentMethodRow consciously falls back to the generic label for them), helpers accept undefined, a dedicated payment-method-brand test table, duplicate shell tests and no-delta stories removed, ReplaceUnknownCard renamed ReplaceNoCardDetails.