### PR TITLE
fix(companion): floating windows draw no splash before they paint (JARVIS-1723)

### DIFF
--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -116,6 +116,24 @@
       }
     })();
 
+    // Floating windows draw no splash.
+    //
+    // The desktop shell floats a few routes over the desktop in transparent,
+    // click-through windows sized well past what they draw: the companion
+    // surface's canvas, the edge glow the size of a display. The splash is a
+    // full-viewport panel in the theme colour, so on one of those it is a
+    // dark rectangle the size of the window, held until the route's chunk
+    // arrives and React replaces it. Nothing is the right thing to show there:
+    // the surface appears when it is ready, and the desktop shows through
+    // until then. Stamped here, before first paint, for the reason the theme
+    // is: a splash that painted and then vanished is the flash this exists to
+    // prevent.
+    (function () {
+      if (window.location.pathname.indexOf("/floating/") !== -1) {
+        document.documentElement.setAttribute("data-floating", "");
+      }
+    })();
+
     // Boot splash label.
     //
     // `index.html` is one static file served to every locale, so the label in the
@@ -302,6 +320,10 @@
         background: #17191C;
         color: #8D99A5;
       }
+    }
+
+    :root[data-floating] #boot-splash {
+      display: none;
     }
   </style>
 </head>

--- a/clients/web/index.html
+++ b/clients/web/index.html
@@ -127,9 +127,14 @@
     // the surface appears when it is ready, and the desktop shows through
     // until then. Stamped here, before first paint, for the reason the theme
     // is: a splash that painted and then vanished is the flash this exists to
