### PR TITLE
feat(contacts): the address form can carry a target contact or a proposed name

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5670,8 +5670,10 @@ paths:
   /v1/contact_prompt_flags:
     post:
       operationId: contact_prompt_flags_post
-      summary: Read flags for a pending contact prompt
-      description: Returns whether the pending prompt asked the gateway to mark the submitted channel verified.
+      summary: Read a pending contact prompt's flags and binding target
+      description:
+        Returns whether the pending prompt asked the gateway to mark the submitted channel verified, plus the
+        contact the parked form targets, or the name and notes it proposes for a contact to create.
       tags:
         - contacts
       requestBody:
@@ -5696,6 +5698,12 @@ paths:
                 properties:
                   verify:
                     type: boolean
+                  contactId:
+                    type: string
+                  displayName:
+                    type: string
+                  notes:
+                    type: string
                 required:
                   - verify
                 additionalProperties: false
@@ -6628,6 +6636,18 @@ paths:
                     Pre-check the form's 'mark verified' box. The guardian's answer on submit decides the attest, so an
                     unchecked box leaves the channel unverified.
                   type: boolean
+                contactId:
+                  description: The contact this address binds to. Fixed by the command, not by the form.
+                  type: string
+                contactDisplayName:
+                  description: That contact's current name, so the form can say where the channel is going.
+                  type: string
+                displayName:
+                  description: Proposed name for a contact this form would create. Editable in the form.
+                  type: string
+                notes:
+                  description: Proposed notes for a contact this form would create.
+                  type: string
                 timeoutMs:
                   description:
                     How long to hold the form open (ms). The caller waits slightly longer than this, so the form closing is

--- a/assistant/src/api/events/contact-request.ts
+++ b/assistant/src/api/events/contact-request.ts
@@ -13,7 +13,8 @@
  *
  * `channel` and `role` are advisory hints, not enforced enums — the
  * client may render any input it likes and post back a structured
- * contact payload.
+ * contact payload. `contactId` is not advisory: it is the contact the
+ * submitted address binds to.
  *
  * Canonical wire-contract source. Daemon code imports the type
  * directly from this file; external consumers import via
@@ -36,6 +37,14 @@ export const ContactRequestEventSchema = z.object({
    * `--verify`. What the guardian submits is what gets attested.
    */
   verify: z.boolean().optional(),
+  /** The contact this address binds to. Fixed by the command, not by the form. */
+  contactId: z.string().optional(),
+  /** That contact's current name, so the form can say where the channel is going. */
+  contactDisplayName: z.string().optional(),
+  /** Proposed name for a contact this form would create. Editable in the form. */
+  displayName: z.string().optional(),
+  /** Proposed notes for a contact this form would create. */
+  notes: z.string().optional(),
 });
 
 export type ContactRequestEvent = z.infer<typeof ContactRequestEventSchema>;

