### PR TITLE
fix(watch): name the retro card's question fields, and stop rendering "undefined"

### DIFF
--- a/assistant/src/__tests__/watch-retro-report-payload.test.ts
+++ b/assistant/src/__tests__/watch-retro-report-payload.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+
+import { WatchRetroSurfaceDataSchema } from "../api/surfaces.js";
+import type { ToolContext } from "../tools/types.js";
+import { executeWatchRetroReport } from "../tools/watch/watch-retro-report.js";
+
+/**
+ * The payload a dev-QA session produced: every question's text under
+ * `question` instead of `prompt`, every option's under `value` instead of
+ * `label`. Both are names the surface schema does not know, so it strips them
+ * and the card draws two pages with nothing on them.
+ */
+const MISNAMED_FIELDS = {
+  task: "Check Slack for unread messages between terminal work",
+  steps: ["Work in the terminal", "Switch to Slack"],
+  questions: [
+    {
+      id: "scope",
+      kind: "pick",
+      question: "Where does this routine end?",
+      options: [
+        { note: "This matches what the recording showed.", value: "Just read" },
+        { value: "Also draft or send replies" },
+      ],
+    },
+  ],
+} as const;
+
+/** The same report with the names the card actually reads. */
+const WELL_FORMED = {
+  task: "Check Slack for unread messages between terminal work",
+  steps: ["Work in the terminal", "Switch to Slack"],
+  questions: [
+    {
+      id: "scope",
+      kind: "pick",
+      prompt: "Where does this routine end?",
+      options: [
+        {
+          id: "scope-read",
+          label: "Just read",
+          note: "This matches what the recording showed.",
+        },
+        { id: "scope-reply", label: "Also draft or send replies" },
+      ],
+    },
+  ],
+} as const;
+
+const context = {} as ToolContext;
+
+async function report(input: unknown): Promise<{
+  content: string;
+  isError: boolean | undefined;
+}> {
+  const result = await executeWatchRetroReport(
+    input as Record<string, unknown>,
+    context,
+  );
+  return { content: result.content, isError: result.isError };
+}
+
+describe("watch_retro_report validates the question shape", () => {
+  test("a well-formed report is recorded", async () => {
+    const result = await report(WELL_FORMED);
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain('"recorded":true');
+  });
+
+  // The failure this whole file exists for. The surface schema is tolerant by
+  // design and will not complain, so the tool is the only layer that can tell
+  // the model, while it still has a turn to spend, that the card it just
+  // described has no text on it.
+  test("a question whose text is under the wrong key is refused by field name", async () => {
+    const result = await report(MISNAMED_FIELDS);
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("questions.0.prompt");
+  });
+
+  test("an option whose label is under the wrong key is refused by field name", async () => {
+    const result = await report({
+      ...WELL_FORMED,
+      questions: [
+        {
+          ...WELL_FORMED.questions[0],
+          options: [
+            { id: "a", value: "Just read" },
+            { id: "b", value: "Also reply" },
+          ],
+        },
+      ],
+    });
+    expect(result.isError).toBe(true);
+    // Named as the missing field, not as the option count. An array whose
+    // entries failed to parse looks empty, and "send more options" is the one
+    // correction that cannot help here.
+    expect(result.content).toContain("questions.0.options.0.label");
+    expect(result.content).not.toContain("two to four options");
+  });
+
+  test("a pick with one option is refused, since the renderer drops it", async () => {
+    const result = await report({
+      ...WELL_FORMED,
+      questions: [
+        {
+          ...WELL_FORMED.questions[0],
+          options: [WELL_FORMED.questions[0].options[0]],
+        },
+      ],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("two to four options");
+  });
+
+  test("a fill needs no options", async () => {
+    const result = await report({
+      ...WELL_FORMED,
+      questions: [
+        {
+          id: "start-phrase",
+          kind: "fill",
+          prompt: "What would you say to kick this off?",
+          suggestion: "check slack for unread",
+        },
+      ],
+    });
+    expect(result.isError).toBe(false);
+  });
+
+  // Two questions under one id is not a parse failure: the renderer keeps the
+  // first and drops the rest, because the id is the key an answer comes back
+  // under. The user loses a page and nothing says why.
+  test("two questions sharing an id are refused", async () => {
+    const result = await report({
+      ...WELL_FORMED,
+      questions: [WELL_FORMED.questions[0], { ...WELL_FORMED.questions[0] }],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain('id "scope"');
+  });
+
+  test("questions stay optional, since a settled recording asks nothing", async () => {
+    const result = await report({ task: "Rename a column", steps: ["Rename"] });
+    expect(result.isError).toBe(false);
+  });
+});
+
+describe("WatchRetroSurfaceDataSchema on a missing required string", () => {
+  // `z.coerce.string()` stringifies whatever it is handed, so an absent field
+  // parsed as the literal "undefined" and rendered as that word on the card.
+  // A blank is what the renderer's own filters are written against.
+  test("an absent prompt and label are blank, not the word undefined", () => {
+    const parsed = WatchRetroSurfaceDataSchema.parse(MISNAMED_FIELDS);
+    const question = parsed.questions?.[0];
+
+    expect(question?.prompt).toBe("");
+    expect(question?.options?.[0]?.label).toBe("");
+    expect(question?.options?.[0]?.id).toBe("");
+  });
+
+  test("an absent task is blank, so the card falls back rather than titling itself undefined", () => {
+    expect(WatchRetroSurfaceDataSchema.parse({ steps: [] }).task).toBe("");
+  });
+
+  // The point of the blank: it is what `isAnswerable` in the renderer filters
+  // an unusable question on. A card built from the misnamed payload shows its
+  // record and no question pages, instead of pages the user cannot read.
+  test("the fields the payload did name still survive", () => {
+    const parsed = WatchRetroSurfaceDataSchema.parse(MISNAMED_FIELDS);
+
+    expect(parsed.task).toBe(
+      "Check Slack for unread messages between terminal work",
+    );
+    expect(parsed.questions?.[0]?.options?.[0]?.note).toBe(
+      "This matches what the recording showed.",
+    );
+  });
+
+  test("a well-formed payload is unchanged by the coercion", () => {
+    const parsed = WatchRetroSurfaceDataSchema.parse(WELL_FORMED);
+
+    expect(parsed.questions?.[0]?.prompt).toBe("Where does this routine end?");
+    expect(parsed.questions?.[0]?.options?.[0]?.label).toBe("Just read");
+  });
+});

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -86,6 +86,23 @@ export function describeSurfaceDataStringParseFailure(
   }
 }
 
+/**
+ * Required string that coerces a scalar, treating an absent field as blank.
+ *
+ * `z.coerce.string()` is not a validator on a missing field: it stringifies
+ * whatever it is handed, so `undefined` parses successfully as the literal
+ * "undefined" and a trailing `.catch()` never runs. That string then renders,
+ * and a field the model simply failed to send reads to the user as a word
+ * nobody wrote. A blank is what the callers already handle: an empty title
+ * falls back to a default, and an empty prompt or label is what the watch
+ * retro card filters an unanswerable question out on.
+ */
+const coercedString = () =>
+  z.preprocess(
+    (value) => (value === undefined || value === null ? "" : value),
+    z.coerce.string().catch(""),
+  );
+
 /** Optional string that drops (rather than rejects on) a non-string value. */
 const tolerantString = () => z.string().optional().catch(undefined);
 
@@ -111,7 +128,7 @@ export const CardSurfaceDataSchema = z.object({
   subtitle: z.string().optional(),
   body: z.string().optional(),
   metadata: z
-    .array(z.object({ label: z.coerce.string(), value: z.coerce.string() }))
+    .array(z.object({ label: coercedString(), value: coercedString() }))
     .optional(),
   /** Optional template name for specialized rendering (e.g. "weather_forecast"). */
   template: z.string().optional(),
@@ -298,7 +315,7 @@ export const FormFieldSchema = z.object({
     .optional()
     .catch(undefined),
   options: z
-    .array(z.object({ label: z.coerce.string(), value: z.coerce.string() }))
+    .array(z.object({ label: coercedString(), value: coercedString() }))
     .optional()
     .catch(undefined),
 });
@@ -353,7 +370,7 @@ export const TableColumnSchema = z.object({
 export type TableColumn = z.infer<typeof TableColumnSchema>;
 
 export const TableCellValueSchema = z.object({
-  text: z.coerce.string().catch(""),
+  text: coercedString(),
   /** SF Symbol name. */
   icon: tolerantString(),
   /** Semantic token: "success" | "warning" | "error" | "muted". */
@@ -402,7 +419,7 @@ export const DynamicPagePreviewSchema = z.object({
   description: tolerantString(),
   icon: tolerantString(),
   metrics: z
-    .array(z.object({ label: z.coerce.string(), value: z.coerce.string() }))
+    .array(z.object({ label: coercedString(), value: coercedString() }))
     .optional()
     .catch(undefined),
   context: z.enum(["app_create", "general"]).optional().catch(undefined),
@@ -467,7 +484,7 @@ export const WorkResultSectionTypeSchema = z.enum([
 export type WorkResultSectionType = z.infer<typeof WorkResultSectionTypeSchema>;
 
 const workResultLabelValue = () => ({
-  label: z.coerce.string().catch(""),
+  label: coercedString(),
   value: z.union([z.string(), z.number()]).catch(""),
 });
 
@@ -483,7 +500,7 @@ export type WorkResultMetadata = z.infer<typeof WorkResultMetadataSchema>;
 
 export const WorkResultItemSchema = z.object({
   id: tolerantString(),
-  title: z.coerce.string().catch(""),
+  title: coercedString(),
   description: tolerantString(),
   status: tolerantString(),
   tone: WorkResultToneSchema.optional().catch(undefined),
@@ -506,7 +523,7 @@ export type WorkResultDiff = z.infer<typeof WorkResultDiffSchema>;
 
 export const WorkResultSectionSchema = z.object({
   id: tolerantString(),
-  title: z.coerce.string().catch(""),
+  title: coercedString(),
   description: tolerantString(),
   type: WorkResultSectionTypeSchema.optional().catch(undefined),
   items: recordArray(WorkResultItemSchema).optional().catch(undefined),
@@ -558,17 +575,17 @@ export type WatchRetroQuestionKind = z.infer<
  * deliberately not the model's guess.
  */
 export const WatchRetroOptionSchema = z.object({
-  id: z.coerce.string().catch(""),
-  label: z.coerce.string().catch(""),
+  id: coercedString(),
+  label: coercedString(),
   /** Short qualifier under the label, e.g. marking the model's own reading. */
   note: tolerantString(),
 });
 export type WatchRetroOption = z.infer<typeof WatchRetroOptionSchema>;
 
 export const WatchRetroQuestionSchema = z.object({
-  id: z.coerce.string().catch(""),
+  id: coercedString(),
   kind: WatchRetroQuestionKindSchema.catch("pick"),
-  prompt: z.coerce.string().catch(""),
+  prompt: coercedString(),
   /** Eyebrow above the prompt, naming why this one is being asked. */
   eyebrow: tolerantString(),
   /** `fill` only: the pre-filled value, so skipping keeps a working answer. */
@@ -583,7 +600,7 @@ export const WATCH_RETRO_MAX_QUESTIONS = 3;
 
 export const WatchRetroSurfaceDataSchema = z.object({
   /** The task, named in one line. The card's title. */
-  task: z.coerce.string().catch(""),
+  task: coercedString(),
   /** What the task is for. The one sentence that makes the steps mean something. */
   purpose: tolerantString(),
   /**

--- a/assistant/src/tools/watch/watch-retro-report.ts
+++ b/assistant/src/tools/watch/watch-retro-report.ts
@@ -34,18 +34,110 @@ import type {
  * that survives a crash between the call and the append: the transcript.
  *
  * **Validation is the model-facing half.** The payload is the card's own
- * schema, so a shape the renderer could not draw is refused here, while the
- * model still has a turn left to correct it. The daemon parses it again before
+ * shape, so one the renderer could not draw is refused here, while the model
+ * still has a turn left to correct it. The daemon parses it again before
  * appending, since a tool result is not a promise about what was persisted.
+ *
+ * **Questions are validated by shape, and the shape is not advertised.** The
+ * surface schema is tolerant and strips what it does not recognize, so a
+ * question sent as `question`/`value` instead of `prompt`/`label` parses clean
+ * and draws a page with no text on it. Checking the shape here turns that into
+ * a rejection naming the field, which the model has a turn left to act on.
+ * Advertising it too would be the surer teacher, but the always-loaded payload
+ * is within a few hundred bytes of the budget
+ * (`browser-skill-baseline-tool-payload`) and the question shape is around 450
+ * of them, spent on every request by every caller for a tool one flow uses.
+ * The divergence is safe in a way the general rule in `zod-tool-schema.ts`
+ * warns it is not: a model reaching this tool has been sent here by
+ * `RETRO_INSTRUCTIONS`, which names every field, so there is no caller that
+ * sees the terse schema without the contract.
  */
+
+/** One alternative on a `pick` or a `gate`. */
+const questionOptionSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  note: z.string().optional().catch(undefined),
+});
+
+/**
+ * One question, held to what the card can actually page through.
+ *
+ * A `pick` or a `gate` with fewer than two options is one button, which is not
+ * a question, and the renderer drops it. More than four is the questionnaire
+ * the paging exists to avoid, on a page that then scrolls. Rejecting either
+ * here means the model hears about the gap it could not name instead of the
+ * user reading a page that is missing or too long to tap through.
+ */
+const questionSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: z.enum(["fill", "pick", "gate"]),
+    prompt: z.string().min(1),
+    eyebrow: z.string().optional().catch(undefined),
+    suggestion: z.string().optional().catch(undefined),
+    // No `.catch`, for the same reason `questions` has none, and for one more:
+    // a swallowed option array reads as an empty one, so a mistyped `label`
+    // would come back as the count complaint below. That answer sends the
+    // model to add options it already sent.
+    options: z.array(questionOptionSchema).optional(),
+  })
+  .refine(
+    (question) => {
+      if (question.kind === "fill") {
+        return true;
+      }
+      const count = question.options?.length ?? 0;
+      return count >= 2 && count <= 4;
+    },
+    {
+      error: 'a "pick" or "gate" needs two to four options',
+      path: ["options"],
+    },
+  );
+
 export const watchRetroReportInputSchema = z.looseObject({
   task: z.string(),
   purpose: z.string().optional().catch(undefined),
   steps: z.array(z.string()).optional().catch(undefined),
   eyebrow: z.string().optional().catch(undefined),
   coverage: z.string().optional().catch(undefined),
-  questions: z.array(z.unknown()).optional().catch(undefined),
+  // No `.catch` here, unlike the decoration around it. A swallowed questions
+  // array is the failure this schema exists to report: the card would draw
+  // without the pages the model meant to ask on, and nothing would say so.
+  questions: z.array(questionSchema).optional(),
 });
+
+/**
+ * The same payload with the question shape left off, which is what the model
+ * is shown. Derived from the validating schema rather than written out beside
+ * it, so the fields around `questions` cannot drift from what is enforced.
+ * See the note above on why this one field is not advertised.
+ */
+const watchRetroReportAdvertisedSchema = watchRetroReportInputSchema.extend({
+  questions: z.array(z.unknown()).optional(),
+});
+
+/**
+ * The first id used by more than one question, or null when they are distinct.
+ *
+ * Checked here rather than in the schema because the renderer's response to a
+ * repeat is to drop the later question, not to fail: the id is the key an
+ * answer is held under, so two questions sharing one would submit whichever
+ * answer landed last for both.
+ */
+function firstDuplicateQuestionId(
+  questions: readonly { id: string }[] | undefined,
+): string | null {
+  const seen = new Set<string>();
+  for (const question of questions ?? []) {
+    if (seen.has(question.id)) {
+      return question.id;
+    }
+    seen.add(question.id);
+  }
+  return null;
+}
 
 export async function executeWatchRetroReport(
   input: Record<string, unknown>,
@@ -55,7 +147,7 @@ export async function executeWatchRetroReport(
   if (!parsed.success) {
     return invalidToolInputResult("watch_retro_report", parsed.error);
   }
-  const { task, steps } = parsed.data;
+  const { task, steps, questions } = parsed.data;
   if (!task || task.trim().length === 0) {
     return {
       content: '"task" is required: name the task the session recorded.',
@@ -72,6 +164,15 @@ export async function executeWatchRetroReport(
       isError: true,
     };
   }
+  // Last, because the record is the part a card cannot do without and a report
+  // missing it should hear about that first.
+  const duplicateId = firstDuplicateQuestionId(questions);
+  if (duplicateId !== null) {
+    return {
+      content: `Two questions share the id "${duplicateId}". An id is the handle an answer comes back under, so the card keeps the first question and drops the rest. Give each one its own.`,
+      isError: true,
+    };
+  }
   return {
     content: JSON.stringify({ recorded: true, steps: steps.length }),
     isError: false,
@@ -81,8 +182,9 @@ export async function executeWatchRetroReport(
 export const watchRetroReportTool = {
   name: "watch_retro_report",
   // Deliberately terse, field descriptions included: this tool is always
-  // registered, so every byte here is spent on every request, and the payload
-  // contract is carried by the retrospective prompt, which is the only caller.
+  // registered, so every byte here is spent on every request. The contract is
+  // carried by the retrospective prompt, its only caller, and enforced by the
+  // validating schema above, which is stricter than what this advertises.
   // `browser-skill-baseline-tool-payload` holds the total to a budget.
   description:
     "Report what a Watch (teach mode) session recorded. Only from a watch retrospective, which gives the payload shape.",
@@ -90,7 +192,7 @@ export const watchRetroReportTool = {
   executionTarget: "sandbox",
   defaultRiskLevel: RiskLevel.Low,
 
-  input_schema: toToolInputSchema(watchRetroReportInputSchema, {
+  input_schema: toToolInputSchema(watchRetroReportAdvertisedSchema, {
     advertiseRequired: ["task", "steps"],
   }),
 

--- a/assistant/src/watch/__tests__/watch-retro.test.ts
+++ b/assistant/src/watch/__tests__/watch-retro.test.ts
@@ -9,6 +9,8 @@ import {
   PROVIDER_ERROR_MESSAGE_KIND,
 } from "../../persistence/conversation-crud.js";
 import { initializeDb } from "../../persistence/db-init.js";
+import { toToolInputSchema } from "../../tools/shared/zod-tool-schema.js";
+import { watchRetroReportInputSchema } from "../../tools/watch/watch-retro-report.js";
 import {
   buildRetroWakeOptions,
   buildWatchRetroPrompt,
@@ -133,6 +135,28 @@ function emptyDispatch() {
 /** A turn that ran and wrote prose but never called the report tool. */
 function proseOnlyDispatch(reply = "Here is what I understood.") {
   return recordingDispatch(reply, undefined, null);
+}
+
+/**
+ * The required property names of the object schema reached by walking `path`,
+ * descending through array `items` wherever the path crosses one.
+ */
+function requiredFieldsUnder(
+  schema: Record<string, unknown>,
+  path: readonly string[],
+): string[] {
+  let node: Record<string, unknown> | undefined = schema;
+  for (const segment of path) {
+    const properties = node?.properties as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    node = properties?.[segment];
+    while (node?.items) {
+      node = node.items as Record<string, unknown>;
+    }
+  }
+  const required = node?.required;
+  return Array.isArray(required) ? (required as string[]) : [];
 }
 
 describe("watch retrospective", () => {
@@ -879,5 +903,38 @@ describe("watch retrospective", () => {
 
     expect(prompt).toContain("<ax-tree>");
     expect(prompt).toContain("</ax-tree>");
+  });
+
+  /**
+   * The instructions are the only place the model learns what to put in a
+   * question, and a field they leave unnamed is one it has to invent a name
+   * for. The surface schema strips what it does not recognize, so an invented
+   * name draws a page with no text on it rather than failing anywhere.
+   *
+   * Read out of the tool's validating schema instead of listed here, so a
+   * field added to the payload cannot be added without a line about it. The
+   * validating one rather than the advertised one, because the question shape
+   * is deliberately not advertised: the prompt is where the model gets it, so
+   * the prompt is what has to be complete.
+   */
+  test("the instructions name every field a question requires", async () => {
+    // A timeline of two words, so a field name found below is one the
+    // instructions wrote rather than one the recording happened to contain.
+    const { sessionId } = recordObservation("Window: Editor");
+    const prompt = buildWatchRetroPrompt(renderWatchTimeline(sessionId));
+
+    const schema = toToolInputSchema(watchRetroReportInputSchema);
+    const questionShape = requiredFieldsUnder(schema, ["questions"]);
+    const optionShape = requiredFieldsUnder(schema, ["questions", "options"]);
+
+    // The two the dev-QA payload came back without, named so the guard reads
+    // as the thing it is defending rather than as an empty loop if the shape
+    // lookup ever returns nothing.
+    expect(questionShape).toContain("prompt");
+    expect(optionShape).toContain("label");
+
+    for (const field of [...questionShape, ...optionShape]) {
+      expect(prompt).toMatch(new RegExp(`\\b${field}\\b`));
+    }
   });
 });

--- a/assistant/src/watch/watch-retro.ts
+++ b/assistant/src/watch/watch-retro.ts
@@ -167,7 +167,7 @@ The payload:
 - \`purpose\`: one sentence on what it is for. This is the only sentence on the card.
 - \`steps\`: the steps in order, as short imperative fragments: "Open the Sentry issue", not "You opened the Sentry issue from the alert email". Three to eight of them. Concrete enough to follow, carrying no purpose of their own.
 - \`eyebrow\`: the session's own facts, e.g. "Watched 4 min, 11 screens".
-- \`questions\`: at most three, most consequential first. Fewer is better, and none is a valid answer if the recording settled everything. Give each one an \`id\` no other question on this card uses.
+- \`questions\`: at most three, most consequential first. Fewer is better, and none is a valid answer if the recording settled everything. Each question is \`{ id, kind, prompt }\`: \`prompt\` is the question worded the way you would ask it out loud, and \`id\` is a handle no other question on this card uses. A \`pick\` or a \`gate\` adds \`options\`, each of them \`{ id, label }\` and optionally a \`note\`: \`label\` is the answer as the user reads it, and \`id\` is that option's own handle. Use those names exactly. A question's text is \`prompt\` and never \`question\` or \`text\`; an option's text is \`label\` and never \`value\` or \`title\`. Anything sent under another name is dropped on the way to the card, and the page it belonged to is lost.
 
 Every question is answerable in one tap and every one is skippable, so ask only about what you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Do not ask the user to confirm something the recording already showed you.
 

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
@@ -318,4 +318,43 @@ describe("WatchRetroSurface", () => {
     fireEvent.click(screen.getByText("Save skill"));
     expect(screen.queryByText("What decides this?")).toBeNull();
   });
+
+  /**
+   * What a payload with the question text under the wrong key degrades to.
+   *
+   * `watch_retro_report` refuses this shape now, so it should not reach a
+   * card. If one ever does, the record is still the half the user is owed, and
+   * a question with no text is dropped the same way an optionless one is. The
+   * schema is what makes that possible: an absent required string parses as
+   * blank rather than as the word "undefined", which used to render.
+   */
+  test("a question whose text arrived under the wrong key leaves the record intact", () => {
+    render(
+      <CardSurface
+        surface={surface({
+          questions: [
+            {
+              id: "scope",
+              kind: "pick",
+              question: "Where does this routine end?",
+              options: [
+                { value: "Just read" },
+                { value: "Also draft or send replies" },
+              ],
+            },
+          ],
+        })}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(
+      screen.getByText("Filing a Linear bug from a Sentry alert"),
+    ).toBeDefined();
+    expect(screen.getByText("Open the Sentry issue")).toBeDefined();
+    expect(screen.queryByText("undefined")).toBeNull();
+    // Dropped rather than drawn: the record page is the only page, so it
+    // carries the closing button rather than a hand-off to a blank question.
+    expect(screen.getByText("Save skill")).toBeDefined();
+  });
 });

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -417,9 +417,14 @@ function QuestionPage({
 
       {question.kind === "fill" ? (
         <div className="mt-3">
+          {/* `Input` is `w-fit` by default, which sizes the box to whatever
+              the suggestion happens to be and clips the rest of it. The
+              trigger phrase is the one thing on this card the user types, and
+              it has to be readable while they edit it. */}
           <Input
             id={promptId}
             type="text"
+            fullWidth
             disabled={disabled}
             value={answer?.answer ?? ""}
             onChange={(event) => {


### PR DESCRIPTION
Follow-up to the paged Watch retro card (#41912), from dev QA. Page one rendered correctly; every question page read `undefined` for the prompt and for each option label.
## What happened

Three things lined up.

**The payload contract never named two fields.** `RETRO_INSTRUCTIONS` documents `id`, `kind`, `suggestion`, `note` and `options`, but not the fields carrying the text a question is made of. The model guessed `question` and `value`; the surface schema reads `prompt` and `label`, so Zod stripped them. Everything the contract *did* name came through, which is why the `note` under the first option and the `fill` suggestion were the only readable text on those pages.

```jsonc
// what the model sent
{ "id": "scope", "kind": "pick",
  "question": "Where does this routine end?",          // schema reads `prompt`
  "options": [{ "value": "Just check and read", ... }] // schema reads `label`
}
```

**`z.coerce.string().catch("")` printed the word.** Coercion is not a validator on a missing field: `String(undefined)` is `"undefined"`, the parse succeeds, and the `.catch` never runs. Had the fields arrived blank, the renderer's own `isAnswerable` would have dropped both questions and the card would have shown its record and nothing else.

**The tool that should have caught it wasn't looking.** `watch_retro_report` claimed in its doc comment to refuse a shape the renderer could not draw, while declaring `questions: z.array(z.unknown())`.

## The fix

- **Prompt** names `prompt` and `label`, says the names are exact, and lists the plausible wrong ones.
- **Schema** gains `coercedString`, which maps nullish to blank before coercing, applied at all twelve sites in `surfaces.ts` that coerce a required string. This class of failure now degrades to a dropped question instead of a printed word.
- **Tool** validates the real question shape. This is the layer that closes the loop: the model self-corrected within the same turn when this tool rejected a malformed `steps`, and it would have had the same chance here. `.catch` came off `questions` and `options` as well, since a swallowed array reports a mistyped `label` as a wrong option *count* and sends the correction the wrong way.

## On the byte budget

The question shape is validated but **not advertised**. The always-loaded tool payload is 34,834 bytes against a 35,000 budget, and the shape is about 450 of them, paid on every request by every caller for a tool one flow uses. The divergence is safe here in a way `zod-tool-schema.ts` warns it usually is not: nothing reaches this tool except via the retrospective prompt, which now names every field. **The serialized payload is unchanged, byte for byte.**

Worth knowing separately: that budget has 166 bytes of headroom on `main`, and the test's comment still claims the payload is "~22 000 chars". The next tool touch will hit it.

## Tests

Cover all three layers, plus a guard for the gap that made this invisible: the instructions are asserted to name every field the validating schema requires, read out of the schema rather than listed, so a field cannot be added to the payload without a line about it. The web test asserts the user-facing outcome (record intact, no `undefined`) and fails without the schema change.

## Not addressed

The retro turn also wrote a prose sign-off despite `Nothing follows it: no prose`, and it renders twice. The duplication is a client merge artifact, not the model writing twice: four persisted messages merge into one, and the last carries a re-aggregated `text` block plus a `thinking` block that is every prior thinking string concatenated. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGAXsbmoKfTJo9E14cC1vc
