### PR TITLE
fix(cli): point channel discovery at plugin search

### DIFF
--- a/assistant/src/cli/__tests__/catalog-search-help.test.ts
+++ b/assistant/src/cli/__tests__/catalog-search-help.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { buildCliCommandHelpContent } from "../../plugins/defaults/memory/substrate/cli-command-content.js";
+import { channelsHelp } from "../commands/channels/index.help.js";
 import { pluginsHelp } from "../commands/plugins.help.js";
 import { skillsHelp } from "../commands/skills.help.js";
 
@@ -33,6 +34,8 @@ describe("catalog search help for setup-intent retrieval", () => {
     expect(indexed.toLowerCase()).toContain("before searching the web");
     expect(indexed).toContain("assistant plugins search");
     expect(indexed).toContain("assistant skills search");
+    expect(indexed.toLowerCase()).toContain("channels");
+    expect(pluginsHelp.description).toContain("channels");
     expect(indexed.toLowerCase()).not.toContain("empty query");
   });
 
@@ -46,5 +49,14 @@ describe("catalog search help for setup-intent retrieval", () => {
     expect(indexed.toLowerCase()).toContain("before searching the web");
     expect(indexed).toContain("assistant skills search");
     expect(indexed).toContain("try web search");
+  });
+
+  test("channels help points missing channels at plugin search", () => {
+    const indexed = buildCliCommandHelpContent(channelsHelp);
+    const list = channelsHelp.subcommands?.find((sub) => sub.name === "list");
+
+    expect(list?.helpText).toBeDefined();
+    expect(indexed).toContain("assistant plugins search <name>");
+    expect(indexed).toContain("not listed");
   });
 });

--- a/assistant/src/cli/commands/channels/__tests__/channels.test.ts
+++ b/assistant/src/cli/commands/channels/__tests__/channels.test.ts
@@ -89,6 +89,32 @@ describe("assistant channels", () => {
         queryParams: { includeRemote: "true" },
       });
     });
