### PR TITLE
feat(web): the address form says which contact the channel is going to

### DIFF
--- a/clients/web/src/domains/chat/api/interactions.ts
+++ b/clients/web/src/domains/chat/api/interactions.ts
@@ -297,20 +297,28 @@ export async function submitConfirmation(
 export async function submitContactPrompt(
   assistantId: string,
   requestId: string,
-  address: string,
-  channelType: string,
-  role?: string,
-  displayName?: string,
-  /**
-   * The verify checkbox as the guardian left it. Sent explicitly (rather than
-   * read back from the parked command) so the attest matches the form.
-   */
-  verify?: boolean,
+  input: {
+    address: string;
+    channelType: string;
+    role?: string;
+    /**
+     * The contact the broadcast named. The parked form is what the gateway
+     * binds to; this echo is what it falls back to when it cannot read one.
+     */
+    contactId?: string;
+    /** Name for a contact this address creates, as the guardian left it. */
+    displayName?: string;
+    /**
+     * The verify checkbox as the guardian left it. Sent explicitly (rather than
+     * read back from the parked command) so the attest matches the form.
+     */
+    verify?: boolean;
+  },
 ): Promise<SubmitSecretResponseResult & { duplicate?: boolean }> {
   try {
     const { data, error, response } = await assistantContactsPromptSubmit({
       path: { assistant_id: assistantId },
-      body: { requestId, address, channelType, role, displayName, verify },
+      body: { requestId, ...input },
       throwOnError: false,
     });
     assertHasResponse(response, error, "Failed to submit contact prompt");

--- a/clients/web/src/domains/chat/components/contact-prompt-card.test.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.test.tsx
@@ -79,7 +79,7 @@ describe("ContactPromptCard defaultValue", () => {
 
     fireEvent.click(saveButton());
 
-    expect(onSubmit).toHaveBeenCalledWith("555-0100", "sms", false);
+    expect(onSubmit).toHaveBeenCalledWith("555-0100", "sms", false, undefined);
   });
 
   test("submits the edited address, not the original defaultValue", () => {
@@ -103,7 +103,12 @@ describe("ContactPromptCard defaultValue", () => {
     fireEvent.click(saveButton());
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit).toHaveBeenCalledWith("edited@example.com", "email", false);
+    expect(onSubmit).toHaveBeenCalledWith(
+      "edited@example.com",
+      "email",
+      false,
+      undefined,
+    );
   });
 
   test("keying by requestId resets the address when a new request arrives", () => {
@@ -178,7 +183,12 @@ describe("ContactPromptCard verify checkbox", () => {
 
     expect(verifyBox().getAttribute("data-state")).toBe("checked");
     fireEvent.click(saveButton());
-    expect(onSubmit).toHaveBeenCalledWith("user@example.com", "email", true);
+    expect(onSubmit).toHaveBeenCalledWith(
+      "user@example.com",
+      "email",
+      true,
+      undefined,
+    );
   });
 
   test("unchecking a pre-checked box submits false, so --verify cannot attest behind the guardian", () => {
@@ -199,6 +209,139 @@ describe("ContactPromptCard verify checkbox", () => {
     fireEvent.click(verifyBox());
     fireEvent.click(saveButton());
 
-    expect(onSubmit).toHaveBeenCalledWith("user@example.com", "email", false);
+    expect(onSubmit).toHaveBeenCalledWith(
+      "user@example.com",
+      "email",
+      false,
+      undefined,
+    );
+  });
+});
+
+describe("ContactPromptCard target contact", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("names the contact the channel is being added to", () => {
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        contactRequest={{
+          requestId: "req-1",
+          channel: "email",
+          contactId: "contact-1",
+          contactDisplayName: "Ada Lovelace",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Adding a channel to Ada Lovelace")).toBeTruthy();
+  });
+
+  test("names no contact when the form targets none", () => {
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        contactRequest={{ requestId: "req-2", channel: "email" }}
+      />,
+    );
+
+    expect(screen.queryByText(/Adding a channel to/)).toBeNull();
+  });
+});
+
+describe("ContactPromptCard proposed name", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function nameInput(): HTMLInputElement {
+    return screen.getByPlaceholderText("Name") as HTMLInputElement;
+  }
+
+  test("seeds an editable name field and submits what the guardian left", () => {
+    const onSubmit = mock(noop);
+
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        onSubmit={onSubmit}
+        contactRequest={{
+          requestId: "req-1",
+          channel: "email",
+          displayName: "Ada",
+          placeholder: "Enter email address",
+        }}
+      />,
+    );
+
+    expect(nameInput().value).toBe("Ada");
+
+    fireEvent.change(nameInput(), { target: { value: "Ada Lovelace" } });
+    fireEvent.change(screen.getByPlaceholderText("Enter email address"), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.click(saveButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      "ada@example.com",
+      "email",
+      false,
+      "Ada Lovelace",
+    );
+  });
+
+  test("blanking a proposed name blocks Save, so no contact is created unnamed", () => {
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        contactRequest={{
+          requestId: "req-2",
+          channel: "email",
+          displayName: "Ada",
+          defaultValue: "ada@example.com",
+        }}
+      />,
+    );
+
+    expect(saveButton().disabled).toBe(false);
+    fireEvent.change(nameInput(), { target: { value: "  " } });
+    expect(saveButton().disabled).toBe(true);
+  });
+
+  test("renders no name field when the form proposes none", () => {
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        contactRequest={{
+          requestId: "req-3",
+          channel: "email",
+          defaultValue: "ada@example.com",
+        }}
+      />,
+    );
+
+    expect(screen.queryByPlaceholderText("Name")).toBeNull();
+  });
+
+  test("shows proposed notes read only", () => {
+    render(
+      <ContactPromptCard
+        {...baseProps}
+        contactRequest={{
+          requestId: "req-4",
+          channel: "email",
+          displayName: "Ada",
+          notes: "Met at the analytical engine talk",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Notes")).toBeTruthy();
+    expect(screen.getByText("Met at the analytical engine talk")).toBeTruthy();
+    expect(
+      screen.queryByDisplayValue("Met at the analytical engine talk"),
+    ).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/contact-prompt-card.test.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.test.tsx
@@ -231,12 +231,12 @@ describe("ContactPromptCard target contact", () => {
           requestId: "req-1",
           channel: "email",
           contactId: "contact-1",
-          contactDisplayName: "Ada Lovelace",
+          contactDisplayName: "Alice Chen",
         }}
       />,
     );
 
-    expect(screen.getByText("Adding a channel to Ada Lovelace")).toBeTruthy();
+    expect(screen.getByText("Adding a channel to Alice Chen")).toBeTruthy();
   });
 
   test("names no contact when the form targets none", () => {
@@ -270,15 +270,15 @@ describe("ContactPromptCard proposed name", () => {
         contactRequest={{
           requestId: "req-1",
           channel: "email",
-          displayName: "Ada",
+          displayName: "Alice",
           placeholder: "Enter email address",
         }}
       />,
     );
 
-    expect(nameInput().value).toBe("Ada");
+    expect(nameInput().value).toBe("Alice");
 
-    fireEvent.change(nameInput(), { target: { value: "Ada Lovelace" } });
+    fireEvent.change(nameInput(), { target: { value: "Alice Chen" } });
     fireEvent.change(screen.getByPlaceholderText("Enter email address"), {
       target: { value: "ada@example.com" },
     });
@@ -288,7 +288,7 @@ describe("ContactPromptCard proposed name", () => {
       "ada@example.com",
       "email",
       false,
-      "Ada Lovelace",
+      "Alice Chen",
     );
   });
 
@@ -299,7 +299,7 @@ describe("ContactPromptCard proposed name", () => {
         contactRequest={{
           requestId: "req-2",
           channel: "email",
-          displayName: "Ada",
+          displayName: "Alice",
           defaultValue: "ada@example.com",
         }}
       />,
@@ -332,16 +332,16 @@ describe("ContactPromptCard proposed name", () => {
         contactRequest={{
           requestId: "req-4",
           channel: "email",
-          displayName: "Ada",
-          notes: "Met at the analytical engine talk",
+          displayName: "Alice",
+          notes: "Met at the design review",
         }}
       />,
     );
 
     expect(screen.getByText("Notes")).toBeTruthy();
-    expect(screen.getByText("Met at the analytical engine talk")).toBeTruthy();
+    expect(screen.getByText("Met at the design review")).toBeTruthy();
     expect(
-      screen.queryByDisplayValue("Met at the analytical engine talk"),
+      screen.queryByDisplayValue("Met at the design review"),
     ).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/contact-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.tsx
@@ -10,20 +10,18 @@ import {
 } from "@vellumai/design-library";
 import { useTranslation } from "@/i18n";
 
+import type { PendingContactRequestState } from "@/types/interaction-ui-types";
+
 export interface ContactPromptCardProps {
-  contactRequest: {
-    requestId: string;
-    channel?: string;
-    placeholder?: string;
-    defaultValue?: string;
-    label?: string;
-    description?: string;
-    role?: string;
-    verify?: boolean;
-  };
+  contactRequest: PendingContactRequestState;
   isSubmitting: boolean;
   accepted: boolean;
-  onSubmit: (address: string, channelType: string, verify: boolean) => void;
+  onSubmit: (
+    address: string,
+    channelType: string,
+    verify: boolean,
+    displayName?: string,
+  ) => void;
   onCancel: () => void;
 }
 
@@ -41,7 +39,17 @@ export function ContactPromptCard({
   // The command only proposes this. What the guardian submits is what gets
   // attested, so the box has to be theirs to uncheck.
   const [verify, setVerify] = useState(contactRequest.verify === true);
-  const canSubmit = address.trim().length > 0 && !isSubmitting && !accepted;
+  // A proposed name means this address would create a contact, so the guardian
+  // gets to name it.
+  const proposesName = Boolean(contactRequest.displayName);
+  const [displayName, setDisplayName] = useState(
+    contactRequest.displayName ?? "",
+  );
+  const canSubmit =
+    address.trim().length > 0 &&
+    (!proposesName || displayName.trim().length > 0) &&
+    !isSubmitting &&
+    !accepted;
 
   // Derive a sensible channelType from the hint (free text → normalised key).
   const channelType = contactRequest.channel?.toLowerCase().trim() || "email";
@@ -51,7 +59,12 @@ export function ContactPromptCard({
     if (!canSubmit) {
       return;
     }
-    onSubmit(address.trim(), channelType, verify);
+    onSubmit(
+      address.trim(),
+      channelType,
+      verify,
+      proposesName ? displayName.trim() : undefined,
+    );
   }
 
   return (
@@ -64,6 +77,16 @@ export function ContactPromptCard({
           >
             {contactRequest.label ?? t("contactPromptCard.addContact")}
           </Typography>
+          {contactRequest.contactDisplayName && (
+            <Typography
+              variant="body-small-default"
+              className="text-[var(--content-secondary)]"
+            >
+              {t("contactPromptCard.addingToContact", {
+                name: contactRequest.contactDisplayName,
+              })}
+            </Typography>
+          )}
           {contactRequest.description && (
             <Typography
               variant="body-small-default"
@@ -95,6 +118,32 @@ export function ContactPromptCard({
         </div>
       ) : (
         <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          {proposesName && (
+            <Input
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder={t("contactPromptCard.namePlaceholder")}
+              disabled={isSubmitting}
+            />
+          )}
+          {/* Read only: `contacts update` is where notes are edited. */}
+          {contactRequest.notes && (
+            <div className="flex flex-col gap-1">
+              <Typography
+                variant="label-small-default"
+                className="text-[var(--content-secondary)]"
+              >
+                {t("contactPromptCard.notesLabel")}
+              </Typography>
+              <Typography
+                variant="body-small-default"
+                className="text-[var(--content-secondary)]"
+              >
+                {contactRequest.notes}
+              </Typography>
+            </div>
+          )}
           <Input
             type="text"
             value={address}

--- a/clients/web/src/domains/chat/contact-actions.ts
+++ b/clients/web/src/domains/chat/contact-actions.ts
@@ -56,6 +56,7 @@ export async function handleContactPromptSubmit(
   address: string,
   channelType: string,
   verify: boolean,
+  displayName?: string,
 ): Promise<void> {
   const { pendingContactRequest, submittingByKind } =
     useInteractionStore.getState();
@@ -87,11 +88,14 @@ export async function handleContactPromptSubmit(
     const result = await submitContactPrompt(
       ctx.assistantId,
       pendingContactRequest.requestId,
-      address,
-      channelType,
-      pendingContactRequest.role,
-      undefined,
-      verify,
+      {
+        address,
+        channelType,
+        role: pendingContactRequest.role,
+        contactId: pendingContactRequest.contactId,
+        displayName,
+        verify,
+      },
     );
     if (!result.ok) {
       captureSubmissionRejection("submit_contact_prompt", result);

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
@@ -159,6 +159,10 @@ export function handleContactRequest(
     description: event.description,
     role: event.role,
     verify: event.verify,
+    contactId: event.contactId,
+    contactDisplayName: event.contactDisplayName,
+    displayName: event.displayName,
+    notes: event.notes,
   });
 }
 

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -520,12 +520,15 @@
   },
   "contactPromptCard": {
     "addContact": "Add a contact",
+    "addingToContact": "Adding a channel to {name}",
     "cancel": "Cancel",
     "contactSaved": "Contact saved",
     "dismiss": "Dismiss",
     "enterAddress": "Enter {channel} address",
     "markVerified": "Mark this address verified",
     "markVerifiedHelp": "A verified address is allowed to message your assistant.",
+    "namePlaceholder": "Name",
+    "notesLabel": "Notes",
     "save": "Save",
     "saving": "Saving…"
   },

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -520,12 +520,15 @@
   },
   "contactPromptCard": {
     "addContact": "Añadir un contacto",
+    "addingToContact": "Añadiendo un canal a {name}",
     "cancel": "Cancelar",
     "contactSaved": "Contacto guardado",
     "dismiss": "Descartar",
     "enterAddress": "Introduce la dirección de {channel}",
     "markVerified": "Marcar esta dirección como verificada",
     "markVerifiedHelp": "Una dirección verificada puede enviar mensajes a tu asistente.",
+    "namePlaceholder": "Nombre",
+    "notesLabel": "Notas",
     "save": "Guardar",
     "saving": "Guardando…"
   },

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -270,8 +270,11 @@
     "recordSaveFailed": "Не удалось сохранить контакт. Попробуйте ещё раз."
   },
   "contactPromptCard": {
+    "addingToContact": "Добавление канала для {name}",
     "markVerified": "Отметить этот адрес как подтверждённый",
-    "markVerifiedHelp": "Подтверждённый адрес может писать вашему ассистенту."
+    "markVerifiedHelp": "Подтверждённый адрес может писать вашему ассистенту.",
+    "namePlaceholder": "Имя",
+    "notesLabel": "Заметки"
   },
   "contactRecordCard": {
     "cancel": "Отмена",

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -516,10 +516,13 @@
   },
   "contactPromptCard": {
     "addContact": "新增聯絡人",
+    "addingToContact": "正在為 {name} 新增管道",
     "cancel": "取消",
     "contactSaved": "聯絡人已儲存",
     "dismiss": "關閉",
     "enterAddress": "輸入 {channel} 位址",
+    "namePlaceholder": "名稱",
+    "notesLabel": "備註",
     "save": "儲存",
     "saving": "正在儲存…"
   },

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -516,10 +516,13 @@
   },
   "contactPromptCard": {
     "addContact": "添加联系人",
+    "addingToContact": "正在为 {name} 添加渠道",
     "cancel": "取消",
     "contactSaved": "联系人已保存",
     "dismiss": "忽略",
     "enterAddress": "输入 {channel} 地址",
+    "namePlaceholder": "名称",
+    "notesLabel": "备注",
     "save": "保存",
     "saving": "正在保存…"
   },

--- a/clients/web/src/types/interaction-ui-types.ts
+++ b/clients/web/src/types/interaction-ui-types.ts
@@ -66,6 +66,14 @@ export interface PendingContactRequestState {
    * unverified no matter what the command proposed.
    */
   verify?: boolean;
+  /** The contact this address binds to. Fixed by the command, not by the form. */
+  contactId?: string;
+  /** That contact's current name, so the form can say where the channel is going. */
+  contactDisplayName?: string;
+  /** Proposed name for a contact this form would create. Editable in the form. */
+  displayName?: string;
+  /** Proposed notes for a contact this form would create. */
+  notes?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- The address card names the contact a channel is being added to, so a targeted bind says where it lands instead of showing a bare address box.
- A form that proposes a name renders an editable name field seeded from it and submits what the guardian left; a form that proposes none renders and submits exactly as before.
- Proposed notes render read only under the name, and the submission echoes the target `contactId` to the gateway.

Part of plan: contacts-cli-channel-binding.md (PR 5 of 12)