-    // prevent.
+    // prevent. The legacy overlay path is kept for a shell mid-update
+    // (`routes.tsx`), and it floats the same way without the segment.
     (function () {
-      if (window.location.pathname.indexOf("/floating/") !== -1) {
+      var path = window.location.pathname;
+      if (
+        path.indexOf("/floating/") !== -1 ||
+        /\/dictation-overlay$/.test(path)
+      ) {
         document.documentElement.setAttribute("data-floating", "");
       }
     })();

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -15,6 +15,19 @@ import { InChatOnboardingController } from "@/domains/chat/in-chat-onboarding/in
 import { NotFound } from "@/components/not-found";
 import { RouteErrorBoundary } from "@/components/route-error-boundary";
 import { RootHydrateFallback } from "@/components/root-hydrate-fallback";
+
+/**
+ * What a floating window shows while its route's chunk loads: nothing.
+ *
+ * These routes are drawn in transparent, click-through windows the desktop
+ * shell floats over the desktop, sized well past what they draw. A spinner
+ * centred in one of those is a spinner floating over the desktop with nothing
+ * around it, and the shell's HTML splash is kept off them for the same reason
+ * (`index.html`). The surface appears when it is ready.
+ */
+function FloatingHydrateFallback() {
+  return null;
+}
 import { ActiveAssistantGate } from "@/components/layout/active-assistant-gate";
 import { remoteGatewayPublicPathPrefix } from "@/lib/auth/remote-gateway-session";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
@@ -351,7 +364,7 @@ export const routeTree = [
   {
     path: "/assistant/floating/companion",
     ErrorBoundary: RouteErrorBoundary,
-    HydrateFallback: RootHydrateFallback,
+    HydrateFallback: FloatingHydrateFallback,
     lazy: {
       Component: () =>
         import("@/components/companion-surface-page").then(
@@ -366,7 +379,7 @@ export const routeTree = [
   {
     path: "/assistant/floating/companion-watch-glow",
     ErrorBoundary: RouteErrorBoundary,
-    HydrateFallback: RootHydrateFallback,
+    HydrateFallback: FloatingHydrateFallback,
     lazy: {
       Component: () =>
         import("@/components/companion-watch-glow-page").then(
@@ -383,7 +396,7 @@ export const routeTree = [
   {
     path: "/assistant/floating/dictation-overlay",
     ErrorBoundary: RouteErrorBoundary,
-    HydrateFallback: RootHydrateFallback,
+    HydrateFallback: FloatingHydrateFallback,
     lazy: {
       Component: () =>
         import("@/components/dictation-overlay-page").then(
@@ -396,7 +409,7 @@ export const routeTree = [
   {
     path: "/assistant/dictation-overlay",
     ErrorBoundary: RouteErrorBoundary,
-    HydrateFallback: RootHydrateFallback,
+    HydrateFallback: FloatingHydrateFallback,
     lazy: {
       Component: () =>
         import("@/components/dictation-overlay-page").then(

--- a/clients/web/src/shell-metadata.test.ts
+++ b/clients/web/src/shell-metadata.test.ts
@@ -157,6 +157,8 @@ describe("SPA shell: boot splash", () => {
    */
   test("keeps the splash off the floating windows", () => {
     expect(SHELL_INIT).toContain('"/floating/"');
+    // The legacy overlay path a shell mid-update still opens (`routes.tsx`).
+    expect(SHELL_INIT).toContain("/dictation-overlay$/");
     expect(SHELL_INIT).toContain('"data-floating"');
     const styles = [...doc.querySelectorAll("style")]
       .map((style) => style.textContent ?? "")

--- a/clients/web/src/shell-metadata.test.ts
+++ b/clients/web/src/shell-metadata.test.ts
@@ -115,7 +115,10 @@ describe("SPA shell: Open Graph metadata", () => {
  */
 const CATALOGS: Record<string, LocaleCatalogs> = Object.fromEntries(
   await Promise.all(
-    SUPPORTED_LOCALES.map(async (locale) => [locale, await loadCatalogs(locale)]),
+    SUPPORTED_LOCALES.map(async (locale) => [
+      locale,
+      await loadCatalogs(locale),
+    ]),
   ),
 );
 
@@ -145,6 +148,24 @@ describe("SPA shell: boot splash", () => {
     expect(doc.querySelector('script[src*="theme-init"]')).toBeNull();
   });
 
+  /**
+   * The desktop shell floats a few routes over the desktop in transparent
+   * windows sized well past what they draw. A splash there is a dark panel
+   * the size of the window, held until the route's chunk lands, so the shell
+   * init stamps those windows before first paint and the splash's own
+   * stylesheet keeps it off them.
+   */
+  test("keeps the splash off the floating windows", () => {
+    expect(SHELL_INIT).toContain('"/floating/"');
+    expect(SHELL_INIT).toContain('"data-floating"');
+    const styles = [...doc.querySelectorAll("style")]
+      .map((style) => style.textContent ?? "")
+      .join("\n");
+    expect(styles).toMatch(
+      /:root\[data-floating\] #boot-splash \{\s*display: none;\s*\}/,
+    );
+  });
+
   test("its static label is the same string the app's own spinner uses", () => {
     expect(splash?.getAttribute("aria-label")).toBe(
       loadingLabel(DEFAULT_LOCALE),
@@ -160,7 +181,9 @@ describe("SPA shell: boot splash", () => {
       if (label === undefined) {
         continue;
       }
-      const pattern = locale.includes("-") ? `"${locale}": ${JSON.stringify(label)}` : `${locale}: ${JSON.stringify(label)}`;
+      const pattern = locale.includes("-")
+        ? `"${locale}": ${JSON.stringify(label)}`
+        : `${locale}: ${JSON.stringify(label)}`;
       expect(SHELL_INIT).toContain(pattern);
     }
   });


### PR DESCRIPTION
## Summary

Every floating window the macOS shell opens (the companion surface, the Teach edge glow, the dictation overlay) showed as a dark rectangle the size of the whole transparent canvas for a beat to a couple of seconds before its content appeared.

Two things painted there before the route mounted:

- **The boot splash** in `index.html`: a fixed, full-viewport panel in the theme colour, held until the route's chunk landed and React replaced it. On a transparent window that is a dark window. The inline shell init now stamps `data-floating` on the document for any `/floating/` path before first paint, and the splash's own stylesheet hides it under that stamp.
- **The router's hydrate fallback**: a spinner centred in the canvas while the lazy chunk loads. The four floating routes now render nothing while loading; the surface appears when it is ready.

Not a change to the canvas size itself. The canvas is still much larger than the creature by design; that is a separate conversation.

## Testing

- `clients/web`: `shell-metadata.test.ts` (15, with a new case pinning the stamp and the rule), `tsc`, eslint clean. `index.html` was not prettier-clean on main and is edited by hand.
- Tried on a device: relaunching the dev app on this branch.

Part of JARVIS-1705. Closes JARVIS-1723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py5RCxLX8GECQCsNTM22Tc
