### PR TITLE
feat(companion): Talk dials on the pill and Teach rides the call row (JARVIS-1715)

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   COMPANION_BASE_AVATAR_BOX,
   COMPANION_BASE_MAX_PILL_WIDTH,
+  VOICE_START_REQUEST_TTL_MS,
   COMPANION_SIZES,
   companionBoxFor,
   companionCardSideFor,
@@ -578,9 +579,41 @@ describe("the dial", () => {
     expect(dialOnTalk({ ...START })).toBe(false);
   });
 
-  test("is bounded, and by less than a parked request lives", () => {
-    expect(COMPANION_DIAL_TIMEOUT_MS).toBeGreaterThan(0);
-    expect(COMPANION_DIAL_TIMEOUT_MS).toBeLessThan(60_000);
+  /**
+   * A dial that closed while its request could still become a session would
+   * reopen on that session a moment later, so the bound outlives the request.
+   */
+  test("outlives the request it is drawn for", () => {
+    expect(COMPANION_DIAL_TIMEOUT_MS).toBeGreaterThan(
+      VOICE_START_REQUEST_TTL_MS,
+    );
+  });
+
+  /**
+   * The press that ends a dial takes the request back by a command the root
+   * layout consumes, since the session's own controls are heard only where a
+   * session is owned and a dial can be ended before any layout owns one.
+   */
+  test("ending it takes the request back through a command", () => {
+    mainWindowOpen = true;
+    dispatched.length = 0;
+    send("vellum:companion:startVoice");
+    dispatched.length = 0;
+
+    send("vellum:voiceActivity:control", { action: "endSession" });
+
+    expect(dispatched).toEqual([{ kind: "cancelVoiceStart" }]);
+    expect(state().dialing).toBe(false);
+  });
+
+  test("an end with no dial takes nothing back", () => {
+    mainWindowOpen = true;
+    send("vellum:voiceActivity:end");
+    dispatched.length = 0;
+
+    send("vellum:voiceActivity:control", { action: "endSession" });
+
+    expect(dispatched).toEqual([]);
   });
 });
 

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -204,6 +204,8 @@ const {
   geometryFor,
   placeCanvas,
   callOnUpdate,
+  COMPANION_DIAL_TIMEOUT_MS,
+  dialOnTalk,
   introOnAdvance,
   setCompanionSurfaceSize,
   shouldShowCompanionSurface,
@@ -563,6 +565,25 @@ describe("avatarOffsetFor", () => {
   });
 });
 
