### PR TITLE
feat(contacts): the record form can propose a merge

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6704,9 +6704,10 @@ paths:
                     - create
                     - update
                     - delete
+                    - merge
                   description: Which record write the guardian is being asked to confirm.
                 contactId:
-                  description: Target contact. Required for update and delete.
+                  description: Target contact. Required for update, delete and merge (the survivor).
                   type: string
                 currentDisplayName:
                   description:
@@ -6722,6 +6723,25 @@ paths:
                   description:
                     The target's channels, resolved by the caller, so a delete confirmation can identify the contact and show
                     what access is about to be lost.
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      address:
+                        type: string
+                    required:
+                      - type
+                      - address
+                donorContactId:
+                  description: The contact being merged away. Present only on a merge.
+                  type: string
+                donorDisplayName:
+                  description: That contact's name, so the confirmation can say who is being absorbed.
+                  type: string
+                donorChannels:
+                  description: The channels moving to the survivor.
                   type: array
                   items:
                     type: object

--- a/assistant/src/api/events/contact-record-request.ts
+++ b/assistant/src/api/events/contact-record-request.ts
@@ -2,9 +2,12 @@
  * `contact_record_request` SSE event.
  *
  * Server to client form asking the guardian to confirm a contact record write
- * the assistant proposed: a create, an update, or a delete. Emitted by the
- * `contacts/record-prompt` IPC route while a `pendingContactPrompts` entry
+ * the assistant proposed: a create, an update, a delete, or a merge. Emitted by
+ * the `contacts/record-prompt` IPC route while a `pendingContactPrompts` entry
  * awaits a reply.
+ *
+ * On a merge, `contactId` is the survivor and `displayName` is the name the
+ * survivor ends up with; the donor is carried in the `donor*` fields.
  *
  * The proposed values are a starting point, not a decision. The guardian may
  * edit the name and notes before submitting, and the client posts the result
