### PR TITLE
fix(slack): a progress plan opens the reply stream (JARVIS-1666)

### DIFF
--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -331,10 +331,10 @@ export async function sendSlackStreamOp(
         channel,
         threadTs: op.anchorMessageId,
         markdownText: op.appended ?? op.text,
-        // Fixed for the stream's lifetime at start, while a plan usually
-        // arrives after the first text flush has opened it. It only affects
-        // how task chunks render, so a stream that never carries a plan still
-        // reads as a plain message.
+        // Fixed for the stream's lifetime at start, so it is set
+        // unconditionally: a plan that first appears on a later append still
+        // renders as a plan. It only affects how task chunks render, so a
+        // stream that never carries one still reads as a plain message.
         taskDisplayMode: "plan",
         planTitle,
         tasks,

--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -924,6 +924,95 @@ describe("createSlackReplySession", () => {
     ]);
   });
 
+  test("opens the stream on a plan shown before any prose", async () => {
+    // What the Slack `ui_show` description actually instructs: show the card
+    // early on a multi-step turn. At that moment the model has written no
+    // prose, so a stream that waits for text holds the plan back until the
+    // final answer, when the steps it narrates are already finished.
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+      coalesceMs: 5,
+    })!;
+
+    session.observeEvent(
+      taskProgressShow([
+        { label: "Search docs", status: "in_progress" },
+        { label: "Summarize", status: "pending" },
+      ]),
+    );
+    session.observeEvent(toolOk("tool-ui-show", "ui_show"));
+    await tick(15);
+
+    // The plan is on Slack before the turn has produced a single character.
+    expect(slackStreamOps()).toEqual([
+      {
+        action: "start",
+        anchorMessageId: THREAD_TS,
+        text: "",
+        appended: "",
+        plan: {
+          steps: [
+            { label: "Search docs", status: "in_progress" },
+            { label: "Summarize", status: "pending" },
+          ],
+        },
+      },
+    ]);
+  });
+
+  test("advances plan steps live while the turn is still working", async () => {
+    const session = createSlackReplySession({
+      sourceChannel: "slack",
+      chatType: "im",
+      replyCallbackUrl: CALLBACK_URL,
+      chatId: CHANNEL,
+      coalesceMs: 5,
+    })!;
+
+    session.observeEvent(
+      taskProgressShow([
+        { label: "Search docs", status: "in_progress" },
+        { label: "Summarize", status: "pending" },
+      ]),
+    );
+    session.observeEvent(toolOk("tool-ui-show", "ui_show"));
+    await tick(15);
+    session.observeEvent(
+      taskProgressUpdate([
+        { label: "Search docs", status: "completed" },
+        { label: "Summarize", status: "in_progress" },
+      ]),
+    );
+    session.observeEvent(toolOk("tool-ui-update", "ui_update"));
+    await tick(15);
+
+    // The advance rides its own task-only append rather than waiting for the
+    // first text, which is the whole point of a live step tracker.
+    const advances = slackStreamOps().filter((op) => op.action === "append");
+    expect(advances).toHaveLength(1);
+    expect(advances[0].plan).toEqual({
+      steps: [
+        { label: "Search docs", status: "completed" },
+        { label: "Summarize", status: "in_progress" },
+      ],
+    });
+
+    session.observeEvent(textDelta("All done."));
+    session.observeEvent(messageComplete("assistant-msg-1"));
+    const reconciliation = await session.finish();
+
+    // The reply still streams into the same message the plan opened.
+    expect(reconciliation).toEqual({
+      mode: "streamed",
+      messageTs: "stream-ts-1",
+      deliveredSegmentCount: 1,
+    });
+    expect(streamedMarkdown()).toBe("All done.");
+  });
+
   test("carries the plan title and step details onto stream ops", async () => {
     const session = createSlackReplySession({
       sourceChannel: "slack",

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -44,8 +44,9 @@ const STREAM_COALESCE_MS = 400;
  * - `streamed`: the reply was delivered live into a single streamed message;
  *   finalize skips re-posting text, reconciles `slackMeta.channelTs` to the
  *   stream `ts`, and posts only attachments.
- * - `fallback`: no stream was opened (ineligible turn, no deliverable text, or
- *   a failed `startStream`); finalize posts the full reply normally.
+ * - `fallback`: no stream was opened (ineligible turn, neither deliverable
+ *   text nor a plan, or a failed `startStream`); finalize posts the full
+ *   reply normally.
  */
 export type SlackStreamReconciliation =
   | { mode: "streamed"; messageTs: string; deliveredSegmentCount: number }
@@ -100,9 +101,9 @@ type StreamState = "idle" | "streaming" | "fallback";
 /**
  * Owns the live-content lifecycle of one Slack DM reply: it consumes the
  * assistant token stream once, opens a streamed message (in plan display
- * mode) on first deliverable text, coalesces deltas into `appendStream`
- * calls, advances a native plan block from `task_progress` surfaces, and
- * finalizes with `stopStream`.
+ * mode) on the first deliverable text or progress plan, whichever comes
+ * first, coalesces deltas into `appendStream` calls, advances a native plan
+ * block from `task_progress` surfaces, and finalizes with `stopStream`.
  *
  * Any stream-call failure degrades gracefully: the session abandons streaming
  * (state `fallback`) and reports back so durable finalize posts the full reply
@@ -197,11 +198,13 @@ export function createSlackReplySession(params: {
   const enqueueStart = (): void => {
     enqueue(async () => {
       const clean = streamableText();
-      if (clean.trim().length === 0) {
+      const plan = activeProgress;
+      // A plan alone opens the stream; text alone does too. Neither means
+      // there is nothing to show yet, so the start is left for a later flush.
+      if (clean.trim().length === 0 && !plan) {
         return;
       }
       const firstChunk = clean.slice(0, SLACK_STREAM_MARKDOWN_LIMIT);
-      const plan = activeProgress;
       try {
         const result = await sendChannelStreamOp(replyCallbackUrl, chatId, {
           action: "start",
@@ -307,6 +310,21 @@ export function createSlackReplySession(params: {
     });
   };
 
+  /**
+   * Whether there is anything worth opening the stream for.
+   *
+   * A plan counts on its own. `chat.startStream` takes `markdown_text` as
+   * optional and fixes `task_display_mode` at start, so a plan-only start is
+   * both legal and the only way task cards can tick while the turn works: the
+   * model is told to show its progress card early on a multi-step turn, which
+   * is precisely the moment it has produced no prose. Requiring text first
+   * would hold every such plan back until the final answer, by which point
+   * the steps it was meant to narrate are already done.
+   */
+  const hasOpenableContent = (): boolean =>
+    hasDeliverableAssistantText(streamableText()) ||
+    activeProgress !== undefined;
+
   const flush = (): void => {
     if (coalesceTimer) {
       clearTimeout(coalesceTimer);
@@ -316,7 +334,7 @@ export function createSlackReplySession(params: {
       return;
     }
     if (!started) {
-      if (!hasDeliverableAssistantText(streamableText())) {
+      if (!hasOpenableContent()) {
         return;
       }
       started = true;
@@ -453,7 +471,10 @@ export function createSlackReplySession(params: {
 
       // A reply that completed before the first coalesced flush still streams
       // as a single start→stop so the transcript holds one streamed message.
-      if (!started && hasDeliverableAssistantText(rawText)) {
+      // A turn whose only output was a plan opens here too, so work the model
+      // narrated only as steps still leaves the user something to read.
+      // `finished` is already set, so the shared check reads the full text.
+      if (!started && hasOpenableContent()) {
         started = true;
         enqueueStart();
       }


### PR DESCRIPTION
## TL;DR

Slack's native plan block never ticked during a turn. A `task_progress` plan could not open the reply stream, so it first reached Slack attached to the final answer, when the steps it was meant to narrate were already done. A plan now opens the stream on its own.

Part of JARVIS-1666.

## What was happening

The reply session opened its stream only once the turn produced deliverable body text. A plan arriving before any prose sat unsent in `activeProgress`.

That is the opposite of what we instruct. The Slack-specific `ui_show` description tells the model to "show it early on multi-step turns and advance step statuses via ui_update as work progresses" - and early on a multi-step turn is precisely when it has written no prose. So on exactly the turns the plan UI exists for, the plan was held back until the end.

Probed against the unfixed code, showing a plan and then doing silent work:

```
OPS AFTER PLAN, BEFORE ANY TEXT: []
OPS AT END: [ start …plan… , stop …plan… ]
```

## The gate was ours, not Slack's

`chat.startStream` takes `markdown_text` as optional and fixes `task_display_mode` at start, so a plan-only start is legal, and it is the only way task cards can tick while the turn works. The rest of the path was already correct: `toSlackStreamTasks` maps steps onto Slack task cards, and starts already request plan display mode.

Two things kept the assumption in place, both updated here: a comment in `send.ts` asserting "a plan usually arrives after the first text flush has opened it", and a test suite whose every plan case opens with a text delta. The instructed order was the untested order.

## Before / after

| Turn | Before | After |
| --- | --- | --- |
| Plan shown early, then silent tool work | Nothing in Slack; plan appears with the final answer, steps already terminal | Stream opens on the plan; steps advance live as `ui_update` lands |
| Text first, then a plan | Unchanged | Unchanged |
| Turn whose only output is a plan | Nothing streamed, falls back to durable delivery | Plan is posted, so the work leaves something to read |
| No text and no plan | No stream | No stream |

## Why it is safe

One shared condition, `hasOpenableContent()`, now gates both the coalesced flush and the end-of-turn start, so the two cannot drift. It widens the open condition and narrows nothing: every turn that streamed before still streams identically, which is what the 31 pre-existing tests pin.

Reconciliation is unaffected. A stream opened by a plan reports `mode: "streamed"` with `deliveredSegmentCount` still counting only text segments, so durable finalize resumes exactly where it did before. A plan-only turn reports 0 delivered segments and finalize posts whatever the durable row owes, which for a silent turn is nothing.

The failure path is unchanged: a rejected `startStream` still drops to `fallback` and durable delivery posts the reply whole.

## Tests

Two regression tests, both verified to fail against the unfixed code:

- a plan shown before any prose opens the stream, asserted on the ops actually sent while the turn is still working;
- a `ui_update` advance rides its own task-only append rather than waiting for text, and the later reply still streams into the same message the plan opened.

Suites run per-file and green: `slack-reply-session` (33), `slack/send` (24), `slack/api` (9), `channel-reply-delivery` (39), `background-dispatch` (31). tsc, eslint and the pinned prettier clean.

## Follow-ups not in this PR

- LUM-3053 (internal narration leaking as Slack reply text) is the sibling bug on the same surface: the session accumulates every `assistant_text_delta` across LLM calls into one growing message. This PR is a prerequisite rather than a fix for it, since it restores the designed progress channel that narration is currently substituting for. Deliberately left separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

## Scope caveat (added after prod-trace verification)

This fixes a real defect, but it is **necessary, not sufficient** for "the Slack plan UI never appears."

Prod turn traces (`telemetry.pii_turn_raw`, 7 days) show the model rarely draws a plan on Slack at all: of 143 Slack turns, only **4** actually called `ui_show` with `template: "task_progress"` in `trace.tool_calls`. So on ~97% of Slack turns there is no plan for this fix to show.

Worth recording the measurement trap: matching `task_progress` against the whole trace reports 112/143, because `trace.tool_definitions` and `trace.system_prompt` both contain the literal string. Only `trace.tool_calls` reflects what the model actually called.

Per-turn the rate is not suppressed on Slack (2.8% vs 1.4% in the app), so this is not a Slack-specific gating bug. The dominant cause is how seldom the card is drawn, which is prompt/behavior work tracked separately and is the same root as LUM-3053.

Not verified: whether the 4 real plans rendered in Slack. That needs the `chat.startStream` response bodies, which only exist in daemon logs.
