### PR TITLE
feat(notifications): let a watched background job stop notifying about its own failure

### DIFF
--- a/assistant/src/notifications/__tests__/background-failure-signal.test.ts
+++ b/assistant/src/notifications/__tests__/background-failure-signal.test.ts
@@ -1,5 +1,20 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
+
+const PRESENCE_FLAG = "activity-presence-suppression";
+
+let webFocused = false;
+const webPresenceArgs: unknown[][] = [];
+const realWebPresence = await import("../../runtime/web-presence.js");
+mock.module("../../runtime/web-presence.js", () => ({
+  ...realWebPresence,
+  isWebConversationFocused: (...args: unknown[]) => {
+    webPresenceArgs.push(args);
+    return webFocused;
+  },
+}));
+
 const emitCalls: Array<Record<string, unknown>> = [];
 mock.module("../emit-signal.js", () => ({
   emitNotificationSignal: (params: Record<string, unknown>) => {
@@ -103,5 +118,86 @@ describe("emitBackgroundFailureSignal", () => {
       jobName: "memory.v2.sweep",
       errorKind: "exception",
     });
+  });
+});
+
+describe("emitBackgroundFailureSignal source-active suppression", () => {
+  beforeEach(() => {
+    emitCalls.length = 0;
+    webFocused = false;
+    webPresenceArgs.length = 0;
+    setOverridesForTesting({ [PRESENCE_FLAG]: true });
+  });
+
+  function emitWithPresence(presenceConversationId: string): void {
+    emitBackgroundFailureSignal({
+      jobName: "watcher-a",
+      sourceChannel: "assistant_tool",
+      sourceContextId: "conv-3",
+      errorKind: "exception",
+      errorMessage: "boom",
+      presenceConversationId,
+    });
+  }
+
+  test("reports the source as visible when the carried conversation is focused", () => {
+    webFocused = true;
+
+    emitWithPresence("conv-3");
+
+    expect(emitCalls[0].attentionHints).toMatchObject({
+      visibleInSourceNow: true,
+    });
+    expect(webPresenceArgs).toEqual([["conv-3"]]);
+  });
+
+  test("reports the source as not visible when the conversation is unfocused", () => {
+    webFocused = false;
+
+    emitWithPresence("conv-3");
+
+    expect(emitCalls[0].attentionHints).toMatchObject({
+      visibleInSourceNow: false,
+    });
+    expect(webPresenceArgs).toEqual([["conv-3"]]);
+  });
+
+  test("the scheduler and sweep-job reports carry no presence conversation", () => {
+    webFocused = true;
+
+    emitBackgroundFailureSignal({
+      jobName: "schedule:job-1",
+      sourceChannel: "scheduler",
+      sourceContextId: "job-1",
+      errorKind: "exception",
+      errorMessage: "retries exhausted",
+    });
+    emitBackgroundFailureSignal({
+      jobName: "memory.v2.sweep",
+      sourceChannel: "scheduler",
+      sourceContextId: "job-9",
+      errorKind: "exception",
+      errorMessage: "boom",
+    });
+
+    expect(emitCalls).toHaveLength(2);
+    for (const emitted of emitCalls) {
+      expect(emitted.attentionHints).toMatchObject({
+        visibleInSourceNow: false,
+      });
+    }
+    expect(webPresenceArgs).toEqual([]);
+  });
+
+  test("the flag off keeps the hint false without reading presence", () => {
+    webFocused = true;
+    setOverridesForTesting({ [PRESENCE_FLAG]: false });
+
+    emitWithPresence("conv-3");
+
+    expect(emitCalls[0].attentionHints).toMatchObject({
+      visibleInSourceNow: false,
+    });
+    expect(webPresenceArgs).toEqual([]);
   });
 });

--- a/assistant/src/notifications/background-failure-signal.ts
+++ b/assistant/src/notifications/background-failure-signal.ts
@@ -50,6 +50,9 @@ export interface BackgroundFailureReport {
    * Conversation this failure is displayed in, when the caller has one.
    * Set it only when the notification would duplicate what is already on
    * screen; `sourceContextId` is polymorphic and cannot be trusted for this.
+   * Holding a conversation id is not enough on its own: the caller has to
+   * know that this particular failure was rendered there, otherwise
+   * suppression destroys the only signal the user would ever get.
    */
   presenceConversationId?: string;
 }

--- a/assistant/src/notifications/background-failure-signal.ts
+++ b/assistant/src/notifications/background-failure-signal.ts
@@ -2,6 +2,7 @@ import type { BackgroundJobErrorKind } from "../runtime/background-job-runner.js
 import { getLogger } from "../util/logger.js";
 import { activityFailedDedupeKey } from "./activity-failed-dedupe.js";
 import { emitNotificationSignal } from "./emit-signal.js";
