### PR TITLE
refactor(windows): export isVisibleAndFocused for parity with macOS

### DIFF
--- a/clients/windows/src/main/main-window.test.ts
+++ b/clients/windows/src/main/main-window.test.ts
@@ -224,6 +224,8 @@ const {
   dispatchToMain,
   ensureVisible,
   installMainWindow,
+  isVisibleAndFocused,
+  toggleVisibility,
 } = await import("./main-window");
 
 const destroyWindows = (): void => {
@@ -503,6 +505,58 @@ describe("Windows main window", () => {
     // THEN the overlay keeps its colors, and none are persisted
     expect(constructed[0]?.setTitleBarOverlay).not.toHaveBeenCalled();
     expect(writeTitleBarOverlayThemeMock).not.toHaveBeenCalled();
+  });
+
+  test("reports attention only when a live window is visible and focused", () => {
+    // GIVEN no window yet
+    expect(isVisibleAndFocused()).toBe(false);
+
+    void ensureVisible();
+    const win = constructed[0];
+    if (!win) {
+      throw new Error("expected a window");
+    }
+    win.emit("ready-to-show");
+
+    // THEN a shown and focused window counts as attended
+    expect(isVisibleAndFocused()).toBe(true);
+
+    win.state.focused = false;
+    expect(isVisibleAndFocused()).toBe(false);
+
+    win.state.focused = true;
+    win.state.visible = false;
+    expect(isVisibleAndFocused()).toBe(false);
+
+    win.state.visible = true;
+    win.state.destroyed = true;
+    expect(isVisibleAndFocused()).toBe(false);
+
+    win.emit("closed");
+    expect(isVisibleAndFocused()).toBe(false);
+  });
+
+  test("toggles a visible focused window to hidden and back", () => {
+    void ensureVisible();
+    const win = constructed[0];
+    if (!win) {
+      throw new Error("expected a window");
+    }
+    win.emit("ready-to-show");
+
+    // WHEN the window has the user's attention
+    toggleVisibility();
+
+    // THEN it hides
+    expect(win.hide).toHaveBeenCalledTimes(1);
+    expect(win.state.visible).toBe(false);
+
+    // WHEN it is off screen
+    toggleVisibility();
+
+    // THEN it comes back rather than hiding again
+    expect(win.hide).toHaveBeenCalledTimes(1);
+    expect(win.state.visible).toBe(true);
   });
 
   test("hides on close and allows close while quitting", () => {

--- a/clients/windows/src/main/main-window.ts
+++ b/clients/windows/src/main/main-window.ts
@@ -149,10 +149,14 @@ export const dispatchToMain = (command: VellumCommand): void => {
   }
 };
 
-export const toggleVisibility = (): void => {
+export const isVisibleAndFocused = (): boolean => {
   const win = current();
-  if (win && !win.isDestroyed() && win.isVisible() && win.isFocused()) {
-    win.hide();
+  return !!win && !win.isDestroyed() && win.isVisible() && win.isFocused();
+};
+
+export const toggleVisibility = (): void => {
+  if (isVisibleAndFocused()) {
+    current()?.hide();
     return;
   }
   ensureVisible();


### PR DESCRIPTION
## Summary

- Extract the inlined `!destroyed && visible && focused` predicate from `toggleVisibility` in the Windows main window into an exported `isVisibleAndFocused()`, mirroring the macOS main window's export of the same name and signature.
- `toggleVisibility` now calls it; behavior is unchanged.
- Add coverage for every branch (no window, destroyed-but-referenced, released, not visible, not focused, all-true) plus a toggle round trip.

Part of plan: watched-activity-suppression.md (PR 3 of 14)