### PR TITLE
feat(companion): a hold over a selection asks the assistant about it (JARVIS-1710)

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
@@ -1,36 +1,80 @@
 import AppKit
 import ApplicationServices
+import Carbon
 
-/// The text selected in the application in front, read over Accessibility.
+/// The text selected in the application in front.
 ///
 /// Read at the moment a hold begins, so a hold made with something highlighted
-/// carries what was highlighted. Accessibility is the only way in: a copy
-/// keystroke would land on the app in front while the hold's own modifiers are
-/// still down, and the hold detector would read the key as a chord and drop the
-/// hold. Applications that expose no selection over Accessibility (a terminal,
-/// a canvas) read as having none.
+/// carries what was highlighted. Accessibility first: the focused element's
+/// selected text, or its selected range picked out of its value. Where that
+/// yields nothing and there is a focused element, a copy keystroke is sent to
+/// the application in front and the pasteboard read and put back. The keystroke
+/// is posted to that application's process rather than the HID stream, so the
+/// raw key monitor that watches the hold never sees it as a chord.
 ///
 /// The read happens on the keyboard event's own thread, ahead of the edge it
-/// travels on, so it is held to a few short waits: an application that does
-/// not answer costs the edge at most `maxReadSeconds`, and the edge carries
-/// how long it was held so the far side can take that off its own clock.
+/// travels on, so it is held to short waits: an application that does not
+/// answer costs the edge at most a few of `requestTimeoutSeconds` and, when the
+/// copy runs, `copyWaitSeconds`. The edge carries how long it was held so the
+/// far side can take that off its own clock.
 enum FrontSelection {
     /// How much of a selection travels. The rest is dropped and flagged.
     static let maxChars = 4000
 
     /// The longest one Accessibility request is given to answer.
     static let requestTimeoutSeconds: Float = 0.05
-    /// The most a read can take, every request having timed out.
-    static let maxReadSeconds: Float = requestTimeoutSeconds * 4
+    /// How long the pasteboard is given to change after the copy keystroke.
+    static let copyWaitSeconds: TimeInterval = 0.12
 
     struct Selection {
         let text: String
         let truncated: Bool
     }
 
-    /// The current selection, or nil where there is none or it cannot be read.
-    static func read() -> Selection? {
-        guard AXIsProcessTrusted() else { return nil }
+    /// Where the text came from, for the log.
+    enum Path: String {
+        case selectedText
+        case range
+        case copy
+        case none
+    }
+
+    /// Everything a read learned, the text aside: what the log carries. No
+    /// user content in here; the bundle id and role name the application and
+    /// the kind of control, not what is in them.
+    struct Outcome {
+        var trusted: Bool
+        var promptShown = false
+        var bundleId: String?
+        var focused = false
+        var role: String?
+        var path: Path = .none
+        var chars = 0
+        var selection: Selection?
+
+        var logLine: String {
+            "trusted=\(trusted) prompt=\(promptShown) app=\(bundleId ?? "-") focused=\(focused) role=\(role ?? "-") path=\(path.rawValue) chars=\(chars)"
+        }
+    }
+
+    /// Whether the Accessibility prompt has been shown by this process. Shown
+    /// the first time a hold needs a selection and the helper is not trusted,
+    /// and not again: the prompt is the system's own dialog, and a hold is
+    /// not the moment to keep raising it.
+    private nonisolated(unsafe) static var promptedForTrust = false
+
+    /// The current selection, and how it was found.
+    static func read() -> Outcome {
+        var outcome = Outcome(trusted: AXIsProcessTrusted())
+        outcome.bundleId = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+        if !outcome.trusted {
+            if !promptedForTrust {
+                promptedForTrust = true
+                outcome.promptShown = true
+                _ = ActionExecutor.checkAccessibilityPermission(prompt: true)
+            }
+            return outcome
+        }
 
         let systemWide = AXUIElementCreateSystemWide()
         AXUIElementSetMessagingTimeout(systemWide, requestTimeoutSeconds)
@@ -41,29 +85,45 @@ enum FrontSelection {
             let focusedValue = focusedRef,
             CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
         else {
-            return nil
+            return outcome
         }
         let focused = focusedValue as! AXUIElement
         AXUIElementSetMessagingTimeout(focused, requestTimeoutSeconds)
+        outcome.focused = true
+        outcome.role = stringAttribute(focused, kAXRoleAttribute as CFString)
 
         var text = stringAttribute(focused, kAXSelectedTextAttribute as CFString) ?? ""
-        if text.isEmpty {
+        var path = Path.selectedText
+        if isBlank(text) {
             // Some text views answer the range but not the selected text
             // itself; the value is the whole document, and the range picks
             // the selection out of it.
             text = selectionFromRange(focused) ?? ""
+            path = .range
         }
+        if isBlank(text) {
+            text = selectionFromCopy() ?? ""
+            path = .copy
+        }
+        guard !isBlank(text) else {
+            return outcome
+        }
+
+        outcome.path = path
+        outcome.chars = text.count
         // Whitespace decides only whether anything is selected. What is
         // selected travels as it is: the indentation of a selected snippet is
         // part of what the user is asking about.
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return nil
-        }
-
         if text.count > maxChars {
-            return Selection(text: String(text.prefix(maxChars)), truncated: true)
+            outcome.selection = Selection(text: String(text.prefix(maxChars)), truncated: true)
+        } else {
+            outcome.selection = Selection(text: text, truncated: false)
         }
-        return Selection(text: text, truncated: false)
+        return outcome
+    }
+
+    private static func isBlank(_ text: String) -> Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private static func selectionFromRange(_ element: AXUIElement) -> String? {
@@ -92,6 +152,59 @@ enum FrontSelection {
             return nil
         }
         return String(utf16[start..<end])
+    }
+
+    /// Copy whatever the application in front has selected and read it off
+    /// the pasteboard, then put the pasteboard back as it was. A pasteboard
+    /// that does not change inside `copyWaitSeconds` means nothing was
+    /// selected, and it is left untouched.
+    private static func selectionFromCopy() -> String? {
+        guard let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier else {
+            return nil
+        }
+        let pasteboard = NSPasteboard.general
+        let changeCountBefore = pasteboard.changeCount
+        let saved: [[NSPasteboard.PasteboardType: Data]] = (pasteboard.pasteboardItems ?? []).map { item in
+            var contents: [NSPasteboard.PasteboardType: Data] = [:]
+            for type in item.types {
+                if let data = item.data(forType: type) {
+                    contents[type] = data
+                }
+            }
+            return contents
+        }
+
+        guard let down = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_C), keyDown: true),
+              let up = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_C), keyDown: false)
+        else {
+            return nil
+        }
+        down.flags = .maskCommand
+        up.flags = .maskCommand
+        down.postToPid(pid)
+        up.postToPid(pid)
+
+        let deadline = Date().addingTimeInterval(copyWaitSeconds)
+        while pasteboard.changeCount == changeCountBefore, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        guard pasteboard.changeCount != changeCountBefore else {
+            return nil
+        }
+        let text = pasteboard.string(forType: .string)
+
+        pasteboard.clearContents()
+        let items = saved.map { contents -> NSPasteboardItem in
+            let item = NSPasteboardItem()
+            for (type, data) in contents {
+                item.setData(data, forType: type)
+            }
+            return item
+        }
+        if !items.isEmpty {
+            pasteboard.writeObjects(items)
+        }
+        return text
     }
 
     private static func stringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
@@ -53,13 +53,17 @@ enum FrontSelection {
             // the selection out of it.
             text = selectionFromRange(focused) ?? ""
         }
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-
-        if trimmed.count > maxChars {
-            return Selection(text: String(trimmed.prefix(maxChars)), truncated: true)
+        // Whitespace decides only whether anything is selected. What is
+        // selected travels as it is: the indentation of a selected snippet is
+        // part of what the user is asking about.
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
         }