+describe("the dial", () => {
+  test("starts on a press with no session on the surface", () => {
+    expect(dialOnTalk(null)).toBe(true);
+  });
+
+  /**
+   * The window that owns the session spends the press on the call the user is
+   * in, so nothing is coming that a dial could wait for.
+   */
+  test("does not start over a running session", () => {
+    expect(dialOnTalk({ ...START })).toBe(false);
+  });
+
+  test("is bounded, and by less than a parked request lives", () => {
+    expect(COMPANION_DIAL_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(COMPANION_DIAL_TIMEOUT_MS).toBeLessThan(60_000);
+  });
+});
+
 describe("the session main holds", () => {
   test("update merges content and leaves the fixed fields alone", () => {
     const running = { ...START };
@@ -674,11 +695,11 @@ describe("geometryFor", () => {
       CompanionSize,
       { maxReach: number; canvasWidth: number; canvasHeight: number }
     > = {
-      small: { maxReach: 261, canvasWidth: 570, canvasHeight: 267 },
-      medium: { maxReach: 361, canvasWidth: 794, canvasHeight: 374 },
-      large: { maxReach: 536, canvasWidth: 1168, canvasHeight: 547 },
-      huge: { maxReach: 711, canvasWidth: 1542, canvasHeight: 720 },
-      ridiculous: { maxReach: 930, canvasWidth: 2100, canvasHeight: 1035 },
+      small: { maxReach: 322, canvasWidth: 692, canvasHeight: 267 },
+      medium: { maxReach: 445, canvasWidth: 962, canvasHeight: 374 },
+      large: { maxReach: 662, canvasWidth: 1420, canvasHeight: 547 },
+      huge: { maxReach: 879, canvasWidth: 1878, canvasHeight: 720 },
+      ridiculous: { maxReach: 1140, canvasWidth: 2520, canvasHeight: 1035 },
     };
     for (const size of COMPANION_SIZES) {
       const { maxReach, canvasWidth, canvasHeight } = geometryFor(size, size);
@@ -826,7 +847,7 @@ describe("geometryFor with the two axes apart", () => {
    * The width is where the gap rule shows: the gap is breathing room, so the
    * smaller of the two boxes decides how much of it there is, and the creature
    * below takes its small pill's gap rather than the chasm its own scale would
-   * ask for, which would put its reach at 315. The two heights are the two
+   * ask for, which would put its reach at 376. The two heights are the two
    * sides of the avatar: the near edge clears the creature's box and the pill's
    * top alike, and the far edge clears the card growing either way.
    */
@@ -836,8 +857,8 @@ describe("geometryFor with the two axes apart", () => {
     expect(BIG_CREATURE).toEqual({
       avatarBox: 110,
       optionsBox: 32,
-      maxReach: 294,
-      canvasWidth: 708,
+      maxReach: 355,
+      canvasWidth: 830,
       riseAbove: 274,
       dropBelow: 115,
       canvasHeight: 389,
@@ -846,8 +867,8 @@ describe("geometryFor with the two axes apart", () => {
     expect(BIG_OPTIONS).toEqual({
       avatarBox: 44,
       optionsBox: 88,
-      maxReach: 666,
-      canvasWidth: 1428,
+      maxReach: 834,
+      canvasWidth: 1764,
       riseAbove: 614,
       dropBelow: 122,
       canvasHeight: 736,

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -326,6 +326,47 @@ const finishIntro = (): void => {
 let call: VoiceActivityState | null = null;
 
 /**
+ * How long a dial is drawn with no session answering it.
+ *
+ * The window asked to start a session answers every press it decides on, with
+ * a `start` or with an `end`, so this only catches the presses it never gets
+ * to decide: a request parked behind a layout that does not mount, or a window
+ * that went away mid-preflight. Longer than any preflight and shorter than the
+ * minute a parked request lives, since a dial that outlives its request is a
+ * pill claiming a call that is no longer coming.
+ */
+export const COMPANION_DIAL_TIMEOUT_MS = 20_000;
+
+/**
+ * Whether Talk has been pressed and no session has answered it yet. See
+ * {@link CompanionSurfaceState.dialing}.
+ *
+ * Held here rather than in the surface's renderer for the reason the session
+ * is: the press leaves that renderer at once, and a reload across the wait
+ * would come back to a pill that had forgotten it was dialing.
+ */
+let dialing = false;
+let dialTimer: ReturnType<typeof setTimeout> | null = null;
+
+const disarmDial = (): void => {
+  if (dialTimer !== null) {
+    clearTimeout(dialTimer);
+    dialTimer = null;
+  }
+};
+
+/**
+ * Whether a Talk press starts a dial.
+ *
+ * Not while a session is already on the surface: the window that owns it
+ * spends the press on the call the user is in, so nothing is coming that a
+ * dial could wait for. A session the store holds but the mirror has not yet
+ * pushed dials anyway, and the `start` that follows within the beat ends it.
+ */
+export const dialOnTalk = (current: VoiceActivityState | null): boolean =>
+  current === null;
+
+/**
  * What the app's window last published about the assistant: its name, whether
  * a turn is running, and the sessions it holds.
  *
@@ -358,6 +399,7 @@ const currentState = (): CompanionSurfaceState => {
     character: character === null ? undefined : character,
     avatarBase64: png === null ? undefined : png.toString("base64"),
     call,
+    dialing,
     intro,
     assistantName: context.assistantName,
     working: context.working,
@@ -563,6 +605,28 @@ const pushState = (): void => {
   if (win) {
     win.webContents.send("vellum:companion:state", currentState());
   }
+};
+
+/**
+ * Start or end the dial, and push the surface if that changed anything.
+ *
+ * The bound is armed with the dial and disarmed with it, whichever way it
+ * ends, so a session that answers in a second does not leave a timer behind to
+ * end a later dial early.
+ */
+const setDialing = (next: boolean): void => {
+  disarmDial();
+  if (next) {
+    dialTimer = setTimeout(() => {
+      dialTimer = null;
+      setDialing(false);
+    }, COMPANION_DIAL_TIMEOUT_MS);
+  }
+  if (dialing === next) {
+    return;
+  }
+  dialing = next;
+  pushState();
 };
 
 /**
@@ -773,6 +837,12 @@ export const installCompanionWindow = (): void => {
    * some other app entirely, so "focused" would name the wrong target.
    */
   on("vellum:companion:startVoice", z.tuple([]), () => {
+    // Drawn before the press is delivered, so the pill answers the hand in
+    // the same beat: the session it asks for opens after a network round trip
+    // in a window the user cannot see.
+    if (dialOnTalk(call)) {
+      setDialing(true);
+    }
     dispatchWithoutRaising({ kind: "startVoice" });
   });
 
@@ -921,6 +991,11 @@ export const installCompanionWindow = (): void => {
       // expected traffic; every field it carries is current, so there is
       // nothing on the running call worth preserving against it.
       call = start;
+      // The session is the answer the dial was waiting for. Cleared before the
+      // push rather than through `setDialing`, so the surface sees one state
+      // with the call on it and not a beat of neither.
+      disarmDial();
+      dialing = false;
       pushState();
     },
   );
@@ -939,7 +1014,12 @@ export const installCompanionWindow = (): void => {
   );
 
   on("vellum:voiceActivity:end", z.tuple([]), () => {
+    // With no session running this is the window asked for one saying no: a
+    // first-run card to answer, an assistant with no voice, a request spent
+    // some other way. Each has shown the user something else, so the dial ends
+    // and the pill closes.
     if (call === null) {
+      setDialing(false);
       return;
     }
     call = null;
@@ -959,6 +1039,13 @@ export const installCompanionWindow = (): void => {
     "vellum:voiceActivity:control",
     z.tuple([voiceActivityControlSchema]),
     ([control]) => {
+      // The end control on a dial is the user changing their mind. The pill
+      // closes here rather than waiting for the window asked to answer, since
+      // that window may hold nothing that can: the press still travels, and
+      // the drain it reaches spends the request rather than starting from it.
+      if (control.action === "endSession") {
+        setDialing(false);
+      }
       const surface = getFloatingWindow(COMPANION_KIND);
       for (const win of BrowserWindow.getAllWindows()) {
         if (
@@ -999,11 +1086,15 @@ export const installCompanionWindow = (): void => {
     if (currentMainWindow() !== null) {
       return;
     }
+    // A dial is a claim on that window too: the request it carries is gone
+    // with the renderer that parked it.
     const claiming =
-      context.watching === true || context.dictating !== undefined;
+      context.watching === true || context.dictating !== undefined || dialing;
     if (!claiming) {
       return;
     }
+    disarmDial();
+    dialing = false;
     context = {
       ...context,
       watching: false,

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -12,6 +12,7 @@ import {
   voiceActivityControlSchema,
   voiceActivityStartSchema,
   COMPANION_BASE_MAX_PILL_WIDTH,
+  VOICE_START_REQUEST_TTL_MS,
   COMPANION_INTRO_ACTIONS,
   COMPANION_INTRO_BEATS,
   companionBoxFor,
@@ -331,11 +332,13 @@ let call: VoiceActivityState | null = null;
  * The window asked to start a session answers every press it decides on, with
  * a `start` or with an `end`, so this only catches the presses it never gets
  * to decide: a request parked behind a layout that does not mount, or a window
- * that went away mid-preflight. Longer than any preflight and shorter than the
- * minute a parked request lives, since a dial that outlives its request is a
- * pill claiming a call that is no longer coming.
+ * that went away mid-preflight. Longer than the request itself can live, by a
+ * margin for a preflight that began at the end of that life, so the dial is
+ * never gone while a session can still arrive from it: a pill that closed on a
+ * call still coming would reopen on the call a moment later, which is the one
+ * thing worse than a long dial.
  */
-export const COMPANION_DIAL_TIMEOUT_MS = 20_000;
+export const COMPANION_DIAL_TIMEOUT_MS = VOICE_START_REQUEST_TTL_MS + 5_000;
 
 /**
  * Whether Talk has been pressed and no session has answered it yet. See
@@ -1040,11 +1043,16 @@ export const installCompanionWindow = (): void => {
     z.tuple([voiceActivityControlSchema]),
     ([control]) => {
       // The end control on a dial is the user changing their mind. The pill
-      // closes here rather than waiting for the window asked to answer, since
-      // that window may hold nothing that can: the press still travels, and
-      // the drain it reaches spends the request rather than starting from it.
-      if (control.action === "endSession") {
+      // closes here rather than waiting for the window asked to answer, and
+      // the request is taken back by a command rather than by this control:
+      // the control is heard only where a session is owned, and a dial can be
+      // ended from a route where nothing owns one yet. The command lands in
+      // the root layout, which is mounted wherever the request was parked.
+      if (control.action === "endSession" && dialing) {
         setDialing(false);
+        if (currentMainWindow() !== null) {
+          dispatchToMain({ kind: "cancelVoiceStart" });
+        }
       }
       const surface = getFloatingWindow(COMPANION_KIND);
       for (const win of BrowserWindow.getAllWindows()) {

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -16,6 +16,7 @@ const toggleWatchMock = mock(() => undefined);
 const answerRetroMock = mock((_open: boolean) => undefined);
 const advanceIntroMock = mock((_action: string) => undefined);
 const contextMenuMock = mock(() => undefined);
+const sendControlMock = mock((_control: { action: string }) => undefined);
 
 const STATE: CompanionSurfaceState = {
   growth: "right",
@@ -38,6 +39,7 @@ const resetState = () => {
   STATE.optionsBox = 44;
   STATE.working = false;
   STATE.call = null;
+  delete STATE.dialing;
   delete STATE.watching;
   delete STATE.captureCount;
   STATE.watchEnabled = true;
@@ -93,7 +95,7 @@ mock.module("@/runtime/companion-surface", () => ({
 }));
 
 mock.module("@/runtime/desktop-voice-activity", () => ({
-  sendVoiceActivityControl: () => undefined,
+  sendVoiceActivityControl: sendControlMock,
 }));
 
 const { CompanionSurfacePage } = await import("./companion-surface-page");
@@ -107,6 +109,7 @@ afterEach(() => {
   toggleWatchMock.mockClear();
   advanceIntroMock.mockClear();
   contextMenuMock.mockClear();
+  sendControlMock.mockClear();
 });
 
 /** The canvas the page fills, which is where the pointer handlers live. */
@@ -1014,6 +1017,63 @@ describe("the companion's introduction", () => {
     pushState();
 
     expect(container.querySelector('[role="group"]')).not.toBeNull();
+  });
+});
+
+/**
+ * The dial, which is main's from the press until a session answers it.
+ *
+ * The press leaves this window the moment it is made, so the pill's answer to
+ * it has to arrive the way the call does: on the pushed state.
+ */
+describe("the dial on the companion surface", () => {
+  test("holds the pill open with the pointer nowhere near it", async () => {
+    STATE.dialing = true;
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    expect(closed(container)).toBe(false);
+    expect(container.textContent).toContain("Calling Ziggy…");
+  });
+
+  test("closes the pill once main says the dial is over", async () => {
+    STATE.dialing = true;
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+
+    STATE.dialing = false;
+    pushState();
+
+    expect(closed(container)).toBe(true);
+  });
+
+  test("hands the end back through main, the way the call's controls go", async () => {
+    STATE.dialing = true;
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+
+    const end = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="End session"]',
+    );
+    if (!end) {
+      throw new Error("Expected the end control to render");
+    }
+    fireEvent.click(end);
+
+    expect(sendControlMock).toHaveBeenCalledWith({ action: "endSession" });
+  });
+
+  test("reads a state that says nothing about it as not dialing", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    expect(closed(container)).toBe(true);
+  });
+
+  test("withdraws the introduction's card, as a call does", async () => {
+    STATE.intro = "talk";
+    STATE.dialing = true;
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    expect(container.querySelector('[role="group"]')).toBeNull();
   });
 });
 

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -84,6 +84,9 @@ export function CompanionSurfacePage() {
   const [avatarSrc, setAvatarSrc] = useState<string | undefined>();
   const [character, setCharacter] = useState<CompanionCharacter | undefined>();
   const [call, setCall] = useState<VoiceActivityState | null>(null);
+  // Whether Talk has been pressed and nothing has answered it yet. Main's, like
+  // the call it waits for: the press left this window the moment it was made.
+  const [dialing, setDialing] = useState(false);
   const [dictating, setDictating] = useState<CompanionDictating | undefined>(
     undefined,
   );
@@ -151,6 +154,9 @@ export function CompanionSurfacePage() {
       );
       setCharacter(state.character);
       setCall(state.call);
+      // Off unless positively on, the way `watching` is read: a shell that
+      // predates the field is not dialing.
+      setDialing(state.dialing === true);
       setAssistantName(state.assistantName);
       setWorking(state.working);
       // Absence is not a session: every state that is not a positive answer
@@ -202,7 +208,7 @@ export function CompanionSurfacePage() {
   // Whether the introduction's card is actually on screen. The beat alone does
   // not settle it: a call withdraws the card while main is still holding the
   // run.
-  const introShown = intro !== null && call === null;
+  const introShown = intro !== null && call === null && !dialing;
 
   /**
    * Give the desktop back when the introduction's card goes away.
@@ -233,6 +239,11 @@ export function CompanionSurfacePage() {
   // microphone the user cannot see. So the call holds the pill open, and
   // hovering it changes nothing: the controls it wants are already there.
   //
+  // A dial is the call's own first beat and ranks with it. The press that
+  // made it leaves this window at once, and a pill that closed behind the
+  // hand while the session it asked for was still on its way would read as
+  // a press that did nothing.
+  //
   // A watch session holds the pill open for the same reason the call does, and
   // ranks below it: the call is something the user is in the middle of, where
   // this one runs beside whatever they are doing. Being outranked costs the
@@ -250,7 +261,7 @@ export function CompanionSurfacePage() {
   // user's own business and this is a caption.
   const introHeld = introPhase(intro);
   const phase: CompanionSurfacePhase =
-    call !== null
+    call !== null || dialing
       ? "call"
       : dictating !== undefined
         ? "dictating"
@@ -428,6 +439,9 @@ export function CompanionSurfacePage() {
         hovered={hovered}
         accentHex={accentHex}
         call={call ?? undefined}
+        // For the dial, which names who is being called. The call itself
+        // carries its own name once it arrives.
+        assistantName={assistantName}
         dictating={dictating}
         dictationText={dictationText}
         // Whether the assistant is busy, on whatever conversation the app has

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -456,17 +456,29 @@ export const SummaryReady: Story = {
  * capture takes it: the creature already carries the turn in its own pose,
  * and a call is a thing the user started and can hear.
  *
- * The widest row the surface draws outside the card: the activity line and five
- * controls, with the stop beside what the session is doing rather than beside
- * End, since two stops in a row is a misclick that ends the wrong one.
+ * The widest row the surface draws outside the card: the activity line and the
+ * handlebar with Teach held down and so spelling its name out, beside what the
+ * session is doing rather than beside End, since two stops in a row is a
+ * misclick that ends the wrong one.
  */
 export const InCallWhileWatching: Story = {
   args: { phase: "call", watching: true, call: DEMO_CALL },
 };
 
-/** Expanded mid-call: the session's own controls, at pill scale. */
+/**
+ * The dial: Talk pressed, and the session it asked for not yet on the surface.
+ *
+ * Who is being called and the one control that means anything yet, the end.
+ * The session opens after a network round trip in a window the user cannot
+ * see, so this is what says the press landed.
+ */
+export const Dialing: Story = {
+  args: { phase: "call", assistantName: "Ziggy" },
+};
+
+/** Expanded mid-call: the handlebar, at pill scale. */
 export const InCall: Story = {
-  args: { phase: "call" },
+  args: { phase: "call", call: DEMO_CALL },
 };
 
 /**
@@ -477,9 +489,6 @@ export const InCall: Story = {
  * until this is answered, so it is the only thing here worth pressing. The
  * activity line says what is being asked; the pill is not the place to render a
  * tool call's arguments, and the app is a click away for that.
- *
- * This is the widest the surface ever gets, so it is what `MAX_PILL_WIDTH` in
- * `companion-window.ts` sizes the canvas to hold.
  */
 export const PendingApproval: Story = {
   args: {
@@ -530,7 +539,7 @@ export const InCallMuted: Story = {
  * stops being readable over a pale one.
  */
 export const OnALightDesktop: Story = {
-  args: { phase: "call", backdrop: "light" },
+  args: { phase: "call", call: DEMO_CALL, backdrop: "light" },
 };
 
 /**

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -41,6 +41,13 @@ const LISTENING_CALL: VoiceActivityState = {
   assistantName: "Ziggy",
 };
 
+/** A control on the pill, found by the name a reader is given for it. */
+const buttonOf = (
+  container: HTMLElement,
+  label: string,
+): HTMLButtonElement | null =>
+  container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+
 /** Every state the surface draws, which several cases here sweep in turn. */
 const PHASES = ["resting", "hover", "watching", "summary", "call"] as const;
 
@@ -1082,6 +1089,142 @@ describe("the companion surface's stop control", () => {
 });
 
 /**
+ * Teach rides the call. A screen read while talking is a question the
+ * assistant can answer as it is asked, so the call row carries the same toggle
+ * the idle row does rather than only the way out of a session already running.
+ */
+describe("Teach on the call row", () => {
+  const teachOf = (container: HTMLElement): HTMLButtonElement | null =>
+    container.querySelector<HTMLButtonElement>('button[aria-label="Teach"]');
+
+  test("is offered beside the call's own controls", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" watchEnabled call={LISTENING_CALL} />,
+    );
+    expect(teachOf(container)).not.toBeNull();
+    expect(teachOf(container)?.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  test("reads as held down while the session runs under the call", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        watchEnabled
+        watching
+        call={LISTENING_CALL}
+      />,
+    );
+    expect(teachOf(container)?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  test("reports the press as the toggle it is", () => {
+    let presses = 0;
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        watchEnabled
+        call={LISTENING_CALL}
+        onWatch={() => {
+          presses += 1;
+        }}
+      />,
+    );
+    const teach = teachOf(container);
+    if (!teach) {
+      throw new Error("Expected Teach to render");
+    }
+    fireEvent.click(teach);
+    expect(presses).toBe(1);
+  });
+
+  test("sits beside what the session is doing, not beside the end", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" watchEnabled call={LISTENING_CALL} />,
+    );
+    const labels = Array.from(container.querySelectorAll("button")).map(
+      (button) => button.getAttribute("aria-label"),
+    );
+    expect(labels).toEqual([
+      "Teach",
+      "Mute microphone",
+      "Mute assistant",
+      "End session",
+    ]);
+  });
+});
+
+/**
+ * The dial: Talk pressed, and the session it asked for not yet on the surface.
+ *
+ * The press leaves the surface at once and the session opens after a network
+ * round trip in a window the user cannot see, so the pill has to be the thing
+ * that says the press landed.
+ */
+describe("the companion surface's dial", () => {
+  test("says who is being called", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" assistantName="Ziggy" />,
+    );
+    expect(container.textContent).toContain("Calling Ziggy…");
+  });
+
+  test("says it is calling with no name to say", () => {
+    const { container } = render(<CompanionSurface phase="call" />);
+    expect(container.textContent).toContain("Calling…");
+    expect(container.textContent).not.toContain("Calling …");
+  });
+
+  test("offers the end, which takes the request back", () => {
+    const actions: string[] = [];
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        assistantName="Ziggy"
+        onControl={(action) => {
+          actions.push(action);
+        }}
+      />,
+    );
+    fireEvent.click(buttonOf(container, "End session")!);
+    expect(actions).toEqual(["endSession"]);
+  });
+
+  /**
+   * Nothing to mute yet. A press on either would be dropped by the window
+   * asked, so the controls are not drawn rather than drawn and inert.
+   */
+  test("draws no mutes with nothing to mute", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" assistantName="Ziggy" />,
+    );
+    expect(buttonOf(container, "Mute microphone")).toBeNull();
+    expect(buttonOf(container, "Mute assistant")).toBeNull();
+  });
+
+  test("keeps the stop of a session already reading the screen", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" assistantName="Ziggy" watching />,
+    );
+    expect(buttonOf(container, "Stop teaching")).not.toBeNull();
+  });
+
+  test("gives way to the session once it arrives", () => {
+    const { container, rerender } = render(
+      <CompanionSurface phase="call" assistantName="Ziggy" />,
+    );
+    rerender(
+      <CompanionSurface
+        phase="call"
+        assistantName="Ziggy"
+        call={LISTENING_CALL}
+      />,
+    );
+    expect(container.textContent).not.toContain("Calling");
+    expect(buttonOf(container, "Mute microphone")).not.toBeNull();
+  });
+});
+
+/**
  * The ceiling the Electron canvas is sized to.
  *
  * `companion-window.ts` sizes its window once, for the widest state this
@@ -1100,12 +1243,6 @@ describe("the companion surface's stop control", () => {
  * report would land in a thread nobody was ever shown.
  */
 describe("the summary a finished watch session leaves on the surface", () => {
-  const buttonOf = (
-    container: HTMLElement,
-    label: string,
-  ): HTMLButtonElement | null =>
-    container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
-
   test("says the summary is being written while the turn runs", () => {
     const { container } = render(
       <CompanionSurface phase="summary" watchRetro="pending" />,
@@ -1196,7 +1333,7 @@ describe("the companion surface's width ceiling", () => {
    * Written out rather than read from the contract, so the cases below assert a
    * number instead of restating the constant they are about.
    */
-  const CANVAS_CEILING = 316;
+  const CANVAS_CEILING = 400;
 
   test("is the width the shared contract publishes", () => {
     expect(COMPANION_BASE_MAX_PILL_WIDTH).toBe(CANVAS_CEILING);

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -141,6 +141,16 @@ export type CompanionSurfacePhase =
    * everything is: that is something they are already inside.
    */
   | "dictating"
+  /**
+   * Call: the pill held open by a live-voice session, or by the press that
+   * asked for one.
+   *
+   * With a session it is the handlebar of the call: what the session is
+   * doing, and the controls that act on it. Without one it is the dial, the
+   * beat between Talk and the session's first word, drawn so the press is
+   * seen to have done something while the session opens in a window the user
+   * cannot see.
+   */
   | "call";
 
 /**
@@ -331,13 +341,19 @@ export const FALLBACK_WIDTHS: Record<
   // has a stated width whatever is in it, so this is the state's actual width
   // rather than a guess at one.
   dictating: TRANSCRIPT_WIDTH + 32,
-  // The row with the stop control on it, which is the widest a call draws: a
-  // watch session adds a fifth control to the four the call already has.
-  call: 288,
+  // The line and the four controls of the handlebar, with Teach held down and
+  // so spelling its name out, which is the widest a call draws.
+  call: 332,
 };
 
 export interface CompanionSurfaceProps {
   phase: CompanionSurfacePhase;
+  /**
+   * Who the dial is calling. Read only while the phase is `call` and there is
+   * no {@link call} yet; a session names its own assistant. Empty is a dial
+   * with no name to say.
+   */
+  assistantName?: string;
   /** The assistant's avatar colour. Fills shapes; never carries text. */
   accentHex?: string;
   /**
@@ -651,6 +667,7 @@ function useObservedCaptures(captureCount: number, watching: boolean): number {
 
 export function CompanionSurface({
   phase,
+  assistantName = "",
   accentHex = DEFAULT_ACCENT,
   avatarSrc,
   character,
@@ -912,7 +929,9 @@ export function CompanionSurface({
             {phase === "call" ? (
               <CallBody
                 call={call}
+                assistantName={assistantName}
                 watching={watching}
+                watchEnabled={watchEnabled}
                 onControl={onControl}
                 onWatch={onWatch}
               />
@@ -1336,37 +1355,58 @@ function IdleBody({
           control is holding the pill open and which press ends it. `pressed`
           rather than `active`, because this one is a state and not a look: a
           reader is told a session is running, where everything else this
-          surface does about it is a colour they never receive.
-
-          It is also what keeps this control's word on the surface while the
-          rest of the row is icons: a running session is the one thing here the
-          user has to be able to find without hunting, and a name revealed only
-          under the pointer is one they would have to go looking for. `pressed`
-          pins it open, so the session names itself for as long as it runs.
-
-          Absent entirely when Watch is not offered, rather than disabled: a
-          user who cannot have the feature is not owed a control that explains
-          itself by refusing them. The pill measures its own contents, so the
-          row simply comes out narrower.
-
-          **The exit outlives the door.** A session running under a flag that
-          has since been turned off still reads the screen, so the row that
-          would have carried Watch carries the stop instead, the same control
-          the call row draws. Hiding the way in is the whole of what
-          the flag does; leaving a capture with nothing that ends it is not
-          something a flag is allowed to cause. */}
-      {watchEnabled ? (
-        <PillButton
-          icon={<Eye className="size-4" />}
-          label={t("companionSurface.teach")}
-          revealLabel
-          pressed={watching}
-          onClick={onWatch}
-        />
-      ) : (
-        watching && <StopWatchingButton onWatch={onWatch} />
-      )}
+          surface does about it is a colour they never receive. */}
+      <TeachButton
+        watching={watching}
+        watchEnabled={watchEnabled}
+        onWatch={onWatch}
+      />
     </>
+  );
+}
+
+/**
+ * The way into a watch session and the way out of it, on whichever row the
+ * user is looking at.
+ *
+ * One control for the two rows that draw it, because it is the same session
+ * either way: a screen being read beside an idle pill and one being read
+ * beside a call are the same capture, and the same press ends both. Its
+ * pressed state is what tells a reader that, and its pinned word is what lets
+ * a looking user find the press without hunting under icons.
+ *
+ * Absent entirely when Watch is not offered, rather than disabled: a user who
+ * cannot have the feature is not owed a control that explains itself by
+ * refusing them. The pill measures its own contents, so the row simply comes
+ * out narrower.
+ *
+ * **The exit outlives the door.** A session running under a flag that has
+ * since been turned off still reads the screen, so the row that would have
+ * carried Teach carries the stop instead. Hiding the way in is the whole of
+ * what the flag does; leaving a capture with nothing that ends it is not
+ * something a flag is allowed to cause.
+ */
+function TeachButton({
+  watching,
+  watchEnabled,
+  onWatch,
+}: {
+  watching: boolean;
+  watchEnabled: boolean;
+  onWatch?: () => void;
+}) {
+  const { t } = useTranslation();
+  if (!watchEnabled) {
+    return watching ? <StopWatchingButton onWatch={onWatch} /> : null;
+  }
+  return (
+    <PillButton
+      icon={<Eye className="size-4" />}
+      label={t("companionSurface.teach")}
+      revealLabel
+      pressed={watching}
+      onClick={onWatch}
+    />
   );
 }
 
@@ -1453,27 +1493,50 @@ function SummaryBody({
  */
 function CallBody({
   call,
+  assistantName,
   watching,
+  watchEnabled,
   onControl,
   onWatch,
 }: {
   call?: VoiceActivityState;
+  assistantName: string;
   watching: boolean;
+  watchEnabled: boolean;
   onControl?: (action: VoiceActivityControlAction, requestId?: string) => void;
   onWatch?: () => void;
 }) {
   const { t } = useTranslation();
+  // The dial: Talk has been pressed and no session has answered. The mutes
+  // have nothing to act on yet and a press on them would be dropped, so the
+  // row is who is being called and the one control that means something, the
+  // end, which is the user changing their mind. Teach stays where it is, so a
+  // session already reading the screen does not lose its stop for the beat.
+  if (call === undefined) {
+    return (
+      <>
+        <span className="ml-1 max-w-[160px] shrink-0 truncate text-[12px] text-white/85">
+          {assistantName === ""
+            ? t("companionSurface.calling")
+            : t("companionSurface.callingNamed", { name: assistantName })}
+        </span>
+        <TeachButton
+          watching={watching}
+          watchEnabled={watchEnabled}
+          onWatch={onWatch}
+        />
+        <EndCallButton onControl={onControl} />
+      </>
+    );
+  }
   // The confirmation takes the row rather than crowding into it. The turn is
   // stopped until it is answered, so it is the only thing here worth pressing,
   // and a pill that tried to carry five controls would make each of them a
   // smaller target than the decision deserves.
   //
-  // The watch session's stop control is among what it excludes. The row already
-  // measures within a couple of points of the canvas ceiling, and what a canvas
-  // too narrow does is clip its trailing control, so adding one here risks
-  // clipping Deny. A blocked turn is reading nothing while it waits, and
-  // answering it lands back on the row that carries the stop.
-  if (call !== undefined && call.approvalRequestId !== "") {
+  // Teach is among what it excludes. A blocked turn is reading nothing while
+  // it waits, and answering it lands back on the row that carries the toggle.
+  if (call.approvalRequestId !== "") {
     return (
       <ApprovalBody
         detail={call.detail}
@@ -1487,9 +1550,8 @@ function CallBody({
   // the more specific of the two ("Reading a file" against "Thinking…") and is
   // empty for most of a call, so this reads as the surface saying more exactly
   // when there is more to say. The mascot carries the state either way.
-  const line = call === undefined ? "Listening" : call.detail || call.label;
-  const muted = call?.muted ?? false;
-  const outputMuted = call?.outputMuted ?? false;
+  const line = call.detail || call.label;
+  const { muted, outputMuted } = call;
 
   return (
     <>
@@ -1503,8 +1565,14 @@ function CallBody({
       </span>
       {/* Beside what the session is doing rather than beside the end control:
           two stops next to each other is a misclick that ends the wrong thing,
-          and only one of the two is irreversible. */}
-      {watching && <StopWatchingButton onWatch={onWatch} />}
+          and only one of the two is irreversible. Teach rides the call rather
+          than being refused by it: a screen read while talking is a question
+          the assistant can answer as it is asked. */}
+      <TeachButton
+        watching={watching}
+        watchEnabled={watchEnabled}
+        onWatch={onWatch}
+      />
       <PillButton
         icon={
           muted ? <MicOff className="size-4" /> : <Mic className="size-4" />
@@ -1537,19 +1605,32 @@ function CallBody({
           );
         }}
       />
-      {/* The room's own end control, at pill scale: the same glyph at the same
-          weight in the same destructive tone. Ending a call is the one
-          irreversible thing on this surface, so it looks identical wherever the
-          user meets it. */}
-      <PillButton
-        icon={<X className="size-4" strokeWidth={2.5} />}
-        label={t("companionSurface.endSession")}
-        tone="negative"
-        onClick={() => {
-          onControl?.("endSession");
-        }}
-      />
+      <EndCallButton onControl={onControl} />
     </>
+  );
+}
+
+/**
+ * The room's own end control, at pill scale: the same glyph at the same weight
+ * in the same destructive tone. Ending a call is the one irreversible thing on
+ * this surface, so it looks identical wherever the user meets it, the dial
+ * included: there it is the press that takes the request back.
+ */
+function EndCallButton({
+  onControl,
+}: {
+  onControl?: (action: VoiceActivityControlAction, requestId?: string) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <PillButton
+      icon={<X className="size-4" strokeWidth={2.5} />}
+      label={t("companionSurface.endSession")}
+      tone="negative"
+      onClick={() => {
+        onControl?.("endSession");
+      }}
+    />
   );
 }
 

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -29,6 +29,15 @@ mock.module("@/runtime/main-window", () => ({
   ensureMainWindowVisible: ensureMainWindowVisibleMock,
 }));
 
+/**
+ * The companion's dial, which a refusal has to close: with no session running,
+ * `end` is the surface being told that none is coming.
+ */
+const endVoiceActivityMock = mock(() => undefined);
+mock.module("@/runtime/desktop-voice-activity", () => ({
+  endVoiceActivity: endVoiceActivityMock,
+}));
+
 mock.module("@/lib/backwards-compat/utils", () => ({
   ...utils,
   whenAssistantVersionKnownFor,
@@ -186,6 +195,7 @@ beforeEach(() => {
   whenAssistantVersionKnownFor.mockClear();
   preflightLiveVoice.mockClear();
   ensureMainWindowVisibleMock.mockClear();
+  endVoiceActivityMock.mockClear();
   versionResolution = Promise.resolve();
   preflightVerdict = { status: "ready" };
   // These tests are about delivery, not about the first-ever entry: a user who
@@ -697,6 +707,59 @@ describe("entry guards", () => {
     expect(useLiveVoiceStore.getState().configNotice).toBe("Set up a voice.");
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(false);
+  });
+
+  /**
+   * The companion draws a dial from the press until a session answers, and a
+   * refusal is the answer "none is coming". Every refusal says so, so the pill
+   * closes on the decision rather than on a timeout.
+   */
+  test("a refusal tells the companion its dial is over", async () => {
+    identityHydrated();
+    registerStarter();
+    preflightVerdict = { status: "not-ready", userMessage: "Set up a voice." };
+
+    requestVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
+
+    expect(endVoiceActivityMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("the first-run card tells the companion its dial is over too", async () => {
+    identityHydrated();
+    registerStarter();
+    useVoicePrefsStore.setState({ firstRunSeen: false });
+
+    requestVoiceStart(navigate);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(endVoiceActivityMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("an assistant too old for live voice tells the companion its dial is over", async () => {
+    identityHydrated("0.10.11");
+    registerStarter();
+
+    requestVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
+
+    expect(endVoiceActivityMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * A start that goes through answers the dial with the session itself, which
+   * the mirror publishes. An `end` here would close the pill under the call.
+   */
+  test("a start that goes through says nothing of the kind", async () => {
+    identityHydrated();
+    registerStarter();
+
+    requestVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
+
+    expectStartedOnFreshDraft();
+    expect(endVoiceActivityMock).not.toHaveBeenCalled();
   });
 
   test("a failed preflight starts anyway rather than blocking voice", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -66,6 +66,7 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 const {
   PENDING_VOICE_START_TTL_MS,
   askVoiceFromSurface,
+  cancelPendingVoiceStart,
   drainPendingVoiceStart,
   requestVoiceStart,
   startVoiceFromSurface,
@@ -470,6 +471,51 @@ describe("a request that will never be served is discarded", () => {
 // ---------------------------------------------------------------------------
 // Exactly-once
 // ---------------------------------------------------------------------------
+
+/**
+ * The companion's dial, ended: the request behind it is taken back wherever it
+ * has got to, so the preflight it may be in the middle of opens nothing.
+ */
+describe("cancelling a pending start", () => {
+  test("spends a parked request", () => {
+    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+
+    cancelPendingVoiceStart();
+
+    expect(isParked()).toBe(false);
+  });
+
+  test("stops a drain that is mid-preflight from starting", async () => {
+    identityHydrated();
+    registerStarter();
+    const preflight: { settle: (() => void) | null } = { settle: null };
+    preflightLiveVoice.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          preflight.settle = () => {
+            resolve(preflightVerdict);
+          };
+        }),
+    );
+
+    requestVoiceStart(navigate);
+    await Promise.resolve();
+    cancelPendingVoiceStart();
+    preflight.settle?.();
+    await drainPendingVoiceStart(navigate);
+
+    expect(starter).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalledWith(
+      expect.stringContaining("/conversation"),
+      expect.anything(),
+    );
+  });
+
+  test("is a no-op with nothing parked", () => {
+    cancelPendingVoiceStart();
+    expect(isParked()).toBe(false);
+  });
+});
 
 describe("one-shot delivery", () => {
   test("repeat drains after a start are free", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -32,6 +32,7 @@ import {
 import { mintVoiceDraftConversation } from "@/domains/chat/voice/voice-draft-conversation";
 import { formatVoiceError } from "@/domains/chat/utils/chat";
 import { supportsLiveVoice } from "@/lib/backwards-compat/use-supports-live-voice";
+import { endVoiceActivity } from "@/runtime/desktop-voice-activity";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { whenAssistantVersionKnownFor } from "@/lib/backwards-compat/utils";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
@@ -158,6 +159,21 @@ export function startVoiceFromSurface(
 }
 
 /**
+ * Take back a start that has been asked for and not yet served.
+ *
+ * What an end pressed with no session running means: the companion's dial is
+ * the only surface that offers one, and the request behind it is either still
+ * parked or partway through its preflight. Spending it here is what stops that
+ * preflight from opening the room a second after the user closed the pill.
+ * The companion itself closes on the press; this is the half it cannot reach.
+ */
+export function cancelPendingVoiceStart(): void {
+  usePendingDeepLinkStore
+    .getState()
+    .consumePendingVoiceStart(PENDING_VOICE_START_TTL_MS);
+}
+
+/**
  * Say that a question asked out loud could not be taken.
  *
  * The question came from another application, and the answer was going to
@@ -273,10 +289,22 @@ export async function drainPendingVoiceStart(
   // been dropped, and the user who asked it from another application is
   // watching the companion for an answer, so the drop is said where they can
   // see it.
+  //
+  // Either way the companion is told. Its Talk draws a dial the moment it is
+  // pressed and holds it until a session answers, and a refusal is the answer
+  // "none is coming": with no session running, `end` is exactly that, and the
+  // pill closes on it rather than on a timeout. Only for a request actually
+  // spent here: the drain runs on every mount and every switch of assistant,
+  // and a refusal of nothing is not an answer to anything.
   const refuse = () => {
-    if (consume()?.ask != null) {
+    const consumed = consume();
+    if (consumed === null) {
+      return;
+    }
+    if (consumed.ask !== null) {
       announceAskRefused();
     }
+    endVoiceActivity();
   };
   // Same eligibility as the composer's entry point: on an assistant too old to
   // serve live voice the link navigates and stops there, exactly as the

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -40,6 +40,7 @@ import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 import { toast } from "@vellumai/design-library/components/toast";
+import { VOICE_START_REQUEST_TTL_MS } from "@vellumai/ipc-contract";
 
 /**
  * How long a parked start-voice request stays live.
@@ -51,8 +52,12 @@ import { toast } from "@vellumai/design-library/components/toast";
  * until some unrelated `ChatLayout` mount drains it and a full-screen voice
  * session opens out of nowhere. A minute is far longer than any legitimate
  * cold launch and far shorter than "later".
+ *
+ * The contract's number, because the companion's dial is drawn against it:
+ * the shell holds the dial for longer than this, so a request that could
+ * still become a session is never one the pill has stopped showing.
  */
-export const PENDING_VOICE_START_TTL_MS = 60_000;
+export const PENDING_VOICE_START_TTL_MS = VOICE_START_REQUEST_TTL_MS;
 
 /**
  * The navigation a start needs from its caller: a path, and whether it
@@ -161,11 +166,13 @@ export function startVoiceFromSurface(
 /**
  * Take back a start that has been asked for and not yet served.
  *
- * What an end pressed with no session running means: the companion's dial is
- * the only surface that offers one, and the request behind it is either still
- * parked or partway through its preflight. Spending it here is what stops that
- * preflight from opening the room a second after the user closed the pill.
- * The companion itself closes on the press; this is the half it cannot reach.
+ * What ending the companion's dial means: the request behind it is either
+ * still parked or partway through its preflight, and spending it here is what
+ * stops that preflight from opening the room a second after the user closed
+ * the pill. Reached through the `cancelVoiceStart` command, which the root
+ * layout consumes on every route, so the press lands whether or not the
+ * layout that owns sessions is mounted yet. The companion itself closes on
+ * the press; this is the half it cannot reach.
  */
 export function cancelPendingVoiceStart(): void {
   usePendingDeepLinkStore

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.test.ts
@@ -28,7 +28,6 @@ mock.module("@/domains/chat/confirmation-actions", () => ({
 
 import { applyLiveActivityControl } from "@/domains/chat/voice/live-voice/use-live-activity-controls";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
-import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
 import {
   useLiveVoiceStore,
   type LiveVoiceSessionControls,
@@ -71,10 +70,6 @@ function pendingConfirmation(requestId: string): void {
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
   useInteractionStore.getState().resetSecretAndConfirmation();
-  usePendingDeepLinkStore.setState({
-    pendingVoiceStartAt: null,
-    pendingVoiceStartAsk: null,
-  });
   handleConfirmationSubmit.mockClear();
   for (const control of Object.values(controls)) {
     control.mockClear();
@@ -181,32 +176,6 @@ describe("applyLiveActivityControl", () => {
     expect(controls.setMuted).not.toHaveBeenCalled();
     expect(controls.setOutputMuted).not.toHaveBeenCalled();
     expect(handleConfirmationSubmit).not.toHaveBeenCalled();
-  });
-
-  /**
-   * The companion's dial is the one surface that offers an end with no session
-   * behind it, and what it ends is the request still on its way to becoming
-   * one. Spent here, so the preflight that request is in the middle of does
-   * not open the room a beat after the user closed the pill.
-   */
-  test("an end with no session takes back a start still on its way", () => {
-    session("idle");
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
-
-    applyLiveActivityControl("endSession");
-
-    expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();
-  });
-
-  test("a mute with no session leaves a pending start where it is", () => {
-    session("idle");
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
-
-    applyLiveActivityControl("muteMicrophone");
-
-    expect(
-      usePendingDeepLinkStore.getState().pendingVoiceStartAt,
-    ).not.toBeNull();
   });
 
   test("a press against a failed session does nothing", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.test.ts
@@ -28,6 +28,7 @@ mock.module("@/domains/chat/confirmation-actions", () => ({
 
 import { applyLiveActivityControl } from "@/domains/chat/voice/live-voice/use-live-activity-controls";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
+import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
 import {
   useLiveVoiceStore,
   type LiveVoiceSessionControls,
@@ -70,6 +71,10 @@ function pendingConfirmation(requestId: string): void {
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
   useInteractionStore.getState().resetSecretAndConfirmation();
+  usePendingDeepLinkStore.setState({
+    pendingVoiceStartAt: null,
+    pendingVoiceStartAsk: null,
+  });
   handleConfirmationSubmit.mockClear();
   for (const control of Object.values(controls)) {
     control.mockClear();
@@ -176,6 +181,32 @@ describe("applyLiveActivityControl", () => {
     expect(controls.setMuted).not.toHaveBeenCalled();
     expect(controls.setOutputMuted).not.toHaveBeenCalled();
     expect(handleConfirmationSubmit).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The companion's dial is the one surface that offers an end with no session
+   * behind it, and what it ends is the request still on its way to becoming
+   * one. Spent here, so the preflight that request is in the middle of does
+   * not open the room a beat after the user closed the pill.
+   */
+  test("an end with no session takes back a start still on its way", () => {
+    session("idle");
+    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+
+    applyLiveActivityControl("endSession");
+
+    expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();
+  });
+
+  test("a mute with no session leaves a pending start where it is", () => {
+    session("idle");
+    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+
+    applyLiveActivityControl("muteMicrophone");
+
+    expect(
+      usePendingDeepLinkStore.getState().pendingVoiceStartAt,
+    ).not.toBeNull();
   });
 
   test("a press against a failed session does nothing", () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.ts
@@ -40,7 +40,6 @@ import {
   setLiveVoiceOutputMuted,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { cancelPendingVoiceStart } from "@/domains/chat/voice/live-voice/start-voice-request";
 import { handleConfirmationSubmit } from "@/domains/chat/confirmation-actions";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import {
@@ -106,16 +105,10 @@ export function applyLiveActivityControl(
   // A press against a session that has already ended does nothing. The island
   // outlives the session by the moment it takes ActivityKit to dismiss it, and
   // an end landing in that window must not tear down a session the user has
-  // since started.
-  //
-  // With one exception: an end with no session is the companion's dial being
-  // closed, and the request behind that dial is still on its way to becoming
-  // a session. Taking it back here is what keeps the pill the user just shut
-  // from opening again a beat later with the call they cancelled on it.
+  // since started, nor take back one still on its way: the companion's dial
+  // is ended by its own command (`cancelVoiceStart`), never by a control
+  // shared with a surface that can deliver a stale end.
   if (!isLiveVoiceSessionActive(session.state)) {
-    if (action === "endSession") {
-      cancelPendingVoiceStart();
-    }
     return;
   }
   switch (action) {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-controls.ts
@@ -40,6 +40,7 @@ import {
   setLiveVoiceOutputMuted,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { cancelPendingVoiceStart } from "@/domains/chat/voice/live-voice/start-voice-request";
 import { handleConfirmationSubmit } from "@/domains/chat/confirmation-actions";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
 import {
@@ -106,7 +107,15 @@ export function applyLiveActivityControl(
   // outlives the session by the moment it takes ActivityKit to dismiss it, and
   // an end landing in that window must not tear down a session the user has
   // since started.
+  //
+  // With one exception: an end with no session is the companion's dial being
+  // closed, and the request behind that dial is still on its way to becoming
+  // a session. Taking it back here is what keeps the pill the user just shut
+  // from opening again a beat later with the call they cancelled on it.
   if (!isLiveVoiceSessionActive(session.state)) {
+    if (action === "endSession") {
+      cancelPendingVoiceStart();
+    }
     return;
   }
   switch (action) {

--- a/clients/web/src/domains/chat/watch/watch-controller.test.ts
+++ b/clients/web/src/domains/chat/watch/watch-controller.test.ts
@@ -100,34 +100,6 @@ const {
 } = await import("./watch-controller");
 const { clearWatchRetro, useWatchRetroStore } = await import("./watch-retro");
 
-/**
- * Live-voice subscriptions, counted.
- *
- * A leaked one is invisible against the real store: teardown is idempotent, so
- * a stale listener fires harmlessly and accumulates one listener per session
- * for the life of the page. Spying on the real `subscribe` rather than mocking
- * the module keeps the real `isLiveVoiceSessionActive` and the real state
- * machine, which are the things these cases are actually driving.
- */
-let liveVoiceListeners = 0;
-const realLiveVoiceSubscribe = useLiveVoiceStore.subscribe.bind(
-  useLiveVoiceStore,
-) as typeof useLiveVoiceStore.subscribe;
-useLiveVoiceStore.subscribe = ((
-  listener: Parameters<typeof realLiveVoiceSubscribe>[0],
-) => {
-  liveVoiceListeners += 1;
-  const unsubscribe = realLiveVoiceSubscribe(listener);
-  let released = false;
-  return () => {
-    if (!released) {
-      released = true;
-      liveVoiceListeners -= 1;
-    }
-    unsubscribe();
-  };
-}) as typeof useLiveVoiceStore.subscribe;
-
 /** The assistant every session in this file is started against. */
 const ASSISTANT_ID = "asst-owner";
 
@@ -360,7 +332,6 @@ beforeEach(() => {
   sockets = [];
   capture = createCaptureFake();
   useLiveVoiceStore.setState({ state: "idle" });
-  liveVoiceListeners = 0;
   // The watch store is module state shared by every case in this file, and the
   // session's own writes are the only thing that ever moves it. Cleared here so
   // a case reads its own session's counts rather than inheriting the previous
@@ -460,27 +431,17 @@ describe("toggling a watch session", () => {
   });
 
   /**
-   * One microphone, one owner. Both sessions capture from the device the
-   * machine has exactly one of, and the call is the one the user is already
-   * in, so the press is spent rather than queued behind it.
+   * A call is not in the way. The session opens its own capture beside the
+   * call's, so the narration reaches both: the call answers it and the watch
+   * records it.
    */
-  test("refuses to start while a live-voice call is running", async () => {
+  test("starts beside a live-voice call", async () => {
     useLiveVoiceStore.setState({ state: "listening" });
-
-    await toggle();
-
-    expect(sockets).toHaveLength(0);
-    expect(capture.calls.started).toBe(0);
-    expect(useWatchStore.getState().watching).toBe(false);
-  });
-
-  test("starts once the call has ended", async () => {
-    useLiveVoiceStore.setState({ state: "listening" });
-    await toggle();
-    useLiveVoiceStore.setState({ state: "idle" });
 
     await startRunning();
 
+    expect(sockets).toHaveLength(1);
+    expect(capture.calls.started).toBe(1);
     expect(useWatchStore.getState().watching).toBe(true);
   });
 
@@ -984,7 +945,6 @@ describe("the flush window after the user stops", () => {
 
     expect(useWatchStore.getState().watching).toBe(false);
     expect(capture.calls.shutdown).toBe(1);
-    expect(liveVoiceListeners).toBe(0);
     expect(assistantListeners.size).toBe(0);
     expect(socket().closeCalls).toEqual([]);
   });
@@ -1083,14 +1043,6 @@ describe("the flush window after the user stops", () => {
    * Only a deliberate stop owes the runtime a flush. Every other ending is
    * already over, so waiting would hold a socket open for nothing.
    */
-  test("does not wait when a call takes the microphone", async () => {
-    await startRunning();
-
-    useLiveVoiceStore.setState({ state: "listening" });
-
-    expect(socket().closeCalls).toEqual([1000]);
-  });
-
   test("does not wait when the assistant changes", async () => {
     await startRunning();
 
@@ -1257,7 +1209,7 @@ describe("the summary a stopped session leaves behind", () => {
 
   /**
    * Every ending that is not the user's own press is something going wrong: a
-   * socket that dropped, a call taking the microphone, the layout going away.
+   * socket that dropped, the layout going away.
    * None of them is a request for a summary, and a runtime that is gone is not
    * going to write one.
    */
@@ -1392,73 +1344,39 @@ describe("a watch session between the socket and the runtime", () => {
 });
 
 /**
- * A call takes the microphone from a watch session.
+ * A watch session and a call share the user, not a microphone.
  *
- * The refusal in `toggleWatch` only covers Watch pressed during a call. Live
- * voice has its own doors, and they do not consult this module, so the session
- * has to give the microphone up rather than every one of those doors having to
- * learn to refuse.
+ * Each opens its own capture, so a call arriving mid-session changes nothing
+ * here: the screen goes on being read, the narration goes on being recorded,
+ * and the call answers it as it is said. That is the point of the pairing, a
+ * user teaching the assistant who can ask it questions as they go.
  */
 describe("a watch session when a call starts", () => {
   const startCall = () => {
     useLiveVoiceStore.setState({ state: "listening" });
   };
 
-  test("ends a running session", async () => {
+  test("keeps a running session running", async () => {
     await startRunning();
 
     startCall();
 
-    expect(capture.calls.shutdown).toBe(1);
-    expect(socket().closeCalls).toEqual([1000]);
-    expect(useWatchStore.getState().watching).toBe(false);
+    expect(capture.calls.shutdown).toBe(0);
+    expect(socket().closeCalls).toEqual([]);
+    expect(useWatchStore.getState().watching).toBe(true);
   });
 
-  /**
-   * A session still waiting on `ready` has a socket the call knows nothing
-   * about, and a microphone about to open the moment the runtime answers.
-   */
-  test("ends a session still pending, before it can open the microphone", async () => {
-    const seen = await flagEmissions(async () => {
-      await startPending();
-      startCall();
-      await serverReady();
-    });
+  test("lets a session still pending open its microphone", async () => {
+    await startPending();
+    startCall();
+    await serverReady();
 
-    expect(capture.calls.started).toBe(0);
-    expect(capture.calls.shutdown).toBe(1);
-    expect(seen).toEqual([]);
-  });
-
-  test("leaves one owner of the microphone", async () => {
-    await startRunning();
     expect(capture.calls.started).toBe(1);
-
-    startCall();
-
-    expect(capture.calls.shutdown).toBe(1);
-    expect(sockets).toHaveLength(1);
+    expect(capture.calls.shutdown).toBe(0);
+    expect(useWatchStore.getState().watching).toBe(true);
   });
 
-  /**
-   * The other direction, which was already guarded and has to stay guarded:
-   * pressing Watch during a call opens nothing.
-   */
-  test("still refuses a press that lands during a call", async () => {
-    startCall();
-
-    await toggle();
-
-    expect(sockets).toHaveLength(0);
-    expect(useWatchStore.getState().watching).toBe(false);
-  });
-
-  /**
-   * A call starting while the version gate resolves. Guarded by the re-read
-   * after the await rather than by the subscription, since there is no session
-   * yet to subscribe on its behalf.
-   */
-  test("cancels a start that is still resolving the version gate", async () => {
+  test("lets a start still resolving the version gate go on to open", async () => {
     activate(ASSISTANT_ID, null);
     const pressed = toggle();
 
@@ -1466,31 +1384,16 @@ describe("a watch session when a call starts", () => {
     activate(ASSISTANT_ID);
     await pressed;
 
-    expect(sockets).toHaveLength(0);
-    expect(useWatchStore.getState().watching).toBe(false);
+    expect(sockets).toHaveLength(1);
   });
 
-  /**
-   * The subscription lives exactly as long as the session does. Left behind it
-   * fires harmlessly, because teardown is idempotent, and accumulates one
-   * listener per session for the life of the page.
-   */
-  test("stops listening for calls once the session is over", async () => {
+  test("still ends on the user's own press", async () => {
     await startRunning();
-    expect(liveVoiceListeners).toBe(1);
+    startCall();
 
     stopWatch();
 
-    expect(liveVoiceListeners).toBe(0);
-  });
-
-  test("leaves nothing behind across repeated sessions", async () => {
-    await startRunning();
-    await stopAndSettle();
-    await startRunning();
-    await stopAndSettle();
-
-    expect(liveVoiceListeners).toBe(0);
+    expect(useWatchStore.getState().watching).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/chat/watch/watch-controller.ts
+++ b/clients/web/src/domains/chat/watch/watch-controller.ts
@@ -15,12 +15,14 @@
  * the way `watch-session-manager.ts` holds one: a second session would compete
  * for the same microphone and interleave two unrelated timelines.
  *
- * **The microphone has one owner, in both directions.** A live-voice call is
- * the other thing on this client that opens it. A toggle that lands while a
- * call is running is refused rather than queued, and a call that starts while
- * a session is running or pending ends that session. The call wins because it
- * is interactive where watching is ambient, which is the precedence the
- * companion surface already draws: its `call` phase outranks `watching`.
+ * **A call and a watch session run side by side.** A live-voice call is the
+ * other thing on this client that opens the microphone, and each opens its
+ * own capture of it: the call hears the narration and answers it, the watch
+ * records it against the screen and writes it up afterwards. Neither refuses
+ * the other and neither ends the other, so a user teaching the assistant can
+ * ask it questions as they go, and a user on a call can start showing it
+ * their screen. The companion surface draws the two together for the same
+ * reason: Teach rides its call row.
  *
  * **An attempt is a session for the purpose of stopping it.** A start is
  * registered in the slot before it resolves the version gate, so the ordinary
@@ -85,10 +87,6 @@ import {
   PairedVoiceUnavailableError,
   VelayWsTokenError,
 } from "@/domains/chat/voice/live-voice/connection";
-import {
-  isLiveVoiceSessionActive,
-  useLiveVoiceStore,
-} from "@/domains/chat/voice/live-voice/live-voice-store";
 import {
   LiveVoiceAudioCapture,
   isSupported as isPcmCaptureSupported,
@@ -478,8 +476,8 @@ function openSession(
    * Every ending that is not the user's own stop lands here directly, and the
    * user's stop lands here once the runtime has answered or the drain has run
    * out of patience. None of those endings owes anyone a flush: a socket that
-   * dropped, a call taking the microphone, a window being destroyed, and a
-   * runtime reporting an error are all already over.
+   * dropped, a window being destroyed, and a runtime reporting an error are
+   * all already over.
    */
   const finish = (): void => {
     if (phase === "done") {
@@ -653,34 +651,6 @@ function openSession(
   }, options.readyTimeoutMs ?? READY_TIMEOUT_MS);
 
   /**
-   * A call takes the microphone, and this session gives it up.
-   *
-   * The refusal in `toggleWatch` covers one direction only: Watch pressed
-   * during a call. The other direction has its own doors, and they do not
-   * consult this module. The companion surface's Talk and the composer's voice
-   * button both start a session without asking whether one is watching, and
-   * two controllers holding the same microphone stream the same audio into two
-   * unrelated sessions.
-   *
-   * Ending here rather than teaching every live-voice entry point to refuse,
-   * for two reasons. A call is interactive and immediate where a watch session
-   * is ambient, so the call is the one that should win. And the surface already
-   * says so: its `call` phase outranks `watching`, so this is the controller
-   * agreeing with what the user is already being shown, rather than a rule
-   * that has to be repeated at each new door somebody adds.
-   */
-  subscriptions.push(
-    useLiveVoiceStore.subscribe((state) => {
-      if (isLiveVoiceSessionActive(state.state)) {
-        console.info(
-          "watch-controller: ending the session, a call has taken the microphone",
-        );
-        finish();
-      }
-    }),
-  );
-
-  /**
    * The session belongs to the assistant it was started for, and ends when
    * that stops being the active one.
    *
@@ -825,10 +795,6 @@ function openSession(
  * stretch can, and so a press cannot be lost to a resolution that outlives the
  * page. Only the start edge resolves anything.
  *
- * A live-voice call refuses the start outright. Both sessions are driven by
- * the one microphone the machine has, and the call is the one the user is
- * already in, so the press is spent rather than queued behind it.
- *
  * An assistant too old to serve `/v1/watch/stream` refuses it too, before any
  * state moves. Without that the press would flip `watching` and then fail the
  * handshake, lighting the surface's capture ring for a session that never
@@ -842,10 +808,6 @@ export async function toggleWatch(
 ): Promise<void> {
   if (session !== null) {
     session.stop();
-    return;
-  }
-  if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
-    console.info("watch-controller: refusing to start while a call is running");
     return;
   }
   const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
@@ -950,16 +912,12 @@ export async function toggleWatch(
   if (cancelled) {
     return;
   }
-  // Re-read across the awaits. A call can have started, and the active
-  // assistant can have moved out from under the gate that just passed. Taken
-  // after the transport resolves rather than before, so the check that decides
-  // is the one nearest the dial; the cost is a minted token spent on a start
-  // that is then discarded, and a single-use token nobody presents just
-  // expires.
-  if (
-    isLiveVoiceSessionActive(useLiveVoiceStore.getState().state) ||
-    useResolvedAssistantsStore.getState().activeAssistantId !== assistantId
-  ) {
+  // Re-read across the awaits: the active assistant can have moved out from
+  // under the gate that just passed. Taken after the transport resolves rather
+  // than before, so the check that decides is the one nearest the dial; the
+  // cost is a minted token spent on a start that is then discarded, and a
+  // single-use token nobody presents just expires.
+  if (useResolvedAssistantsStore.getState().activeAssistantId !== assistantId) {
     releaseAttempt();
     return;
   }

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -152,6 +152,8 @@
   },
   "companionSurface": {
     "allow": "Allow",
+    "calling": "Calling…",
+    "callingNamed": "Calling {name}…",
     "deny": "Deny",
     "dictating": "Listening",
     "dictatingTranscribing": "Thinking",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -152,6 +152,8 @@
   },
   "companionSurface": {
     "allow": "Permitir",
+    "calling": "Llamando…",
+    "callingNamed": "Llamando a {name}…",
     "deny": "Denegar",
     "endSession": "Finalizar sesión",
     "muteAssistant": "Silenciar asistente",

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -152,6 +152,8 @@
   },
   "companionSurface": {
     "allow": "允許",
+    "calling": "正在呼叫…",
+    "callingNamed": "正在呼叫 {name}…",
     "deny": "拒絕",
     "endSession": "結束會話",
     "muteAssistant": "將助理靜音",

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -152,6 +152,8 @@
   },
   "companionSurface": {
     "allow": "允许",
+    "calling": "正在呼叫…",
+    "callingNamed": "正在呼叫 {name}…",
     "deny": "拒绝",
     "endSession": "结束会话",
     "muteAssistant": "静音助手",

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -19,7 +19,10 @@ import {
   isLiveVoiceSessionActive,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { startVoiceFromSurface } from "@/domains/chat/voice/live-voice/start-voice-request";
+import {
+  cancelPendingVoiceStart,
+  startVoiceFromSurface,
+} from "@/domains/chat/voice/live-voice/start-voice-request";
 import {
   clearWatchRetro,
   useWatchRetroStore,
@@ -334,6 +337,13 @@ export function RootLayout() {
       // See `startVoiceFromSurface` for the three steps and why the window
       // stays where it is.
       startVoiceFromSurface(navigate);
+    },
+    cancelVoiceStart: () => {
+      // The companion's dial, ended. Handled here rather than beside the
+      // session's controls because there may be no session yet and no layout
+      // that owns one: the request is parked, and this layout is the one
+      // mounted on every route it can be parked from.
+      cancelPendingVoiceStart();
     },
     toggleVoice: () => {
       // The global Talk shortcut. Starting is Talk's own behaviour; ending is

--- a/packages/ipc-contract/src/accelerators.ts
+++ b/packages/ipc-contract/src/accelerators.ts
@@ -44,6 +44,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommand["kind"], string> = {
   removePairedAssistant: "",
   quickInputSubmit: "",
   startVoice: "",
+  cancelVoiceStart: "",
   toggleVoice: "",
   toggleWatch: "",
   answerWatchRetro: "",

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -941,8 +941,13 @@ export const COMPANION_BASE_CARD_HEIGHT = 290;
  * A ceiling rather than a width, since every other state is as wide as its
  * content. Main sizes the canvas to hold this much beyond the gap, so a state
  * that wanted more would be clipped by the window.
+ *
+ * Generous on purpose. The call row is a handlebar that grows with what it
+ * carries, and the canvas is click-through, so room the pill never uses costs
+ * the desktop nothing where a control clipped off the end costs the user the
+ * control.
  */
-export const COMPANION_BASE_MAX_PILL_WIDTH = 316;
+export const COMPANION_BASE_MAX_PILL_WIDTH = 400;
 
 /**
  * The room between the avatar's edge and the options pill beside it, at the
@@ -1405,6 +1410,21 @@ export interface CompanionSurfaceState {
    * that only shows itself on hover is a live microphone the user cannot see.
    */
   call: VoiceActivityState | null;
+  /**
+   * Whether Talk has been pressed and no session has answered it yet.
+   *
+   * The press leaves the surface at once and the session it asks for opens in
+   * the app's window, behind whatever the user is working in, after a network
+   * round trip. Without this the pill draws nothing across that wait, and a
+   * press that changes nothing on screen reads as a press that did nothing.
+   * Main sets it on the press and clears it when the session's `start`
+   * arrives, when the window asked declines by sending `end` with no session
+   * running, when the user ends the dial from the pill, or after a bound.
+   *
+   * Optional, and absence means not dialing, the bargain
+   * {@link CompanionSurfaceState.watching} makes with absence.
+   */
+  dialing?: boolean;
   /**
    * The assistant's avatar as a base64 PNG, or `undefined` when there is none.
    *

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -25,6 +25,19 @@
  * focused renderer window via `vellum:command` IPC; the renderer routes
  * them through the event bus.
  */
+/**
+ * How long a `startVoice` request stays live once asked for, in the renderer
+ * that parked it.
+ *
+ * The park exists for one race, a request that lands before the layout that
+ * owns sessions mounts, which resolves in seconds or not at all. A bound is
+ * what stops a request bounced by a route guard from opening a session out of
+ * nowhere on some later mount. Here in the contract because the shell reads
+ * it too: the companion draws a dial for the request and has to know how long
+ * one can still turn into a session.
+ */
+export const VOICE_START_REQUEST_TTL_MS = 60_000;
+
 export type VellumCommand =
   | { kind: "newConversation" }
   | { kind: "currentConversation" }
@@ -72,6 +85,17 @@ export type VellumCommand =
    * running is a no-op, because the running session is the one the user is in.
    */
   | { kind: "startVoice" }
+  /**
+   * Take back a `startVoice` that has been asked for and not yet served, which
+   * is what ending the companion's dial means.
+   *
+   * A command rather than a session control, because there may be no session
+   * to control yet: the request is parked or partway through its preflight,
+   * and the layout that owns sessions may not even be mounted. The root
+   * layout consumes commands for the life of the window, so this one lands
+   * whatever route the app is on. See {@link VOICE_START_REQUEST_TTL_MS}.
+   */
+  | { kind: "cancelVoiceStart" }
   /**
    * Turn a watch session on or off, the way the companion surface's Watch
    * option asks.


### PR DESCRIPTION
## Summary

Second slice of the call-first companion (JARVIS-1705). Pressing Talk now reads as starting a call, and Teach becomes an in-call action instead of something the call refuses.

- **The pill dials.** Talk used to change nothing on the surface until the session's `connecting` phase arrived, after the entry guards and a readiness round trip in a window the user cannot see. Main now sets `dialing` on the pushed state the moment Talk is pressed and clears it when the mirror's `start` lands, when the drain declines a request it actually spent (sent as `voiceActivity.end` with no session running), when the user presses End on the dial, or after a 20s bound. The pill draws "Calling {name}…" plus End; the mutes stay off the row until there is a session to mute.
- **End on a dial takes the request back.** Main closes the pill at once, and the chat window's control handler consumes the parked start so an in-flight preflight cannot open the room a beat after the user shut the pill.
- **Teach rides the call row** as the same toggle the idle row draws (`TeachButton`, one component for both rows). The watch controller no longer refuses a press during a call and no longer ends a session when a call starts. The two run on their own mic captures: the call answers the narration as it is said, the watch records it against the screen and summarizes afterwards. That is deliberate: questions asked while teaching get answered on the spot.
- **The pill's ceiling grows** (`COMPANION_BASE_MAX_PILL_WIDTH` 316 to 400) so the handlebar fits with Teach held down and has room for the camera and screen-share controls that come next. The canvas is click-through, so the extra width costs the desktop nothing. Geometry fixtures in the main-process tests are re-pinned.

Camera and screen share are the next slice; desktop has no screen-capture path in the web client yet.

## Contract

One optional field on `CompanionSurfaceState` (`dialing?: boolean`, absence reads as not dialing). No new channels: an `end` with no session running already means "return the surface to rest".

## Copy

Two new `companionSurface` keys (`calling`, `callingNamed`) in en, es, zh, zh-TW. ru has no `companionSurface` block today, so it falls back to English as the rest of that block does.

## Testing

- `clients/web`: `companion-surface.test.tsx` (131), `companion-surface-page.test.tsx` (53), `watch-controller.test.ts` (81), `start-voice-request.test.ts` (37), `use-live-activity-controls.test.ts` (14), `catalogs.test.ts` (210), all green. `bun run typecheck`, eslint, prettier 3.8.1 clean.
- `clients/macos`: `companion-window.test.ts` (86) green, `bun run typecheck` clean.
- Not yet exercised on a device: the dial's timing against a real preflight, and the double capture's echo behaviour (the assistant's own speech reaching the watch transcript through the speaker).

Part of JARVIS-1705. Closes JARVIS-1715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py5RCxLX8GECQCsNTM22Tc
