### PR TITLE
fix(web): sanitize the tool detail header title

### DIFF
--- a/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.test.tsx
@@ -316,6 +316,41 @@ describe("ToolDetailPanel", () => {
     expect(getByText("Running…")).toBeDefined();
   });
 
+  test("collapses whitespace in the header title", () => {
+    // The activity sentence is model-written; a newline in it would render as
+    // a gap in a single-line header.
+    const { container } = render(
+      <ToolDetailPanel
+        detail={makeDetail({
+          activity: "  Reading the risk helpers\n  and the badge styles  ",
+        })}
+        onClose={noop}
+      />,
+    );
+
+    // Asserted on the raw node rather than through `getByText`, whose default
+    // normalizer collapses whitespace itself and so cannot tell a sanitized
+    // title from an unsanitized one.
+    const heading = container.querySelector("[title]");
+    expect(heading?.getAttribute("title")).toBe(
+      "Reading the risk helpers and the badge styles",
+    );
+    expect(heading?.textContent).toBe(
+      "Reading the risk helpers and the badge styles",
+    );
+  });
+
+  test("falls back to the phase title when there is no activity", () => {
+    const { getByText } = render(
+      <ToolDetailPanel
+        detail={makeDetail({ activity: "", title: "Spawning subagent" })}
+        onClose={noop}
+      />,
+    );
+
+    expect(getByText("Spawning subagent")).toBeDefined();
+  });
+
   test("clicking close fires onClose", () => {
     const onClose = mock(() => {});
     const { getByLabelText } = render(

--- a/clients/web/src/domains/chat/components/tool-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/tool-detail-panel.tsx
@@ -266,7 +266,10 @@ export function ToolDetailBody({
  * activity underneath the tool name.
  */
 export function toolDetailHeaderTitle(detail: ToolDetailPayload): string {
-  return detail.activity || detail.title;
+  // The activity sentence is written by the model, so it can carry newlines or
+  // runs of spaces that a single-line header would render as gaps. Collapse
+  // them here rather than at each of the three panels that show it.
+  return (detail.activity || detail.title).replace(/\s+/g, " ").trim();
 }
 
 export function ToolDetailPanel({

--- a/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
+++ b/clients/web/src/domains/chat/components/tool-progress-card/derive-step-label.ts
@@ -58,7 +58,7 @@ function readString(input: Record<string, unknown>, ...keys: string[]): string {
   for (const key of keys) {
     const value = input[key];
     if (typeof value === "string" && value.trim().length > 0) {
-      return value;
+      return value.trim();
     }
   }
   return "";


### PR DESCRIPTION
## TL;DR

The tool detail panel's header title comes from a sentence the model writes. It
reaches the header without being trimmed or flattened, so one stray newline
renders as a gap in the middle of a one-line title.

One-line fix plus the guard, split out of the larger tool-detail work so the
bug is visible on its own.

## What a user was experiencing

| Before | After |
| --- | --- |
| An activity sentence carrying a newline or padding renders in the header exactly as written, so the title breaks across a gap or starts indented | The header shows one clean line |

Latent rather than live: across **235,364 calls in a week**, production carries
no such sentence today. But the sentence is model-written, the header is a
single line, and nothing was stopping it.

## Why it is right

Two things were wrong and both are small:

- `readString` in `derive-step-label` gates on `value.trim()` and then returns
  the **raw** value, so the trim it just performed is thrown away.
- Nothing collapses whitespace inside the sentence, even though the bash
  command right beside it is collapsed for exactly this reason.

`toolDetailHeaderTitle` is the one function all three panels that show a tool
detail derive their title from, so the collapse lands there rather than at
three call sites.

## Why it is safe

`readString` feeds the whole step-label pipeline, so trimming it could in
principle move a label somewhere else. It cannot: the function already treated
a whitespace-only value as absent, so the only change is that a value with
padding loses the padding. Suites downstream of it pass unchanged, including
the card, timeline and phase-grouping tests.

## The first test for this was useless

It passed against the unfixed code. `getByText` normalizes whitespace itself,
so it literally cannot distinguish a sanitized title from an unsanitized one.
The test asserts the raw node's `textContent` and `title` attribute now, and I
verified it fails when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->