### PR TITLE
feat(gateway): bind a submitted address to the contact the form targeted

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5672,8 +5672,9 @@ paths:
       operationId: contact_prompt_flags_post
       summary: Read a pending contact prompt's flags and binding target
       description:
-        Returns whether the pending prompt asked the gateway to mark the submitted channel verified, plus the
-        contact the parked form targets, or the name and notes it proposes for a contact to create.
+        Returns whether a form is still parked under this id, whether the pending prompt asked the gateway to mark
+        the submitted channel verified, and the contact the parked form targets, or the name and notes it proposes for a
+        contact to create. known=false means no such form is pending, so nothing it may have targeted can be read.
       tags:
         - contacts
       requestBody:
@@ -5696,6 +5697,9 @@ paths:
               schema:
                 type: object
                 properties:
+                  known:
+                    type: boolean
+                    description: Whether a form is still parked under this requestId. False leaves the target unreadable rather than absent.
                   verify:
                     type: boolean
                   contactId:
@@ -5705,6 +5709,7 @@ paths:
                   notes:
                     type: string
                 required:
+                  - known
                   - verify
                 additionalProperties: false
   /v1/contact-channels/{contactChannelId}:

--- a/assistant/src/runtime/routes/__tests__/contact-address-prompt-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-address-prompt-route.test.ts
@@ -108,7 +108,7 @@ describe("contacts_prompt binding target", () => {
     // submission still resolves by address the way it always has.
     expect(
       promptFlags.handler({ body: { requestId: message.requestId } }),
-    ).toEqual({ verify: false });
+    ).toEqual({ known: true, verify: false });
 
     await settle(pending, message.requestId as string);
   });
