### PR TITLE
refactor(slack): the rows the daemon authors write the neutral envelope

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -42,6 +42,8 @@ let metadataWriteFailuresRemaining = 0;
 
 /** Per-test override for the synthetic Slack `ts` returned by deliverChannelReply. */
 let nextDeliveryTs: string | null = null;
+/** Per-segment ts values, consumed in order before `nextDeliveryTs`. */
+const deliveryTsQueue: string[] = [];
 
 type RenderedHistoryStub = {
   text: string;
@@ -91,12 +93,12 @@ mock.module("../runtime/gateway-client.js", () => ({
       throw new Error("Simulated delivery failure (502)");
     }
     deliveryCalls.push({ callbackUrl, payload });
+    const queued = deliveryTsQueue.shift();
+    if (queued !== undefined) {
+      return { ok: true, ts: queued };
+    }
     if (nextDeliveryTs !== null) {
-      const ts = nextDeliveryTs;
-      // Only the first segment of a multi-segment delivery should carry
-      // back a meaningful ts for `channelTs` reconciliation. Tests that
-      // need specific ts values per-segment can re-set this between calls.
-      return { ok: true, ts };
+      return { ok: true, ts: nextDeliveryTs };
     }
     return { ok: true };
   },
@@ -191,9 +193,13 @@ mock.module("../persistence/conversation-crud.js", () => ({
 // The reconciler writes the outbound-posts index through delivery-crud;
 // stub it so this suite stays DB-free while capturing the writes.
 const recordedOutboundPosts: Array<Record<string, string>> = [];
+/** Runs after each index write: a seam to observe or interleave a deletion before the envelope stamp. */
+let onRecordOutboundPost: ((post: Record<string, string>) => void) | null =
+  null;
 mock.module("../persistence/delivery-crud.js", () => ({
   recordOutboundPost: (post: Record<string, string>) => {
     recordedOutboundPosts.push(post);
+    onRecordOutboundPost?.(post);
   },
 }));
 
@@ -238,6 +244,9 @@ describe("channel-reply-delivery", () => {
     updateMessageMetadataCalls.length = 0;
     metadataWriteFailuresRemaining = 0;
     nextDeliveryTs = null;
+    deliveryTsQueue.length = 0;
+    recordedOutboundPosts.length = 0;
+    onRecordOutboundPost = null;
     renderedHistoryContentQueue.length = 0;
     renderedHistoryContentByContent.clear();
     renderedHistoryContent = {
@@ -1227,24 +1236,24 @@ describe("channel-reply-delivery", () => {
   // reconciliation every outbound assistant row falls through to the
   // legacy/flat fallback and is excluded from thread-tag rendering and the
   // active-thread focus block.
-  describe("slackMeta.channelTs reconciliation", () => {
-    /** Build the outer envelope mirroring `handleMessageComplete`'s write. */
-    function partialSlackEnvelope(
-      channelId: string,
-      threadTs?: string,
-    ): string {
-      // Note: this matches the partial write — channelTs is intentionally
-      // absent so `readSlackMetadata` returns null until reconciliation runs.
-      const inner: Record<string, unknown> = {
-        source: "slack",
-        eventKind: "message",
-        channelId,
-        ...(threadTs ? { threadTs } : {}),
-      };
+  describe("sent-message-id reconciliation", () => {
+    /**
+     * Build the outer envelope mirroring `buildAssistantChannelMetadata`'s
+     * write for a Slack reply: the neutral envelope, Slack's own fields on
+     * its passthrough, and no `messageId` yet, since the row is written
+     * before the post.
+     */
+    function partialEnvelope(channelId: string, threadId?: string): string {
       return JSON.stringify({
         userMessageChannel: "slack",
         assistantMessageChannel: "slack",
-        slackMeta: JSON.stringify(inner),
+        providerMeta: JSON.stringify({
+          source: "slack",
+          conversationExternalId: channelId,
+          eventKind: "message",
+          ...(threadId ? { threadId } : {}),
+          timestampTimezone: "America/New_York",
+        }),
       });
     }
 
@@ -1252,15 +1261,15 @@ describe("channel-reply-delivery", () => {
       conversationId: string,
       messageId: string,
       channelId: string,
-      threadTs?: string,
+      threadId?: string,
     ): void {
       conversationMessages.push({
         id: messageId,
         role: "assistant",
         content: '[{"type":"text","text":"hello"}]',
-        metadata: partialSlackEnvelope(channelId, threadTs),
+        metadata: partialEnvelope(channelId, threadId),
       });
-      // Set up renderer to produce one segment so onMessageTs fires once.
+      // One segment, so onMessageTs fires once.
       renderedHistoryContent = {
         text: "hello",
         textSegments: ["hello"],
@@ -1272,7 +1281,25 @@ describe("channel-reply-delivery", () => {
       };
     }
 
-    it("writes channelTs into slackMeta from the gateway-returned ts (top-level reply)", async () => {
+    function twoSegments(): void {
+      renderedHistoryContent = {
+        text: "AlphaBeta",
+        textSegments: ["Alpha", "Beta"],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0", "tool:0", "text:1"],
+        surfaces: [],
+        thinkingSegments: [],
+      };
+    }
+
+    function envelopeOf(messageId: string): Record<string, unknown> {
+      const row = conversationMessages.find((m) => m.id === messageId);
+      const outer = JSON.parse(row?.metadata ?? "{}") as Record<string, string>;
+      return JSON.parse(outer.providerMeta) as Record<string, unknown>;
+    }
+
+    it("writes the gateway-returned ts as the row's messageId (top-level reply)", async () => {
       pushPartialAssistantRow("conv-recon-top", "msg-recon-top", "C123");
       nextDeliveryTs = "1700000123.000456";
 
@@ -1284,19 +1311,25 @@ describe("channel-reply-delivery", () => {
       );
 
       expect(updateMessageMetadataCalls.length).toBe(1);
-      const call = updateMessageMetadataCalls[0];
-      expect(call.messageId).toBe("msg-recon-top");
-      const merged = call.updates.slackMeta as string;
-      expect(typeof merged).toBe("string");
-      const parsed = JSON.parse(merged) as Record<string, unknown>;
-      expect(parsed.source).toBe("slack");
-      expect(parsed.channelId).toBe("C123");
-      expect(parsed.eventKind).toBe("message");
-      expect(parsed.channelTs).toBe("1700000123.000456");
-      expect(parsed.threadTs).toBeUndefined();
+      expect(updateMessageMetadataCalls[0].messageId).toBe("msg-recon-top");
+      const envelope = envelopeOf("msg-recon-top");
+      expect(envelope.source).toBe("slack");
+      expect(envelope.conversationExternalId).toBe("C123");
+      expect(envelope.eventKind).toBe("message");
+      expect(envelope.messageId).toBe("1700000123.000456");
+      expect(envelope.threadId).toBeUndefined();
+      // Slack's own field survived the stamp.
+      expect(envelope.timestampTimezone).toBe("America/New_York");
+      expect(recordedOutboundPosts).toHaveLength(1);
+      expect(recordedOutboundPosts[0]).toMatchObject({
+        sourceChannel: "slack",
+        externalChatId: "C123",
+        providerMessageId: "1700000123.000456",
+        messageId: "msg-recon-top",
+      });
     });
 
-    it("preserves an existing threadTs when reconciling channelTs (threaded reply)", async () => {
+    it("preserves an existing threadId when stamping the id (threaded reply)", async () => {
       pushPartialAssistantRow(
         "conv-recon-thread",
         "msg-recon-thread",
@@ -1312,16 +1345,14 @@ describe("channel-reply-delivery", () => {
         "assistant-recon-thread",
       );
 
-      expect(updateMessageMetadataCalls.length).toBe(1);
-      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
-      const parsed = JSON.parse(merged) as Record<string, unknown>;
-      expect(parsed.threadTs).toBe("1234.5678");
-      expect(parsed.channelTs).toBe("1700000200.000700");
+      const envelope = envelopeOf("msg-recon-thread");
+      expect(envelope.threadId).toBe("1234.5678");
+      expect(envelope.messageId).toBe("1700000200.000700");
     });
 
-    it("does NOT call updateMessageMetadata when the assistant row has no slackMeta", async () => {
-      // vellum/telegram/non-slack outbound: the row's metadata envelope has
-      // no slackMeta sub-key. The reconciler must short-circuit silently.
+    it("does NOT call updateMessageMetadata when the assistant row has no envelope", async () => {
+      // vellum outbound: the row's metadata carries no provider envelope.
+      // The reconciler must short-circuit silently.
       conversationMessages.push({
         id: "msg-vellum",
         role: "assistant",
@@ -1350,17 +1381,12 @@ describe("channel-reply-delivery", () => {
       );
 
       expect(updateMessageMetadataCalls.length).toBe(0);
+      expect(recordedOutboundPosts.length).toBe(0);
     });
 
-    it("does NOT call updateMessageMetadata when slackMeta already has channelTs", async () => {
-      // Idempotency: a re-delivery (e.g. from channel-retry-sweep) must not
-      // overwrite a channelTs that is already in place.
-      const existingMeta = JSON.stringify({
-        source: "slack",
-        eventKind: "message",
-        channelId: "C789",
-        channelTs: "1699999999.000111",
-      });
+    it("does NOT write again when the row already names the ts", async () => {
+      // Idempotency: a redelivery of the same message must not write the
+      // row or the index again.
       conversationMessages.push({
         id: "msg-already",
         role: "assistant",
@@ -1368,7 +1394,12 @@ describe("channel-reply-delivery", () => {
         metadata: JSON.stringify({
           userMessageChannel: "slack",
           assistantMessageChannel: "slack",
-          slackMeta: existingMeta,
+          providerMeta: JSON.stringify({
+            source: "slack",
+            conversationExternalId: "C789",
+            eventKind: "message",
+            messageId: "1699999999.000111",
+          }),
         }),
       });
       renderedHistoryContent = {
@@ -1380,7 +1411,7 @@ describe("channel-reply-delivery", () => {
         surfaces: [],
         thinkingSegments: [],
       };
-      nextDeliveryTs = "1700000400.000999";
+      nextDeliveryTs = "1699999999.000111";
 
       await deliverReplyViaCallback(
         "conv-already",
@@ -1390,23 +1421,13 @@ describe("channel-reply-delivery", () => {
       );
 
       expect(updateMessageMetadataCalls.length).toBe(0);
+      expect(recordedOutboundPosts.length).toBe(0);
     });
 
-    it("only reconciles from the FIRST segment's ts when the reply is split", async () => {
+    it("records every segment of a split reply: the first as messageId, the rest as additional posts, all in the index", async () => {
       pushPartialAssistantRow("conv-multi", "msg-multi", "C999");
-      // Two-segment delivery: only the first segment's ts is the canonical
-      // channelTs for the persisted row. Subsequent segments correspond to
-      // independent Slack messages.
-      renderedHistoryContent = {
-        text: "AlphaBeta",
-        textSegments: ["Alpha", "Beta"],
-        toolCalls: [],
-        toolCallsBeforeText: false,
-        contentOrder: ["text:0", "tool:0", "text:1"],
-        surfaces: [],
-        thinkingSegments: [],
-      };
-      nextDeliveryTs = "1700000500.000111";
+      twoSegments();
+      deliveryTsQueue.push("1700000500.000111", "1700000500.000222");
 
       await deliverReplyViaCallback(
         "conv-multi",
@@ -1415,12 +1436,14 @@ describe("channel-reply-delivery", () => {
         "assistant-multi",
       );
 
-      // Two delivery POSTs but only one metadata write — the first ts wins.
       expect(deliveryCalls.length).toBe(2);
-      expect(updateMessageMetadataCalls.length).toBe(1);
-      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
-      const parsed = JSON.parse(merged) as Record<string, unknown>;
-      expect(parsed.channelTs).toBe("1700000500.000111");
+      expect(updateMessageMetadataCalls.length).toBe(2);
+      const envelope = envelopeOf("msg-multi");
+      expect(envelope.messageId).toBe("1700000500.000111");
+      expect(envelope.additionalMessageIds).toEqual(["1700000500.000222"]);
+      expect(
+        recordedOutboundPosts.map((post) => post.providerMessageId),
+      ).toEqual(["1700000500.000111", "1700000500.000222"]);
     });
 
     it("composes with caller-supplied onMessageTs without losing either side-effect", async () => {
@@ -1440,20 +1463,18 @@ describe("channel-reply-delivery", () => {
         },
       );
 
-      // Caller's onMessageTs still fires for the delivered segment.
       expect(callerTsSeen).toEqual(["1700000600.000222"]);
-      // And reconciliation still wrote channelTs.
-      expect(updateMessageMetadataCalls.length).toBe(1);
-      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
-      const parsed = JSON.parse(merged) as Record<string, unknown>;
-      expect(parsed.channelTs).toBe("1700000600.000222");
+      expect(envelopeOf("msg-compose").messageId).toBe("1700000600.000222");
     });
 
-    it("after reconciliation, readSlackMetadata returns a valid envelope", async () => {
-      // End-to-end: this is the assertion that the ORIGINAL gap test
-      // (`outbound-slack-persistence.test.ts:209`) was inverted on. Once
-      // reconciliation runs, readSlackMetadata must accept the merged value.
+    it("after reconciliation, the row has a Slack view the transcript renderer accepts", async () => {
+      // The Slack renderers read the neutral envelope through its Slack
+      // view; before the stamp there is none, after it there is.
       pushPartialAssistantRow("conv-readback", "msg-readback", "C222");
+      const { readSlackMetadataFromMessageMetadata } =
+        await import("../messaging/providers/slack/message-metadata.js");
+      const before = conversationMessages.find((m) => m.id === "msg-readback");
+      expect(readSlackMetadataFromMessageMetadata(before?.metadata)).toBeNull();
       nextDeliveryTs = "1700000700.000333";
 
       await deliverReplyViaCallback(
@@ -1463,22 +1484,18 @@ describe("channel-reply-delivery", () => {
         "assistant-readback",
       );
 
-      expect(updateMessageMetadataCalls.length).toBe(1);
-      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
-      // Imported here so the production read path (the same one the renderer
-      // uses) is what actually validates the merged envelope.
-      const { readSlackMetadata } =
-        await import("../messaging/providers/slack/message-metadata.js");
-      const parsed = readSlackMetadata(merged);
-      expect(parsed).not.toBeNull();
-      expect(parsed?.channelTs).toBe("1700000700.000333");
-      expect(parsed?.channelId).toBe("C222");
-      expect(parsed?.source).toBe("slack");
-      expect(parsed?.eventKind).toBe("message");
+      const after = conversationMessages.find((m) => m.id === "msg-readback");
+      const view = readSlackMetadataFromMessageMetadata(after?.metadata);
+      expect(view).not.toBeNull();
+      expect(view?.channelTs).toBe("1700000700.000333");
+      expect(view?.channelId).toBe("C222");
+      expect(view?.source).toBe("slack");
+      expect(view?.eventKind).toBe("message");
+      expect(view?.timestampTimezone).toBe("America/New_York");
     });
 
     it("retries a reconciliation write that hits transient SQLite contention", async () => {
-      // The stamp is the only durable record of the post's ts: no later sweep
+      // The stamp is the only durable record of the post's id: no later sweep
       // heals a miss once the event is marked delivered, so a SQLITE_BUSY on
       // the first attempt must not lose it.
       pushPartialAssistantRow("conv-busy", "msg-busy", "C333");
@@ -1493,30 +1510,19 @@ describe("channel-reply-delivery", () => {
       );
 
       expect(updateMessageMetadataCalls.length).toBe(1);
-      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
-      const parsed = JSON.parse(merged) as Record<string, unknown>;
-      expect(parsed.channelTs).toBe("1700000800.000444");
+      expect(envelopeOf("msg-busy").messageId).toBe("1700000800.000444");
     });
 
     it("stamps from a later segment when the first segment's write is lost", async () => {
-      // The row records the first ts that reaches a DURABLE write, not the
-      // first ts observed. A first-invocation latch would forfeit channelTs
-      // forever when that write fails, which is the reconciliation gap this
-      // reproduces: the reply posts successfully and the row never gains its
-      // own id, so history projects no `slackMessage` for it.
+      // The row records the first id that reaches a DURABLE write, not the
+      // first id observed: a first-invocation latch would forfeit the id
+      // forever when that write fails, and the row would never gain an id
+      // of its own.
       pushPartialAssistantRow("conv-lost", "msg-lost", "C444");
-      renderedHistoryContent = {
-        text: "AlphaBeta",
-        textSegments: ["Alpha", "Beta"],
-        toolCalls: [],
-        toolCallsBeforeText: false,
-        contentOrder: ["text:0", "tool:0", "text:1"],
-        surfaces: [],
-        thinkingSegments: [],
-      };
-      nextDeliveryTs = "1700000900.000555";
+      twoSegments();
+      deliveryTsQueue.push("1700000900.000555", "1700000900.000556");
       // Exhaust the initial attempt plus every `withSqliteRetry` retry, so the
-      // first segment's reconciliation is genuinely swallowed.
+      // first segment's stamp is genuinely swallowed.
       metadataWriteFailuresRemaining = 4;
 
       await deliverReplyViaCallback(
@@ -1526,14 +1532,14 @@ describe("channel-reply-delivery", () => {
         "assistant-lost",
       );
 
-      // Both segments posted; the surviving write carries the second post's ts
-      // rather than leaving the row without any id of its own.
       expect(deliveryCalls.length).toBe(2);
       expect(updateMessageMetadataCalls.length).toBe(1);
-      const merged = updateMessageMetadataCalls[0].updates.slackMeta as string;
-      const { readSlackMetadata } =
-        await import("../messaging/providers/slack/message-metadata.js");
-      expect(readSlackMetadata(merged)).not.toBeNull();
+      expect(envelopeOf("msg-lost").messageId).toBe("1700000900.000556");
+      // Both posts still reached the index, which does not depend on the
+      // envelope write.
+      expect(
+        recordedOutboundPosts.map((post) => post.providerMessageId),
+      ).toEqual(["1700000900.000555", "1700000900.000556"]);
     });
 
     it("commits the reconciliation write before posting the next segment", async () => {
@@ -1541,16 +1547,14 @@ describe("channel-reply-delivery", () => {
       // boundary. Otherwise a crash between two posts of a split reply loses
       // the stamp for a message the reader can already see.
       pushPartialAssistantRow("conv-order", "msg-order", "C555");
-      renderedHistoryContent = {
-        text: "AlphaBeta",
-        textSegments: ["Alpha", "Beta"],
-        toolCalls: [],
-        toolCallsBeforeText: false,
-        contentOrder: ["text:0", "tool:0", "text:1"],
-        surfaces: [],
-        thinkingSegments: [],
+      twoSegments();
+      deliveryTsQueue.push("1700001000.000666", "1700001000.000667");
+      const seenAtSecondPost: unknown[] = [];
+      onRecordOutboundPost = (post) => {
+        if (post.providerMessageId === "1700001000.000667") {
+          seenAtSecondPost.push(envelopeOf("msg-order").messageId);
+        }
       };
-      nextDeliveryTs = "1700001000.000666";
 
       await deliverReplyViaCallback(
         "conv-order",
@@ -1559,17 +1563,84 @@ describe("channel-reply-delivery", () => {
         "assistant-order",
       );
 
-      // The row already parses through the strict reader by the time the
-      // second POST goes out, which is what makes the second segment a no-op.
-      const row = conversationMessages.find((m) => m.id === "msg-order");
-      const envelope = JSON.parse(row?.metadata ?? "{}") as Record<
-        string,
-        unknown
-      >;
-      const { readSlackMetadata } =
-        await import("../messaging/providers/slack/message-metadata.js");
-      expect(readSlackMetadata(envelope.slackMeta as string)).not.toBeNull();
-      expect(updateMessageMetadataCalls.length).toBe(1);
+      expect(seenAtSecondPost).toEqual(["1700001000.000666"]);
+    });
+
+    it("keeps a deletion that lands between the index write and the envelope stamp", async () => {
+      // Once the index names the post, a delete resolves to the row and
+      // stamps the envelope that still lacks its id. The stamp that follows
+      // must read that state, not the one it saw before the index write,
+      // and keep the row fully deleted: its only post is gone.
+      pushPartialAssistantRow("conv-window", "msg-window", "C666");
+      nextDeliveryTs = "1700001100.000777";
+      onRecordOutboundPost = () => {
+        const row = conversationMessages.find((m) => m.id === "msg-window")!;
+        const outer = JSON.parse(row.metadata!) as Record<string, string>;
+        row.metadata = JSON.stringify({
+          ...outer,
+          providerMeta: JSON.stringify({
+            ...(JSON.parse(outer.providerMeta) as Record<string, unknown>),
+            deletedMessageIds: ["1700001100.000777"],
+            deletedAt: 1700001101000,
+          }),
+        });
+      };
+
+      await deliverReplyViaCallback(
+        "conv-window",
+        "C666",
+        "http://gateway/deliver/slack",
+        "assistant-window",
+      );
+
+      const envelope = envelopeOf("msg-window");
+      expect(envelope.messageId).toBe("1700001100.000777");
+      expect(envelope.deletedMessageIds).toEqual(["1700001100.000777"]);
+      expect(envelope.deletedAt).toBe(1700001101000);
+    });
+
+    it("clears the row-level marker when a later post arrives after every known post was deleted", async () => {
+      // The first post was deleted before the second segment reconciled, so
+      // the row read as fully deleted. The second post is on the channel,
+      // so the row is not; the per-post record of the first deletion stays.
+      conversationMessages.push({
+        id: "msg-revive",
+        role: "assistant",
+        content: '[{"type":"text","text":"hello"}]',
+        metadata: JSON.stringify({
+          assistantMessageChannel: "slack",
+          providerMeta: JSON.stringify({
+            source: "slack",
+            conversationExternalId: "C777",
+            eventKind: "message",
+            messageId: "1700001200.000100",
+            deletedMessageIds: ["1700001200.000100"],
+            deletedAt: 1700001201000,
+          }),
+        }),
+      });
+      renderedHistoryContent = {
+        text: "second",
+        textSegments: ["second"],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0"],
+        surfaces: [],
+        thinkingSegments: [],
+      };
+      nextDeliveryTs = "1700001200.000200";
+
+      await deliverReplyViaCallback(
+        "conv-revive",
+        "C777",
+        "http://gateway/deliver/slack",
+        "assistant-revive",
+      );
+
+      const envelope = envelopeOf("msg-revive");
+      expect(envelope.additionalMessageIds).toEqual(["1700001200.000200"]);
+      expect(envelope.deletedMessageIds).toEqual(["1700001200.000100"]);
+      expect(envelope.deletedAt).toBeUndefined();
     });
   });
 });

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -1424,6 +1424,118 @@ describe("channel-reply-delivery", () => {
       expect(recordedOutboundPosts.length).toBe(0);
     });
 
+    it("stamps a reply reserved with Slack's pre-send envelope and converges it onto the neutral one", async () => {
+      // Transitional: such a row is pending for the retry sweep only when a
+      // daemon that reserved Slack replies under `slackMeta` left it there.
+      conversationMessages.push({
+        id: "msg-presend-slack",
+        role: "assistant",
+        content: '[{"type":"text","text":"hello"}]',
+        metadata: JSON.stringify({
+          userMessageChannel: "slack",
+          assistantMessageChannel: "slack",
+          slackMeta: JSON.stringify({
+            source: "slack",
+            eventKind: "message",
+            channelId: "C321",
+            threadTs: "1700000000.000001",
+            timestampTimezone: "America/New_York",
+            timestampTimezoneLabel: "EST",
+          }),
+        }),
+      });
+      renderedHistoryContent = {
+        text: "hello",
+        textSegments: ["hello"],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0"],
+        surfaces: [],
+        thinkingSegments: [],
+      };
+      nextDeliveryTs = "1700000321.000111";
+
+      await deliverReplyViaCallback(
+        "conv-presend",
+        "C321",
+        "http://gateway/deliver/slack",
+        "assistant-presend",
+      );
+
+      expect(recordedOutboundPosts).toHaveLength(1);
+      expect(recordedOutboundPosts[0]).toMatchObject({
+        sourceChannel: "slack",
+        externalChatId: "C321",
+        providerMessageId: "1700000321.000111",
+        messageId: "msg-presend-slack",
+      });
+      const row = conversationMessages.find(
+        (m) => m.id === "msg-presend-slack",
+      );
+      const outer = JSON.parse(row?.metadata ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      // One envelope per row: the pre-send Slack one is gone, the turn's
+      // other keys survive.
+      expect(outer.slackMeta).toBeUndefined();
+      expect(outer.userMessageChannel).toBe("slack");
+      expect(envelopeOf("msg-presend-slack")).toEqual({
+        source: "slack",
+        conversationExternalId: "C321",
+        eventKind: "message",
+        threadId: "1700000000.000001",
+        messageId: "1700000321.000111",
+        timestampTimezone: "America/New_York",
+        timestampTimezoneLabel: "EST",
+      });
+      const { readSlackMetadataFromMessageMetadata } =
+        await import("../messaging/providers/slack/message-metadata.js");
+      expect(readSlackMetadataFromMessageMetadata(row?.metadata)).toMatchObject(
+        {
+          channelTs: "1700000321.000111",
+          threadTs: "1700000000.000001",
+          timestampTimezoneLabel: "EST",
+        },
+      );
+    });
+
+    it("leaves a Slack reply that already names its post under slackMeta alone", async () => {
+      conversationMessages.push({
+        id: "msg-slack-complete",
+        role: "assistant",
+        content: '[{"type":"text","text":"hello"}]',
+        metadata: JSON.stringify({
+          slackMeta: JSON.stringify({
+            source: "slack",
+            eventKind: "message",
+            channelId: "C321",
+            channelTs: "1700000100.000001",
+          }),
+        }),
+      });
+      renderedHistoryContent = {
+        text: "hello",
+        textSegments: ["hello"],
+        toolCalls: [],
+        toolCallsBeforeText: false,
+        contentOrder: ["text:0"],
+        surfaces: [],
+        thinkingSegments: [],
+      };
+      nextDeliveryTs = "1700000321.000222";
+
+      await deliverReplyViaCallback(
+        "conv-complete",
+        "C321",
+        "http://gateway/deliver/slack",
+        "assistant-complete",
+      );
+
+      expect(updateMessageMetadataCalls.length).toBe(0);
+      expect(recordedOutboundPosts.length).toBe(0);
+    });
+
     it("records every segment of a split reply: the first as messageId, the rest as additional posts, all in the index", async () => {
       pushPartialAssistantRow("conv-multi", "msg-multi", "C999");
       twoSegments();

--- a/assistant/src/__tests__/conversation-runtime-assembly.test.ts
+++ b/assistant/src/__tests__/conversation-runtime-assembly.test.ts
@@ -6031,6 +6031,63 @@ describe("assembleSlackChronologicalMessages", () => {
     expect(replyText).not.toContain("→ M");
   });
 
+  test("post-reconciliation: an assistant row on the neutral envelope renders chronologically too", () => {
+    // A Slack reply row is written with the neutral envelope every channel
+    // writes; the chronological assembler reads it through the envelope's
+    // Slack view, so it takes the same path as a legacy `slackMeta` row.
+    const SLACK_CHANNEL_ID_2 = "C0THREAD";
+    const ASSISTANT_TS = "1700001000.000111";
+    const REPLY_TS = "1700001020.000222";
+    const SLACK_CAPS_CHANNEL: ChannelCapabilities = {
+      channel: "slack",
+      dashboardCapable: false,
+      supportsDynamicUi: false,
+      supportsVoiceInput: false,
+      chatType: "channel",
+    };
+    const userReplyMeta: SlackMessageMetadata = {
+      source: "slack",
+      channelId: SLACK_CHANNEL_ID_2,
+      channelTs: REPLY_TS,
+      threadTs: ASSISTANT_TS,
+      displayName: "@alice",
+      eventKind: "message",
+    };
+    const rows: SlackTranscriptInputRow[] = [
+      row(
+        "assistant",
+        "Earlier reply",
+        1700001000_000,
+        JSON.stringify({
+          userMessageChannel: "slack",
+          assistantMessageChannel: "slack",
+          providerMeta: JSON.stringify({
+            source: "slack",
+            conversationExternalId: SLACK_CHANNEL_ID_2,
+            messageId: ASSISTANT_TS,
+            eventKind: "message",
+          }),
+        }),
+      ),
+      row(
+        "user",
+        "Following up",
+        1700001020_000,
+        metadataEnvelope(userReplyMeta),
+      ),
+    ];
+
+    const result = assembleSlackChronologicalMessages(rows, SLACK_CAPS_CHANNEL);
+    expect(result).not.toBeNull();
+    expect(result!.length).toBe(2);
+    const assistantText = (result![0].content[0] as { text: string }).text;
+    expect(assistantText).toContain("Earlier reply");
+    const replyText = (result![1].content[0] as { text: string }).text;
+    expect(replyText).toBe(
+      `[11/14/23 22:30 @alice]: ${slackExternal("Following up", "@alice")}`,
+    );
+  });
+
   test("post-reconciliation: assistant row appears in active-thread focus block", () => {
     // The active-thread focus block at
     // `conversation-runtime-assembly.ts:1387` filters out rows with null

--- a/assistant/src/__tests__/delete-propagation.test.ts
+++ b/assistant/src/__tests__/delete-propagation.test.ts
@@ -20,6 +20,7 @@ import { eq } from "drizzle-orm";
 
 import {
   readSlackMetadata,
+  readSlackMetadataFromMessageMetadata,
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import { getDb } from "../persistence/db-connection.js";
@@ -689,6 +690,82 @@ describe("Slack delete propagation", () => {
     expect(slackMeta!.deletedAt).toBeDefined();
     expect(slackMeta!.channelTs).toBe(postTs);
     expect(readProviderMetadata(row!.metadata)!.deletedAt).toBeDefined();
+  });
+
+  test("deleting the assistant's own Slack post stamps its neutral envelope per post", async () => {
+    // A Slack reply row carries the neutral envelope every channel writes,
+    // so its deletion takes the same per-post path as any channel's: the
+    // gateway forwards the delete unattributed (Slack names the author,
+    // never the deleter), the row resolves through the id its envelope
+    // names, and the Slack renderers read the stamp through the Slack view.
+    const chatId = "C0123CHANNEL";
+    const postTs = "1725100000.000900";
+    const minted = recordInbound("slack", chatId, "evt-earlier-user-msg");
+    const messageId = "assistant-slack-reply-1";
+    getDb()
+      .insert(messages)
+      .values({
+        id: messageId,
+        conversationId: minted.conversationId,
+        role: "assistant",
+        content: "The reply that was later deleted from the thread",
+        metadata: JSON.stringify({
+          assistantMessageChannel: "slack",
+          providerMeta: JSON.stringify({
+            source: "slack",
+            conversationExternalId: chatId,
+            messageId: postTs,
+            threadId: "1725100000.000100",
+            eventKind: "message",
+            timestampTimezone: "America/New_York",
+          }),
+        }),
+        createdAt: Date.now(),
+      })
+      .run();
+
+    const req = new Request("http://localhost:8080/channels/inbound", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Gateway-Origin": TEST_BEARER_TOKEN,
+      },
+      body: JSON.stringify({
+        sourceChannel: "slack",
+        interface: "slack",
+        conversationExternalId: chatId,
+        externalMessageId: "evt-del-own-post",
+        eventKind: "delete",
+        content: "",
+        actorExternalId: "slack-system",
+        sourceMetadata: {
+          messageId: postTs,
+          threadId: "1725100000.000100",
+          actorUnattributed: true,
+        },
+      }),
+    });
+    const resp = await handleChannelInbound(req, undefined, TEST_BEARER_TOKEN);
+    const json = (await resp.json()) as Record<string, unknown>;
+    expect(json.accepted).toBe(true);
+    expect(json.deleted).toBe(true);
+    expect(json.messageId).toBe(messageId);
+
+    const row = getDb()
+      .select()
+      .from(messages)
+      .where(eq(messages.id, messageId))
+      .get();
+    expect(row!.content).toBe(
+      "The reply that was later deleted from the thread",
+    );
+    const neutral = readProviderMetadata(row!.metadata);
+    expect(neutral!.deletedMessageIds).toEqual([postTs]);
+    expect(neutral!.deletedAt).toBeDefined();
+    const view = readSlackMetadataFromMessageMetadata(row!.metadata);
+    expect(view!.channelTs).toBe(postTs);
+    expect(view!.deletedAt).toBe(neutral!.deletedAt);
+    expect(view!.timestampTimezone).toBe("America/New_York");
   });
 
   test("delete for unknown ts is a no-op", async () => {

--- a/assistant/src/__tests__/list-messages-page-latest.test.ts
+++ b/assistant/src/__tests__/list-messages-page-latest.test.ts
@@ -527,6 +527,48 @@ describe("handleListMessages page=latest", () => {
     expect(body.messages[0].slackMessage).toBeUndefined();
   });
 
+  test("a reconciled assistant row on the neutral envelope projects the same slackMessage", async () => {
+    // The row a Slack reply is written with today: the neutral envelope,
+    // Slack's own fields on its passthrough, `messageId` back-filled by the
+    // post-send reconciliation. The wire projection reads it through the
+    // envelope's Slack view, so the client sees exactly what a legacy
+    // `slackMeta` row projects.
+    const conv = createConversation();
+    const db = getDb();
+    db.insert(messages)
+      .values({
+        id: "msg-slack-neutral",
+        conversationId: conv.id,
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Posted to Slack" }]),
+        metadata: JSON.stringify({
+          userMessageChannel: "slack",
+          assistantMessageChannel: "slack",
+          providerMeta: JSON.stringify({
+            source: "slack",
+            conversationExternalId: "C123ABCDEF",
+            messageId: "1710000000.000200",
+            threadId: "1710000000.000100",
+            eventKind: "message",
+            timestampTimezone: "America/New_York",
+            timestampTimezoneLabel: "ET",
+          }),
+        }),
+        createdAt: 1,
+      })
+      .run();
+
+    const body = await callList({ conversationId: conv.id, page: "latest" });
+
+    const slackMessage = body.messages[0].slackMessage;
+    expect(slackMessage).toBeDefined();
+    expect(slackMessage?.channelId).toBe("C123ABCDEF");
+    expect(slackMessage?.channelTs).toBe("1710000000.000200");
+    expect(slackMessage?.threadTs).toBe("1710000000.000100");
+    expect(slackMessage?.eventKind).toBe("message");
+    expect(slackMessage?.messageLink).toBeDefined();
+  });
+
   test("the reconciled assistant row projects slackMessage with the post's own ts", async () => {
     // The other half of the same chain: once reconciliation stamps the ts the
     // transport returned, the identical row projects a full envelope. Built by

--- a/assistant/src/__tests__/outbound-slack-persistence.test.ts
+++ b/assistant/src/__tests__/outbound-slack-persistence.test.ts
@@ -183,7 +183,7 @@ import {
   handleLlmCallStarted,
   handleMessageComplete,
 } from "../daemon/conversation-agent-loop-handlers.js";
-import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
+import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { deliverReplyViaCallback } from "../runtime/channel-reply-delivery.js";
 import { setConfig } from "./helpers/set-config.js";
 
@@ -284,13 +284,14 @@ describe("outbound assistant Slack metadata persistence", () => {
     nextDeliveryTs = null;
   });
 
-  test("stamps slackMeta with threadTs from the turn's inbound thread id", async () => {
+  test("stamps the neutral envelope with the turn's inbound thread id", async () => {
     const conversationId = "conv-slack-threaded";
     const channelId = "C123CHANNEL";
 
-    // The turn arrived in a thread — its inbound thread ts is captured on the
+    // The turn arrived in a thread: its inbound thread ts is captured on the
     // trust context (`sourceThreadId`) at ingress, and the reply is stamped
-    // from that turn-local value.
+    // from that turn-local value. A Slack reply row writes the same neutral
+    // envelope every channel writes; Slack's own fields ride its passthrough.
     const deps = makeDeps(conversationId, {
       assistantMessageChannel: "slack",
       requesterChatId: channelId,
@@ -300,27 +301,29 @@ describe("outbound assistant Slack metadata persistence", () => {
     await handleMessageComplete(state, deps, makeMessageCompleteEvent("hi"));
 
     const persisted = lastAssistantPersisted();
-    const slackMetaRaw = persisted.metadata?.slackMeta;
-    expect(typeof slackMetaRaw).toBe("string");
+    expect(persisted.metadata?.slackMeta).toBeUndefined();
+    const providerMetaRaw = persisted.metadata?.providerMeta;
+    expect(typeof providerMetaRaw).toBe("string");
 
-    const slackMeta = JSON.parse(slackMetaRaw as string) as Record<
+    const providerMeta = JSON.parse(providerMetaRaw as string) as Record<
       string,
       unknown
     >;
-    expect(slackMeta.source).toBe("slack");
-    expect(slackMeta.eventKind).toBe("message");
-    expect(slackMeta.channelId).toBe(channelId);
-    expect(slackMeta.threadTs).toBe("1234.5678");
+    expect(providerMeta.source).toBe("slack");
+    expect(providerMeta.eventKind).toBe("message");
+    expect(providerMeta.conversationExternalId).toBe(channelId);
+    expect(providerMeta.threadId).toBe("1234.5678");
 
     // Persistence runs BEFORE the Slack adapter posts the message, so the
-    // authoritative `ts` (-> `channelTs`) is not yet known at this layer.
-    // The post-send reconciliation in `deliverReplyViaCallback` fills the
-    // field once the gateway returns the Slack-assigned ts (covered by
-    // `channel-reply-delivery.test.ts`). Until that runs, the partial
-    // metadata is intentionally rejected by `readSlackMetadata` so callers
-    // that try to use it before reconciliation get a clear null.
-    expect(slackMeta.channelTs).toBeUndefined();
-    expect(readSlackMetadata(slackMetaRaw as string)).toBeNull();
+    // authoritative ts (the envelope's `messageId`) is not yet known at this
+    // layer. The post-send reconciliation in `deliverReplyViaCallback` fills
+    // it once the gateway returns the Slack-assigned ts (covered by
+    // `channel-reply-delivery.test.ts`). Until then the row has no Slack
+    // view, so a Slack reader gets a clear null rather than a half row.
+    expect(providerMeta.messageId).toBeUndefined();
+    expect(
+      readSlackMetadataFromMessageMetadata(JSON.stringify(persisted.metadata)),
+    ).toBeNull();
   });
 
   test("stamps assistant Slack rows with effective timestamp timezone and no speaker suffix", async () => {
@@ -343,16 +346,12 @@ describe("outbound assistant Slack metadata persistence", () => {
     );
 
     const persisted = lastAssistantPersisted();
-    const slackMetaRaw = persisted.metadata?.slackMeta;
-    expect(typeof slackMetaRaw).toBe("string");
-
-    const slackMeta = JSON.parse(slackMetaRaw as string) as Record<
-      string,
-      unknown
-    >;
-    expect(slackMeta.timestampTimezone).toBe("America/Denver");
-    expect(slackMeta.timestampTimezoneLabel).toBe("MT");
-    expect(slackMeta.speakerTimezoneLabel).toBeUndefined();
+    const providerMeta = JSON.parse(
+      persisted.metadata?.providerMeta as string,
+    ) as Record<string, unknown>;
+    expect(providerMeta.timestampTimezone).toBe("America/Denver");
+    expect(providerMeta.timestampTimezoneLabel).toBe("MT");
+    expect(providerMeta.speakerTimezoneLabel).toBeUndefined();
   });
 
   test("falls back to the turn client timezone when no configured user timezone is set", async () => {
@@ -372,14 +371,14 @@ describe("outbound assistant Slack metadata persistence", () => {
     );
 
     const persisted = lastAssistantPersisted();
-    const slackMeta = JSON.parse(
-      persisted.metadata?.slackMeta as string,
+    const providerMeta = JSON.parse(
+      persisted.metadata?.providerMeta as string,
     ) as Record<string, unknown>;
-    expect(slackMeta.timestampTimezone).toBe("America/Los_Angeles");
-    expect(slackMeta.timestampTimezoneLabel).toBe("PT");
+    expect(providerMeta.timestampTimezone).toBe("America/Los_Angeles");
+    expect(providerMeta.timestampTimezoneLabel).toBe("PT");
   });
 
-  test("post-send reconciliation preserves assistant Slack timezone metadata", async () => {
+  test("post-send reconciliation gives the row its Slack view, timezone fields intact", async () => {
     setConfig("ui", { userTimezone: "America/Denver" });
     const conversationId = "conv-slack-reconcile-timezone";
     const channelId = "C999RECONCILE";
@@ -397,9 +396,9 @@ describe("outbound assistant Slack metadata persistence", () => {
     );
 
     const persisted = lastAssistantPersisted();
-    const beforeRaw = persisted.metadata?.slackMeta;
-    expect(typeof beforeRaw).toBe("string");
-    expect(readSlackMetadata(beforeRaw as string)).toBeNull();
+    expect(
+      readSlackMetadataFromMessageMetadata(JSON.stringify(persisted.metadata)),
+    ).toBeNull();
 
     nextDeliveryTs = "1772678280.000200";
     await deliverReplyViaCallback(
@@ -414,19 +413,28 @@ describe("outbound assistant Slack metadata persistence", () => {
       (candidate) => candidate.id === persisted.id,
     );
     expect(typeof row?.metadata).toBe("string");
-    const envelope = JSON.parse(row!.metadata!) as Record<string, unknown>;
-    const reconciled = readSlackMetadata(envelope.slackMeta as string);
-    expect(reconciled).not.toBeNull();
-    expect(reconciled!.channelTs).toBe("1772678280.000200");
-    expect(reconciled!.timestampTimezone).toBe("America/Denver");
-    expect(reconciled!.timestampTimezoneLabel).toBe("MT");
-    expect(reconciled!.speakerTimezoneLabel).toBeUndefined();
+    // The Slack renderers read the reconciled row through its Slack view.
+    const view = readSlackMetadataFromMessageMetadata(row!.metadata!);
+    expect(view).not.toBeNull();
+    expect(view!.channelId).toBe(channelId);
+    expect(view!.channelTs).toBe("1772678280.000200");
+    expect(view!.timestampTimezone).toBe("America/Denver");
+    expect(view!.timestampTimezoneLabel).toBe("MT");
+    expect(view!.speakerTimezoneLabel).toBeUndefined();
+    // And the post is in the outbound index, exactly as any channel's is.
+    expect(recordedOutboundPosts).toContainEqual({
+      sourceChannel: "slack",
+      externalChatId: channelId,
+      providerMessageId: "1772678280.000200",
+      messageId: persisted.id,
+      conversationId,
+    });
   });
 
-  test("stamps slackMeta WITHOUT threadTs for top-level Slack replies", async () => {
+  test("stamps no threadId for top-level Slack replies", async () => {
     const conversationId = "conv-slack-toplevel";
     const channelId = "C456NOTHREAD";
-    // The turn arrived at the channel root — no `sourceThreadId` on the trust
+    // The turn arrived at the channel root: no `sourceThreadId` on the trust
     // context, so the reply targets the channel root, not a thread.
 
     const deps = makeDeps(conversationId, {
@@ -437,20 +445,14 @@ describe("outbound assistant Slack metadata persistence", () => {
     await handleMessageComplete(state, deps, makeMessageCompleteEvent("hello"));
 
     const persisted = lastAssistantPersisted();
-    const slackMetaRaw = persisted.metadata?.slackMeta;
-    expect(typeof slackMetaRaw).toBe("string");
-
-    const slackMeta = JSON.parse(slackMetaRaw as string) as Record<
-      string,
-      unknown
-    >;
-    expect(slackMeta.source).toBe("slack");
-    expect(slackMeta.eventKind).toBe("message");
-    expect(slackMeta.channelId).toBe(channelId);
-    // threadTs is intentionally absent — top-level reply.
-    expect(slackMeta.threadTs).toBeUndefined();
-    // channelTs is still absent for the same persistence-vs-send reason.
-    expect(slackMeta.channelTs).toBeUndefined();
+    const providerMeta = JSON.parse(
+      persisted.metadata?.providerMeta as string,
+    ) as Record<string, unknown>;
+    expect(providerMeta.source).toBe("slack");
+    expect(providerMeta.eventKind).toBe("message");
+    expect(providerMeta.conversationExternalId).toBe(channelId);
+    expect(providerMeta.threadId).toBeUndefined();
+    expect(providerMeta.messageId).toBeUndefined();
   });
 
   test("envelope resolves from the turn's actor when the slot has moved", async () => {
@@ -479,17 +481,17 @@ describe("outbound assistant Slack metadata persistence", () => {
 
     const persisted = lastAssistantPersisted();
     expect(persisted.metadata?.provenanceTrustClass).toBe("trusted_contact");
-    const slackMeta = JSON.parse(
-      persisted.metadata?.slackMeta as string,
+    const providerMeta = JSON.parse(
+      persisted.metadata?.providerMeta as string,
     ) as Record<string, unknown>;
-    expect(slackMeta.channelId).toBe("C-CONTACT");
-    expect(slackMeta.threadTs).toBe("1723300000.000100");
+    expect(providerMeta.conversationExternalId).toBe("C-CONTACT");
+    expect(providerMeta.threadId).toBe("1723300000.000100");
   });
 
   test("ignores a non-ts sourceThreadId", async () => {
     const conversationId = "conv-slack-bad-thread";
     const channelId = "C789BAD";
-    // A malformed thread id must not be stamped as a threadTs (isSlackTs guard).
+    // A malformed thread id must not be stamped as a thread (isSlackTs guard).
     const deps = makeDeps(conversationId, {
       assistantMessageChannel: "slack",
       requesterChatId: channelId,
@@ -503,13 +505,10 @@ describe("outbound assistant Slack metadata persistence", () => {
     );
 
     const persisted = lastAssistantPersisted();
-    const slackMetaRaw = persisted.metadata?.slackMeta;
-    expect(typeof slackMetaRaw).toBe("string");
-    const slackMeta = JSON.parse(slackMetaRaw as string) as Record<
-      string,
-      unknown
-    >;
-    expect(slackMeta.threadTs).toBeUndefined();
+    const providerMeta = JSON.parse(
+      persisted.metadata?.providerMeta as string,
+    ) as Record<string, unknown>;
+    expect(providerMeta.threadId).toBeUndefined();
   });
 
   test("does NOT stamp slackMeta on non-Slack outbound assistant messages", async () => {

--- a/assistant/src/__tests__/thread-backfill.test.ts
+++ b/assistant/src/__tests__/thread-backfill.test.ts
@@ -104,6 +104,7 @@ import * as slackBackfill from "../messaging/providers/slack/backfill.js";
 import {
   buildSlackTimezoneMetadata,
   readSlackMetadata,
+  readSlackMetadataFromMessageMetadata,
   writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import type { MessageRow } from "../persistence/conversation-crud.js";
@@ -360,12 +361,13 @@ function readPersistedSlackRows(conversationId: string): PersistedRow[] {
       out.push(blank);
       continue;
     }
-    const slackMetaRaw = envelope.slackMeta;
-    if (typeof slackMetaRaw !== "string") {
+    // Either envelope: a person's row still writes `slackMeta`, a
+    // bot-authored row the neutral envelope with Slack's fields riding it.
+    const slackMeta = readSlackMetadataFromMessageMetadata(row.metadata);
+    if (slackMeta === null) {
       out.push(blank);
       continue;
     }
-    const slackMeta = readSlackMetadata(slackMetaRaw);
     out.push({
       role: row.role,
       content: unwrapExternalContent(row.content),

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -26,8 +26,6 @@ import type { ProviderMessageMetadata } from "../messaging/provider-message-meta
 import {
   formatSlackTimezoneLabel,
   isSlackTs,
-  type SlackMessageMetadata,
-  writeSlackMetadata,
 } from "../messaging/providers/slack/message-metadata.js";
 import {
   recordCompactionEndBestEffort,
@@ -1345,9 +1343,9 @@ function resolveAssistantReplyTimestampTimezone(ctx: Conversation): string {
  * snapshot that handleMessageComplete used to compute at end-of-turn. All
  * inputs (channel context, trust context, turnStartedAt) are stable across
  * the LLM call, so building this once at reserve is equivalent to building
- * it at complete. Slack reply rows further stamp a `slackMeta` sub-object —
- * the `channelTs` field stays absent here and is back-filled by
- * `deliverReplyViaCallback` after the gateway returns the ts.
+ * it at complete. The envelope's `messageId` stays absent here and is
+ * back-filled by `deliverReplyViaCallback` after the transport returns the
+ * sent message's id.
  */
 function buildAssistantChannelMetadata(
   state: EventHandlerState,
@@ -1363,61 +1361,59 @@ function buildAssistantChannelMetadata(
     sentAt: state.turnStartedAt,
   };
 
-  if (deps.turnChannelContext.assistantMessageChannel === "slack") {
-    // The whole envelope resolves from one turn-local snapshot: the actor the
-    // provenance above names is the actor whose channel and thread the row
-    // routes to. Reading the live slot here instead would let a concurrent
-    // inbound repoint the reply mid-turn, and could stamp one actor's class
-    // beside another actor's routing identity.
-    const rowTrust = turnOrRestingTrust(deps.ctx);
-    const channelId = rowTrust?.requesterChatId;
-    if (channelId) {
-      // This turn's own inbound thread id (the same field guardian-approval
-      // cards read). Deliberately not the shared conversation binding: on a
-      // legacy flat→thread aliased Slack conversation a concurrent inbound
-      // can rewrite the binding's externalThreadId mid-turn.
-      const turnThreadTs = rowTrust?.sourceThreadId;
-      const threadTs = isSlackTs(turnThreadTs) ? turnThreadTs : undefined;
-      const timestampTimezone = resolveAssistantReplyTimestampTimezone(
-        deps.ctx,
-      );
-      const timestampTimezoneLabel = formatSlackTimezoneLabel(
-        timestampTimezone,
-        { nowMs: state.turnStartedAt },
-      );
-      const partialSlackMeta: Partial<SlackMessageMetadata> = {
-        source: "slack",
-        eventKind: "message",
-        channelId,
-        ...(threadTs ? { threadTs } : {}),
-        timestampTimezone,
-        ...(timestampTimezoneLabel ? { timestampTimezoneLabel } : {}),
-      };
-      // `channelTs` is filled in by the post-send reconciliation step in
-      // `deliverReplyViaCallback`; cast through the Partial to satisfy
-      // the writer's type at this pre-send boundary.
-      metadata.slackMeta = writeSlackMetadata(
-        partialSlackMeta as SlackMessageMetadata,
-      );
-    }
-  } else if (deps.turnChannelContext.assistantMessageChannel !== "vellum") {
-    // Every other channel row describes itself in the neutral envelope
-    // `readProviderMetadata` serves, the shape a plugin channel writes too.
-    // `messageId` stays absent here and is back-filled by the post-send
-    // reconciliation once the transport returns the sent message's id, which
-    // is what lets a later reaction on this row resolve back to it. No
-    // `threadId`: a value there asserts a thread exists, and the reply's
-    // routing thread is delivery state, not a fact about this row.
-    const chatId = turnOrRestingTrust(deps.ctx)?.requesterChatId;
-    if (chatId) {
-      metadata.providerMeta = JSON.stringify({
-        source: deps.turnChannelContext.assistantMessageChannel,
-        conversationExternalId: chatId,
-        eventKind: "message",
-      } satisfies ProviderMessageMetadata);
-    }
+  const channel = deps.turnChannelContext.assistantMessageChannel;
+  if (channel === "vellum") {
+    // A vellum turn is not a provider message: no envelope.
+    return metadata;
   }
-
+  // Every channel row describes itself in the neutral envelope
+  // `readProviderMetadata` serves, the shape a plugin channel writes too.
+  // `messageId` stays absent here and is back-filled by the post-send
+  // reconciliation once the transport returns the sent message's id, which
+  // is what lets a later reaction or delete on this row resolve back to it.
+  //
+  // The whole envelope resolves from one turn-local snapshot: the actor the
+  // provenance above names is the actor whose channel and thread the row
+  // routes to. Reading the live slot here instead would let a concurrent
+  // inbound repoint the reply mid-turn, and could stamp one actor's class
+  // beside another actor's routing identity.
+  const rowTrust = turnOrRestingTrust(deps.ctx);
+  const chatId = rowTrust?.requesterChatId;
+  if (!chatId) {
+    return metadata;
+  }
+  const envelope: ProviderMessageMetadata = {
+    source: channel,
+    conversationExternalId: chatId,
+    eventKind: "message",
+  };
+  if (channel === "slack") {
+    // Slack's own facts ride the schema's passthrough and come back through
+    // the envelope's Slack view (`slackViewOfProviderMetadata`). The thread
+    // is this turn's own inbound thread id (the same field guardian-approval
+    // cards read), stated because the reply is posted in it and the Slack
+    // transcript is assembled by thread. Deliberately not the shared
+    // conversation binding: on a legacy flat-to-thread aliased Slack
+    // conversation a concurrent inbound can rewrite the binding's
+    // externalThreadId mid-turn.
+    const turnThreadTs = rowTrust?.sourceThreadId;
+    const threadTs = isSlackTs(turnThreadTs) ? turnThreadTs : undefined;
+    const timestampTimezone = resolveAssistantReplyTimestampTimezone(deps.ctx);
+    const timestampTimezoneLabel = formatSlackTimezoneLabel(timestampTimezone, {
+      nowMs: state.turnStartedAt,
+    });
+    metadata.providerMeta = JSON.stringify({
+      ...envelope,
+      ...(threadTs ? { threadId: threadTs } : {}),
+      ...(timestampTimezone ? { timestampTimezone } : {}),
+      ...(timestampTimezoneLabel ? { timestampTimezoneLabel } : {}),
+    });
+    return metadata;
+  }
+  // No `threadId` on the other channels: a value there asserts a thread
+  // exists, and the reply's routing thread is delivery state, not a fact
+  // about this row.
+  metadata.providerMeta = JSON.stringify(envelope);
   return metadata;
 }
 

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -33,10 +33,7 @@ import {
   stripUserTextBlocksByPrefix,
 } from "../context/strip-injections.js";
 import { getDocumentsForConversation } from "../documents/document-store.js";
-import {
-  readSlackMetadata,
-  readSlackMetadataFromMessageMetadata,
-} from "../messaging/providers/slack/message-metadata.js";
+import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
 import {
   compareSlackTs,
   extractTagLineTexts,
@@ -76,9 +73,11 @@ import type {
 import type { ContentBlock, Message } from "../providers/types.js";
 import type { TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
+import { trustClassSchema } from "../runtime/trust-class.js";
 import type { SubagentState } from "../subagent/types.js";
 import { TERMINAL_STATUSES } from "../subagent/types.js";
 import { canonicalizeInboundIdentity } from "../util/canonicalize-identity.js";
+import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
 import { channelSupportsInlineOptions } from "./channel-ui-capability.js";
 import { findConversationOrSubagent } from "./conversation-registry.js";
@@ -1162,29 +1161,12 @@ function placeholderForBlockType(type: ContentBlock["type"]): string | null {
  *   renderer drops the redundant `@user` placeholder.
  */
 function rowToRenderable(row: SlackTranscriptInputRow): RenderableSlackMessage {
-  let slackMeta: ReturnType<typeof readSlackMetadata> = null;
-  let provenanceTrustClass: TrustClass | undefined;
-  if (row.metadata) {
-    try {
-      const outer = JSON.parse(row.metadata) as {
-        slackMeta?: unknown;
-        provenanceTrustClass?: unknown;
-      };
-      if (typeof outer.slackMeta === "string") {
-        slackMeta = readSlackMetadata(outer.slackMeta);
-      }
-      if (
-        outer.provenanceTrustClass === "guardian" ||
-        outer.provenanceTrustClass === "trusted_contact" ||
-        outer.provenanceTrustClass === "unverified_contact" ||
-        outer.provenanceTrustClass === "unknown"
-      ) {
-        provenanceTrustClass = outer.provenanceTrustClass;
-      }
-    } catch {
-      // Malformed metadata — fall through to legacy/null treatment.
-    }
-  }
+  const slackMeta = readSlackMetadataFromMessageMetadata(row.metadata);
+  const provenanceTrustClass = row.metadata
+    ? trustClassSchema.safeParse(
+        safeParseRecord(row.metadata).provenanceTrustClass,
+      ).data
+    : undefined;
 
   const isReaction = slackMeta?.eventKind === "reaction";
   let senderLabel: string | null;
@@ -2611,10 +2593,9 @@ export async function applyRuntimeInjections(
   // so the provider prefix through those messages stays byte-identical.
   // Frozen `<memory>` card blocks are untouched. With the v3 flag off no
   // spotlight blocks exist and this is a content no-op.
-  let runMessagesForAssembly = stripTailUserTextBlocksByPrefix(
-    runMessages,
-    [MEMORY_SPOTLIGHT_MATCHER],
-  );
+  let runMessagesForAssembly = stripTailUserTextBlocksByPrefix(runMessages, [
+    MEMORY_SPOTLIGHT_MATCHER,
+  ]);
 
   // v2 suppression: when `memory.v3.live` is on AND the v3 injector
   // produced a block this turn (possibly empty-text on an all-repeat turn), v3

--- a/assistant/src/daemon/reaction-record.test.ts
+++ b/assistant/src/daemon/reaction-record.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { readSlackMetadataFromMessageMetadata } from "../messaging/providers/slack/message-metadata.js";
 import type { QueuedReactionRecord } from "./reaction-record.js";
 
 let persisted: Array<{
@@ -75,24 +76,35 @@ describe("persistReactionRecords", () => {
     expect(row.metadata?.slackMeta).toBeUndefined();
   });
 
-  test("a Slack record writes the slackMeta envelope the Slack context reads", async () => {
+  test("a Slack record writes the neutral envelope, which the Slack context reads through its Slack view", async () => {
     await persistReactionRecords("conv-1", [
       record({ channel: "slack", chatId: "C1", messageId: "1700.1" }),
     ]);
     const row = persisted[0]!;
-    expect(row.metadata?.providerMeta).toBeUndefined();
-    const slackMeta = JSON.parse(String(row.metadata?.slackMeta)) as {
+    expect(row.metadata?.slackMeta).toBeUndefined();
+    const envelope = JSON.parse(String(row.metadata?.providerMeta)) as {
       source: string;
-      channelId: string;
-      channelTs: string;
+      conversationExternalId: string;
       eventKind: string;
-      reaction: { emoji: string; targetChannelTs: string; op: string };
+      reaction: { targetMessageId: string; emoji: string; op: string };
     };
-    expect(slackMeta.source).toBe("slack");
-    expect(slackMeta.channelId).toBe("C1");
-    expect(slackMeta.channelTs).toBe("1700.1");
-    expect(slackMeta.eventKind).toBe("reaction");
-    expect(slackMeta.reaction).toEqual({
+    expect(envelope.source).toBe("slack");
+    expect(envelope.conversationExternalId).toBe("C1");
+    expect(envelope.eventKind).toBe("reaction");
+    expect(envelope.reaction).toEqual({
+      targetMessageId: "1700.1",
+      emoji: "🎉",
+      op: "added",
+    });
+    // The Slack transcript's view of the same row: the reacted message's ts
+    // stands in as `channelTs`, as the Slack envelope stores it.
+    const view = readSlackMetadataFromMessageMetadata(
+      JSON.stringify(row.metadata),
+    );
+    expect(view?.channelId).toBe("C1");
+    expect(view?.channelTs).toBe("1700.1");
+    expect(view?.eventKind).toBe("reaction");
+    expect(view?.reaction).toEqual({
       emoji: "🎉",
       targetChannelTs: "1700.1",
       op: "added",

--- a/assistant/src/daemon/reaction-record.ts
+++ b/assistant/src/daemon/reaction-record.ts
@@ -16,7 +16,7 @@
  * included.
  */
 import type { ChannelId } from "../channels/types.js";
-import { buildReactionRowEnvelope } from "../messaging/reaction-envelopes.js";
+import { buildNeutralReactionMeta } from "../messaging/reaction-envelopes.js";
 import {
   addMessage,
   REACTION_MESSAGE_KIND,
@@ -54,7 +54,11 @@ export async function persistReactionRecords(
         emoji: record.emoji,
         op: record.op,
       };
-      const envelope = buildReactionRowEnvelope(facts);
+      // The assistant's own rows carry the neutral envelope on every channel;
+      // the Slack renderers read it through the envelope's Slack view.
+      const envelope = {
+        providerMeta: JSON.stringify(buildNeutralReactionMeta(facts)),
+      };
       await addMessage(conversationId, "assistant", "[reaction]", {
         metadata: {
           messageKind: REACTION_MESSAGE_KIND,

--- a/assistant/src/messaging/provider-message-metadata.ts
+++ b/assistant/src/messaging/provider-message-metadata.ts
@@ -113,6 +113,18 @@ export type ProviderMessageMetadata = z.infer<
 >;
 
 /**
+ * Whether every post a row names is among its deleted ones, which is exactly
+ * when the row-level `deletedAt` is warranted. A row naming no post is a
+ * single post by construction, so an empty list reads as fully deleted.
+ */
+export function everyPostDeleted(
+  postIds: readonly string[],
+  deletedIds: readonly string[] | undefined,
+): boolean {
+  return postIds.every((id) => deletedIds?.includes(id) === true);
+}
+
+/**
  * Parse and validate a serialized `ProviderMessageMetadata`, the counterpart of
  * `readSlackMetadata` for the neutral shape. Anything that does not parse or
  * does not validate reads as null.

--- a/assistant/src/messaging/providers/slack/message-metadata.test.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.test.ts
@@ -7,6 +7,7 @@ import {
   readSlackMetadata,
   readSlackMetadataFromMessageMetadata,
   type SlackMessageMetadata,
+  slackViewOfProviderMetadata,
   writeSlackMetadata,
 } from "./message-metadata.js";
 
@@ -392,5 +393,95 @@ describe("mergeSlackMetadata", () => {
     const parsed = readSlackMetadata(merged);
     expect(parsed?.reaction).toEqual(reactionMeta.reaction);
     expect(parsed?.displayName).toBe("Bob");
+  });
+});
+
+describe("slackViewOfProviderMetadata", () => {
+  test("maps a Slack reply row's neutral envelope onto the Slack view, extras included", () => {
+    const view = slackViewOfProviderMetadata({
+      source: "slack",
+      conversationExternalId: "C123",
+      messageId: "1700000000.000100",
+      threadId: "1700000000.000001",
+      eventKind: "message",
+      timestampTimezone: "America/New_York",
+      timestampTimezoneLabel: "ET",
+      slackFiles: [{ name: "report.pdf", mimetype: "application/pdf" }],
+      deletedAt: 1700000001000,
+    });
+    expect(view).toEqual({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      threadTs: "1700000000.000001",
+      eventKind: "message",
+      timestampTimezone: "America/New_York",
+      timestampTimezoneLabel: "ET",
+      slackFiles: [{ name: "report.pdf", mimetype: "application/pdf" }],
+      deletedAt: 1700000001000,
+    });
+  });
+
+  test("a reaction row's view stores the reacted message's ts as channelTs", () => {
+    const view = slackViewOfProviderMetadata({
+      source: "slack",
+      conversationExternalId: "C123",
+      eventKind: "reaction",
+      actorExternalId: "U1",
+      displayName: "Alice",
+      reaction: {
+        targetMessageId: "1700000000.000100",
+        emoji: "tada",
+        op: "added",
+        actorDisplayName: "Alice",
+      },
+    });
+    expect(view).toEqual({
+      source: "slack",
+      channelId: "C123",
+      channelTs: "1700000000.000100",
+      actorExternalUserId: "U1",
+      displayName: "Alice",
+      eventKind: "reaction",
+      reaction: {
+        emoji: "tada",
+        op: "added",
+        targetChannelTs: "1700000000.000100",
+        actorDisplayName: "Alice",
+      },
+    });
+  });
+
+  test("a row naming no post yet, or another channel's row, has no Slack view", () => {
+    expect(
+      slackViewOfProviderMetadata({
+        source: "slack",
+        conversationExternalId: "C123",
+        eventKind: "message",
+      }),
+    ).toBeNull();
+    expect(
+      slackViewOfProviderMetadata({
+        source: "discord",
+        conversationExternalId: "999",
+        messageId: "1",
+        eventKind: "message",
+      }),
+    ).toBeNull();
+  });
+
+  test("readSlackMetadataFromMessageMetadata serves the neutral envelope before the nested one", () => {
+    const metadata = JSON.stringify({
+      assistantMessageChannel: "slack",
+      providerMeta: JSON.stringify({
+        source: "slack",
+        conversationExternalId: "C123",
+        messageId: "1700000000.000100",
+        eventKind: "message",
+      }),
+    });
+    expect(readSlackMetadataFromMessageMetadata(metadata)?.channelTs).toBe(
+      "1700000000.000100",
+    );
   });
 });

--- a/assistant/src/messaging/providers/slack/message-metadata.test.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.test.ts
@@ -4,6 +4,7 @@ import {
   buildSlackTimezoneMetadata,
   formatSlackTimezoneLabel,
   mergeSlackMetadata,
+  providerMetadataOfPreSendSlackEnvelope,
   readSlackMetadata,
   readSlackMetadataFromMessageMetadata,
   type SlackMessageMetadata,
@@ -393,6 +394,47 @@ describe("mergeSlackMetadata", () => {
     const parsed = readSlackMetadata(merged);
     expect(parsed?.reaction).toEqual(reactionMeta.reaction);
     expect(parsed?.displayName).toBe("Bob");
+  });
+});
+
+describe("providerMetadataOfPreSendSlackEnvelope", () => {
+  test("reads a pre-send Slack envelope as the neutral shape, Slack's own fields riding along", () => {
+    expect(
+      providerMetadataOfPreSendSlackEnvelope({
+        slackMeta: JSON.stringify({
+          source: "slack",
+          eventKind: "message",
+          channelId: "C1",
+          threadTs: "1700000000.000001",
+          timestampTimezone: "America/New_York",
+        }),
+      }),
+    ).toEqual({
+      source: "slack",
+      conversationExternalId: "C1",
+      eventKind: "message",
+      threadId: "1700000000.000001",
+      timestampTimezone: "America/New_York",
+    });
+  });
+
+  test("reads as null for a reconciled row, a non-Slack envelope, and a row without slackMeta", () => {
+    expect(
+      providerMetadataOfPreSendSlackEnvelope({
+        slackMeta: JSON.stringify({
+          source: "slack",
+          eventKind: "message",
+          channelId: "C1",
+          channelTs: "1700000000.000002",
+        }),
+      }),
+    ).toBeNull();
+    expect(
+      providerMetadataOfPreSendSlackEnvelope({
+        slackMeta: JSON.stringify({ source: "telegram", channelId: "C1" }),
+      }),
+    ).toBeNull();
+    expect(providerMetadataOfPreSendSlackEnvelope({})).toBeNull();
   });
 });
 

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-import type { ProviderMessageMetadata } from "../../provider-message-metadata.js";
+import {
+  type ProviderMessageMetadata,
+  readProviderMessageMetadata,
+} from "../../provider-message-metadata.js";
 
 /**
  * Typed Slack message metadata stored flat in the `messages.metadata` column
@@ -258,6 +261,13 @@ export function readSlackMetadata(
   return result.success ? result.data : null;
 }
 
+/**
+ * Read a row's Slack view from its stored metadata, whichever envelope the
+ * row carries: the neutral `providerMeta` (every row the daemon authors, and
+ * the end state for every Slack row) or the nested `slackMeta` that inbound
+ * Slack rows still write. `allowFlatLegacy` also accepts the pre-envelope
+ * flat form.
+ */
 export function readSlackMetadataFromMessageMetadata(
   metadata: string | null | undefined,
   opts?: { allowFlatLegacy?: boolean },
@@ -279,6 +289,18 @@ export function readSlackMetadataFromMessageMetadata(
     return null;
   }
 
+  // A row the daemon authors (an assistant reply, its own reaction, a
+  // bot-authored backfill row) describes itself in the neutral envelope;
+  // its Slack view is derived from that, so every Slack reader serves both
+  // envelopes without a branch of its own.
+  const neutral = readProviderMessageMetadata(parent.providerMeta);
+  if (neutral !== null) {
+    const view = slackViewOfProviderMetadata(neutral);
+    if (view !== null) {
+      return view;
+    }
+  }
+
   const nested = parent.slackMeta;
   if (typeof nested === "string") {
     const parsedNested = readSlackMetadata(nested);
@@ -288,6 +310,80 @@ export function readSlackMetadataFromMessageMetadata(
   }
 
   return opts?.allowFlatLegacy ? readSlackMetadata(metadata) : null;
+}
+
+/**
+ * Slack's own fields, carried on the neutral envelope's passthrough by rows
+ * that write it. They have no neutral counterpart: the Slack transcript
+ * renderer is a provider renderer by design and reads them through the
+ * Slack view.
+ */
+const SLACK_ONLY_FIELDS = [
+  "channelName",
+  "timestampTimezone",
+  "timestampTimezoneLabel",
+  "speakerTimezoneLabel",
+  "actorTimezone",
+  "actorTimezoneLabel",
+  "actorTimezoneOffsetSeconds",
+  "slackFiles",
+] as const;
+
+/**
+ * The Slack view of a neutral envelope: the inverse of
+ * `slackMetadataAsProviderMetadata`, for the Slack renderers and the backfill
+ * readers. A reaction row's `channelTs` is the reacted message's ts, as the
+ * Slack envelope stores it. Null for a non-Slack envelope, and for one that
+ * names no post yet (a reply before its post-send reconciliation), which is
+ * also what the strict reader says of a pre-send Slack envelope.
+ */
+export function slackViewOfProviderMetadata(
+  meta: ProviderMessageMetadata,
+): SlackMessageMetadata | null {
+  if (meta.source !== "slack") {
+    return null;
+  }
+  const channelTs =
+    meta.eventKind === "reaction"
+      ? meta.reaction?.targetMessageId
+      : meta.messageId;
+  if (channelTs === undefined) {
+    return null;
+  }
+  const candidate: Record<string, unknown> = {
+    source: "slack",
+    channelId: meta.conversationExternalId,
+    channelTs,
+    ...(meta.threadId !== undefined ? { threadTs: meta.threadId } : {}),
+    ...(meta.displayName !== undefined
+      ? { displayName: meta.displayName }
+      : {}),
+    ...(meta.actorExternalId !== undefined
+      ? { actorExternalUserId: meta.actorExternalId }
+      : {}),
+    eventKind: meta.eventKind,
+    ...(meta.reaction
+      ? {
+          reaction: {
+            emoji: meta.reaction.emoji,
+            op: meta.reaction.op,
+            targetChannelTs: meta.reaction.targetMessageId,
+            ...(meta.reaction.actorDisplayName
+              ? { actorDisplayName: meta.reaction.actorDisplayName }
+              : {}),
+          },
+        }
+      : {}),
+    ...(meta.editedAt !== undefined ? { editedAt: meta.editedAt } : {}),
+    ...(meta.deletedAt !== undefined ? { deletedAt: meta.deletedAt } : {}),
+  };
+  for (const field of SLACK_ONLY_FIELDS) {
+    if (meta[field] !== undefined) {
+      candidate[field] = meta[field];
+    }
+  }
+  const result = slackMessageMetadataSchema.safeParse(candidate);
+  return result.success ? result.data : null;
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/message-metadata.ts
+++ b/assistant/src/messaging/providers/slack/message-metadata.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { safeParseRecord } from "../../../util/json.js";
 import {
   type ProviderMessageMetadata,
   readProviderMessageMetadata,
@@ -426,6 +427,43 @@ export function slackMetadataAsProviderMetadata(
       : {}),
     ...(meta.editedAt !== undefined ? { editedAt: meta.editedAt } : {}),
     ...(meta.deletedAt !== undefined ? { deletedAt: meta.deletedAt } : {}),
+  };
+}
+
+/**
+ * The neutral envelope of a reply row reserved with Slack's own pre-send
+ * envelope: a `slackMeta` naming the channel and thread but no `channelTs`,
+ * the id the post-send reconciliation fills in.
+ *
+ * Transitional: a reply the daemon reserves carries the neutral envelope from
+ * the start, so this serves only a reply still pending for the retry sweep
+ * that a daemon reserving Slack replies under `slackMeta` left there; the
+ * reconciliation stamps it and converges the row onto the neutral envelope,
+ * Slack's own fields riding the schema's passthrough. Delete once no such
+ * row can be pending. A `slackMeta` that already names its post is a
+ * reconciled row and reads as null here; `readSlackMetadata` serves it.
+ */
+export function providerMetadataOfPreSendSlackEnvelope(
+  envelope: Record<string, unknown>,
+): ProviderMessageMetadata | null {
+  if (typeof envelope.slackMeta !== "string") {
+    return null;
+  }
+  const { source, channelId, channelTs, threadTs, ...slackFields } =
+    safeParseRecord(envelope.slackMeta);
+  if (
+    source !== "slack" ||
+    typeof channelId !== "string" ||
+    channelTs !== undefined
+  ) {
+    return null;
+  }
+  return {
+    ...slackFields,
+    source: "slack",
+    conversationExternalId: channelId,
+    eventKind: "message",
+    ...(typeof threadTs === "string" ? { threadId: threadTs } : {}),
   };
 }
 

--- a/assistant/src/messaging/reaction-envelopes.ts
+++ b/assistant/src/messaging/reaction-envelopes.ts
@@ -3,10 +3,10 @@
  * facts so the inbound intercept and the assistant's own reaction records
  * cannot drift apart.
  *
- * Slack keeps its own envelope because its transcript context builds
- * provider history from rows and reads only `slackMeta`; every other channel
- * writes the neutral shape `readProviderMetadata` serves to channel-agnostic
- * readers.
+ * The assistant's own reaction rows write the neutral shape on every channel,
+ * as every row the daemon authors does. Inbound Slack reaction rows still
+ * write Slack's own envelope, which `readProviderMetadata` maps on read; the
+ * Slack transcript reads the neutral envelope through its Slack view.
  */
 import type { ChannelId } from "../channels/types.js";
 import type { ProviderMessageMetadata } from "./provider-message-metadata.js";
@@ -50,11 +50,11 @@ export function buildNeutralReactionMeta(
 }
 
 /**
- * The serialized metadata key a reaction row stores, chosen per channel:
- * Slack rows write `slackMeta`, every other channel the neutral
- * `providerMeta`. The one owner of that choice, so the three writers (the
- * inbound intercept, the assistant's own reaction records, and the
- * reaction-wake turn) cannot drift.
+ * The serialized metadata key an inbound reaction row stores, chosen per
+ * channel: Slack rows write `slackMeta`, every other channel the neutral
+ * `providerMeta`. The one owner of that choice, so the two inbound writers
+ * (the intercept and the reaction-wake turn) cannot drift. The assistant's
+ * own reaction records write `buildNeutralReactionMeta` directly.
  */
 export function buildReactionRowEnvelope(
   facts: ReactionEnvelopeFacts,

--- a/assistant/src/messaging/read-provider-metadata.ts
+++ b/assistant/src/messaging/read-provider-metadata.ts
@@ -20,9 +20,10 @@ import {
  * understands them. History assembly, the conversation route and the
  * transcript renderer then work for a channel nobody here has heard of.
  *
- * `slackMeta` is Slack's own envelope, mapped on read. It holds fields no
- * other channel has an equivalent for, so Slack keeps writing it and loses
- * nothing. A channel that writes `providerMeta` needs no adapter at all.
+ * `slackMeta` is Slack's own envelope, mapped on read. Inbound Slack rows
+ * still write it; the Slack-only fields it holds have no neutral equivalent
+ * and ride the neutral envelope's passthrough on the rows the daemon
+ * authors. A channel that writes `providerMeta` needs no adapter at all.
  *
  * Normalizing on read is what allows both. Writing stays where provider
  * detail legitimately lives, and nothing is stored twice.

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -12,7 +12,6 @@ import {
   parseExternalContentEnvelope,
   wrapUntrustedContent,
 } from "../../../../../security/untrusted-content.js";
-import { safeParseRecord } from "../../../../../util/json.js";
 import { getLogger } from "../../logging.js";
 import type { RecallSearchContext, RecallSearchResult } from "../types.js";
 
@@ -301,7 +300,19 @@ function parseSlackRecallMetadata(rawMetadata: string | null): {
   if (!slackMeta) {
     return null;
   }
-  const metadata = safeParseRecord(rawMetadata);
+  // The trust class sits beside the envelope, on the row's top-level
+  // metadata. Parsed here rather than through the host's JSON helper, which
+  // is outside the plugin's import boundary.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawMetadata);
+  } catch {
+    parsed = null;
+  }
+  const metadata =
+    parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
 
   return {
     ...(slackMeta.displayName ? { displayName: slackMeta.displayName } : {}),

--- a/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
+++ b/assistant/src/plugins/defaults/memory/context-search/sources/conversations.ts
@@ -4,7 +4,7 @@ import {
   searchMessageIdsLexical,
 } from "@vellumai/plugin-api";
 
-import { readSlackMetadata } from "../../../../../messaging/providers/slack/message-metadata.js";
+import { readSlackMetadataFromMessageMetadata } from "../../../../../messaging/providers/slack/message-metadata.js";
 import { AUTO_ANALYSIS_SOURCE } from "../../../../../persistence/auto-analysis-constants.js";
 import { isLexicalBackfillComplete } from "../../../../../persistence/checkpoints.js";
 import { rawAll } from "../../../../../persistence/raw-query.js";
@@ -12,6 +12,7 @@ import {
   parseExternalContentEnvelope,
   wrapUntrustedContent,
 } from "../../../../../security/untrusted-content.js";
+import { safeParseRecord } from "../../../../../util/json.js";
 import { getLogger } from "../../logging.js";
 import type { RecallSearchContext, RecallSearchResult } from "../types.js";
 
@@ -296,25 +297,11 @@ function parseSlackRecallMetadata(rawMetadata: string | null): {
     return null;
   }
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawMetadata);
-  } catch {
-    return null;
-  }
-
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return null;
-  }
-
-  const metadata = parsed as Record<string, unknown>;
-  if (typeof metadata.slackMeta !== "string") {
-    return null;
-  }
-  const slackMeta = readSlackMetadata(metadata.slackMeta);
+  const slackMeta = readSlackMetadataFromMessageMetadata(rawMetadata);
   if (!slackMeta) {
     return null;
   }
+  const metadata = safeParseRecord(rawMetadata);
 
   return {
     ...(slackMeta.displayName ? { displayName: slackMeta.displayName } : {}),

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -210,27 +210,33 @@ the gateway's Channel Identity Vocabulary, which covers the wire side.
   channel, including one this repo has no code for, which is why a new
   channel belongs here rather than in a sixth key of its own.
 
-  Every channel except Slack writes it: a reaction row carries the whole
-  shape (`inbound-stages/reaction-intercept.ts`), an edit or a delete
-  stamps `editedAt` / `deletedAt` onto whatever the row already said about
-  itself through `mergeProviderMessageMetadata`
-  (`inbound-stages/edit-intercept.ts`, `inbound-message-handler.ts`), and an
-  outbound assistant reply is stamped with a partial envelope at reserve time
-  (`buildAssistantChannelMetadata`) whose `messageId` (and, for a reply
+  Every row the daemon authors writes it on every channel, Slack included:
+  an outbound assistant reply is stamped with a partial envelope at reserve
+  time (`buildAssistantChannelMetadata`) whose `messageId` (and, for a reply
   split into several posts, `additionalMessageIds`) the post-send
   reconciliation in `channel-reply-delivery.ts` back-fills from the
-  transport's delivery results. The same reconciliation writes each id into
+  transport's delivery results, the assistant's own reaction rows write it
+  (`daemon/reaction-record.ts`), and bot-authored Slack backfill rows write
+  it. Every channel except Slack writes it for inbound rows too: a reaction
+  row carries the whole shape (`inbound-stages/reaction-intercept.ts`), and
+  an edit or a delete stamps `editedAt` / `deletedAt` onto whatever the row
+  already said about itself through `mergeProviderMessageMetadata`
+  (`inbound-stages/edit-intercept.ts`, `inbound-message-handler.ts`). The same reconciliation writes each id into
   the `channel_outbound_posts` index (the outbound counterpart of
   `channel_inbound_events`' provider-id resolution), which is what lets a
   later reaction or delete naming the assistant's own post resolve back to
   its row exactly; the envelope stays the row's self-description, and the
   capped envelope scan in `findMessageByProviderMessageId` survives only as
-  the transitional fallback for rows reconciled before the table. Slack
-  keeps writing `slackMeta`, and `readProviderMetadata` maps that envelope
-  onto this shape on read, so the channel-agnostic readers in
-  `persistence/delivery-crud.ts` (thread evidence, and finding the
-  conversation that holds a given provider message id) serve both without a
-  per-channel branch.
+  the transitional fallback for rows reconciled before the table. Inbound
+  Slack rows still write `slackMeta` (transitional: the end state is this
+  envelope on every Slack row, with `slackMeta` as the read-compat arm for
+  historical rows). The two envelopes map onto each other on read, in both
+  directions: `readProviderMetadata` serves a `slackMeta` row as this shape
+  to the channel-agnostic readers in `persistence/delivery-crud.ts`, and
+  `readSlackMetadataFromMessageMetadata` serves a neutral row as Slack's
+  view (`slackViewOfProviderMetadata`, Slack's own fields riding the
+  schema's passthrough) to the Slack renderers and backfill readers, so no
+  reader on either side carries a per-envelope branch.
 
 ### Channel verification: gateway-owned
 

--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -227,8 +227,12 @@ the gateway's Channel Identity Vocabulary, which covers the wire side.
   later reaction or delete naming the assistant's own post resolve back to
   its row exactly; the envelope stays the row's self-description, and the
   capped envelope scan in `findMessageByProviderMessageId` survives only as
-  the transitional fallback for rows reconciled before the table. Inbound
-  Slack rows still write `slackMeta` (transitional: the end state is this
+  the transitional fallback for rows reconciled before the table. A reply
+  still pending for the retry sweep that was reserved with Slack's own
+  pre-send envelope converges onto this envelope when that reconciliation
+  stamps it (`providerMetadataOfPreSendSlackEnvelope`, transitional in the
+  same way). Inbound Slack rows still write `slackMeta` (transitional: the
+  end state is this
   envelope on every Slack row, with `slackMeta` as the read-compat arm for
   historical rows). The two envelopes map onto each other on read, in both
   directions: `readProviderMetadata` serves a `slackMeta` row as this shape

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -9,6 +9,7 @@ import {
   readProviderMessageMetadata,
 } from "../messaging/provider-message-metadata.js";
 import { editChannelMessage } from "../messaging/providers/index.js";
+import { providerMetadataOfPreSendSlackEnvelope } from "../messaging/providers/slack/message-metadata.js";
 import { getAttachmentMetadataForMessage } from "../persistence/attachments-store.js";
 import {
   getMessageById,
@@ -541,7 +542,8 @@ export async function deliverReplyViaCallback(
 /**
  * Build an `onMessageTs` handler that reconciles the persisted assistant
  * row's provider message ids from the transport's authoritative ones. Every
- * channel's reply row carries the neutral envelope, so there is one rule:
+ * channel's reply row carries the neutral envelope (`readReplyEnvelope`
+ * names the one pending row that may not yet), so there is one rule:
  * the first reported id becomes `providerMeta.messageId`, the further posts
  * of a reply split at tool boundaries or length limits accumulate under
  * `additionalMessageIds`, and every id lands in the `channel_outbound_posts`
@@ -568,9 +570,7 @@ function makeSentMessageIdReconciler(
       if (row === null || row.metadata === null) {
         return;
       }
-      const providerMeta = readProviderMessageMetadata(
-        safeParseRecord(row.metadata).providerMeta,
-      );
+      const providerMeta = readReplyEnvelope(safeParseRecord(row.metadata));
       if (
         providerMeta === null ||
         providerIdPatchFor(providerMeta, ts) === null
@@ -621,9 +621,8 @@ function stampSentMessageId(messageId: string, ts: string): void {
   if (row === null || row.metadata === null) {
     return;
   }
-  const providerMeta = readProviderMessageMetadata(
-    safeParseRecord(row.metadata).providerMeta,
-  );
+  const envelope = safeParseRecord(row.metadata);
+  const providerMeta = readReplyEnvelope(envelope);
   if (providerMeta === null) {
     return;
   }
@@ -646,7 +645,27 @@ function stampSentMessageId(messageId: string, ts: string): void {
         ? { deletedAt }
         : {}),
     }),
+    // A row reserved with Slack's pre-send envelope converges on the neutral
+    // one here: `updateMessageMetadata` serializes the merged envelope with
+    // `JSON.stringify`, which drops a key set to undefined.
+    ...(envelope.slackMeta !== undefined ? { slackMeta: undefined } : {}),
   });
+}
+
+/**
+ * The envelope a reply row stamps its sent ids onto: the neutral one every
+ * reply the daemon reserves carries, or, for a reply still pending from a
+ * daemon that reserved Slack replies under Slack's own envelope, the neutral
+ * reading of that pre-send envelope (transitional; see
+ * `providerMetadataOfPreSendSlackEnvelope`).
+ */
+function readReplyEnvelope(
+  envelope: Record<string, unknown>,
+): ProviderMessageMetadata | null {
+  return (
+    readProviderMessageMetadata(envelope.providerMeta) ??
+    providerMetadataOfPreSendSlackEnvelope(envelope)
+  );
 }
 
 /**

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -4,9 +4,11 @@ import { stripVellumLinks } from "../daemon/assistant-attachments.js";
 import type { RenderedHistoryContent } from "../daemon/handlers/shared.js";
 import { renderHistoryContent } from "../daemon/handlers/shared.js";
 import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
-import { readProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
+import {
+  everyPostDeleted,
+  readProviderMessageMetadata,
+} from "../messaging/provider-message-metadata.js";
 import { editChannelMessage } from "../messaging/providers/index.js";
-import { readSlackMetadata } from "../messaging/providers/slack/message-metadata.js";
 import { getAttachmentMetadataForMessage } from "../persistence/attachments-store.js";
 import {
   getMessageById,
@@ -16,6 +18,7 @@ import {
 } from "../persistence/conversation-crud.js";
 import { isReactionMessageMetadata } from "../persistence/conversation-types.js";
 import { recordOutboundPost } from "../persistence/delivery-crud.js";
+import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
 import { withSqliteRetry } from "../util/sqlite-retry.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
@@ -433,12 +436,10 @@ async function deliverPersistedAssistantMessageViaCallback(
   // Compose an `onMessageTs` that reconciles the persisted assistant row's
   // provider message ids as the transport reports the authoritative ones.
   // The assistant row is written BEFORE the gateway POST, so its pre-send
-  // envelope names no id of its own: a Slack row's partial `slackMeta` lacks
-  // `channelTs` and reads as null through `readSlackMetadata`, and a
-  // neutral-envelope row lacks the `messageId` a later reaction or
-  // delete naming it resolves by. A reply split into several segments reports one
-  // id per posted provider message, all reconciled onto this one row; see
-  // `makeSentMessageIdReconciler` for the per-envelope rules.
+  // envelope lacks the `messageId` a later reaction or delete naming it
+  // resolves by. A reply split into several segments reports one id per
+  // posted provider message, all reconciled onto this one row; see
+  // `makeSentMessageIdReconciler`.
   const reconcileOnMessageTs = makeSentMessageIdReconciler(msg.id);
   const callerOnMessageTs = options?.onMessageTs;
   const composedOnMessageTs = async (ts: string): Promise<void> => {
@@ -539,163 +540,113 @@ export async function deliverReplyViaCallback(
 
 /**
  * Build an `onMessageTs` handler that reconciles the persisted assistant
- * row's provider message ids from the transport's authoritative ones:
- * `slackMeta.channelTs` for a Slack row, `providerMeta.messageId` plus
- * `additionalMessageIds` for a row carrying the neutral envelope (Discord
- * today, any transport whose delivery result reports the sent id). The
- * back-filled ids are what let a later reaction or delete naming the
- * assistant's own post resolve back to this row.
+ * row's provider message ids from the transport's authoritative ones. Every
+ * channel's reply row carries the neutral envelope, so there is one rule:
+ * the first reported id becomes `providerMeta.messageId`, the further posts
+ * of a reply split at tool boundaries or length limits accumulate under
+ * `additionalMessageIds`, and every id lands in the `channel_outbound_posts`
+ * index, which is what lets a later reaction or delete naming any of the
+ * assistant's posts resolve back to this row.
  *
- * Behavior:
- * - A Slack row keeps the first ts that reaches a durable write. `channelTs`
- *   is the one id its envelope names, so once it is present the strict-reader
- *   check below makes every later invocation a no-op and the split reply's
- *   later segments, which are independent Slack messages, cannot overwrite it.
- * - A neutral-envelope row records every reported id: the first as
- *   `messageId`, the rest under `additionalMessageIds`, all naming this
- *   same row. An id already recorded (a redelivery) is skipped.
- * - No-op when the row was persisted with neither envelope (e.g. vellum
- *   outbound).
- * - Every write retries transient SQLite contention (`withSqliteRetry`),
- *   because this is the only durable record of the sent message's id and
- *   nothing revisits it once the event is marked delivered. Remaining
- *   failures are logged and swallowed so a DB error cannot break the
- *   outbound delivery itself.
+ * An id the row already names is a redelivery and is skipped. A row
+ * persisted with no envelope (e.g. vellum outbound) is left untouched. Every
+ * write retries transient SQLite contention (`withSqliteRetry`), because
+ * this is the only durable record of the sent message's id and nothing
+ * revisits it once the event is marked delivered. Remaining failures are
+ * logged and swallowed so a DB error cannot break the outbound delivery
+ * itself.
  */
 function makeSentMessageIdReconciler(
   messageId: string,
 ): (ts: string) => Promise<void> {
-  // Rises only once a Slack stamp has committed, so a write that fails
-  // leaves the next segment's ts free to stamp the row.
-  let slackStamped = false;
   return async (ts: string): Promise<void> => {
-    // Only ever set on the Slack branch, so a neutral-envelope row (which
-    // records every reported id) is never gated here. Checked before the row
-    // is re-read so a split Slack reply pays one read, not one per segment.
-    if (!ts || slackStamped) {
+    if (!ts) {
       return;
     }
     try {
-      // Re-read the row's current metadata so a concurrent edit-propagation
-      // write (e.g. `editedAt`) is not clobbered. `updateMessageMetadata`
-      // shallow-merges into the top-level envelope, and the per-channel
-      // sub-object is merged manually below so we can preserve fields on
-      // the partial pre-send envelope (`mergeSlackMetadata` would call
-      // `readSlackMetadata` which rejects the partial form for lacking
-      // channelTs, exactly the state we are reconciling).
       const row = getMessageById(messageId);
       if (row === null || row.metadata === null) {
         return;
       }
-      let envelope: Record<string, unknown>;
-      try {
-        envelope = JSON.parse(row.metadata) as Record<string, unknown>;
-      } catch {
-        return;
-      }
-      const slackMetaRaw =
-        typeof envelope.slackMeta === "string" ? envelope.slackMeta : null;
-      if (slackMetaRaw === null) {
-        await reconcileProviderMessageId(
-          messageId,
-          row.conversationId,
-          envelope,
-          ts,
-        );
-        return;
-      }
-      // If the existing slackMeta already parses cleanly via the strict
-      // reader, channelTs is already present (a prior reconciliation ran,
-      // or backfill stamped the field) — nothing to do.
-      if (readSlackMetadata(slackMetaRaw) !== null) {
-        return;
-      }
-      // Lenient parse of the partial slackMeta so we can preserve every
-      // field already written by `handleMessageComplete` (source,
-      // eventKind, channelId, threadTs, ...) while patching channelTs in.
-      let existingSlackMeta: Record<string, unknown>;
-      try {
-        const parsed = JSON.parse(slackMetaRaw) as unknown;
-        if (
-          parsed === null ||
-          typeof parsed !== "object" ||
-          Array.isArray(parsed)
-        ) {
-          return;
-        }
-        existingSlackMeta = parsed as Record<string, unknown>;
-      } catch {
-        return;
-      }
-      const mergedSlackMeta = JSON.stringify({
-        ...existingSlackMeta,
-        channelTs: ts,
-        // Force `source: "slack"` for parity with `mergeSlackMetadata`'s
-        // invariant — the reader rejects anything else and we never want a
-        // reconciled row to slip through with a stale source.
-        source: "slack",
-      });
-      await withSqliteRetry(
-        () => updateMessageMetadata(messageId, { slackMeta: mergedSlackMeta }),
-        { op: "reconcile_slack_channel_ts", context: { messageId } },
+      const providerMeta = readProviderMessageMetadata(
+        safeParseRecord(row.metadata).providerMeta,
       );
-      slackStamped = true;
+      if (
+        providerMeta === null ||
+        providerIdPatchFor(providerMeta, ts) === null
+      ) {
+        return;
+      }
+      // The index first: it is the resolution contract, and the insert is
+      // conflict-ignoring, so a redelivered id is a no-op there too.
+      await withSqliteRetry(
+        () =>
+          recordOutboundPost({
+            sourceChannel: providerMeta.source,
+            externalChatId: providerMeta.conversationExternalId,
+            providerMessageId: ts,
+            messageId,
+            conversationId: row.conversationId,
+          }),
+        { op: "record_outbound_post", context: { messageId } },
+      );
+      // The envelope is read and written in one synchronous step, re-read on
+      // every attempt, and the delete stage stamps its rows the same way, so
+      // neither overwrites the other's patch: bun:sqlite is synchronous and
+      // nothing yields between the read and the write.
+      await withSqliteRetry(() => stampSentMessageId(messageId, ts), {
+        op: "reconcile_sent_message_id",
+        context: { messageId },
+      });
     } catch (err) {
       log.warn(
         { err, messageId },
-        "Failed to reconcile slackMeta.channelTs on outbound assistant row",
+        "Failed to reconcile the sent message id on the outbound assistant row",
       );
     }
   };
 }
 
 /**
- * The neutral-envelope arm of the reconciliation: record the transport's
- * sent-message id on the row's `providerMeta`. The first reported id
- * becomes `messageId`; further ids (a reply split at tool boundaries posts
- * several provider messages) accumulate under `additionalMessageIds`. An id
- * the envelope already names is a redelivery and is skipped, and a row
- * carrying no valid neutral envelope is left untouched.
+ * Record a reported id on the row's envelope. A post just reported is on the
+ * channel, so the row-level deletion marker is recomputed: it stays only
+ * when every post the row now names, this one included, is already recorded
+ * as deleted (a deletion can land between the index write and this stamp,
+ * and it can name this very post); a marker left by an earlier state in
+ * which every known post was gone is cleared. Synchronous by design; see
+ * the caller.
  */
-async function reconcileProviderMessageId(
-  messageId: string,
-  conversationId: string,
-  envelope: Record<string, unknown>,
-  ts: string,
-): Promise<void> {
-  const providerMeta = readProviderMessageMetadata(envelope.providerMeta);
+function stampSentMessageId(messageId: string, ts: string): void {
+  const row = getMessageById(messageId);
+  if (row === null || row.metadata === null) {
+    return;
+  }
+  const providerMeta = readProviderMessageMetadata(
+    safeParseRecord(row.metadata).providerMeta,
+  );
   if (providerMeta === null) {
     return;
   }
-  // Every reported id lands in the `channel_outbound_posts` index (the
-  // resolution contract) as well as on the envelope (the row's
-  // self-description). One writer for both, so they cannot drift; the
-  // insert is conflict-ignoring, so a redelivered id is a no-op there too.
-  // It retries contention on the same grounds as the envelope writes below:
-  // the index is the only record a later reaction or delete resolves
-  // through, and nothing revisits this id once delivery settles.
-  await withSqliteRetry(
-    () =>
-      recordOutboundPost({
-        sourceChannel: providerMeta.source,
-        externalChatId: providerMeta.conversationExternalId,
-        providerMessageId: ts,
-        messageId,
-        conversationId,
-      }),
-    { op: "record_outbound_post", context: { messageId } },
-  );
   const patch = providerIdPatchFor(providerMeta, ts);
   if (patch === null) {
     return;
   }
-  await withSqliteRetry(
-    () =>
-      updateMessageMetadata(messageId, {
-        providerMeta: JSON.stringify({ ...providerMeta, ...patch }),
-      }),
-    { op: "reconcile_provider_message_id", context: { messageId } },
-  );
+  const posts = [
+    ...(providerMeta.messageId !== undefined ? [providerMeta.messageId] : []),
+    ...(providerMeta.additionalMessageIds ?? []),
+    ts,
+  ];
+  const { deletedAt, ...rest } = providerMeta;
+  updateMessageMetadata(messageId, {
+    providerMeta: JSON.stringify({
+      ...rest,
+      ...patch,
+      ...(deletedAt !== undefined &&
+      everyPostDeleted(posts, providerMeta.deletedMessageIds)
+        ? { deletedAt }
+        : {}),
+    }),
+  });
 }
 
 /**

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1869,6 +1869,15 @@ async function persistBackfilledSlackMessage(params: {
   );
   const slackTranscriptTimestampTimezone =
     resolveSlackTranscriptTimestampTimezone();
+  const slackTimezoneFields = buildSlackTimezoneMetadata({
+    actorTimezone,
+    actorTimezoneLabel,
+    actorTimezoneOffsetSeconds: message.metadata?.actorTimezoneOffsetSeconds,
+    timestampTimezone: slackTranscriptTimestampTimezone?.timestampTimezone,
+    timestampTimezoneLabel:
+      slackTranscriptTimestampTimezone?.timestampTimezoneLabel,
+    speakerTimezoneLabel: isGuardian ? undefined : actorTimezoneLabel,
+  });
   const slackMeta: SlackMessageMetadata = {
     source: "slack",
     channelId: params.channelId,
@@ -1877,15 +1886,7 @@ async function persistBackfilledSlackMessage(params: {
     ...(message.threadId ? { threadTs: message.threadId } : {}),
     ...(message.sender?.name ? { displayName: message.sender.name } : {}),
     ...(actorExternalUserId ? { actorExternalUserId } : {}),
-    ...buildSlackTimezoneMetadata({
-      actorTimezone,
-      actorTimezoneLabel,
-      actorTimezoneOffsetSeconds: message.metadata?.actorTimezoneOffsetSeconds,
-      timestampTimezone: slackTranscriptTimestampTimezone?.timestampTimezone,
-      timestampTimezoneLabel:
-        slackTranscriptTimestampTimezone?.timestampTimezoneLabel,
-      speakerTimezoneLabel: isGuardian ? undefined : actorTimezoneLabel,
-    }),
+    ...slackTimezoneFields,
     ...(slackFiles.length > 0 ? { slackFiles } : {}),
   };
 
@@ -1907,9 +1908,32 @@ async function persistBackfilledSlackMessage(params: {
     ? message.timestamp
     : undefined;
 
+  // A row the daemon authors carries the neutral envelope, Slack's own fields
+  // riding its passthrough; a person's row keeps Slack's envelope for now.
+  const envelope =
+    role === "assistant"
+      ? {
+          providerMeta: JSON.stringify({
+            source: "slack",
+            conversationExternalId: params.channelId,
+            messageId: message.id,
+            eventKind: "message",
+            ...(message.threadId ? { threadId: message.threadId } : {}),
+            ...(message.sender?.name
+              ? { displayName: message.sender.name }
+              : {}),
+            ...(actorExternalUserId
+              ? { actorExternalId: actorExternalUserId }
+              : {}),
+            ...slackTimezoneFields,
+            ...(slackFiles.length > 0 ? { slackFiles } : {}),
+          } satisfies ProviderMessageMetadata),
+        }
+      : { slackMeta: writeSlackMetadata(slackMeta) };
+
   const persisted = await addMessage(params.conversationId, role, rawText, {
     metadata: {
-      slackMeta: writeSlackMetadata(slackMeta),
+      ...envelope,
       ...(sentAt !== undefined ? { sentAt } : {}),
       provenanceTrustClass: isGuardian ? "guardian" : "unknown",
       provenanceSourceChannel: "slack",


### PR DESCRIPTION
**TL;DR:** Slack was the one channel whose reply rows kept a channel-shaped envelope (`slackMeta`) on the daemon's side of the seam. Those rows now write the same neutral `providerMeta` envelope every other channel writes, Slack's own fields riding the schema's passthrough, and the Slack renderers read them back through the envelope's Slack view. That is the layering the channel capability map's North Star states (gateway normalizes inbound, daemon stores one neutral envelope, adapters translate outbound) and the "one provenance envelope per row" decision of 2026-08-31. It also gives Slack per-post deletion and index-exact resolution without a second copy of either, which is what #41975 tried to add under Slack names and was withdrawn for.

Part of LUM-3521. Replaces #41975.

## What changes for the user

| Before | After |
| --- | --- |
| Someone deletes the second post of a split Slack reply: nothing recorded | The post is marked deleted; the surviving posts stay visible and quotable |
| Someone deletes the first post of a split Slack reply: the whole reply reads as gone | Only that post; the row-level marker lands once every post is gone |
| A reaction or delete on an older Slack post resolved only within the envelope scan window | Every Slack post delivered from this release on is in `channel_outbound_posts` and resolves exactly, at any age |
| A delete racing the Slack post-send reconciliation could be lost or over-applied | The envelope stamp is one synchronous read-modify-write, re-read per retry, and recomputes the row marker when a post is added |
| What a person says on Slack, the Slack transcript the model reads, the web's Slack deep links and thread links | unchanged |

## Design

- **One envelope on the rows the daemon authors.** Reserve-time replies (`buildAssistantChannelMetadata`), the post-send reconciliation, the daemon's own reaction records, and bot-authored backfill rows all write `providerMeta` with `source: "slack"`. Slack-only facts (`threadId`, timezone labels, file markers, channel name) ride the passthrough the neutral schema already declares for exactly this.
- **One reader, both envelopes.** `readSlackMetadataFromMessageMetadata`, which every Slack renderer and backfill reader already calls, now serves a neutral row through `slackViewOfProviderMetadata`, the inverse of the existing `slackMetadataAsProviderMetadata`. No reader gained a branch; the two raw `JSON.parse` readers (the Slack transcript assembler, the memory recall source) moved onto it.
- **One reconciler arm.** The Slack arm of the post-send reconciliation is gone. The remaining arm writes the index first, then stamps the envelope in a synchronous read-modify-write, and keeps `deletedAt` only when every post the row now names is recorded deleted.
- **One transitional read.** A Slack reply reserved by the previous daemon and still pending for the retry sweep carries Slack's pre-send envelope. The reconciler reads it through `providerMetadataOfPreSendSlackEnvelope` (Slack side of the seam), indexes and stamps the post, and converges the row onto the neutral envelope. Marked transitional in its docstring and in `runtime/AGENTS.md`; it goes once no such row can be pending.
- **The delete stage is untouched.** A Slack reply row no longer carries `slackMeta`, so it takes the neutral arm by construction: per-post `deletedMessageIds`, `deletedAt` once all are gone.
- **Inbound Slack rows keep `slackMeta` for now.** They are the next step of the same decision (their writers are ingest, backfill, edits, reactions); `readProviderMetadata` keeps mapping them on read, and historical rows of both kinds keep reading correctly. No backfill, no migration.

## Why this is safe

- Additive: the neutral schema is unchanged apart from one exported predicate; historical `slackMeta` rows read exactly as before through the existing mapper, and the strict `readSlackMetadata` is untouched.
- A pre-send neutral row has no Slack view, the same answer the strict reader gives a pre-send `slackMeta` row, so the pins that depend on "no view until reconciled" still hold (`list-messages-page-latest`).
- `tsc` clean. Nineteen test files run and pass, including the Slack transcript assembly (208), the reconciler suite (rewritten for the single arm, with the deletion-in-window and marker-recompute interleavings, the pre-send Slack row, and a reconciled `slackMeta` row left alone), outbound persistence, thread and DM backfill, reaction persistence, delete propagation (with the assistant's own Slack post on the neutral envelope), and the wire projection (a neutral Slack reply projects the same `slackMessage` as a legacy row).

## Deferred

- Inbound Slack rows onto the neutral envelope, and then the web's Slack-specific `slackMessage` wire envelope and its readers. Both are on the capability map's State of play as the following steps.
- Deleting the pre-send Slack read arm, once a release has shipped in which no daemon reserves Slack replies under `slackMeta`.
- One formatter-only reflow of an unrelated line in `conversation-runtime-assembly.ts` rode along with the file's edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
