### PR TITLE
i18n(web): complete Simplified and Traditional Chinese localization for settings and skills

### DIFF
--- a/clients/web/src/components/voice-transcript-toggles.tsx
+++ b/clients/web/src/components/voice-transcript-toggles.tsx
@@ -71,6 +71,7 @@ export function VoiceTranscriptToggles({
   showDescription = false,
   showRecommendedBadge = false,
 }: VoiceTranscriptTogglesProps) {
+  const { t } = useTranslation();
   const showUserTranscript = useVoicePrefsStore.use.showUserTranscript();
   const showAssistantTranscript =
     useVoicePrefsStore.use.showAssistantTranscript();
@@ -92,6 +93,23 @@ export function VoiceTranscriptToggles({
     },
   };
 
+  const getToggleLabel = (prefKey: VoiceTranscriptPrefKey, fallback: string) => {
+    if (prefKey === "showUserTranscript") {
+      return t("voiceTranscriptToggles.userTranscriptLabel", fallback);
+    }
+    return t("voiceTranscriptToggles.assistantTranscriptLabel", fallback);
+  };
+
+  const getToggleDescription = (
+    prefKey: VoiceTranscriptPrefKey,
+    fallback: string,
+  ) => {
+    if (prefKey === "showUserTranscript") {
+      return t("voiceTranscriptToggles.userTranscriptDescription", fallback);
+    }
+    return t("voiceTranscriptToggles.assistantTranscriptDescription", fallback);
+  };
+
   return (
     <>
       {VOICE_TRANSCRIPT_TOGGLES.map((def) => {
@@ -99,8 +117,12 @@ export function VoiceTranscriptToggles({
         return (
           <TranscriptToggleRow
             key={def.prefKey}
-            label={def.label}
-            description={showDescription ? def.description : undefined}
+            label={getToggleLabel(def.prefKey, def.label)}
+            description={
+              showDescription
+                ? getToggleDescription(def.prefKey, def.description)
+                : undefined
+            }
             showBadge={showRecommendedBadge}
             checked={binding.checked}
             onChange={binding.onChange}

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -828,8 +828,9 @@ export function ComposerSettingsMenu({
   // Access trigger: the active preset's name beside its icon, as a floating
   // pill on mobile (Figma 7840-8819) and as an action-row button on desktop
   // (Figma 7471-25243).
+  const activePresetLabel = t(activePreset.labelKey, activePreset.label);
   const accessLabel = tChat("composerSettingsMenu.accessAria", {
-    label: activePreset.label,
+    label: activePresetLabel,
   });
   const accessTrigger = isMobile ? (
     <Button
@@ -845,7 +846,7 @@ export function ComposerSettingsMenu({
       <span aria-hidden="true" className={pillIconClass}>
         <AccessIcon />
       </span>
-      {activePreset.label}
+      {activePresetLabel}
     </Button>
   ) : (
     <Button
@@ -856,7 +857,7 @@ export function ComposerSettingsMenu({
       className={`${triggerClass} ${triggerLabelClass} ${inertActionRowTriggerClass} shrink-0`}
       disabled={!accessLive}
     >
-      {activePreset.label}
+      {activePresetLabel}
     </Button>
   );
 
@@ -934,6 +935,8 @@ export function ComposerSettingsMenu({
   // the two layouts can never drift apart.
   const accessMenuItems = accessItems.map(({ preset, isActive, isDefault }) => {
     const PresetIcon = preset.icon;
+    const presetLabel = t(preset.labelKey, preset.label);
+    const presetDesc = t(preset.descriptionKey, preset.description);
     return (
       <Menu.Item
         key={preset.id}
@@ -952,9 +955,9 @@ export function ComposerSettingsMenu({
             <Check className="h-3.5 w-3.5 text-[var(--system-positive-strong)]" />
           ) : undefined
         }
-        title={preset.description}
+        title={presetDesc}
       >
-        {preset.label}
+        {presetLabel}
         {isDefault && (
           <span className="ml-1 text-[var(--content-tertiary)]">
             {tChat("composerSettingsMenu.defaultSuffix")}
@@ -1039,7 +1042,7 @@ export function ComposerSettingsMenu({
     // the real one lands; the trigger itself is always mounted, so the profile
     // section below it is reachable either way.
     const activeSummary = [
-      accessSettled ? activePreset.label : null,
+      accessSettled ? activePresetLabel : null,
       displayProfileLabel,
     ]
       .filter(Boolean)
@@ -1098,30 +1101,33 @@ export function ComposerSettingsMenu({
                 <SectionLabel>
                   {tChat("composerSettingsMenu.assistantAccess")}
                 </SectionLabel>
-                {accessItems.map(({ preset, isActive, isDefault }) => (
-                  <PanelItem
-                    key={preset.id}
-                    icon={preset.icon}
-                    label={
-                      isDefault
-                        ? tChat("composerSettingsMenu.defaultLabel", {
-                            label: preset.label,
-                          })
-                        : preset.label
-                    }
-                    active={isActive}
-                    className="max-md:[&>span:first-child]:gap-[11px]"
-                    trailingAction={
-                      isActive ? (
-                        <Check className="h-4 w-4 text-[var(--system-positive-strong)]" />
-                      ) : undefined
-                    }
-                    onSelect={() => {
-                      handleSelect(preset);
-                      setAccessOpen(false);
-                    }}
-                  />
-                ))}
+                {accessItems.map(({ preset, isActive, isDefault }) => {
+                  const presetLabel = t(preset.labelKey, preset.label);
+                  return (
+                    <PanelItem
+                      key={preset.id}
+                      icon={preset.icon}
+                      label={
+                        isDefault
+                          ? tChat("composerSettingsMenu.defaultLabel", {
+                              label: presetLabel,
+                            })
+                          : presetLabel
+                      }
+                      active={isActive}
+                      className="max-md:[&>span:first-child]:gap-[11px]"
+                      trailingAction={
+                        isActive ? (
+                          <Check className="h-4 w-4 text-[var(--system-positive-strong)]" />
+                        ) : undefined
+                      }
+                      onSelect={() => {
+                        handleSelect(preset);
+                        setAccessOpen(false);
+                      }}
+                    />
+                  );
+                })}
               </BottomSheet.Body>
             </BottomSheet.Content>
           </BottomSheet.Root>

--- a/clients/web/src/domains/intelligence/components/skills/category-sidebar.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/category-sidebar.tsx
@@ -5,6 +5,22 @@ import type { CategoryInfo } from "@/domains/intelligence/skills/use-skill-categ
 import { useTranslation } from "@/i18n";
 import { Button } from "@vellumai/design-library";
 
+const CATEGORY_KEYS = {
+  email: "categories.email",
+  calendar: "categories.calendar",
+  messaging: "categories.messaging",
+  browsing: "categories.browsing",
+  productivity: "categories.productivity",
+  development: "categories.development",
+  voice: "categories.voice",
+  commerce: "categories.commerce",
+  content: "categories.content",
+  health: "categories.health",
+  system: "categories.system",
+  integrations: "categories.integrations",
+  other: "categories.other",
+} as const;
+
 interface CategorySidebarProps {
   selected: string | null;
   onSelect: (category: string | null) => void;
@@ -26,8 +42,10 @@ export function CategorySidebar({
   ariaLabel,
 }: CategorySidebarProps) {
   const { t } = useTranslation("intelligence");
-  const getCategoryLabel = (cat: CategoryInfo) =>
-    t(`categories.${cat.slug}`, cat.label);
+  const getCategoryLabel = (cat: CategoryInfo) => {
+    const key = CATEGORY_KEYS[cat.slug as keyof typeof CATEGORY_KEYS];
+    return key ? t(key, cat.label) : cat.label;
+  };
 
   const sortedCategories = [...categories].sort((a, b) =>
     getCategoryLabel(a).localeCompare(getCategoryLabel(b)),

--- a/clients/web/src/domains/intelligence/components/skills/category-sidebar.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/category-sidebar.tsx
@@ -26,8 +26,11 @@ export function CategorySidebar({
   ariaLabel,
 }: CategorySidebarProps) {
   const { t } = useTranslation("intelligence");
+  const getCategoryLabel = (cat: CategoryInfo) =>
+    t(`categories.${cat.slug}`, cat.label);
+
   const sortedCategories = [...categories].sort((a, b) =>
-    a.label.localeCompare(b.label),
+    getCategoryLabel(a).localeCompare(getCategoryLabel(b)),
   );
 
   return (
@@ -49,7 +52,7 @@ export function CategorySidebar({
           <CategoryRow
             key={cat.slug}
             icon={Icon}
-            label={cat.label}
+            label={getCategoryLabel(cat)}
             count={counts[cat.slug] ?? 0}
             isActive={selected === cat.slug}
             showCount={showCounts}

--- a/clients/web/src/domains/settings/components/risk-tolerance-settings.tsx
+++ b/clients/web/src/domains/settings/components/risk-tolerance-settings.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -19,15 +19,19 @@ function Divider() {
   );
 }
 
-const PRESET_OPTIONS = THRESHOLD_PRESETS.map((p) => ({
-  value: p.id,
-  label: p.label,
-  icon: <p.icon className="h-3.5 w-3.5" />,
-}));
-
 export function RiskToleranceSettings() {
   const { t } = useTranslation("settings");
   const assistantId = useActiveAssistantId();
+
+  const presetOptions = useMemo(
+    () =>
+      THRESHOLD_PRESETS.map((p) => ({
+        value: p.id,
+        label: t(p.labelKey, p.label),
+        icon: <p.icon className="h-3.5 w-3.5" />,
+      })),
+    [t],
+  );
 
   const queryClient = useQueryClient();
   const { data: thresholds, isError: loadError } = useQuery({
@@ -178,13 +182,13 @@ export function RiskToleranceSettings() {
             <Select
               value={interactivePresetId}
               onChange={handleInteractiveChange}
-              options={PRESET_OPTIONS}
+              options={presetOptions}
               disabled={dropdownsDisabled}
             />
           </div>
           {interactivePreset && (
             <p className="mt-2 text-body-small-default text-[var(--content-tertiary)]">
-              {interactivePreset.description}
+              {t(interactivePreset.descriptionKey, interactivePreset.description)}
             </p>
           )}
         </div>
@@ -220,13 +224,13 @@ export function RiskToleranceSettings() {
                 <Select
                   value={autonomousPresetId}
                   onChange={handleAutonomousChange}
-                  options={PRESET_OPTIONS}
+                  options={presetOptions}
                   disabled={dropdownsDisabled}
                 />
               </div>
               {autonomousPreset && (
                 <p className="mt-2 text-body-small-default text-[var(--content-tertiary)]">
-                  {autonomousPreset.description}
+                  {t(autonomousPreset.descriptionKey, autonomousPreset.description)}
                 </p>
               )}
             </div>
@@ -244,13 +248,13 @@ export function RiskToleranceSettings() {
                 <Select
                   value={headlessPresetId}
                   onChange={handleHeadlessChange}
-                  options={PRESET_OPTIONS}
+                  options={presetOptions}
                   disabled={dropdownsDisabled}
                 />
               </div>
               {headlessPreset && (
                 <p className="mt-2 text-body-small-default text-[var(--content-tertiary)]">
-                  {headlessPreset.description}
+                  {t(headlessPreset.descriptionKey, headlessPreset.description)}
                 </p>
               )}
             </div>

--- a/clients/web/src/domains/settings/pages/debug-page.tsx
+++ b/clients/web/src/domains/settings/pages/debug-page.tsx
@@ -9,14 +9,15 @@ import { DebugControlsPanel } from "@/domains/settings/components/panels/debug-c
 import { DoctorPanel } from "@/domains/settings/components/panels/doctor-panel";
 import { resolveDebugTabParam } from "@/domains/settings/pages/debug-page.helpers";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { useTranslation } from "@/i18n";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { Tabs } from "@vellumai/design-library/components/tabs";
 
 const ALL_TABS = [
-  { id: "general", label: "General" },
-  { id: "terminal", label: "Terminal" },
-  { id: "doctor", label: "Doctor" },
-  { id: "conversations", label: "Conversations" },
+  { id: "general", labelKey: "debugPage.tabs.general", defaultLabel: "General" },
+  { id: "terminal", labelKey: "debugPage.tabs.terminal", defaultLabel: "Terminal" },
+  { id: "doctor", labelKey: "debugPage.tabs.doctor", defaultLabel: "Doctor" },
+  { id: "conversations", labelKey: "debugPage.tabs.conversations", defaultLabel: "Conversations" },
 ] as const;
 
 type DebugTabId = (typeof ALL_TABS)[number]["id"];
@@ -24,6 +25,7 @@ type DebugTabId = (typeof ALL_TABS)[number]["id"];
 const DEFAULT_TAB: DebugTabId = "general";
 
 export function DebugPage() {
+  const { t } = useTranslation("settings");
   const [searchParams, setSearchParams] = useSearchParams();
   const assistantId = useActiveAssistantId();
   const navigate = useNavigate();
@@ -91,7 +93,7 @@ export function DebugPage() {
         <Tabs.List>
           {tabs.map((tab) => (
             <Tabs.Trigger key={tab.id} value={tab.id}>
-              {tab.label}
+              {t(tab.labelKey, tab.defaultLabel)}
             </Tabs.Trigger>
           ))}
         </Tabs.List>

--- a/clients/web/src/domains/settings/pages/voice-page.tsx
+++ b/clients/web/src/domains/settings/pages/voice-page.tsx
@@ -292,7 +292,7 @@ function CaptionsCard() {
       <div className="flex flex-col gap-2">
         <VoiceTranscriptToggles showDescription />
         <p className={`${labelClasses} pt-1`}>
-          {VOICE_TRANSCRIPT_RECOMMENDATION}
+          {t("voicePage.captionsRecommendation", VOICE_TRANSCRIPT_RECOMMENDATION)}
         </p>
       </div>
     </DetailCard>

--- a/clients/web/src/domains/settings/settings-layout.tsx
+++ b/clients/web/src/domains/settings/settings-layout.tsx
@@ -1,7 +1,8 @@
 import { LogIn, LogOut } from "lucide-react";
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 
+import { useTranslation } from "@/i18n";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
 import { handleLogout } from "@/lib/auth/handle-logout";
@@ -36,6 +37,7 @@ export function SettingsLayout() {
     setWindowsMenuBarSuppressed(true);
     return () => setWindowsMenuBarSuppressed(false);
   }, [setWindowsMenuBarSuppressed]);
+  const { t } = useTranslation("settings");
   const isNativeAndroid = useIsNativeAndroid();
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   // The Bookmarks and Credentials tabs need routes that only newer assistants
@@ -54,12 +56,49 @@ export function SettingsLayout() {
   // (`usePlatformGate() === "full"`), matching billing-page.tsx's
   // `showBillingTab`. Signed-out / self-hosted users see just "Usage".
   const billingGate = usePlatformGate();
-  const billingLabel = billingGate === "full" ? "Billing & Usage" : "Usage";
   const { pathname } = useLocation();
   const navigate = useNavigate();
   // Show Log Out when a platform session exists, Log In otherwise.
   const hasPlatformSession = useHasPlatformSession();
   const { login } = useOnboardingLogin();
+
+  const getSidebarLabel = useCallback(
+    (id: string, defaultLabel: string) => {
+      switch (id) {
+        case "assistant-status":
+          return t("sidebar.general", "General");
+        case "model":
+          return t("sidebar.model", "Models & Services");
+        case "integrations":
+          return t("sidebar.integrations", "Integrations");
+        case "credentials":
+          return t("sidebar.credentials", "Credentials");
+        case "notifications":
+          return t("sidebar.notifications", "Notifications");
+        case "voice":
+          return t("sidebar.voice", "Voice");
+        case "sounds":
+          return t("sidebar.sounds", "Sounds");
+        case "privacy":
+          return t("sidebar.privacy", "Permissions & Privacy");
+        case "bookmarks":
+          return t("sidebar.bookmarks", "Bookmarks");
+        case "billing":
+          return billingGate === "full"
+            ? t("sidebar.billingUsage", "Billing & Usage")
+            : t("sidebar.usage", "Usage");
+        case "community":
+          return t("sidebar.community", "Community");
+        case "debug":
+          return t("sidebar.debug", "Debug");
+        case "developer":
+          return t("sidebar.developer", "Developer");
+        default:
+          return defaultLabel;
+      }
+    },
+    [t, billingGate],
+  );
 
   const filteredItems = useMemo(
     () =>
@@ -80,54 +119,69 @@ export function SettingsLayout() {
           return false;
         }
         return true;
-      }).map((item) =>
-        item.id === "billing" ? { ...item, label: billingLabel } : item,
-      ),
+      }).map((item) => ({
+        ...item,
+        label: getSidebarLabel(item.id, item.label),
+      })),
     [
       isNativeAndroid,
       supportsBookmarks,
       canUseInternalActions,
       supportsCredentials,
-      billingLabel,
+      getSidebarLabel,
     ],
   );
 
   const bottomItems = useMemo<SidebarItem[]>(() => {
     const items: SidebarItem[] = [];
     if (settingsDeveloperNav) {
-      items.push(...SETTINGS_SIDEBAR.filter((item) => item.id === "developer"));
+      items.push(
+        ...SETTINGS_SIDEBAR.filter((item) => item.id === "developer").map(
+          (item) => ({
+            ...item,
+            label: getSidebarLabel(item.id, item.label),
+          }),
+        ),
+      );
     }
     // The auth action is pinned to the very bottom of the nav.
     items.push(
       hasPlatformSession
         ? {
             id: "logout",
-            label: "Log Out",
+            label: t("sidebar.logout", "Log Out"),
             icon: LogOut,
             onSelect: () => void handleLogout(navigate),
           }
         : {
             id: "login",
-            label: "Log In",
+            label: t("sidebar.login", "Log In"),
             icon: LogIn,
             onSelect: () => void login(),
           },
     );
     return items;
-  }, [settingsDeveloperNav, hasPlatformSession, navigate, login]);
+  }, [
+    settingsDeveloperNav,
+    hasPlatformSession,
+    navigate,
+    login,
+    t,
+    getSidebarLabel,
+  ]);
 
   const pageTitle = useMemo(() => {
     if (pathname === routes.settings.root) {
-      return "Settings";
+      return t("sidebar.title", "Settings");
     }
     const match = SETTINGS_SIDEBAR.find(
       (item) => pathname === item.href || pathname.startsWith(item.href + "/"),
     );
     if (match) {
-      return match.id === "billing" ? billingLabel : match.label;
+      return getSidebarLabel(match.id, match.label);
     }
-    return "Settings";
-  }, [pathname, billingLabel]);
+    return t("sidebar.title", "Settings");
+  }, [pathname, t, getSidebarLabel]);
 
   return (
     <SidebarShell

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -804,7 +804,11 @@
     "body": "Speech providers, transcription, and API keys live in <modelsLink>Models & Services</modelsLink>."
   },
   "voiceTranscriptToggles": {
-    "recommendedOff": "Recommended off"
+    "recommendedOff": "Recommended off",
+    "userTranscriptLabel": "Show the words you say",
+    "userTranscriptDescription": "Live transcription while you speak.",
+    "assistantTranscriptLabel": "Show the words the assistant says",
+    "assistantTranscriptDescription": "Text alongside the spoken response."
   },
   "windowsMenuBar": {
     "developer": "Developer",
@@ -838,6 +842,24 @@
       "slack": "Download your assistant's avatar to upload as the app icon.",
       "discord": "Download your assistant's avatar to upload as the bot icon.",
       "telegram": "Download your assistant's avatar, then send it to BotFather with /setuserpic."
+    }
+  },
+  "thresholdPresets": {
+    "strict": {
+      "label": "Strict",
+      "description": "Always ask before acting. No actions are auto-approved."
+    },
+    "conservative": {
+      "label": "Conservative",
+      "description": "Auto-approve low-risk actions, like web searches and reading and writing files in its own workspace."
+    },
+    "relaxed": {
+      "label": "Relaxed",
+      "description": "Auto-approve low and medium-risk actions, like changing files outside its own workspace."
+    },
+    "fullAccess": {
+      "label": "Full access",
+      "description": "Auto-approve all actions, including high-risk and unrecognized commands. Your assistant will never ask for permission."
     }
   }
 }

--- a/clients/web/src/i18n/locales/en/intelligence.json
+++ b/clients/web/src/i18n/locales/en/intelligence.json
@@ -431,5 +431,20 @@
       "v1": "Migrate my memory from v1 to v3. That's most likely two hops, your \"Memory v2 Migration\" skill and then your \"Memory v3 Migration\" skill, but work out what my assistant actually needs and follow whichever skills you use exactly.\n\nRun it in the background and tell me when it's done, or if something blocks.",
       "enable": "Turn my memory back on. I'd like you to start remembering things from our conversations again."
     }
+  },
+  "categories": {
+    "email": "Email",
+    "calendar": "Calendar",
+    "messaging": "Messaging",
+    "browsing": "Browsing",
+    "productivity": "Productivity",
+    "development": "Development",
+    "voice": "Voice",
+    "commerce": "Commerce",
+    "content": "Content",
+    "health": "Health",
+    "system": "System",
+    "integrations": "Integrations",
+    "other": "Other"
   }
 }

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -2237,7 +2237,8 @@
     "turnTakingTitle": "Turn taking",
     "voiceShortcutSubtitle": "Press the shortcut to start or end a voice conversation, from anywhere in the app.",
     "voiceShortcutSubtitleDesktop": "Global shortcut for starting/ending a voice conversation.",
-    "voiceShortcutTitle": "Voice Mode Shortcut"
+    "voiceShortcutTitle": "Voice Mode Shortcut",
+    "captionsRecommendation": "We recommend keeping both off to start. It feels more like a real conversation."
   },
   "voicePickerCard": {
     "changeButton": "Change",
@@ -2310,5 +2311,32 @@
     "redirectHint": "Add this URL to your OAuth app's redirect settings.",
     "redirectUrl": "Redirect URL",
     "waitingAuthorization": "Waiting for authorization..."
+  },
+  "sidebar": {
+    "general": "General",
+    "model": "Models & Services",
+    "integrations": "Integrations",
+    "credentials": "Credentials",
+    "notifications": "Notifications",
+    "voice": "Voice",
+    "sounds": "Sounds",
+    "privacy": "Permissions & Privacy",
+    "bookmarks": "Bookmarks",
+    "usage": "Usage",
+    "billingUsage": "Billing & Usage",
+    "community": "Community",
+    "debug": "Debug",
+    "developer": "Developer",
+    "logout": "Log Out",
+    "login": "Log In",
+    "title": "Settings"
+  },
+  "debugPage": {
+    "tabs": {
+      "general": "General",
+      "terminal": "Terminal",
+      "doctor": "Doctor",
+      "conversations": "Conversations"
+    }
   }
 }

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -802,7 +802,11 @@
     "body": "語音提供者、轉錄和 API 金鑰位於<modelsLink>模型與服務</modelsLink>中。"
   },
   "voiceTranscriptToggles": {
-    "recommendedOff": "建議關閉"
+    "recommendedOff": "建議關閉",
+    "userTranscriptLabel": "顯示你說的話",
+    "userTranscriptDescription": "在你說話時即時轉錄文字。",
+    "assistantTranscriptLabel": "顯示助手說的話",
+    "assistantTranscriptDescription": "在語音回覆旁同步顯示文字。"
   },
   "windowsMenuBar": {
     "developer": "開發人員",
@@ -836,6 +840,24 @@
       "slack": "下載您的助理頭像，以上傳為應用程式圖示。",
       "discord": "下載您的助理頭像，以上傳為機器人圖示。",
       "telegram": "下載您的助理頭像，然後透過 /setuserpic 傳送給 BotFather。"
+    }
+  },
+  "thresholdPresets": {
+    "strict": {
+      "label": "嚴格",
+      "description": "執行任何操作前均需確認。不自動批准任何操作。"
+    },
+    "conservative": {
+      "label": "保守",
+      "description": "自動批准低風險操作，例如網路搜尋以及在其自身工作區中讀寫檔案。"
+    },
+    "relaxed": {
+      "label": "寬鬆",
+      "description": "自動批准低風險與中等風險操作，例如修改其工作區之外的檔案。"
+    },
+    "fullAccess": {
+      "label": "完全存取",
+      "description": "自動批准所有操作，包括高風險和無法識別的指令。助手將絕不請求權限確認。"
     }
   }
 }

--- a/clients/web/src/i18n/locales/zh-TW/intelligence.json
+++ b/clients/web/src/i18n/locales/zh-TW/intelligence.json
@@ -138,7 +138,7 @@
     },
     "superpowers": {
       "description": "我能做的事情",
-      "label": "超能力"
+      "label": "技能"
     },
     "workspace": {
       "description": "我的檔案",
@@ -282,7 +282,7 @@
     "library": "程式庫",
     "memory": "記憶",
     "schedules": "排程",
-    "superpowers": "我的超能力",
+    "superpowers": "我的技能",
     "workspace": "工作區"
   },
   "skillDetail": {
@@ -304,7 +304,7 @@
   },
   "skillDetailPage": {
     "backToConversation": "返回對話",
-    "backToSuperpowers": "返回我的超能力",
+    "backToSuperpowers": "返回技能",
     "notFoundSubtitle": "此技能可能已被移除，或連結已過期。",
     "notFoundTitle": "找不到技能"
   },
@@ -336,7 +336,7 @@
   "superpowersFilters": {
     "categoriesLabel": "類別",
     "done": "完成",
-    "filterAriaLabel": "篩選超能力",
+    "filterAriaLabel": "篩選技能",
     "filterLabel": {
       "all": "全部",
       "assistantMemory": "助理記憶",
@@ -347,15 +347,15 @@
       "skills": "技能"
     },
     "filtersTitle": "篩選器",
-    "searchAriaLabel": "搜尋超能力",
-    "searchPlaceholder": "搜尋超能力",
+    "searchAriaLabel": "搜尋技能",
+    "searchPlaceholder": "搜尋技能",
     "sourceLabel": "來源",
     "statusLabel": "狀態",
     "typeLabel": "類型"
   },
   "superpowersTab": {
     "catalogBrowsingUnavailableNotice": "外掛程式目錄瀏覽暫時無法使用。已安裝的外掛程式仍列於下方。",
-    "categoriesAriaLabel": "超能力類別",
+    "categoriesAriaLabel": "技能類別",
     "dismissTipAriaLabel": "關閉提示",
     "emptyState": {
       "assistantMemorySubtitle": "您的助理從過去對話中建立的技能將會顯示在此處。",
@@ -369,9 +369,9 @@
       "customSubtitle": "透過在聊天中描述您的需求來建立自訂技能。",
       "customTitle": "無自訂技能",
       "defaultSubtitle": "請檢查您與 Vellum 目錄的連線。",
-      "defaultTitle": "無可用超能力",
+      "defaultTitle": "無可用技能",
       "installedSubtitle": "在聊天中要求您的助理搜尋並安裝新的技能和外掛程式。",
-      "installedTitle": "未安裝超能力",
+      "installedTitle": "未安裝技能",
       "pluginsSubtitle": "瀏覽目錄以安裝可擴充您助理的外掛程式。",
       "pluginsTitle": "未找到外掛程式",
       "skillsshSubtitle": "未找到 skills.sh 技能。請嘗試搜尋目錄。",
@@ -382,7 +382,7 @@
       "vellumTitle": "無 Vellum 技能"
     },
     "errorStateSubtitle": "發生錯誤。請嘗試重新整理頁面。",
-    "errorStateTitle": "載入超能力失敗",
+    "errorStateTitle": "載入技能失敗",
     "pluginsUnavailableNotice": "外掛程式暫時無法使用。技能仍列於下方。",
     "skillsUnavailableNotice": "技能暫時無法使用。外掛程式仍列於下方。",
     "tipBannerText": "透過在聊天中描述您的需求來建立新的自訂技能，或安裝外掛程式以擴充您的助理。"
@@ -431,5 +431,20 @@
       "v1": "將我的記憶從 v1 遷移至 v3。這很可能是兩個步驟，先是您的「記憶功能 v2 遷移」技能，然後是您的「記憶功能 v3 遷移」技能，但請弄清楚我的助理實際需要什麼，並嚴格遵循您使用的任何技能。\n\n請在背景執行，並在完成時或遇到阻礙時通知我。",
       "enable": "請重新開啟我的記憶功能。我希望您再次開始記憶我們對話中的內容。"
     }
+  },
+  "categories": {
+    "email": "電子郵件",
+    "calendar": "行事曆",
+    "messaging": "訊息",
+    "browsing": "瀏覽",
+    "productivity": "生產力",
+    "development": "開發",
+    "voice": "語音",
+    "commerce": "電商",
+    "content": "內容",
+    "health": "健康",
+    "system": "系統",
+    "integrations": "整合",
+    "other": "其他"
   }
 }

--- a/clients/web/src/i18n/locales/zh-TW/settings.json
+++ b/clients/web/src/i18n/locales/zh-TW/settings.json
@@ -2209,7 +2209,8 @@
     "turnTakingTitle": "輪流說話",
     "voiceShortcutSubtitle": "在應用程式中的任何位置按下捷徑，以開始或結束語音對話。",
     "voiceShortcutSubtitleDesktop": "用於開始/結束語音對話的全域捷徑。",
-    "voiceShortcutTitle": "語音模式捷徑"
+    "voiceShortcutTitle": "語音模式捷徑",
+    "captionsRecommendation": "我們建議初次使用時保持關閉，體驗更接近真實對話。"
   },
   "voicePickerCard": {
     "changeButton": "變更",
@@ -2282,5 +2283,32 @@
     "redirectHint": "將此網址新增至您的 OAuth 應用程式的重新導向設定中。",
     "redirectUrl": "重新導向網址",
     "waitingAuthorization": "等待授權中..."
+  },
+  "sidebar": {
+    "general": "一般",
+    "model": "模型與服務",
+    "integrations": "整合",
+    "credentials": "憑證",
+    "notifications": "通知",
+    "voice": "語音",
+    "sounds": "聲音",
+    "privacy": "權限與隱私",
+    "bookmarks": "書籤",
+    "usage": "用量",
+    "billingUsage": "帳單與用量",
+    "community": "社群",
+    "debug": "偵錯",
+    "developer": "開發者",
+    "logout": "登出",
+    "login": "登入",
+    "title": "設定"
+  },
+  "debugPage": {
+    "tabs": {
+      "general": "一般",
+      "terminal": "終端機",
+      "doctor": "診斷",
+      "conversations": "對話"
+    }
   }
 }

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -146,7 +146,7 @@
   },
   "cacheBreakpointMapCard": {
     "description": "此请求的前缀中，{count, plural, other {# 个缓存断点}} 的分布位置，以及哪些段是从缓存读取的，哪些是重新创建的。",
-    "estimatedTokens": "≈ {count} 个令牌",
+    "estimatedTokens": "≈ {count} 个 Token",
     "fullMissBody": "此轮中每个段都已重新创建。请与上方缓存差异中的上一轮进行比较，以找到发生变化的块。",
     "fullMissTitle": "完整缓存未命中",
     "loadError": "无法加载请求负载以映射缓存断点。",
@@ -157,7 +157,7 @@
     "statusRead": "从缓存读取",
     "statusUnknown": "已缓存",
     "title": "缓存断点",
-    "tokenEstimateNote": "令牌计数是根据文本长度估算的。"
+    "tokenEstimateNote": "Token 计数是根据文本长度估算的。"
   },
   "cacheDiffCard": {
     "changedLabel": "已更改",
@@ -203,7 +203,7 @@
     "unchangedLines": "⋯ {count} 行未更改"
   },
   "cacheHealthCard": {
-    "barAriaLabel": "提示词缓存细分：{total} 个令牌，其中 {segments}（{percent} 已缓存）。",
+    "barAriaLabel": "提示词缓存细分：{total} 个 Token，其中 {segments}（{percent} 已缓存）。",
     "barSegment": "{count} {label}",
     "cached": "已缓存",
     "description": "此调用的提示词有多少来自提示词缓存。",
@@ -211,11 +211,11 @@
     "segmentFresh": "新鲜输入",
     "segmentRead": "从缓存读取",
     "statusFullMissBody": "此调用的提示词均未从缓存中读取。",
-    "statusFullMissReCreatedSuffix": " 本轮有 {count} 个令牌写入缓存，但均未被重用 - 这通常意味着自上一轮以来缓存的前缀已更改。",
+    "statusFullMissReCreatedSuffix": " 本轮有 {count} 个 Token写入缓存，但均未被重用 - 这通常意味着自上一轮以来缓存的前缀已更改。",
     "statusFullMissTitle": "完全缓存未命中",
-    "statusHealthyBody": "此调用的提示词有 {percent}（{count} 个令牌）来自缓存。",
+    "statusHealthyBody": "此调用的提示词有 {percent}（{count} 个 Token）来自缓存。",
     "statusHealthyTitle": "健康的缓存重用",
-    "statusPartialBody": "此调用的提示词有 {percent}（{count} 个令牌）来自缓存；其余部分在本轮重新处理。",
+    "statusPartialBody": "此调用的提示词有 {percent}（{count} 个 Token）来自缓存；其余部分在本轮重新处理。",
     "statusPartialTitle": "部分缓存重用",
     "title": "缓存健康状况",
     "unavailableNote": "此调用未报告提示词缓存使用情况。",
@@ -429,7 +429,7 @@
   "compactionTab": {
     "compactedMessages": "{count} 已压缩",
     "compactedPreserved": "已压缩 / 已保留",
-    "contextTokens": "上下文令牌",
+    "contextTokens": "上下文 Token",
     "duration": "持续时间",
     "durationMs": "{count} 毫秒",
     "emptyBody": "压缩归因于紧随其后运行的调用。如果您在此处预期有压缩，请检查对话是否在此调用之前超出了其上下文预算。",
@@ -524,7 +524,7 @@
     "percentFull": "已使用 {percentage}%",
     "ringAria": "上下文窗口已使用 {percentage}%",
     "title": "上下文窗口",
-    "tokensUsed": "已使用 {used} / {max} 令牌"
+    "tokensUsed": "已使用 {used} / {max} Token"
   },
   "conversationActions": {
     "archive": "归档",
@@ -961,7 +961,7 @@
     "inContextPill": "在上下文中: {count}",
     "injectedMemoryContextTitle": "注入的记忆上下文",
     "injectedPill": "已注入: {count}",
-    "injectedTokensLabel": "注入的令牌",
+    "injectedTokensLabel": "注入的 Token",
     "latencyMs": "{ms} 毫秒",
     "loading": "加载中…",
     "loggedMemorySelectionSubtitle": "根据 v3 选择渲染，本轮未注入。",
@@ -1120,17 +1120,17 @@
     "message": "此对话分支所源自的对话已被删除，因此分支点之前的消息已丢失。此后发送的所有内容均完好无损。"
   },
   "overviewTab": {
-    "cacheTokensLabel": "缓存令牌",
+    "cacheTokensLabel": "缓存 Token",
     "conversationSubtitle": "迄今为止所有计费LLM调用的累计总额。",
     "conversationTitle": "对话",
     "createdLabel": "创建时间",
     "durationLabel": "持续时间",
     "estimatedCostLabel": "预估费用",
     "failedStatus": "失败",
-    "firstTokenKindLabel": "首个令牌类型",
-    "firstTokenLatencySubtitle": "此轮次首个令牌响应时间去向，由助手测量。",
-    "firstTokenLatencyTitle": "首个令牌延迟",
-    "inputTokensLabel": "输入令牌",
+    "firstTokenKindLabel": "首个 Token类型",
+    "firstTokenLatencySubtitle": "此轮次首个 Token响应时间去向，由助手测量。",
+    "firstTokenLatencyTitle": "首个 Token延迟",
+    "inputTokensLabel": "输入 Token",
     "latencyMs": "{ms} 毫秒",
     "loopExitReasonLabel": "循环退出原因",
     "modelLabel": "模型",
@@ -1139,7 +1139,7 @@
     "normalizedSummaryUnavailableSubtitle": "此调用仍包含原始请求和响应负载。",
     "normalizedSummaryUnavailableTitle": "标准化摘要不可用",
     "otherLabel": "其他",
-    "outputTokensLabel": "输出令牌",
+    "outputTokensLabel": "输出 Token",
     "providerLabel": "提供商",
     "requestMessagesLabel": "请求消息",
     "statusLabel": "状态",
@@ -1147,8 +1147,8 @@
     "toolCallsLabel": "工具调用",
     "toolsAvailableLabel": "可用工具",
     "totalCostSoFarLabel": "迄今总费用",
-    "totalToFirstTokenLabel": "至首个令牌总计",
-    "usageSubtitle": "由助手路由标准化的令牌和调用计数。",
+    "totalToFirstTokenLabel": "至首个 Token总计",
+    "usageSubtitle": "由助手路由标准化的Token 和调用计数。",
     "usageTitle": "用量"
   },
   "pageTabs": {
@@ -1243,7 +1243,7 @@
     "promptSectionsTitle": "提示词部分"
   },
   "providerBillingBanner": {
-    "body": "向您的提供商充值或降低模型令牌限制。",
+    "body": "向您的提供商充值或降低模型Token 限制。",
     "title": "您的 API 密钥需要充值"
   },
   "pullRefreshSpinner": {

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -530,9 +530,9 @@
     "connectSlack": "连接 Slack",
     "connecting": "正在连接…",
     "credentialsSaved": "凭据已保存",
-    "instructions": "在 Slack 的确认屏幕上，展开 <credentials>您的应用凭据</credentials> 并复制两个令牌。",
-    "skipNotice": "该屏幕还提供命令行演练和 <download>下载应用文件</download> 按钮。请跳过这两项。它们会设置一个独立的本地应用，而此助手只需要这两个令牌。",
-    "savedBody": "两个令牌都已保存。Slack 这边已完成。"
+    "instructions": "在 Slack 的确认屏幕上，展开 <credentials>您的应用凭据</credentials> 并复制两个 Token。",
+    "skipNotice": "该屏幕还提供命令行演练和 <download>下载应用文件</download> 按钮。请跳过这两项。它们会设置一个独立的本地应用，而此助手只需要这两个 Token。",
+    "savedBody": "两个 Token都已保存。Slack 这边已完成。"
   },
   "slackSetupWizard": {
     "channelLabel": "Slack",
@@ -622,7 +622,7 @@
     "openBotFather": "打开 BotFather",
     "stepDisplayName": "给它一个显示名称，这是人们在聊天中看到的名称",
     "stepSendNewBot": "发送 <strong>/newbot</strong>",
-    "stepTokenReply": "BotFather 会在 <strong>Use this token to access the HTTP API</strong> 之后回复一个令牌",
+    "stepTokenReply": "BotFather 会在 <strong>Use this token to access the HTTP API</strong> 之后回复一个 Token",
     "stepUsername": "给它一个用户名，该用户名必须是唯一的，并以 <strong>bot</strong> 结尾"
   },
   "telegramSetupWizard": {
@@ -802,7 +802,11 @@
     "body": "语音提供商、转录和 API 密钥位于<modelsLink>模型与服务</modelsLink>中。"
   },
   "voiceTranscriptToggles": {
-    "recommendedOff": "建议关闭"
+    "recommendedOff": "建议关闭",
+    "userTranscriptLabel": "显示你说的话",
+    "userTranscriptDescription": "在你说话时实时转录文字。",
+    "assistantTranscriptLabel": "显示助手说的话",
+    "assistantTranscriptDescription": "在语音回复旁同步显示文本。"
   },
   "windowsMenuBar": {
     "developer": "开发者",
@@ -836,6 +840,24 @@
       "slack": "下载您的助手头像以上传为应用图标。",
       "discord": "下载您的助手头像以上传为机器人图标。",
       "telegram": "下载您的助手头像，然后使用 /setuserpic 发送给 BotFather。"
+    }
+  },
+  "thresholdPresets": {
+    "strict": {
+      "label": "严格",
+      "description": "执行任何操作前均需确认。不自动批准任何操作。"
+    },
+    "conservative": {
+      "label": "保守",
+      "description": "自动批准低风险操作，例如网络搜索以及在其自身工作区中读写文件。"
+    },
+    "relaxed": {
+      "label": "宽松",
+      "description": "自动批准低风险与中等风险操作，例如修改其工作区之外的文件。"
+    },
+    "fullAccess": {
+      "label": "完全访问",
+      "description": "自动批准所有操作，包括高风险和无法识别的命令。助手将绝不请求权限确认。"
     }
   }
 }

--- a/clients/web/src/i18n/locales/zh/intelligence.json
+++ b/clients/web/src/i18n/locales/zh/intelligence.json
@@ -138,7 +138,7 @@
     },
     "superpowers": {
       "description": "我能做的事情",
-      "label": "超能力"
+      "label": "技能"
     },
     "workspace": {
       "description": "我的文件",
@@ -282,7 +282,7 @@
     "library": "库",
     "memory": "记忆",
     "schedules": "定时任务",
-    "superpowers": "我的超能力",
+    "superpowers": "我的技能",
     "workspace": "工作区"
   },
   "skillDetail": {
@@ -304,7 +304,7 @@
   },
   "skillDetailPage": {
     "backToConversation": "返回对话",
-    "backToSuperpowers": "返回我的超能力",
+    "backToSuperpowers": "返回技能",
     "notFoundSubtitle": "此技能可能已被移除，或链接已过期。",
     "notFoundTitle": "未找到技能"
   },
@@ -336,7 +336,7 @@
   "superpowersFilters": {
     "categoriesLabel": "类别",
     "done": "完成",
-    "filterAriaLabel": "筛选超能力",
+    "filterAriaLabel": "筛选技能",
     "filterLabel": {
       "all": "全部",
       "assistantMemory": "助手记忆",
@@ -347,15 +347,15 @@
       "skills": "技能"
     },
     "filtersTitle": "筛选器",
-    "searchAriaLabel": "搜索超能力",
-    "searchPlaceholder": "搜索超能力",
+    "searchAriaLabel": "搜索技能",
+    "searchPlaceholder": "搜索技能",
     "sourceLabel": "来源",
     "statusLabel": "状态",
     "typeLabel": "类型"
   },
   "superpowersTab": {
     "catalogBrowsingUnavailableNotice": "插件目录浏览暂时不可用。已安装的插件仍列于下方。",
-    "categoriesAriaLabel": "超能力类别",
+    "categoriesAriaLabel": "技能类别",
     "dismissTipAriaLabel": "关闭提示",
     "emptyState": {
       "assistantMemorySubtitle": "您的助手从过去的对话中创作的技能将显示在此处。",
@@ -369,9 +369,9 @@
       "customSubtitle": "通过在聊天中描述您的需求来创建自定义技能。",
       "customTitle": "无自定义技能",
       "defaultSubtitle": "检查您与 Vellum 目录的连接。",
-      "defaultTitle": "无可用超能力",
+      "defaultTitle": "无可用技能",
       "installedSubtitle": "在聊天中要求您的助手搜索并安装新技能和插件。",
-      "installedTitle": "未安装超能力",
+      "installedTitle": "未安装技能",
       "pluginsSubtitle": "浏览目录以安装扩展您助手的插件。",
       "pluginsTitle": "未找到插件",
       "skillsshSubtitle": "未找到 skills.sh 技能。请尝试搜索目录。",
@@ -382,7 +382,7 @@
       "vellumTitle": "无 Vellum 技能"
     },
     "errorStateSubtitle": "发生错误。请尝试刷新页面。",
-    "errorStateTitle": "加载超能力失败",
+    "errorStateTitle": "加载技能失败",
     "pluginsUnavailableNotice": "插件暂时不可用。技能仍列于下方。",
     "skillsUnavailableNotice": "技能暂时不可用。插件仍列于下方。",
     "tipBannerText": "通过在聊天中描述您的需求来创建新的自定义技能，或安装插件以扩展您的助手。"
@@ -431,5 +431,20 @@
       "v1": "将我的记忆从 v1 迁移到 v3。这很可能是两步操作，您的“记忆 v2 迁移”技能，然后是您的“记忆 v3 迁移”技能，但请弄清楚我的助手实际需要什么，并严格遵循您使用的任何技能。\n\n在后台运行它，并在完成后或遇到阻碍时通知我。",
       "enable": "重新开启我的记忆。我希望您再次开始记住我们对话中的内容。"
     }
+  },
+  "categories": {
+    "email": "邮件",
+    "calendar": "日历",
+    "messaging": "消息",
+    "browsing": "浏览",
+    "productivity": "生产力",
+    "development": "开发",
+    "voice": "语音",
+    "commerce": "电商",
+    "content": "内容",
+    "health": "健康",
+    "system": "系统",
+    "integrations": "集成",
+    "other": "其他"
   }
 }

--- a/clients/web/src/i18n/locales/zh/settings.json
+++ b/clients/web/src/i18n/locales/zh/settings.json
@@ -615,7 +615,7 @@
   "customPlanRow": {
     "configure": "配置",
     "currentPlanTag": "您的当前计划",
-    "genericDescriptor": "选择自定义CPU算力、内存和存储。或者直接添加一些令牌。",
+    "genericDescriptor": "选择自定义CPU算力、内存和存储。或者直接添加一些 Token。",
     "prompt": "需要更符合您需求的服务吗？",
     "title": "自定义计划"
   },
@@ -1059,7 +1059,7 @@
     "toastRemoved": "已移除 {serverId}",
     "toastUpdateFailed": "更新 {serverId} 失败",
     "toastUpdated": "已更新 {serverId}",
-    "totalTokens": "共计约 {count} 个令牌",
+    "totalTokens": "共计约 {count} 个 Token",
     "totalTools": "{count, plural, other {# 个工具}}"
   },
   "mcpServerCard": {
@@ -1067,7 +1067,7 @@
     "authenticating": "正在认证...",
     "configure": "配置",
     "configureTooltip": "配置",
-    "estimatedTokens": "~{count} 个令牌",
+    "estimatedTokens": "~{count} 个 Token",
     "oauthBadge": "OAuth",
     "reAuth": "重新认证",
     "reAuthTooltip": "重新认证 OAuth",
@@ -1084,7 +1084,7 @@
     "toggleDisableAriaLabel": "禁用 {serverId}",
     "toggleEnableAriaLabel": "启用 {serverId}",
     "toolCount": "{count, plural, other {# 个工具}}",
-    "toolTokensAbbrev": "~{count} 令牌"
+    "toolTokensAbbrev": "~{count} Token"
   },
   "mcpServerDetailModal": {
     "apiKey": "API 密钥",
@@ -1112,9 +1112,9 @@
     "save": "保存",
     "saving": "正在保存...",
     "tableDescription": "描述",
-    "tableTokens": "令牌",
+    "tableTokens": "Token",
     "tableTool": "工具",
-    "tokenOverhead": "总预估令牌开销：~{count} 个令牌",
+    "tokenOverhead": "总预估 Token 开销：~{count} 个 Token",
     "toolEstimatedTokens": "~{count}"
   },
   "mediaEmbedsCard": {
@@ -1436,14 +1436,14 @@
     "effortLabel": "努力程度",
     "effortSegmentDefault": "默认",
     "enableExtendedThinkingLabel": "启用扩展思考",
-    "maxOutputTokensLabel": "最大输出令牌数",
+    "maxOutputTokensLabel": "最大输出 Token 数",
     "reset": "重置",
     "speedLabel": "速度",
-    "streamThinkingTokensLabel": "流式思考令牌",
+    "streamThinkingTokensLabel": "流式思考 Token",
     "temperatureLabel": "温度",
     "thinkingLevelInheritHint": "(默认 = 继承)",
     "thinkingLevelLabel": "思考级别",
-    "tokensAriaLabel": "{label} (令牌)",
+    "tokensAriaLabel": "{label} (Token)",
     "topPLabel": "Top P",
     "verbosityLabel": "详细程度"
   },
@@ -1467,8 +1467,8 @@
     "saving": "正在保存…"
   },
   "profileEditor": {
-    "maxTokensNoInputRoom": "最大令牌数 ({maxTokens}) 将整个 {window} 令牌上下文窗口保留用于输出，导致您的消息没有空间。请减少此值（例如 8000）。",
-    "maxTokensOverCap": "最大令牌数 ({maxTokens}) 超过了模型的最大输出 {cap} 令牌。请将其减少到 {cap} 或更少。",
+    "maxTokensNoInputRoom": "最大 Token 数 ({maxTokens}) 将整个 {window} Token上下文窗口保留用于输出，导致您的消息没有空间。请减少此值（例如 8000）。",
+    "maxTokensOverCap": "最大 Token 数 ({maxTokens}) 超过了模型的最大输出 {cap} Token。请将其减少到 {cap} 或更少。",
     "nameRequired": "名称为必填项",
     "nameTaken": "此名称已被占用",
     "providerRequired": "请选择提供商",
@@ -1535,8 +1535,8 @@
     "managedByVellum": "由 Vellum 管理",
     "openProfileAriaLabel": "打开配置文件 {displayName}",
     "configIssueModelUnknown": "此配置文件的模型无法从其提供商处获取。",
-    "configIssueNoInputRoom": "此配置文件的最大输出令牌数在模型的上下文窗口中没有为输入留下空间。",
-    "configIssueOverOutputCap": "此配置文件的最大输出令牌数超出了其模型支持的范围。",
+    "configIssueNoInputRoom": "此配置文件的最大输出 Token 数在模型的上下文窗口中没有为输入留下空间。",
+    "configIssueOverOutputCap": "此配置文件的最大输出 Token 数超出了其模型支持的范围。",
     "providerUnavailableDefault": "此配置文件的提供商不可用。",
     "providerUnavailableFixable": "{message} 点击修复。",
     "view": "查看"
@@ -2073,7 +2073,7 @@
     "costLabel": "成本",
     "dailyTrend": "每日趋势",
     "dailyTrendBy": "按 {group} 的每日趋势",
-    "directInputTokensLabel": "直接输入令牌",
+    "directInputTokensLabel": "直接输入 Token",
     "failedToLoadUsage": "未能加载使用情况。",
     "groupByActor": "执行者",
     "groupByConversation": "对话",
@@ -2090,7 +2090,7 @@
     "noBreakdownDataSubtitle": "此分组没有记录使用情况",
     "noBreakdownDataTitle": "无明细数据",
     "optimizeSettingsButton": "优化设置",
-    "outputTokensLabel": "输出令牌",
+    "outputTokensLabel": "输出 Token",
     "percentOfTotalLabel": "占总计百分比",
     "range30d": "最近 30 天",
     "range7d": "最近 7 天",
@@ -2100,7 +2100,7 @@
     "rangeYesterday": "昨天",
     "retry": "重试",
     "title": "使用情况",
-    "tokensLabel": "令牌",
+    "tokensLabel": "Token",
     "totalsAriaLabel": "总计",
     "turnsLabel": "轮次",
     "unknownSchedule": "未知定时任务 ({scheduleId})"
@@ -2209,7 +2209,8 @@
     "turnTakingTitle": "轮流说话",
     "voiceShortcutSubtitle": "在应用中的任何位置按下快捷方式以开始或结束语音对话。",
     "voiceShortcutSubtitleDesktop": "用于开始/结束语音对话的全局快捷方式。",
-    "voiceShortcutTitle": "语音模式快捷方式"
+    "voiceShortcutTitle": "语音模式快捷方式",
+    "captionsRecommendation": "我们建议初次使用时保持关闭，体验更接近真实对话。"
   },
   "voicePickerCard": {
     "changeButton": "更改",
@@ -2282,5 +2283,32 @@
     "redirectHint": "将此 URL 添加到您的 OAuth 应用的重定向设置中。",
     "redirectUrl": "重定向 URL",
     "waitingAuthorization": "等待授权..."
+  },
+  "sidebar": {
+    "general": "常规",
+    "model": "模型与服务",
+    "integrations": "集成",
+    "credentials": "凭据",
+    "notifications": "通知",
+    "voice": "语音",
+    "sounds": "声音",
+    "privacy": "权限与隐私",
+    "bookmarks": "书签",
+    "usage": "用量",
+    "billingUsage": "账单与用量",
+    "community": "社区",
+    "debug": "调试",
+    "developer": "开发者",
+    "logout": "退出登录",
+    "login": "登录",
+    "title": "设置"
+  },
+  "debugPage": {
+    "tabs": {
+      "general": "常规",
+      "terminal": "终端",
+      "doctor": "诊断",
+      "conversations": "会话"
+    }
   }
 }

--- a/clients/web/src/utils/threshold-presets.ts
+++ b/clients/web/src/utils/threshold-presets.ts
@@ -16,8 +16,10 @@ export type RiskThreshold =
 export interface ThresholdPreset {
   id: string;
   label: string;
+  labelKey: string;
   riskThreshold: RiskThreshold;
   description: string;
+  descriptionKey: string;
   icon: LucideIcon;
 }
 
@@ -25,32 +27,40 @@ export const THRESHOLD_PRESETS: ThresholdPreset[] = [
   {
     id: "strict",
     label: "Strict",
+    labelKey: "thresholdPresets.strict.label",
     riskThreshold: "none",
     description: "Always ask before acting. No actions are auto-approved.",
+    descriptionKey: "thresholdPresets.strict.description",
     icon: Lock,
   },
   {
     id: "conservative",
     label: "Conservative",
+    labelKey: "thresholdPresets.conservative.label",
     riskThreshold: "low",
     description:
       "Auto-approve low-risk actions, like web searches and reading and writing files in its own workspace.",
+    descriptionKey: "thresholdPresets.conservative.description",
     icon: ShieldCheck,
   },
   {
     id: "relaxed",
     label: "Relaxed",
+    labelKey: "thresholdPresets.relaxed.label",
     riskThreshold: "medium",
     description:
       "Auto-approve low and medium-risk actions, like changing files outside its own workspace.",
+    descriptionKey: "thresholdPresets.relaxed.description",
     icon: Shield,
   },
   {
     id: "fullAccess",
     label: "Full access",
+    labelKey: "thresholdPresets.fullAccess.label",
     riskThreshold: "high",
     description:
       "Auto-approve all actions, including high-risk and unrecognized commands. Your assistant will never ask for permission.",
+    descriptionKey: "thresholdPresets.fullAccess.description",
     icon: ShieldOff,
   },
 ];


### PR DESCRIPTION
## Summary
- Complete missing i18n hooks and dictionaries for Settings layout sidebar, bottom actions, and tab titles.
- Localize Debug page tabs (`general`, `terminal`, `doctor`, `conversations`).
- Localize voice transcription captions toggles and recommendation note.
- Localize risk tolerance / assistant access presets (`strict`, `conservative`, `relaxed`, `fullAccess`) in composer settings menu and risk settings page.
- Localize skill categories in skill management sidebar.
- Refine Chinese localization terminology:
  - Standardize "Skills" translation (revert anthropomorphized "我的超能力" to "技能").
  - Retain "Token" for LLM metrics/context usage instead of "令牌".
  - Update Traditional Chinese (`zh-TW`) dictionaries synchronously.

## Test plan
- Verified `bun test` for voice toggles and voice settings.
- Ran `bun run typecheck` across `clients/web`.
- Verified pre-commit hooks (lint + typecheck) pass cleanly.