### PR TITLE
fix: dedupe tests, align the retirement recipe, and true up gate comments

### DIFF
--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -365,16 +365,16 @@ inline in `App/project.yml` under the `AppEnvironment` template.
   Settings -> General -> Preferences -> App icon
   (`clients/web/src/domains/settings/components/app-icon-modal.tsx`), which
   every capable iOS shell offers: a native iOS shell carrying the `AppIcon`
-  plugin is the whole gate, with no flag in front of it. The picker cycles
-  eyes and color over the same component library the artwork is generated
-  from, seeds its selection from the assistant's avatar when that avatar is a
-  character one, and resets back to the target's primary icon. Applying is
-  always a press: iOS puts up a system alert of its own on every icon change,
-  so nothing swaps on its own. Version skew degrades in two layers, neither an
-  error: a shell without the `AppIcon` plugin reports unsupported, so the
-  picker row does not render at all, and on a shell that has the plugin a
-  composed name is applied only when the shell lists it in `available`, so a
-  missing name reads as a disabled Set button rather than a failed swap.
+  plugin is the whole gate. The picker cycles eyes and color over the same
+  component library the artwork is generated from, seeds its selection from
+  the assistant's avatar when that avatar is a character one, and resets back
+  to the target's primary icon. Applying is always a press: iOS puts up a
+  system alert of its own on every icon change, so nothing swaps on its own.
+  Version skew degrades in two layers, neither an error: a shell without the
+  `AppIcon` plugin reports unsupported, so the picker row does not render at
+  all, and on a shell that has the plugin a composed name is applied only when
+  the shell lists it in `available`, so a missing name reads as a disabled Set
+  button rather than a failed swap.
 - `App/App/Base.lproj/LaunchScreen.storyboard` references the `Splash`
   imageset in `Assets.xcassets/`. Those 2732×2732 PNGs are a solid green
   background with a centered white V — same palette as the icon.

--- a/clients/web/src/domains/settings/components/app-icon-row.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.tsx
@@ -7,8 +7,8 @@
  * an avatar switched to an uploaded image leaves the old icon in place until
  * someone resets it from the picker.
  *
- * Draws nothing at all outside the native mobile shells, with the running
- * shell's own flag off, or on a build that ships no alternate icons.
+ * Draws nothing at all outside the native mobile shells, on Android with
+ * `android-avatar-app-icon` off, or on a build that ships no alternate icons.
  */
 import { useState } from "react";
 

--- a/clients/web/src/hooks/use-app-icon-sync.test.tsx
+++ b/clients/web/src/hooks/use-app-icon-sync.test.tsx
@@ -138,17 +138,6 @@ describe("useAppIconSync", () => {
     expect(getAppIconState).not.toHaveBeenCalled();
   });
 
