### PR TITLE
refactor(contracts): single-source the desktop presence state union

### DIFF
--- a/assistant/src/runtime/assistant-event-hub.ts
+++ b/assistant/src/runtime/assistant-event-hub.ts
@@ -12,8 +12,15 @@
  * Client-oriented queries (list, find-by-capability) are methods on the hub.
  */
 
+import {
+  DESKTOP_PRESENCE_STATES,
+  type DesktopPresenceState,
+} from "@vellumai/service-contracts/desktop-presence";
+
 import type { AssistantEvent } from "../api/index.js";
 import type { HostProxyCapability, InterfaceId } from "../channels/types.js";
+
+export { DESKTOP_PRESENCE_STATES, type DesktopPresenceState };
 
 // ---------------------------------------------------------------------------
 // Message type → capability inference
@@ -94,14 +101,6 @@ interface BaseSubscriberEntry {
    */
   connectionId: string;
 }
-
-/**
- * The presence states a desktop client may report. Single runtime source: the
- * stored type and the route's wire enum both derive from this tuple.
- */
-export const DESKTOP_PRESENCE_STATES = ["active", "idle", "away"] as const;
-
-export type DesktopPresenceState = (typeof DESKTOP_PRESENCE_STATES)[number];
 
 export interface ClientPresence {
   state: DesktopPresenceState;

--- a/bun.lock
+++ b/bun.lock
@@ -564,6 +564,7 @@
         "@vellumai/electron-utils": "workspace:*",
         "@vellumai/ipc-contract": "workspace:*",
         "@vellumai/local-mode": "workspace:*",
+        "@vellumai/service-contracts": "workspace:*",
         "electron-store": "11.0.2",
         "jszip": "3.10.1",
       },

--- a/packages/electron-desktop/package.json
+++ b/packages/electron-desktop/package.json
@@ -92,6 +92,7 @@
     "@vellumai/electron-utils": "workspace:*",
     "@vellumai/ipc-contract": "workspace:*",
     "@vellumai/local-mode": "workspace:*",
+    "@vellumai/service-contracts": "workspace:*",
     "electron-store": "11.0.2",
     "jszip": "3.10.1"
   },

--- a/packages/electron-desktop/src/desktop-presence-monitor.ts
+++ b/packages/electron-desktop/src/desktop-presence-monitor.ts
@@ -1,6 +1,8 @@
 import { powerMonitor } from "electron";
 
-export type PresenceState = "active" | "idle" | "away";
+import type { DesktopPresenceState } from "@vellumai/service-contracts/desktop-presence";
+
+export type PresenceState = DesktopPresenceState;
 
 export const IDLE_THRESHOLD_MS = 10 * 60_000;
 export const POLL_INTERVAL_MS = 30_000;

--- a/packages/electron-desktop/src/host-proxy/poster.ts
+++ b/packages/electron-desktop/src/host-proxy/poster.ts
@@ -15,7 +15,9 @@
  * via the optional refreshAuth callback and retries once.
  */
 
-export type PresenceState = "active" | "idle" | "away";
+import type { DesktopPresenceState } from "@vellumai/service-contracts/desktop-presence";
+
+export type PresenceState = DesktopPresenceState;
 
 // ---------------------------------------------------------------------------
 // Payload interfaces — match the daemon route request bodies

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -10,6 +10,7 @@
     "./conversation-handle": "./src/conversation-handle.ts",
     "./client-metadata": "./src/client-metadata.ts",
     "./credential-rpc": "./src/credential-rpc.ts",
+    "./desktop-presence": "./src/desktop-presence.ts",
     "./ingress": "./src/ingress.ts",
     "./no-response": "./src/no-response.ts",
     "./remote-web-pairing": "./src/remote-web-pairing.ts",

--- a/packages/service-contracts/src/desktop-presence.ts
+++ b/packages/service-contracts/src/desktop-presence.ts
@@ -1,0 +1,11 @@
+/**
+ * The presence states a desktop client may report. Single runtime source for
+ * the daemon's stored type, the client route's wire enum, and the Electron
+ * presence monitor.
+ *
+ * Member order is load-bearing: the route feeds this tuple to `z.enum`, so
+ * reordering rewrites the generated `assistant/openapi.yaml`.
+ */
+export const DESKTOP_PRESENCE_STATES = ["active", "idle", "away"] as const;
+
+export type DesktopPresenceState = (typeof DESKTOP_PRESENCE_STATES)[number];


### PR DESCRIPTION
## Summary

- Move `DESKTOP_PRESENCE_STATES` / `DesktopPresenceState` into a new `@vellumai/service-contracts/desktop-presence` module; `assistant-event-hub.ts` now re-exports it so `client-routes.ts` and the hub test helpers need no edit.
- Point the two byte-identical `PresenceState` unions in `packages/electron-desktop` (`desktop-presence-monitor.ts`, `host-proxy/poster.ts`) at the shared type, which keeps `clients/macos/src/main/presence.ts` and `host-proxy/router.ts` compiling untouched.
- Pure de-duplication, no behavior change. Member order is preserved, and `bun run generate:openapi -- --check` reports `openapi.yaml is up to date`.

Part of plan: watched-activity-suppression.md (PR 14 of 14)