-        return Selection(text: trimmed, truncated: false)
+
+        if text.count > maxChars {
+            return Selection(text: String(text.prefix(maxChars)), truncated: true)
+        }
+        return Selection(text: text, truncated: false)
     }
 
     private static func selectionFromRange(_ element: AXUIElement) -> String? {

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
@@ -45,12 +45,12 @@ enum FrontSelection {
     /// The most pasteboard text that is saved and put back around a copy.
     static let maxRestoredBytes = 256 * 1024
 
-    /// Pasteboard types that mean the user has something copied which a
-    /// string cannot stand in for: an image, a file, a document. A copy
-    /// would replace it with text and the restore could only give the text
-    /// back, so no copy is attempted over these.
-    private static let irreplaceableTypes: [NSPasteboard.PasteboardType] = [
-        .tiff, .png, .pdf, .fileURL, .fileContents,
+    /// The pasteboard types a saved string gives back whole. Anything else
+    /// on the pasteboard, an image, a file, rich text beside its plain text,
+    /// is something the restore could only hand back as text, so no copy is
+    /// attempted over it. An empty pasteboard qualifies.
+    private static let restorableTypes: Set<NSPasteboard.PasteboardType> = [
+        .string, NSPasteboard.PasteboardType("NSStringPboardType"),
     ]
 
     /// Everything a read learned, the text aside: what the log carries. No
@@ -201,7 +201,7 @@ enum FrontSelection {
         }
         let pasteboard = NSPasteboard.general
         let types = pasteboard.types ?? []
-        if types.contains(where: { irreplaceableTypes.contains($0) }) {
+        if types.contains(where: { !restorableTypes.contains($0) }) {
             return .skipped
         }
         let savedData = types.contains(.string) ? pasteboard.data(forType: .string) : nil

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
@@ -1,0 +1,88 @@
+import AppKit
+import ApplicationServices
+
+/// The text selected in the application in front, read over Accessibility.
+///
+/// Read at the moment a hold begins, so a hold made with something highlighted
+/// carries what was highlighted. Accessibility is the only way in: a copy
+/// keystroke would land on the app in front while the hold's own modifiers are
+/// still down, and the hold detector would read the key as a chord and drop the
+/// hold. Applications that expose no selection over Accessibility (a terminal,
+/// a canvas) read as having none.
+enum FrontSelection {
+    /// How much of a selection travels. The rest is dropped and flagged.
+    static let maxChars = 4000
+
+    struct Selection {
+        let text: String
+        let truncated: Bool
+    }
+
+    /// The current selection, or nil where there is none or it cannot be read.
+    static func read() -> Selection? {
+        guard AXIsProcessTrusted() else { return nil }
+
+        let systemWide = AXUIElementCreateSystemWide()
+        AXUIElementSetMessagingTimeout(systemWide, 0.25)
+        var focusedRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            systemWide, kAXFocusedUIElementAttribute as CFString, &focusedRef
+        ) == .success,
+            let focusedValue = focusedRef,
+            CFGetTypeID(focusedValue) == AXUIElementGetTypeID()
+        else {
+            return nil
+        }
+        let focused = focusedValue as! AXUIElement
+        AXUIElementSetMessagingTimeout(focused, 0.25)
+
+        var text = stringAttribute(focused, kAXSelectedTextAttribute as CFString) ?? ""
+        if text.isEmpty {
+            // Some text views answer the range but not the selected text
+            // itself; the value is the whole document, and the range picks
+            // the selection out of it.
+            text = selectionFromRange(focused) ?? ""
+        }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if trimmed.count > maxChars {
+            return Selection(text: String(trimmed.prefix(maxChars)), truncated: true)
+        }
+        return Selection(text: trimmed, truncated: false)
+    }
+
+    private static func selectionFromRange(_ element: AXUIElement) -> String? {
+        var rangeRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(
+            element, kAXSelectedTextRangeAttribute as CFString, &rangeRef
+        ) == .success,
+            let rangeValue = rangeRef,
+            CFGetTypeID(rangeValue) == AXValueGetTypeID()
+        else {
+            return nil
+        }
+        var range = CFRange()
+        guard AXValueGetValue(rangeValue as! AXValue, .cfRange, &range), range.length > 0 else {
+            return nil
+        }
+        guard let value = stringAttribute(element, kAXValueAttribute as CFString) else {
+            return nil
+        }
+        let utf16 = value.utf16
+        guard range.location >= 0,
+              range.location + range.length <= utf16.count,
+              let start = utf16.index(utf16.startIndex, offsetBy: range.location, limitedBy: utf16.endIndex),
+              let end = utf16.index(start, offsetBy: range.length, limitedBy: utf16.endIndex)
+        else {
+            return nil
+        }
+        return String(utf16[start..<end])
+    }
+
+    private static func stringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
+        return value as? String
+    }
+}

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
@@ -31,13 +31,27 @@ enum FrontSelection {
         let truncated: Bool
     }
 
-    /// Where the text came from, for the log.
+    /// Where the text came from, for the log. `copySkipped` is a copy that was
+    /// not attempted because the pasteboard held something it could not be
+    /// given back cheaply.
     enum Path: String {
         case selectedText
         case range
         case copy
+        case copySkipped
         case none
     }
+
+    /// The most pasteboard text that is saved and put back around a copy.
+    static let maxRestoredBytes = 256 * 1024
+
+    /// Pasteboard types that mean the user has something copied which a
+    /// string cannot stand in for: an image, a file, a document. A copy
+    /// would replace it with text and the restore could only give the text
+    /// back, so no copy is attempted over these.
+    private static let irreplaceableTypes: [NSPasteboard.PasteboardType] = [
+        .tiff, .png, .pdf, .fileURL, .fileContents,
+    ]
 
     /// Everything a read learned, the text aside: what the log carries. No
     /// user content in here; the bundle id and role name the application and
@@ -102,10 +116,18 @@ enum FrontSelection {
             path = .range
         }
         if isBlank(text) {
-            text = selectionFromCopy() ?? ""
-            path = .copy
+            switch selectionFromCopy() {
+            case .text(let copied):
+                text = copied
+                path = .copy
+            case .nothing:
+                path = .copy
+            case .skipped:
+                path = .copySkipped
+            }
         }
         guard !isBlank(text) else {
+            outcome.path = path == .copySkipped ? .copySkipped : .none
             return outcome
         }
 
@@ -154,30 +176,44 @@ enum FrontSelection {
         return String(utf16[start..<end])
     }
 
+    enum CopyResult {
+        case text(String)
+        case nothing
+        case skipped
+    }
+
     /// Copy whatever the application in front has selected and read it off
     /// the pasteboard, then put the pasteboard back as it was. A pasteboard
     /// that does not change inside `copyWaitSeconds` means nothing was
     /// selected, and it is left untouched.
-    private static func selectionFromCopy() -> String? {
+    ///
+    /// What is saved is the pasteboard's text, as `ActionExecutor` saves it
+    /// around a paste: reading every representation of everything on the
+    /// pasteboard is unbounded work on the keyboard callback (a lazily
+    /// supplied image waits on its owner), and a pasteboard holding an image
+    /// or a file is left alone rather than replaced with text. The restore
+    /// also mirrors `ActionExecutor`'s guard: it only happens while the
+    /// pasteboard still holds the copy, so a write by anyone else in the
+    /// meantime is never overwritten.
+    private static func selectionFromCopy() -> CopyResult {
         guard let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier else {
-            return nil
+            return .nothing
         }
         let pasteboard = NSPasteboard.general
-        let changeCountBefore = pasteboard.changeCount
-        let saved: [[NSPasteboard.PasteboardType: Data]] = (pasteboard.pasteboardItems ?? []).map { item in
-            var contents: [NSPasteboard.PasteboardType: Data] = [:]
-            for type in item.types {
-                if let data = item.data(forType: type) {
-                    contents[type] = data
-                }
-            }
-            return contents
+        let types = pasteboard.types ?? []
+        if types.contains(where: { irreplaceableTypes.contains($0) }) {
+            return .skipped
         }
+        let savedData = types.contains(.string) ? pasteboard.data(forType: .string) : nil
+        if let savedData, savedData.count > maxRestoredBytes {
+            return .skipped
+        }
+        let changeCountBefore = pasteboard.changeCount
 
         guard let down = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_C), keyDown: true),
               let up = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_ANSI_C), keyDown: false)
         else {
-            return nil
+            return .nothing
         }
         down.flags = .maskCommand
         up.flags = .maskCommand
@@ -188,23 +224,21 @@ enum FrontSelection {
         while pasteboard.changeCount == changeCountBefore, Date() < deadline {
             Thread.sleep(forTimeInterval: 0.01)
         }
-        guard pasteboard.changeCount != changeCountBefore else {
-            return nil
+        let changeCountAfterCopy = pasteboard.changeCount
+        guard changeCountAfterCopy != changeCountBefore else {
+            return .nothing
         }
         let text = pasteboard.string(forType: .string)
 
-        pasteboard.clearContents()
-        let items = saved.map { contents -> NSPasteboardItem in
-            let item = NSPasteboardItem()
-            for (type, data) in contents {
-                item.setData(data, forType: type)
+        // Only while the pasteboard still holds the copy. Anyone who wrote to
+        // it since owns it now, and what was saved is not theirs to lose.
+        if pasteboard.changeCount == changeCountAfterCopy {
+            pasteboard.clearContents()
+            if let savedData {
+                pasteboard.setData(savedData, forType: .string)
             }
-            return item
         }
-        if !items.isEmpty {
-            pasteboard.writeObjects(items)
-        }
-        return text
+        return text.map { .text($0) } ?? .nothing
     }
 
     private static func stringAttribute(_ element: AXUIElement, _ attribute: CFString) -> String? {

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
@@ -9,9 +9,19 @@ import ApplicationServices
 /// still down, and the hold detector would read the key as a chord and drop the
 /// hold. Applications that expose no selection over Accessibility (a terminal,
 /// a canvas) read as having none.
+///
+/// The read happens on the keyboard event's own thread, ahead of the edge it
+/// travels on, so it is held to a few short waits: an application that does
+/// not answer costs the edge at most `maxReadSeconds`, and the edge carries
+/// how long it was held so the far side can take that off its own clock.
 enum FrontSelection {
     /// How much of a selection travels. The rest is dropped and flagged.
     static let maxChars = 4000
+
+    /// The longest one Accessibility request is given to answer.
+    static let requestTimeoutSeconds: Float = 0.05
+    /// The most a read can take, every request having timed out.
+    static let maxReadSeconds: Float = requestTimeoutSeconds * 4
 
     struct Selection {
         let text: String
@@ -23,7 +33,7 @@ enum FrontSelection {
         guard AXIsProcessTrusted() else { return nil }
 
         let systemWide = AXUIElementCreateSystemWide()
-        AXUIElementSetMessagingTimeout(systemWide, 0.25)
+        AXUIElementSetMessagingTimeout(systemWide, requestTimeoutSeconds)
         var focusedRef: CFTypeRef?
         guard AXUIElementCopyAttributeValue(
             systemWide, kAXFocusedUIElementAttribute as CFString, &focusedRef
@@ -34,7 +44,7 @@ enum FrontSelection {
             return nil
         }
         let focused = focusedValue as! AXUIElement
-        AXUIElementSetMessagingTimeout(focused, 0.25)
+        AXUIElementSetMessagingTimeout(focused, requestTimeoutSeconds)
 
         var text = stringAttribute(focused, kAXSelectedTextAttribute as CFString) ?? ""
         if text.isEmpty {

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/FrontSelection.swift
@@ -45,13 +45,12 @@ enum FrontSelection {
     /// The most pasteboard text that is saved and put back around a copy.
     static let maxRestoredBytes = 256 * 1024
 
-    /// The pasteboard types a saved string gives back whole. Anything else
-    /// on the pasteboard, an image, a file, rich text beside its plain text,
-    /// is something the restore could only hand back as text, so no copy is
-    /// attempted over it. An empty pasteboard qualifies.
-    private static let restorableTypes: Set<NSPasteboard.PasteboardType> = [
-        .string, NSPasteboard.PasteboardType("NSStringPboardType"),
-    ]
+    /// The pasteboard types a saved string gives back whole: the one type
+    /// the snapshot below reads. Anything else on the pasteboard, an image,
+    /// a file, rich text beside its plain text, a legacy string type, is
+    /// something the restore could not put back, so no copy is attempted
+    /// over it. An empty pasteboard qualifies.
+    private static let restorableTypes: Set<NSPasteboard.PasteboardType> = [.string]
 
     /// Everything a read learned, the text aside: what the log carries. No
     /// user content in here; the bundle id and role name the application and

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -244,21 +244,29 @@ final class MacHelper: @unchecked Sendable {
     }
 
     func emitModifierHold(state: String) {
+        var params: [String: Any] = [
+            "kind": "modifierHold",
+            "state": state,
+        ]
         if state == "down" {
             guard !isModifierHoldDown else { return }
             isModifierHoldDown = true
+            // What the user had highlighted when the keys went down travels
+            // with the edge, so the hold can be about it. Character counts
+            // only in the log; the text itself is the user's.
+            if let selection = FrontSelection.read() {
+                params["selection"] = [
+                    "text": selection.text,
+                    "truncated": selection.truncated,
+                ]
+                log("modifier hold down with selection chars=\(selection.text.count) truncated=\(selection.truncated)")
+            }
         } else if state == "up" {
             guard isModifierHoldDown else { return }
             isModifierHoldDown = false
         }
 
-        writeNotification(
-            method: "hotkey.event",
-            params: [
-                "kind": "modifierHold",
-                "state": state,
-            ]
-        )
+        writeNotification(method: "hotkey.event", params: params)
     }
 
     /// Every modifier this keyboard reports, so anything outside the configured
@@ -1156,7 +1164,18 @@ private func writePermissionStatusAndExit() {
     }
 }
 
-if CommandLine.arguments.contains("--request-speech-recognition") {
+if CommandLine.arguments.contains("--front-selection") {
+    // A probe for what the application in front exposes: run it with something
+    // highlighted and it prints what a hold would carry, then exits.
+    let selection = FrontSelection.read()
+    var payload: [String: Any] = ["trusted": AXIsProcessTrusted()]
+    payload["text"] = selection?.text ?? NSNull()
+    payload["truncated"] = selection?.truncated ?? false
+    let data = try! JSONSerialization.data(withJSONObject: payload, options: [])
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+    exit(0)
+} else if CommandLine.arguments.contains("--request-speech-recognition") {
     MainActor.assumeIsolated {
         NSApplication.shared.setActivationPolicy(.prohibited)
         if SFSpeechRecognizer.authorizationStatus() == .notDetermined {

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -257,16 +257,16 @@ final class MacHelper: @unchecked Sendable {
             // was. Character counts only in the log; the text itself is the
             // user's.
             let readStarted = Date()
-            let selection = FrontSelection.read()
+            let outcome = FrontSelection.read()
             let heldMs = Int(Date().timeIntervalSince(readStarted) * 1000)
             params["heldMs"] = heldMs
-            if let selection {
+            if let selection = outcome.selection {
                 params["selection"] = [
                     "text": selection.text,
                     "truncated": selection.truncated,
                 ]
-                log("modifier hold down with selection chars=\(selection.text.count) truncated=\(selection.truncated) readMs=\(heldMs)")
             }
+            log("modifier hold down: selection \(outcome.logLine) truncated=\(outcome.selection?.truncated ?? false) readMs=\(heldMs)")
         } else if state == "up" {
             guard isModifierHoldDown else { return }
             isModifierHoldDown = false
@@ -1173,10 +1173,18 @@ private func writePermissionStatusAndExit() {
 if CommandLine.arguments.contains("--front-selection") {
     // A probe for what the application in front exposes: run it with something
     // highlighted and it prints what a hold would carry, then exits.
-    let selection = FrontSelection.read()
-    var payload: [String: Any] = ["trusted": AXIsProcessTrusted()]
-    payload["text"] = selection?.text ?? NSNull()
-    payload["truncated"] = selection?.truncated ?? false
+    let outcome = FrontSelection.read()
+    var payload: [String: Any] = [
+        "trusted": outcome.trusted,
+        "promptShown": outcome.promptShown,
+        "app": outcome.bundleId ?? NSNull(),
+        "focused": outcome.focused,
+        "role": outcome.role ?? NSNull(),
+        "path": outcome.path.rawValue,
+        "chars": outcome.chars,
+    ]
+    payload["text"] = outcome.selection?.text ?? NSNull()
+    payload["truncated"] = outcome.selection?.truncated ?? false
     let data = try! JSONSerialization.data(withJSONObject: payload, options: [])
     FileHandle.standardOutput.write(data)
     FileHandle.standardOutput.write(Data("\n".utf8))

--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -252,14 +252,20 @@ final class MacHelper: @unchecked Sendable {
             guard !isModifierHoldDown else { return }
             isModifierHoldDown = true
             // What the user had highlighted when the keys went down travels
-            // with the edge, so the hold can be about it. Character counts
-            // only in the log; the text itself is the user's.
-            if let selection = FrontSelection.read() {
+            // with the edge, so the hold can be about it. The read holds the
+            // edge for as long as it takes, and the edge says how long that
+            // was. Character counts only in the log; the text itself is the
+            // user's.
+            let readStarted = Date()
+            let selection = FrontSelection.read()
+            let heldMs = Int(Date().timeIntervalSince(readStarted) * 1000)
+            params["heldMs"] = heldMs
+            if let selection {
                 params["selection"] = [
                     "text": selection.text,
                     "truncated": selection.truncated,
                 ]
-                log("modifier hold down with selection chars=\(selection.text.count) truncated=\(selection.truncated)")
+                log("modifier hold down with selection chars=\(selection.text.count) truncated=\(selection.truncated) readMs=\(heldMs)")
             }
         } else if state == "up" {
             guard isModifierHoldDown else { return }

--- a/clients/macos/src/main/hotkey-helper.test.ts
+++ b/clients/macos/src/main/hotkey-helper.test.ts
@@ -21,8 +21,10 @@ class FakeHotkeyChild extends FakeChild {
 }
 
 const appState = { isPackaged: false, appPath: "/repo/clients/macos" };
-const handlers: Record<string, (event: unknown, ...args: unknown[]) => unknown> =
-  {};
+const handlers: Record<
+  string,
+  (event: unknown, ...args: unknown[]) => unknown
+> = {};
 const appListeners = new Map<string, () => void>();
 
 type FakeWebContents = EventEmitter & {
@@ -128,9 +130,8 @@ const {
   requestMacHelperSpeechRecognitionPermission,
 } = await import("./hotkey-helper");
 
-const { getMacHelperAppPath, getMacHelperPath } = await import(
-  "./sidecar/mac-helper-path"
-);
+const { getMacHelperAppPath, getMacHelperPath } =
+  await import("./sidecar/mac-helper-path");
 
 const invokeFnPushToTalk = (enable: boolean) =>
   handlers["vellum:helper:hotkey:fnPushToTalk"](
@@ -246,7 +247,7 @@ describe("permission request launchers", () => {
     expect(args[5]).toBe("--status-output");
     expect(args[6]).toBeString();
 
-    await writeFile(args[6]!, "{\"status\":\"granted\"}");
+    await writeFile(args[6]!, '{"status":"granted"}');
     lastChild?.emit("exit", 0);
     expect(await pending).toBe("granted");
   });
@@ -295,12 +296,12 @@ describe("installHotkeyHelper", () => {
     installHotkeyHelper();
     const pending = invokePing();
 
-    expect(lastChild?.stdin.writes[0]).toContain("\"jsonrpc\":\"2.0\"");
-    expect(lastChild?.stdin.writes[0]).toContain("\"method\":\"ping\"");
+    expect(lastChild?.stdin.writes[0]).toContain('"jsonrpc":"2.0"');
+    expect(lastChild?.stdin.writes[0]).toContain('"method":"ping"');
 
     lastChild?.stdout.emit(
       "data",
-      Buffer.from("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"pong\"}\n"),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":"pong"}\n'),
     );
 
     expect(await pending).toBe("pong");
@@ -326,7 +327,7 @@ describe("installHotkeyHelper", () => {
     const pending = invokePing();
     lastChild?.stdout.emit(
       "data",
-      Buffer.from("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"pong\"}\n"),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":"pong"}\n'),
     );
     expect(await pending).toBe("pong");
 
@@ -381,17 +382,15 @@ describe("installHotkeyHelper", () => {
     expect(spawnCalls[0]?.[0]).toBe(
       "/repo/clients/macos/resources/vellum-mac-helper.app/Contents/MacOS/vellum-mac-helper",
     );
-    expect(lastChild?.stdin.writes[0]).toContain("\"jsonrpc\":\"2.0\"");
+    expect(lastChild?.stdin.writes[0]).toContain('"jsonrpc":"2.0"');
     expect(lastChild?.stdin.writes[0]).toContain(
-      "\"method\":\"hotkey.fnPushToTalk\"",
+      '"method":"hotkey.fnPushToTalk"',
     );
-    expect(lastChild?.stdin.writes[0]).toContain("\"enable\":true");
+    expect(lastChild?.stdin.writes[0]).toContain('"enable":true');
 
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":{"enabled":true}}\n'),
     );
 
     expect(await pending).toEqual({ ok: true, enabled: true });
@@ -407,7 +406,7 @@ describe("installHotkeyHelper", () => {
     const pending = invokePing();
     lastChild?.stdout.emit(
       "data",
-      Buffer.from("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"pong\"}\n"),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":"pong"}\n'),
     );
     expect(await pending).toBe("pong");
 
@@ -429,9 +428,7 @@ describe("installHotkeyHelper", () => {
     const pending = invokeFnPushToTalk(true);
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":{"enabled":true}}\n'),
     );
     expect(await pending).toEqual({ ok: true, enabled: true });
 
@@ -442,9 +439,9 @@ describe("installHotkeyHelper", () => {
     expect(spawnCalls).toHaveLength(2);
     expect(lastChild).not.toBe(crashed);
     expect(lastChild?.stdin.writes[0]).toContain(
-      "\"method\":\"hotkey.fnPushToTalk\"",
+      '"method":"hotkey.fnPushToTalk"',
     );
-    expect(lastChild?.stdin.writes[0]).toContain("\"enable\":true");
+    expect(lastChild?.stdin.writes[0]).toContain('"enable":true');
   });
 
   test("maps JSON-RPC helper errors to hotkey results", async () => {
@@ -454,7 +451,7 @@ describe("installHotkeyHelper", () => {
     lastChild?.stdout.emit(
       "data",
       Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32603,\"message\":\"Carbon failed\"}}\n",
+        '{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Carbon failed"}}\n',
       ),
     );
 
@@ -478,14 +475,12 @@ describe("installHotkeyHelper", () => {
     lastChild?.stdout.emit(
       "data",
       Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"method\":\"hotkey.event\",\"params\":{\"kind\":\"fnPushToTalk\",\"state\":\"down\"}}\n",
+        '{"jsonrpc":"2.0","method":"hotkey.event","params":{"kind":"fnPushToTalk","state":"down"}}\n',
       ),
     );
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":{"enabled":true}}\n'),
     );
 
     expect(await pending).toEqual({ ok: true, enabled: true });
@@ -498,6 +493,32 @@ describe("installHotkeyHelper", () => {
     );
   });
 
+  test("carries the selection a hold began over through to the owner", async () => {
+    installHotkeyHelper();
+
+    const pending = invokeFnPushToTalk(true);
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from(
+        '{"jsonrpc":"2.0","method":"hotkey.event","params":{"kind":"modifierHold","state":"down","selection":{"text":"the powerhouse","truncated":false}}}\n',
+      ),
+    );
+    lastChild?.stdout.emit(
+      "data",
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":{"enabled":true}}\n'),
+    );
+
+    expect(await pending).toEqual({ ok: true, enabled: true });
+    expect(defaultSender.send).toHaveBeenCalledWith(
+      "vellum:helper:hotkey:event",
+      {
+        kind: "modifierHold",
+        state: "down",
+        selection: { text: "the powerhouse", truncated: false },
+      },
+    );
+  });
+
   test("keeps the helper enabled while another owner remains", async () => {
     installHotkeyHelper();
     const first = makeWebContents();
@@ -506,9 +527,7 @@ describe("installHotkeyHelper", () => {
     const firstEnable = invokeFnPushToTalkFrom(true, first);
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":{"enabled":true}}\n'),
     );
     expect(await firstEnable).toEqual({ ok: true, enabled: true });
 
@@ -527,7 +546,7 @@ describe("installHotkeyHelper", () => {
     lastChild?.stdout.emit(
       "data",
       Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"method\":\"hotkey.event\",\"params\":{\"kind\":\"fnPushToTalk\",\"state\":\"down\"}}\n",
+        '{"jsonrpc":"2.0","method":"hotkey.event","params":{"kind":"fnPushToTalk","state":"down"}}\n',
       ),
     );
     expect(first.send).toHaveBeenCalledWith("vellum:helper:hotkey:event", {
@@ -537,12 +556,10 @@ describe("installHotkeyHelper", () => {
     expect(second.send).not.toHaveBeenCalled();
 
     const firstDisable = invokeFnPushToTalkFrom(false, first);
-    expect(lastChild?.stdin.writes.at(-1)).toContain("\"enable\":false");
+    expect(lastChild?.stdin.writes.at(-1)).toContain('"enable":false');
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"enabled\":false}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":2,"result":{"enabled":false}}\n'),
     );
     expect(await firstDisable).toEqual({ ok: true, enabled: false });
   });
@@ -555,33 +572,27 @@ describe("installHotkeyHelper", () => {
     const firstEnable = invokeFnPushToTalkFrom(true, first);
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":{"enabled":true}}\n'),
     );
     expect(await firstEnable).toEqual({ ok: true, enabled: true });
 
     const firstDisable = invokeFnPushToTalkFrom(false, first);
-    expect(lastChild?.stdin.writes.at(-1)).toContain("\"enable\":false");
+    expect(lastChild?.stdin.writes.at(-1)).toContain('"enable":false');
 
     const secondEnable = invokeFnPushToTalkFrom(true, second);
     expect(lastChild?.stdin.writes).toHaveLength(2);
 
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"enabled\":false}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":2,"result":{"enabled":false}}\n'),
     );
     await wait(0);
 
     expect(lastChild?.stdin.writes).toHaveLength(3);
-    expect(lastChild?.stdin.writes.at(-1)).toContain("\"enable\":true");
+    expect(lastChild?.stdin.writes.at(-1)).toContain('"enable":true');
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":3,\"result\":{\"enabled\":true}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":3,"result":{"enabled":true}}\n'),
     );
 
     expect(await firstDisable).toEqual({ ok: true, enabled: true });
@@ -590,7 +601,7 @@ describe("installHotkeyHelper", () => {
     lastChild?.stdout.emit(
       "data",
       Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"method\":\"hotkey.event\",\"params\":{\"kind\":\"fnPushToTalk\",\"state\":\"down\"}}\n",
+        '{"jsonrpc":"2.0","method":"hotkey.event","params":{"kind":"fnPushToTalk","state":"down"}}\n',
       ),
     );
     expect(second.send).toHaveBeenCalledWith("vellum:helper:hotkey:event", {
@@ -604,15 +615,13 @@ describe("installHotkeyHelper", () => {
     const pending = invokeFnPushToTalk(true);
     lastChild?.stdout.emit(
       "data",
-      Buffer.from(
-        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"enabled\":true}}\n",
-      ),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":{"enabled":true}}\n'),
     );
     await pending;
 
     appListeners.get("before-quit")?.();
 
-    expect(lastChild?.stdin.writes.at(-1)).toContain("\"enable\":false");
+    expect(lastChild?.stdin.writes.at(-1)).toContain('"enable":false');
     expect(lastChild?.stdin.ended).toBe(true);
   });
 
@@ -621,7 +630,7 @@ describe("installHotkeyHelper", () => {
     const pending = invokePing();
     lastChild?.stdout.emit(
       "data",
-      Buffer.from("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"pong\"}\n"),
+      Buffer.from('{"jsonrpc":"2.0","id":1,"result":"pong"}\n'),
     );
     await pending;
 
@@ -629,9 +638,7 @@ describe("installHotkeyHelper", () => {
     appListeners.get("before-quit")?.();
     shuttingDown?.emit("close", 0, null);
 
-    await expect(invokePing()).rejects.toThrow(
-      "mac helper is not available",
-    );
+    await expect(invokePing()).rejects.toThrow("mac helper is not available");
     expect(spawnCalls).toHaveLength(1);
   });
 });

--- a/clients/macos/src/main/hotkey-helper.ts
+++ b/clients/macos/src/main/hotkey-helper.ts
@@ -74,6 +74,7 @@ const HOTKEY_EVENT_SCHEMA = z.object({
       truncated: z.boolean(),
     })
     .optional(),
+  heldMs: z.number().optional(),
 });
 
 const HOTKEY_RESULT_SCHEMA = z.object({

--- a/clients/macos/src/main/hotkey-helper.ts
+++ b/clients/macos/src/main/hotkey-helper.ts
@@ -56,9 +56,7 @@ export type {
   ModifierHoldRegistrationResult,
 };
 
-export type MacHelperPermissionKind =
-  | "speechRecognition"
-  | "inputMonitoring";
+export type MacHelperPermissionKind = "speechRecognition" | "inputMonitoring";
 
 export type MacHelperPermissionStatus =
   | "unknown"
@@ -70,6 +68,12 @@ export type MacHelperPermissionStatus =
 const HOTKEY_EVENT_SCHEMA = z.object({
   kind: z.enum(["fnPushToTalk", "modifierHold"]),
   state: z.enum(["down", "up"]),
+  selection: z
+    .object({
+      text: z.string(),
+      truncated: z.boolean(),
+    })
+    .optional(),
 });
 
 const HOTKEY_RESULT_SCHEMA = z.object({
@@ -197,9 +201,7 @@ const applyModifierHold = async (
   }
 };
 
-const fnPushToTalk = async (
-  enable: boolean,
-): Promise<FnPushToTalkResult> => {
+const fnPushToTalk = async (enable: boolean): Promise<FnPushToTalkResult> => {
   try {
     const result = await client.call("hotkey.fnPushToTalk", { enable });
     const parsed = HOTKEY_RESULT_SCHEMA.safeParse(result);
@@ -256,30 +258,21 @@ const queryBundledMacHelperPermission = async (
   const outputPath = path.join(tempDir, "status.json");
 
   try {
-    await openMacHelperApp(
-      [
-        "--permission-status",
-        kind,
-        "--status-output",
-        outputPath,
-      ],
-    );
+    await openMacHelperApp([
+      "--permission-status",
+      kind,
+      "--status-output",
+      outputPath,
+    ]);
     return await readPermissionStatusFile(outputPath);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }
 };
 
-const openMacHelperApp = async (
-  helperArgs: string[],
-): Promise<void> => {
+const openMacHelperApp = async (helperArgs: string[]): Promise<void> => {
   await new Promise<void>((resolve, reject) => {
-    const args = [
-      "-n",
-      getMacHelperAppPath(),
-      "--args",
-      ...helperArgs,
-    ];
+    const args = ["-n", getMacHelperAppPath(), "--args", ...helperArgs];
     const child = spawn("open", args, { stdio: "ignore" });
     let settled = false;
 
@@ -376,7 +369,9 @@ const setDictationPartials = async (
       audioChunkCount = 0;
     }
     const replaced =
-      previousOwner && previousOwner !== webContents && !previousOwner.isDestroyed()
+      previousOwner &&
+      previousOwner !== webContents &&
+      !previousOwner.isDestroyed()
         ? ` (replaced wc=${previousOwner.id})`
         : "";
     const tap = enable && parsed.data.tap ? ` tap=${parsed.data.tap}` : "";
@@ -510,9 +505,7 @@ const enableFnPushToTalkForOwner = async (
 
   const result = await syncFnPushToTalkRegistration();
   if (!result.ok) {
-    log.warn(
-      `[mac-helper] failed to enable Fn push-to-talk: ${result.reason}`,
-    );
+    log.warn(`[mac-helper] failed to enable Fn push-to-talk: ${result.reason}`);
     removeHotkeyOwner(webContents.id);
     void syncFnPushToTalkRegistration();
   }

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -346,6 +346,7 @@ function resetLiveVoiceMocks() {
     prewarm: livePrewarmSpy,
     cancelPrewarm: liveCancelPrewarmSpy,
     start: liveStarterSpy,
+    sendText: () => false,
   });
   // Default to the returning-user path so the entry-point mic starts a session
   // directly. First-run interception (the prefs card) is covered by

--- a/clients/web/src/domains/chat/components/voice-input-button.tsx
+++ b/clients/web/src/domains/chat/components/voice-input-button.tsx
@@ -242,7 +242,12 @@ function addDictationSessionBreadcrumb(
 // ---------------------------------------------------------------------------
 
 export interface VoiceInputButtonHandle {
-  start: () => void;
+  /**
+   * Begin a recording. `false` when one could not begin: the button is
+   * disabled, the platform cannot record, or the previous session is still
+   * transcribing.
+   */
+  start: () => boolean;
   stop: () => void;
 }
 
@@ -1119,16 +1124,17 @@ export const VoiceInputButton = forwardRef<
     () => ({
       start: () => {
         if (disabled || !assistantId || !supported) {
-          return;
+          return false;
         }
         // Refuse to start while the previous session is still transcribing.
         // Mirrors the visual `disabled` + `aria-busy` state on the button
         // and prevents push-to-talk from silently dropping the in-flight
         // transcript by incrementing the session id mid-flight.
         if (useVoiceRecordingStore.getState().phase === "processing") {
-          return;
+          return false;
         }
         startRecording();
+        return true;
       },
       stop: stopRecording,
     }),

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -288,6 +288,9 @@ export function formatVoiceError(code: string): string {
       clientName: clientOsDisplayName(detectClientOs()),
     });
   }
+  if (code === "voice-ask-unavailable") {
+    return t("chat:voiceErrors.askUnavailable");
+  }
   return (
     VOICE_ERROR_MESSAGES[code] ??
     `Voice input failed (${code}). Try again or type your message.`

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -41,18 +41,31 @@ mock.module("@/domains/chat/components/voice-input-button", () => ({
   }),
 }));
 
+type HoldStart = {
+  selection: { text: string; truncated: boolean } | null;
+};
 let holdHandlers: {
-  onHoldStart: () => void;
+  onHoldStart: (start: HoldStart) => void;
   onHoldEnd: () => void;
 } | null = null;
 mock.module("@/domains/chat/voice/use-hold-to-dictate", () => ({
   HOLD_ARMING_MS: 220,
   useHoldToDictate: (options: {
-    onHoldStart: () => void;
+    onHoldStart: (start: HoldStart) => void;
     onHoldEnd: () => void;
   }) => {
     holdHandlers = options;
   },
+}));
+
+const askedTexts: string[] = [];
+let nextAskTaken = true;
+mock.module("@/domains/chat/voice/live-voice/start-voice-request", () => ({
+  askVoiceFromSurface: (_navigate: unknown, ask: string) => {
+    askedTexts.push(ask);
+    return nextAskTaken;
+  },
+  startVoiceFromSurface: () => undefined,
 }));
 
 mock.module("@/domains/chat/hooks/use-dictation-overlay-sync", () => ({
@@ -141,6 +154,8 @@ afterEach(() => {
   nextTextInsertionStatus = "unavailable";
   nextDictationResult = null;
   insertedTexts.length = 0;
+  askedTexts.length = 0;
+  nextAskTaken = true;
   toastErrorMock.mockClear();
   useVoiceRecordingStore.getState().reset();
   useComposerStore.getState().setInput("");
@@ -272,9 +287,8 @@ describe("GlobalPushToTalkBridge", () => {
  * never reach the cursor, and a turn is spent that nobody asked for.
  */
 test("drives its own recorder, not whatever claimed dictation last", async () => {
-  const { registerPushToTalkTarget } = await import(
-    "@/domains/chat/voice/push-to-talk-target"
-  );
+  const { registerPushToTalkTarget } =
+    await import("@/domains/chat/voice/push-to-talk-target");
   const composerStart = mock(() => undefined);
   const composerStop = mock(() => undefined);
   const release = registerPushToTalkTarget({
@@ -285,7 +299,7 @@ test("drives its own recorder, not whatever claimed dictation last", async () =>
   renderBridge("a1");
 
   act(() => {
-    holdHandlers?.onHoldStart();
+    holdHandlers?.onHoldStart({ selection: null });
   });
   useVoiceRecordingStore.setState({ phase: "recording" });
   act(() => {
@@ -297,4 +311,92 @@ test("drives its own recorder, not whatever claimed dictation last", async () =>
   expect(voiceStopMock).toHaveBeenCalled();
 
   release();
+});
+
+/**
+ * A hold made over a selection is a question about it. The words go to the
+ * assistant with the selection quoted ahead of them, and nothing is pasted or
+ * cleaned up: the cleanup pass rewrites words meant for a document.
+ */
+describe("a hold over a selection", () => {
+  test("asks the assistant instead of pasting", async () => {
+    nextTextInsertionStatus = "inserted";
+    nextDictationResult = { mode: "dictation", text: "cleaned" };
+    const voiceInput = renderBridge("a1");
+
+    act(() => {
+      holdHandlers?.onHoldStart({
+        selection: { text: "the powerhouse\nof the cell", truncated: false },
+      });
+    });
+    await act(async () => {
+      await voiceInput.onTranscript("what does this mean");
+    });
+
+    expect(askedTexts).toEqual([
+      "> the powerhouse\n> of the cell\n\nwhat does this mean",
+    ]);
+    expect(insertedTexts).toEqual([]);
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("says when a selection was cut short", async () => {
+    const voiceInput = renderBridge("a1");
+
+    act(() => {
+      holdHandlers?.onHoldStart({
+        selection: { text: "a long passage", truncated: true },
+      });
+    });
+    await act(async () => {
+      await voiceInput.onTranscript("summarize this");
+    });
+
+    expect(askedTexts).toEqual([
+      "> a long passage\n> [selection continues]\n\nsummarize this",
+    ]);
+  });
+
+  test("is spent by its own transcript, so the next hold dictates", async () => {
+    nextTextInsertionStatus = "inserted";
+    const voiceInput = renderBridge("a1");
+
+    act(() => {
+      holdHandlers?.onHoldStart({
+        selection: { text: "selected", truncated: false },
+      });
+    });
+    await act(async () => {
+      await voiceInput.onTranscript("first");
+    });
+    act(() => {
+      holdHandlers?.onHoldStart({ selection: null });
+    });
+    await act(async () => {
+      await voiceInput.onTranscript("second");
+    });
+
+    expect(askedTexts).toHaveLength(1);
+    expect(insertedTexts).toEqual(["second"]);
+  });
+
+  test("tells the user when the call cannot take the question", async () => {
+    nextAskTaken = false;
+    const voiceInput = renderBridge("a1");
+
+    act(() => {
+      holdHandlers?.onHoldStart({
+        selection: { text: "selected", truncated: false },
+      });
+    });
+    await act(async () => {
+      await voiceInput.onTranscript("what is this");
+    });
+
+    expect(insertedTexts).toEqual([]);
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      formatVoiceError("voice-ask-unavailable"),
+      { id: "voice-error:voice-ask-unavailable" },
+    );
+  });
 });

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -61,11 +61,13 @@ mock.module("@/domains/chat/voice/use-hold-to-dictate", () => ({
 
 const askedTexts: string[] = [];
 let nextAskTaken = true;
+const announceAskRefusedMock = mock(() => undefined);
 mock.module("@/domains/chat/voice/live-voice/start-voice-request", () => ({
   askVoiceFromSurface: (_navigate: unknown, ask: string) => {
     askedTexts.push(ask);
     return nextAskTaken;
   },
+  announceAskRefused: announceAskRefusedMock,
   startVoiceFromSurface: () => undefined,
 }));
 
@@ -159,6 +161,7 @@ afterEach(() => {
   insertedTexts.length = 0;
   askedTexts.length = 0;
   nextAskTaken = true;
+  announceAskRefusedMock.mockClear();
   toastErrorMock.mockClear();
   useVoiceRecordingStore.getState().reset();
   useComposerStore.getState().setInput("");
@@ -421,9 +424,6 @@ describe("a hold over a selection", () => {
     });
 
     expect(insertedTexts).toEqual([]);
-    expect(toastErrorMock).toHaveBeenCalledWith(
-      formatVoiceError("voice-ask-unavailable"),
-      { id: "voice-error:voice-ask-unavailable" },
-    );
+    expect(announceAskRefusedMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -25,6 +25,7 @@ const insertedTexts: string[] = [];
 let nextDictationResult: { mode: "dictation"; text: string } | null = null;
 let overlayStopCallback: (() => void) | null = null;
 const voiceStopMock = mock(() => undefined);
+const voiceStartMock = mock(() => true);
 type ToastErrorOptions = { id?: string };
 const toastErrorMock = mock(
   (_message: string, _options?: ToastErrorOptions) => undefined,
@@ -34,7 +35,7 @@ mock.module("@/domains/chat/components/voice-input-button", () => ({
   VoiceInputButton: forwardRef<unknown, VoiceInputButtonProps>((props, ref) => {
     latestVoiceInputProps = props;
     useImperativeHandle(ref, () => ({
-      start: () => undefined,
+      start: voiceStartMock,
       stop: voiceStopMock,
     }));
     return null;
@@ -151,6 +152,8 @@ afterEach(() => {
   latestVoiceInputProps = null;
   overlayStopCallback = null;
   voiceStopMock.mockClear();
+  voiceStartMock.mockClear();
+  voiceStartMock.mockReturnValue(true);
   nextTextInsertionStatus = "unavailable";
   nextDictationResult = null;
   insertedTexts.length = 0;
@@ -378,6 +381,30 @@ describe("a hold over a selection", () => {
 
     expect(askedTexts).toHaveLength(1);
     expect(insertedTexts).toEqual(["second"]);
+  });
+
+  test("a hold the recorder refuses does not rebind the selection", async () => {
+    nextTextInsertionStatus = "inserted";
+    const voiceInput = renderBridge("a1");
+
+    act(() => {
+      holdHandlers?.onHoldStart({
+        selection: { text: "first", truncated: false },
+      });
+    });
+    // The first transcript is still being finished when the next hold lands,
+    // so the recorder turns it away.
+    voiceStartMock.mockReturnValue(false);
+    act(() => {
+      holdHandlers?.onHoldStart({
+        selection: { text: "second", truncated: false },
+      });
+    });
+    await act(async () => {
+      await voiceInput.onTranscript("what is this");
+    });
+
+    expect(askedTexts).toEqual(["> first\n\nwhat is this"]);
   });
 
   test("tells the user when the call cannot take the question", async () => {

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -1,4 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+
+import type { HotkeySelection } from "@vellumai/ipc-contract";
 
 import {
   VoiceInputButton,
@@ -8,6 +11,7 @@ import { useComposerStore } from "@/domains/chat/composer-store";
 import { useDictationOverlaySync } from "@/domains/chat/hooks/use-dictation-overlay-sync";
 import { formatVoiceError } from "@/domains/chat/utils/chat";
 import { postDictation } from "@/domains/chat/voice/dictation-api";
+import { askVoiceFromSurface } from "@/domains/chat/voice/live-voice/start-voice-request";
 import { getPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
 import { supportsKeyboardActivation } from "@/domains/chat/voice/keyboard-activation-host";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
@@ -35,6 +39,26 @@ interface GlobalPushToTalkBridgeProps {
  * cost is being measured. The log line below carries what each hold paid.
  */
 const CLEANUP_DEADLINE_MS = 5000;
+
+/**
+ * The turn a hold made over a selection becomes: the selection, quoted, and
+ * then the words. The selection comes first because it is what the words are
+ * about, and quoted so the model and the transcript both read it as something
+ * the user is pointing at rather than something they said. A selection the
+ * helper cut short says so, so the model does not reason about an ending it
+ * never saw.
+ */
+export function composeSelectionAsk(
+  selection: HotkeySelection,
+  words: string,
+): string {
+  const quoted = selection.text
+    .split("\n")
+    .map((line) => `> ${line}`)
+    .join("\n");
+  const tail = selection.truncated ? "\n> [selection continues]" : "";
+  return `${quoted}${tail}\n\n${words}`;
+}
 
 function appendTranscript(current: string, text: string): string {
   const trimmed = text.trim();
@@ -74,6 +98,14 @@ export function GlobalPushToTalkBridge({
   });
   const setVoiceAudioLevel = useVoiceRecordingStore.use.setAudioLevel();
   const holdToDictateEnabled = useHoldToDictateEnabled();
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
+  useEffect(() => {
+    navigateRef.current = navigate;
+  }, [navigate]);
+  // What the hold in progress began over. Read when its transcript lands,
+  // which decides whether the words go to the cursor or to the assistant.
+  const holdSelectionRef = useRef<HotkeySelection | null>(null);
 
   useEffect(() => {
     if (!voiceStream) {
@@ -134,13 +166,16 @@ export function GlobalPushToTalkBridge({
   // Hold to dictate, from whatever app the user is in. The same target the
   // overlay's stop button drives, so a hold and a press are the same dictation
   // and land the same way: through `handleTranscript` below, which cleans the
-  // transcript up and drops it at the cursor.
+  // transcript up and drops it at the cursor. A hold made over a selection is
+  // the one exception: its words are a question about the selection, and go
+  // to the assistant instead.
   useHoldToDictate({
     enabled: holdToDictateEnabled,
-    onHoldStart: () => {
+    onHoldStart: ({ selection }) => {
       if (useVoiceRecordingStore.getState().phase === "recording") {
         return;
       }
+      holdSelectionRef.current = selection;
       // Read by the recording session as it starts, which decides there
       // whether the local transcript is the authority.
       markHoldDictation(true);
@@ -157,6 +192,26 @@ export function GlobalPushToTalkBridge({
 
   const handleTranscript = useCallback(
     async (rawText: string): Promise<void> => {
+      const selection = holdSelectionRef.current;
+      holdSelectionRef.current = null;
+      if (selection !== null) {
+        // A question about what was highlighted. Not pasted, and not cleaned
+        // up: the cleanup pass rewrites words meant for a document, and these
+        // are meant for the assistant, who hears them as said. The reply is
+        // spoken, on the call the companion shows while it plays.
+        const ask = composeSelectionAsk(selection, rawText);
+        const taken = askVoiceFromSurface(
+          (to, options) => navigateRef.current(to, options),
+          ask,
+        );
+        console.info(
+          `dictation: ask selectionChars=${selection.text.length} truncated=${selection.truncated} words=${rawText.length} taken=${taken}`,
+        );
+        if (!taken) {
+          showVoiceErrorToast("voice-ask-unavailable");
+        }
+        return;
+      }
       let insertText = rawText;
       // The cleanup pass: one model call that punctuates, drops the fillers,
       // adapts the tone to the application in front and applies the user's

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -175,11 +175,16 @@ export function GlobalPushToTalkBridge({
       if (useVoiceRecordingStore.getState().phase === "recording") {
         return;
       }
-      holdSelectionRef.current = selection;
       // Read by the recording session as it starts, which decides there
       // whether the local transcript is the authority.
       markHoldDictation(true);
-      holdTarget()?.start();
+      // The selection binds to the recording that began over it and to no
+      // other. A hold the recorder refuses (the previous transcript is still
+      // being finished) leaves the previous hold's selection where it was,
+      // so that transcript is still about what it was held over.
+      if (holdTarget()?.start() === true) {
+        holdSelectionRef.current = selection;
+      }
     },
     onHoldEnd: () => {
       markHoldDictation(false);

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -11,7 +11,10 @@ import { useComposerStore } from "@/domains/chat/composer-store";
 import { useDictationOverlaySync } from "@/domains/chat/hooks/use-dictation-overlay-sync";
 import { formatVoiceError } from "@/domains/chat/utils/chat";
 import { postDictation } from "@/domains/chat/voice/dictation-api";
-import { askVoiceFromSurface } from "@/domains/chat/voice/live-voice/start-voice-request";
+import {
+  announceAskRefused,
+  askVoiceFromSurface,
+} from "@/domains/chat/voice/live-voice/start-voice-request";
 import { getPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
 import { supportsKeyboardActivation } from "@/domains/chat/voice/keyboard-activation-host";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
@@ -213,7 +216,7 @@ export function GlobalPushToTalkBridge({
           `dictation: ask selectionChars=${selection.text.length} truncated=${selection.truncated} words=${rawText.length} taken=${taken}`,
         );
         if (!taken) {
-          showVoiceErrorToast("voice-ask-unavailable");
+          announceAskRefused();
         }
         return;
       }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -77,6 +77,7 @@ function makeStarter() {
     prewarm: mock(() => {}),
     cancelPrewarm: mock(() => {}),
     start: mock((_assistantId: string, _conversationId: string | null) => {}),
+    sendText: mock((_text: string) => false),
   };
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -267,13 +267,28 @@ export interface LiveVoiceSessionStarter {
    * is live, so the assistant speaks without waiting for the user. It becomes
    * a real user message in the conversation, so a caller passes one only where
    * that reads honestly. See `voice-entry-greeting.ts` for the rule and the
-   * copy.
+   * copy. `seedVisible` renders it as the user's own message rather than
+   * hiding it, for a seed that is their words; `endAfterSeedReply` ends the
+   * session once its reply has been heard.
    */
   start(
     assistantId: string,
     conversationId: string | null,
-    options?: { seedText?: string },
+    options?: LiveVoiceSeedOptions,
   ): void;
+  /**
+   * Put a typed turn to the running session. Returns whether it went out: a
+   * session that is not up, or an assistant without typed turns, takes
+   * nothing, and the caller keeps the words.
+   */
+  sendText(text: string): boolean;
+}
+
+/** The first turn a session takes on a caller's behalf, and what follows it. */
+export interface LiveVoiceSeedOptions {
+  seedText?: string;
+  seedVisible?: boolean;
+  endAfterSeedReply?: boolean;
 }
 
 export interface LiveVoiceState {

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -49,6 +49,7 @@ mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
 
 const {
   PENDING_VOICE_START_TTL_MS,
+  askVoiceFromSurface,
   drainPendingVoiceStart,
   requestVoiceStart,
   startVoiceFromSurface,
@@ -96,11 +97,14 @@ const starter = mock((assistantId: string, conversationId: string | null) => {
   useLiveVoiceStore.getState().setState("listening");
 });
 
+const sendText = mock((_text: string) => true);
+
 function registerStarter(): void {
   useLiveVoiceStore.getState().setStarter({
     prewarm: () => {},
     cancelPrewarm: () => {},
     start: starter,
+    sendText,
   });
 }
 
@@ -153,6 +157,7 @@ function expectStartedOnFreshDraft(): void {
 }
 
 beforeEach(() => {
+  sendText.mockClear();
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setStarter(null);
   __resetPendingDeepLinkForTesting();
@@ -522,6 +527,53 @@ describe("startVoiceFromSurface", () => {
     // That session is the one the user is in. Navigating would only walk the
     // app away from the composer that owns it.
     expect(navigate).not.toHaveBeenCalled();
+    expect(isParked()).toBe(false);
+  });
+});
+
+/**
+ * A question put from outside the chat: on a running session it is a turn on
+ * that session; otherwise a session opens for it, asks it as the user's own
+ * words, and ends once the reply has been heard.
+ */
+describe("askVoiceFromSurface", () => {
+  test("opens a session for the question that speaks it and then ends", async () => {
+    identityHydrated();
+    registerStarter();
+
+    expect(askVoiceFromSurface(navigate, "> the cell\n\nwhat is this")).toBe(
+      true,
+    );
+    await flushDrain();
+
+    const draftId = mintedConversationId();
+    expect(starter).toHaveBeenCalledWith("assistant-1", draftId, {
+      seedText: "> the cell\n\nwhat is this",
+      seedVisible: true,
+      endAfterSeedReply: true,
+    });
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  test("puts the question to a running session as a turn", () => {
+    identityHydrated();
+    registerStarter();
+    useLiveVoiceStore.getState().setState("listening");
+
+    expect(askVoiceFromSurface(navigate, "what is this")).toBe(true);
+
+    expect(sendText).toHaveBeenCalledWith("what is this");
+    expect(navigate).not.toHaveBeenCalled();
+    expect(isParked()).toBe(false);
+  });
+
+  test("reports a running session that cannot take the turn", () => {
+    identityHydrated();
+    registerStarter();
+    sendText.mockReturnValueOnce(false);
+    useLiveVoiceStore.getState().setState("speaking");
+
+    expect(askVoiceFromSurface(navigate, "what is this")).toBe(false);
     expect(isParked()).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -47,6 +47,13 @@ mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
   preflightLiveVoice,
 }));
 
+const toastError = mock((_message: string, _options?: { id?: string }) => {});
+mock.module("@vellumai/design-library/components/toast", () => ({
+  toast: { error: toastError },
+  Toaster: () => null,
+  ToastContent: () => null,
+}));
+
 const {
   PENDING_VOICE_START_TTL_MS,
   askVoiceFromSurface,
@@ -158,6 +165,7 @@ function expectStartedOnFreshDraft(): void {
 
 beforeEach(() => {
   sendText.mockClear();
+  toastError.mockClear();
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setStarter(null);
   __resetPendingDeepLinkForTesting();
@@ -565,6 +573,48 @@ describe("askVoiceFromSurface", () => {
     expect(sendText).toHaveBeenCalledWith("what is this");
     expect(navigate).not.toHaveBeenCalled();
     expect(isParked()).toBe(false);
+  });
+
+  test("says so when the assistant cannot serve the question", async () => {
+    // A plain start on an assistant too old for live voice stops quietly,
+    // as the composer renders no voice button. A question was asked out
+    // loud from another application, so its drop is said.
+    identityHydrated("0.10.11");
+    registerStarter();
+
+    askVoiceFromSurface(navigate, "what is this");
+    await flushDrain();
+
+    expect(starter).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  test("says so when the assistant is not ready to talk", async () => {
+    identityHydrated();
+    registerStarter();
+    preflightVerdict = { status: "not-ready", userMessage: "Set up a voice." };
+
+    askVoiceFromSurface(navigate, "what is this");
+    await flushDrain();
+
+    expect(starter).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  test("a session that started mid-preflight takes the question as a turn", async () => {
+    identityHydrated();
+    registerStarter();
+    preflightLiveVoice.mockImplementationOnce(async () => {
+      useLiveVoiceStore.getState().setState("listening");
+      return preflightVerdict;
+    });
+
+    askVoiceFromSurface(navigate, "what is this");
+    await flushDrain();
+
+    expect(starter).not.toHaveBeenCalled();
+    expect(sendText).toHaveBeenCalledWith("what is this");
+    expect(toastError).not.toHaveBeenCalled();
   });
 
   test("reports a running session that cannot take the turn", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -587,6 +587,8 @@ describe("askVoiceFromSurface", () => {
 
     expect(starter).not.toHaveBeenCalled();
     expect(toastError).toHaveBeenCalledTimes(1);
+    // The notice is in the app's window, and the user is in another app.
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalled();
   });
 
   test("says so when the assistant is not ready to talk", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -30,6 +30,7 @@ import {
   voiceReadiness,
 } from "@/domains/chat/voice/live-voice/voice-entry-guards";
 import { mintVoiceDraftConversation } from "@/domains/chat/voice/voice-draft-conversation";
+import { formatVoiceError } from "@/domains/chat/utils/chat";
 import { supportsLiveVoice } from "@/lib/backwards-compat/use-supports-live-voice";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { whenAssistantVersionKnownFor } from "@/lib/backwards-compat/utils";
@@ -37,6 +38,7 @@ import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
+import { toast } from "@vellumai/design-library/components/toast";
 
 /**
  * How long a parked start-voice request stays live.
@@ -251,11 +253,22 @@ export async function drainPendingVoiceStart(
     usePendingDeepLinkStore
       .getState()
       .consumePendingVoiceStart(PENDING_VOICE_START_TTL_MS);
+  // A plain start that stops here has handed the user something to look at
+  // instead (no button, the card, the notice). A question that stops here has
+  // been dropped, and the user who asked it from another application is
+  // watching the companion for an answer, so the drop is said out loud.
+  const refuse = () => {
+    if (consume()?.ask != null) {
+      toast.error(formatVoiceError("voice-ask-unavailable"), {
+        id: "voice-error:voice-ask-unavailable",
+      });
+    }
+  };
   // Same eligibility as the composer's entry point: on an assistant too old to
   // serve live voice the link navigates and stops there, exactly as the
   // composer renders no voice button.
   if (!supportsLiveVoice(assistantId)) {
-    consume();
+    refuse();
     return;
   }
   // The same two guards the composer's voice button runs. Without them a
@@ -271,7 +284,7 @@ export async function drainPendingVoiceStart(
     // beat: there is something to answer. Fire and forget, since nothing below
     // depends on the window being up.
     void ensureMainWindowVisible();
-    consume();
+    refuse();
     return;
   }
   const readiness = await voiceReadiness(assistantId);
@@ -288,7 +301,16 @@ export async function drainPendingVoiceStart(
   // it finds already running: the starter would refuse a second anyway, and
   // navigating would only leave the composer that owns it.
   if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
-    consume();
+    // That session is the one the user is in, so a question goes to it.
+    const ask = consume()?.ask ?? null;
+    if (
+      ask !== null &&
+      useLiveVoiceStore.getState().starter?.sendText(ask) !== true
+    ) {
+      toast.error(formatVoiceError("voice-ask-unavailable"), {
+        id: "voice-error:voice-ask-unavailable",
+      });
+    }
     return;
   }
   // A switch to another assistant mid-preflight, on the other hand, is a race
@@ -303,7 +325,7 @@ export async function drainPendingVoiceStart(
   }
   publishConfigNotice(readiness.notice);
   if (!readiness.allowed) {
-    consume();
+    refuse();
     return;
   }
   // Re-read across the readiness await, as above: a controller that unmounted

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -158,6 +158,21 @@ export function startVoiceFromSurface(
 }
 
 /**
+ * Say that a question asked out loud could not be taken.
+ *
+ * The question came from another application, and the answer was going to
+ * come back through the companion. A notice drawn in the app's window sits
+ * behind whatever the user is working in, so this is the one refusal that
+ * raises the window: the alternative is a hold that did nothing.
+ */
+export function announceAskRefused(): void {
+  void ensureMainWindowVisible();
+  toast.error(formatVoiceError("voice-ask-unavailable"), {
+    id: "voice-error:voice-ask-unavailable",
+  });
+}
+
+/**
  * Put a question to the assistant out loud, from a surface outside the chat.
  *
  * A session already running is the one the user is in, so the question goes
@@ -256,12 +271,11 @@ export async function drainPendingVoiceStart(
   // A plain start that stops here has handed the user something to look at
   // instead (no button, the card, the notice). A question that stops here has
   // been dropped, and the user who asked it from another application is
-  // watching the companion for an answer, so the drop is said out loud.
+  // watching the companion for an answer, so the drop is said where they can
+  // see it.
   const refuse = () => {
     if (consume()?.ask != null) {
-      toast.error(formatVoiceError("voice-ask-unavailable"), {
-        id: "voice-error:voice-ask-unavailable",
-      });
+      announceAskRefused();
     }
   };
   // Same eligibility as the composer's entry point: on an assistant too old to
@@ -307,9 +321,7 @@ export async function drainPendingVoiceStart(
       ask !== null &&
       useLiveVoiceStore.getState().starter?.sendText(ask) !== true
     ) {
-      toast.error(formatVoiceError("voice-ask-unavailable"), {
-        id: "voice-error:voice-ask-unavailable",
-      });
+      announceAskRefused();
     }
     return;
   }

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -93,6 +93,19 @@ function bindFreshConversation(navigate: VoiceStartNavigate): string {
 }
 
 /**
+ * What a start-voice request can carry besides the request itself.
+ */
+export interface VoiceStartRequestOptions {
+  /**
+   * A question to put to the session as its first turn, spoken back and then
+   * done: the session ends once the reply has been heard. For a press that
+   * already knows what the user wants to say, such as a hold made over a
+   * selection. The turn is the user's own words, so it renders as theirs.
+   */
+  ask?: string;
+}
+
+/**
  * Ask for a live-voice session.
  *
  * Always parks first, then drains: one code path for both the warm case (a
@@ -102,8 +115,11 @@ function bindFreshConversation(navigate: VoiceStartNavigate): string {
  * `navigate` serves the warm case only. A parked request is drained by the
  * controller, which navigates with its own.
  */
-export function requestVoiceStart(navigate: VoiceStartNavigate): void {
-  usePendingDeepLinkStore.getState().setPendingVoiceStart();
+export function requestVoiceStart(
+  navigate: VoiceStartNavigate,
+  options: VoiceStartRequestOptions = {},
+): void {
+  usePendingDeepLinkStore.getState().setPendingVoiceStart(options.ask);
   void drainPendingVoiceStart(navigate);
 }
 
@@ -128,12 +144,41 @@ export function requestVoiceStart(navigate: VoiceStartNavigate): void {
  *   exception is the first-run card below: it asks a question, and a question
  *   drawn behind whatever the user is working in is a press that did nothing.
  */
-export function startVoiceFromSurface(navigate: VoiceStartNavigate): void {
+export function startVoiceFromSurface(
+  navigate: VoiceStartNavigate,
+  options: VoiceStartRequestOptions = {},
+): void {
   if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
     return;
   }
   void navigate(routes.assistant);
-  requestVoiceStart(navigate);
+  requestVoiceStart(navigate, options);
+}
+
+/**
+ * Put a question to the assistant out loud, from a surface outside the chat.
+ *
+ * A session already running is the one the user is in, so the question goes
+ * to it as a turn and the session carries on as it was. Otherwise one is
+ * started for the question alone: it asks, the reply is spoken, and it ends,
+ * so a question asked from another application does not leave the user on an
+ * open call they did not reach for.
+ *
+ * Returns whether the question was taken. A running session that cannot take
+ * typed turns (an older assistant) declines rather than dropping the words
+ * silently.
+ */
+export function askVoiceFromSurface(
+  navigate: VoiceStartNavigate,
+  ask: string,
+): boolean {
+  const store = useLiveVoiceStore.getState();
+  if (isLiveVoiceSessionActive(store.state)) {
+    return store.starter?.sendText(ask) === true;
+  }
+  void navigate(routes.assistant);
+  requestVoiceStart(navigate, { ask });
+  return true;
 }
 
 /**
@@ -202,7 +247,7 @@ export async function drainPendingVoiceStart(
   // the things that can still become true (a controller that has not
   // registered yet, an assistant switched away from mid-preflight) leave the
   // request parked rather than losing it.
-  const consume = (): boolean =>
+  const consume = () =>
     usePendingDeepLinkStore
       .getState()
       .consumePendingVoiceStart(PENDING_VOICE_START_TTL_MS);
@@ -267,12 +312,24 @@ export async function drainPendingVoiceStart(
   if (readyStarter === null) {
     return;
   }
-  if (!consume()) {
+  const consumed = consume();
+  if (consumed === null) {
     return;
   }
   // No `prewarm()` here, unlike the composer: prewarming exists to unlock
   // playback while a user gesture is still active, and this path has no gesture
   // to borrow (Siri, the Action Button, a Live Activity tap). `start()` creates
   // its own player when none was reserved.
-  readyStarter.start(assistantId, bindFreshConversation(navigate));
+  const conversationId = bindFreshConversation(navigate);
+  if (consumed.ask === null) {
+    readyStarter.start(assistantId, conversationId);
+    return;
+  }
+  // The question is the user's own words, so it renders as theirs, and the
+  // session is for the question alone: it ends once the reply has been heard.
+  readyStarter.start(assistantId, conversationId, {
+    seedText: consumed.ask,
+    seedVisible: true,
+    endAfterSeedReply: true,
+  });
 }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -178,10 +178,11 @@ export function useLiveVoiceSessionController(
   // `observeAudioState: false` — the controller consumes nothing reactive
   // beyond the low-frequency `state`/`error` fields, so high-frequency
   // amplitude/transcript updates must not re-render the mounting layout.
-  const { start, prewarmPlayback, cancelPrewarmedPlayback } = useLiveVoice({
-    ...options,
-    observeAudioState: false,
-  });
+  const { start, sendText, prewarmPlayback, cancelPrewarmedPlayback } =
+    useLiveVoice({
+      ...options,
+      observeAudioState: false,
+    });
 
   // A parked start-voice request is drained here, and the drain lands on the
   // conversation it mints for the session (see `start-voice-request.ts`). Held
@@ -206,7 +207,10 @@ export function useLiveVoiceSessionController(
         void start(assistantId, conversationId ?? undefined, {
           handsFree: true,
           ...(options?.seedText ? { seedText: options.seedText } : {}),
+          ...(options?.seedVisible ? { seedVisible: true } : {}),
+          ...(options?.endAfterSeedReply ? { endAfterSeedReply: true } : {}),
         }),
+      sendText,
     });
     // A start-voice deep link that arrived before this mount (cold launch from
     // Siri / the Action Button / a Live Activity tap) is parked; now that a
@@ -217,7 +221,7 @@ export function useLiveVoiceSessionController(
     return () => {
       useLiveVoiceStore.getState().setStarter(null);
     };
-  }, [start, prewarmPlayback, cancelPrewarmedPlayback]);
+  }, [start, sendText, prewarmPlayback, cancelPrewarmedPlayback]);
 
   // The drain's second trigger, and the only one a parked request has once the
   // starter is registered: the effect above runs on the starter's identity, not

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -3633,7 +3633,7 @@ describe("speak first (seed turn)", () => {
       expect(h.view.result.current.state).toBe("idle");
     });
 
-    test("stays up when the user starts talking", async () => {
+    test("stays up for good once the user starts talking", async () => {
       const h = renderController({ endAfterSeedReplyQuietMs: QUIET_MS });
       await startAsk(h);
       speak(h, 2);
@@ -3644,9 +3644,65 @@ describe("speak first (seed turn)", () => {
       await act(async () => {
         await sleep(QUIET_MS * 2);
       });
-
       expect(h.view.result.current.state).toBe("listening");
       expect(h.client.ended).toBe(false);
+
+      // The follow-up is answered, and the conversation is theirs now: the
+      // reply to it does not end the session either.
+      act(() => {
+        h.client.emit("utteranceEnd", {
+          type: "utterance_end",
+          seq: 6,
+          reason: "silence",
+        });
+        h.client.emit("sttFinal", { type: "stt_final", seq: 7, text: "and" });
+      });
+      speak(h, 8);
+      await finishSpeaking(h, 10);
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+      expect(h.view.result.current.state).toBe("listening");
+      expect(h.client.ended).toBe(false);
+    });
+
+    test("keeps the ask's shape across a pre-ready connect retry", async () => {
+      const h = renderController({
+        endAfterSeedReplyQuietMs: QUIET_MS,
+        reconnectBackoffMs: FAST_BACKOFF,
+      });
+      h.client.textInputSupported = true;
+      await act(async () => {
+        await h.view.result.current.start("assistant-1", "conv-1", {
+          handsFree: true,
+          seedText: "what is this",
+          seedVisible: true,
+          endAfterSeedReply: true,
+        });
+      });
+      await act(async () => {
+        await flushMicrotasks();
+      });
+      await act(async () => {
+        const err: LiveVoiceClientError = {
+          reason: "connection-failed",
+          message: "Live-voice WebSocket error",
+        };
+        h.client.emit("error", err);
+      });
+      await act(async () => {
+        await sleep(30);
+      });
+      await emitReady(h, "s2");
+
+      expect(h.client.sentText).toEqual(["what is this"]);
+      expect(h.client.sentTextOptions).toEqual([{ hidden: false }]);
+      speak(h, 2);
+      await finishSpeaking(h, 4);
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+      expect(h.view.result.current.state).toBe("idle");
     });
 
     test("a plain seed leaves the session up", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -72,6 +72,7 @@ function renderController(
     observeAudioState?: boolean;
     reconnectBackoffMs?: number[];
     heldPlaybackTimeoutMs?: number;
+    endAfterSeedReplyQuietMs?: number;
     /**
      * Configure each FakeCapture at creation — before the controller calls
      * `capture.start()`, which happens synchronously at connect time (so
@@ -3533,6 +3534,134 @@ describe("speak first (seed turn)", () => {
 
     expect(h.view.result.current.state).toBe("listening");
     expect(h.client.sentText).toEqual([SEED]);
+  });
+
+  test("a seed that is the user's own words renders as theirs", async () => {
+    const h = renderController();
+    h.client.textInputSupported = true;
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1", {
+        handsFree: true,
+        seedText: "what is this",
+        seedVisible: true,
+      });
+    });
+    await emitReady(h);
+
+    expect(h.client.sentText).toEqual(["what is this"]);
+    expect(h.client.sentTextOptions).toEqual([{ hidden: false }]);
+  });
+
+  /**
+   * A question asked from another application is answered and done: the
+   * session ends once the reply has been heard and nothing else has started.
+   */
+  describe("ending after the seed's reply", () => {
+    const QUIET_MS = 30;
+
+    async function startAsk(h: ReturnType<typeof renderController>) {
+      h.client.textInputSupported = true;
+      await act(async () => {
+        await h.view.result.current.start("assistant-1", "conv-1", {
+          handsFree: true,
+          seedText: "what is this",
+          seedVisible: true,
+          endAfterSeedReply: true,
+        });
+      });
+      await emitReady(h);
+      expect(h.client.sentText).toEqual(["what is this"]);
+    }
+
+    function speak(h: ReturnType<typeof renderController>, seq: number) {
+      act(() => {
+        h.client.emit("thinking", { type: "thinking", seq, turnId: "t1" });
+        h.client.emit("ttsAudio", {
+          type: "tts_audio",
+          seq: seq + 1,
+          mimeType: "audio/pcm",
+          sampleRate: 24000,
+          dataBase64: "AAAA",
+        });
+      });
+    }
+
+    async function finishSpeaking(
+      h: ReturnType<typeof renderController>,
+      seq: number,
+    ) {
+      await act(async () => {
+        h.client.emit("ttsDone", { type: "tts_done", seq, turnId: "t1" });
+        h.player.finishPlayback();
+        await flushMicrotasks();
+      });
+    }
+
+    test("ends once the reply has been heard and the turn stays quiet", async () => {
+      const h = renderController({ endAfterSeedReplyQuietMs: QUIET_MS });
+      await startAsk(h);
+      speak(h, 2);
+      await finishSpeaking(h, 4);
+      expect(h.view.result.current.state).toBe("listening");
+
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+
+      expect(h.view.result.current.state).toBe("idle");
+      expect(h.client.ended).toBe(true);
+    });
+
+    test("stays up when the reply goes on after a pause, as a tool run does", async () => {
+      const h = renderController({ endAfterSeedReplyQuietMs: QUIET_MS });
+      await startAsk(h);
+      speak(h, 2);
+      await finishSpeaking(h, 4);
+      // The daemon's next `thinking` lands inside the quiet.
+      speak(h, 5);
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+      expect(h.view.result.current.state).toBe("speaking");
+      expect(h.client.ended).toBe(false);
+
+      // The second piece is the last one.
+      await finishSpeaking(h, 7);
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+      expect(h.view.result.current.state).toBe("idle");
+    });
+
+    test("stays up when the user starts talking", async () => {
+      const h = renderController({ endAfterSeedReplyQuietMs: QUIET_MS });
+      await startAsk(h);
+      speak(h, 2);
+      await finishSpeaking(h, 4);
+      act(() => {
+        h.client.emit("speechStarted", { type: "speech_started", seq: 5 });
+      });
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+
+      expect(h.view.result.current.state).toBe("listening");
+      expect(h.client.ended).toBe(false);
+    });
+
+    test("a plain seed leaves the session up", async () => {
+      const h = renderController({ endAfterSeedReplyQuietMs: QUIET_MS });
+      await startWithSeed(h);
+      await emitReady(h);
+      speak(h, 2);
+      await finishSpeaking(h, 4);
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+
+      expect(h.view.result.current.state).toBe("listening");
+      expect(h.client.ended).toBe(false);
+    });
   });
 
   test("a fresh session after one that greeted greets again", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -3633,7 +3633,7 @@ describe("speak first (seed turn)", () => {
       expect(h.view.result.current.state).toBe("idle");
     });
 
-    test("stays up for good once the user starts talking", async () => {
+    test("stays up for good once the user says something", async () => {
       const h = renderController({ endAfterSeedReplyQuietMs: QUIET_MS });
       await startAsk(h);
       speak(h, 2);
@@ -3664,6 +3664,34 @@ describe("speak first (seed turn)", () => {
       });
       expect(h.view.result.current.state).toBe("listening");
       expect(h.client.ended).toBe(false);
+    });
+
+    test("still ends when the onset was room noise the server took back", async () => {
+      const h = renderController({ endAfterSeedReplyQuietMs: QUIET_MS });
+      await startAsk(h);
+      speak(h, 2);
+      await finishSpeaking(h, 4);
+      act(() => {
+        h.client.emit("speechStarted", { type: "speech_started", seq: 5 });
+      });
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+      expect(h.client.ended).toBe(false);
+
+      await act(async () => {
+        h.client.emit("utteranceDiscarded", {
+          type: "utterance_discarded",
+          seq: 6,
+        });
+        await flushMicrotasks();
+      });
+      await act(async () => {
+        await sleep(QUIET_MS * 2);
+      });
+
+      expect(h.view.result.current.state).toBe("idle");
+      expect(h.client.ended).toBe(true);
     });
 
     test("keeps the ask's shape across a pre-ready connect retry", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -97,6 +97,7 @@ import {
   type TtsAudioChunk,
 } from "@/domains/chat/voice/live-voice/tts-playback";
 import { describeBusyFailure } from "@/domains/chat/voice/live-voice/busy-failure";
+import { fixedT } from "@/i18n";
 import {
   isLiveVoiceSessionActive,
   type LiveVoiceErrorRecovery,
@@ -975,6 +976,18 @@ export function useLiveVoice(
               });
               if (sent && startOptions.endAfterSeedReply === true) {
                 session.endAfterReply = true;
+              }
+              // A session that exists for its seed has nothing to do when
+              // the assistant cannot take the turn (one that predates typed
+              // turns declines it at `sendText`'s gate). Left up, it would
+              // be an open microphone with the question silently gone, so
+              // it fails instead and says why.
+              if (!sent && startOptions.endAfterSeedReply === true) {
+                finishWithError(
+                  session,
+                  teardown,
+                  fixedT("chat")("liveVoiceStatus.askUnsupported"),
+                );
               }
             }
           });

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -187,6 +187,12 @@ export interface UseLiveVoiceResult {
   ) => Promise<void>;
   /** End the session and release the mic, socket, and audio context. */
   stop: () => Promise<void>;
+  /**
+   * Put a typed turn to the running session, as the user's own words. `false`
+   * when there is no session up to take it or the assistant does not take
+   * typed turns; the caller keeps the text either way.
+   */
+  sendText: (text: string) => boolean;
 }
 
 /** Per-session options for {@link UseLiveVoiceResult.start}. */
@@ -211,7 +217,29 @@ export interface LiveVoiceStartOptions {
    * assistant greet twice.
    */
   seedText?: string;
+  /**
+   * Render the seed as the user's own message rather than hiding it. For a
+   * seed that is their words, such as a question they asked from another
+   * application, which reads as theirs in the transcript.
+   */
+  seedVisible?: boolean;
+  /**
+   * End the session once the reply to the seed has been heard, so a question
+   * asked from outside the room is answered and done rather than leaving the
+   * user on an open call. The end waits out a short quiet after playback
+   * drains, since a reply that runs a tool speaks in more than one piece.
+   */
+  endAfterSeedReply?: boolean;
 }
+
+/**
+ * How long a session that ends after its seed's reply waits, once the reply's
+ * audio has drained, for the turn to prove over. A reply that acknowledges and
+ * then runs a tool speaks twice, with the daemon's `thinking` frame for the
+ * tool run arriving inside this window; the user starting to speak lands
+ * inside it too. Either one keeps the session up.
+ */
+export const END_AFTER_SEED_REPLY_QUIET_MS = 2000;
 
 /** Injectable factories so tests can supply mock primitives. */
 export interface UseLiveVoiceOptions {
@@ -248,6 +276,12 @@ export interface UseLiveVoiceOptions {
    * uses {@link HELD_PLAYBACK_TIMEOUT_MS}.
    */
   heldPlaybackTimeoutMs?: number;
+  /**
+   * Override how long a session that ends after its seed's reply waits for the
+   * turn to prove over. Primarily a test seam; production uses
+   * {@link END_AFTER_SEED_REPLY_QUIET_MS}.
+   */
+  endAfterSeedReplyQuietMs?: number;
 }
 
 /**
@@ -300,6 +334,12 @@ interface SessionContext {
   responseEpoch: number;
   /** Whether an interrupt was already sent for the current response. */
   interruptSent: boolean;
+  /**
+   * Whether the session ends once the reply to its seed has been heard (see
+   * `LiveVoiceStartOptions.endAfterSeedReply`). Set when the seed goes out and
+   * spent by the end that follows, so a reconnect never inherits it.
+   */
+  endAfterReply: boolean;
   /** Whether an automatic ptt_release is already in flight for this utterance. */
   releaseInFlight: boolean;
   /** Accumulated speech duration (ms) in the current utterance. */
@@ -812,6 +852,7 @@ export function useLiveVoice(
         responseAudioStarted: false,
         responseEpoch: 0,
         interruptSent: false,
+        endAfterReply: false,
         releaseInFlight: false,
         speechMs: 0,
         silenceMs: 0,
@@ -923,12 +964,18 @@ export function useLiveVoice(
             const seedText = pendingSeedTextRef.current;
             pendingSeedTextRef.current = null;
             if (seedText !== null) {
-              // `hidden`: the seed is an instruction, not something the user
-              // typed, so it drives the turn and stays in the model's context
-              // while never rendering in the transcript. An assistant too old
-              // to know the field persists it visibly instead, which is why
-              // the copy still reads as a sentence a person could have sent.
-              sendTextTurn(session, seedText, { hidden: true });
+              // `hidden`: a seed that is an instruction rather than something
+              // the user typed drives the turn and stays in the model's
+              // context while never rendering in the transcript. An assistant
+              // too old to know the field persists it visibly instead, which
+              // is why the copy still reads as a sentence a person could have
+              // sent. A seed that is the user's own words renders as theirs.
+              const sent = sendTextTurn(session, seedText, {
+                hidden: startOptions.seedVisible !== true,
+              });
+              if (sent && startOptions.endAfterSeedReply === true) {
+                session.endAfterReply = true;
+              }
             }
           });
         }),
@@ -1148,7 +1195,29 @@ export function useLiveVoice(
           if (!live()) {
             return;
           }
-          void finishResponseAfterPlayback(session, teardown);
+          void finishResponseAfterPlayback(session, teardown).then(() => {
+            if (!live() || !session.endAfterReply) {
+              return;
+            }
+            // The reply has been heard. Wait out the quiet before ending, and
+            // end only if nothing has started since: a `thinking` frame for a
+            // tool run bumps the epoch, and the user speaking opens an
+            // utterance. Either means the turn is not over.
+            const epoch = session.responseEpoch;
+            setTimeout(() => {
+              if (
+                !live() ||
+                !session.endAfterReply ||
+                session.responseEpoch !== epoch ||
+                session.utteranceOpen ||
+                useLiveVoiceStore.getState().state !== "listening"
+              ) {
+                return;
+              }
+              session.endAfterReply = false;
+              void stop();
+            }, opts.endAfterSeedReplyQuietMs ?? END_AFTER_SEED_REPLY_QUIET_MS);
+          });
         }),
         client.on("minimizeRoom", () => {
           if (!live()) {
@@ -1484,6 +1553,19 @@ export function useLiveVoice(
   // cancels any pending reconnect so it can't fire after unmount.
   useEffect(() => () => teardown(), [teardown]);
 
+  /**
+   * Put a typed turn to the running session, as the user's own words.
+   * `false` when there is no session up to take it, or the assistant does
+   * not take typed turns; the caller keeps the text either way.
+   */
+  const sendText = useCallback((text: string): boolean => {
+    const session = sessionRef.current;
+    if (!session) {
+      return false;
+    }
+    return sendTextTurn(session, text);
+  }, []);
+
   return {
     state,
     partialTranscript,
@@ -1495,6 +1577,7 @@ export function useLiveVoice(
     cancelPrewarmedPlayback,
     start,
     stop,
+    sendText,
   };
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -913,6 +913,32 @@ export function useLiveVoice(
       const live = () =>
         sessionRef.current === session && session.generation === generation;
 
+      // The reply to the seed has been heard. Wait out the quiet before
+      // ending, and end only if nothing has started since: a `thinking`
+      // frame for a tool run bumps the epoch, an utterance the user has
+      // open keeps the session for them, and an accepted one disarms the
+      // end outright. Runs again after a discarded utterance, since room
+      // noise that opened one and was retracted is not the user carrying on.
+      const endAfterReplyWhenQuiet = (): void => {
+        if (!live() || !session.endAfterReply) {
+          return;
+        }
+        const epoch = session.responseEpoch;
+        setTimeout(() => {
+          if (
+            !live() ||
+            !session.endAfterReply ||
+            session.responseEpoch !== epoch ||
+            session.utteranceOpen ||
+            useLiveVoiceStore.getState().state !== "listening"
+          ) {
+            return;
+          }
+          session.endAfterReply = false;
+          void stop();
+        }, opts.endAfterSeedReplyQuietMs ?? END_AFTER_SEED_REPLY_QUIET_MS);
+      };
+
       session.unsubscribes.push(
         client.on("ready", (frame) => {
           if (!live()) {
@@ -1014,10 +1040,6 @@ export function useLiveVoice(
           }
           session.utteranceOpen = true;
           s.setUtteranceOpen(true);
-          // The user carrying on is the conversation continuing: a session
-          // that was to end after its seed's reply stays up for as long as
-          // they want it.
-          session.endAfterReply = false;
           // Server VAD fires on room noise as well as on speech, so hold the
           // flushed audio instead of destroying it: `utterance_discarded`
           // retracts a wrong barge-in and puts the reply back. A second onset
@@ -1033,6 +1055,11 @@ export function useLiveVoice(
           session.utteranceOpen = false;
           const s = useLiveVoiceStore.getState();
           s.setUtteranceOpen(false);
+          // The user carrying on is the conversation continuing: a session
+          // that was to end after its seed's reply stays up for as long as
+          // they want it. An accepted utterance rather than an onset, since
+          // server VAD opens one for room noise too.
+          session.endAfterReply = false;
           // End of user speech: stamp the client-heard latency start; the
           // response's first tts_audio consumes it (see
           // beginAssistantAudioIfNeeded). Manual mode stamps at the
@@ -1051,6 +1078,12 @@ export function useLiveVoice(
           // The discarded utterance never becomes a turn: drop its
           // end-of-speech stamp so it can't pair with a later turn's audio.
           session.speechEndedAtMs = null;
+          // The onset that opened this utterance also held off the end of a
+          // session that was to end after its reply. Nothing was said, so the
+          // end is owed again once whatever is playing has been heard.
+          void session.player.waitUntilDrained().then(() => {
+            endAfterReplyWhenQuiet();
+          });
           // The utterance the barge-in opened held no speech, so the barge-in
           // was wrong: put the flushed reply back rather than leaving silence
           // where the answer was. Resuming sets `speaking` itself.
@@ -1220,26 +1253,7 @@ export function useLiveVoice(
             return;
           }
           void finishResponseAfterPlayback(session, teardown).then(() => {
-            if (!live() || !session.endAfterReply) {
-              return;
-            }
-            // The reply has been heard. Wait out the quiet before ending, and
-            // end only if nothing has started since: a `thinking` frame for a
-            // tool run bumps the epoch, and the user speaking disarms the end
-            // outright. Either means the turn is not over.
-            const epoch = session.responseEpoch;
-            setTimeout(() => {
-              if (
-                !live() ||
-                !session.endAfterReply ||
-                session.responseEpoch !== epoch ||
-                useLiveVoiceStore.getState().state !== "listening"
-              ) {
-                return;
-              }
-              session.endAfterReply = false;
-              void stop();
-            }, opts.endAfterSeedReplyQuietMs ?? END_AFTER_SEED_REPLY_QUIET_MS);
+            endAfterReplyWhenQuiet();
           });
         }),
         client.on("minimizeRoom", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -493,7 +493,14 @@ export function useLiveVoice(
   // reconnect path and greets a second time on a socket blip. The ref outlives
   // every attempt, so a connect that fails before `ready` still owes the
   // greeting to whichever attempt finally lands.
-  const pendingSeedTextRef = useRef<string | null>(null);
+  //
+  // The seed's own options ride with it, since the connect attempts that
+  // follow the first carry no start options of their own.
+  const pendingSeedRef = useRef<{
+    text: string;
+    visible: boolean;
+    endAfterReply: boolean;
+  } | null>(null);
   const connectSessionRef = useRef<
     | ((
         assistantId: string,
@@ -962,19 +969,19 @@ export function useLiveVoice(
             if (!live() || !session.captureRunning) {
               return;
             }
-            const seedText = pendingSeedTextRef.current;
-            pendingSeedTextRef.current = null;
-            if (seedText !== null) {
+            const seed = pendingSeedRef.current;
+            pendingSeedRef.current = null;
+            if (seed !== null) {
               // `hidden`: a seed that is an instruction rather than something
               // the user typed drives the turn and stays in the model's
               // context while never rendering in the transcript. An assistant
               // too old to know the field persists it visibly instead, which
               // is why the copy still reads as a sentence a person could have
               // sent. A seed that is the user's own words renders as theirs.
-              const sent = sendTextTurn(session, seedText, {
-                hidden: startOptions.seedVisible !== true,
+              const sent = sendTextTurn(session, seed.text, {
+                hidden: !seed.visible,
               });
-              if (sent && startOptions.endAfterSeedReply === true) {
+              if (sent && seed.endAfterReply) {
                 session.endAfterReply = true;
               }
               // A session that exists for its seed has nothing to do when
@@ -982,7 +989,7 @@ export function useLiveVoice(
               // turns declines it at `sendText`'s gate). Left up, it would
               // be an open microphone with the question silently gone, so
               // it fails instead and says why.
-              if (!sent && startOptions.endAfterSeedReply === true) {
+              if (!sent && seed.endAfterReply) {
                 finishWithError(
                   session,
                   teardown,
@@ -1007,6 +1014,10 @@ export function useLiveVoice(
           }
           session.utteranceOpen = true;
           s.setUtteranceOpen(true);
+          // The user carrying on is the conversation continuing: a session
+          // that was to end after its seed's reply stays up for as long as
+          // they want it.
+          session.endAfterReply = false;
           // Server VAD fires on room noise as well as on speech, so hold the
           // flushed audio instead of destroying it: `utterance_discarded`
           // retracts a wrong barge-in and puts the reply back. A second onset
@@ -1214,15 +1225,14 @@ export function useLiveVoice(
             }
             // The reply has been heard. Wait out the quiet before ending, and
             // end only if nothing has started since: a `thinking` frame for a
-            // tool run bumps the epoch, and the user speaking opens an
-            // utterance. Either means the turn is not over.
+            // tool run bumps the epoch, and the user speaking disarms the end
+            // outright. Either means the turn is not over.
             const epoch = session.responseEpoch;
             setTimeout(() => {
               if (
                 !live() ||
                 !session.endAfterReply ||
                 session.responseEpoch !== epoch ||
-                session.utteranceOpen ||
                 useLiveVoiceStore.getState().state !== "listening"
               ) {
                 return;
@@ -1554,7 +1564,15 @@ export function useLiveVoice(
       // Armed here rather than inside `connectSession`, which the reconnect
       // path also enters carrying the same `startOptions`: a session that
       // already greeted must not greet again when its socket comes back.
-      pendingSeedTextRef.current = startOptions?.seedText?.trim() || null;
+      const seedText = startOptions?.seedText?.trim() || null;
+      pendingSeedRef.current =
+        seedText === null
+          ? null
+          : {
+              text: seedText,
+              visible: startOptions?.seedVisible === true,
+              endAfterReply: startOptions?.endAfterSeedReply === true,
+            };
       await connectSession(assistantId, conversationId, startOptions ?? {});
     },
     [connectSession, clearReconnectTimer],

--- a/clients/web/src/domains/chat/voice/use-hold-to-dictate.test.tsx
+++ b/clients/web/src/domains/chat/voice/use-hold-to-dictate.test.tsx
@@ -21,13 +21,16 @@ mock.module("@/runtime/hotkey", () => ({
   },
 }));
 
-const { HOLD_ARMING_MS, useHoldToDictate } = await import(
-  "@/domains/chat/voice/use-hold-to-dictate"
-);
+const { HOLD_ARMING_MS, useHoldToDictate } =
+  await import("@/domains/chat/voice/use-hold-to-dictate");
 
-const press = () => {
+const press = (selection?: HotkeyEvent["selection"]) => {
   act(() => {
-    emitHotkeyEvent?.({ kind: "modifierHold", state: "down" });
+    emitHotkeyEvent?.({
+      kind: "modifierHold",
+      state: "down",
+      ...(selection ? { selection } : {}),
+    });
   });
 };
 
@@ -46,9 +49,7 @@ const settle = async (ms: number) => {
 const renderHold = () => {
   const onHoldStart = mock(() => {});
   const onHoldEnd = mock(() => {});
-  const view = renderHook(() =>
-    useHoldToDictate({ onHoldStart, onHoldEnd }),
-  );
+  const view = renderHook(() => useHoldToDictate({ onHoldStart, onHoldEnd }));
   return { onHoldStart, onHoldEnd, view };
 };
 
@@ -78,6 +79,24 @@ describe("hold to dictate", () => {
    * its own key, so a release inside the delay is someone typing Ctrl+Option+F
    * rather than reaching for dictation.
    */
+  test("hands the selection the hold began over to the start", async () => {
+    const { onHoldStart } = renderHold();
+    press({ text: "the powerhouse of the cell", truncated: false });
+    await settle(HOLD_ARMING_MS + 20);
+    expect(onHoldStart).toHaveBeenCalledWith({
+      selection: { text: "the powerhouse of the cell", truncated: false },
+    });
+    release();
+  });
+
+  test("starts with no selection when the edge carried none", async () => {
+    const { onHoldStart } = renderHold();
+    press();
+    await settle(HOLD_ARMING_MS + 20);
+    expect(onHoldStart).toHaveBeenCalledWith({ selection: null });
+    release();
+  });
+
   test("never opens it for a hold that ends inside the delay", async () => {
     const { onHoldStart, onHoldEnd } = renderHold();
 

--- a/clients/web/src/domains/chat/voice/use-hold-to-dictate.test.tsx
+++ b/clients/web/src/domains/chat/voice/use-hold-to-dictate.test.tsx
@@ -101,6 +101,16 @@ describe("hold to dictate", () => {
     release();
   });
 
+  test("opens on the edge when the helper's read has already outlasted the delay", async () => {
+    const { onHoldStart, onHoldEnd } = renderHold();
+    // The read took longer than the arming delay, and the user let go while
+    // it ran, so the `up` lands right behind the `down`.
+    press({ text: "selected", truncated: false }, HOLD_ARMING_MS + 30);
+    expect(onHoldStart).toHaveBeenCalledTimes(1);
+    release();
+    expect(onHoldEnd).toHaveBeenCalledTimes(1);
+  });
+
   test("starts with no selection when the edge carried none", async () => {
     const { onHoldStart } = renderHold();
     press();

--- a/clients/web/src/domains/chat/voice/use-hold-to-dictate.test.tsx
+++ b/clients/web/src/domains/chat/voice/use-hold-to-dictate.test.tsx
@@ -24,12 +24,16 @@ mock.module("@/runtime/hotkey", () => ({
 const { HOLD_ARMING_MS, useHoldToDictate } =
   await import("@/domains/chat/voice/use-hold-to-dictate");
 
-const press = (selection?: HotkeyEvent["selection"]) => {
+const press = (
+  selection?: HotkeyEvent["selection"],
+  heldMs?: HotkeyEvent["heldMs"],
+) => {
   act(() => {
     emitHotkeyEvent?.({
       kind: "modifierHold",
       state: "down",
       ...(selection ? { selection } : {}),
+      ...(heldMs !== undefined ? { heldMs } : {}),
     });
   });
 };
@@ -86,6 +90,14 @@ describe("hold to dictate", () => {
     expect(onHoldStart).toHaveBeenCalledWith({
       selection: { text: "the powerhouse of the cell", truncated: false },
     });
+    release();
+  });
+
+  test("takes the time the helper held the edge off the arming delay", async () => {
+    const { onHoldStart } = renderHold();
+    press({ text: "selected", truncated: false }, HOLD_ARMING_MS - 20);
+    await settle(40);
+    expect(onHoldStart).toHaveBeenCalledTimes(1);
     release();
   });
 

--- a/clients/web/src/domains/chat/voice/use-hold-to-dictate.ts
+++ b/clients/web/src/domains/chat/voice/use-hold-to-dictate.ts
@@ -116,11 +116,15 @@ export function useHoldToDictate({
       if (event.state === "down") {
         cancelArming();
         const selection = event.selection ?? null;
+        // The helper may have held the edge to read the selection. That time
+        // was part of the hold, so it comes off the arming delay rather than
+        // being added to it.
+        const armingMs = Math.max(0, HOLD_ARMING_MS - (event.heldMs ?? 0));
         armingTimer = setTimeout(() => {
           armingTimer = null;
           open = true;
           handlers.current.onHoldStart({ selection });
-        }, HOLD_ARMING_MS);
+        }, armingMs);
         return;
       }
       endIfOpen();

--- a/clients/web/src/domains/chat/voice/use-hold-to-dictate.ts
+++ b/clients/web/src/domains/chat/voice/use-hold-to-dictate.ts
@@ -118,8 +118,15 @@ export function useHoldToDictate({
         const selection = event.selection ?? null;
         // The helper may have held the edge to read the selection. That time
         // was part of the hold, so it comes off the arming delay rather than
-        // being added to it.
-        const armingMs = Math.max(0, HOLD_ARMING_MS - (event.heldMs ?? 0));
+        // being added to it. A hold the read has already carried past the
+        // delay opens here and now: its `up` may be queued right behind this
+        // edge, and a deferred open would be cancelled by it.
+        const armingMs = HOLD_ARMING_MS - (event.heldMs ?? 0);
+        if (armingMs <= 0) {
+          open = true;
+          handlers.current.onHoldStart({ selection });
+          return;
+        }
         armingTimer = setTimeout(() => {
           armingTimer = null;
           open = true;

--- a/clients/web/src/domains/chat/voice/use-hold-to-dictate.ts
+++ b/clients/web/src/domains/chat/voice/use-hold-to-dictate.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-import type { KeyboardModifier } from "@vellumai/ipc-contract";
+import type { HotkeySelection, KeyboardModifier } from "@vellumai/ipc-contract";
 
 import {
   setModifierHold,
@@ -41,9 +41,19 @@ export const HOLD_TO_DICTATE_MODIFIERS: KeyboardModifier[] = [
  */
 export const HOLD_ARMING_MS = 220;
 
+/** What a hold began over. */
+export interface HoldStart {
+  /**
+   * What the user had highlighted when the keys went down, when anything was.
+   * Read once, at the `down` edge, so a hold is about what was selected as it
+   * began and not about what the user clicks on while talking.
+   */
+  selection: HotkeySelection | null;
+}
+
 export interface HoldToDictateHandlers {
   /** Open the microphone. Called once the hold has outlasted the arming delay. */
-  onHoldStart: () => void;
+  onHoldStart: (start: HoldStart) => void;
   /**
    * Close it and keep what was said. Called only where `onHoldStart` was, so a
    * hold that never armed never reaches this.
@@ -105,10 +115,11 @@ export function useHoldToDictate({
       }
       if (event.state === "down") {
         cancelArming();
+        const selection = event.selection ?? null;
         armingTimer = setTimeout(() => {
           armingTimer = null;
           open = true;
-          handlers.current.onHoldStart();
+          handlers.current.onHoldStart({ selection });
         }, HOLD_ARMING_MS);
         return;
       }

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
@@ -120,6 +120,7 @@ function registerStarter(): void {
         .setSessionContext(assistantId, conversationId ?? null);
       useLiveVoiceStore.getState().setState("listening");
     },
+    sendText: () => false,
   });
 }
 

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -120,6 +120,7 @@ const asStarter = (start: (a: string, c: string | null) => void) => ({
   prewarm: () => {},
   cancelPrewarm: () => {},
   start,
+  sendText: () => false,
 });
 
 const resetStores = () => {

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -863,6 +863,7 @@
     "startVoiceMode": "Start voice mode"
   },
   "liveVoiceStatus": {
+    "askUnsupported": "This assistant can’t take a question this way yet. Update it and try again.",
     "connecting": "Connecting…",
     "ending": "Ending…",
     "listening": "Listening…",

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1696,6 +1696,7 @@
     "seed": "Hey, I just started a voice conversation with you. This message is sent automatically. Greet me in one short sentence, then ask what I'd like to work on."
   },
   "voiceErrors": {
+    "askUnavailable": "The call you’re on can’t take a question right now.",
     "nativeSttNoTranscript": "{clientName} Native Dictation didn’t return a transcript. Check native speech recognition in system settings, then try again."
   },
   "voiceFirstRunCard": {

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1697,7 +1697,7 @@
     "seed": "Hey, I just started a voice conversation with you. This message is sent automatically. Greet me in one short sentence, then ask what I'd like to work on."
   },
   "voiceErrors": {
-    "askUnavailable": "The call you’re on can’t take a question right now.",
+    "askUnavailable": "Your assistant can’t take a spoken question right now.",
     "nativeSttNoTranscript": "{clientName} Native Dictation didn’t return a transcript. Check native speech recognition in system settings, then try again."
   },
   "voiceFirstRunCard": {

--- a/clients/web/src/stores/pending-deep-link-store.ts
+++ b/clients/web/src/stores/pending-deep-link-store.ts
@@ -45,6 +45,14 @@ export interface PendingDeepLinkState {
    */
   pendingVoiceStartAt: number | null;
   /**
+   * The first turn the parked start-voice request takes on its session, or
+   * `null` for a plain start. A press from a surface that already knows what
+   * the user wants to say (a hold made over a selection) parks its question
+   * here, and the drain hands it to the starter. Travels with
+   * `pendingVoiceStartAt` and clears with it.
+   */
+  pendingVoiceStartAsk: string | null;
+  /**
    * A message that a *proven* App Intent asked to send into a specific
    * conversation (`deeplink.sendToThread` with `provenance: "intent"`), or
    * `null` if none. Unlike `pendingComposerMessage` this is a request to
@@ -110,17 +118,21 @@ export interface PendingDeepLinkActions {
    * none was set. Used by `useDeepLinkConsumer` in the chat domain.
    */
   consumePendingComposerMessage: () => string | null;
-  /** Park a start-voice deep link until a session starter is registered. */
-  setPendingVoiceStart: () => void;
   /**
-   * Read and clear the parked start-voice request. Returns `false` when none
+   * Park a start-voice request until a session starter is registered, with
+   * the first turn it should take, if it has one. A newer park replaces the
+   * older one's ask.
+   */
+  setPendingVoiceStart: (ask?: string) => void;
+  /**
+   * Read and clear the parked start-voice request. Returns `null` when none
    * was parked, and when the parked one is older than `maxAgeMs` — a park that
    * was never drained (its navigation bounced off a route guard, say) must not
    * open a full-screen voice session minutes later. Either way the park is
    * cleared. Used by `drainPendingVoiceStart` in the live-voice domain,
    * which owns the age bound.
    */
-  consumePendingVoiceStart: (maxAgeMs: number) => boolean;
+  consumePendingVoiceStart: (maxAgeMs: number) => { ask: string | null } | null;
   /**
    * Park a proven send-into-thread request. A newer request replaces an
    * older one: the most recent intent wins, same as the composer message.
@@ -176,6 +188,7 @@ const usePendingDeepLinkStoreBase = create<PendingDeepLinkStore>()(
   (set, get) => ({
     pendingComposerMessage: null,
     pendingVoiceStartAt: null,
+    pendingVoiceStartAsk: null,
     pendingThreadSend: null,
     pendingCamera: null,
     pendingConversationListAt: null,
@@ -188,14 +201,19 @@ const usePendingDeepLinkStoreBase = create<PendingDeepLinkStore>()(
       }
       return message;
     },
-    setPendingVoiceStart: () => set({ pendingVoiceStartAt: Date.now() }),
+    setPendingVoiceStart: (ask) =>
+      set({
+        pendingVoiceStartAt: Date.now(),
+        pendingVoiceStartAsk: ask ?? null,
+      }),
     consumePendingVoiceStart: (maxAgeMs) => {
-      const parkedAt = get().pendingVoiceStartAt;
+      const { pendingVoiceStartAt: parkedAt, pendingVoiceStartAsk: ask } =
+        get();
       if (parkedAt === null) {
-        return false;
+        return null;
       }
-      set({ pendingVoiceStartAt: null });
-      return Date.now() - parkedAt <= maxAgeMs;
+      set({ pendingVoiceStartAt: null, pendingVoiceStartAsk: null });
+      return Date.now() - parkedAt <= maxAgeMs ? { ask } : null;
     },
     setPendingThreadSend: (threadId, message) =>
       set({ pendingThreadSend: { threadId, message, parkedAt: Date.now() } }),
@@ -234,6 +252,7 @@ export function __resetPendingDeepLinkForTesting(): void {
   usePendingDeepLinkStoreBase.setState({
     pendingComposerMessage: null,
     pendingVoiceStartAt: null,
+    pendingVoiceStartAsk: null,
     pendingThreadSend: null,
     pendingCamera: null,
     pendingConversationListAt: null,

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -200,9 +200,22 @@ export type HotkeyEventKind =
   | "voiceModeChord"
   | "modifierHold";
 
+/**
+ * What the user had highlighted in the application in front when a hold
+ * began. Read by the helper over Accessibility at the `down` edge and carried
+ * on it, so a hold made with something selected can be about the selection.
+ * Bounded at the helper; `truncated` says the text is a prefix.
+ */
+export interface HotkeySelection {
+  text: string;
+  truncated: boolean;
+}
+
 export interface HotkeyEvent {
   kind: HotkeyEventKind;
   state: HotkeyEventState;
+  /** Only on a `modifierHold` `down`, and only when something was selected. */
+  selection?: HotkeySelection;
 }
 
 export type FnPushToTalkResult =

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -216,6 +216,13 @@ export interface HotkeyEvent {
   state: HotkeyEventState;
   /** Only on a `modifierHold` `down`, and only when something was selected. */
   selection?: HotkeySelection;
+  /**
+   * How long the keys had already been down when this edge was sent, where
+   * the helper held it to read the selection. A consumer timing the hold from
+   * the edge takes this off its clock, so a slow application in front costs
+   * the read and not the hold.
+   */
+  heldMs?: number;
 }
 
 export type FnPushToTalkResult =


### PR DESCRIPTION
## Summary
- Highlight text in any app, hold Ctrl+Option, ask, release: the words go to the assistant with the selection quoted ahead of them, on a live-voice session that speaks the reply and ends once it has been heard. A hold with nothing selected dictates exactly as before.
- The mac-helper reads the front app's selection at the hold's `down` edge (`FrontSelection.swift`) and carries it on the `modifierHold` hotkey event (`HotkeyEvent.selection`, capped at 4000 chars with a `truncated` flag, plus `heldMs` so the renderer takes the read's time off its arming delay). A `--front-selection` probe flag prints what a hold would carry.
- The renderer routes a selection-hold through a new `askVoiceFromSurface`: a running session takes the question as a turn (`LiveVoiceSessionStarter.sendText`); otherwise the start-voice request parks the question and the drain starts a session with it as a visible seed (`seedVisible`) that ends after its reply (`endAfterSeedReply`).

## Decisions worth a look
- **Select first, then hold.** The selection is read once, at key-down. Ctrl is the contextual-menu modifier, so selecting mid-hold is not a gesture that works, and reading at release would make the hold about whatever was clicked while talking.
- **Accessibility first, then a copy.** The focused element's `AXSelectedText`, then its selected range picked out of its value, then a Cmd+C posted to the front app's process (not the HID stream, so the hold detector never sees it as a chord) with the pasteboard saved and put back. A pasteboard that does not change inside 120ms means nothing was selected and it is left untouched. A helper not yet trusted for Accessibility asks for it the first time a hold needs a selection, once per process. Every hold-down logs the read's outcome (trust, front app, element role, path, chars, ms; never content). Known edge: editors that copy the current line on an empty selection (VS Code's default) will read that line as the selection.
- **The session ends after the reply, with a quiet.** A question asked from another app should not leave the user on an open hands-free call. `END_AFTER_SEED_REPLY_QUIET_MS` (2s) after playback drains, the session ends unless a new `thinking` bumped the response epoch or the user opened an utterance, so a reply that acknowledges and then runs a tool is not cut off. A running session is left running.
- **No cleanup pass and no paste.** The cleanup pass rewrites words meant for a document; these are meant for the assistant, who hears them as said. The question renders in the transcript as the user's own message with the selection as a quoted block, so the model and the user both see what it was about.

## Testing
- `bun test` on every touched web file (hold hook, bridge, start-voice request, live-voice hook incl. the four end-after-reply cases, store, deep-link consumer, composer): all green.
- Web and macOS `tsc` clean with `@vellumai/ipc-contract` pointed at this branch (the worktree otherwise resolves it to `main`); ipc-contract `tsc` clean; macOS `hotkey-helper` test via `scripts/run-tests.ts`.
- Swift: `swift build` and `build-mac-helper.sh` (Developer ID signed) succeed.
- **Verified on a live rig** (helper rebuilt, app restarted): highlight in Chrome, hold, ask, release, spoken reply. Helper log: `trusted=true app=com.google.Chrome focused=true role=AXWebArea path=selectedText chars=1284 readMs=27` (1ms on later holds).
- **Not yet exercised in the field:** the `range` and Cmd+C paths. Which apps need them is an open question.
- **Stale Accessibility grant, a symptom to know:** a helper that was once granted Accessibility under an ad-hoc signature reads `trusted=false` after the Developer ID build, and the prompt does not reappear because TCC thinks it already answered. Fix: `tccutil reset Accessibility ai.vellum.assistant-local.mac-helper`, restart the app, grant when the first selection-hold prompts.

## Original prompt
After hold-to-dictate landed, the next step was for the same gesture to ask rather than dictate when something on screen is highlighted: hold, say "what does this mean?", and have the answer go through the agent loop and come back spoken. The selection and the spoken path both existed as parts (the daemon's dictation route already knows `selectedText`; live voice already takes typed turns), so this wires the selection from the helper to the renderer and the question onto a voice session.

Closes JARVIS-1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pvqq8r7e5DG6WyQpabTK13
