### PR TITLE
feat(assistant): on-demand pod desktop session streamed over /v1/desktop/stream

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -790,6 +790,12 @@ graph LR
     WAKE -->|"assistant report only"| CONV
 ```
 
+## Pod Desktop Stream
+
+A containerized assistant can serve an interactive desktop on demand: one `Xtigervnc` X server (display `:99`, built-in VNC server on `localhost:5999`, `-localhost -SecurityTypes None`), `openbox`, the `vncconfig -nowin` clipboard bridge, and Playwright's Chromium with its own profile under `$VELLUM_WORKSPACE_DIR/data/desktop-profile`. `DesktopSessionManager` (`assistant/src/desktop/desktop-session-manager.ts`) owns the tree: the first viewer starts it, one viewer holds the slot at a time, the tree lingers five minutes after the last viewer leaves so a reconnect is instant, and it is torn down on that expiry, when the X server or window manager exits, or by `RuntimeHttpServer.stop()`. A browser exit is normal use and only costs the next viewer a fresh window. Gated by the `pod-desktop` flag and `IS_CONTAINERIZED` (`desktop-feature.ts`), so a daemon without the X binaries never advertises it.
+
+**Transport.** `/v1/desktop/stream` is a pure RFB byte pipe: after the upgrade, every frame in both directions is binary and `DesktopStreamBridge` (`desktop-stream-bridge.ts`) pumps it to and from the VNC port, buffering client bytes that arrive before that socket is up. Nothing is signaled in-band; outcomes are close codes: `1008` desktop disabled, `1013` another viewer holds the slot, `1011` the desktop failed to start or died under the viewer, `1001` runtime shutting down. The daemon upgrade is gated exactly as `/v1/watch/stream` (private-network peer and origin, gateway service token), and a disabled feature is reported with `1008` after the upgrade rather than a pre-upgrade 404 because the gateway relays close codes, not HTTP statuses, to the browser. VNC needs no password: only same-pod processes can reach the loopback port, and the authenticated upgrade is the only bridge to it.
+
 ## Maintenance Rule
 
 When architecture changes, update the relevant domain architecture document(s) above and keep this index aligned.

--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update && apt-get install -y \
     bubblewrap \
     ca-certificates \
     curl \
+    dbus-x11 \
     debootstrap \
     debian-archive-keyring \
     debconf \
@@ -94,18 +95,21 @@ RUN apt-get update && apt-get install -y \
     lsof \
     make \
     mount \
+    openbox \
     openssl \
     procps \
     python3 \
     python3-pip \
     sqlite3 \
     sudo \
+    tigervnc-standalone-server \
     util-linux \
     util-linux-extra \
     unzip \
     uuid-runtime \
     vim \
     wget \
+    xauth \
     xclip \
     xdg-utils \
     && rm -rf /var/lib/apt/lists/*

--- a/assistant/src/desktop/desktop-feature.ts
+++ b/assistant/src/desktop/desktop-feature.ts
@@ -1,0 +1,22 @@
+import { isAssistantFeatureFlagEnabled } from "../config/assistant-feature-flags.js";
+import type { AssistantConfig } from "../config/schema.js";
+
+const POD_DESKTOP_FLAG = "pod-desktop" as const;
+
+/**
+ * Whether this daemon serves `/v1/desktop/stream`.
+ *
+ * Requires both the `pod-desktop` flag and a containerized runtime: the X
+ * server, window manager and VNC bridge only exist in the assistant image, so
+ * a macOS or self-hosted daemon never advertises the surface regardless of
+ * the flag.
+ */
+export function isPodDesktopEnabled(
+  config: AssistantConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return (
+    env.IS_CONTAINERIZED === "true" &&
+    isAssistantFeatureFlagEnabled(POD_DESKTOP_FLAG, config)
+  );
+}

--- a/assistant/src/desktop/desktop-session-manager.test.ts
+++ b/assistant/src/desktop/desktop-session-manager.test.ts
@@ -1,0 +1,411 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "bun:test";
+
+import { setOverridesForTesting } from "../__tests__/feature-flag-test-helpers.js";
+import type { AssistantConfig } from "../config/schema.js";
+import { isPodDesktopEnabled } from "./desktop-feature.js";
+import {
+  DESKTOP_DISPLAY,
+  DESKTOP_VNC_PORT,
+  type DesktopChild,
+  type DesktopChildRole,
+  DesktopSessionManager,
+  type DesktopSpawnRequest,
+} from "./desktop-session-manager.js";
+import {
+  DesktopStreamBridge,
+  type DesktopTcpHandlers,
+  type DesktopTcpSocket,
+} from "./desktop-stream-bridge.js";
+
+const profileDir = mkdtempSync(join(tmpdir(), "desktop-session-test-"));
+afterAll(() => {
+  rmSync(profileDir, { recursive: true, force: true });
+});
+
+/** A child the test exits by hand. */
+class FakeChild implements DesktopChild {
+  private static nextPid = 1000;
+  readonly pid = FakeChild.nextPid++;
+  readonly exited: Promise<number>;
+  private settle!: (code: number) => void;
+
+  constructor(
+    readonly role: DesktopChildRole,
+    readonly request: DesktopSpawnRequest,
+  ) {
+    this.exited = new Promise((resolve) => {
+      this.settle = resolve;
+    });
+  }
+
+  kill(): void {}
+
+  exit(code = 0): void {
+    this.settle(code);
+  }
+}
+
+const LINGER_MS = 20;
+
+function newManager() {
+  const spawned: FakeChild[] = [];
+  const killed: FakeChild[] = [];
+  let vncReady = true;
+  const manager = new DesktopSessionManager({
+    spawn: (role, request) => {
+      const child = new FakeChild(role, request);
+      spawned.push(child);
+      return child;
+    },
+    probeVncPort: async () => vncReady,
+    resolveChromiumPath: async () => "/fake/chromium",
+    killProcessGroup: (child) => {
+      killed.push(child as FakeChild);
+    },
+    lingerMs: LINGER_MS,
+    readyDeadlineMs: 30,
+    profileDir,
+  });
+  return {
+    manager,
+    spawned,
+    killed,
+    setVncReady: (ready: boolean) => {
+      vncReady = ready;
+    },
+    child: (role: DesktopChildRole) =>
+      spawned.filter((c) => c.role === role).at(-1)!,
+    roles: () => spawned.map((c) => c.role),
+  };
+}
+
+/** Let the browser launch (one awaited path resolution) land. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function newViewer() {
+  const lost: string[] = [];
+  return {
+    lost,
+    viewer: { onDesktopLost: (reason: string) => lost.push(reason) },
+  };
+}
+
+describe("DesktopSessionManager process tree", () => {
+  test("concurrent callers share one start of the whole tree", async () => {
+    const h = newManager();
+    const [a, b] = await Promise.all([
+      h.manager.ensureDesktopRunning(),
+      h.manager.ensureDesktopRunning(),
+    ]);
+    await settle();
+
+    expect(a).toEqual({ display: DESKTOP_DISPLAY, vncPort: DESKTOP_VNC_PORT });
+    expect(b).toEqual(a);
+    expect(h.roles()).toEqual([
+      "x-server",
+      "window-manager",
+      "clipboard",
+      "browser",
+    ]);
+    expect(h.manager.isRunning).toBe(true);
+
+    const x = h.child("x-server").request.cmd;
+    expect(x.slice(0, 2)).toEqual(["Xtigervnc", ":99"]);
+    expect(x).toContain("-localhost");
+    expect(x[x.indexOf("-SecurityTypes") + 1]).toBe("None");
+    expect(x[x.indexOf("-rfbport") + 1]).toBe(String(DESKTOP_VNC_PORT));
+    for (const role of ["window-manager", "clipboard", "browser"] as const) {
+      expect(h.child(role).request.env.DISPLAY).toBe(":99");
+    }
+    expect(h.child("clipboard").request.cmd).toEqual(["vncconfig", "-nowin"]);
+    const browser = h.child("browser").request.cmd;
+    expect(browser[0]).toBe("/fake/chromium");
+    expect(browser).toContain(`--user-data-dir=${profileDir}`);
+  });
+
+  test("a VNC port that never opens fails the start and kills the X server, and a retry works", async () => {
+    const h = newManager();
+    h.setVncReady(false);
+
+    await expect(h.manager.ensureDesktopRunning()).rejects.toThrow(/not ready/);
+    expect(h.killed).toEqual([h.child("x-server")]);
+    expect(h.manager.isRunning).toBe(false);
+
+    h.setVncReady(true);
+    await h.manager.ensureDesktopRunning();
+    expect(h.manager.isRunning).toBe(true);
+    expect(h.roles().filter((r) => r === "x-server")).toHaveLength(2);
+  });
+
+  test("an X server exit tears the tree down and tells the viewer", async () => {
+    const h = newManager();
+    const { viewer, lost } = newViewer();
+    expect(h.manager.acquireViewerSlot(viewer)).toEqual({ ok: true });
+    await h.manager.ensureDesktopRunning();
+    await settle();
+
+    h.child("x-server").exit(1);
+    await settle();
+
+    expect(lost).toEqual(["x-server exited"]);
+    expect(h.manager.isRunning).toBe(false);
+    expect(h.manager.hasViewer).toBe(false);
+    expect(h.killed.map((c) => c.role).sort()).toEqual([
+      "browser",
+      "clipboard",
+      "window-manager",
+    ]);
+  });
+
+  test("a browser exit keeps the desktop and the next viewer gets a fresh one", async () => {
+    const h = newManager();
+    await h.manager.ensureDesktopRunning();
+    await settle();
+
+    h.child("browser").exit(0);
+    await settle();
+    expect(h.manager.isRunning).toBe(true);
+    expect(h.killed).toEqual([]);
+
+    await h.manager.ensureDesktopRunning();
+    await settle();
+    expect(h.roles().filter((r) => r === "browser")).toHaveLength(2);
+  });
+
+  test("destroy kills everything, is idempotent, and refuses what comes after", async () => {
+    const h = newManager();
+    await h.manager.ensureDesktopRunning();
+    await settle();
+
+    h.manager.destroy();
+    h.manager.destroy();
+
+    expect(h.killed).toHaveLength(4);
+    expect(h.manager.isRunning).toBe(false);
+    expect(h.manager.acquireViewerSlot(newViewer().viewer)).toEqual({
+      ok: false,
+      reason: "shutting-down",
+    });
+    await expect(h.manager.ensureDesktopRunning()).rejects.toThrow();
+  });
+});
+
+describe("DesktopSessionManager viewer slot", () => {
+  test("holds one viewer and only the holder can release it", () => {
+    const h = newManager();
+    const first = newViewer().viewer;
+    const second = newViewer().viewer;
+
+    expect(h.manager.acquireViewerSlot(first)).toEqual({ ok: true });
+    expect(h.manager.acquireViewerSlot(second)).toEqual({
+      ok: false,
+      reason: "busy",
+    });
+
+    h.manager.releaseViewerSlot(second);
+    expect(h.manager.hasViewer).toBe(true);
+
+    h.manager.releaseViewerSlot(first);
+    expect(h.manager.hasViewer).toBe(false);
+    expect(h.manager.acquireViewerSlot(second)).toEqual({ ok: true });
+  });
+
+  test("the tree lingers after the last viewer leaves, then is torn down", async () => {
+    const h = newManager();
+    const { viewer } = newViewer();
+    h.manager.acquireViewerSlot(viewer);
+    await h.manager.ensureDesktopRunning();
+    await settle();
+
+    h.manager.releaseViewerSlot(viewer);
+    expect(h.manager.isRunning).toBe(true);
+
+    await sleep(LINGER_MS * 2);
+    expect(h.manager.isRunning).toBe(false);
+    expect(h.killed).toHaveLength(4);
+  });
+
+  test("a viewer returning inside the linger window keeps the tree", async () => {
+    const h = newManager();
+    const { viewer } = newViewer();
+    h.manager.acquireViewerSlot(viewer);
+    await h.manager.ensureDesktopRunning();
+    await settle();
+
+    h.manager.releaseViewerSlot(viewer);
+    h.manager.acquireViewerSlot(viewer);
+    await sleep(LINGER_MS * 2);
+
+    expect(h.manager.isRunning).toBe(true);
+    expect(h.killed).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bridge
+// ---------------------------------------------------------------------------
+
+class FakeWs {
+  readonly sent: Uint8Array[] = [];
+  closeCode: number | null = null;
+  closeReason: string | null = null;
+
+  send(data: Uint8Array): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCode = code ?? null;
+    this.closeReason = reason ?? null;
+  }
+}
+
+class FakeTcp implements DesktopTcpSocket {
+  readonly writes: Uint8Array[] = [];
+  ended = false;
+  handlers!: DesktopTcpHandlers;
+
+  write(data: Uint8Array): number {
+    this.writes.push(data);
+    return data.byteLength;
+  }
+
+  end(): void {
+    this.ended = true;
+  }
+}
+
+function newBridge(manager: DesktopSessionManager, enabled = true) {
+  const ws = new FakeWs();
+  const tcp = new FakeTcp();
+  let release: (() => void) | null = null;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const bridge = new DesktopStreamBridge(ws, {
+    enabled,
+    manager,
+    connect: async (_port, handlers) => {
+      tcp.handlers = handlers;
+      await gate;
+      return tcp;
+    },
+  });
+  return { ws, tcp, bridge, connectNow: () => release!() };
+}
+
+describe("DesktopStreamBridge", () => {
+  test("pumps bytes both ways and flushes frames that beat the VNC socket", async () => {
+    const h = newManager();
+    const b = newBridge(h.manager);
+    const started = b.bridge.start();
+    await settle();
+
+    b.bridge.handleClientFrame(new Uint8Array([1, 2, 3]));
+    b.bridge.handleClientFrame(new Uint8Array([4]).buffer);
+    b.bridge.handleClientFrame("text frames are not RFB");
+    expect(b.tcp.writes).toEqual([]);
+
+    b.connectNow();
+    await started;
+    expect(b.tcp.writes).toEqual([
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array([4]),
+    ]);
+
+    b.tcp.handlers.onData(new Uint8Array([9, 9]));
+    expect(b.ws.sent).toEqual([new Uint8Array([9, 9])]);
+    expect(b.ws.closeCode).toBeNull();
+
+    b.bridge.handleClose();
+    expect(b.tcp.ended).toBe(true);
+    expect(h.manager.hasViewer).toBe(false);
+  });
+
+  test("a second socket closes 1013 and leaves the first untouched", async () => {
+    const h = newManager();
+    const first = newBridge(h.manager);
+    first.connectNow();
+    await first.bridge.start();
+
+    const second = newBridge(h.manager);
+    await second.bridge.start();
+
+    expect(second.ws.closeCode).toBe(1013);
+    expect(first.ws.closeCode).toBeNull();
+    expect(h.manager.hasViewer).toBe(true);
+
+    second.bridge.handleClose();
+    expect(h.manager.hasViewer).toBe(true);
+  });
+
+  test("closes 1011 when the desktop fails to start and frees the slot", async () => {
+    const h = newManager();
+    h.setVncReady(false);
+    const b = newBridge(h.manager);
+    await b.bridge.start();
+
+    expect(b.ws.closeCode).toBe(1011);
+    expect(h.manager.hasViewer).toBe(false);
+  });
+
+  test("closes 1011 when the desktop dies under the viewer", async () => {
+    const h = newManager();
+    const b = newBridge(h.manager);
+    b.connectNow();
+    await b.bridge.start();
+    await settle();
+
+    h.child("window-manager").exit(1);
+    await settle();
+
+    expect(b.ws.closeCode).toBe(1011);
+    expect(b.ws.closeReason).toContain("window-manager exited");
+    expect(b.tcp.ended).toBe(true);
+  });
+
+  test("closes 1008 when the desktop is disabled, without touching the manager", async () => {
+    const h = newManager();
+    const b = newBridge(h.manager, false);
+    await b.bridge.start();
+
+    expect(b.ws.closeCode).toBe(1008);
+    expect(h.spawned).toEqual([]);
+    expect(h.manager.hasViewer).toBe(false);
+  });
+
+  test("closes 1001 once the runtime is shutting down", async () => {
+    const h = newManager();
+    h.manager.destroy();
+    const b = newBridge(h.manager);
+    await b.bridge.start();
+
+    expect(b.ws.closeCode).toBe(1001);
+  });
+});
+
+describe("isPodDesktopEnabled", () => {
+  const config = {} as AssistantConfig;
+
+  test("needs both the flag and a containerized runtime", () => {
+    setOverridesForTesting({ "pod-desktop": true });
+    expect(isPodDesktopEnabled(config, { IS_CONTAINERIZED: "true" })).toBe(
+      true,
+    );
+    expect(isPodDesktopEnabled(config, {})).toBe(false);
+
+    setOverridesForTesting({ "pod-desktop": false });
+    expect(isPodDesktopEnabled(config, { IS_CONTAINERIZED: "true" })).toBe(
+      false,
+    );
+  });
+});

--- a/assistant/src/desktop/desktop-session-manager.ts
+++ b/assistant/src/desktop/desktop-session-manager.ts
@@ -1,0 +1,428 @@
+/**
+ * On-demand pod desktop: one Xtigervnc X server with its built-in VNC server
+ * on localhost, an openbox window manager, the vncconfig clipboard bridge and
+ * Playwright's Chromium.
+ *
+ * The process tree starts lazily on the first `/v1/desktop/stream` socket,
+ * serves one viewer at a time, lingers for a while after the last viewer
+ * leaves so a reconnect is instant, and is torn down on expiry, on a crash of
+ * the X server or window manager, or on runtime shutdown.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { importPlaywright } from "../tools/browser/runtime-check.js";
+import { buildSanitizedEnv } from "../tools/terminal/safe-env.js";
+import { terminateProcessTree } from "../util/host-process.js";
+import { getLogger } from "../util/logger.js";
+import { getDataDir } from "../util/platform.js";
+import { sleep } from "../util/retry.js";
+
+const log = getLogger("desktop-session");
+
+export const DESKTOP_DISPLAY = ":99";
+export const DESKTOP_VNC_PORT = 5999;
+export const DESKTOP_GEOMETRY = "1440x900";
+export const DESKTOP_LINGER_MS = 5 * 60_000;
+const VNC_READY_DEADLINE_MS = 10_000;
+const VNC_PROBE_INTERVAL_MS = 100;
+const KILL_GRACE_MS = 2_000;
+const CHROMIUM_INSTALL_TIMEOUT_MS = 300_000;
+
+export interface DesktopInfo {
+  readonly display: string;
+  readonly vncPort: number;
+}
+
+export type DesktopChildRole =
+  | "x-server"
+  | "window-manager"
+  | "clipboard"
+  | "browser";
+
+/** The slice of `Bun.Subprocess` the manager drives, so tests can fake it. */
+export interface DesktopChild {
+  readonly pid: number;
+  readonly exited: Promise<number>;
+  kill(signal?: NodeJS.Signals | number): void;
+}
+
+export interface DesktopSpawnRequest {
+  readonly cmd: readonly string[];
+  readonly env: Record<string, string>;
+}
+
+/** Callback surface of the socket holding the viewer slot. */
+export interface DesktopViewer {
+  /** The desktop went away underneath the viewer (crash, idle expiry, shutdown). */
+  onDesktopLost(reason: string): void;
+}
+
+export type AcquireViewerSlotResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: "busy" | "shutting-down" };
+
+export interface DesktopSessionManagerOptions {
+  readonly spawn?: (
+    role: DesktopChildRole,
+    request: DesktopSpawnRequest,
+  ) => DesktopChild;
+  /** Whether the VNC server accepts connections on `port`. */
+  readonly probeVncPort?: (port: number) => Promise<boolean>;
+  /** Path of the Chromium binary to launch, installing it when needed. */
+  readonly resolveChromiumPath?: () => Promise<string>;
+  readonly killProcessGroup?: (child: DesktopChild) => void;
+  readonly lingerMs?: number;
+  readonly readyDeadlineMs?: number;
+  readonly profileDir?: string;
+}
+
+export class DesktopSessionManager {
+  private readonly children = new Map<DesktopChildRole, DesktopChild>();
+  private starting: Promise<DesktopInfo> | null = null;
+  private running = false;
+  /** Bumped on every teardown so an in-flight start notices it lost its tree. */
+  private generation = 0;
+  private viewer: DesktopViewer | null = null;
+  private lingerTimer: ReturnType<typeof setTimeout> | null = null;
+  private ingressClosed = false;
+
+  private readonly spawn: NonNullable<DesktopSessionManagerOptions["spawn"]>;
+  private readonly probeVncPort: NonNullable<
+    DesktopSessionManagerOptions["probeVncPort"]
+  >;
+  private readonly resolveChromiumPath: NonNullable<
+    DesktopSessionManagerOptions["resolveChromiumPath"]
+  >;
+  private readonly killProcessGroup: NonNullable<
+    DesktopSessionManagerOptions["killProcessGroup"]
+  >;
+  private readonly lingerMs: number;
+  private readonly readyDeadlineMs: number;
+  private readonly profileDir: string;
+
+  constructor(options: DesktopSessionManagerOptions = {}) {
+    this.spawn = options.spawn ?? spawnDetached;
+    this.probeVncPort = options.probeVncPort ?? probeTcpPort;
+    this.resolveChromiumPath =
+      options.resolveChromiumPath ?? resolvePlaywrightChromium;
+    this.killProcessGroup = options.killProcessGroup ?? killProcessGroup;
+    this.lingerMs = options.lingerMs ?? DESKTOP_LINGER_MS;
+    this.readyDeadlineMs = options.readyDeadlineMs ?? VNC_READY_DEADLINE_MS;
+    this.profileDir =
+      options.profileDir ?? join(getDataDir(), "desktop-profile");
+  }
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+
+  get hasViewer(): boolean {
+    return this.viewer !== null;
+  }
+
+  // ── Viewer slot ────────────────────────────────────────────────────
+
+  acquireViewerSlot(viewer: DesktopViewer): AcquireViewerSlotResult {
+    if (this.ingressClosed) {
+      return { ok: false, reason: "shutting-down" };
+    }
+    if (this.viewer) {
+      return { ok: false, reason: "busy" };
+    }
+    this.viewer = viewer;
+    this.clearLinger();
+    return { ok: true };
+  }
+
+  /**
+   * Give the slot back. Only the holder can release it, so a socket that was
+   * turned away as busy never disturbs the viewer that turned it away.
+   */
+  releaseViewerSlot(viewer: DesktopViewer): void {
+    if (this.viewer !== viewer) {
+      return;
+    }
+    this.viewer = null;
+    if (this.running || this.starting) {
+      this.armLinger();
+    }
+  }
+
+  // ── Process tree ───────────────────────────────────────────────────
+
+  /** Start the desktop if needed. Concurrent callers share one start. */
+  ensureDesktopRunning(): Promise<DesktopInfo> {
+    if (this.ingressClosed) {
+      return Promise.reject(new Error("Desktop ingress is closed"));
+    }
+    if (this.running) {
+      void this.ensureBrowser(this.childEnv(), this.generation);
+      return Promise.resolve(desktopInfo());
+    }
+    this.starting ??= this.startDesktop().finally(() => {
+      this.starting = null;
+    });
+    return this.starting;
+  }
+
+  /** Refuse new viewers and kill the process tree. Safe to call repeatedly. */
+  destroy(): void {
+    this.ingressClosed = true;
+    this.teardown("shutdown");
+  }
+
+  private async startDesktop(): Promise<DesktopInfo> {
+    const generation = this.generation;
+    const env = this.childEnv();
+    this.launch("x-server", xServerCommand(), env);
+
+    const ready = await this.waitForVnc(generation);
+    if (this.generation !== generation) {
+      throw new Error("Desktop was torn down while starting");
+    }
+    if (!ready) {
+      this.teardown("vnc-not-ready");
+      throw new Error(
+        `Desktop VNC server not ready on port ${DESKTOP_VNC_PORT} after ${this.readyDeadlineMs}ms`,
+      );
+    }
+
+    this.launch("window-manager", ["openbox"], env);
+    this.launch("clipboard", ["vncconfig", "-nowin"], env);
+    this.running = true;
+    log.info({ display: DESKTOP_DISPLAY }, "Desktop started");
+    void this.ensureBrowser(env, generation);
+    return desktopInfo();
+  }
+
+  private async waitForVnc(generation: number): Promise<boolean> {
+    const deadline = Date.now() + this.readyDeadlineMs;
+    while (this.generation === generation) {
+      if (await this.probeVncPort(DESKTOP_VNC_PORT)) {
+        return true;
+      }
+      if (Date.now() >= deadline) {
+        return false;
+      }
+      await sleep(VNC_PROBE_INTERVAL_MS);
+    }
+    return false;
+  }
+
+  /**
+   * Launch Chromium unless it is already up. Runs after the X server is
+   * serving so the viewer sees a desktop while a first-time install
+   * completes. A user closing the browser is normal, so its exit never tears
+   * the desktop down; the next viewer gets a fresh window.
+   */
+  private async ensureBrowser(
+    env: Record<string, string>,
+    generation: number,
+  ): Promise<void> {
+    if (this.children.has("browser")) {
+      return;
+    }
+    try {
+      const executable = await this.resolveChromiumPath();
+      if (this.generation !== generation || this.children.has("browser")) {
+        return;
+      }
+      mkdirSync(this.profileDir, { recursive: true });
+      this.launch("browser", browserCommand(executable, this.profileDir), env);
+    } catch (err) {
+      log.warn({ err }, "Desktop browser failed to launch");
+    }
+  }
+
+  private launch(
+    role: DesktopChildRole,
+    cmd: readonly string[],
+    env: Record<string, string>,
+  ): void {
+    const child = this.spawn(role, { cmd, env });
+    this.children.set(role, child);
+    child.exited.then(
+      (code) => this.onChildExit(role, child, code),
+      (err: unknown) => this.onChildExit(role, child, err),
+    );
+  }
+
+  private onChildExit(
+    role: DesktopChildRole,
+    child: DesktopChild,
+    outcome: unknown,
+  ): void {
+    if (this.children.get(role) !== child) {
+      return;
+    }
+    this.children.delete(role);
+    if (role === "browser") {
+      log.info({ outcome }, "Desktop browser exited");
+      return;
+    }
+    log.warn({ role, outcome }, "Desktop process exited, tearing down");
+    this.teardown(`${role} exited`);
+  }
+
+  private teardown(reason: string): void {
+    this.clearLinger();
+    this.generation += 1;
+    this.running = false;
+    for (const child of this.children.values()) {
+      this.killProcessGroup(child);
+    }
+    this.children.clear();
+    const viewer = this.viewer;
+    this.viewer = null;
+    if (viewer) {
+      viewer.onDesktopLost(reason);
+    }
+  }
+
+  private armLinger(): void {
+    this.clearLinger();
+    this.lingerTimer = setTimeout(() => {
+      this.lingerTimer = null;
+      log.info("Desktop idle, tearing down");
+      this.teardown("idle");
+    }, this.lingerMs);
+    this.lingerTimer.unref?.();
+  }
+
+  private clearLinger(): void {
+    if (this.lingerTimer) {
+      clearTimeout(this.lingerTimer);
+      this.lingerTimer = null;
+    }
+  }
+
+  private childEnv(): Record<string, string> {
+    return { ...buildSanitizedEnv(), DISPLAY: DESKTOP_DISPLAY };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+function xServerCommand(): string[] {
+  return [
+    "Xtigervnc",
+    DESKTOP_DISPLAY,
+    "-localhost",
+    "-SecurityTypes",
+    "None",
+    "-rfbport",
+    String(DESKTOP_VNC_PORT),
+    "-geometry",
+    DESKTOP_GEOMETRY,
+    "-depth",
+    "24",
+    "-desktop",
+    "Vellum",
+  ];
+}
+
+function browserCommand(executable: string, profileDir: string): string[] {
+  // The daemon runs as root in the pod, where Chromium refuses its own
+  // sandbox; Playwright launches with the same flag.
+  return [
+    executable,
+    "--no-sandbox",
+    "--no-first-run",
+    "--disable-dev-shm-usage",
+    "--start-maximized",
+    `--user-data-dir=${profileDir}`,
+  ];
+}
+
+function desktopInfo(): DesktopInfo {
+  return { display: DESKTOP_DISPLAY, vncPort: DESKTOP_VNC_PORT };
+}
+
+// ---------------------------------------------------------------------------
+// Default collaborators
+// ---------------------------------------------------------------------------
+
+function spawnDetached(
+  _role: DesktopChildRole,
+  request: DesktopSpawnRequest,
+): DesktopChild {
+  // Each child leads its own process group so teardown can kill everything
+  // it forked (Chromium's renderers, openbox's autostart) in one signal.
+  return Bun.spawn([...request.cmd], {
+    env: request.env,
+    detached: true,
+    stdio: ["ignore", "ignore", "ignore"],
+    windowsHide: true,
+  });
+}
+
+/** SIGTERM the group so X and Chromium exit cleanly, then hard-kill stragglers. */
+function killProcessGroup(child: DesktopChild): void {
+  try {
+    process.kill(-child.pid, "SIGTERM");
+  } catch {
+    // Already gone, or not a group leader; the tree kill below covers it.
+  }
+  setTimeout(() => terminateProcessTree(child), KILL_GRACE_MS).unref();
+}
+
+async function probeTcpPort(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        open(socket) {
+          resolve(true);
+          socket.end();
+        },
+        data() {},
+        connectError() {
+          resolve(false);
+        },
+      },
+    }).catch(() => resolve(false));
+  });
+}
+
+async function resolvePlaywrightChromium(): Promise<string> {
+  const { chromium } = await importPlaywright();
+  const executable = chromium.executablePath();
+  if (existsSync(executable)) {
+    return executable;
+  }
+  log.info("Desktop browser not installed, installing via playwright");
+  const install = Bun.spawn(["bunx", "playwright", "install", "chromium"], {
+    stdio: ["ignore", "ignore", "pipe"],
+    windowsHide: true,
+  });
+  const timer = setTimeout(() => install.kill(), CHROMIUM_INSTALL_TIMEOUT_MS);
+  const exitCode = await install.exited.finally(() => clearTimeout(timer));
+  if (exitCode !== 0) {
+    const stderr = (await new Response(install.stderr).text()).trim();
+    throw new Error(
+      `playwright install chromium failed: ${stderr || `exit code ${exitCode}`}`,
+    );
+  }
+  return executable;
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let sharedManager: DesktopSessionManager | null = null;
+
+/**
+ * The process-wide desktop session manager. One instance because there is
+ * one display and one VNC port; lazily created so importing this module
+ * costs nothing until a socket arrives.
+ */
+export function getDesktopSessionManager(): DesktopSessionManager {
+  sharedManager ??= new DesktopSessionManager();
+  return sharedManager;
+}

--- a/assistant/src/desktop/desktop-stream-bridge.ts
+++ b/assistant/src/desktop/desktop-stream-bridge.ts
@@ -1,0 +1,202 @@
+/**
+ * Pumps raw RFB bytes between one `/v1/desktop/stream` WebSocket and the
+ * desktop's VNC server on localhost.
+ *
+ * The socket is a pure byte pipe: every frame in both directions is binary
+ * RFB data, and outcomes are signaled with close codes only (1008 feature
+ * disabled, 1013 busy, 1011 desktop failed or stopped, 1001 shutting down).
+ * The gateway relays close codes but not pre-upgrade HTTP statuses, which is
+ * why a disabled feature is reported after the upgrade rather than as a 404.
+ */
+
+import {
+  type DesktopSessionManager,
+  type DesktopViewer,
+  getDesktopSessionManager,
+} from "./desktop-session-manager.js";
+
+/** Frames a client may send before the VNC socket is up; RFB handshakes are tiny. */
+const MAX_PENDING_BYTES = 1024 * 1024;
+
+export interface DesktopStreamClientSocket {
+  send(data: Uint8Array): void;
+  close(code?: number, reason?: string): void;
+}
+
+export interface DesktopTcpSocket {
+  /** Returns the bytes accepted; fewer than offered means backpressure. */
+  write(data: Uint8Array): number;
+  end(): void;
+}
+
+export interface DesktopTcpHandlers {
+  onData(data: Uint8Array): void;
+  onDrain(): void;
+  onClose(): void;
+  onError(err: Error): void;
+}
+
+export type DesktopTcpConnect = (
+  port: number,
+  handlers: DesktopTcpHandlers,
+) => Promise<DesktopTcpSocket>;
+
+export interface DesktopStreamBridgeOptions {
+  /** Whether this daemon serves the desktop at all. Defaults to enabled. */
+  readonly enabled?: boolean;
+  readonly manager?: DesktopSessionManager;
+  readonly connect?: DesktopTcpConnect;
+}
+
+export class DesktopStreamBridge {
+  private readonly ws: DesktopStreamClientSocket;
+  private readonly enabled: boolean;
+  private readonly manager: DesktopSessionManager;
+  private readonly connect: DesktopTcpConnect;
+  private readonly viewer: DesktopViewer;
+
+  private tcp: DesktopTcpSocket | null = null;
+  /** Client bytes waiting on the VNC socket, or on backpressure once it is up. */
+  private pending: Uint8Array[] = [];
+  private pendingBytes = 0;
+  private closed = false;
+  private ownsSlot = false;
+
+  constructor(
+    ws: DesktopStreamClientSocket,
+    options: DesktopStreamBridgeOptions = {},
+  ) {
+    this.ws = ws;
+    this.enabled = options.enabled ?? true;
+    this.manager = options.manager ?? getDesktopSessionManager();
+    this.connect = options.connect ?? connectToVnc;
+    this.viewer = {
+      onDesktopLost: (reason) => this.fail(1011, `Desktop stopped: ${reason}`),
+    };
+  }
+
+  /** Claim the viewer slot, start the desktop, and dial its VNC port. */
+  async start(): Promise<void> {
+    if (!this.enabled) {
+      this.fail(1008, "Desktop is not available on this assistant");
+      return;
+    }
+    const slot = this.manager.acquireViewerSlot(this.viewer);
+    if (!slot.ok) {
+      if (slot.reason === "busy") {
+        this.fail(1013, "Desktop is in use by another viewer");
+      } else {
+        this.fail(1001, "The assistant is shutting down");
+      }
+      return;
+    }
+    this.ownsSlot = true;
+
+    let vncPort: number;
+    try {
+      ({ vncPort } = await this.manager.ensureDesktopRunning());
+    } catch {
+      this.fail(1011, "Desktop failed to start");
+      return;
+    }
+    if (this.closed) {
+      return;
+    }
+
+    let tcp: DesktopTcpSocket;
+    try {
+      tcp = await this.connect(vncPort, {
+        onData: (data) => this.ws.send(data),
+        onDrain: () => this.flush(),
+        onClose: () => this.fail(1011, "Desktop connection closed"),
+        onError: () => this.fail(1011, "Desktop connection failed"),
+      });
+    } catch {
+      this.fail(1011, "Desktop connection failed");
+      return;
+    }
+    if (this.closed) {
+      tcp.end();
+      return;
+    }
+    this.tcp = tcp;
+    this.flush();
+  }
+
+  handleClientFrame(message: string | Uint8Array | ArrayBuffer): void {
+    if (this.closed || typeof message === "string") {
+      return;
+    }
+    const bytes =
+      message instanceof ArrayBuffer ? new Uint8Array(message) : message;
+    if (this.pendingBytes + bytes.byteLength > MAX_PENDING_BYTES) {
+      this.fail(1009, "Desktop stream backlog exceeded");
+      return;
+    }
+    this.pending.push(bytes);
+    this.pendingBytes += bytes.byteLength;
+    this.flush();
+  }
+
+  /** The client socket closed; the caller has already seen the close frame. */
+  handleClose(): void {
+    this.release();
+  }
+
+  private flush(): void {
+    const tcp = this.tcp;
+    if (!tcp) {
+      return;
+    }
+    while (this.pending.length > 0) {
+      const chunk = this.pending[0]!;
+      const written = tcp.write(chunk);
+      if (written < 0) {
+        this.fail(1011, "Desktop connection closed");
+        return;
+      }
+      this.pendingBytes -= written;
+      if (written < chunk.byteLength) {
+        this.pending[0] = chunk.subarray(written);
+        return;
+      }
+      this.pending.shift();
+    }
+  }
+
+  private fail(code: number, reason: string): void {
+    if (this.closed) {
+      return;
+    }
+    this.release();
+    this.ws.close(code, reason);
+  }
+
+  private release(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.pending = [];
+    this.pendingBytes = 0;
+    this.tcp?.end();
+    this.tcp = null;
+    if (this.ownsSlot) {
+      this.ownsSlot = false;
+      this.manager.releaseViewerSlot(this.viewer);
+    }
+  }
+}
+
+const connectToVnc: DesktopTcpConnect = async (port, handlers) =>
+  Bun.connect({
+    hostname: "127.0.0.1",
+    port,
+    socket: {
+      data: (_socket, data) => handlers.onData(data),
+      drain: () => handlers.onDrain(),
+      close: () => handlers.onClose(),
+      error: (_socket, err) => handlers.onError(err),
+      connectError: (_socket, err) => handlers.onError(err),
+    },
+  });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -32,6 +32,9 @@ import {
 } from "../daemon/daemon-readiness.js";
 import { processMessage } from "../daemon/process-message.js";
 import { makeAddrInUseError } from "../daemon/startup-error.js";
+import { isPodDesktopEnabled } from "../desktop/desktop-feature.js";
+import { getDesktopSessionManager } from "../desktop/desktop-session-manager.js";
+import { DesktopStreamBridge } from "../desktop/desktop-stream-bridge.js";
 import {
   createLiveVoiceConnection,
   type LiveVoiceConnection,
@@ -196,6 +199,18 @@ interface WatchStreamWebSocketData {
   session?: WatchStreamSession;
 }
 
+/**
+ * WebSocket data attached to `/v1/desktop/stream` connections. The socket
+ * carries raw RFB bytes, bridged to the pod desktop's VNC server.
+ */
+interface DesktopStreamWebSocketData {
+  wsType: "desktop-stream";
+  /** Whether the pod desktop is enabled here; the bridge closes 1008 when not. */
+  enabled: boolean;
+  /** Bound at open time so message/close handlers reach this socket's pump. */
+  bridge?: DesktopStreamBridge;
+}
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -235,7 +250,8 @@ export class RuntimeHttpServer {
       | MediaStreamWebSocketData
       | SttStreamWebSocketData
       | LiveVoiceWebSocketData
-      | WatchStreamWebSocketData;
+      | WatchStreamWebSocketData
+      | DesktopStreamWebSocketData;
     this.server = Bun.serve<AllWebSocketData>({
       port: this.port,
       hostname: this.hostname,
@@ -383,6 +399,18 @@ export class RuntimeHttpServer {
             void session.start();
             return;
           }
+          if (data.wsType === "desktop-stream") {
+            log.info(
+              { enabled: data.enabled },
+              "Desktop stream WebSocket opened",
+            );
+            const bridge = new DesktopStreamBridge(ws, {
+              enabled: data.enabled,
+            });
+            data.bridge = bridge;
+            void bridge.start();
+            return;
+          }
           log.warn("WebSocket opened with unknown data type — closing");
           ws.close(1008, "Unknown WebSocket type");
         },
@@ -431,6 +459,10 @@ export class RuntimeHttpServer {
             } else {
               session.handleBinaryAudio(message);
             }
+            return;
+          }
+          if (data.wsType === "desktop-stream") {
+            data.bridge?.handleClientFrame(message);
             return;
           }
           log.warn("WebSocket message on unknown data type — closing");
@@ -524,6 +556,14 @@ export class RuntimeHttpServer {
                 activeWatchStreamSessions.delete(watchData.sessionId);
               }
             }
+            return;
+          }
+          if (data.wsType === "desktop-stream") {
+            log.info(
+              { code, reason: reason?.toString() },
+              "Desktop stream WebSocket closed",
+            );
+            data.bridge?.handleClose();
             return;
           }
           log.warn(
@@ -666,6 +706,8 @@ export class RuntimeHttpServer {
     // that a socket closing just before shutdown had already under way.
     await drainWatchRetros();
 
+    getDesktopSessionManager().destroy();
+
     const liveVoiceManager = getLiveVoiceSessionManager();
     const liveVoiceSessionId = liveVoiceManager.activeSessionId;
     if (liveVoiceSessionId) {
@@ -767,6 +809,15 @@ export class RuntimeHttpServer {
       req.headers.get("upgrade")?.toLowerCase() === "websocket"
     ) {
       return this.handleWatchStreamUpgrade(req, server);
+    }
+
+    // WebSocket upgrade for the pod desktop RFB stream, under the same
+    // private-network restrictions and gateway-service token verification.
+    if (
+      path === "/v1/desktop/stream" &&
+      req.headers.get("upgrade")?.toLowerCase() === "websocket"
+    ) {
+      return this.handleDesktopStreamUpgrade(req, server);
     }
 
     // Twilio webhook endpoints — before auth check because Twilio
@@ -1103,6 +1154,50 @@ export class RuntimeHttpServer {
         clientId,
         sessionId: crypto.randomUUID(),
       } satisfies WatchStreamWebSocketData,
+    });
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+    // Bun's WebSocket upgrade consumes the request, so no Response is sent.
+    return undefined!;
+  }
+
+  /**
+   * Handle WebSocket upgrade for `/v1/desktop/stream`.
+   *
+   * Gated exactly as `/v1/watch/stream` is. A daemon without the pod desktop
+   * still upgrades and then closes the socket with 1008, so the browser sees
+   * the feature-disabled code through the gateway's pump.
+   */
+  private handleDesktopStreamUpgrade(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Response {
+    if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
+      return httpError(
+        "FORBIDDEN",
+        "Direct desktop stream access disabled: only private network peers allowed",
+        403,
+      );
+    }
+
+    const tokenError = this.verifyGatewayServiceToken(req);
+    if (tokenError) {
+      return tokenError;
+    }
+
+    let enabled = false;
+    try {
+      enabled = isPodDesktopEnabled(getConfig());
+    } catch (err) {
+      log.warn({ err }, "Failed to read config for desktop stream gate");
+    }
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "desktop-stream",
+        enabled,
+      } satisfies DesktopStreamWebSocketData,
     });
     if (!upgraded) {
       return new Response("WebSocket upgrade failed", { status: 500 });

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -429,6 +429,14 @@
       "label": "Model-First Profile Create",
       "description": "Reverses the two questions the web client's New Model modal asks when creating an inference profile. Off: the modal asks for a provider first and then offers that provider's models. On: it opens on one searchable list of every catalog model the assistant can reach, deduplicated across providers, and only then asks which provider serves the chosen model. That second question is skipped when a single provider serves it, answered with radio cards when several do, and turned into an inline connect form (API key, setup, or ChatGPT sign-in) when the chosen route has no connection yet. Editing an existing profile is unchanged either way, and both flows persist the same profile shape.",
       "defaultEnabled": false
+    },
+    {
+      "id": "pod-desktop",
+      "scope": "assistant",
+      "key": "pod-desktop",
+      "label": "Pod Desktop",
+      "description": "Serves an on-demand interactive desktop (Xtigervnc, openbox, Chromium) from a containerized assistant over the /v1/desktop/stream WebSocket as raw RFB bytes. Off: the runtime refuses the upgrade with 404 and never starts the X server. Only honored when IS_CONTAINERIZED is true; a macOS or self-hosted daemon ignores the flag.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -435,7 +435,7 @@
       "scope": "assistant",
       "key": "pod-desktop",
       "label": "Pod Desktop",
-      "description": "Serves an on-demand interactive desktop (Xtigervnc, openbox, Chromium) from a containerized assistant over the /v1/desktop/stream WebSocket as raw RFB bytes. Off: the runtime refuses the upgrade with 404 and never starts the X server. Only honored when IS_CONTAINERIZED is true; a macOS or self-hosted daemon ignores the flag.",
+      "description": "Streams an interactive desktop from a containerized assistant pod to the web client over /v1/desktop/stream. Off: no desktop affordance is rendered. On: the chat header offers a desktop panel that views and controls the pod's display.",
       "defaultEnabled": false
     }
   ]

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -429,6 +429,14 @@
       "label": "Model-First Profile Create",
       "description": "Reverses the two questions the web client's New Model modal asks when creating an inference profile. Off: the modal asks for a provider first and then offers that provider's models. On: it opens on one searchable list of every catalog model the assistant can reach, deduplicated across providers, and only then asks which provider serves the chosen model. That second question is skipped when a single provider serves it, answered with radio cards when several do, and turned into an inline connect form (API key, setup, or ChatGPT sign-in) when the chosen route has no connection yet. Editing an existing profile is unchanged either way, and both flows persist the same profile shape.",
       "defaultEnabled": false
+    },
+    {
+      "id": "pod-desktop",
+      "scope": "assistant",
+      "key": "pod-desktop",
+      "label": "Pod Desktop",
+      "description": "Serves an on-demand interactive desktop (Xtigervnc, openbox, Chromium) from a containerized assistant over the /v1/desktop/stream WebSocket as raw RFB bytes. Off: the runtime refuses the upgrade with 404 and never starts the X server. Only honored when IS_CONTAINERIZED is true; a macOS or self-hosted daemon ignores the flag.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -435,7 +435,7 @@
       "scope": "assistant",
       "key": "pod-desktop",
       "label": "Pod Desktop",
-      "description": "Serves an on-demand interactive desktop (Xtigervnc, openbox, Chromium) from a containerized assistant over the /v1/desktop/stream WebSocket as raw RFB bytes. Off: the runtime refuses the upgrade with 404 and never starts the X server. Only honored when IS_CONTAINERIZED is true; a macOS or self-hosted daemon ignores the flag.",
+      "description": "Streams an interactive desktop from a containerized assistant pod to the web client over /v1/desktop/stream. Off: no desktop affordance is rendered. On: the chat header offers a desktop panel that views and controls the pod's display.",
       "defaultEnabled": false
     }
   ]


### PR DESCRIPTION
## Summary
- Adds `DesktopSessionManager` (`assistant/src/desktop/`): a lazy, single-slot session that starts `Xtigervnc :99 -localhost -SecurityTypes None` (VNC on `localhost:5999`), `openbox`, `vncconfig -nowin` and Playwright's Chromium (dedicated profile under `data/desktop-profile`) on the first viewer, lingers 5 minutes after the last viewer, and tears the process-group tree down on idle expiry, X/window-manager crash, or runtime shutdown.
- Adds the `/v1/desktop/stream` WebSocket to the runtime: same private-network + `svc_gateway` service-token gate as watch, then a pure RFB byte pipe (`DesktopStreamBridge`) between the socket and the VNC port. Outcomes are close codes only: 1008 feature disabled, 1013 busy, 1011 failed/stopped, 1001 shutting down. Per the gateway contract (#41949), a disabled feature upgrades and closes 1008 rather than answering 404.
- Adds the `pod-desktop` assistant flag (`defaultEnabled: false`, also requires `IS_CONTAINERIZED=true`), the `tigervnc-standalone-server`, `openbox`, `dbus-x11` and `xauth` image packages, and an ARCHITECTURE.md section.

Notes for review: Playwright's Chromium is not baked into the image (the browser tool installs it on demand), so the desktop does the same after the X server is up; a first-time open shows an empty openbox desktop until `playwright install chromium` finishes. A user closing Chromium is treated as normal use (the next viewer gets a fresh window) rather than a crash. Needs the companion Terraform flag in vellum-assistant-platform.

Part of plan: pod-desktop-streaming.md (PR 1 of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YDF6hHcX7aPZsc6TuByhy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41952" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->