+import { resolveVisibleInSourceNow } from "./resolve-visible-in-source.js";
 import type { NotificationSourceChannel } from "./signal.js";
 
 const log = getLogger("background-failure-signal");
@@ -45,6 +46,12 @@ export interface BackgroundFailureReport {
    * Used only when the failure carries no attribution of its own.
    */
   fallbackProviderScope?: string;
+  /**
+   * Conversation this failure is displayed in, when the caller has one.
+   * Set it only when the notification would duplicate what is already on
+   * screen; `sourceContextId` is polymorphic and cannot be trusted for this.
+   */
+  presenceConversationId?: string;
 }
 
 /**
@@ -101,7 +108,9 @@ export function emitBackgroundFailureSignal(
       requiresAction: false,
       urgency: "medium",
       isAsyncBackground: true,
-      visibleInSourceNow: false,
+      visibleInSourceNow: resolveVisibleInSourceNow({
+        conversationId: report.presenceConversationId,
+      }),
     },
   }).catch((emitErr) => {
     log.warn(

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -13,18 +13,23 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { setOverridesForTesting } from "../../__tests__/feature-flag-test-helpers.js";
 import type { TrustContext } from "../../daemon/trust-context-types.js";
 
 // ── Module mocks ─────────────────────────────────────────────────────
 
 let bootstrapCalls = 0;
 let bootstrapLastArgs: Record<string, unknown> | null = null;
+let bootstrapError: Error | null = null;
 const STUB_CONVERSATION_ID = "conv-test-1";
 
 mock.module("../../persistence/conversation-bootstrap.js", () => ({
   bootstrapConversation: (opts: Record<string, unknown>) => {
     bootstrapCalls += 1;
     bootstrapLastArgs = opts;
+    if (bootstrapError) {
+      throw bootstrapError;
+    }
     return { id: STUB_CONVERSATION_ID };
   },
 }));
@@ -34,10 +39,14 @@ const addMessageCalls: Array<{
   role: string;
   content: string;
 }> = [];
+let addMessageError: Error | null = null;
 
 mock.module("../../persistence/conversation-crud.js", () => ({
   addMessage: async (conversationId: string, role: string, content: string) => {
     addMessageCalls.push({ conversationId, role, content });
+    if (addMessageError) {
+      throw addMessageError;
+    }
     return { id: `msg-${addMessageCalls.length}` };
   },
   reserveMessage: mock(async () => ({ id: "msg-reserve" })),
@@ -94,6 +103,20 @@ mock.module("../pre-first-message-gate.js", () => ({
   hasReceivedUserMessage: () => preFirstMessageGateOpen,
 }));
 
+// Web presence backs the `visibleInSourceNow` attention hint. Recording the
+// arguments lets the suppression tests assert not just the resolved hint but
+// whether presence was consulted at all.
+let webConversationFocused = false;
+const webPresenceArgs: unknown[][] = [];
+const realWebPresence = await import("../web-presence.js");
+mock.module("../web-presence.js", () => ({
+  ...realWebPresence,
+  isWebConversationFocused: (...args: unknown[]) => {
+    webPresenceArgs.push(args);
+    return webConversationFocused;
+  },
+}));
+
 // Import after mocks are in place.
 const { runBackgroundJob } = await import("../background-job-runner.js");
 
@@ -120,10 +143,14 @@ function baseOpts(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   bootstrapCalls = 0;
   bootstrapLastArgs = null;
+  bootstrapError = null;
   processMessageCalls.length = 0;
   emitCalls.length = 0;
   addMessageCalls.length = 0;
+  addMessageError = null;
   preFirstMessageGateOpen = true;
+  webConversationFocused = false;
+  webPresenceArgs.length = 0;
   processMessageImpl = async () => ({ messageId: "msg-1" });
   emitImpl = async () => ({
     signalId: "sig-1",
@@ -530,5 +557,93 @@ describe("runBackgroundJob", () => {
       expect(bootstrapCalls).toBe(1);
       expect(processMessageCalls).toHaveLength(1);
     });
+  });
+});
+
+// Runs last on purpose: it is the only block that turns the presence flag on,
+// so every test above reads the flag in its default off state.
+describe("runBackgroundJob presence suppression opt-in", () => {
+  beforeEach(() => {
+    setOverridesForTesting({ "activity-presence-suppression": true });
+    webConversationFocused = true;
+  });
+
+  function emittedHint(): Record<string, unknown> {
+    expect(emitCalls).toHaveLength(1);
+    return emitCalls[0].attentionHints as Record<string, unknown>;
+  }
+
+  test("a carried turn failure lets a focused conversation suppress the alert", async () => {
+    // Every path that stamps a failed turn outcome emits `conversation_error`
+    // first, so the focused conversation is already showing this failure.
+    processMessageImpl = async () => ({
+      messageId: "msg-failed-turn",
+      turnFailure: { failureCode: "PROVIDER_BILLING" },
+    });
+
+    const result = await runBackgroundJob(baseOpts());
+
+    expect(result.ok).toBe(false);
+    expect(emittedHint()).toMatchObject({ visibleInSourceNow: true });
+    expect(webPresenceArgs).toEqual([[STUB_CONVERSATION_ID]]);
+  });
+
+  test("a timeout alerts even when the conversation is focused", async () => {
+    // The timeout does not abort `processMessage`, so the transcript still
+    // reads as an in-progress turn and there is no rendered error to duplicate.
+    processMessageImpl = () => new Promise(() => {});
+
+    const result = await runBackgroundJob(baseOpts({ timeoutMs: 20 }));
+
+    expect(result.errorKind).toBe("timeout");
+    expect(emittedHint()).toMatchObject({ visibleInSourceNow: false });
+    expect(webPresenceArgs).toEqual([]);
+  });
+
+  test("a throw out of processMessage alerts even when the conversation is focused", async () => {
+    // Message preparation and persistence run before the agent loop, so a
+    // throw from there never reaches the code that renders a failure.
+    processMessageImpl = async () => {
+      throw new Error("failed to persist the user message");
+    };
+
+    const result = await runBackgroundJob(baseOpts());
+
+    expect(result.errorKind).toBe("exception");
+    expect(result.turnFailure).toBeUndefined();
+    expect(emittedHint()).toMatchObject({ visibleInSourceNow: false });
+    expect(webPresenceArgs).toEqual([]);
+  });
+
+  test("a sandwich persistence failure alerts even when the conversation is focused", async () => {
+    // The conversation exists and is focused, but nothing has run in it yet.
+    addMessageError = new Error("sandwich write failed");
+
+    const result = await runBackgroundJob(
+      baseOpts({
+        assistantSandwich: {
+          preamble: "TRUSTED_PRE",
+          content: "UNTRUSTED_PAYLOAD",
+          postamble: "TRUSTED_POST",
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.conversationId).toBe(STUB_CONVERSATION_ID);
+    expect(processMessageCalls).toHaveLength(0);
+    expect(emittedHint()).toMatchObject({ visibleInSourceNow: false });
+    expect(webPresenceArgs).toEqual([]);
+  });
+
+  test("a bootstrap failure alerts even when a conversation is focused", async () => {
+    bootstrapError = new Error("bootstrap boom");
+
+    const result = await runBackgroundJob(baseOpts());
+
+    expect(result.ok).toBe(false);
+    expect(result.conversationId).toBe("");
+    expect(emittedHint()).toMatchObject({ visibleInSourceNow: false });
+    expect(webPresenceArgs).toEqual([]);
   });
 });

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -436,6 +436,7 @@ export async function runBackgroundJob(
         jobName: opts.jobName,
         sourceChannel: "assistant_tool",
         sourceContextId: conversationId,
+        presenceConversationId: conversationId,
         errorKind,
         errorMessage: error.message,
         ...(failureCode !== undefined ? { failureCode } : {}),

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -436,7 +436,16 @@ export async function runBackgroundJob(
         jobName: opts.jobName,
         sourceChannel: "assistant_tool",
         sourceContextId: conversationId,
-        presenceConversationId: conversationId,
+        // Presence suppression is only safe when this conversation already
+        // rendered the failure. A carried `turnFailure` is that proof: every
+        // path that stamps a failed turn outcome emits `conversation_error`
+        // first. The other arrivals here render nothing to duplicate. A
+        // timeout leaves `processMessage` running, so the transcript still
+        // reads as an in-progress turn, and bootstrap or message-persistence
+        // throws never reach the agent loop at all.
+        ...(turnFailure !== undefined
+          ? { presenceConversationId: conversationId }
+          : {}),
         errorKind,
         errorMessage: error.message,
         ...(failureCode !== undefined ? { failureCode } : {}),


### PR DESCRIPTION
## Summary

- `BackgroundFailureReport` gains an optional `presenceConversationId`, and `emitBackgroundFailureSignal` resolves `visibleInSourceNow` from it via `resolveVisibleInSourceNow` instead of hardcoding `false`. `sourceContextId` is polymorphic (conversation or job id), so the opt-in is explicit rather than inferred.
- `background-job-runner.ts` opts in by passing its already-in-scope `conversationId`. The `scheduler` and `sweep-job` callers are untouched: neither has a conversation, and both keep notifying.
- Tests pin the matrix (focused true, unfocused false, flag off false with no presence read) plus the scheduler and sweep-job report shapes. With `activity-presence-suppression` off (its default), behavior is unchanged.

Part of plan: watched-activity-suppression.md (PR 6 of 14)