### PR TITLE
feat(web): add camera-mode view settings

### DIFF
--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -19,10 +19,11 @@ scrim.
       the mobile sheet, on a notched device and on a Dynamic Island device. The
       pill sits below the island, on the minimize control's line, and never
       behind it.
-- [ ] The pill clears the corner control. Give the assistant a name of 40
+- [ ] The pill clears both corner controls. Give the assistant a name of 40
       characters or more and open the camera at portrait phone width. The name
       truncates to an ellipsis, the dot and "Photo" stay whole, and the pill's
-      edge never reaches the minimize control.
+      edge never reaches the view-options button or the minimize control behind
+      it.
 - [ ] The pill clears the grabber. In the mobile sheet, the pill sits below the
       grabber and the grabber still takes the pull-down.
 - [ ] The sheet goes full-bleed for the camera. Open the camera in the mobile
@@ -50,9 +51,27 @@ scrim.
       spoken once, as "Photo. Listening" or "Photo. {name} speaking". Mute the
       mic mid-turn and the announcement carries "Muted". Nothing says the state
       a second time.
-- [ ] VoiceOver reaches every control. Swipe through the chrome: minimize,
-      flash, shutter, flip, mic, speaker, camera, end. Each name matches what a
-      press does, and the flash names the state it is in rather than the act.
+- [ ] VoiceOver reaches every control. Swipe through the chrome: view options,
+      minimize, flash, shutter, flip, mic, speaker, camera, end. Each name
+      matches what a press does, and the flash names the state it is in rather
+      than the act.
+- [ ] View options opens as a panel, not a sheet. Tap the sliders button in the
+      corner with the camera up. The panel opens anchored under the button, its
+      switches take a tap, and tapping the feed outside it dismisses it. It is
+      never announced as a modal dialog that traps VoiceOver, and it never
+      arrives dead to touch.
+- [ ] The kept-frame switch reaches the thumbnail. Enter Live, wait for the
+      crimson thumbnail beside the photo strip, then turn "Kept frame" off. The
+      thumbnail goes, the row it sat in goes with it when no photos are in the
+      strip, and the assistant keeps answering questions about what the camera
+      is pointed at. Turn it back on and the next keep draws again.
+- [ ] Both switches survive a reload and a second tab. Set them, background and
+      relaunch the app: they come back as set. With two web tabs open, a change
+      in one is reflected in the other's panel.
+- [ ] The readout row appears only where the readout does. On a staff or
+      flagged session the panel has two rows; on an ordinary session it has one.
+      Where both exist, Settings, Debug, General and this panel move the same
+      switch in both directions.
 - [ ] VoiceOver hears a failure. Deny the camera permission in Settings, then
       press the camera control. The refusal is spoken, not only drawn.
 - [ ] The capture pulse reads. Take a photo against a bright frame and a dark
@@ -132,9 +151,12 @@ rather than the pill going on claiming a stream nothing is reading.
       Display), reload, open the camera. The status dot holds still and fully
       lit. The shutter's capture pulse still fires and is shorter. The core's
       morph has no overshoot.
-- [ ] Keyboard walk. Tab from the top of the room: minimize, shutter, flip, mic,
-      speaker, camera, end. Every focus ring is a white outline legible over the
-      feed, including over a white frame.
+- [ ] Keyboard walk. Tab from the top of the room: view options, minimize,
+      shutter, flip, mic, speaker, camera, end. Every focus ring is a white
+      outline legible over the feed, including over a white frame.
+- [ ] Escape closes the panel before it minimizes the room. With the view
+      options open, one Escape closes the panel and leaves the room up; a second
+      minimizes the room.
 - [ ] A mouse can hold. Press and keep the button down on the shutter for half a
       second: Live starts, and releasing takes no photo. Press and drag off the
       button before the half second and nothing happens at all.
@@ -179,6 +201,17 @@ the redesign is called shipped.
 - [ ] Minimize in camera mode. The design gives the camera view only the grabber
       and end session as exits. The build keeps the top-right minimize control,
       which is the only discoverable exit on desktop. Confirm.
+- [ ] Pill centring with two corner controls. The design centres the pill on the
+      screen against a single corner control. The build centres it in the band
+      the corner cluster leaves, so it sits a little left of screen centre: with
+      two 52px controls there, a screen-centred pill reaches under them at phone
+      width before its own floor width is spent. Confirm the band centring, or
+      ask for a pill that may narrow past its floor instead.
+- [ ] View options as a panel on touch. The chat column's other panels open as a
+      bottom sheet on a phone. This one stays anchored on every form factor: the
+      room is itself a sheet whose flush camera state inerts the overlay host it
+      shares, so a nested sheet arrives inert. Confirm the anchored panel on a
+      phone, or ask for the sheet and the room's inerting reworked with it.
 - [ ] Capture feedback reaches the deep-link overlay too. The shutter is shared,
       so dimming the core while a frame uploads restyles the overlay's shutter
       as well as the room's, and it is an opacity dip rather than the core

--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -70,8 +70,8 @@ scrim.
       in one is reflected in the other's panel.
 - [ ] The readout row appears only where the readout does. On a staff or
       flagged session the panel has two rows; on an ordinary session it has one.
-      Where both exist, Settings, Debug, General and this panel move the same
-      switch in both directions.
+      This panel is the only place the readout is switched on and off, so check
+      Settings, Debug, General carries no row for it.
 - [ ] VoiceOver hears a failure. Deny the camera permission in Settings, then
       press the camera control. The refusal is spoken, not only drawn.
 - [ ] The capture pulse reads. Take a photo against a bright frame and a dark

--- a/clients/web/src/domains/chat/voice/camera-mode-screen.stories.tsx
+++ b/clients/web/src/domains/chat/voice/camera-mode-screen.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * Camera mode as one screen: the feed, the two scrims, the status pill, the
- * shutter row and the session controls, at the offsets and in the stacking
- * order the room gives them.
+ * top-right corner cluster, the shutter row and the session controls, at the
+ * offsets and in the stacking order the room gives them.
  *
  * The per-component stories next door each answer one question about one
  * control over video. This file answers the ones only the assembled surface
@@ -17,7 +17,15 @@
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { CameraOff, Mic, MicOff, Volume2, X } from "lucide-react";
+import {
+  CameraOff,
+  ChevronDown,
+  Mic,
+  MicOff,
+  SlidersHorizontal,
+  Volume2,
+  X,
+} from "lucide-react";
 
 // The pill's blink and the shutter's morph and capture pulse are hand-written
 // keyframes in the app stylesheet, which Storybook's preview.css does not pull
@@ -55,6 +63,14 @@ const STORY_INSET = "1.25rem";
  */
 const SHUTTER_ROW_BOTTOM = `calc(6.125rem + ${STORY_INSET})`;
 