+
+    test("human list output points missing channels at plugin search", async () => {
+      mockResponses = [
+        {
+          ok: true,
+          result: { success: true, snapshots: [emptySnapshot("slack")] },
+        },
+      ];
+      const out = await runCli("channels", "list");
+      expect(out).toContain("assistant plugins search <name>");
+      expect(out).toContain("not listed");
+    });
+
+    test("json list output omits the plugin-search hint", async () => {
+      mockResponses = [
+        {
+          ok: true,
+          result: { success: true, snapshots: [emptySnapshot("slack")] },
+        },
+      ];
+      const out = await runCli("channels", "list", "--json");
+      expect(out).not.toContain("assistant plugins search");
+      expect(JSON.parse(out)).toEqual({
+        snapshots: [emptySnapshot("slack")],
+      });
+    });
   });
 
   describe("two-axis rendering", () => {

--- a/assistant/src/cli/commands/channels/index.help.ts
+++ b/assistant/src/cli/commands/channels/index.help.ts
@@ -14,6 +14,9 @@ export const KNOWN_CHANNELS = [
   "a2a",
 ] as const;
 
+export const CHANNELS_PLUGIN_SEARCH_HINT =
+  "If the channel you are looking for is not listed, search the plugin marketplace with 'assistant plugins search <name>'.";
+
 export const channelsHelp: CliCommandHelp = {
   name: "channels",
   description:
@@ -22,6 +25,9 @@ export const channelsHelp: CliCommandHelp = {
 Channels are the messaging surfaces the assistant talks over — slack,
 telegram, whatsapp, email, phone, vellum, platform, a2a. Each channel
 has a probe that reports whether it's configured and reachable.
+
+${CHANNELS_PLUGIN_SEARCH_HINT} Plugins can bundle additional channels
+from other Vellum users.
 
   list                    Overview of every channel + ready state
   get <channel>           Live snapshot of one channel (always re-probes)
@@ -45,6 +51,14 @@ Examples:
           defaultValue: false,
         },
       ],
+      helpText: `
+Shows readiness for every built-in channel.
+
+${CHANNELS_PLUGIN_SEARCH_HINT}
+
+Examples:
+  $ assistant channels list
+  $ assistant channels list --json`,
     },
     {
       name: "get",
@@ -53,7 +67,7 @@ Examples:
       arguments: [
         {
           name: "<channel>",
-          description: `Channel id: ${KNOWN_CHANNELS.join(", ")}`,
+          description: `Channel id: ${KNOWN_CHANNELS.join(", ")}. If the channel is not in this list, run 'assistant plugins search <name>'.`,
         },
       ],
       options: [

--- a/assistant/src/cli/commands/channels/index.ts
+++ b/assistant/src/cli/commands/channels/index.ts
@@ -20,7 +20,7 @@ import { applyCommandHelp, subcommand } from "../../lib/cli-command-help.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
-import { channelsHelp } from "./index.help.js";
+import { CHANNELS_PLUGIN_SEARCH_HINT, channelsHelp } from "./index.help.js";
 
 // ---------------------------------------------------------------------------
 // Snapshot shape
@@ -95,6 +95,8 @@ function renderList(snapshots: ChannelSnapshot[]): void {
   for (const s of sorted) {
     log.info(`${statusGlyph(s)} ${s.channel.padEnd(12)}  ${statusState(s)}`);
   }
+  log.info("");
+  log.info(CHANNELS_PLUGIN_SEARCH_HINT);
 }
 
 function renderSnapshot(s: ChannelSnapshot): void {
@@ -185,7 +187,9 @@ export function registerChannelsCommand(program: Command): void {
             (s) => s.channel === channel,
           );
           if (!snapshot) {
-            log.error(`No readiness probe registered for channel: ${channel}`);
+            log.error(
+              `No readiness probe registered for channel: ${channel}. If you are looking for a community channel, run 'assistant plugins search ${channel}'.`,
+            );
             process.exitCode = 1;
             return;
           }

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -10,12 +10,13 @@ import {
 
 export const pluginsHelp: CliCommandHelp = {
   name: "plugins",
-  description: "List, search, install, and manage plugins.",
+  description:
+    "Manage external plugins, which bundle apps, channels, MCPs, skills and more from other Vellum users",
   helpText: `
-Plugins are superpowers: installable extensions that add skills, tools, integrations,
-and so much more from the Vellum Community. When the user asks to set up,
-install, connect, or integrate a product, service, or app, run
-'assistant plugins search <name>' first before searching the web.`,
+Plugins are superpowers: installable extensions that add apps, channels, MCPs,
+skills, tools, integrations, and so much more from other Vellum users. When the
+user asks to set up, install, connect, or integrate a product, service, or app,
+run 'assistant plugins search <name>' first before searching the web.`,
   subcommands: [
     {
       name: "install",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

An assistant asked to "setup imessage" ran `assistant --help` and `assistant channels list`, then stopped. The top-level plugins one-liner did not mention that plugins can bundle channels, so it never ran `assistant plugins search imessage`.

This updates that one-liner and adds an explicit pointer from `assistant channels list` (help + human output) and unknown-channel `get` errors to `assistant plugins search`.

## Summary

- Rewrite the `assistant plugins` description to: "Manage external plugins, which bundle apps, channels, MCPs, skills and more from other Vellum users"
- Tell `channels list` / `channels get` readers to search the plugin marketplace when the channel they want is not in the built-in set
- Keep `--json` list output unchanged (hint is human-help only)

## Test plan

- `cd assistant && bun test src/cli/__tests__/catalog-search-help.test.ts src/cli/commands/channels/__tests__/channels.test.ts` (16 pass)
- Rendered `assistant --help` / `plugins --help` / `channels --help` / `channels list --help` / `channels get --help` from `buildCliProgramTree()`

## Risk

Low. Help text and human CLI output only. No API, persistence, or runtime channel behavior changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a4c1828-df19-4b5f-ac34-80cd3e66bea8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a4c1828-df19-4b5f-ac34-80cd3e66bea8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

