### PR TITLE
feat(web): pin the assistant section to the foot of the sidebar, with the avatar eyes

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.tsx
+++ b/clients/web/src/components/collapsible-nav-section.tsx
@@ -172,6 +172,18 @@ interface CollapsibleNavSectionSectionProps extends Omit<
 > {
   value: string;
   icon?: LucideIcon;
+  /**
+   * Leading glyph for sections whose mark is not a Lucide icon — currently
+   * the assistant-initiated section, which carries the assistant's own eyes.
+   * Takes the same slot as {@link icon} (same box, same axis, both header
+   * branches) and wins when both are given, so a section states its glyph
+   * once whichever kind it is.
+   *
+   * Sized by the caller: the slot hugs its content rather than scaling it,
+   * because the eye sprite has its own aspect ratio and a forced 12px square
+   * would distort it.
+   */
+  iconNode?: ReactNode;
   label: string;
   trailing?: ReactNode;
   contextMenuContent?: ReactNode;
@@ -226,6 +238,7 @@ interface CollapsibleNavSectionSectionProps extends Omit<
 function CollapsibleNavSectionSection({
   value,
   icon: Icon,
+  iconNode,
   label,
   trailing,
   contextMenuContent,
@@ -249,16 +262,24 @@ function CollapsibleNavSectionSection({
   /* One slot for both header branches. The collapsible and non-collapsible
      headers show the same glyph on the same axis, so they read it from here
      rather than each rendering their own copy. */
-  const iconSlot = Icon ? (
+  const glyph = iconNode ?? (Icon ? <Icon size={12} aria-hidden /> : null);
+  const iconSlot = glyph ? (
     <span
       data-slot="collapsible-nav-section-icon"
       /* Hugs the glyph. A chip-width box with the glyph centred in it padded
          the icon away from both edges, so the header read as indented from
          the row surfaces below it. Centring is the collapsed rail's need,
          and the rail draws its own tiles. */
-      className="relative inline-flex h-[14px] w-[14px] shrink-0 items-center justify-center"
+      className={cn(
+        "relative inline-flex h-[14px] w-[14px] shrink-0 items-center justify-center",
+        /* Only a Lucide glyph takes the tertiary ink: it draws in
+           `currentColor`. A custom node carries its own colour (the eye
+           sprite's paths are filled from the avatar palette), so tinting the
+           box would do nothing to it and would only mislead the next reader. */
+        !iconNode && "text-[var(--content-tertiary)]",
+      )}
     >
-      <Icon size={12} aria-hidden className="text-[var(--content-tertiary)]" />
+      {glyph}
     </span>
   ) : null;
 
@@ -272,7 +293,8 @@ function CollapsibleNavSectionSection({
     SIDEBAR_SECTION_TITLE_TEXT_CLASSES,
     /* `!` twice over: the shared title classes pin their own weight the same
        way, so a plain utility here loses to them rather than replacing them. */
-    card && "text-body-small-default max-md:text-body-small-default font-[500]!",
+    card &&
+      "text-body-small-default max-md:text-body-small-default font-[500]!",
   );
 
   const titleStyle = {
@@ -499,7 +521,9 @@ function CollapsibleNavSectionSection({
             contentClassName,
           )}
           style={{
-            paddingLeft: card ? 0 : SIDEBAR_ROW_PADDING_X + SIDEBAR_SECTION_INDENT,
+            paddingLeft: card
+              ? 0
+              : SIDEBAR_ROW_PADDING_X + SIDEBAR_SECTION_INDENT,
             paddingRight: card ? 0 : SIDEBAR_ROW_PADDING_X,
           }}
         >
@@ -517,7 +541,9 @@ function CollapsibleNavSectionSection({
             contentClassName,
           )}
           style={{
-            paddingLeft: card ? 0 : SIDEBAR_ROW_PADDING_X + SIDEBAR_SECTION_INDENT,
+            paddingLeft: card
+              ? 0
+              : SIDEBAR_ROW_PADDING_X + SIDEBAR_SECTION_INDENT,
             paddingRight: card ? 0 : SIDEBAR_ROW_PADDING_X,
           }}
         >

--- a/clients/web/src/domains/chat/components/assistant-side-menu-assistant-section.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu-assistant-section.stories.tsx
@@ -1,0 +1,204 @@
+/**
+ * The whole sidebar, with the assistant-initiated section in it.
+ *
+ * The section stories next door render one card. This renders the real
+ * {@link AssistantSideMenu} — assistant pill, New Chat, every section, the
+ * Preferences footer — so the section can be judged where it actually lives:
+ * pinned at the foot of the list, directly above Preferences, with Chats
+ * above it taking the leftover height.
+ *
+ * Nothing is stubbed at the component layer. The menu runs its own
+ * `useSidebarState`, which reads the daemon's section index through
+ * `useSidebarSectionsQuery`; seeding `sidebarSectionsQueryKey` makes that
+ * query resolve from cache, so the section list here is the one the app
+ * builds, in the order the app orders it. Each section's rows come from its
+ * own `useSectionConversations`, seeded the same way. No network, no daemon,
+ * no feature flag — the daemon's flag decides whether the `assistant` index
+ * row exists, and seeding it is exactly the on state.
+ *
+ * Every seeded value is a production type (`SidebarIndexSection`,
+ * `ConversationListPage`, `Conversation`), so a drift in any of those shapes
+ * breaks this build rather than surfacing later in the app.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useSidebarLayoutStore } from "@/domains/chat/sidebar-layout-store";
+import type { Conversation } from "@/types/conversation-types";
+import {
+  SYSTEM_ALL_GROUP_ID,
+  SYSTEM_ASSISTANT_GROUP_ID,
+  SYSTEM_PINNED_GROUP_ID,
+  sidebarSectionsQueryKey,
+  type SidebarIndexSection,
+} from "@/utils/conversation-list-fetchers";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
+import { listPage } from "@/utils/conversation-list.test-helper";
+
+const ASSISTANT_ID = "asst-storybook";
+
+/** The avatar accent the section tint reads. Swap to audit other colors. */
+const ACCENT = "#C4436A";
+
+/**
+ * Threads the way a heartbeat realization actually reads — an observation the
+ * user did not ask for, carrying the detail that makes it worth surfacing.
+ */
+const ASSISTANT_THREADS: Conversation[] = [
+  {
+    conversationId: "a1",
+    title: "Your Tuesday reviews keep slipping past 6pm",
+    hasUnseenLatestAssistantMessage: true,
+  },
+  {
+    conversationId: "a2",
+    title: "The contractor never sent the revised quote",
+    hasUnseenLatestAssistantMessage: true,
+  },
+  {
+    conversationId: "a3",
+    title: "You've rewritten the same paragraph four times",
+  },
+];
+
+const CHATS: Conversation[] = [
+  { conversationId: "c1", title: "Fernweh Coffee landing page" },
+  { conversationId: "c2", title: "Lease renewal" },
+  { conversationId: "c3", title: "Weekend hike recommendations" },
+  { conversationId: "c4", title: "Resume feedback" },
+  {
+    conversationId: "c5",
+    title: "Weekly meal plan",
+    hasUnseenLatestAssistantMessage: true,
+  },
+  { conversationId: "c6", title: "Home gym setup" },
+  { conversationId: "c7", title: "Budget spreadsheet help" },
+];
+
+const PINNED: Conversation[] = [
+  { conversationId: "p1", title: "Investor update draft", isPinned: true },
+];
+
+function seededClient(assistantThreads: Conversation[]): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+    },
+  });
+
+  /* The section index: what the daemon serves from
+     GET /v1/conversations/sections. The `assistant` row is emitted only under
+     the `assistant-initiated-threads` flag, so its presence here *is* the
+     flag being on. */
+  const index: SidebarIndexSection[] = [
+    { kind: "pinned", total: PINNED.length, unread: 0 },
+    { kind: "chats", total: CHATS.length, unread: 1 },
+    {
+      kind: "assistant",
+      total: assistantThreads.length,
+      unread: assistantThreads.filter(
+        (c) => c.hasUnseenLatestAssistantMessage === true,
+      ).length,
+    },
+  ];
+  client.setQueryData(sidebarSectionsQueryKey(ASSISTANT_ID), index);
+
+  // Each section fetches its own rows; seed the key each one asks for.
+  client.setQueryData(
+    conversationListQueryKey(ASSISTANT_ID, {
+      groupId: SYSTEM_ASSISTANT_GROUP_ID,
+    }),
+    listPage(assistantThreads),
+  );
+  client.setQueryData(
+    conversationListQueryKey(ASSISTANT_ID, { groupId: SYSTEM_ALL_GROUP_ID }),
+    listPage(CHATS),
+  );
+  client.setQueryData(
+    conversationListQueryKey(ASSISTANT_ID, { groupId: SYSTEM_PINNED_GROUP_ID }),
+    listPage(PINNED),
+  );
+
+  return client;
+}
+
+function Scene({
+  assistantThreads,
+  assistantName,
+}: {
+  assistantThreads: Conversation[];
+  assistantName: string | null;
+}) {
+  // Opens the per-section query gate (it checks the connected version).
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity(assistantName, "0.12.0", ASSISTANT_ID);
+  // A clean layout store, so a stored section order from another story cannot
+  // decide this one's arrangement.
+  useSidebarLayoutStore.setState({
+    assistantId: ASSISTANT_ID,
+    openCategories: [],
+    openCustomGroups: [],
+    sectionOrder: [],
+  });
+
+  return (
+    <QueryClientProvider client={seededClient(assistantThreads)}>
+      {/* The rail's real height and width, so "pinned above Preferences" and
+          the leftover-space split between Chats and this section are both
+          visible rather than implied. */}
+      <div
+        style={{ height: 720, ["--avatar-accent" as string]: ACCENT }}
+        className="flex w-[264px] flex-col"
+      >
+        <AssistantSideMenu
+          assistantId={ASSISTANT_ID}
+          assistantName={assistantName}
+          conversations={[...CHATS, ...PINNED]}
+          collapsed={false}
+          variant="rail"
+          onSelectConversation={() => {}}
+          footerAction={
+            <div className="rounded-full bg-[var(--surface-lift)] px-3 py-2 text-body-small-lighter text-[var(--content-secondary)]">
+              Preferences
+            </div>
+          }
+        />
+      </div>
+    </QueryClientProvider>
+  );
+}
+
+const meta = {
+  title: "Chat/AssistantSideMenuWithAssistantSection",
+  component: Scene,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof Scene>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The arrangement to judge: Pinned and Chats above, the assistant's own
+ * section at the foot of the list directly above Preferences, tinted in the
+ * avatar's color with the assistant's eyes where a topic glyph would sit.
+ */
+export const Default: Story = {
+  args: { assistantThreads: ASSISTANT_THREADS, assistantName: "Ada" },
+};
+
+/** Before the assistant is named, the header falls back to "On My Mind". */
+export const UnnamedAssistant: Story = {
+  args: { assistantThreads: ASSISTANT_THREADS, assistantName: null },
+};
+
+/**
+ * Nothing yet. The section still renders — its empty state is what explains
+ * it to someone who has no threads — and Chats keeps the leftover height.
+ */
+export const EmptySection: Story = {
+  args: { assistantThreads: [], assistantName: "Ada" },
+};

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -405,7 +405,8 @@ export function AssistantSideMenu({
 
   const listContext: ConversationListContextValue = {
     overlayCards: variant === "overlay",
-    scrollParent: variant === "overlay" ? (bodyElement ?? undefined) : undefined,
+    scrollParent:
+      variant === "overlay" ? (bodyElement ?? undefined) : undefined,
     activeConversationId,
     activeConversationProcessing,
     processingConversationIds,
@@ -476,6 +477,18 @@ export function AssistantSideMenu({
     });
   };
 
+  /* Index of the last section that may claim the rail's leftover space: the
+     last one that is not the bottom-pinned assistant section. -1 when the
+     list holds nothing else, so nothing fills. */
+  const lastFillIndex = (() => {
+    for (let i = sidebar.sections.length - 1; i >= 0; i--) {
+      if (sidebar.sections[i]!.type !== "assistant") {
+        return i;
+      }
+    }
+    return -1;
+  })();
+
   const renderSection = (section: SidebarSection, index: number) => (
     <SidebarSectionItem
       key={section.key}
@@ -493,7 +506,14 @@ export function AssistantSideMenu({
       // near-empty box the same size as a busy one beside it. The overlay
       // skips that fill: its lists scroll with the drawer body so rows
       // can travel clear of the floating action pills.
-      isLast={variant === "rail" && index === sidebar.sections.length - 1}
+      //
+      // "Bottom-most" here means the last *space-claiming* section, which is
+      // not the last rendered one once the assistant section is pinned below
+      // everything. That section hugs its own rows against the Preferences
+      // footer; handing it the fill instead would stretch a short list of
+      // realizations down the rail and squeeze Chats — the list that actually
+      // grows — into a fixed box above it.
+      isLast={variant === "rail" && index === lastFillIndex}
     />
   );
 

--- a/clients/web/src/domains/chat/components/conversation-nav-section.tsx
+++ b/clients/web/src/domains/chat/components/conversation-nav-section.tsx
@@ -197,6 +197,8 @@ export interface ConversationNavSectionProps extends ConversationRowListProps {
   value: string;
   label: string;
   icon?: LucideIcon;
+  /** Leading glyph for a section whose mark is not a Lucide icon. */
+  iconNode?: ReactNode;
   trailing?: ReactNode;
   /**
    * Bulk/group actions for this section's header. Rendered as a right-click
@@ -223,6 +225,7 @@ export function ConversationNavSection({
   value,
   label,
   icon,
+  iconNode,
   trailing,
   groupMenu,
   collapsedIndicator,
@@ -240,6 +243,7 @@ export function ConversationNavSection({
       value={value}
       card={overlayCards}
       icon={icon}
+      iconNode={iconNode}
       label={label}
       trailing={trailing}
       contextMenuContent={

--- a/clients/web/src/domains/chat/components/sidebar-section-item.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-item.tsx
@@ -22,6 +22,7 @@
 import type { ReactNode } from "react";
 
 import type { CollapsibleNavSectionDrag } from "@/components/collapsible-nav-section";
+import { AssistantEyesMark } from "@/domains/chat/components/assistant-eyes-mark";
 import { AssistantSectionEmptyState } from "@/domains/chat/components/assistant-section-empty-state";
 import { SidebarSectionCard } from "@/domains/chat/components/sidebar-section-card";
 import {
@@ -102,6 +103,17 @@ export function SidebarSectionItem({
     <SidebarSectionCard
       value={section.key}
       icon={sectionIcon(section)}
+      /* The assistant's own eyes stand where the topic glyph would, because
+         this section is a person rather than a category. `AssistantEyesMark`
+         renders `null` without a character avatar (custom image, or still
+         loading), and the slot collapses to the Lucide fallback in that
+         case — so a custom-image avatar gets a plain header rather than a
+         gap where a mark should be. */
+      iconNode={
+        isAssistantSection ? (
+          <AssistantEyesMark assistantId={assistantId} width={16} />
+        ) : undefined
+      }
       label={label}
       /* The one section painted in the assistant's own color, so it reads as
          coming from someone rather than as another bucket. `--avatar-accent`
@@ -110,11 +122,12 @@ export function SidebarSectionItem({
          surface itself: mixing a percentage of `--surface-lift` into
          `--surface-lift` is exactly `--surface-lift`, which is what every
          other card paints. A `transparent` fallback would instead punch a
-         hole in the card. Kept low (7%) because this sits behind
-         conversation rows that still have to read as ordinary rows. */
+         hole in the card. 18% is the balance point: strong enough that the
+         card reads as a different surface at a glance, short of reading as
+         selected — the rows on top still have to read as ordinary rows. */
       cardClassName={
         isAssistantSection
-          ? "bg-[color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_7%,var(--surface-lift))]"
+          ? "bg-[color-mix(in_srgb,var(--avatar-accent,var(--surface-lift))_18%,var(--surface-lift))]"
           : undefined
       }
       /* The "…" button and the header's right-click menu both render from

--- a/clients/web/src/domains/chat/use-sidebar-state.test.tsx
+++ b/clients/web/src/domains/chat/use-sidebar-state.test.tsx
@@ -715,9 +715,8 @@ describe("useSidebarState index unread threading", () => {
 });
 
 describe("useSidebarState assistant-initiated section", () => {
-  test("renders from the index row, leading the default order", () => {
-    // It is the one section the assistant fills by itself, so it is what the
-    // user should meet first on opening the app.
+  test("renders from the index row, at the foot of the list", () => {
+    // It sits at the bottom, directly above the Preferences footer.
     sidebarSectionsImpl = [
       { kind: "assistant", total: 3, unread: 1 },
       { kind: "pinned", total: 1, unread: 0 },
@@ -728,8 +727,57 @@ describe("useSidebarState assistant-initiated section", () => {
       useSidebarState({ assistantId: "asst-1", conversations: [] }),
     );
 
-    expect(result.current.sections[0]?.key).toBe("assistant");
-    expect(result.current.sections[0]?.label).toBe("On My Mind");
+    const sections = result.current.sections;
+    expect(sections.at(-1)?.key).toBe("assistant");
+    expect(sections.at(-1)?.label).toBe("On My Mind");
+  });
+
+  test("stays at the foot under a stored order that puts it first", () => {
+    // The pin is applied to the rendered order, not to the stored preference,
+    // so an order written before this section existed — or one a drag left
+    // saying otherwise — still resolves to the bottom.
+    // Chats before Pinned inverts the default, so this also proves the stored
+    // order is genuinely being read — otherwise the assertion below would
+    // hold for the default order too and prove nothing.
+    localStorage.setItem(
+      "vellum:sidebar-section-order:asst-1",
+      JSON.stringify(["assistant", "recents", "pinned"]),
+    );
+    sidebarSectionsImpl = [
+      { kind: "assistant", total: 3, unread: 1 },
+      { kind: "pinned", total: 1, unread: 0 },
+      { kind: "chats", total: 5, unread: 0 },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations: [] }),
+    );
+
+    expect(result.current.sections.map((s) => s.key)).toEqual([
+      "recents",
+      "pinned",
+      "assistant",
+    ]);
+  });
+
+  test("cannot be nudged out of its slot, and nothing can be nudged past it", () => {
+    sidebarSectionsImpl = [
+      { kind: "assistant", total: 3, unread: 1 },
+      { kind: "pinned", total: 1, unread: 0 },
+      { kind: "chats", total: 5, unread: 0 },
+    ];
+
+    const { result } = renderHook(() =>
+      useSidebarState({ assistantId: "asst-1", conversations: [] }),
+    );
+
+    // The pinned section itself never moves.
+    expect(result.current.canMoveSection("assistant", -1)).toBe(false);
+    expect(result.current.canMoveSection("assistant", 1)).toBe(false);
+    // And Chats, the last orderable section, has nowhere further down to go —
+    // rather than offering a swap the pin would silently undo.
+    expect(result.current.canMoveSection("recents", 1)).toBe(false);
+    expect(result.current.canMoveSection("recents", -1)).toBe(true);
   });
 
   test("renders at zero, the way Chats does", () => {

--- a/clients/web/src/domains/chat/use-sidebar-state.ts
+++ b/clients/web/src/domains/chat/use-sidebar-state.ts
@@ -58,9 +58,11 @@ import {
   isKnownPrimaryKey,
 } from "@/domains/chat/utils/sidebar-group-collapse-storage";
 import {
+  ASSISTANT_SECTION_KEY,
   mergeSectionOrder,
   moveSectionKey,
   nextStoredOrder,
+  pinAssistantSectionLast,
 } from "@/domains/chat/utils/sidebar-section-order";
 import {
   saveViewMode,
@@ -294,26 +296,6 @@ export function useSidebarState({
       const rowsByChannelId = new Map(
         grouped.channelSections.map((s) => [s.channelId, s.conversations]),
       );
-      /* Leads the default order: it is the one section the assistant fills
-         by itself, so it is what the user should see first on opening the
-         app. The daemon emits the row only under the flag and only ever one
-         of it, so no gate is needed here beyond its presence. Unlike every
-         section but Chats it renders at zero, because its empty state is
-         what explains the section to someone who has no threads yet.
-
-         `all` is empty rather than derived: these rows are withheld from the
-         foreground list the fallback buckets are built from, so there is no
-         derived bucket to fall back to. The section's own query fills it. */
-      const assistantRow = indexSections.find((s) => s.kind === "assistant");
-      if (assistantRow) {
-        list.push({
-          type: "assistant",
-          key: "assistant",
-          label: ASSISTANT_SECTION_LABEL,
-          all: [],
-          unread: assistantRow.unread,
-        });
-      }
       const pinnedRow = indexSections.find((s) => s.kind === "pinned");
       if (pinnedRow) {
         list.push({
@@ -373,6 +355,30 @@ export function useSidebarState({
             unread: row.unread,
           });
         }
+      }
+      /* Last, and pinned there — it sits at the foot of the list, directly
+         above the Preferences footer, wherever the user has arranged
+         everything else (see `pinAssistantSectionLast`). Pushed last here so
+         the default order needs no separate rule; the pin is what holds it
+         against a stored order that says otherwise.
+
+         The daemon emits the row only under the flag, and only one of it, so
+         its presence is the whole gate. Unlike every section but Chats it
+         renders at zero, because its empty state is what explains the section
+         to someone who has no threads yet.
+
+         `all` is empty rather than derived: these rows are withheld from the
+         foreground list the fallback buckets are built from, so there is no
+         derived bucket to fall back to. The section's own query fills it. */
+      const assistantRow = indexSections.find((s) => s.kind === "assistant");
+      if (assistantRow) {
+        list.push({
+          type: "assistant",
+          key: ASSISTANT_SECTION_KEY,
+          label: ASSISTANT_SECTION_LABEL,
+          all: [],
+          unread: assistantRow.unread,
+        });
       }
       return list;
     }
@@ -440,27 +446,50 @@ export function useSidebarState({
         ? defaultKeys
         : mergeSectionOrder(defaultKeys, sectionOrder);
     const byKey = new Map(defaultSections.map((s) => [s.key, s]));
-    return ordered.map((key) => byKey.get(key)!);
+    /* The pin is applied to the rendered order rather than to the stored
+       preference, so a stored list written before this section existed — or
+       one a drag left saying something else — still renders it last. */
+    return pinAssistantSectionLast(ordered).map((key) => byKey.get(key)!);
   }, [defaultSections, sectionOrder]);
 
   const onReorderSections = useCallback(
     (orderedKeys: string[]) => {
-      setSectionOrder(nextStoredOrder(sectionOrder, orderedKeys));
+      // A drag can drop something below the pinned section; normalizing here
+      // means the stored order never disagrees with what renders.
+      setSectionOrder(
+        nextStoredOrder(sectionOrder, pinAssistantSectionLast(orderedKeys)),
+      );
     },
     [sectionOrder, setSectionOrder],
   );
 
   // The order `key` would land in after a nudge, or null when the nudge
-  // changes nothing, which now means only one thing: `key` is already at
-  // that end of the list. Sections reorder freely otherwise.
+  // changes nothing: `key` is already at that end of the orderable list, or
+  // it is the bottom-pinned assistant section, which does not move.
   const orderAfterMove = useCallback(
     (key: string, delta: -1 | 1): string[] | null => {
-      const current = sections.map((s) => s.key);
+      if (key === ASSISTANT_SECTION_KEY) {
+        return null;
+      }
+      /* Nudges run over the orderable keys alone, so the section below the
+         pinned one is at the end of the list as far as a move is concerned —
+         "down" from there is a no-op rather than a swap that the pin would
+         silently undo. */
+      const current = sections
+        .map((s) => s.key)
+        .filter((k) => k !== ASSISTANT_SECTION_KEY);
       const moved = moveSectionKey(current, key, delta);
       if (!moved) {
         return null;
       }
-      return moved.join("\0") === current.join("\0") ? null : moved;
+      if (moved.join("\0") === current.join("\0")) {
+        return null;
+      }
+      // Re-append the pinned key (when the section exists at all) so the
+      // stored order this produces already agrees with what renders.
+      return sections.some((s) => s.key === ASSISTANT_SECTION_KEY)
+        ? [...moved, ASSISTANT_SECTION_KEY]
+        : moved;
     },
     [sections],
   );

--- a/clients/web/src/domains/chat/utils/sidebar-section-order.ts
+++ b/clients/web/src/domains/chat/utils/sidebar-section-order.ts
@@ -37,6 +37,32 @@ import { createKeyedStorageAccessor } from "@/utils/typed-storage";
  */
 const MAX_STORED_KEYS = 100;
 
+/**
+ * Section key for the assistant-initiated threads.
+ *
+ * The one section that is not user-orderable: it sits at the bottom of the
+ * list, directly above the Preferences footer, wherever the user has arranged
+ * everything else. See {@link pinAssistantSectionLast}.
+ */
+export const ASSISTANT_SECTION_KEY = "assistant";
+
+/**
+ * Move {@link ASSISTANT_SECTION_KEY} to the end of `keys`, if present.
+ *
+ * Applied to the *rendered* order and to every reorder result, so the stored
+ * preference list can say whatever it likes about this key and the section
+ * still renders last. That keeps the pin from depending on storage being
+ * well-formed: a stored order written before the section existed, or one a
+ * drag left in an odd state, both resolve to the same place.
+ *
+ * A no-op when the key is absent, which is every assistant without the
+ * section.
+ */
+export function pinAssistantSectionLast(keys: readonly string[]): string[] {
+  const rest = keys.filter((key) => key !== ASSISTANT_SECTION_KEY);
+  return rest.length === keys.length ? rest : [...rest, ASSISTANT_SECTION_KEY];
+}
+
 // ---------------------------------------------------------------------------
 // Order merging
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four changes, all to placement and treatment of the assistant-initiated section.

**Pinned to the foot of the list.** Moved from the head to the end, directly above the Preferences footer, and pinned there — the one section the user cannot reorder, and nothing else can be nudged past it (`canMoveSection("recents", 1)` is now `false` rather than offering a swap the pin would silently undo). `pinAssistantSectionLast` is applied to the *rendered* order and to every reorder result, not to the stored preference, so an order written before the section existed — or one a drag left in an odd state — still resolves to the bottom.

**`isLast` now means the last space-claiming section.** It previously meant the last rendered one. With the section pinned below everything, handing it the rail's leftover height would stretch a short list of realizations down the sidebar and squeeze Chats — the list that actually grows — into a fixed box above it.

**Avatar eyes in the header**, where a topic glyph would sit, because this section is a person rather than a category. That needed a new `iconNode` slot on `CollapsibleNavSection`: the eye sprite is not a Lucide icon and has its own aspect ratio, so a forced 12px square would distort it. `icon` still takes a `LucideIcon`; `iconNode` wins when both are given, and only the Lucide branch takes the tertiary ink (the sprite is filled from the avatar palette and would ignore it anyway). `AssistantEyesMark` returns `null` without a character avatar, so a custom-image avatar falls back to the Lucide glyph rather than leaving a gap.

**Tint raised 7% → 18%.** The subtle version was hard to see beside a plain card.

## Story

Adds `Chat/AssistantSideMenuWithAssistantSection` — the whole sidebar, not one card: assistant pill, New Chat, every section, Preferences footer. The menu runs its own `useSidebarState`, which reads the daemon's section index; seeding `sidebarSectionsQueryKey` resolves that from cache, so the section list is the one the app builds, in the order the app orders it. Seeding the `assistant` index row is exactly the flag-on state, since the daemon emits that row only under the flag.

Every seeded value is a production type (`SidebarIndexSection`, `ConversationListPage`, `Conversation`), so drift in any of those breaks this build rather than surfacing later in the app.

## Tests

3 new, covering the pin: renders at the foot; stays there under a stored order that puts it first (the stored order inverts Pinned/Chats too, so the assertion cannot pass vacuously on the default order); and neither it nor its neighbour can be nudged across the boundary.

Existing suites pass: side menu (73), collapsible-nav-section (16), section-order (18), section-item (6), section-conversations (21), collapsed-rail (4).
