### PR TITLE
fix(companion): drop the accent glow behind the macOS companion avatar

### DIFF
--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -122,7 +122,7 @@ export interface CompanionLayout {
    * the pill's bottom sits on.
    *
    * Shorter than {@link CompanionLayout.avatarHalf}: the box runs past the
-   * drawing to hold the glow and the bob's slack, and it is the drawing the eye
+   * drawing to hold the bob's slack, and it is the drawing the eye
    * lines the pill up with.
    */
   baseline: number;

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -1141,9 +1141,9 @@ describe("the companion's own menu", () => {
 });
 
 /**
- * The glow is the assistant's own light, not the surface's: an idle companion
- * with no call running glows its character's accent, and a running call's
- * accent wins over it.
+ * The capsule is the assistant's own colour, not the surface's: an idle
+ * companion with no call running wears its character's accent, and a running
+ * call's accent wins over it.
  */
 describe("the companion's accent colour", () => {
   const CHARACTER = {
@@ -1165,22 +1165,23 @@ describe("the companion's accent colour", () => {
   });
 
   /**
-   * The glow is the only thing on the surface painted in the accent, so it is
-   * where the resolved colour is read back from.
+   * The resting capsule is painted whole in the accent and is always mounted,
+   * so it is where the resolved colour is read back from.
    *
    * Awaited, because the state the colour comes from arrives after mount, so
    * the first render is always the default.
    */
-  const expectGlow = async (
+  const expectAccent = async (
     container: HTMLElement,
     hex: string,
   ): Promise<void> => {
     await waitFor(() => {
-      const glow = container.querySelector<HTMLElement>(".companion-glow");
-      if (!glow) {
-        throw new Error("Expected the glow to render");
+      const capsule =
+        container.querySelector<HTMLElement>(".companion-capsule");
+      if (!capsule) {
+        throw new Error("Expected the capsule to render");
       }
-      expect(glow.style.background.trim().toLowerCase()).toContain(hex);
+      expect(capsule.style.background.trim().toLowerCase()).toContain(hex);
     });
   };
 
@@ -1188,7 +1189,7 @@ describe("the companion's accent colour", () => {
     STATE.character = { ...CHARACTER };
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectGlow(container, "#e9642f");
+    await expectAccent(container, "#e9642f");
   });
 
   test("lets a running call's accent win", async () => {
@@ -1196,7 +1197,7 @@ describe("the companion's accent colour", () => {
     STATE.call = listening("#123456");
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectGlow(container, "#123456");
+    await expectAccent(container, "#123456");
   });
 
   /**
@@ -1209,7 +1210,7 @@ describe("the companion's accent colour", () => {
     STATE.call = listening("");
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectGlow(container, "#e9642f");
+    await expectAccent(container, "#e9642f");
   });
 
   /**
@@ -1219,6 +1220,6 @@ describe("the companion's accent colour", () => {
   test("falls back to the component default without a character", async () => {
     const { container } = render(<CompanionSurfacePage />);
 
-    await expectGlow(container, "#5eead4");
+    await expectAccent(container, "#5eead4");
   });
 });

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -360,8 +360,8 @@ export function CompanionSurfacePage() {
   // The avatar's own colour. A running call publishes one, and it wins: it is
   // the colour the call surfaces elsewhere are already tinted with. Outside a
   // call the character's palette id resolves to the same hex the app draws the
-  // creature in, so the resting glow is the assistant's colour rather than the
-  // component's teal default.
+  // creature in, so the resting capsule is the assistant's colour rather than
+  // the component's teal default.
   //
   // The call's hex is `""` until the avatar resolves and the contract makes no
   // promise it parses, so anything that is not an obvious `#RRGGBB` falls

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -56,10 +56,6 @@ const ringOf = (container: HTMLElement): HTMLElement | null =>
 const bobOf = (container: HTMLElement): HTMLElement | null =>
   container.querySelector<HTMLElement>(".companion-avatar-bob");
 
-/** The creature's own light, which rides inside the bob. */
-const glowOf = (container: HTMLElement): HTMLElement | null =>
-  container.querySelector<HTMLElement>(".companion-glow");
-
 describe("the companion surface's working ring", () => {
   test("is absent while nothing is running", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
@@ -487,7 +483,7 @@ describe("the companion surface's anchor in the canvas", () => {
   /**
    * The creature's visible bottom is the fixed point. The pill's bottom sits on
    * it rather than on the avatar's box, which runs a further 8 points down to
-   * hold the glow, and the mascot never moves whichever way the pill or the
+   * hold the bob's slack, and the mascot never moves whichever way the pill or the
    * card grows.
    */
   test("sits the pill's bottom on the creature's visible bottom", () => {
@@ -1413,17 +1409,26 @@ describe("the companion surface's text selection", () => {
  * a screenshot.
  */
 describe("the resting avatar's idle motion", () => {
-  test("bobs on a wrapper of its own, with the glow riding inside it", () => {
-    const { container } = render(
-      <CompanionSurface phase="resting" accentHex="#ff8800" />,
-    );
+  test("bobs on a wrapper of its own", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
 
-    const bob = bobOf(container);
-    expect(bob).not.toBeNull();
+    expect(bobOf(container)).not.toBeNull();
+  });
 
-    const glow = glowOf(container);
-    expect(glow?.parentElement).toBe(bob);
-    expect(glow?.style.background.toLowerCase()).toContain("#ff8800");
+  /**
+   * The creature carries no light of its own: a blurred disc of the accent
+   * behind it made it read as a lit control rather than as something standing
+   * on the desktop, so nothing is painted behind the artwork in any phase.
+   */
+  test("draws nothing behind the creature", () => {
+    for (const phase of PHASES) {
+      const { container } = render(
+        <CompanionSurface phase={phase} accentHex="#ff8800" />,
+      );
+      expect(container.querySelector(".companion-glow")).toBeNull();
+      expect(bobOf(container)?.querySelector(".blur-lg")).toBeNull();
+      cleanup();
+    }
   });
 
   /**
@@ -1468,43 +1473,27 @@ describe("the resting avatar's idle motion", () => {
   });
 
   /**
-   * The glow is the creature's own light and the creature is on screen in every
-   * phase, so it is lit in every phase. Nothing stacks under it: the pill is a
-   * separate shape a gap away rather than a body the halo would read as a
-   * second ring around.
-   */
-  test("glows in every phase, not only at rest", () => {
-    for (const phase of PHASES) {
-      const { container } = render(<CompanionSurface phase={phase} />);
-      expect(glowOf(container)).not.toBeNull();
-      cleanup();
-    }
-  });
-
-  /**
    * A reader who has asked for stillness gets it from two places: the
    * `prefers-reduced-motion` block beside the keyframes, and the inline
    * `animation: none` here. The doubling is deliberate, since a stylesheet that
    * failed to load is a surface that moves anyway, and this is the half a
    * reader of the component can see.
    *
-   * Held still rather than dropped: the glow is the creature's own light and
-   * the bob's baseline is where the creature belongs, so both stay drawn.
+   * Held still rather than dropped: the bob's baseline is where the creature
+   * belongs, so it stays drawn.
    */
-  test("holds the bob and the glow still under reduced motion", () => {
+  test("holds the bob still under reduced motion", () => {
     reducedMotion = true;
 
     const { container } = render(<CompanionSurface phase="resting" />);
 
     expect(bobOf(container)?.style.animation).toBe("none");
-    expect(glowOf(container)?.style.animation).toBe("none");
   });
 
-  test("leaves both running for a reader who asked for nothing", () => {
+  test("leaves it running for a reader who asked for nothing", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
 
     expect(bobOf(container)?.style.animation).toBe("");
-    expect(glowOf(container)?.style.animation).toBe("");
   });
 
   /**

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -244,7 +244,7 @@ const RESTING_HEIGHT = 10;
  * peeking out from behind a bordered pill reads as peeking out of a slot in a
  * device, and the pill is meant to be the creature's own colour and nothing
  * else. The ring still carries a turn at rest: its bright arc orbits and its
- * glow falls on the desktop, and neither needs a dark line to be seen.
+ * light falls on the desktop, and neither needs a dark line to be seen.
  *
  * One statement of it, because two things are sized from it and they must not
  * drift. The capsule is drawn at it, and the box the working ring rides matches
@@ -767,7 +767,7 @@ export function CompanionSurface({
     // **On the creature's visible bottom.** The pill's bottom edge sits on the
     // bottom of the artwork, so the two keep one baseline whatever the pill is
     // carrying. The line is the artwork, not the avatar's *box*, which runs an
-    // `INNER_GAP` further down to hold the glow and the bob's slack. Which edge
+    // `INNER_GAP` further down to hold the bob's slack. Which edge
     // of the canvas that line is measured from is the host's call (see
     // `CompanionSurfaceCardGrowth`).
     top: lineAt(cardGrowth, baseline),
@@ -935,8 +935,8 @@ export function CompanionSurface({
           </div>
         </div>
       </div>
-      {/* Drawn after the pill so the glow, which falls off well past the
-        creature, lands over the pill's leading edge rather than under it. */}
+      {/* Drawn after the pill so the creature lands over the pill's leading
+        edge rather than under it. */}
       <Avatar
         accentHex={accentHex}
         avatarSrc={avatarSrc}
@@ -993,16 +993,14 @@ export function CompanionSurface({
  * in the pill, which is what lets the pill change width and shape underneath
  * without the creature moving a pixel.
  *
- * The glow sits behind the image and is blurred well past it, so it falls off
- * into the desktop rather than ending on an edge. A halo sized to its own
- * source has nowhere to fall off and reads as a ring around the avatar rather
- * than as light coming off it.
+ * No light behind the creature. It once sat on a blurred disc of its own
+ * accent, and the halo went because it made the creature read as a lit control
+ * rather than as something standing on the desktop.
  *
  * **The bob is a wrapper, not a class on the artwork.** `AnimatedAvatar` owns
  * `transform` on its own `<svg>` for the breathe and the morph, and a second
  * animation on that node would silently replace one of them. Everything that
- * belongs to the creature rides inside the wrapper, glow included, so the light
- * travels with what is casting it. The edge sits outside the wrapper: it is
+ * belongs to the creature rides inside the wrapper. The edge sits outside it: it is
  * drawn on the shape rather than on the artwork, so a ring saying something is
  * running holds still while the creature breathes under it.
  *
@@ -1123,7 +1121,7 @@ function Avatar({
         {@link RESTING_BOX}. The shadow stays, since it is what holds any of
         this against a desktop the surface does not own. */}
       <div
-        className="absolute top-1/2 left-1/2 rounded-full shadow-lg shadow-black/40 transition-opacity duration-200"
+        className="companion-capsule absolute top-1/2 left-1/2 rounded-full shadow-lg shadow-black/40 transition-opacity duration-200"
         style={{
           width: RESTING_BOX.width,
           height: RESTING_BOX.height,
@@ -1173,14 +1171,6 @@ function Avatar({
           className="companion-avatar-bob relative grid place-items-center"
           style={{ animation: reduce ? "none" : undefined }}
         >
-          <span
-            className="companion-glow absolute size-10 rounded-full blur-lg"
-            style={{
-              background: accentHex,
-              animation: reduce ? "none" : undefined,
-            }}
-            aria-hidden
-          />
           {character !== undefined ? (
             // The live creature, composed here rather than shipped as pixels. It
             // blinks, twitches and breathes on its own, which is the whole reason

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -263,31 +263,15 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   50% { transform: translateY(-3px); }
 }
 
-/* The glow's breath, with both ends written out. Tailwind's `animate-pulse`
-   synthesises its 0%/100% from whatever opacity the element already carries,
-   which on a glow this faint is a swing nobody can see. */
-@keyframes companion-glow-breathe {
-  0%, 100% { opacity: 0.32; }
-  50% { opacity: 0.5; }
-}
-
 .companion-avatar-bob {
   animation: companion-avatar-bob 5s ease-in-out infinite;
   will-change: transform;
 }
 
-.companion-glow {
-  /* Where the breath starts and where it is held when it cannot run. */
-  opacity: 0.32;
-  animation: companion-glow-breathe 4s ease-in-out infinite;
-}
-
-/* Held still rather than dropped: the glow is the avatar's own colour thrown
-   onto the desktop, so it stays lit at rest, and the creature keeps its
-   baseline rather than disappearing from it. */
+/* Held still rather than dropped: the creature keeps its baseline rather than
+   disappearing from it. */
 @media (prefers-reduced-motion: reduce) {
-  .companion-avatar-bob,
-  .companion-glow {
+  .companion-avatar-bob {
     animation: none;
   }
 }
@@ -307,10 +291,10 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 /* Companion surface working ring: a band of the assistant's accent travelling
  * around the edge of the macOS floating companion while a turn is in flight.
  *
- * The surface's resting state already carries a pulsing accent glow behind the
- * avatar, so a second pulse would not read as a second thing. Travel is the
- * property nothing else on the surface uses, which is what lets "it is working"
- * be legible out of the corner of an eye without reading a word.
+ * The creature already breathes and bobs at rest, so a pulse would not read as
+ * a second thing. Travel is the property nothing else on the surface uses,
+ * which is what lets "it is working" be legible out of the corner of an eye
+ * without reading a word.
  *
  * The band is the border and not the fill: the conic gradient is masked down to
  * the padding band so the light rides the edge instead of washing across the


### PR DESCRIPTION
## Summary
- Remove the blurred accent disc that sat behind the creature whenever the macOS companion was out of its resting capsule. It read as a lit control rather than as something standing on the desktop.
- Drop its breathe keyframes and reduced-motion hold from `index.css`, and update the comments that described it.
- The accent still paints the resting capsule and the working ring. The page test that reads the resolved colour back now reads it from the capsule, which gains a `companion-capsule` class for that.

## Test plan
- [x] `bun test src/components/companion-surface.test.tsx src/components/companion-surface-page.test.tsx` (169 pass)
- [x] `bun run typecheck` and eslint on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Scz8sMPare3kQHVdzTDD1G