### PR TITLE
fix(guardian-forms): a dismissal is a distinguishable outcome, not just an error string

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6657,6 +6657,8 @@ paths:
                     type: string
                   verified:
                     type: boolean
+                  cancelled:
+                    type: boolean
                 required:
                   - ok
                 additionalProperties: false
@@ -6754,6 +6756,8 @@ paths:
                   notesSaved:
                     type: boolean
                   nothingWritten:
+                    type: boolean
+                  cancelled:
                     type: boolean
                 required:
                   - ok

--- a/assistant/src/runtime/__tests__/guardian-form-registry.test.ts
+++ b/assistant/src/runtime/__tests__/guardian-form-registry.test.ts
@@ -183,38 +183,6 @@ describe("hasUnclaimedGuardianForm", () => {
   });
 });
 
-describe("resolveFormFromCallback", () => {
-  test("passes a writer's own fields through untouched", async () => {
-    // The rail is only reusable if a new form's result reaches its caller. A
-    // callback that enumerated contact fields would drop everything else.
-    const { requestId, settled } = openForm();
-
-    const { resolveFormFromCallback } =
-      await import("../routes/guardian-form-routes.js");
-    resolveFormFromCallback({
-      body: { requestId, id: "row-7", rows: 3, skipped: false },
-    } as never);
-
-    expect(await settled).toEqual({
-      ok: true,
-      id: "row-7",
-      rows: 3,
-      skipped: false,
-    } as never);
-  });
-
-  test("an error makes the outcome a failure", async () => {
-    const { requestId, settled } = openForm();
-    const { resolveFormFromCallback } =
-      await import("../routes/guardian-form-routes.js");
-    resolveFormFromCallback({
-      body: { requestId, error: "nope", id: "ignored" },
-    } as never);
-
-    expect(await settled).toEqual({ ok: false, error: "nope" });
-  });
-});
-
 describe("claiming names the form", () => {
   test("a claim for a different kind is refused", async () => {
     // An id alone does not say which form it belongs to. Without this check a

--- a/assistant/src/runtime/routes/__tests__/guardian-form-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/guardian-form-routes.test.ts
@@ -13,10 +13,16 @@ import {
 } from "../../guardian-form-registry.js";
 import { resolveFormFromCallback } from "../guardian-form-routes.js";
 
+/**
+ * What a parked form settles as here. The rail passes a writer's own fields
+ * through, so the base result alone would reject them as excess properties.
+ */
+type PassthroughResult = GuardianFormResult & Record<string, unknown>;
+
 /** Park a form and hand back the id its broadcast carried. */
 function park() {
   let requestId = "";
-  const settled = openGuardianForm<GuardianFormResult>({
+  const settled = openGuardianForm<PassthroughResult>({
     kind: "test.form",
     broadcast: {
       open: (id) => {

--- a/assistant/src/runtime/routes/__tests__/guardian-form-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/guardian-form-routes.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the form-agnostic resolve callback.
+ *
+ * Every guardian form's outcome comes back through this one function, so what
+ * it passes through and what it overrides is wire contract for all of them.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  type GuardianFormResult,
+  openGuardianForm,
+} from "../../guardian-form-registry.js";
+import { resolveFormFromCallback } from "../guardian-form-routes.js";
+
+/** Park a form and hand back the id its broadcast carried. */
+function park() {
+  let requestId = "";
+  const settled = openGuardianForm<GuardianFormResult>({
+    kind: "test.form",
+    broadcast: {
+      open: (id) => {
+        requestId = id;
+      },
+      closed: () => {},
+    },
+  });
+  return { requestId, settled };
+}
+
+describe("resolveFormFromCallback", () => {
+  test("a failure keeps the fields sent alongside its error", async () => {
+    const { requestId, settled } = park();
+
+    expect(
+      resolveFormFromCallback({
+        body: { requestId, error: "Cancelled by user", cancelled: true },
+      }),
+    ).toEqual({ resolved: true });
+
+    expect(await settled).toEqual({
+      ok: false,
+      error: "Cancelled by user",
+      cancelled: true,
+    });
+  });
+
+  test("a writer's own ok cannot turn its error into a success", async () => {
+    const { requestId, settled } = park();
+
+    resolveFormFromCallback({
+      body: { requestId, ok: true, error: "The write failed" },
+    });
+
+    expect(await settled).toEqual({ ok: false, error: "The write failed" });
+  });
+
+  test("a result with no error still passes its fields through as a success", async () => {
+    // The rail is only reusable if a new form's result reaches its caller. A
+    // callback that enumerated contact fields would drop everything else.
+    const { requestId, settled } = park();
+
+    resolveFormFromCallback({
+      body: { requestId, contactId: "ct_1", verified: true },
+    });
+
+    expect(await settled).toEqual({
+      ok: true,
+      contactId: "ct_1",
+      verified: true,
+    });
+  });
+
+  test("resolving a form nobody is waiting on reports that it landed nowhere", () => {
+    expect(
+      resolveFormFromCallback({ body: { requestId: "never-parked" } }),
+    ).toEqual({ resolved: false });
+  });
+});

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -82,6 +82,8 @@ export interface ContactPromptResult {
   notesSaved?: boolean;
   /** Whether nothing the submission asked for landed. */
   nothingWritten?: boolean;
+  /** The guardian dismissed the form. Nothing was written. */
+  cancelled?: boolean;
 }
 
 /**
@@ -346,6 +348,7 @@ export const CONTACT_PROMPT_ROUTES: RouteDefinition[] = [
       channelType: z.string().optional(),
       address: z.string().optional(),
       verified: z.boolean().optional(),
+      cancelled: z.boolean().optional(),
     }),
   },
   {
@@ -368,6 +371,7 @@ export const CONTACT_PROMPT_ROUTES: RouteDefinition[] = [
       contactId: z.string().optional(),
       notesSaved: z.boolean().optional(),
       nothingWritten: z.boolean().optional(),
+      cancelled: z.boolean().optional(),
     }),
   },
   {

--- a/assistant/src/runtime/routes/guardian-form-routes.ts
+++ b/assistant/src/runtime/routes/guardian-form-routes.ts
@@ -39,9 +39,11 @@ const ClaimParams = RequestIdParams.extend({
 /**
  * Hand a writer's report to the call parked on the form.
  *
- * Everything but `requestId` and `error` is passed through untouched, so a
- * form's result is whatever its writer chose to send. An `error` is what makes
- * it a failure; there is no other flag.
+ * `requestId` and `error` stay the rail's, and an `error` is still what makes
+ * the outcome a failure. Fields sent alongside reach the parked caller on a
+ * failure as well as on a success, so a writer can mark an outcome rather than
+ * only describe it (a dismissal sends `cancelled`). The rail's own fields land
+ * last: a writer's `ok` cannot overturn its `error`.
  */
 export function resolveFormFromCallback({ body = {} }: RouteHandlerArgs): {
   resolved: boolean;
@@ -54,7 +56,7 @@ export function resolveFormFromCallback({ body = {} }: RouteHandlerArgs): {
     body as never;
 
   const result: GuardianFormResult = error
-    ? { ok: false, error }
+    ? { ...rest, ok: false, error }
     : { ok: true, ...rest };
   return resolveGuardianForm(requestId, result);
 }

--- a/assistant/src/runtime/routes/guardian-form-routes.ts
+++ b/assistant/src/runtime/routes/guardian-form-routes.ts
@@ -39,11 +39,11 @@ const ClaimParams = RequestIdParams.extend({
 /**
  * Hand a writer's report to the call parked on the form.
  *
- * `requestId` and `error` stay the rail's, and an `error` is still what makes
- * the outcome a failure. Fields sent alongside reach the parked caller on a
- * failure as well as on a success, so a writer can mark an outcome rather than
- * only describe it (a dismissal sends `cancelled`). The rail's own fields land
- * last: a writer's `ok` cannot overturn its `error`.
+ * `requestId` and `error` belong to the rail, and an `error` is what makes the
+ * outcome a failure. Every other field reaches the parked caller, on a failure
+ * as well as on a success, so a writer can mark an outcome rather than only
+ * describe it (a dismissal sends `cancelled`). The rail's own fields land last,
+ * so a writer's `ok` cannot overturn its `error`.
  */
 export function resolveFormFromCallback({ body = {} }: RouteHandlerArgs): {
   resolved: boolean;

--- a/gateway/src/__tests__/guardian-form-submit.test.ts
+++ b/gateway/src/__tests__/guardian-form-submit.test.ts
@@ -97,10 +97,22 @@ describe("submitGuardianForm", () => {
 
     expect(res.status).toBe(200);
     expect(write).not.toHaveBeenCalled();
+    // The marker is what a client branches on; the string stays because an
+    // older daemon has nothing else to read.
     expect(resolveCall()?.body).toEqual({
       requestId: "req-2",
       error: "Cancelled by user",
+      cancelled: true,
     });
+  });
+
+  test("a write's resolution carries no cancellation marker", async () => {
+    await submitGuardianForm({
+      requestId: "req-2b",
+      write: async () => ({ resolution: { contactId: "c1" } }),
+    });
+
+    expect(resolveCall()?.body).not.toHaveProperty("cancelled");
   });
 
   test("a failure the writer classified keeps its own status", async () => {

--- a/gateway/src/__tests__/guardian-form-submit.test.ts
+++ b/gateway/src/__tests__/guardian-form-submit.test.ts
@@ -97,8 +97,6 @@ describe("submitGuardianForm", () => {
 
     expect(res.status).toBe(200);
     expect(write).not.toHaveBeenCalled();
-    // The marker is what a client branches on; the string stays because an
-    // older daemon has nothing else to read.
     expect(resolveCall()?.body).toEqual({
       requestId: "req-2",
       error: "Cancelled by user",

--- a/gateway/src/http/routes/guardian-form-submit.ts
+++ b/gateway/src/http/routes/guardian-form-submit.ts
@@ -114,7 +114,7 @@ export async function submitGuardianForm(
   if (options.cancelled === true) {
     await reportResolution(
       requestId,
-      { requestId, error: "Cancelled by user" },
+      { requestId, error: "Cancelled by user", cancelled: true },
       settleDeadline,
       resolveOperation,
     );


### PR DESCRIPTION
## Summary

- The gateway's guardian-form cancel path now reports `{ error: "Cancelled by user", cancelled: true }`. The string stays, so an older daemon or CLI sees exactly today's shape; the marker is what a new caller branches on instead of matching text.
- `resolveFormFromCallback` no longer drops the fields a writer sent alongside an `error`, so the marker reaches the parked call. `rest` is spread first on the failure branch, so a writer sending its own `ok`/`error` cannot overturn the rail's verdict.
- `cancelled` is declared on `ContactPromptResult` and on both contact prompt routes' response bodies (`assistant/openapi.yaml` regenerated).

Compatible in both skew directions: an old client keeps seeing `ok:false` plus the error string, and a new one gets a field it can act on. PR 2 turns this into a clean exit 0 for a dismissed `assistant contacts` form.

Note on `guardian-form-registry.test.ts`: its `resolveFormFromCallback` block asserted that siblings are dropped on the error branch, which is the behavior this PR changes. It moved to the new `routes/__tests__/guardian-form-routes.test.ts`, which is where those tests belong now.

Part of plan: contacts-cli-channel-binding.md (PR 1 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk8rCmt2otiCFYLMiA5pB5