-  test("runs on the iOS shell with no flags set", async () => {
-    // The iOS picker is unconditional: a capable shell is the whole gate.
-    const { result } = await renderSync();
-
-    await waitFor(() => {
-      expect(result.current.enabled).toBe(true);
-    });
-    expect(result.current.targetIcon).toBe(ICON);
-    expect(result.current.canSyncAvatar).toBe(true);
-  });
-
   test("runs on the Android shell behind its own flag", async () => {
     nativeIOS = false;
     nativeAndroid = true;

--- a/clients/web/src/hooks/use-app-icon-sync.ts
+++ b/clients/web/src/hooks/use-app-icon-sync.ts
@@ -70,8 +70,7 @@ export function useAppIconSync(assistantId: string | null): AppIconSync {
   const isNativeAndroid = useIsNativeAndroid();
   const androidFlagEnabled =
     useClientFeatureFlagStore.use.androidAvatarAppIcon();
-  // The picker is unconditional on iOS shells. Android keeps its own flag, so
-  // its rollout opens on its own schedule.
+  // Android keeps its own flag, so its rollout opens on its own schedule.
   const gateOpen = isNativeIOS || (isNativeAndroid && androidFlagEnabled);
 
   const { state } = useAssistantAvatar(assistantId);

--- a/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
+++ b/clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   ASSISTANT_FLAG_DEFAULTS,
+  ASSISTANT_STRING_FLAG_DEFAULTS,
   CLIENT_FLAG_DEFAULTS,
   CLIENT_STRING_FLAG_DEFAULTS,
   getEnvFlagOverridesForScope,
@@ -88,6 +89,8 @@ describe("feature flag catalog", () => {
   test("does not expose the GA iOS avatar app icon as a feature flag", () => {
     expect("iosAvatarAppIcon" in CLIENT_FLAG_DEFAULTS).toBe(false);
     expect("iosAvatarAppIcon" in ASSISTANT_FLAG_DEFAULTS).toBe(false);
+    expect("iosAvatarAppIcon" in CLIENT_STRING_FLAG_DEFAULTS).toBe(false);
+    expect("iosAvatarAppIcon" in ASSISTANT_STRING_FLAG_DEFAULTS).toBe(false);
   });
 
   test("does not expose GA summarize-up-to-here as a feature flag", () => {

--- a/meta/feature-flags/AGENTS.md
+++ b/meta/feature-flags/AGENTS.md
@@ -50,13 +50,7 @@ The `id` and `key` fields in `feature-flag-registry.json` **must match** and bot
 
 1. **Remove the code reads and the registry entry in the same PR.** A registry-only removal breaks the gated surface silently: the web flag stores hold `Record<string, boolean>` state behind the `createSelectors` Proxy (`clients/web/src/utils/create-selectors.ts`), so `store.use.<removedKey>()` still type-checks and just returns `undefined`. The gate reads falsy, the surface vanishes, and no type check or test fails.
 
-2. Run the sync script so the bundled copies match the canonical registry:
-
-   ```bash
-   bun run meta/sync-bundled-copies.ts
-   ```
-
-   Commit the regenerated `clients/web/src/lib/feature-flags/feature-flag-registry.json` alongside `meta/feature-flags/feature-flag-registry.json`. CI byte-compares them (`bun run meta/sync-bundled-copies.ts --check`), so a stale copy fails the build.
+2. Run `bun run meta/sync-bundled-copies.ts`. Commit the regenerated `clients/web/src/lib/feature-flags/feature-flag-registry.json` alongside `meta/feature-flags/feature-flag-registry.json`. CI byte-compares them (`bun run meta/sync-bundled-copies.ts --check`), so a stale copy fails the build.
 
 3. Add a negative assertion to `clients/web/src/lib/feature-flags/feature-flag-catalog.test.ts`, following the existing block of such tests:
 
@@ -69,18 +63,17 @@ The `id` and `key` fields in `feature-flag-registry.json` **must match** and bot
    });
    ```
 
-   Assert against every catalog the flag's scope and type map to. `clients/web/src/lib/feature-flags/feature-flag-catalog.ts` exports four: `CLIENT_FLAG_DEFAULTS` and `ASSISTANT_FLAG_DEFAULTS` hold only boolean-valued flags, `CLIENT_STRING_FLAG_DEFAULTS` and `ASSISTANT_STRING_FLAG_DEFAULTS` only string-valued ones, and each is filtered to its own scope. Covering all four is the reliable choice: a subset that misses the retired flag's scope-and-type pair still passes after the key comes back, so an assistant-scoped string flag checked against the boolean pair plus the client string catalog is reintroduced silently. The assertion pins the removal so a later registry edit cannot quietly reintroduce the key.
+   Assert the key is absent from all four catalogs `feature-flag-catalog.ts` exports, as the sample does. A subset can silently miss the flag's own scope-and-type pair, so an assistant-scoped string flag checked against only the two boolean catalogs and the client string one still passes once the key comes back.
 
 4. Delete the flag's row from `meta/feature-flags/PENDING_PLATFORM_PRS.md` if one remains, and sweep the other rows for cross-references naming the retired key. A replacement flag's row often cites the key it supersedes. Read the row's Status column before deleting it: a pending row can track an already-open provisioning PR in `vellum-assistant-platform` rather than unstarted work. Close that PR, or update it to drop the retired key, as part of the retirement. Deleting the row alone leaves the PR free to merge later and create a live LaunchDarkly flag with no reader and nothing left tracking its cleanup.
 
-5. **Archive the LaunchDarkly flag in a separate follow-up PR** in `vellum-assistant-platform` that sets `archived = true` on the flag's Terraform entry, unless the flag was never provisioned. A dark-shipped flag whose only platform record is the `PENDING_PLATFORM_PRS.md` row deleted in step 4 has no Terraform entry to archive, and retirement ends at step 4 once that row is gone and any provisioning PR it links is closed: do not create the flag on the platform just to archive it. Otherwise archive it, and **never remove the entry**: deleting the key destroys the LaunchDarkly flag and its history. See the "Feature Flags (LaunchDarkly)" section of `../vellum-assistant-platform/AGENTS.md` for the Terraform side. Open the archival PR for a provisioned flag as part of retiring it: app-side removals whose archival PR never follows leave orphaned live flags in LaunchDarkly with nothing left reading them.
+5. **Archive the LaunchDarkly flag in a separate follow-up PR** in `vellum-assistant-platform`. The app-code PR of steps 1 through 4 goes first, and the archival PR is opened as part of the same retirement: an app-side removal whose archival never follows leaves an orphaned live flag with nothing reading it.
 
-   **Merge the archival PR only once every shipped reader of the flag has stopped reading it.** Archiving stops LaunchDarkly serving the flag's targeted value, so any build still reading the key silently falls back to its bundled registry default. The simplest case is a flag whose only reader is the hosted web bundle: the gate is the app-side PR merging and its web deploy going live. Two kinds of reader extend the wait past that point:
+   **Merge the archival PR only once every shipped reader has stopped reading the flag.** Archiving stops LaunchDarkly serving the targeted value, so any build still reading the key silently falls back to its bundled registry default. A flag whose only reader is the hosted web bundle is the simplest case: the app-code PR merging and its web deploy going live is the whole gate. Packaged desktop builds serve `clients/web/dist` from disk, and assistant code resolves remote flags itself rather than through the web bundle, so either one keeps reading the key until the release carrying the removal reaches users. Gate the archival on that rollout instead of on the web deploy.
 
-   - **Packaged desktop builds.** The macOS, Windows, and Linux apps bundle `clients/web/dist` into their installers and serve it from disk, so installed versions keep reading the key regardless of what the live website serves. Wait for the release carrying the removal to reach those users.
-   - **Assistant-scope flags.** Assistant code resolves remote flags itself rather than through the web bundle, so a released assistant keeps reading the key until it updates.
+   **A flag that was never provisioned is the exception.** A dark-shipped flag whose only platform record is the `PENDING_PLATFORM_PRS.md` row deleted in step 4 has no Terraform entry to archive. Retirement ends at step 4 once that row is gone and any provisioning PR it links is closed. Do not create the flag on the platform just to archive it.
 
-   When readers like these exist, gate the archival on their rollout, not on the web deploy.
+   Archive, never delete: removing the entry destroys the LaunchDarkly flag and its history. See the "Feature Flags (LaunchDarkly)" section of `../vellum-assistant-platform/AGENTS.md` for the Terraform mechanics.
 
 ## Creating a Feature Gate
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for retire-ios-app-icon-flag.md.

**Gaps:** a duplicate iOS baseline test; the catalog negative test covering two catalogs while the recipe prescribes four; internally inconsistent and platform-doc-duplicating recipe prose; six comments restating the absent iOS flag where one suffices, one of them stale
**Fix:** duplicate test deleted, the negative test asserts all four catalogs, the recipe states one rule once and defers mechanics to the platform doc, and the gate comments state the asymmetric gate accurately in one place