### PR TITLE
Retire Fireworks minimax-m2p7; migrate stale pins to minimax-m3

### DIFF
--- a/assistant/src/__tests__/workspace-migration-152-repair-retired-fireworks-minimax-m2p7-model-id.test.ts
+++ b/assistant/src/__tests__/workspace-migration-152-repair-retired-fireworks-minimax-m2p7-model-id.test.ts
@@ -1,0 +1,233 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repairRetiredFireworksMinimaxM2p7ModelIdMigration } from "../workspace/migrations/152-repair-retired-fireworks-minimax-m2p7-model-id.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+const STALE = "accounts/fireworks/models/minimax-m2p7";
+const REPLACEMENT = "accounts/fireworks/models/minimax-m3";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-152-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function seedRows(rows: Array<{ name: string; provider: string }>): void {
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+  db.run(`CREATE TABLE IF NOT EXISTS provider_connections (
+    name TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+  for (const row of rows) {
+    db.query(
+      `INSERT INTO provider_connections (name, provider, auth, created_at, updated_at) VALUES (?, ?, '{"type":"api_key"}', 1, 1)`,
+    ).run(row.name, row.provider);
+  }
+  db.close();
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("152-repair-retired-fireworks-minimax-m2p7-model-id migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(repairRetiredFireworksMinimaxM2p7ModelIdMigration.id).toBe(
+      "152-repair-retired-fireworks-minimax-m2p7-model-id",
+    );
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
+      "152-repair-retired-fireworks-minimax-m2p7-model-id",
+    );
+  });
+
+  test("repairs the stale ID in default, call sites, and profiles", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: STALE },
+        callSites: {
+          recall: { model: STALE, maxTokens: 4096 },
+          heartbeat: { model: `${STALE}-tuned` },
+          malformed: STALE,
+        },
+        profiles: {
+          "cost-optimized": { provider: "vellum", model: STALE },
+          legacy: { model: STALE },
+        },
+      },
+    });
+
+    repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.model).toBe(REPLACEMENT);
+    expect(llm.callSites.recall.maxTokens).toBe(4096);
+    // Non-exact matches and malformed leaves are untouched.
+    expect(llm.callSites.heartbeat.model).toBe(`${STALE}-tuned`);
+    expect(llm.callSites.malformed).toBe(STALE);
+    // Managed profiles stamped provider "vellum" carry Fireworks model IDs.
+    expect(llm.profiles["cost-optimized"].model).toBe(REPLACEMENT);
+    expect(llm.profiles.legacy.model).toBe(REPLACEMENT);
+  });
+
+  test("repairs entry-bound fragments whose row kind is fireworks or vellum", () => {
+    seedRows([
+      { name: "my-fireworks", provider: "fireworks" },
+      { name: "managed-alt", provider: "vellum" },
+    ]);
+    writeConfig({
+      llm: {
+        profiles: {
+          bound: { provider: "my-fireworks", model: STALE },
+          managed: { provider: "managed-alt", model: STALE },
+        },
+      },
+    });
+
+    repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.profiles.bound.model).toBe(REPLACEMENT);
+    expect(llm.profiles.managed.model).toBe(REPLACEMENT);
+  });
+
+  test("leaves fragments with an explicit other provider untouched", () => {
+    seedRows([{ name: "byo-compat", provider: "openai-compatible" }]);
+    writeConfig({
+      llm: {
+        default: { provider: "openai-compatible", model: STALE },
+        profiles: {
+          byo: { provider: "openai-compatible", model: STALE },
+          // Entry-bound profile whose row kind is not repairable.
+          compatBound: { provider: "byo-compat", model: STALE },
+          // Entry name with no row: dangling, so nothing proves it is a
+          // fireworks-kind route.
+          dangling: { provider: "ghost", model: STALE },
+        },
+      },
+    });
+
+    repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.default.model).toBe(STALE);
+    expect(llm.profiles.byo.model).toBe(STALE);
+    expect(llm.profiles.compatBound.model).toBe(STALE);
+    expect(llm.profiles.dangling.model).toBe(STALE);
+  });
+
+  test("leaves entry-name providers untouched when no DB file exists", () => {
+    writeConfig({
+      llm: {
+        profiles: { bound: { provider: "my-fireworks", model: STALE } },
+      },
+    });
+
+    repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir);
+
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.profiles.bound.model).toBe(STALE);
+  });
+
+  test("throws when an entry-name provider needs rows and the DB is unreadable", () => {
+    // A DB file without the provider_connections table is unqueryable, so
+    // the run must fail (and retry later) instead of skipping the profile.
+    mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+    writeFileSync(join(workspaceDir, "data", "db", "assistant.db"), "");
+    writeConfig({
+      llm: {
+        profiles: { bound: { provider: "my-fireworks", model: STALE } },
+      },
+    });
+
+    expect(() =>
+      repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir),
+    ).toThrow();
+    const llm = readConfig().llm as Record<string, any>;
+    expect(llm.profiles.bound.model).toBe(STALE);
+
+    // Vendor and absent providers never need the rows, so the same broken
+    // DB does not block their repair.
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: STALE },
+        profiles: { legacy: { model: STALE } },
+      },
+    });
+    repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir);
+    const repaired = readConfig().llm as Record<string, any>;
+    expect(repaired.default.model).toBe(REPLACEMENT);
+    expect(repaired.profiles.legacy.model).toBe(REPLACEMENT);
+  });
+
+  test("is idempotent and a no-op without the stale ID", () => {
+    writeConfig({
+      llm: {
+        default: { provider: "fireworks", model: STALE },
+        profiles: { fine: { provider: "fireworks", model: REPLACEMENT } },
+      },
+    });
+
+    repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir);
+    const first = readConfig();
+    repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(first);
+
+    const llm = first.llm as Record<string, any>;
+    expect(llm.default.model).toBe(REPLACEMENT);
+    expect(llm.profiles.fine.model).toBe(REPLACEMENT);
+  });
+
+  test("handles missing config, missing llm block, and invalid JSON", () => {
+    // No config.json at all.
+    expect(() =>
+      repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeConfig({ theme: "dark" });
+    repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ theme: "dark" });
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    expect(() =>
+      repairRetiredFireworksMinimaxM2p7ModelIdMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1007,10 +1007,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         },
       },
       // MiniMax M2.7 (accounts/fireworks/models/minimax-m2p7) is
-      // intentionally absent: Fireworks withdrew its serverless deployment
-      // 2026-08 (the model page still claims serverless support, but the
-      // serving API 404s it). Workspace migration 152 repairs stale pins
-      // to minimax-m3.
+      // intentionally absent: Fireworks has no serverless deployment for
+      // it (the model page claims serverless support, but the serving API
+      // returns 404).
       {
         id: "accounts/fireworks/models/deepseek-v4-pro-0813",
         displayName: "DeepSeek V4 Pro",

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1006,17 +1006,11 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
           cacheReadPer1mTokens: 0.06,
         },
       },
-      {
-        id: "accounts/fireworks/models/minimax-m2p7",
-        displayName: "MiniMax M2.7",
-        contextWindowTokens: 196608,
-        maxOutputTokens: 25000,
-        supportsThinking: false,
-        supportsCaching: false,
-        supportsVision: false,
-        supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.3, outputPer1mTokens: 1.2 },
-      },
+      // MiniMax M2.7 (accounts/fireworks/models/minimax-m2p7) is
+      // intentionally absent: Fireworks withdrew its serverless deployment
+      // 2026-08 (the model page still claims serverless support, but the
+      // serving API 404s it). Workspace migration 152 repairs stale pins
+      // to minimax-m3.
       {
         id: "accounts/fireworks/models/deepseek-v4-pro-0813",
         displayName: "DeepSeek V4 Pro",

--- a/assistant/src/workspace/migrations/152-repair-retired-fireworks-minimax-m2p7-model-id.ts
+++ b/assistant/src/workspace/migrations/152-repair-retired-fireworks-minimax-m2p7-model-id.ts
@@ -8,21 +8,19 @@ import type { WorkspaceMigration } from "./types.js";
  * Repair the retired Fireworks MiniMax M2.7 model ID in workspace LLM
  * config.
  *
- * Fireworks withdrew the serverless deployment of
- * `accounts/fireworks/models/minimax-m2p7` (2026-08): the model page still
- * claims serverless support, but chat/completions calls fail with a 404
- * "Model not found, inaccessible, and/or not deployed". Existing configs
- * can pin the ID in `llm.default`, `llm.callSites.*`, and `llm.profiles.*`,
- * both from picking it directly and from migration 137, which wrote it
- * over retired `minimax-m2p5` pins.
+ * Fireworks has no serverless deployment of
+ * `accounts/fireworks/models/minimax-m2p7`: the model page claims
+ * serverless support, but chat/completions calls fail with a 404 "Model
+ * not found, inaccessible, and/or not deployed". Existing configs can pin
+ * the ID in `llm.default`, `llm.callSites.*`, and `llm.profiles.*`.
  *
  * Repair those leaves only on an exact stale match, replacing with
  * `accounts/fireworks/models/minimax-m3`: the only MiniMax model Fireworks
- * still serves serverless, at the same per-token pricing. Because m3 is
- * also the balanced-intent template's model, a repaired hand-edited
- * `custom-*` profile can read as unedited to `ensureByokDefaultProfiles`
- * and collapse into the balanced default. That is acceptable: the
- * collapsed copy routes to the same model this migration writes.
+ * serves serverless, at the same per-token pricing. Because m3 is also the
+ * balanced-intent template's model, a repaired hand-edited `custom-*`
+ * profile can read as unedited to `ensureByokDefaultProfiles` and collapse
+ * into the balanced default. That is acceptable: the collapsed copy routes
+ * to the same model this migration writes.
  *
  * Provider guard: the stale ID belongs to the `fireworks` provider and also
  * appears in managed profiles stamped `provider: "vellum"` (which route

--- a/assistant/src/workspace/migrations/152-repair-retired-fireworks-minimax-m2p7-model-id.ts
+++ b/assistant/src/workspace/migrations/152-repair-retired-fireworks-minimax-m2p7-model-id.ts
@@ -1,0 +1,200 @@
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import type { WorkspaceMigration } from "./types.js";
+
+/**
+ * Repair the retired Fireworks MiniMax M2.7 model ID in workspace LLM
+ * config.
+ *
+ * Fireworks withdrew the serverless deployment of
+ * `accounts/fireworks/models/minimax-m2p7` (2026-08): the model page still
+ * claims serverless support, but chat/completions calls fail with a 404
+ * "Model not found, inaccessible, and/or not deployed". Existing configs
+ * can pin the ID in `llm.default`, `llm.callSites.*`, and `llm.profiles.*`,
+ * both from picking it directly and from migration 137, which wrote it
+ * over retired `minimax-m2p5` pins.
+ *
+ * Repair those leaves only on an exact stale match, replacing with
+ * `accounts/fireworks/models/minimax-m3`: the only MiniMax model Fireworks
+ * still serves serverless, at the same per-token pricing. Because m3 is
+ * also the balanced-intent template's model, a repaired hand-edited
+ * `custom-*` profile can read as unedited to `ensureByokDefaultProfiles`
+ * and collapse into the balanced default. That is acceptable: the
+ * collapsed copy routes to the same model this migration writes.
+ *
+ * Provider guard: the stale ID belongs to the `fireworks` provider and also
+ * appears in managed profiles stamped `provider: "vellum"` (which route
+ * Fireworks-account model IDs through the managed proxy). Under the entries
+ * model (migration 145) `provider` can also hold a `provider_connections`
+ * entry name whose row kind drives dispatch. A fragment is repaired when
+ * its `provider` is `"fireworks"`, `"vellum"`, absent, or an entry name
+ * whose row kind is one of those. Any other provider is left untouched: an
+ * `openai-compatible` endpoint may legitimately serve a model by the stale
+ * name.
+ */
+export const repairRetiredFireworksMinimaxM2p7ModelIdMigration: WorkspaceMigration =
+  {
+    id: "152-repair-retired-fireworks-minimax-m2p7-model-id",
+    description:
+      "Repair retired Fireworks accounts/fireworks/models/minimax-m2p7 model ID in workspace LLM config",
+    run(workspaceDir: string): void {
+      const configPath = join(workspaceDir, "config.json");
+      if (!existsSync(configPath)) {
+        return;
+      }
+
+      // Read outside the parse catch: a transient filesystem error (EIO,
+      // EACCES) must reach the runner so the migration retries, while
+      // malformed JSON is a permanent state this migration cannot repair.
+      const rawText = readFileSync(configPath, "utf-8");
+
+      let config: Record<string, unknown>;
+      try {
+        const raw = JSON.parse(rawText);
+        if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+          return;
+        }
+        config = raw as Record<string, unknown>;
+      } catch {
+        return;
+      }
+
+      const llm = readObject(config.llm);
+      if (llm === null) {
+        return;
+      }
+
+      // Entry rows load lazily: only a stale fragment whose provider is
+      // neither a repairable vendor nor absent needs them. An unreadable DB
+      // then fails the run (retried next boot) rather than checkpointing a
+      // pass that skips entry-bound profiles.
+      let rows: Map<string, string> | null | undefined;
+      const isRepairableProvider = (provider: unknown): boolean => {
+        if (provider === undefined) {
+          return true;
+        }
+        if (typeof provider !== "string") {
+          return false;
+        }
+        if (REPAIRABLE_PROVIDERS.has(provider)) {
+          return true;
+        }
+        if (rows === undefined) {
+          rows = readConnectionRows(workspaceDir);
+        }
+        if (rows === null) {
+          throw new Error(
+            "provider_connections is not readable; retrying the model-ID repair on the next run",
+          );
+        }
+        const kind = rows.get(provider);
+        return kind !== undefined && REPAIRABLE_PROVIDERS.has(kind);
+      };
+
+      let changed = false;
+
+      changed =
+        repairFragment(readObject(llm.default), isRepairableProvider) ||
+        changed;
+
+      const callSites = readObject(llm.callSites);
+      if (callSites !== null) {
+        for (const rawConfig of Object.values(callSites)) {
+          changed =
+            repairFragment(readObject(rawConfig), isRepairableProvider) ||
+            changed;
+        }
+      }
+
+      const profiles = readObject(llm.profiles);
+      if (profiles !== null) {
+        for (const rawProfile of Object.values(profiles)) {
+          changed =
+            repairFragment(readObject(rawProfile), isRepairableProvider) ||
+            changed;
+        }
+      }
+
+      if (!changed) {
+        return;
+      }
+
+      // Write-then-rename so an interrupted write cannot leave config.json
+      // truncated: a torn in-place write would parse as invalid JSON on the
+      // retry, which the catch above treats as "nothing to do", letting the
+      // runner checkpoint the migration as completed against a corrupt file.
+      const tmpPath = `${configPath}.migration-152.tmp`;
+      writeFileSync(tmpPath, JSON.stringify(config, null, 2) + "\n");
+      renameSync(tmpPath, configPath);
+    },
+    // The exact-match rewrite is idempotent, so a transient failure (full
+    // disk, I/O error) is safe to retry on later startups.
+    retryFailedCheckpoint: true,
+    down(_workspaceDir: string): void {
+      // Forward-only: reintroducing the retired model ID would break
+      // Fireworks calls.
+    },
+  };
+
+// ---------------------------------------------------------------------------
+// Helpers: self-contained per workspace migrations AGENTS.md
+// ---------------------------------------------------------------------------
+
+const STALE_MODEL_ID = "accounts/fireworks/models/minimax-m2p7";
+const REPLACEMENT_MODEL_ID = "accounts/fireworks/models/minimax-m3";
+const REPAIRABLE_PROVIDERS = new Set(["fireworks", "vellum"]);
+
+function repairFragment(
+  fragment: Record<string, unknown> | null,
+  isRepairableProvider: (provider: unknown) => boolean,
+): boolean {
+  if (fragment === null) {
+    return false;
+  }
+  if (fragment.model !== STALE_MODEL_ID) {
+    return false;
+  }
+  if (!isRepairableProvider(fragment.provider)) {
+    return false;
+  }
+  fragment.model = REPLACEMENT_MODEL_ID;
+  return true;
+}
+
+/**
+ * Connection name -> provider kind, or null when the DB or table is not
+ * readable. The caller fails the run on null: entry-name providers must be
+ * judged against real rows, never guessed. An absent DB file is a real
+ * state (no rows, so every entry name is dangling and stays untouched).
+ */
+function readConnectionRows(workspaceDir: string): Map<string, string> | null {
+  const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(dbPath)) {
+    return new Map();
+  }
+  let db: Database;
+  try {
+    db = new Database(dbPath);
+  } catch {
+    return null;
+  }
+  try {
+    const rows = db
+      .query(`SELECT name, provider FROM provider_connections`)
+      .all() as Array<{ name: string; provider: string }>;
+    return new Map(rows.map((r) => [r.name, r.provider]));
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -149,6 +149,7 @@ import { stripUnsupportedFallbackProfilesMigration } from "./148-strip-unsupport
 import { repointBackupProfileSelectionsMigration } from "./149-repoint-backup-profile-selections.js";
 import { sttFluxProviderToModelFamilyMigration } from "./150-stt-flux-provider-to-model-family.js";
 import { repairRenamedFireworksDeepseekProModelIdMigration } from "./151-repair-renamed-fireworks-deepseek-pro-model-id.js";
+import { repairRetiredFireworksMinimaxM2p7ModelIdMigration } from "./152-repair-retired-fireworks-minimax-m2p7-model-id.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -313,4 +314,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repointBackupProfileSelectionsMigration,
   sttFluxProviderToModelFamilyMigration,
   repairRenamedFireworksDeepseekProModelIdMigration,
+  repairRetiredFireworksMinimaxM2p7ModelIdMigration,
 ];

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -430,15 +430,6 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
     {
-      id: "accounts/fireworks/models/minimax-m2p7",
-      displayName: "MiniMax M2.7",
-      vendor: "minimax",
-      family: "minimax-m",
-      contextWindowTokens: 196_608,
-      defaultContextWindowTokens: 196_608,
-      maxOutputTokens: 25_000,
-    },
-    {
       id: "accounts/fireworks/models/deepseek-v4-pro-0813",
       displayName: "DeepSeek V4 Pro",
       vendor: "deepseek",

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -870,22 +870,6 @@
           }
         },
         {
-          "id": "accounts/fireworks/models/minimax-m2p7",
-          "displayName": "MiniMax M2.7",
-          "contextWindowTokens": 196608,
-          "maxOutputTokens": 25000,
-          "defaultContextWindowTokens": 196608,
-          "longContextMode": "unsupported",
-          "supportsThinking": false,
-          "supportsCaching": false,
-          "supportsVision": false,
-          "supportsToolUse": true,
-          "pricing": {
-            "inputPer1mTokens": 0.3,
-            "outputPer1mTokens": 1.2
-          }
-        },
-        {
           "id": "accounts/fireworks/models/deepseek-v4-pro-0813",
           "displayName": "DeepSeek V4 Pro",
           "contextWindowTokens": 1040000,


### PR DESCRIPTION
## Summary
- Remove `accounts/fireworks/models/minimax-m2p7` from the canonical catalog (`model-catalog.ts`), the generated `meta/llm-provider-catalog.json`, and the hand-maintained web mirror. OpenRouter's `minimax/minimax-m2.7` stays since OpenRouter still serves it.
- Add workspace migration **152** (151 is now the DeepSeek V4 Pro rename) repairing exact stale pins in `llm.default`, `llm.callSites.*`, and `llm.profiles.*` to `minimax-m3`, the only MiniMax model Fireworks still serves serverless, at identical per-token pricing. Same fireworks/vellum/entry-kind provider guard as migrations 146 and 151. This also catches pins that migration 137 wrote over the retired `minimax-m2p5`.
- Migration 137's reason to avoid the balanced-intent model (repaired profiles reading as unedited to `ensureByokDefaultProfiles`) is unavoidable here and benign: a collapsed copy routes to the same model.

## Original prompt
Re-lands #41807, which was closed alongside the platform revert (vellum-assistant-platform#10248) while the retire-vs-rename question was open. The user asked to remove MiniMax M2.7 the same way the other deprecated Fireworks-hosted models were removed, then to raise the matching companion PR. A fresh probe confirms the retirement: the Fireworks serving API answers 404 for `minimax-m2p7` before auth (while `minimax-m3` answers 401 on the identical request), no dated `minimax-m2p7-*` successor responds, and the serverless pricing docs list only MiniMax M3. The platform side re-landed as vellum-assistant-platform#10289.

## Rollout notes
- Merge order relative to the platform PR is user-neutral: upstream already 404s the model, so clients still offering it fail either way until this lands. Once vellum-assistant-platform#10289 deploys, those requests get the intentional "not yet supported" 400 instead of the provider 404.
- Migration 152 is forward-only (no `down`), exact-match idempotent, and retries on transient failure.

## Verification notes
- `bun run sync:llm-catalog` regenerates `meta/llm-provider-catalog.json` with no diff.
- `bun test`: migration 137/146/151/152 suites, `llm-catalog-parity`, `workspace-migrations-runner`, web `llm-model-catalog` parity, `llm-model-vendors`, `model-first-candidates`, `model-first-groups`, `profile-create-model-first` all pass.
- Pre-existing on main (not introduced here): running `workspace-migration-151-*.test.ts` and `workspace-migrations-runner.test.ts` in the same `bun test` invocation fails 7 of the 151 tests with `ENOENT config.json`; each file passes alone. Reproduced on origin/main `6170736501`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UbpQ3ubFaehbdZmtXBXoz
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->