### PR TITLE
Run the icon drift and web icon tests when native color sources change

### DIFF
--- a/.github/workflows/ci-main-native-drift.yaml
+++ b/.github/workflows/ci-main-native-drift.yaml
@@ -12,11 +12,20 @@ on:
       - 'assistant/src/avatar/**'
       - 'packages/avatar-catalog/**'
       - 'clients/android/app/src/main/res/**'
+      # The per-flavor resources hold each environment's launcher color.
+      - 'clients/android/app/src/dev/res/**'
+      - 'clients/android/app/src/staging/res/**'
+      - 'clients/android/app/src/production/res/**'
       # The generator also owns the manifest's activity-alias block.
       - 'clients/android/app/src/main/AndroidManifest.xml'
       - 'clients/ios/App/App/AppIcon.icon/**'
       - 'clients/ios/App/App/AppIcon-Dev.icon/**'
       - 'clients/ios/App/App/AppIcon-Staging.icon/**'
+      # The xcconfigs name the icon bundle each environment builds against,
+      # and the desktop shells keep their own per-environment icon manifests.
+      - 'clients/ios/App/App/Config/**'
+      - 'clients/macos/build-resources/icons/**'
+      - 'clients/linux/build-resources/icons/**'
       # Both native shells embed the web layer's marketing attribution
       # allowlist; the same drift tests pin the two copies to it.
       - 'clients/web/src/domains/account/social-auth.ts'

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -24,6 +24,14 @@ on:
       # The web LLM catalog parity test reads this file, so daemon-side catalog
       # regenerations must run the web tests too.
       - 'meta/llm-provider-catalog.json'
+      # The app icon row test reads these native color sources off disk, so a
+      # native-only color edit still has to run the web tests.
+      - 'clients/android/app/src/dev/res/values/colors.xml'
+      - 'clients/android/app/src/staging/res/values/colors.xml'
+      - 'clients/android/app/src/production/res/values/colors.xml'
+      - 'clients/ios/App/App/AppIcon.icon/**'
+      - 'clients/ios/App/App/AppIcon-Dev.icon/**'
+      - 'clients/ios/App/App/AppIcon-Staging.icon/**'
       - '.github/workflows/ci-main-web.yaml'
 
 # Serialize runs per branch and cancel superseded in-flight runs — only the

--- a/.github/workflows/pr-native-drift.yaml
+++ b/.github/workflows/pr-native-drift.yaml
@@ -11,11 +11,20 @@ on:
       - 'assistant/src/avatar/**'
       - 'packages/avatar-catalog/**'
       - 'clients/android/app/src/main/res/**'
+      # The per-flavor resources hold each environment's launcher color.
+      - 'clients/android/app/src/dev/res/**'
+      - 'clients/android/app/src/staging/res/**'
+      - 'clients/android/app/src/production/res/**'
       # The generator also owns the manifest's activity-alias block.
       - 'clients/android/app/src/main/AndroidManifest.xml'
       - 'clients/ios/App/App/AppIcon.icon/**'
       - 'clients/ios/App/App/AppIcon-Dev.icon/**'
       - 'clients/ios/App/App/AppIcon-Staging.icon/**'
+      # The xcconfigs name the icon bundle each environment builds against,
+      # and the desktop shells keep their own per-environment icon manifests.
+      - 'clients/ios/App/App/Config/**'
+      - 'clients/macos/build-resources/icons/**'
+      - 'clients/linux/build-resources/icons/**'
       # Both native shells embed the web layer's marketing attribution
       # allowlist; the same drift tests pin the two copies to it.
       - 'clients/web/src/domains/account/social-auth.ts'

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -23,6 +23,14 @@ on:
       # The web LLM catalog parity test reads this file, so daemon-side catalog
       # regenerations must run the web tests on the PR that introduces drift.
       - 'meta/llm-provider-catalog.json'
+      # The app icon row test reads these native color sources off disk, so a
+      # native-only color edit still has to run the web tests.
+      - 'clients/android/app/src/dev/res/values/colors.xml'
+      - 'clients/android/app/src/staging/res/values/colors.xml'
+      - 'clients/android/app/src/production/res/values/colors.xml'
+      - 'clients/ios/App/App/AppIcon.icon/**'
+      - 'clients/ios/App/App/AppIcon-Dev.icon/**'
+      - 'clients/ios/App/App/AppIcon-Staging.icon/**'
       - '.github/workflows/pr-web.yaml'
 
 concurrency:


### PR DESCRIPTION
## Summary
- Both native-drift workflows now watch the Android flavor resource dirs, the iOS Config xcconfigs, and the desktop icon manifests
- pr-web triggers on the native color sources that app-icon-row.test.tsx reads off disk, so a native-only color edit can no longer skip every icon test

Part of plan: standardize-icon-env-colors.md (PR 4 of 4)