### PR TITLE
Canonize the iOS icon P3 encodings and the web ground constants

### DIFF
--- a/clients/ios/App/App/AppIcon-Dev.icon/icon.json
+++ b/clients/ios/App/App/AppIcon-Dev.icon/icon.json
@@ -2,13 +2,13 @@
   "fill-specializations": [
     {
       "value": {
-        "solid": "display-p3:1.00000,0.53333,0.78824,1.00000"
+        "solid": "display-p3:0.93870,0.55755,0.77770,1.00000"
       }
     },
     {
       "appearance": "dark",
       "value": {
-        "solid": "display-p3:1.00000,0.53333,0.78824,1.00000"
+        "solid": "display-p3:0.93870,0.55755,0.77770,1.00000"
       }
     }
   ],

--- a/clients/ios/App/App/AppIcon-Staging.icon/icon.json
+++ b/clients/ios/App/App/AppIcon-Staging.icon/icon.json
@@ -2,13 +2,13 @@
   "fill-specializations": [
     {
       "value": {
-        "solid": "display-p3:0.91373,0.78824,0.10196,1.00000"
+        "solid": "display-p3:0.89313,0.79283,0.28410,1.00000"
       }
     },
     {
       "appearance": "dark",
       "value": {
-        "solid": "display-p3:0.91373,0.78824,0.10196,1.00000"
+        "solid": "display-p3:0.89313,0.79283,0.28410,1.00000"
       }
     }
   ],

--- a/clients/ios/App/App/Config/Extension-Dev.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Dev.xcconfig
@@ -11,10 +11,11 @@ APP_GROUP_ID = group.ai.vocify-inc.vellum-assistant-ios.dev
 BUNDLE_DISPLAY_NAME = Vellum Dev
 BUNDLE_URL_SCHEME = vellum-assistant-dev
 
-// The ground the app's mark is drawn on, which must equal `fill.solid`
-// in `App/AppIcon-Dev.icon/icon.json`: the widget draws the containing app's
-// icon, and this build's icon is not the production one.
-APP_ICON_GROUND = display-p3:1.00000,0.53333,0.78824,1.00000
+// The ground the app's mark is drawn on, which must equal the
+// `fill-specializations` solid in `App/AppIcon-Dev.icon/icon.json`: the widget
+// draws the containing app's icon, and this build's icon is not the production
+// one.
+APP_ICON_GROUND = display-p3:0.93870,0.55755,0.77770,1.00000
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.dev.VoiceActivity
 
 // Exact portal profile name; must equal release-ios.yaml's `ext_profile_name`.

--- a/clients/ios/App/App/Config/Extension-Staging.xcconfig
+++ b/clients/ios/App/App/Config/Extension-Staging.xcconfig
@@ -11,10 +11,11 @@ APP_GROUP_ID = group.ai.vocify-inc.vellum-assistant-ios.staging
 BUNDLE_DISPLAY_NAME = Vellum Staging
 BUNDLE_URL_SCHEME = vellum-assistant-staging
 
-// The ground the app's mark is drawn on, which must equal `fill.solid`
-// in `App/AppIcon-Staging.icon/icon.json`: the widget draws the containing app's
-// icon, and this build's icon is not the production one.
-APP_ICON_GROUND = display-p3:0.91373,0.78824,0.10196,1.00000
+// The ground the app's mark is drawn on, which must equal the
+// `fill-specializations` solid in `App/AppIcon-Staging.icon/icon.json`: the
+// widget draws the containing app's icon, and this build's icon is not the
+// production one.
+APP_ICON_GROUND = display-p3:0.89313,0.79283,0.28410,1.00000
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.staging.VoiceActivity
 
 // Exact portal profile name; must equal release-ios.yaml's `ext_profile_name`.

--- a/clients/ios/App/App/Config/Extension.xcconfig
+++ b/clients/ios/App/App/Config/Extension.xcconfig
@@ -10,9 +10,9 @@ APP_GROUP_ID = group.ai.vocify-inc.vellum-assistant-ios
 BUNDLE_DISPLAY_NAME = Vellum
 BUNDLE_URL_SCHEME = vellum-assistant
 
-// The ground the app's mark is drawn on, which must equal `fill.solid`
-// in `App/AppIcon.icon/icon.json`: the widget draws the containing app's
-// icon, and this build's icon is not the production one.
+// The ground the app's mark is drawn on, which must equal the
+// `fill-specializations` solid in `App/AppIcon.icon/icon.json`: the widget
+// draws the containing app's icon, and each build ships its own.
 APP_ICON_GROUND = display-p3:0.37749,0.60064,0.34581,1.00000
 PRODUCT_BUNDLE_IDENTIFIER = ai.vocify-inc.vellum-assistant-ios.VoiceActivity
 

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -313,12 +313,13 @@ inline in `App/project.yml` under the `AppEnvironment` template.
   width. The six paths in `Assets/eyes.svg` are copied verbatim out of
   `getCharacterComponents().eyeStyles`, keeping the icon and the in-app
   avatars in sync.
-- `AppIcon-Staging.icon` (yellow) and `AppIcon-Dev.icon` (pink) carry the
-  same eyes; only the `fill.solid` colour differs.
-- `fill.solid` is a **Display P3** value, so an sRGB hex has to be
-  converted before it goes in. Pasting the raw sRGB components straight
-  through renders noticeably more saturated than the hex you started
-  from.
+- `AppIcon-Staging.icon` (`#E9C91A`) and `AppIcon-Dev.icon` (`#FF88C9`)
+  carry the same eyes; only the `fill-specializations` colour differs.
+- A bundle's `fill-specializations` solid is a **Display P3** value, so an
+  sRGB hex has to be converted before it goes in. All three bundles carry a
+  true conversion of their hex. Pasting the raw sRGB components straight
+  through renders noticeably more saturated than the hex you started from,
+  which is why the conversion is required rather than optional.
 - `App/App/AvatarIcons.xcassets` holds the alternate icons, one
   `.appiconset` per eye style and color, named `avatar-eyes-<eye>-<color>`.
   Every combination ships: 9 eye styles × 6 colors, so 54 sets. Each set is a

