### PR TITLE
refactor(channels): the post-send reconciliation is a module callable outside a turn

### DIFF
--- a/assistant/src/runtime/AGENTS.md
+++ b/assistant/src/runtime/AGENTS.md
@@ -214,7 +214,7 @@ the gateway's Channel Identity Vocabulary, which covers the wire side.
   an outbound assistant reply is stamped with a partial envelope at reserve
   time (`buildAssistantChannelMetadata`) whose `messageId` (and, for a reply
   split into several posts, `additionalMessageIds`) the post-send
-  reconciliation in `channel-reply-delivery.ts` back-fills from the
+  reconciliation in `outbound-post-reconciliation.ts` back-fills from the
   transport's delivery results, the assistant's own reaction rows write it
   (`daemon/reaction-record.ts`), and bot-authored Slack backfill rows write
   it. Every channel except Slack writes it for inbound rows too: a reaction

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -3,25 +3,15 @@ import type { MessageAudience } from "@vellumai/gateway-client";
 import { stripVellumLinks } from "../daemon/assistant-attachments.js";
 import type { RenderedHistoryContent } from "../daemon/handlers/shared.js";
 import { renderHistoryContent } from "../daemon/handlers/shared.js";
-import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
-import {
-  everyPostDeleted,
-  readProviderMessageMetadata,
-} from "../messaging/provider-message-metadata.js";
 import { editChannelMessage } from "../messaging/providers/index.js";
-import { providerMetadataOfPreSendSlackEnvelope } from "../messaging/providers/slack/message-metadata.js";
 import { getAttachmentMetadataForMessage } from "../persistence/attachments-store.js";
 import {
   getMessageById,
   getMessages,
   parseMessageMetadata,
-  updateMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { isReactionMessageMetadata } from "../persistence/conversation-types.js";
-import { recordOutboundPost } from "../persistence/delivery-crud.js";
-import { safeParseRecord } from "../util/json.js";
 import { getLogger } from "../util/logger.js";
-import { withSqliteRetry } from "../util/sqlite-retry.js";
 import type { ChannelDeliveryResult } from "./gateway-client.js";
 import { deliverChannelReply } from "./gateway-client.js";
 import type { RuntimeAttachmentMetadata } from "./http-types.js";
@@ -29,6 +19,7 @@ import {
   containsNoResponseMarker,
   stripNoResponseMarkers,
 } from "./no-response.js";
+import { makeSentMessageIdReconciler } from "./outbound-post-reconciliation.js";
 
 const log = getLogger("channel-reply-delivery");
 
@@ -537,156 +528,4 @@ export async function deliverReplyViaCallback(
       break;
     }
   }
