### PR TITLE
feat(watch): rebuild the teach retro card on the design system

### DIFF
--- a/assistant/src/watch/watch-retro.ts
+++ b/assistant/src/watch/watch-retro.ts
@@ -163,10 +163,10 @@ Then make exactly one \`watch_retro_report\` call. That call is the last thing y
 
 The payload:
 
-- \`task\`: the task in one line, named the way the user would name it.
-- \`purpose\`: one sentence on what it is for. This is the only sentence on the card.
+- \`task\`: the task, named the way the user would name it. Six words at most, and no trailing clause explaining it: it is a card title, not a sentence.
+- \`purpose\`: what it is for, in under twelve words. Skip it when the task already says it; a line restating the title is worse than no line.
 - \`steps\`: the steps in order, as short imperative fragments: "Open the Sentry issue", not "You opened the Sentry issue from the alert email". Three to eight of them. Concrete enough to follow, carrying no purpose of their own.
-- \`eyebrow\`: the session's own facts, e.g. "Watched 4 min, 11 screens".
+- \`eyebrow\`: what the session cost, in the teaching's own words, e.g. "Taught in 4 min" or "Taught in 4 min, 11 screens". Never "watched": the user taught you this, they did not perform for you.
 - \`questions\`: at most three, most consequential first. Fewer is better, and none is a valid answer if the recording settled everything. Each question is \`{ id, kind, prompt }\`: \`prompt\` is the question worded the way you would ask it out loud, and \`id\` is a handle no other question on this card uses. A \`pick\` or a \`gate\` adds \`options\`, each of them \`{ id, label }\` and optionally a \`note\`: \`label\` is the answer as the user reads it, and \`id\` is that option's own handle. Use those names exactly. A question's text is \`prompt\` and never \`question\` or \`text\`; an option's text is \`label\` and never \`value\` or \`title\`. Anything sent under another name is dropped on the way to the card, and the page it belonged to is lost.
 
 Every question is answerable in one tap and every one is skippable, so ask only about what you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Do not ask the user to confirm something the recording already showed you.

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.stories.tsx
@@ -92,15 +92,16 @@ function RetroPreview({ templateData }: { templateData: RetroTemplateData }) {
   );
 }
 
-/** Tap off the record, so the story opens on the first question. */
+/** Tap off the recap, so the story opens on the first question. */
 async function toFirstQuestion(canvasElement: HTMLElement) {
   const canvas = within(canvasElement);
-  await userEvent.click(await canvas.findByText("That's it"));
+  await userEvent.click(await canvas.findByText("Looks right"));
 }
 
 const TRIGGER_QUESTION = {
   id: "trigger",
   kind: "fill",
+  eyebrow: "Trigger",
   prompt: "What would you say to start this?",
   suggestion: "file this Sentry bug",
 };
@@ -108,6 +109,7 @@ const TRIGGER_QUESTION = {
 const PRIORITY_QUESTION = {
   id: "priority",
   kind: "pick",
+  eyebrow: "Priority",
   prompt: "You set this one to High. What decides that?",
   options: [
     {
@@ -123,6 +125,7 @@ const PRIORITY_QUESTION = {
 const RESOLVE_QUESTION = {
   id: "resolve",
   kind: "gate",
+  eyebrow: "Resolving",
   prompt: "Resolving the Sentry issue once the ticket exists, on my own?",
   options: [
     { id: "confirm", label: "Ask me first", note: "The safer default" },
@@ -132,8 +135,8 @@ const RESOLVE_QUESTION = {
 
 const FULL_REPORT: RetroTemplateData = {
   task: "Filing a Linear bug from a Sentry alert",
-  purpose: "So an overnight crash has a ticket waiting by morning.",
-  eyebrow: "Watched 4 min, 11 screens",
+  purpose: "So an overnight crash has a ticket by morning.",
+  eyebrow: "Taught in 4 min, 11 screens",
   steps: [
     "Open the Sentry issue from the alert email",
     "Copy the stack trace and the first-seen timestamp",
@@ -183,7 +186,7 @@ export const BoundedRecording: Story = {
       templateData={{
         task: "Triaging the overnight alert queue",
         purpose: "So the queue is empty before standup.",
-        eyebrow: "Watched 12 min, 40 screens",
+        eyebrow: "Taught in 12 min, 40 screens",
         coverage:
           "The recording starts partway in, so the first few alerts are missing and nothing was seen about how the queue is opened.",
         steps: [
@@ -256,10 +259,9 @@ export const LongContent: Story = {
   render: () => (
     <RetroPreview
       templateData={{
-        task: "Preparing the weekly competitor-intel digest for the leadership channel",
-        purpose:
-          "So Monday's leadership sync opens with the week's competitive movement already summarized and sourced.",
-        eyebrow: "Watched 18 min, 63 screens",
+        task: "Weekly competitor-intel digest",
+        purpose: "So Monday's sync opens with the week already summarized.",
+        eyebrow: "Taught in 18 min, 63 screens",
         coverage:
           "The recording ends before the digest was posted, so nothing was seen about which channel it goes to or who is tagged on it.",
         steps: [
@@ -276,6 +278,7 @@ export const LongContent: Story = {
           {
             id: "scope",
             kind: "pick",
+            eyebrow: "Scope",
             prompt:
               "Some weeks a competitor gets no mention at all. What decides whether one appears in the digest?",
             options: [
@@ -314,8 +317,8 @@ export const UnusableQuestionDropped: Story = {
   render: () => (
     <RetroPreview
       templateData={{
-        task: "Checking Slack for unread messages between terminal work",
-        eyebrow: "Watched 14 sec, 1 narration",
+        task: "Checking Slack between terminal work",
+        eyebrow: "Taught in 14 sec",
         steps: [
           "Work in the terminal",
           "Switch to Slack",
@@ -333,4 +336,21 @@ export const UnusableQuestionDropped: Story = {
       }}
     />
   ),
+};
+
+/**
+ * The summary, reached by tapping through every question. The last page before
+ * anything is saved, and the only place the session can be dropped.
+ */
+export const Summary: Story = {
+  render: () => <RetroPreview templateData={FULL_REPORT} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByText("Looks right"));
+    await userEvent.click(await canvas.findByText("Next"));
+    await userEvent.click(
+      await canvas.findByText("Over 100 events in an hour"),
+    );
+    await userEvent.click(await canvas.findByText("Ask me first"));
+  },
 };

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.stories.tsx
@@ -1,0 +1,336 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { userEvent, within } from "storybook/test";
+
+import type { Surface } from "@/domains/chat/types/types";
+
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
+
+import { SurfaceRouter } from "./surface-router";
+
+/**
+ * The card a Watch (teach mode) session ends on, one page at a time.
+ *
+ * Rendered through `SurfaceRouter` rather than by importing the component,
+ * because the retro rides an ordinary `card` under a `watch_retro` template
+ * and the template dispatch is part of what these stories are showing. A
+ * renderer that did not know the template would draw `title`/`subtitle`/`body`
+ * instead, which is the fallback the payload carries for older clients.
+ *
+ * Page one is always the record. Stories that are about a question page use a
+ * `play` step to tap past it, so the page under discussion is the one on
+ * screen when the story opens.
+ */
+const meta: Meta = {
+  title: "Chat/Surfaces/WatchRetro",
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <TranscriptColumn>
+        <Story />
+      </TranscriptColumn>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+/** The card's `templateData`, which is the whole of the report. */
+type RetroTemplateData = Record<string, unknown>;
+
+function retroSurface(templateData: RetroTemplateData): Surface {
+  const task = (templateData.task as string | undefined) ?? "";
+  const steps = (templateData.steps as string[] | undefined) ?? [];
+  return {
+    surfaceId: "watch-retro-story",
+    surfaceType: "card",
+    title: task,
+    data: {
+      // Derived the way `watch-retro.ts` derives them, so the degraded view a
+      // template-unaware renderer would draw stays visible in Storybook too.
+      title: task,
+      ...(templateData.purpose ? { subtitle: templateData.purpose } : {}),
+      body: steps.map((step, index) => `${index + 1}. ${step}`).join("\n"),
+      template: "watch_retro",
+      templateData,
+    },
+  } as Surface;
+}
+
+/**
+ * The card with its answers wired up, so tapping through the pages behaves the
+ * way it does in a conversation. The submitted payload is logged rather than
+ * sent, and the card marks itself completed so the end of the flow is visible.
+ */
+function RetroPreview({ templateData }: { templateData: RetroTemplateData }) {
+  const [surface, setSurface] = useState(() => retroSurface(templateData));
+  const [submitted, setSubmitted] = useState<unknown>(null);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <SurfaceRouter
+        surface={surface}
+        onAction={(_surfaceId, actionId, data) => {
+          setSubmitted({ actionId, ...data });
+          setSurface((current) => ({
+            ...current,
+            completed: true,
+            completionSummary:
+              actionId === "discard" ? "Cancelled" : "Skill saved",
+          }));
+        }}
+      />
+      {submitted !== null && (
+        <pre className="overflow-x-auto rounded-lg bg-[var(--surface-overlay)] p-3 text-body-small-default text-[var(--content-quiet)]">
+          {JSON.stringify(submitted, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+/** Tap off the record, so the story opens on the first question. */
+async function toFirstQuestion(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  await userEvent.click(await canvas.findByText("That's it"));
+}
+
+const TRIGGER_QUESTION = {
+  id: "trigger",
+  kind: "fill",
+  prompt: "What would you say to start this?",
+  suggestion: "file this Sentry bug",
+};
+
+const PRIORITY_QUESTION = {
+  id: "priority",
+  kind: "pick",
+  prompt: "You set this one to High. What decides that?",
+  options: [
+    {
+      id: "events",
+      label: "Over 100 events in an hour",
+      note: "What the recording shows",
+    },
+    { id: "customer", label: "It touched a customer account" },
+    { id: "ask", label: "Ask me each time" },
+  ],
+};
+
+const RESOLVE_QUESTION = {
+  id: "resolve",
+  kind: "gate",
+  prompt: "Resolving the Sentry issue once the ticket exists, on my own?",
+  options: [
+    { id: "confirm", label: "Ask me first", note: "The safer default" },
+    { id: "auto", label: "Go ahead and resolve it" },
+  ],
+};
+
+const FULL_REPORT: RetroTemplateData = {
+  task: "Filing a Linear bug from a Sentry alert",
+  purpose: "So an overnight crash has a ticket waiting by morning.",
+  eyebrow: "Watched 4 min, 11 screens",
+  steps: [
+    "Open the Sentry issue from the alert email",
+    "Copy the stack trace and the first-seen timestamp",
+    "Open a new Linear issue in JARVIS",
+    "Paste the trace into the description",
+    "Set priority and assign to the on-call engineer",
+    "Paste the Linear link back into the Sentry issue",
+  ],
+  questions: [TRIGGER_QUESTION, PRIORITY_QUESTION, RESOLVE_QUESTION],
+};
+
+/**
+ * The whole flow: record, then three questions, then a submitted payload.
+ * The one to open when the question is how the card feels to tap through.
+ */
+export const FullWalkthrough: Story = {
+  render: () => <RetroPreview templateData={FULL_REPORT} />,
+};
+
+/**
+ * The record with nothing optional set. No eyebrow, no purpose, no coverage
+ * line, and no questions, so the progress bar is gone and the card is only
+ * what was seen.
+ */
+export const RecordOnly: Story = {
+  render: () => (
+    <RetroPreview
+      templateData={{
+        task: "Restarting the staging worker",
+        steps: [
+          "Open the deploy dashboard",
+          "Select the staging worker",
+          "Restart it and wait for green",
+        ],
+      }}
+    />
+  ),
+};
+
+/**
+ * A session the recording only partly covers. The coverage line is where that
+ * is said, rather than hedged inside the steps.
+ */
+export const BoundedRecording: Story = {
+  render: () => (
+    <RetroPreview
+      templateData={{
+        task: "Triaging the overnight alert queue",
+        purpose: "So the queue is empty before standup.",
+        eyebrow: "Watched 12 min, 40 screens",
+        coverage:
+          "The recording starts partway in, so the first few alerts are missing and nothing was seen about how the queue is opened.",
+        steps: [
+          "Sort the queue by first seen",
+          "Open the oldest unacknowledged alert",
+          "Acknowledge it and leave a one-line note",
+        ],
+      }}
+    />
+  ),
+};
+
+/** A `pick`: named alternatives, the recording's own reading marked and first. */
+export const PickQuestion: Story = {
+  render: () => (
+    <RetroPreview
+      templateData={{
+        ...FULL_REPORT,
+        questions: [PRIORITY_QUESTION],
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await toFirstQuestion(canvasElement);
+  },
+};
+
+/**
+ * A `gate`: a destructive step, with the cautious answer first because a
+ * skipped question takes it.
+ */
+export const GateQuestion: Story = {
+  render: () => (
+    <RetroPreview
+      templateData={{
+        ...FULL_REPORT,
+        questions: [RESOLVE_QUESTION],
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await toFirstQuestion(canvasElement);
+  },
+};
+
+/**
+ * A `fill`: the trigger phrase, pre-filled with the model's guess. The only
+ * typing on the card, and the one field a recording cannot supply.
+ */
+export const FillQuestion: Story = {
+  render: () => (
+    <RetroPreview
+      templateData={{
+        ...FULL_REPORT,
+        questions: [TRIGGER_QUESTION],
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await toFirstQuestion(canvasElement);
+  },
+};
+
+/**
+ * The card at its longest: eight steps, a long title, and options that wrap.
+ * Where the paging is under the most pressure, so it is the story to check a
+ * spacing or type change against.
+ */
+export const LongContent: Story = {
+  render: () => (
+    <RetroPreview
+      templateData={{
+        task: "Preparing the weekly competitor-intel digest for the leadership channel",
+        purpose:
+          "So Monday's leadership sync opens with the week's competitive movement already summarized and sourced.",
+        eyebrow: "Watched 18 min, 63 screens",
+        coverage:
+          "The recording ends before the digest was posted, so nothing was seen about which channel it goes to or who is tagged on it.",
+        steps: [
+          "Open the competitor-intel Slack channel",
+          "Read everything posted since last Monday",
+          "Open each linked article and skim for pricing or packaging changes",
+          "Copy anything about pricing into the running doc",
+          "Group the week's items by competitor",
+          "Write a two-line summary for each competitor that moved",
+          "Add the source links under each summary",
+          "Read the whole thing back once before posting",
+        ],
+        questions: [
+          {
+            id: "scope",
+            kind: "pick",
+            prompt:
+              "Some weeks a competitor gets no mention at all. What decides whether one appears in the digest?",
+            options: [
+              {
+                id: "moved",
+                label: "Only competitors that did something new this week",
+                note: "What the recording shows, since two were skipped",
+              },
+              {
+                id: "all",
+                label:
+                  "Every competitor on the list, with 'no change' where there is nothing",
+              },
+              {
+                id: "pricing",
+                label: "Only pricing and packaging changes, whoever made them",
+              },
+            ],
+          },
+        ],
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await toFirstQuestion(canvasElement);
+  },
+};
+
+/**
+ * What a payload the model got wrong degrades to. The question's text arrived
+ * under `question` rather than `prompt`, so it has no text at all and the card
+ * drops it, leaving the record whole. Kept as a story because this is the
+ * shape a live session produced, and the card has to stay presentable in it.
+ */
+export const UnusableQuestionDropped: Story = {
+  render: () => (
+    <RetroPreview
+      templateData={{
+        task: "Checking Slack for unread messages between terminal work",
+        eyebrow: "Watched 14 sec, 1 narration",
+        steps: [
+          "Work in the terminal",
+          "Switch to Slack",
+          "Check for unread messages",
+          "Switch back to the terminal",
+        ],
+        questions: [
+          {
+            id: "scope",
+            kind: "pick",
+            question: "Where does this routine end?",
+            options: [{ value: "Just read" }, { value: "Also reply" }],
+          },
+        ],
+      }}
+    />
+  ),
+};

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
@@ -109,8 +109,8 @@ describe("WatchRetroSurface", () => {
     );
 
     // Past the recap, then skip all three questions, which lands on the
-    // summary. Nothing is submitted until saving is asked for there: the card
-    // no longer commits at the end of a run of Skips.
+    // summary. Skipping every page reaches review without submitting: saving
+    // is its own act, asked for on the summary and nowhere else.
     fireEvent.click(screen.getByText("Looks right"));
     fireEvent.click(screen.getByText("Skip"));
     fireEvent.click(screen.getByText("Skip"));

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
@@ -108,12 +108,16 @@ describe("WatchRetroSurface", () => {
       />,
     );
 
-    // Past the record, then skip all three questions.
-    fireEvent.click(screen.getByText("That's it"));
+    // Past the recap, then skip all three questions, which lands on the
+    // summary. Nothing is submitted until saving is asked for there: the card
+    // no longer commits at the end of a run of Skips.
+    fireEvent.click(screen.getByText("Looks right"));
     fireEvent.click(screen.getByText("Skip"));
     fireEvent.click(screen.getByText("Skip"));
     fireEvent.click(screen.getByText("Skip"));
+    expect(calls).toHaveLength(0);
 
+    fireEvent.click(screen.getByText("Save skill"));
     expect(calls).toHaveLength(1);
     // A `card` is not one-shot daemon-side, so the card has to ask to be
     // completed or it stays answerable after it has been answered.
@@ -162,7 +166,7 @@ describe("WatchRetroSurface", () => {
       />,
     );
 
-    fireEvent.click(screen.getByText("That's it"));
+    fireEvent.click(screen.getByText("Looks right"));
     fireEvent.click(screen.getByText("Next"));
     // A single-select surface commits on tap everywhere else in the app, so
     // the pick page carries no advance button: the option is the gesture.
@@ -174,6 +178,10 @@ describe("WatchRetroSurface", () => {
     ).toBeDefined();
 
     fireEvent.click(screen.getByText("Go ahead"));
+    // The gate was the last question, so this lands on the summary rather than
+    // submitting. Saving is the explicit act.
+    expect(calls).toHaveLength(0);
+    fireEvent.click(screen.getByText("Save skill"));
     const answers = calls[0]!.data!.answers as {
       questionId: string;
       optionId?: string;
@@ -202,6 +210,108 @@ describe("WatchRetroSurface", () => {
     // saves rather than advancing to a page that does not exist.
     fireEvent.click(screen.getByText("Save skill"));
     expect(calls).toEqual(["answer"]);
+  });
+
+  test("goes back a page, and back to any page already visited", () => {
+    render(<CardSurface surface={surface()} onAction={() => undefined} />);
+
+    fireEvent.click(screen.getByText("Looks right"));
+    expect(screen.getByText("What would you say to start this?")).toBeDefined();
+
+    // Back steps one page at a time.
+    fireEvent.click(screen.getByText("Back"));
+    expect(
+      screen.getByText("Filing a Linear bug from a Sentry alert"),
+    ).toBeDefined();
+
+    // The step row jumps further than one page: a decision made three pages
+    // ago is one tap away rather than a restart. Only visited steps are
+    // navigable, which is what makes the row safe to expose.
+    fireEvent.click(screen.getByText("Looks right"));
+    fireEvent.click(screen.getByText("Next"));
+    expect(
+      screen.getByText("You set this one to High. What decides that?"),
+    ).toBeDefined();
+    fireEvent.click(screen.getByText("Recap"));
+    expect(
+      screen.getByText("Filing a Linear bug from a Sentry alert"),
+    ).toBeDefined();
+  });
+
+  test("an answer changed from the summary is the one submitted", () => {
+    const calls: { data?: Record<string, unknown> }[] = [];
+    render(
+      <CardSurface
+        surface={surface()}
+        onAction={(_surfaceId, _actionId, data) => {
+          calls.push({ data });
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Looks right"));
+    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByText("Over 100 events"));
+    fireEvent.click(screen.getByText("Ask me first"));
+
+    // On the summary, every line is the answer to something asked earlier and
+    // goes back to where it was asked. Changing one there has to reach the
+    // payload, or the review step would be decoration. These questions carry
+    // no `eyebrow`, so the row is titled by the prompt, which is the fallback.
+    fireEvent.click(
+      screen.getByText("You set this one to High. What decides that?"),
+    );
+    fireEvent.click(screen.getByText("It hit a customer"));
+    fireEvent.click(screen.getByText("Save skill"));
+
+    const answers = calls[0]!.data!.answers as {
+      questionId: string;
+      optionId?: string;
+    }[];
+    expect(answers[1]).toMatchObject({
+      questionId: "priority",
+      optionId: "customer",
+    });
+  });
+
+  test("the session can only be dropped from the summary", () => {
+    const calls: string[] = [];
+    render(
+      <CardSurface
+        surface={surface()}
+        onAction={(_surfaceId, actionId) => {
+          calls.push(actionId);
+        }}
+      />,
+    );
+
+    // Nothing destructive while the user is still reading what they have.
+    expect(screen.queryByText("Don't save")).toBeNull();
+
+    fireEvent.click(screen.getByText("Looks right"));
+    fireEvent.click(screen.getByText("Skip"));
+    fireEvent.click(screen.getByText("Skip"));
+    fireEvent.click(screen.getByText("Skip"));
+
+    fireEvent.click(screen.getByText("Don't save"));
+    expect(calls).toEqual(["discard"]);
+  });
+
+  test("saying the recap read wrong ends the card without saving", () => {
+    const calls: string[] = [];
+    render(
+      <CardSurface
+        surface={surface()}
+        onAction={(_surfaceId, actionId) => {
+          calls.push(actionId);
+        }}
+      />,
+    );
+
+    // A correction rather than a refusal: the turn picks the action up and
+    // asks what was off, so it does not go through the discard path.
+    fireEvent.click(screen.getByText("Something's off"));
+    expect(calls).toEqual(["not_right"]);
   });
 
   test("falls back to a readable card when the template is not recognized", () => {
@@ -290,11 +400,12 @@ describe("WatchRetroSurface", () => {
     // Answers are held under the question id, so two questions sharing one
     // would share a slot: answering either would overwrite the other, and both
     // would submit whichever answer landed last. The first use of an id wins.
-    fireEvent.click(screen.getByText("That's it"));
+    fireEvent.click(screen.getByText("Looks right"));
     expect(screen.getByText("First question")).toBeDefined();
     expect(screen.queryByText("Second question")).toBeNull();
 
     fireEvent.click(screen.getByText("First B"));
+    fireEvent.click(screen.getByText("Save skill"));
     const answers = calls[0]!.data!.answers as { optionId?: string }[];
     expect(answers).toHaveLength(1);
     expect(answers[0]).toMatchObject({ optionId: "b" });

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -12,7 +12,12 @@ import {
   type StepperStep,
   Typography,
 } from "@vellumai/design-library";
-import { GraduationCap, Loader2 } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  GraduationCap,
+  Loader2,
+} from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import type { Surface } from "@/domains/chat/types/types";
@@ -352,52 +357,25 @@ export function WatchRetroSurface({
         />
       )}
 
-      <div className="mt-6 flex items-center gap-2">
-        {/* A `pick` and a `gate` commit on tap, matching every other
-            single-select surface in the app, so their page carries no advance
-            button. The recap, a `fill` and the summary have nothing to tap, so
-            they keep one. */}
-        {(onRecap || onSummary || currentQuestion?.kind === "fill") && (
-          <Button
-            variant="primary"
-            disabled={submitting}
-            leftIcon={
-              submitting ? <Loader2 className="animate-spin" /> : undefined
-            }
-            onClick={() => {
-              advance(answers);
-            }}
-          >
-            {onSummary || totalPages === 1
-              ? t("watchRetroSurface.save")
-              : onRecap
-                ? t("watchRetroSurface.looksRight")
-                : t("watchRetroSurface.next")}
-          </Button>
-        )}
+      {/* Back left, everything else right, primary last. That is the shape
+          `form-surface` uses for its paged footer and the order every
+          `Modal.Footer` puts its buttons in, so the forward action is always
+          the rightmost thing on the card. */}
+      <div className="mt-6 flex items-center justify-between gap-2">
+        <div>
+          {!onRecap && (
+            <Button
+              variant="outlined"
+              disabled={submitting}
+              leftIcon={<ChevronLeft />}
+              onClick={goBack}
+            >
+              {t("watchRetroSurface.back")}
+            </Button>
+          )}
+        </div>
 
-        {!onRecap && (
-          <Button variant="ghost" disabled={submitting} onClick={goBack}>
-            {t("watchRetroSurface.back")}
-          </Button>
-        )}
-
-        {currentQuestion && (
-          <Button
-            variant="ghost"
-            disabled={submitting}
-            onClick={() => {
-              // The default is already in `answers`, so a skip only has to
-              // move on. It stays marked skipped so the model can tell an
-              // accepted default from a chosen one.
-              advance(answers);
-            }}
-          >
-            {t("watchRetroSurface.skip")}
-          </Button>
-        )}
-
-        <div className="ml-auto flex items-center gap-2">
+        <div className="flex items-center gap-2">
           {/* Says the recap read wrong, which is a correction rather than a
               refusal: the turn picks it up and asks what was off. */}
           {onRecap && (
@@ -412,6 +390,21 @@ export function WatchRetroSurface({
             </Button>
           )}
 
+          {currentQuestion && (
+            <Button
+              variant="ghost"
+              disabled={submitting}
+              onClick={() => {
+                // The default is already in `answers`, so a skip only has to
+                // move on. It stays marked skipped so the model can tell an
+                // accepted default from a chosen one.
+                advance(answers);
+              }}
+            >
+              {t("watchRetroSurface.skip")}
+            </Button>
+          )}
+
           {/* The one place the session can be thrown away, next to the thing
               being thrown away. */}
           {(onSummary || totalPages === 1) && (
@@ -423,6 +416,32 @@ export function WatchRetroSurface({
               }}
             >
               {t("watchRetroSurface.dontSave")}
+            </Button>
+          )}
+
+          {/* A `pick` and a `gate` commit on tap, matching every other
+              single-select surface in the app, so their page carries no
+              advance button. The recap, a `fill` and the summary have nothing
+              to tap, so they keep one. */}
+          {(onRecap || onSummary || currentQuestion?.kind === "fill") && (
+            <Button
+              variant="primary"
+              disabled={submitting}
+              leftIcon={
+                submitting ? <Loader2 className="animate-spin" /> : undefined
+              }
+              rightIcon={
+                onSummary || totalPages === 1 ? undefined : <ChevronRight />
+              }
+              onClick={() => {
+                advance(answers);
+              }}
+            >
+              {onSummary || totalPages === 1
+                ? t("watchRetroSurface.save")
+                : onRecap
+                  ? t("watchRetroSurface.looksRight")
+                  : t("watchRetroSurface.next")}
             </Button>
           )}
         </div>

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -585,14 +585,14 @@ function QuestionPage({
         >
           {/* Rows in the shape `choice-surface` gives its options, which is the
               app's single-select: separate raised rows, no dividers, a mark
-              that says which one is standing. `ListRow` was the wrong
-              primitive here twice over. Its `[&+&]` hairline is meant for a
-              flush settings list, so a divider under a filled row read as a
-              section break rather than as a gap between two options. And a
-              radio group cannot commit on tap: Radix moves the selection on
-              arrow keys, so advancing on change would carry a keyboard user
-              off the page before they reached the third option. A button per
-              option keeps the tap-to-commit gesture and leaves Tab and Enter
+              that says which one is standing. Two primitives sit closer to
+              this than they belong. `ListRow` draws a `[&+&]` hairline for a
+              flush settings list, which under a filled row reads as a section
+              break rather than as the gap between two options. And a
+              `RadioGroup` cannot commit on tap: Radix moves the selection on
+              arrow keys, so advancing on change carries a keyboard user off
+              the page before they reach the third option. A button per option
+              keeps the tap-to-commit gesture and leaves Tab and Enter
               working. */}
           {(question.options ?? []).map((option, index) => {
             const selected = selectedOptionId === option.id;
@@ -613,8 +613,8 @@ function QuestionPage({
                 )}
               >
                 {/* The mark, not the fill, is what says which option is
-                    standing. A background alone left a middle selection
-                    looking like a section of its own. */}
+                    standing: a background on its own reads as a section of
+                    its own when the middle option carries it. */}
                 <span
                   aria-hidden
                   className={cn(

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -13,6 +13,7 @@ import {
   Typography,
 } from "@vellumai/design-library";
 import {
+  Check,
   ChevronLeft,
   ChevronRight,
   GraduationCap,
@@ -22,6 +23,7 @@ import { useCallback, useMemo, useState } from "react";
 
 import type { Surface } from "@/domains/chat/types/types";
 import { useTranslation } from "@/i18n";
+import { cn } from "@/utils/misc";
 
 /**
  * The end of a Watch (teach mode) session: what the assistant was taught, the
@@ -581,21 +583,70 @@ function QuestionPage({
           role="group"
           aria-labelledby={promptId}
         >
-          {(question.options ?? []).map((option, index) => (
-            <ListRow
-              key={option.id || `${index}-${option.label}`}
-              title={option.label}
-              subtitle={option.note}
-              // The first option is the standing answer until another is
-              // tapped, so it is the one drawn as selected.
-              selected={selectedOptionId === option.id}
-              disabled={disabled}
-              showChevron={false}
-              onClick={() => {
-                onPick(option.id, option.label);
-              }}
-            />
-          ))}
+          {/* Rows in the shape `choice-surface` gives its options, which is the
+              app's single-select: separate raised rows, no dividers, a mark
+              that says which one is standing. `ListRow` was the wrong
+              primitive here twice over. Its `[&+&]` hairline is meant for a
+              flush settings list, so a divider under a filled row read as a
+              section break rather than as a gap between two options. And a
+              radio group cannot commit on tap: Radix moves the selection on
+              arrow keys, so advancing on change would carry a keyboard user
+              off the page before they reached the third option. A button per
+              option keeps the tap-to-commit gesture and leaves Tab and Enter
+              working. */}
+          {(question.options ?? []).map((option, index) => {
+            const selected = selectedOptionId === option.id;
+            return (
+              <button
+                key={option.id || `${index}-${option.label}`}
+                type="button"
+                aria-pressed={selected}
+                disabled={disabled}
+                onClick={() => {
+                  onPick(option.id, option.label);
+                }}
+                className={cn(
+                  "flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-left transition-colors",
+                  "bg-[var(--surface-overlay)] hover:bg-[var(--surface-active)]",
+                  "disabled:cursor-default disabled:opacity-70",
+                  selected && "ring-1 ring-[var(--primary-base)]",
+                )}
+              >
+                {/* The mark, not the fill, is what says which option is
+                    standing. A background alone left a middle selection
+                    looking like a section of its own. */}
+                <span
+                  aria-hidden
+                  className={cn(
+                    "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border transition-colors",
+                    selected
+                      ? "border-transparent bg-[var(--primary-base)] text-[var(--content-inset)]"
+                      : "border-[var(--border-element)]",
+                  )}
+                >
+                  {selected && <Check className="h-3.5 w-3.5" />}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <Typography
+                    as="span"
+                    variant="body-medium-default"
+                    className="block text-[color:var(--content-strong)]"
+                  >
+                    {option.label}
+                  </Typography>
+                  {option.note && (
+                    <Typography
+                      as="span"
+                      variant="body-small-default"
+                      className="mt-0.5 block text-[color:var(--content-quiet)]"
+                    >
+                      {option.note}
+                    </Typography>
+                  )}
+                </span>
+              </button>
+            );
+          })}
         </div>
       )}
     </div>
@@ -647,7 +698,7 @@ function SummaryPage({
         </Typography>
       )}
 
-      <div className="mt-6 grid gap-1">
+      <div className="mt-6">
         {trigger && (
           <ListRow
             title={t("watchRetroSurface.summarySay")}

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -3,45 +3,53 @@ import {
   type WatchRetroSurfaceData,
   WatchRetroSurfaceDataSchema,
 } from "@vellumai/assistant-api";
-import { Button, Input } from "@vellumai/design-library";
-import { Eye, Loader2 } from "lucide-react";
+import {
+  Button,
+  Card,
+  Input,
+  ListRow,
+  Stepper,
+  type StepperStep,
+  Typography,
+} from "@vellumai/design-library";
+import { GraduationCap, Loader2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
-import { PageProgress } from "@/domains/chat/components/surfaces/page-progress";
 import type { Surface } from "@/domains/chat/types/types";
 import { useTranslation } from "@/i18n";
-import { cn } from "@/utils/misc";
 
 /**
- * The end of a Watch (teach mode) session: what the assistant saw, and the few
- * things the recording could not settle.
+ * The end of a Watch (teach mode) session: what the assistant was taught, the
+ * few things the recording could not settle, and a last look before any of it
+ * is kept.
  *
- * **One thing per page.** Page one is the record. Every question after it gets
- * a page of its own, so the card is short enough to read at a glance and the
- * questions are never a list to work through.
+ * **One thing per page.** The recap is page one, every question gets a page of
+ * its own, and the summary is the last. The card stays short enough to read at
+ * a glance and no question is a list item to work through.
+ *
+ * **The flow is a `Stepper`, which is also how you go back.** Steps before the
+ * current one are navigable, so a decision made three pages ago is one tap
+ * away rather than unreachable. The summary repeats the same affordance as
+ * rows, since that is where a user is most likely to want it.
+ *
+ * **Nothing destructive until the summary.** The recap offers to move forward
+ * or to say it read wrong; keeping or dropping the skill is asked once, at the
+ * end, next to the thing being kept. A user cannot throw the session away
+ * before seeing what it produced.
  *
  * **A `card` template rather than a surface type.** `CardSurface` routes here
  * on `data.template`, so a renderer that predates the template still draws the
  * surface's `title`, `subtitle` and `body` instead of an unsupported-surface
  * notice. The retro is the whole of what a finished session gives the user and
- * the turn writes no prose beside it, so it has to survive a client older than
- * this file.
- *
- * **The record leads, and the paging is what allows that.** A question on its
- * own page is not competing with the steps for attention, and the record is
- * what a user needs in order to answer anything else. The two go together: the
- * questions may only sit behind the record for as long as they have pages of
- * their own.
+ * the turn writes no prose beside it, so it has to survive an older client.
  *
  * **Every page is skippable and every skip is safe.** Skipping advances with a
- * default already in hand, so a user who taps through without reading still
- * lands on an answer the model can build from. `defaultAnswerFor` owns which
- * default: the first option, which the payload contract requires to be the
- * cautious answer on a gate and the model's own reading on a pick.
+ * default already in hand. `defaultAnswerFor` owns which: the first option,
+ * which the payload contract requires to be the cautious answer on a gate and
+ * the model's own reading on a pick.
  *
  * **One submission, at the end.** Answers accumulate in local state and go out
- * as a single action payload rather than one turn per question. The surface is
- * registered one-shot daemon-side, so that first action is also its last.
+ * as a single action payload rather than one turn per question.
  */
 
 interface WatchRetroSurfaceProps {
@@ -73,9 +81,9 @@ interface WatchRetroAnswer {
  *
  * A `fill` starts on its suggestion, which is what makes skipping it an
  * acceptance rather than a blank. A `pick` and a `gate` start on their first
- * option: the payload contract puts the model's reading first on a pick and the
- * cautious answer first on a gate, so this one rule covers both without the
- * renderer having to know which is which.
+ * option: the payload contract puts the model's reading first on a pick and
+ * the cautious answer first on a gate, so this one rule covers both without
+ * the renderer having to know which is which.
  */
 function defaultAnswerFor(question: WatchRetroQuestion): WatchRetroAnswer {
   const firstOption = question.options?.[0];
@@ -116,11 +124,9 @@ function isAnswerable(question: WatchRetroQuestion): boolean {
  * The questions this card can actually page through, in payload order.
  *
  * Ids are the key answers are held under and the handle the model matches on,
- * so a repeated one would collapse two pages into a single slot: answering
- * either would overwrite the other, and both questions would submit whichever
- * answer landed last. Nothing upstream guarantees they are distinct, so the
- * first use of an id wins and later claimants are dropped, the same way an
- * unanswerable question is.
+ * so a repeated one would collapse two pages into a single slot. Nothing
+ * upstream guarantees they are distinct, so the first use of an id wins and
+ * later claimants are dropped, the same way an unanswerable question is.
  */
 function usableQuestions(
   questions: readonly WatchRetroQuestion[],
@@ -157,16 +163,56 @@ export function WatchRetroSurface({
 
   const [pageIndex, setPageIndex] = useState(0);
   const [submitting, setSubmitting] = useState(false);
+  // Whether the summary has been reached. Once it has, the card is being
+  // reviewed rather than filled in, and every page returns there.
+  const [reviewed, setReviewed] = useState(false);
   const [answers, setAnswers] = useState<Record<string, WatchRetroAnswer>>(() =>
     Object.fromEntries(
       questions.map((question) => [question.id, defaultAnswerFor(question)]),
     ),
   );
 
-  // Page 0 is the record; every page after it is one question.
-  const totalPages = questions.length + 1;
-  const isLastPage = pageIndex >= totalPages - 1;
-  const currentQuestion = pageIndex === 0 ? null : questions[pageIndex - 1];
+  // Page 0 is the recap, then one page per question. The summary is the last
+  // page, and only earns one when there is something to summarize: with no
+  // questions the recap already is the summary, and a second page repeating it
+  // would be a step that asks nothing.
+  const hasSummary = questions.length > 0;
+  const summaryIndex = hasSummary ? questions.length + 1 : -1;
+  const totalPages = questions.length + (hasSummary ? 2 : 1);
+  const onRecap = pageIndex === 0;
+  const onSummary = hasSummary && pageIndex === summaryIndex;
+  const currentQuestion =
+    onRecap || onSummary ? null : questions[pageIndex - 1];
+
+  const steps = useMemo<StepperStep[]>(() => {
+    const questionSteps = questions.map((question, index) => ({
+      id: question.id,
+      // The model names why a question is being asked in `eyebrow`, which is
+      // the short label this needs. Numbered only when it did not.
+      label:
+        question.eyebrow ??
+        t("watchRetroSurface.stepQuestion", {
+          number: index + 1,
+        }),
+    }));
+    return [
+      { id: "__recap", label: t("watchRetroSurface.stepRecap") },
+      ...questionSteps,
+      ...(hasSummary
+        ? [{ id: "__summary", label: t("watchRetroSurface.stepSummary") }]
+        : []),
+    ];
+  }, [hasSummary, questions, t]);
+
+  const goToPage = useCallback(
+    (next: number) => {
+      setPageIndex(next);
+      if (hasSummary && next === summaryIndex) {
+        setReviewed(true);
+      }
+    },
+    [hasSummary, summaryIndex],
+  );
 
   const submit = useCallback(
     async (actionId: string, collected: Record<string, WatchRetroAnswer>) => {
@@ -191,55 +237,83 @@ export function WatchRetroSurface({
         // Released unconditionally, matching `SurfaceContainer`. A rejection is
         // not the signal a failure arrives on: `handleSurfaceAction` reports a
         // failed submit to the user and returns normally, so a reset that only
-        // ran on a thrown error would leave every control on the card disabled
-        // after a dropped request, with the composer still blocked behind an
-        // interactive surface nobody can answer. On the success path the
-        // surface completes and the card is replaced, so the reset is unseen.
+        // ran on a thrown error would leave every control disabled after a
+        // dropped request, with the composer still blocked behind an
+        // interactive surface nobody can answer.
         setSubmitting(false);
       }
     },
     [onAction, questions, submitting, surface.surfaceId],
   );
 
+  /**
+   * Move forward one page, or submit when there is nowhere left to go.
+   *
+   * Only a card with no questions ends by advancing; everything else stops on
+   * the summary, where saving is an explicit act rather than the far end of
+   * tapping Next.
+   */
   const advance = useCallback(
-    (next: Record<string, WatchRetroAnswer>, actionId: string) => {
+    (next: Record<string, WatchRetroAnswer>) => {
       setAnswers(next);
-      if (isLastPage) {
-        void submit(actionId, next);
+      if (pageIndex >= totalPages - 1) {
+        void submit("answer", next);
         return;
       }
-      setPageIndex((prev) => prev + 1);
+      // A page left after the summary has been seen goes back to it. Someone
+      // who jumped back from the summary to change one answer came to change
+      // that answer, not to walk forward through the questions they had
+      // already settled.
+      goToPage(reviewed ? summaryIndex : pageIndex + 1);
     },
-    [isLastPage, submit],
+    [goToPage, pageIndex, reviewed, submit, summaryIndex, totalPages],
   );
 
   /** Record an answer and move on. A tap on an option is both, in one gesture. */
   const answerAndAdvance = useCallback(
     (question: WatchRetroQuestion, answer: WatchRetroAnswer) => {
-      advance({ ...answers, [question.id]: answer }, "answer");
+      advance({ ...answers, [question.id]: answer });
     },
     [advance, answers],
   );
 
-  const skip = useCallback(() => {
-    // The default is already in `answers`, so a skip only has to move on. It is
-    // recorded as skipped so the model can tell an accepted default from a
-    // chosen one.
-    advance(answers, "skip");
-  }, [advance, answers]);
+  const goBack = useCallback(() => {
+    goToPage(Math.max(0, pageIndex - 1));
+  }, [goToPage, pageIndex]);
 
   const heading = data.task || t("watchRetroSurface.untitledTask");
-  const onRecord = currentQuestion === null || currentQuestion === undefined;
 
   return (
-    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
+    <Card padding="lg" bordered>
       {totalPages > 1 && (
-        <PageProgress current={pageIndex} total={totalPages} />
+        // The session's own facts ride the end of the step row rather than
+        // sitting above the title. Three left-aligned lines of near-equal
+        // weight gave the recap no first thing to read; the title is that
+        // thing, so everything else gets out of its column.
+        <div className="mb-6 flex items-end gap-4 border-b border-[var(--border-base)]">
+          <Stepper
+            steps={steps}
+            current={pageIndex}
+            disabled={submitting}
+            onStepSelect={goToPage}
+            className="min-w-0 flex-1 border-b-0"
+          />
+          {data.eyebrow && <SessionFacts eyebrow={data.eyebrow} />}
+        </div>
       )}
 
-      {onRecord ? (
-        <RecordPage data={data} heading={heading} />
-      ) : (
+      {onRecap && (
+        <RecapPage
+          data={data}
+          heading={heading}
+          // Both only appear here when there is no step row and no summary to
+          // carry them, which is the single-page card.
+          showEyebrow={totalPages === 1}
+          showPurpose={!hasSummary}
+        />
+      )}
+
+      {currentQuestion && (
         <QuestionPage
           question={currentQuestion}
           answer={answers[currentQuestion.id]}
@@ -268,12 +342,22 @@ export function WatchRetroSurface({
         />
       )}
 
-      <div className="mt-4 flex items-center gap-2">
+      {onSummary && (
+        <SummaryPage
+          data={data}
+          questions={questions}
+          answers={answers}
+          disabled={submitting}
+          onEdit={goToPage}
+        />
+      )}
+
+      <div className="mt-6 flex items-center gap-2">
         {/* A `pick` and a `gate` commit on tap, matching every other
             single-select surface in the app, so their page carries no advance
-            button. The record and a `fill` have nothing to tap, so they keep
-            one. */}
-        {(onRecord || currentQuestion.kind === "fill") && (
+            button. The recap, a `fill` and the summary have nothing to tap, so
+            they keep one. */}
+        {(onRecap || onSummary || currentQuestion?.kind === "fill") && (
           <Button
             variant="primary"
             disabled={submitting}
@@ -281,27 +365,56 @@ export function WatchRetroSurface({
               submitting ? <Loader2 className="animate-spin" /> : undefined
             }
             onClick={() => {
-              advance(answers, isLastPage ? "answer" : "next");
+              advance(answers);
             }}
           >
-            {isLastPage
+            {onSummary || totalPages === 1
               ? t("watchRetroSurface.save")
-              : onRecord
-                ? t("watchRetroSurface.thatsIt")
+              : onRecap
+                ? t("watchRetroSurface.looksRight")
                 : t("watchRetroSurface.next")}
           </Button>
         )}
 
-        {!onRecord && (
-          <Button variant="ghost" disabled={submitting} onClick={skip}>
+        {!onRecap && (
+          <Button variant="ghost" disabled={submitting} onClick={goBack}>
+            {t("watchRetroSurface.back")}
+          </Button>
+        )}
+
+        {currentQuestion && (
+          <Button
+            variant="ghost"
+            disabled={submitting}
+            onClick={() => {
+              // The default is already in `answers`, so a skip only has to
+              // move on. It stays marked skipped so the model can tell an
+              // accepted default from a chosen one.
+              advance(answers);
+            }}
+          >
             {t("watchRetroSurface.skip")}
           </Button>
         )}
 
-        {/* Only on the record. A user who does not want the skill kept says so
-            before answering questions about it. */}
-        {onRecord && (
-          <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-2">
+          {/* Says the recap read wrong, which is a correction rather than a
+              refusal: the turn picks it up and asks what was off. */}
+          {onRecap && (
+            <Button
+              variant="ghost"
+              disabled={submitting}
+              onClick={() => {
+                void submit("not_right", answers);
+              }}
+            >
+              {t("watchRetroSurface.somethingOff")}
+            </Button>
+          )}
+
+          {/* The one place the session can be thrown away, next to the thing
+              being thrown away. */}
+          {(onSummary || totalPages === 1) && (
             <Button
               variant="ghost"
               disabled={submitting}
@@ -309,66 +422,91 @@ export function WatchRetroSurface({
                 void submit("discard", answers);
               }}
             >
-              {t("watchRetroSurface.discard")}
+              {t("watchRetroSurface.dontSave")}
             </Button>
-          </div>
-        )}
+          )}
+        </div>
       </div>
+    </Card>
+  );
+}
+
+/** The teaching's own line: how long it took, and how much was seen. */
+function SessionFacts({ eyebrow }: { eyebrow: string }) {
+  return (
+    <div className="flex shrink-0 items-center gap-1.5 pb-2 text-[color:var(--content-quiet)]">
+      <GraduationCap className="h-3.5 w-3.5 shrink-0" />
+      <Typography variant="body-small-default">{eyebrow}</Typography>
     </div>
   );
 }
 
-/** Page one: the account of the session, and nothing to answer. */
-function RecordPage({
+/** Page one: what the session was taught, and nothing to answer. */
+function RecapPage({
   data,
   heading,
+  showEyebrow,
+  showPurpose,
 }: {
   data: WatchRetroSurfaceData;
   heading: string;
+  showEyebrow: boolean;
+  showPurpose: boolean;
 }) {
   return (
     <div>
-      {data.eyebrow && (
-        <div className="flex items-center gap-1.5 text-body-small-default text-[var(--content-quiet)]">
-          <Eye className="h-3.5 w-3.5 shrink-0" />
-          <span>{data.eyebrow}</span>
+      {showEyebrow && data.eyebrow && (
+        <div className="mb-1.5">
+          <SessionFacts eyebrow={data.eyebrow} />
         </div>
       )}
 
-      <div className="mt-1 text-title-small text-[var(--content-strong)]">
+      {/* The one thing to read first. The steps under it are what the page is
+          actually asking about, so nothing else competes for the top. */}
+      <Typography variant="title-medium" as="h3">
         {heading}
-      </div>
+      </Typography>
 
-      {data.purpose && (
-        <p className="mt-1 text-body-medium-lighter text-[var(--content-quiet)]">
+      {showPurpose && data.purpose && (
+        <Typography
+          variant="body-medium-lighter"
+          as="p"
+          className="mt-1.5 text-[color:var(--content-quiet)]"
+        >
           {data.purpose}
-        </p>
+        </Typography>
       )}
 
       {data.steps.length > 0 && (
-        <ol className="mt-3 grid gap-1">
+        <ol className="mt-6 grid gap-2.5">
           {data.steps.map((step, index) => (
             <li
               key={`${index}-${step}`}
-              className="grid grid-cols-[1.25rem_1fr] items-baseline gap-2"
+              className="grid grid-cols-[1.25rem_1fr] items-baseline gap-3"
             >
-              <span className="text-right text-body-small-default tabular-nums text-[var(--content-quiet)]">
+              <Typography
+                variant="body-small-default"
+                className="text-right tabular-nums text-[color:var(--content-quiet)]"
+              >
                 {index + 1}
-              </span>
-              <span className="text-body-medium-default text-[var(--content-default)]">
-                {step}
-              </span>
+              </Typography>
+              <Typography variant="body-medium-default">{step}</Typography>
             </li>
           ))}
         </ol>
       )}
 
       {/* A bounded recording says so here rather than hedging inside the steps:
-          the steps are what was seen, and the gap is a fact about the session. */}
+          the steps are what was taught, and the gap is a fact about the
+          session. */}
       {data.coverage && (
-        <p className="mt-3 text-body-small-default text-[var(--content-quiet)]">
+        <Typography
+          variant="body-small-default"
+          as="p"
+          className="mt-5 text-[color:var(--content-quiet)]"
+        >
           {data.coverage}
-        </p>
+        </Typography>
       )}
     </div>
   );
@@ -393,34 +531,20 @@ function QuestionPage({
 
   return (
     <div>
-      {question.eyebrow && (
-        <div className="text-label-small-default uppercase tracking-wide text-[var(--content-quiet)]">
-          {question.eyebrow}
-        </div>
-      )}
-
       {question.kind === "fill" ? (
-        <label
-          htmlFor={promptId}
-          className="mt-1 block text-title-small text-[var(--content-strong)]"
-        >
+        <Typography variant="title-small" as="label" htmlFor={promptId}>
           {question.prompt}
-        </label>
+        </Typography>
       ) : (
-        <div
-          id={promptId}
-          className="mt-1 text-title-small text-[var(--content-strong)]"
-        >
+        <Typography variant="title-small" as="h3" id={promptId}>
           {question.prompt}
-        </div>
+        </Typography>
       )}
 
       {question.kind === "fill" ? (
-        <div className="mt-3">
-          {/* `Input` is `w-fit` by default, which sizes the box to whatever
-              the suggestion happens to be and clips the rest of it. The
-              trigger phrase is the one thing on this card the user types, and
-              it has to be readable while they edit it. */}
+        <div className="mt-5">
+          {/* `Input` is `w-fit` by default, which sizes the box to whatever the
+              suggestion happens to be and clips the rest of it. */}
           <Input
             id={promptId}
             type="text"
@@ -434,45 +558,128 @@ function QuestionPage({
         </div>
       ) : (
         <div
-          className="mt-3 grid gap-2"
+          className="mt-5 grid gap-2"
           role="group"
           aria-labelledby={promptId}
         >
-          {/* Hand-built rather than a design-library `Button`: an option is a
-              full-width row carrying a label over a secondary note, which no
-              button variant renders. Matches `choice-surface`, whose option
-              rows have the same shape. */}
           {(question.options ?? []).map((option, index) => (
-            <button
+            <ListRow
               key={option.id || `${index}-${option.label}`}
-              type="button"
-              disabled={disabled}
+              title={option.label}
+              subtitle={option.note}
               // The first option is the standing answer until another is
-              // tapped, so it is the one drawn as pressed.
-              aria-pressed={selectedOptionId === option.id}
+              // tapped, so it is the one drawn as selected.
+              selected={selectedOptionId === option.id}
+              disabled={disabled}
+              showChevron={false}
               onClick={() => {
                 onPick(option.id, option.label);
               }}
-              className={cn(
-                "flex w-full cursor-pointer flex-col items-start gap-0.5 rounded-lg p-3 text-left transition-colors disabled:cursor-default disabled:opacity-70",
-                "bg-[var(--surface-overlay)] hover:bg-[var(--surface-active)]",
-                selectedOptionId === option.id
-                  ? "ring-1 ring-[var(--primary-base)]"
-                  : "",
-              )}
-            >
-              <span className="text-body-medium-default text-[var(--content-strong)]">
-                {option.label}
-              </span>
-              {option.note && (
-                <span className="text-body-small-default text-[var(--content-quiet)]">
-                  {option.note}
-                </span>
-              )}
-            </button>
+            />
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * The last page: the skill as it will be saved.
+ *
+ * Every line is the answer to something asked earlier and navigates back to
+ * where it was asked, so changing a decision costs one tap rather than a
+ * restart. The trigger phrase leads because it is the part the user typed and
+ * the part they will have to remember.
+ */
+function SummaryPage({
+  data,
+  questions,
+  answers,
+  disabled,
+  onEdit,
+}: {
+  data: WatchRetroSurfaceData;
+  questions: readonly WatchRetroQuestion[];
+  answers: Record<string, WatchRetroAnswer>;
+  disabled: boolean;
+  onEdit: (pageIndex: number) => void;
+}) {
+  const { t } = useTranslation("chat");
+  const triggerIndex = questions.findIndex(
+    (question) => question.kind === "fill",
+  );
+  const trigger = triggerIndex >= 0 ? questions[triggerIndex] : undefined;
+
+  return (
+    <div>
+      <Typography variant="title-medium" as="h3">
+        {t("watchRetroSurface.summaryTitle")}
+      </Typography>
+
+      {/* What the skill is for, read at the moment the user decides whether to
+          keep it rather than while they are checking the steps. */}
+      {data.purpose && (
+        <Typography
+          variant="body-medium-lighter"
+          as="p"
+          className="mt-1.5 text-[color:var(--content-quiet)]"
+        >
+          {data.purpose}
+        </Typography>
+      )}
+
+      <div className="mt-6 grid gap-1">
+        {trigger && (
+          <ListRow
+            title={t("watchRetroSurface.summarySay")}
+            trailing={
+              <Typography variant="body-medium-default">
+                {answers[trigger.id]?.answer ||
+                  t("watchRetroSurface.summaryUnanswered")}
+              </Typography>
+            }
+            disabled={disabled}
+            onClick={() => {
+              onEdit(triggerIndex + 1);
+            }}
+          />
+        )}
+
+        <ListRow
+          title={t("watchRetroSurface.summarySteps")}
+          trailing={
+            <Typography variant="body-medium-default">
+              {t("watchRetroSurface.stepCount", { count: data.steps.length })}
+            </Typography>
+          }
+          disabled={disabled}
+          onClick={() => {
+            onEdit(0);
+          }}
+        />
+
+        {questions.map((question, index) =>
+          question.kind === "fill" ? null : (
+            <ListRow
+              key={question.id}
+              // The eyebrow is the short name for what the question settled,
+              // which is what a summary line wants. The prompt is the fallback,
+              // and it is a sentence, so it truncates to one line.
+              title={question.eyebrow ?? question.prompt}
+              trailing={
+                <Typography variant="body-medium-default">
+                  {answers[question.id]?.answer ||
+                    t("watchRetroSurface.summaryUnanswered")}
+                </Typography>
+              }
+              disabled={disabled}
+              onClick={() => {
+                onEdit(index + 1);
+              }}
+            />
+          ),
+        )}
+      </div>
     </div>
   );
 }

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1817,11 +1817,21 @@
     "reactionSomeone": "Someone"
   },
   "watchRetroSurface": {
-    "discard": "Discard",
+    "back": "Back",
+    "dontSave": "Don't save",
+    "looksRight": "Looks right",
     "next": "Next",
     "save": "Save skill",
     "skip": "Skip",
-    "thatsIt": "That's it",
+    "somethingOff": "Something's off",
+    "stepCount": "{count, plural, one {# step} other {# steps}}",
+    "stepQuestion": "Question {number}",
+    "stepRecap": "Recap",
+    "stepSummary": "Save",
+    "summarySay": "Say",
+    "summarySteps": "Steps",
+    "summaryTitle": "Ready to save",
+    "summaryUnanswered": "Not set",
     "untitledTask": "What I saw"
   }
 }


### PR DESCRIPTION
Follow-up to #41986, from a design pass on the Watch (teach mode) retro card with @alex-nork in Storybook.

## Why

Dev QA raised seven things at once. Most had one cause: the card drew its own primitives, so it inherited none of the system's spacing, hierarchy or navigation.

| Raised | Now |
|---|---|
| Too tight | `Card padding="lg"`, steps at `gap-2.5`, sections at `mt-6` |
| Too many words in the first three lines | Prompt caps `task` at six words and `purpose` at twelve, and lets the model skip `purpose` |
| Unclear what Discard does | Gone from page one; the keep-or-drop decision is on the summary as **Don't save** |
| "That's it" as a CTA | **Looks right**, with **Something's off** as the counterpart |
| "taught" not "watch(ed)" | Eyebrow reads "Taught in 4 min", graduation-cap icon, and the prompt forbids "watched" |
| Not using the design system | `Card`, `Stepper`, `Typography`, `ListRow` replace a hand-rolled div, bespoke page dots and raw type classes |
| No way to go to a previous step | Visited `Stepper` steps are navigable, plus a `Back` button |
| Wanted a summary before creating | New final step listing trigger, step count and every answer |

## The summary step

Lists the trigger phrase, the step count and each answer, every row navigating back to where it was asked. Once it has been seen the card is in review: changing an answer returns to the summary rather than walking forward through questions already settled.

Writing the test for that caught a flaw in my own first cut, where an edit from the summary walked you forward through the remaining questions. Fixed, and covered.

## Button placement follows the existing convention

The card had its primary on the left with Back and Skip trailing it, the reverse of both precedents:

- `form-surface.tsx:382` (the other paged surface, same folder): `justify-between`, Back left with `ChevronLeft`, primary right with `ChevronRight`.
- `Modal.Footer` / `BottomSheet.Footer`: `justify-end`, primary ordered last in every usage sampled.

Now: Back left, everything else right, primary last.

## Options are the app's single-select, not a divided list

`ListRow` was wrong for options twice over. Its `[&+&]` hairline is meant for a flush settings list, so a divider under a filled row read as a section break, under a rounded corner. And a selection shown only as a background left a middle option looking like a section of its own.

They match `choice-surface` now: separate raised rows, no dividers, and a check mark carrying the selection.

Deliberately **not** a `RadioGroup`, which would otherwise be the systematic answer: Radix moves selection on arrow keys and these options commit on tap, so advancing on change would carry a keyboard user off the page before the third option. A button per option keeps the gesture and leaves Tab/Enter working. `ListRow` stays on the summary, stacked flush, which is what it is for.

## Storybook

Nine stories under **Chat / Surfaces / WatchRetro**, one per state, rendered through `SurfaceRouter` so the template dispatch is covered. Question and summary stories use `play` steps to open on the page under discussion. `UnusableQuestionDropped` carries the real payload that broke in QA, so the degraded case stays visible.

## Notes

- Daemon is unchanged. `Something's off` rides the existing generic custom-action path.
- English catalog only, matching #41912; `fallbackLng` covers the rest.

## Verification

223 tests pass (component + i18n catalogs), typecheck and lint clean on `assistant/` and `clients/web/`, and every story rendered headless to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGAXsbmoKfTJo9E14cC1vc