--- a/clients/web/src/components/ios-widget-previews/vellum-app-icon-mark.tsx
+++ b/clients/web/src/components/ios-widget-previews/vellum-app-icon-mark.tsx
@@ -20,8 +20,8 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
 /** The three grounds the Icon Composer bundles declare, in sRGB. */
 export const APP_ICON_GROUNDS = {
-  production: "#4E9857",
-  staging: "#E7C91A",
+  production: "#4C9B50",
+  staging: "#E9C91A",
   dev: "#FF88C9",
 } as const;
 

--- a/clients/web/src/domains/settings/components/app-icon-row.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.test.tsx
@@ -469,9 +469,8 @@ describe("AppIconRow", () => {
       });
     });
 
-    // The two bundles hold sRGB channels in a display-p3 fill, so the readings
-    // are visibly different colors rather than rounding of each other. sRGB is
-    // the closest a renderer that cannot parse `color()` can get.
+    // The bundle fill and the hex name one color in two gamuts, so the sRGB
+    // reading is what a renderer that cannot parse `color()` falls back to.
     test("paints the sRGB ground where color() will not parse", async () => {
       dropDisplayP3Support();
       shellAppId = "ai.vocify-inc.vellum-assistant-ios.dev";

--- a/clients/web/src/domains/settings/components/app-icon-row.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.tsx
@@ -45,20 +45,18 @@ interface IconGround {
 /**
  * Vellum Dev draws its icon on pink, `clients/ios/App/App/AppIcon-Dev.icon`.
  *
- * That bundle declares its fill in display-p3 and holds sRGB channels there
- * rather than the conversion `clients/ios/README.md` asks for, so the installed
- * icon is the more saturated of the two on a wide-gamut screen. Naming the same
- * coordinates keeps the thumbnail from undershooting the icon it depicts;
- * {@link APP_ICON_GROUNDS} carries only the sRGB reading.
+ * That bundle declares its fill as the Display P3 conversion of the sRGB hex
+ * {@link APP_ICON_GROUNDS} carries. Naming the same coordinates draws the
+ * thumbnail in the gamut the installed icon is drawn in.
  */
 const DEV_GROUND: IconGround = {
-  displayP3: "color(display-p3 1 0.53333 0.78824)",
+  displayP3: "color(display-p3 0.9387 0.55755 0.7777)",
   srgb: APP_ICON_GROUNDS.dev,
 };
 
 /** Vellum Staging's yellow, read the same way off `AppIcon-Staging.icon`. */
 const STAGING_GROUND: IconGround = {
-  displayP3: "color(display-p3 0.91373 0.78824 0.10196)",
+  displayP3: "color(display-p3 0.89313 0.79283 0.2841)",
   srgb: APP_ICON_GROUNDS.staging,
 };
 


### PR DESCRIPTION
## Summary
- AppIcon-Dev and AppIcon-Staging fills become true Display P3 conversions of #FF88C9 and #E9C91A, with the Extension xcconfigs in verbatim lockstep, so the rendered icons match their nominal hexes
- APP_ICON_GROUNDS corrects to #4C9B50 / #E9C91A / #FF88C9 and the Settings row's P3 literals follow the bundles
- Conversion method verified by reproducing production's known-good value and round-tripping each new value within 1/255

## Conversion numbers

Method: sRGB EOTF, sRGB-to-XYZ (D65), XYZ-to-Display-P3, P3 OETF, rounded to five decimals.

| Env | sRGB hex | Display P3 |
| --- | --- | --- |
| production (unchanged) | #4C9B50 | `display-p3:0.37749,0.60064,0.34581,1.00000` |
| staging | #E9C91A | `display-p3:0.89313,0.79283,0.28410,1.00000` |
| dev | #FF88C9 | `display-p3:0.93870,0.55755,0.77770,1.00000` |

**Verification 1, production reproduction.** Running #4C9B50 through the method yields 0.37748831, 0.60064212, 0.34581341, which rounds to the committed `0.37749,0.60064,0.34581` exactly. The production bundle and Extension.xcconfig value are byte-identical to base.

**Verification 2, round trips.** Converting each rounded P3 triple back to sRGB returns the original hex, with per-channel error far under 1/255:

| Env | round trip | max channel delta (of 255) |
| --- | --- | --- |
| production | #4C9B50 | 0.0010 |
| staging | #E9C91A | 0.0013 |
| dev | #FF88C9 | 0.0011 |

The old dev and staging bundle values (`1.00000,0.53333,0.78824` and `0.91373,0.78824,0.10196`) were raw sRGB channels pasted into P3 fields, which render oversaturated on a wide-gamut screen.

## Verification

- `cd clients/ios && bun test scripts/__tests__/`: 89 pass, 0 fail (lockstep, dark entries, distinctness, five-decimal spelling)
- `cd clients/web && bun run test:ci -- src/domains/settings/components/app-icon-row.test.tsx src/components/avatar/app-icon-preview.test.tsx`: 2 passed
- `bunx tsc --noEmit` in `clients/web`: no new errors (the remaining ones reproduce identically on the base branch)

Part of plan: standardize-icon-env-colors.md (PR 1 of 4)