### PR TITLE
feat(gateway): proxy /v1/desktop/stream to the runtime and open it through velay

### DIFF
--- a/gateway/src/__tests__/desktop-stream-websocket.test.ts
+++ b/gateway/src/__tests__/desktop-stream-websocket.test.ts
@@ -1,0 +1,544 @@
+import { afterEach, beforeEach, describe, test, expect, mock } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
+import type { DesktopStreamSocketData } from "../http/routes/desktop-stream-websocket.js";
+
+/** The bound guardian's actor principal, which `mintEdgeToken` defaults to. */
+const GUARDIAN_PRINCIPAL = "test-user";
+
+/** The bound guardian's platform user id, for the velay-attested path. */
+const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
+
+// The desktop is a guardian-only surface, so the upgrade pins the caller to
+// the binding. Both lookups are mocked BEFORE the module under test is
+// imported, the way the watch stream's tests do it.
+let mockFindVellumGuardian = mock(
+  async (): Promise<{ principalId: string } | null> => ({
+    principalId: GUARDIAN_PRINCIPAL,
+  }),
+);
+mock.module("../auth/guardian-bootstrap.js", () => ({
+  findVellumGuardian: () => mockFindVellumGuardian(),
+}));
+
+let mockReadCredential = mock(
+  async (_key: string): Promise<string | undefined> => VELAY_USER_ID,
+);
+mock.module("../credential-reader.js", () => ({
+  readCredential: (key: string) => mockReadCredential(key),
+}));
+
+const {
+  createDesktopStreamWebsocketHandler,
+  getDesktopStreamWebsocketHandlers,
+} = await import("../http/routes/desktop-stream-websocket.js");
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+/** Mint a valid actor edge JWT for desktop stream auth. */
+function mintEdgeToken(actorPrincipalId: string = GUARDIAN_PRINCIPAL): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: `actor:test-assistant:${actorPrincipalId}`,
+    scope_profile: "actor_client_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+/** Mint a service-style token (no actor principal). */
+function mintServiceEdgeToken(): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    port: 7830,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+function makeFakeServer(upgradeResult: boolean = true) {
+  return {
+    requestIP: mock(() => ({
+      address: "127.0.0.1",
+      family: "IPv4",
+      port: 54000,
+    })),
+    upgrade: mock(() => upgradeResult),
+  } as unknown as import("bun").Server<unknown>;
+}
+
+/** The socket data the handler asked Bun to attach to the upgraded socket. */
+function upgradedData(
+  server: import("bun").Server<unknown>,
+): DesktopStreamSocketData {
+  const call = (server.upgrade as ReturnType<typeof mock>).mock
+    .calls[0] as unknown[];
+  return (call[1] as { data: DesktopStreamSocketData }).data;
+}
+
+beforeEach(() => {
+  mockFindVellumGuardian = mock(async () => ({
+    principalId: GUARDIAN_PRINCIPAL,
+  }));
+  mockReadCredential = mock(async (_key: string) => VELAY_USER_ID);
+});
+
+afterEach(() => {
+  delete process.env.IS_PLATFORM;
+});
+
+// ---------------------------------------------------------------------------
+// createDesktopStreamWebsocketHandler: upgrade handler tests
+// ---------------------------------------------------------------------------
+
+describe("createDesktopStreamWebsocketHandler", () => {
+  const upgrade = async (
+    url: string,
+    init: RequestInit = { headers: { upgrade: "websocket" } },
+    config = makeConfig(),
+    upgradeResult = true,
+  ) => {
+    const handler = createDesktopStreamWebsocketHandler(config);
+    const server = makeFakeServer(upgradeResult);
+    return { res: await handler(new Request(url, init), server), server };
+  };
+
+  test("upgrades when the token query parameter is valid", async () => {
+    const { res, server } = await upgrade(
+      `http://localhost:7830/v1/desktop/stream?token=${mintEdgeToken()}`,
+    );
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+    expect(upgradedData(server)).toMatchObject({ wsType: "desktop-stream" });
+  });
+
+  test("upgrades when the Authorization header is valid", async () => {
+    const { res, server } = await upgrade(
+      "http://localhost:7830/v1/desktop/stream",
+      {
+        headers: {
+          upgrade: "websocket",
+          authorization: `Bearer ${mintEdgeToken()}`,
+        },
+      },
+    );
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns 401 when no token is provided", async () => {
+    const { res, server } = await upgrade(
+      "http://localhost:7830/v1/desktop/stream",
+    );
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when the token is invalid", async () => {
+    const { res, server } = await upgrade(
+      "http://localhost:7830/v1/desktop/stream?token=bad-token",
+    );
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The client-facing half of the proxy takes actors and nothing else. A
+   * service credential reaching it would hand the pod's desktop to a token
+   * minted for machine to machine traffic.
+   */
+  test("returns 401 for a service token, which has no actor principal", async () => {
+    const { res, server } = await upgrade(
+      `http://localhost:7830/v1/desktop/stream?token=${mintServiceEdgeToken()}`,
+    );
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 426 when the request is not a WebSocket upgrade", async () => {
+    const { res, server } = await upgrade(
+      `http://localhost:7830/v1/desktop/stream?token=${mintEdgeToken()}`,
+      {},
+    );
+
+    expect(res!.status).toBe(426);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 500 when the Bun upgrade fails", async () => {
+    const { res } = await upgrade(
+      `http://localhost:7830/v1/desktop/stream?token=${mintEdgeToken()}`,
+      { headers: { upgrade: "websocket" } },
+      makeConfig(),
+      false,
+    );
+
+    expect(res!.status).toBe(500);
+  });
+
+  test("allows an unauthenticated upgrade when auth is disabled (dev bypass)", async () => {
+    const { res, server } = await upgrade(
+      "http://localhost:7830/v1/desktop/stream",
+      { headers: { upgrade: "websocket" } },
+      makeConfig({ runtimeProxyRequireAuth: false }),
+    );
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The guardian pin
+// ---------------------------------------------------------------------------
+
+/**
+ * The proxy replaces the caller's identity with a service token upstream, so
+ * the runtime cannot tell one actor from another: whoever this upgrade admits
+ * gets the pod's desktop. This is the only place a non-guardian can be
+ * refused.
+ */
+describe("createDesktopStreamWebsocketHandler: the guardian pin", () => {
+  const upgrade = async (token: string) => {
+    const handler = createDesktopStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/desktop/stream?token=${token}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    return { res: await handler(req, server), server };
+  };
+
+  test("admits the bound guardian", async () => {
+    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("refuses a valid actor token that is not the bound guardian", async () => {
+    const { res, server } = await upgrade(mintEdgeToken("someone-else"));
+
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("refuses when no guardian binding exists", async () => {
+    mockFindVellumGuardian = mock(async () => null);
+
+    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
+
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("answers 503 when the binding lookup fails", async () => {
+    mockFindVellumGuardian = mock(async () => {
+      throw new Error("db down");
+    });
+
+    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
+
+    expect(res!.status).toBe(503);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The managed path, where velay validated the browser's token and injected the
+ * caller. The attestation proves the caller is *a* platform user who traversed
+ * velay, not that they are this assistant's guardian, so it is cross-checked
+ * against the stored `platform_user_id`.
+ */
+describe("createDesktopStreamWebsocketHandler: velay-attested managed auth", () => {
+  const VELAY_ORG_ID = "22222222-2222-2222-2222-222222222222";
+
+  const managedUpgrade = async ({
+    userId = VELAY_USER_ID,
+    bridgeProof = true,
+    token,
+    managed = true,
+  }: {
+    userId?: string;
+    bridgeProof?: boolean;
+    token?: string;
+    managed?: boolean;
+  }) => {
+    if (managed) {
+      process.env.IS_PLATFORM = "true";
+    } else {
+      delete process.env.IS_PLATFORM;
+    }
+    const headers = new Headers({
+      upgrade: "websocket",
+      "x-velay-user-id": userId,
+      "x-velay-org-id": VELAY_ORG_ID,
+      "x-velay-actor": "user",
+    });
+    if (bridgeProof) {
+      setVelayBridgeAuthHeader(headers);
+    }
+    const handler = createDesktopStreamWebsocketHandler(makeConfig());
+    const query = token ? `?token=${token}` : "";
+    const req = new Request(`http://localhost:7830/v1/desktop/stream${query}`, {
+      headers,
+    });
+    const server = makeFakeServer();
+    return { res: await handler(req, server), server };
+  };
+
+  test("admits an attested caller who is the bound guardian", async () => {
+    const { res, server } = await managedUpgrade({});
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("refuses an attested caller who is not the bound guardian", async () => {
+    mockReadCredential = mock(
+      async () => "99999999-9999-9999-9999-999999999999",
+    );
+
+    const { res, server } = await managedUpgrade({});
+
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A direct request to a reachable gateway can spoof the header names. It
+   * cannot know the process-local bridge proof, which is what says the request
+   * really arrived through this gateway's own loopback bridge.
+   */
+  test("ignores spoofed velay headers with no bridge proof", async () => {
+    const { res, server } = await managedUpgrade({ bridgeProof: false });
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  /** Falling through must not fall past the pin. */
+  test("still pins the token path in managed mode", async () => {
+    const { res } = await managedUpgrade({
+      bridgeProof: false,
+      token: mintEdgeToken("someone-else"),
+    });
+
+    expect(res!.status).toBe(403);
+  });
+
+  test("does not trust velay headers outside managed mode", async () => {
+    const { res, server } = await managedUpgrade({ managed: false });
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDesktopStreamWebsocketHandlers: the byte pipe, against a real upstream
+// ---------------------------------------------------------------------------
+
+/**
+ * RFB is a binary protocol, and noVNC reads the socket as RFB and nothing
+ * else, so these run the pump against a real loopback WebSocket server posing
+ * as the runtime: bytes have to arrive byte-identical in both directions, and
+ * the runtime's close code has to arrive as itself.
+ */
+describe("getDesktopStreamWebsocketHandlers", () => {
+  type FakeRuntime = {
+    server: ReturnType<typeof Bun.serve>;
+    received: Uint8Array[];
+    /** Resolves with the upstream socket once the pump has dialed in. */
+    connected: Promise<import("bun").ServerWebSocket<unknown>>;
+    upgradeUrl: () => URL | undefined;
+  };
+
+  /** A loopback server that records what it is sent and echoes a banner. */
+  function startFakeRuntime(banner?: Uint8Array): FakeRuntime {
+    const received: Uint8Array[] = [];
+    let upgradeUrl: URL | undefined;
+    let resolveConnected!: (ws: import("bun").ServerWebSocket<unknown>) => void;
+    const connected = new Promise<import("bun").ServerWebSocket<unknown>>(
+      (resolve) => {
+        resolveConnected = resolve;
+      },
+    );
+    const server = Bun.serve({
+      port: 0,
+      fetch(req, srv) {
+        upgradeUrl = new URL(req.url);
+        if (srv.upgrade(req)) {
+          return undefined as never;
+        }
+        return new Response("not a websocket", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          if (banner) {
+            ws.send(banner);
+          }
+          resolveConnected(ws);
+        },
+        message(_ws, message) {
+          received.push(
+            typeof message === "string"
+              ? new TextEncoder().encode(message)
+              : new Uint8Array(message),
+          );
+        },
+        close() {},
+      },
+    });
+    return { server, received, connected, upgradeUrl: () => upgradeUrl };
+  }
+
+  function createFakeDownstreamWs(runtime: FakeRuntime) {
+    const sent: (string | Uint8Array)[] = [];
+    const closes: { code: number; reason: string }[] = [];
+    const data: DesktopStreamSocketData = {
+      wsType: "desktop-stream",
+      config: makeConfig({
+        assistantRuntimeBaseUrl: `http://127.0.0.1:${runtime.server.port}`,
+      }),
+    };
+    return {
+      data,
+      sent,
+      closes,
+      send: mock((msg: string | Uint8Array) => {
+        sent.push(msg);
+      }),
+      close: mock((code?: number, reason?: string) => {
+        closes.push({ code: code ?? 1000, reason: reason ?? "" });
+      }),
+    };
+  }
+
+  /** Poll until `predicate` holds, so the tests need no fixed sleeps. */
+  async function waitFor(predicate: () => boolean, timeoutMs = 2000) {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate()) {
+      if (Date.now() > deadline) {
+        throw new Error("timed out waiting for condition");
+      }
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  }
+
+  /** The RFB version banner, the first thing a VNC server sends. */
+  const RFB_BANNER = new TextEncoder().encode("RFB 003.008\n");
+
+  let runtime: FakeRuntime;
+  afterEach(() => {
+    runtime?.server.stop(true);
+  });
+
+  test("dials the runtime's /v1/desktop/stream with a service token and nothing else", async () => {
+    runtime = startFakeRuntime();
+    const handlers = getDesktopStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs(runtime);
+
+    handlers.open(ws as never);
+    await runtime.connected;
+
+    const url = runtime.upgradeUrl()!;
+    expect(url.pathname).toBe("/v1/desktop/stream");
+    expect([...url.searchParams.keys()]).toEqual(["token"]);
+  });
+
+  test("delivers the runtime's bytes downstream byte-identical", async () => {
+    runtime = startFakeRuntime(RFB_BANNER);
+    const handlers = getDesktopStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs(runtime);
+
+    handlers.open(ws as never);
+    await waitFor(() => ws.sent.length > 0);
+
+    const frame = ws.sent[0]!;
+    expect(typeof frame).not.toBe("string");
+    expect(Array.from(frame as Uint8Array)).toEqual(Array.from(RFB_BANNER));
+  });
+
+  test("delivers the viewer's bytes upstream byte-identical, including frames sent before the dial completes", async () => {
+    runtime = startFakeRuntime();
+    const handlers = getDesktopStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs(runtime);
+    // Every byte value, so a text-vs-binary or encoding slip cannot hide.
+    const early = new Uint8Array(256).map((_, i) => i);
+    const late = new Uint8Array([0xff, 0x00, 0x7f, 0x80]);
+
+    handlers.open(ws as never);
+    handlers.message(ws as never, early);
+    await runtime.connected;
+    await waitFor(() => runtime.received.length === 1);
+    handlers.message(ws as never, late);
+    await waitFor(() => runtime.received.length === 2);
+
+    expect(Array.from(runtime.received[0]!)).toEqual(Array.from(early));
+    expect(Array.from(runtime.received[1]!)).toEqual(Array.from(late));
+  });
+
+  test("propagates the runtime's close code downstream verbatim", async () => {
+    runtime = startFakeRuntime();
+    const handlers = getDesktopStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs(runtime);
+
+    handlers.open(ws as never);
+    const upstream = await runtime.connected;
+    upstream.close(1013, "desktop busy");
+    await waitFor(() => ws.closes.length > 0);
+
+    expect(ws.closes[0]).toEqual({ code: 1013, reason: "desktop busy" });
+  });
+
+  test("propagates the viewer's close code upstream verbatim", async () => {
+    runtime = startFakeRuntime();
+    const handlers = getDesktopStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs(runtime);
+
+    handlers.open(ws as never);
+    await runtime.connected;
+    const upstreamClose = mock(ws.data.upstream!.close.bind(ws.data.upstream));
+    ws.data.upstream!.close = upstreamClose;
+
+    handlers.close(ws as never, 4001, "viewer left");
+
+    expect(upstreamClose).toHaveBeenCalledWith(4001, "viewer left");
+    expect(ws.data.pendingMessages).toBeUndefined();
+  });
+});

--- a/gateway/src/http/routes/desktop-stream-websocket.ts
+++ b/gateway/src/http/routes/desktop-stream-websocket.ts
@@ -1,0 +1,80 @@
+/**
+ * `/v1/desktop/stream`: a containerized assistant's on-demand desktop, proxied
+ * to the runtime as a raw RFB (VNC) byte pipe.
+ *
+ * The client half is a noVNC viewer in the web client; the runtime half
+ * bridges the socket to the pod's loopback VNC server. Neither can reach the
+ * other directly, since the runtime is unreachable from outside the private
+ * network, so this is the hop that makes the feature work from a browser.
+ *
+ * The socket is RFB and nothing else: every frame in both directions is a
+ * binary frame of RFB bytes, passed through verbatim, and there are no control
+ * frames for this proxy to inspect. Errors travel as close codes, which the
+ * shared pump carries from either side to the other unchanged, so the
+ * runtime's `1013` (desktop busy), `1011` (desktop failed to start) and
+ * `1008` (feature disabled or unsupported) reach the browser as themselves.
+ *
+ * Guardian-only, the way the watch stream is and for the same reason: the
+ * proxy replaces the caller's identity with a service token upstream, so
+ * whoever the gateway admits is who gets the pod's desktop, and this upgrade
+ * is the only place a non-guardian actor can be refused.
+ */
+
+import {
+  createRuntimeAudioStreamHandlers,
+  type RuntimeAudioStreamState,
+} from "./runtime-audio-stream.js";
+import { authorizeGuardianStream } from "./guardian-pin.js";
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+
+const log = getLogger("desktop-stream-ws");
+
+export type DesktopStreamSocketData = RuntimeAudioStreamState & {
+  wsType: "desktop-stream";
+};
+
+/**
+ * Create the upgrade handler for `/v1/desktop/stream`.
+ *
+ * Authenticates the downstream caller as the bound guardian, on either the
+ * managed velay-attested path or the actor edge JWT path, and dials upstream
+ * with a short-lived service token. The route takes no query parameters: a
+ * session starts with the upgrade and ends with the close.
+ */
+export function createDesktopStreamWebsocketHandler(config: GatewayConfig) {
+  return async function handleUpgrade(
+    req: Request,
+    server: import("bun").Server<unknown>,
+  ): Promise<Response | undefined> {
+    const denied = await authorizeGuardianStream(req, config, log);
+    if (denied) {
+      return denied;
+    }
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "desktop-stream",
+        config,
+      } satisfies DesktopStreamSocketData,
+    });
+
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+
+    return undefined;
+  };
+}
+
+/**
+ * WebSocket handlers for Bun.serve() that pump RFB bytes between the viewer
+ * and the runtime's `/v1/desktop/stream`.
+ */
+export function getDesktopStreamWebsocketHandlers() {
+  return createRuntimeAudioStreamHandlers<DesktopStreamSocketData>({
+    upstreamPath: "/v1/desktop/stream",
+    log,
+    label: "desktop stream",
+  });
+}

--- a/gateway/src/http/routes/guardian-pin.ts
+++ b/gateway/src/http/routes/guardian-pin.ts
@@ -27,14 +27,18 @@
  * Not every audio proxy wants this. `/v1/stt/stream` carries dictation, which
  * is not a guardian-only surface and accepts any valid actor, which is why the
  * pin is something a route opts into rather than something the shared
- * authorization applies to everything.
+ * authorization applies to everything. A runtime-stream proxy opts in by
+ * calling {@link authorizeGuardianStream}, which runs both shapes in order.
  */
 
 import type { Logger } from "pino";
 
+import { authorizeRuntimeAudioStream } from "./runtime-audio-stream.js";
 import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
+import type { GatewayConfig } from "../../config.js";
 import { credentialKey } from "../../credential-key.js";
 import { readCredential } from "../../credential-reader.js";
+import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
 
 const VELAY_USER_ID_HEADER = "x-velay-user-id";
 const VELAY_ORG_ID_HEADER = "x-velay-org-id";
@@ -134,4 +138,62 @@ export async function requireBoundGuardian(
     return new Response("Forbidden", { status: 403 });
   }
   return null;
+}
+
+/**
+ * The whole gate for a guardian-only runtime-stream upgrade: the managed path
+ * first, then the shared actor-token gate with the pin layered on top.
+ *
+ * Returns null when the caller may open the socket, else the Response to send
+ * instead. The managed path is taken before the token path exactly as live
+ * voice takes it: velay validated the browser's token and injected the caller,
+ * and the bridge proof is what says this request really came through the
+ * gateway's own loopback bridge rather than from someone who guessed the
+ * header names. An incomplete attestation falls through, so a managed
+ * deployment still accepts a valid actor edge JWT.
+ */
+export async function authorizeGuardianStream(
+  req: Request,
+  config: GatewayConfig,
+  log: Logger,
+): Promise<Response | null> {
+  // Checked here as well as in the shared gate, because the managed path
+  // below skips that gate entirely: without this, a managed caller sending a
+  // plain request would fall through to `server.upgrade` and get a 500.
+  if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return new Response("Upgrade Required", { status: 426 });
+  }
+
+  if (isPlatformManaged() && config.runtimeProxyRequireAuth) {
+    const velayContext = extractVelayAttestedContext(req);
+    if (velayContext) {
+      if (requestHasVelayBridgeAuth(req)) {
+        const guardianError = await requireManagedGuardian(
+          velayContext.userId,
+          log,
+        );
+        if (guardianError) {
+          return guardianError;
+        }
+        log.info(
+          { userId: velayContext.userId, orgId: velayContext.orgId },
+          "guardian pin: authenticated via velay-attested managed context",
+        );
+        return null;
+      }
+      log.warn("guardian pin: ignoring velay context without bridge proof");
+    }
+  }
+
+  const auth = authorizeRuntimeAudioStream(req, config, log);
+  if (!auth.ok) {
+    return auth.response;
+  }
+  // A null principal is the dev bypass, which validated no token and has
+  // nothing to compare. That bypass turns runtime proxy auth off wholesale,
+  // and this is not the place to reintroduce it.
+  if (auth.actorPrincipalId === null) {
+    return null;
+  }
+  return requireBoundGuardian(auth.actorPrincipalId, log);
 }

--- a/gateway/src/http/routes/runtime-audio-stream.ts
+++ b/gateway/src/http/routes/runtime-audio-stream.ts
@@ -4,12 +4,13 @@
  * frames between that client and the runtime.
  *
  * The gateway has more than one of these. `/v1/stt/stream` carries dictation
- * audio and `/v1/watch/stream` carries a watch session's narration, and as
- * proxies they are the same object: authenticate the downstream actor, dial a
- * fresh upstream socket with a short-lived service token, and pass frames
- * through in both directions until either end goes away. What differs is the
- * upstream path and which query parameters travel with it, which is why those
- * are the arguments here.
+ * audio, `/v1/watch/stream` carries a watch session's narration, and
+ * `/v1/desktop/stream` carries a pod desktop's RFB bytes, and as proxies they
+ * are the same object: authenticate the downstream actor, dial a fresh
+ * upstream socket with a short-lived service token, and pass frames through
+ * verbatim in both directions until either end goes away, each side's close
+ * code carried to the other. What differs is the upstream path and which
+ * query parameters travel with it, which is why those are the arguments here.
  *
  * **What the shared gate settles, and what it deliberately leaves open.** It
  * settles that the caller is *an* actor on this assistant: a valid edge JWT,
@@ -161,7 +162,7 @@ export interface RuntimeAudioStreamHandlerOptions<
   /** What this stream is called in log messages, e.g. `"STT stream"`. */
   label: string;
   /** Query parameters carried upstream, built from the socket's own state. */
-  upstreamParams: (data: T) => Record<string, string>;
+  upstreamParams?: (data: T) => Record<string, string>;
   /** Extra fields worth logging alongside every message about this socket. */
   logContext?: (data: T) => Record<string, unknown>;
 }
@@ -181,7 +182,7 @@ export function createRuntimeAudioStreamHandlers<
   upstreamPath,
   log,
   label,
-  upstreamParams,
+  upstreamParams = () => ({}),
   logContext = () => ({}),
 }: RuntimeAudioStreamHandlerOptions<T>) {
   return {

--- a/gateway/src/http/routes/watch-stream-websocket.ts
+++ b/gateway/src/http/routes/watch-stream-websocket.ts
@@ -15,24 +15,17 @@
  * with two queries rather than two implementations that agree today.
  *
  * What is this route's own is who may open it. Watch is guardian-only and
- * dictation is not, so the pin below is layered here rather than added to the
+ * dictation is not, so the pin is opted into here rather than added to the
  * shared gate, where it would take dictation with it.
  */
 
 import {
-  authorizeRuntimeAudioStream,
   createRuntimeAudioStreamHandlers,
   type RuntimeAudioStreamState,
 } from "./runtime-audio-stream.js";
-import {
-  extractVelayAttestedContext,
-  isPlatformManaged,
-  requireBoundGuardian,
-  requireManagedGuardian,
-} from "./guardian-pin.js";
+import { authorizeGuardianStream } from "./guardian-pin.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
-import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
 
 const log = getLogger("watch-stream-ws");
 
@@ -77,65 +70,9 @@ export function createWatchStreamWebsocketHandler(config: GatewayConfig) {
     req: Request,
     server: import("bun").Server<unknown>,
   ): Promise<Response | undefined> {
-    // Checked here as well as in the shared gate, because the managed path
-    // below skips that gate entirely: without this, a managed caller sending a
-    // plain request would fall through to `server.upgrade` and get a 500.
-    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
-      return new Response("Upgrade Required", { status: 426 });
-    }
-
-    // Managed/cloud path, taken before the token path exactly as live voice
-    // takes it: velay validated the browser's token and injected the caller,
-    // and the bridge proof is what says this request really came through the
-    // gateway's own loopback bridge rather than from someone who guessed the
-    // header names. An incomplete attestation falls through, so a managed
-    // deployment still accepts a valid actor edge JWT.
-    let managedGuardian = false;
-    if (isPlatformManaged() && config.runtimeProxyRequireAuth) {
-      const velayContext = extractVelayAttestedContext(req);
-      if (velayContext) {
-        if (requestHasVelayBridgeAuth(req)) {
-          const guardianError = await requireManagedGuardian(
-            velayContext.userId,
-            log,
-          );
-          if (guardianError) {
-            return guardianError;
-          }
-          log.info(
-            { userId: velayContext.userId, orgId: velayContext.orgId },
-            "Watch stream WS: authenticated via velay-attested managed context",
-          );
-          managedGuardian = true;
-        } else {
-          log.warn(
-            "Watch stream WS: ignoring velay context without bridge proof",
-          );
-        }
-      }
-    }
-
-    // The token path, and its half of the pin. Skipped entirely when velay
-    // already attested this caller as the guardian: there is no edge JWT on
-    // that path to validate, and requiring one would reject the managed
-    // callers the attestation exists to admit.
-    if (!managedGuardian) {
-      const auth = authorizeRuntimeAudioStream(req, config, log);
-      if (!auth.ok) {
-        return auth.response;
-      }
-      // A null principal is the dev bypass, which validated no token and has
-      // nothing to compare. That bypass turns runtime proxy auth off
-      // wholesale, and this is not the place to reintroduce it.
-      if (auth.actorPrincipalId !== null) {
-        const guardianError = await requireBoundGuardian(
-          auth.actorPrincipalId,
-          log,
-        );
-        if (guardianError) {
-          return guardianError;
-        }
-      }
+    const denied = await authorizeGuardianStream(req, config, log);
+    if (denied) {
+      return denied;
     }
 
     const url = new URL(req.url);

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -55,6 +55,11 @@ import {
   type WatchStreamSocketData,
 } from "./http/routes/watch-stream-websocket.js";
 import {
+  createDesktopStreamWebsocketHandler,
+  getDesktopStreamWebsocketHandlers,
+  type DesktopStreamSocketData,
+} from "./http/routes/desktop-stream-websocket.js";
+import {
   createSpeechRelayUpgradeHandler,
   getSpeechRelayWebsocketHandlers,
   type SpeechRelaySocketData,
@@ -322,6 +327,16 @@ function isWatchStreamSocketData(data: unknown): data is WatchStreamSocketData {
   );
 }
 
+function isDesktopStreamSocketData(
+  data: unknown,
+): data is DesktopStreamSocketData {
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { wsType?: unknown }).wsType === "desktop-stream"
+  );
+}
+
 function isLiveVoiceSocketData(data: unknown): data is LiveVoiceSocketData {
   return (
     !!data &&
@@ -547,6 +562,7 @@ async function main() {
   });
   const handleSttStreamWs = createSttStreamWebsocketHandler(config);
   const handleWatchStreamWs = createWatchStreamWebsocketHandler(config);
+  const handleDesktopStreamWs = createDesktopStreamWebsocketHandler(config);
   const handleLiveVoiceWs = createLiveVoiceWebsocketHandler(config);
   const handleSpeechRelaySttWs = createSpeechRelayUpgradeHandler(
     config,
@@ -571,6 +587,7 @@ async function main() {
   const pluginWebhookWebsocketHandlers = getPluginWebhookWebsocketHandlers();
   const sttStreamWebsocketHandlers = getSttStreamWebsocketHandlers();
   const watchStreamWebsocketHandlers = getWatchStreamWebsocketHandlers();
+  const desktopStreamWebsocketHandlers = getDesktopStreamWebsocketHandlers();
   const liveVoiceWebsocketHandlers = getLiveVoiceWebsocketHandlers();
   const speechRelayWebsocketHandlers = getSpeechRelayWebsocketHandlers();
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
@@ -1902,6 +1919,10 @@ async function main() {
           watchStreamWebsocketHandlers.open(ws as never);
           return;
         }
+        if (isDesktopStreamSocketData(ws.data)) {
+          desktopStreamWebsocketHandlers.open(ws as never);
+          return;
+        }
         if (isLiveVoiceSocketData(ws.data)) {
           liveVoiceWebsocketHandlers.open(ws as never);
           return;
@@ -1929,6 +1950,10 @@ async function main() {
           watchStreamWebsocketHandlers.message(ws as never, message);
           return;
         }
+        if (isDesktopStreamSocketData(ws.data)) {
+          desktopStreamWebsocketHandlers.message(ws as never, message);
+          return;
+        }
         if (isLiveVoiceSocketData(ws.data)) {
           liveVoiceWebsocketHandlers.message(ws as never, message);
           return;
@@ -1954,6 +1979,10 @@ async function main() {
         }
         if (isWatchStreamSocketData(ws.data)) {
           watchStreamWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        if (isDesktopStreamSocketData(ws.data)) {
+          desktopStreamWebsocketHandlers.close(ws as never, code, reason);
           return;
         }
         if (isLiveVoiceSocketData(ws.data)) {
@@ -2185,6 +2214,17 @@ async function main() {
     // assistant has no transport at all and never reaches here.
     if (url.pathname === "/v1/watch/stream") {
       const upgradeResult = await handleWatchStreamWs(req, server);
+      if (upgradeResult !== undefined) {
+        return upgradeResult;
+      }
+      return undefined as unknown as Response;
+    }
+
+    // Same two shapes as the watch stream, and guardian-only for the same
+    // reason: the proxy replaces the caller's identity upstream, so whoever
+    // the gateway admits is who gets the pod's desktop.
+    if (url.pathname === "/v1/desktop/stream") {
+      const upgradeResult = await handleDesktopStreamWs(req, server);
       if (upgradeResult !== undefined) {
         return upgradeResult;
       }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1159,6 +1159,64 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/desktop/stream": {
+        get: {
+          summary: "Pod desktop stream WebSocket",
+          description:
+            "Accepts a WebSocket upgrade for a containerized assistant's on-demand desktop. Authenticates the client using an edge JWT (the bound guardian's actor principal) and proxies frames bidirectionally to the assistant runtime's /v1/desktop/stream endpoint using a gateway service token. Every frame in both directions is a binary frame of raw RFB (VNC) bytes; there are no control frames. Errors are signaled with close codes, propagated verbatim from the runtime: 1013 desktop busy (another viewer holds the slot), 1011 desktop failed to start, 1008 feature disabled or unsupported.",
+          operationId: "desktopStreamWebsocket",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "token",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description:
+                "Edge JWT for authentication (alternative to Authorization header, since browser WebSocket upgrades cannot set custom headers).",
+            },
+          ],
+          responses: {
+            "101": {
+              description:
+                "WebSocket upgrade successful - bidirectional RFB byte proxying begins.",
+            },
+            "401": {
+              description: "Unauthorized - missing or invalid token",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "403": {
+              description: "Forbidden - caller is not the bound guardian",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "426": {
+              description:
+                "Upgrade Required - request is not a WebSocket upgrade",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "500": {
+              description: "WebSocket upgrade failed",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/v1/live-voice": {
         get: {
           summary: "Live voice WebSocket",

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -63,6 +63,9 @@ describe("VELAY_ALLOWED_PATHS", () => {
       // and injects the attested caller, and the gateway's handler admits only
       // the guardian on it. Self-hosted assistants bypass velay entirely.
       "/v1/watch/stream": true,
+      // The pod desktop rides the tunnel the same way: a guardian-only RFB
+      // byte pipe the web client dials with a velay-minted token.
+      "/v1/desktop/stream": true,
       "/assistant/credentials/enter": true,
       "/v1/credential-requests/peek": true,
       "/v1/credential-requests/submit": true,
@@ -123,6 +126,7 @@ describe("the registration allowlist and the bridge's WebSocket allowlist", () =
     "/v1/live-voice",
     "/v1/stt/stream",
     "/v1/watch/stream",
+    "/v1/desktop/stream",
   ];
 
   it("admits every tunnelled WebSocket route at both layers", () => {
@@ -149,7 +153,13 @@ describe("the registration allowlist and the bridge's WebSocket allowlist", () =
   });
 
   it("admits no near miss of a tunnelled route at either layer", () => {
-    for (const path of ["/v1/watch", "/v1/watch/stream/extra", "/v1/speech"]) {
+    for (const path of [
+      "/v1/watch",
+      "/v1/watch/stream/extra",
+      "/v1/desktop",
+      "/v1/desktop/stream/extra",
+      "/v1/speech",
+    ]) {
       expect({
         path,
         registration: compiled().some((re) => re.test(path)),

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -31,6 +31,11 @@
  *
  *   - `^/v1/watch/stream` — exact match for the browser watch-session
  *     WebSocket, which carries a session's narration audio.
+ *   - `^/v1/desktop/stream` — exact match for the browser pod-desktop
+ *     WebSocket, a raw RFB byte pipe to the pod's VNC server. Guardian-only
+ *     at the gateway handler, the same shape as the watch stream: velay
+ *     validates the browser's minted token on this path and injects the
+ *     attested caller.
  *
  * `/v1/watch/stream` was deliberately absent until the client could use it.
  * The note that stood here argued the entry was premature on its own, and it
@@ -62,6 +67,7 @@ export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
   "^/v1/live-voice$",
   "^/v1/stt/stream$",
   "^/v1/watch/stream$",
+  "^/v1/desktop/stream$",
   "^/assistant/credentials/enter$",
   "^/v1/credential-requests/(peek|submit)$",
 ]);

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -27,6 +27,7 @@ export const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
   "/v1/live-voice",
   "/v1/stt/stream",
   "/v1/watch/stream",
+  "/v1/desktop/stream",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- Add the gateway half of the pod desktop stream: `/v1/desktop/stream` authenticates the downstream caller as the bound guardian (velay-attested managed path or actor edge JWT, service tokens refused), dials the runtime's `/v1/desktop/stream` with the gateway service token, and pumps binary RFB frames verbatim in both directions with close codes (1013 busy, 1011 failed to start, 1008 disabled) propagated unchanged.
- Extract the guardian-pinned upgrade authorization that watch and desktop now share into `authorizeGuardianStream` in `guardian-pin.ts`; the watch handler behaves identically (its tests are unchanged and green).
- Open the route through velay at both allowlist layers (`VELAY_ALLOWED_PATHS` and the bridge's exact WebSocket list), extend the symmetry guard, and document the route in the gateway OpenAPI schema so the route-schema guard passes.

Part of plan: pod-desktop-streaming.md (PR 2 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YDF6hHcX7aPZsc6TuByhy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->