### PR TITLE
test(linux): the bare-modifier hold is a macOS-only bridge method

### DIFF
--- a/clients/linux/src/preload/bridge-parity.test.ts
+++ b/clients/linux/src/preload/bridge-parity.test.ts
@@ -78,7 +78,13 @@ const LINUX_ONLY_SURFACE = [
   "menu.popup",
   "menu.titles",
 ];
-const MACOS_ONLY_SURFACE = ["helper.hotkey.fnPushToTalk"];
+// The macOS helper watches the raw keyboard, which is where the Fn tap and
+// the bare-modifier hold come from. The Linux sidecar has no such tap, so
+// its hotkey surface is the shortcut chord alone.
+const MACOS_ONLY_SURFACE = [
+  "helper.hotkey.fnPushToTalk",
+  "helper.hotkey.setModifierHold",
+];
 
 test("the composed Linux bridge satisfies every applicable VellumBridge key", () => {
   const bridge = composeLinuxBridge();

--- a/clients/linux/src/preload/features/dictation.ts
+++ b/clients/linux/src/preload/features/dictation.ts
@@ -38,7 +38,8 @@ const subscribe =
 
 /**
  * The Linux helper's bridge: dictation plus the global voice mode chord.
- * `hotkey.fnPushToTalk` is absent (Linux has no Fn-key contract).
+ * `hotkey.fnPushToTalk` and `hotkey.setModifierHold` are absent: both need
+ * a raw keyboard tap, and the Linux sidecar has none.
  * `setVoiceModeChord` registers the voice mode shortcut's bare-modifier
  * chord with the helper when a sidecar exists.
  */


### PR DESCRIPTION
## Summary
- `helper.hotkey.setModifierHold` joins `MACOS_ONLY_SURFACE` in `bridge-parity.test.ts`. The contract already documents it as absent on shells whose helper cannot watch the raw keyboard, which is the Linux sidecar; a stub would be the wrong side of that delta.
- The Linux dictation feature's doc comment names both absent methods.

## Original prompt
Main's "CI/CD Main Linux" run has been red since #41793 landed: #41902 added the bare-modifier hold to the macOS preload bridge while the Linux client PR was in review, and the parity test it brought lists the macOS-only surface explicitly. Every PR's "PR Linux Checks" fails on it in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pvqq8r7e5DG6WyQpabTK13