### PR TITLE
fix: round-4 micro-polish for the payment modal Link plan

### DIFF
--- a/clients/web/src/domains/settings/components/payment-method-modal-shell.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-modal-shell.tsx
@@ -10,6 +10,7 @@
 import { Loader2, X } from "lucide-react";
 import { type ReactNode } from "react";
 
+import { FIELD_STACK_CLASS } from "@/domains/settings/components/field-skeletons";
 import {
   brandLabel,
   cardExpiryLabel,
@@ -165,7 +166,7 @@ export function PaymentMethodModalShell({
                 data-testid="payment-method-modal-fields"
                 aria-busy={locked}
                 className={cn(
-                  "flex flex-col gap-[10px]",
+                  FIELD_STACK_CLASS,
                   locked && "pointer-events-none opacity-45",
                 )}
               >

--- a/clients/web/src/domains/settings/components/payment-method-row.stories.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.stories.tsx
@@ -27,8 +27,8 @@ type Story = StoryObj<typeof meta>;
 
 /**
  * The default row: the brand named through `brandDisplayLabel` (the raw
- * `"visa"` reads as "Visa", and a brand we hold no label for reads as the
- * generic saved-card copy), the last four digits, and the Replace card action.
+ * `"visa"` reads as "Visa"), the last four digits, and the Replace card
+ * action.
  */
 export const Default: Story = {};
 

--- a/clients/web/src/domains/settings/utils/payment-method-brand.ts
+++ b/clients/web/src/domains/settings/utils/payment-method-brand.ts
@@ -27,7 +27,7 @@ export function brandLabel(brand: string | null | undefined): string | null {
   if (!key) {
     return null;
   }
-  return BRAND_LABELS[key] ?? null;
+  return Object.hasOwn(BRAND_LABELS, key) ? BRAND_LABELS[key] : null;
 }
 
 /** The brand label, or the one fallback for a card we can name no brand for. */

--- a/packages/electron-desktop/src/csp.test.ts
+++ b/packages/electron-desktop/src/csp.test.ts
@@ -134,7 +134,7 @@ describe("CSP_POLICY", () => {
   });
 
   test("frame-src is a superset of the web bundle's frame-src meta", () => {
-    // See the superset note in csp.ts. Link drifted exactly this way once.
+    // See the superset note in csp.ts.
     const indexHtml = readFileSync(
       join(import.meta.dir, "../../../clients/web/index.html"),
       "utf8",


### PR DESCRIPTION
## Summary
Final self-review round for payment-modal-link-passthrough.md: the drift-guard test comment is present-tense only (codex P1 on #41937), the row story doc describes only what the story renders, the shell's field stack uses the shared FIELD_STACK_CLASS constant, and the brand map lookup is structural (Object.hasOwn) so the no-brand invariant does not depend on Stripe's enum.