### PR TITLE
feat(notifications): every delivery without buttons carries its typed-reply instruction

### DIFF
--- a/assistant/docs/guardian-request-flow.md
+++ b/assistant/docs/guardian-request-flow.md
@@ -21,7 +21,7 @@ anti-pattern was retired in #35642 and again in the ask_question redesign).
   notification pipeline                          (notifications/emit-signal.ts →
   decision engine → destination resolver →        decision-engine.ts → destination-resolver.ts →
   broadcaster builds the card context ONCE        broadcaster.ts: resolveApprovalContext /
-  (generic actions[] + plainTextFallback)         resolveQuestionOptionsContext)
+  (generic actions[] + plainTextFallback)         resolveQuestionContext)
         │
         ▼ per-channel rendering ONLY
   channel adapters                               (notifications/adapters/{telegram,slack,macos,platform},

--- a/assistant/src/__tests__/notification-discord-adapter.test.ts
+++ b/assistant/src/__tests__/notification-discord-adapter.test.ts
@@ -179,6 +179,31 @@ describe("DiscordAdapter.send", () => {
     );
   });
 
+  test("a question with no options is sent as text with its typed-reply instruction", async () => {
+    const adapter = new DiscordAdapter();
+    const result = await adapter.send(
+      makePayload({
+        approvalContext: {
+          requestId: "req-voice-1",
+          actions: [],
+          plainTextFallback:
+            'Reference code: DEF456. Reply "DEF456 <your answer>".',
+          intent: "question",
+        },
+      }),
+      makeDestination(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(sendCalls).toHaveLength(1);
+    // No buttons to draw, so no components are attempted and the
+    // instruction joins the text.
+    expect(sendCalls[0].approval).toBeUndefined();
+    expect(sendCalls[0].text).toEndWith(
+      'Reference code: DEF456. Reply "DEF456 <your answer>".',
+    );
+  });
+
   test("a destination without a guardian user id fails without calling the API", async () => {
     const adapter = new DiscordAdapter();
     const result = await adapter.send(

--- a/assistant/src/__tests__/notification-slack-adapter.test.ts
+++ b/assistant/src/__tests__/notification-slack-adapter.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for the Slack notification adapter's send path: which deliveries
+ * render a card and which go out as text carrying the typed-reply
+ * instruction.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type {
+  ChannelDeliveryPayload,
+  ChannelDestination,
+} from "../notifications/types.js";
+
+const sendCalls: Array<{
+  chatId: string;
+  text: string;
+  options: Record<string, unknown> | undefined;
+}> = [];
+
+const actualSend = await import("../messaging/providers/slack/send.js");
+mock.module("../messaging/providers/slack/send.js", () => ({
+  ...actualSend,
+  sendSlackReply: async (
+    chatId: string,
+    text: string,
+    options?: Record<string, unknown>,
+  ) => {
+    sendCalls.push({ chatId, text, options });
+    return { ts: String(1700000000 + sendCalls.length), channel: chatId };
+  },
+}));
+
+const { SlackAdapter } = await import("../notifications/adapters/slack.js");
+
+function makePayload(
+  overrides?: Partial<ChannelDeliveryPayload>,
+): ChannelDeliveryPayload {
+  return {
+    sourceEventName: "guardian.question",
+    copy: {
+      title: "Question",
+      body: "What time works?",
+      deliveryText: "What time works?",
+    },
+    urgency: "high",
+    ...overrides,
+  };
+}
+
+function makeDestination(): ChannelDestination {
+  return { channel: "slack", endpoint: "D0GUARDIAN" };
+}
+
+describe("SlackAdapter.send", () => {
+  beforeEach(() => {
+    sendCalls.length = 0;
+  });
+
+  test("a question with no options is sent as text with its typed-reply instruction", async () => {
+    const adapter = new SlackAdapter();
+    const result = await adapter.send(
+      makePayload({
+        contextPayload: {
+          requestId: "req-voice-1",
+          requestCode: "DEF456",
+          requestKind: "pending_question",
+          questionText: "What time works?",
+        },
+        approvalContext: {
+          requestId: "req-voice-1",
+          actions: [],
+          plainTextFallback:
+            'Reference code: DEF456. Reply "DEF456 <your answer>".',
+          intent: "question",
+        },
+      }),
+      makeDestination(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(sendCalls).toHaveLength(1);
+    // No buttons to draw, so no card: text, with the instruction appended.
+    expect(sendCalls[0]?.options?.blocks).toBeUndefined();
+    expect(sendCalls[0]?.text).toBe(
+      'What time works?\n\nReference code: DEF456. Reply "DEF456 <your answer>".',
+    );
+  });
+
+  test("a question with options renders a card whose text carries no instruction", async () => {
+    const adapter = new SlackAdapter();
+    await adapter.send(
+      makePayload({
+        copy: {
+          title: "Question",
+          body: "Which one?\n\n1. Left\n2. Right",
+          deliveryText: "Which one?\n\n1. Left\n2. Right",
+        },
+        contextPayload: {
+          requestId: "req-q-1",
+          requestCode: "ABC123",
+          requestKind: "pending_question",
+          questionText: "Which one?",
+          options: [
+            { id: "left", label: "Left" },
+            { id: "right", label: "Right" },
+          ],
+        },
+        approvalContext: {
+          requestId: "req-q-1",
+          actions: [
+            { id: "answer_0", label: "Left" },
+            { id: "answer_1", label: "Right" },
+            { id: "answer_skip", label: "Skip" },
+          ],
+          plainTextFallback:
+            'Reference code: ABC123. Reply "ABC123 <your answer>".',
+          intent: "question",
+        },
+      }),
+      makeDestination(),
+    );
+
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0]?.options?.blocks).toBeDefined();
+    expect(sendCalls[0]?.text).not.toContain("ABC123");
+    // The send layer keeps the approval so a rejected card can retry as
+    // text with the instruction re-attached.
+    expect(
+      (sendCalls[0]?.options?.approval as { requestId?: string } | undefined)
+        ?.requestId,
+    ).toBe("req-q-1");
+  });
+});

--- a/assistant/src/__tests__/notification-telegram-adapter.test.ts
+++ b/assistant/src/__tests__/notification-telegram-adapter.test.ts
@@ -323,6 +323,42 @@ describe("TelegramAdapter", () => {
     expect(call.text).toContain("XYZW");
   });
 
+  test("a question with no options is sent as text with its typed-reply instruction", async () => {
+    const adapter = new TelegramAdapter();
+    const payload = makePayload({
+      sourceEventName: "guardian.question",
+      copy: {
+        title: "Question",
+        body: "What time works?",
+        deliveryText: "What time works?",
+      },
+      contextPayload: {
+        requestId: "req-voice-1",
+        requestCode: "DEF456",
+        requestKind: "pending_question",
+        questionText: "What time works?",
+      },
+      approvalContext: {
+        requestId: "req-voice-1",
+        actions: [],
+        plainTextFallback:
+          'Reference code: DEF456. Reply "DEF456 <your answer>".',
+        intent: "question",
+      },
+    });
+
+    const result = await adapter.send(payload, makeDestination());
+
+    expect(result.success).toBe(true);
+    expect(sendCalls).toHaveLength(1);
+    // No buttons to draw, so no keyboard is attempted and the instruction
+    // joins the text: this is the only place the guardian learns the code.
+    expect(sendCalls[0]?.approval).toBeUndefined();
+    expect(sendCalls[0]?.text).toBe(
+      'What time works?\n\nReference code: DEF456. Reply "DEF456 <your answer>".',
+    );
+  });
+
   describe("update", () => {
     test("edits the delivered message in place and keeps its id", async () => {
       const adapter = new TelegramAdapter();

--- a/assistant/src/notifications/AGENTS.md
+++ b/assistant/src/notifications/AGENTS.md
@@ -2,7 +2,7 @@
 
 All notification producers **MUST** go through `emitNotificationSignal()` in `notifications/emit-signal.ts`. Do not bypass the pipeline by broadcasting events directly -- the pipeline handles event persistence, deduplication, decision routing, and delivery audit.
 
-Guardian-request cards (approvals, questions) ride this pipeline end to end -- the full lifecycle map is [docs/guardian-request-flow.md](../../docs/guardian-request-flow.md). Card actions (`actions[]`) are built **once, centrally** in the broadcaster's context resolvers (`resolveApprovalContext` / `resolveQuestionOptionsContext`); channel adapters render only. Adding buttons for a new request kind = a broadcaster context branch, never adapter parsing.
+Guardian-request cards (approvals, questions) ride this pipeline end to end -- the full lifecycle map is [docs/guardian-request-flow.md](../../docs/guardian-request-flow.md). Card actions (`actions[]`) are built **once, centrally** in the broadcaster's context resolvers (`resolveApprovalContext` / `resolveQuestionContext`); channel adapters render only. Adding buttons for a new request kind = a broadcaster context branch, never adapter parsing.
 
 When a notification flow creates a server-side conversation (e.g. guardian question conversations, task run conversations), the conversation and initial message **MUST** be persisted before the conversation-created event is emitted. This ensures the macOS/iOS client can immediately fetch the conversation contents when it receives the event.
 

--- a/assistant/src/notifications/__tests__/broadcaster.test.ts
+++ b/assistant/src/notifications/__tests__/broadcaster.test.ts
@@ -718,7 +718,7 @@ describe("NotificationBroadcaster question option actions", () => {
     expect(approval?.plainTextFallback).toContain("your answer");
   });
 
-  test("an option-less pending_question (voice) carries no card actions", async () => {
+  test("an option-less pending_question (voice) carries the typed-reply instruction and no actions", async () => {
     const { adapter, sends } = makeCapturingAdapter("platform");
     const broadcaster = new NotificationBroadcaster([adapter]);
 
@@ -735,9 +735,40 @@ describe("NotificationBroadcaster question option actions", () => {
     );
 
     expect(sends.length).toBe(1);
-    // Answer-mode without options renders as plain text with request-code
-    // instructions — no approve/reject pair is ever attached to a question.
-    expect(sends[0]?.payload.approvalContext).toBeUndefined();
+    // No buttons to draw, so the transports send text and append the
+    // instruction; an approve/reject pair is never attached to a question.
+    const approval = sends[0]?.payload.approvalContext;
+    expect(approval?.requestId).toBe("req-v1");
+    expect(approval?.actions).toEqual([]);
+    expect(approval?.intent).toBe("question");
+    expect(approval?.plainTextFallback).toBe(
+      'Reference code: DEF456. Reply "DEF456 <your answer>".',
+    );
+  });
+
+  test("a coded question that fails strict parsing still carries its typed-reply instruction", async () => {
+    const { adapter, sends } = makeCapturingAdapter("platform");
+    const broadcaster = new NotificationBroadcaster([adapter]);
+
+    await broadcaster.broadcastDecision(
+      questionSignal({
+        requestKind: "pending_question",
+        requestId: "req-lenient-1",
+        requestCode: "abc999",
+        // A null requester id fails the strict schema (string | undefined).
+        requesterExternalUserId: null,
+        questionText: "What time works?",
+      }),
+      decisionForPlatform(),
+    );
+
+    expect(sends.length).toBe(1);
+    const approval = sends[0]?.payload.approvalContext;
+    expect(approval?.requestId).toBe("req-lenient-1");
+    expect(approval?.actions).toEqual([]);
+    expect(approval?.plainTextFallback).toBe(
+      'Reference code: ABC999. Reply "ABC999 <your answer>".',
+    );
   });
 
   test("tool_approval payloads keep the approve/reject action pair", async () => {

--- a/assistant/src/notifications/adapters/discord.ts
+++ b/assistant/src/notifications/adapters/discord.ts
@@ -31,7 +31,11 @@ import type {
   DeliveryResult,
   NotificationChannel,
 } from "../types.js";
-import { appendPlainTextFallback, resolveMessageText } from "./shared.js";
+import {
+  appendPlainTextFallback,
+  rendersActions,
+  resolveMessageText,
+} from "./shared.js";
 
 const log = getLogger("notif-adapter-discord");
 
@@ -60,7 +64,7 @@ export class DiscordAdapter implements ChannelAdapter {
     try {
       const channelId = await openDiscordDmChannel(guardianUserId);
 
-      if (approval) {
+      if (rendersActions(approval)) {
         // Attempt rich delivery with component buttons; on failure, fall
         // back to the plain-text card below.
         try {
@@ -108,8 +112,8 @@ export class DiscordAdapter implements ChannelAdapter {
         }
       }
 
-      // When falling back from rich delivery, append the plain-text
-      // instructions so the guardian still knows how to approve/reject.
+      // Text without buttons carries the typed-reply instructions, whether
+      // the rich delivery failed or the request never had buttons to draw.
       const sent = await sendDiscordReply(
         { channelId },
         appendPlainTextFallback(messageText, approval),

--- a/assistant/src/notifications/adapters/shared.ts
+++ b/assistant/src/notifications/adapters/shared.ts
@@ -35,10 +35,23 @@ export function resolveMessageText(payload: ChannelDeliveryPayload): string {
 }
 
 /**
- * Append an approval's typed-command instructions to the message text, when
- * the copy does not already carry them. Used by adapters delivering an
- * approval without live buttons (Discord always; Telegram when its rich
- * delivery fails), so the guardian still knows how to decide.
+ * Whether an approval context has buttons to draw. A context with no actions
+ * (an option-less question) is answered by typed reply, so it takes the
+ * plain-text path with {@link appendPlainTextFallback} rather than a card
+ * with nothing on it.
+ */
+export function rendersActions(
+  approval: ChannelDeliveryPayload["approvalContext"],
+): approval is NonNullable<ChannelDeliveryPayload["approvalContext"]> {
+  return approval != null && approval.actions.length > 0;
+}
+
+/**
+ * Append an approval's typed-reply instructions to the message text, when
+ * the text does not already carry them. This is the only place reply
+ * mechanics join a message: composed copy never carries them, so an adapter
+ * sending text without live buttons (no actions to draw, or a rich delivery
+ * that failed) appends them here and the guardian still knows how to answer.
  */
 export function appendPlainTextFallback(
   text: string,

--- a/assistant/src/notifications/adapters/slack.ts
+++ b/assistant/src/notifications/adapters/slack.ts
@@ -39,7 +39,11 @@ import type {
   DeliveryResult,
   NotificationChannel,
 } from "../types.js";
-import { resolveMessageText } from "./shared.js";
+import {
+  appendPlainTextFallback,
+  rendersActions,
+  resolveMessageText,
+} from "./shared.js";
 
 const log = getLogger("notif-adapter-slack");
 
@@ -444,13 +448,19 @@ export class SlackAdapter implements ChannelAdapter {
       // `approval` rides along with the prebuilt card blocks so the send
       // layer treats a rejected Block Kit payload as an approval prompt:
       // its block-free retry re-attaches `plainTextFallback` reply
-      // instructions instead of posting text with no way to respond.
-      const result = payload.approvalContext
+      // instructions instead of posting text with no way to respond. A
+      // context with no buttons to draw is answered by typed reply, so its
+      // instructions join the text up front.
+      const result = rendersActions(payload.approvalContext)
         ? await sendSlackReply(chatId, messageText, {
             blocks: buildApprovalNotificationBlocks(payload, messageText),
             approval: payload.approvalContext,
           })
-        : await sendSlackReply(chatId, messageText, { useBlocks: true });
+        : await sendSlackReply(
+            chatId,
+            appendPlainTextFallback(messageText, payload.approvalContext),
+            { useBlocks: true },
+          );
 
       log.info(
         { sourceEventName: payload.sourceEventName, chatId, ts: result.ts },

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -23,7 +23,11 @@ import type {
   DeliveryResult,
   NotificationChannel,
 } from "../types.js";
-import { appendPlainTextFallback, resolveMessageText } from "./shared.js";
+import {
+  appendPlainTextFallback,
+  rendersActions,
+  resolveMessageText,
+} from "./shared.js";
 
 const log = getLogger("notif-adapter-telegram");
 
@@ -50,7 +54,7 @@ export class TelegramAdapter implements ChannelAdapter {
     const approval = payload.approvalContext;
 
     try {
-      if (approval) {
+      if (rendersActions(approval)) {
         // Attempt rich delivery with inline keyboard buttons.
         // On failure, fall back to plain text below.
         try {
@@ -72,8 +76,8 @@ export class TelegramAdapter implements ChannelAdapter {
         }
       }
 
-      // When falling back from rich delivery, append the plain-text
-      // instructions so the guardian still knows how to approve/reject.
+      // Text without buttons carries the typed-reply instructions, whether
+      // the rich delivery failed or the request never had buttons to draw.
       const sent = await sendTelegramReply(
         chatId,
         appendPlainTextFallback(messageText, approval),

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -33,11 +33,13 @@ import {
 } from "./deliveries-store.js";
 import { resolveDestinations } from "./destination-resolver.js";
 import {
+  buildGuardianRequestCodeInstruction,
   buildQuestionAnswerActions,
   buildToolApprovalSourceView,
   parseGuardianQuestionPayload,
   parseInteractiveApprovalPayload,
   resolveGuardianInstructionModeFromPayload,
+  resolveGuardianQuestionInstructionMode,
   type ToolApprovalSourceView,
 } from "./guardian-question-mode.js";
 import { nonEmpty } from "./notification-utils.js";
@@ -103,19 +105,19 @@ function resolveApprovalContext(
   }
 
   if (signal.sourceEventName === "guardian.question") {
-    // Answer-mode question with structured options (an ask_question prompt):
-    // render the options as card actions so every channel adapter shows
-    // tappable choices. Built here — once per broadcast — so adapters stay
-    // rendering-only; the reply router recognizes the action ids as answer
-    // selections (see parseQuestionAnswerActionId).
-    const questionContext = resolveQuestionOptionsContext(payload);
+    // Answer-mode question: options render as card actions so every channel
+    // adapter shows tappable choices, and an option-less question carries
+    // its typed-reply instruction. Built here, once per broadcast, so
+    // adapters stay rendering-only; the reply router recognizes the action
+    // ids as answer selections (see parseQuestionAnswerActionId).
+    const questionContext = resolveQuestionContext(payload);
     if (questionContext) {
       return questionContext;
     }
 
     const parsed = parseInteractiveApprovalPayload(payload);
     if (!parsed) {
-      return undefined;
+      return resolveCodedTextContext(payload);
     }
     const requestId = parsed.requestId;
 
@@ -139,7 +141,10 @@ function resolveApprovalContext(
       approval: {
         requestId,
         actions: APPROVAL_ACTIONS,
-        plainTextFallback: `Reply "${parsed.requestCode?.toUpperCase() ?? requestId} approve" or "${parsed.requestCode?.toUpperCase() ?? requestId} reject"`,
+        plainTextFallback: buildGuardianRequestCodeInstruction(
+          parsed.requestCode?.toUpperCase() ?? requestId,
+          "approval",
+        ),
         permissionDetails: toolName
           ? {
               toolName,
@@ -157,14 +162,47 @@ function resolveApprovalContext(
 }
 
 /**
- * Card actions for an answer-mode `pending_question` payload carrying
- * structured options: one action per option plus Skip, ids in the
- * answer-selection scheme. Returns `undefined` for approval-mode payloads,
- * option-less questions (voice questions answer by free text), and anything
- * that fails strict parsing — those fall through to the approval/plain-text
- * paths.
+ * A `guardian.question` payload that fails strict parsing draws no buttons
+ * anywhere, so its only way to be answered is the typed reply. When it
+ * still names a request id and code, it gets a context with no actions and
+ * the instruction for its mode, which the transports render as text plus
+ * the instruction. Without those it is undefined, as before.
  */
-function resolveQuestionOptionsContext(
+function resolveCodedTextContext(
+  payload: Record<string, unknown>,
+): ResolvedApprovalContext | undefined {
+  const requestId = nonEmpty(
+    typeof payload.requestId === "string" ? payload.requestId : undefined,
+  );
+  const requestCode = nonEmpty(
+    typeof payload.requestCode === "string" ? payload.requestCode : undefined,
+  );
+  if (!requestId || !requestCode) {
+    return undefined;
+  }
+  return {
+    approval: {
+      requestId,
+      actions: [],
+      plainTextFallback: buildGuardianRequestCodeInstruction(
+        requestCode.toUpperCase(),
+        resolveGuardianQuestionInstructionMode(payload).mode,
+      ),
+    },
+  };
+}
+
+/**
+ * The card context for an answer-mode `pending_question`: one action per
+ * option plus Skip, ids in the answer-selection scheme, and the typed-reply
+ * instruction as the text fallback. An option-less question (a voice
+ * question, answered by free text) carries no actions, only the fallback:
+ * the transports read an empty action set as "send text, append the
+ * instruction", which is the one way that question stays answerable.
+ * Returns `undefined` for approval-mode payloads and anything that fails
+ * strict parsing; those fall through to the approval path.
+ */
+function resolveQuestionContext(
   payload: Record<string, unknown>,
 ): ResolvedApprovalContext | undefined {
   const parsed = parseGuardianQuestionPayload(payload);
@@ -174,21 +212,19 @@ function resolveQuestionOptionsContext(
   if (resolveGuardianInstructionModeFromPayload(parsed).mode !== "answer") {
     return undefined;
   }
-  const options = parsed.options;
-  if (!options || options.length === 0) {
-    return undefined;
-  }
   const requestId = nonEmpty(parsed.requestId);
   if (!requestId) {
     return undefined;
   }
 
-  const code = parsed.requestCode?.toUpperCase() ?? requestId;
   return {
     approval: {
       requestId,
-      actions: buildQuestionAnswerActions(options),
-      plainTextFallback: `Reply "${code} <your answer>".`,
+      actions: buildQuestionAnswerActions(parsed.options ?? []),
+      plainTextFallback: buildGuardianRequestCodeInstruction(
+        parsed.requestCode?.toUpperCase() ?? requestId,
+        "answer",
+      ),
       intent: "question",
     },
   };

--- a/assistant/src/notifications/broadcaster.ts
+++ b/assistant/src/notifications/broadcaster.ts
@@ -42,7 +42,7 @@ import {
   resolveGuardianQuestionInstructionMode,
   type ToolApprovalSourceView,
 } from "./guardian-question-mode.js";
-import { nonEmpty } from "./notification-utils.js";
+import { nonEmpty, readPayloadString } from "./notification-utils.js";
 import type { NotificationSignal } from "./signal.js";
 import type {
   ChannelAdapter,
@@ -171,12 +171,8 @@ function resolveApprovalContext(
 function resolveCodedTextContext(
   payload: Record<string, unknown>,
 ): ResolvedApprovalContext | undefined {
-  const requestId = nonEmpty(
-    typeof payload.requestId === "string" ? payload.requestId : undefined,
-  );
-  const requestCode = nonEmpty(
-    typeof payload.requestCode === "string" ? payload.requestCode : undefined,
-  );
+  const requestId = nonEmpty(readPayloadString(payload, "requestId"));
+  const requestCode = nonEmpty(readPayloadString(payload, "requestCode"));
   if (!requestId || !requestCode) {
     return undefined;
   }

--- a/assistant/src/runtime/question-request-guardian-bridge.ts
+++ b/assistant/src/runtime/question-request-guardian-bridge.ts
@@ -4,7 +4,7 @@
  *
  * Mirrors `confirmation-request-guardian-bridge.ts` for the question kind:
  * emits the notification signal (the broadcaster renders the options as card
- * actions — see `resolveQuestionOptionsContext`) and records the resulting
+ * actions — see `resolveQuestionContext`) and records the resulting
  * card deliveries so reply routing can address taps back to the request.
  *
  * Unlike the confirmation bridge — which escalates a NON-guardian's request TO

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -59,6 +59,15 @@ export type PermissionRequestDetails = z.infer<
 export const ApprovalUIMetadataSchema = z.object({
   requestId: z.string(),
   actions: z.array(ApprovalActionOptionSchema),
+  /**
+   * Typed-reply instructions for a transport that sends text without
+   * buttons. Two producers, two shapes: the notification pipeline sends the
+   * instructions alone and always beside a message text, so a transport
+   * appends them; the legacy in-turn approval rail sends prompt plus
+   * instructions and a transport may use them as the whole message when no
+   * text is given. An empty `actions` list means there is nothing to draw
+   * and the instructions are the message's only affordance.
+   */
   plainTextFallback: z.string(),
   permissionDetails: PermissionRequestDetailsSchema.optional(),
   /**


### PR DESCRIPTION
## TL;DR

Every guardian-request delivery that goes out without buttons now carries its typed-reply instruction from the transport, not from whatever the composed copy happened to say. First of three PRs that move reply mechanics out of composed copy and into the card's text fallback (this one; then access requests; then guardian questions, which depends on this).

Part of LUM-3517. Refs LUM-3522.

## Before / after

| Delivery | Before | After |
| --- | --- | --- |
| Option-less voice question on Telegram, Discord, Slack | No approval context; answerable only because the copy carried the code line | Context with `actions: []` and `Reference code: X. Reply "X <your answer>".`; adapters send text and append it |
| Coded question that fails strict parsing | Same | Same, instruction by mode |
| Question with options, approvals, access requests | Buttons; fallback appended only if the rich send fails | Unchanged |
| Copy | Unchanged | Unchanged. The appended instruction deduplicates against copy that already carries it, so nothing doubles while enforcement still exists |

## Design

- `resolveQuestionContext` (was `resolveQuestionOptionsContext`) emits a context for every answer-mode question; `resolveCodedTextContext` covers a coded payload that fails strict parsing. Both use `buildGuardianRequestCodeInstruction`, the builder the router's replies use, and the approval-mode fallback now does too, so there is one sentence shape.
- `rendersActions(approval)` in `adapters/shared.ts` gates rich delivery in Telegram, Discord, and Slack. An empty action set goes to the text path with `appendPlainTextFallback`. Slack gains that path (it previously sent an approval-less text with blocks).
- `ApprovalUIMetadata.plainTextFallback` is documented on the contract: the pipeline sends instructions only beside a text; the legacy in-turn rail sends prompt plus instructions and may use it as the whole message; an empty `actions` list means there is nothing to draw.

## Why this is safe

- Adapters change only the branch condition; the rich path and the failure path are the same code. Delivery recording and withdrawal read only channel, destination, and message id, and the contract's `actions` array has no minimum.
- The dedupe in `appendPlainTextFallback` is a substring check, and the enforced copy line contains the fallback sentence, so today's channels see the same text they saw before.
- Tests: broadcaster contexts for the two new shapes; Telegram, Discord, and Slack adapters sending an option-less question as text with the instruction; Slack card path unchanged. Per-file runs green for broadcaster, the three adapters, Slack send, the Slack card builder, and the decision fallback suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->