### PR TITLE
feat(ipc): add a window-attention channel so the renderer can learn it is off screen

### DIFF
--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -144,6 +144,9 @@ export const CONNECTIVITY_RETRY = "vellum:connectivity:retry";
 export const NOTIFICATIONS_SHOW = "vellum:notifications:show";
 export const NOTIFICATIONS_ACTION = "vellum:notifications:action";
 
+// Window attention
+export const WINDOW_ATTENTION = "vellum:window:attention";
+
 // Bundle confirm
 export const BUNDLE_CONFIRM_GET_DATA = "vellum:bundleConfirm:getData";
 export const BUNDLE_CONFIRM_RESPOND = "vellum:bundleConfirm:respond";

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -2,10 +2,10 @@
  * Zod schemas for IPC payload types that main validates at the channel
  * boundary.
  *
- * Only types that flow renderer→main and are `.parse()`d / `.safeParse()`d
- * in a `handle()` or `on()` registration have schemas here. Types that
- * flow main→renderer (commands, hotkey catalogs, power events, etc.) are
- * plain TypeScript types in `./types.ts` — the renderer trusts main.
+ * Types that flow renderer→main and are `.parse()`d / `.safeParse()`d in a
+ * `handle()` or `on()` registration have schemas here. Most types that flow
+ * main→renderer (commands, hotkey catalogs, power events, etc.) are plain
+ * TypeScript types in `./types.ts`; the renderer trusts main.
  *
  * Consumers:
  *   - Main: `import { assistantStatusSchema } from "@vellumai/ipc-contract"`
@@ -42,6 +42,16 @@ export const showNotificationPayloadSchema = z.object({
   conversationId: z.string().optional(),
   toolCallId: z.string().optional(),
   deepLinkMetadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Window attention
+// ---------------------------------------------------------------------------
+
+export const windowAttentionPayloadSchema = z.object({
+  visible: z.boolean(),
+  focused: z.boolean(),
+  minimized: z.boolean(),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -606,6 +606,21 @@ export interface NotificationActionEvent {
 }
 
 // ---------------------------------------------------------------------------
+// Window attention
+// ---------------------------------------------------------------------------
+
+/**
+ * Main → renderer: authoritative main-window state. Kept as three
+ * independent booleans so consumers pick their own strictness without
+ * another contract change.
+ */
+export interface WindowAttentionPayload {
+  visible: boolean;
+  focused: boolean;
+  minimized: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // Bundles
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `WINDOW_ATTENTION` (`vellum:window:attention`), `WindowAttentionPayload` (`visible` / `focused` / `minimized`), and `windowAttentionPayloadSchema` to `@vellumai/ipc-contract`, alongside their notification equivalents. All three surface through the existing `export *` barrel.
- `backgroundThrottling: false` on every Vellum Electron window disables the Page Visibility API, so the renderer cannot tell it is off screen. Only the main process can, and this is the contract it will publish over.
- Contract only: no consumer imports these yet, so this PR changes no behavior. `bunx tsc --noEmit` passes in `packages/ipc-contract`.

Part of plan: watched-activity-suppression.md (PR 1 of 14)