### PR TITLE
feat(ios): add go-to-conversation notification action and keep line breaks

### DIFF
--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -609,20 +609,22 @@ describe("emitAssistantReplyNotification", () => {
   });
 
   // Control characters would otherwise ride into the APNs payload verbatim.
-  test("strips control characters and newlines out of the preview", async () => {
+  // Newlines stay: iOS (and other lock screens) render them as line breaks.
+  test("strips control characters and keeps line breaks in the preview", async () => {
     assistantRow = makeAssistantRow([
       { type: "text", text: "Hello\n\tthere" },
     ] as ContentBlock[]);
 
     await run();
 
-    expect(emitCalls[0].contextPayload.requestedMessage).toBe("Hello there");
+    expect(emitCalls[0].contextPayload.requestedMessage).toBe("Hello\nthere");
   });
 
-  // Blank lines and list indentation would otherwise spend the preview's
-  // length budget on whitespace. The bullets go with them: a lock screen
-  // renders the marker as literal punctuation, not as a list.
-  test("collapses whitespace runs in the preview", async () => {
+  // List indentation and extra blank lines would otherwise spend the preview's
+  // length budget on whitespace. Markdown list markers are already gone after
+  // flattening; the remaining line breaks are the structure a lock screen can
+  // render.
+  test("keeps paragraph breaks after collapsing horizontal whitespace", async () => {
     assistantRow = makeAssistantRow([
       { type: "text", text: "  Here:\n\n  - item\n  - other  " },
     ] as ContentBlock[]);
@@ -630,7 +632,7 @@ describe("emitAssistantReplyNotification", () => {
     await run();
 
     expect(emitCalls[0].contextPayload.requestedMessage).toBe(
-      "Here: item other",
+      "Here:\n\nitem\nother",
     );
   });
 
@@ -684,7 +686,7 @@ describe("emitAssistantReplyNotification", () => {
       await run();
 
       expect(emitCalls[0].contextPayload.requestedMessage).toBe(
-        "Fixed it: const a = 1;",
+        "Fixed it:\n\nconst a = 1;",
       );
     });
 
@@ -699,7 +701,7 @@ describe("emitAssistantReplyNotification", () => {
       await run();
 
       expect(emitCalls[0].contextPayload.requestedMessage).toBe(
-        "Keys Env Key dev 4Y4L",
+        "Keys\n\nEnv Key\ndev 4Y4L",
       );
     });
 

--- a/assistant/src/notifications/__tests__/notification-utils.test.ts
+++ b/assistant/src/notifications/__tests__/notification-utils.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  collapseHorizontalWhitespace,
   describeMedia,
   mediaEmbeds,
+  sanitizeMultilineMessagePreview,
   stripMarkdownForPreview,
 } from "../notification-utils.js";
 
@@ -227,6 +229,35 @@ describe("mediaEmbeds", () => {
         mediaEmbeds("![a][ref]\n\n[ref]: vellum://workspace/a.png")[0]?.tracked,
       ).toBe(false);
     });
+  });
+});
+
+describe("collapseHorizontalWhitespace", () => {
+  test("keeps paragraph breaks and trims line padding", () => {
+    expect(collapseHorizontalWhitespace("  Here:\n\n  item  \n  other  ")).toBe(
+      "Here:\n\nitem\nother",
+    );
+  });
+
+  test("collapses three or more newlines to one blank line", () => {
+    expect(collapseHorizontalWhitespace("a\n\n\n\nb")).toBe("a\n\nb");
+  });
+});
+
+describe("sanitizeMultilineMessagePreview", () => {
+  test("keeps newlines and strips other control characters", () => {
+    expect(sanitizeMultilineMessagePreview("Hello\n\tWorld")).toBe(
+      "Hello\nWorld",
+    );
+    expect(sanitizeMultilineMessagePreview("Test\r\nMessage")).toBe(
+      "Test\nMessage",
+    );
+  });
+
+  test("clamps to the shared preview budget", () => {
+    const result = sanitizeMultilineMessagePreview("A".repeat(250));
+    expect(result).toHaveLength(200);
+    expect(result.endsWith("…")).toBe(true);
   });
 });
 

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -36,6 +36,7 @@ import {
   describeMedia,
   mediaEmbeds,
   sanitizeMessagePreview,
+  sanitizeMultilineMessagePreview,
   sanitizeNotificationTitle,
   stripMarkdownForPreview,
 } from "./notification-utils.js";
