### PR TITLE
fix(platform): verify a stored managed credential instead of trusting its presence

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24370,7 +24370,9 @@ paths:
     post:
       operationId: platform_connect_post
       summary: Connect to the Vellum Platform
-      description: Checks existing credentials and emits the show_platform_login signal for connected clients to show a login UI.
+      description:
+        Checks whether the stored platform credentials still connect. Reports a stored key the platform rejects as
+        credentialRejected, so the caller can direct the user to sign in again and replace it.
       tags:
         - platform
       responses:
@@ -24386,6 +24388,8 @@ paths:
                   baseUrl:
                     type: string
                   showPlatformLogin:
+                    type: boolean
+                  credentialRejected:
                     type: boolean
                 additionalProperties: false
   /v1/platform/credits:
@@ -24754,6 +24758,32 @@ paths:
                   - selectedCreditTier
                   - package
                   - entitlements
+                additionalProperties: false
+  /v1/platform/verify-credential:
+    post:
+      operationId: platform_verifycredential_post
+      summary: Verify the Vellum-managed credential against the platform
+      description:
+        Asks the platform whether the stored assistant API key authenticates. POST because it performs a check; the
+        result is returned, not stored.
+      tags:
+        - platform
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum:
+                      - valid
+                      - rejected
+                      - unknown
+                required:
+                  - status
                 additionalProperties: false
   /v1/playground/seed-conversation:
     post:

--- a/assistant/src/__tests__/credential-health-service.test.ts
+++ b/assistant/src/__tests__/credential-health-service.test.ts
@@ -53,6 +53,12 @@ let managedPingOutcome:
   | { kind: "credential_required" }
   | { kind: "throw"; message: string } = { kind: "status", status: 200 };
 