@@ -25,8 +28,8 @@ import { z } from "zod";
 export const ContactRecordRequestEventSchema = z.object({
   type: z.literal("contact_record_request"),
   requestId: z.string(),
-  operation: z.enum(["create", "update", "delete"]),
-  /** Target of an update or delete. Absent on create. */
+  operation: z.enum(["create", "update", "delete", "merge"]),
+  /** Target of an update, delete or merge. Absent on create. */
   contactId: z.string().optional(),
   /** Current name of the target, so the form can show what is changing. */
   currentDisplayName: z.string().optional(),
@@ -40,6 +43,15 @@ export const ContactRecordRequestEventSchema = z.object({
    * same-named contacts it is about, and what access is about to be lost.
    */
   channels: z
+    .array(z.object({ type: z.string(), address: z.string() }))
+    .optional(),
+
+  /** The contact being merged away. Present only on a merge. */
+  donorContactId: z.string().optional(),
+  /** That contact's name, so the confirmation can say who is being absorbed. */
+  donorDisplayName: z.string().optional(),
+  /** The channels moving to the survivor. */
+  donorChannels: z
     .array(z.object({ type: z.string(), address: z.string() }))
     .optional(),
 

--- a/assistant/src/runtime/routes/__tests__/contact-record-prompt-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-record-prompt-route.test.ts
@@ -119,8 +119,8 @@ describe("contacts_record_prompt", () => {
     expect(await pending).toEqual({ ok: false, error: "Cancelled by user" });
   });
 
-  test("update and delete require a contact id, and broadcast nothing without one", async () => {
-    for (const operation of ["update", "delete"]) {
+  test("update, delete and merge require a contact id, and broadcast nothing without one", async () => {
+    for (const operation of ["update", "delete", "merge"]) {
       broadcasts = [];
       const result = (await recordPrompt.handler({
         body: { operation, displayName: "Alice" },
@@ -132,10 +132,66 @@ describe("contacts_record_prompt", () => {
     }
   });
 
-  test("rejects an operation outside create/update/delete", async () => {
+  test("rejects an operation outside create/update/delete/merge", async () => {
     expect(() =>
       recordPrompt.handler({ body: { operation: "promote" } }),
     ).toThrow();
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  test("a merge broadcasts the survivor and the contact being absorbed", async () => {
+    const donorChannels = [{ type: "email", address: "bob@example.com" }];
+    const pending = recordPrompt.handler({
+      body: {
+        operation: "merge",
+        contactId: "ct_survivor",
+        currentDisplayName: "Alice",
+        donorContactId: "ct_donor",
+        donorDisplayName: "Bob",
+        donorChannels,
+      },
+    }) as Promise<Record<string, unknown>>;
+
+    const message = broadcasts.find((b) => b.type === "contact_record_request");
+    expect(message).toMatchObject({
+      operation: "merge",
+      contactId: "ct_survivor",
+      donorContactId: "ct_donor",
+      donorDisplayName: "Bob",
+      donorChannels,
+    });
+
+    resolvePrompt.handler({
+      body: { requestId: parkedRequestId(), contactId: "ct_survivor" },
+    });
+    expect(await pending).toEqual({ ok: true, contactId: "ct_survivor" });
+  });
+
+  test("a merge without a donor is refused, and broadcasts nothing", async () => {
+    const result = (await recordPrompt.handler({
+      body: { operation: "merge", contactId: "ct_survivor" },
+    })) as Record<string, unknown>;
+
+    expect(result).toEqual({
+      ok: false,
+      error: "donorContactId is required to merge",
+    });
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  test("a contact cannot be merged into itself", async () => {
+    const result = (await recordPrompt.handler({
+      body: {
+        operation: "merge",
+        contactId: "ct_1",
+        donorContactId: "ct_1",
+      },
+    })) as Record<string, unknown>;
+
+    expect(result).toEqual({
+      ok: false,
+      error: "Cannot merge a contact with itself",
+    });
     expect(broadcasts).toHaveLength(0);
   });
 

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -4,7 +4,7 @@
  * Two commands park on the guardian-form rail:
  *   - `contacts/prompt` collects a channel address and binds a channel.
  *   - `contacts/record-prompt` confirms a contact record write the assistant
- *     proposed (create, update, delete). No channel is touched.
+ *     proposed (create, update, delete, merge). No address is bound.
  *
  * Flow, identical for both:
  *   1. CLI calls the IPC route with what the assistant proposes.
@@ -165,12 +165,14 @@ const ContactPromptParams = z.object({
 
 const ContactRecordPromptParams = z.object({
   operation: z
-    .enum(["create", "update", "delete"])
+    .enum(["create", "update", "delete", "merge"])
     .describe("Which record write the guardian is being asked to confirm."),
   contactId: z
     .string()
     .optional()
-    .describe("Target contact. Required for update and delete."),
+    .describe(
+      "Target contact. Required for update, delete and merge (the survivor).",
+    ),
   currentDisplayName: z
     .string()
     .optional()
@@ -189,6 +191,21 @@ const ContactRecordPromptParams = z.object({
     .describe(
       "The target's channels, resolved by the caller, so a delete confirmation can identify the contact and show what access is about to be lost.",
     ),
+
+  donorContactId: z
+    .string()
+    .optional()
+    .describe("The contact being merged away. Present only on a merge."),
+  donorDisplayName: z
+    .string()
+    .optional()
+    .describe(
+      "That contact's name, so the confirmation can say who is being absorbed.",
+    ),
+  donorChannels: z
+    .array(z.object({ type: z.string(), address: z.string() }))
+    .optional()
+    .describe("The channels moving to the survivor."),
 
   displayName: z
     .string()
@@ -304,6 +321,9 @@ async function handleContactRecordPrompt({
     currentDisplayName,
     currentNotes,
     channels,
+    donorContactId,
+    donorDisplayName,
+    donorChannels,
     displayName,
     notes,
     notesProposed,
@@ -314,6 +334,15 @@ async function handleContactRecordPrompt({
 
   if (operation !== "create" && !contactId) {
     return { ok: false, error: `contactId is required to ${operation}` };
+  }
+
+  if (operation === "merge") {
+    if (!donorContactId) {
+      return { ok: false, error: "donorContactId is required to merge" };
+    }
+    if (donorContactId === contactId) {
+      return { ok: false, error: "Cannot merge a contact with itself" };
+    }
   }
 
   // Clients hold one contact card at a time, so a second broadcast replaces the
@@ -331,7 +360,7 @@ async function handleContactRecordPrompt({
   return openGuardianForm<ContactPromptResult>({
     kind: RECORD_FORM,
     timeoutMs,
-    logContext: { operation, contactId },
+    logContext: { operation, contactId, donorContactId },
     broadcast: {
       open: (requestId) =>
         broadcastMessage({
@@ -342,6 +371,9 @@ async function handleContactRecordPrompt({
           currentDisplayName,
           currentNotes,
           channels,
+          donorContactId,
+          donorDisplayName,
+          donorChannels,
           displayName,
           notes,
           notesProposed,

--- a/clients/web/src/domains/chat/api/interactions.ts
+++ b/clients/web/src/domains/chat/api/interactions.ts
@@ -188,7 +188,7 @@ export async function submitContactRecord(
   requestId: string,
   input:
     | {
-        operation: "create" | "update" | "delete";
+        operation: "create" | "update" | "delete" | "merge";
         contactId?: string;
         displayName?: string;
         notes?: string;

--- a/clients/web/src/types/interaction-ui-types.ts
+++ b/clients/web/src/types/interaction-ui-types.ts
@@ -69,14 +69,14 @@ export interface PendingContactRequestState {
 }
 
 /**
- * A contact record write (create, update, delete) the assistant proposed and
- * the guardian has not answered yet. The proposed values seed the form; what
- * the guardian submits is what gets written.
+ * A contact record write (create, update, delete, merge) the assistant proposed
+ * and the guardian has not answered yet. The proposed values seed the form;
+ * what the guardian submits is what gets written.
  */
 export interface PendingContactRecordRequestState {
   requestId: string;
-  operation: "create" | "update" | "delete";
-  /** Target of an update or delete. Absent on create. */
+  operation: "create" | "update" | "delete" | "merge";
+  /** Target of an update or delete, and the survivor of a merge. */
   contactId?: string;
   /** The target's current name, so the form can show what is changing. */
   currentDisplayName?: string;

--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Vellum Gateway API",
-    "version": "0.11.7",
+    "version": "0.11.8",
     "description": "Auto-generated OpenAPI specification for the Vellum Gateway HTTP endpoints."
   },
   "servers": [{ "url": "", "description": "Same-origin (gateway)" }],
@@ -1410,10 +1410,14 @@
                   "operation": {
                     "description": "Required unless cancelled is true",
                     "type": "string",
-                    "enum": ["create", "update", "delete"]
+                    "enum": ["create", "update", "delete", "merge"]
                   },
                   "contactId": {
-                    "description": "Required to update or delete",
+                    "description": "Required to update or delete, and the survivor of a merge",
+                    "type": "string"
+                  },
+                  "donorContactId": {
+                    "description": "The contact merged away. Required for a merge.",
                     "type": "string"
                   },
                   "displayName": { "type": "string" },

--- a/gateway/src/http/routes/contacts-control-plane-routes.ts
+++ b/gateway/src/http/routes/contacts-control-plane-routes.ts
@@ -156,10 +156,17 @@ const ContactRecordSubmitRequestSchema = z.object({
     .string()
     .describe("The contact_record_request id broadcast by the assistant"),
   operation: z
-    .enum(["create", "update", "delete"])
+    .enum(["create", "update", "delete", "merge"])
     .optional()
     .describe("Required unless cancelled is true"),
-  contactId: z.string().optional().describe("Required to update or delete"),
+  contactId: z
+    .string()
+    .optional()
+    .describe("Required to update or delete, and the survivor of a merge"),
+  donorContactId: z
+    .string()
+    .optional()
+    .describe("The contact merged away. Required for a merge."),
   displayName: z.string().optional(),
   notes: z.string().nullable().optional(),
   expectedChannels: z


### PR DESCRIPTION
## Summary

- `contacts_record_prompt` accepts `operation: "merge"` and carries `donorContactId`, `donorDisplayName` and `donorChannels` on the `contact_record_request` event, with `contactId` as the survivor.
- A merge missing its donor, or naming the survivor as the donor, is rejected before a form opens. Create, update and delete are unchanged.
- No `expectedChannels`-style guard on merge: a delete has one because a cascade destroys access, whereas a merge reparents channels to the survivor, so a channel gained while the form was open moves rather than being lost.
- Beyond the plan's file list, `clients/web` gets two type-level widenings (`PendingContactRecordRequestState["operation"]` and `submitContactRecord`'s input union). `pr-web.yaml` runs on `assistant/src/api/**`, so without them the Type Check job fails on the pass-through in `handleContactRecordRequest`. The merge card, i18n and submit payload are PR 10.

Part of plan: contacts-cli-channel-binding.md (PR 8 of 12)