@@ -50,10 +51,10 @@ const DESKTOP_PRESENCE_FLAG = "desktop-presence-suppression" as const;
 const WEB_PRESENCE_FLAG = "web-presence-suppression" as const;
 
 /**
- * Collapse whitespace runs ahead of the sanitizers' truncation: blank lines and
- * list indentation would otherwise eat into the copy's length budget.
+ * Flatten a title onto one line. Notification titles cannot wrap, and
+ * `normalizeTitle` discards any string that still contains a newline.
  */
-function collapseWhitespace(value: string): string {
+function flattenTitleWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
@@ -229,9 +230,8 @@ export async function emitAssistantReplyNotification(params: {
     // text nor media stays silent.
     const text = stringifyMessageContent(assistantRow.content);
     const preview =
-      sanitizeMessagePreview(
-        collapseWhitespace(stripMarkdownForPreview(text)),
-      ) || sanitizeMessagePreview(describeReplyMedia(text, assistantMessageId));
+      sanitizeMultilineMessagePreview(stripMarkdownForPreview(text)) ||
+      sanitizeMessagePreview(describeReplyMedia(text, assistantMessageId));
     if (!preview) {
       return;
     }
@@ -242,7 +242,7 @@ export async function emitAssistantReplyNotification(params: {
     // title from the body, which reads better than an empty or placeholder
     // conversation title.
     const requestedTitle = sanitizeNotificationTitle(
-      collapseWhitespace(conversation.title ?? ""),
+      flattenTitleWhitespace(conversation.title ?? ""),
     );
 
     // Read as close to the emit as possible: nothing short-circuits on it.

--- a/assistant/src/notifications/notification-utils.ts
+++ b/assistant/src/notifications/notification-utils.ts
@@ -9,7 +9,10 @@
 import type { Root, RootContent } from "mdast";
 
 import { parseMarkdown } from "../messaging/content/parse.js";
-import { stripAnsiAndControlChars } from "../util/ansi.js";
+import {
+  stripAnsiAndControlChars,
+  stripAnsiSequences,
+} from "../util/ansi.js";
 import { isPlainObject } from "../util/object.js";
 
 // ── String helpers ──────────────────────────────────────────────────────────
@@ -235,6 +238,40 @@ export function describeMedia(labels: string[]): string {
  */
 function sanitize(value: string, maxLength: number): string {
   return truncate(stripAnsiAndControlChars(value, " ").trim(), maxLength);
+}
+
+/**
+ * Collapse horizontal whitespace and blank-line runs while keeping paragraph
+ * breaks. Tabs become spaces. Three or more consecutive newlines collapse to
+ * one blank line so padding does not eat the preview budget.
+ */
+export function collapseHorizontalWhitespace(value: string): string {
+  return value
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/**
+ * Sanitize a notification body that should keep its line breaks.
+ *
+ * ANSI sequences and non-newline control characters are stripped; `\r\n` and
+ * `\r` become `\n`. Horizontal whitespace is collapsed. The result is clamped
+ * to {@link MESSAGE_PREVIEW_MAX_LENGTH}.
+ *
+ * Single-line surfaces (titles, identity fields, channel previews that must
+ * not wrap) should keep using {@link sanitizeMessagePreview}.
+ */
+export function sanitizeMultilineMessagePreview(value: string): string {
+  const normalized = stripAnsiSequences(value)
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]+/g, " ");
+  return truncate(
+    collapseHorizontalWhitespace(normalized),
+    MESSAGE_PREVIEW_MAX_LENGTH,
+  );
 }
 
 /**

--- a/clients/ios/App/App/AppDelegate.swift
+++ b/clients/ios/App/App/AppDelegate.swift
@@ -7,6 +7,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Categories persist across launches, so remote pushes can show the
+        // action after the first open even when JS has not yet registered.
+        NotificationCategories.register()
+
         // A QR scan that launches the terminated app delivers the connect URL
         // here as well as through `application(_:open:)`. Persist the origin
         // now, synchronously, so the bridge boots straight to it — by the time

--- a/clients/ios/App/App/NotificationCategories.swift
+++ b/clients/ios/App/App/NotificationCategories.swift
@@ -1,0 +1,35 @@
+import UserNotifications
+
+/// OS notification categories the iOS shell registers at launch.
+///
+/// Remote pushes can arrive before the Capacitor bridge has run, so the
+/// category must exist in `UNUserNotificationCenter` independently of JS.
+/// The identifier and action id stay aligned with
+/// `NOTIFICATION_INTENT_ACTION_TYPE_ID` in `clients/web/src/runtime/notifications.ts`
+/// and `APNS_CONVERSATION_CATEGORY` on the platform APNs sender.
+enum NotificationCategories {
+    static let intentIdentifier = "notificationIntent"
+    static let viewActionIdentifier = "view"
+    /// English fallback used before the web catalog can re-register a localized title.
+    static let viewActionTitle = "Go to Conversation"
+
+    static func intentCategory() -> UNNotificationCategory {
+        let view = UNNotificationAction(
+            identifier: viewActionIdentifier,
+            title: viewActionTitle,
+            options: [.foreground]
+        )
+        return UNNotificationCategory(
+            identifier: intentIdentifier,
+            actions: [view],
+            intentIdentifiers: [],
+            options: []
+        )
+    }
+
+    static func register() {
+        UNUserNotificationCenter.current().setNotificationCategories([
+            intentCategory(),
+        ])
+    }
+}

--- a/clients/ios/App/AppTests/NotificationCategoriesTests.swift
+++ b/clients/ios/App/AppTests/NotificationCategoriesTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+import UserNotifications
+
+final class NotificationCategoriesTests: XCTestCase {
+    func testIntentCategoryExposesTheGoToConversationAction() {
+        let category = NotificationCategories.intentCategory()
+        XCTAssertEqual(category.identifier, "notificationIntent")
+        XCTAssertEqual(category.actions.count, 1)
+        XCTAssertEqual(category.actions[0].identifier, "view")
+        XCTAssertEqual(category.actions[0].title, "Go to Conversation")
+        XCTAssertTrue(category.actions[0].options.contains(.foreground))
+    }
+}

--- a/clients/ios/App/project.yml
+++ b/clients/ios/App/project.yml
@@ -222,6 +222,7 @@ targets:
     sources:
       - path: AppTests
       - path: App/Attribution.swift
+      - path: App/NotificationCategories.swift
     settings:
       base:
         GENERATE_INFOPLIST_FILE: "YES"

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -319,6 +319,9 @@
   "lazyBoundary": {
     "loadError": "This section couldn't load. Reload the page to try again."
   },
+  "localNotification": {
+    "goToConversation": "Go to Conversation"
+  },
   "macosAppBanner": {
     "ariaLabel": "Download the macOS app",
     "ctaAriaLabel": "Download macOS app",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -317,6 +317,9 @@
   "lazyBoundary": {
     "loadError": "Esta sección no se pudo cargar. Recarga la página para intentarlo de nuevo."
   },
+  "localNotification": {
+    "goToConversation": "Ir a la conversación"
+  },
   "macosAppBanner": {
     "ariaLabel": "Descargar la app de macOS",
     "ctaAriaLabel": "Descargar la app de macOS",

--- a/clients/web/src/i18n/locales/ru/common.json
+++ b/clients/web/src/i18n/locales/ru/common.json
@@ -107,6 +107,9 @@
     "started": "Скачивание началось",
     "startedDescription": "Файл {filename} появится в загрузках браузера."
   },
+  "localNotification": {
+    "goToConversation": "Перейти к диалогу"
+  },
   "managedServicesBanner": {
     "body": "Управляемые сервисы тарифицируются и списываются с баланса аккаунта Vellum. <link>Смотреть цены</link>"
   },

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -317,6 +317,9 @@
   "lazyBoundary": {
     "loadError": "此區段無法載入。請重新載入頁面再試一次。"
   },
+  "localNotification": {
+    "goToConversation": "前往對話"
+  },
   "macosAppBanner": {
     "ariaLabel": "下載 macOS 應用程式",
     "ctaAriaLabel": "下載 macOS 應用程式",

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -317,6 +317,9 @@
   "lazyBoundary": {
     "loadError": "此部分无法加载。请重新加载页面重试。"
   },
+  "localNotification": {
+    "goToConversation": "前往对话"
+  },
   "macosAppBanner": {
     "ariaLabel": "下载 macOS 应用",
     "ctaAriaLabel": "下载 macOS 应用",

--- a/clients/web/src/runtime/notifications.test.ts
+++ b/clients/web/src/runtime/notifications.test.ts
@@ -44,18 +44,38 @@ mock.module("@/runtime/android-notification-channels", () => ({
   ANDROID_ALERTS_CHANNEL_ID: "vellum-alerts",
   ensureAndroidAlertsChannel: ensureAndroidAlertsChannelMock,
 }));
+mock.module("@/i18n", () => ({
+  t: (key: string) =>
+    key === "localNotification.goToConversation"
+      ? "Go to Conversation"
+      : key,
+}));
 
 // ── @capacitor/local-notifications ───────────────────────────────────────────
 
 interface ScheduleArg {
-  notifications: Array<{ id: number; title: string; body: string; channelId?: string }>;
+  notifications: Array<{
+    id: number;
+    title: string;
+    body: string;
+    channelId?: string;
+    actionTypeId?: string;
+  }>;
+}
+interface RegisterActionTypesArg {
+  types: Array<{
+    id: string;
+    actions: Array<{ id: string; title: string; foreground?: boolean }>;
+  }>;
 }
 const scheduleMock = mock(async (_arg: ScheduleArg) => {});
+const registerActionTypesMock = mock(async (_arg: RegisterActionTypesArg) => {});
 mock.module("@capacitor/local-notifications", () => ({
   LocalNotifications: {
     checkPermissions: async () => ({ display: "granted" }),
     requestPermissions: async () => ({ display: "granted" }),
     schedule: scheduleMock,
+    registerActionTypes: registerActionTypesMock,
     addListener: async () => ({ remove: async () => {} }),
   },
 }));
@@ -77,6 +97,8 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
 }));
 
 const {
+  NOTIFICATION_INTENT_ACTION_TYPE_ID,
+  NOTIFICATION_INTENT_VIEW_ACTION_ID,
   postForegroundRemotePush,
   postLocalNotification,
   __resetNotificationsStateForTests,
@@ -101,6 +123,7 @@ beforeEach(() => {
   nativeAndroid = false;
   sessionConfirmedAssistantId = null;
   scheduleMock.mockClear();
+  registerActionTypesMock.mockClear();
   ackMock.mockClear();
   ackArgs.length = 0;
   ensureAndroidAlertsChannelMock.mockClear();
@@ -283,5 +306,40 @@ describe("postLocalNotification remote-push dedup (native branch)", () => {
     await Promise.all([first, waiter]);
     expect(scheduleMock).toHaveBeenCalledTimes(2);
     expect(ackArgs.map(({ body }) => body.success)).toEqual([true, true]);
+  });
+
+  test("registers a go-to-conversation action and attaches it when a conversation is present", async () => {
+    await postLocalNotification({
+      ...baseArgs,
+      deepLinkMetadata: { conversationId: "conv-xyz" },
+    });
+
+    expect(registerActionTypesMock).toHaveBeenCalledTimes(1);
+    expect(registerActionTypesMock.mock.calls[0]?.[0]).toEqual({
+      types: [
+        {
+          id: NOTIFICATION_INTENT_ACTION_TYPE_ID,
+          actions: [
+            {
+              id: NOTIFICATION_INTENT_VIEW_ACTION_ID,
+              title: "Go to Conversation",
+              foreground: true,
+            },
+          ],
+        },
+      ],
+    });
+    expect(
+      scheduleMock.mock.calls[0]?.[0].notifications[0]?.actionTypeId,
+    ).toBe(NOTIFICATION_INTENT_ACTION_TYPE_ID);
+  });
+
+  test("registers the action type even when the banner has no conversation", async () => {
+    await postLocalNotification(baseArgs);
+
+    expect(registerActionTypesMock).toHaveBeenCalledTimes(1);
+    expect(
+      scheduleMock.mock.calls[0]?.[0].notifications[0]?.actionTypeId,
+    ).toBeUndefined();
   });
 });

--- a/clients/web/src/runtime/notifications.ts
+++ b/clients/web/src/runtime/notifications.ts
@@ -31,6 +31,7 @@ import type { PushNotificationSchema } from "@capacitor/push-notifications";
 
 import { notificationintentresultPost } from "@/generated/daemon/sdk.gen";
 import type { NotificationintentresultPostData } from "@/generated/daemon/types.gen";
+import { t } from "@/i18n";
 import {
   ANDROID_ALERTS_CHANNEL_ID,
   ensureAndroidAlertsChannel,
@@ -54,12 +55,24 @@ export interface NotificationTapPayload {
   deliveryId?: string;
 }
 
+/**
+ * Capacitor / APNs category for the "Go to Conversation" action. Must stay
+ * aligned with `NotificationCategories.intentIdentifier` in the iOS shell and
+ * `APNS_CONVERSATION_CATEGORY` on the platform APNs sender.
+ */
+export const NOTIFICATION_INTENT_ACTION_TYPE_ID = "notificationIntent";
+
+/** Action id inside {@link NOTIFICATION_INTENT_ACTION_TYPE_ID}. */
+export const NOTIFICATION_INTENT_VIEW_ACTION_ID = "view";
+
 /** Current notification permission status, cached after first resolution. */
 type PermissionState = "granted" | "denied" | "prompt" | "unsupported";
 
 let cachedPermission: PermissionState | null = null;
 let pendingPermissionRequest: Promise<PermissionState> | null = null;
 let tapListenersRegistered = false;
+let conversationActionTypeRegistered = false;
+let conversationActionTypePromise: Promise<void> | null = null;
 let tapHandler: ((payload: NotificationTapPayload) => void) | null = null;
 const recentNativeDeliveryIds = new Set<string>();
 const nativeDeliveryPromises = new Map<string, Promise<void>>();
@@ -204,6 +217,47 @@ async function requestPermissionOnce(): Promise<PermissionState> {
   }
 }
 
+/**
+ * Register the conversation action category with the OS. Capacitor's
+ * `registerActionTypes` replaces the process-wide category set, so this
+ * must include every action type we rely on. The iOS shell also registers
+ * the same identifier at launch so remote pushes can show the action
+ * before JS loads.
+ */
+async function ensureConversationActionType(): Promise<void> {
+  if (conversationActionTypeRegistered) {
+    return;
+  }
+  if (conversationActionTypePromise) {
+    await conversationActionTypePromise;
+    return;
+  }
+  conversationActionTypePromise = (async () => {
+    try {
+      await LocalNotifications.registerActionTypes({
+        types: [
+          {
+            id: NOTIFICATION_INTENT_ACTION_TYPE_ID,
+            actions: [
+              {
+                id: NOTIFICATION_INTENT_VIEW_ACTION_ID,
+                title: t("localNotification.goToConversation"),
+                foreground: true,
+              },
+            ],
+          },
+        ],
+      });
+      conversationActionTypeRegistered = true;
+    } catch {
+      // Best-effort: banners still fire without the action button.
+    } finally {
+      conversationActionTypePromise = null;
+    }
+  })();
+  await conversationActionTypePromise;
+}
+
 async function registerTapListeners(): Promise<void> {
   if (tapListenersRegistered) {
     return;
@@ -232,6 +286,7 @@ async function registerTapListeners(): Promise<void> {
     return;
   }
   try {
+    await ensureConversationActionType();
     await LocalNotifications.addListener(
       "localNotificationActionPerformed",
       (action) => {
@@ -509,9 +564,13 @@ export async function postLocalNotification(
       title: args.title,
       body: args.body,
       extra: tapPayload,
+      ...(conversationId
+        ? { actionTypeId: NOTIFICATION_INTENT_ACTION_TYPE_ID }
+        : {}),
       ...(isNativeAndroid() ? { channelId: ANDROID_ALERTS_CHANNEL_ID } : {}),
     };
     try {
+      await ensureConversationActionType();
       const correlationId = args.correlationId ?? args.deliveryId;
       if (correlationId && isNativeAndroid()) {
         await scheduleNativeDelivery(correlationId, notification);
@@ -596,6 +655,8 @@ export function __resetNotificationsStateForTests(): void {
   cachedPermission = null;
   pendingPermissionRequest = null;
   tapListenersRegistered = false;
+  conversationActionTypeRegistered = false;
+  conversationActionTypePromise = null;
   tapHandler = null;
   recentNativeDeliveryIds.clear();
   nativeDeliveryPromises.clear();

--- a/clients/web/src/runtime/push-registration.test.ts
+++ b/clients/web/src/runtime/push-registration.test.ts
@@ -400,6 +400,16 @@ describe("pushNotificationActionPerformed tap routing", () => {
     expect(published).toEqual([{ threadId: "conv-456" }]);
   });
 
+  test("routes a Go to Conversation action the same as a tap", async () => {
+    await registerForRemotePush("assistant-1");
+    actionPerformedHandler?.({
+      actionId: "view",
+      notification: { data: { deep_link: { conversationId: "conv-view" } } },
+    });
+
+    expect(published).toEqual([{ threadId: "conv-view" }]);
+  });
+
   test("publishes nothing for absent or malformed data", async () => {
     await registerForRemotePush("assistant-1");
     tap(undefined);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
[LUM-3497](https://linear.app/vellum/issue/LUM-3497): iOS notifications should offer a way to jump to the conversation (macOS parity) and should keep the original line breaks in the notification body.

Companion platform PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/10267 (sets `aps.category` on remote APNs alerts). Either PR can merge first.

## Summary
- Register a `notificationIntent` category on iOS at launch (`NotificationCategories.swift`) and again from Capacitor when the web client schedules a local banner.
- Attach a **Go to Conversation** action (foreground) when the notification has a conversation id. Tap and action both reuse the existing `deeplink.openThread` path.
- Keep paragraph breaks in assistant-reply notification bodies. Titles stay single-line. Other single-line sanitizers (`sanitizeMessagePreview`) are unchanged.

## Test plan
- `cd assistant && bun test src/notifications/__tests__/assistant-reply-producer.test.ts src/notifications/__tests__/notification-utils.test.ts` (125 pass)
- `cd clients/web && bun test src/runtime/notifications.test.ts` (14 pass)
- `cd clients/web && bun test src/runtime/push-registration.test.ts` (33 pass, including `actionId: "view"`)
- Device/TestFlight: long-press an iOS notification and confirm the action opens the conversation; confirm multi-paragraph reply bodies wrap instead of running on.

## Risk
- Capacitor `registerActionTypes` replaces the process-wide category set. The JS registration uses the same identifier as the native launch registration so remote pushes keep working after the web layer loads.
- Remote-push action buttons also need the companion platform change (`aps.category`). Local banners work from this PR alone.
- Line-break preservation applies to assistant-reply copy only. Guardian copy already kept paragraph breaks.

Part of LUM-3497
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e931136-3d13-4007-a9d6-0047b37a7775?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e931136-3d13-4007-a9d6-0047b37a7775&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