-}
-
-/**
- * Build an `onMessageTs` handler that reconciles the persisted assistant
- * row's provider message ids from the transport's authoritative ones. Every
- * channel's reply row carries the neutral envelope (`readReplyEnvelope`
- * names the one pending row that may not yet), so there is one rule:
- * the first reported id becomes `providerMeta.messageId`, the further posts
- * of a reply split at tool boundaries or length limits accumulate under
- * `additionalMessageIds`, and every id lands in the `channel_outbound_posts`
- * index, which is what lets a later reaction or delete naming any of the
- * assistant's posts resolve back to this row.
- *
- * An id the row already names is a redelivery and is skipped. A row
- * persisted with no envelope (e.g. vellum outbound) is left untouched. Every
- * write retries transient SQLite contention (`withSqliteRetry`), because
- * this is the only durable record of the sent message's id and nothing
- * revisits it once the event is marked delivered. Remaining failures are
- * logged and swallowed so a DB error cannot break the outbound delivery
- * itself.
- */
-function makeSentMessageIdReconciler(
-  messageId: string,
-): (ts: string) => Promise<void> {
-  return async (ts: string): Promise<void> => {
-    if (!ts) {
-      return;
-    }
-    try {
-      const row = getMessageById(messageId);
-      if (row === null || row.metadata === null) {
-        return;
-      }
-      const providerMeta = readReplyEnvelope(safeParseRecord(row.metadata));
-      if (
-        providerMeta === null ||
-        providerIdPatchFor(providerMeta, ts) === null
-      ) {
-        return;
-      }
-      // The index first: it is the resolution contract, and the insert is
-      // conflict-ignoring, so a redelivered id is a no-op there too.
-      await withSqliteRetry(
-        () =>
-          recordOutboundPost({
-            sourceChannel: providerMeta.source,
-            externalChatId: providerMeta.conversationExternalId,
-            providerMessageId: ts,
-            messageId,
-            conversationId: row.conversationId,
-          }),
-        { op: "record_outbound_post", context: { messageId } },
-      );
-      // The envelope is read and written in one synchronous step, re-read on
-      // every attempt, and the delete stage stamps its rows the same way, so
-      // neither overwrites the other's patch: bun:sqlite is synchronous and
-      // nothing yields between the read and the write.
-      await withSqliteRetry(() => stampSentMessageId(messageId, ts), {
-        op: "reconcile_sent_message_id",
-        context: { messageId },
-      });
-    } catch (err) {
-      log.warn(
-        { err, messageId },
-        "Failed to reconcile the sent message id on the outbound assistant row",
-      );
-    }
-  };
-}
-
-/**
- * Record a reported id on the row's envelope. A post just reported is on the
- * channel, so the row-level deletion marker is recomputed: it stays only
- * when every post the row now names, this one included, is already recorded
- * as deleted (a deletion can land between the index write and this stamp,
- * and it can name this very post); a marker left by an earlier state in
- * which every known post was gone is cleared. Synchronous by design; see
- * the caller.
- */
-function stampSentMessageId(messageId: string, ts: string): void {
-  const row = getMessageById(messageId);
-  if (row === null || row.metadata === null) {
-    return;
-  }
-  const envelope = safeParseRecord(row.metadata);
-  const providerMeta = readReplyEnvelope(envelope);
-  if (providerMeta === null) {
-    return;
-  }
-  const patch = providerIdPatchFor(providerMeta, ts);
-  if (patch === null) {
-    return;
-  }
-  const posts = [
-    ...(providerMeta.messageId !== undefined ? [providerMeta.messageId] : []),
-    ...(providerMeta.additionalMessageIds ?? []),
-    ts,
-  ];
-  const { deletedAt, ...rest } = providerMeta;
-  updateMessageMetadata(messageId, {
-    providerMeta: JSON.stringify({
-      ...rest,
-      ...patch,
-      ...(deletedAt !== undefined &&
-      everyPostDeleted(posts, providerMeta.deletedMessageIds)
-        ? { deletedAt }
-        : {}),
-    }),
-    // A row reserved with Slack's pre-send envelope converges on the neutral
-    // one here: `updateMessageMetadata` serializes the merged envelope with
-    // `JSON.stringify`, which drops a key set to undefined.
-    ...(envelope.slackMeta !== undefined ? { slackMeta: undefined } : {}),
-  });
-}
-
-/**
- * The envelope a reply row stamps its sent ids onto: the neutral one every
- * reply the daemon reserves carries, or, for a reply still pending from a
- * daemon that reserved Slack replies under Slack's own envelope, the neutral
- * reading of that pre-send envelope (transitional; see
- * `providerMetadataOfPreSendSlackEnvelope`).
- */
-function readReplyEnvelope(
-  envelope: Record<string, unknown>,
-): ProviderMessageMetadata | null {
-  return (
-    readProviderMessageMetadata(envelope.providerMeta) ??
-    providerMetadataOfPreSendSlackEnvelope(envelope)
-  );
-}
-
-/**
- * Where a newly reported id belongs on the neutral envelope: `messageId` when
- * the row names none yet, otherwise appended to `additionalMessageIds`.
- * `null` when the envelope already names it, which is a redelivery.
- */
-function providerIdPatchFor(
-  providerMeta: ProviderMessageMetadata,
-  ts: string,
-): Partial<ProviderMessageMetadata> | null {
-  if (providerMeta.messageId === undefined) {
-    return { messageId: ts };
-  }
-  if (
-    providerMeta.messageId === ts ||
-    providerMeta.additionalMessageIds?.includes(ts)
-  ) {
-    return null;
-  }
-  return {
-    additionalMessageIds: [...(providerMeta.additionalMessageIds ?? []), ts],
-  };
 }