+// Managed assistant-credential mock state. The verdict is what the platform
+// answers about the stored assistant API key; `platformClientAvailable` covers
+// the case where the client cannot be built at all.
+let assistantKeyVerdict: "valid" | "rejected" | "unknown" = "valid";
+let platformClientAvailable = true;
+
 // ── Module mocks ─────────────────────────────────────────────────────
 
 mock.module("../security/secure-keys.js", () => ({
@@ -123,14 +129,20 @@ mock.module("../security/token-manager.js", () => ({
 // seeded into the real workspace config via `seedGoogleOAuthMode` below.
 mock.module("../platform/client.js", () => ({
   VellumPlatformClient: {
-    create: async () => ({
-      platformAssistantId: "test-assistant",
-      fetch: async (_path: string) => ({
-        ok: managedListResponse.ok,
-        status: managedListResponse.status,
-        json: async () => managedListResponse.body ?? { results: [] },
-      }),
-    }),
+    create: async () => {
+      if (!platformClientAvailable) {
+        return null;
+      }
+      return {
+        platformAssistantId: "test-assistant",
+        fetch: async (_path: string) => ({
+          ok: managedListResponse.ok,
+          status: managedListResponse.status,
+          json: async () => managedListResponse.body ?? { results: [] },
+        }),
+        verifyCredential: async () => assistantKeyVerdict,
+      };
+    },
   },
 }));
 
@@ -164,8 +176,12 @@ mock.module("../oauth/platform-connection.js", () => ({
 
 import { setConfig } from "./helpers/set-config.js";
 
-const { checkAllCredentials, checkCredentialForProvider, _setFetchFn } =
-  await import("../credential-health/credential-health-service.js");
+const {
+  checkAllCredentials,
+  checkAssistantApiKey,
+  checkCredentialForProvider,
+  _setFetchFn,
+} = await import("../credential-health/credential-health-service.js");
 
 /** Seed the real workspace config's `services.google-oauth.mode`. */
 function seedGoogleOAuthMode(mode: "managed" | "your-own"): void {
@@ -259,6 +275,8 @@ describe("credential-health-service", () => {
     seedGoogleOAuthMode("your-own");
     managedListResponse = { ok: true, status: 200, body: { results: [] } };
     managedPingOutcome = { kind: "status", status: 200 };
+    assistantKeyVerdict = "valid";
+    platformClientAvailable = true;
   });
 
   test("returns empty report when no providers exist", async () => {
@@ -761,6 +779,76 @@ describe("credential-health-service", () => {
 
       const result = await checkCredentialForProvider("google");
       expect(result!.status).toBe("missing_token");
+    });
+  });
+
+  describe("managed assistant credential", () => {
+    const KEY = "credential/vellum/assistant_api_key";
+    const BASE_URL = "credential/vellum/platform_base_url";
+
+    // Checked directly rather than through `checkAllCredentials`: the managed
+    // credential is not enrolled in the heartbeat pass yet, because the alert
+    // that pass raises has nowhere to send the reader until the notification
+    // carries the repair.
+    const assistantKeyResult = checkAssistantApiKey;
+
+    test("is not reported when the workspace was never connected", async () => {
+      expect(await assistantKeyResult()).toBeNull();
+    });
+
+    test("is missing_token when a platform identity exists without a key", async () => {
+      secureKeyValues.set(BASE_URL, "https://platform.example");
+
+      const result = await assistantKeyResult();
+      expect(result!.status).toBe("missing_token");
+      expect(result!.canAutoRecover).toBe(true);
+    });
+
+    test("is healthy when the platform accepts the stored key", async () => {
+      secureKeyValues.set(BASE_URL, "https://platform.example");
+      secureKeyValues.set(KEY, "stored-key");
+      assistantKeyVerdict = "valid";
+
+      expect((await assistantKeyResult())!.status).toBe("healthy");
+    });
+
+    test("is revoked when the platform rejects the stored key", async () => {
+      secureKeyValues.set(BASE_URL, "https://platform.example");
+      secureKeyValues.set(KEY, "stored-key");
+      assistantKeyVerdict = "rejected";
+
+      const result = await assistantKeyResult();
+      expect(result!.status).toBe("revoked");
+      // Recovery needs a signed-in client to rotate the key, but no
+      // re-authorization from the user.
+      expect(result!.canAutoRecover).toBe(true);
+    });
+
+    // The anti-churn invariant: only a settled rejection may read as revoked,
+    // because `revoked` is what drives a rotation. An unsettled answer (server
+    // error, transport failure) must degrade to `unreachable`, which the
+    // heartbeat drops before notifying.
+    test("an unsettled platform answer is unreachable, never revoked", async () => {
+      secureKeyValues.set(BASE_URL, "https://platform.example");
+      secureKeyValues.set(KEY, "stored-key");
+      assistantKeyVerdict = "unknown";
+
+      expect((await assistantKeyResult())!.status).toBe("unreachable");
+    });
+
+    test("an unreadable credential store is unreachable, never revoked", async () => {
+      secureKeyValues.set(BASE_URL, "https://platform.example");
+      markUnreachable(KEY);
+
+      expect((await assistantKeyResult())!.status).toBe("unreachable");
+    });
+
+    test("is unreachable when the platform client cannot be built", async () => {
+      secureKeyValues.set(BASE_URL, "https://platform.example");
+      secureKeyValues.set(KEY, "stored-key");
+      platformClientAvailable = false;
+
+      expect((await assistantKeyResult())!.status).toBe("unreachable");
     });
   });
 });

--- a/assistant/src/__tests__/platform-client-verify-credential.test.ts
+++ b/assistant/src/__tests__/platform-client-verify-credential.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+let platformAssistantId = "asst_123";
+let fetchImpl: (
+  url: string,
+  init?: RequestInit,
+) => Promise<Response> = async () => new Response("{}", { status: 200 });
+const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+
+mock.module("../platform/feature-gate.js", () => ({
+  arePlatformFeaturesEnabled: () => true,
+}));
+
+mock.module("../providers/platform-proxy/context.js", () => ({
+  resolveManagedProxyContext: async () => ({
+    enabled: true,
+    platformBaseUrl: "https://platform.test/",
+    assistantApiKey: "assistant-key",
+  }),
+}));
+
+mock.module("../config/env.js", () => ({
+  getPlatformAssistantId: () => platformAssistantId,
+}));
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async () => null,
+}));
+
+const { VellumPlatformClient } = await import("../platform/client.js");
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  platformAssistantId = "asst_123";
+  fetchCalls.length = 0;
+  fetchImpl = async () => new Response("{}", { status: 200 });
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    fetchCalls.push({ url, init });
+    return fetchImpl(url, init);
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function createClient() {
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    throw new Error("client prerequisites were not satisfied");
+  }
+  return client;
+}
+
+describe("VellumPlatformClient.verifyCredential", () => {
+  test("an accepted request is a valid credential, asked on the owner-consent carrier with the stored key", async () => {
+    const client = await createClient();
+
+    expect(await client.verifyCredential()).toBe("valid");
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]?.url).toBe(
+      "https://platform.test/v1/assistants/asst_123/owner-consent/",
+    );
+    const headers = new Headers(fetchCalls[0]?.init?.headers);
+    expect(headers.get("Authorization")).toBe("Api-Key assistant-key");
+    // The heartbeat awaits this check, so it must carry a deadline.
+    expect(fetchCalls[0]?.init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  // Only the platform's own refusal may drive a rotation.
+  test.each([401, 403])("a %i is the settled rejection", async (status) => {
+    fetchImpl = async () => new Response("", { status });
+    const client = await createClient();
+    expect(await client.verifyCredential()).toBe("rejected");
+  });
+
+  test("a server error is unsettled, not a rejection", async () => {
+    fetchImpl = async () => new Response("", { status: 503 });
+    const client = await createClient();
+    expect(await client.verifyCredential()).toBe("unknown");
+  });
+
+  test("an unreachable platform is unsettled, not a rejection", async () => {
+    fetchImpl = async () => {
+      throw new TypeError("fetch failed");
+    };
+    const client = await createClient();
+    expect(await client.verifyCredential()).toBe("unknown");
+  });
+
+  test("without a platform assistant id there is nothing to verify", async () => {
+    platformAssistantId = "";
+    const client = await createClient();
+    expect(await client.verifyCredential()).toBe("unknown");
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/assistant/src/cli/commands/platform/__tests__/connect.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/connect.test.ts
@@ -69,6 +69,35 @@ describe("assistant platform connect", () => {
     expect(parsed.showPlatformLogin).toBe(true);
   });
 
+  // A stored key the platform rejects is a recovery, not a first setup: the
+  // outcome has to reach the caller in the response, since the daemon's login
+  // signal has no shipped consumer.
+  test("a rejected stored credential is reported as such", async () => {
+    mockResponse = {
+      ok: true,
+      result: { showPlatformLogin: true, credentialRejected: true },
+    };
+
+    const program = buildProgram();
+    const stdoutChunks: string[] = [];
+    const origWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown) => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await program.parseAsync(["node", "assistant", "connect", "--json"]);
+    } finally {
+      process.stdout.write = origWrite;
+    }
+
+    const parsed = JSON.parse(stdoutChunks.join(""));
+    expect(parsed.ok).toBe(true);
+    expect(parsed.credentialRejected).toBe(true);
+    expect(parsed.alreadyConnected).toBeUndefined();
+  });
+
   test("already connected returns success with existing base URL", async () => {
     mockResponse = {
       ok: true,

--- a/assistant/src/cli/commands/platform/connect.ts
+++ b/assistant/src/cli/commands/platform/connect.ts
@@ -12,6 +12,7 @@ export function registerPlatformConnectCommand(platform: Command): void {
         alreadyConnected?: boolean;
         baseUrl?: string;
         showPlatformLogin?: boolean;
+        credentialRejected?: boolean;
       }>("platform_connect", {});
       if (!r.ok) {
         return exitFromIpcResult(
@@ -27,6 +28,13 @@ export function registerPlatformConnectCommand(platform: Command): void {
           log.info(
             `Already connected to platform at ${r.result.baseUrl}. ` +
               `Run 'assistant platform disconnect' first to reconnect.`,
+          );
+        } else if (r.result?.credentialRejected) {
+          // The daemon's login signal has no shipped consumer, so this line is
+          // the only thing that tells the user what replaces the key.
+          log.info(
+            "The stored platform credential was rejected by the platform. " +
+              "Run 'vellum login' to sign in again and replace it.",
           );
         } else {
           log.info(

--- a/assistant/src/cli/commands/platform/connect.ts
+++ b/assistant/src/cli/commands/platform/connect.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
+import type { PlatformConnectResponse } from "../../../runtime/routes/platform-routes.js";
 import { subcommand } from "../../lib/cli-command-help.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -8,12 +9,10 @@ import { shouldOutputJson, writeOutput } from "../../output.js";
 export function registerPlatformConnectCommand(platform: Command): void {
   subcommand(platform, "connect").action(
     async (_opts: Record<string, unknown>, cmd: Command) => {
-      const r = await cliIpcCall<{
-        alreadyConnected?: boolean;
-        baseUrl?: string;
-        showPlatformLogin?: boolean;
-        credentialRejected?: boolean;
-      }>("platform_connect", {});
+      const r = await cliIpcCall<PlatformConnectResponse>(
+        "platform_connect",
+        {},
+      );
       if (!r.ok) {
         return exitFromIpcResult(
           { ok: false, error: r.error, statusCode: r.statusCode },

--- a/assistant/src/cli/commands/platform/connect.ts
+++ b/assistant/src/cli/commands/platform/connect.ts
@@ -29,11 +29,13 @@ export function registerPlatformConnectCommand(platform: Command): void {
               `Run 'assistant platform disconnect' first to reconnect.`,
           );
         } else if (r.result?.credentialRejected) {
-          // The daemon's login signal has no shipped consumer, so this line is
-          // the only thing that tells the user what replaces the key.
+          // No client shows a login screen for the daemon's signal, so this
+          // line is what tells the user what replaces the key. A plain sign-in
+          // stops at "already logged in" before the credential pass runs;
+          // --force runs it.
           log.info(
             "The stored platform credential was rejected by the platform. " +
-              "Run 'vellum login' to sign in again and replace it.",
+              "Run 'vellum login --force' to sign in again and replace it.",
           );
         } else {
           log.info(

--- a/assistant/src/credential-health/credential-health-service.ts
+++ b/assistant/src/credential-health/credential-health-service.ts
@@ -38,6 +38,11 @@ import {
   expectedScopesForStoredToken,
   scopeDifference,
 } from "../oauth/scope-utils.js";
+import { credentialKey } from "../security/credential-key.js";
+import {
+  getSecureKeyAsync,
+  getSecureKeyResultAsync,
+} from "../security/secure-keys.js";
 import {
   TokenExpiredError,
   withValidToken,
@@ -608,6 +613,131 @@ async function checkManagedProvider(
   }
 
   return results;
+}
+
+/**
+ * Connection id for the Vellum-managed assistant credential.
+ *
+ * The credential is a single workspace-wide slot rather than one row per
+ * account, so it carries the credential-store key as its id instead of a
+ * connection uuid.
+ */
+const ASSISTANT_API_KEY_CONNECTION_ID = "vellum:assistant_api_key";
+
+/**
+ * Health of the platform-provisioned assistant API key, the credential that
+ * authenticates Vellum-managed inference.
+ *
+ * Deliberately not part of {@link checkAllCredentials} yet. Adding it there
+ * makes the heartbeat raise a `credential.health_alert` for this credential,
+ * and that alert has nowhere to send the reader until the notification carries
+ * the repair. It is used on demand for now, by the route a client calls to
+ * confirm a credential it just wrote.
+ *
+ * This is the one credential the assistant cannot mint for itself: the
+ * platform issues it and a signed-in client writes it in. For a self-hosted
+ * or local assistant the platform deliberately does not self-heal a dead key
+ * (`recover_expired_assistant_api_key` excludes registrations of that kind,
+ * because the client owns the reprovision flow), so its health has to be
+ * observed here and acted on by a client.
+ *
+ * Statuses map onto the shared vocabulary:
+ *   - `missing_token`: no key is stored, so managed inference cannot run.
+ *   - `revoked`: the platform settled that the stored key is not accepted.
+ *   - `unreachable`: the credential store or the platform did not answer, so
+ *     health is unknown. The heartbeat drops these before notifying, which is
+ *     what keeps a transient outage from raising a credential alert.
+ *
+ * `canAutoRecover` is true for both failure statuses: recovery needs no
+ * re-authorization from the user, only a signed-in client to rotate the key.
+ */
+export async function checkAssistantApiKey(): Promise<CredentialHealthResult | null> {
+  const base: Omit<
+    CredentialHealthResult,
+    "status" | "details" | "canAutoRecover"
+  > = {
+    connectionId: ASSISTANT_API_KEY_CONNECTION_ID,
+    provider: "vellum",
+    accountInfo: null,
+    missingScopes: [],
+  };
+
+  const stored = await getSecureKeyResultAsync(
+    credentialKey("vellum", "assistant_api_key"),
+  );
+
+  if (stored.unreachable) {
+    return {
+      ...base,
+      status: "unreachable",
+      details:
+        "The credential store is unreachable, so Vellum's managed credentials could not be checked.",
+      canAutoRecover: false,
+    };
+  }
+
+  if (stored.value == null) {
+    // A workspace that was never connected to the platform has no managed
+    // credential and is not unhealthy. Only an install that already carries
+    // the rest of a platform identity is missing something.
+    const baseUrl = await getSecureKeyAsync(
+      credentialKey("vellum", "platform_base_url"),
+    );
+    if (!baseUrl) {
+      return null;
+    }
+    return {
+      ...base,
+      status: "missing_token",
+      details:
+        "No Vellum-managed credentials are stored yet. Log in to the Vellum platform to set them up.",
+      canAutoRecover: true,
+    };
+  }
+
+  const { VellumPlatformClient } = await import("../platform/client.js");
+  const client = await VellumPlatformClient.create();
+  if (!client) {
+    return {
+      ...base,
+      status: "unreachable",
+      details:
+        "The Vellum platform client could not be built, so Vellum's managed credentials could not be checked.",
+      canAutoRecover: false,
+    };
+  }
+
+  const verdict = await client.verifyCredential();
+  if (verdict === "rejected") {
+    return {
+      ...base,
+      status: "revoked",
+      // Names the recovery the app actually performs. A replacement is
+      // provisioned only when someone asks for one, from the repair action or
+      // by logging in from the command line, so the copy points at that
+      // action rather than at reconnecting something the reader never
+      // connected.
+      details:
+        "Vellum's managed credentials stopped working, so chat and background tasks that use them are paused. Restoring takes a moment and will not affect anything else.",
+      canAutoRecover: true,
+    };
+  }
+  if (verdict === "unknown") {
+    return {
+      ...base,
+      status: "unreachable",
+      details:
+        "Vellum did not answer the managed-credential check. Health is unknown until the next check.",
+      canAutoRecover: false,
+    };
+  }
+
+  return {
+    ...base,
+    status: "healthy",
+    details: "Vellum's managed credentials are working.",
+    canAutoRecover: true,
+  };
 }
 
 // ── Public API ────────────────────────────────────────────────────────

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -106,6 +106,9 @@ async function resolvePlatformClientConfig(): Promise<PlatformClientConfig | nul
 // credential backend must answer from cache instead of stalling the banner.
 const CONFIGURED_PROBE_DEADLINE_MS = 500;
 
+/** Bound for the credential check; the heartbeat waits on it. */
+const CREDENTIAL_VERIFY_TIMEOUT_MS = 5_000;
+
 let lastKnownConfigured: boolean | null = null;
 // Single-flight slot with rotation: concurrent probes share one resolution,
 // while a flight some caller already gave up on is replaced so a hung
@@ -305,6 +308,56 @@ export class VellumPlatformClient {
     } catch (err) {
       log.debug({ err }, "owner-consent fetch failed — treating as unknown");
       return null;
+    }
+  }
+
+  /**
+   * Ask the platform whether this client's assistant API key still
+   * authenticates.
+   *
+   * `"rejected"` is a settled negative: the platform answered, and the answer
+   * was that the credential is not accepted (401/403, which is how
+   * `AssistantAPIKeyAuthentication` reports a revoked, expired, or unknown
+   * key). Only that verdict may drive a rotation, because rotating on a
+   * network blip would replace a working credential for no reason.
+   * `"unknown"` covers every unsettled case (no assistant id, transport
+   * failure, server error) and means "ask again later", never "broken".
+   *
+   * The carrier is the owner-consent endpoint. Nothing here reads consent:
+   * the request is a side-effect-free authenticated GET this client already
+   * makes, and the only thing inspected is whether authentication succeeded.
+   * The platform exposes no dedicated credential-verification endpoint, so
+   * the carrier is named here rather than left implicit at call sites.
+   */
+  async verifyCredential(): Promise<"valid" | "rejected" | "unknown"> {
+    if (!this.assistantId) {
+      return "unknown";
+    }
+
+    try {
+      const res = await this.fetch(
+        `/v1/assistants/${this.assistantId}/owner-consent/`,
+        // The heartbeat awaits this check, so an unanswered request must
+        // settle as unknown rather than hold the credential pass open.
+        { signal: AbortSignal.timeout(CREDENTIAL_VERIFY_TIMEOUT_MS) },
+      );
+      if (res.ok) {
+        return "valid";
+      }
+      if (res.status === 401 || res.status === 403) {
+        return "rejected";
+      }
+      log.debug(
+        { status: res.status },
+        "credential verification returned an unsettled status",
+      );
+      return "unknown";
+    } catch (err) {
+      log.debug(
+        { err },
+        "credential verification could not reach the platform",
+      );
+      return "unknown";
     }
   }
 

--- a/assistant/src/platform/client.ts
+++ b/assistant/src/platform/client.ts
@@ -5,6 +5,8 @@
  * authenticated fetch for all platform API calls.
  */
 
+import type { PlatformCredentialVerificationStatus } from "@vellumai/service-contracts/platform-credential";
+
 import { getPlatformAssistantId } from "../config/env.js";
 import { resolveManagedProxyContext } from "../providers/platform-proxy/context.js";
 import { credentialKey } from "../security/credential-key.js";
@@ -329,7 +331,7 @@ export class VellumPlatformClient {
    * The platform exposes no dedicated credential-verification endpoint, so
    * the carrier is named here rather than left implicit at call sites.
    */
-  async verifyCredential(): Promise<"valid" | "rejected" | "unknown"> {
+  async verifyCredential(): Promise<PlatformCredentialVerificationStatus> {
     if (!this.assistantId) {
       return "unknown";
     }

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -25,6 +25,10 @@
  *     invoice list and returns a single invoice by Stripe invoice ID.
  */
 
+import {
+  type PlatformVerifyCredentialResponse,
+  PlatformVerifyCredentialResponseSchema,
+} from "@vellumai/service-contracts/platform-credential";
 import { z } from "zod";
 
 import { isPlatformRemote } from "../../config/env-registry.js";
@@ -88,18 +92,8 @@ const PlatformConnectResponseSchema = z.object({
    */
   credentialRejected: z.boolean().optional(),
 });
-type PlatformConnectResponse = z.infer<typeof PlatformConnectResponseSchema>;
-
-/**
- * Result of asking the platform, right now, whether the stored managed
- * credential authenticates. The route performs the check; nothing caches the
- * answer, so a caller that needs it fresh asks again.
- */
-const PlatformVerifyCredentialResponseSchema = z.object({
-  status: z.enum(["valid", "rejected", "unknown"]),
-});
-type PlatformVerifyCredentialResponse = z.infer<
-  typeof PlatformVerifyCredentialResponseSchema
+export type PlatformConnectResponse = z.infer<
+  typeof PlatformConnectResponseSchema
 >;
 
 const PlatformDisconnectResponseSchema = z.object({

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -26,6 +26,7 @@
  */
 
 import {
+  type PlatformCredentialVerificationStatus,
   type PlatformVerifyCredentialResponse,
   PlatformVerifyCredentialResponseSchema,
 } from "@vellumai/service-contracts/platform-credential";
@@ -284,10 +285,9 @@ async function handlePlatformConnect(
     credentialRejected = true;
   }
 
-  // The outcome travels in the response: the caller is the CLI, which tells
-  // the user what to do. The broadcast is kept for any client that listens
-  // for it; no shipped client currently does, so it must not be the only
-  // way the answer reaches anyone.
+  // The outcome travels in the response, where the CLI reads it and tells the
+  // user what to do. Nothing shipped consumes the signal below, so the
+  // response is the only path the answer reaches anyone by.
   broadcastMessage({ type: "show_platform_login" });
 
   return credentialRejected
@@ -296,26 +296,15 @@ async function handlePlatformConnect(
 }
 
 /**
- * Check the stored managed credential against the platform and report what it
- * found. Nothing is stored: each caller that needs the answer asks, so there is
- * no verdict to go stale.
- *
- * Exists so a client that has just written a replacement can confirm it works
- * before telling the reader it does. Storing a credential proves only that the
- * write landed; a replacement can be rejected in turn, and a repair reported
- * as successful on the strength of the write alone would be a receipt for
- * something that never happened.
- */
-/**
  * Ask the platform whether the stored managed credential authenticates.
+ * Nothing is stored: each caller that needs the answer asks, so there is no
+ * verdict to go stale.
  *
  * Shared by the verification route and by connect, so the two cannot disagree
  * about what "connected" means. Never throws: an unsettled answer is
  * `"unknown"`, which no caller treats as evidence of a dead credential.
  */
-async function verifyStoredCredential(): Promise<
-  "valid" | "rejected" | "unknown"
-> {
+async function verifyStoredCredential(): Promise<PlatformCredentialVerificationStatus> {
   try {
     const { checkAssistantApiKey } =
       await import("../../credential-health/credential-health-service.js");

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -5,8 +5,9 @@
  *   - platform_status (GET platform/status): aggregates platform context,
  *     credentials, assistant ID, and webhook secret. (Velay tunnel status
  *     lives on the gateway — see gateway_status.)
- *   - platform_connect (POST platform/connect): checks existing credentials
- *     and emits the show_platform_login signal to connected clients.
+ *   - platform_connect (POST platform/connect): reports whether the stored
+ *     credentials still connect, and when the stored key has been rejected,
+ *     says so, so the caller can tell the user what replaces it.
  *   - platform_disconnect (POST platform/disconnect): deletes stored platform
  *     credentials and emits platform_disconnected signal.
  *   - platform_callback_routes_register (POST platform/callback-routes/register):
@@ -80,8 +81,26 @@ const PlatformConnectResponseSchema = z.object({
   alreadyConnected: z.boolean().optional(),
   baseUrl: z.string().optional(),
   showPlatformLogin: z.boolean().optional(),
+  /**
+   * The stored managed credential exists but the platform rejects it. Distinct
+   * from "nothing stored": the user is not setting up, they are recovering,
+   * and what replaces the key is a fresh sign-in, not a first one.
+   */
+  credentialRejected: z.boolean().optional(),
 });
 type PlatformConnectResponse = z.infer<typeof PlatformConnectResponseSchema>;
+
+/**
+ * Result of asking the platform, right now, whether the stored managed
+ * credential authenticates. The route performs the check; nothing caches the
+ * answer, so a caller that needs it fresh asks again.
+ */
+const PlatformVerifyCredentialResponseSchema = z.object({
+  status: z.enum(["valid", "rejected", "unknown"]),
+});
+type PlatformVerifyCredentialResponse = z.infer<
+  typeof PlatformVerifyCredentialResponseSchema
+>;
 
 const PlatformDisconnectResponseSchema = z.object({
   disconnected: z.literal(true),
@@ -249,17 +268,84 @@ async function handlePlatformConnect(
     ),
   ]);
 
+  // Stored credentials only count as a connection while they still
+  // authenticate. Answering "already connected" for a key the platform has
+  // rejected would report nothing to do about the one thing that needs doing,
+  // and no client would get the signal to rotate it.
+  //
+  // Checked here rather than read from a cache: connect is a deliberate user
+  // action, so one request is affordable, and an answer computed now cannot go
+  // stale between the check and the answer. An unreachable platform leaves the
+  // stored credentials counting as a connection, so a network problem never
+  // strands a working install by reporting it disconnected.
+  let credentialRejected = false;
   if (existingUrl && existingApiKey) {
-    return {
-      alreadyConnected: true,
-      baseUrl: existingUrl,
-    };
+    const verified = await verifyStoredCredential();
+    if (verified !== "rejected") {
+      return {
+        alreadyConnected: true,
+        baseUrl: existingUrl,
+      };
+    }
+    credentialRejected = true;
   }
 
-  // Emit signal for connected clients to show the platform login UI
+  // The outcome travels in the response: the caller is the CLI, which tells
+  // the user what to do. The broadcast is kept for any client that listens
+  // for it; no shipped client currently does, so it must not be the only
+  // way the answer reaches anyone.
   broadcastMessage({ type: "show_platform_login" });
 
-  return { showPlatformLogin: true };
+  return credentialRejected
+    ? { showPlatformLogin: true, credentialRejected: true }
+    : { showPlatformLogin: true };
+}
+
+/**
+ * Check the stored managed credential against the platform and report what it
+ * found. Nothing is stored: each caller that needs the answer asks, so there is
+ * no verdict to go stale.
+ *
+ * Exists so a client that has just written a replacement can confirm it works
+ * before telling the reader it does. Storing a credential proves only that the
+ * write landed; a replacement can be rejected in turn, and a repair reported
+ * as successful on the strength of the write alone would be a receipt for
+ * something that never happened.
+ */
+/**
+ * Ask the platform whether the stored managed credential authenticates.
+ *
+ * Shared by the verification route and by connect, so the two cannot disagree
+ * about what "connected" means. Never throws: an unsettled answer is
+ * `"unknown"`, which no caller treats as evidence of a dead credential.
+ */
+async function verifyStoredCredential(): Promise<
+  "valid" | "rejected" | "unknown"
+> {
+  try {
+    const { checkAssistantApiKey } =
+      await import("../../credential-health/credential-health-service.js");
+    const result = await checkAssistantApiKey();
+    if (result === null) {
+      // No platform identity at all, so there is nothing to verify.
+      return "unknown";
+    }
+    if (result.status === "healthy") {
+      return "valid";
+    }
+    if (result.status === "revoked" || result.status === "missing_token") {
+      return "rejected";
+    }
+    return "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+async function handlePlatformVerifyCredential(
+  _args: RouteHandlerArgs,
+): Promise<PlatformVerifyCredentialResponse> {
+  return { status: await verifyStoredCredential() };
 }
 
 async function handlePlatformDisconnect(
@@ -711,10 +797,30 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Connect to the Vellum Platform",
     description:
-      "Checks existing credentials and emits the show_platform_login signal for connected clients to show a login UI.",
+      "Checks whether the stored platform credentials still connect. Reports a stored key the platform rejects as credentialRejected, so the caller can direct the user to sign in again and replace it.",
     tags: ["platform"],
     handler: handlePlatformConnect,
     responseBody: PlatformConnectResponseSchema,
+  },
+  {
+    operationId: "platform_verify_credential",
+    endpoint: "platform/verify-credential",
+    method: "POST",
+    // The in-app repair calls this through the gateway with an actor token,
+    // the same caller shape as platform_status, so it takes that route's
+    // principal bundle. A local-only policy would 403 every browser repair
+    // after it had already rotated and stored the replacement. Read scope:
+    // the route performs a check and mutates nothing.
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Verify the Vellum-managed credential against the platform",
+    description:
+      "Asks the platform whether the stored assistant API key authenticates. POST because it performs a check; the result is returned, not stored.",
+    tags: ["platform"],
+    handler: handlePlatformVerifyCredential,
+    responseBody: PlatformVerifyCredentialResponseSchema,
   },
   {
     operationId: "platform_disconnect",

--- a/cli/src/__tests__/assistant-api-key-resolution.test.ts
+++ b/cli/src/__tests__/assistant-api-key-resolution.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as realPlatformClient from "../lib/platform-client.js";
+
+const calls: string[] = [];
+let verifyResult: "valid" | "rejected" | "unknown" | null = "valid";
+let readResult: { value: string | null; unreachable: boolean } = {
+  value: "stored-key",
+  unreachable: false,
+};
+
+mock.module("../lib/platform-client.js", () => ({
+  ...realPlatformClient,
+  verifyGatewayManagedCredential: mock(async () => {
+    calls.push("verify");
+    return verifyResult;
+  }),
+  readGatewayCredential: mock(async () => {
+    calls.push("read");
+    return readResult;
+  }),
+  reprovisionAssistantApiKey: mock(async () => {
+    calls.push("reprovision");
+    return { provisioning: { assistant_api_key: "fresh-key" } };
+  }),
+}));
+
+const { resolveAssistantApiKeyForInjection } =
+  await import("../lib/assistant-api-key-resolution.js");
+
+const ARGS = {
+  registrationApiKey: null,
+  runtimeUrl: "http://localhost:20101",
+  bearerToken: "actor",
+  token: "session",
+  organizationId: "org",
+  clientInstallationId: "install",
+  runtimeAssistantId: "qa-loopback-auth",
+  clientPlatform: "cli",
+};
+
+beforeEach(() => {
+  calls.length = 0;
+  verifyResult = "valid";
+  readResult = { value: "stored-key", unreachable: false };
+});
+
+describe("resolveAssistantApiKeyForInjection", () => {
+  test("a key the registration just issued wins without asking the gateway", async () => {
+    const resolved = await resolveAssistantApiKeyForInjection({
+      ...ARGS,
+      registrationApiKey: "registration-key",
+    });
+    expect(resolved).toEqual({
+      apiKey: "registration-key",
+      source: "registration",
+    });
+    expect(calls).toEqual([]);
+  });
+
+  // The verdict comes first and the key is read after it, so the value
+  // returned is the one the verdict covered, never one a concurrent repair
+  // has since replaced.
+  test("a stored key the platform accepts is read after the verdict", async () => {
+    const resolved = await resolveAssistantApiKeyForInjection(ARGS);
+    expect(resolved).toEqual({ apiKey: "stored-key", source: "stored" });
+    expect(calls).toEqual(["verify", "read"]);
+  });
+
+  test("a stored key the platform rejects is replaced without being read", async () => {
+    verifyResult = "rejected";
+    const resolved = await resolveAssistantApiKeyForInjection(ARGS);
+    expect(resolved).toEqual({ apiKey: "fresh-key", source: "reprovisioned" });
+    expect(calls).toEqual(["verify", "reprovision"]);
+  });
+
+  // An unsettled answer is not a rejection: the stored key stays in use.
+  test("an unsettled verdict keeps the stored key", async () => {
+    verifyResult = "unknown";
+    const resolved = await resolveAssistantApiKeyForInjection(ARGS);
+    expect(resolved).toEqual({ apiKey: "stored-key", source: "stored" });
+    expect(calls).not.toContain("reprovision");
+  });
+
+  // Rotating while the gateway is down would start the grace clock on a key
+  // the assistant still needs, with nowhere to store the replacement.
+  test("an unreachable gateway withholds rotation", async () => {
+    verifyResult = null;
+    readResult = { value: null, unreachable: true };
+    const resolved = await resolveAssistantApiKeyForInjection(ARGS);
+    expect(resolved).toEqual({ apiKey: null, source: "unavailable" });
+    expect(calls).not.toContain("reprovision");
+  });
+
+  test("a reachable assistant with no key stored is provisioned one", async () => {
+    verifyResult = "unknown";
+    readResult = { value: null, unreachable: false };
+    const resolved = await resolveAssistantApiKeyForInjection(ARGS);
+    expect(resolved).toEqual({ apiKey: "fresh-key", source: "reprovisioned" });
+    expect(calls).toEqual(["verify", "read", "reprovision"]);
+  });
+});

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -10,6 +10,7 @@ import {
   saveAssistantEntry,
   setActiveAssistant,
 } from "../lib/assistant-config";
+import { resolveAssistantApiKeyForInjection } from "../lib/assistant-api-key-resolution";
 import { computeDeviceId } from "../lib/guardian-token";
 import { openBrowser } from "../lib/open-browser";
 import {
@@ -20,9 +21,7 @@ import {
   fetchPlatformAssistants,
   getPlatformUrl,
   injectCredentialsIntoAssistant,
-  readGatewayCredential,
   readPlatformToken,
-  reprovisionAssistantApiKey,
   savePlatformToken,
 } from "../lib/platform-client";
 import { syncCloudAssistants } from "../lib/sync-cloud-assistants";
@@ -405,33 +404,21 @@ export async function login(): Promise<void> {
           `Registered assistant: ${registration.assistant.name} (${registration.assistant.id})`,
         );
 
-        // Resolve the API key to inject, mirroring the macOS app's
-        // LocalAssistantBootstrapService 3-step flow:
-        // 1. Use fresh key from registration (first-time only)
-        // 2. Use existing key from the daemon's credential store
-        // 3. Reprovision (rotate) as a last resort — this revokes the
-        //    old key server-side, so we only do it when the gateway
-        //    confirms no key exists (not when it's merely unreachable).
-        let assistantApiKey = registration.assistant_api_key;
-        if (!assistantApiKey) {
-          const cached = await readGatewayCredential(
-            entry.runtimeUrl,
-            "vellum:assistant_api_key",
-            entry.bearerToken,
-          );
-          if (cached.value) {
-            assistantApiKey = cached.value;
-          } else if (!cached.unreachable) {
-            console.log("No API key available locally — reprovisioning...");
-            const reprovision = await reprovisionAssistantApiKey(
-              token,
-              orgId,
-              clientInstallationId,
-              entry.assistantId,
-              "cli",
-            );
-            assistantApiKey = reprovision.provisioning.assistant_api_key;
-          }
+        // Which key to hand the assistant, and why. Shared with teleport so
+        // the two injection paths cannot drift.
+        const resolved = await resolveAssistantApiKeyForInjection({
+          registrationApiKey: registration.assistant_api_key,
+          runtimeUrl: entry.runtimeUrl,
+          bearerToken: entry.bearerToken,
+          token,
+          organizationId: orgId,
+          clientInstallationId,
+          runtimeAssistantId: entry.assistantId,
+          clientPlatform: "cli",
+        });
+        const assistantApiKey = resolved.apiKey;
+        if (resolved.source === "reprovisioned") {
+          console.log("Provisioning a replacement API key...");
         }
 
         // Inject credentials into the running assistant via the gateway,

--- a/cli/src/commands/teleport.ts
+++ b/cli/src/commands/teleport.ts
@@ -1,3 +1,4 @@
+import { resolveAssistantApiKeyForInjection } from "../lib/assistant-api-key-resolution";
 import {
   findAssistantByName,
   loadAllAssistants,
@@ -23,8 +24,6 @@ import {
   platformRequestSignedUrl,
   VersionMismatchError,
   ensureSelfHostedLocalRegistration,
-  readGatewayCredential,
-  reprovisionAssistantApiKey,
   injectCredentialsIntoAssistant,
   fetchCurrentUser,
   fetchOrganizationId,
@@ -1154,30 +1153,19 @@ async function tryInjectPlatformCredentials(
       platformOrganizationId: orgId,
     });
 
-    // Resolve the API key: 1) fresh from registration, 2) existing from
-    // daemon credential store, 3) reprovision as last resort (revokes old key).
-    // Only reprovision when the gateway confirms no key exists — not when
-    // the gateway is merely unreachable (would revoke without injecting).
-    let assistantApiKey = registration.assistant_api_key;
-    if (!assistantApiKey) {
-      const cached = await readGatewayCredential(
-        entry.runtimeUrl,
-        "vellum:assistant_api_key",
-        entry.bearerToken,
-      );
-      if (cached.value) {
-        assistantApiKey = cached.value;
-      } else if (!cached.unreachable) {
-        const reprovision = await reprovisionAssistantApiKey(
-          token,
-          orgId,
-          clientInstallationId,
-          entry.assistantId,
-          "cli",
-        );
-        assistantApiKey = reprovision.provisioning.assistant_api_key;
-      }
-    }
+    // Which key to hand the assistant, and why. Shared with login so the two
+    // injection paths cannot drift.
+    const resolvedKey = await resolveAssistantApiKeyForInjection({
+      registrationApiKey: registration.assistant_api_key,
+      runtimeUrl: entry.runtimeUrl,
+      bearerToken: entry.bearerToken,
+      token,
+      organizationId: orgId,
+      clientInstallationId,
+      runtimeAssistantId: entry.assistantId,
+      clientPlatform: "cli",
+    });
+    const assistantApiKey = resolvedKey.apiKey;
 
     const allInjected = await injectCredentialsIntoAssistant({
       gatewayUrl: entry.runtimeUrl,

--- a/cli/src/lib/assistant-api-key-resolution.ts
+++ b/cli/src/lib/assistant-api-key-resolution.ts
@@ -40,10 +40,13 @@ export interface ResolvedAssistantApiKey {
  * assistant already holds, then a rotation.
  *
  * A stored key the platform has rejected is skipped, because reinjecting it
- * repairs nothing while looking like a repair. Rotation is still withheld
- * when the gateway is merely unreachable: rotating without being able to
- * store the replacement would start the platform's grace clock on a key the
- * assistant still needs, with nothing to hand it in exchange.
+ * repairs nothing while looking like a repair. The verdict is asked for
+ * before the key is read, so the key returned is one the verdict covers: a
+ * repair that lands between the two requests is then read, not overwritten
+ * by the value it replaced. Rotation is still withheld when the gateway is
+ * merely unreachable: rotating without being able to store the replacement
+ * would start the platform's grace clock on a key the assistant still needs,
+ * with nothing to hand it in exchange.
  */
 export async function resolveAssistantApiKeyForInjection(
   args: ResolveAssistantApiKeyArgs,
@@ -52,26 +55,24 @@ export async function resolveAssistantApiKeyForInjection(
     return { apiKey: args.registrationApiKey, source: "registration" };
   }
 
-  const cached = await readGatewayCredential(
+  const status = await verifyGatewayManagedCredential(
     args.runtimeUrl,
-    "vellum:assistant_api_key",
     args.bearerToken,
   );
-
-  // Only worth asking when there is a key to ask about: with none stored the
-  // answer changes nothing, and a first login would pay for the round trip
-  // every time.
-  if (cached.value) {
-    const status = await verifyGatewayManagedCredential(
+  // A settled rejection came from a gateway that answered, so the
+  // replacement can be stored; the rejected key is not worth reading.
+  if (status !== "rejected") {
+    const cached = await readGatewayCredential(
       args.runtimeUrl,
+      "vellum:assistant_api_key",
       args.bearerToken,
     );
-    if (status !== "rejected") {
+    if (cached.value) {
       return { apiKey: cached.value, source: "stored" };
     }
-  }
-  if (cached.unreachable) {
-    return { apiKey: null, source: "unavailable" };
+    if (cached.unreachable) {
+      return { apiKey: null, source: "unavailable" };
+    }
   }
 
   const reprovision = await reprovisionAssistantApiKey(

--- a/cli/src/lib/assistant-api-key-resolution.ts
+++ b/cli/src/lib/assistant-api-key-resolution.ts
@@ -1,0 +1,88 @@
+/**
+ * Resolve which assistant API key to inject into a running assistant.
+ *
+ * The one place that decides, for every flow that hands a local assistant its
+ * platform credentials (`login`, `teleport`). Keeping the decision here means a
+ * rule about which stored key is usable holds in all of them at once.
+ */
+import {
+  readGatewayCredential,
+  reprovisionAssistantApiKey,
+  verifyGatewayManagedCredential,
+} from "./platform-client.js";
+
+/** Where the key came from, so callers can report what they did. */
+export type AssistantApiKeySource =
+  | "registration"
+  | "stored"
+  | "reprovisioned"
+  | "unavailable";
+
+export interface ResolveAssistantApiKeyArgs {
+  /** Key the registration returned, set only when it had none before. */
+  registrationApiKey: string | null;
+  runtimeUrl: string;
+  bearerToken?: string;
+  token: string;
+  organizationId: string;
+  clientInstallationId: string;
+  runtimeAssistantId: string;
+  clientPlatform: string;
+}
+
+export interface ResolvedAssistantApiKey {
+  apiKey: string | null;
+  source: AssistantApiKeySource;
+}
+
+/**
+ * Three steps, in order: the key the registration just issued, the key the
+ * assistant already holds, then a rotation.
+ *
+ * A stored key the platform has rejected is skipped, because reinjecting it
+ * repairs nothing while looking like a repair. Rotation is still withheld
+ * when the gateway is merely unreachable: rotating without being able to
+ * store the replacement would start the platform's grace clock on a key the
+ * assistant still needs, with nothing to hand it in exchange.
+ */
+export async function resolveAssistantApiKeyForInjection(
+  args: ResolveAssistantApiKeyArgs,
+): Promise<ResolvedAssistantApiKey> {
+  if (args.registrationApiKey) {
+    return { apiKey: args.registrationApiKey, source: "registration" };
+  }
+
+  const cached = await readGatewayCredential(
+    args.runtimeUrl,
+    "vellum:assistant_api_key",
+    args.bearerToken,
+  );
+
+  // Only worth asking when there is a key to ask about: with none stored the
+  // answer changes nothing, and a first login would pay for the round trip
+  // every time.
+  if (cached.value) {
+    const status = await verifyGatewayManagedCredential(
+      args.runtimeUrl,
+      args.bearerToken,
+    );
+    if (status !== "rejected") {
+      return { apiKey: cached.value, source: "stored" };
+    }
+  }
+  if (cached.unreachable) {
+    return { apiKey: null, source: "unavailable" };
+  }
+
+  const reprovision = await reprovisionAssistantApiKey(
+    args.token,
+    args.organizationId,
+    args.clientInstallationId,
+    args.runtimeAssistantId,
+    args.clientPlatform,
+  );
+  return {
+    apiKey: reprovision.provisioning.assistant_api_key,
+    source: "reprovisioned",
+  };
+}

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -289,7 +289,10 @@ export interface ReprovisionApiKeyResponse {
  * Reprovision (rotate) the API key for a self-hosted local assistant.
  *
  * Calls `POST /v1/assistants/self-hosted-local/reprovision-api-key/`.
- * Returns a fresh API key. The previous key is revoked server-side.
+ * Returns a fresh API key. The platform keeps the previous key valid for a
+ * grace period rather than revoking it on the spot, so a rotation whose
+ * replacement never gets stored leaves the assistant on a key that still
+ * works until that window closes.
  */
 export async function reprovisionAssistantApiKey(
   token: string,
@@ -350,15 +353,60 @@ export interface GatewayCredentialResult {
 }
 
 /**
+ * Ask a running assistant to check its stored managed credential against the
+ * platform, via the gateway-proxied `POST /v1/platform/verify-credential`.
+ *
+ * Returns `"rejected"` only when the platform settled that answer. Every other
+ * case, including a daemon too old to serve the route and any failure to reach
+ * one, returns null: the answer decides whether a key is rotated, so an absent
+ * answer must never read as a rejection.
+ *
+ * Never throws.
+ */
+export async function verifyGatewayManagedCredential(
+  gatewayUrl: string,
+  bearerToken?: string,
+): Promise<"valid" | "rejected" | "unknown" | null> {
+  try {
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (bearerToken) {
+      headers["Authorization"] = `Bearer ${bearerToken}`;
+    }
+
+    const response = await loopbackSafeFetch(
+      `${gatewayUrl}/v1/platform/verify-credential`,
+      {
+        method: "POST",
+        headers,
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!response.ok) {
+      return null;
+    }
+
+    const json = (await response.json()) as { status?: unknown };
+    const status = json.status;
+    if (status === "valid" || status === "rejected" || status === "unknown") {
+      return status;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read an existing credential from the assistant's secret store via the
  * gateway-proxied `POST /v1/secrets/read` endpoint (with `reveal: true`).
  *
  * Returns a result distinguishing "key not found" (`value: null,
  * unreachable: false`) from "gateway unreachable" (`value: null,
  * unreachable: true`). Callers should only reprovision when the gateway
- * is reachable but the key is genuinely missing — reprovisioning while
- * the gateway is down would revoke the old key server-side without being
- * able to inject the replacement.
+ * is reachable: the platform keeps the outgoing key valid for a grace
+ * period, so reprovisioning while the gateway is down does not break the
+ * assistant immediately, but it starts a clock on a key the caller cannot
+ * yet replace.
  *
  * Never throws.
  */
@@ -385,7 +433,7 @@ export async function readGatewayCredential(
 
     if (!response.ok) {
       // 5xx means the gateway/daemon backend is down — treat as unreachable
-      // so callers don't revoke a potentially valid key.
+      // so callers don't rotate away from a working key they cannot replace.
       return { value: null, unreachable: response.status >= 500 };
     }
 

--- a/cli/src/lib/platform-client.ts
+++ b/cli/src/lib/platform-client.ts
@@ -1,4 +1,8 @@
 import {
+  type PlatformCredentialVerificationStatus,
+  PlatformVerifyCredentialResponseSchema,
+} from "@vellumai/service-contracts/platform-credential";
+import {
   chmodSync,
   readFileSync,
   writeFileSync,
@@ -366,7 +370,7 @@ export interface GatewayCredentialResult {
 export async function verifyGatewayManagedCredential(
   gatewayUrl: string,
   bearerToken?: string,
-): Promise<"valid" | "rejected" | "unknown" | null> {
+): Promise<PlatformCredentialVerificationStatus | null> {
   try {
     const headers: Record<string, string> = { Accept: "application/json" };
     if (bearerToken) {
@@ -385,10 +389,11 @@ export async function verifyGatewayManagedCredential(
       return null;
     }
 
-    const json = (await response.json()) as { status?: unknown };
-    const status = json.status;
-    if (status === "valid" || status === "rejected" || status === "unknown") {
-      return status;
+    const parsed = PlatformVerifyCredentialResponseSchema.safeParse(
+      await response.json(),
+    );
+    if (parsed.success) {
+      return parsed.data.status;
     }
     return null;
   } catch {

--- a/packages/service-contracts/package.json
+++ b/packages/service-contracts/package.json
@@ -22,7 +22,8 @@
     "./redacted-credential": "./src/redacted-credential.ts",
     "./secret-detection": "./src/secret-detection.ts",
     "./stripe-currency": "./src/stripe-currency.ts",
-    "./error": "./src/error.ts"
+    "./error": "./src/error.ts",
+    "./platform-credential": "./src/platform-credential.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",

--- a/packages/service-contracts/src/index.ts
+++ b/packages/service-contracts/src/index.ts
@@ -28,6 +28,7 @@ export * from "./rpc.js";
 export * from "./trust-rules.js";
 export * from "./ingress.js";
 export * from "./no-response.js";
+export * from "./platform-credential.js";
 export * from "./remote-web-pairing.js";
 export * from "./twilio-ingress.js";
 export * from "./url-normalization.js";

--- a/packages/service-contracts/src/platform-credential.ts
+++ b/packages/service-contracts/src/platform-credential.ts
@@ -1,0 +1,41 @@
+/**
+ * Wire contract for asking an assistant whether its stored platform-managed
+ * credential still authenticates.
+ *
+ * The daemon route is the authoritative serving side:
+ *   - `POST /v1/platform/verify-credential`
+ *       (`assistant/src/runtime/routes/platform-routes.ts`)
+ *
+ * The daemon's platform client produces the verdict, the route reports it,
+ * and the `vellum` CLI reads it before deciding whether a stored key can be
+ * re-injected (`cli/src/lib/assistant-api-key-resolution.ts`), so all three
+ * share one definition and cannot silently drift. The web app reads the same
+ * shape through its generated daemon client.
+ */
+import { z } from "zod";
+
+/**
+ * What the platform said about the stored credential, right now.
+ *
+ *   - `valid`: the platform accepted it.
+ *   - `rejected`: the platform refused it (unauthorized or forbidden); the
+ *     credential needs replacing.
+ *   - `unknown`: the check itself could not run (no credential stored, the
+ *     platform unreachable, a server error). Not evidence either way.
+ */
+export const PlatformCredentialVerificationStatusSchema = z.enum([
+  "valid",
+  "rejected",
+  "unknown",
+]);
+export type PlatformCredentialVerificationStatus = z.infer<
+  typeof PlatformCredentialVerificationStatusSchema
+>;
+
+/** `POST /v1/platform/verify-credential` response body. */
+export const PlatformVerifyCredentialResponseSchema = z.object({
+  status: PlatformCredentialVerificationStatusSchema,
+});
+export type PlatformVerifyCredentialResponse = z.infer<
+  typeof PlatformVerifyCredentialResponseSchema
+>;


### PR DESCRIPTION
## TL;DR

Part of LUM-3508. The daemon and CLI half of the managed-credential recovery, split out of #41918 so it can land first: a stored managed credential is now checked against the platform where checking matters, instead of being trusted because it exists. `platform connect` stops answering "Already connected" on a dead key, the CLI login and teleport flows detect a rejected key and provision a replacement instead of re-injecting it, and a new daemon route lets a client confirm a credential it just wrote. The web half (the in-app repair button) follows in #41918 and gates on this route by version, which is why this lands first.

## What a user experiences

| | Before | After |
| --- | --- | --- |
| `platform connect` with a stored key the platform has rejected | "Already connected" | verifies the key first; reports the rejection (`credentialRejected`) and names the forced CLI sign-in that replaces it (a plain sign-in stops at "already logged in" before the credential pass), instead of announcing a login screen no shipped client shows |
| Logging in from the CLI, or teleporting, with a rejected key stored | re-injects the same dead key | detects the rejection and provisions a replacement |
| Either flow while the gateway is unreachable | n/a | withholds rotation, so an outage cannot rotate a key it then fails to store |
| A client that wants to know whether a stored credential works | no way to ask | `POST /v1/platform/verify-credential` answers valid, rejected, or unknown |

The platform already does its half. `reprovision-api-key` rotates an existing key and keeps the outgoing one valid for a 24 hour grace period. `recover_expired_assistant_api_key` self-heals platform-hosted assistants while **deliberately excluding** self-hosted and local registrations, in its own words, "because their clients own the reprovision flow". No client ever implemented that ownership for a rejected key. This is the client's half.

| Site | Gate | Effect on a rejected key |
| --- | --- | --- |
| CLI login / teleport | `if (!assistantApiKey)` | re-inject the same rejected key |
| platform connect | url and key present | `alreadyConnected: true` |

## Why this is the right design

**Validity is checked, not cached.** The spike cached credential validity in the daemon. Five of its review findings were lifecycle bugs in that cache (delete and disconnect left it stale; an unsettled observation erased a settled rejection; a rejected replacement kept a cleared verdict; a restart made the repair inert). Each was patched individually, and six patches to make one primitive behave is the design saying it is wrong. Here validity is checked where checking matters: the repair verifies the credential it just wrote through `platform_verify_credential`; `platform connect` verifies before answering, since it is a deliberate user action and one request is affordable; both go through one helper so they cannot disagree about what "connected" means. There is no stored verdict, so there is no verdict lifecycle to get wrong.

**One resolver for the CLI.** The login and teleport flows each carried the same three-step key resolution written out separately; a rule applied to one was invisible in the other. Both now call `resolveAssistantApiKeyForInjection`, which skips a stored key only on a settled rejection and still withholds rotation when the gateway is merely unreachable, so a login during an outage cannot rotate a key it then fails to store.

**The verdict has one definition.** `valid`, `rejected`, `unknown` and the route's response shape are declared once in `@vellumai/service-contracts/platform-credential`, the seam the daemon and the `vellum` CLI already share (the CLI does not import from the daemon by design). The route embeds that schema, the CLI parses responses with it, the daemon's platform client returns its type, and the assistant CLI's `connect` command imports the route's own response type rather than restating it. The web reads the same shape through its generated daemon client.

**The key injected is the key verified.** The resolver asks for the verdict first and reads the stored key after it, so a repair that lands between the two requests is read rather than overwritten by the value it replaced; a rejected key is never read at all. The resolver's test asserts the order.

## Why this is safe

**No new privilege.** Rotation requires an authenticated *user* session; holding the dead assistant key grants nothing. It is scoped to the caller's own registration tuple, throttled at 30/min, and the org assistant cap still applies. The verification route performs a check and mutates nothing, so it carries read scope and the same principal bundle as `platform_status`, whose caller shape it shares.

**Nothing rotates unattended.** Rotation happens only when someone asks: the banner's button, or the CLI flows. Routine identity resolution leaves a stored key alone (`resolution alone never rotates a stored key`).

**Rotation is not destructive** even then. The platform keeps the outgoing key valid for 24 hours, so a rotation whose injection fails leaves the install no worse off.

**An unsettled answer is never evidence of a dead credential.** Transport failures, server errors, and an unreachable platform all read as `unknown`. Connect keeps counting stored credentials as a connection on `unknown`, so a network problem never strands a working install by reporting it disconnected.

**Additive on the wire.** One new route; no existing response shape changes. An older client is unaffected.

**The login broadcast is not the answer's only path.** `platform connect` always emitted `show_platform_login`; a repo-wide search finds no shipped consumer (the web chat handler lists it as a no-op). The outcome now travels in the response, and the CLI says what replaces a rejected key. Removing the dead event is a separate cleanup: its type is shared vocabulary copied into the clients.

## Deliberately not here

The web app's half: the banner button that performs the repair in-app, its sign-in gate, and the version gate that keeps it from calling this route on an older daemon. That is #41918, reduced to `clients/web` only. Its version floor has to name a build that actually carries this route, which only exists once this merges, so it waits on this PR; on daemons without the route its repair still works (the stored replacement is the repair), it just cannot confirm it.

## Testing

Per-file runs, all green in this worktree: credential health (40), the verify transport (6: carrier, auth, deadline, and the accepted, refused, erroring, unreachable, and identity-less cases), the CLI key resolver (6, including call order), the connect command (4), the route tests, CLI and assistant typecheck. The credential-health check for the assistant key is exported for the route and deliberately not enrolled in the periodic sweep, and the test file says why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

