### PR TITLE
refactor(assistant): use RegExp.escape instead of hand-rolled escapes

### DIFF
--- a/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
+++ b/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
@@ -35,7 +35,7 @@ describe("forbidden legacy symbols", () => {
       "calls.webhookBaseUrl",
     ];
     const escapedPattern = forbiddenSymbols
-      .map((symbol) => symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+      .map((symbol) => RegExp.escape(symbol))
       .join("|");
 
     const repoRoot = resolve(__dirname, "..", "..", "..");

--- a/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
+++ b/assistant/src/__tests__/forbidden-legacy-symbols.test.ts
@@ -34,11 +34,23 @@ describe("forbidden legacy symbols", () => {
       "twilio_webhook_config",
       "calls.webhookBaseUrl",
     ];
+    // This pattern is POSIX ERE for `git grep -E`, not a JavaScript RegExp:
+    // ERE has no `\x` escapes, so `RegExp.escape` would turn the pattern
+    // into one that matches nothing and the test would pass empty.
     const escapedPattern = forbiddenSymbols
-      .map((symbol) => RegExp.escape(symbol))
+      .map((symbol) => symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
       .join("|");
 
     const repoRoot = resolve(__dirname, "..", "..", "..");
+    // Positive control: the pattern must still match the symbols as written
+    // in this very file, so a broken pattern fails loudly instead of
+    // matching nothing.
+    const selfMatches = execSync(
+      `git grep -c -E "${escapedPattern}" -- "assistant/src/__tests__/forbidden-legacy-symbols.test.ts"`,
+      { cwd: repoRoot, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    expect(selfMatches.trim()).not.toBe("");
+
     let matches = "";
     try {
       // Use git grep so only tracked files are searched. This automatically

--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -441,7 +441,7 @@ const NAMESPACE_IMPORT = "*";
  *  namespace import yields the {@link NAMESPACE_IMPORT} sentinel — it reaches
  *  the whole surface, so it must not slip past the anti-backslide check. */
 function symbolsImportedFrom(source: string, hostPathSuffix: string): string[] {
-  const escaped = hostPathSuffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escaped = RegExp.escape(hostPathSuffix);
   const from = String.raw`\s*from\s*['"]([^'"]*` + escaped + String.raw`)['"]`;
   const namedRegex = new RegExp(
     String.raw`import\s+(?:type\s+)?\{([^}]*)\}` + from,

--- a/assistant/src/daemon/dictation-text-processing.ts
+++ b/assistant/src/daemon/dictation-text-processing.ts
@@ -5,7 +5,6 @@
  * - applyDictionary: post-LLM, dictation + command modes (including fallback paths)
  */
 
-import { escapeRegExp } from "../util/regexp.js";
 import type {
   DictationDictionaryEntry,
   DictationSnippet,
@@ -61,7 +60,7 @@ export function expandSnippets(
 
   // Build a single alternation pattern for single-pass replacement
   const alternatives = sorted.map((s) =>
-    wrapWordBoundary(escapeRegExp(s.trigger), s.trigger),
+    wrapWordBoundary(RegExp.escape(s.trigger), s.trigger),
   );
   const pattern = new RegExp(`(?:${alternatives.join("|")})`, "gi");
 
@@ -112,7 +111,7 @@ export function applyDictionary(
   }
 
   const entries: EntryWithPattern[] = sorted.map((entry) => {
-    const escaped = escapeRegExp(entry.spoken);
+    const escaped = RegExp.escape(entry.spoken);
     const wholeWord = entry.wholeWord !== false; // default true
     const pat = wholeWord ? wrapWordBoundary(escaped, entry.spoken) : escaped;
     return { pattern: pat, entry };

--- a/assistant/src/daemon/dictation-text-processing.ts
+++ b/assistant/src/daemon/dictation-text-processing.ts
@@ -5,15 +5,11 @@
  * - applyDictionary: post-LLM, dictation + command modes (including fallback paths)
  */
 
+import { escapeRegExp } from "../util/regexp.js";
 import type {
   DictationDictionaryEntry,
   DictationSnippet,
 } from "./dictation-profile-store.js";
-
-/** Escape a string for safe use inside a RegExp. */
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
 
 /**
  * Wrap an escaped pattern with word boundaries.

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -7,6 +7,7 @@
  */
 import { rawAll, rawGet, rawRun } from "../persistence/raw-query.js";
 import { getLogger } from "../util/logger.js";
+import { escapeRegExp } from "../util/regexp.js";
 
 const log = getLogger("document-store");
 
@@ -470,10 +471,6 @@ export type ReplaceInDocumentResult =
   | { success: true; replacements_made: number; content_changed: boolean }
   | { success: false; error: string };
 
-function escapeRegExpChars(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /**
  * Find and replace text within a document — like sed.
  * Supports literal text and regex patterns with optional backreferences.
@@ -497,7 +494,7 @@ export function replaceInDocument(
     const flags = "g" + (options.caseSensitive === true ? "" : "i");
     const pattern = options.regex
       ? new RegExp(find, flags)
-      : new RegExp(escapeRegExpChars(find), flags);
+      : new RegExp(escapeRegExp(find), flags);
 
     const totalMatches = [...row.content.matchAll(pattern)].length;
     if (

--- a/assistant/src/documents/document-store.ts
+++ b/assistant/src/documents/document-store.ts
@@ -7,7 +7,6 @@
  */
 import { rawAll, rawGet, rawRun } from "../persistence/raw-query.js";
 import { getLogger } from "../util/logger.js";
-import { escapeRegExp } from "../util/regexp.js";
 
 const log = getLogger("document-store");
 
@@ -494,7 +493,7 @@ export function replaceInDocument(
     const flags = "g" + (options.caseSensitive === true ? "" : "i");
     const pattern = options.regex
       ? new RegExp(find, flags)
-      : new RegExp(escapeRegExp(find), flags);
+      : new RegExp(RegExp.escape(find), flags);
 
     const totalMatches = [...row.content.matchAll(pattern)].length;
     if (

--- a/assistant/src/home/conversation-starter-validation.ts
+++ b/assistant/src/home/conversation-starter-validation.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_USER_REFERENCE,
   resolveUserReference,
 } from "../prompts/user-reference.js";
+import { escapeRegExp } from "../util/regexp.js";
 
 export interface ConversationStarterText {
   label: string;
@@ -81,8 +82,4 @@ function mentionsCurrentUser(
   return context.userReferences.some((reference) =>
     new RegExp(`\\b${escapeRegExp(reference)}\\b`, "i").test(text),
   );
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/assistant/src/home/conversation-starter-validation.ts
+++ b/assistant/src/home/conversation-starter-validation.ts
@@ -2,7 +2,6 @@ import {
   DEFAULT_USER_REFERENCE,
   resolveUserReference,
 } from "../prompts/user-reference.js";
-import { escapeRegExp } from "../util/regexp.js";
 
 export interface ConversationStarterText {
   label: string;
@@ -80,6 +79,6 @@ function mentionsCurrentUser(
   context: ConversationStarterValidationContext,
 ): boolean {
   return context.userReferences.some((reference) =>
-    new RegExp(`\\b${escapeRegExp(reference)}\\b`, "i").test(text),
+    new RegExp(`\\b${RegExp.escape(reference)}\\b`, "i").test(text),
   );
 }

--- a/assistant/src/notifications/access-request-copy.ts
+++ b/assistant/src/notifications/access-request-copy.ts
@@ -286,7 +286,7 @@ export function hasAccessRequestInstructions(
   }
   const handshakeOffered = options?.handshakeOffered ?? true;
   const normalized = normalizeForDirectiveMatching(text);
-  const escapedCode = requestCode.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedCode = RegExp.escape(requestCode);
   // Each directive must follow "reply" without a preceding negation word.
   // Negative lookbehinds reject "do not reply", "don't reply", "never reply".
   const trustRe = buildCodeDirectiveRegex(escapedCode, "trust");

--- a/assistant/src/notifications/guardian-question-mode.ts
+++ b/assistant/src/notifications/guardian-question-mode.ts
@@ -632,10 +632,6 @@ export function hasGuardianRequestCodeInstruction(
   }
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function normalizeInstructionText(value: string): string {
   return value
     .replace(/[ \t]+\n/g, "\n")
@@ -662,7 +658,7 @@ export function stripConflictingGuardianRequestInstructions(
   requestCode: string,
   mode: GuardianQuestionInstructionMode,
 ): string {
-  const escapedCode = escapeRegExp(requestCode);
+  const escapedCode = RegExp.escape(requestCode);
   const next =
     mode === "answer"
       ? text.replace(buildApprovalInstructionPattern(escapedCode), "")
@@ -681,7 +677,7 @@ export function stripGuardianRequestCodeInstructions(
   text: string,
   requestCode: string,
 ): string {
-  const escapedCode = escapeRegExp(requestCode);
+  const escapedCode = RegExp.escape(requestCode);
   const next = text
     .replace(buildApprovalInstructionPattern(escapedCode), "")
     .replace(buildAnswerInstructionPattern(escapedCode), "")

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -17,6 +17,7 @@ import {
   wrapUntrustedContent,
 } from "../security/untrusted-content.js";
 import { getLogger } from "../util/logger.js";
+import { escapeRegExp } from "../util/regexp.js";
 import { isLexicalBackfillComplete } from "./checkpoints.js";
 import { unseenAttentionStateConditions } from "./conversation-attention-store.js";
 import type { ConversationRow } from "./conversation-crud.js";
@@ -1248,10 +1249,6 @@ function wrapRecallEvidenceExcerpt(
   return origin
     ? wrapUntrustedContent(excerpt, { source, sourceDetail: origin })
     : wrapUntrustedContent(excerpt, { source });
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/assistant/src/persistence/conversation-queries.ts
+++ b/assistant/src/persistence/conversation-queries.ts
@@ -17,7 +17,6 @@ import {
   wrapUntrustedContent,
 } from "../security/untrusted-content.js";
 import { getLogger } from "../util/logger.js";
-import { escapeRegExp } from "../util/regexp.js";
 import { isLexicalBackfillComplete } from "./checkpoints.js";
 import { unseenAttentionStateConditions } from "./conversation-attention-store.js";
 import type { ConversationRow } from "./conversation-crud.js";
@@ -1272,7 +1271,7 @@ function findEarliestMatch(
     ).exec(text);
   };
 
-  const whole = execAnchored(escapeRegExp(query));
+  const whole = execAnchored(RegExp.escape(query));
   if (whole) {
     return { index: whole.index, length: whole[0].length };
   }
@@ -1282,7 +1281,9 @@ function findEarliestMatch(
   if (tokens.length === 0) {
     return null;
   }
-  const match = execAnchored(tokens.map(escapeRegExp).join("|"));
+  const match = execAnchored(
+    tokens.map((token) => RegExp.escape(token)).join("|"),
+  );
   return match ? { index: match.index, length: match[0].length } : null;
 }
 

--- a/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-prompt-flag-gating-guard.test.ts
+++ b/assistant/src/plugins/defaults/memory/substrate/__tests__/consolidation-prompt-flag-gating-guard.test.ts
@@ -103,12 +103,8 @@ function loadDefaultDisabledAssistantFlagKeys(): string[] {
     .sort();
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function featureFlagKeyPattern(key: string): RegExp {
-  const escaped = escapeRegExp(key);
+  const escaped = RegExp.escape(key);
   if (key.includes("-")) {
     return new RegExp(`(?:^|[^a-z0-9-])${escaped}(?:$|[^a-z0-9-])`, "i");
   }

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -7,7 +7,6 @@
  *   3. Deterministic fallback templates (natural, scenario-specific messages)
  */
 import { getLogger } from "../util/logger.js";
-import { escapeRegExp } from "../util/regexp.js";
 import type {
   ApprovalCopyGenerator,
   ApprovalMessageContext,
@@ -50,7 +49,7 @@ export function includesRequiredKeywords(
     return true;
   }
   return requiredKeywords.every((keyword) => {
-    const re = new RegExp(`\\b${escapeRegExp(keyword)}\\b`, "i");
+    const re = new RegExp(`\\b${RegExp.escape(keyword)}\\b`, "i");
     return re.test(text);
   });
 }

--- a/assistant/src/runtime/approval-message-composer.ts
+++ b/assistant/src/runtime/approval-message-composer.ts
@@ -7,6 +7,7 @@
  *   3. Deterministic fallback templates (natural, scenario-specific messages)
  */
 import { getLogger } from "../util/logger.js";
+import { escapeRegExp } from "../util/regexp.js";
 import type {
   ApprovalCopyGenerator,
   ApprovalMessageContext,
@@ -38,11 +39,6 @@ export function composeApprovalMessage(
   }
 
   return getFallbackMessage(context);
-}
-
-/** @internal Exported for use by the daemon-injected generator implementation. */
-export function escapeRegExp(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /** @internal Exported for use by the daemon-injected generator implementation. */

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -8,7 +8,6 @@
  *
  * Follows the same pattern as approval-message-composer.ts.
  */
-import { escapeRegExp } from "../util/regexp.js";
 import type {
   ComposeGuardianActionMessageOptions,
   GuardianActionMessageContext,
@@ -55,7 +54,7 @@ export function includesRequiredKeywords(
     return true;
   }
   return requiredKeywords.every((keyword) => {
-    const re = new RegExp(`\\b${escapeRegExp(keyword)}\\b`, "i");
+    const re = new RegExp(`\\b${RegExp.escape(keyword)}\\b`, "i");
     return re.test(text);
   });
 }

--- a/assistant/src/runtime/guardian-action-message-composer.ts
+++ b/assistant/src/runtime/guardian-action-message-composer.ts
@@ -8,6 +8,7 @@
  *
  * Follows the same pattern as approval-message-composer.ts.
  */
+import { escapeRegExp } from "../util/regexp.js";
 import type {
   ComposeGuardianActionMessageOptions,
   GuardianActionMessageContext,
@@ -54,10 +55,7 @@ export function includesRequiredKeywords(
     return true;
   }
   return requiredKeywords.every((keyword) => {
-    const re = new RegExp(
-      `\\b${keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`,
-      "i",
-    );
+    const re = new RegExp(`\\b${escapeRegExp(keyword)}\\b`, "i");
     return re.test(text);
   });
 }

--- a/assistant/src/runtime/http-router.ts
+++ b/assistant/src/runtime/http-router.ts
@@ -10,6 +10,7 @@
  * `normalizeEndpointForPolicy`.
  */
 
+import { escapeRegExp } from "../util/regexp.js";
 import { enforcePolicy } from "./auth/route-policy.js";
 import type { AuthContext } from "./auth/types.js";
 import { httpError } from "./http-errors.js";
@@ -202,15 +203,11 @@ function compileRoute(def: HTTPRouteDefinition): CompiledRoute {
         const typePattern = PARAM_TYPE_PATTERNS[paramTypeMap.get(name) ?? ""];
         return typePattern ? `(${typePattern})` : "([^/]+)";
       }
-      return escapeRegex(segment);
+      return escapeRegExp(segment);
     })
     .join("\\/");
 
   const regex = new RegExp(`^${regexSource}$`);
 
   return { def, regex, paramNames };
-}
-
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/assistant/src/runtime/http-router.ts
+++ b/assistant/src/runtime/http-router.ts
@@ -10,7 +10,6 @@
  * `normalizeEndpointForPolicy`.
  */
 
-import { escapeRegExp } from "../util/regexp.js";
 import { enforcePolicy } from "./auth/route-policy.js";
 import type { AuthContext } from "./auth/types.js";
 import { httpError } from "./http-errors.js";
@@ -203,7 +202,7 @@ function compileRoute(def: HTTPRouteDefinition): CompiledRoute {
         const typePattern = PARAM_TYPE_PATTERNS[paramTypeMap.get(name) ?? ""];
         return typePattern ? `(${typePattern})` : "([^/]+)";
       }
-      return escapeRegExp(segment);
+      return RegExp.escape(segment);
     })
     .join("\\/");
 

--- a/assistant/src/util/regexp.ts
+++ b/assistant/src/util/regexp.ts
@@ -1,0 +1,4 @@
+/** Escape a literal for use inside a `RegExp` source string. */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/assistant/src/util/regexp.ts
+++ b/assistant/src/util/regexp.ts
@@ -1,4 +1,0 @@
-/** Escape a literal for use inside a `RegExp` source string. */
-export function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}


### PR DESCRIPTION
## TL;DR

Ten places in `assistant/src` hand-rolled the same regex-literal escape (`value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")`), one of them exported "for the daemon-injected generator" and imported by nothing. The runtime already has the platform API: Bun 1.3.9 ships `RegExp.escape` and TypeScript 5.9 types it. Every site now calls that, and no helper exists.

## What changed

| Site | Before | After |
| --- | --- | --- |
| `daemon/dictation-text-processing.ts` | private `escapeRegExp` | `RegExp.escape` |
| `documents/document-store.ts` | private `escapeRegExpChars` | `RegExp.escape` |
| `home/conversation-starter-validation.ts` | private `escapeRegExp` | `RegExp.escape` |
| `notifications/access-request-copy.ts` | inline replace | `RegExp.escape` |
| `notifications/guardian-question-mode.ts` | private `escapeRegExp` | `RegExp.escape` |
| `persistence/conversation-queries.ts` | private `escapeRegExp` | `RegExp.escape` |
| `runtime/approval-message-composer.ts` | exported `escapeRegExp`, imported by nothing | `RegExp.escape`; the stale export is gone |
| `runtime/guardian-action-message-composer.ts` | inline replace | `RegExp.escape` |
| `runtime/http-router.ts` | private `escapeRegex` | `RegExp.escape` |
| two guard tests | test-local copies | `RegExp.escape` |
| `forbidden-legacy-symbols.test.ts` | inline escape feeding `git grep -E` | unchanged, with a positive control (see below) |

## Why this is safe

- `RegExp.escape` escapes a superset of what the old expression did: a leading letter or digit and any whitespace become `\xNN`, and `-,=<>#&~/` are escaped too. That is equivalent when the result is `RegExp` source outside a character class, which every converted site is (verified by reading each call: `\b...\b` word patterns, alternations, anchored sources, the router's path source). No site interpolates into `[...]`, where `\x2d` and `-` would differ. Probed on Bun 1.3.9 under the `u`, `i`, and `iu` flags.
- One site is not a JavaScript regex: `forbidden-legacy-symbols.test.ts` builds a pattern for `git grep -E`, which is POSIX ERE with no `\x` escapes. With `RegExp.escape` that pattern matched nothing and the test passed empty. It keeps the plain escape, and now has a positive control that the pattern matches the symbols written in the test file itself, so it cannot pass empty again.
- The remaining `replace(/[\\%_]/g, ...)` calls are SQL LIKE escapes and are untouched.
- Verified at the runtime, not the types: `bun -e 'RegExp.escape("a.b*c(1) x")'` on Bun 1.3.9 returns the escaped string, and `tsc --noEmit` accepts the call.
- Per-file runs green for every module with a test: approval-message-composer, dictation-text-processing, both conversation-queries files, guardian-question-mode, notification-decision-strategy, the three guard tests, and seed-conversation.

## Relationship to #41988

#41988 rewrites `guardian-question-mode.ts` and `access-request-copy.ts` and will conflict on the deleted helper hunk; it merges after this and takes the native call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