--- a/assistant/src/runtime/outbound-post-reconciliation.ts
+++ b/assistant/src/runtime/outbound-post-reconciliation.ts
@@ -1,0 +1,183 @@
+/**
+ * Post-send reconciliation of an outbound assistant row.
+ *
+ * A row the daemon authors for a channel post is written before the channel
+ * has it, so its envelope names no provider message id. Once the transport
+ * reports the id the channel assigned, this module records it in two places
+ * with one writer: the `channel_outbound_posts` index, which is the
+ * resolution contract a later reaction or delete naming the post resolves
+ * through, and the row's own `providerMeta` envelope, which stays the row's
+ * self-description. The two cannot drift because nothing else writes either.
+ *
+ * Callable outside a turn: the reply path composes it into its delivery
+ * callback, and any other producer that persists a row and then delivers it
+ * through a channel adapter reconciles the acknowledged id the same way.
+ */
+
+import type { ProviderMessageMetadata } from "../messaging/provider-message-metadata.js";
+import {
+  everyPostDeleted,
+  readProviderMessageMetadata,
+} from "../messaging/provider-message-metadata.js";
+import { providerMetadataOfPreSendSlackEnvelope } from "../messaging/providers/slack/message-metadata.js";
+import {
+  getMessageById,
+  updateMessageMetadata,
+} from "../persistence/conversation-crud.js";
+import { recordOutboundPost } from "../persistence/delivery-crud.js";
+import { safeParseRecord } from "../util/json.js";
+import { getLogger } from "../util/logger.js";
+import { withSqliteRetry } from "../util/sqlite-retry.js";
+
+const log = getLogger("outbound-post-reconciliation");
+
+/**
+ * Build a handler that reconciles the persisted assistant row's provider
+ * message ids from the transport's authoritative ones. Every channel's
+ * outbound row carries the neutral envelope (`readReplyEnvelope` names the
+ * one pending row that may not yet), so there is one rule: the first
+ * reported id becomes `providerMeta.messageId`, the further posts of a reply
+ * split at tool boundaries or length limits accumulate under
+ * `additionalMessageIds`, and every id lands in the `channel_outbound_posts`
+ * index, which is what lets a later reaction or delete naming any of the
+ * assistant's posts resolve back to this row.
+ *
+ * An id the row already names is a redelivery and is skipped. A row
+ * persisted with no envelope (e.g. vellum outbound) is left untouched. Every
+ * write retries transient SQLite contention (`withSqliteRetry`), because
+ * this is the only durable record of the sent message's id and nothing
+ * revisits it once the delivery settles. Remaining failures are logged and
+ * swallowed so a DB error cannot break the outbound delivery itself.
+ */
+export function makeSentMessageIdReconciler(
+  messageId: string,
+): (ts: string) => Promise<void> {
+  return async (ts: string): Promise<void> => {
+    if (!ts) {
+      return;
+    }
+    try {
+      const row = getMessageById(messageId);
+      if (row === null || row.metadata === null) {
+        return;
+      }
+      const providerMeta = readReplyEnvelope(safeParseRecord(row.metadata));
+      if (
+        providerMeta === null ||
+        providerIdPatchFor(providerMeta, ts) === null
+      ) {
+        return;
+      }
+      // The index first: it is the resolution contract, and the insert is
+      // conflict-ignoring, so a redelivered id is a no-op there too.
+      await withSqliteRetry(
+        () =>
+          recordOutboundPost({
+            sourceChannel: providerMeta.source,
+            externalChatId: providerMeta.conversationExternalId,
+            providerMessageId: ts,
+            messageId,
+            conversationId: row.conversationId,
+          }),
+        { op: "record_outbound_post", context: { messageId } },
+      );
+      // The envelope is read and written in one synchronous step, re-read on
+      // every attempt, and the delete stage stamps its rows the same way, so
+      // neither overwrites the other's patch: bun:sqlite is synchronous and
+      // nothing yields between the read and the write.
+      await withSqliteRetry(() => stampSentMessageId(messageId, ts), {
+        op: "reconcile_sent_message_id",
+        context: { messageId },
+      });
+    } catch (err) {
+      log.warn(
+        { err, messageId },
+        "Failed to reconcile the sent message id on the outbound assistant row",
+      );
+    }
+  };
+}
+
+/**
+ * Record a reported id on the row's envelope. A post just reported is on the
+ * channel, so the row-level deletion marker is recomputed: it stays only
+ * when every post the row now names, this one included, is already recorded
+ * as deleted (a deletion can land between the index write and this stamp,
+ * and it can name this very post); a marker left by an earlier state in
+ * which every known post was gone is cleared. Synchronous by design; see
+ * the caller.
+ */
+function stampSentMessageId(messageId: string, ts: string): void {
+  const row = getMessageById(messageId);
+  if (row === null || row.metadata === null) {
+    return;
+  }
+  const envelope = safeParseRecord(row.metadata);
+  const providerMeta = readReplyEnvelope(envelope);
+  if (providerMeta === null) {
+    return;
+  }
+  const patch = providerIdPatchFor(providerMeta, ts);
+  if (patch === null) {
+    return;
+  }
+  const posts = [
+    ...(providerMeta.messageId !== undefined ? [providerMeta.messageId] : []),
+    ...(providerMeta.additionalMessageIds ?? []),
+    ts,
+  ];
+  const { deletedAt, ...rest } = providerMeta;
+  updateMessageMetadata(messageId, {
+    providerMeta: JSON.stringify({
+      ...rest,
+      ...patch,
+      ...(deletedAt !== undefined &&
+      everyPostDeleted(posts, providerMeta.deletedMessageIds)
+        ? { deletedAt }
+        : {}),
+    }),
+    // A row reserved with Slack's pre-send envelope converges on the neutral
+    // one here: `updateMessageMetadata` serializes the merged envelope with
+    // `JSON.stringify`, which drops a key set to undefined.
+    ...(envelope.slackMeta !== undefined ? { slackMeta: undefined } : {}),
+  });
+}
+
+/**
+ * The envelope an outbound row stamps its sent ids onto: the neutral one
+ * every row the daemon reserves carries, or, for a reply still pending from
+ * a daemon that reserved Slack replies under Slack's own envelope, the
+ * neutral reading of that pre-send envelope (transitional; see
+ * `providerMetadataOfPreSendSlackEnvelope`).
+ */
+function readReplyEnvelope(
+  envelope: Record<string, unknown>,
+): ProviderMessageMetadata | null {
+  return (
+    readProviderMessageMetadata(envelope.providerMeta) ??
+    providerMetadataOfPreSendSlackEnvelope(envelope)
+  );
+}
+
+/**
+ * Where a newly reported id belongs on the neutral envelope: `messageId` when
+ * the row names none yet, otherwise appended to `additionalMessageIds`.
+ * `null` when the envelope already names it, which is a redelivery.
+ */
+function providerIdPatchFor(
+  providerMeta: ProviderMessageMetadata,
+  ts: string,
+): Partial<ProviderMessageMetadata> | null {
+  if (providerMeta.messageId === undefined) {
+    return { messageId: ts };
+  }
+  if (
+    providerMeta.messageId === ts ||
+    providerMeta.additionalMessageIds?.includes(ts)
+  ) {
+    return null;
+  }
+  return {
+    additionalMessageIds: [...(providerMeta.additionalMessageIds ?? []), ts],
+  };
+}


