### PR TITLE
fix(channels): a reaction-only turn posts no reply (LUM-3520)

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 
+import { REACTION_MESSAGE_KIND } from "../persistence/conversation-types.js";
 import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
 import type { RuntimeAttachmentMetadata } from "../runtime/http-types.js";
 
@@ -148,6 +149,19 @@ mock.module("../persistence/conversation-crud.js", () => ({
   },
   getMessageById: (messageId: string) =>
     conversationMessages.find((m) => m.id === messageId) ?? null,
+  // Stands in for the schema-validated parse. The delivery reader pairs it
+  // with the real `isReactionMessageMetadata`, so the marker the assertions
+  // turn on is still the production predicate reading a production-shaped row.
+  parseMessageMetadata: (metadataJson: string | null) => {
+    if (!metadataJson) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(metadataJson) as Record<string, unknown>;
+    } catch {
+      return undefined;
+    }
+  },
   updateMessageMetadata: (
     messageId: string,
     updates: Record<string, unknown>,
@@ -189,9 +203,24 @@ mock.module("../persistence/attachments-store.js", () => ({
   getFilePathForAttachment: () => null,
 }));
 
+/**
+ * Renders keyed by a row's raw string content, consulted ahead of the queue.
+ * The queue and the shared default are argument-blind, so a suite that mixes
+ * rows in one scan cannot otherwise tell them apart, and a row the code under
+ * test is supposed to skip would still render as its neighbour.
+ */
+const renderedHistoryContentByContent = new Map<string, RenderedHistoryStub>();
+
 mock.module("../daemon/handlers/shared.js", () => ({
-  renderHistoryContent: () =>
-    renderedHistoryContentQueue.shift() ?? renderedHistoryContent,
+  renderHistoryContent: (content: unknown) => {
+    if (typeof content === "string") {
+      const keyed = renderedHistoryContentByContent.get(content);
+      if (keyed) {
+        return keyed;
+      }
+    }
+    return renderedHistoryContentQueue.shift() ?? renderedHistoryContent;
+  },
 }));
 
 const {
@@ -210,6 +239,7 @@ describe("channel-reply-delivery", () => {
     metadataWriteFailuresRemaining = 0;
     nextDeliveryTs = null;
     renderedHistoryContentQueue.length = 0;
+    renderedHistoryContentByContent.clear();
     renderedHistoryContent = {
       text: "",
       textSegments: [],
@@ -262,6 +292,129 @@ describe("channel-reply-delivery", () => {
     expect(findAssistantReplyMessageIdForTurn("conv-1", "user-target")).toBe(
       "assistant-target",
     );
+  });
+
+  describe("reaction rows are never a turn's reply", () => {
+    /** The body `persistReactionRecords` stores; never channel-visible text. */
+    const SENTINEL = "[reaction]";
+
+    const stubFor = (text: string): RenderedHistoryStub => ({
+      text,
+      textSegments: [text],
+      toolCalls: [],
+      toolCallsBeforeText: false,
+      contentOrder: ["text:0"],
+      surfaces: [],
+      thinkingSegments: [],
+    });
+
+    /**
+     * The row `persistReactionRecords` writes at the turn boundary, rendering
+     * as the stored sentinel exactly as the real renderer would. Read
+     * literally that text is what reaches the channel, so these tests fail on
+     * a guard that only stops short of the delivery call.
+     */
+    const reactionRow = (id: string): MockMessageRow => {
+      renderedHistoryContentByContent.set(SENTINEL, stubFor(SENTINEL));
+      return {
+        id,
+        role: "assistant",
+        content: SENTINEL,
+        metadata: JSON.stringify({
+          messageKind: REACTION_MESSAGE_KIND,
+          provenanceSourceChannel: "slack",
+        }),
+      };
+    };
+
+    /** How the turn's one non-reaction assistant row renders. */
+    const renderAs = (text: string): void => {
+      renderedHistoryContent = stubFor(text);
+    };
+
+    it("resolves a reaction-only turn to its silence marker, not the sentinel row", () => {
+      conversationMessages.push(
+        { id: "user-target", role: "user", content: "target" },
+        {
+          id: "assistant-silence",
+          role: "assistant",
+          content: "<no_response/>",
+        },
+        // Drained after the turn's own rows, so it is the newest row and the
+        // one a newest-first scan reaches first.
+        reactionRow("assistant-reaction"),
+      );
+      renderAs("<no_response/>");
+
+      expect(findAssistantReplyMessageIdForTurn("conv-1", "user-target")).toBe(
+        "assistant-silence",
+      );
+    });
+
+    it("posts nothing at all for a reaction-only turn", async () => {
+      conversationMessages.push(
+        { id: "user-target", role: "user", content: "target" },
+        {
+          id: "assistant-silence",
+          role: "assistant",
+          content: "<no_response/>",
+        },
+        reactionRow("assistant-reaction"),
+      );
+      renderAs("<no_response/>");
+
+      await deliverReplyViaCallback(
+        "conv-1",
+        "chat-1",
+        "http://gateway/deliver/slack",
+        "assistant-1",
+        { messageId: "assistant-silence", sinceMessageId: "user-target" },
+      );
+
+      expect(deliveryCalls).toEqual([]);
+    });
+
+    it("delivers the turn's real reply when a reaction row is newer than it", async () => {
+      conversationMessages.push(
+        { id: "user-target", role: "user", content: "target" },
+        { id: "assistant-real", role: "assistant", content: "real reply" },
+        reactionRow("assistant-reaction"),
+      );
+      renderAs("Done.");
+
+      await deliverReplyViaCallback(
+        "conv-1",
+        "chat-1",
+        "http://gateway/deliver/slack",
+        "assistant-1",
+        { sinceMessageId: "user-target" },
+      );
+
+      expect(deliveryCalls).toHaveLength(1);
+      expect(deliveryCalls[0].payload.text).toBe("Done.");
+    });
+
+    it("falls through to the real reply when the stored reply id names a reaction row", async () => {
+      // The retry sweep persists whatever the turn scan returned, so a reply
+      // id latched before this guard existed still points at a reaction row.
+      conversationMessages.push(
+        { id: "user-target", role: "user", content: "target" },
+        { id: "assistant-real", role: "assistant", content: "real reply" },
+        reactionRow("assistant-reaction"),
+      );
+      renderAs("Done.");
+
+      await deliverReplyViaCallback(
+        "conv-1",
+        "chat-1",
+        "http://gateway/deliver/slack",
+        "assistant-1",
+        { messageId: "assistant-reaction", sinceMessageId: "user-target" },
+      );
+
+      expect(deliveryCalls).toHaveLength(1);
+      expect(deliveryCalls[0].payload.text).toBe("Done.");
+    });
   });
 
   it("sends non-empty text segments as separate messages and puts attachments on the last segment", async () => {

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -11,8 +11,10 @@ import { getAttachmentMetadataForMessage } from "../persistence/attachments-stor
 import {
   getMessageById,
   getMessages,
+  parseMessageMetadata,
   updateMessageMetadata,
 } from "../persistence/conversation-crud.js";
+import { isReactionMessageMetadata } from "../persistence/conversation-types.js";
 import { recordOutboundPost } from "../persistence/delivery-crud.js";
 import { getLogger } from "../util/logger.js";
 import { withSqliteRetry } from "../util/sqlite-retry.js";
@@ -294,10 +296,48 @@ export type DeliverReplyOptions = {
 
 type PersistedMessage = ReturnType<typeof getMessages>[number];
 
+/**
+ * A row read that contributes nothing to deliver. Spelled out rather than
+ * rendered from empty content so the read stays independent of the renderer;
+ * the annotation is what keeps it complete as the shape grows.
+ */
+const NO_REPLY_CONTENT: RenderedHistoryContent = {
+  text: "",
+  toolCalls: [],
+  toolCallsBeforeText: false,
+  textSegments: [],
+  contentOrder: [],
+  surfaces: [],
+  thinkingSegments: [],
+  attachments: [],
+  contentBlocks: [],
+};
+
+/**
+ * Read a persisted assistant row as a candidate channel reply.
+ *
+ * A reaction row reads as empty on purpose. Its `"[reaction]"` body is a
+ * storage sentinel for an emoji the react tool already delivered to the
+ * channel, not speech the turn owes anyone, and the row is drained at the
+ * turn boundary, so it is the newest assistant row of any turn that
+ * reacted. Read literally, its non-empty text counts as a real deliverable
+ * reply and outranks the turn's actual reply (or its `<no_response/>`
+ * silence) in every newest-first scan below, posting the raw sentinel to the
+ * channel as visible text. Reading it as empty is what makes a reaction-only
+ * turn silent, and it is the one seam every delivery path shares: the turn
+ * scan, the unbounded fallback sweep, and the targeted `messageId` path,
+ * which needs it too because the sweep durably stores whatever the scan
+ * returns. The history renderers project these rows as a structured reaction
+ * fact for the same reason; delivery owes the channel nothing for them.
+ */
 function readPersistedAssistantReply(msg: PersistedMessage): {
   rendered: RenderedHistoryContent;
   replyAttachments: RuntimeAttachmentMetadata[];
 } {
+  if (isReactionMessageMetadata(parseMessageMetadata(msg.metadata))) {
+    return { rendered: NO_REPLY_CONTENT, replyAttachments: [] };
+  }
+
   const parsed: unknown = msg.content;
   const rendered = renderHistoryContent(parsed);
 


### PR DESCRIPTION
## TL;DR

A Slack turn whose entire reply was a reaction posted a standalone message reading `[reaction]` into the thread, on top of the reaction itself landing correctly. Reaction rows are now read as carrying nothing to deliver, so a reaction-only turn is silent on the channel.

Fixes LUM-3520.

## What was happening

`react_to_message` queues a reaction record; the agent loop drains it at the turn boundary into an assistant row whose body is the `"[reaction]"` storage sentinel. Because the drain runs after the turn's own rows settle, that row is the **newest** assistant row of any turn that reacted, and every delivery scan reads newest-first.

`readPersistedAssistantReply` rendered the row literally, so its non-empty text counted as a real deliverable reply and outranked the turn's bare `<no_response/>` row. The selected row's text was then delivered verbatim.

The transcript renderers already guard against this (they project these rows as a structured reaction fact instead of rendering the stored text). Channel delivery was the path missing the same invariant.

## Before / after

| Turn | Before | After |
| --- | --- | --- |
| Assistant reacts, says nothing | Reaction lands, **plus** a message reading `[reaction]` posted to the thread | Reaction lands, nothing posted |
| Assistant reacts and replies | Real reply delivered (the targeted reply id short-circuits the scan) | Unchanged |
| Retry of a turn whose stored reply id names a reaction row | Re-posts `[reaction]` on every retry | Falls through to the turn's real reply, or to silence |

## Why it is safe

The guard is one seam, in the single function all three delivery paths already funnel their row reads through: the turn scan, the unbounded fallback sweep, and the targeted `messageId` path. A reaction row reads as empty, so it is skipped as a reply candidate and the scan continues to the turn's real reply or its `<no_response/>` silence marker, which delivers as deliberate silence exactly as it does today.

The targeted `messageId` path needed it too, and not only defensively: the retry sweep persists whatever the turn scan returned (`storeReplyMessageId`), so a reply id latched before this fix can already name a reaction row. Without the guard there, such an event would keep posting the sentinel on every retry.

The predicate is the canonical `isReactionMessageMetadata` on the row's `messageKind`, not a text match on the sentinel body, so it cannot catch a real reply that happens to contain that string. Only assistant rows are scanned, and inbound reaction rows are role `user`, so they were never in scope.

The empty value is a typed `RenderedHistoryContent` constant rather than a render of empty content, which keeps the read independent of the renderer; the annotation makes the compiler enforce it stays complete as that shape grows.

## Tests

Four regression tests, each verified to fail without the guard. The reaction row renders as its real `[reaction]` sentinel in the fixture, so the tests fail on the delivered text, not merely on row selection: the reaction-only case fails with `"text": "[reaction]"` in the delivery call, reproducing the reported symptom exactly.

Making that possible needed one test-scaffolding fix: the suite's `renderHistoryContent` mock ignored its argument, so every row in a scan rendered identically and a row the code is supposed to skip still rendered as its neighbour. It now keys off the row's content, which is what lets these tests discriminate at all. Three of the four passed against the unfixed code until that was corrected.

Suites run per-file and green: `channel-reply-delivery`, `channel-retry-sweep`, `outbound-slack-persistence`, `conversation-runtime-assembly`, `background-dispatch`, `react-to-message`, `reaction-intercept`, `reaction-persistence`, `conversation-agent-loop`, plus the remaining reaction-touching suites.

## Not done here

- The ticket suggested checking the unbounded fallback sweep for the same gap. It shares `readPersistedAssistantReply`, so this fix covers it; no separate change was needed.
- Events whose stored reply id already names a reaction row are handled at read time by the targeted-path fallback above rather than backfilled. A data migration would touch delivery rows for no behavioural gain, since the read path now recovers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->