### PR TITLE
chore(web): drop dead gateway WS URL builders and trim desktop stream comments

### DIFF
--- a/clients/web/src/domains/chat/desktop/desktop-connection.ts
+++ b/clients/web/src/domains/chat/desktop/desktop-connection.ts
@@ -1,18 +1,13 @@
 /**
  * Transport for the pod desktop stream: which URL to dial, and what the
- * socket's close code means once it is gone. The route is a pure RFB byte
- * pipe with no control frames, so close codes are the runtime's only word.
+ * socket's close code means once it is gone.
  */
 
 import { resolveGatewayWsUrl } from "@/domains/chat/voice/live-voice/connection";
 
 const DESKTOP_STREAM_ROUTE = "/v1/desktop/stream";
 
-/**
- * Close codes the runtime uses to refuse or end a desktop session. In the
- * application range (4000+) so they cannot collide with velay's own 1013
- * tunnel-drop code or be remapped by the gateway's velay bridge.
- */
+// Mirrors the assistant's `DESKTOP_CLOSE`; the rationale is in ARCHITECTURE.md.
 const DESKTOP_CLOSE_UNAVAILABLE = 4008;
 const DESKTOP_CLOSE_FAILED = 4011;
 const DESKTOP_CLOSE_BUSY = 4013;

--- a/clients/web/src/domains/chat/desktop/desktop-panel.test.tsx
+++ b/clients/web/src/domains/chat/desktop/desktop-panel.test.tsx
@@ -153,12 +153,16 @@ const status = (): string | null =>
   screen.queryByTestId("desktop-panel-status")?.getAttribute("data-state") ??
   null;
 
