### PR TITLE
Android launcher backgrounds adopt the standard dev and staging colors

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -64,9 +64,15 @@ The default launcher icon is the `quirky` eye pair from the avatar library in
 in `app/src/main/res/drawable/ic_launcher_foreground.xml` and in the
 pre-adaptive `app/src/main/res/mipmap-anydpi/ic_launcher*.xml` fallbacks are
 copied verbatim from that table and only repositioned by a VectorDrawable
-`<group>`, so the icon stays in sync with the in-app avatars. Launcher
-background colors distinguish production (`#4C9B50`, the avatar palette green),
-staging, and dev installs.
+`<group>`, so the icon stays in sync with the in-app avatars.
+
+Each flavor's `launcher_background` in
+`app/src/<flavor>/res/values/colors.xml` distinguishes the installs: production
+`#4C9B50` (the avatar palette green), staging `#E9C91A`, and dev `#FF88C9`.
+Those three are the shared cross-platform standard: a flavor and the iOS
+`AppIcon-*.icon` bundle for the same environment sit on the same color, which
+the web app names once as `APP_ICON_GROUNDS`. Change one and change the rest
+with it.
 
 ### Alternate Icons
 

--- a/clients/android/app/src/dev/res/values/colors.xml
+++ b/clients/android/app/src/dev/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="launcher_background">#2457C5</color>
+    <color name="launcher_background">#FF88C9</color>
 </resources>

--- a/clients/android/app/src/staging/res/values/colors.xml
+++ b/clients/android/app/src/staging/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="launcher_background">#C84C09</color>
+    <color name="launcher_background">#E9C91A</color>
 </resources>

--- a/clients/web/src/domains/settings/components/app-icon-row.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.test.tsx
@@ -511,11 +511,11 @@ describe("AppIconRow", () => {
     });
   });
 
