### PR TITLE
fix(plugins): synthesize package.json on marketplace tarball install

### DIFF
--- a/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
@@ -225,11 +225,6 @@ describe("installPluginFromPlatform — success", () => {
     expect(pkg.name).toBe("openseo");
     expect(pkg.version).toBe("0.0.0");
     expect(pkg.peerDependencies["@vellumai/plugin-api"]).toBeDefined();
-    const meta = readInstallMeta(target);
-    if (!meta) {
-      throw new Error("expected install meta after a successful platform install");
-    }
-    expect(meta.fingerprint.files["package.json"]).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test("leaves an upstream package.json in place", async () => {

--- a/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
@@ -225,9 +225,11 @@ describe("installPluginFromPlatform — success", () => {
     expect(pkg.name).toBe("openseo");
     expect(pkg.version).toBe("0.0.0");
     expect(pkg.peerDependencies["@vellumai/plugin-api"]).toBeDefined();
-    expect(readInstallMeta(target)?.fingerprint.files["package.json"]).toMatch(
-      /^[0-9a-f]{64}$/,
-    );
+    const meta = readInstallMeta(target);
+    if (!meta) {
+      throw new Error("expected install meta after a successful platform install");
+    }
+    expect(meta.fingerprint.files["package.json"]).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test("leaves an upstream package.json in place", async () => {

--- a/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
+++ b/assistant/src/cli/lib/__tests__/install-from-platform.test.ts
@@ -177,6 +177,7 @@ describe("installPluginFromPlatform — success", () => {
     );
     expect(existsSync(join(target, "README.md"))).toBe(true);
     expect(existsSync(join(target, "skills", "read", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(target, "package.json"))).toBe(true);
 
     // Provenance records the pinned commit and the verified ETag.
     const meta = readInstallMeta(target);
@@ -184,6 +185,80 @@ describe("installPluginFromPlatform — success", () => {
     expect(meta?.source.repo).toBe("reading-pal");
     expect(meta?.source.owner).toBe("vellum-ai");
     expect(meta?.etag?.startsWith('"sha256:')).toBe(true);
+  });
+
+  test("synthesizes a minimal package.json when the tarball ships none", async () => {
+    const fetchFn = makeInstallFetch({
+      entries: [
+        {
+          name: "skills/keyword-research/SKILL.md",
+          content:
+            "---\nname: keyword-research\ndescription: Discover keyword opportunities.\n---\n",
+        },
+        {
+          name: "mcp.json",
+          content: JSON.stringify({
+            mcpServers: { openseo: { url: "https://app.openseo.so/mcp" } },
+          }),
+        },
+      ],
+      ref: "c".repeat(40),
+      repo: "every-app/open-seo",
+      sourcePath: "plugins/openseo",
+    });
+
+    const result = await installPluginFromPlatform(
+      { name: "openseo" },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    const target = join(pluginsDir, "openseo");
+    expect(result.fileCount).toBe(2);
+    expect(
+      existsSync(join(target, "skills", "keyword-research", "SKILL.md")),
+    ).toBe(true);
+    const pkg = JSON.parse(readFileSync(join(target, "package.json"), "utf-8"));
+    expect(pkg.name).toBe("openseo");
+    expect(pkg.version).toBe("0.0.0");
+    expect(pkg.peerDependencies["@vellumai/plugin-api"]).toBeDefined();
+    expect(readInstallMeta(target)?.fingerprint.files["package.json"]).toMatch(
+      /^[0-9a-f]{64}$/,
+    );
+  });
+
+  test("leaves an upstream package.json in place", async () => {
+    const fetchFn = makeInstallFetch({
+      entries: [
+        {
+          name: "package.json",
+          content: JSON.stringify({
+            name: "reading-pal",
+            version: "1.2.3",
+            peerDependencies: { "@vellumai/plugin-api": ">=0.8.0" },
+          }),
+        },
+        { name: "README.md", content: "# reading pal" },
+      ],
+    });
+
+    await installPluginFromPlatform(
+      { name: "reading-pal" },
+      {
+        fetch: fetchFn,
+        platformBaseUrl: PLATFORM,
+        workspacePluginsDir: pluginsDir,
+      },
+    );
+
+    const pkg = JSON.parse(
+      readFileSync(join(pluginsDir, "reading-pal", "package.json"), "utf-8"),
+    );
+    expect(pkg.name).toBe("reading-pal");
+    expect(pkg.version).toBe("1.2.3");
   });
 
   test("sends the API key as an Api-Key Authorization header when present", async () => {

--- a/assistant/src/cli/lib/install-from-github.ts
+++ b/assistant/src/cli/lib/install-from-github.ts
@@ -1134,12 +1134,16 @@ function normalizeInstalledManifest(
  * (`buildPluginFromDir`) hard-requires a `package.json` validated against
  * `PluginPackageJsonSchema` and silently skips the plugin when it's missing.
  *
- * The synthesized manifest carries the install name and the default
- * `@vellumai/plugin-api` peer dependency range. No foreign-ecosystem manifest
- * data is read — the install name is the only identity we trust for an
- * untrusted direct install.
+ * Used by both the GitHub clone path and the platform tarball path. The
+ * synthesized manifest carries the install name and the default
+ * `@vellumai/plugin-api` peer dependency range. No foreign-ecosystem
+ * manifest data is read: the install name is the only identity we trust
+ * when upstream ships no Vellum package.json.
  */
-function synthesizeMinimalPackageJson(name: string, stagingDir: string): void {
+export function synthesizeMinimalPackageJson(
+  name: string,
+  stagingDir: string,
+): void {
   const manifestPath = join(stagingDir, "package.json");
 
   const manifest: PackageManifest = {

--- a/assistant/src/cli/lib/install-from-platform.ts
+++ b/assistant/src/cli/lib/install-from-platform.ts
@@ -8,7 +8,9 @@
  * and extracts it into the plugin's install directory — it does NOT clone the
  * plugin from GitHub itself, and it does NOT emit `plugin_installed` telemetry
  * (hitting this endpoint *is* the recorded install; the server rejects that
- * event type on the usual ingest path).
+ * event type on the usual ingest path). A tarball that ships no
+ * `package.json` gets the same synthesized manifest the GitHub clone path
+ * writes, so the loader still registers the plugin's skills.
  *
  *     GET {PLATFORM_BASE_URL}/v1/plugins/{name}/install/
  *
@@ -42,6 +44,7 @@ import {
   PluginNotFoundError,
   PluginSourceUnavailableError,
   sanitizePluginName,
+  synthesizeMinimalPackageJson,
 } from "./install-from-github.js";
 
 /**
@@ -196,6 +199,14 @@ export async function installPluginFromPlatform(
   if (fileCount === 0) {
     rmSync(stagingDir, { recursive: true, force: true });
     throw new PluginNotFoundError(name, meta.ref ?? "", meta.repo ?? name);
+  }
+
+  // Same default as the GitHub clone path: a marketplace tarball that
+  // ships skills/mcp.json but no Vellum package.json still has to load.
+  // The loader skips a directory with no manifest, so synthesize one
+  // before the fingerprint and swap.
+  if (!existsSync(join(stagingDir, "package.json"))) {
+    synthesizeMinimalPackageJson(name, stagingDir);
   }
 
   await confirmStagedOrAbort(name, stagingDir, deps.confirmStaged);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Marketplace install of OpenSEO (and any other skills-only plugin) produced a tree with no `package.json`. The loader requires a manifest and skipped the plugin, so skills never registered. The GitHub clone path already synthesizes a minimal Vellum `package.json` when upstream ships none. Marketplace installs go through the platform tarball (`installPluginFromPlatform`) and missed that step.

Reuse `synthesizeMinimalPackageJson` after tarball extract, before the staged swap and fingerprint.

## Test plan

- [x] `cd assistant && bun test src/cli/lib/__tests__/install-from-platform.test.ts` (tarball with no manifest synthesizes `package.json`; upstream manifest is left in place)
- [x] `cd assistant && bun test src/cli/lib/__tests__/install-from-github.test.ts` (clone-path synthesis unchanged)

## Risk

Low. Synthesis runs only when the extracted tree has no `package.json`. An upstream manifest is left in place. Fingerprint includes the synthesized file so upgrades compare cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7b8bf6f-54e1-4819-aa1f-4fc6e4ce0a8e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7b8bf6f-54e1-4819-aa1f-4fc6e4ce0a8e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

