### PR TITLE
docs(feature-flags): describe the presence flags as they actually behave

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -370,7 +370,7 @@
       "scope": "assistant",
       "key": "desktop-presence-suppression",
       "label": "Desktop Presence Suppression",
-      "description": "Gates whether a `chat.assistant_reply` push is suppressed while a Mac desktop client reports itself attended. On by default; turn it off to restore unconditional reply pushes.",
+      "description": "Gates whether a `chat.assistant_reply` push is suppressed while a macOS or Windows desktop client reports itself attended. On by default; turn it off to restore unconditional reply pushes.",
       "defaultEnabled": true
     },
     {
@@ -378,7 +378,7 @@
       "scope": "assistant",
       "key": "web-presence-suppression",
       "label": "Web Presence Suppression",
-      "description": "Gates whether a `chat.assistant_reply` push is suppressed while a browser tab reports itself visible on that conversation. On by default; turn it off to restore unconditional reply pushes for web-visible conversations.",
+      "description": "Gates whether a `chat.assistant_reply` push is suppressed while a browser tab or desktop app window reports itself visible on that conversation. On by default; turn it off to restore unconditional reply pushes for web-visible conversations.",
       "defaultEnabled": true
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -370,7 +370,7 @@
       "scope": "assistant",
       "key": "desktop-presence-suppression",
       "label": "Desktop Presence Suppression",
-      "description": "Gates whether a `chat.assistant_reply` push is suppressed while a Mac desktop client reports itself attended. On by default; turn it off to restore unconditional reply pushes.",
+      "description": "Gates whether a `chat.assistant_reply` push is suppressed while a macOS or Windows desktop client reports itself attended. On by default; turn it off to restore unconditional reply pushes.",
       "defaultEnabled": true
     },
     {
@@ -378,7 +378,7 @@
       "scope": "assistant",
       "key": "web-presence-suppression",
       "label": "Web Presence Suppression",
-      "description": "Gates whether a `chat.assistant_reply` push is suppressed while a browser tab reports itself visible on that conversation. On by default; turn it off to restore unconditional reply pushes for web-visible conversations.",
+      "description": "Gates whether a `chat.assistant_reply` push is suppressed while a browser tab or desktop app window reports itself visible on that conversation. On by default; turn it off to restore unconditional reply pushes for web-visible conversations.",
       "defaultEnabled": true
     },
     {


### PR DESCRIPTION
## Summary

- `desktop-presence-suppression`: the gate covers `DESKTOP_INTERFACES = ["macos", "windows"]` since PR #41076, so the description now says "a macOS or Windows desktop client" instead of "a Mac desktop client".
- `web-presence-suppression`: the Electron renderer reports conversation-scoped presence by the end of this feature branch, so the description now says "a browser tab or desktop app window".
- Description strings only; `id`, `key`, and `defaultEnabled` untouched. Bundled registry copies re-synced with `bun run meta/sync-bundled-copies.ts`.

Part of plan: watched-activity-suppression.md (PR 4 of 14)