+/** Let pending microtasks (URL resolution, clipboard promises) settle. */
+const flush = () =>
+  act(async () => {
+    await Promise.resolve();
+  });
+
 /** Mount the panel and let the URL resolve, which is when noVNC attaches. */
 const mountPanel = async () => {
   render(<DesktopPanel assistantId="asst-1" />);
-  await act(async () => {
-    await Promise.resolve();
-  });
+  await flush();
 };
 
 beforeEach(() => {
@@ -311,9 +315,7 @@ describe("DesktopPanel", () => {
     act(() => socket().serverClose(1006));
 
     fireEvent.click(screen.getByRole("button", { name: "Reconnect" }));
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flush();
 
     expect(FakeWebSocket.instances).toHaveLength(2);
     expect(FakeRFB.instances).toHaveLength(2);
@@ -345,9 +347,7 @@ describe("DesktopPanel", () => {
     await mountPanel();
 
     act(() => rfb().emit("clipboard", { text: "from the pod" }));
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flush();
 
     expect(written).toEqual(["from the pod"]);
   });
@@ -371,9 +371,7 @@ describe("DesktopPanel", () => {
       window.dispatchEvent(new Event("focus"));
       window.dispatchEvent(new Event("copy"));
     });
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await flush();
 
     expect(rfb().pasted).toEqual([selected]);
     node.remove();

--- a/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
@@ -7,9 +7,10 @@
  *     CSRF + org header via the interceptor). We spy on `client.post` rather
  *     than `mock.module`-ing the whole SDK, matching the pattern in
  *     `domains/chat/inspector/compaction-trail-fetch.test.ts`.
- *   - `buildLiveVoiceWsUrl` — must produce the cloud velay URL with the
- *     `assistantId` in the path, a URL-encoded `?token=`, the `wss` scheme,
- *     and `conversationId` propagated only when supplied.
+ *   - `buildVelayWsUrl` / `buildSelfHostedGatewayWsUrl` and the resolvers on
+ *     top of them: the cloud velay URL carries the `assistantId` in the path,
+ *     a URL-encoded `?token=`, and the `wss` scheme; the self-hosted URL
+ *     follows the ingress and bypasses the HTTP-only local proxy.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -18,8 +19,8 @@ import { client } from "@/generated/api/client.gen";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 
 import {
-  buildLiveVoiceWsUrl,
-  buildSelfHostedLiveVoiceWsUrl,
+  buildSelfHostedGatewayWsUrl,
+  buildVelayWsUrl,
   getVelayWsScheme,
   isPairedGatewayIngress,
   VelayWsTokenError,
@@ -114,58 +115,33 @@ describe("mintVelayWsToken", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildLiveVoiceWsUrl
+// buildVelayWsUrl
 // ---------------------------------------------------------------------------
 
-describe("buildLiveVoiceWsUrl", () => {
-  test("builds the cloud velay URL with assistantId path + wss scheme + ?token=", () => {
-    const url = new URL(
-      buildLiveVoiceWsUrl({ assistantId: "assistant-1", token: "tok-abc" }),
-    );
-    expect(url.protocol).toBe("wss:");
-    expect(url.host).toBe("velay.vellum.ai");
-    expect(url.pathname).toBe("/assistant-1/v1/live-voice");
-    expect(url.searchParams.get("token")).toBe("tok-abc");
-    expect(url.searchParams.has("conversationId")).toBe(false);
-  });
+describe("buildVelayWsUrl", () => {
+  const args = { assistantId: "assistant-1", routePath: "/v1/live-voice" };
 
   test("URL-encodes tokens containing reserved characters", () => {
     const token = "a/b+c=d e";
-    const raw = buildLiveVoiceWsUrl({ assistantId: "assistant-1", token });
+    const raw = buildVelayWsUrl({ ...args, token });
     // The encoded form must round-trip back to the original token.
     expect(new URL(raw).searchParams.get("token")).toBe(token);
     // And the raw string must not carry the unencoded reserved chars.
     expect(raw).not.toContain("token=a/b+c=d e");
   });
 
-  test("appends conversationId as an additional query param when provided", () => {
-    const url = new URL(
-      buildLiveVoiceWsUrl({
-        assistantId: "assistant-1",
-        conversationId: "conv-xyz",
-        token: "tok-abc",
-      }),
-    );
-    expect(url.searchParams.get("token")).toBe("tok-abc");
-    expect(url.searchParams.get("conversationId")).toBe("conv-xyz");
-  });
-
   test("derives the velay host from the injected platform URL (Electron shell)", () => {
     window.__VELLUM_CONFIG__ = {
       platformUrl: "https://staging-platform.vellum.ai",
     };
-    const url = new URL(
-      buildLiveVoiceWsUrl({ assistantId: "assistant-1", token: "tok-abc" }),
-    );
+    const url = new URL(buildVelayWsUrl({ ...args, token: "tok-abc" }));
     expect(url.protocol).toBe("wss:");
     expect(url.host).toBe("velay-staging.vellum.ai");
   });
 
   test("falls back to the prod velay host for an off-convention platform URL", () => {
     window.__VELLUM_CONFIG__ = { platformUrl: "http://localhost:8000" };
-    const url = new URL(
-      buildLiveVoiceWsUrl({ assistantId: "assistant-1", token: "tok-abc" }),
-    );
+    const url = new URL(buildVelayWsUrl({ ...args, token: "tok-abc" }));
     expect(url.host).toBe("velay.vellum.ai");
   });
 });
@@ -191,45 +167,21 @@ describe("getVelayWsScheme", () => {
 });
 
 // ---------------------------------------------------------------------------
-// buildSelfHostedLiveVoiceWsUrl
+// buildSelfHostedGatewayWsUrl
 // ---------------------------------------------------------------------------
 
-describe("buildSelfHostedLiveVoiceWsUrl", () => {
-  test("maps an https ingress to wss, no assistantId path prefix, actor token", () => {
-    const url = new URL(
-      buildSelfHostedLiveVoiceWsUrl({
-        ingressUrl: "https://x.ngrok-free.app",
-        token: "actor-tok",
-      }),
-    );
-    expect(url.protocol).toBe("wss:");
-    expect(url.host).toBe("x.ngrok-free.app");
-    // Gateway serves /v1/live-voice directly — no /<assistantId> prefix.
-    expect(url.pathname).toBe("/v1/live-voice");
-    expect(url.searchParams.get("token")).toBe("actor-tok");
-    expect(url.searchParams.has("conversationId")).toBe(false);
-  });
-
-  test("maps a plain-http local ingress to ws", () => {
-    const url = new URL(
-      buildSelfHostedLiveVoiceWsUrl({
-        ingressUrl: "http://localhost:8787",
-        token: "actor-tok",
-      }),
-    );
-    expect(url.protocol).toBe("ws:");
-    expect(url.host).toBe("localhost:8787");
-    expect(url.pathname).toBe("/v1/live-voice");
-  });
+describe("buildSelfHostedGatewayWsUrl", () => {
+  const args = { routePath: "/v1/live-voice", token: "actor-tok" };
 
   test("local __gateway proxy path: dials the loopback gateway port directly", () => {
-    // The HTTP-only __gateway proxy can't carry a WS upgrade, so live-voice must
-    // bypass it and hit 127.0.0.1:<port> directly. Origin host + prefix dropped.
+    // The HTTP-only __gateway proxy can't carry a WS upgrade, so the socket
+    // bypasses it and hits 127.0.0.1:<port>. Origin host, prefix, query, and
+    // hash are all dropped; the bypass keys off the path, not the scheme.
     const url = new URL(
-      buildSelfHostedLiveVoiceWsUrl({
-        ingressUrl: "http://localhost:3000/assistant/__gateway/7821?a=1#frag",
-        conversationId: "conv-xyz",
-        token: "actor-tok",
+      buildSelfHostedGatewayWsUrl({
+        ...args,
+        ingressUrl: "https://app.example/assistant/__gateway/7821?a=1#frag",
+        params: { conversationId: "conv-xyz" },
       }),
     );
     expect(url.protocol).toBe("ws:");
@@ -241,51 +193,25 @@ describe("buildSelfHostedLiveVoiceWsUrl", () => {
     expect(url.searchParams.get("conversationId")).toBe("conv-xyz");
   });
 
-  test("local __gateway path bypasses even an https origin (Electron app://-style)", () => {
-    // The bypass keys off the proxy path, not the origin scheme, so a live-voice
-    // WS never rides the same-origin proxy regardless of host.
+  test("paired __gateway-paired path throws PairedVoiceUnavailableError on any origin", () => {
+    // The paired proxy is HTTP-only with no loopback port to bypass to, so the
+    // builder fails typed before any dial. On an Electron app:// origin a raw
+    // dial would otherwise throw an opaque WebSocket construction error.
+    for (const ingressUrl of [
+      "http://localhost:3000/assistant/__gateway-paired/asst-1",
+      "app://vellum/assistant/__gateway-paired/asst-1",
+    ]) {
+      expect(() =>
+        buildSelfHostedGatewayWsUrl({ ...args, ingressUrl }),
+      ).toThrow(PairedVoiceUnavailableError);
+    }
+  });
+
+  test("remote ingress keeps its host and path prefix, drops query and hash", () => {
     const url = new URL(
-      buildSelfHostedLiveVoiceWsUrl({
-        ingressUrl: "https://app.example/assistant/__gateway/18101",
-        token: "actor-tok",
-      }),
-    );
-    expect(url.protocol).toBe("ws:");
-    expect(url.host).toBe("127.0.0.1:18101");
-    expect(url.pathname).toBe("/v1/live-voice");
-  });
-
-  test("paired __gateway-paired path throws PairedVoiceUnavailableError (browser origin)", () => {
-    // The paired proxy is HTTP-only and has no loopback port to bypass to, so
-    // no WS URL exists; the builder must fail typed instead of producing a
-    // ws://localhost URL no host upgrades.
-    expect(() =>
-      buildSelfHostedLiveVoiceWsUrl({
-        ingressUrl: "http://localhost:3000/assistant/__gateway-paired/asst-1",
-        token: "actor-tok",
-      }),
-    ).toThrow(PairedVoiceUnavailableError);
-  });
-
-  test("paired __gateway-paired path throws on an Electron app:// origin too", () => {
-    // The app:// protocol can't be rewritten to wss (the WHATWG setter no-ops
-    // on non-special to special), so a raw dial would throw an opaque
-    // WebSocket construction error; the builder fails typed before any dial.
-    expect(() =>
-      buildSelfHostedLiveVoiceWsUrl({
-        ingressUrl: "app://vellum/assistant/__gateway-paired/asst-1",
-        token: "actor-tok",
-      }),
-    ).toThrow(PairedVoiceUnavailableError);
-  });
-
-  test("remote ingress (no __gateway path) keeps its host and appends the route", () => {
-    // A real remote gateway ingress is dialled as-is — only the local proxy path
-    // is rewritten to loopback.
-    const url = new URL(
-      buildSelfHostedLiveVoiceWsUrl({
+      buildSelfHostedGatewayWsUrl({
+        ...args,
         ingressUrl: "https://x.ngrok-free.app/gw?a=1#frag",
-        token: "actor-tok",
       }),
     );
     expect(url.protocol).toBe("wss:");
@@ -298,7 +224,7 @@ describe("buildSelfHostedLiveVoiceWsUrl", () => {
 });
 
 // ---------------------------------------------------------------------------
-// resolveGatewayWsUrl — the routing every gateway WS shares
+// resolveGatewayWsUrl: the routing every gateway WS shares
 // ---------------------------------------------------------------------------
 
 describe("resolveGatewayWsUrl", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -37,18 +37,8 @@
  * routes through the platform `client` — that interceptor attaches the session
  * cookie + CSRF + `Vellum-Organization-Id`.
  *
- * ---------------------------------------------------------------------------
- * Shared with more than live voice
- * ---------------------------------------------------------------------------
- *
- * The transport pieces here are route-agnostic: {@link resolveGatewayWsUrl},
- * {@link buildSelfHostedGatewayWsUrl}, {@link buildVelayWsUrl}, and
- * {@link mintVelayWsToken} are what watch (`domains/chat/watch`) and the pod
- * desktop (`domains/chat/desktop`) dial through as well. Only the
- * `…LiveVoiceWsUrl` wrappers are live voice's own. The file keeps its name and
- * its home because live voice is where the rules were worked out and is still
- * their principal user; the alternative is a second module that restates them
- * and drifts.
+ * This module is the route-agnostic gateway WS transport shared by live voice,
+ * watch (`domains/chat/watch`), and the pod desktop (`domains/chat/desktop`).
  */
 
 import { velayHostForPlatformHost } from "@vellumai/service-contracts/ingress";
@@ -180,14 +170,6 @@ export function getVelayWsScheme(host: string): "ws" | "wss" {
   return loopback ? "ws" : "wss";
 }
 
-export interface BuildLiveVoiceWsUrlArgs {
-  assistantId: string;
-  /** Optional conversation to attach the live-voice session to. */
-  conversationId?: string;
-  /** Short-lived token from {@link mintVelayWsToken}. */
-  token: string;
-}
-
 export interface BuildVelayWsUrlArgs {
   assistantId: string;
   /** Gateway route to open, e.g. `/v1/live-voice` or `/v1/watch/stream`. */
@@ -236,39 +218,6 @@ export function buildVelayWsUrl({
     url.searchParams.set(key, value);
   }
   return url.toString();
-}
-
-/**
- * Build the velay live-voice WebSocket URL for the cloud path. Thin wrapper
- * over {@link buildVelayWsUrl} for the `/v1/live-voice` route.
- *
- * This is the cloud builder. The self-hosted/local path uses
- * {@link buildSelfHostedLiveVoiceWsUrl}; {@link resolveLiveVoiceWsUrl} chooses
- * between them.
- */
-export function buildLiveVoiceWsUrl({
-  assistantId,
-  conversationId,
-  token,
-}: BuildLiveVoiceWsUrlArgs): string {
-  return buildVelayWsUrl({
-    assistantId,
-    routePath: LIVE_VOICE_ROUTE,
-    token,
-    params: conversationId ? { conversationId } : undefined,
-  });
-}
-
-export interface BuildSelfHostedLiveVoiceWsUrlArgs {
-  /**
-   * The user's gateway ingress URL (e.g. `https://x.ngrok-free.app` or a plain
-   * `http://localhost:{port}`), from {@link getSelfHostedIngressUrl}.
-   */
-  ingressUrl: string;
-  /** Optional conversation to attach the live-voice session to. */
-  conversationId?: string;
-  /** Platform actor edge JWT from {@link getSelfHostedActorToken}. */
-  token: string;
 }
 
 /**
@@ -380,24 +329,6 @@ export function buildSelfHostedGatewayWsUrl({
     target.searchParams.set(key, value);
   }
   return target.toString();
-}
-
-/**
- * Build the live-voice WebSocket URL for the self-hosted / local path. Thin
- * wrapper over {@link buildSelfHostedGatewayWsUrl} for the `/v1/live-voice`
- * route; the gateway serves it directly (no velay `/<assistantId>` prefix).
- */
-export function buildSelfHostedLiveVoiceWsUrl({
-  ingressUrl,
-  conversationId,
-  token,
-}: BuildSelfHostedLiveVoiceWsUrlArgs): string {
-  return buildSelfHostedGatewayWsUrl({
-    ingressUrl,
-    routePath: LIVE_VOICE_ROUTE,
-    token,
-    params: conversationId ? { conversationId } : undefined,
-  });
 }
 
 export interface ResolveGatewayWsUrlArgs {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -1,11 +1,10 @@
 /**
  * Tests for the browser live-voice WebSocket client.
  *
- * `mintVelayWsToken` is mocked at module scope so no real HTTP/SDK call
- * happens; `buildLiveVoiceWsUrl` is kept real so we exercise the genuine
- * connection.ts URL builder (no hardcoded host in the client). The WebSocket is
- * a hand-rolled fake injected via the client's `webSocketFactory` option — no
- * global patching needed.
+ * `resolveLiveVoiceWsUrl` is mocked at module scope to compose the velay URL
+ * the client would dial, so no real HTTP/SDK call happens. The WebSocket is a
+ * hand-rolled fake injected via the client's `webSocketFactory` option, so no
+ * global patching is needed.
  *
  * Coverage: start-frame on open, every server frame -> typed event, binary
  * audio passthrough, connect timeout when no `ready`, `busy` handling, mint

--- a/clients/web/src/domains/chat/watch/watch-controller.test.ts
+++ b/clients/web/src/domains/chat/watch/watch-controller.test.ts
@@ -91,7 +91,6 @@ const { useAssistantIdentityStore } =
 const { MIN_VERSION: RETRO_MIN_VERSION } =
   await import("@/lib/backwards-compat/watch-retro-completion");
 const {
-  buildWatchStreamWsUrl,
   isWatchSessionActive,
   resolveWatchStreamWsUrl,
   stopWatch,
@@ -388,28 +387,16 @@ afterEach(() => {
   assistantListeners.clear();
 });
 
-describe("the watch stream URL", () => {
-  test("carries the actor token and the capture's audio format", () => {
-    const url = new URL(
-      buildWatchStreamWsUrl({
-        ingressUrl: "https://gateway.example.com",
-        token: "actor-jwt",
-      }),
-    );
-    expect(url.protocol).toBe("wss:");
+describe("toggling a watch session", () => {
+  test("opens the stream with the actor token and audio format, and starts the microphone", async () => {
+    await startRunning();
+
+    expect(sockets).toHaveLength(1);
+    const url = new URL(socket().url);
     expect(url.pathname).toBe("/v1/watch/stream");
     expect(url.searchParams.get("token")).toBe("actor-jwt");
     expect(url.searchParams.get("mimeType")).toBe("audio/pcm");
     expect(url.searchParams.get("sampleRate")).toBe("16000");
-  });
-});
-
-describe("toggling a watch session", () => {
-  test("opens the stream and starts the microphone", async () => {
-    await startRunning();
-
-    expect(sockets).toHaveLength(1);
-    expect(socket().url).toContain("/v1/watch/stream");
     expect(capture.calls.started).toBe(1);
     expect(useWatchStore.getState().watching).toBe(true);
   });

--- a/clients/web/src/domains/chat/watch/watch-controller.ts
+++ b/clients/web/src/domains/chat/watch/watch-controller.ts
@@ -77,10 +77,7 @@
 
 import { create } from "zustand";
 
-import {
-  buildSelfHostedGatewayWsUrl,
-  resolveGatewayWsUrl,
-} from "@/domains/chat/voice/live-voice/connection";
+import { resolveGatewayWsUrl } from "@/domains/chat/voice/live-voice/connection";
 import {
   isLiveVoiceSessionActive,
   useLiveVoiceStore,
@@ -255,44 +252,8 @@ let drainRelease: Promise<void> | null = null;
 const WATCH_STREAM_ROUTE = "/v1/watch/stream";
 
 /**
- * Build the self-hosted watch stream WebSocket URL:
- *
- *   ws(s)://<ingressHost>/v1/watch/stream?token=…&mimeType=audio/pcm&sampleRate=16000
- *
- * The same shape as `buildSttStreamWsUrl`, and through the same helper, so the
- * two audio streams cannot drift into two ideas of how to reach the gateway.
- * Exported for unit tests.
- */
-export function buildWatchStreamWsUrl({
-  ingressUrl,
-  token,
-}: {
-  ingressUrl: string;
-  token: string;
-}): string {
-  return buildSelfHostedGatewayWsUrl({
-    ingressUrl,
-    routePath: WATCH_STREAM_ROUTE,
-    token,
-    params: LIVE_VOICE_AUDIO_FORMAT_PARAMS,
-  });
-}
-
-/**
  * Resolve the watch stream WebSocket URL for `assistantId`. Thin wrapper over
  * {@link resolveGatewayWsUrl} for the `/v1/watch/stream` route.
- *
- * On the managed path velay injects the authenticated user and org as
- * `X-Velay-*` headers; the gateway takes its managed branch on those and
- * cross-checks the caller against the stored `platform_user_id`
- * (`gateway/src/http/routes/guardian-pin.ts`). On the self-hosted path it
- * validates the actor JWT against the guardian binding instead, so the
- * guardian-only rule is the same rule on both paths, proven two ways.
- *
- * Throws `PairedVoiceUnavailableError` for a paired ingress and
- * `VelayWsTokenError` for a missing actor token or a refused mint, so a
- * start that cannot resolve a URL is distinguishable from one this
- * environment simply does not support. Exported for unit tests.
  */
 export function resolveWatchStreamWsUrl(assistantId: string): Promise<string> {
   return resolveGatewayWsUrl({


### PR DESCRIPTION
## Summary
Round-2 review cleanup for pod-desktop-streaming.md (web side).

- Delete `buildLiveVoiceWsUrl`, `buildSelfHostedLiveVoiceWsUrl` (and their `Build*Args` interfaces) and `buildWatchStreamWsUrl`: zero production callers since `resolveGatewayWsUrl` landed. Drop the `buildSelfHostedGatewayWsUrl` import `watch-controller.ts` kept only for the dead builder.
- Replace their describe blocks with `buildVelayWsUrl` / `buildSelfHostedGatewayWsUrl` suites carrying only the assertions not already covered by the resolver suites (token URL-encoding, velay host derivation and prod fallback, local-proxy loopback bypass with query/hash dropped, paired-path throw on browser and app:// origins, remote path-prefix handling). The watch self-hosted URL params now assert on the real dialled socket.
- Fix the stale `live-voice-client.test.ts` header (it mocks `resolveLiveVoiceWsUrl`, not the deleted builder).
- Em dash in the `resolveGatewayWsUrl` test banner replaced with a colon.
- Trim comments: `resolveWatchStreamWsUrl` docblock to two lines, the `connection.ts` module header to one sentence naming it the shared gateway WS transport, and `desktop-connection.ts` to one line pointing at the assistant's `DESKTOP_CLOSE` / ARCHITECTURE.md.
- `desktop-panel.test.tsx`: local `flush()` helper replaces five repeated `act(async () => { await Promise.resolve(); })` blocks.

Net -203 lines. Touched suites: 180 tests pass locally (with the gitignored generated client copied in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YDF6hHcX7aPZsc6TuByhy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41983" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->