### PR TITLE
docs(slack): reading back what you sent, thread by thread

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T12:58:28.000Z"
+      "updatedAt": "2026-09-02T13:18:50.000Z"
     },
     {
       "id": "public-ingress",
@@ -880,7 +880,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T21:17:09.000Z"
+      "updatedAt": "2026-09-02T20:00:00.000Z"
     },
     {
       "id": "slack-app-setup",

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -96,29 +96,31 @@ When someone asks what you sent them earlier ("what did you send me this morning
 
 Reading Slack back is three calls on `slack_channel`. That is your own bot identity, and it is the right one here: a DM with you is your app's own DM, the posts you are looking for were made as the bot, and the history scopes this needs (`im:history`, `mpim:history`, `channels:history`, `groups:history`) are ones the app setup already requests.
 
-1. **Know where you are.** Your `<turn_context>` names the chat as `chat_id` and, when this message is in a thread, the thread as `thread_id`. If a turn carries neither, the person's contact record has the DM as `externalChatId` (see User Resolution below).
+1. **Know where you are.** When your `<turn_context>` carries `chat_id` (and `thread_id` for a message in a thread), that is the chat. Otherwise the person's contact record has the DM as `externalChatId` (see User Resolution below).
 
 2. **Read the top level.** `conversations.history` returns only top-level messages, never thread replies. In a DM with you, every proactive post you made (a digest, a notification, a check-in from a scheduled run) is top-level and appears here directly. Each thread you have taken part in appears only as its parent, carrying `reply_count`, `latest_reply`, and `reply_users`.
+
+   Do not put the time window you were asked about into `oldest` here: history filters by each parent's own timestamp, and a thread started days ago can hold a reply you made this morning. Read recent parents by count instead, and follow `response_metadata.next_cursor` while the parents are still newer than the window you care about.
 
    ```bash
    assistant oauth request --provider slack_channel \
      -X POST \
-     -d '{"channel":"D0123456789","limit":50,"oldest":"1716000000.000001"}' \
+     -d '{"channel":"D0123456789","limit":100}' \
      /conversations.history --json
    ```
 
-3. **Read the threads you replied in.** Your own user id comes from `auth.test` (`user_id` in the response). For each parent whose `reply_users` includes it, fetch the thread; the first message returned is the parent, the rest are the replies in order.
+3. **Read the threads you replied in.** Your own user id comes from `auth.test` (`user_id` in the response). Keep the parents whose `reply_users` includes it and whose `latest_reply` is not older than the window; fetch each of those threads. The first message returned is the parent, the rest are the replies in order; pick the replies whose `ts` falls in the window, and follow `next_cursor` on a long thread.
 
    ```bash
    assistant oauth request --provider slack_channel /auth.test --json
 
    assistant oauth request --provider slack_channel \
      -X POST \
-     -d '{"channel":"D0123456789","ts":"1756800000.000100"}' \
+     -d '{"channel":"D0123456789","ts":"1756800000.000100","limit":200}' \
      /conversations.replies --json
    ```
 
-In an agent-style DM, every conversation the person starts with you is its own thread, so what you said in an earlier chat lives in that chat's replies, not in the thread you are answering from now. Read the parents from step 2 by time, then step 3 for the ones in the window.
+In an agent-style DM, every conversation the person starts with you is its own thread, so what you said in an earlier chat lives in that chat's replies, not in the thread you are answering from now. The parents from step 2 are the list of those chats; step 3 reads the ones you spoke in.
 
 Do not reach for `search.messages` here. It is a user-token method: on `slack_channel` it fails with `not_allowed_token_type`, and on `slack` it would read as the person who connected the integration, with their reach, which is not what re-reading your own DM calls for.
 

--- a/skills/slack/SKILL.md
+++ b/skills/slack/SKILL.md
@@ -90,6 +90,40 @@ assistant oauth request --provider slack_channel \
   /conversations.replies --json
 ```
 
+### Read back what you sent
+
+When someone asks what you sent them earlier ("what did you send me this morning", "quote the digest from yesterday"), look in this order: the current conversation first; then `recall`, which searches your other conversations; then Slack itself, for anything older or posted from a scheduled run or a notification.
+
+Reading Slack back is three calls on `slack_channel`. That is your own bot identity, and it is the right one here: a DM with you is your app's own DM, the posts you are looking for were made as the bot, and the history scopes this needs (`im:history`, `mpim:history`, `channels:history`, `groups:history`) are ones the app setup already requests.
+
+1. **Know where you are.** Your `<turn_context>` names the chat as `chat_id` and, when this message is in a thread, the thread as `thread_id`. If a turn carries neither, the person's contact record has the DM as `externalChatId` (see User Resolution below).
+
+2. **Read the top level.** `conversations.history` returns only top-level messages, never thread replies. In a DM with you, every proactive post you made (a digest, a notification, a check-in from a scheduled run) is top-level and appears here directly. Each thread you have taken part in appears only as its parent, carrying `reply_count`, `latest_reply`, and `reply_users`.
+
+   ```bash
+   assistant oauth request --provider slack_channel \
+     -X POST \
+     -d '{"channel":"D0123456789","limit":50,"oldest":"1716000000.000001"}' \
+     /conversations.history --json
+   ```
+
+3. **Read the threads you replied in.** Your own user id comes from `auth.test` (`user_id` in the response). For each parent whose `reply_users` includes it, fetch the thread; the first message returned is the parent, the rest are the replies in order.
+
+   ```bash
+   assistant oauth request --provider slack_channel /auth.test --json
+
+   assistant oauth request --provider slack_channel \
+     -X POST \
+     -d '{"channel":"D0123456789","ts":"1756800000.000100"}' \
+     /conversations.replies --json
+   ```
+
+In an agent-style DM, every conversation the person starts with you is its own thread, so what you said in an earlier chat lives in that chat's replies, not in the thread you are answering from now. Read the parents from step 2 by time, then step 3 for the ones in the window.
+
+Do not reach for `search.messages` here. It is a user-token method: on `slack_channel` it fails with `not_allowed_token_type`, and on `slack` it would read as the person who connected the integration, with their reach, which is not what re-reading your own DM calls for.
+
+If any of these calls fails with `missing_scope`, the installed app holds fewer scopes than the setup requests. Do not work around it: `assistant channels get slack` re-probes the install and names the missing scopes with the reinstall step, and the **slack-app-setup** skill walks the reconnect.
+
 ### Add a reaction
 
 ```bash


### PR DESCRIPTION
**TL;DR:** The Slack skill gains a "Read back what you sent" section: where to look first (the conversation, then `recall`, then Slack), and the three-call Slack read on `slack_channel` (`auth.test`, `conversations.history`, `conversations.replies`) that finds the assistant's own posts in a DM, including posts made from scheduled runs and notifications and replies made in other threads. It says why `search.messages` is not part of this flow and routes a `missing_scope` failure to the existing readiness and reconnect flow. Docs only, plus the regenerated skills catalog. Part of LUM-3525.

## Why

In LUM-3525 an assistant was asked, in a Slack DM, for the check-in it had sent that morning. It dug for ten steps and told the user Slack was "being stingy about letting me reread my own DM." The skill documents `conversations.history` and `conversations.replies` separately but never says what a DM with the app looks like: every chat the person starts is its own thread, `conversations.history` returns only thread parents and top-level posts, and the assistant's own replies live behind `conversations.replies` on the threads it took part in. Nothing told the model how to get from "read my DM" to those calls, and nothing told it not to fall back to `search.messages` on a bot token.

## What changes for the user

| Situation | Before | After |
| --- | --- | --- |
| Asks in a Slack DM what the assistant sent earlier that day | Unguided API digging; often a fallback to `search.messages`, which a bot token cannot call | The skill names the three calls, the parent filter (`reply_users` containing the bot's own `user_id`, `latest_reply` inside the window), and where proactive posts show up |
| The assistant's earlier reply was in a different chat (thread) of the same DM, or in a thread that started before the window | Invisible to `conversations.history` alone, or dropped by a parent-time `oldest` bound | Found: parents are read by count, kept by `latest_reply`, then `conversations.replies` filtered by reply `ts` |
| More parents or replies than one page | Silently truncated | `response_metadata.next_cursor` is followed on both calls |
| A call fails with `missing_scope` | Improvised workarounds | Pointed at `assistant channels get slack` (names the missing scopes and the reinstall step) and the `slack-app-setup` skill |
| Everything else in the skill | | Unchanged |

## Identity and scopes, verified against source

Every call in the section is on `slack_channel`. On the `oauth request` path that provider resolves to the stored bot token by its declared access field (`credential-token-resolver.ts`, `manual-token-providers.ts`, `byo-connection.ts`), in every install configuration, including one that also holds a pasted user token; that token and a `slack` OAuth connection are read only by the messaging adapter's and runtime routes' user-identity resolver, which this flow does not touch. The bot is the right identity for this read: a DM with the app is the app's own DM, the posts were made as the bot, and `auth.test` returns the bot's own `user_id` for the parent filter.

The scopes the three calls need (`im:history`, `mpim:history`, `channels:history`, `groups:history`) are in the non-optional bot list of both manifests and in the readiness check's required set. A manifest declaration is not a grant on an older installation, which is why the section routes `missing_scope` to the live check rather than to any workaround. No manifest, provider seed, credential path, or token-resolution change is in this diff, because the verified path needs none.

`search.messages` is not used: it is a user-token method (`not_allowed_token_type` on the bot token), and on `slack` it would read as the person who connected the integration, with their reach, which is not what re-reading the app's own DM calls for.

## Time windows and pagination

Slack's `oldest` on `conversations.history` bounds each parent's own timestamp, so a thread started days ago that holds a reply from this morning would be dropped by a window applied there. The section therefore reads recent parents by count, keeps the ones whose `latest_reply` is inside the window, and applies the window to the replies' own `ts`. Both calls page with `response_metadata.next_cursor`.

## The catalog

`skills/catalog.json` is regenerated. Its `updatedAt` per skill is the author date of the last commit touching that skill's directory (`scripts/skills/generate-catalog.mjs`), so this PR's commit is authored with a pinned date that matches the value written for the Slack entry; CI's regeneration on the merge ref reproduces it. The regeneration also picks up one entry that had drifted on `main` since the catalog was last regenerated there.

## Why this is safe

- Documentation only, plus the generated catalog: one new subsection in `skills/slack/SKILL.md`; no scripts, no manifest, no code.
- Skill linter passes for this skill (the linter's existing findings are in other skills and unchanged by this PR); prettier clean.
- The `chat_id` and `thread_id` lines the section refers to are added by #42015; the section says "when your turn context carries them" and falls back to the contact's `externalChatId`, so the two PRs merge independently in either order.
- LUM-3525 stays open until the failure is reproduced on a Slack-connected non-production assistant; this section and #42015 are the mitigation for the most likely failure, not a verified fix. The reporter's send path, calls, and installed grants remain unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
