### PR TITLE
feat(web): Live sight fits a phone, and is felt on one

### DIFF
--- a/clients/web/.storybook/viewports.ts
+++ b/clients/web/.storybook/viewports.ts
@@ -19,6 +19,16 @@ export const SB_VIEWPORTS = {
     type: "mobile" as const,
   },
   /**
+   * The narrowest phone the app runs on. For the surfaces whose content is a
+   * fixed number of fixed-size things in a row, where 390px has slack that
+   * hides whether the row fits at all.
+   */
+  sbNarrowPhone: {
+    name: "Mobile (narrow)",
+    styles: { width: "320px", height: "568px" },
+    type: "mobile" as const,
+  },
+  /**
    * A desktop window too short for what it holds. Height is the whole point:
    * a dialog that keeps room for an open menu has to give that room back
    * here, and a story pinned to it shows whether the footer survives.

--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -155,9 +155,9 @@ which is the thing to watch for battery and heat below.
 
 ## Small screens and rotation
 
-Both shells. The camera's floor had never been drawn at phone width with Live
-running, because Live only reached the phones with the native frame source, so
-until then the kept-frame thumbnail could appear on a desktop only.
+Both shells. Live reaches a phone through the native frame source, so the kept
+frame and the photo strip share a floor at widths no desktop imposes on them,
+and every check here is about what that floor does as it runs out of room.
 
 Handsets, not simulators: the iOS Simulator provides no camera feed, so it
 answers nothing here.
@@ -178,12 +178,12 @@ answers nothing here.
       and legible over a bright frame, and that the scrim does not reach the
       status pill at the top.
 - [ ] Rotating with Live running. Enter Live, rotate the device, rotate back.
-      Android recreates the camera fragment on rotation and this has never been
-      run with sampling active, so watch for all of: the pill stays Live or
-      drops cleanly back to photo (never Live over a dead poll), the tuning
-      readout's decision rate is unchanged rather than doubled, no keep from
-      before the rotation lands in the transcript after one from after it, and
-      the viewfinder is live video rather than a frozen frame.
+      Android recreates the camera fragment on rotation, and no automated test
+      covers a rotation with sampling active, so watch for all of: the pill
+      stays Live or drops cleanly back to photo (never Live over a dead poll),
+      the tuning readout's decision rate is unchanged rather than doubled, no
+      keep from before the rotation lands in the transcript after one from
+      after it, and the viewfinder is live video rather than a frozen frame.
 
 ## Android
 
@@ -204,12 +204,13 @@ answers nothing here.
       the "Live on iPhone" section here too: the hold enters Live, keeps pulse
       and land in the transcript, and a device that keeps nothing shows the
       slow-bridge signature rather than hanging.
-- [ ] Haptics reach Android at all. The shell has always linked the plugin and
-      the app never asked it for these two effects, so this is the first build
-      where either fires here. Hold the shutter: a light tap at half a second,
-      then one per keep, the same as iPhone. Check the rest of the app kept its
-      manners with them: a long-press on a conversation row, a pull to refresh,
-      and a send all tap once, none of them twice.
+- [ ] Haptics on Android. The light impact is the only effect this shell fires,
+      so it is the whole surface to check. Hold the shutter: a tap at half a
+      second, then one per keep, the same as iPhone. Then the gesture that has
+      an effect at each end: pull the transcript to refresh and feel exactly one
+      tap, as it crosses the threshold. Its completion is a heavier impact or a
+      notification, neither of which Android fires, so a second tap there is the
+      regression to watch for.
 - [ ] TalkBack says it once. Same check as VoiceOver above.
 
 ## Desktop web and macOS

--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -127,6 +127,15 @@ which is the thing to watch for battery and heat below.
       second the haptic fires, the ring goes crimson, the pill says Live and the
       hint changes to "Live · Tap to stop". Letting go takes no photo, so
       nothing joins the strip and nothing new lands in the transcript.
+- [ ] Every keep is felt. With Live running on a subject the gate keeps from,
+      one light tap lands with each crimson thumbnail and no others: a scene the
+      gate skips is silent, and so is a keep that never reaches the call. Turn
+      the phone to airplane mode mid-Live and hold it on a new subject: through
+      the reconnect gap nothing taps, because nothing was shared. The tap is
+      what the feature has instead of a screen the user is looking at, since
+      Live is aimed at the thing being talked about.
+- [ ] The tap is not the shutter's. Take ordinary photos: no haptic fires on a
+      tap, only on the hold that enters Live and on the keeps that follow.
 - [ ] The hold survives a real thumb. Hold with the phone at arm's length: a
       small wobble still enters Live. Slide the thumb off the shutter, or more
       than a finger's width across it, and nothing happens: no photo either,
@@ -143,6 +152,38 @@ which is the thing to watch for battery and heat below.
 - [ ] VoiceOver says the mode. With Live running, VoiceOver reads "Live.
       Listening" on the next state change, and the shutter is named "Stop live".
       Back on photo it reads "Photo. Listening" and "Take a photo".
+
+## Small screens and rotation
+
+Both shells. The camera's floor had never been drawn at phone width with Live
+running, because Live only reached the phones with the native frame source, so
+until then the kept-frame thumbnail could appear on a desktop only.
+
+Handsets, not simulators: the iOS Simulator provides no camera feed, so it
+answers nothing here.
+
+- [ ] The capture row fits the narrowest phone. On a 320pt-wide device, take
+      three photos and then hold for Live: the three receipts and the crimson
+      kept frame sit in one row above the shutter. Nothing is clipped at the
+      right edge, nothing scrolls or wraps, and the row is on its own line
+      rather than reaching the shutter or the flip control. Storybook's
+      Chat/Voice/CameraModeScreen, story "NarrowPhoneCaptureRow", is the same
+      composition at the same width to check it against.
+- [ ] The row clears the sensor housing in landscape. Rotate to landscape with
+      photos on the floor: the first thumbnail starts inboard of the notch on
+      the notched side, on the same left edge the tuning readout uses.
+- [ ] The landscape floor still reads. Rotate with the camera up. The bottom
+      scrim's 15rem floor is most of a short viewport, so check that the
+      shutter, the hint, the capture row and the session row are all on screen
+      and legible over a bright frame, and that the scrim does not reach the
+      status pill at the top.
+- [ ] Rotating with Live running. Enter Live, rotate the device, rotate back.
+      Android recreates the camera fragment on rotation and this has never been
+      run with sampling active, so watch for all of: the pill stays Live or
+      drops cleanly back to photo (never Live over a dead poll), the tuning
+      readout's decision rate is unchanged rather than doubled, no keep from
+      before the rotation lands in the transcript after one from after it, and
+      the viewfinder is live video rather than a frozen frame.
 
 ## Android
 
@@ -163,6 +204,12 @@ which is the thing to watch for battery and heat below.
       the "Live on iPhone" section here too: the hold enters Live, keeps pulse
       and land in the transcript, and a device that keeps nothing shows the
       slow-bridge signature rather than hanging.
+- [ ] Haptics reach Android at all. The shell has always linked the plugin and
+      the app never asked it for these two effects, so this is the first build
+      where either fires here. Hold the shutter: a light tap at half a second,
+      then one per keep, the same as iPhone. Check the rest of the app kept its
+      manners with them: a long-press on a conversation row, a pull to refresh,
+      and a send all tap once, none of them twice.
 - [ ] TalkBack says it once. Same check as VoiceOver above.
 
 ## Desktop web and macOS

--- a/clients/web/src/domains/chat/voice/camera-mode-screen.stories.tsx
+++ b/clients/web/src/domains/chat/voice/camera-mode-screen.stories.tsx
@@ -418,17 +418,19 @@ export const LongAssistantName: Story = {
 };
 
 /**
- * The floor with everything on it at once, at the narrowest width the app runs
- * at: three photo receipts, Live's kept frame beside them, and the shutter in
+ * The floor at its fullest, at the narrowest width the app runs at: the photo
+ * strip at its three-tile cap, Live's kept frame beside it, and the shutter in
  * Live below.
  *
  * The read to check is the capture row's right edge against the shutter's
  * column. Four 44px tiles and the 8px between them is 200px of content behind a
- * 24px offset, so at 320px the row ends well short of the right edge and sits
- * on a line of its own above the shutter, rather than wrapping, scrolling, or
- * running under the flip control. This is the combination that had never been
- * drawn at phone width: Live only reached the phones with the native frame
- * source, so before that the kept frame could only ever appear on a desktop.
+ * 24px offset, so at 320px the row ends well short of the right edge and holds
+ * a line of its own above the shutter, rather than wrapping, scrolling, or
+ * running under the flip control.
+ *
+ * This composition belongs to a phone and reaches one only through the native
+ * frame source, so this story is where its geometry is answerable: a desktop
+ * width has slack enough to hide whether the row fits.
  */
 export const NarrowPhoneCaptureRow: Story = {
   args: { mode: "live", photos: 3, keptFrame: true },

--- a/clients/web/src/domains/chat/voice/camera-mode-screen.stories.tsx
+++ b/clients/web/src/domains/chat/voice/camera-mode-screen.stories.tsx
@@ -42,6 +42,8 @@ import {
   type CameraMode,
 } from "./voice-room/camera-status-pill";
 import type { CameraVoiceState } from "./voice-room/use-camera-voice-state";
+import type { VoiceRoomPhoto } from "./voice-room/use-voice-room-camera";
+import { VoiceRoomCaptureRow } from "./voice-room/voice-room-capture-row";
 import { VoiceRoomControl } from "./voice-room/voice-room-control";
 
 /**
@@ -79,6 +81,28 @@ const SHUTTER_LABELS: Record<CameraMode, string> = {
 
 const noop = () => {};
 
+/**
+ * A flat swatch standing in for a captured frame, since the row draws whatever
+ * bytes the camera handed it and the question these stories ask is how wide the
+ * tiles are, not what is in them.
+ */
+const captureThumb = (hue: number) =>
+  `data:image/svg+xml,${encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="88" height="88"><rect width="88" height="88" fill="hsl(${hue} 42% 52%)"/></svg>`,
+  )}`;
+
+/** The strip at the cap the camera hook holds it to: three, oldest first. */
+const FULL_STRIP: readonly VoiceRoomPhoto[] = [
+  { id: 1, previewUrl: captureThumb(28), status: "sent" },
+  { id: 2, previewUrl: captureThumb(96), status: "sent" },
+  { id: 3, previewUrl: captureThumb(210), status: "sending" },
+];
+
+const KEPT_FRAME = {
+  attachmentId: "att-story",
+  previewUrl: captureThumb(340),
+};
+
 interface CameraModeScreenProps {
   /** What the camera is doing. Drives the pill's fill and the shutter's core. */
   mode?: CameraMode;
@@ -90,6 +114,10 @@ interface CameraModeScreenProps {
   assistantName?: string;
   /** Mic off: the control goes red and loses the row's only white fill. */
   micMuted?: boolean;
+  /** How many photo receipts sit on the floor's left edge. Capped at three. */
+  photos?: number;
+  /** Whether Live's newest kept frame sits beside them. */
+  keptFrame?: boolean;
 }
 
 /**
@@ -113,6 +141,8 @@ function CameraModeScreen({
   statusLabel,
   assistantName,
   micMuted = false,
+  photos = 0,
+  keptFrame = false,
 }: CameraModeScreenProps) {
   return (
     <div className="relative h-dvh w-full overflow-hidden bg-black">
@@ -183,14 +213,19 @@ function CameraModeScreen({
       </div>
 
       {/* The shutter row, a row of its own above the session controls, with
-          the hint over it. Full width here because the app's is: flash and
-          flip ride the room's edges rather than a fixed measure. The room
-          shows the hint only where Live can run; this screen always can, so
-          it always carries one. */}
+          the hint over it and the capture row above that. Full width here
+          because the app's is: flash and flip ride the room's edges rather
+          than a fixed measure, and the capture row rides the left one. The
+          room shows the hint only where Live can run; this screen always can,
+          so it always carries one. */}
       <div
         className="absolute inset-x-0 z-10 flex flex-col items-center gap-3"
         style={{ bottom: SHUTTER_ROW_BOTTOM }}
       >
+        <VoiceRoomCaptureRow
+          photos={FULL_STRIP.slice(0, photos)}
+          keptFrame={keptFrame ? KEPT_FRAME : null}
+        />
         <CameraRowScene
           className="w-full"
           hint={{ mode }}
@@ -260,6 +295,8 @@ const meta: Meta<typeof CameraModeScreen> = {
     statusLabel: "Listening…",
     assistantName: "Luna",
     micMuted: false,
+    photos: 0,
+    keptFrame: false,
   },
   argTypes: {
     mode: {
@@ -273,6 +310,12 @@ const meta: Meta<typeof CameraModeScreen> = {
       control: { type: "inline-radio" },
       description:
         "Whose voice is live. The room derives it; the pill paints it.",
+    },
+    photos: {
+      options: [0, 1, 2, 3],
+      control: { type: "inline-radio" },
+      description:
+        "How many photo receipts are on the floor. Three is the cap the camera hook holds the strip to.",
     },
     statusLabel: {
       options: [
@@ -372,6 +415,24 @@ export const LongAssistantName: Story = {
     statusLabel: "Speaking…",
     assistantName: "A considerably longer configured assistant name",
   },
+};
+
+/**
+ * The floor with everything on it at once, at the narrowest width the app runs
+ * at: three photo receipts, Live's kept frame beside them, and the shutter in
+ * Live below.
+ *
+ * The read to check is the capture row's right edge against the shutter's
+ * column. Four 44px tiles and the 8px between them is 200px of content behind a
+ * 24px offset, so at 320px the row ends well short of the right edge and sits
+ * on a line of its own above the shutter, rather than wrapping, scrolling, or
+ * running under the flip control. This is the combination that had never been
+ * drawn at phone width: Live only reached the phones with the native frame
+ * source, so before that the kept frame could only ever appear on a desktop.
+ */
+export const NarrowPhoneCaptureRow: Story = {
+  args: { mode: "live", photos: 3, keptFrame: true },
+  globals: { viewport: { value: "sbNarrowPhone" } },
 };
 
 /**

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.test.tsx
@@ -114,6 +114,17 @@ mock.module("@/domains/chat/api/messages", () => ({
   deleteChatAttachment,
 }));
 
+/**
+ * The keep's own feedback, replaced because the real one lazy-imports a
+ * Capacitor plugin that has no bridge here. What the cases check is which
+ * frames it fires for, which is the wiring; whether a light impact is the right
+ * effect is the haptics util's business.
+ */
+const hapticLight = mock(async () => {});
+mock.module("@/utils/haptics", () => ({
+  haptic: { light: hapticLight },
+}));
+
 const { useVoiceRoomSight } = await import("./use-voice-room-sight");
 const { publish } = await import("@/lib/event-bus");
 const { minimizeVoiceRoom, restoreVoiceRoom, useLiveVoiceStore } =
@@ -256,6 +267,7 @@ beforeEach(() => {
   captureVideoFrame.mockClear();
   uploadChatAttachment.mockClear();
   deleteChatAttachment.mockClear();
+  hapticLight.mockClear();
   pendingUploads = [];
   autoUploadId = 0;
   uploadsResolveImmediately = true;
@@ -527,6 +539,28 @@ describe("useVoiceRoomSight: sharing a keep", () => {
     // The daemon owns a frame it was told about and reclaims it if the
     // persist fails, so nothing here may delete the row.
     expect(deleteChatAttachment).not.toHaveBeenCalled();
+  });
+
+  test("a keep the call was given is felt once", async () => {
+    // The pulse is on a screen nobody is watching: Live is held at arm's
+    // length, aimed at whatever is being talked about.
+    const { view } = renderSight();
+
+    await keepFrame();
+
+    expect(hapticLight).toHaveBeenCalledTimes(1);
+    expect(view.result.current.heldFrame?.attachmentId).toBe("att-1");
+  });
+
+  test("a keep the session refused is felt not at all", async () => {
+    // Same reason the thumbnail stays down for one: nothing was shared, so
+    // there is nothing to report.
+    controls.sightFrame.mockImplementation(() => false);
+    renderSight();
+
+    await keepFrame();
+
+    expect(hapticLight).not.toHaveBeenCalled();
   });
 
   test("sends each keep exactly once", async () => {

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
@@ -645,12 +645,12 @@ export function useVoiceRoomSight(
               abandonUpload();
               return;
             }
-            // The one beat on this path a user asked for and cannot watch for:
-            // Live is held at arm's length, aimed at the thing being talked
-            // about rather than at the thumbnail. Here rather than at the keep,
-            // because this is where a frame becomes one the call was given, and
-            // every frame the gate keeps but a guard refuses reaches
-            // `abandonUpload` above instead.
+            // The one beat on this path the user cannot watch for: Live is
+            // held at arm's length, aimed at the scene rather than at the
+            // thumbnail. It fires here, after the send is accepted, because
+            // this is where a frame becomes one the call was given; every
+            // frame a guard refuses reaches `abandonUpload` above and stays
+            // silent.
             void haptic.light();
             hold({
               attachmentId: uploaded.id,

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
@@ -106,6 +106,7 @@ import {
 } from "@/lib/camera/native-frame-source";
 import { captureError } from "@/lib/sentry/capture-error";
 import { captureNativeVoiceCameraSample } from "@/runtime/native-voice-camera";
+import { haptic } from "@/utils/haptics";
 
 import {
   captureVideoFrame,
@@ -644,6 +645,13 @@ export function useVoiceRoomSight(
               abandonUpload();
               return;
             }
+            // The one beat on this path a user asked for and cannot watch for:
+            // Live is held at arm's length, aimed at the thing being talked
+            // about rather than at the thumbnail. Here rather than at the keep,
+            // because this is where a frame becomes one the call was given, and
+            // every frame the gate keeps but a guard refuses reaches
+            // `abandonUpload` above instead.
+            void haptic.light();
             hold({
               attachmentId: uploaded.id,
               previewUrl: URL.createObjectURL(frame),

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-capture-row.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-capture-row.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Tests for `VoiceRoomCaptureRow`, the receipts and the kept frame on the
+ * camera's floor.
+ *
+ * Load-bearing contracts: that an empty floor draws no row at all, so the
+ * column above the shutter does not carry an empty band, and that the strip and
+ * the kept frame share one row.
+ *
+ * The row's offset and its width are not checkable here. happy-dom lays nothing
+ * out, and it drops the `max()` the offset is written as rather than storing
+ * it, so both the padding and the geometry are answered in a browser against
+ * `camera-mode-screen.stories.tsx`, story "NarrowPhoneCaptureRow".
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { VoiceRoomCaptureRow } from "@/domains/chat/voice/voice-room/voice-room-capture-row";
+import type { VoiceRoomPhoto } from "@/domains/chat/voice/voice-room/use-voice-room-camera";
+
+afterEach(() => {
+  cleanup();
+});
+
+const PHOTOS: readonly VoiceRoomPhoto[] = [
+  { id: 1, previewUrl: "blob:one", status: "sent" },
+  { id: 2, previewUrl: "blob:two", status: "sending" },
+  { id: 3, previewUrl: "blob:three", status: "failed" },
+];
+
+const KEPT = { attachmentId: "att-1", previewUrl: "blob:kept" };
+
+describe("VoiceRoomCaptureRow", () => {
+  test("draws nothing with no photos and no kept frame", () => {
+    render(<VoiceRoomCaptureRow photos={[]} keptFrame={null} />);
+
+    expect(screen.queryByTestId("voice-room-capture-row")).toBeNull();
+  });
+
+  test("draws the strip and the kept frame in one row", () => {
+    render(<VoiceRoomCaptureRow photos={PHOTOS} keptFrame={KEPT} />);
+
+    const row = screen.getByTestId("voice-room-capture-row");
+    expect(screen.getAllByTestId("voice-room-photo")).toHaveLength(3);
+    expect(row.contains(screen.getByTestId("voice-room-photo-strip"))).toBe(
+      true,
+    );
+    expect(row.contains(screen.getByTestId("voice-room-sight-frame"))).toBe(
+      true,
+    );
+  });
+
+  test("draws the row for a kept frame with no photos behind it", () => {
+    render(<VoiceRoomCaptureRow photos={[]} keptFrame={KEPT} />);
+
+    expect(screen.getByTestId("voice-room-capture-row")).not.toBeNull();
+    expect(screen.queryByTestId("voice-room-photo-strip")).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-capture-row.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-capture-row.tsx
@@ -1,0 +1,110 @@
+/**
+ * What the camera has sent, in one row at the floor's left edge: the receipts
+ * for the photos the user took, and beside them the newest frame Live shared on
+ * its own.
+ *
+ * A photo in the strip is a receipt for something the user did. A photo taken
+ * on a call goes somewhere the user cannot see, since the viewfinder does not
+ * change, the assistant may say nothing for seconds, and the transcript is
+ * behind the room; without the strip the press is indistinguishable from a dead
+ * button, which is what sends people pressing it again. The kept frame is the
+ * opposite, a frame nobody asked for, so it has to be visible at the moment it
+ * goes rather than only afterwards. They wear the same shape so the two read as
+ * one row, and the kept one wears the capture accent so they are not read as
+ * the same thing.
+ *
+ * `aria-hidden` throughout. Every photo and every keep lands in the transcript
+ * as its own message, which is the accessible record and the place a user
+ * deletes one from, and the room's live region announces failures in words.
+ *
+ * Left-aligned so it never sits under the shutter, and its own left offset
+ * rides the safe area the way every other edge-anchored piece of the camera's
+ * chrome does: in landscape on a notched phone a flat gap puts the first
+ * thumbnail under the sensor housing.
+ *
+ * At its widest the row is four 44px tiles and the 8px between them, so 200px
+ * of content behind a 24px offset. That fits the narrowest phone the app runs
+ * on with room to spare, which is why it neither caps nor scrolls: a strip that
+ * cannot overflow needs no overflow behavior, and the cap that guarantees it
+ * lives where the photos are kept ({@link VoiceRoomCamera}).
+ */
+
+import { X } from "lucide-react";
+
+import { cn } from "@vellumai/design-library";
+
+import { cameraModeStyle } from "./camera-mode-paint";
+import type { VoiceRoomPhoto } from "./use-voice-room-camera";
+import type { VoiceRoomSightFrame } from "./use-voice-room-sight";
+import { SAFE_AREA_LEFT } from "./voice-room-layout";
+
+/** The design's offset from the room's edge, floored by the safe area. */
+const CAPTURE_ROW_LEFT = `max(1.5rem, ${SAFE_AREA_LEFT})`;
+
+export interface VoiceRoomCaptureRowProps {
+  /** The recent photos, oldest first. Capped by the camera hook at three. */
+  readonly photos: readonly VoiceRoomPhoto[];
+  /**
+   * The newest view Live shared, or null. Null while Live is off, and while
+   * the camera's view options have the thumbnail stood down.
+   */
+  readonly keptFrame: VoiceRoomSightFrame | null;
+}
+
+export function VoiceRoomCaptureRow({
+  photos,
+  keptFrame,
+}: VoiceRoomCaptureRowProps) {
+  if (photos.length === 0 && !keptFrame) {
+    return null;
+  }
+  return (
+    <div
+      data-testid="voice-room-capture-row"
+      className="flex items-center gap-2 self-start"
+      style={{ paddingLeft: CAPTURE_ROW_LEFT }}
+    >
+      {photos.length > 0 ? (
+        <ul
+          aria-hidden
+          data-testid="voice-room-photo-strip"
+          className="flex items-center gap-2"
+        >
+          {photos.map((photo) => (
+            <li key={photo.id} className="relative">
+              <img
+                src={photo.previewUrl}
+                alt=""
+                data-testid="voice-room-photo"
+                data-status={photo.status}
+                className={cn(
+                  "size-11 rounded-lg border object-cover transition",
+                  "border-[var(--room-border)]",
+                  photo.status === "sending" && "opacity-50",
+                  photo.status === "failed" && "opacity-40 grayscale",
+                )}
+              />
+              {photo.status === "failed" ? (
+                <span className="absolute inset-0 flex items-center justify-center">
+                  <X className="size-5 text-red-300" strokeWidth={3} />
+                </span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {/* Keyed on the id, which replays the ring on every keep. */}
+      {keptFrame ? (
+        <img
+          key={keptFrame.attachmentId}
+          src={keptFrame.previewUrl}
+          alt=""
+          aria-hidden
+          data-testid="voice-room-sight-frame"
+          style={cameraModeStyle()}
+          className="sight-frame-kept size-11 rounded-lg object-cover ring-2 ring-[var(--camera-accent)]"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -162,7 +162,6 @@ import {
   CAMERA_MEDIA_GLASS_CLASS,
   CAMERA_SCRIM_BOTTOM,
   CAMERA_SCRIM_TOP,
-  cameraModeStyle,
 } from "./camera-mode-paint";
 import { CameraShutterHint } from "./camera-shutter-hint";
 import { CameraViewSettings } from "./camera-view-settings";
@@ -170,6 +169,7 @@ import {
   CameraStatusPill,
   useCameraStatusAnnouncement,
 } from "./camera-status-pill";
+import { VoiceRoomCaptureRow } from "./voice-room-capture-row";
 import { useActiveConnectSurface } from "./use-active-connect-surface";
 import { useCameraVoiceState } from "./use-camera-voice-state";
 import { useChatHeaderBottom } from "./use-chat-header-bottom";
@@ -1283,85 +1283,16 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
               {errorMessage}
             </p>
           ) : null}
-          {/* What the shutter did.
-
-              A photo taken on a call goes somewhere the user cannot see: the
-              viewfinder does not change, the assistant may say nothing for
-              seconds, and the transcript is behind the room. Without this the
-              press is indistinguishable from a dead button, which is what
-              sends people pressing it again.
+          {/* What the shutter did, and what Live sent on its own.
 
               A strip of recent frames rather than a confirmation step, because
               the question is "did that go?", which can only be answered after
               the fact. A dialog before the send would interrupt the one action
               this surface is built to repeat, and still would not answer it.
-              The shutter press is the consent.
-
-              Dimmed while in flight, struck through when it failed, plain when
-              the assistant has it. Aligned left so it never sits under the
-              shutter, and `aria-hidden` because the live region already
-              announces failures in words. */}
-          {photos.length > 0 || keptFrame ? (
-            <div
-              data-testid="voice-room-capture-row"
-              className="flex items-center gap-2 self-start pl-6"
-            >
-              {photos.length > 0 ? (
-                <ul
-                  aria-hidden
-                  data-testid="voice-room-photo-strip"
-                  className="flex items-center gap-2"
-                >
-                  {photos.map((photo) => (
-                    <li key={photo.id} className="relative">
-                      <img
-                        src={photo.previewUrl}
-                        alt=""
-                        data-testid="voice-room-photo"
-                        data-status={photo.status}
-                        className={cn(
-                          "size-11 rounded-lg border object-cover transition",
-                          "border-[var(--room-border)]",
-                          photo.status === "sending" && "opacity-50",
-                          photo.status === "failed" && "opacity-40 grayscale",
-                        )}
-                      />
-                      {photo.status === "failed" ? (
-                        <span className="absolute inset-0 flex items-center justify-center">
-                          <X className="size-5 text-red-300" strokeWidth={3} />
-                        </span>
-                      ) : null}
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
-              {/* The newest view the call was given.
-
-                  A photo in the strip is a receipt for something the user did;
-                  this is the opposite, a frame nobody asked for, so it has to
-                  be visible at the moment it goes rather than only after the
-                  fact. It wears the strip's shape so the two read as one row,
-                  and the capture accent so they are not read as the same
-                  thing. Keyed on the id, which replays the ring on every keep.
-
-                  `aria-hidden` for the same reason as the strip: every keep
-                  lands in the transcript as its own message, which is the
-                  accessible record of it. That record is also why the camera's
-                  view options can stand this down: what it draws is a
-                  convenience, and the transcript is the account. */}
-              {keptFrame ? (
-                <img
-                  key={keptFrame.attachmentId}
-                  src={keptFrame.previewUrl}
-                  alt=""
-                  aria-hidden
-                  data-testid="voice-room-sight-frame"
-                  style={cameraModeStyle()}
-                  className="sight-frame-kept size-11 rounded-lg object-cover ring-2 ring-[var(--camera-accent)]"
-                />
-              ) : null}
-            </div>
-          ) : null}
+              The shutter press is the consent. The camera's view options can
+              stand the kept frame down: what it draws is a convenience, and
+              the transcript is the account. */}
+          <VoiceRoomCaptureRow photos={photos} keptFrame={keptFrame} />
 
           {/* What the shutter offers, above the shutter.
 

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -194,7 +194,7 @@
       "scope": "client",
       "key": "camera-gate-debug-hud",
       "label": "Camera Gate Debug HUD",
-      "description": "Unlock the camera frame gate's tuning readout: the Settings toggle that turns it on, and the live panel over the composer's sight tile and the voice room's viewfinder showing motion, novelty and detail against their thresholds, the check that decided each frame, and sliders that move those thresholds while the camera runs. Staff sessions get it without the flag; the flag is for local gateway sessions, which carry no platform identity and are where the gate is tuned.",
+      "description": "Unlock the camera frame gate's tuning readout: the switch in the camera's view options that turns it on, and the live panel over the composer's sight tile and the voice room's viewfinder showing motion, novelty and detail against their thresholds, the check that decided each frame, and sliders that move those thresholds while the camera runs. Staff sessions get it without the flag; the flag is for local gateway sessions, which carry no platform identity and are where the gate is tuned.",
       "defaultEnabled": false
     },
     {

--- a/clients/web/src/utils/haptics.test.ts
+++ b/clients/web/src/utils/haptics.test.ts
@@ -83,27 +83,29 @@ describe("haptic on iOS", () => {
 });
 
 describe("haptic on Android", () => {
-  test("fires both impacts", async () => {
+  test("fires the light impact", async () => {
     nativePlatform = "android";
 
     await haptic.light();
-    await haptic.medium();
     await haptic.refreshThreshold();
 
-    expect(impactMock).toHaveBeenCalledTimes(3);
+    expect(impactMock).toHaveBeenCalledTimes(2);
     expect(impactMock.mock.calls.map(([options]) => options.style)).toEqual([
       "LIGHT",
-      "MEDIUM",
       "LIGHT",
     ]);
   });
 
-  test("fires neither notification", async () => {
+  test("fires nothing that reports the end of a gesture", async () => {
+    // The pull to refresh crosses its threshold on `light` and finishes on one
+    // of these three. Widening any of them makes that one gesture buzz twice.
     nativePlatform = "android";
 
+    await haptic.medium();
     await haptic.success();
     await haptic.error();
 
+    expect(impactMock).not.toHaveBeenCalled();
     expect(notificationMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/utils/haptics.test.ts
+++ b/clients/web/src/utils/haptics.test.ts
@@ -83,17 +83,27 @@ describe("haptic on iOS", () => {
 });
 
 describe("haptic on Android", () => {
-  test("only fires the pull-to-refresh threshold impact", async () => {
+  test("fires both impacts", async () => {
     nativePlatform = "android";
 
     await haptic.light();
     await haptic.medium();
-    await haptic.success();
-    await haptic.error();
     await haptic.refreshThreshold();
 
-    expect(impactMock).toHaveBeenCalledTimes(1);
-    expect(impactMock).toHaveBeenCalledWith({ style: "LIGHT" });
+    expect(impactMock).toHaveBeenCalledTimes(3);
+    expect(impactMock.mock.calls.map(([options]) => options.style)).toEqual([
+      "LIGHT",
+      "MEDIUM",
+      "LIGHT",
+    ]);
+  });
+
+  test("fires neither notification", async () => {
+    nativePlatform = "android";
+
+    await haptic.success();
+    await haptic.error();
+
     expect(notificationMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/utils/haptics.ts
+++ b/clients/web/src/utils/haptics.ts
@@ -23,15 +23,23 @@ const lightImpact = (enabled: boolean): Promise<void> =>
 const light = (): Promise<void> => lightImpact(isNativeMobile());
 
 /**
- * Thin haptic-feedback wrapper. The impacts run on both native mobile shells,
- * the notifications only on native iOS. The pull-to-refresh threshold is the
- * light impact under the name its call site reads by. The lazy imports keep the
- * plugin out of plain browser contexts.
+ * Thin haptic-feedback wrapper. The lazy imports keep the plugin out of plain
+ * browser contexts.
+ *
+ * The light impact runs on both native mobile shells. Everything else runs on
+ * native iOS only, and the split is deliberate rather than an omission: a
+ * gesture is usually reported by a light impact on the way in and a heavier one
+ * on the way out (the pull to refresh crosses its threshold on `light` and
+ * finishes on `medium` or a notification), so widening the second half would
+ * make one gesture buzz an Android device twice.
+ *
+ * The pull-to-refresh threshold is the light impact under the name its call
+ * site reads by.
  */
 export const haptic = {
   light,
   medium: () =>
-    runWhen(isNativeMobile(), async () => {
+    runWhen(isNativeIOS(), async () => {
       const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
       await Haptics.impact({ style: ImpactStyle.Medium });
     }),

--- a/clients/web/src/utils/haptics.ts
+++ b/clients/web/src/utils/haptics.ts
@@ -1,7 +1,4 @@
-import {
-  isNativeIOS,
-  isNativeMobile,
-} from "@/runtime/platform-detection";
+import { isNativeIOS, isNativeMobile } from "@/runtime/platform-detection";
 
 const runWhen = async (
   enabled: boolean,
@@ -23,15 +20,18 @@ const lightImpact = (enabled: boolean): Promise<void> =>
     await Haptics.impact({ style: ImpactStyle.Light });
   });
 
+const light = (): Promise<void> => lightImpact(isNativeMobile());
+
 /**
- * Thin haptic-feedback wrapper. Standard effects run only on native iOS. The
- * pull-to-refresh threshold also runs on Android. The lazy imports keep the
+ * Thin haptic-feedback wrapper. The impacts run on both native mobile shells,
+ * the notifications only on native iOS. The pull-to-refresh threshold is the
+ * light impact under the name its call site reads by. The lazy imports keep the
  * plugin out of plain browser contexts.
  */
 export const haptic = {
-  light: () => lightImpact(isNativeIOS()),
+  light,
   medium: () =>
-    runWhen(isNativeIOS(), async () => {
+    runWhen(isNativeMobile(), async () => {
       const { Haptics, ImpactStyle } = await import("@capacitor/haptics");
       await Haptics.impact({ style: ImpactStyle.Medium });
     }),
@@ -45,5 +45,5 @@ export const haptic = {
       const { Haptics, NotificationType } = await import("@capacitor/haptics");
       await Haptics.notification({ type: NotificationType.Error });
     }),
-  refreshThreshold: () => lightImpact(isNativeMobile()),
+  refreshThreshold: light,
 };

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -194,7 +194,7 @@
       "scope": "client",
       "key": "camera-gate-debug-hud",
       "label": "Camera Gate Debug HUD",
-      "description": "Unlock the camera frame gate's tuning readout: the Settings toggle that turns it on, and the live panel over the composer's sight tile and the voice room's viewfinder showing motion, novelty and detail against their thresholds, the check that decided each frame, and sliders that move those thresholds while the camera runs. Staff sessions get it without the flag; the flag is for local gateway sessions, which carry no platform identity and are where the gate is tuned.",
+      "description": "Unlock the camera frame gate's tuning readout: the switch in the camera's view options that turns it on, and the live panel over the composer's sight tile and the voice room's viewfinder showing motion, novelty and detail against their thresholds, the check that decided each frame, and sliders that move those thresholds while the camera runs. Staff sessions get it without the flag; the flag is for local gateway sessions, which carry no platform identity and are where the gate is tuned.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
# Live sight fits a phone, and is felt on one

The mobile polish pass now that native Live is merged. Three parts:

## Haptics reach Android

`haptic.light` and `haptic.medium` now fire on both native mobile shells; the
notification effects stay iOS-only. The shutter's hold-into-Live tap (already
in the code, silently no-oping on Android) turns on, and every keep the call
is actually GIVEN taps once, at the send-success seam, so a frame any guard
refuses stays silent. Blast radius note: the widening is global, so existing
light/medium call sites (long-press, palette, composer, gallery, pull-refresh)
start firing on Android for the first time; a QA row asks a handset pass to
confirm nothing double-fires.

## The capture row, measured at phone width

DOM-measured in a browser at 320x568 with the strip full (3 photos + kept
frame): 224px of row against a 320px viewport, 35px above the shutter, no
overflow, so nothing is capped or shrunk. The real defect found instead: the
row's flat 24px offset ignored the safe area, putting the first thumbnail
under the sensor housing in landscape; it now floors on
`--safe-area-inset-left` like the rest of the camera's edge chrome. The row
is extracted to `voice-room-capture-row.tsx` (markup and testids verbatim;
the 134 voice-room tests pass unchanged) so the new 320pt story renders the
shipped component.

## QA doc rows

Small-screens-and-rotation section (320pt fit, landscape sensor clearance and
scrim floor, rotation with Live active: Android recreates its preview
fragment and this has never run with sampling on) plus the two haptics rows.
The battery/thermal row already existed and is not duplicated.

Also riding: the `camera-gate-debug-hud` registry description no longer names
the removed Settings toggle (canonical + bundled copies synced).

## Known-and-deferred

Landscape's bottom stack (scrim floor at max(38%,15rem)) can crowd the pill
band on a 320px-tall viewport; written up as a QA check, not silently fixed.
`success`/`error` haptics remain iOS-only, leaving pull-refresh
partial/complete asymmetric on Android; flagged for a future haptics pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
