### PR TITLE
fix(cli): dismissing a contacts form exits 0 with a plain message, not an error

### DIFF
--- a/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
@@ -128,7 +128,7 @@ describe("contacts address prompt", () => {
 
     expect(stdout).toContain("Cancelled: nothing was written");
     expect(stderr).toBe("");
-    expect(process.exitCode).toBeFalsy();
+    expect(process.exitCode).toBe(130);
   });
 
   test("a dismissal in --json emits one object carrying the marker", async () => {
@@ -146,7 +146,7 @@ describe("contacts address prompt", () => {
     // second would make this throw.
     expect(JSON.parse(stdout)).toEqual({ ok: true, cancelled: true });
     expect(stderr).toBe("");
-    expect(process.exitCode).toBeFalsy();
+    expect(process.exitCode).toBe(130);
   });
 
   test("a form that failed still reports an error and exits nonzero", async () => {

--- a/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for `contacts prompt`: what it puts in front of the guardian, and how
+ * it reports the answer that comes back.
+ *
+ * The form is seeded from the request body and the guardian submits what it
+ * shows, so the body is pinned here alongside the outcomes the command has to
+ * tell apart: a bind, a dismissal, and a genuine failure.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+interface IpcCall {
+  operationId: string;
+  options?: Record<string, unknown>;
+  /** Transport options, where the socket deadline lives. */
+  callOptions?: { timeoutMs?: number };
+}
+
+let calls: IpcCall[] = [];
+
+/** What the daemon returns once the guardian has filled the form in. */
+const boundChannel = {
+  ok: true,
+  channelType: "email",
+  address: "alice@example.com",
+  channelId: "ch_1",
+  contactId: "ct_1",
+  verified: true,
+};
+
+/** The dismissal shape: the marker, and the reason that reads alongside it. */
+const dismissal = { ok: false, error: "Cancelled by user", cancelled: true };
+
+/** What `contacts_prompt` answers with. */
+let promptResult: Record<string, unknown> = boundChannel;
+
+/**
+ * The ordinary answers. Held as a named function so `beforeEach` can put it
+ * back: a test that installs its own implementation would otherwise leave it
+ * in place for everything after it, since clearing a mock keeps the last
+ * implementation.
+ */
+const baseIpcImplementation = async (
+  operationId: string,
+  options?: Record<string, unknown>,
+  callOptions?: { timeoutMs?: number },
+) => {
+  calls.push({ operationId, options, callOptions });
+  return { ok: true, result: promptResult };
+};
+
+const cliIpcCallMock = mock(baseIpcImplementation);
+
+const actualCliClient = await import("../../ipc/cli-client.js");
+mock.module("../../ipc/cli-client.js", () => ({
+  ...actualCliClient,
+  cliIpcCall: cliIpcCallMock,
+}));
+
+const { runAssistantCommandFull } = await import("./run-assistant-command.js");
+
+function addressPromptBody(): Record<string, unknown> {
+  const call = calls.find((c) => c.operationId === "contacts_prompt");
+  expect(call).toBeDefined();
+  return (call!.options as { body: Record<string, unknown> }).body;
+}
+
+describe("contacts address prompt", () => {
+  beforeEach(() => {
+    calls = [];
+    promptResult = boundChannel;
+    // Global and sticky: the failure case below sets it, and a later test
+    // asserting success would otherwise read its exit code as its own.
+    // Cleared to 0 rather than undefined, which does not reset it.
+    process.exitCode = 0;
+    cliIpcCallMock.mockClear();
+    cliIpcCallMock.mockImplementation(baseIpcImplementation);
+  });
+
+  test("the form is seeded with what the caller asked for", async () => {
+    await runAssistantCommandFull(
+      "contacts",
+      "prompt",
+      "--channel",
+      "email",
+      "--label",
+      "Work email",
+      "--default-value",
+      "alice@example.com",
+      "--verify",
+    );
+
+    const body = addressPromptBody();
+    expect(body.channel).toBe("email");
+    expect(body.label).toBe("Work email");
+    expect(body.defaultValue).toBe("alice@example.com");
+    expect(body.verify).toBe(true);
+    // An unstated role is a stated "unknown": the form seeds a role either way,
+    // so leaving it off the body would let the daemon pick a different one.
+    expect(body.role).toBe("unknown");
+  });
+
+  test("--verify is a proposal, so the reported status is the guardian's", async () => {
+    promptResult = { ...boundChannel, verified: false };
+
+    const { stdout } = await runAssistantCommandFull(
+      "contacts",
+      "prompt",
+      "--channel",
+      "email",
+      "--verify",
+    );
+
+    expect(stdout).toContain("Registered email channel: alice@example.com");
+    expect(stdout).toContain("Status:     unverified");
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  test("a dismissal is a clean exit, not a failed bind", async () => {
+    promptResult = dismissal;
+
+    const { stdout, stderr } = await runAssistantCommandFull(
+      "contacts",
+      "prompt",
+      "--channel",
+      "email",
+    );
+
+    expect(stdout).toContain("Cancelled: nothing was written");
+    expect(stderr).toBe("");
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  test("a dismissal in --json emits one object carrying the marker", async () => {
+    promptResult = dismissal;
+
+    const { stdout, stderr } = await runAssistantCommandFull(
+      "contacts",
+      "prompt",
+      "--channel",
+      "email",
+      "--json",
+    );
+
+    // Parsing the whole of stdout is the assertion that it is one object: a
+    // second would make this throw.
+    expect(JSON.parse(stdout)).toEqual({ ok: true, cancelled: true });
+    expect(stderr).toBe("");
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  test("a form that failed still reports an error and exits nonzero", async () => {
+    promptResult = { ok: false, error: "Channel resolution failed" };
+
+    const { stderr } = await runAssistantCommandFull(
+      "contacts",
+      "prompt",
+      "--channel",
+      "email",
+    );
+
+    expect(stderr).toContain("Channel resolution failed");
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
@@ -56,6 +56,8 @@ let readFails = false;
 let notesSaved: boolean | undefined;
 /** Whether the daemon reports that nothing the guardian submitted landed. */
 let nothingWritten: boolean | undefined;
+/** Whether the guardian closed the form instead of answering it. */
+let dismissed = false;
 
 const baseIpcImplementation = async (
   operationId: string,
@@ -69,6 +71,13 @@ const baseIpcImplementation = async (
       return { ok: false, error: "Contact not found", statusCode: 404 };
     }
     return { ok: true, result: { ok: true, contact: contactForRead } };
+  }
+  if (dismissed) {
+    // The rail keeps the human-readable reason alongside the marker.
+    return {
+      ok: true,
+      result: { ok: false, error: "Cancelled by user", cancelled: true },
+    };
   }
   return {
     ok: true,
@@ -84,7 +93,8 @@ mock.module("../../ipc/cli-client.js", () => ({
   cliIpcCall: cliIpcCallMock,
 }));
 
-const { runAssistantCommand } = await import("./run-assistant-command.js");
+const { runAssistantCommand, runAssistantCommandFull } =
+  await import("./run-assistant-command.js");
 
 function recordPromptBody(): Record<string, unknown> {
   const call = calls.find((c) => c.operationId === "contacts_record_prompt");
@@ -99,6 +109,7 @@ describe("contacts record prompts", () => {
     readFails = false;
     notesSaved = undefined;
     nothingWritten = undefined;
+    dismissed = false;
     // Global and sticky: the failure-path cases below set it, and a later test
     // asserting success would otherwise read their exit code as its own.
     // Cleared to 0 rather than undefined, which does not reset it.
@@ -324,6 +335,47 @@ describe("contacts record prompts", () => {
 
     expect(calls.some((c) => c.operationId === "contacts_record_prompt")).toBe(
       false,
+    );
+  });
+
+  describe("a dismissed form", () => {
+    const operations: [string, string[]][] = [
+      ["create", ["contacts", "create", "--name", "Alice"]],
+      ["update", ["contacts", "update", "ct_1", "--name", "Alice Chen"]],
+      ["delete", ["contacts", "delete", "ct_1"]],
+    ];
+
+    test.each(operations)(
+      "%s reports it as a clean exit",
+      async (_op, argv) => {
+        // Nothing was written and nothing failed, so an error envelope here
+        // would read as a write that went wrong.
+        dismissed = true;
+
+        const { stdout, stderr } = await runAssistantCommandFull(...argv);
+
+        expect(stdout).toContain("Cancelled: nothing was written");
+        expect(stderr).toBe("");
+        expect(process.exitCode).toBeFalsy();
+      },
+    );
+
+    test.each(operations)(
+      "%s --json emits one object carrying the marker",
+      async (_op, argv) => {
+        dismissed = true;
+
+        const { stdout, stderr } = await runAssistantCommandFull(
+          ...argv,
+          "--json",
+        );
+
+        // Parsing the whole of stdout is the assertion that it is one object:
+        // a second would make this throw.
+        expect(JSON.parse(stdout)).toEqual({ ok: true, cancelled: true });
+        expect(stderr).toBe("");
+        expect(process.exitCode).toBeFalsy();
+      },
     );
   });
 });

--- a/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
@@ -356,7 +356,7 @@ describe("contacts record prompts", () => {
 
         expect(stdout).toContain("Cancelled: nothing was written");
         expect(stderr).toBe("");
-        expect(process.exitCode).toBeFalsy();
+        expect(process.exitCode).toBe(130);
       },
     );
 
@@ -374,7 +374,7 @@ describe("contacts record prompts", () => {
         // a second would make this throw.
         expect(JSON.parse(stdout)).toEqual({ ok: true, cancelled: true });
         expect(stderr).toBe("");
-        expect(process.exitCode).toBeFalsy();
+        expect(process.exitCode).toBe(130);
       },
     );
   });

--- a/assistant/src/cli/__tests__/run-assistant-command.ts
+++ b/assistant/src/cli/__tests__/run-assistant-command.ts
@@ -4,6 +4,30 @@ export interface AssistantCommandResult {
 }
 
 /**
+ * Collect a stream's writes into `chunks`. The override must invoke the
+ * callback (when provided) so that `Writable` streams piped into the real
+ * stream (e.g. pino's CLI destination) can drain: without it only the first
+ * write lands and the rest hang in backpressure. The second argument can be
+ * either an encoding string or the callback.
+ */
+function captureWrites(chunks: string[]): typeof process.stdout.write {
+  return ((
+    chunk: string | Uint8Array,
+    encoding?: unknown,
+    cb?: (err?: Error | null) => void,
+  ) => {
+    chunks.push(
+      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
+    );
+    const callback = typeof encoding === "function" ? encoding : cb;
+    if (typeof callback === "function") {
+      callback();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+}
+
+/**
  * CLI test utility — run an assistant CLI command via the real program,
  * capturing stdout and stderr.
  *
@@ -24,32 +48,20 @@ export async function runAssistantCommandFull(
   });
 
   const stdoutChunks: string[] = [];
-  const originalWrite = process.stdout.write;
-  // Override must invoke the callback (when provided) so that `Writable` streams
-  // piped into `process.stdout` (e.g. pino's CLI destination) can drain.
-  // Without this, only the first write lands and subsequent writes hang in
-  // backpressure. The second arg can be either an encoding string or the callback.
-  process.stdout.write = ((
-    chunk: string | Uint8Array,
-    encoding?: unknown,
-    cb?: (err?: Error | null) => void,
-  ) => {
-    stdoutChunks.push(
-      typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk),
-    );
-    const callback = typeof encoding === "function" ? encoding : cb;
-    if (typeof callback === "function") {
-      callback();
-    }
-    return true;
-  }) as typeof process.stdout.write;
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+  process.stdout.write = captureWrites(stdoutChunks);
+  // `writeError` reaches process.stderr directly, so commander's `writeErr`
+  // alone would miss a command's own error output.
+  process.stderr.write = captureWrites(stderrChunks);
 
   try {
     await program.parseAsync(["node", "assistant", ...args]);
   } catch {
     /* commander exit override throws */
   } finally {
-    process.stdout.write = originalWrite;
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
   }
 
   return {

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -60,6 +60,8 @@ interface ContactPromptResult {
   contactId?: string;
   /** Whether the channel is attested, as the guardian's checkbox left it. */
   verified?: boolean;
+  /** The guardian dismissed the form. Nothing was written. */
+  cancelled?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -258,6 +260,19 @@ async function readContactForPrompt(
 }
 
 /**
+ * The guardian closed the form without answering it. Nothing was written and
+ * nothing went wrong, so this is a success exit with a plain line rather than
+ * an error envelope a caller would read as a failed write.
+ */
+function reportFormDismissal(cmd: Command): void {
+  if (shouldOutputJson(cmd)) {
+    writeOutput(cmd, { ok: true, cancelled: true });
+  } else {
+    process.stdout.write("Cancelled: nothing was written\n");
+  }
+}
+
+/**
  * Park on the guardian's answer to a contact-record form, then report what was
  * actually written. The submitted values can differ from the proposed ones, so
  * the result is re-read rather than echoed back from the request.
@@ -277,6 +292,7 @@ async function runRecordPrompt(
     contactId?: string;
     notesSaved?: boolean;
     nothingWritten?: boolean;
+    cancelled?: boolean;
   }>(
     "contacts_record_prompt",
     { body: { ...body, timeoutMs } },
@@ -288,6 +304,10 @@ async function runRecordPrompt(
       r as { ok: false; error?: string; statusCode?: number },
       cmd,
     );
+  }
+
+  if (r.result?.cancelled === true) {
+    return reportFormDismissal(cmd);
   }
 
   if (!r.result?.ok) {
@@ -627,6 +647,10 @@ export function registerContactsCommand(program: Command): void {
               r as { ok: false; error?: string; statusCode?: number },
               cmd,
             );
+          }
+
+          if (r.result?.cancelled === true) {
+            return reportFormDismissal(cmd);
           }
 
           if (!r.result?.ok) {

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -261,8 +261,12 @@ async function readContactForPrompt(
 
 /**
  * The guardian closed the form without answering it. Nothing was written and
- * nothing went wrong, so this is a success exit with a plain line rather than
- * an error envelope a caller would read as a failed write.
+ * nothing went wrong, so this reports a plain line rather than an error
+ * envelope a caller would read as a failed write.
+ *
+ * Exit 130 is the conventional user-interrupt code, and the same one
+ * `credentials request` uses for a declined prompt, so a caller can tell a
+ * deliberate dismissal from a genuine failure without parsing output.
  */
 function reportFormDismissal(cmd: Command): void {
   if (shouldOutputJson(cmd)) {
@@ -270,6 +274,7 @@ function reportFormDismissal(cmd: Command): void {
   } else {
     process.stdout.write("Cancelled: nothing was written\n");
   }
+  process.exitCode = 130;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `contacts create`/`update`/`delete` and `contacts prompt` branch on the `cancelled` marker PR 1 put on the guardian-form rail, so a dismissed form prints `Cancelled: nothing was written` and exits 0 instead of surfacing `{"ok":false,"error":"Cancelled by user"}` as an error.
- With `--json` a dismissal emits exactly one object, `{"ok":true,"cancelled":true}`, so callers branch on a field rather than matching a message string. A genuine form failure (timeout, failed write) still writes to stderr and exits nonzero.
- Tests: new `contacts-address-prompt-cli.test.ts` pins the `contacts_prompt` request body and both dismissal modes; the record-prompt suite gains create/update/delete dismissal cases. `runAssistantCommandFull` also captures direct `process.stderr` writes, which is where `writeError` lands, so the "nothing on stderr" assertions are real rather than vacuous.

Worth a reviewer's eye: `credentials prompt` reports its own user cancel with exit 130. This surface keeps exit 0 per the plan (exit 2 is already `exitFromIpcResult`'s 4xx code, and `--json` callers read `cancelled`), so the two differ deliberately.

Part of plan: contacts-cli-channel-binding.md (PR 2 of 12)