--- a/assistant/src/runtime/routes/__tests__/contact-address-prompt-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-address-prompt-route.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the daemon `contacts_prompt` route's binding target.
+ *
+ * The command, not the form, decides which contact a submitted address binds
+ * to. The target therefore rides both the broadcast (so the card can say where
+ * the channel is going) and the parked form's meta, which is what a client too
+ * old to echo it reads back through `contact_prompt_flags`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type Broadcast = Record<string, unknown>;
+
+let broadcasts: Broadcast[] = [];
+
+const broadcastMock = mock((message: Broadcast) => {
+  broadcasts.push(message);
+});
+
+const actualHub = await import("../../assistant-event-hub.js");
+mock.module("../../assistant-event-hub.js", () => ({
+  ...actualHub,
+  broadcastMessage: broadcastMock,
+}));
+
+const { CONTACT_PROMPT_ROUTES } = await import("../contact-prompt-routes.js");
+
+function routeFor(operationId: string) {
+  const route = CONTACT_PROMPT_ROUTES.find(
+    (r) => r.operationId === operationId,
+  );
+  if (!route) {
+    throw new Error(`route ${operationId} not registered`);
+  }
+  return route;
+}
+
+const addressPrompt = routeFor("contacts_prompt");
+const resolvePrompt = routeFor("resolve_contact_prompt");
+const promptFlags = routeFor("contact_prompt_flags");
+
+/** The broadcast for the only prompt parked so far. */
+function parkedRequest(): Broadcast {
+  const message = broadcasts.find((b) => b.type === "contact_request");
+  expect(message).toBeDefined();
+  return message!;
+}
+
+/** Settle the parked form so the test's pending call returns. */
+async function settle(pending: Promise<unknown>, requestId: string) {
+  resolvePrompt.handler({ body: { requestId, contactId: "ct_1" } });
+  await pending;
+}
+
+describe("contacts_prompt binding target", () => {
+  beforeEach(() => {
+    broadcasts = [];
+    broadcastMock.mockClear();
+  });
+
+  test("broadcasts the target contact and its name", async () => {
+    const pending = addressPrompt.handler({
+      body: {
+        channel: "email",
+        contactId: "ct_1",
+        contactDisplayName: "Alice",
+      },
+    }) as Promise<Record<string, unknown>>;
+
+    const message = parkedRequest();
+    expect(message.contactId).toBe("ct_1");
+    expect(message.contactDisplayName).toBe("Alice");
+    expect(message.displayName).toBeUndefined();
+    expect(message.notes).toBeUndefined();
+
+    await settle(pending, message.requestId as string);
+  });
+
+  test("broadcasts a proposed name and notes for a contact to create", async () => {
+    const pending = addressPrompt.handler({
+      body: { channel: "email", displayName: "Bob", notes: "Plumber" },
+    }) as Promise<Record<string, unknown>>;
+
+    const message = parkedRequest();
+    expect(message.displayName).toBe("Bob");
+    expect(message.notes).toBe("Plumber");
+    expect(message.contactId).toBeUndefined();
+
+    await settle(pending, message.requestId as string);
+  });
+
+  test("a plain prompt carries no target at all", async () => {
+    const pending = addressPrompt.handler({
+      body: { channel: "email" },
+    }) as Promise<Record<string, unknown>>;
+
+    const message = parkedRequest();
+    for (const key of [
+      "contactId",
+      "contactDisplayName",
+      "displayName",
+      "notes",
+    ]) {
+      expect(message[key]).toBeUndefined();
+    }
+
+    // And the gateway reads back only the verify flag, so an untargeted
+    // submission still resolves by address the way it always has.
+    expect(
+      promptFlags.handler({ body: { requestId: message.requestId } }),
+    ).toEqual({ verify: false });
+
+    await settle(pending, message.requestId as string);
+  });
+
+  test("the gateway reads the target back off the parked form", async () => {
+    const pending = addressPrompt.handler({
+      body: { channel: "email", contactId: "ct_1", verify: true },
+    }) as Promise<Record<string, unknown>>;
+    const requestId = parkedRequest().requestId as string;
+
+    // Read from the daemon rather than the submission, so a client that
+    // predates the field still binds where the command said.
+    expect(promptFlags.handler({ body: { requestId } })).toEqual({
+      verify: true,
+      contactId: "ct_1",
+    });
+
+    await settle(pending, requestId);
+  });
+
+  test("the proposed name and notes are parked too", async () => {
+    const pending = addressPrompt.handler({
+      body: { channel: "email", displayName: "Bob", notes: "Plumber" },
+    }) as Promise<Record<string, unknown>>;
+    const requestId = parkedRequest().requestId as string;
+
+    expect(promptFlags.handler({ body: { requestId } })).toEqual({
+      verify: false,
+      displayName: "Bob",
+      notes: "Plumber",
+    });
+
+    await settle(pending, requestId);
+  });
+
+  test("naming a contact and proposing a new one is refused, and opens no form", async () => {
+    const result = (await addressPrompt.handler({
+      body: { channel: "email", contactId: "ct_1", displayName: "Bob" },
+    })) as Record<string, unknown>;
+
+    expect(result.ok).toBe(false);
+    expect(String(result.error)).toContain("contactId");
+    expect(String(result.error)).toContain("displayName");
+    expect(broadcasts).toHaveLength(0);
+  });
+});

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -136,6 +136,28 @@ const ContactPromptParams = z.object({
     .describe(
       "Pre-check the form's 'mark verified' box. The guardian's answer on submit decides the attest, so an unchecked box leaves the channel unverified.",
     ),
+  contactId: z
+    .string()
+    .optional()
+    .describe(
+      "The contact this address binds to. Fixed by the command, not by the form.",
+    ),
+  contactDisplayName: z
+    .string()
+    .optional()
+    .describe(
+      "That contact's current name, so the form can say where the channel is going.",
+    ),
+  displayName: z
+    .string()
+    .optional()
+    .describe(
+      "Proposed name for a contact this form would create. Editable in the form.",
+    ),
+  notes: z
+    .string()
+    .optional()
+    .describe("Proposed notes for a contact this form would create."),
   timeoutMs: TimeoutMsParam,
 });
 
