### PR TITLE
fix(companion): keep the peeking ghost inside the resting capsule

### DIFF
--- a/clients/web/src/components/companion-peek.test.tsx
+++ b/clients/web/src/components/companion-peek.test.tsx
@@ -70,7 +70,10 @@ describe("how far the creature comes up", () => {
     expect(geometry.exposed).toBeCloseTo(PEEK_SIZE_MAX * 0.39);
   });
 
-  /** The ghost is the creature that used to reach the capsule's full width. */
+  /**
+   * The ghost is the catalog creature the cap constrains: its face sits high
+   * enough that exposure alone would draw it at the capsule's full width.
+   */
   test("never draws any creature in the catalog wider than the cap", () => {
     for (const shape of BUNDLED_COMPONENTS.bodyShapes) {
       for (const eyes of BUNDLED_COMPONENTS.eyeStyles) {

--- a/clients/web/src/components/companion-peek.test.tsx
+++ b/clients/web/src/components/companion-peek.test.tsx
@@ -9,6 +9,7 @@ import {
   PEEK_EDGES,
   PEEK_EXPOSED_MAX,
   PEEK_INTERVAL_SECONDS,
+  PEEK_SIZE_MAX,
   peekDelayMs,
   peekGeometry,
   pickEdge,
@@ -55,13 +56,33 @@ describe("how far the creature comes up", () => {
     }
   });
 
-  test("draws a high-faced creature at full size", () => {
+  /**
+   * The size cap, not the capsule's width: a square as wide as the capsule
+   * puts a full-width body's sides past the capsule's rounded ends.
+   */
+  test("draws a high-faced creature at the size cap, inside the capsule", () => {
     const geometry = peekGeometry(
       { eyeCenterFrac: 0.3, eyeHalfFrac: 0.05 },
       CAPSULE.width,
     );
-    expect(geometry.size).toBe(CAPSULE.width);
-    expect(geometry.exposed).toBeCloseTo(28 * 0.39);
+    expect(PEEK_SIZE_MAX).toBeLessThan(CAPSULE.width);
+    expect(geometry.size).toBe(PEEK_SIZE_MAX);
+    expect(geometry.exposed).toBeCloseTo(PEEK_SIZE_MAX * 0.39);
+  });
+
+  /** The ghost is the creature that used to reach the capsule's full width. */
+  test("never draws any creature in the catalog wider than the cap", () => {
+    for (const shape of BUNDLED_COMPONENTS.bodyShapes) {
+      for (const eyes of BUNDLED_COMPONENTS.eyeStyles) {
+        const metrics = avatarPeekMetrics(BUNDLED_COMPONENTS, {
+          bodyShape: shape.id,
+          eyeStyle: eyes.id,
+          color: "teal",
+        });
+        const geometry = peekGeometry(metrics!, CAPSULE.width);
+        expect(geometry.size).toBeLessThanOrEqual(PEEK_SIZE_MAX);
+      }
+    }
   });
 
   /** Rather than exposing a tall slab of body to get its eyes over the rim. */

--- a/clients/web/src/components/companion-peek.tsx
+++ b/clients/web/src/components/companion-peek.tsx
@@ -95,6 +95,19 @@ const DUCK_SECONDS = 0.22;
  */
 export const PEEK_EXPOSED_MAX = 14;
 
+/**
+ * The widest the creature's square is drawn, in points.
+ *
+ * Below the capsule's own width, on purpose. The exposure cap alone lets a
+ * creature whose face sits near its crown come up at the capsule's full width,
+ * and a body that is still full-width at eye level (the ghost) then has its
+ * sides cut flat by the rim exactly where the capsule's ends round away
+ * beneath them: the creature stands out past the pill instead of rising from
+ * behind it. This is what the widest of the other creatures already draws at,
+ * and there the cut stays behind the capsule.
+ */
+export const PEEK_SIZE_MAX = 24;
+
 /** Air between the eye ink's bottom and the rim, as a fraction of the square. */
 const EYE_PAD_FRAC = 0.04;
 
@@ -107,8 +120,10 @@ const HEADROOM = 4;
 /**
  * How far the creature is drawn, on every axis, from the measurements.
  *
- * `size` is the creature's square. `exposed` is how much of it shows past the
- * rim at the top of the rise: down to just under the eye ink. `clip` is the
+ * `size` is the creature's square: the capsule's width, or less where
+ * {@link PEEK_SIZE_MAX} or the exposure cap says so. `exposed` is how much of
+ * it shows past the rim at the top of the rise: down to just under the eye
+ * ink. `clip` is the
  * box it is drawn in, whose bottom edge is the rim, and `rest` is how far
  * below the top of the rise it sits when hidden: its whole exposure plus a
  * little, so nothing of it shows through the clip's bottom edge.
@@ -128,7 +143,11 @@ export const peekGeometry = (
     0.95,
     Math.max(0.25, metrics.eyeCenterFrac + metrics.eyeHalfFrac + EYE_PAD_FRAC),
   );
-  const size = Math.min(fullSize, PEEK_EXPOSED_MAX / exposedFrac);
+  const size = Math.min(
+    fullSize,
+    PEEK_SIZE_MAX,
+    PEEK_EXPOSED_MAX / exposedFrac,
+  );
   const exposed = size * exposedFrac;
   return {
     size,


### PR DESCRIPTION
## Summary

- The resting-capsule peek sizes the creature by exposure alone, so a high-faced body (the ghost) came up at the capsule's full 28pt width. Its sides, cut flat at the rim, stood out past the capsule's rounded ends and read as clipped.
- Adds `PEEK_SIZE_MAX = 24` to the peek geometry, which is what the widest of the other creatures already draws at. The ghost now sits inside the capsule; every other creature is unchanged.
- Tests: the high-faced case asserts the cap rather than the capsule width, and a catalog sweep asserts no creature exceeds it.

## Before / after (Storybook `CompanionPeek / Held`)

Before: ghost as wide as the capsule, sides standing past the rounded ends.
After: ghost inside the capsule like the rest. Other shapes unchanged.

## Test plan

- [x] `bun test src/components/companion-peek.test.tsx` (16 pass)
- [x] `bun test src/components/companion-surface.test.tsx` (126 pass)
- [x] Storybook `Held` and `HeldBelow` screenshots checked headless

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hNBGhLnHx3VmuWSc4CAch