### PR TITLE
fix(web): only skip the banner when the window is actually on screen

### DIFF
--- a/clients/web/src/hooks/use-notification-intent-sync.test.tsx
+++ b/clients/web/src/hooks/use-notification-intent-sync.test.tsx
@@ -1,14 +1,25 @@
 /**
  * `useNotificationIntentSync` forwards `notification_intent` SSE events to
- * `postLocalNotification`, including remote-push acceptance metadata.
+ * `postLocalNotification`, including remote-push acceptance metadata, and
+ * skips the ones whose conversation is already in front of the user.
+ *
+ * The skip needs all three of: the store's active conversation, a route that
+ * mounts the chat surface, and a window on screen. Route is driven by a real
+ * `MemoryRouter` so the basename behaves as it does in remote-gateway mode;
+ * window attention is a stubbed read.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
 
 import { __resetForTesting, publish } from "@/lib/event-bus";
 import { useConversationStore } from "@/stores/conversation-store";
+import { routes } from "@/utils/routes";
 import type { PostLocalNotificationArgs } from "@/runtime/notifications";
+
+const CONVERSATION_ID = "conv-1";
 
 const postedArgs: PostLocalNotificationArgs[] = [];
 const postLocalNotificationMock = mock(
@@ -30,13 +41,37 @@ mock.module("@/lib/sounds/sound-manager", () => ({
   getSoundManager: () => ({ play: async () => {} }),
 }));
 
-const { useNotificationIntentSync } = await import(
-  "@/hooks/use-notification-intent-sync"
-);
+let attended = true;
+mock.module("@/runtime/event-sources/electron-window-attention", () => ({
+  isWindowAttended: () => attended,
+}));
+
+const { useNotificationIntentSync } =
+  await import("@/hooks/use-notification-intent-sync");
+
+const originalHref = window.location.href;
+
+/**
+ * Mount the hook on `pathname`, optionally behind an ingress basename. The
+ * browser URL is moved to the prefixed path too, the way remote-gateway mode
+ * serves it, so the router path and `window.location.pathname` disagree
+ * exactly as they do there.
+ */
+function mountAt(pathname: string, basename?: string): void {
+  const entry = basename ? `${basename}${pathname}` : pathname;
+  window.location.href = `http://localhost${entry}`;
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter basename={basename} initialEntries={[entry]}>
+      {children}
+    </MemoryRouter>
+  );
+  renderHook(() => useNotificationIntentSync("assistant-1"), { wrapper });
+}
 
 function publishNotificationIntent(overrides: {
   remotePushDispatched?: boolean;
   remotePushPlatforms?: ("ios" | "android")[];
+  deepLinkMetadata?: Record<string, unknown>;
 }) {
   act(() => {
     publish("sse.event", {
@@ -55,9 +90,32 @@ function publishNotificationIntent(overrides: {
   });
 }
 
+/** An intent deep-linking to the conversation the store is sitting on. */
+function publishForActiveConversation() {
+  publishNotificationIntent({
+    deepLinkMetadata: { conversationId: CONVERSATION_ID },
+  });
+}
+
+function expectSuppressed() {
+  expect(postedArgs).toHaveLength(0);
+  expect(sendAckMock).toHaveBeenCalledTimes(1);
+  expect(sendAckMock).toHaveBeenLastCalledWith(
+    "assistant-1",
+    "delivery-1",
+    true,
+  );
+}
+
+function expectNotified() {
+  expect(postedArgs).toHaveLength(1);
+  expect(sendAckMock).not.toHaveBeenCalled();
+}
+
 beforeEach(() => {
   __resetForTesting();
   useConversationStore.getState().reset();
+  attended = true;
   postedArgs.length = 0;
   postLocalNotificationMock.mockClear();
   sendAckMock.mockClear();
@@ -66,11 +124,12 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   __resetForTesting();
+  window.location.href = originalHref;
 });
 
 describe("useNotificationIntentSync", () => {
   test("passes remote push acceptance through to postLocalNotification", () => {
-    renderHook(() => useNotificationIntentSync("assistant-1"));
+    mountAt(routes.assistant);
 
     publishNotificationIntent({
       remotePushDispatched: true,
@@ -93,12 +152,88 @@ describe("useNotificationIntentSync", () => {
   });
 
   test("leaves remotePushDispatched undefined when the daemon omits it", () => {
-    renderHook(() => useNotificationIntentSync("assistant-1"));
+    mountAt(routes.assistant);
 
     publishNotificationIntent({});
 
     expect(postedArgs).toHaveLength(1);
     expect(postedArgs[0]?.remotePushDispatched).toBeUndefined();
     expect(postedArgs[0]?.remotePushPlatforms).toBeUndefined();
+  });
+});
+
+describe("useNotificationIntentSync already-watching skip", () => {
+  beforeEach(() => {
+    useConversationStore.getState().setActiveConversationId(CONVERSATION_ID);
+  });
+
+  test("skips and acks while the window is on screen and focused", () => {
+    mountAt(routes.conversation(CONVERSATION_ID));
+
+    publishForActiveConversation();
+
+    expectSuppressed();
+  });
+
+  test("notifies when the window is off screen or unfocused", () => {
+    attended = false;
+    mountAt(routes.conversation(CONVERSATION_ID));
+
+    publishForActiveConversation();
+
+    expectNotified();
+  });
+
+  test("notifies for another conversation while attended", () => {
+    mountAt(routes.conversation(CONVERSATION_ID));
+
+    publishNotificationIntent({
+      deepLinkMetadata: { conversationId: "conv-other" },
+    });
+
+    expectNotified();
+  });
+
+  test("notifies for another conversation while unattended", () => {
+    attended = false;
+    mountAt(routes.conversation(CONVERSATION_ID));
+
+    publishNotificationIntent({
+      deepLinkMetadata: { conversationId: "conv-other" },
+    });
+
+    expectNotified();
+  });
+
+  test("skips on the assistant index, which mounts the chat surface", () => {
+    mountAt(routes.assistant);
+
+    publishForActiveConversation();
+
+    expectSuppressed();
+  });
+
+  test("notifies on the inspector, which replaces the transcript", () => {
+    mountAt(routes.inspect(CONVERSATION_ID));
+
+    publishForActiveConversation();
+
+    expectNotified();
+  });
+
+  test("notifies on a route that mounts no chat surface", () => {
+    mountAt(routes.settings.root);
+
+    publishForActiveConversation();
+
+    expectNotified();
+  });
+
+  test("skips behind a remote-gateway ingress basename", () => {
+    mountAt(routes.conversation(CONVERSATION_ID), "/assistant-123");
+
+    publishForActiveConversation();
+
+    expectSuppressed();
   });
 });

--- a/clients/web/src/hooks/use-notification-intent-sync.ts
+++ b/clients/web/src/hooks/use-notification-intent-sync.ts
@@ -4,9 +4,9 @@
  * Turns daemon-pushed notification intents into local browser or
  * Capacitor notifications. Skips guardian-scoped notifications
  * (the web client does not participate in guardian binding) and
- * notifications targeting the conversation the user is actively
- * viewing (verified by both store state and URL pathname, since
- * `activeConversationId` persists across route changes).
+ * notifications for the conversation the user is watching right now,
+ * which takes three facts: the store's active conversation, a route
+ * that mounts the chat surface, and a window that is on screen.
  *
  * Acks every notification back to the daemon so delivery audit
  * trails stay consistent with the macOS client.
@@ -16,14 +16,18 @@
  * - runtime/notifications.ts — notification scheduling and ack API
  */
 
+import { useLocation } from "react-router";
+
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { getSoundManager } from "@/lib/sounds/sound-manager";
+import { isWindowAttended } from "@/runtime/event-sources/electron-window-attention";
 import {
   extractConversationId,
   postLocalNotification,
   sendNotificationIntentAck,
 } from "@/runtime/notifications";
 import { useConversationStore } from "@/stores/conversation-store";
+import { isConversationChatPath } from "@/utils/routes";
 
 /**
  * Subscribes to `notification_intent` SSE events via the event bus
@@ -32,6 +36,10 @@ import { useConversationStore } from "@/stores/conversation-store";
  * @param assistantId — current assistant; `null` disables the subscription
  */
 export function useNotificationIntentSync(assistantId: string | null): void {
+  // Basename-relative, unlike `window.location.pathname`, which carries the
+  // public ingress prefix in remote-gateway mode.
+  const { pathname } = useLocation();
+
   useBusSubscription("sse.event", (envelope) => {
     const event = envelope.message;
     if (event.type !== "notification_intent") {
@@ -48,10 +56,10 @@ export function useNotificationIntentSync(assistantId: string | null): void {
       return;
     }
 
-    // Suppress the banner when the user is already viewing the target
-    // conversation. `activeConversationId` is never cleared on navigation,
-    // so we also verify the URL matches the conversation route — otherwise
-    // a stale id would suppress notifications on home/settings/etc.
+    // Suppress only when the message is already in front of the user.
+    // `activeConversationId` survives navigation, so the route has to agree;
+    // a window minimized on that conversation shows nothing, and a skip there
+    // would ack a delivery nobody saw.
     const metadataConversationId = extractConversationId(
       event.deepLinkMetadata,
     );
@@ -59,7 +67,8 @@ export function useNotificationIntentSync(assistantId: string | null): void {
       metadataConversationId &&
       metadataConversationId ===
         useConversationStore.getState().activeConversationId &&
-      window.location.pathname.startsWith("/assistant/conversations/")
+      isConversationChatPath(pathname) &&
+      isWindowAttended()
     ) {
       if (assistantId && event.deliveryId) {
         void sendNotificationIntentAck(assistantId, event.deliveryId, true);


### PR DESCRIPTION
## Summary

- The already-viewing skip in `use-notification-intent-sync.ts` checked the deep-link conversation and the pathname but neither visibility nor focus. A desktop app minimized on conversation X swallowed X's notification **and acked it to the daemon as a successful delivery**. The skip now also requires `isWindowAttended()` (`visible && focused && !minimized`, per renderer, so a pop-out answers for its own window). Ships unflagged: its only effect is to notify more.
- Ack semantics are unchanged. When the skip does apply, `sendNotificationIntentAck(..., true)` still fires, matching the cooldown path in `packages/electron-desktop/src/notifications.ts`.
- The hand-rolled `window.location.pathname.startsWith("/assistant/conversations/")` is replaced by the shared `isConversationChatPath()` helper reading `useLocation()`. The suppression branch had no test coverage at all; every case below is new.

### The three route deltas, all intended

1. **Remote-gateway mode is fixed.** `window.location.pathname` carries the public ingress prefix (`/assistant-123/...`) while `routes.ts` paths are basename-less, so the skip never fired at all in that mode. `useLocation()` is basename-relative. Pinned by a test that puts the browser URL on the prefixed path and the router on a basename, so the two disagree exactly as they do in production.
2. **The `/assistant` index route starts suppressing.** It renders the chat surface directly rather than redirecting to `/conversations/:id`, so the old `startsWith` missed the landing conversation the user is actually reading.
3. **The `/assistant/conversations/:id/inspect` subroute stops suppressing.** The inspector renders LLM call logs with no composer and no transcript, so an arriving message is never visible there and a skip loses it outright. That page is behind the `internal-thread-actions` client flag (`defaultEnabled: false`), so this reaches internal sessions only.

### Behavior

| Route | Window | Before | After |
| --- | --- | --- | --- |
| `/assistant/conversations/X` | attended | skip + ack | skip + ack |
| `/assistant/conversations/X` | minimized or blurred | skip + ack | **notify** |
| `/assistant` (index, on X) | attended | notify | **skip + ack** |
| `/assistant/conversations/X/inspect` | attended | skip + ack | **notify** |
| `/assistant-123/assistant/conversations/X` (remote gateway) | attended | notify | **skip + ack** |
| any route, conversation != X | either | notify | notify |
| `/assistant/settings` | either | notify | notify |

### Verification

`cd clients/web && bun run test:ci src/hooks/use-notification-intent-sync.test.tsx` (8 new cases plus the 2 existing passthrough tests), `bunx tsc --noEmit`, `bunx eslint`, `bunx prettier@3.8.1 --check`.

Mutation-checked, each mutation failing only the tests that pin it:
- drop `isWindowAttended()` → "notifies when the window is off screen or unfocused" fails
- `pathname.startsWith("/assistant/conversations/")` instead of the helper → the index-route and inspector tests fail
- `isConversationChatPath(window.location.pathname)` → only the ingress-basename test fails

Note: the plan's PR 12 also lists a docblock correction in `use-web-presence-report.ts`; that file is owned by PR 11 on this feature branch and carries the correction there.

Part of plan: watched-activity-suppression.md (PR 12 of 14)