@@ -122,6 +122,7 @@ describe("contacts_prompt binding target", () => {
     // Read from the daemon rather than the submission, so a client that
     // predates the field still binds where the command said.
     expect(promptFlags.handler({ body: { requestId } })).toEqual({
+      known: true,
       verify: true,
       contactId: "ct_1",
     });
@@ -136,12 +137,23 @@ describe("contacts_prompt binding target", () => {
     const requestId = parkedRequest().requestId as string;
 
     expect(promptFlags.handler({ body: { requestId } })).toEqual({
+      known: true,
       verify: false,
       displayName: "Bob",
       notes: "Plumber",
     });
 
     await settle(pending, requestId);
+  });
+
+  test("a form this process never parked reads back as unknown", () => {
+    // A restart between the gateway's claim and this read leaves the target
+    // unreadable rather than absent, and the gateway refuses the write rather
+    // than resolving the address itself.
+    expect(promptFlags.handler({ body: { requestId: "req-gone" } })).toEqual({
+      known: false,
+      verify: false,
+    });
   });
 
   test("naming a contact and proposing a new one is refused, and opens no form", async () => {

--- a/assistant/src/runtime/routes/__tests__/contact-address-prompt-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-address-prompt-route.test.ts
@@ -166,4 +166,17 @@ describe("contacts_prompt binding target", () => {
     expect(String(result.error)).toContain("displayName");
     expect(broadcasts).toHaveLength(0);
   });
+
+  test("naming a contact and proposing notes is refused, and opens no form", async () => {
+    // A targeted bind writes no record, so notes riding along would be
+    // reported as saved and dropped.
+    const result = (await addressPrompt.handler({
+      body: { channel: "email", contactId: "ct_1", notes: "Met at the talk" },
+    })) as Record<string, unknown>;
+
+    expect(result.ok).toBe(false);
+    expect(String(result.error)).toContain("contactId");
+    expect(String(result.error)).toContain("notes");
+    expect(broadcasts).toHaveLength(0);
+  });
 });

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -364,20 +364,29 @@ const PARKED_TARGET_KEYS = ["contactId", "displayName", "notes"] as const;
  * Read-only state for a pending prompt. The gateway asks this before it writes,
  * so the flag and the binding target come from the parked form rather than from
  * whatever the submitting client knew to echo.
+ *
+ * `known` says whether a form is still parked under the id. A restart between
+ * the gateway's claim and this read leaves a form this process never saw, and
+ * without the flag it answers exactly like one that parked no target, which
+ * would leave the gateway resolving the address by itself.
  */
 function readContactPromptFlags({
   body = {},
-}: RouteHandlerArgs): ParkedPromptTarget & { verify: boolean } {
+}: RouteHandlerArgs): ParkedPromptTarget & { verify: boolean; known: boolean } {
   const { requestId } = ContactPromptFlagsParams.parse(body);
-  const meta = getGuardianFormMeta(requestId) ?? {};
+  const meta = getGuardianFormMeta(requestId);
   const target: ParkedPromptTarget = {};
   for (const key of PARKED_TARGET_KEYS) {
-    const value = meta[key];
+    const value = meta?.[key];
     if (typeof value === "string") {
       target[key] = value;
     }
   }
-  return { verify: meta.verify === true, ...target };
+  return {
+    known: meta !== undefined,
+    verify: meta?.verify === true,
+    ...target,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -481,10 +490,15 @@ export const CONTACT_PROMPT_ROUTES: RouteDefinition[] = [
     handler: readContactPromptFlags,
     summary: "Read a pending contact prompt's flags and binding target",
     description:
-      "Returns whether the pending prompt asked the gateway to mark the submitted channel verified, plus the contact the parked form targets, or the name and notes it proposes for a contact to create.",
+      "Returns whether a form is still parked under this id, whether the pending prompt asked the gateway to mark the submitted channel verified, and the contact the parked form targets, or the name and notes it proposes for a contact to create. known=false means no such form is pending, so nothing it may have targeted can be read.",
     tags: ["contacts"],
     requestBody: ContactPromptFlagsParams,
     responseBody: z.object({
+      known: z
+        .boolean()
+        .describe(
+          "Whether a form is still parked under this requestId. False leaves the target unreadable rather than absent.",
+        ),
       verify: z.boolean(),
       contactId: z.string().optional(),
       displayName: z.string().optional(),

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -240,11 +240,11 @@ async function handleContactPrompt({
     timeoutMs,
   } = ContactPromptParams.parse(body);
 
-  if (contactId && displayName) {
+  if (contactId && (displayName !== undefined || notes !== undefined)) {
     return {
       ok: false,
       error:
-        "Pass either contactId (bind to an existing contact) or displayName (create a new one), not both.",
+        "Pass either contactId (bind to an existing contact) or displayName and notes (create a new one), not both. A contact that already exists is edited with 'assistant contacts update'.",
     };
   }
 

--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Vellum Gateway API",
-    "version": "0.11.7",
+    "version": "0.11.8",
     "description": "Auto-generated OpenAPI specification for the Vellum Gateway HTTP endpoints."
   },
   "servers": [{ "url": "", "description": "Same-origin (gateway)" }],
@@ -1352,6 +1352,10 @@
                   },
                   "role": { "type": "string" },
                   "displayName": { "type": "string" },
+                  "contactId": {
+                    "description": "The contact the parked form targets, echoed back from the broadcast. The parked form is authoritative.",
+                    "type": "string"
+                  },
                   "verify": {
                     "description": "The form's 'mark verified' checkbox as the guardian left it. Omit only from clients that predate the checkbox; the parked command's flag is then used instead.",
                     "type": "boolean"

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -32,6 +32,12 @@ initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 const ipcThrowOn = new Map<string, Error>();
 
 /**
+ * What `contact_prompt_flags` reports the parked form was opened with: the
+ * verify flag and the contact the command targeted. Set per test.
+ */
+let parkedFlags: Record<string, unknown> = {};
+
+/**
  * The gateway claims a form before writing, so every submission in this suite
  * needs the claim granted unless the test is about losing it. Shared with the
  * per-test overrides below so none of them can drop it by omission.
@@ -39,6 +45,9 @@ const ipcThrowOn = new Map<string, Error>();
 function defaultIpcResponse(method: string): Record<string, unknown> {
   if (method === "contact_prompt_claim") {
     return { claimed: true, settleMs: 180_000 };
+  }
+  if (method === "contact_prompt_flags") {
+    return { ...parkedFlags };
   }
   return { resolved: true };
 }
@@ -143,6 +152,7 @@ beforeEach(() => {
     return defaultIpcResponse(method);
   });
   ipcThrowOn.clear();
+  parkedFlags = {};
 
   const gwDb = getGatewayDb();
   gwDb.delete(gwContactChannels).run();
@@ -216,12 +226,7 @@ describe("handleContactPromptSubmit", () => {
 
   test("guardian prompt — --verify attests the submitted channel", async () => {
     seedGuardian();
-    ipcMock.mockImplementation(async (method: string) => {
-      if (method === "contact_prompt_flags") {
-        return { resolved: true, verify: true };
-      }
-      return defaultIpcResponse(method);
-    });
+    parkedFlags = { verify: true };
 
     const res = await handleContactPromptSubmit(
       makeRequest({
@@ -314,15 +319,10 @@ describe("handleContactPromptSubmit", () => {
     expect(callsFor(ipcMock, "resolve_contact_prompt")).toHaveLength(0);
   });
 
-  test("submitted verify:true attests without reading the parked flag", async () => {
+  test("submitted verify:true attests over a parked flag that says no", async () => {
     seedGuardian();
     // The parked flag says no. The form says yes, and the form is the answer.
-    ipcMock.mockImplementation(async (method: string) => {
-      if (method === "contact_prompt_flags") {
-        return { resolved: true, verify: false };
-      }
-      return defaultIpcResponse(method);
-    });
+    parkedFlags = { verify: false };
 
     const res = await handleContactPromptSubmit(
       makeRequest({
@@ -341,7 +341,6 @@ describe("handleContactPromptSubmit", () => {
       .where(eq(gwContactChannels.address, "+12025550143"))
       .get();
     expect(channel!.verifiedVia).toBe("manual");
-    expect(callsFor(ipcMock, "contact_prompt_flags")).toHaveLength(0);
   });
 
   test("the resolve reports what the channel actually is, not what was asked", async () => {
@@ -424,12 +423,7 @@ describe("handleContactPromptSubmit", () => {
   test("submitted verify:false leaves the channel unverified even when the command asked for --verify", async () => {
     seedGuardian();
     // The guardian unchecked the box the command pre-checked. Their answer wins.
-    ipcMock.mockImplementation(async (method: string) => {
-      if (method === "contact_prompt_flags") {
-        return { resolved: true, verify: true };
-      }
-      return defaultIpcResponse(method);
-    });
+    parkedFlags = { verify: true };
 
     const res = await handleContactPromptSubmit(
       makeRequest({
@@ -448,7 +442,6 @@ describe("handleContactPromptSubmit", () => {
       .where(eq(gwContactChannels.address, "+12025550144"))
       .get();
     expect(channel!.verifiedVia).toBeNull();
-    expect(callsFor(ipcMock, "contact_prompt_flags")).toHaveLength(0);
   });
 
   test("guardian prompt — reuses channel already bound to guardian", async () => {
@@ -1151,5 +1144,228 @@ describe("handleContactPromptSubmit", () => {
 
     // Committed bind on an existing guardian — caches invalidated despite 500.
     expectEmittedContactsChanged(ipcMock);
+  });
+  // -------------------------------------------------------------------------
+  // Targeted binds: the parked form says which contact the address is for.
+  // -------------------------------------------------------------------------
+
+  function seedContact(id: string, name: string): void {
+    const now = Date.now();
+    getGatewayDb()
+      .insert(gwContacts)
+      .values({
+        id,
+        displayName: name,
+        role: "contact",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  function seedChannel(id: string, contactId: string, address: string): void {
+    const now = Date.now();
+    getGatewayDb()
+      .insert(gwContactChannels)
+      .values({
+        id,
+        contactId,
+        type: "email",
+        address,
+        isPrimary: true,
+        status: "unverified",
+        policy: "allow",
+        interactionCount: 0,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  test("targeted bind: attaches the channel to the contact the form named", async () => {
+    seedContact("c-alice", "Alice");
+    parkedFlags = { contactId: "c-alice" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-target",
+        address: "alice.work@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    // The address joins the named contact instead of minting a duplicate
+    // named after itself.
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+    const channels = getGatewayDb().select().from(gwContactChannels).all();
+    expect(channels).toHaveLength(1);
+    expect(channels[0].contactId).toBe("c-alice");
+
+    const ipcCall = resolveCall(ipcMock);
+    expect(ipcCall.body.contactId).toBe("c-alice");
+    expect(ipcCall.body.channelId).toBe(channels[0].id);
+    expectEmittedContactsChanged(ipcMock);
+  });
+
+  test("targeted bind: reuses a channel the target already holds", async () => {
+    seedContact("c-alice", "Alice");
+    seedChannel("chan-alice", "c-alice", "alice@example.com");
+    parkedFlags = { contactId: "c-alice" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-target-reuse",
+        address: "alice@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const channels = getGatewayDb().select().from(gwContactChannels).all();
+    expect(channels).toHaveLength(1);
+    expect(channels[0].id).toBe("chan-alice");
+    expect(resolveCall(ipcMock).body.channelId).toBe("chan-alice");
+  });
+
+  test("targeted bind: 409 naming the contact the address belongs to", async () => {
+    seedContact("c-alice", "Alice");
+    seedContact("c-bob", "Bob");
+    seedChannel("chan-bob", "c-bob", "bob@example.com");
+    parkedFlags = { contactId: "c-alice" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-target-conflict",
+        address: "bob@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toContain('"Bob"');
+    expect(body.error).toContain("c-bob");
+    expect(body.error).toContain("assistant contacts merge");
+
+    // Nothing moved: the channel still belongs to Bob and no channel was
+    // minted for the target.
+    const channels = getGatewayDb().select().from(gwContactChannels).all();
+    expect(channels).toHaveLength(1);
+    expect(channels[0].contactId).toBe("c-bob");
+    expect(callsFor(ipcMock, "contacts_mirror_upsert_full")).toHaveLength(0);
+    expect(typeof resolveCall(ipcMock).body.error).toBe("string");
+    expectNoEmit(ipcMock);
+  });
+
+  test("targeted bind: 404 for an id no contact has, minting nothing", async () => {
+    parkedFlags = { contactId: "no-such-contact" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-target-missing",
+        address: "ghost@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toContain("no-such-contact");
+    expect(body.error).toContain("assistant contacts list");
+
+    // An unknown explicit id is an INSERT in ContactStore, so the guard is
+    // what keeps a typo from minting a contact named after the address.
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(0);
+    expect(getGatewayDb().select().from(gwContactChannels).all()).toHaveLength(
+      0,
+    );
+    expectNoEmit(ipcMock);
+  });
+
+  test("targeted bind: an unreadable parked target falls back to the client's echo", async () => {
+    seedContact("c-alice", "Alice");
+    ipcThrowOn.set("contact_prompt_flags", new Error("daemon unreachable"));
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-target-echo",
+        address: "alice.echo@example.com",
+        channelType: "email",
+        contactId: "c-alice",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+    const channels = getGatewayDb().select().from(gwContactChannels).all();
+    expect(channels).toHaveLength(1);
+    expect(channels[0].contactId).toBe("c-alice");
+  });
+
+  test("named create: the contact takes the proposed name and notes, not the address", async () => {
+    parkedFlags = { displayName: "Alice", notes: "Neighbour" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-named-create",
+        address: "alice@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const contacts = getGatewayDb().select().from(gwContacts).all();
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].displayName).toBe("Alice");
+
+    // Notes are assistant-owned, so they reach the DB over the mirror op.
+    const mirror = callsFor(ipcMock, "contacts_mirror_upsert_full");
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].body.displayName).toBe("Alice");
+    expect(mirror[0].body.notes).toBe("Neighbour");
+  });
+
+  test("named create: the name the guardian left in the form wins over the parked one", async () => {
+    parkedFlags = { displayName: "Alice" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-named-edited",
+        address: "alice.edited@example.com",
+        channelType: "email",
+        displayName: "Alice Green",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const contacts = getGatewayDb().select().from(gwContacts).all();
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].displayName).toBe("Alice Green");
+  });
+
+  test("named create: 409 rather than renaming the contact that holds the address", async () => {
+    seedContact("c-bob", "Bob");
+    seedChannel("chan-bob", "c-bob", "bob@example.com");
+    parkedFlags = { displayName: "Alice" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-named-conflict",
+        address: "bob@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toContain('"Bob"');
+
+    // An upsert matching on the channel would have renamed Bob to Alice.
+    const contacts = getGatewayDb().select().from(gwContacts).all();
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].displayName).toBe("Bob");
+    expectNoEmit(ipcMock);
   });
 });

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -1211,6 +1211,27 @@ describe("handleContactPromptSubmit", () => {
     expectEmittedContactsChanged(ipcMock);
   });
 
+  test("targeted bind: the mirror repair carries the target's stored name", async () => {
+    seedContact("c-alice", "Alice Chen");
+    parkedFlags = { known: true, verify: false, contactId: "c-alice" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-target-mirror-name",
+        address: "alice.mirror@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    // The mirror row can be missing, and its create path names a contact after
+    // the channel address when the op carries no name.
+    const mirror = callsFor(ipcMock, "contacts_mirror_upsert_full");
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].body.contactId).toBe("c-alice");
+    expect(mirror[0].body.displayName).toBe("Alice Chen");
+  });
+
   test("targeted bind: reuses a channel the target already holds", async () => {
     seedContact("c-alice", "Alice");
     seedChannel("chan-alice", "c-alice", "alice@example.com");

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -1304,6 +1304,39 @@ describe("handleContactPromptSubmit", () => {
     expect(channels[0].contactId).toBe("c-alice");
   });
 
+  test("targeted bind: the named target wins over a submitted guardian role", async () => {
+    seedGuardian();
+    seedContact("c-alice", "Alice");
+    parkedFlags = { contactId: "c-alice" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-target-over-role",
+        address: "alice.role@example.com",
+        channelType: "email",
+        role: "guardian",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    // The card named Alice, so the address is Alice's; a role the client sent
+    // alongside it must not hand the address guardian identity.
+    const channels = getGatewayDb().select().from(gwContactChannels).all();
+    expect(channels).toHaveLength(1);
+    expect(channels[0].contactId).toBe("c-alice");
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContactChannels)
+        .where(eq(gwContactChannels.contactId, "guardian-1"))
+        .all(),
+    ).toHaveLength(0);
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(2);
+
+    expect(resolveCall(ipcMock).body.contactId).toBe("c-alice");
+  });
+
   test("named create: the contact takes the proposed name and notes, not the address", async () => {
     parkedFlags = { displayName: "Alice", notes: "Neighbour" };
 
@@ -1325,6 +1358,28 @@ describe("handleContactPromptSubmit", () => {
     expect(mirror).toHaveLength(1);
     expect(mirror[0].body.displayName).toBe("Alice");
     expect(mirror[0].body.notes).toBe("Neighbour");
+  });
+
+  test("parked notes are kept when the form proposes no name", async () => {
+    parkedFlags = { notes: "Neighbour" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-notes-only",
+        address: "neighbour@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+
+    // Notes and name are independently optional, so a nameless confirmation
+    // still carries the notes the guardian saw over the mirror op.
+    const mirror = callsFor(ipcMock, "contacts_mirror_upsert_full");
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].body.notes).toBe("Neighbour");
+    expect(mirror[0].body.displayName).toBeUndefined();
   });
 
   test("named create: the name the guardian left in the form wins over the parked one", async () => {

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -1306,6 +1306,31 @@ describe("handleContactPromptSubmit", () => {
     expect(channels[0].contactId).toBe("c-alice");
   });
 
+  test("targeted bind: a readable untargeted form ignores an echoed contact id", async () => {
+    seedContact("c-alice", "Alice");
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-echo-injection",
+        address: "stranger@example.com",
+        channelType: "email",
+        contactId: "c-alice",
+      }),
+    );
+
+    // The form named no target, so the address gets its own contact. Honoring
+    // the echo here would let a stale or crafted submission attach an address
+    // to a contact the guardian's card never showed.
+    expect(res.status).toBe(200);
+    const aliceChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.contactId, "c-alice"))
+      .all();
+    expect(aliceChannels).toHaveLength(0);
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(2);
+  });
+
   test("targeted bind: 503 when neither the parked target nor an echo says who to bind", async () => {
     seedContact("c-alice", "Alice");
     ipcThrowOn.set("contact_prompt_flags", new Error("daemon unreachable"));

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -47,7 +47,9 @@ function defaultIpcResponse(method: string): Record<string, unknown> {
     return { claimed: true, settleMs: 180_000 };
   }
   if (method === "contact_prompt_flags") {
-    return { ...parkedFlags };
+    // A daemon still holding the form reports known:true alongside whatever it
+    // parked. A test overrides it to stand in for one that has forgotten it.
+    return { known: true, ...parkedFlags };
   }
   return { resolved: true };
 }
@@ -1453,5 +1455,92 @@ describe("handleContactPromptSubmit", () => {
     expect(contacts).toHaveLength(1);
     expect(contacts[0].displayName).toBe("Bob");
     expectNoEmit(ipcMock);
+  });
+
+  test("503 when the daemon no longer holds the form and no echo says who to bind", async () => {
+    seedContact("c-alice", "Alice");
+    // A restart between the claim and this read leaves a daemon that answers
+    // the flags call successfully about a form it knows nothing about.
+    parkedFlags = { known: false };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-forgotten",
+        address: "mystery@example.com",
+        channelType: "email",
+      }),
+    );
+
+    // Read as "no target parked", the address would resolve itself and could
+    // land on a contact the guardian's card never named.
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(false);
+    expect(body.error).toContain("Nothing was written");
+
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+    expect(getGatewayDb().select().from(gwContactChannels).all()).toHaveLength(
+      0,
+    );
+    expect(callsFor(ipcMock, "contacts_mirror_upsert_full")).toHaveLength(0);
+    expectNoEmit(ipcMock);
+    expect(resolveCall(ipcMock).body.error).toContain("Nothing was written");
+  });
+
+  test("parked notes with no proposed name: 409 rather than rewriting the notes of the contact that holds the address", async () => {
+    seedContact("c-bob", "Bob");
+    seedChannel("chan-bob", "c-bob", "bob@example.com");
+    parkedFlags = { notes: "Neighbour" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-notes-conflict",
+        address: "bob@example.com",
+        channelType: "email",
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toContain('"Bob"');
+    expect(body.error).toContain("assistant contacts merge");
+
+    // Notes are assistant-owned, so an upsert resolving the address to Bob
+    // would have overwritten his over the mirror op.
+    expect(callsFor(ipcMock, "contacts_mirror_upsert_full")).toHaveLength(0);
+    expect(callsFor(ipcMock, "contacts_mirror_upsert_contact")).toHaveLength(0);
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+    expect(getGatewayDb().select().from(gwContactChannels).all()).toHaveLength(
+      1,
+    );
+    expectNoEmit(ipcMock);
+  });
+
+  test("guardian bootstrap takes the parked name and notes, not the address", async () => {
+    parkedFlags = { displayName: "Vargas", notes: "Lives upstairs" };
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-guardian-parked",
+        address: "vargas@example.com",
+        channelType: "email",
+        role: "guardian",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    // A client with nowhere to type a name still bootstraps the guardian under
+    // the one the form proposed, rather than under the address.
+    const contacts = getGatewayDb().select().from(gwContacts).all();
+    expect(contacts).toHaveLength(1);
+    expect(contacts[0].role).toBe("guardian");
+    expect(contacts[0].displayName).toBe("Vargas");
+
+    // Notes are assistant-owned, so they reach the DB over the mirror op.
+    const mirror = callsFor(ipcMock, "contacts_mirror_upsert_contact");
+    expect(mirror).toHaveLength(1);
+    expect(mirror[0].body.displayName).toBe("Vargas");
+    expect(mirror[0].body.notes).toBe("Lives upstairs");
   });
 });

--- a/gateway/src/__tests__/contact-prompt-submit.test.ts
+++ b/gateway/src/__tests__/contact-prompt-submit.test.ts
@@ -1304,6 +1304,37 @@ describe("handleContactPromptSubmit", () => {
     expect(channels[0].contactId).toBe("c-alice");
   });
 
+  test("targeted bind: 503 when neither the parked target nor an echo says who to bind", async () => {
+    seedContact("c-alice", "Alice");
+    ipcThrowOn.set("contact_prompt_flags", new Error("daemon unreachable"));
+
+    const res = await handleContactPromptSubmit(
+      makeRequest({
+        requestId: "req-target-unreadable",
+        address: "mystery@example.com",
+        channelType: "email",
+      }),
+    );
+
+    // An untargeted form is indistinguishable from one whose target could not
+    // be read, so resolving from the address could bind it to somebody the
+    // guardian's card never named.
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(false);
+    expect(body.error).toContain("Nothing was written");
+
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+    expect(getGatewayDb().select().from(gwContactChannels).all()).toHaveLength(
+      0,
+    );
+    expect(callsFor(ipcMock, "contacts_mirror_upsert_full")).toHaveLength(0);
+    expectNoEmit(ipcMock);
+
+    // The parked command hears why, rather than sitting until its settle timer.
+    expect(resolveCall(ipcMock).body.error).toContain("Nothing was written");
+  });
+
   test("targeted bind: the named target wins over a submitted guardian role", async () => {
     seedGuardian();
     seedContact("c-alice", "Alice");

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -192,8 +192,8 @@ export async function handleContactPromptSubmit(
  *
  * Read from the daemon rather than taken from the client, so a client that
  * does not send the target fields still binds where the command said. Returns
- * null when the daemon could not be reached; the caller then falls back to
- * whatever the client echoed.
+ * null when the daemon could not be reached, which leaves the client's echo as
+ * the only thing the caller has to bind by.
  */
 async function readParkedPromptTarget(requestId: string): Promise<{
   verify?: boolean;
@@ -214,7 +214,7 @@ async function readParkedPromptTarget(requestId: string): Promise<{
   } catch (err) {
     log.warn(
       { err, requestId },
-      "contact-prompt-submit: contact_prompt_flags IPC failed; falling back to what the client submitted",
+      "contact-prompt-submit: contact_prompt_flags IPC failed; the parked target is unreadable",
     );
     return null;
   }
@@ -241,6 +241,27 @@ async function bindSubmittedChannel(input: {
     canonicalizeInboundIdentity(channelType, address) ?? address.trim();
 
   const parked = await readParkedPromptTarget(requestId);
+
+  // An untargeted form and a targeted one whose target cannot be read look
+  // identical from here, so resolving from the address risks handing the
+  // address to a contact other than the one the guardian's card named. The
+  // claim this write holds was granted moments ago, which makes an unreadable
+  // target an anomaly worth refusing: nothing is written and the guardian can
+  // submit again.
+  if (parked === null && !input.contactId) {
+    log.error(
+      { requestId, channelType, address: normalizedAddress },
+      "contact-prompt-submit: the parked target is unreadable and the client echoed none",
+    );
+    return {
+      failure: {
+        error:
+          "Could not read the form's target from the assistant. Nothing was written; try again.",
+        status: 503,
+      },
+    };
+  }
+
   const parkedVerify = parked?.verify;
   // The command fixes the target and the form cannot edit it, so the parked
   // value leads and the client's echo stands in for a read that failed. The
@@ -249,13 +270,6 @@ async function bindSubmittedChannel(input: {
   const targetContactId = parked?.contactId ?? input.contactId;
   const proposedName = displayName ?? parked?.displayName;
   const proposedNotes = parked?.notes;
-
-  if (parked === null && !input.contactId) {
-    log.error(
-      { requestId, channelType, address: normalizedAddress },
-      "contact-prompt-submit: the parked target is unreadable and the client echoed none; resolving the contact from the address",
-    );
-  }
 
   try {
     // A named target decides the bind, whatever role the client sent: the form

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -187,6 +187,19 @@ export async function handleContactPromptSubmit(
   });
 }
 
+/** What the daemon reports a parked address form was opened with. */
+interface ParkedPromptTarget {
+  /**
+   * Whether a form is still parked under the id. A daemon that predates the
+   * field sends none, so only an explicit false says the form is gone.
+   */
+  known?: boolean;
+  verify?: boolean;
+  contactId?: string;
+  displayName?: string;
+  notes?: string;
+}
+
 /**
  * What the parked form says this submission is for.
  *
@@ -195,22 +208,14 @@ export async function handleContactPromptSubmit(
  * null when the daemon could not be reached, which leaves the client's echo as
  * the only thing the caller has to bind by.
  */
-async function readParkedPromptTarget(requestId: string): Promise<{
-  verify?: boolean;
-  contactId?: string;
-  displayName?: string;
-  notes?: string;
-} | null> {
+async function readParkedPromptTarget(
+  requestId: string,
+): Promise<ParkedPromptTarget | null> {
   try {
     const result = await ipcCallAssistant("contact_prompt_flags", {
       body: { requestId },
     });
-    return result as {
-      verify?: boolean;
-      contactId?: string;
-      displayName?: string;
-      notes?: string;
-    };
+    return result as ParkedPromptTarget;
   } catch (err) {
     log.warn(
       { err, requestId },
@@ -247,10 +252,12 @@ async function bindSubmittedChannel(input: {
   // address to a contact other than the one the guardian's card named. The
   // claim this write holds was granted moments ago, which makes an unreadable
   // target an anomaly worth refusing: nothing is written and the guardian can
-  // submit again.
-  if (parked === null && !input.contactId) {
+  // submit again. A daemon holding no such form answers known:false, which is
+  // what a restart between the claim and this read leaves behind.
+  const parkedTargetUnreadable = parked === null || parked.known === false;
+  if (parkedTargetUnreadable && !input.contactId) {
     log.error(
-      { requestId, channelType, address: normalizedAddress },
+      { requestId, channelType, address: normalizedAddress, parked },
       "contact-prompt-submit: the parked target is unreadable and the client echoed none",
     );
     return {
@@ -309,16 +316,19 @@ async function bindSubmittedChannel(input: {
         requestId,
         channelType,
         address: normalizedAddress,
-        displayName,
+        displayName: proposedName,
+        notes: proposedNotes,
         verify: input.verify,
         parkedVerify,
       });
     }
 
-    // A proposed name creates the contact under it. An address another contact
-    // already holds is a conflict here, rather than the silent rename of that
-    // contact an upsert matching on the channel would do.
-    if (proposedName) {
+    // Any proposal is intent to create the contact, so the address turning out
+    // to belong to somebody else is a conflict here rather than the silent
+    // rewrite of that contact an upsert matching on the channel would do.
+    // Notes count as a proposal: they land on whichever contact the upsert
+    // resolves to, which for a matched address is a bystander's record.
+    if (proposedName !== undefined || proposedNotes !== undefined) {
       const existingChannel = findChannelByAddress(
         channelType,
         normalizedAddress,
@@ -351,12 +361,12 @@ async function bindSubmittedChannel(input: {
       });
     }
 
+    // Nothing was proposed, so the address speaks for itself: the contact that
+    // holds it, or a new one named after it.
     return await bindAddressToItsOwnContact({
       requestId,
       channelType,
       address: normalizedAddress,
-      displayName,
-      notes: proposedNotes,
       verify: input.verify,
       parkedVerify,
     });
@@ -369,16 +379,21 @@ async function bindSubmittedChannel(input: {
 /**
  * Bind the address to the guardian contact, minting that contact when
  * bootstrap has not yet run. There must only ever be one.
+ *
+ * The proposed name and notes seed a guardian this bind mints. A guardian that
+ * already exists keeps both: the form is about the address, and rewriting the
+ * record behind it is what `contacts update` confirms separately.
  */
 async function bindGuardianChannel(args: {
   requestId: string;
   channelType: string;
   address: string;
   displayName?: string;
+  notes?: string;
   verify: boolean | undefined;
   parkedVerify: boolean | undefined;
 }): Promise<GuardianFormWriteOutcome> {
-  const { requestId, channelType, address, displayName } = args;
+  const { requestId, channelType, address, displayName, notes } = args;
 
   // The guardian lives in the gateway DB (source of truth), so resolve from
   // there rather than from the assistant mirror.
@@ -430,6 +445,9 @@ async function bindGuardianChannel(args: {
         contactId,
         displayName: effectiveDisplayName,
         contactType: "human",
+        // Notes are assistant-owned, so the mirror is the only side that has
+        // a column for them.
+        notes,
       },
     });
   } catch (mirrorErr) {

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -101,6 +101,11 @@ interface ContactPromptSubmitBody {
    * {@link promptWantsVerify}).
    */
   verify?: boolean;
+  /**
+   * The contact the broadcast named as the binding target, echoed back. The
+   * parked form is authoritative; this stands in when it cannot be read.
+   */
+  contactId?: string;
   /** The guardian dismissed the form. Unblocks the waiting call without writing. */
   cancelled?: boolean;
 }
@@ -128,6 +133,10 @@ export async function handleContactPromptSubmit(
   // value through to the NOT NULL display_name column (which would 500).
   const displayName =
     typeof body.displayName === "string" ? body.displayName : undefined;
+  // A non-string contactId reads as omitted, leaving the parked form to say
+  // what this submission binds to.
+  const echoedContactId =
+    typeof body.contactId === "string" ? body.contactId : undefined;
 
   if (!requestId || typeof requestId !== "string") {
     return Response.json(
@@ -172,9 +181,43 @@ export async function handleContactPromptSubmit(
         channelType,
         role,
         displayName,
+        contactId: echoedContactId,
         verify: body.verify,
       }),
   });
+}
+
+/**
+ * What the parked form says this submission is for.
+ *
+ * Read from the daemon rather than taken from the client, so a client that
+ * does not send the target fields still binds where the command said. Returns
+ * null when the daemon could not be reached; the caller then falls back to
+ * whatever the client echoed.
+ */
+async function readParkedPromptTarget(requestId: string): Promise<{
+  verify?: boolean;
+  contactId?: string;
+  displayName?: string;
+  notes?: string;
+} | null> {
+  try {
+    const result = await ipcCallAssistant("contact_prompt_flags", {
+      body: { requestId },
+    });
+    return result as {
+      verify?: boolean;
+      contactId?: string;
+      displayName?: string;
+      notes?: string;
+    };
+  } catch (err) {
+    log.warn(
+      { err, requestId },
+      "contact-prompt-submit: contact_prompt_flags IPC failed; falling back to what the client submitted",
+    );
+    return null;
+  }
 }
 
 /**
@@ -189,280 +232,456 @@ async function bindSubmittedChannel(input: {
   channelType: string;
   role?: "guardian" | "trusted-contact" | "unknown";
   displayName?: string;
+  contactId?: string;
   verify?: boolean;
 }): Promise<GuardianFormWriteOutcome> {
   const { requestId, address, channelType, role, displayName } = input;
 
   const normalizedAddress =
     canonicalizeInboundIdentity(channelType, address) ?? address.trim();
-  const effectiveDisplayName = displayName ?? normalizedAddress;
-  const isGuardian = role === "guardian";
-  const now = Date.now();
 
-  let contactId: string;
-  let channelId: string;
+  const parked = await readParkedPromptTarget(requestId);
+  const parkedVerify = parked?.verify;
+  // The command fixes the target and the form cannot edit it, so the parked
+  // value leads and the client's echo stands in for a read that failed. The
+  // name is the form's own field, so the submitted one leads and the parked
+  // value stands in for a client with nowhere to type it.
+  const targetContactId = parked?.contactId ?? input.contactId;
+  const proposedName = displayName ?? parked?.displayName;
+  const proposedNotes = parked?.notes;
+
+  if (parked === null && !input.contactId) {
+    log.error(
+      { requestId, channelType, address: normalizedAddress },
+      "contact-prompt-submit: the parked target is unreadable and the client echoed none; resolving the contact from the address",
+    );
+  }
 
   try {
-    // -----------------------------------------------------------------------
-    // Phase 1: Resolve contact
-    //
-    // Guardian prompts always bind to the existing guardian contact — there
-    // must only ever be one.  Non-guardian prompts reuse an existing contact
-    // (found via a matching channel address) or create a new one.
-    // -----------------------------------------------------------------------
-    let createdNewContact = false;
-
-    if (isGuardian) {
-      // Guardian lives in the gateway DB (source of truth). Resolve from the
-      // gateway DB, not the assistant mirror.
-      const guardianRow = getGatewayDb()
-        .select({ id: gwContacts.id })
-        .from(gwContacts)
-        .where(eq(gwContacts.role, "guardian"))
-        .orderBy(asc(gwContacts.createdAt))
-        .get();
-      if (guardianRow) {
-        contactId = guardianRow.id;
-      } else {
-        // Bootstrap hasn't run yet — create the guardian contact gateway-first.
-        // upsertContact can't be used here: its create path forces
-        // role="contact". Guardian role writes stay raw per the
-        // ContactStore.upsertContact SECURITY note, but hit the gateway DB
-        // (source of truth) first, then mirror to the assistant DB best-effort.
-        log.warn(
-          { channelType, address: normalizedAddress },
-          "contact-prompt-submit: no guardian contact found, creating one",
-        );
-        contactId = crypto.randomUUID();
-        createdNewContact = true;
-        getGatewayDb()
-          .insert(gwContacts)
-          .values({
-            id: contactId,
-            displayName: effectiveDisplayName,
-            role: "guardian",
-            createdAt: now,
-            updatedAt: now,
-          })
-          .onConflictDoNothing()
-          .run();
-        try {
-          await ipcCallAssistant("contacts_mirror_upsert_contact", {
-            body: {
-              contactId,
-              displayName: effectiveDisplayName,
-              contactType: "human",
-            },
-          });
-        } catch (mirrorErr) {
-          log.warn(
-            { err: mirrorErr },
-            "contact-prompt-submit: assistant DB guardian contact mirror INSERT failed",
-          );
-        }
-      }
-    } else {
-      // Non-guardian: resolve/create the contact + channel gateway-first via
-      // ContactStore.upsertContact. The gateway DB is the source of truth; the
-      // assistant DB receives a best-effort mirror.
-      const store = getStore();
-      const { contact } = await store.upsertContact({
-        // omit-to-preserve: pass the caller's optional displayName, NOT
-        // effectiveDisplayName. An existing contact keeps its name; a brand-new
-        // contact falls back to the canonical channel address inside upsertContact.
-        displayName,
-        channels: [
-          { type: channelType, address: normalizedAddress, isPrimary: true },
-        ],
-      });
-      contactId = contact.id;
-
-      // Invalidate the daemon guardian-id/role caches after the committed
-      // gateway contact write — before the read-back guard, so a
-      // resolveChannelId miss still drops the stale caches.
-      void ipcCallAssistant("emit_event", {
-        body: { kind: "contacts_changed" },
-      } as unknown as Record<string, unknown>).catch(() => {});
-
-      channelId = resolveChannelId(contactId, channelType, normalizedAddress);
-
-      log.info(
-        { channelType, address: normalizedAddress, contactId, channelId },
-        "contact-prompt-submit: upserted contact + channel via ContactStore",
-      );
-
-      if (!channelId) {
-        log.error(
-          { channelType, address: normalizedAddress, contactId },
-          "contact-prompt-submit: channel resolution failed after upsert",
-        );
-        return CHANNEL_RESOLUTION_FAILED;
-      }
-
-      // Non-guardian is fully resolved by upsertContact; skip the guardian-only
-      // Phase 2 channel-creation block below and go straight to resolve.
-      return await channelResolution({
+    if (role === "guardian") {
+      return await bindGuardianChannel({
         requestId,
-        contactId,
-        channelId,
         channelType,
         address: normalizedAddress,
+        displayName,
         verify: input.verify,
+        parkedVerify,
       });
     }
 
-    // -----------------------------------------------------------------------
-    // Phase 2: Resolve channel
-    //
-    // If a channel for (type, address) already points to our contact, reuse it.
-    // If it points to a different contact and we are binding as guardian, that
-    // is a conflict the caller must resolve — return 409.  Otherwise create a
-    // new channel bound to the resolved contact.
-    // -----------------------------------------------------------------------
-    const existingChannel = getGatewayDb()
-      .select({
-        id: gwContactChannels.id,
-        contactId: gwContactChannels.contactId,
-      })
-      .from(gwContactChannels)
-      .where(
-        and(
-          eq(gwContactChannels.type, channelType),
-          sql`${gwContactChannels.address} = ${normalizedAddress} COLLATE NOCASE`,
-        ),
-      )
-      .get();
+    // The target's row is checked first because upsertContact INSERTs an
+    // unknown explicit id, which would mint a stray contact for a typo'd one.
+    if (targetContactId) {
+      const target = getStore().getContact(targetContactId);
 
-    if (existingChannel && existingChannel.contactId === contactId) {
-      // Reuse is success-guaranteed: the gateway channel already belongs to
-      // this guardian. Best-effort heal the assistant-DB mirror (passing the
-      // guardian's id keeps the gateway DB authoritative for role="guardian").
-      // The gateway-side syncChannels UPDATE here is incidental — the real
-      // purpose is recovering a stale mirror — so a transient gateway error
-      // must never fail the request.
-      try {
-        await getStore().upsertContact({
-          id: contactId,
-          channels: [
-            { type: channelType, address: normalizedAddress, isPrimary: true },
-          ],
-        });
-      } catch (healErr) {
+      if (!target) {
         log.warn(
-          { err: healErr, contactId, channelType, address: normalizedAddress },
-          "contact-prompt-submit: guardian reuse mirror-heal failed (best-effort), continuing with existing channel",
+          { requestId, contactId: targetContactId, channelType },
+          "contact-prompt-submit: the form's target contact does not exist",
         );
-      }
-      channelId = existingChannel.id;
-      log.info(
-        { channelType, address: normalizedAddress, contactId, channelId },
-        "contact-prompt-submit: channel already exists",
-      );
-    } else if (existingChannel) {
-      // Channel exists but belongs to a different contact.  The caller must
-      // clean up the stale binding before a guardian channel can be created.
-      log.warn(
-        {
-          channelType,
-          address: normalizedAddress,
-          contactId,
-          existingContactId: existingChannel.contactId,
-        },
-        "contact-prompt-submit: channel already assigned to another contact",
-      );
-      return {
-        failure: {
-          error: "Channel already assigned to another contact",
-          status: 409,
-        },
-      };
-    } else {
-      // Compensating delete — only remove the contact if we created it here.
-      // "Stale over lost": delete gateway-first, then mirror the delete to
-      // the assistant DB best-effort. Used by both the bind-failure path and
-      // the empty-channelId guard below.
-      const rollbackCreatedContact = async (): Promise<void> => {
-        if (!createdNewContact) return;
-        getGatewayDb()
-          .delete(gwContacts)
-          .where(eq(gwContacts.id, contactId))
-          .run();
-        try {
-          await ipcCallAssistant("contacts_mirror_delete_contact", {
-            body: { contactId },
-          });
-        } catch (mirrorErr) {
-          log.warn(
-            { err: mirrorErr },
-            "contact-prompt-submit: assistant DB contact rollback mirror DELETE failed",
-          );
-        }
-      };
-
-      try {
-        // Bind gateway-first. Passing the guardian's id keys the update to the
-        // existing guardian; the gateway DB is authoritative for role="guardian"
-        // and the channel, and the assistant mirror carries identity/info only.
-        await getStore().upsertContact({
-          id: contactId,
-          channels: [
-            { type: channelType, address: normalizedAddress, isPrimary: true },
-          ],
-        });
-        channelId = resolveChannelId(contactId, channelType, normalizedAddress);
-      } catch (channelErr) {
-        log.error(
-          { channelErr, contactId, channelType },
-          "contact-prompt-submit: channel bind failed, rolling back contact",
-        );
-        await rollbackCreatedContact();
-
         return {
-          failure: { error: "Failed to create contact channel", status: 500 },
+          failure: {
+            error: `Contact "${targetContactId}" not found. Run 'assistant contacts list' to find contact ids.`,
+            status: 404,
+          },
         };
       }
 
-      if (!channelId) {
-        log.error(
-          { channelType, address: normalizedAddress, contactId },
-          "contact-prompt-submit: channel resolution failed after guardian bind, rolling back contact",
+      return await bindChannelToContact({
+        requestId,
+        contactId: target.id,
+        channelType,
+        address: normalizedAddress,
+        verify: input.verify,
+        parkedVerify,
+        conflictHint: MERGE_HINT,
+      });
+    }
+
+    // A proposed name creates the contact under it. An address another contact
+    // already holds is a conflict here, rather than the silent rename of that
+    // contact an upsert matching on the channel would do.
+    if (proposedName) {
+      const existingChannel = findChannelByAddress(
+        channelType,
+        normalizedAddress,
+      );
+      if (existingChannel) {
+        log.warn(
+          {
+            requestId,
+            channelType,
+            address: normalizedAddress,
+            existingContactId: existingChannel.contactId,
+          },
+          "contact-prompt-submit: the proposed contact's address belongs to another contact",
         );
-        await rollbackCreatedContact();
-        // A freshly-created guardian was just rolled back (net no change). An
-        // existing guardian's channel bind committed and is NOT rolled back, so
-        // invalidate the daemon caches even though the read-back missed.
-        if (!createdNewContact) {
-          void ipcCallAssistant("emit_event", {
-            body: { kind: "contacts_changed" },
-          } as unknown as Record<string, unknown>).catch(() => {});
-        }
-        return CHANNEL_RESOLUTION_FAILED;
+        return channelOwnedByAnotherContact(
+          existingChannel.contactId,
+          channelType,
+          MERGE_HINT,
+        );
       }
 
-      log.info(
-        { channelType, address: normalizedAddress, contactId, channelId },
-        "contact-prompt-submit: created new channel",
-      );
+      return await bindAddressToItsOwnContact({
+        requestId,
+        channelType,
+        address: normalizedAddress,
+        displayName: proposedName,
+        notes: proposedNotes,
+        verify: input.verify,
+        parkedVerify,
+      });
     }
+
+    return await bindAddressToItsOwnContact({
+      requestId,
+      channelType,
+      address: normalizedAddress,
+      displayName,
+      verify: input.verify,
+      parkedVerify,
+    });
   } catch (err) {
     log.error({ err, requestId }, "contact-prompt-submit: DB error");
     return { failure: { error: "Database error", status: 500 } };
   }
+}
+
+/**
+ * Bind the address to the guardian contact, minting that contact when
+ * bootstrap has not yet run. There must only ever be one.
+ */
+async function bindGuardianChannel(args: {
+  requestId: string;
+  channelType: string;
+  address: string;
+  displayName?: string;
+  verify: boolean | undefined;
+  parkedVerify: boolean | undefined;
+}): Promise<GuardianFormWriteOutcome> {
+  const { requestId, channelType, address, displayName } = args;
+
+  // The guardian lives in the gateway DB (source of truth), so resolve from
+  // there rather than from the assistant mirror.
+  const guardianRow = getGatewayDb()
+    .select({ id: gwContacts.id })
+    .from(gwContacts)
+    .where(eq(gwContacts.role, "guardian"))
+    .orderBy(asc(gwContacts.createdAt))
+    .get();
+
+  if (guardianRow) {
+    return await bindChannelToContact({
+      requestId,
+      contactId: guardianRow.id,
+      channelType,
+      address,
+      verify: args.verify,
+      parkedVerify: args.parkedVerify,
+      conflictHint: GUARDIAN_CONFLICT_HINT,
+    });
+  }
+
+  // Bootstrap has not run, so create the guardian contact gateway-first.
+  // upsertContact can't be used here: its create path forces role="contact".
+  // Guardian role writes stay raw per the ContactStore.upsertContact SECURITY
+  // note, but hit the gateway DB (source of truth) first, then mirror to the
+  // assistant DB best-effort.
+  log.warn(
+    { channelType, address },
+    "contact-prompt-submit: no guardian contact found, creating one",
+  );
+  const now = Date.now();
+  const contactId = crypto.randomUUID();
+  const effectiveDisplayName = displayName ?? address;
+  getGatewayDb()
+    .insert(gwContacts)
+    .values({
+      id: contactId,
+      displayName: effectiveDisplayName,
+      role: "guardian",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+    .run();
+  try {
+    await ipcCallAssistant("contacts_mirror_upsert_contact", {
+      body: {
+        contactId,
+        displayName: effectiveDisplayName,
+        contactType: "human",
+      },
+    });
+  } catch (mirrorErr) {
+    log.warn(
+      { err: mirrorErr },
+      "contact-prompt-submit: assistant DB guardian contact mirror INSERT failed",
+    );
+  }
+
+  return await bindChannelToContact({
+    requestId,
+    contactId,
+    channelType,
+    address,
+    verify: args.verify,
+    parkedVerify: args.parkedVerify,
+    conflictHint: GUARDIAN_CONFLICT_HINT,
+    // Compensating delete for the contact this bind was created for.
+    // "Stale over lost": delete gateway-first, then mirror the delete to the
+    // assistant DB best-effort.
+    onRollback: async () => {
+      getGatewayDb()
+        .delete(gwContacts)
+        .where(eq(gwContacts.id, contactId))
+        .run();
+      try {
+        await ipcCallAssistant("contacts_mirror_delete_contact", {
+          body: { contactId },
+        });
+      } catch (mirrorErr) {
+        log.warn(
+          { err: mirrorErr },
+          "contact-prompt-submit: assistant DB contact rollback mirror DELETE failed",
+        );
+      }
+    },
+  });
+}
+
+/**
+ * Attach the address to a contact that already exists.
+ *
+ * A channel the contact already holds for the address is reused; one another
+ * contact holds is a conflict, since reassigning it would move an admitted
+ * address out from under whoever it belongs to.
+ *
+ * `onRollback` undoes a contact minted for this bind. Its absence is what
+ * makes a missed read-back still worth a cache invalidation: the contact
+ * predates the bind, so the committed channel write stands.
+ */
+async function bindChannelToContact(args: {
+  requestId: string;
+  contactId: string;
+  channelType: string;
+  address: string;
+  verify: boolean | undefined;
+  parkedVerify: boolean | undefined;
+  onRollback?: () => Promise<void>;
+  conflictHint: string;
+}): Promise<GuardianFormWriteOutcome> {
+  const { requestId, contactId, channelType, address, onRollback } = args;
+
+  const existingChannel = findChannelByAddress(channelType, address);
+  let channelId: string;
+
+  if (existingChannel && existingChannel.contactId === contactId) {
+    // Reuse is success-guaranteed: the gateway channel already belongs to this
+    // contact. Best-effort heal the assistant-DB mirror (passing the contact's
+    // id keys the update to it, keeping the gateway DB authoritative). The
+    // gateway-side syncChannels UPDATE here is incidental, the real purpose is
+    // recovering a stale mirror, so a transient gateway error must never fail
+    // the request.
+    try {
+      await getStore().upsertContact({
+        id: contactId,
+        channels: [{ type: channelType, address, isPrimary: true }],
+      });
+    } catch (healErr) {
+      log.warn(
+        { err: healErr, contactId, channelType, address },
+        "contact-prompt-submit: reuse mirror-heal failed (best-effort), continuing with existing channel",
+      );
+    }
+    channelId = existingChannel.id;
+    log.info(
+      { channelType, address, contactId, channelId },
+      "contact-prompt-submit: channel already exists",
+    );
+  } else if (existingChannel) {
+    log.warn(
+      {
+        channelType,
+        address,
+        contactId,
+        existingContactId: existingChannel.contactId,
+      },
+      "contact-prompt-submit: channel already assigned to another contact",
+    );
+    return channelOwnedByAnotherContact(
+      existingChannel.contactId,
+      channelType,
+      args.conflictHint,
+    );
+  } else {
+    try {
+      // Bind gateway-first. Passing the contact's id keys the update to the
+      // existing contact; the gateway DB is authoritative for the ACL fields
+      // and the channel, and the assistant mirror carries identity/info only.
+      await getStore().upsertContact({
+        id: contactId,
+        channels: [{ type: channelType, address, isPrimary: true }],
+      });
+      channelId = resolveChannelId(contactId, channelType, address);
+    } catch (channelErr) {
+      log.error(
+        { channelErr, contactId, channelType },
+        "contact-prompt-submit: channel bind failed",
+      );
+      await onRollback?.();
+
+      return {
+        failure: { error: "Failed to create contact channel", status: 500 },
+      };
+    }
+
+    if (!channelId) {
+      log.error(
+        { channelType, address, contactId },
+        "contact-prompt-submit: channel resolution failed after bind",
+      );
+      if (onRollback) {
+        // The contact this bind minted is gone with it, so the pair is a net
+        // no change and the daemon's caches never saw either.
+        await onRollback();
+      } else {
+        emitContactsChanged();
+      }
+      return CHANNEL_RESOLUTION_FAILED;
+    }
+
+    log.info(
+      { channelType, address, contactId, channelId },
+      "contact-prompt-submit: created new channel",
+    );
+  }
 
   // Invalidate the daemon guardian-id/role caches after a gateway-owned
-  // guardian bind/rebind/reuse.
-  void ipcCallAssistant("emit_event", {
-    body: { kind: "contacts_changed" },
-  } as unknown as Record<string, unknown>).catch(() => {});
+  // bind/rebind/reuse.
+  emitContactsChanged();
 
   return await channelResolution({
     requestId,
     contactId,
     channelId,
     channelType,
-    address: normalizedAddress,
-    verify: input.verify,
+    address,
+    verify: args.verify,
+    parkedVerify: args.parkedVerify,
   });
+}
+
+/**
+ * Resolve the address to the contact that owns it, creating one when nothing
+ * does. Gateway-first via ContactStore.upsertContact: the gateway DB is the
+ * source of truth; the assistant DB receives a best-effort mirror.
+ */
+async function bindAddressToItsOwnContact(args: {
+  requestId: string;
+  channelType: string;
+  address: string;
+  displayName?: string;
+  notes?: string;
+  verify: boolean | undefined;
+  parkedVerify: boolean | undefined;
+}): Promise<GuardianFormWriteOutcome> {
+  const { requestId, channelType, address, displayName, notes } = args;
+
+  const { contact } = await getStore().upsertContact({
+    // omit-to-preserve: an existing contact keeps its name, and a brand-new one
+    // with none falls back to the canonical channel address inside
+    // upsertContact.
+    displayName,
+    notes,
+    channels: [{ type: channelType, address, isPrimary: true }],
+  });
+  const contactId = contact.id;
+
+  // Invalidate the daemon guardian-id/role caches after the committed gateway
+  // contact write, before the read-back guard, so a resolveChannelId miss
+  // still drops the stale caches.
+  emitContactsChanged();
+
+  const channelId = resolveChannelId(contactId, channelType, address);
+
+  log.info(
+    { channelType, address, contactId, channelId },
+    "contact-prompt-submit: upserted contact + channel via ContactStore",
+  );
+
+  if (!channelId) {
+    log.error(
+      { channelType, address, contactId },
+      "contact-prompt-submit: channel resolution failed after upsert",
+    );
+    return CHANNEL_RESOLUTION_FAILED;
+  }
+
+  return await channelResolution({
+    requestId,
+    contactId,
+    channelId,
+    channelType,
+    address,
+    verify: args.verify,
+    parkedVerify: args.parkedVerify,
+  });
+}
+
+/** The channel bound to a (type, address) pair, if there is one. */
+function findChannelByAddress(
+  channelType: string,
+  address: string,
+): { id: string; contactId: string } | undefined {
+  return getGatewayDb()
+    .select({
+      id: gwContactChannels.id,
+      contactId: gwContactChannels.contactId,
+    })
+    .from(gwContactChannels)
+    .where(
+      and(
+        eq(gwContactChannels.type, channelType),
+        sql`${gwContactChannels.address} = ${address} COLLATE NOCASE`,
+      ),
+    )
+    .get();
+}
+
+/** What to do about an address bound to a contact other than the target. */
+const MERGE_HINT =
+  "Run 'assistant contacts merge <keepId> <donorId>' if they are the same person.";
+
+/** The guardian's channel cannot be minted while another contact holds it. */
+const GUARDIAN_CONFLICT_HINT =
+  "Clear that binding before binding the address to the guardian.";
+
+/**
+ * The address belongs to somebody else. Naming them is what makes the refusal
+ * actionable: the guardian can see whether it is the same person under two
+ * records or a genuinely different one.
+ */
+function channelOwnedByAnotherContact(
+  otherContactId: string,
+  channelType: string,
+  conflictHint: string,
+): GuardianFormWriteOutcome {
+  const other = getStore().getContact(otherContactId);
+  return {
+    failure: {
+      error: `That ${channelType} address is already bound to "${other?.displayName ?? "Unknown"}" (${otherContactId}). ${conflictHint}`,
+      status: 409,
+    },
+  };
+}
+
+/** Drop the daemon's contact caches after a committed gateway contact write. */
+function emitContactsChanged(): void {
+  void ipcCallAssistant("emit_event", {
+    body: { kind: "contacts_changed" },
+  } as unknown as Record<string, unknown>).catch(() => {});
 }
 
 /**
@@ -475,31 +694,19 @@ const CHANNEL_RESOLUTION_FAILED: GuardianFormWriteOutcome = {
 
 /**
  * Whether the guardian left the "mark verified" box checked.
+ *
+ * The checkbox is the answer: `--verify` only pre-checks it, so a guardian who
+ * unchecks the box must not get a verified channel. A client with no checkbox
+ * sends no answer, and the parked flag stands in for one.
  */
-async function promptWantsVerify(
-  requestId: string,
+function promptWantsVerify(
   submitted: boolean | undefined,
-): Promise<boolean> {
-  // The checkbox is the answer. `--verify` only pre-checks it, so a guardian
-  // who unchecks the box must not get a verified channel.
+  parkedVerify: boolean | undefined,
+): boolean {
   if (typeof submitted === "boolean") {
     return submitted;
   }
-  // A client with no checkbox sends no answer, so the parked flag stands in
-  // for one. Read out of band because such a client has no field to echo it
-  // back in.
-  try {
-    const result = await ipcCallAssistant("contact_prompt_flags", {
-      body: { requestId },
-    });
-    return (result as { verify?: boolean }).verify === true;
-  } catch (err) {
-    log.warn(
-      { err, requestId },
-      "contact-prompt-submit: contact_prompt_flags IPC failed; leaving channel unverified",
-    );
-    return false;
-  }
+  return parkedVerify === true;
 }
 
 /**
@@ -513,6 +720,7 @@ async function channelResolution(args: {
   channelType: string;
   address: string;
   verify: boolean | undefined;
+  parkedVerify: boolean | undefined;
 }): Promise<GuardianFormWriteOutcome> {
   const { requestId, contactId, channelId, channelType, address } = args;
   // What the channel ends up as, not what was asked for: the guardian's box
@@ -520,7 +728,7 @@ async function channelResolution(args: {
   // reuses an already verified channel stays verified whether or not this
   // submission asked for it.
   let verified = false;
-  if (await promptWantsVerify(requestId, args.verify)) {
+  if (promptWantsVerify(args.verify, args.parkedVerify)) {
     try {
       // A resolved row means the channel is attested, whether this call is what
       // wrote it or it already was.

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -270,11 +270,14 @@ async function bindSubmittedChannel(input: {
   }
 
   const parkedVerify = parked?.verify;
-  // The command fixes the target and the form cannot edit it, so the parked
-  // value leads and the client's echo stands in for a read that failed. The
-  // name is the form's own field, so the submitted one leads and the parked
+  // The command fixes the target and the form cannot edit it, so a readable
+  // parked form is the only word on it: a readable form naming no target means
+  // there is none, and an echo is honored only when that form cannot be read.
+  // The name is the form's own field, so the submitted one leads and the parked
   // value stands in for a client with nowhere to type it.
-  const targetContactId = parked?.contactId ?? input.contactId;
+  const targetContactId = parkedTargetUnreadable
+    ? input.contactId
+    : parked?.contactId;
   const proposedName = displayName ?? parked?.displayName;
   const proposedNotes = parked?.notes;
 

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -258,19 +258,11 @@ async function bindSubmittedChannel(input: {
   }
 
   try {
-    if (role === "guardian") {
-      return await bindGuardianChannel({
-        requestId,
-        channelType,
-        address: normalizedAddress,
-        displayName,
-        verify: input.verify,
-        parkedVerify,
-      });
-    }
-
-    // The target's row is checked first because upsertContact INSERTs an
-    // unknown explicit id, which would mint a stray contact for a typo'd one.
+    // A named target decides the bind, whatever role the client sent: the form
+    // showed that contact, so binding the address anywhere else would grant an
+    // identity the guardian never saw. The target's row is read before the
+    // upsert because upsertContact INSERTs an unknown explicit id, which would
+    // mint a stray contact for a typo'd one.
     if (targetContactId) {
       const target = getStore().getContact(targetContactId);
 
@@ -295,6 +287,17 @@ async function bindSubmittedChannel(input: {
         verify: input.verify,
         parkedVerify,
         conflictHint: MERGE_HINT,
+      });
+    }
+
+    if (role === "guardian") {
+      return await bindGuardianChannel({
+        requestId,
+        channelType,
+        address: normalizedAddress,
+        displayName,
+        verify: input.verify,
+        parkedVerify,
       });
     }
 
@@ -339,6 +342,7 @@ async function bindSubmittedChannel(input: {
       channelType,
       address: normalizedAddress,
       displayName,
+      notes: proposedNotes,
       verify: input.verify,
       parkedVerify,
     });

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -306,6 +306,7 @@ async function bindSubmittedChannel(input: {
       return await bindChannelToContact({
         requestId,
         contactId: target.id,
+        contactDisplayName: target.displayName,
         channelType,
         address: normalizedAddress,
         verify: input.verify,
@@ -504,6 +505,11 @@ async function bindGuardianChannel(args: {
 async function bindChannelToContact(args: {
   requestId: string;
   contactId: string;
+  /**
+   * The contact's stored name. Carried into the mirror writes so a repair of a
+   * missing mirror row names it, rather than falling back to the address.
+   */
+  contactDisplayName?: string;
   channelType: string;
   address: string;
   verify: boolean | undefined;
@@ -511,7 +517,14 @@ async function bindChannelToContact(args: {
   onRollback?: () => Promise<void>;
   conflictHint: string;
 }): Promise<GuardianFormWriteOutcome> {
-  const { requestId, contactId, channelType, address, onRollback } = args;
+  const {
+    requestId,
+    contactId,
+    contactDisplayName,
+    channelType,
+    address,
+    onRollback,
+  } = args;
 
   const existingChannel = findChannelByAddress(channelType, address);
   let channelId: string;
@@ -526,6 +539,7 @@ async function bindChannelToContact(args: {
     try {
       await getStore().upsertContact({
         id: contactId,
+        displayName: contactDisplayName,
         channels: [{ type: channelType, address, isPrimary: true }],
       });
     } catch (healErr) {
@@ -561,6 +575,7 @@ async function bindChannelToContact(args: {
       // and the channel, and the assistant mirror carries identity/info only.
       await getStore().upsertContact({
         id: contactId,
+        displayName: contactDisplayName,
         channels: [{ type: channelType, address, isPrimary: true }],
       });
       channelId = resolveChannelId(contactId, channelType, address);

--- a/gateway/src/http/routes/contacts-control-plane-routes.ts
+++ b/gateway/src/http/routes/contacts-control-plane-routes.ts
@@ -137,6 +137,12 @@ const ContactPromptSubmitRequestSchema = z.object({
     .describe("Required unless cancelled is true"),
   role: z.string().optional(),
   displayName: z.string().optional(),
+  contactId: z
+    .string()
+    .optional()
+    .describe(
+      "The contact the parked form targets, echoed back from the broadcast. The parked form is authoritative.",
+    ),
   verify: z
     .boolean()
     .optional()


### PR DESCRIPTION
## Summary

- The gateway reads the parked form's binding target over `contact_prompt_flags` and binds the submitted address to that contact, so `contacts prompt`/`channels add` against a named contact no longer creates an address-named duplicate. The client's echoed `contactId` is the fallback when the daemon read fails.
- An address already bound to a different contact is a 409 naming that contact and suggesting `assistant contacts merge`; an unknown target id is a 404 that mints nothing (`upsertContactGatewayWrites` INSERTs an unknown explicit id).
- A form that proposed a name creates the contact under that name with its notes. Plain `contacts prompt` (guardian bind, match-by-address reuse, address-named create) is unchanged.

### Notes for review

- `promptWantsVerify` is now pure and takes the parked flag from the single `contact_prompt_flags` read, so this removes an IPC round trip rather than adding one. Two existing tests asserted that a submitted `verify` answer meant zero flag reads; they now assert the stronger thing, that the submitted answer wins over the opposite parked flag.
- Deviation from the plan, deliberate: `proposedName` is `submitted ?? parked`, not `parked ?? submitted`. The proposed name is an editable form field (PR 3 documents it that way, and PR 5 renders it as an input), so the guardian's edit has to win, exactly as the verify checkbox does. `contactId` keeps the plan's ordering because the command fixes it and the form cannot edit it.
- `gateway/openapi.json` also picks up a `0.11.7` to `0.11.8` version line the committed file was missing.

Part of plan: contacts-cli-channel-binding.md (PR 4 of 12)