### PR TITLE
feat(electron): publish authoritative main-window attention to the renderer

### DIFF
--- a/packages/electron-desktop/package.json
+++ b/packages/electron-desktop/package.json
@@ -79,6 +79,7 @@
     "./text-context-menu": "./src/text-context-menu.ts",
     "./tray-model": "./src/tray-model.ts",
     "./vellumapp-protocol": "./src/vellumapp-protocol.ts",
+    "./window-attention": "./src/window-attention.ts",
     "./window-readiness": "./src/window-readiness.ts",
     "./window-state": "./src/window-state.ts",
     "./workos-pkce": "./src/workos-pkce.ts",

--- a/packages/electron-desktop/src/window-attention.test.ts
+++ b/packages/electron-desktop/src/window-attention.test.ts
@@ -1,0 +1,273 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { BrowserWindow } from "electron";
+
+// `app.on` subscriptions are captured by event name so the test can fire
+// them at will, and `BrowserWindow.getAllWindows` returns a controllable
+// stub list standing in for the renderer windows that receive the payload.
+type Listener = () => void;
+const appListeners = new Map<string, Listener>();
+const appOnMock = mock((event: string, listener: Listener) => {
+  appListeners.set(event, listener);
+});
+const appOffMock = mock((event: string, _listener: Listener) => {
+  appListeners.delete(event);
+});
+
+type SendMock = ReturnType<typeof mock>;
+interface StubRenderer {
+  isDestroyed: () => boolean;
+  webContents: { send: SendMock };
+}
+let windows: StubRenderer[] = [];
+
+mock.module("electron", () => ({
+  app: { on: appOnMock, off: appOffMock },
+  BrowserWindow: { getAllWindows: () => windows },
+}));
+
+const { installWindowAttention } = await import("./window-attention");
+
+const CHANNEL = "vellum:window:attention";
+
+const makeRenderer = (destroyed = false): StubRenderer => ({
+  isDestroyed: () => destroyed,
+  webContents: { send: mock(() => undefined) },
+});
+
+interface StubMainWindow {
+  destroyed: boolean;
+  visible: boolean;
+  focused: boolean;
+  minimized: boolean;
+  listeners: Map<string, Set<Listener>>;
+  isDestroyed: () => boolean;
+  isVisible: () => boolean;
+  isFocused: () => boolean;
+  isMinimized: () => boolean;
+  on: (event: string, listener: Listener) => void;
+  off: (event: string, listener: Listener) => void;
+  emit: (event: string) => void;
+}
+
+const makeMainWindow = (): StubMainWindow => {
+  const listeners = new Map<string, Set<Listener>>();
+  const win: StubMainWindow = {
+    destroyed: false,
+    visible: true,
+    focused: true,
+    minimized: false,
+    listeners,
+    isDestroyed: () => win.destroyed,
+    isVisible: () => win.visible,
+    isFocused: () => win.focused,
+    isMinimized: () => win.minimized,
+    on: (event, listener) => {
+      const existing = listeners.get(event) ?? new Set<Listener>();
+      existing.add(listener);
+      listeners.set(event, existing);
+    },
+    off: (event, listener) => {
+      listeners.get(event)?.delete(listener);
+    },
+    emit: (event) => {
+      for (const listener of [...(listeners.get(event) ?? [])]) {
+        listener();
+      }
+    },
+  };
+  return win;
+};
+
+const install = (win: StubMainWindow | null): (() => void) => {
+  return installWindowAttention({
+    currentMainWindow: () => win as unknown as BrowserWindow | null,
+  });
+};
+
+const payloads = (renderer: StubRenderer): unknown[] => {
+  return renderer.webContents.send.mock.calls.map((call) => call[1]);
+};
+
+beforeEach(() => {
+  appListeners.clear();
+  appOnMock.mockClear();
+  appOffMock.mockClear();
+  windows = [];
+});
+
+describe("installWindowAttention", () => {
+  test("emits the live window state once on install", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+
+    const teardown = install(makeMainWindow());
+
+    expect(renderer.webContents.send).toHaveBeenCalledTimes(1);
+    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, {
+      visible: true,
+      focused: true,
+      minimized: false,
+    });
+    teardown();
+  });
+
+  test("emits on browser-window-blur and browser-window-focus", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const main = makeMainWindow();
+    const teardown = install(main);
+
+    main.focused = false;
+    appListeners.get("browser-window-blur")?.();
+    main.focused = true;
+    appListeners.get("browser-window-focus")?.();
+
+    expect(payloads(renderer)).toEqual([
+      { visible: true, focused: true, minimized: false },
+      { visible: true, focused: false, minimized: false },
+      { visible: true, focused: true, minimized: false },
+    ]);
+    teardown();
+  });
+
+  test("emits on the window's own minimize and restore", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const main = makeMainWindow();
+    const teardown = install(main);
+
+    main.minimized = true;
+    main.focused = false;
+    main.emit("minimize");
+    main.minimized = false;
+    main.focused = true;
+    main.emit("restore");
+
+    expect(payloads(renderer)).toEqual([
+      { visible: true, focused: true, minimized: false },
+      { visible: true, focused: false, minimized: true },
+      { visible: true, focused: true, minimized: false },
+    ]);
+    teardown();
+  });
+
+  test("emits on the window's own hide and show", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const main = makeMainWindow();
+    const teardown = install(main);
+
+    main.visible = false;
+    main.focused = false;
+    main.emit("hide");
+    main.visible = true;
+    main.focused = true;
+    main.emit("show");
+
+    expect(payloads(renderer)).toEqual([
+      { visible: true, focused: true, minimized: false },
+      { visible: false, focused: false, minimized: false },
+      { visible: true, focused: true, minimized: false },
+    ]);
+    teardown();
+  });
+
+  test("suppresses a duplicate consecutive payload", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const main = makeMainWindow();
+    const teardown = install(main);
+
+    appListeners.get("browser-window-focus")?.();
+    appListeners.get("browser-window-focus")?.();
+    main.emit("restore");
+
+    expect(renderer.webContents.send).toHaveBeenCalledTimes(1);
+    teardown();
+  });
+
+  test("reports all false when the accessor returns null", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+
+    const teardown = install(null);
+
+    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, {
+      visible: false,
+      focused: false,
+      minimized: false,
+    });
+    teardown();
+  });
+
+  test("reports all false when the window is destroyed", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const main = makeMainWindow();
+    main.destroyed = true;
+
+    const teardown = install(main);
+
+    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, {
+      visible: false,
+      focused: false,
+      minimized: false,
+    });
+    expect(main.listeners.size).toBe(0);
+    teardown();
+  });
+
+  test("binds the window once the accessor stops returning null", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    let main: StubMainWindow | null = null;
+    const teardown = installWindowAttention({
+      currentMainWindow: () => main as unknown as BrowserWindow | null,
+    });
+
+    main = makeMainWindow();
+    appListeners.get("browser-window-focus")?.();
+    main.minimized = true;
+    main.focused = false;
+    main.emit("minimize");
+
+    expect(payloads(renderer)).toEqual([
+      { visible: false, focused: false, minimized: false },
+      { visible: true, focused: true, minimized: false },
+      { visible: true, focused: false, minimized: true },
+    ]);
+    teardown();
+  });
+
+  test("skips destroyed renderer windows", () => {
+    const alive = makeRenderer();
+    const dead = makeRenderer(true);
+    windows = [alive, dead];
+
+    const teardown = install(makeMainWindow());
+
+    expect(alive.webContents.send).toHaveBeenCalled();
+    expect(dead.webContents.send).not.toHaveBeenCalled();
+    teardown();
+  });
+
+  test("teardown removes the app and window listeners", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const main = makeMainWindow();
+    const teardown = install(main);
+
+    teardown();
+
+    expect(appOffMock).toHaveBeenCalledTimes(2);
+    expect(appListeners.size).toBe(0);
+    for (const listeners of main.listeners.values()) {
+      expect(listeners.size).toBe(0);
+    }
+
+    main.minimized = true;
+    main.emit("minimize");
+    expect(renderer.webContents.send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/electron-desktop/src/window-attention.test.ts
+++ b/packages/electron-desktop/src/window-attention.test.ts
@@ -5,7 +5,7 @@ import type { BrowserWindow } from "electron";
 // `app.on` subscriptions are captured by event name so the test can fire
 // them at will, and `BrowserWindow.getAllWindows` returns a controllable
 // stub list standing in for the renderer windows that receive the payload.
-type Listener = () => void;
+type Listener = (...args: unknown[]) => void;
 const appListeners = new Map<string, Listener>();
 const appOnMock = mock((event: string, listener: Listener) => {
   appListeners.set(event, listener);
@@ -15,10 +15,61 @@ const appOffMock = mock((event: string, _listener: Listener) => {
 });
 
 type SendMock = ReturnType<typeof mock>;
-interface StubRenderer {
-  isDestroyed: () => boolean;
-  webContents: { send: SendMock };
+
+interface StubEmitter {
+  listeners: Map<string, Set<Listener>>;
+  on: (event: string, listener: Listener) => void;
+  once: (event: string, listener: Listener) => void;
+  off: (event: string, listener: Listener) => void;
+  emit: (event: string) => void;
+  listenerCount: (event: string) => number;
 }
+
+const makeEmitter = (): StubEmitter => {
+  const listeners = new Map<string, Set<Listener>>();
+  const onceListeners = new Set<Listener>();
+  return {
+    listeners,
+    on: (event, listener) => {
+      const existing = listeners.get(event) ?? new Set<Listener>();
+      existing.add(listener);
+      listeners.set(event, existing);
+    },
+    once: (event, listener) => {
+      onceListeners.add(listener);
+      const existing = listeners.get(event) ?? new Set<Listener>();
+      existing.add(listener);
+      listeners.set(event, existing);
+    },
+    off: (event, listener) => {
+      listeners.get(event)?.delete(listener);
+      onceListeners.delete(listener);
+    },
+    emit: (event) => {
+      for (const listener of [...(listeners.get(event) ?? [])]) {
+        if (onceListeners.has(listener)) {
+          onceListeners.delete(listener);
+          listeners.get(event)?.delete(listener);
+        }
+        listener();
+      }
+    },
+    listenerCount: (event) => listeners.get(event)?.size ?? 0,
+  };
+};
+
+interface StubWebContents extends StubEmitter {
+  destroyed: boolean;
+  isDestroyed: () => boolean;
+  send: SendMock;
+}
+
+interface StubRenderer {
+  destroyed: boolean;
+  isDestroyed: () => boolean;
+  webContents: StubWebContents;
+}
+
 let windows: StubRenderer[] = [];
 
 mock.module("electron", () => ({
@@ -30,51 +81,46 @@ const { installWindowAttention } = await import("./window-attention");
 
 const CHANNEL = "vellum:window:attention";
 
-const makeRenderer = (destroyed = false): StubRenderer => ({
-  isDestroyed: () => destroyed,
-  webContents: { send: mock(() => undefined) },
-});
+const ATTENDED = { visible: true, focused: true, minimized: false };
+const UNATTENDED = { visible: false, focused: false, minimized: false };
 
-interface StubMainWindow {
+const makeRenderer = (destroyed = false): StubRenderer => {
+  const contents: StubWebContents = {
+    ...makeEmitter(),
+    destroyed,
+    isDestroyed: () => contents.destroyed,
+    send: mock(() => undefined),
+  };
+  const renderer: StubRenderer = {
+    destroyed,
+    isDestroyed: () => renderer.destroyed,
+    webContents: contents,
+  };
+  return renderer;
+};
+
+interface StubMainWindow extends StubEmitter {
   destroyed: boolean;
   visible: boolean;
   focused: boolean;
   minimized: boolean;
-  listeners: Map<string, Set<Listener>>;
   isDestroyed: () => boolean;
   isVisible: () => boolean;
   isFocused: () => boolean;
   isMinimized: () => boolean;
-  on: (event: string, listener: Listener) => void;
-  off: (event: string, listener: Listener) => void;
-  emit: (event: string) => void;
 }
 
 const makeMainWindow = (): StubMainWindow => {
-  const listeners = new Map<string, Set<Listener>>();
   const win: StubMainWindow = {
+    ...makeEmitter(),
     destroyed: false,
     visible: true,
     focused: true,
     minimized: false,
-    listeners,
     isDestroyed: () => win.destroyed,
     isVisible: () => win.visible,
     isFocused: () => win.focused,
     isMinimized: () => win.minimized,
-    on: (event, listener) => {
-      const existing = listeners.get(event) ?? new Set<Listener>();
-      existing.add(listener);
-      listeners.set(event, existing);
-    },
-    off: (event, listener) => {
-      listeners.get(event)?.delete(listener);
-    },
-    emit: (event) => {
-      for (const listener of [...(listeners.get(event) ?? [])]) {
-        listener();
-      }
-    },
   };
   return win;
 };
@@ -104,11 +150,7 @@ describe("installWindowAttention", () => {
     const teardown = install(makeMainWindow());
 
     expect(renderer.webContents.send).toHaveBeenCalledTimes(1);
-    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, {
-      visible: true,
-      focused: true,
-      minimized: false,
-    });
+    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, ATTENDED);
     teardown();
   });
 
@@ -124,9 +166,9 @@ describe("installWindowAttention", () => {
     appListeners.get("browser-window-focus")?.();
 
     expect(payloads(renderer)).toEqual([
-      { visible: true, focused: true, minimized: false },
+      ATTENDED,
       { visible: true, focused: false, minimized: false },
-      { visible: true, focused: true, minimized: false },
+      ATTENDED,
     ]);
     teardown();
   });
@@ -145,9 +187,9 @@ describe("installWindowAttention", () => {
     main.emit("restore");
 
     expect(payloads(renderer)).toEqual([
-      { visible: true, focused: true, minimized: false },
+      ATTENDED,
       { visible: true, focused: false, minimized: true },
-      { visible: true, focused: true, minimized: false },
+      ATTENDED,
     ]);
     teardown();
   });
@@ -165,10 +207,32 @@ describe("installWindowAttention", () => {
     main.focused = true;
     main.emit("show");
 
+    expect(payloads(renderer)).toEqual([ATTENDED, UNATTENDED, ATTENDED]);
+    teardown();
+  });
+
+  test("publishes an unattended payload when the main window closes", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const main = makeMainWindow();
+    let current: StubMainWindow | null = main;
+    const teardown = installWindowAttention({
+      currentMainWindow: () => current as unknown as BrowserWindow | null,
+    });
+
+    // A blur leaves the renderer holding a visible-but-unfocused window; the
+    // destruction that follows is the only edge that can correct `visible`.
+    main.focused = false;
+    appListeners.get("browser-window-blur")?.();
+
+    main.destroyed = true;
+    current = null;
+    main.emit("closed");
+
     expect(payloads(renderer)).toEqual([
-      { visible: true, focused: true, minimized: false },
-      { visible: false, focused: false, minimized: false },
-      { visible: true, focused: true, minimized: false },
+      ATTENDED,
+      { visible: true, focused: false, minimized: false },
+      UNATTENDED,
     ]);
     teardown();
   });
@@ -187,17 +251,55 @@ describe("installWindowAttention", () => {
     teardown();
   });
 
+  test("delivers to a renderer created after the last attention change", () => {
+    const first = makeRenderer();
+    windows = [first];
+    const teardown = install(makeMainWindow());
+
+    // No attention transition happens between the install and the new window,
+    // so only the per-recipient record can tell that it has heard nothing.
+    const late = makeRenderer();
+    windows = [first, late];
+    appListeners.get("browser-window-created")?.({}, late);
+    late.webContents.emit("did-finish-load");
+
+    expect(payloads(late)).toEqual([ATTENDED]);
+    expect(first.webContents.send).toHaveBeenCalledTimes(1);
+    teardown();
+  });
+
+  test("re-delivers to a renderer that reloads", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const teardown = install(makeMainWindow());
+
+    renderer.webContents.emit("did-finish-load");
+
+    expect(payloads(renderer)).toEqual([ATTENDED, ATTENDED]);
+    teardown();
+  });
+
+  test("drops the subscriptions for a destroyed webContents", () => {
+    const renderer = makeRenderer();
+    windows = [renderer];
+    const teardown = install(makeMainWindow());
+
+    expect(renderer.webContents.listenerCount("did-finish-load")).toBe(1);
+    renderer.webContents.destroyed = true;
+    renderer.webContents.emit("destroyed");
+
+    expect(renderer.webContents.listenerCount("did-finish-load")).toBe(0);
+    expect(renderer.webContents.listenerCount("destroyed")).toBe(0);
+    teardown();
+  });
+
   test("reports all false when the accessor returns null", () => {
     const renderer = makeRenderer();
     windows = [renderer];
 
     const teardown = install(null);
 
-    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, {
-      visible: false,
-      focused: false,
-      minimized: false,
-    });
+    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, UNATTENDED);
     teardown();
   });
 
@@ -209,11 +311,7 @@ describe("installWindowAttention", () => {
 
     const teardown = install(main);
 
-    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, {
-      visible: false,
-      focused: false,
-      minimized: false,
-    });
+    expect(renderer.webContents.send).toHaveBeenCalledWith(CHANNEL, UNATTENDED);
     expect(main.listeners.size).toBe(0);
     teardown();
   });
@@ -233,8 +331,8 @@ describe("installWindowAttention", () => {
     main.emit("minimize");
 
     expect(payloads(renderer)).toEqual([
-      { visible: false, focused: false, minimized: false },
-      { visible: true, focused: true, minimized: false },
+      UNATTENDED,
+      ATTENDED,
       { visible: true, focused: false, minimized: true },
     ]);
     teardown();
@@ -252,7 +350,7 @@ describe("installWindowAttention", () => {
     teardown();
   });
 
-  test("teardown removes the app and window listeners", () => {
+  test("teardown removes the app, window, and renderer listeners", () => {
     const renderer = makeRenderer();
     windows = [renderer];
     const main = makeMainWindow();
@@ -260,11 +358,13 @@ describe("installWindowAttention", () => {
 
     teardown();
 
-    expect(appOffMock).toHaveBeenCalledTimes(2);
+    expect(appOffMock).toHaveBeenCalledTimes(3);
     expect(appListeners.size).toBe(0);
     for (const listeners of main.listeners.values()) {
       expect(listeners.size).toBe(0);
     }
+    expect(renderer.webContents.listenerCount("did-finish-load")).toBe(0);
+    expect(renderer.webContents.listenerCount("destroyed")).toBe(0);
 
     main.minimized = true;
     main.emit("minimize");

--- a/packages/electron-desktop/src/window-attention.ts
+++ b/packages/electron-desktop/src/window-attention.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, app } from "electron";
+import type { WebContents } from "electron";
 
 import { WINDOW_ATTENTION } from "@vellumai/ipc-contract";
 import type { WindowAttentionPayload } from "@vellumai/ipc-contract";
@@ -13,8 +14,19 @@ import type { WindowAttentionPayload } from "@vellumai/ipc-contract";
  * focus and blur events.
  *
  * The publisher is event driven, never polled: `browser-window-focus` /
- * `browser-window-blur` plus the main window's own show, hide, minimize, and
- * restore events are edge complete for the three booleans published here.
+ * `browser-window-blur` plus the main window's own show, hide, minimize,
+ * restore, and closed events are edge complete for the three booleans
+ * published here. `closed` carries its own weight: a blur can leave renderers
+ * holding a visible-but-unfocused window that is then destroyed, and without
+ * that edge nothing corrects `visible` until an unrelated transition.
+ *
+ * Delivery is tracked per `webContents`, not once globally, because the
+ * channel is push only and has no request or replay path. Pop-out windows are
+ * separate page loads, so renderers routinely appear between attention
+ * transitions; a global "same as last time" cache would leave those
+ * uninitialized. Each renderer is instead sent the current payload when its
+ * page finishes loading (a reload counts as a fresh page), and identical
+ * repeats are dropped per recipient so the dedup benefit survives.
  */
 
 const UNATTENDED: WindowAttentionPayload = {
@@ -23,13 +35,14 @@ const UNATTENDED: WindowAttentionPayload = {
   minimized: false,
 };
 
-type MainWindowEvent = "show" | "hide" | "minimize" | "restore";
+type MainWindowEvent = "show" | "hide" | "minimize" | "restore" | "closed";
 
 const MAIN_WINDOW_EVENTS: MainWindowEvent[] = [
   "show",
   "hide",
   "minimize",
   "restore",
+  "closed",
 ];
 
 export interface WindowAttentionDependencies {
@@ -58,19 +71,15 @@ const isSamePayload = (
   );
 };
 
-const broadcast = (payload: WindowAttentionPayload): void => {
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (win.isDestroyed()) {
-      continue;
-    }
-    win.webContents.send(WINDOW_ATTENTION, payload);
-  }
-};
-
 export function installWindowAttention(
   deps: WindowAttentionDependencies,
 ): () => void {
-  let lastPayload: WindowAttentionPayload | null = null;
+  // Keyed by `webContents` so a renderer that never reaches its `destroyed`
+  // event still falls out of the record once Electron drops it.
+  const delivered = new WeakMap<WebContents, WindowAttentionPayload>();
+  // Subscriptions have to be enumerable for teardown, so this one is a strong
+  // Map; every entry removes itself on `destroyed`.
+  const untrackers = new Map<WebContents, () => void>();
   let boundWindow: BrowserWindow | null = null;
 
   function detachWindow(): void {
@@ -87,7 +96,7 @@ export function installWindowAttention(
   // fresh window after one is rebuilt, so binding is resolved on every edge.
   function rebind(win: BrowserWindow | null): void {
     detachWindow();
-    if (!win || win.isDestroyed()) {
+    if (!win) {
       return;
     }
     const emitter: NodeJS.EventEmitter = win;
@@ -97,27 +106,75 @@ export function installWindowAttention(
     boundWindow = win;
   }
 
-  function publish(): void {
-    const win = deps.currentMainWindow();
-    if (win !== boundWindow) {
-      rebind(win);
-    }
-    const payload = readAttention(win);
-    if (lastPayload && isSamePayload(lastPayload, payload)) {
+  function track(contents: WebContents): void {
+    if (untrackers.has(contents) || contents.isDestroyed()) {
       return;
     }
-    lastPayload = payload;
-    broadcast(payload);
+    const onLoad = (): void => {
+      // A load hands the channel to a document that has heard nothing, so the
+      // previous delivery to this `webContents` no longer counts.
+      delivered.delete(contents);
+      publish();
+    };
+    const untrack = (): void => {
+      untrackers.delete(contents);
+      delivered.delete(contents);
+      contents.off("did-finish-load", onLoad);
+      contents.off("destroyed", untrack);
+    };
+    contents.on("did-finish-load", onLoad);
+    contents.once("destroyed", untrack);
+    untrackers.set(contents, untrack);
+  }
+
+  function sendTo(
+    contents: WebContents,
+    payload: WindowAttentionPayload,
+  ): void {
+    if (contents.isDestroyed()) {
+      return;
+    }
+    const previous = delivered.get(contents);
+    if (previous && isSamePayload(previous, payload)) {
+      return;
+    }
+    delivered.set(contents, payload);
+    contents.send(WINDOW_ATTENTION, payload);
+  }
+
+  function publish(): void {
+    const win = deps.currentMainWindow();
+    const live = win && !win.isDestroyed() ? win : null;
+    if (live !== boundWindow) {
+      rebind(live);
+    }
+    const payload = readAttention(live);
+    for (const target of BrowserWindow.getAllWindows()) {
+      if (target.isDestroyed()) {
+        continue;
+      }
+      track(target.webContents);
+      sendTo(target.webContents, payload);
+    }
+  }
+
+  function onWindowCreated(_event: unknown, win: BrowserWindow): void {
+    track(win.webContents);
   }
 
   app.on("browser-window-focus", publish);
   app.on("browser-window-blur", publish);
+  app.on("browser-window-created", onWindowCreated);
 
   publish();
 
   return (): void => {
     app.off("browser-window-focus", publish);
     app.off("browser-window-blur", publish);
+    app.off("browser-window-created", onWindowCreated);
+    for (const untrack of [...untrackers.values()]) {
+      untrack();
+    }
     detachWindow();
   };
 }

--- a/packages/electron-desktop/src/window-attention.ts
+++ b/packages/electron-desktop/src/window-attention.ts
@@ -1,0 +1,123 @@
+import { BrowserWindow, app } from "electron";
+
+import { WINDOW_ATTENTION } from "@vellumai/ipc-contract";
+import type { WindowAttentionPayload } from "@vellumai/ipc-contract";
+
+/**
+ * Authoritative main-window state, published from main to every renderer.
+ *
+ * Every Vellum window sets `backgroundThrottling: false`, which also disables
+ * the Page Visibility API. A renderer therefore reads `document.visibilityState`
+ * as "visible" forever and never receives `visibilitychange`, so it cannot tell
+ * that it is off screen. Main can, through `BrowserWindow` state plus the app's
+ * focus and blur events.
+ *
+ * The publisher is event driven, never polled: `browser-window-focus` /
+ * `browser-window-blur` plus the main window's own show, hide, minimize, and
+ * restore events are edge complete for the three booleans published here.
+ */
+
+const UNATTENDED: WindowAttentionPayload = {
+  visible: false,
+  focused: false,
+  minimized: false,
+};
+
+type MainWindowEvent = "show" | "hide" | "minimize" | "restore";
+
+const MAIN_WINDOW_EVENTS: MainWindowEvent[] = [
+  "show",
+  "hide",
+  "minimize",
+  "restore",
+];
+
+export interface WindowAttentionDependencies {
+  currentMainWindow: () => BrowserWindow | null;
+}
+
+const readAttention = (win: BrowserWindow | null): WindowAttentionPayload => {
+  if (!win || win.isDestroyed()) {
+    return UNATTENDED;
+  }
+  return {
+    visible: win.isVisible(),
+    focused: win.isFocused(),
+    minimized: win.isMinimized(),
+  };
+};
+
+const isSamePayload = (
+  a: WindowAttentionPayload,
+  b: WindowAttentionPayload,
+): boolean => {
+  return (
+    a.visible === b.visible &&
+    a.focused === b.focused &&
+    a.minimized === b.minimized
+  );
+};
+
+const broadcast = (payload: WindowAttentionPayload): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) {
+      continue;
+    }
+    win.webContents.send(WINDOW_ATTENTION, payload);
+  }
+};
+
+export function installWindowAttention(
+  deps: WindowAttentionDependencies,
+): () => void {
+  let lastPayload: WindowAttentionPayload | null = null;
+  let boundWindow: BrowserWindow | null = null;
+
+  function detachWindow(): void {
+    if (boundWindow && !boundWindow.isDestroyed()) {
+      const emitter: NodeJS.EventEmitter = boundWindow;
+      for (const event of MAIN_WINDOW_EVENTS) {
+        emitter.off(event, publish);
+      }
+    }
+    boundWindow = null;
+  }
+
+  // The accessor can return null before the shell builds its window, and a
+  // fresh window after one is rebuilt, so binding is resolved on every edge.
+  function rebind(win: BrowserWindow | null): void {
+    detachWindow();
+    if (!win || win.isDestroyed()) {
+      return;
+    }
+    const emitter: NodeJS.EventEmitter = win;
+    for (const event of MAIN_WINDOW_EVENTS) {
+      emitter.on(event, publish);
+    }
+    boundWindow = win;
+  }
+
+  function publish(): void {
+    const win = deps.currentMainWindow();
+    if (win !== boundWindow) {
+      rebind(win);
+    }
+    const payload = readAttention(win);
+    if (lastPayload && isSamePayload(lastPayload, payload)) {
+      return;
+    }
+    lastPayload = payload;
+    broadcast(payload);
+  }
+
+  app.on("browser-window-focus", publish);
+  app.on("browser-window-blur", publish);
+
+  publish();
+
+  return (): void => {
+    app.off("browser-window-focus", publish);
+    app.off("browser-window-blur", publish);
+    detachWindow();
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `packages/electron-desktop/src/window-attention.ts` exporting `installWindowAttention({ currentMainWindow })`, which broadcasts `{ visible, focused, minimized }` on the `WINDOW_ATTENTION` channel to every live `BrowserWindow`.
- Emissions are event driven (`browser-window-focus` / `browser-window-blur` plus the main window's own `show` / `hide` / `minimize` / `restore`), never polled; identical consecutive payloads are suppressed and the returned teardown removes every listener.
- Not installed by any client yet, so this changes no runtime behavior. The `./window-attention` subpath is added to the package exports map so PR 9 can import it.

Part of plan: watched-activity-suppression.md (PR 5 of 14)