### PR TITLE
fix(web): let Escape reach the pod desktop instead of closing the modal

### DIFF
--- a/clients/web/src/domains/chat/desktop/pod-desktop-affordance.test.tsx
+++ b/clients/web/src/domains/chat/desktop/pod-desktop-affordance.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The modal around the desktop panel: Escape has to reach the pod, since
+ * closing the modal unmounts the panel and gives up the viewer slot.
+ *
+ * The stores are mocked to a flagged-on assistant, and the panel to a marker
+ * that records its own unmount, which is what ends the session.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useEffect } from "react";
+
+mock.module("@/stores/assistant-feature-flag-store", () => ({
+  useAssistantFeatureFlagStore: { use: { podDesktop: () => true } },
+}));
+
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: { use: { activeAssistantId: () => "asst-1" } },
+}));
+
+let panelUnmounts = 0;
+
+mock.module("./desktop-panel", () => ({
+  DesktopPanel: () => {
+    useEffect(() => {
+      return () => {
+        panelUnmounts += 1;
+      };
+    }, []);
+    return <div data-testid="desktop-panel" />;
+  },
+}));
+
+const { PodDesktopAffordance } = await import("./pod-desktop-affordance");
+
+const openDesktop = async () => {
+  render(<PodDesktopAffordance />);
+  fireEvent.click(screen.getByRole("button", { name: "Open desktop" }));
+  await waitFor(() =>
+    expect(screen.getByTestId("desktop-panel")).not.toBeNull(),
+  );
+};
+
+beforeEach(() => {
+  panelUnmounts = 0;
+});
+
+afterEach(cleanup);
+
+describe("PodDesktopAffordance", () => {
+  test("Escape leaves the modal open and the panel mounted", async () => {
+    await openDesktop();
+
+    fireEvent.keyDown(document.activeElement ?? document.body, {
+      key: "Escape",
+    });
+
+    expect(screen.getByRole("dialog")).not.toBeNull();
+    expect(screen.getByTestId("desktop-panel")).not.toBeNull();
+    expect(panelUnmounts).toBe(0);
+  });
+
+  test("the close button still dismisses the modal", async () => {
+    await openDesktop();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(panelUnmounts).toBe(1);
+  });
+});

--- a/clients/web/src/domains/chat/desktop/pod-desktop-affordance.tsx
+++ b/clients/web/src/domains/chat/desktop/pod-desktop-affordance.tsx
@@ -39,7 +39,13 @@ export function PodDesktopAffordance() {
         onClick={() => setOpen(true)}
       />
       <Modal.Root open={open} onOpenChange={setOpen}>
-        <Modal.Content size="xl" className="h-[calc(100vh-2rem)]">
+        <Modal.Content
+          size="xl"
+          className="h-[calc(100vh-2rem)]"
+          // Escape belongs to the remote desktop (dismissing its dialogs,
+          // leaving fullscreen); the close button and overlay still dismiss.
+          onEscapeKeyDown={(event) => event.preventDefault()}
+        >
           <Modal.Header>
             <Modal.Title>{t("podDesktop.title")}</Modal.Title>
           </Modal.Header>

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -58,7 +58,6 @@ import { assertHasResponse } from "@/utils/api-errors";
  */
 const DEFAULT_VELAY_HOST = "velay.vellum.ai";
 
-/** The route both transports open, on the gateway either way. */
 const LIVE_VOICE_ROUTE = "/v1/live-voice";
 
 export class VelayWsTokenError extends Error {


### PR DESCRIPTION
## Summary
Round-3 review fixes for pod-desktop-streaming.md (web side).

- Radix's capture-phase Escape handler closed the desktop modal before noVNC saw the key, unmounting the panel, closing the socket, and releasing the pod's single viewer slot. `Modal.Content` now passes `onEscapeKeyDown={(e) => e.preventDefault()}` so Escape reaches the remote Chromium (dismiss dialogs, exit fullscreen, cancel find); the close button and overlay click still dismiss.
- New `pod-desktop-affordance.test.tsx`: Escape with the desktop open leaves the dialog and panel mounted (no unmount, so no session teardown); the close button still dismisses. The test fails without the fix.
- Dropped the filler doc comment above `LIVE_VOICE_ROUTE` in `live-voice/connection.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YDF6hHcX7aPZsc6TuByhy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41992" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->