-  // Android draws its launcher field from per-flavor resources that share
-  // nothing with the iOS bundles, so the thumbnail standing in for the primary
-  // icon reads the shell's platform as well as its build.
+  // Android draws its launcher field from per-flavor resources that name the
+  // same colors as the iOS bundles in plain sRGB, so the thumbnail standing in
+  // for the primary icon reads the shell's platform as well as its build.
   describe("the default thumbnail follows the Android flavor", () => {
-    test("draws the dev flavor's blue field", async () => {
+    test("draws the dev flavor's pink field", async () => {
       runOnAndroidShell("ai.vellum.assistant.dev");
 
       await renderRow();
@@ -523,10 +523,14 @@ describe("AppIconRow", () => {
       await waitFor(() => {
         expect(previewFill()).toBe(flavorLauncherBackground("dev"));
       });
+      // Naming one ground for both platforms is only honest while the flavor
+      // declares that shared color, so the row cannot drift back to a literal
+      // of its own without failing here.
+      expect(flavorLauncherBackground("dev")).toBe(APP_ICON_GROUNDS.dev);
       expect(previewEyePaths()).toEqual(catalogPaths("quirky"));
     });
 
-    test("draws the staging flavor's orange field", async () => {
+    test("draws the staging flavor's yellow field", async () => {
       runOnAndroidShell("ai.vellum.assistant.staging");
 
       await renderRow();
@@ -534,6 +538,9 @@ describe("AppIconRow", () => {
       await waitFor(() => {
         expect(previewFill()).toBe(flavorLauncherBackground("staging"));
       });
+      expect(flavorLauncherBackground("staging")).toBe(
+        APP_ICON_GROUNDS.staging,
+      );
       expect(previewEyePaths()).toEqual(catalogPaths("quirky"));
     });
 

--- a/clients/web/src/domains/settings/components/app-icon-row.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.test.tsx
@@ -523,9 +523,9 @@ describe("AppIconRow", () => {
       await waitFor(() => {
         expect(previewFill()).toBe(flavorLauncherBackground("dev"));
       });
-      // Naming one ground for both platforms is only honest while the flavor
-      // declares that shared color, so the row cannot drift back to a literal
-      // of its own without failing here.
+      // Naming one ground for both platforms holds only while the flavor
+      // resource and the shared constant agree, so this comparison fails
+      // whenever either side moves alone.
       expect(flavorLauncherBackground("dev")).toBe(APP_ICON_GROUNDS.dev);
       expect(previewEyePaths()).toEqual(catalogPaths("quirky"));
     });

--- a/clients/web/src/domains/settings/components/app-icon-row.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.tsx
@@ -38,23 +38,28 @@ const ROW_PREVIEW_SIZE = 32;
 interface IconGround {
   /** The fill the shell's Icon Composer bundle declares. */
   displayP3: string;
-  /** sRGB stand-in, for a renderer that cannot parse `color()`. */
+  /**
+   * The same color in sRGB: what the Android flavor's `launcher_background`
+   * declares, and what a renderer that cannot parse `color()` falls back to.
+   */
   srgb: string;
 }
 
 /**
- * Vellum Dev draws its icon on pink, `clients/ios/App/App/AppIcon-Dev.icon`.
+ * Vellum Dev draws its icon on pink on both platforms.
  *
- * That bundle declares its fill as the Display P3 conversion of the sRGB hex
- * {@link APP_ICON_GROUNDS} carries. Naming the same coordinates draws the
- * thumbnail in the gamut the installed icon is drawn in.
+ * `clients/ios/App/App/AppIcon-Dev.icon` declares its fill as the Display P3
+ * conversion of the sRGB hex {@link APP_ICON_GROUNDS} carries, and
+ * `clients/android/app/src/dev/res/values/colors.xml` declares that hex itself.
+ * Naming the same coordinates draws the thumbnail in the gamut the installed
+ * icon is drawn in.
  */
 const DEV_GROUND: IconGround = {
   displayP3: "color(display-p3 0.9387 0.55755 0.7777)",
   srgb: APP_ICON_GROUNDS.dev,
 };
 
-/** Vellum Staging's yellow, read the same way off `AppIcon-Staging.icon`. */
+/** Vellum Staging's yellow, read the same way off the same pair of shells. */
 const STAGING_GROUND: IconGround = {
   displayP3: "color(display-p3 0.89313 0.79283 0.2841)",
   srgb: APP_ICON_GROUNDS.staging,
@@ -70,28 +75,12 @@ const STAGING_GROUND: IconGround = {
  * belongs to the installed build while that variable names the web deploy: a
  * Staging shell loading a dev server would otherwise draw pink under a yellow
  * icon. Production is absent: the catalog green
- * {@link DEFAULT_APP_ICON_TRAITS} names is already that shell's ground, and its
- * bundle carries a true conversion of it.
+ * {@link DEFAULT_APP_ICON_TRAITS} names is already that shell's ground on both
+ * platforms, and its iOS bundle carries a true conversion of it.
  */
 const PRIMARY_ICON_GROUND: Partial<Record<ShellEnvironment, IconGround>> = {
   dev: DEV_GROUND,
   staging: STAGING_GROUND,
-};
-
-/**
- * Ground the Android shells draw their launcher icon on, keyed by the shell's
- * own environment.
- *
- * These are the per-flavor `launcher_background` resources in
- * `clients/android/app/src/<flavor>/res/values/colors.xml`, which the platform
- * declares in plain sRGB and ships no wide-gamut variant of, so they are named
- * once rather than paired the way the iOS bundles above are. Production is
- * absent for the same reason it is absent there: its `launcher_background` is
- * already the catalog green {@link DEFAULT_APP_ICON_TRAITS} names.
- */
-const ANDROID_PRIMARY_ICON_GROUND: Partial<Record<ShellEnvironment, string>> = {
-  dev: "#2457C5",
-  staging: "#C84C09",
 };
 
 /**
@@ -144,8 +133,9 @@ function primaryIconEnvironment(
 /**
  * Ground the running shell's primary icon carries, undefined on production and
  * while the shell has yet to answer, which draws the production green for the
- * frame or two that takes. The two platforms ship unrelated fields for the same
- * environment, so the shell's OS picks the map and the shell's build keys it.
+ * frame or two that takes. Both platforms ground the same environment in the
+ * same color and only the gamut parts them: an Android `launcher_background` is
+ * plain sRGB and the flavors ship no wide-gamut variant of it.
  */
 function primaryIconGround(
   shell: ShellEnvironment | null | undefined,
@@ -155,9 +145,8 @@ function primaryIconGround(
   if (!environment) {
     return undefined;
   }
-  return android
-    ? ANDROID_PRIMARY_ICON_GROUND[environment]
-    : groundFill(PRIMARY_ICON_GROUND[environment]);
+  const ground = PRIMARY_ICON_GROUND[environment];
+  return android ? ground?.srgb : groundFill(ground);
 }
 
 export function AppIconRow() {


### PR DESCRIPTION
## Summary
- Dev and staging launcher_background move to the cross-platform standard (#FF88C9, #E9C91A); production already matches
- The Settings thumbnail's Android grounds collapse onto APP_ICON_GROUNDS so the two can no longer drift apart
- Android README documents the standard palette

Part of plan: standardize-icon-env-colors.md (PR 2 of 4)