### PR TITLE
test(gateway): adopt the shared runtime-stream test harness in every stream suite

### DIFF
--- a/gateway/src/__tests__/desktop-stream-websocket.test.ts
+++ b/gateway/src/__tests__/desktop-stream-websocket.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, test, expect, mock } from "bun:test";
 import type { DesktopStreamSocketData } from "../http/routes/desktop-stream-websocket.js";
 import {
   GUARDIAN_PRINCIPAL,
+  createFakeDownstreamWs,
   makeConfig,
   makeFakeServer,
   mintEdgeToken,
@@ -120,28 +121,17 @@ describe("getDesktopStreamWebsocketHandlers", () => {
     return { server, received, connected, upgradeUrl: () => upgradeUrl };
   }
 
-  /** `sendStatus` is what Bun reports for each downstream send; 0 is a drop. */
-  function createFakeDownstreamWs(runtime: FakeRuntime, sendStatus = 1) {
-    const sent: (string | Uint8Array)[] = [];
-    const closes: { code: number; reason: string }[] = [];
-    const data: DesktopStreamSocketData = {
-      wsType: "desktop-stream",
-      config: makeConfig({
-        assistantRuntimeBaseUrl: `http://127.0.0.1:${runtime.server.port}`,
-      }),
-    };
-    return {
-      data,
-      sent,
-      closes,
-      send: mock((msg: string | Uint8Array) => {
-        sent.push(msg);
-        return sendStatus;
-      }),
-      close: mock((code?: number, reason?: string) => {
-        closes.push({ code: code ?? 1000, reason: reason ?? "" });
-      }),
-    };
+  /** A viewer socket whose pump dials `runtime`. */
+  function makeViewerWs(runtime: FakeRuntime, sendStatus?: number) {
+    return createFakeDownstreamWs<DesktopStreamSocketData>(
+      {
+        wsType: "desktop-stream",
+        config: makeConfig({
+          assistantRuntimeBaseUrl: `http://127.0.0.1:${runtime.server.port}`,
+        }),
+      },
+      { sendStatus },
+    );
   }
 
   /** Poll until `predicate` holds, so the tests need no fixed sleeps. */
@@ -166,7 +156,7 @@ describe("getDesktopStreamWebsocketHandlers", () => {
   test("dials the runtime's /v1/desktop/stream with a service token and nothing else", async () => {
     runtime = startFakeRuntime();
     const handlers = getDesktopStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs(runtime);
+    const ws = makeViewerWs(runtime);
 
     handlers.open(ws as never);
     await runtime.connected;
@@ -179,7 +169,7 @@ describe("getDesktopStreamWebsocketHandlers", () => {
   test("delivers the runtime's bytes downstream byte-identical", async () => {
     runtime = startFakeRuntime(RFB_BANNER);
     const handlers = getDesktopStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs(runtime);
+    const ws = makeViewerWs(runtime);
 
     handlers.open(ws as never);
     await waitFor(() => ws.sent.length > 0);
@@ -198,7 +188,7 @@ describe("getDesktopStreamWebsocketHandlers", () => {
   test("closes both sides when a downstream send is dropped", async () => {
     runtime = startFakeRuntime(RFB_BANNER);
     const handlers = getDesktopStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs(runtime, 0);
+    const ws = makeViewerWs(runtime, 0);
 
     handlers.open(ws as never);
     const upstreamClose = mock(ws.data.upstream!.close.bind(ws.data.upstream));
@@ -212,7 +202,7 @@ describe("getDesktopStreamWebsocketHandlers", () => {
   test("delivers the viewer's bytes upstream byte-identical, including frames sent before the dial completes", async () => {
     runtime = startFakeRuntime();
     const handlers = getDesktopStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs(runtime);
+    const ws = makeViewerWs(runtime);
     // Every byte value, so a text-vs-binary or encoding slip cannot hide.
     const early = new Uint8Array(256).map((_, i) => i);
     const late = new Uint8Array([0xff, 0x00, 0x7f, 0x80]);
@@ -231,7 +221,7 @@ describe("getDesktopStreamWebsocketHandlers", () => {
   test("propagates the runtime's close code downstream verbatim", async () => {
     runtime = startFakeRuntime();
     const handlers = getDesktopStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs(runtime);
+    const ws = makeViewerWs(runtime);
 
     handlers.open(ws as never);
     const upstream = await runtime.connected;
@@ -244,7 +234,7 @@ describe("getDesktopStreamWebsocketHandlers", () => {
   test("propagates the viewer's close code upstream verbatim", async () => {
     runtime = startFakeRuntime();
     const handlers = getDesktopStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs(runtime);
+    const ws = makeViewerWs(runtime);
 
     handlers.open(ws as never);
     await runtime.connected;

--- a/gateway/src/__tests__/live-voice-websocket.test.ts
+++ b/gateway/src/__tests__/live-voice-websocket.test.ts
@@ -10,15 +10,18 @@ import {
   test,
 } from "bun:test";
 
-import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
-import { initSigningKey, mintToken } from "../auth/token-service.js";
-import type { GatewayConfig } from "../config.js";
 import type { LiveVoiceSocketData } from "../http/routes/live-voice-websocket.js";
 import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
-
-// The bound-guardian platform user id, shared by the velay mock and the velay
-// tests (their attested caller must match it to authenticate).
-const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
+import {
+  GUARDIAN_PRINCIPAL,
+  VELAY_USER_ID,
+  createFakeDownstreamWs,
+  makeConfig,
+  makeFakeServer,
+  mintEdgeToken,
+  mintServiceEdgeToken,
+  upgradedData,
+} from "./runtime-stream-test-utils.js";
 
 // The live-voice upgrade pins actor tokens to the bound guardian. Mock the
 // binding lookup (set BEFORE importing the module under test) so the actor
@@ -26,7 +29,7 @@ const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
 // `mintEdgeToken`'s default principal.
 let mockFindVellumGuardian = mock(
   async (): Promise<{ principalId: string } | null> => ({
-    principalId: "test-user",
+    principalId: GUARDIAN_PRINCIPAL,
   }),
 );
 mock.module("../auth/guardian-bootstrap.js", () => ({
@@ -46,84 +49,9 @@ mock.module("../credential-reader.js", () => ({
 const { createLiveVoiceWebsocketHandler, getLiveVoiceWebsocketHandlers } =
   await import("../http/routes/live-voice-websocket.js");
 
-const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
-initSigningKey(TEST_SIGNING_KEY);
-
 const WS_CONNECTING = WebSocket.CONNECTING;
 const WS_OPEN = WebSocket.OPEN;
 const WS_CLOSED = WebSocket.CLOSED;
-
-function mintEdgeToken(actorPrincipalId: string = "test-user"): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: `actor:test-assistant:${actorPrincipalId}`,
-    scope_profile: "actor_client_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
-function mintServiceEdgeToken(): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: "svc:gateway:self",
-    scope_profile: "gateway_service_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
-function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
-    assistantRuntimeBaseUrl: "http://localhost:7821",
-    routingEntries: [],
-    port: 7830,
-    runtimeProxyRequireAuth: true,
-    shutdownDrainMs: 5000,
-    runtimeTimeoutMs: 30000,
-    runtimeMaxRetries: 2,
-    runtimeInitialBackoffMs: 500,
-    maxWebhookPayloadBytes: 1048576,
-    logFile: { dir: undefined, retentionDays: 30 },
-    maxAttachmentBytes: {
-      telegram: 50 * 1024 * 1024,
-      slack: 100 * 1024 * 1024,
-      whatsapp: 16 * 1024 * 1024,
-      default: 50 * 1024 * 1024,
-    },
-    maxAttachmentConcurrency: 3,
-    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-    trustProxy: false,
-    ...overrides,
-  };
-}
-
-function makeFakeServer(upgradeResult: boolean = true) {
-  return {
-    requestIP: mock(() => ({
-      address: "127.0.0.1",
-      family: "IPv4",
-      port: 54000,
-    })),
-    upgrade: mock(() => upgradeResult),
-  } as unknown as import("bun").Server<unknown>;
-}
-
-function createFakeDownstreamWs(data: LiveVoiceSocketData) {
-  const sent: (string | Uint8Array)[] = [];
-  const closes: { code: number; reason: string }[] = [];
-  return {
-    data,
-    sent,
-    closes,
-    send: mock((msg: string | Uint8Array) => {
-      sent.push(msg);
-    }),
-    close: mock((code?: number, reason?: string) => {
-      closes.push({ code: code ?? 1000, reason: reason ?? "" });
-    }),
-  };
-}
 
 function createFakeUpstreamWs() {
   const listeners: Record<string, ((...args: unknown[]) => void)[]> = {};
@@ -155,7 +83,9 @@ function createFakeUpstreamWs() {
 // Reset both mocks to their success defaults — file-scoped so per-test
 // overrides never leak into later describes.
 beforeEach(() => {
-  mockFindVellumGuardian = mock(async () => ({ principalId: "test-user" }));
+  mockFindVellumGuardian = mock(async () => ({
+    principalId: GUARDIAN_PRINCIPAL,
+  }));
   mockReadCredential = mock(async () => VELAY_USER_ID);
 });
 
@@ -175,10 +105,8 @@ describe("createLiveVoiceWebsocketHandler", () => {
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
 
-    const call = (server.upgrade as ReturnType<typeof mock>).mock
-      .calls[0] as unknown[];
-    expect(call[0]).toBe(req);
-    expect((call[1] as { data: LiveVoiceSocketData }).data).toEqual({
+    expect(server.upgrade).toHaveBeenCalledWith(req, expect.anything());
+    expect(upgradedData<LiveVoiceSocketData>(server)).toEqual({
       wsType: "live-voice",
       config,
     });
@@ -518,6 +446,11 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   const OriginalWebSocket = globalThis.WebSocket;
   let fakeUpstream: ReturnType<typeof createFakeUpstreamWs>;
   let handlers: ReturnType<typeof getLiveVoiceWebsocketHandlers>;
+  const makeLiveVoiceWs = (config = makeConfig()) =>
+    createFakeDownstreamWs<LiveVoiceSocketData>({
+      wsType: "live-voice",
+      config,
+    });
 
   beforeEach(() => {
     fakeUpstream = createFakeUpstreamWs();
@@ -537,12 +470,9 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   });
 
   test("open targets the runtime live voice websocket with a service token", async () => {
-    const ws = createFakeDownstreamWs({
-      wsType: "live-voice",
-      config: makeConfig({
-        assistantRuntimeBaseUrl: "http://runtime.internal:7821",
-      }),
-    });
+    const ws = makeLiveVoiceWs(
+      makeConfig({ assistantRuntimeBaseUrl: "http://runtime.internal:7821" }),
+    );
 
     handlers.open(ws as never);
 
@@ -556,10 +486,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   });
 
   test("buffers downstream text and binary messages before upstream opens", async () => {
-    const ws = createFakeDownstreamWs({
-      wsType: "live-voice",
-      config: makeConfig(),
-    });
+    const ws = makeLiveVoiceWs();
     const binaryFrame = new Uint8Array([1, 2, 3]);
 
     handlers.open(ws as never);
@@ -571,10 +498,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   });
 
   test("flushes buffered messages on upstream open", async () => {
-    const ws = createFakeDownstreamWs({
-      wsType: "live-voice",
-      config: makeConfig(),
-    });
+    const ws = makeLiveVoiceWs();
     const binaryFrame = new Uint8Array([4, 5, 6]);
 
     handlers.open(ws as never);
@@ -589,10 +513,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   });
 
   test("forwards downstream binary audio frames without JSON conversion", async () => {
-    const ws = createFakeDownstreamWs({
-      wsType: "live-voice",
-      config: makeConfig(),
-    });
+    const ws = makeLiveVoiceWs();
     const binaryFrame = new Uint8Array([9, 8, 7]);
 
     handlers.open(ws as never);
@@ -605,10 +526,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   });
 
   test("forwards upstream text and binary frames to the downstream socket", async () => {
-    const ws = createFakeDownstreamWs({
-      wsType: "live-voice",
-      config: makeConfig(),
-    });
+    const ws = makeLiveVoiceWs();
 
     handlers.open(ws as never);
     fakeUpstream.emit("message", { data: '{"type":"ready"}' });
@@ -620,10 +538,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   });
 
   test("closes downstream with 1008 on pending buffer overflow", async () => {
-    const ws = createFakeDownstreamWs({
-      wsType: "live-voice",
-      config: makeConfig(),
-    });
+    const ws = makeLiveVoiceWs();
 
     handlers.open(ws as never);
     for (let i = 0; i < 100; i++) {
@@ -635,10 +550,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   });
 
   test("downstream close clears pending messages and closes connecting upstream", async () => {
-    const ws = createFakeDownstreamWs({
-      wsType: "live-voice",
-      config: makeConfig(),
-    });
+    const ws = makeLiveVoiceWs();
 
     handlers.open(ws as never);
     handlers.message(ws as never, "pending");
@@ -651,10 +563,7 @@ describe("getLiveVoiceWebsocketHandlers", () => {
   });
 
   test("upstream close and error events close the downstream socket", async () => {
-    const ws = createFakeDownstreamWs({
-      wsType: "live-voice",
-      config: makeConfig(),
-    });
+    const ws = makeLiveVoiceWs();
 
     handlers.open(ws as never);
     fakeUpstream.emit("close", { code: 1001, reason: "going away" });

--- a/gateway/src/__tests__/runtime-stream-test-utils.ts
+++ b/gateway/src/__tests__/runtime-stream-test-utils.ts
@@ -1,7 +1,8 @@
 /**
- * Shared harness for the runtime-stream WebSocket proxies (`/v1/stt/stream`,
- * `/v1/watch/stream`, `/v1/desktop/stream`): edge tokens, a gateway config,
- * and a fake `Bun.Server` whose `upgrade` result is scripted.
+ * Shared harness for the gateway's WebSocket proxy routes (`/v1/stt/stream`,
+ * `/v1/watch/stream`, `/v1/desktop/stream`, `/v1/live-voice`, the speech
+ * relay): edge tokens, a gateway config, a fake `Bun.Server` whose `upgrade`
+ * result is scripted, and a fake downstream socket that records traffic.
  */
 
 import { mock } from "bun:test";
@@ -84,4 +85,28 @@ export function upgradedData<T>(server: import("bun").Server<unknown>): T {
   const call = (server.upgrade as ReturnType<typeof mock>).mock
     .calls[0] as unknown[];
   return (call[1] as { data: T }).data;
+}
+
+/**
+ * A downstream (client-facing) socket that records what it is sent and how
+ * it is closed. `sendStatus` is what Bun reports for each send; 0 is a drop.
+ */
+export function createFakeDownstreamWs<T>(
+  data: T,
+  options: { sendStatus?: number } = {},
+) {
+  const sent: (string | Uint8Array)[] = [];
+  const closes: { code: number; reason: string }[] = [];
+  return {
+    data,
+    sent,
+    closes,
+    send: mock((msg: string | Uint8Array) => {
+      sent.push(msg);
+      return options.sendStatus ?? 1;
+    }),
+    close: mock((code?: number, reason?: string) => {
+      closes.push({ code: code ?? 1000, reason: reason ?? "" });
+    }),
+  };
 }

--- a/gateway/src/__tests__/speech-relay-websocket.test.ts
+++ b/gateway/src/__tests__/speech-relay-websocket.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, test, expect, mock } from "bun:test";
 import type { GatewayConfig } from "../config.js";
-import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
 import type { CredentialCache } from "../credential-cache.js";
 import {
@@ -10,9 +10,12 @@ import {
   type SpeechRelaySocketData,
 } from "../http/routes/speech-relay-websocket.js";
 import { VELAY_FORWARDED_HEADER } from "../velay/bridge-utils.js";
-
-const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
-initSigningKey(TEST_SIGNING_KEY);
+import {
+  makeConfig as makeGatewayConfig,
+  makeFakeServer,
+  mintEdgeToken,
+  upgradedData,
+} from "./runtime-stream-test-utils.js";
 
 /** The daemon's self-minted service token — the only accepted principal. */
 function mintDaemonServiceToken(): string {
@@ -40,45 +43,12 @@ function mintOverScopedDaemonToken(): string {
   });
 }
 
-/** An actor edge token — valid signature, wrong principal for this path. */
-function mintActorToken(): string {
-  return mintToken({
-    aud: "vellum-gateway",
-    sub: "actor:test-assistant:test-user",
-    scope_profile: "actor_client_v1",
-    policy_epoch: CURRENT_POLICY_EPOCH,
-    ttlSeconds: 300,
-  });
-}
-
+/** The relay dials an explicit velay origin; the derivation tests unset it. */
 function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
-  return {
-    assistantRuntimeBaseUrl: "http://localhost:7821",
-    routingEntries: [],
-    port: 7830,
-    runtimeProxyRequireAuth: true,
-    shutdownDrainMs: 5000,
-    runtimeTimeoutMs: 30000,
-    runtimeMaxRetries: 2,
-    runtimeInitialBackoffMs: 500,
-    maxWebhookPayloadBytes: 1048576,
-    logFile: { dir: undefined, retentionDays: 30 },
+  return makeGatewayConfig({
     velayBaseUrl: "https://velay.test",
-    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
-    trustProxy: false,
     ...overrides,
-  } as GatewayConfig;
-}
-
-function makeFakeServer(upgradeResult: boolean = true) {
-  return {
-    requestIP: mock(() => ({
-      address: "127.0.0.1",
-      family: "IPv4",
-      port: 54000,
-    })),
-    upgrade: mock(() => upgradeResult),
-  } as unknown as import("bun").Server<unknown>;
+  });
 }
 
 function makeCredentials(apiKey: string | undefined): CredentialCache {
@@ -152,12 +122,11 @@ describe("velay origin derivation", () => {
     );
 
     expect(await handler(req, server)).toBeUndefined();
-    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
-      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
-    expect(new URL(data.data.upstreamWsUrl).origin).toBe(
+    const data = upgradedData<SpeechRelaySocketData>(server);
+    expect(new URL(data.upstreamWsUrl).origin).toBe(
       "wss://velay-staging.vellum.ai",
     );
-    expect(new URL(data.data.upstreamHttpUrl).origin).toBe(
+    expect(new URL(data.upstreamHttpUrl).origin).toBe(
       "https://velay-staging.vellum.ai",
     );
   });
@@ -185,12 +154,8 @@ describe("velay origin derivation", () => {
       );
 
       expect(await handler(req, server)).toBeUndefined();
-      const data = (
-        server.upgrade as unknown as { mock: { calls: unknown[][] } }
-      ).mock.calls[0]![1] as { data: SpeechRelaySocketData };
-      expect(new URL(data.data.upstreamWsUrl).origin).toBe(
-        "wss://velay.vellum.ai",
-      );
+      const data = upgradedData<SpeechRelaySocketData>(server);
+      expect(new URL(data.upstreamWsUrl).origin).toBe("wss://velay.vellum.ai");
     }
   });
 
@@ -209,9 +174,8 @@ describe("velay origin derivation", () => {
     );
 
     expect(await handler(req, server)).toBeUndefined();
-    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
-      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
-    expect(new URL(data.data.upstreamWsUrl).origin).toBe("wss://velay.test");
+    const data = upgradedData<SpeechRelaySocketData>(server);
+    expect(new URL(data.upstreamWsUrl).origin).toBe("wss://velay.test");
   });
 });
 
@@ -228,9 +192,8 @@ describe("createSpeechRelayUpgradeHandler — gate", () => {
 
     expect(await handler(req, server)).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
-    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
-      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
-    const upstream = new URL(data.data.upstreamWsUrl);
+    const data = upgradedData<SpeechRelaySocketData>(server);
+    const upstream = new URL(data.upstreamWsUrl);
     expect(upstream.origin).toBe("wss://velay.test");
     expect(upstream.pathname).toBe("/v1/speech/stt/stream");
     expect(upstream.searchParams.get("encoding")).toBe("linear16");
@@ -253,9 +216,8 @@ describe("createSpeechRelayUpgradeHandler — gate", () => {
     );
 
     expect(await handler(req, server)).toBeUndefined();
-    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
-      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
-    const upstream = new URL(data.data.upstreamWsUrl);
+    const data = upgradedData<SpeechRelaySocketData>(server);
+    const upstream = new URL(data.upstreamWsUrl);
     expect(upstream.pathname).toBe("/v2/speech/stt/stream");
     expect(upstream.searchParams.get("contract")).toBe("flux");
     // Without eager_eot_threshold reaching Deepgram there are no eager turn
@@ -295,11 +257,8 @@ describe("createSpeechRelayUpgradeHandler — gate", () => {
     );
 
     expect(await handler(req, server)).toBeUndefined();
-    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
-      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
-    expect(new URL(data.data.upstreamWsUrl).pathname).toBe(
-      "/v1/speech/tts/stream",
-    );
+    const data = upgradedData<SpeechRelaySocketData>(server);
+    expect(new URL(data.upstreamWsUrl).pathname).toBe("/v1/speech/tts/stream");
   });
 
   test("forwards the tts voice model to velay", async () => {
@@ -316,9 +275,8 @@ describe("createSpeechRelayUpgradeHandler — gate", () => {
     );
 
     expect(await handler(req, server)).toBeUndefined();
-    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
-      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
-    const upstream = new URL(data.data.upstreamWsUrl);
+    const data = upgradedData<SpeechRelaySocketData>(server);
+    const upstream = new URL(data.upstreamWsUrl);
     expect(upstream.searchParams.get("model")).toBe("cjVigY5qzO86Huf0OWal");
   });
 
@@ -340,7 +298,7 @@ describe("createSpeechRelayUpgradeHandler — gate", () => {
       credentials: makeCredentials("vk-1"),
     });
     const req = new Request(
-      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${mintActorToken()}`,
+      `http://127.0.0.1:7830/v1/speech/stt/stream?key=${mintEdgeToken()}`,
       { headers: { upgrade: "websocket" } },
     );
 
@@ -715,12 +673,9 @@ describe("getSpeechRelayWebsocketHandlers", () => {
     );
 
     expect(await handler(req, server)).toBeUndefined();
-    const data = (server.upgrade as unknown as { mock: { calls: unknown[][] } })
-      .mock.calls[0]![1] as { data: SpeechRelaySocketData };
-    expect(data.data.upstreamWsUrl.startsWith("wss://velay.test/")).toBe(true);
-    expect(data.data.upstreamHttpUrl.startsWith("https://velay.test/")).toBe(
-      true,
-    );
+    const data = upgradedData<SpeechRelaySocketData>(server);
+    expect(data.upstreamWsUrl.startsWith("wss://velay.test/")).toBe(true);
+    expect(data.upstreamHttpUrl.startsWith("https://velay.test/")).toBe(true);
   });
 
   test("a daemon close during the credential read prevents the velay dial", async () => {

--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -1,9 +1,11 @@
 import { describe, test, expect, mock } from "bun:test";
 import {
+  createFakeDownstreamWs,
   makeConfig,
   makeFakeServer,
   mintEdgeToken,
   mintServiceEdgeToken,
+  upgradedData,
 } from "./runtime-stream-test-utils.js";
 
 // Dictation is NOT a guardian-only surface. The binding lookup is mocked to a
@@ -122,12 +124,9 @@ describe("createSttStreamWebsocketHandler", () => {
     expect(res).toBeUndefined();
     expect(server.upgrade).toHaveBeenCalledTimes(1);
 
-    // Verify provider is undefined in socket data
-    const upgradeCall = (server.upgrade as ReturnType<typeof mock>).mock
-      .calls[0] as unknown[];
-    const opts = upgradeCall[1] as { data: SttStreamSocketData };
-    expect(opts.data.provider).toBeUndefined();
-    expect(opts.data.mimeType).toBe("audio/webm");
+    const data = upgradedData<SttStreamSocketData>(server);
+    expect(data.provider).toBeUndefined();
+    expect(data.mimeType).toBe("audio/webm");
   });
 
   test("returns 400 when mimeType is missing", () => {
@@ -237,12 +236,11 @@ describe("createSttStreamWebsocketHandler", () => {
     const server = makeFakeServer();
     handler(req, server);
 
-    const upgradeCall = (server.upgrade as ReturnType<typeof mock>).mock
-      .calls[0] as unknown[];
-    const opts = upgradeCall[1] as { data: SttStreamSocketData };
-    expect(opts.data.provider).toBe("deepgram");
-    expect(opts.data.mimeType).toBe("audio/webm");
-    expect(opts.data.sampleRate).toBe(16000);
+    expect(upgradedData<SttStreamSocketData>(server)).toMatchObject({
+      provider: "deepgram",
+      mimeType: "audio/webm",
+      sampleRate: 16000,
+    });
   });
 });
 
@@ -251,32 +249,17 @@ describe("createSttStreamWebsocketHandler", () => {
 // ---------------------------------------------------------------------------
 
 describe("getSttStreamWebsocketHandlers", () => {
-  function createFakeDownstreamWs(data: Partial<SttStreamSocketData> = {}) {
-    const sent: (string | Uint8Array)[] = [];
-    const closes: { code: number; reason: string }[] = [];
-    const fullData: SttStreamSocketData = {
+  const makeSttWs = () =>
+    createFakeDownstreamWs<SttStreamSocketData>({
       wsType: "stt-stream",
       config: makeConfig(),
       provider: "deepgram",
       mimeType: "audio/webm",
-      ...data,
-    };
-    return {
-      data: fullData,
-      sent,
-      closes,
-      send: mock((msg: string | Uint8Array) => {
-        sent.push(msg);
-      }),
-      close: mock((code?: number, reason?: string) => {
-        closes.push({ code: code ?? 1000, reason: reason ?? "" });
-      }),
-    };
-  }
+    });
 
   test("open handler initializes pending messages buffer", () => {
     const handlers = getSttStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeSttWs();
 
     // The open handler creates a WebSocket to upstream which will fail in test,
     // but pendingMessages should be initialized before that happens.
@@ -291,7 +274,7 @@ describe("getSttStreamWebsocketHandlers", () => {
 
   test("message handler buffers messages when upstream is not connected", () => {
     const handlers = getSttStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeSttWs();
     ws.data.pendingMessages = [];
 
     handlers.message(ws as never, "test-audio-frame");
@@ -301,7 +284,7 @@ describe("getSttStreamWebsocketHandlers", () => {
 
   test("message handler closes connection on buffer overflow", () => {
     const handlers = getSttStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeSttWs();
     ws.data.pendingMessages = new Array(100).fill("x"); // At MAX_PENDING_MESSAGES
 
     handlers.message(ws as never, "overflow-frame");
@@ -311,7 +294,7 @@ describe("getSttStreamWebsocketHandlers", () => {
 
   test("close handler cleans up pending messages and closes upstream", () => {
     const handlers = getSttStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeSttWs();
     ws.data.pendingMessages = ["some-data"];
 
     const fakeUpstream = {
@@ -328,7 +311,7 @@ describe("getSttStreamWebsocketHandlers", () => {
 
   test("close handler is safe when upstream is already closed", () => {
     const handlers = getSttStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeSttWs();
 
     const fakeUpstream = {
       readyState: WebSocket.CLOSED,

--- a/gateway/src/__tests__/watch-stream-websocket.test.ts
+++ b/gateway/src/__tests__/watch-stream-websocket.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, mock } from "bun:test";
 import type { WatchStreamSocketData } from "../http/routes/watch-stream-websocket.js";
 import {
   GUARDIAN_PRINCIPAL,
+  createFakeDownstreamWs,
   makeConfig,
   makeFakeServer,
   mintEdgeToken,
@@ -224,32 +225,17 @@ describe("createWatchStreamWebsocketHandler", () => {
 // ---------------------------------------------------------------------------
 
 describe("getWatchStreamWebsocketHandlers", () => {
-  function createFakeDownstreamWs(data: Partial<WatchStreamSocketData> = {}) {
-    const sent: (string | Uint8Array)[] = [];
-    const closes: { code: number; reason: string }[] = [];
-    const fullData: WatchStreamSocketData = {
+  const makeWatchWs = () =>
+    createFakeDownstreamWs<WatchStreamSocketData>({
       wsType: "watch-stream",
       config: makeConfig(),
       mimeType: "audio/pcm",
       sampleRate: 16000,
-      ...data,
-    };
-    return {
-      data: fullData,
-      sent,
-      closes,
-      send: mock((msg: string | Uint8Array) => {
-        sent.push(msg);
-      }),
-      close: mock((code?: number, reason?: string) => {
-        closes.push({ code: code ?? 1000, reason: reason ?? "" });
-      }),
-    };
-  }
+    });
 
   test("open initializes the pending message buffer", async () => {
     const handlers = getWatchStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeWatchWs();
 
     // Dialing upstream fails in a test process; the buffer is set up first.
     try {
@@ -268,7 +254,7 @@ describe("getWatchStreamWebsocketHandlers", () => {
    */
   test("message buffers frames that arrive before upstream connects", async () => {
     const handlers = getWatchStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeWatchWs();
     ws.data.pendingMessages = [];
 
     handlers.message(ws as never, "narration-frame");
@@ -278,7 +264,7 @@ describe("getWatchStreamWebsocketHandlers", () => {
 
   test("message closes the socket rather than buffering without bound", async () => {
     const handlers = getWatchStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeWatchWs();
     ws.data.pendingMessages = new Array(100).fill("x");
 
     handlers.message(ws as never, "overflow-frame");
@@ -288,7 +274,7 @@ describe("getWatchStreamWebsocketHandlers", () => {
 
   test("message forwards straight through once upstream is open", async () => {
     const handlers = getWatchStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeWatchWs();
     ws.data.pendingMessages = [];
     const upstream = {
       readyState: WebSocket.OPEN,
@@ -304,7 +290,7 @@ describe("getWatchStreamWebsocketHandlers", () => {
 
   test("close releases the buffer and closes upstream with the same code", async () => {
     const handlers = getWatchStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeWatchWs();
     ws.data.pendingMessages = ["some-data"];
     const upstream = {
       readyState: WebSocket.OPEN,
@@ -320,7 +306,7 @@ describe("getWatchStreamWebsocketHandlers", () => {
 
   test("close is safe when upstream is already gone", async () => {
     const handlers = getWatchStreamWebsocketHandlers();
-    const ws = createFakeDownstreamWs();
+    const ws = makeWatchWs();
     const upstream = {
       readyState: WebSocket.CLOSED,
       close: mock(() => {}),


### PR DESCRIPTION
## Summary
Round-2 review cleanup for pod-desktop-streaming.md (gateway tests).

- `live-voice-websocket.test.ts` drops its byte-identical copies of `mintEdgeToken`, `mintServiceEdgeToken`, `makeConfig`, `makeFakeServer`, the signing-key init, and `VELAY_USER_ID`, and imports them from `runtime-stream-test-utils.ts`.
- `speech-relay-websocket.test.ts` drops its `makeConfig`/`makeFakeServer`/signing-key copies and its `mintActorToken` (identical to `mintEdgeToken()`). It keeps a one-line `makeConfig` wrapper that pins `velayBaseUrl` over the shared config, plus its two daemon-specific token minters, which the harness has no reason to express.
- The harness gains a generic `createFakeDownstreamWs<T>(data, { sendStatus? })`, replacing the four per-suite copies (stt, watch, live-voice, desktop). The desktop suite's `sendStatus` knob is the only option.
- The hand-rolled `server.upgrade.mock.calls[0][1].data` extraction in speech-relay, stt, and live-voice is replaced by the harness's `upgradedData`.
- Every export in the harness has at least one importer.

Test-only change; no production gateway code touched. Net -152 lines.

## Verification
Each touched suite run individually with `bun test`; gateway `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YDF6hHcX7aPZsc6TuByhy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41982" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->