+/**
+ * The right edge of the band the pill is centred in: the story inset plus the
+ * corner cluster (two 52px controls and the 4px between them) plus the 8px the
+ * pill never closes. `voice-room.tsx` keeps the real expression, which adds the
+ * safe-area inset the room's own controls ride.
+ */
+const PILL_BAND_RIGHT = `calc(${STORY_INSET} + 7.25rem)`;
+
 /** The shutter's accessible name per mode, mirroring the room's catalog copy. */
 const SHUTTER_LABELS: Record<CameraMode, string> = {
   photo: "Take photo",
@@ -82,7 +98,9 @@ interface CameraModeScreenProps {
  *
  * Everything visible here is the real component: `CameraStatusPill`, the
  * shutter row's `CameraShutter` and `CameraFlashControl` through
- * `CameraRowScene`, and the four `VoiceRoomControl`s of the session row. What
+ * `CameraRowScene`, and the `VoiceRoomControl`s of the corner cluster and the
+ * session row. The corner's view-options control is its trigger only, since
+ * the panel it opens reads live stores this scene has none of. What
  * this scene supplies is only what the app supplies around them: the frame,
  * the two scrims, and where each piece sits. In the app that job belongs to
  * `voice-room.tsx`, which wires the same pieces to the live session and the
@@ -122,13 +140,13 @@ function CameraModeScreen({
         style={{ background: CAMERA_SCRIM_BOTTOM }}
       />
 
-      {/* Top-centre, on the corner chrome's line. The room also caps the
-          pill's width so a long name cannot run under the minimize control;
-          that ceiling is the room's to know, and the pill's own
-          `LongAssistantName` story is where it is exercised. */}
+      {/* The pill, centred in the band the corner cluster leaves rather than on
+          the screen: the cluster holds two controls, and a pill centred on the
+          screen would reach under them at phone width before its own floor
+          width was spent. */}
       <div
-        className="pointer-events-none absolute left-1/2 z-10 -translate-x-1/2"
-        style={{ top: STORY_INSET }}
+        className="pointer-events-none absolute z-10 flex justify-center"
+        style={{ top: STORY_INSET, left: STORY_INSET, right: PILL_BAND_RIGHT }}
       >
         <CameraStatusPill
           mode={mode}
@@ -136,6 +154,32 @@ function CameraModeScreen({
           statusLabel={statusLabel}
           assistantName={assistantName}
         />
+      </div>
+
+      {/* The corner cluster: the camera's view options, then minimize on the
+          extreme corner. Both wear the glass corner treatment rather than the
+          session row's fills, so the corner reads as chrome over the feed
+          instead of joining the row of acts at the bottom. */}
+      <div
+        className="absolute z-10 flex items-center gap-1"
+        style={{ top: STORY_INSET, right: STORY_INSET }}
+      >
+        <VoiceRoomControl
+          bare
+          surface="camera"
+          label="Camera view options"
+          onClick={noop}
+        >
+          <SlidersHorizontal className="size-5" />
+        </VoiceRoomControl>
+        <VoiceRoomControl
+          bare
+          surface="camera"
+          label="Minimize voice room"
+          onClick={noop}
+        >
+          <ChevronDown className="size-5" />
+        </VoiceRoomControl>
       </div>
 
       {/* The shutter row, a row of its own above the session controls, with
@@ -312,6 +356,23 @@ export const MicMutedControls: Story = {
  * be read against each other in one frame.
  */
 export const LiveMode: Story = { args: { mode: "live" } };
+
+/**
+ * A configured name long enough to run out of room, at the width where it has
+ * the least: the case the corner cluster made harder by taking a second
+ * control.
+ *
+ * The read to check is the right edge. The name truncates to an ellipsis, the
+ * dot and the mode word stay whole, and nothing about the pill reaches the
+ * view-options button beside minimize.
+ */
+export const LongAssistantName: Story = {
+  args: {
+    voiceState: "assistant",
+    statusLabel: "Speaking…",
+    assistantName: "A considerably longer configured assistant name",
+  },
+};
 
 /**
  * The same composition at a desktop width, which is the room's `content` and

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
@@ -5,8 +5,8 @@
  * The availability rule itself belongs to `lib/camera/frame-gate-debug-access`
  * and is stubbed here, so what is under test is the component's own wiring:
  * which rows a session sees, which store each row writes, and the panel
- * portaling inside the component's box rather than beside the room, which is
- * what keeps it clear of the sheet's inert sweep.
+ * rendering into the host it is handed. Which element that host is, and where
+ * the room puts it, is the room's own subject in `voice-room.test.tsx`.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -34,9 +34,17 @@ const trigger = () => screen.getByTestId("camera-view-settings");
 const panel = () => screen.queryByTestId("camera-view-settings-panel");
 const row = (name: string) => screen.queryByRole("switch", { name });
 
+/** Stands in for the element the room owns and hands down. */
+let panelHost: HTMLDivElement | null = null;
+
+/** Render the control with a host to put its panel in. */
+function renderSettings(): void {
+  render(<CameraViewSettings panelHost={panelHost} />);
+}
+
 /** Open the panel the way a user does. */
 async function openPanel(): Promise<void> {
-  render(<CameraViewSettings />);
+  renderSettings();
   await act(async () => {
     fireEvent.click(trigger());
   });
@@ -44,17 +52,21 @@ async function openPanel(): Promise<void> {
 
 beforeEach(() => {
   hudAvailable = false;
+  panelHost = document.createElement("div");
+  document.body.appendChild(panelHost);
   useCameraGateDebugStore.setState({ hudEnabled: false });
   useVoicePrefsStore.setState({ showKeptFrame: true });
 });
 
 afterEach(() => {
   cleanup();
+  panelHost?.remove();
+  panelHost = null;
 });
 
 describe("CameraViewSettings", () => {
   test("shows the button, and nothing else until it is pressed", async () => {
-    render(<CameraViewSettings />);
+    renderSettings();
 
     expect(trigger().getAttribute("aria-label")).toBe("Camera view options");
     expect(panel()).toBeNull();
@@ -71,7 +83,7 @@ describe("CameraViewSettings", () => {
     // `VoiceRoomControl` is the room's element rather than the design
     // library's, so a trigger composed onto it only works because it passes
     // what it is handed through to the button underneath.
-    render(<CameraViewSettings />);
+    renderSettings();
     expect(trigger().getAttribute("aria-haspopup")).toBe("dialog");
     expect(trigger().getAttribute("aria-expanded")).toBe("false");
 
@@ -82,14 +94,15 @@ describe("CameraViewSettings", () => {
     expect(trigger().getAttribute("aria-expanded")).toBe("true");
   });
 
-  test("the panel lands inside the button's own box, not beside the room", async () => {
+  test("the panel renders into the host it is handed, not beside the trigger", async () => {
     await openPanel();
 
-    // The room portals its sheet into `#viewport-overlays` and inerts that
-    // host's other children while the camera is flush, so a panel portaled
-    // there arrives dead. This one is a descendant of the control it opens
-    // from, which that sweep never reaches.
-    expect(trigger().parentElement?.contains(panel())).toBe(true);
+    // The host is the room's, and being the room's is what keeps the panel
+    // clear of both the sheet's inert sweep and the corner cluster's own
+    // stacking context. Rendering beside the trigger would put it back in the
+    // second of those.
+    expect(panelHost?.contains(panel())).toBe(true);
+    expect(trigger().parentElement?.contains(panel())).toBe(false);
   });
 
   test("a session without the readout gets the thumbnail row alone", async () => {
@@ -105,6 +118,27 @@ describe("CameraViewSettings", () => {
 
     expect(row("Frame gate readout")).not.toBeNull();
     expect(row("Kept frame")).not.toBeNull();
+  });
+
+  test("each switch points at its own description", async () => {
+    hudAvailable = true;
+    await openPanel();
+
+    /** The text a screen reader is given after the switch's name. */
+    const describedText = (name: string): string | undefined => {
+      const id = row(name)?.getAttribute("aria-describedby");
+      return id ? (document.getElementById(id)?.textContent ?? "") : undefined;
+    };
+
+    // The thumbnail row's line is the only place the panel says the sending
+    // carries on, so a switch that did not point at it would offer to turn
+    // Live's signal off with the reassurance left on screen and out of reach.
+    expect(describedText("Kept frame")).toBe(
+      "The last frame Live sent, beside your photos. Live keeps sending either way.",
+    );
+    expect(describedText("Frame gate readout")).toBe(
+      "The tuning readout for what Live keeps.",
+    );
   });
 
   test("the thumbnail row writes the voice preference", async () => {

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
@@ -216,7 +216,7 @@ describe("CameraViewSettings", () => {
     expect(row("Kept frame")?.getAttribute("aria-checked")).toBe("false");
   });
 
-  test("the readout row writes the switch the Settings page shares", async () => {
+  test("the readout row writes the persisted switch", async () => {
     hudAvailable = true;
     await openPanel();
 

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
@@ -105,6 +105,59 @@ describe("CameraViewSettings", () => {
     expect(trigger().parentElement?.contains(panel())).toBe(false);
   });
 
+  /**
+   * Dismissal by tap, which the popover's own outside-press handling does not
+   * deliver here: it waits for a document-level `click`, and WebKit does not
+   * synthesize one for a tap on the bare viewfinder this panel opens over.
+   */
+  describe("the backdrop", () => {
+    const backdrop = () =>
+      screen.queryByTestId("camera-view-settings-backdrop");
+
+    test("is absent until the panel is open, so it swallows nothing", () => {
+      renderSettings();
+
+      expect(backdrop()).toBeNull();
+    });
+
+    test("closes the panel on a tap, and goes with it", async () => {
+      await openPanel();
+      expect(backdrop()).not.toBeNull();
+
+      await act(async () => {
+        fireEvent.click(backdrop()!);
+      });
+
+      expect(panel()).toBeNull();
+      // Gone as well as closed: the room underneath answers presses again,
+      // and the shutter is the press this must not go on intercepting.
+      expect(backdrop()).toBeNull();
+    });
+
+    test("carries its own click handler rather than leaving it to the document", async () => {
+      await openPanel();
+
+      // The whole point on iOS: a document-level listener never hears a tap on
+      // a noninteractive element, so the dismissal has to ride a handler the
+      // element carries itself.
+      expect(backdrop()?.onclick).toBeTruthy();
+    });
+
+    test("sits under the panel, so a press inside the panel is the panel's", async () => {
+      await openPanel();
+      const inside = row("Kept frame")!;
+
+      await act(async () => {
+        fireEvent.click(inside);
+      });
+
+      // The switch answered, and the panel is still up: the backdrop covers
+      // the room, not the surface it belongs to.
+      expect(panel()).not.toBeNull();
+      expect(useVoicePrefsStore.getState().showKeptFrame).toBe(false);
+    });
+  });
+
   test("a session without the readout gets the thumbnail row alone", async () => {
     await openPanel();
 

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
@@ -94,6 +94,16 @@ describe("CameraViewSettings", () => {
     expect(trigger().getAttribute("aria-expanded")).toBe("true");
   });
 
+  test("the panel is announced by its own heading", async () => {
+    await openPanel();
+
+    // Radix presents the content as a dialog, and an unnamed dialog is
+    // announced as nothing at all.
+    const labelledBy = panel()?.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    expect(document.getElementById(labelledBy ?? "")?.textContent).toBe("Show");
+  });
+
   test("the panel renders into the host it is handed, not beside the trigger", async () => {
     await openPanel();
 

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for `CameraViewSettings`.
+ *
+ * What the panel offers, who it offers it to, and where it lands in the DOM.
+ * The availability rule itself belongs to `lib/camera/frame-gate-debug-access`
+ * and is stubbed here, so what is under test is the component's own wiring:
+ * which rows a session sees, which store each row writes, and the panel
+ * portaling inside the component's box rather than beside the room, which is
+ * what keeps it clear of the sheet's inert sweep.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+
+let hudAvailable = false;
+mock.module("@/hooks/use-camera-gate-hud", () => ({
+  useCameraGateHudAvailable: () => hudAvailable,
+  useCameraGateHudEnabled: () => false,
+}));
+
+const { CameraViewSettings } = await import("./camera-view-settings");
+const { useCameraGateDebugStore } =
+  await import("@/stores/camera-gate-debug-store");
+const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
+
+const trigger = () => screen.getByTestId("camera-view-settings");
+const panel = () => screen.queryByTestId("camera-view-settings-panel");
+const row = (name: string) => screen.queryByRole("switch", { name });
+
+/** Open the panel the way a user does. */
+async function openPanel(): Promise<void> {
+  render(<CameraViewSettings />);
+  await act(async () => {
+    fireEvent.click(trigger());
+  });
+}
+
+beforeEach(() => {
+  hudAvailable = false;
+  useCameraGateDebugStore.setState({ hudEnabled: false });
+  useVoicePrefsStore.setState({ showKeptFrame: true });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CameraViewSettings", () => {
+  test("shows the button, and nothing else until it is pressed", async () => {
+    render(<CameraViewSettings />);
+
+    expect(trigger().getAttribute("aria-label")).toBe("Camera view options");
+    expect(panel()).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(trigger());
+    });
+
+    expect(panel()).not.toBeNull();
+    expect(trigger().getAttribute("aria-pressed")).toBe("true");
+  });
+
+  test("the room's control carries the popover's own state", async () => {
+    // `VoiceRoomControl` is the room's element rather than the design
+    // library's, so a trigger composed onto it only works because it passes
+    // what it is handed through to the button underneath.
+    render(<CameraViewSettings />);
+    expect(trigger().getAttribute("aria-haspopup")).toBe("dialog");
+    expect(trigger().getAttribute("aria-expanded")).toBe("false");
+
+    await act(async () => {
+      fireEvent.click(trigger());
+    });
+
+    expect(trigger().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  test("the panel lands inside the button's own box, not beside the room", async () => {
+    await openPanel();
+
+    // The room portals its sheet into `#viewport-overlays` and inerts that
+    // host's other children while the camera is flush, so a panel portaled
+    // there arrives dead. This one is a descendant of the control it opens
+    // from, which that sweep never reaches.
+    expect(trigger().parentElement?.contains(panel())).toBe(true);
+  });
+
+  test("a session without the readout gets the thumbnail row alone", async () => {
+    await openPanel();
+
+    expect(row("Kept frame")).not.toBeNull();
+    expect(row("Frame gate readout")).toBeNull();
+  });
+
+  test("a session with the readout gets both rows", async () => {
+    hudAvailable = true;
+    await openPanel();
+
+    expect(row("Frame gate readout")).not.toBeNull();
+    expect(row("Kept frame")).not.toBeNull();
+  });
+
+  test("the thumbnail row writes the voice preference", async () => {
+    await openPanel();
+    expect(row("Kept frame")?.getAttribute("aria-checked")).toBe("true");
+
+    await act(async () => {
+      fireEvent.click(row("Kept frame")!);
+    });
+
+    expect(useVoicePrefsStore.getState().showKeptFrame).toBe(false);
+    expect(row("Kept frame")?.getAttribute("aria-checked")).toBe("false");
+  });
+
+  test("the readout row writes the switch the Settings page shares", async () => {
+    hudAvailable = true;
+    await openPanel();
+
+    await act(async () => {
+      fireEvent.click(row("Frame gate readout")!);
+    });
+
+    expect(useCameraGateDebugStore.getState().hudEnabled).toBe(true);
+    // The thumbnail is a different preference, and one row must not move the
+    // other.
+    expect(useVoicePrefsStore.getState().showKeptFrame).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
@@ -1,0 +1,136 @@
+/**
+ * Camera mode's view options: the corner button, and the compact panel it
+ * opens.
+ *
+ * Two rows, and neither changes what the camera does. The frame-gate readout
+ * shares the switch the Settings page writes, so one preference answers both
+ * entry points; the kept-frame thumbnail is a voice preference of its own.
+ * Hiding either one hides a drawing, and Live goes on sampling, sending and
+ * recording every kept frame in the transcript.
+ *
+ * Anchored on every form factor, a touch phone included. The room is itself a
+ * bottom sheet portaled into `#viewport-overlays`, and while the camera is
+ * flush `useInertBehindSheet` marks that host's other children `inert`, so a
+ * second sheet portaled beside the room lands inert and dead. The panel
+ * portals into this component's own box inside the room instead, which is
+ * below the level that sweep reaches.
+ *
+ * Over the feed the panel takes the shared over-media scrim rather than a
+ * theme surface, for the reason `camera-mode-paint.ts` gives: what is behind
+ * it is arbitrary video, so a token is as likely to vanish into the frame as
+ * to read on it.
+ */
+
+import { useState, type ReactNode } from "react";
+import { SlidersHorizontal } from "lucide-react";
+
+import {
+  Popover,
+  PortalContainerProvider,
+  Toggle,
+  cn,
+} from "@vellumai/design-library";
+
+import { useTranslation } from "@/i18n";
+import { useCameraGateHudAvailable } from "@/hooks/use-camera-gate-hud";
+import { useCameraGateDebugStore } from "@/stores/camera-gate-debug-store";
+import { useVoicePrefsStore } from "@/stores/voice-prefs-store";
+
+import { CAMERA_MEDIA_GLASS_CLASS, cameraModeStyle } from "./camera-mode-paint";
+import { VoiceRoomControl } from "./voice-room-control";
+
+/**
+ * One row: what the switch shows, what it costs, and the switch.
+ *
+ * The copy carries its own color rather than the design library's label and
+ * helper slots, which paint in theme tokens the feed behind this panel makes
+ * unreadable.
+ */
+function ViewOptionRow({
+  title,
+  description,
+  checked,
+  onChange,
+}: {
+  title: string;
+  description: ReactNode;
+  checked: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        <p className="text-body-medium-default text-white">{title}</p>
+        <p className="text-body-small-default text-white/65">{description}</p>
+      </div>
+      <div className="shrink-0 pt-0.5">
+        <Toggle checked={checked} onChange={onChange} aria-label={title} />
+      </div>
+    </div>
+  );
+}
+
+export function CameraViewSettings() {
+  const { t } = useTranslation("chat");
+  const [open, setOpen] = useState(false);
+  // The panel's portal target, held in state so the first render that has the
+  // box also has somewhere to portal into.
+  const [panelHost, setPanelHost] = useState<HTMLDivElement | null>(null);
+  const hudAvailable = useCameraGateHudAvailable();
+  const hudEnabled = useCameraGateDebugStore.use.hudEnabled();
+  const setHudEnabled = useCameraGateDebugStore.use.setHudEnabled();
+  const showKeptFrame = useVoicePrefsStore.use.showKeptFrame();
+  const setShowKeptFrame = useVoicePrefsStore.use.setShowKeptFrame();
+
+  return (
+    <div ref={setPanelHost}>
+      <PortalContainerProvider container={panelHost}>
+        <Popover.Root open={open} onOpenChange={setOpen}>
+          <Popover.Trigger asChild>
+            <VoiceRoomControl
+              label={t("cameraViewOptions.buttonAria")}
+              bare
+              surface="camera"
+              pressed={open}
+              data-testid="camera-view-settings"
+              // Corner chrome is bare, so an open panel is the one state the
+              // treatment has no fill for: it takes the hover fill instead.
+              className={open ? "bg-black/60 text-white" : undefined}
+            >
+              <SlidersHorizontal className="size-5" />
+            </VoiceRoomControl>
+          </Popover.Trigger>
+          <Popover.Content
+            side="bottom"
+            align="end"
+            sideOffset={8}
+            data-testid="camera-view-settings-panel"
+            style={cameraModeStyle()}
+            className={cn(
+              "flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-3 rounded-lg p-3 shadow-lg",
+              CAMERA_MEDIA_GLASS_CLASS,
+            )}
+          >
+            <p className="text-label-small-default uppercase tracking-wide text-white/60">
+              {t("cameraViewOptions.title")}
+            </p>
+            {hudAvailable ? (
+              <ViewOptionRow
+                title={t("cameraViewOptions.gateHudTitle")}
+                description={t("cameraViewOptions.gateHudDescription")}
+                checked={hudEnabled}
+                onChange={setHudEnabled}
+              />
+            ) : null}
+            <ViewOptionRow
+              title={t("cameraViewOptions.keptFrameTitle")}
+              description={t("cameraViewOptions.keptFrameDescription")}
+              checked={showKeptFrame}
+              onChange={setShowKeptFrame}
+            />
+          </Popover.Content>
+        </Popover.Root>
+      </PortalContainerProvider>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
@@ -2,11 +2,11 @@
  * Camera mode's view options: the corner button, and the compact panel it
  * opens.
  *
- * Two rows, and neither changes what the camera does. The frame-gate readout
- * shares the switch the Settings page writes, so one preference answers both
- * entry points; the kept-frame thumbnail is a voice preference of its own.
- * Hiding either one hides a drawing, and Live goes on sampling, sending and
- * recording every kept frame in the transcript.
+ * Two rows, and neither changes what the camera does. This is where the
+ * frame-gate readout is switched on and off, over the viewfinder its numbers
+ * describe; the kept-frame thumbnail is a voice preference of its own. Hiding
+ * either one hides a drawing, and Live goes on sampling, sending and recording
+ * every kept frame in the transcript.
  *
  * Anchored on every form factor, a touch phone included. The room is itself a
  * bottom sheet portaled into `#viewport-overlays`, and while the camera is

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
@@ -11,9 +11,10 @@
  * Anchored on every form factor, a touch phone included. The room is itself a
  * bottom sheet portaled into `#viewport-overlays`, and while the camera is
  * flush `useInertBehindSheet` marks that host's other children `inert`, so a
- * second sheet portaled beside the room lands inert and dead. The panel
- * portals into this component's own box inside the room instead, which is
- * below the level that sweep reaches.
+ * second sheet portaled beside the room lands inert and dead. The panel goes
+ * into {@link CameraViewSettingsProps.panelHost} instead, an element the room
+ * owns inside itself, which is below the level that sweep reaches and above
+ * the chrome the corner button sits in.
  *
  * Over the feed the panel takes the shared over-media scrim rather than a
  * theme surface, for the reason `camera-mode-paint.ts` gives: what is behind
@@ -42,9 +43,16 @@ import { VoiceRoomControl } from "./voice-room-control";
 /**
  * One row: what the switch shows, what it costs, and the switch.
  *
- * The copy carries its own color rather than the design library's label and
- * helper slots, which paint in theme tokens the feed behind this panel makes
- * unreadable.
+ * The copy goes through the design library's own label and helper slots, so
+ * the switch is named by the first and described by the second, and the line
+ * saying Live keeps sending is read out with the switch that would hide its
+ * signal rather than sitting unattached beside it.
+ *
+ * Each string carries its own color in a span inside those slots. The slots
+ * paint in theme tokens, which is right over a surface the app painted and
+ * wrong over an arbitrary camera frame; the inner span is what the text
+ * actually takes. The row is reversed so the copy leads and the switch closes
+ * it, matching the panel's reading order rather than the slots' default.
  */
 function ViewOptionRow({
   title,
@@ -58,24 +66,29 @@ function ViewOptionRow({
   onChange: (next: boolean) => void;
 }) {
   return (
-    <div className="flex items-start justify-between gap-3">
-      <div className="min-w-0">
-        <p className="text-body-medium-default text-white">{title}</p>
-        <p className="text-body-small-default text-white/65">{description}</p>
-      </div>
-      <div className="shrink-0 pt-0.5">
-        <Toggle checked={checked} onChange={onChange} aria-label={title} />
-      </div>
-    </div>
+    <Toggle
+      checked={checked}
+      onChange={onChange}
+      className="w-full flex-row-reverse justify-between"
+      label={<span className="text-white">{title}</span>}
+      helperText={<span className="text-white/65">{description}</span>}
+    />
   );
 }
 
-export function CameraViewSettings() {
+export interface CameraViewSettingsProps {
+  /**
+   * Where the panel renders. The room owns it, so the panel clears the corner
+   * cluster's own stacking context: portaled into that cluster it would sit at
+   * the chrome's tier and the control row painted over it. Null until the room
+   * has committed the element, which no press can beat.
+   */
+  panelHost: HTMLElement | null;
+}
+
+export function CameraViewSettings({ panelHost }: CameraViewSettingsProps) {
   const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
-  // The panel's portal target, held in state so the first render that has the
-  // box also has somewhere to portal into.
-  const [panelHost, setPanelHost] = useState<HTMLDivElement | null>(null);
   const hudAvailable = useCameraGateHudAvailable();
   const hudEnabled = useCameraGateDebugStore.use.hudEnabled();
   const setHudEnabled = useCameraGateDebugStore.use.setHudEnabled();
@@ -83,54 +96,52 @@ export function CameraViewSettings() {
   const setShowKeptFrame = useVoicePrefsStore.use.setShowKeptFrame();
 
   return (
-    <div ref={setPanelHost}>
-      <PortalContainerProvider container={panelHost}>
-        <Popover.Root open={open} onOpenChange={setOpen}>
-          <Popover.Trigger asChild>
-            <VoiceRoomControl
-              label={t("cameraViewOptions.buttonAria")}
-              bare
-              surface="camera"
-              pressed={open}
-              data-testid="camera-view-settings"
-              // Corner chrome is bare, so an open panel is the one state the
-              // treatment has no fill for: it takes the hover fill instead.
-              className={open ? "bg-black/60 text-white" : undefined}
-            >
-              <SlidersHorizontal className="size-5" />
-            </VoiceRoomControl>
-          </Popover.Trigger>
-          <Popover.Content
-            side="bottom"
-            align="end"
-            sideOffset={8}
-            data-testid="camera-view-settings-panel"
-            style={cameraModeStyle()}
-            className={cn(
-              "flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-3 rounded-lg p-3 shadow-lg",
-              CAMERA_MEDIA_GLASS_CLASS,
-            )}
+    <PortalContainerProvider container={panelHost}>
+      <Popover.Root open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild>
+          <VoiceRoomControl
+            label={t("cameraViewOptions.buttonAria")}
+            bare
+            surface="camera"
+            pressed={open}
+            data-testid="camera-view-settings"
+            // Corner chrome is bare, so an open panel is the one state the
+            // treatment has no fill for: it takes the hover fill instead.
+            className={open ? "bg-black/60 text-white" : undefined}
           >
-            <p className="text-label-small-default uppercase tracking-wide text-white/60">
-              {t("cameraViewOptions.title")}
-            </p>
-            {hudAvailable ? (
-              <ViewOptionRow
-                title={t("cameraViewOptions.gateHudTitle")}
-                description={t("cameraViewOptions.gateHudDescription")}
-                checked={hudEnabled}
-                onChange={setHudEnabled}
-              />
-            ) : null}
+            <SlidersHorizontal className="size-5" />
+          </VoiceRoomControl>
+        </Popover.Trigger>
+        <Popover.Content
+          side="bottom"
+          align="end"
+          sideOffset={8}
+          data-testid="camera-view-settings-panel"
+          style={cameraModeStyle()}
+          className={cn(
+            "flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-3 rounded-lg p-3 shadow-lg",
+            CAMERA_MEDIA_GLASS_CLASS,
+          )}
+        >
+          <p className="text-label-small-default uppercase tracking-wide text-white/60">
+            {t("cameraViewOptions.title")}
+          </p>
+          {hudAvailable ? (
             <ViewOptionRow
-              title={t("cameraViewOptions.keptFrameTitle")}
-              description={t("cameraViewOptions.keptFrameDescription")}
-              checked={showKeptFrame}
-              onChange={setShowKeptFrame}
+              title={t("cameraViewOptions.gateHudTitle")}
+              description={t("cameraViewOptions.gateHudDescription")}
+              checked={hudEnabled}
+              onChange={setHudEnabled}
             />
-          </Popover.Content>
-        </Popover.Root>
-      </PortalContainerProvider>
-    </div>
+          ) : null}
+          <ViewOptionRow
+            title={t("cameraViewOptions.keptFrameTitle")}
+            description={t("cameraViewOptions.keptFrameDescription")}
+            checked={showKeptFrame}
+            onChange={setShowKeptFrame}
+          />
+        </Popover.Content>
+      </Popover.Root>
+    </PortalContainerProvider>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
@@ -31,7 +31,7 @@
  * keeps a dismissing tap from reaching the shutter underneath it.
  */
 
-import { useState, type ReactNode } from "react";
+import { useId, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { SlidersHorizontal } from "lucide-react";
 
@@ -99,6 +99,7 @@ export interface CameraViewSettingsProps {
 export function CameraViewSettings({ panelHost }: CameraViewSettingsProps) {
   const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
+  const titleId = useId();
   const hudAvailable = useCameraGateHudAvailable();
   const hudEnabled = useCameraGateDebugStore.use.hudEnabled();
   const setHudEnabled = useCameraGateDebugStore.use.setHudEnabled();
@@ -138,13 +139,19 @@ export function CameraViewSettings({ panelHost }: CameraViewSettingsProps) {
           align="end"
           sideOffset={8}
           data-testid="camera-view-settings-panel"
+          // Radix presents this as a dialog, and an unnamed one is announced
+          // as nothing. The heading it already carries is the name.
+          aria-labelledby={titleId}
           style={cameraModeStyle()}
           className={cn(
             "flex w-72 max-w-[calc(100vw-2rem)] flex-col gap-3 rounded-lg p-3 shadow-lg",
             CAMERA_MEDIA_GLASS_CLASS,
           )}
         >
-          <p className="text-label-small-default uppercase tracking-wide text-white/60">
+          <p
+            id={titleId}
+            className="text-label-small-default uppercase tracking-wide text-white/60"
+          >
             {t("cameraViewOptions.title")}
           </p>
           {hudAvailable ? (

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
@@ -20,9 +20,19 @@
  * theme surface, for the reason `camera-mode-paint.ts` gives: what is behind
  * it is arbitrary video, so a token is as likely to vanish into the frame as
  * to read on it.
+ *
+ * A tap anywhere else closes it, through a backdrop of the panel's own rather
+ * than the popover's outside-press handling. That handling waits for a
+ * document-level `click`, which WebKit never synthesizes for a tap on a
+ * noninteractive target, and the target here is a bare viewfinder. The
+ * backdrop carries its own `onClick`, which is what `docs/CAPACITOR.md` asks
+ * of any overlay that has to answer a tap, and what the design library's own
+ * sheet overlay does. Closing on the click rather than the press is also what
+ * keeps a dismissing tap from reaching the shutter underneath it.
  */
 
 import { useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { SlidersHorizontal } from "lucide-react";
 
 import {
@@ -97,6 +107,17 @@ export function CameraViewSettings({ panelHost }: CameraViewSettingsProps) {
 
   return (
     <PortalContainerProvider container={panelHost}>
+      {open && panelHost
+        ? createPortal(
+            <div
+              aria-hidden
+              data-testid="camera-view-settings-backdrop"
+              className="fixed inset-0"
+              onClick={() => setOpen(false)}
+            />,
+            panelHost,
+          )
+        : null}
       <Popover.Root open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <VoiceRoomControl

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-control.tsx
@@ -22,7 +22,7 @@
  */
 
 import { Tooltip, cn } from "@vellumai/design-library";
-import type { ReactNode } from "react";
+import type { ComponentProps, MouseEventHandler, ReactNode } from "react";
 
 import { CAMERA_MEDIA_GLASS_CLASS, cameraModeStyle } from "./camera-mode-paint";
 
@@ -141,7 +141,15 @@ function treatmentClass({
   );
 }
 
-export interface VoiceRoomControlProps {
+/**
+ * Anything not named here reaches the underlying `<button>`, `ref` included,
+ * so a primitive that composes through `asChild` (the view-options popover's
+ * trigger) drives this control rather than being swallowed by it.
+ */
+export interface VoiceRoomControlProps extends Omit<
+  ComponentProps<"button">,
+  "aria-label" | "aria-pressed" | "children" | "className" | "onClick" | "type"
+> {
   /** Accessible name, and the tooltip's text unless `tooltip` overrides it. */
   label: string;
   /**
@@ -151,7 +159,7 @@ export interface VoiceRoomControlProps {
    * keeps going").
    */
   tooltip?: string;
-  onClick: () => void;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
   /** The glyph. Sized by the caller, since the shutter's siblings vary. */
   children: ReactNode;
   /**
@@ -198,9 +206,10 @@ export function VoiceRoomControl({
   disabled,
   className,
   "data-testid": testId,
+  ...rest
 }: VoiceRoomControlProps) {
   return (
-    <Tooltip content={tooltip ?? label}>
+    <Tooltip content={tooltip ?? label} {...rest}>
       <button
         type="button"
         onClick={onClick}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -1216,6 +1216,75 @@ describe("VoiceRoom: top-right corner", () => {
     // room draws once the feed is gone.
     expect(screen.queryByTestId("camera-view-settings")).toBeNull();
   });
+
+  /**
+   * Where the view-options panel is drawn, which is the room's answer rather
+   * than the control's.
+   *
+   * Two constraints pull opposite ways. Inside the room, or the sheet's inert
+   * sweep over the portal host's other children reaches it; outside the corner
+   * cluster, or the control rows that follow that cluster at the same tier
+   * paint over it in a short viewport.
+   */
+  describe("the view-options panel's host", () => {
+    /** Open the camera and then the panel. */
+    async function openViewOptions(): Promise<void> {
+      stubMediaDevices(async () => fakeStream());
+      seedCameraCapableAssistant();
+      startOwnedSession("listening");
+      render(<VoiceRoom />);
+      await act(async () => {
+        fireEvent.click(cameraToggle()!);
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("camera-view-settings"));
+      });
+    }
+
+    test("sits above every layer the room draws, and last among them", async () => {
+      await openViewOptions();
+      const host = screen.getByTestId("camera-view-settings-host");
+
+      // Over the chrome band and the control rows at `z-10`, and over the
+      // connect card at `z-20`.
+      expect(host.className).toContain("z-30");
+
+      // Last in the room as well, so the tier is not the only thing holding
+      // it up.
+      for (const testId of [
+        "voice-room-camera-controls",
+        "voice-room-controls",
+      ]) {
+        const earlier = screen.getByTestId(testId);
+        expect(
+          earlier.compareDocumentPosition(host) &
+            Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeGreaterThan(0);
+      }
+    });
+
+    test("keeps the panel in the room and out of the corner cluster", async () => {
+      await openViewOptions();
+      const panel = screen.getByTestId("camera-view-settings-panel");
+
+      expect(
+        screen.getByTestId("camera-view-settings-host").contains(panel),
+      ).toBe(true);
+      // Still the room's own subtree: the portal host the sheet shares with
+      // the app's other overlays never sees it, and the native preview, which
+      // hides everything outside the room, still draws it.
+      expect(roomDialog()?.contains(panel)).toBe(true);
+      expect(
+        document.getElementById("viewport-overlays")?.contains(panel) ?? false,
+      ).toBe(false);
+      // And not back inside the cluster, whose tier the control rows beat.
+      expect(
+        screen
+          .getByTestId("camera-view-settings")
+          .parentElement?.contains(panel),
+      ).toBe(false);
+    });
+  });
 });
 
 describe("VoiceRoom — mute toggle", () => {

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -248,6 +248,26 @@ mock.module("@/domains/chat/api/messages", () => ({
   uploadChatAttachment: uploadChatAttachmentSpy,
 }));
 
+// Sight is left real except for the frame it holds. A kept frame is the end of
+// a chain (decode, canvas readback, upload) that no test environment runs, and
+// the room's own job is only to decide whether to draw it, so the hook runs
+// unchanged and a test can put a frame in its hand. Null by default, which is
+// what every other test in this file sees.
+let mockHeldFrame: { attachmentId: string; previewUrl: string } | null = null;
+// Bound before the registry entry is replaced, since `mock.module` rewrites
+// the namespace this was read from: reaching back through it inside the
+// factory would call the mock.
+const { useVoiceRoomSight: realUseVoiceRoomSight } =
+  await import("@/domains/chat/voice/voice-room/use-voice-room-sight");
+mock.module("@/domains/chat/voice/voice-room/use-voice-room-sight", () => ({
+  useVoiceRoomSight: (
+    ...args: Parameters<typeof realUseVoiceRoomSight>
+  ): ReturnType<typeof realUseVoiceRoomSight> => {
+    const sight = realUseVoiceRoomSight(...args);
+    return mockHeldFrame ? { ...sight, heldFrame: mockHeldFrame } : sight;
+  },
+}));
+
 // Imported after the mocks so the room picks up the mocked modules.
 const { VoiceRoom } =
   await import("@/domains/chat/voice/voice-room/voice-room");
@@ -315,6 +335,7 @@ beforeEach(() => {
   controls.stop.mockClear();
   controls.release.mockClear();
   controls.interrupt.mockClear();
+  mockHeldFrame = null;
   useLiveVoiceStore.getState().reset();
   useConversationStore
     .getState()
@@ -1160,14 +1181,40 @@ describe("VoiceRoom — minimize (session keeps running)", () => {
 
 describe("VoiceRoom: top-right corner", () => {
   test("holds the minimize and nothing else", () => {
-    // The corner is down to one control. A cluster of small chrome competed
-    // with the room's own cast, so the in-session settings gear was deleted;
-    // voice and listening language are picked in Settings.
+    // With no viewfinder up the corner is down to one control. A cluster of
+    // small chrome competed with the room's own cast, so the in-session
+    // settings gear was deleted; voice and listening language are picked in
+    // Settings.
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(minimizeButton()).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Voice settings" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Show captions" })).toBeNull();
+    expect(screen.queryByTestId("camera-view-settings")).toBeNull();
+  });
+
+  test("gains the camera's view options while the viewfinder is up", async () => {
+    stubMediaDevices(async () => fakeStream());
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    // Inboard of minimize, which keeps the extreme corner: the light exit is
+    // the one muscle memory reaches for without looking.
+    expect(screen.getByTestId("camera-view-settings")).not.toBeNull();
+    expect(minimizeButton()).not.toBeNull();
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    // Closing the viewfinder takes the options with it: they name nothing the
+    // room draws once the feed is gone.
+    expect(screen.queryByTestId("camera-view-settings")).toBeNull();
   });
 });
 
@@ -1809,11 +1856,16 @@ describe("VoiceRoom: camera", () => {
     expect(screen.getByTestId("camera-status-pill").textContent).toContain(
       "Photo",
     );
-    // Centred on the minimize control's own line, so the room hands it a
-    // ceiling that keeps a long assistant name clear of that corner.
-    expect(
-      screen.getByTestId("camera-status-pill-slot").getAttribute("style"),
-    ).toContain("max-width");
+    // On the corner chrome's own line and centred in the band that chrome
+    // leaves, so a long assistant name truncates inside a ceiling instead of
+    // running under the cluster. The right reserve is the two-control one.
+    expect(screen.getByTestId("camera-status-pill-slot").className).toContain(
+      "left-[var(--camera-pill-left)] right-[var(--camera-pill-right)]",
+    );
+    expect(roomDialog()?.getAttribute("style")).toContain(
+      "--camera-pill-right: calc(max(1.25rem, var(--safe-area-inset-right",
+    );
+    expect(roomDialog()?.getAttribute("style")).toContain(")) + 7.25rem)");
     // Between the feed (`z-[2]`) and the chrome (`z-10`), and inert: the
     // bottom scrim lies over the shutter and the whole control row.
     const bottomScrim = screen.getByTestId("voice-room-scrim-bottom");
@@ -2050,6 +2102,7 @@ describe("VoiceRoom: camera", () => {
     ).map((button) => button.getAttribute("aria-label"));
 
     expect(order).toEqual([
+      "Camera view options",
       "Minimize voice room",
       "Take a photo",
       "Flip camera",
@@ -2166,6 +2219,74 @@ describe("VoiceRoom: camera", () => {
     } finally {
       restoreCapture();
     }
+  });
+
+  /**
+   * The kept-frame thumbnail: what the camera's view options can stand down.
+   *
+   * The preference reaches the drawing and nothing else. Sampling, sending and
+   * the transcript record of a kept frame are `use-voice-room-sight.ts`'s and
+   * are unchanged by it, which is why the frame arrives here through the hook
+   * either way and only the render is asked about.
+   */
+  describe("the kept-frame thumbnail", () => {
+    const keptFrame = () => screen.queryByTestId("voice-room-sight-frame");
+
+    /** Open the camera with a frame already held. */
+    async function openCameraHoldingAFrame(): Promise<void> {
+      mockHeldFrame = {
+        attachmentId: "att-kept-1",
+        previewUrl: "blob:kept-frame",
+      };
+      stubMediaDevices(async () => fakeStream());
+      seedCameraCapableAssistant();
+      startOwnedSession("listening");
+      render(<VoiceRoom />);
+      await act(async () => {
+        fireEvent.click(cameraToggle()!);
+      });
+    }
+
+    test("is drawn while the preference is on", async () => {
+      await openCameraHoldingAFrame();
+
+      expect(keptFrame()?.getAttribute("src")).toBe("blob:kept-frame");
+    });
+
+    test("is gone once the preference is off, and takes its row with it", async () => {
+      await openCameraHoldingAFrame();
+
+      await act(async () => {
+        useVoicePrefsStore.getState().setShowKeptFrame(false);
+      });
+
+      expect(keptFrame()).toBeNull();
+      // No photos taken, so hiding the thumbnail empties the row it shared
+      // with the strip: an empty inset row would hold space for nothing.
+      expect(screen.queryByTestId("voice-room-capture-row")).toBeNull();
+    });
+
+    test("hiding it leaves the photo strip alone", async () => {
+      const restoreCapture = stubFrameCapture();
+      try {
+        await openCameraHoldingAFrame();
+        await act(async () => {
+          fireEvent.click(screen.getByTestId("voice-room-shutter"));
+        });
+
+        await act(async () => {
+          useVoicePrefsStore.getState().setShowKeptFrame(false);
+        });
+
+        // A photo is a receipt for something the user did, and no view
+        // preference speaks for it.
+        expect(screen.getAllByTestId("voice-room-photo")).toHaveLength(1);
+        expect(screen.getByTestId("voice-room-capture-row")).not.toBeNull();
+        expect(keptFrame()).toBeNull();
+      } finally {
+        restoreCapture();
+      }
+    });
   });
 
   test("a photo the assistant refuses is struck from the strip", async () => {
@@ -2510,6 +2631,7 @@ describe("VoiceRoom: camera", () => {
       ).map((button) => button.getAttribute("aria-label"));
 
       expect(order).toEqual([
+        "Camera view options",
         "Minimize voice room",
         "Stop live",
         "Flip camera",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -1193,9 +1193,9 @@ describe("VoiceRoom: top-right corner", () => {
     expect(screen.queryByTestId("camera-view-settings")).toBeNull();
   });
 
-  test("gains the camera's view options while the viewfinder is up", async () => {
+  test("gains the camera's view options where Live is on offer", async () => {
     stubMediaDevices(async () => fakeStream());
-    seedCameraCapableAssistant();
+    seedLiveCapableAssistant();
     startOwnedSession("listening");
     render(<VoiceRoom />);
 
@@ -1207,6 +1207,8 @@ describe("VoiceRoom: top-right corner", () => {
     // the one muscle memory reaches for without looking.
     expect(screen.getByTestId("camera-view-settings")).not.toBeNull();
     expect(minimizeButton()).not.toBeNull();
+    // The pill's band gives up the two-control cluster on that side.
+    expect(roomDialog()?.getAttribute("style")).toContain(")) + 7.25rem)");
 
     await act(async () => {
       fireEvent.click(cameraToggle()!);
@@ -1215,6 +1217,29 @@ describe("VoiceRoom: top-right corner", () => {
     // Closing the viewfinder takes the options with it: they name nothing the
     // room draws once the feed is gone.
     expect(screen.queryByTestId("camera-view-settings")).toBeNull();
+    expect(screen.queryByTestId("camera-view-settings-host")).toBeNull();
+  });
+
+  test("offers no view options where Live cannot run", async () => {
+    // A native preview, or an assistant that predates `sight_frame`. Neither
+    // keeps a frame and neither gives the gate a decision to draw, so both
+    // switches would name something that cannot happen. The camera-capable
+    // seed is exactly that assistant.
+    stubMediaDevices(async () => fakeStream());
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    expect(screen.getByTestId("voice-room-viewfinder")).not.toBeNull();
+    expect(screen.queryByTestId("camera-view-settings")).toBeNull();
+    expect(screen.queryByTestId("camera-view-settings-host")).toBeNull();
+    // Minimize stands alone up there, so the pill's band gives up one control
+    // rather than holding a gap for a button that is not drawn.
+    expect(roomDialog()?.getAttribute("style")).toContain(")) + 3.75rem)");
   });
 
   /**
@@ -1230,7 +1255,7 @@ describe("VoiceRoom: top-right corner", () => {
     /** Open the camera and then the panel. */
     async function openViewOptions(): Promise<void> {
       stubMediaDevices(async () => fakeStream());
-      seedCameraCapableAssistant();
+      seedLiveCapableAssistant();
       startOwnedSession("listening");
       render(<VoiceRoom />);
       await act(async () => {
@@ -1283,6 +1308,32 @@ describe("VoiceRoom: top-right corner", () => {
           .getByTestId("camera-view-settings")
           .parentElement?.contains(panel),
       ).toBe(false);
+    });
+
+    test("hands the room back once a tap outside dismisses the panel", async () => {
+      await openViewOptions();
+
+      // The backdrop rides the same host, so it covers the room's controls
+      // for exactly as long as the panel is up.
+      const backdrop = screen.getByTestId("camera-view-settings-backdrop");
+      expect(
+        screen.getByTestId("camera-view-settings-host").contains(backdrop),
+      ).toBe(true);
+
+      await act(async () => {
+        fireEvent.click(backdrop);
+      });
+
+      expect(screen.queryByTestId("camera-view-settings-panel")).toBeNull();
+      expect(screen.queryByTestId("camera-view-settings-backdrop")).toBeNull();
+      // Nothing full-bleed is left over the shutter, so the next press is the
+      // camera's.
+      expect(screen.getByTestId("voice-room-shutter")).not.toBeNull();
+      expect(
+        screen
+          .getByTestId("camera-view-settings-host")
+          .querySelector(".fixed.inset-0"),
+      ).toBeNull();
     });
   });
 });
@@ -1927,14 +1978,15 @@ describe("VoiceRoom: camera", () => {
     );
     // On the corner chrome's own line and centred in the band that chrome
     // leaves, so a long assistant name truncates inside a ceiling instead of
-    // running under the cluster. The right reserve is the two-control one.
+    // running under the cluster. This assistant cannot run Live, so the corner
+    // holds minimize alone and the band gives up one control's worth.
     expect(screen.getByTestId("camera-status-pill-slot").className).toContain(
       "left-[var(--camera-pill-left)] right-[var(--camera-pill-right)]",
     );
     expect(roomDialog()?.getAttribute("style")).toContain(
       "--camera-pill-right: calc(max(1.25rem, var(--safe-area-inset-right",
     );
-    expect(roomDialog()?.getAttribute("style")).toContain(")) + 7.25rem)");
+    expect(roomDialog()?.getAttribute("style")).toContain(")) + 3.75rem)");
     // Between the feed (`z-[2]`) and the chrome (`z-10`), and inert: the
     // bottom scrim lies over the shutter and the whole control row.
     const bottomScrim = screen.getByTestId("voice-room-scrim-bottom");
@@ -2171,7 +2223,6 @@ describe("VoiceRoom: camera", () => {
     ).map((button) => button.getAttribute("aria-label"));
 
     expect(order).toEqual([
-      "Camera view options",
       "Minimize voice room",
       "Take a photo",
       "Flip camera",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -228,14 +228,20 @@ const CORNER_GAP = "1.25rem";
  * without a bound the pill runs under that chrome and off a phone-width room.
  *
  * Each side gives up only what stands on it: the room's corner offset on the
- * left, and on the right that offset plus the cluster (two 3.25rem controls
- * and the 0.25rem between them) plus a 0.5rem gap the two never close. Reserving
- * the right's share on both sides instead would leave a phone-width room less
- * than the pill's own floor, and the pill would overhang the cluster rather
- * than truncate inside its ceiling.
+ * left, and on the right that offset plus the cluster plus a 0.5rem gap the
+ * two never close. Reserving the right's share on both sides instead would
+ * leave a phone-width room less than the pill's own floor, and the pill would
+ * overhang the cluster rather than truncate inside its ceiling.
+ *
+ * Two right-hand reserves because the cluster is two sizes. Minimize stands
+ * there alone at 3.25rem; where the view options join it the cluster is both
+ * controls and the 0.25rem between them. Reserving for two against a corner
+ * holding one would shift the pill off the band's centre for a control that
+ * is not there.
  */
 const CAMERA_PILL_LEFT = `max(${CORNER_GAP}, ${SAFE_AREA_LEFT})`;
-const CAMERA_PILL_RIGHT = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 7.25rem)`;
+const CAMERA_PILL_RIGHT_ONE_CONTROL = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 3.75rem)`;
+const CAMERA_PILL_RIGHT_TWO_CONTROLS = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 7.25rem)`;
 
 /**
  * The tier the camera's view-options panel renders on, above every layer the
@@ -671,6 +677,12 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // the room is on, so the offer and the mode answer to one value: a shutter
   // that takes the hold is a shutter whose Live has somewhere to read from.
   const liveOffered = cameraOpen && liveAvailable;
+  // The view options are on offer wherever Live is. Both switches name
+  // something only a Live run produces: the thumbnail of the last frame it
+  // sent, and the readout of the gate deciding which frames those are. Where
+  // Live cannot run there is nothing for either to show, so the corner carries
+  // no button rather than a panel of switches that do nothing.
+  const viewOptionsOffered = liveOffered;
   // The shutter's two acts, which are two different sentences rather than one
   // with the mode pushed into it.
   const shutterLabel = live
@@ -814,8 +826,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // inset, the latter adds the gap to it so the grabber fits between. The panel
   // and the header-resting sheet start below the app's own chrome, where the
   // inset is not their edge to clear. The band's two edges ride along, since
-  // the pill's slot is told where they are the same way: see
-  // {@link CAMERA_PILL_RIGHT}.
+  // the pill's slot is told where they are the same way, and the right one
+  // follows how many controls the corner is holding: see
+  // {@link CAMERA_PILL_RIGHT_TWO_CONTROLS}.
   const topBandVars = {
     "--room-chrome-top": fullscreen
       ? `max(${CORNER_GAP}, ${SAFE_AREA_TOP})`
@@ -826,7 +839,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       ? `calc(0.5rem + ${SAFE_AREA_TOP})`
       : "0.5rem",
     "--camera-pill-left": CAMERA_PILL_LEFT,
-    "--camera-pill-right": CAMERA_PILL_RIGHT,
+    "--camera-pill-right": viewOptionsOffered
+      ? CAMERA_PILL_RIGHT_TWO_CONTROLS
+      : CAMERA_PILL_RIGHT_ONE_CONTROL,
   } as CSSProperties;
 
   const body = (
@@ -1085,7 +1100,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           own; that offset already clears the sheet's grabber. Centred in the
           band the chrome leaves rather than on the room, which is what keeps a
           long name inside a ceiling at phone width: see
-          {@link CAMERA_PILL_RIGHT}.
+          {@link CAMERA_PILL_RIGHT_TWO_CONTROLS}.
 
           Camera-only. With the viewfinder closed the room says all of this
           through the look itself (the avatar's visual, the state caption, the
@@ -1117,11 +1132,12 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
 
           Minimize is never gated behind avatar readiness, so the room can
           always be dismissed even mid-load / on failure, and it keeps the
-          extreme corner. View options is camera-only and sits inboard of it:
-          the room with no viewfinder up carries nothing but minimize here,
-          since a cluster of small chrome against the look competes with the
-          room's own cast for attention. Voice and listening language are
-          Settings' either way. */}
+          extreme corner. View options sits inboard of it and only where Live
+          is on offer, which is the only place its switches name anything the
+          room draws; every other room carries nothing but minimize here, since
+          a cluster of small chrome against the look competes with the room's
+          own cast for attention. Voice and listening language are Settings'
+          either way. */}
       <div
         // An equal gap from both edges, so the control reads as sitting in the
         // corner rather than floating near it. The top comes off the room's own
@@ -1129,7 +1145,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         style={{ right: `max(${CORNER_GAP}, ${SAFE_AREA_RIGHT})` }}
         className="absolute top-[var(--room-chrome-top)] z-10 flex items-center gap-1"
       >
-        {cameraOpen ? <CameraViewSettings panelHost={viewOptionsHost} /> : null}
+        {viewOptionsOffered ? (
+          <CameraViewSettings panelHost={viewOptionsHost} />
+        ) : null}
         <VoiceRoomControl
           label={t("voiceRoom.minimizeAria")}
           tooltip={t("voiceRoom.minimizeTooltip")}
@@ -1528,7 +1546,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           host's own children) and visible under the native preview, which
           hides everything outside this subtree. See
           {@link VIEW_OPTIONS_HOST_LAYER}. */}
-      {cameraOpen ? (
+      {viewOptionsOffered ? (
         <div
           ref={setViewOptionsHost}
           data-testid="camera-view-settings-host"

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -238,6 +238,23 @@ const CAMERA_PILL_LEFT = `max(${CORNER_GAP}, ${SAFE_AREA_LEFT})`;
 const CAMERA_PILL_RIGHT = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 7.25rem)`;
 
 /**
+ * The tier the camera's view-options panel renders on, above every layer the
+ * room draws: the chrome band and the control rows at `z-10`, and the connect
+ * card at `z-20`.
+ *
+ * The panel is the one surface here the user opened on purpose, so nothing the
+ * room paints may cover it. It cannot simply live in the corner cluster it is
+ * triggered from: that cluster is a `z-10` positioned element and so its own
+ * stacking context, which the later `z-10` control rows paint over, and in a
+ * short viewport (a phone held sideways) the rows reach the panel's box.
+ *
+ * The host is a zero-size element rather than a full-bleed layer, so it can
+ * never take a press meant for the feed; the panel inside it is positioned
+ * against the trigger rather than against the host.
+ */
+const VIEW_OPTIONS_HOST_LAYER = "z-30";
+
+/**
  * The flash button's accessible name, per state.
  *
  * It names the state and not the act, because the button has three states and
@@ -570,6 +587,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // Whether the viewfinder draws the accented thumbnail of the newest frame
   // Live gave the call. The camera's view options write it.
   const showKeptFrame = useVoicePrefsStore.use.showKeptFrame();
+  // Where the view-options panel renders. See the host element near the foot
+  // of the room, and {@link VIEW_OPTIONS_HOST_LAYER}.
+  const [viewOptionsHost, setViewOptionsHost] = useState<HTMLDivElement | null>(
+    null,
+  );
 
   // Backwards-compat fallback for assistants that can still raise
   // `oauth_connect` mid-call — see use-supports-noninteractive-voice-turns.ts
@@ -1107,7 +1129,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         style={{ right: `max(${CORNER_GAP}, ${SAFE_AREA_RIGHT})` }}
         className="absolute top-[var(--room-chrome-top)] z-10 flex items-center gap-1"
       >
-        {cameraOpen ? <CameraViewSettings /> : null}
+        {cameraOpen ? <CameraViewSettings panelHost={viewOptionsHost} /> : null}
         <VoiceRoomControl
           label={t("voiceRoom.minimizeAria")}
           tooltip={t("voiceRoom.minimizeTooltip")}
@@ -1499,6 +1521,20 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           <X className="size-5" strokeWidth={2.5} />
         </VoiceRoomControl>
       </div>
+
+      {/* The view-options panel's host: last of the room's chrome, so it wins
+          a tie on DOM order as well as on its tier. Inside the room, which is
+          what keeps it out of the sheet's inert sweep (that covers the portal
+          host's own children) and visible under the native preview, which
+          hides everything outside this subtree. See
+          {@link VIEW_OPTIONS_HOST_LAYER}. */}
+      {cameraOpen ? (
+        <div
+          ref={setViewOptionsHost}
+          data-testid="camera-view-settings-host"
+          className={cn("absolute left-0 top-0", VIEW_OPTIONS_HOST_LAYER)}
+        />
+      ) : null}
 
       {/* Screen readers get session-state changes here; the avatar is the
           visual channel, so this stays off-screen.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -165,6 +165,7 @@ import {
   cameraModeStyle,
 } from "./camera-mode-paint";
 import { CameraShutterHint } from "./camera-shutter-hint";
+import { CameraViewSettings } from "./camera-view-settings";
 import {
   CameraStatusPill,
   useCameraStatusAnnouncement,
@@ -222,15 +223,19 @@ const AVATAR_SIZE = 220;
 const CORNER_GAP = "1.25rem";
 
 /**
- * Ceiling on the camera status pill, which is centred on the same line as the
- * top-right minimize control and grows in both directions from there. A
- * configured assistant name is arbitrarily long, so without this the pill runs
- * under that control and off a phone-width room. Each side gives up the corner
- * chrome's own offset, the control's 3.25rem box, and a gap so the two never
- * touch; a percentage resolves against the room, which is what the pill has to
- * fit inside.
+ * The band the camera status pill is centred in, on the same line as the
+ * top-right corner chrome. A configured assistant name is arbitrarily long, so
+ * without a bound the pill runs under that chrome and off a phone-width room.
+ *
+ * Each side gives up only what stands on it: the room's corner offset on the
+ * left, and on the right that offset plus the cluster (two 3.25rem controls
+ * and the 0.25rem between them) plus a 0.5rem gap the two never close. Reserving
+ * the right's share on both sides instead would leave a phone-width room less
+ * than the pill's own floor, and the pill would overhang the cluster rather
+ * than truncate inside its ceiling.
  */
-const CAMERA_PILL_MAX_WIDTH = `calc(100% - 2 * (max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 3.75rem))`;
+const CAMERA_PILL_LEFT = `max(${CORNER_GAP}, ${SAFE_AREA_LEFT})`;
+const CAMERA_PILL_RIGHT = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 7.25rem)`;
 
 /**
  * The flash button's accessible name, per state.
@@ -562,6 +567,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // preference is the Settings page's, read here.
   const showAssistantTranscript =
     useVoicePrefsStore.use.showAssistantTranscript();
+  // Whether the viewfinder draws the accented thumbnail of the newest frame
+  // Live gave the call. The camera's view options write it.
+  const showKeptFrame = useVoicePrefsStore.use.showKeptFrame();
 
   // Backwards-compat fallback for assistants that can still raise
   // `oauth_connect` mid-call — see use-supports-noninteractive-voice-turns.ts
@@ -607,6 +615,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       facing: camera.facing,
       nativePreview: camera.native,
     });
+  // The thumbnail the room draws, which the view options can stand down. Only
+  // the drawing: the frame behind it was sampled, sent and recorded in the
+  // transcript before this is read, and the hook goes on holding it either way
+  // so a retraction still has something to take back.
+  const keptFrame = showKeptFrame ? heldFrame : null;
   // Closing the viewfinder is the other way a user ends Live, and it does not
   // go through `setLive`. The mode comes down behind it, on the render the
   // close schedules, which is too late for a frame whose upload lands in
@@ -778,7 +791,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // flush camera sheet reach the notch: the former clamps its gap up to the
   // inset, the latter adds the gap to it so the grabber fits between. The panel
   // and the header-resting sheet start below the app's own chrome, where the
-  // inset is not their edge to clear.
+  // inset is not their edge to clear. The band's two edges ride along, since
+  // the pill's slot is told where they are the same way: see
+  // {@link CAMERA_PILL_RIGHT}.
   const topBandVars = {
     "--room-chrome-top": fullscreen
       ? `max(${CORNER_GAP}, ${SAFE_AREA_TOP})`
@@ -788,6 +803,8 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
     "--room-grabber-top": cameraSheet
       ? `calc(0.5rem + ${SAFE_AREA_TOP})`
       : "0.5rem",
+    "--camera-pill-left": CAMERA_PILL_LEFT,
+    "--camera-pill-right": CAMERA_PILL_RIGHT,
   } as CSSProperties;
 
   const body = (
@@ -1041,10 +1058,12 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       ) : null}
 
       {/* Camera mode's status readout: what the camera is doing, and what the
-          session is doing. Top-centre, on the same offset the corner chrome
-          uses, so it shares a line with the minimize control instead of
-          floating on a rhythm of its own; that offset already clears the
-          sheet's grabber.
+          session is doing. On the same offset the corner chrome uses, so it
+          shares a line with that chrome instead of floating on a rhythm of its
+          own; that offset already clears the sheet's grabber. Centred in the
+          band the chrome leaves rather than on the room, which is what keeps a
+          long name inside a ceiling at phone width: see
+          {@link CAMERA_PILL_RIGHT}.
 
           Camera-only. With the viewfinder closed the room says all of this
           through the look itself (the avatar's visual, the state caption, the
@@ -1053,8 +1072,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       {cameraOpen ? (
         <div
           data-testid="camera-status-pill-slot"
-          className="pointer-events-none absolute left-1/2 top-[var(--room-chrome-top)] z-10 -translate-x-1/2"
-          style={{ maxWidth: CAMERA_PILL_MAX_WIDTH }}
+          className="pointer-events-none absolute left-[var(--camera-pill-left)] right-[var(--camera-pill-right)] top-[var(--room-chrome-top)] z-10 flex justify-center"
         >
           <CameraStatusPill
             mode={cameraMode}
@@ -1065,21 +1083,23 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         </div>
       ) : null}
 
-      {/* Top-right: minimize, alone.
+      {/* Top-right: minimize, with the camera's view options beside it.
 
           The corner is where every other surface in the app puts "get this off
-          my screen", and that is now exactly what it does — the session keeps
+          my screen", and that is exactly what it does: the session keeps
           running on the composer's voice bar or the title-bar pill. It used to
           END the call, which put the most destructive act in the room at the
           one spot muscle memory reaches for without looking; hanging up moved
           into the control row below, where it sits among the other things you
           do to a call and has to be aimed at.
 
-          Never gated behind avatar readiness, so the room can always be
-          dismissed even mid-load / on failure. Nothing else shares the corner:
-          the in-session settings gear was deleted because a cluster of small
-          chrome competed with the room's own cast for attention. Voice and
-          listening language are Settings' now. */}
+          Minimize is never gated behind avatar readiness, so the room can
+          always be dismissed even mid-load / on failure, and it keeps the
+          extreme corner. View options is camera-only and sits inboard of it:
+          the room with no viewfinder up carries nothing but minimize here,
+          since a cluster of small chrome against the look competes with the
+          room's own cast for attention. Voice and listening language are
+          Settings' either way. */}
       <div
         // An equal gap from both edges, so the control reads as sitting in the
         // corner rather than floating near it. The top comes off the room's own
@@ -1087,6 +1107,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         style={{ right: `max(${CORNER_GAP}, ${SAFE_AREA_RIGHT})` }}
         className="absolute top-[var(--room-chrome-top)] z-10 flex items-center gap-1"
       >
+        {cameraOpen ? <CameraViewSettings /> : null}
         <VoiceRoomControl
           label={t("voiceRoom.minimizeAria")}
           tooltip={t("voiceRoom.minimizeTooltip")}
@@ -1238,8 +1259,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
               the assistant has it. Aligned left so it never sits under the
               shutter, and `aria-hidden` because the live region already
               announces failures in words. */}
-          {photos.length > 0 || heldFrame ? (
-            <div className="flex items-center gap-2 self-start pl-6">
+          {photos.length > 0 || keptFrame ? (
+            <div
+              data-testid="voice-room-capture-row"
+              className="flex items-center gap-2 self-start pl-6"
+            >
               {photos.length > 0 ? (
                 <ul
                   aria-hidden
@@ -1280,11 +1304,13 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
 
                   `aria-hidden` for the same reason as the strip: every keep
                   lands in the transcript as its own message, which is the
-                  accessible record of it. */}
-              {heldFrame ? (
+                  accessible record of it. That record is also why the camera's
+                  view options can stand this down: what it draws is a
+                  convenience, and the transcript is the account. */}
+              {keptFrame ? (
                 <img
-                  key={heldFrame.attachmentId}
-                  src={heldFrame.previewUrl}
+                  key={keptFrame.attachmentId}
+                  src={keptFrame.previewUrl}
                   alt=""
                   aria-hidden
                   data-testid="voice-room-sight-frame"

--- a/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -7,18 +7,15 @@ import { PlatformLoginNotice } from "@/components/platform-login-notice";
 import { AssistantBackups } from "@/domains/settings/components/assistant-backups";
 import { RecoveryModeControls } from "@/domains/settings/components/recovery-mode-controls";
 import { RestartAssistant } from "@/domains/settings/components/restart-assistant";
-import { useCameraGateHudAvailable } from "@/hooks/use-camera-gate-hud";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { useTranslation } from "@/i18n";
 import { isVellumStaff } from "@/lib/auth/staff";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAuthStore } from "@/stores/auth-store";
-import { useCameraGateDebugStore } from "@/stores/camera-gate-debug-store";
 import { clearConsentForUser } from "@/lib/consent/consent-persistence";
 import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { toast } from "@vellumai/design-library/components/toast";
-import { Toggle } from "@vellumai/design-library/components/toggle";
 
 export function DebugControlsPanel() {
   const { t } = useTranslation("settings");
@@ -26,12 +23,6 @@ export function DebugControlsPanel() {
   const user = useAuthStore.use.user();
   const platformGate = usePlatformGate();
   const showInternalControls = isVellumStaff(user);
-  // A wider audience than the staff rows above: the flag exists so a local
-  // gateway session, which carries no platform identity and is where the gate
-  // gets tuned, can reach the switch.
-  const showCameraGateHud = useCameraGateHudAvailable();
-  const cameraGateHudEnabled = useCameraGateDebugStore.use.hudEnabled();
-  const setCameraGateHudEnabled = useCameraGateDebugStore.use.setHudEnabled();
 
   const [assistant, setAssistant] = useState<Assistant | null>(null);
   const [loading, setLoading] = useState(true);
@@ -137,26 +128,6 @@ export function DebugControlsPanel() {
                 >
                   {t("debugControlsPanel.replay")}
                 </Button>
-              </div>
-            </div>
-          )}
-
-          {showCameraGateHud && (
-            <div className="flex items-center justify-between rounded-lg border border-[var(--border-base)] px-4 py-3 dark:border-[var(--border-base)]">
-              <div className="min-w-0">
-                <p className="text-body-medium-default text-[var(--content-default)]">
-                  {t("debugControlsPanel.cameraGateHudTitle")}
-                </p>
-                <p className="text-body-small-default text-[var(--content-tertiary)]">
-                  {t("debugControlsPanel.cameraGateHudDescription")}
-                </p>
-              </div>
-              <div className="ml-4 shrink-0">
-                <Toggle
-                  checked={cameraGateHudEnabled}
-                  onChange={setCameraGateHudEnabled}
-                  aria-label={t("debugControlsPanel.cameraGateHudTitle")}
-                />
               </div>
             </div>
           )}

--- a/clients/web/src/hooks/use-camera-gate-hud.ts
+++ b/clients/web/src/hooks/use-camera-gate-hud.ts
@@ -12,9 +12,9 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useAuthStore } from "@/stores/auth-store";
 
 /**
- * Whether this session may turn the readout on at all. The settings toggle
- * gates its own visibility on this, so a session that can never see the panel
- * is not offered a switch for it.
+ * Whether this session may turn the readout on at all. The camera's view
+ * options gate the row's presence on this, so a session that can never see
+ * the readout is not offered a switch for it.
  */
 export function useCameraGateHudAvailable(): boolean {
   const user = useAuthStore.use.user();

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -278,6 +278,14 @@
     "photo": "Photo",
     "yourAssistant": "Your assistant"
   },
+  "cameraViewOptions": {
+    "buttonAria": "Camera view options",
+    "gateHudDescription": "The tuning readout for what Live keeps.",
+    "gateHudTitle": "Frame gate readout",
+    "keptFrameDescription": "The last frame Live sent, beside your photos. Live keeps sending either way.",
+    "keptFrameTitle": "Kept frame",
+    "title": "Show"
+  },
   "cardSurface": {
     "tasksProgress": "{completed} / {total} tasks"
   },

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -640,8 +640,6 @@
   },
   "debugControlsPanel": {
     "backups": "Backups",
-    "cameraGateHudDescription": "Show live motion, novelty and detail scores over the camera, with sliders for the frame gate's thresholds.",
-    "cameraGateHudTitle": "Camera gate readout",
     "loadFailedToast": "Failed to load assistant info",
     "loading": "Loading assistant info...",
     "loginNotice": "Log in to the Vellum platform to manage backups.",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -278,6 +278,14 @@
     "photo": "Foto",
     "yourAssistant": "Tu asistente"
   },
+  "cameraViewOptions": {
+    "buttonAria": "Opciones de vista de la cámara",
+    "gateHudDescription": "El panel de ajuste de lo que conserva el modo en vivo.",
+    "gateHudTitle": "Lectura del filtro de fotogramas",
+    "keptFrameDescription": "El último fotograma enviado en vivo, junto a tus fotos. El envío continúa igualmente.",
+    "keptFrameTitle": "Último fotograma",
+    "title": "Mostrar"
+  },
   "cardSurface": {
     "tasksProgress": "{completed} / {total} tareas"
   },

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -184,6 +184,14 @@
     "photo": "Фото",
     "yourAssistant": "Ваш ассистент"
   },
+  "cameraViewOptions": {
+    "buttonAria": "Параметры отображения камеры",
+    "gateHudDescription": "Панель настройки того, что сохраняет прямой эфир.",
+    "gateHudTitle": "Показатели фильтра кадров",
+    "keptFrameDescription": "Последний кадр, отправленный в эфире, рядом с вашими фото. Отправка продолжается в любом случае.",
+    "keptFrameTitle": "Последний кадр",
+    "title": "Показывать"
+  },
   "channelReferenceChip": {
     "heading": "Ссылка на сообщение из {channel}",
     "headingWithSender": "Ссылка на сообщение {sender} в {channel}",

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -277,6 +277,14 @@
     "photo": "相片",
     "yourAssistant": "您的助理"
   },
+  "cameraViewOptions": {
+    "buttonAria": "相機顯示選項",
+    "gateHudDescription": "用於調整即時模式保留哪些畫面的面板。",
+    "gateHudTitle": "影格篩選讀數",
+    "keptFrameDescription": "即時模式傳送的最近一格，顯示在照片旁邊。無論是否顯示，都會繼續傳送。",
+    "keptFrameTitle": "最近一格",
+    "title": "顯示"
+  },
   "cardSurface": {
     "tasksProgress": "已完成 {completed} / 共 {total} 個任務"
   },

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -277,6 +277,14 @@
     "photo": "照片",
     "yourAssistant": "您的助手"
   },
+  "cameraViewOptions": {
+    "buttonAria": "相机显示选项",
+    "gateHudDescription": "用于调整实时模式保留哪些画面的面板。",
+    "gateHudTitle": "帧筛选读数",
+    "keptFrameDescription": "实时模式发送的最近一帧，显示在照片旁边。无论是否显示，都会继续发送。",
+    "keptFrameTitle": "最近一帧",
+    "title": "显示"
+  },
   "cardSurface": {
     "tasksProgress": "已完成 {completed} / 共 {total} 个任务"
   },

--- a/clients/web/src/lib/camera/frame-gate-debug-access.test.ts
+++ b/clients/web/src/lib/camera/frame-gate-debug-access.test.ts
@@ -252,29 +252,43 @@ describe("camera gate readout access", () => {
   /**
    * What another window's write does to this one.
    *
-   * The restore is the store's and the account check is this module's, which
-   * is the whole reason the listener is wired here: a second window can sign
-   * the browser into a different account, so the payload it leaves behind is
-   * not automatically this tab's to adopt.
+   * The owner check is this module's and the payload's shape is the store's,
+   * which is the whole reason the listener is wired here: a second window can
+   * sign the browser into a different account, so the payload it leaves behind
+   * is not automatically this tab's to read.
    */
   describe("another tab's write", () => {
-    /** Leave a payload behind and tell this tab about it, as a tab swap does. */
+    /** The payload a tab owned by `ownerUserId` leaves on the key. */
+    function payloadFrom(ownerUserId: string, minDetail: number): string {
+      return JSON.stringify({
+        state: {
+          hudEnabled: true,
+          ownerUserId,
+          overrides: { ...defaultFrameGateOverrides(), minDetail },
+        },
+        version: 0,
+      });
+    }
+
+    /** Leave a payload behind and tell this tab about it, as another tab does. */
     async function arriveFromAnotherTab(
       ownerUserId: string,
       minDetail: number,
     ): Promise<void> {
-      localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({
-          state: {
-            hudEnabled: true,
-            ownerUserId,
-            overrides: { ...defaultFrameGateOverrides(), minDetail },
-          },
-          version: 0,
-        }),
+      const newValue = payloadFrom(ownerUserId, minDetail);
+      localStorage.setItem(STORAGE_KEY, newValue);
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEY, newValue }),
       );
-      window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    /** Announce a payload this tab could not read even if it wanted to. */
+    async function arriveUnreadable(newValue: string | null): Promise<void> {
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEY, newValue }),
+      );
       await Promise.resolve();
       await Promise.resolve();
     }
@@ -291,31 +305,88 @@ describe("camera gate readout access", () => {
       expect(FRAME_GATE_LIVE_OPTIONS.minDetail).toBe(42);
     });
 
-    test("from another account is dropped, and takes nothing to the gate", async () => {
-      // The window that wrote it signed the browser into a different account.
-      // Restoring it here would hand this session a switch and a set of
-      // thresholds it never asked for, with no panel on screen to say so.
+    test("naming no owner is read, and the claim then settles it", async () => {
+      // A slice written before any account claimed it. Nobody owns it, so
+      // there is no account for this tab to disagree with and it is read; the
+      // claim that follows is what binds it, and binding a preference no
+      // session recorded is what puts the switch back to shipped. That is the
+      // store's standing rule for an unowned payload, not a new one.
       useAuthStore.setState({ user: STAFF_USER });
-      useCameraGateDebugStore.getState().setHudEnabled(false);
+      const store = useCameraGateDebugStore.getState();
+      store.setHudEnabled(true);
+      store.setOverride("minDetail", 30);
 
-      await arriveFromAnotherTab(OTHER_STAFF_USER.id ?? "", 42);
+      const newValue = JSON.stringify({
+        state: {
+          hudEnabled: true,
+          ownerUserId: null,
+          overrides: { ...defaultFrameGateOverrides(), minDetail: 42 },
+        },
+        version: 0,
+      });
+      localStorage.setItem(STORAGE_KEY, newValue);
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEY, newValue }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
 
       const state = useCameraGateDebugStore.getState();
-      expect(state.hudEnabled).toBe(false);
-      expect(state.overrides).toEqual(defaultFrameGateOverrides());
       expect(state.ownerUserId).toBe(STAFF_USER.id);
-      expect(FRAME_GATE_LIVE_OPTIONS.minDetail).toBe(
+      expect(state.hudEnabled).toBe(false);
+      expect(state.overrides.minDetail).toBe(
         DEFAULT_FRAME_GATE_OPTIONS.minDetail,
       );
     });
 
-    test("under another key is not this store's to answer", async () => {
+    test("from another account is refused outright, with nothing written back", async () => {
+      // Adopting it and correcting afterwards would persist the correction,
+      // the other tab would read that and correct it back, and two signed-in
+      // accounts would trade the key with nobody touching a switch. Refusing
+      // to read it is what has no second half.
+      useAuthStore.setState({ user: STAFF_USER });
+      const store = useCameraGateDebugStore.getState();
+      store.setHudEnabled(true);
+      store.setOverride("minDetail", 30);
+
+      const foreign = payloadFrom(OTHER_STAFF_USER.id ?? "", 42);
+      localStorage.setItem(STORAGE_KEY, foreign);
+      const writes: string[] = [];
+      const setItem = localStorage.setItem.bind(localStorage);
+      localStorage.setItem = (key: string, value: string) => {
+        writes.push(key);
+        setItem(key, value);
+      };
+      try {
+        window.dispatchEvent(
+          new StorageEvent("storage", { key: STORAGE_KEY, newValue: foreign }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      } finally {
+        localStorage.setItem = setItem;
+      }
+
+      // Nothing of this tab's moved, and nothing of this tab's was written:
+      // the key still holds the other account's payload, which is theirs until
+      // somebody's next boot claims it.
+      const state = useCameraGateDebugStore.getState();
+      expect(state.hudEnabled).toBe(true);
+      expect(state.overrides.minDetail).toBe(30);
+      expect(state.ownerUserId).toBe(STAFF_USER.id);
+      expect(FRAME_GATE_LIVE_OPTIONS.minDetail).toBe(30);
+      expect(writes).toEqual([]);
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(foreign);
+    });
+
+    test("that cannot be read is left alone", async () => {
+      // A removal, a hand-edited value, and a payload with no state in it.
+      // None of them says whose preference this is, so none of them is acted
+      // on, and none of them throws out of the handler. The key is left
+      // holding something this tab would otherwise have taken, so an event
+      // that was acted on anyway would show up here.
       useAuthStore.setState({ user: STAFF_USER });
       useCameraGateDebugStore.getState().setHudEnabled(true);
-
-      // A payload nobody announced. Reading it would mean any key's event
-      // restores this slice, which is a switch moving under a session that
-      // changed nothing.
       localStorage.setItem(
         STORAGE_KEY,
         JSON.stringify({
@@ -327,9 +398,28 @@ describe("camera gate readout access", () => {
           version: 0,
         }),
       );
+
+      await arriveUnreadable(null);
+      await arriveUnreadable("not json at all");
+      await arriveUnreadable(JSON.stringify({ version: 0 }));
+
+      expect(useCameraGateDebugStore.getState().hudEnabled).toBe(true);
+    });
+
+    test("under another key is not this store's to answer", async () => {
+      useAuthStore.setState({ user: STAFF_USER });
+      useCameraGateDebugStore.getState().setHudEnabled(true);
+
+      // A payload nobody announced. Reading it would mean any key's event
+      // restores this slice, which is a switch moving under a session that
+      // changed nothing.
+      localStorage.setItem(STORAGE_KEY, payloadFrom(STAFF_USER.id ?? "", 42));
       localStorage.setItem("vellum:debug:somethingElse", "{}");
       window.dispatchEvent(
-        new StorageEvent("storage", { key: "vellum:debug:somethingElse" }),
+        new StorageEvent("storage", {
+          key: "vellum:debug:somethingElse",
+          newValue: "{}",
+        }),
       );
       await Promise.resolve();
       await Promise.resolve();

--- a/clients/web/src/lib/camera/frame-gate-debug-access.test.ts
+++ b/clients/web/src/lib/camera/frame-gate-debug-access.test.ts
@@ -249,6 +249,107 @@ describe("camera gate readout access", () => {
     expect(FRAME_GATE_LIVE_OPTIONS.minDetail).toBe(42);
   });
 
+  /**
+   * What another window's write does to this one.
+   *
+   * The restore is the store's and the account check is this module's, which
+   * is the whole reason the listener is wired here: a second window can sign
+   * the browser into a different account, so the payload it leaves behind is
+   * not automatically this tab's to adopt.
+   */
+  describe("another tab's write", () => {
+    /** Leave a payload behind and tell this tab about it, as a tab swap does. */
+    async function arriveFromAnotherTab(
+      ownerUserId: string,
+      minDetail: number,
+    ): Promise<void> {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            hudEnabled: true,
+            ownerUserId,
+            overrides: { ...defaultFrameGateOverrides(), minDetail },
+          },
+          version: 0,
+        }),
+      );
+      window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    test("from the same account reaches this tab, and the gate with it", async () => {
+      useAuthStore.setState({ user: STAFF_USER });
+      useCameraGateDebugStore.getState().setHudEnabled(false);
+
+      await arriveFromAnotherTab(STAFF_USER.id ?? "", 42);
+
+      const state = useCameraGateDebugStore.getState();
+      expect(state.hudEnabled).toBe(true);
+      expect(state.overrides.minDetail).toBe(42);
+      expect(FRAME_GATE_LIVE_OPTIONS.minDetail).toBe(42);
+    });
+
+    test("from another account is dropped, and takes nothing to the gate", async () => {
+      // The window that wrote it signed the browser into a different account.
+      // Restoring it here would hand this session a switch and a set of
+      // thresholds it never asked for, with no panel on screen to say so.
+      useAuthStore.setState({ user: STAFF_USER });
+      useCameraGateDebugStore.getState().setHudEnabled(false);
+
+      await arriveFromAnotherTab(OTHER_STAFF_USER.id ?? "", 42);
+
+      const state = useCameraGateDebugStore.getState();
+      expect(state.hudEnabled).toBe(false);
+      expect(state.overrides).toEqual(defaultFrameGateOverrides());
+      expect(state.ownerUserId).toBe(STAFF_USER.id);
+      expect(FRAME_GATE_LIVE_OPTIONS.minDetail).toBe(
+        DEFAULT_FRAME_GATE_OPTIONS.minDetail,
+      );
+    });
+
+    test("under another key is not this store's to answer", async () => {
+      useAuthStore.setState({ user: STAFF_USER });
+      useCameraGateDebugStore.getState().setHudEnabled(true);
+
+      // A payload nobody announced. Reading it would mean any key's event
+      // restores this slice, which is a switch moving under a session that
+      // changed nothing.
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          state: {
+            hudEnabled: false,
+            ownerUserId: STAFF_USER.id,
+            overrides: defaultFrameGateOverrides(),
+          },
+          version: 0,
+        }),
+      );
+      localStorage.setItem("vellum:debug:somethingElse", "{}");
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "vellum:debug:somethingElse" }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(useCameraGateDebugStore.getState().hudEnabled).toBe(true);
+      localStorage.removeItem("vellum:debug:somethingElse");
+    });
+
+    test("stops arriving once the access sync is torn down", async () => {
+      useAuthStore.setState({ user: STAFF_USER });
+      useCameraGateDebugStore.getState().setHudEnabled(false);
+      stopAccessSync?.();
+      stopAccessSync = null;
+
+      await arriveFromAnotherTab(STAFF_USER.id ?? "", 42);
+
+      expect(useCameraGateDebugStore.getState().hudEnabled).toBe(false);
+    });
+  });
+
   test("a switch left on by a session with no access never reaches the gate", () => {
     const store = useCameraGateDebugStore.getState();
     store.setHudEnabled(true);

--- a/clients/web/src/lib/camera/frame-gate-debug-access.test.ts
+++ b/clients/web/src/lib/camera/frame-gate-debug-access.test.ts
@@ -284,10 +284,15 @@ describe("camera gate readout access", () => {
       await Promise.resolve();
     }
 
-    /** Announce a payload this tab could not read even if it wanted to. */
-    async function arriveUnreadable(newValue: string | null): Promise<void> {
+    /** Leave the key holding something this tab could not read, and announce it. */
+    async function arriveUnreadable(raw: string | null): Promise<void> {
+      if (raw === null) {
+        localStorage.removeItem(STORAGE_KEY);
+      } else {
+        localStorage.setItem(STORAGE_KEY, raw);
+      }
       window.dispatchEvent(
-        new StorageEvent("storage", { key: STORAGE_KEY, newValue }),
+        new StorageEvent("storage", { key: STORAGE_KEY, newValue: raw }),
       );
       await Promise.resolve();
       await Promise.resolve();
@@ -351,59 +356,68 @@ describe("camera gate readout access", () => {
 
       const foreign = payloadFrom(OTHER_STAFF_USER.id ?? "", 42);
       localStorage.setItem(STORAGE_KEY, foreign);
-      const writes: string[] = [];
-      const setItem = localStorage.setItem.bind(localStorage);
-      localStorage.setItem = (key: string, value: string) => {
-        writes.push(key);
-        setItem(key, value);
-      };
-      try {
-        window.dispatchEvent(
-          new StorageEvent("storage", { key: STORAGE_KEY, newValue: foreign }),
-        );
-        await Promise.resolve();
-        await Promise.resolve();
-      } finally {
-        localStorage.setItem = setItem;
-      }
+
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEY, newValue: foreign }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
 
       // Nothing of this tab's moved, and nothing of this tab's was written:
-      // the key still holds the other account's payload, which is theirs until
-      // somebody's next boot claims it.
+      // the key still holds the other account's payload byte for byte, which
+      // is theirs until somebody's next boot claims it. A correction would
+      // have replaced it with one owned by this account, which is the write
+      // the other tab would have answered.
       const state = useCameraGateDebugStore.getState();
       expect(state.hudEnabled).toBe(true);
       expect(state.overrides.minDetail).toBe(30);
       expect(state.ownerUserId).toBe(STAFF_USER.id);
       expect(FRAME_GATE_LIVE_OPTIONS.minDetail).toBe(30);
-      expect(writes).toEqual([]);
       expect(localStorage.getItem(STORAGE_KEY)).toBe(foreign);
     });
 
     test("that cannot be read is left alone", async () => {
-      // A removal, a hand-edited value, and a payload with no state in it.
-      // None of them says whose preference this is, so none of them is acted
-      // on, and none of them throws out of the handler. The key is left
-      // holding something this tab would otherwise have taken, so an event
-      // that was acted on anyway would show up here.
+      // A key that was removed, a hand-edited value, and a payload with no
+      // state in it. None of them says whose preference this is, so none is
+      // acted on, and none throws out of the handler. The last shape is the
+      // one a restore would visibly take: it parses, so a handler that went
+      // ahead would merge it and put this session's switch out.
       useAuthStore.setState({ user: STAFF_USER });
       useCameraGateDebugStore.getState().setHudEnabled(true);
-      localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({
-          state: {
-            hudEnabled: false,
-            ownerUserId: STAFF_USER.id,
-            overrides: defaultFrameGateOverrides(),
-          },
-          version: 0,
-        }),
-      );
 
       await arriveUnreadable(null);
       await arriveUnreadable("not json at all");
       await arriveUnreadable(JSON.stringify({ version: 0 }));
 
       expect(useCameraGateDebugStore.getState().hudEnabled).toBe(true);
+    });
+
+    test("is checked against the key as it stands, not the value it announced", async () => {
+      // A third window replaces the key between this event being queued and
+      // this handler running. The event still names this account, and the
+      // restore would take the key, so trusting the event would smuggle the
+      // other account's payload in behind a check that passed.
+      useAuthStore.setState({ user: STAFF_USER });
+      const store = useCameraGateDebugStore.getState();
+      store.setHudEnabled(true);
+      store.setOverride("minDetail", 30);
+
+      const announced = payloadFrom(STAFF_USER.id ?? "", 42);
+      const onDiskNow = payloadFrom(OTHER_STAFF_USER.id ?? "", 99);
+      localStorage.setItem(STORAGE_KEY, onDiskNow);
+
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEY, newValue: announced }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const state = useCameraGateDebugStore.getState();
+      expect(state.hudEnabled).toBe(true);
+      expect(state.overrides.minDetail).toBe(30);
+      expect(FRAME_GATE_LIVE_OPTIONS.minDetail).toBe(30);
+      // Byte for byte what the third window left, so this tab wrote nothing.
+      expect(localStorage.getItem(STORAGE_KEY)).toBe(onDiskNow);
     });
 
     test("under another key is not this store's to answer", async () => {

--- a/clients/web/src/lib/camera/frame-gate-debug-access.ts
+++ b/clients/web/src/lib/camera/frame-gate-debug-access.ts
@@ -29,7 +29,10 @@
 import { isVellumStaff } from "@/lib/auth/staff";
 import { syncFrameGateDebugOptions } from "@/lib/camera/frame-gate-debug";
 import { useAuthStore, type AuthUser } from "@/stores/auth-store";
-import { useCameraGateDebugStore } from "@/stores/camera-gate-debug-store";
+import {
+  useCameraGateDebugStore,
+  watchCameraGateDebugStorage,
+} from "@/stores/camera-gate-debug-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 /**
@@ -103,6 +106,13 @@ function onAuthChange(): void {
  * The subscriptions carry no selector: the answer is a function of slices in
  * three stores, and a selectorless subscriber runs on every write to any of
  * them, including the persist middleware restoring a switch left on.
+ *
+ * Another tab's write is restored here too, and settled through the same
+ * {@link onAuthChange} an account change runs. A second window can sign the
+ * browser into a different account, so a payload arriving from one names an
+ * owner that has to be checked against whoever this tab holds before its
+ * thresholds are allowed anywhere near the gate. The store restores; the claim
+ * decides whether what it restored is this account's to keep.
  */
 export function setupCameraGateHudAccessSync(): () => void {
   onAuthChange();
@@ -113,9 +123,11 @@ export function setupCameraGateHudAccessSync(): () => void {
   const unsubscribeDebug = useCameraGateDebugStore.subscribe(
     applyEffectiveOptions,
   );
+  const unwatchStorage = watchCameraGateDebugStorage(onAuthChange);
   return () => {
     unsubscribeAuth();
     unsubscribeFlags();
     unsubscribeDebug();
+    unwatchStorage();
   };
 }

--- a/clients/web/src/lib/camera/frame-gate-debug-access.ts
+++ b/clients/web/src/lib/camera/frame-gate-debug-access.ts
@@ -101,18 +101,41 @@ function onAuthChange(): void {
 }
 
 /**
+ * Whether a payload another tab left is this tab's to read.
+ *
+ * Answered before anything is restored, because the alternative is a loop. A
+ * foreign payload adopted here would be corrected by the claim, that
+ * correction is a persisted write, and the tab that wrote the original reads
+ * it and corrects it back: two signed-in accounts trading the key with nobody
+ * touching a switch. Refusing to read it costs this tab nothing, since the
+ * preference it is holding is already its own.
+ *
+ * A payload naming no owner is accepted: nothing has claimed it, so there is
+ * no account to disagree with, and the claim that follows the restore is what
+ * binds it. A window with no user resolved yet accepts nothing owned, which is
+ * the same caution {@link claimForCurrentUser} takes for the same reason: boot
+ * and a token refresh both look like a signed-out window.
+ */
+function ownsPersistedPreference(ownerUserId: string | null): boolean {
+  if (ownerUserId === null) {
+    return true;
+  }
+  return ownerUserId === (useAuthStore.getState().user?.id ?? null);
+}
+
+/**
  * Call once at startup. Returns an unsubscribe for tests.
  *
  * The subscriptions carry no selector: the answer is a function of slices in
  * three stores, and a selectorless subscriber runs on every write to any of
  * them, including the persist middleware restoring a switch left on.
  *
- * Another tab's write is restored here too, and settled through the same
+ * Another tab's write is picked up here too, gated on
+ * {@link ownsPersistedPreference} and then settled through the same
  * {@link onAuthChange} an account change runs. A second window can sign the
- * browser into a different account, so a payload arriving from one names an
- * owner that has to be checked against whoever this tab holds before its
- * thresholds are allowed anywhere near the gate. The store restores; the claim
- * decides whether what it restored is this account's to keep.
+ * browser into a different account, so the owner named in the event is checked
+ * before anything is restored, and only a payload this tab may hold reaches
+ * the store or the gate.
  */
 export function setupCameraGateHudAccessSync(): () => void {
   onAuthChange();
@@ -123,7 +146,10 @@ export function setupCameraGateHudAccessSync(): () => void {
   const unsubscribeDebug = useCameraGateDebugStore.subscribe(
     applyEffectiveOptions,
   );
-  const unwatchStorage = watchCameraGateDebugStorage(onAuthChange);
+  const unwatchStorage = watchCameraGateDebugStorage(
+    ownsPersistedPreference,
+    onAuthChange,
+  );
   return () => {
     unsubscribeAuth();
     unsubscribeFlags();

--- a/clients/web/src/stores/camera-gate-debug-store.test.ts
+++ b/clients/web/src/stores/camera-gate-debug-store.test.ts
@@ -287,68 +287,6 @@ describe("camera gate debug store", () => {
     });
   });
 
-  test("another tab's write reaches this one, and the gate with it", async () => {
-    // The switch is offered in two places (Settings, and the camera's view
-    // options), and a session can have both open in different windows. The
-    // persist middleware writes but does not listen, so the `storage` event is
-    // the only thing that carries one window's choice to the next.
-    const store = useCameraGateDebugStore.getState();
-    store.setHudEnabled(false);
-    expect(FRAME_GATE_LIVE_OPTIONS.noveltyThreshold).toBe(
-      DEFAULT_FRAME_GATE_OPTIONS.noveltyThreshold,
-    );
-
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        state: {
-          hudEnabled: true,
-          overrides: { ...defaultFrameGateOverrides(), noveltyThreshold: 1.1 },
-          ownerUserId: null,
-        },
-        version: 0,
-      }),
-    );
-    window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
-    await Promise.resolve();
-
-    expect(useCameraGateDebugStore.getState().hudEnabled).toBe(true);
-    // Restored through the same `merge` a reload goes through, and pushed to
-    // the gate by the same subscription a local write uses.
-    expect(useCameraGateDebugStore.getState().overrides.noveltyThreshold).toBe(
-      1.1,
-    );
-    expect(FRAME_GATE_LIVE_OPTIONS.noveltyThreshold).toBe(1.1);
-  });
-
-  test("a write to another key is not this store's to answer", async () => {
-    const store = useCameraGateDebugStore.getState();
-    store.setHudEnabled(true);
-
-    // A payload nobody announced. Reading it would mean this store restores
-    // itself on any key's event, which is a switch flipping under a session
-    // that changed nothing.
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        state: {
-          hudEnabled: false,
-          overrides: defaultFrameGateOverrides(),
-          ownerUserId: null,
-        },
-        version: 0,
-      }),
-    );
-    localStorage.setItem("vellum:debug:somethingElse", "{}");
-    window.dispatchEvent(
-      new StorageEvent("storage", { key: "vellum:debug:somethingElse" }),
-    );
-    await Promise.resolve();
-
-    expect(useCameraGateDebugStore.getState().hudEnabled).toBe(true);
-    localStorage.removeItem("vellum:debug:somethingElse");
-  });
-
   test("reset puts every slider and the gate back to the defaults", () => {
     const store = useCameraGateDebugStore.getState();
     store.setHudEnabled(true);

--- a/clients/web/src/stores/camera-gate-debug-store.test.ts
+++ b/clients/web/src/stores/camera-gate-debug-store.test.ts
@@ -287,6 +287,68 @@ describe("camera gate debug store", () => {
     });
   });
 
+  test("another tab's write reaches this one, and the gate with it", async () => {
+    // The switch is offered in two places (Settings, and the camera's view
+    // options), and a session can have both open in different windows. The
+    // persist middleware writes but does not listen, so the `storage` event is
+    // the only thing that carries one window's choice to the next.
+    const store = useCameraGateDebugStore.getState();
+    store.setHudEnabled(false);
+    expect(FRAME_GATE_LIVE_OPTIONS.noveltyThreshold).toBe(
+      DEFAULT_FRAME_GATE_OPTIONS.noveltyThreshold,
+    );
+
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          hudEnabled: true,
+          overrides: { ...defaultFrameGateOverrides(), noveltyThreshold: 1.1 },
+          ownerUserId: null,
+        },
+        version: 0,
+      }),
+    );
+    window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+    await Promise.resolve();
+
+    expect(useCameraGateDebugStore.getState().hudEnabled).toBe(true);
+    // Restored through the same `merge` a reload goes through, and pushed to
+    // the gate by the same subscription a local write uses.
+    expect(useCameraGateDebugStore.getState().overrides.noveltyThreshold).toBe(
+      1.1,
+    );
+    expect(FRAME_GATE_LIVE_OPTIONS.noveltyThreshold).toBe(1.1);
+  });
+
+  test("a write to another key is not this store's to answer", async () => {
+    const store = useCameraGateDebugStore.getState();
+    store.setHudEnabled(true);
+
+    // A payload nobody announced. Reading it would mean this store restores
+    // itself on any key's event, which is a switch flipping under a session
+    // that changed nothing.
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          hudEnabled: false,
+          overrides: defaultFrameGateOverrides(),
+          ownerUserId: null,
+        },
+        version: 0,
+      }),
+    );
+    localStorage.setItem("vellum:debug:somethingElse", "{}");
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: "vellum:debug:somethingElse" }),
+    );
+    await Promise.resolve();
+
+    expect(useCameraGateDebugStore.getState().hudEnabled).toBe(true);
+    localStorage.removeItem("vellum:debug:somethingElse");
+  });
+
   test("reset puts every slider and the gate back to the defaults", () => {
     const store = useCameraGateDebugStore.getState();
     store.setHudEnabled(true);

--- a/clients/web/src/stores/camera-gate-debug-store.ts
+++ b/clients/web/src/stores/camera-gate-debug-store.ts
@@ -2,9 +2,9 @@
  * Zustand store for the camera frame gate's tuning readout.
  *
  * Owns two things: whether the readout is on, and the threshold values its
- * sliders hold. The settings panel writes the first, the readout writes the
- * second, and both are remembered across reloads so a tuning session survives
- * the dev-server restarts that tuning involves.
+ * sliders hold. The camera's view options write the first, the readout writes
+ * the second, and both are remembered across reloads so a tuning session
+ * survives the dev-server restarts that tuning involves.
  *
  * **Storage model:**
  *
@@ -22,9 +22,9 @@
  *   to the next, whether the previous session was signed out of or expired.
  * - Cross-tab updates: the persist middleware doesn't sync across tabs on its
  *   own. {@link watchCameraGateDebugStorage} listens for `storage` events on
- *   the key and re-reads the slice, so the two places the switch is offered
- *   (Settings, and the camera's view options) agree across every window the
- *   account has open. The restored payload goes through the same `merge` a
+ *   the key and re-reads the slice, so every window the account has open
+ *   agrees about the switch rather than each holding the value it last wrote.
+ *   The restored payload goes through the same `merge` a
  *   reload does, so a stale or hand-edited value is clamped exactly as one
  *   from disk. A payload belonging to another account is not restored at all:
  *   the owner named in the event is checked first, by a caller that knows

--- a/clients/web/src/stores/camera-gate-debug-store.ts
+++ b/clients/web/src/stores/camera-gate-debug-store.ts
@@ -20,6 +20,13 @@
  *   only ever applied to the account it belongs to: `claimForUser` drops it
  *   for anyone else, so a shared browser never hands one person's thresholds
  *   to the next, whether the previous session was signed out of or expired.
+ * - Cross-tab updates: the persist middleware doesn't sync across tabs on its
+ *   own. We listen for `storage` events on the key and call
+ *   `persist.rehydrate()` to pull in the other tab's write, so the two places
+ *   the switch is offered (Settings, and the camera's view options) agree
+ *   across every window the account has open. The restored payload goes
+ *   through the same `merge` a reload does, so a hand-edited or stale value
+ *   from another tab is clamped and claimed exactly as one from disk.
  *
  * **What every write does.** A write moves this slice and nothing else. The
  * gate's live options record is owned by `lib/camera/frame-gate-debug.ts` and
@@ -194,6 +201,18 @@ const useCameraGateDebugStoreBase = create<CameraGateDebugStore>()(
 export const useCameraGateDebugStore = createSelectors(
   useCameraGateDebugStoreBase,
 );
+
+// ---------------------------------------------------------------------------
+// Cross-tab sync
+// ---------------------------------------------------------------------------
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (event) => {
+    if (event.key === CAMERA_GATE_DEBUG_STORE_KEY) {
+      void useCameraGateDebugStoreBase.persist.rehydrate();
+    }
+  });
+}
 
 /**
  * Put the readout back to its shipped state when a session ends.

--- a/clients/web/src/stores/camera-gate-debug-store.ts
+++ b/clients/web/src/stores/camera-gate-debug-store.ts
@@ -21,12 +21,15 @@
  *   for anyone else, so a shared browser never hands one person's thresholds
  *   to the next, whether the previous session was signed out of or expired.
  * - Cross-tab updates: the persist middleware doesn't sync across tabs on its
- *   own. We listen for `storage` events on the key and call
- *   `persist.rehydrate()` to pull in the other tab's write, so the two places
- *   the switch is offered (Settings, and the camera's view options) agree
- *   across every window the account has open. The restored payload goes
- *   through the same `merge` a reload does, so a hand-edited or stale value
- *   from another tab is clamped and claimed exactly as one from disk.
+ *   own. {@link watchCameraGateDebugStorage} listens for `storage` events on
+ *   the key and re-reads the slice, so the two places the switch is offered
+ *   (Settings, and the camera's view options) agree across every window the
+ *   account has open. The restored payload goes through the same `merge` a
+ *   reload does, so a stale or hand-edited value is clamped exactly as one
+ *   from disk. Whose account the restored payload belongs to is settled by
+ *   the caller, which is the half this module cannot answer: another tab can
+ *   sign the browser into a different account, and the payload it leaves
+ *   behind names an owner this tab has to be told about.
  *
  * **What every write does.** A write moves this slice and nothing else. The
  * gate's live options record is owned by `lib/camera/frame-gate-debug.ts` and
@@ -206,12 +209,35 @@ export const useCameraGateDebugStore = createSelectors(
 // Cross-tab sync
 // ---------------------------------------------------------------------------
 
-if (typeof window !== "undefined") {
-  window.addEventListener("storage", (event) => {
-    if (event.key === CAMERA_GATE_DEBUG_STORE_KEY) {
-      void useCameraGateDebugStoreBase.persist.rehydrate();
+/**
+ * Re-read this slice whenever another tab writes it, and hand back an
+ * unsubscribe.
+ *
+ * `onRestored` runs once the payload is in. It is where the caller settles
+ * whose preference was just restored: another tab can sign the browser into a
+ * different account between two writes, and the payload names an owner that
+ * only a module holding this tab's identity can check. Restoring first and
+ * settling after is what keeps the storage key's shape here and the account
+ * rules there.
+ */
+export function watchCameraGateDebugStorage(
+  onRestored: () => void,
+): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  const onStorage = (event: StorageEvent): void => {
+    if (event.key !== CAMERA_GATE_DEBUG_STORE_KEY) {
+      return;
     }
-  });
+    void Promise.resolve(useCameraGateDebugStoreBase.persist.rehydrate()).then(
+      onRestored,
+    );
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener("storage", onStorage);
+  };
 }
 
 /**

--- a/clients/web/src/stores/camera-gate-debug-store.ts
+++ b/clients/web/src/stores/camera-gate-debug-store.ts
@@ -209,7 +209,7 @@ export const useCameraGateDebugStore = createSelectors(
 // ---------------------------------------------------------------------------
 
 /**
- * The account a payload another tab wrote belongs to, or nothing readable.
+ * The account the payload on the key belongs to, or nothing readable.
  *
  * A `null` owner is a real answer: a slice written before any account claimed
  * it names none, and the claim that follows a restore is what settles those.
@@ -257,6 +257,14 @@ function readPersistedOwner(
  * the owner is parsed here; whether that owner is the one this tab is signed
  * in as is the caller's, so it answers `shouldAccept`. `onRestored` then runs
  * for an accepted payload only.
+ *
+ * What is checked is the key as it stands, not the value the event carried.
+ * Those differ whenever a third write lands between an event being queued and
+ * this handler running, and the restore below takes the key rather than the
+ * event, so checking the event would be checking something else. Both reads
+ * sit in one synchronous block: `persist.rehydrate()` calls `getItem` on a
+ * synchronous storage and settles before it returns, so nothing can replace
+ * the key between the answer and the restore.
  */
 export function watchCameraGateDebugStorage(
   shouldAccept: (ownerUserId: string | null) => boolean,
@@ -269,7 +277,9 @@ export function watchCameraGateDebugStorage(
     if (event.key !== CAMERA_GATE_DEBUG_STORE_KEY) {
       return;
     }
-    const owner = readPersistedOwner(event.newValue);
+    const owner = readPersistedOwner(
+      localStorage.getItem(CAMERA_GATE_DEBUG_STORE_KEY),
+    );
     if (!owner.readable || !shouldAccept(owner.ownerUserId)) {
       return;
     }

--- a/clients/web/src/stores/camera-gate-debug-store.ts
+++ b/clients/web/src/stores/camera-gate-debug-store.ts
@@ -26,10 +26,9 @@
  *   (Settings, and the camera's view options) agree across every window the
  *   account has open. The restored payload goes through the same `merge` a
  *   reload does, so a stale or hand-edited value is clamped exactly as one
- *   from disk. Whose account the restored payload belongs to is settled by
- *   the caller, which is the half this module cannot answer: another tab can
- *   sign the browser into a different account, and the payload it leaves
- *   behind names an owner this tab has to be told about.
+ *   from disk. A payload belonging to another account is not restored at all:
+ *   the owner named in the event is checked first, by a caller that knows
+ *   which account this tab holds.
  *
  * **What every write does.** A write moves this slice and nothing else. The
  * gate's live options record is owned by `lib/camera/frame-gate-debug.ts` and
@@ -210,17 +209,57 @@ export const useCameraGateDebugStore = createSelectors(
 // ---------------------------------------------------------------------------
 
 /**
- * Re-read this slice whenever another tab writes it, and hand back an
- * unsubscribe.
+ * The account a payload another tab wrote belongs to, or nothing readable.
  *
- * `onRestored` runs once the payload is in. It is where the caller settles
- * whose preference was just restored: another tab can sign the browser into a
- * different account between two writes, and the payload names an owner that
- * only a module holding this tab's identity can check. Restoring first and
- * settling after is what keeps the storage key's shape here and the account
- * rules there.
+ * A `null` owner is a real answer: a slice written before any account claimed
+ * it names none, and the claim that follows a restore is what settles those.
+ * An absent value (the key was removed) or a payload that does not parse is
+ * not an answer at all, and nothing is restored from one.
+ */
+function readPersistedOwner(
+  raw: string | null,
+): { readable: true; ownerUserId: string | null } | { readable: false } {
+  if (raw === null) {
+    return { readable: false };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { readable: false };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { readable: false };
+  }
+  const state = (parsed as { state?: unknown }).state;
+  if (typeof state !== "object" || state === null) {
+    return { readable: false };
+  }
+  const owner = (state as { ownerUserId?: unknown }).ownerUserId;
+  return {
+    readable: true,
+    ownerUserId: typeof owner === "string" ? owner : null,
+  };
+}
+
+/**
+ * Re-read this slice when another tab writes one this tab is allowed to hold,
+ * and hand back an unsubscribe.
+ *
+ * The owner is checked BEFORE anything is restored. Adopting a payload and
+ * correcting it afterwards looks equivalent and is not: the correction is
+ * itself a persisted write, the other tab reads it, corrects it back, and two
+ * signed-in accounts trade the key forever. A payload this tab may not hold is
+ * therefore left entirely alone, on disk and in memory, and the account that
+ * wrote it keeps it until someone's next boot claims it.
+ *
+ * The split is what each side knows. The payload's shape is this module's, so
+ * the owner is parsed here; whether that owner is the one this tab is signed
+ * in as is the caller's, so it answers `shouldAccept`. `onRestored` then runs
+ * for an accepted payload only.
  */
 export function watchCameraGateDebugStorage(
+  shouldAccept: (ownerUserId: string | null) => boolean,
   onRestored: () => void,
 ): () => void {
   if (typeof window === "undefined") {
@@ -228,6 +267,10 @@ export function watchCameraGateDebugStorage(
   }
   const onStorage = (event: StorageEvent): void => {
     if (event.key !== CAMERA_GATE_DEBUG_STORE_KEY) {
+      return;
+    }
+    const owner = readPersistedOwner(event.newValue);
+    if (!owner.readable || !shouldAccept(owner.ownerUserId)) {
       return;
     }
     void Promise.resolve(useCameraGateDebugStoreBase.persist.rehydrate()).then(

--- a/clients/web/src/stores/voice-prefs-store.test.ts
+++ b/clients/web/src/stores/voice-prefs-store.test.ts
@@ -19,6 +19,7 @@ beforeEach(() => {
     pauseBeforeReplyMs: null,
     interruptSensitivity: null,
     flashMode: "off",
+    showKeptFrame: true,
   });
 });
 
@@ -86,6 +87,29 @@ describe("useVoicePrefsStore — voice-mode preferences", () => {
     expect(persisted.pauseBeforeReplyMs).toBe(1500);
     expect(persisted.interruptSensitivity).toBe("low");
     expect(persisted.flashMode).toBe("auto");
+    expect(persisted.showKeptFrame).toBe(true);
+  });
+});
+
+describe("useVoicePrefsStore: the kept-frame thumbnail", () => {
+  test("ships on, so a call keeps Live's one visible signal until it is turned off", () => {
+    // The shipped value rather than the reset above, which is a test fixture.
+    expect(useVoicePrefsStore.getInitialState().showKeptFrame).toBe(true);
+  });
+
+  test("setShowKeptFrame flips only that field, and survives a reload", () => {
+    useVoicePrefsStore.getState().setShowKeptFrame(false);
+
+    expect(useVoicePrefsStore.getState().showKeptFrame).toBe(false);
+    expect(useVoicePrefsStore.getState().flashMode).toBe("off");
+
+    const persisted = JSON.parse(
+      localStorage.getItem(VOICE_PREFS_STORE_KEY) as string,
+    ).state;
+    expect(persisted.showKeptFrame).toBe(false);
+
+    useVoicePrefsStore.getState().setShowKeptFrame(true);
+    expect(useVoicePrefsStore.getState().showKeptFrame).toBe(true);
   });
 });
 

--- a/clients/web/src/stores/voice-prefs-store.ts
+++ b/clients/web/src/stores/voice-prefs-store.ts
@@ -126,6 +126,16 @@ export interface VoicePrefsState {
    * silently picked for them.
    */
   flashMode: FlashMode;
+  /**
+   * Whether the viewfinder draws the accented thumbnail of the newest frame
+   * Live gave the call.
+   *
+   * A view preference, not a capture one: sampling, sending and the
+   * transcript record of every kept frame are the same either way. On by
+   * default, because the thumbnail is the only place the surface itself says
+   * a frame just went.
+   */
+  showKeptFrame: boolean;
 }
 
 export interface VoicePrefsActions {
@@ -139,6 +149,8 @@ export interface VoicePrefsActions {
   setInterruptSensitivity: (next: InterruptSensitivity | null) => void;
   /** Record the flash mode the user picked. See {@link VoicePrefsState.flashMode}. */
   setFlashMode: (next: FlashMode) => void;
+  /** Show or hide the kept-frame thumbnail. See {@link VoicePrefsState.showKeptFrame}. */
+  setShowKeptFrame: (next: boolean) => void;
 }
 
 export type VoicePrefsStore = VoicePrefsState & VoicePrefsActions;
@@ -156,6 +168,7 @@ const INITIAL_STATE: VoicePrefsState = {
   pauseBeforeReplyMs: null,
   interruptSensitivity: null,
   flashMode: "off",
+  showKeptFrame: true,
 };
 
 // ---------------------------------------------------------------------------
@@ -186,6 +199,7 @@ const useVoicePrefsStoreBase = create<VoicePrefsStore>()(
       setInterruptSensitivity: (next: InterruptSensitivity | null) =>
         set({ interruptSensitivity: next }),
       setFlashMode: (next: FlashMode) => set({ flashMode: next }),
+      setShowKeptFrame: (next: boolean) => set({ showKeptFrame: next }),
     }),
     {
       name: VOICE_PREFS_STORE_KEY,
@@ -197,6 +211,7 @@ const useVoicePrefsStoreBase = create<VoicePrefsStore>()(
         pauseBeforeReplyMs: state.pauseBeforeReplyMs,
         interruptSensitivity: state.interruptSensitivity,
         flashMode: state.flashMode,
+        showKeptFrame: state.showKeptFrame,
       }),
     },
   ),


### PR DESCRIPTION
# Camera-mode view settings

Camera mode gains a glass corner button (top-right, inboard of minimize, camera-
only) that opens a compact anchored panel with two view toggles:

- **Frame-gate readout**: reuses the persisted `hudEnabled` switch the Settings
  Debug page already writes, so the two entry points cannot drift; the row
  renders only for sessions where the readout is available at all (staff or the
  `camera-gate-debug-hud` flag).
- **Kept-frame thumbnail**: a new `showKeptFrame` voice preference (default on)
  gating only the crimson thumbnail's render sites. Live goes on sampling,
  sending, and recording every kept frame in the transcript either way; the
  hook still holds the frame so retractions have something to take back.

## Presentation choices worth review

- **Anchored on every form factor.** The room is itself a non-modal bottom
  sheet portaled into `#viewport-overlays`, and the flush camera state inerts
  that host's other direct children, so both branches of `AdaptivePopover`
  would arrive inert. The panel instead portals into the control's own box via
  a nested `PortalContainerProvider`, below the level the inert sweep reaches.
- **The status pill now centres in the band the corner chrome leaves** rather
  than on the room. With two 52px controls in the corner, a room-centred pill
  reaches under them at phone width before spending its own floor width;
  reserving the cluster's share on both sides leaves less than the pill's
  minimum. Visible shift on camera surfaces; flagged for design sign-off in
  docs/CAMERA_MODE_QA.md.
- `VoiceRoomControl` now passes unnamed props through to its button (via the
  Tooltip's documented forwarding path), so a Radix `asChild` trigger can
  drive it. Additive; existing call sites unchanged.

## Verification

Per-file suites: voice-room 127, camera-view-settings 7 (new),
voice-prefs-store 15, voice-room-control 2, camera-status-pill 29,
use-voice-room-sight 61 (untouched), i18n catalogs 210. Nine behavior
assertions red-green proved, including the default-on ship state, the
render-site-only gating, and the shared-switch wiring. QA rows added for what
happy-dom cannot exercise (popover position over the transformed room box,
touch-device panel, `left: max(...)` insets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