@@ -211,16 +233,34 @@ async function handleContactPrompt({
     description,
     role,
     verify,
+    contactId,
+    contactDisplayName,
+    displayName,
+    notes,
     timeoutMs,
   } = ContactPromptParams.parse(body);
+
+  if (contactId && displayName) {
+    return {
+      ok: false,
+      error:
+        "Pass either contactId (bind to an existing contact) or displayName (create a new one), not both.",
+    };
+  }
 
   return openGuardianForm<ContactPromptResult>({
     kind: ADDRESS_FORM,
     timeoutMs,
-    // Read back by the gateway when a client too old for the checkbox submits
-    // no answer of its own.
-    meta: { verify: verify === true },
-    logContext: { channel, role, verify: verify === true },
+    // Read back by the gateway when a client too old for these fields submits
+    // no answer of its own. Parking the target here rather than leaving it to
+    // the client is what makes such a client still bind where the command said.
+    meta: {
+      verify: verify === true,
+      ...(contactId ? { contactId } : {}),
+      ...(displayName ? { displayName } : {}),
+      ...(notes !== undefined ? { notes } : {}),
+    },
+    logContext: { channel, role, verify: verify === true, contactId },
     broadcast: {
       open: (requestId) =>
         broadcastMessage({
@@ -236,6 +276,10 @@ async function handleContactPrompt({
           // can show what submitting will do; the client's answer is what the
           // gateway acts on.
           verify: verify === true,
+          contactId,
+          contactDisplayName,
+          displayName,
+          notes,
         }),
       closed: announceContactFormClosed,
     },
@@ -307,16 +351,33 @@ async function handleContactRecordPrompt({
   });
 }
 
+/** What a parked address form said its submission is for. */
+interface ParkedPromptTarget {
+  contactId?: string;
+  displayName?: string;
+  notes?: string;
+}
+
+const PARKED_TARGET_KEYS = ["contactId", "displayName", "notes"] as const;
+
 /**
- * Read-only flags for a pending prompt. The gateway asks this after it writes
- * the channel so a `--verify` prompt can attest without the client having to
- * echo the flag on submit.
+ * Read-only state for a pending prompt. The gateway asks this before it writes,
+ * so the flag and the binding target come from the parked form rather than from
+ * whatever the submitting client knew to echo.
  */
-function readContactPromptFlags({ body = {} }: RouteHandlerArgs): {
-  verify: boolean;
-} {
+function readContactPromptFlags({
+  body = {},
+}: RouteHandlerArgs): ParkedPromptTarget & { verify: boolean } {
   const { requestId } = ContactPromptFlagsParams.parse(body);
-  return { verify: getGuardianFormMeta(requestId)?.verify === true };
+  const meta = getGuardianFormMeta(requestId) ?? {};
+  const target: ParkedPromptTarget = {};
+  for (const key of PARKED_TARGET_KEYS) {
+    const value = meta[key];
+    if (typeof value === "string") {
+      target[key] = value;
+    }
+  }
+  return { verify: meta.verify === true, ...target };
 }
 
 // ---------------------------------------------------------------------------
@@ -418,13 +479,16 @@ export const CONTACT_PROMPT_ROUTES: RouteDefinition[] = [
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
     handler: readContactPromptFlags,
-    summary: "Read flags for a pending contact prompt",
+    summary: "Read a pending contact prompt's flags and binding target",
     description:
-      "Returns whether the pending prompt asked the gateway to mark the submitted channel verified.",
+      "Returns whether the pending prompt asked the gateway to mark the submitted channel verified, plus the contact the parked form targets, or the name and notes it proposes for a contact to create.",
     tags: ["contacts"],
     requestBody: ContactPromptFlagsParams,
     responseBody: z.object({
       verify: z.boolean(),
+      contactId: z.string().optional(),
+      displayName: z.string().optional(),
+      notes: z.string().optional(),
     }),
   },
 ];


### PR DESCRIPTION
## Summary

- `contacts_prompt` accepts `contactId`/`contactDisplayName` (bind to an existing contact) or `displayName`/`notes` (propose a new one), and broadcasts them on `contact_request`. Passing both a target and a proposed name is refused before any form opens.
- The target is parked in the guardian-form registry's `meta`, not just echoed in the broadcast, and `contact_prompt_flags` now returns it alongside `verify`. A client that predates these fields therefore still binds where the command said instead of recreating today's address-named duplicate.
- Daemon-side wire foundation only: no gateway, web client or CLI changes. PR 4 makes the gateway honor the target, PR 5 renders it, PR 6 adds `contacts channels add`.

`contact_prompt_flags` keeps its operationId: it is a gateway/daemon wire name and a rename would break a gateway running against this daemon.

Part of plan: contacts-cli-channel-binding.md (PR 3 of 12)