### PR TITLE
fix(web): pod desktop clipboard leak, 4xxx close codes, lazy noVNC, shared gateway WS resolver

### DIFF
--- a/clients/web/src/domains/chat/desktop/desktop-connection.test.ts
+++ b/clients/web/src/domains/chat/desktop/desktop-connection.test.ts
@@ -1,79 +1,24 @@
 /**
- * The desktop stream's transport rules: which URL each deployment kind dials,
- * which one gets refused, and what a close code means once the socket is gone.
- *
- * Nothing is `mock.module`-ed: bun shares one process across test files, so a
- * stand-in for the connection module would outlive this file. The managed
- * path's mint is intercepted at the platform client's `post`, the way
- * `live-voice/connection.test.ts` does it, so every URL asserted on below is
- * the one the app would dial.
+ * The desktop stream's close-code contract, plus one smoke test that the
+ * route resolves through the shared gateway resolver (whose routing rules are
+ * covered in `live-voice/connection.test.ts`).
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
-import {
-  PairedVoiceUnavailableError,
-  VelayWsTokenError,
-} from "@/domains/chat/voice/live-voice/connection";
-import { client } from "@/generated/api/client.gen";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 
 import {
-  buildDesktopStreamWsUrl,
   desktopEndReasonForClose,
-  desktopEndReasonForResolveError,
   resolveDesktopStreamWsUrl,
 } from "./desktop-connection";
 
-/** Bodies the mint endpoint was posted, in order. */
-let mintCalls: Array<Record<string, unknown> | undefined> = [];
-const originalPost = client.post;
-
-beforeEach(() => {
-  mintCalls = [];
-  client.post = mock(async (options: { body?: Record<string, unknown> }) => {
-    mintCalls.push(options.body);
-    return {
-      data: { token: "velay-token", expiresAt: "2099-01-01T00:00:00Z" },
-      error: null,
-      response: new Response(null, { status: 200 }),
-    };
-  }) as typeof client.post;
-  setSelfHostedConnection(null);
-});
-
 afterEach(() => {
-  client.post = originalPost;
   setSelfHostedConnection(null);
-});
-
-describe("the desktop stream URL", () => {
-  test("dials the gateway ingress with the actor token", () => {
-    const url = new URL(
-      buildDesktopStreamWsUrl({
-        ingressUrl: "https://gateway.example.com",
-        token: "actor-jwt",
-      }),
-    );
-    expect(url.protocol).toBe("wss:");
-    expect(url.pathname).toBe("/v1/desktop/stream");
-    expect(url.searchParams.get("token")).toBe("actor-jwt");
-  });
-
-  test("bypasses the local HTTP-only proxy for a direct loopback dial", () => {
-    const url = new URL(
-      buildDesktopStreamWsUrl({
-        ingressUrl: "http://localhost:3000/assistant/__gateway/8500",
-        token: "actor-jwt",
-      }),
-    );
-    expect(url.origin).toBe("ws://127.0.0.1:8500");
-    expect(url.pathname).toBe("/v1/desktop/stream");
-  });
 });
 
 describe("resolving the desktop stream URL", () => {
-  test("self-hosted: dials the ingress directly and mints nothing", async () => {
+  test("dials the desktop route on the gateway", async () => {
     setSelfHostedConnection({
       url: "http://localhost:8500",
       token: "actor-jwt",
@@ -81,70 +26,32 @@ describe("resolving the desktop stream URL", () => {
 
     const url = new URL(await resolveDesktopStreamWsUrl("asst-1"));
 
-    expect(url.protocol).toBe("ws:");
-    expect(url.host).toBe("localhost:8500");
+    expect(url.origin).toBe("ws://localhost:8500");
     expect(url.pathname).toBe("/v1/desktop/stream");
     expect(url.searchParams.get("token")).toBe("actor-jwt");
-    expect(mintCalls).toEqual([]);
-  });
-
-  test("self-hosted: refuses before the actor token is provisioned", async () => {
-    setSelfHostedConnection({ url: "http://localhost:8500", token: null });
-
-    await expect(resolveDesktopStreamWsUrl("asst-1")).rejects.toBeInstanceOf(
-      VelayWsTokenError,
-    );
-  });
-
-  test("paired: refuses outright rather than dialling an HTTP-only proxy", async () => {
-    setSelfHostedConnection({
-      url: "http://localhost:3000/assistant/__gateway-paired/asst-1",
-      token: "actor-jwt",
-    });
-
-    await expect(resolveDesktopStreamWsUrl("asst-1")).rejects.toBeInstanceOf(
-      PairedVoiceUnavailableError,
-    );
-    expect(mintCalls).toEqual([]);
-  });
-
-  test("managed: mints a velay token and dials velay with it", async () => {
-    const url = new URL(await resolveDesktopStreamWsUrl("asst-1"));
-
-    expect(mintCalls).toEqual([{ assistantId: "asst-1" }]);
-    expect(url.protocol).toBe("wss:");
-    expect(url.host).toBe("velay.vellum.ai");
-    // The `/<assistantId>` prefix selects the tunnel; velay strips it to
-    // recover the upstream path it matches its allowlist against.
-    expect(url.pathname).toBe("/asst-1/v1/desktop/stream");
-    expect(url.searchParams.get("token")).toBe("velay-token");
   });
 });
 
 describe("what a close code means", () => {
-  test("1013 is another viewer holding the slot", () => {
-    expect(desktopEndReasonForClose(1013)).toBe("busy");
+  test("4013 is another viewer holding the slot", () => {
+    expect(desktopEndReasonForClose(4013)).toBe("busy");
   });
 
-  test("1008 is an assistant with no desktop to serve", () => {
-    expect(desktopEndReasonForClose(1008)).toBe("unavailable");
+  test("4008 is an assistant with no desktop to serve", () => {
+    expect(desktopEndReasonForClose(4008)).toBe("unavailable");
   });
 
-  test("1011 is a desktop that did not start", () => {
-    expect(desktopEndReasonForClose(1011)).toBe("failed");
+  test("4011 is a desktop that did not start", () => {
+    expect(desktopEndReasonForClose(4011)).toBe("failed");
+  });
+
+  test("velay's 1013 tunnel drop is a lost connection, not a busy desktop", () => {
+    expect(desktopEndReasonForClose(1013)).toBe("lost");
   });
 
   test("anything else is a connection worth retrying", () => {
     expect(desktopEndReasonForClose(1000)).toBe("lost");
     expect(desktopEndReasonForClose(1006)).toBe("lost");
-  });
-
-  test("a paired refusal reads as unavailable, other resolve errors as failed", () => {
-    expect(
-      desktopEndReasonForResolveError(new PairedVoiceUnavailableError()),
-    ).toBe("unavailable");
-    expect(
-      desktopEndReasonForResolveError(new VelayWsTokenError(403, "refused")),
-    ).toBe("failed");
+    expect(desktopEndReasonForClose(3001)).toBe("lost");
   });
 });

--- a/clients/web/src/domains/chat/desktop/desktop-connection.ts
+++ b/clients/web/src/domains/chat/desktop/desktop-connection.ts
@@ -1,45 +1,21 @@
 /**
  * Transport for the pod desktop stream: which URL to dial, and what the
- * socket's close code means once it is gone.
- *
- * `/v1/desktop/stream` is a pure RFB byte pipe. Session start is implicit in
- * the upgrade, teardown starts when the socket closes, and the runtime speaks
- * to the client only through WebSocket close codes. There are no JSON control
- * frames on this socket: noVNC's `Websock` treats it as RFB-only and a text
- * frame would corrupt the stream.
- *
- * The URL is chosen by deployment kind exactly as watch and live voice choose
- * theirs (`watch-controller.ts`, `live-voice/connection.ts`): a self-hosted
- * assistant is dialled straight at the user's gateway ingress with the actor
- * edge JWT in `?token=`, and a managed one is dialled through velay with a
- * short-lived minted token. A paired assistant has no WebSocket transport at
- * all (its proxy is HTTP-only), so it is refused up front rather than left to
- * hang on a socket that never opens.
+ * socket's close code means once it is gone. The route is a pure RFB byte
+ * pipe with no control frames, so close codes are the runtime's only word.
  */
 
-import {
-  buildSelfHostedGatewayWsUrl,
-  buildVelayWsUrl,
-  isPairedGatewayIngress,
-  mintVelayWsToken,
-  PairedVoiceUnavailableError,
-  VelayWsTokenError,
-} from "@/domains/chat/voice/live-voice/connection";
-import {
-  getSelfHostedActorToken,
-  getSelfHostedIngressUrl,
-} from "@/lib/self-hosted/connection";
+import { resolveGatewayWsUrl } from "@/domains/chat/voice/live-voice/connection";
 
-/** The route both transports open, on the gateway either way. */
-export const DESKTOP_STREAM_ROUTE = "/v1/desktop/stream";
+const DESKTOP_STREAM_ROUTE = "/v1/desktop/stream";
 
 /**
- * Close codes the runtime uses to refuse or end a desktop session. Part of
- * the cross-service contract; the gateway relays them verbatim.
+ * Close codes the runtime uses to refuse or end a desktop session. In the
+ * application range (4000+) so they cannot collide with velay's own 1013
+ * tunnel-drop code or be remapped by the gateway's velay bridge.
  */
-export const DESKTOP_CLOSE_BUSY = 1013;
-export const DESKTOP_CLOSE_FAILED = 1011;
-export const DESKTOP_CLOSE_UNAVAILABLE = 1008;
+const DESKTOP_CLOSE_UNAVAILABLE = 4008;
+const DESKTOP_CLOSE_FAILED = 4011;
+const DESKTOP_CLOSE_BUSY = 4013;
 
 /**
  * Why a desktop session is over, as the panel explains it.
@@ -47,7 +23,7 @@ export const DESKTOP_CLOSE_UNAVAILABLE = 1008;
  * - `busy`: another viewer holds the single session slot.
  * - `unavailable`: the assistant cannot serve a desktop (flag off, not a
  *   containerized pod, or a paired deployment with no WebSocket transport).
- * - `failed`: the desktop did not start, or the handshake was refused.
+ * - `failed`: the desktop did not start, died, or the handshake was refused.
  * - `lost`: anything else, which is a connection worth retrying.
  */
 export type DesktopEndReason = "busy" | "unavailable" | "failed" | "lost";
@@ -66,71 +42,16 @@ export function desktopEndReasonForClose(code: number): DesktopEndReason {
   }
 }
 
-/** The reason a URL that could not be resolved leaves the panel with. */
-export function desktopEndReasonForResolveError(
-  err: unknown,
-): DesktopEndReason {
-  return err instanceof PairedVoiceUnavailableError ? "unavailable" : "failed";
-}
-
 /**
- * Build the self-hosted desktop stream WebSocket URL:
- *
- *   ws(s)://<ingressHost>/v1/desktop/stream?token=…
- *
- * Through the same helper as the audio streams, so every gateway WebSocket
- * the browser opens follows one idea of how to reach the gateway. Exported
- * for unit tests.
+ * Resolve the desktop stream WebSocket URL for `assistantId`. Thin wrapper
+ * over {@link resolveGatewayWsUrl} for the `/v1/desktop/stream` route.
  */
-export function buildDesktopStreamWsUrl({
-  ingressUrl,
-  token,
-}: {
-  ingressUrl: string;
-  token: string;
-}): string {
-  return buildSelfHostedGatewayWsUrl({
-    ingressUrl,
-    routePath: DESKTOP_STREAM_ROUTE,
-    token,
-  });
-}
-
-/**
- * Resolve the desktop stream WebSocket URL for `assistantId`, choosing the
- * transport by deployment kind exactly as `resolveWatchStreamWsUrl` does.
- *
- * Throws rather than returning null, so a panel that cannot resolve a URL can
- * say why:
- *
- * - {@link PairedVoiceUnavailableError} for a paired ingress, which has no
- *   WebSocket transport.
- * - {@link VelayWsTokenError} when the ingress is known but its actor token
- *   has not been provisioned yet (a brief post-hatch window), and for a mint
- *   the platform refuses.
- */
-export async function resolveDesktopStreamWsUrl(
+export function resolveDesktopStreamWsUrl(
   assistantId: string,
 ): Promise<string> {
-  const ingressUrl = getSelfHostedIngressUrl();
-  if (ingressUrl) {
-    if (isPairedGatewayIngress(ingressUrl)) {
-      throw new PairedVoiceUnavailableError();
-    }
-    const token = getSelfHostedActorToken();
-    if (!token) {
-      throw new VelayWsTokenError(
-        0,
-        "Self-hosted desktop has no actor token yet; the gateway isn't ready.",
-      );
-    }
-    return buildDesktopStreamWsUrl({ ingressUrl, token });
-  }
-
-  const { token } = await mintVelayWsToken(assistantId);
-  return buildVelayWsUrl({
+  return resolveGatewayWsUrl({
     assistantId,
     routePath: DESKTOP_STREAM_ROUTE,
-    token,
+    label: "desktop",
   });
 }

--- a/clients/web/src/domains/chat/desktop/desktop-panel.test.tsx
+++ b/clients/web/src/domains/chat/desktop/desktop-panel.test.tsx
@@ -1,13 +1,21 @@
 /**
- * The desktop panel's states, driven from the two things that can end a
- * session: the socket's close code and noVNC's own events.
+ * The desktop panel's states, driven from the things that can end a session:
+ * the socket's close code, noVNC's own events, and the connect timeout.
  *
  * noVNC is stood in for with a fake that records what the session configures
- * and lets a test raise its events; the socket is a fake handed in through the
- * session's factory seam. No real socket or display is touched.
+ * and lets a test raise its events; the global WebSocket is a fake, and the
+ * URL resolver is mocked so no transport rules run here.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import {
   act,
   cleanup,
@@ -15,8 +23,6 @@ import {
   render,
   screen,
 } from "@testing-library/react";
-
-import type { DesktopSessionOptions } from "./desktop-session";
 
 type Listener = (event: unknown) => void;
 
@@ -27,6 +33,7 @@ class FakeRFB {
   resizeSession = false;
   clipViewport = true;
   disconnectCalls = 0;
+  pasted: string[] = [];
   private listeners = new Map<string, Listener[]>();
 
   constructor(_target: HTMLElement, channel: unknown) {
@@ -38,7 +45,9 @@ class FakeRFB {
     this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
   }
 
-  clipboardPasteFrom(_text: string): void {}
+  clipboardPasteFrom(text: string): void {
+    this.pasted.push(text);
+  }
 
   disconnect(): void {
     this.disconnectCalls += 1;
@@ -54,6 +63,8 @@ class FakeRFB {
 mock.module("@novnc/novnc", () => ({ default: FakeRFB }));
 
 class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
   static instances: FakeWebSocket[] = [];
   url: string;
   binaryType = "blob";
@@ -83,19 +94,43 @@ class FakeWebSocket {
   }
 }
 
-const { DesktopPanel } = await import("./desktop-panel");
+const originalWebSocket = globalThis.WebSocket;
+globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
 
 /** The URL the resolver answers with, or an error it throws. */
 let resolved: string | Error = "ws://127.0.0.1:8500/v1/desktop/stream?token=t";
 
-const sessionOptions: DesktopSessionOptions = {
-  webSocketFactory: (url) => new FakeWebSocket(url) as unknown as WebSocket,
-  resolveWsUrl: async () => {
+const connection = await import("./desktop-connection");
+mock.module("./desktop-connection", () => ({
+  ...connection,
+  resolveDesktopStreamWsUrl: mock(async () => {
     if (resolved instanceof Error) {
       throw resolved;
     }
     return resolved;
-  },
+  }),
+}));
+
+const { DesktopPanel } = await import("./desktop-panel");
+
+// bun:test has no fake timers, so the session's connect timeout is captured
+// from a patched `setTimeout` and fired by hand.
+interface Timeout {
+  fn: () => void;
+  ms: number;
+  cleared: boolean;
+}
+let timeouts: Timeout[] = [];
+const originalSetTimeout = globalThis.setTimeout;
+const originalClearTimeout = globalThis.clearTimeout;
+
+/** The session's connect timeout, whether or not it has since been cleared. */
+const connectTimer = (): Timeout => {
+  const timer = timeouts.find((t) => t.ms === 15_000);
+  if (!timer) {
+    throw new Error("Expected the session to arm a connect timeout");
+  }
+  return timer;
 };
 
 const rfb = (): FakeRFB => {
@@ -120,7 +155,7 @@ const status = (): string | null =>
 
 /** Mount the panel and let the URL resolve, which is when noVNC attaches. */
 const mountPanel = async () => {
-  render(<DesktopPanel assistantId="asst-1" sessionOptions={sessionOptions} />);
+  render(<DesktopPanel assistantId="asst-1" />);
   await act(async () => {
     await Promise.resolve();
   });
@@ -129,10 +164,23 @@ const mountPanel = async () => {
 beforeEach(() => {
   FakeRFB.instances = [];
   FakeWebSocket.instances = [];
+  timeouts = [];
   resolved = "ws://127.0.0.1:8500/v1/desktop/stream?token=t";
+  globalThis.setTimeout = ((fn: () => void, ms?: number) => {
+    timeouts.push({ fn, ms: ms ?? 0, cleared: false });
+    return timeouts.length;
+  }) as unknown as typeof globalThis.setTimeout;
+  globalThis.clearTimeout = ((id: unknown) => {
+    const timer = typeof id === "number" ? timeouts[id - 1] : undefined;
+    if (timer) {
+      timer.cleared = true;
+    }
+  }) as typeof globalThis.clearTimeout;
 });
 
 afterEach(() => {
+  globalThis.setTimeout = originalSetTimeout;
+  globalThis.clearTimeout = originalClearTimeout;
   cleanup();
 });
 
@@ -156,10 +204,10 @@ describe("DesktopPanel", () => {
     expect(status()).toBeNull();
   });
 
-  test("1013 says another viewer has the desktop, with no reconnect", async () => {
+  test("4013 says another viewer has the desktop, with no reconnect", async () => {
     await mountPanel();
 
-    act(() => socket().serverClose(1013));
+    act(() => socket().serverClose(4013));
 
     expect(status()).toBe("busy");
     expect(
@@ -168,22 +216,32 @@ describe("DesktopPanel", () => {
     expect(screen.queryByRole("button", { name: "Reconnect" })).toBeNull();
   });
 
-  test("1008 says the assistant has no desktop, with no reconnect", async () => {
+  test("4008 says the assistant has no desktop, with no reconnect", async () => {
     await mountPanel();
 
-    act(() => socket().serverClose(1008));
+    act(() => socket().serverClose(4008));
 
     expect(status()).toBe("unavailable");
     expect(screen.queryByRole("button", { name: "Reconnect" })).toBeNull();
   });
 
-  test("1011 says the desktop could not start and offers a reconnect", async () => {
+  test("4011 says the desktop could not start and offers a reconnect", async () => {
     await mountPanel();
 
-    act(() => socket().serverClose(1011));
+    act(() => socket().serverClose(4011));
 
     expect(status()).toBe("failed");
     expect(screen.getByText("The desktop couldn't start.")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Reconnect" })).not.toBeNull();
+  });
+
+  test("velay's 1013 tunnel drop is a lost connection with a reconnect", async () => {
+    await mountPanel();
+    act(() => rfb().emit("connect"));
+
+    act(() => socket().serverClose(1013));
+
+    expect(status()).toBe("lost");
     expect(screen.getByRole("button", { name: "Reconnect" })).not.toBeNull();
   });
 
@@ -206,7 +264,7 @@ describe("DesktopPanel", () => {
     await mountPanel();
 
     act(() => {
-      socket().serverClose(1013);
+      socket().serverClose(4013);
       rfb().emit("disconnect", { clean: false });
     });
 
@@ -220,6 +278,32 @@ describe("DesktopPanel", () => {
 
     expect(status()).toBe("failed");
     expect(rfb().disconnectCalls).toBe(1);
+  });
+
+  test("a socket that never opens times out as a lost connection", async () => {
+    await mountPanel();
+
+    act(() => connectTimer().fn());
+
+    expect(status()).toBe("lost");
+    expect(rfb().disconnectCalls).toBe(1);
+    expect(screen.getByRole("button", { name: "Reconnect" })).not.toBeNull();
+  });
+
+  test("a session that connects in time disarms the timeout", async () => {
+    await mountPanel();
+
+    act(() => rfb().emit("connect"));
+
+    expect(connectTimer().cleared).toBe(true);
+  });
+
+  test("unmounting while connecting disarms the timeout", async () => {
+    await mountPanel();
+
+    cleanup();
+
+    expect(connectTimer().cleared).toBe(true);
   });
 
   test("reconnect opens a fresh session", async () => {
@@ -255,7 +339,7 @@ describe("DesktopPanel", () => {
         writeText: async (text: string) => {
           written.push(text);
         },
-        readText: async () => "",
+        readText: async () => "never read",
       },
     });
     await mountPanel();
@@ -268,6 +352,33 @@ describe("DesktopPanel", () => {
     expect(written).toEqual(["from the pod"]);
   });
 
+  test("a local copy reaches the pod; the clipboard is never read on focus", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async () => {},
+        readText: async () => "copied in another app",
+      },
+    });
+    await mountPanel();
+    const node = document.createTextNode("selected here");
+    document.body.appendChild(node);
+    document.getSelection()?.selectAllChildren(document.body);
+    const selected = document.getSelection()?.toString() ?? "";
+    expect(selected).toContain("selected here");
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(new Event("copy"));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(rfb().pasted).toEqual([selected]);
+    node.remove();
+  });
+
   test("closes the session on unmount", async () => {
     await mountPanel();
 
@@ -275,4 +386,8 @@ describe("DesktopPanel", () => {
 
     expect(rfb().disconnectCalls).toBe(1);
   });
+});
+
+afterAll(() => {
+  globalThis.WebSocket = originalWebSocket;
 });

--- a/clients/web/src/domains/chat/desktop/desktop-panel.tsx
+++ b/clients/web/src/domains/chat/desktop/desktop-panel.tsx
@@ -1,34 +1,32 @@
 import { Button } from "@vellumai/design-library";
 import { Loader2 } from "lucide-react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useTranslation } from "@/i18n";
 
+import type { DesktopEndReason } from "./desktop-connection";
 import {
   openDesktopSession,
-  type DesktopSessionOptions,
   type DesktopSessionState,
 } from "./desktop-session";
 
+/** Endings a fresh session might get past. */
+const RETRYABLE_END_REASONS: ReadonlySet<DesktopEndReason> = new Set([
+  "failed",
+  "lost",
+]);
+
 export interface DesktopPanelProps {
   assistantId: string;
-  /** Test seams, threaded through to {@link openDesktopSession}. */
-  sessionOptions?: DesktopSessionOptions;
 }
 
 /**
- * The interactive view of a pod desktop.
- *
- * Opens a session on mount and closes it on unmount; the viewport fills
- * whatever box it is given, and noVNC resizes the remote display to match.
- * Everything but a live picture is drawn over the viewport: a spinner while
- * connecting, and once the session ends, why it ended and (where retrying
- * can help) a way to reconnect.
+ * The interactive view of a pod desktop. Opens a session on mount and closes
+ * it on unmount; noVNC resizes the remote display to fit the viewport. A
+ * status overlay covers the viewport until the picture is live, and again
+ * once the session ends, with a Reconnect button where retrying can help.
  */
-export function DesktopPanel({
-  assistantId,
-  sessionOptions,
-}: DesktopPanelProps) {
+export function DesktopPanel({ assistantId }: DesktopPanelProps) {
   const { t } = useTranslation("chat");
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [state, setState] = useState<DesktopSessionState>({
@@ -36,11 +34,6 @@ export function DesktopPanel({
   });
   // Bumped by Reconnect; the effect below reopens the session on each change.
   const [attempt, setAttempt] = useState(0);
-
-  const optionsRef = useRef(sessionOptions);
-  useLayoutEffect(() => {
-    optionsRef.current = sessionOptions;
-  }, [sessionOptions]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -51,7 +44,6 @@ export function DesktopPanel({
       assistantId,
       container,
       onState: setState,
-      options: optionsRef.current,
     });
     return () => session.close();
   }, [assistantId, attempt]);
@@ -84,15 +76,9 @@ export function DesktopPanel({
           ) : (
             <>
               <span className="text-body-medium-lighter">
-                {state.reason === "busy"
-                  ? t("podDesktop.busy")
-                  : state.reason === "unavailable"
-                    ? t("podDesktop.unavailable")
-                    : state.reason === "failed"
-                      ? t("podDesktop.failed")
-                      : t("podDesktop.lost")}
+                {t(`podDesktop.${state.reason}`)}
               </span>
-              {state.reason === "failed" || state.reason === "lost" ? (
+              {RETRYABLE_END_REASONS.has(state.reason) ? (
                 <Button variant="outlined" onClick={reconnect}>
                   {t("podDesktop.reconnectButton")}
                 </Button>

--- a/clients/web/src/domains/chat/desktop/desktop-panel.tsx
+++ b/clients/web/src/domains/chat/desktop/desktop-panel.tsx
@@ -10,6 +10,14 @@ import {
   type DesktopSessionState,
 } from "./desktop-session";
 
+// Spelled out rather than templated so the catalog-usage guard sees each key.
+const END_REASON_KEY = {
+  busy: "podDesktop.busy",
+  unavailable: "podDesktop.unavailable",
+  failed: "podDesktop.failed",
+  lost: "podDesktop.lost",
+} as const satisfies Record<DesktopEndReason, string>;
+
 /** Endings a fresh session might get past. */
 const RETRYABLE_END_REASONS: ReadonlySet<DesktopEndReason> = new Set([
   "failed",
@@ -76,7 +84,7 @@ export function DesktopPanel({ assistantId }: DesktopPanelProps) {
           ) : (
             <>
               <span className="text-body-medium-lighter">
-                {t(`podDesktop.${state.reason}`)}
+                {t(END_REASON_KEY[state.reason])}
               </span>
               {RETRYABLE_END_REASONS.has(state.reason) ? (
                 <Button variant="outlined" onClick={reconnect}>

--- a/clients/web/src/domains/chat/desktop/desktop-session.ts
+++ b/clients/web/src/domains/chat/desktop/desktop-session.ts
@@ -1,50 +1,33 @@
 /**
- * One viewing session on the pod desktop: the socket, the noVNC client on
- * top of it, and the clipboard bridge between the two machines.
- *
- * **The socket is opened here, not by noVNC.** noVNC accepts a WebSocket-like
- * object in place of a URL, and that is what lets this module see the close
- * code: its own `disconnect` event carries only `{ clean }`, and the close
- * code is the runtime's only word on why a session ended (busy, unavailable,
- * failed). The close listener is registered before noVNC attaches, so it
- * runs first and the reason it reads wins over the generic `disconnect`.
- *
- * **Resize is the protocol's, not ours.** `resizeSession` makes noVNC send
- * RFB `SetDesktopSize` whenever the container changes size, which the pod's
- * X server honors natively. No control channel exists for it.
- *
- * Framework-agnostic on purpose: the panel is a thin React wrapper, and the
- * seams in {@link DesktopSessionOptions} let a test drive every ending
- * without a socket or a display.
+ * One viewing session on the pod desktop. The socket is opened here rather
+ * than by noVNC because noVNC's `disconnect` event carries only `{ clean }`
+ * and the close code is the runtime's only word on why a session ended; the
+ * close listener is registered before noVNC attaches so the coded reason wins.
  */
 
 import RFB from "@novnc/novnc";
 
+import { PairedVoiceUnavailableError } from "@/domains/chat/voice/live-voice/connection";
+
 import {
   desktopEndReasonForClose,
-  desktopEndReasonForResolveError,
   resolveDesktopStreamWsUrl,
   type DesktopEndReason,
 } from "./desktop-connection";
+
+/** Give up on a socket that has neither opened nor been refused by then. */
+const CONNECT_TIMEOUT_MS = 15_000;
 
 export type DesktopSessionState =
   | { kind: "connecting" }
   | { kind: "connected" }
   | { kind: "ended"; reason: DesktopEndReason };
 
-/** Injection seams for tests. */
-export interface DesktopSessionOptions {
-  webSocketFactory?: (url: string) => WebSocket;
-  /** Resolves the socket URL. Defaults to {@link resolveDesktopStreamWsUrl}. */
-  resolveWsUrl?: (assistantId: string) => Promise<string>;
-}
-
 export interface OpenDesktopSessionArgs {
   assistantId: string;
   /** The element noVNC renders its canvas into. */
   container: HTMLElement;
   onState: (state: DesktopSessionState) => void;
-  options?: DesktopSessionOptions;
 }
 
 export interface DesktopSession {
@@ -54,13 +37,13 @@ export interface DesktopSession {
 
 /**
  * Open a session against `assistantId`, reporting every state change through
- * `onState`. Never reports after `close()`.
+ * `onState`. The caller owns the initial "connecting" state. Never reports
+ * after `close()`.
  */
 export function openDesktopSession({
   assistantId,
   container,
   onState,
-  options = {},
 }: OpenDesktopSessionArgs): DesktopSession {
   let done = false;
   let ws: WebSocket | null = null;
@@ -95,7 +78,7 @@ export function openDesktopSession({
   const attach = (url: string): void => {
     let client: RFB;
     try {
-      ws = (options.webSocketFactory ?? ((u: string) => new WebSocket(u)))(url);
+      ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
       ws.addEventListener("close", (event) => {
         end(desktopEndReasonForClose(event.code));
@@ -110,7 +93,12 @@ export function openDesktopSession({
     client.scaleViewport = true;
     client.resizeSession = true;
     client.clipViewport = false;
+
+    const connectTimer = setTimeout(() => end("lost"), CONNECT_TIMEOUT_MS);
+    teardown.push(() => clearTimeout(connectTimer));
+
     client.addEventListener("connect", () => {
+      clearTimeout(connectTimer);
       if (!done) {
         onState({ kind: "connected" });
       }
@@ -125,8 +113,10 @@ export function openDesktopSession({
       void navigator.clipboard?.writeText(event.detail.text).catch(() => {});
     });
 
-    // Local copy: text copied anywhere in this window is offered to the pod's
-    // clipboard, so a paste on the desktop finds it.
+    // Local copy: text copied in this window is offered to the pod's
+    // clipboard. Only an explicit copy gesture reaches the pod; the clipboard
+    // is never read on its own, since anything copied elsewhere is readable
+    // by the assistant once it lands there.
     const onCopy = (): void => {
       const text = document.getSelection()?.toString();
       if (text) {
@@ -135,26 +125,9 @@ export function openDesktopSession({
     };
     window.addEventListener("copy", onCopy);
     teardown.push(() => window.removeEventListener("copy", onCopy));
-
-    // Text copied in another app reaches the pod when the window comes back
-    // into focus. Reading the clipboard needs a permission the browser may
-    // withhold; a refusal leaves the remote clipboard as it was.
-    const onFocus = (): void => {
-      void navigator.clipboard
-        ?.readText()
-        .then((text) => {
-          if (!done && text) {
-            client.clipboardPasteFrom(text);
-          }
-        })
-        .catch(() => {});
-    };
-    window.addEventListener("focus", onFocus);
-    teardown.push(() => window.removeEventListener("focus", onFocus));
   };
 
-  onState({ kind: "connecting" });
-  void (options.resolveWsUrl ?? resolveDesktopStreamWsUrl)(assistantId).then(
+  void resolveDesktopStreamWsUrl(assistantId).then(
     (url) => {
       if (!done) {
         attach(url);
@@ -162,7 +135,9 @@ export function openDesktopSession({
     },
     (err: unknown) => {
       console.warn("desktop-session: no desktop transport", err);
-      end(desktopEndReasonForResolveError(err));
+      end(
+        err instanceof PairedVoiceUnavailableError ? "unavailable" : "failed",
+      );
     },
   );
 

--- a/clients/web/src/domains/chat/desktop/pod-desktop-affordance.tsx
+++ b/clients/web/src/domains/chat/desktop/pod-desktop-affordance.tsx
@@ -1,25 +1,23 @@
 import { Button, Modal } from "@vellumai/design-library";
 import { Monitor } from "lucide-react";
-import { useState } from "react";
+import { lazy, useState } from "react";
 
+import { LazyBoundary } from "@/components/lazy-boundary";
 import { useTranslation } from "@/i18n";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
-import { DesktopPanel } from "./desktop-panel";
+// The panel pulls in noVNC, which nobody should download for a default-off
+// feature; the chunk loads the first time the modal opens.
+const DesktopPanel = lazy(() =>
+  import("./desktop-panel").then((m) => ({ default: m.DesktopPanel })),
+);
 
 /**
  * The header control that opens the pod desktop, and the modal it opens.
- *
- * Renders nothing unless the `pod-desktop` assistant flag is positively on
- * for the active assistant. The flag is served per assistant and defaults
- * off, so an assistant that cannot serve a desktop (no container, no X
- * server) never advertises one; the runtime's own gate is the backstop, and
- * its refusal reaches the panel as a close code it explains.
- *
- * The panel mounts only while the modal is open, which is what starts and
- * ends the session: Radix unmounts closed content, and the panel closes its
- * session on unmount.
+ * Renders nothing unless the per-assistant `pod-desktop` flag is positively
+ * on, since it is off wherever no desktop exists; the runtime's own refusal
+ * is the backstop. The panel mounts only while the modal is open.
  */
 export function PodDesktopAffordance() {
   const { t } = useTranslation("chat");
@@ -46,7 +44,9 @@ export function PodDesktopAffordance() {
             <Modal.Title>{t("podDesktop.title")}</Modal.Title>
           </Modal.Header>
           <Modal.Body className="min-h-0 overflow-hidden p-0">
-            <DesktopPanel assistantId={assistantId} />
+            <LazyBoundary>
+              <DesktopPanel assistantId={assistantId} />
+            </LazyBoundary>
           </Modal.Body>
         </Modal.Content>
       </Modal.Root>

--- a/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
@@ -25,6 +25,7 @@ import {
   VelayWsTokenError,
   mintVelayWsToken,
   PairedVoiceUnavailableError,
+  resolveGatewayWsUrl,
   resolveLiveVoiceWsUrl,
 } from "./connection";
 
@@ -293,6 +294,68 @@ describe("buildSelfHostedLiveVoiceWsUrl", () => {
     expect(url.hash).toBe("");
     expect(url.searchParams.get("a")).toBeNull();
     expect(url.searchParams.get("token")).toBe("actor-tok");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveGatewayWsUrl — the routing every gateway WS shares
+// ---------------------------------------------------------------------------
+
+describe("resolveGatewayWsUrl", () => {
+  const args = {
+    assistantId: "asst-1",
+    routePath: "/v1/desktop/stream",
+    label: "desktop",
+  };
+
+  test("self-hosted: dials the ingress directly and mints nothing", async () => {
+    setSelfHostedConnection({
+      url: "http://localhost:8500",
+      token: "actor-jwt",
+    });
+
+    const url = new URL(await resolveGatewayWsUrl(args));
+
+    expect(url.origin).toBe("ws://localhost:8500");
+    expect(url.pathname).toBe("/v1/desktop/stream");
+    expect(url.searchParams.get("token")).toBe("actor-jwt");
+    expect(captured).toBeNull();
+  });
+
+  test("self-hosted: refuses before the actor token is provisioned, naming the stream", async () => {
+    setSelfHostedConnection({ url: "http://localhost:8500", token: null });
+
+    await expect(resolveGatewayWsUrl(args)).rejects.toThrow(
+      /Self-hosted desktop has no actor token yet/,
+    );
+    expect(captured).toBeNull();
+  });
+
+  test("paired: refuses outright rather than dialling an HTTP-only proxy", async () => {
+    setSelfHostedConnection({
+      url: "http://localhost:3000/assistant/__gateway-paired/asst-1",
+      token: "actor-jwt",
+    });
+
+    await expect(resolveGatewayWsUrl(args)).rejects.toBeInstanceOf(
+      PairedVoiceUnavailableError,
+    );
+    expect(captured).toBeNull();
+  });
+
+  test("managed: mints a velay token and dials velay with it, params included", async () => {
+    const url = new URL(
+      await resolveGatewayWsUrl({ ...args, params: { sampleRate: "16000" } }),
+    );
+
+    expect(captured?.body).toEqual({ assistantId: "asst-1" });
+    expect(url.protocol).toBe("wss:");
+    expect(url.host).toBe("velay.vellum.ai");
+    // The `/<assistantId>` prefix selects the tunnel; velay strips it to
+    // recover the upstream path it matches its allowlist against.
+    expect(url.pathname).toBe("/asst-1/v1/desktop/stream");
+    expect(url.searchParams.get("token")).toBe("tok-abc");
+    expect(url.searchParams.get("sampleRate")).toBe("16000");
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -41,14 +41,14 @@
  * Shared with more than live voice
  * ---------------------------------------------------------------------------
  *
- * The transport pieces here are route-agnostic and have a second caller:
+ * The transport pieces here are route-agnostic: {@link resolveGatewayWsUrl},
  * {@link buildSelfHostedGatewayWsUrl}, {@link buildVelayWsUrl}, and
- * {@link mintVelayWsToken} are what a watch session dials through as well
- * (`domains/chat/watch/watch-controller.ts`). Only the `…LiveVoiceWsUrl`
- * wrappers and {@link resolveLiveVoiceWsUrl} are live voice's own. The file
- * keeps its name and its home because live voice is where the rules were
- * worked out and is still their principal user; the alternative is a second
- * module that restates them and drifts.
+ * {@link mintVelayWsToken} are what watch (`domains/chat/watch`) and the pod
+ * desktop (`domains/chat/desktop`) dial through as well. Only the
+ * `…LiveVoiceWsUrl` wrappers are live voice's own. The file keeps its name and
+ * its home because live voice is where the rules were worked out and is still
+ * their principal user; the alternative is a second module that restates them
+ * and drifts.
  */
 
 import { velayHostForPlatformHost } from "@vellumai/service-contracts/ingress";
@@ -67,6 +67,9 @@ import { assertHasResponse } from "@/utils/api-errors";
  * `VITE_VELAY_HOST` override nor the platform-host derivation applies.
  */
 const DEFAULT_VELAY_HOST = "velay.vellum.ai";
+
+/** The route both transports open, on the gateway either way. */
+const LIVE_VOICE_ROUTE = "/v1/live-voice";
 
 export class VelayWsTokenError extends Error {
   readonly status: number;
@@ -250,7 +253,7 @@ export function buildLiveVoiceWsUrl({
 }: BuildLiveVoiceWsUrlArgs): string {
   return buildVelayWsUrl({
     assistantId,
-    routePath: "/v1/live-voice",
+    routePath: LIVE_VOICE_ROUTE,
     token,
     params: conversationId ? { conversationId } : undefined,
   });
@@ -391,37 +394,44 @@ export function buildSelfHostedLiveVoiceWsUrl({
 }: BuildSelfHostedLiveVoiceWsUrlArgs): string {
   return buildSelfHostedGatewayWsUrl({
     ingressUrl,
-    routePath: "/v1/live-voice",
+    routePath: LIVE_VOICE_ROUTE,
     token,
     params: conversationId ? { conversationId } : undefined,
   });
 }
 
-export interface ResolveLiveVoiceWsUrlArgs {
+export interface ResolveGatewayWsUrlArgs {
   assistantId: string;
-  /** Optional conversation to attach the live-voice session to. */
-  conversationId?: string;
+  /** Gateway route to open, e.g. `/v1/live-voice` or `/v1/watch/stream`. */
+  routePath: string;
+  /** Names the stream in the not-ready error, e.g. `live voice`. */
+  label: string;
+  /** Extra query params to append after `token`. */
+  params?: Record<string, string>;
 }
 
 /**
- * Resolve the live-voice WebSocket URL for the current assistant, choosing the
- * transport by deployment kind (see the module doc comment):
+ * Resolve a gateway WebSocket URL for `assistantId`, choosing the transport by
+ * deployment kind (see the module doc comment). Live voice, watch, and the pod
+ * desktop all route through here.
  *
- * - **Self-hosted / local** — when {@link getSelfHostedIngressUrl} is primed,
+ * - **Self-hosted / local**: when {@link getSelfHostedIngressUrl} is primed,
  *   connect straight to the user's gateway with the actor edge JWT. No velay
  *   token-exchange happens. Throws {@link VelayWsTokenError} if the ingress is
  *   known but the actor token hasn't been provisioned yet (a brief post-hatch
  *   window), so the caller surfaces a connection failure rather than dialling an
  *   unauthenticated socket. A paired ingress throws
  *   {@link PairedVoiceUnavailableError} first: the paired proxy is HTTP-only,
- *   so no live-voice transport exists and the caller surfaces the
- *   voice-unavailable reason.
- * - **Cloud** — mint a short-lived velay WS token and build the velay URL.
+ *   so no WebSocket transport exists and the caller surfaces the
+ *   unavailable reason.
+ * - **Cloud**: mint a short-lived velay WS token and build the velay URL.
  */
-export async function resolveLiveVoiceWsUrl({
+export async function resolveGatewayWsUrl({
   assistantId,
-  conversationId,
-}: ResolveLiveVoiceWsUrlArgs): Promise<string> {
+  routePath,
+  label,
+  params,
+}: ResolveGatewayWsUrlArgs): Promise<string> {
   const ingressUrl = getSelfHostedIngressUrl();
   if (ingressUrl) {
     if (isPairedGatewayIngress(ingressUrl)) {
@@ -431,12 +441,39 @@ export async function resolveLiveVoiceWsUrl({
     if (!token) {
       throw new VelayWsTokenError(
         0,
-        "Self-hosted live voice has no actor token yet; the gateway isn't ready.",
+        `Self-hosted ${label} has no actor token yet; the gateway isn't ready.`,
       );
     }
-    return buildSelfHostedLiveVoiceWsUrl({ ingressUrl, conversationId, token });
+    return buildSelfHostedGatewayWsUrl({
+      ingressUrl,
+      routePath,
+      token,
+      params,
+    });
   }
 
   const { token } = await mintVelayWsToken(assistantId);
-  return buildLiveVoiceWsUrl({ assistantId, conversationId, token });
+  return buildVelayWsUrl({ assistantId, routePath, token, params });
+}
+
+export interface ResolveLiveVoiceWsUrlArgs {
+  assistantId: string;
+  /** Optional conversation to attach the live-voice session to. */
+  conversationId?: string;
+}
+
+/**
+ * Resolve the live-voice WebSocket URL for the current assistant. Thin wrapper
+ * over {@link resolveGatewayWsUrl} for the `/v1/live-voice` route.
+ */
+export function resolveLiveVoiceWsUrl({
+  assistantId,
+  conversationId,
+}: ResolveLiveVoiceWsUrlArgs): Promise<string> {
+  return resolveGatewayWsUrl({
+    assistantId,
+    routePath: LIVE_VOICE_ROUTE,
+    label: "live voice",
+    params: conversationId ? { conversationId } : undefined,
+  });
 }

--- a/clients/web/src/domains/chat/watch/watch-controller.ts
+++ b/clients/web/src/domains/chat/watch/watch-controller.ts
@@ -79,11 +79,7 @@ import { create } from "zustand";
 
 import {
   buildSelfHostedGatewayWsUrl,
-  buildVelayWsUrl,
-  isPairedGatewayIngress,
-  mintVelayWsToken,
-  PairedVoiceUnavailableError,
-  VelayWsTokenError,
+  resolveGatewayWsUrl,
 } from "@/domains/chat/voice/live-voice/connection";
 import {
   isLiveVoiceSessionActive,
@@ -99,10 +95,6 @@ import { LIVE_VOICE_AUDIO_FORMAT_PARAMS } from "@/domains/chat/voice/live-voice/
 import { beginWatchRetro } from "@/domains/chat/watch/watch-retro";
 import { supportsWatchRetroCompletion } from "@/lib/backwards-compat/watch-retro-completion";
 import { resolveSupportsWatchSessions } from "@/lib/backwards-compat/watch-sessions";
-import {
-  getSelfHostedActorToken,
-  getSelfHostedIngressUrl,
-} from "@/lib/self-hosted/connection";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
@@ -287,53 +279,26 @@ export function buildWatchStreamWsUrl({
 }
 
 /**
- * Resolve the watch stream WebSocket URL for `assistantId`, choosing the
- * transport by deployment kind exactly as {@link resolveLiveVoiceWsUrl} does.
+ * Resolve the watch stream WebSocket URL for `assistantId`. Thin wrapper over
+ * {@link resolveGatewayWsUrl} for the `/v1/watch/stream` route.
  *
- * - **Self-hosted / local** — dial the user's own gateway ingress with the
- *   actor edge JWT. No token is minted; the gateway validates the JWT and
- *   checks its principal against the guardian binding.
- * - **Managed / cloud** — mint a short-lived velay token and dial velay, which
- *   validates and consumes it, then injects the authenticated user and org as
- *   `X-Velay-*` headers. The gateway takes its managed branch on those and
- *   cross-checks the caller against the stored `platform_user_id`
- *   (`gateway/src/http/routes/guardian-pin.ts`), so the guardian-only rule is
- *   the same rule on both paths, proven two different ways.
+ * On the managed path velay injects the authenticated user and org as
+ * `X-Velay-*` headers; the gateway takes its managed branch on those and
+ * cross-checks the caller against the stored `platform_user_id`
+ * (`gateway/src/http/routes/guardian-pin.ts`). On the self-hosted path it
+ * validates the actor JWT against the guardian binding instead, so the
+ * guardian-only rule is the same rule on both paths, proven two ways.
  *
- * Throws rather than returning null, so a start that cannot resolve a URL is
- * distinguishable from one this environment simply does not support:
- *
- * - {@link PairedVoiceUnavailableError} for a paired ingress, whose proxy is
- *   HTTP-only with no loopback to fall back to. Still genuinely unsupported.
- * - {@link VelayWsTokenError} when the ingress is known but its actor token
- *   has not been provisioned yet (a brief post-hatch window), and for a mint
- *   that the platform refuses.
- *
- * Exported for unit tests.
+ * Throws `PairedVoiceUnavailableError` for a paired ingress and
+ * `VelayWsTokenError` for a missing actor token or a refused mint, so a
+ * start that cannot resolve a URL is distinguishable from one this
+ * environment simply does not support. Exported for unit tests.
  */
-export async function resolveWatchStreamWsUrl(
-  assistantId: string,
-): Promise<string> {
-  const ingressUrl = getSelfHostedIngressUrl();
-  if (ingressUrl) {
-    if (isPairedGatewayIngress(ingressUrl)) {
-      throw new PairedVoiceUnavailableError();
-    }
-    const token = getSelfHostedActorToken();
-    if (!token) {
-      throw new VelayWsTokenError(
-        0,
-        "Self-hosted watch has no actor token yet; the gateway isn't ready.",
-      );
-    }
-    return buildWatchStreamWsUrl({ ingressUrl, token });
-  }
-
-  const { token } = await mintVelayWsToken(assistantId);
-  return buildVelayWsUrl({
+export function resolveWatchStreamWsUrl(assistantId: string): Promise<string> {
+  return resolveGatewayWsUrl({
     assistantId,
     routePath: WATCH_STREAM_ROUTE,
-    token,
+    label: "watch",
     params: LIVE_VOICE_AUDIO_FORMAT_PARAMS,
   });
 }

--- a/clients/web/src/generated
+++ b/clients/web/src/generated
@@ -1,0 +1,1 @@
+/Users/maddieabboud/projects/vellum-assistant/clients/web/src/generated

--- a/clients/web/src/generated
+++ b/clients/web/src/generated
@@ -1,1 +1,0 @@
-/Users/maddieabboud/projects/vellum-assistant/clients/web/src/generated

--- a/clients/web/src/types/novnc.d.ts
+++ b/clients/web/src/types/novnc.d.ts
@@ -1,20 +1,12 @@
 /**
- * Ambient types for `@novnc/novnc`, which ships no declarations.
- *
- * Covers only the surface `domains/chat/desktop/desktop-session.ts` uses. The
- * package's `exports` field maps the bare specifier to `core/rfb.js`, so the
- * class is the default export of `@novnc/novnc` itself.
+ * Ambient types for `@novnc/novnc`, which ships no declarations. Covers only
+ * the surface `domains/chat/desktop/desktop-session.ts` uses. The package's
+ * `exports` field maps the bare specifier to `core/rfb.js`, so the class is
+ * the default export of `@novnc/novnc` itself.
  *
  * Reference: https://github.com/novnc/noVNC/blob/master/docs/API.md
  */
 declare module "@novnc/novnc" {
-  export interface RFBOptions {
-    shared?: boolean;
-    credentials?: { username?: string; password?: string; target?: string };
-    repeaterID?: string;
-    wsProtocols?: string[];
-  }
-
   export interface RFBEventMap {
     connect: CustomEvent<Record<string, never>>;
     disconnect: CustomEvent<{ clean: boolean }>;
@@ -23,24 +15,13 @@ declare module "@novnc/novnc" {
   }
 
   export default class RFB {
-    constructor(
-      target: HTMLElement,
-      urlOrChannel: string | WebSocket,
-      options?: RFBOptions,
-    );
+    constructor(target: HTMLElement, urlOrChannel: string | WebSocket);
     scaleViewport: boolean;
     resizeSession: boolean;
     clipViewport: boolean;
-    viewOnly: boolean;
-    focusOnClick: boolean;
     clipboardPasteFrom(text: string): void;
     disconnect(): void;
-    focus(): void;
     addEventListener<K extends keyof RFBEventMap>(
-      type: K,
-      listener: (event: RFBEventMap[K]) => void,
-    ): void;
-    removeEventListener<K extends keyof RFBEventMap>(
       type: K,
       listener: (event: RFBEventMap[K]) => void,
     ): void;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for pod-desktop-streaming.md (web side).

- Clipboard leak: the window `focus` listener that read `navigator.clipboard` and pushed it into the pod is gone. Only an explicit in-app `copy` reaches the pod; remote `clipboard` events still mirror to the browser. Test asserts a focus never pastes.
- Close codes move to the application range: 4013 busy (terminal), 4008 unavailable (terminal), 4011 failed (Reconnect), everything else lost (Reconnect). velay's 1013 tunnel drop now reads as lost with a Reconnect instead of busy.
- Lazy noVNC: `PodDesktopAffordance` loads `DesktopPanel` via `React.lazy` inside `LazyBoundary`, so the VNC client leaves the main bundle.
- 15s connect timeout in `openDesktopSession`; a socket that never opens ends as lost with a Reconnect. Tested with a patched `setTimeout`/`clearTimeout` (bun:test has no fake timers).
- One shared `resolveGatewayWsUrl({ assistantId, routePath, label, params })` in `live-voice/connection.ts`; live voice, watch, and desktop are thin wrappers. `buildDesktopStreamWsUrl` deleted. The four routing cases now test the shared helper; desktop keeps one smoke test.
- `novnc.d.ts` trimmed to the surface the session uses.
- `DesktopPanel` no longer takes `sessionOptions`; the panel test mocks `./desktop-connection` and `globalThis.WebSocket` with `mock.module`.
- Simplifications: session no longer emits a synchronous connecting state, reason copy via `t(\`podDesktop.${reason}\`)`, retryable reasons in one set, resolve-error mapping inlined, module-private constants, headers cut to the WHY.

Close-code contract: 4013 busy / 4008 unavailable / 4011 failed (reconnectable) / anything else lost (reconnectable); assistant side lands in a sibling PR.

## Verification
- `bun test` on desktop-connection, desktop-panel, live-voice/connection, watch-controller: all green.
- `tsc --noEmit` reports nothing in touched files; remaining errors are pre-existing in untouched files (stale `@vellumai/ipc-contract` via the worktree's node_modules symlink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YDF6hHcX7aPZsc6TuByhy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->