### PR TITLE
fix(gateway): desktop stream dropped-frame handling, shared guardian-stream tests, comment trims

### DIFF
--- a/gateway/src/__tests__/desktop-stream-websocket.test.ts
+++ b/gateway/src/__tests__/desktop-stream-websocket.test.ts
@@ -1,33 +1,17 @@
-import { afterEach, beforeEach, describe, test, expect, mock } from "bun:test";
-import type { GatewayConfig } from "../config.js";
-import { initSigningKey, mintToken } from "../auth/token-service.js";
-import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
-import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
+import { afterEach, describe, test, expect, mock } from "bun:test";
 import type { DesktopStreamSocketData } from "../http/routes/desktop-stream-websocket.js";
+import {
+  GUARDIAN_PRINCIPAL,
+  makeConfig,
+  makeFakeServer,
+  mintEdgeToken,
+  upgradedData,
+} from "./runtime-stream-test-utils.js";
 
-/** The bound guardian's actor principal, which `mintEdgeToken` defaults to. */
-const GUARDIAN_PRINCIPAL = "test-user";
-
-/** The bound guardian's platform user id, for the velay-attested path. */
-const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
-
-// The desktop is a guardian-only surface, so the upgrade pins the caller to
-// the binding. Both lookups are mocked BEFORE the module under test is
-// imported, the way the watch stream's tests do it.
-let mockFindVellumGuardian = mock(
-  async (): Promise<{ principalId: string } | null> => ({
-    principalId: GUARDIAN_PRINCIPAL,
-  }),
-);
+// The pin itself is covered in `guardian-pin.test.ts`; the binding is mocked
+// here only so the route can be shown to wire it in.
 mock.module("../auth/guardian-bootstrap.js", () => ({
-  findVellumGuardian: () => mockFindVellumGuardian(),
-}));
-
-let mockReadCredential = mock(
-  async (_key: string): Promise<string | undefined> => VELAY_USER_ID,
-);
-mock.module("../credential-reader.js", () => ({
-  readCredential: (key: string) => mockReadCredential(key),
+  findVellumGuardian: async () => ({ principalId: GUARDIAN_PRINCIPAL }),
 }));
 
 const {
@@ -35,337 +19,46 @@ const {
   getDesktopStreamWebsocketHandlers,
 } = await import("../http/routes/desktop-stream-websocket.js");
 
-const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
-initSigningKey(TEST_SIGNING_KEY);
-
-/** Mint a valid actor edge JWT for desktop stream auth. */
-function mintEdgeToken(actorPrincipalId: string = GUARDIAN_PRINCIPAL): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: `actor:test-assistant:${actorPrincipalId}`,
-    scope_profile: "actor_client_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
-/** Mint a service-style token (no actor principal). */
-function mintServiceEdgeToken(): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: "svc:gateway:self",
-    scope_profile: "gateway_service_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
-function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
-    assistantRuntimeBaseUrl: "http://localhost:7821",
-    routingEntries: [],
-    port: 7830,
-    runtimeProxyRequireAuth: true,
-    shutdownDrainMs: 5000,
-    runtimeTimeoutMs: 30000,
-    runtimeMaxRetries: 2,
-    runtimeInitialBackoffMs: 500,
-    maxWebhookPayloadBytes: 1048576,
-    logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: {
-      telegram: 50 * 1024 * 1024,
-      slack: 100 * 1024 * 1024,
-      whatsapp: 16 * 1024 * 1024,
-      default: 50 * 1024 * 1024,
-    },
-    maxAttachmentConcurrency: 3,
-    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-    trustProxy: false,
-    ...overrides,
-  } as GatewayConfig;
-}
-
-function makeFakeServer(upgradeResult: boolean = true) {
-  return {
-    requestIP: mock(() => ({
-      address: "127.0.0.1",
-      family: "IPv4",
-      port: 54000,
-    })),
-    upgrade: mock(() => upgradeResult),
-  } as unknown as import("bun").Server<unknown>;
-}
-
-/** The socket data the handler asked Bun to attach to the upgraded socket. */
-function upgradedData(
-  server: import("bun").Server<unknown>,
-): DesktopStreamSocketData {
-  const call = (server.upgrade as ReturnType<typeof mock>).mock
-    .calls[0] as unknown[];
-  return (call[1] as { data: DesktopStreamSocketData }).data;
-}
-
-beforeEach(() => {
-  mockFindVellumGuardian = mock(async () => ({
-    principalId: GUARDIAN_PRINCIPAL,
-  }));
-  mockReadCredential = mock(async (_key: string) => VELAY_USER_ID);
-});
-
-afterEach(() => {
-  delete process.env.IS_PLATFORM;
-});
-
 // ---------------------------------------------------------------------------
 // createDesktopStreamWebsocketHandler: upgrade handler tests
 // ---------------------------------------------------------------------------
 
 describe("createDesktopStreamWebsocketHandler", () => {
-  const upgrade = async (
-    url: string,
-    init: RequestInit = { headers: { upgrade: "websocket" } },
-    config = makeConfig(),
-    upgradeResult = true,
-  ) => {
-    const handler = createDesktopStreamWebsocketHandler(config);
-    const server = makeFakeServer(upgradeResult);
-    return { res: await handler(new Request(url, init), server), server };
-  };
-
-  test("upgrades when the token query parameter is valid", async () => {
-    const { res, server } = await upgrade(
-      `http://localhost:7830/v1/desktop/stream?token=${mintEdgeToken()}`,
-    );
-
-    expect(res).toBeUndefined();
-    expect(server.upgrade).toHaveBeenCalledTimes(1);
-    expect(upgradedData(server)).toMatchObject({ wsType: "desktop-stream" });
-  });
-
-  test("upgrades when the Authorization header is valid", async () => {
-    const { res, server } = await upgrade(
-      "http://localhost:7830/v1/desktop/stream",
-      {
-        headers: {
-          upgrade: "websocket",
-          authorization: `Bearer ${mintEdgeToken()}`,
-        },
-      },
-    );
-
-    expect(res).toBeUndefined();
-    expect(server.upgrade).toHaveBeenCalledTimes(1);
-  });
-
-  test("returns 401 when no token is provided", async () => {
-    const { res, server } = await upgrade(
-      "http://localhost:7830/v1/desktop/stream",
-    );
-
-    expect(res!.status).toBe(401);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  test("returns 401 when the token is invalid", async () => {
-    const { res, server } = await upgrade(
-      "http://localhost:7830/v1/desktop/stream?token=bad-token",
-    );
-
-    expect(res!.status).toBe(401);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  /**
-   * The client-facing half of the proxy takes actors and nothing else. A
-   * service credential reaching it would hand the pod's desktop to a token
-   * minted for machine to machine traffic.
-   */
-  test("returns 401 for a service token, which has no actor principal", async () => {
-    const { res, server } = await upgrade(
-      `http://localhost:7830/v1/desktop/stream?token=${mintServiceEdgeToken()}`,
-    );
-
-    expect(res!.status).toBe(401);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  test("returns 426 when the request is not a WebSocket upgrade", async () => {
-    const { res, server } = await upgrade(
-      `http://localhost:7830/v1/desktop/stream?token=${mintEdgeToken()}`,
-      {},
-    );
-
-    expect(res!.status).toBe(426);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  test("returns 500 when the Bun upgrade fails", async () => {
-    const { res } = await upgrade(
-      `http://localhost:7830/v1/desktop/stream?token=${mintEdgeToken()}`,
-      { headers: { upgrade: "websocket" } },
-      makeConfig(),
-      false,
-    );
-
-    expect(res!.status).toBe(500);
-  });
-
-  test("allows an unauthenticated upgrade when auth is disabled (dev bypass)", async () => {
-    const { res, server } = await upgrade(
-      "http://localhost:7830/v1/desktop/stream",
-      { headers: { upgrade: "websocket" } },
-      makeConfig({ runtimeProxyRequireAuth: false }),
-    );
-
-    expect(res).toBeUndefined();
-    expect(server.upgrade).toHaveBeenCalledTimes(1);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// The guardian pin
-// ---------------------------------------------------------------------------
-
-/**
- * The proxy replaces the caller's identity with a service token upstream, so
- * the runtime cannot tell one actor from another: whoever this upgrade admits
- * gets the pod's desktop. This is the only place a non-guardian can be
- * refused.
- */
-describe("createDesktopStreamWebsocketHandler: the guardian pin", () => {
-  const upgrade = async (token: string) => {
+  const upgrade = async (token: string, upgradeResult = true) => {
     const handler = createDesktopStreamWebsocketHandler(makeConfig());
+    const server = makeFakeServer(upgradeResult);
     const req = new Request(
       `http://localhost:7830/v1/desktop/stream?token=${token}`,
       { headers: { upgrade: "websocket" } },
     );
-    const server = makeFakeServer();
     return { res: await handler(req, server), server };
   };
 
-  test("admits the bound guardian", async () => {
+  test("upgrades the bound guardian", async () => {
     const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
+    expect(upgradedData<DesktopStreamSocketData>(server)).toMatchObject({
+      wsType: "desktop-stream",
+    });
   });
 
-  test("refuses a valid actor token that is not the bound guardian", async () => {
+  /**
+   * The proxy replaces the caller's identity upstream, so whoever this upgrade
+   * admits gets the pod's desktop. The route has to opt into the pin.
+   */
+  test("refuses a non-guardian actor", async () => {
     const { res, server } = await upgrade(mintEdgeToken("someone-else"));
 
     expect(res!.status).toBe(403);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 
-  test("refuses when no guardian binding exists", async () => {
-    mockFindVellumGuardian = mock(async () => null);
+  test("returns 500 when the Bun upgrade fails", async () => {
+    const { res } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL), false);
 
-    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
-
-    expect(res!.status).toBe(403);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  test("answers 503 when the binding lookup fails", async () => {
-    mockFindVellumGuardian = mock(async () => {
-      throw new Error("db down");
-    });
-
-    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
-
-    expect(res!.status).toBe(503);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-});
-
-/**
- * The managed path, where velay validated the browser's token and injected the
- * caller. The attestation proves the caller is *a* platform user who traversed
- * velay, not that they are this assistant's guardian, so it is cross-checked
- * against the stored `platform_user_id`.
- */
-describe("createDesktopStreamWebsocketHandler: velay-attested managed auth", () => {
-  const VELAY_ORG_ID = "22222222-2222-2222-2222-222222222222";
-
-  const managedUpgrade = async ({
-    userId = VELAY_USER_ID,
-    bridgeProof = true,
-    token,
-    managed = true,
-  }: {
-    userId?: string;
-    bridgeProof?: boolean;
-    token?: string;
-    managed?: boolean;
-  }) => {
-    if (managed) {
-      process.env.IS_PLATFORM = "true";
-    } else {
-      delete process.env.IS_PLATFORM;
-    }
-    const headers = new Headers({
-      upgrade: "websocket",
-      "x-velay-user-id": userId,
-      "x-velay-org-id": VELAY_ORG_ID,
-      "x-velay-actor": "user",
-    });
-    if (bridgeProof) {
-      setVelayBridgeAuthHeader(headers);
-    }
-    const handler = createDesktopStreamWebsocketHandler(makeConfig());
-    const query = token ? `?token=${token}` : "";
-    const req = new Request(`http://localhost:7830/v1/desktop/stream${query}`, {
-      headers,
-    });
-    const server = makeFakeServer();
-    return { res: await handler(req, server), server };
-  };
-
-  test("admits an attested caller who is the bound guardian", async () => {
-    const { res, server } = await managedUpgrade({});
-
-    expect(res).toBeUndefined();
-    expect(server.upgrade).toHaveBeenCalledTimes(1);
-  });
-
-  test("refuses an attested caller who is not the bound guardian", async () => {
-    mockReadCredential = mock(
-      async () => "99999999-9999-9999-9999-999999999999",
-    );
-
-    const { res, server } = await managedUpgrade({});
-
-    expect(res!.status).toBe(403);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  /**
-   * A direct request to a reachable gateway can spoof the header names. It
-   * cannot know the process-local bridge proof, which is what says the request
-   * really arrived through this gateway's own loopback bridge.
-   */
-  test("ignores spoofed velay headers with no bridge proof", async () => {
-    const { res, server } = await managedUpgrade({ bridgeProof: false });
-
-    expect(res!.status).toBe(401);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  /** Falling through must not fall past the pin. */
-  test("still pins the token path in managed mode", async () => {
-    const { res } = await managedUpgrade({
-      bridgeProof: false,
-      token: mintEdgeToken("someone-else"),
-    });
-
-    expect(res!.status).toBe(403);
-  });
-
-  test("does not trust velay headers outside managed mode", async () => {
-    const { res, server } = await managedUpgrade({ managed: false });
-
-    expect(res!.status).toBe(401);
-    expect(server.upgrade).not.toHaveBeenCalled();
+    expect(res!.status).toBe(500);
   });
 });
 
@@ -427,7 +120,8 @@ describe("getDesktopStreamWebsocketHandlers", () => {
     return { server, received, connected, upgradeUrl: () => upgradeUrl };
   }
 
-  function createFakeDownstreamWs(runtime: FakeRuntime) {
+  /** `sendStatus` is what Bun reports for each downstream send; 0 is a drop. */
+  function createFakeDownstreamWs(runtime: FakeRuntime, sendStatus = 1) {
     const sent: (string | Uint8Array)[] = [];
     const closes: { code: number; reason: string }[] = [];
     const data: DesktopStreamSocketData = {
@@ -442,6 +136,7 @@ describe("getDesktopStreamWebsocketHandlers", () => {
       closes,
       send: mock((msg: string | Uint8Array) => {
         sent.push(msg);
+        return sendStatus;
       }),
       close: mock((code?: number, reason?: string) => {
         closes.push({ code: code ?? 1000, reason: reason ?? "" });
@@ -492,6 +187,26 @@ describe("getDesktopStreamWebsocketHandlers", () => {
     const frame = ws.sent[0]!;
     expect(typeof frame).not.toBe("string");
     expect(Array.from(frame as Uint8Array)).toEqual(Array.from(RFB_BANNER));
+    expect(ws.closes).toEqual([]);
+  });
+
+  /**
+   * Past Bun's backpressure limit a send is dropped, and a missing frame
+   * corrupts an ordered RFB stream: the viewer cannot resync, so both sides
+   * are closed instead.
+   */
+  test("closes both sides when a downstream send is dropped", async () => {
+    runtime = startFakeRuntime(RFB_BANNER);
+    const handlers = getDesktopStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs(runtime, 0);
+
+    handlers.open(ws as never);
+    const upstreamClose = mock(ws.data.upstream!.close.bind(ws.data.upstream));
+    ws.data.upstream!.close = upstreamClose;
+    await waitFor(() => ws.closes.length > 0);
+
+    expect(ws.closes[0]).toEqual({ code: 1011, reason: "Viewer too slow" });
+    expect(upstreamClose).toHaveBeenCalledWith(1011, "Viewer too slow");
   });
 
   test("delivers the viewer's bytes upstream byte-identical, including frames sent before the dial completes", async () => {
@@ -520,10 +235,10 @@ describe("getDesktopStreamWebsocketHandlers", () => {
 
     handlers.open(ws as never);
     const upstream = await runtime.connected;
-    upstream.close(1013, "desktop busy");
+    upstream.close(4013, "desktop busy");
     await waitFor(() => ws.closes.length > 0);
 
-    expect(ws.closes[0]).toEqual({ code: 1013, reason: "desktop busy" });
+    expect(ws.closes[0]).toEqual({ code: 4013, reason: "desktop busy" });
   });
 
   test("propagates the viewer's close code upstream verbatim", async () => {

--- a/gateway/src/__tests__/guardian-pin.test.ts
+++ b/gateway/src/__tests__/guardian-pin.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, test, expect, mock } from "bun:test";
+import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
+import { getLogger } from "../logger.js";
+import {
+  GUARDIAN_PRINCIPAL,
+  VELAY_USER_ID,
+  makeConfig,
+  mintEdgeToken,
+  mintServiceEdgeToken,
+} from "./runtime-stream-test-utils.js";
+
+// Both lookups are mocked BEFORE the module under test is imported, so the
+// pin is testable without gateway DB state.
+let mockFindVellumGuardian = mock(
+  async (): Promise<{ principalId: string } | null> => ({
+    principalId: GUARDIAN_PRINCIPAL,
+  }),
+);
+mock.module("../auth/guardian-bootstrap.js", () => ({
+  findVellumGuardian: () => mockFindVellumGuardian(),
+}));
+
+let mockReadCredential = mock(
+  async (_key: string): Promise<string | undefined> => VELAY_USER_ID,
+);
+mock.module("../credential-reader.js", () => ({
+  readCredential: (key: string) => mockReadCredential(key),
+}));
+
+const { authorizeGuardianStream } =
+  await import("../http/routes/guardian-pin.js");
+
+const log = getLogger("guardian-pin-test");
+const STREAM_URL = "http://localhost:7830/v1/watch/stream";
+
+beforeEach(() => {
+  mockFindVellumGuardian = mock(async () => ({
+    principalId: GUARDIAN_PRINCIPAL,
+  }));
+  mockReadCredential = mock(async (_key: string) => VELAY_USER_ID);
+});
+
+afterEach(() => {
+  delete process.env.IS_PLATFORM;
+});
+
+/**
+ * The proxies replace the caller's identity with a service token upstream, so
+ * the daemon cannot tell one actor from another: whoever this gate admits is
+ * treated as the owner. This is the only place a non-guardian can be refused.
+ */
+describe("authorizeGuardianStream: the actor token path", () => {
+  const authorize = (token?: string, config = makeConfig()) =>
+    authorizeGuardianStream(
+      new Request(token ? `${STREAM_URL}?token=${token}` : STREAM_URL, {
+        headers: { upgrade: "websocket" },
+      }),
+      config,
+      log,
+    );
+
+  test("admits the bound guardian", async () => {
+    expect(await authorize(mintEdgeToken(GUARDIAN_PRINCIPAL))).toBeNull();
+  });
+
+  test("refuses a valid actor token that is not the bound guardian", async () => {
+    const res = await authorize(mintEdgeToken("someone-else"));
+
+    expect(res!.status).toBe(403);
+  });
+
+  test("refuses when no guardian binding exists", async () => {
+    mockFindVellumGuardian = mock(async () => null);
+
+    const res = await authorize(mintEdgeToken(GUARDIAN_PRINCIPAL));
+
+    expect(res!.status).toBe(403);
+  });
+
+  /**
+   * A lookup that throws leaves the answer unknown. Reporting that as
+   * "forbidden" would misread a database problem as a permission one.
+   */
+  test("answers 503 when the binding lookup fails", async () => {
+    mockFindVellumGuardian = mock(async () => {
+      throw new Error("db down");
+    });
+
+    const res = await authorize(mintEdgeToken(GUARDIAN_PRINCIPAL));
+
+    expect(res!.status).toBe(503);
+  });
+
+  test("returns 401 when no token is provided", async () => {
+    const res = await authorize();
+
+    expect(res!.status).toBe(401);
+    expect(mockFindVellumGuardian).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 for a service token, which has no actor principal", async () => {
+    const res = await authorize(mintServiceEdgeToken());
+
+    expect(res!.status).toBe(401);
+  });
+
+  test("returns 426 when the request is not a WebSocket upgrade", async () => {
+    const res = await authorizeGuardianStream(
+      new Request(`${STREAM_URL}?token=${mintEdgeToken()}`),
+      makeConfig(),
+      log,
+    );
+
+    expect(res!.status).toBe(426);
+  });
+
+  /** The dev bypass validates no token, so there is no principal to pin. */
+  test("admits an unauthenticated caller when auth is disabled", async () => {
+    const res = await authorize(
+      undefined,
+      makeConfig({ runtimeProxyRequireAuth: false }),
+    );
+
+    expect(res).toBeNull();
+    expect(mockFindVellumGuardian).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The managed path, where velay validated the browser's token and injected the
+ * caller. The attestation proves the caller is *a* platform user who traversed
+ * velay, not that they are this assistant's guardian, so it is cross-checked
+ * against the stored `platform_user_id`.
+ */
+describe("authorizeGuardianStream: the velay-attested managed path", () => {
+  const VELAY_ORG_ID = "22222222-2222-2222-2222-222222222222";
+
+  const managedAuthorize = ({
+    userId = VELAY_USER_ID,
+    actor = "user",
+    orgId = VELAY_ORG_ID as string | null,
+    bridgeProof = true,
+    token,
+    managed = true,
+    upgrade = true,
+  }: {
+    userId?: string;
+    actor?: string;
+    orgId?: string | null;
+    bridgeProof?: boolean;
+    token?: string;
+    managed?: boolean;
+    upgrade?: boolean;
+  }) => {
+    if (managed) {
+      process.env.IS_PLATFORM = "true";
+    } else {
+      delete process.env.IS_PLATFORM;
+    }
+    const headers = new Headers({
+      "x-velay-user-id": userId,
+      "x-velay-actor": actor,
+    });
+    if (upgrade) {
+      headers.set("upgrade", "websocket");
+    }
+    if (orgId !== null) {
+      headers.set("x-velay-org-id", orgId);
+    }
+    if (bridgeProof) {
+      setVelayBridgeAuthHeader(headers);
+    }
+    const query = token ? `?token=${token}` : "";
+    return authorizeGuardianStream(
+      new Request(`${STREAM_URL}${query}`, { headers }),
+      makeConfig(),
+      log,
+    );
+  };
+
+  test("admits an attested caller who is the bound guardian", async () => {
+    expect(await managedAuthorize({})).toBeNull();
+  });
+
+  test("refuses an attested caller who is not the bound guardian", async () => {
+    mockReadCredential = mock(
+      async () => "99999999-9999-9999-9999-999999999999",
+    );
+
+    const res = await managedAuthorize({});
+
+    expect(res!.status).toBe(403);
+  });
+
+  test("refuses when this assistant has no platform user stored", async () => {
+    mockReadCredential = mock(async () => undefined);
+
+    const res = await managedAuthorize({});
+
+    expect(res!.status).toBe(403);
+  });
+
+  test("answers 503 when the platform user lookup fails", async () => {
+    mockReadCredential = mock(async () => {
+      throw new Error("credential store down");
+    });
+
+    const res = await managedAuthorize({});
+
+    expect(res!.status).toBe(503);
+  });
+
+  /**
+   * A direct request to a reachable gateway can spoof the header names. It
+   * cannot know the process-local bridge proof, which is what says the request
+   * really arrived through this gateway's own loopback bridge.
+   */
+  test("ignores spoofed velay headers with no bridge proof", async () => {
+    const res = await managedAuthorize({ bridgeProof: false });
+
+    expect(res!.status).toBe(401);
+    expect(mockReadCredential).not.toHaveBeenCalled();
+  });
+
+  test("falls through to the token path on an incomplete attestation", async () => {
+    const res = await managedAuthorize({
+      orgId: null,
+      token: mintEdgeToken(GUARDIAN_PRINCIPAL),
+    });
+
+    expect(res).toBeNull();
+  });
+
+  /** Falling through must not fall past the pin. */
+  test("still pins the token path in managed mode", async () => {
+    const res = await managedAuthorize({
+      actor: "service",
+      token: mintEdgeToken("someone-else"),
+    });
+
+    expect(res!.status).toBe(403);
+  });
+
+  test("does not trust velay headers outside managed mode", async () => {
+    const res = await managedAuthorize({ managed: false });
+
+    expect(res!.status).toBe(401);
+  });
+
+  /**
+   * The managed path skips the shared gate, so the upgrade header is checked
+   * before it: a plain managed request must get 426, not a failed upgrade.
+   */
+  test("answers 426 for a plain request even when velay attests the guardian", async () => {
+    const res = await managedAuthorize({ upgrade: false });
+
+    expect(res!.status).toBe(426);
+    expect(mockReadCredential).not.toHaveBeenCalled();
+  });
+});

--- a/gateway/src/__tests__/runtime-stream-test-utils.ts
+++ b/gateway/src/__tests__/runtime-stream-test-utils.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared harness for the runtime-stream WebSocket proxies (`/v1/stt/stream`,
+ * `/v1/watch/stream`, `/v1/desktop/stream`): edge tokens, a gateway config,
+ * and a fake `Bun.Server` whose `upgrade` result is scripted.
+ */
+
+import { mock } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+
+/** The bound guardian's actor principal, which `mintEdgeToken` defaults to. */
+export const GUARDIAN_PRINCIPAL = "test-user";
+
+/** The bound guardian's platform user id, for the velay-attested path. */
+export const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
+
+initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long"));
+
+/** Mint a valid actor edge JWT. */
+export function mintEdgeToken(
+  actorPrincipalId: string = GUARDIAN_PRINCIPAL,
+): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: `actor:test-assistant:${actorPrincipalId}`,
+    scope_profile: "actor_client_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+/** Mint a service-style token (no actor principal). */
+export function mintServiceEdgeToken(): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+export function makeConfig(
+  overrides: Partial<GatewayConfig> = {},
+): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    port: 7830,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+export function makeFakeServer(upgradeResult: boolean = true) {
+  return {
+    requestIP: mock(() => ({
+      address: "127.0.0.1",
+      family: "IPv4",
+      port: 54000,
+    })),
+    upgrade: mock(() => upgradeResult),
+  } as unknown as import("bun").Server<unknown>;
+}
+
+/** The socket data the handler asked Bun to attach to the upgraded socket. */
+export function upgradedData<T>(server: import("bun").Server<unknown>): T {
+  const call = (server.upgrade as ReturnType<typeof mock>).mock
+    .calls[0] as unknown[];
+  return (call[1] as { data: T }).data;
+}

--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect, mock } from "bun:test";
-import type { GatewayConfig } from "../config.js";
-import { initSigningKey, mintToken } from "../auth/token-service.js";
-import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+import {
+  makeConfig,
+  makeFakeServer,
+  mintEdgeToken,
+  mintServiceEdgeToken,
+} from "./runtime-stream-test-utils.js";
 
 // Dictation is NOT a guardian-only surface. The binding lookup is mocked to a
 // principal that no token below matches, so any consultation of it would
@@ -19,67 +22,6 @@ mock.module("../auth/guardian-bootstrap.js", () => ({
 const { createSttStreamWebsocketHandler, getSttStreamWebsocketHandlers } =
   await import("../http/routes/stt-stream-websocket.js");
 import type { SttStreamSocketData } from "../http/routes/stt-stream-websocket.js";
-
-const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
-initSigningKey(TEST_SIGNING_KEY);
-
-/** Mint a valid actor edge JWT for STT stream auth. */
-function mintEdgeToken(actorPrincipalId: string = "test-user"): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: `actor:test-assistant:${actorPrincipalId}`,
-    scope_profile: "actor_client_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
-/** Mint a service-style token (no actor principal). */
-function mintServiceEdgeToken(): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: "svc:gateway:self",
-    scope_profile: "gateway_service_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
-function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
-    assistantRuntimeBaseUrl: "http://localhost:7821",
-    routingEntries: [],
-    port: 7830,
-    runtimeProxyRequireAuth: true,
-    shutdownDrainMs: 5000,
-    runtimeTimeoutMs: 30000,
-    runtimeMaxRetries: 2,
-    runtimeInitialBackoffMs: 500,
-    maxWebhookPayloadBytes: 1048576,
-    logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: {
-      telegram: 50 * 1024 * 1024,
-      slack: 100 * 1024 * 1024,
-      whatsapp: 16 * 1024 * 1024,
-      default: 50 * 1024 * 1024,
-    },
-    maxAttachmentConcurrency: 3,
-    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-    trustProxy: false,
-    ...overrides,
-  } as GatewayConfig;
-}
-
-function makeFakeServer(upgradeResult: boolean = true) {
-  return {
-    requestIP: mock(() => ({
-      address: "127.0.0.1",
-      family: "IPv4",
-      port: 54000,
-    })),
-    upgrade: mock(() => upgradeResult),
-  } as unknown as import("bun").Server<unknown>;
-}
 
 // ---------------------------------------------------------------------------
 // createSttStreamWebsocketHandler — upgrade handler tests

--- a/gateway/src/__tests__/watch-stream-websocket.test.ts
+++ b/gateway/src/__tests__/watch-stream-websocket.test.ts
@@ -1,123 +1,26 @@
-import { afterEach, beforeEach, describe, test, expect, mock } from "bun:test";
-import type { GatewayConfig } from "../config.js";
-import { initSigningKey, mintToken } from "../auth/token-service.js";
-import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
-import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
+import { describe, test, expect, mock } from "bun:test";
 import type { WatchStreamSocketData } from "../http/routes/watch-stream-websocket.js";
+import {
+  GUARDIAN_PRINCIPAL,
+  makeConfig,
+  makeFakeServer,
+  mintEdgeToken,
+  mintServiceEdgeToken,
+  upgradedData,
+} from "./runtime-stream-test-utils.js";
 
-/** The bound guardian's actor principal, which `mintEdgeToken` defaults to. */
-const GUARDIAN_PRINCIPAL = "test-user";
-
-/** The bound guardian's platform user id, for the velay-attested path. */
-const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
-
-// Watch is a guardian-only surface, so the upgrade pins the caller to the
-// binding. Both lookups are mocked BEFORE the module under test is imported,
-// the way `live-voice-websocket.test.ts` does it, so the pin is testable
-// without gateway DB state.
-let mockFindVellumGuardian = mock(
-  async (): Promise<{ principalId: string } | null> => ({
-    principalId: GUARDIAN_PRINCIPAL,
-  }),
-);
+// The pin itself is covered in `guardian-pin.test.ts`; the binding is mocked
+// here only so the route can be shown to wire it in.
 mock.module("../auth/guardian-bootstrap.js", () => ({
-  findVellumGuardian: () => mockFindVellumGuardian(),
-}));
-
-let mockReadCredential = mock(
-  async (_key: string): Promise<string | undefined> => VELAY_USER_ID,
-);
-mock.module("../credential-reader.js", () => ({
-  readCredential: (key: string) => mockReadCredential(key),
+  findVellumGuardian: async () => ({ principalId: GUARDIAN_PRINCIPAL }),
 }));
 
 const { createWatchStreamWebsocketHandler, getWatchStreamWebsocketHandlers } =
   await import("../http/routes/watch-stream-websocket.js");
 
-const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
-initSigningKey(TEST_SIGNING_KEY);
-
-/** Mint a valid actor edge JWT for watch stream auth. */
-function mintEdgeToken(actorPrincipalId: string = "test-user"): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: `actor:test-assistant:${actorPrincipalId}`,
-    scope_profile: "actor_client_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
-/** Mint a service-style token (no actor principal). */
-function mintServiceEdgeToken(): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: "svc:gateway:self",
-    scope_profile: "gateway_service_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
-function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
-    assistantRuntimeBaseUrl: "http://localhost:7821",
-    routingEntries: [],
-    port: 7830,
-    runtimeProxyRequireAuth: true,
-    shutdownDrainMs: 5000,
-    runtimeTimeoutMs: 30000,
-    runtimeMaxRetries: 2,
-    runtimeInitialBackoffMs: 500,
-    maxWebhookPayloadBytes: 1048576,
-    logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: {
-      telegram: 50 * 1024 * 1024,
-      slack: 100 * 1024 * 1024,
-      whatsapp: 16 * 1024 * 1024,
-      default: 50 * 1024 * 1024,
-    },
-    maxAttachmentConcurrency: 3,
-    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-    trustProxy: false,
-    ...overrides,
-  } as GatewayConfig;
-}
-
-function makeFakeServer(upgradeResult: boolean = true) {
-  return {
-    requestIP: mock(() => ({
-      address: "127.0.0.1",
-      family: "IPv4",
-      port: 54000,
-    })),
-    upgrade: mock(() => upgradeResult),
-  } as unknown as import("bun").Server<unknown>;
-}
-
-/** The socket data the handler asked Bun to attach to the upgraded socket. */
-function upgradedData(
-  server: import("bun").Server<unknown>,
-): WatchStreamSocketData {
-  const call = (server.upgrade as ReturnType<typeof mock>).mock
-    .calls[0] as unknown[];
-  return (call[1] as { data: WatchStreamSocketData }).data;
-}
-
 // ---------------------------------------------------------------------------
 // createWatchStreamWebsocketHandler: upgrade handler tests
 // ---------------------------------------------------------------------------
-
-beforeEach(() => {
-  mockFindVellumGuardian = mock(async () => ({
-    principalId: GUARDIAN_PRINCIPAL,
-  }));
-  mockReadCredential = mock(async (_key: string) => VELAY_USER_ID);
-});
-
-afterEach(() => {
-  delete process.env.IS_PLATFORM;
-});
 
 describe("createWatchStreamWebsocketHandler", () => {
   const TEST_TOKEN = mintEdgeToken();
@@ -133,7 +36,7 @@ describe("createWatchStreamWebsocketHandler", () => {
 
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
-    expect(upgradedData(server)).toMatchObject({
+    expect(upgradedData<WatchStreamSocketData>(server)).toMatchObject({
       wsType: "watch-stream",
       mimeType: "audio/pcm",
       sampleRate: 16000,
@@ -166,7 +69,7 @@ describe("createWatchStreamWebsocketHandler", () => {
     const server = makeFakeServer();
     await handler(req, server);
 
-    expect(upgradedData(server)).toMatchObject({
+    expect(upgradedData<WatchStreamSocketData>(server)).toMatchObject({
       conversationId: "conv-1",
       clientId: "host-1",
     });
@@ -186,7 +89,7 @@ describe("createWatchStreamWebsocketHandler", () => {
     const server = makeFakeServer();
     await handler(req, server);
 
-    const data = upgradedData(server);
+    const data = upgradedData<WatchStreamSocketData>(server);
     expect(data.conversationId).toBeUndefined();
     expect(data.clientId).toBeUndefined();
   });
@@ -297,193 +200,21 @@ describe("createWatchStreamWebsocketHandler", () => {
 
     expect(res!.status).toBe(400);
   });
-});
 
-// ---------------------------------------------------------------------------
-// The guardian pin
-// ---------------------------------------------------------------------------
-
-/**
- * Watch reads the owner's screen, and the daemon resolves whose screen from
- * the guardian binding rather than from the request. A non-guardian actor who
- * gets past this upgrade therefore does not observe their own screen: they
- * observe the guardian's. The proxy also replaces the caller's identity with a
- * service token upstream, so the daemon cannot tell the difference. This
- * upgrade is the only place that actor can be refused.
- */
-describe("createWatchStreamWebsocketHandler: the guardian pin", () => {
-  const upgrade = async (token: string) => {
+  /**
+   * Watch reads the owner's screen, and the proxy replaces the caller's
+   * identity upstream, so the route has to opt into the guardian pin.
+   */
+  test("refuses a non-guardian actor", async () => {
     const handler = createWatchStreamWebsocketHandler(makeConfig());
     const req = new Request(
-      `http://localhost:7830/v1/watch/stream?token=${token}&mimeType=audio/pcm`,
+      `http://localhost:7830/v1/watch/stream?token=${mintEdgeToken("someone-else")}&mimeType=audio/pcm`,
       { headers: { upgrade: "websocket" } },
     );
     const server = makeFakeServer();
-    return { res: await handler(req, server), server };
-  };
-
-  test("admits the bound guardian", async () => {
-    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
-
-    expect(res).toBeUndefined();
-    expect(server.upgrade).toHaveBeenCalledTimes(1);
-  });
-
-  /** The finding: a valid token that belongs to somebody else. */
-  test("refuses a valid actor token that is not the bound guardian", async () => {
-    const { res, server } = await upgrade(mintEdgeToken("someone-else"));
+    const res = await handler(req, server);
 
     expect(res!.status).toBe(403);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  test("refuses when no guardian binding exists", async () => {
-    mockFindVellumGuardian = mock(async () => null);
-
-    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
-
-    expect(res!.status).toBe(403);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  /**
-   * A lookup that throws leaves the answer unknown. Reporting that as
-   * "forbidden" would misread a database problem as a permission one.
-   */
-  test("answers 503 when the binding lookup fails", async () => {
-    mockFindVellumGuardian = mock(async () => {
-      throw new Error("db down");
-    });
-
-    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
-
-    expect(res!.status).toBe(503);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-});
-
-/**
- * The managed path, where velay validated the browser's token and injected the
- * caller. The attestation proves the caller is *a* platform user who traversed
- * velay, not that they are this assistant's guardian, so it is cross-checked
- * against the stored `platform_user_id`.
- */
-describe("createWatchStreamWebsocketHandler: velay-attested managed auth", () => {
-  const VELAY_ORG_ID = "22222222-2222-2222-2222-222222222222";
-
-  const managedUpgrade = async ({
-    userId = VELAY_USER_ID,
-    actor = "user",
-    orgId = VELAY_ORG_ID as string | null,
-    bridgeProof = true,
-    token,
-    managed = true,
-  }: {
-    userId?: string;
-    actor?: string;
-    orgId?: string | null;
-    bridgeProof?: boolean;
-    token?: string;
-    managed?: boolean;
-  }) => {
-    if (managed) {
-      process.env.IS_PLATFORM = "true";
-    } else {
-      delete process.env.IS_PLATFORM;
-    }
-    const headers = new Headers({
-      upgrade: "websocket",
-      "x-velay-user-id": userId,
-      "x-velay-actor": actor,
-    });
-    if (orgId !== null) {
-      headers.set("x-velay-org-id", orgId);
-    }
-    if (bridgeProof) {
-      setVelayBridgeAuthHeader(headers);
-    }
-    const handler = createWatchStreamWebsocketHandler(makeConfig());
-    const query = token ? `&token=${token}` : "";
-    const req = new Request(
-      `http://localhost:7830/v1/watch/stream?mimeType=audio/pcm${query}`,
-      { headers },
-    );
-    const server = makeFakeServer();
-    return { res: await handler(req, server), server };
-  };
-
-  test("admits an attested caller who is the bound guardian", async () => {
-    const { res, server } = await managedUpgrade({});
-
-    expect(res).toBeUndefined();
-    expect(server.upgrade).toHaveBeenCalledTimes(1);
-  });
-
-  test("refuses an attested caller who is not the bound guardian", async () => {
-    mockReadCredential = mock(
-      async () => "99999999-9999-9999-9999-999999999999",
-    );
-
-    const { res, server } = await managedUpgrade({});
-
-    expect(res!.status).toBe(403);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  test("refuses when this assistant has no platform user stored", async () => {
-    mockReadCredential = mock(async () => undefined);
-
-    const { res } = await managedUpgrade({});
-
-    expect(res!.status).toBe(403);
-  });
-
-  test("answers 503 when the platform user lookup fails", async () => {
-    mockReadCredential = mock(async () => {
-      throw new Error("credential store down");
-    });
-
-    const { res } = await managedUpgrade({});
-
-    expect(res!.status).toBe(503);
-  });
-
-  /**
-   * A direct request to a reachable gateway can spoof the header names. It
-   * cannot know the process-local bridge proof, which is what says the request
-   * really arrived through this gateway's own loopback bridge.
-   */
-  test("ignores spoofed velay headers with no bridge proof", async () => {
-    const { res, server } = await managedUpgrade({ bridgeProof: false });
-
-    expect(res!.status).toBe(401);
-    expect(server.upgrade).not.toHaveBeenCalled();
-  });
-
-  test("falls through to the token path on an incomplete attestation", async () => {
-    const { res, server } = await managedUpgrade({
-      orgId: null,
-      token: mintEdgeToken(GUARDIAN_PRINCIPAL),
-    });
-
-    expect(res).toBeUndefined();
-    expect(server.upgrade).toHaveBeenCalledTimes(1);
-  });
-
-  /** Falling through must not fall past the pin. */
-  test("still pins the token path in managed mode", async () => {
-    const { res } = await managedUpgrade({
-      actor: "service",
-      token: mintEdgeToken("someone-else"),
-    });
-
-    expect(res!.status).toBe(403);
-  });
-
-  test("does not trust velay headers outside managed mode", async () => {
-    const { res, server } = await managedUpgrade({ managed: false });
-
-    expect(res!.status).toBe(401);
     expect(server.upgrade).not.toHaveBeenCalled();
   });
 });

--- a/gateway/src/http/routes/desktop-stream-websocket.ts
+++ b/gateway/src/http/routes/desktop-stream-websocket.ts
@@ -1,23 +1,8 @@
 /**
  * `/v1/desktop/stream`: a containerized assistant's on-demand desktop, proxied
- * to the runtime as a raw RFB (VNC) byte pipe.
- *
- * The client half is a noVNC viewer in the web client; the runtime half
- * bridges the socket to the pod's loopback VNC server. Neither can reach the
- * other directly, since the runtime is unreachable from outside the private
- * network, so this is the hop that makes the feature work from a browser.
- *
- * The socket is RFB and nothing else: every frame in both directions is a
- * binary frame of RFB bytes, passed through verbatim, and there are no control
- * frames for this proxy to inspect. Errors travel as close codes, which the
- * shared pump carries from either side to the other unchanged, so the
- * runtime's `1013` (desktop busy), `1011` (desktop failed to start) and
- * `1008` (feature disabled or unsupported) reach the browser as themselves.
- *
- * Guardian-only, the way the watch stream is and for the same reason: the
- * proxy replaces the caller's identity with a service token upstream, so
- * whoever the gateway admits is who gets the pod's desktop, and this upgrade
- * is the only place a non-guardian actor can be refused.
+ * to the runtime as a raw RFB (VNC) byte pipe with close codes relayed
+ * verbatim. Guardian-only: the proxy replaces the caller's identity upstream,
+ * so this upgrade is the only place a non-guardian actor can be refused.
  */
 
 import {
@@ -34,14 +19,7 @@ export type DesktopStreamSocketData = RuntimeAudioStreamState & {
   wsType: "desktop-stream";
 };
 
-/**
- * Create the upgrade handler for `/v1/desktop/stream`.
- *
- * Authenticates the downstream caller as the bound guardian, on either the
- * managed velay-attested path or the actor edge JWT path, and dials upstream
- * with a short-lived service token. The route takes no query parameters: a
- * session starts with the upgrade and ends with the close.
- */
+/** Upgrade handler for `/v1/desktop/stream`; the route takes no parameters. */
 export function createDesktopStreamWebsocketHandler(config: GatewayConfig) {
   return async function handleUpgrade(
     req: Request,
@@ -67,10 +45,7 @@ export function createDesktopStreamWebsocketHandler(config: GatewayConfig) {
   };
 }
 
-/**
- * WebSocket handlers for Bun.serve() that pump RFB bytes between the viewer
- * and the runtime's `/v1/desktop/stream`.
- */
+/** `Bun.serve` handlers pumping RFB bytes to the runtime's `/v1/desktop/stream`. */
 export function getDesktopStreamWebsocketHandlers() {
   return createRuntimeAudioStreamHandlers<DesktopStreamSocketData>({
     upstreamPath: "/v1/desktop/stream",

--- a/gateway/src/http/routes/guardian-pin.ts
+++ b/gateway/src/http/routes/guardian-pin.ts
@@ -141,16 +141,10 @@ export async function requireBoundGuardian(
 }
 
 /**
- * The whole gate for a guardian-only runtime-stream upgrade: the managed path
- * first, then the shared actor-token gate with the pin layered on top.
- *
- * Returns null when the caller may open the socket, else the Response to send
- * instead. The managed path is taken before the token path exactly as live
- * voice takes it: velay validated the browser's token and injected the caller,
- * and the bridge proof is what says this request really came through the
- * gateway's own loopback bridge rather than from someone who guessed the
- * header names. An incomplete attestation falls through, so a managed
- * deployment still accepts a valid actor edge JWT.
+ * The whole gate for a guardian-only runtime-stream upgrade: the velay-attested
+ * managed path first, then the actor-token gate with the pin on top. Returns
+ * null when the caller may open the socket, else the Response to send. An
+ * incomplete attestation falls through, so managed still accepts an edge JWT.
  */
 export async function authorizeGuardianStream(
   req: Request,
@@ -189,9 +183,8 @@ export async function authorizeGuardianStream(
   if (!auth.ok) {
     return auth.response;
   }
-  // A null principal is the dev bypass, which validated no token and has
-  // nothing to compare. That bypass turns runtime proxy auth off wholesale,
-  // and this is not the place to reintroduce it.
+  // A null principal is the dev bypass: no token was validated, so there is
+  // nothing to compare, and the bypass is not to be reintroduced here.
   if (auth.actorPrincipalId === null) {
     return null;
   }

--- a/gateway/src/http/routes/runtime-audio-stream.ts
+++ b/gateway/src/http/routes/runtime-audio-stream.ts
@@ -3,14 +3,10 @@
  * gate that decides whether a client may open one, and the pump that carries
  * frames between that client and the runtime.
  *
- * The gateway has more than one of these. `/v1/stt/stream` carries dictation
- * audio, `/v1/watch/stream` carries a watch session's narration, and
- * `/v1/desktop/stream` carries a pod desktop's RFB bytes, and as proxies they
- * are the same object: authenticate the downstream actor, dial a fresh
- * upstream socket with a short-lived service token, and pass frames through
- * verbatim in both directions until either end goes away, each side's close
- * code carried to the other. What differs is the upstream path and which
- * query parameters travel with it, which is why those are the arguments here.
+ * Shared by `/v1/stt/stream`, `/v1/watch/stream` and `/v1/desktop/stream`:
+ * authenticate the downstream actor, dial upstream with a short-lived service
+ * token, and pass frames through verbatim both ways, each side's close code
+ * carried to the other. Only the upstream path and query parameters differ.
  *
  * **What the shared gate settles, and what it deliberately leaves open.** It
  * settles that the caller is *an* actor on this assistant: a valid edge JWT,
@@ -223,7 +219,14 @@ export function createRuntimeAudioStreamHandlers<
           typeof event.data === "string"
             ? event.data
             : new Uint8Array(event.data as ArrayBuffer);
-        ws.send(data);
+        // Bun returns 0 when the frame was dropped past its backpressure
+        // limit. A missing frame corrupts an ordered stream (RFB cannot
+        // resync), so both sides close rather than carry on silently.
+        if (ws.send(data) === 0) {
+          log.warn(context, `${label} dropped a downstream frame, closing`);
+          ws.close(1011, "Viewer too slow");
+          upstream.close(1011, "Viewer too slow");
+        }
       });
 
       upstream.addEventListener("close", (event) => {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2220,9 +2220,7 @@ async function main() {
       return undefined as unknown as Response;
     }
 
-    // Same two shapes as the watch stream, and guardian-only for the same
-    // reason: the proxy replaces the caller's identity upstream, so whoever
-    // the gateway admits is who gets the pod's desktop.
+    // Guardian-only through the same gate as the watch stream.
     if (url.pathname === "/v1/desktop/stream") {
       const upgradeResult = await handleDesktopStreamWs(req, server);
       if (upgradeResult !== undefined) {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1163,7 +1163,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Pod desktop stream WebSocket",
           description:
-            "Accepts a WebSocket upgrade for a containerized assistant's on-demand desktop. Authenticates the client using an edge JWT (the bound guardian's actor principal) and proxies frames bidirectionally to the assistant runtime's /v1/desktop/stream endpoint using a gateway service token. Every frame in both directions is a binary frame of raw RFB (VNC) bytes; there are no control frames. Errors are signaled with close codes, propagated verbatim from the runtime: 1013 desktop busy (another viewer holds the slot), 1011 desktop failed to start, 1008 feature disabled or unsupported.",
+            "Accepts a WebSocket upgrade from the bound guardian for a containerized assistant's on-demand desktop and proxies raw RFB (VNC) bytes bidirectionally to the assistant runtime's /v1/desktop/stream, relaying the runtime's close codes verbatim.",
           operationId: "desktopStreamWebsocket",
           security: [{ BearerAuth: [] }],
           parameters: [

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -31,11 +31,9 @@
  *
  *   - `^/v1/watch/stream` — exact match for the browser watch-session
  *     WebSocket, which carries a session's narration audio.
- *   - `^/v1/desktop/stream` — exact match for the browser pod-desktop
+ *   - `^/v1/desktop/stream`: exact match for the browser pod-desktop
  *     WebSocket, a raw RFB byte pipe to the pod's VNC server. Guardian-only
- *     at the gateway handler, the same shape as the watch stream: velay
- *     validates the browser's minted token on this path and injects the
- *     attested caller.
+ *     at the gateway handler, the same shape as the watch stream.
  *
  * `/v1/watch/stream` was deliberately absent until the client could use it.
  * The note that stood here argued the entry was premature on its own, and it


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for pod-desktop-streaming.md (gateway side).

- Shared pump checks the downstream `ws.send()` status: Bun returns 0 when a frame is dropped past its backpressure limit, which silently corrupts an ordered RFB stream, so both sides now close with 1011 "Viewer too slow". Covered by a new test against a real loopback upstream. The upstream direction is the WHATWG client `WebSocket`, whose `send()` returns void, so there is no equivalent signal to act on there.
- New `guardian-pin.test.ts` exercises `authorizeGuardianStream` directly (token path, velay-attested managed path, the 426 re-check ahead of the managed path, dev bypass). The desktop and watch route tests keep one "refuses a non-guardian actor" wiring test each, and the token/config/fake-server harness is hoisted into `runtime-stream-test-utils.ts` shared by the desktop, watch, and stt route tests. Net -298 lines.
- Close-code passthrough test samples 4013 (the runtime's application-range busy code) instead of 1013.
- Comment trims: desktop route header, `authorizeGuardianStream` docblock, the runtime-audio-stream header paragraph, the duplicated desktop paragraph in `index.ts`, and a one-sentence OpenAPI description. Em dash on the new `allowed-paths.ts` bullet replaced with a colon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YDF6hHcX7aPZsc6TuByhy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41957" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->