### PR DESCRIPTION
**TL;DR:** The post-send reconciliation of an outbound assistant row (record the channel's message id in `channel_outbound_posts`, then stamp it on the row's `providerMeta`) moves out of `channel-reply-delivery.ts` into its own module, `outbound-post-reconciliation.ts`, and is exported. No behavior change: the reply path composes the same function into its delivery callback as before. This is the first step toward recording proactive posts (notification deliveries, messaging-tool sends) the same way replies are recorded, which needs the reconciliation callable outside a turn. Part of LUM-3525.

## Why

Today the only writer of `channel_outbound_posts` and the only stamp of a sent id onto an outbound row live inside the conversation reply path. A notification delivered to a Slack DM, or a message sent through the messaging tool, ends up on the channel with no index entry and no acknowledged id on any row, so a later deletion cannot resolve to it and `recall` cannot find it. The follow-up PRs give those producers the same registration replies have, after the channel acknowledges the post. For that, the reconciliation has to be a module a non-turn producer can import without pulling in the reply-delivery machinery.

## What changes for the user

Nothing. Same rows, same index writes, same envelope stamps, same retry and logging behavior, in the same order.

## Design

`makeSentMessageIdReconciler(messageId)` and its three helpers (`stampSentMessageId`, `readReplyEnvelope`, `providerIdPatchFor`) are moved verbatim into `runtime/outbound-post-reconciliation.ts`, with the module header stating the invariant they keep: one writer for both the index and the envelope, so the two cannot drift. `channel-reply-delivery.ts` imports the reconciler and drops the imports only those helpers used. The transitional read of a pre-send Slack envelope (`providerMetadataOfPreSendSlackEnvelope`, from #42001) moves with them unchanged. The runtime doc's message-metadata vocabulary now names the new module as the reconciliation's home.

## Why this is safe

- A move, not a rewrite: the function bodies are byte-for-byte the originals; only the module boundary and the export change.
- The reply path's composition (`deliverPersistedAssistantMessageViaCallback` builds the handler and awaits it per segment) is untouched.
- The reconciler suite, the outbound Slack persistence tests, the retry sweep tests, and the background dispatch tests exercise it through the delivery module's public functions and through module-path mocks of `persistence/delivery-crud.js` and `persistence/conversation-crud.js`, which the new module imports by the same paths.
- Typecheck clean; prettier clean. Tests run on CI at exact HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->