### PR TITLE
feat(gateway): the record form can commit a contact merge

### DIFF
--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -1395,7 +1395,7 @@
         "operationId": "contactsRecordSubmit",
         "summary": "Submit a contact-record form",
         "tags": ["contacts"],
-        "description": "Completes a contact_record_request the assistant broadcast: writes the contact record the guardian confirmed (display name and notes only, never a channel), then unblocks the waiting command. A cancelled submission unblocks it without writing.",
+        "description": "Completes a contact_record_request the assistant broadcast: writes the record the guardian confirmed, then unblocks the waiting command. A create or update writes display name and notes, never a channel; a merge moves the donor's channels to the survivor and deletes the donor. A cancelled submission unblocks the command without writing.",
         "requestBody": {
           "required": true,
           "content": {

--- a/gateway/src/__tests__/contact-record-submit.test.ts
+++ b/gateway/src/__tests__/contact-record-submit.test.ts
@@ -5,8 +5,9 @@
  * parks a CLI call and broadcasts a proposal, and nothing lands until the
  * guardian's client posts here. The suite pins that contract:
  * - create / update / delete write what was submitted, not what was proposed
- * - the record surface never touches channels
- * - a guardian contact cannot be deleted through it
+ * - the record surface never touches channels, except a merge, which moves the
+ *   donor's channels to the survivor
+ * - a guardian contact cannot be deleted or merged away through it
  * - a dismissal unblocks the parked call without writing
  * - every outcome resolves the parked call, so the CLI never hangs
  */
@@ -868,5 +869,168 @@ describe("contact record submit", () => {
 
     expect(res.status).toBe(400);
     expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(0);
+  });
+
+  test("merge moves the donor's channels to the survivor and deletes the donor", async () => {
+    seedContact("c-keep", "Alice");
+    seedChannel("c-keep", "email", "alice@example.com");
+    seedContact("c-donor", "Alice (work)");
+    seedChannel("c-donor", "telegram", "12345");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge"),
+        operation: "merge",
+        contactId: "c-keep",
+        donorContactId: "c-donor",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .where(eq(gwContacts.id, "c-donor"))
+        .get(),
+    ).toBeUndefined();
+    const survivorChannels = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.contactId, "c-keep"))
+      .all();
+    expect(survivorChannels.map((ch) => ch.type).sort()).toEqual([
+      "email",
+      "telegram",
+    ]);
+
+    const resolved = resolveCall();
+    expect(resolved.body.contactId).toBe("c-keep");
+    expect(resolved.body.merged).toBe(true);
+  });
+
+  test("a merge carrying a display name renames the survivor", async () => {
+    seedContact("c-keep-named", "Alice");
+    seedContact("c-donor-named", "Alice Chen");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge-rename"),
+        operation: "merge",
+        contactId: "c-keep-named",
+        donorContactId: "c-donor-named",
+        displayName: "Alice Chen",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const row = getGatewayDb()
+      .select()
+      .from(gwContacts)
+      .where(eq(gwContacts.id, "c-keep-named"))
+      .get();
+    expect(row!.displayName).toBe("Alice Chen");
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+  });
+
+  test("merge refuses to absorb the guardian contact", async () => {
+    seedContact("c-survivor", "Alice");
+    seedContact("g-donor", "Owner", "guardian");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge-guardian"),
+        operation: "merge",
+        contactId: "c-survivor",
+        donorContactId: "g-donor",
+        displayName: "Alice Chen",
+      }),
+    );
+
+    // The store's own message, not a generic 500: the guardian can be the
+    // survivor instead, and the command can say so.
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      accepted: false,
+      error:
+        "Cannot merge away a guardian contact. Keep the guardian as the survivor instead.",
+    });
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(2);
+    // The submitted rename is part of the merge, so a refused merge leaves it
+    // unwritten rather than renaming a contact that absorbed nobody.
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .where(eq(gwContacts.id, "c-survivor"))
+        .get()!.displayName,
+    ).toBe("Alice");
+    expect(resolveCall().body.error).toBe(
+      "Cannot merge away a guardian contact. Keep the guardian as the survivor instead.",
+    );
+  });
+
+  test("merge naming an unknown donor is refused and writes nothing", async () => {
+    seedContact("c-lonely", "Alice");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge-ghost"),
+        operation: "merge",
+        contactId: "c-lonely",
+        donorContactId: "does-not-exist",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      accepted: false,
+      error: 'Contact "does-not-exist" not found',
+    });
+    expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+  });
+
+  test("merge without a donor is rejected before the form is claimed", async () => {
+    seedContact("c-no-donor", "Alice");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge-nodonor"),
+        operation: "merge",
+        contactId: "c-no-donor",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    // The form is still open, so the guardian can answer it properly.
+    expect(callsFor("contact_prompt_claim")).toHaveLength(0);
+    expect(callsFor("resolve_contact_prompt")).toHaveLength(0);
+  });
+
+  test("a merge of a contact with itself is rejected", async () => {
+    seedContact("c-self", "Alice");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge-self"),
+        operation: "merge",
+        contactId: "c-self",
+        donorContactId: "c-self",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      accepted: false,
+      error: "Cannot merge a contact with itself",
+    });
+    expect(callsFor("contact_prompt_claim")).toHaveLength(0);
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .where(eq(gwContacts.id, "c-self"))
+        .get(),
+    ).toBeDefined();
   });
 });

--- a/gateway/src/__tests__/contact-record-submit.test.ts
+++ b/gateway/src/__tests__/contact-record-submit.test.ts
@@ -1037,6 +1037,65 @@ describe("contact record submit", () => {
     ).toBeDefined();
   });
 
+  test("a merge carrying an explicit notes clear is rejected too", async () => {
+    seedContact("c-keep-null", "Alice");
+    seedContact("c-donor-null", "Alice C");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge-notes-null"),
+        operation: "merge",
+        contactId: "c-keep-null",
+        donorContactId: "c-donor-null",
+        notes: null,
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(callsFor("contact_prompt_claim")).toHaveLength(0);
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .where(eq(gwContacts.id, "c-donor-null"))
+        .get(),
+    ).toBeDefined();
+  });
+
+  test("a merge renaming the survivor to blank is rejected before anything commits", async () => {
+    seedContact("c-keep-blank", "Alice");
+    seedContact("c-donor-blank", "Alice C");
+    seedChannel("c-donor-blank", "email", "alice.c@example.com");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge-blank-name"),
+        operation: "merge",
+        contactId: "c-keep-blank",
+        donorContactId: "c-donor-blank",
+        displayName: "   ",
+      }),
+    );
+
+    // The rename runs after the merge commits, so accepting this would delete
+    // the donor and then report the whole submission as failed.
+    expect(res.status).toBe(400);
+    expect(callsFor("contact_prompt_claim")).toHaveLength(0);
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .where(eq(gwContacts.id, "c-donor-blank"))
+        .get(),
+    ).toBeDefined();
+    const donorChannel = getGatewayDb()
+      .select()
+      .from(gwContactChannels)
+      .where(eq(gwContactChannels.id, "c-donor-blank-email"))
+      .get();
+    expect(donorChannel?.contactId).toBe("c-donor-blank");
+  });
+
   test("a merge of a contact with itself is rejected", async () => {
     seedContact("c-self", "Alice");
 

--- a/gateway/src/__tests__/contact-record-submit.test.ts
+++ b/gateway/src/__tests__/contact-record-submit.test.ts
@@ -18,6 +18,7 @@ import {
   describe,
   expect,
   mock,
+  spyOn,
   test,
 } from "bun:test";
 
@@ -126,6 +127,7 @@ const { initGatewayDb, getGatewayDb, resetGatewayDb } =
 const { contactChannels: gwContactChannels, contacts: gwContacts } =
   await import("../db/schema.js");
 const { eq } = await import("drizzle-orm");
+const { ContactStore } = await import("../db/contact-store.js");
 
 function makeRequest(body: Record<string, unknown>): Request {
   return new Request("http://localhost:7830/v1/contacts/record/submit", {
@@ -931,6 +933,50 @@ describe("contact record submit", () => {
       .get();
     expect(row!.displayName).toBe("Alice Chen");
     expect(getGatewayDb().select().from(gwContacts).all()).toHaveLength(1);
+  });
+
+  test("a merge whose rename cannot land still reports the merge", async () => {
+    seedContact("c-keep-gone", "Alice");
+    seedContact("c-donor-gone", "Alice Chen");
+    seedChannel("c-donor-gone", "email", "alice.chen@example.com");
+
+    // The survivor disappears between the merge and the rename, which is the
+    // window the rename's own transaction cannot cover.
+    const originalMerge = ContactStore.prototype.mergeContacts;
+    const spy = spyOn(
+      ContactStore.prototype,
+      "mergeContacts",
+    ).mockImplementation(async function (
+      this: InstanceType<typeof ContactStore>,
+      keepId: string,
+      mergeId: string,
+    ) {
+      const merged = await originalMerge.call(this, keepId, mergeId);
+      getGatewayDb().delete(gwContacts).where(eq(gwContacts.id, keepId)).run();
+      return merged;
+    });
+
+    try {
+      const res = await handleContactRecordSubmit(
+        makeRequest({
+          requestId: openForm("req-merge-rename-gone"),
+          operation: "merge",
+          contactId: "c-keep-gone",
+          donorContactId: "c-donor-gone",
+          displayName: "Alice C",
+        }),
+      );
+
+      // The donor is already gone, so reporting failure would describe a merge
+      // that happened as one that did not.
+      expect(res.status).toBe(200);
+      const resolved = resolveCall();
+      expect(resolved?.body.merged).toBe(true);
+      expect(resolved?.body.renamed).toBe(false);
+      expect(resolved?.body.error).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   test("merge refuses to absorb the guardian contact", async () => {

--- a/gateway/src/__tests__/contact-record-submit.test.ts
+++ b/gateway/src/__tests__/contact-record-submit.test.ts
@@ -1007,6 +1007,36 @@ describe("contact record submit", () => {
     expect(callsFor("resolve_contact_prompt")).toHaveLength(0);
   });
 
+  test("a merge carrying notes is rejected before the form is claimed", async () => {
+    seedContact("c-keep", "Alice");
+    seedContact("c-donor", "Alice C");
+
+    const res = await handleContactRecordSubmit(
+      makeRequest({
+        requestId: openForm("req-merge-notes"),
+        operation: "merge",
+        contactId: "c-keep",
+        donorContactId: "c-donor",
+        notes: "Same person",
+      }),
+    );
+
+    // The merge combines both sets of notes, so accepting a submitted set
+    // would either drop it or overwrite the combination.
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.accepted).toBe(false);
+    expect(String(body.error)).toContain("combines both contacts' notes");
+    expect(callsFor("contact_prompt_claim")).toHaveLength(0);
+    expect(
+      getGatewayDb()
+        .select()
+        .from(gwContacts)
+        .where(eq(gwContacts.id, "c-donor"))
+        .get(),
+    ).toBeDefined();
+  });
+
   test("a merge of a contact with itself is rejected", async () => {
     seedContact("c-self", "Alice");
 

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -657,14 +657,23 @@ export async function handleContactRecordSubmit(
       );
     }
     // The merge combines both contacts' notes itself, so a submitted set would
-    // either be dropped or overwrite that. Refusing says so.
-    if (body.notes !== undefined && body.notes !== null) {
+    // either be dropped or overwrite that. A null is an explicit clear on the
+    // update path, so it is refused here too rather than passed over.
+    if (body.notes !== undefined) {
       return Response.json(
         {
           accepted: false,
           error:
             "A merge combines both contacts' notes, so notes cannot be submitted with it. Edit them afterwards with 'assistant contacts update'.",
         },
+        { status: 400 },
+      );
+    }
+    // The rename runs after the merge has committed, so a name that would be
+    // refused there has to be refused before anything is written.
+    if (typeof body.displayName === "string" && !body.displayName.trim()) {
+      return Response.json(
+        { accepted: false, error: "displayName must be a non-empty string" },
         { status: 400 },
       );
     }

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -656,6 +656,18 @@ export async function handleContactRecordSubmit(
         { status: 400 },
       );
     }
+    // The merge combines both contacts' notes itself, so a submitted set would
+    // either be dropped or overwrite that. Refusing says so.
+    if (body.notes !== undefined && body.notes !== null) {
+      return Response.json(
+        {
+          accepted: false,
+          error:
+            "A merge combines both contacts' notes, so notes cannot be submitted with it. Edit them afterwards with 'assistant contacts update'.",
+        },
+        { status: 400 },
+      );
+    }
   }
 
   // A non-string displayName (an explicit null included) reads as omitted, so

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -16,7 +16,7 @@
 import { and, asc, eq, sql } from "drizzle-orm";
 
 import { getGatewayDb } from "../../db/connection.js";
-import { ContactStore } from "../../db/contact-store.js";
+import { ContactStore, MergeContactsError } from "../../db/contact-store.js";
 import {
   contactChannels as gwContactChannels,
   contacts as gwContacts,
@@ -27,6 +27,7 @@ import { canonicalizeInboundIdentity } from "../../verification/identity.js";
 import {
   ContactRecordNativeError,
   deleteContactCore,
+  mergeContactsCore,
   upsertContactRecordCore,
 } from "./contacts-control-plane-proxy.js";
 import {
@@ -557,8 +558,10 @@ async function channelResolution(args: {
 
 interface ContactRecordSubmitBody {
   requestId: string;
-  operation?: "create" | "update" | "delete";
+  operation?: "create" | "update" | "delete" | "merge";
   contactId?: string;
+  /** The contact being merged away. Required for a merge. */
+  donorContactId?: string;
   displayName?: string;
   notes?: string | null;
   /** The channels the delete confirmation listed. */
@@ -571,13 +574,14 @@ interface ContactRecordSubmitBody {
  * POST /v1/contacts/record/submit
  *
  * The record half of the contact-form rail: the guardian confirmed (and may
- * have edited) a create, update, or delete the assistant proposed. Writes it,
- * then unblocks the parked CLI call.
+ * have edited) a create, update, delete, or merge the assistant proposed.
+ * Writes it, then unblocks the parked CLI call.
  *
  * The submitted operation is trusted as posted rather than checked against the
  * parked proposal. A caller who can reach this route can already reach
- * `POST /v1/contacts` and `DELETE /v1/contacts/:id` at the same edge auth, so
- * a readback would buy no privilege, only a round trip.
+ * `POST /v1/contacts`, `POST /v1/contacts/merge` and `DELETE /v1/contacts/:id`
+ * at the same edge auth, so a readback would buy no privilege, only a round
+ * trip.
  */
 export async function handleContactRecordSubmit(
   req: Request,
@@ -592,7 +596,7 @@ export async function handleContactRecordSubmit(
     );
   }
 
-  const { requestId, operation, contactId } = body;
+  const { requestId, operation, contactId, donorContactId } = body;
 
   if (!requestId || typeof requestId !== "string") {
     return Response.json(
@@ -619,12 +623,14 @@ export async function handleContactRecordSubmit(
   if (
     operation !== "create" &&
     operation !== "update" &&
-    operation !== "delete"
+    operation !== "delete" &&
+    operation !== "merge"
   ) {
     return Response.json(
       {
         accepted: false,
-        error: 'operation must be one of: "create", "update", "delete"',
+        error:
+          'operation must be one of: "create", "update", "delete", "merge"',
       },
       { status: 400 },
     );
@@ -635,6 +641,21 @@ export async function handleContactRecordSubmit(
       { accepted: false, error: `contactId is required to ${operation}` },
       { status: 400 },
     );
+  }
+
+  if (operation === "merge") {
+    if (!donorContactId || typeof donorContactId !== "string") {
+      return Response.json(
+        { accepted: false, error: "donorContactId is required to merge" },
+        { status: 400 },
+      );
+    }
+    if (donorContactId === contactId) {
+      return Response.json(
+        { accepted: false, error: "Cannot merge a contact with itself" },
+        { status: 400 },
+      );
+    }
   }
 
   // A non-string displayName (an explicit null included) reads as omitted, so
@@ -653,6 +674,7 @@ export async function handleContactRecordSubmit(
         requestId,
         operation,
         contactId,
+        donorContactId,
         displayName,
         notes: body.notes,
         expectedChannels: Array.isArray(body.expectedChannels)
@@ -671,13 +693,21 @@ export async function handleContactRecordSubmit(
  */
 async function writeContactRecord(input: {
   requestId: string;
-  operation: "create" | "update" | "delete";
+  operation: "create" | "update" | "delete" | "merge";
   contactId?: string;
+  donorContactId?: string;
   displayName?: string;
   notes?: string | null;
   expectedChannels?: Array<{ type: string; address: string }>;
 }): Promise<GuardianFormWriteOutcome> {
-  const { requestId, operation, contactId, displayName, notes } = input;
+  const {
+    requestId,
+    operation,
+    contactId,
+    donorContactId,
+    displayName,
+    notes,
+  } = input;
 
   try {
     if (operation === "delete") {
@@ -689,6 +719,28 @@ async function writeContactRecord(input: {
       await deleteContactCore(contactId!, input.expectedChannels);
       log.info({ requestId, contactId }, "contact-record-submit: deleted");
       return { resolution: { contactId } };
+    }
+
+    if (operation === "merge") {
+      await mergeContactsCore({
+        keepId: contactId!,
+        mergeId: donorContactId!,
+      });
+      // The guardian can rename the survivor on the same form. The rename is
+      // its own write, ordered after the merge so a refused merge renames
+      // nothing.
+      if (displayName !== undefined) {
+        await upsertContactRecordCore({
+          operation: "update",
+          contactId: contactId!,
+          displayName,
+        });
+      }
+      log.info(
+        { requestId, contactId, donorContactId },
+        "contact-record-submit: merged",
+      );
+      return { resolution: { contactId, merged: true } };
     }
 
     const { contact, notesSaved, nothingWritten } =
@@ -705,7 +757,10 @@ async function writeContactRecord(input: {
     );
     return { resolution: { contactId: writtenId, notesSaved, nothingWritten } };
   } catch (err) {
-    if (err instanceof ContactRecordNativeError) {
+    if (
+      err instanceof ContactRecordNativeError ||
+      err instanceof MergeContactsError
+    ) {
       return { failure: { error: err.message, status: err.statusCode } };
     }
     log.error({ err, requestId, operation }, "contact-record-submit: failed");

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -749,19 +749,37 @@ async function writeContactRecord(input: {
       });
       // The guardian can rename the survivor on the same form. The rename is
       // its own write, ordered after the merge so a refused merge renames
-      // nothing.
+      // nothing. The merge has committed by this point, so a rename that
+      // cannot land leaves the survivor under its old name rather than
+      // reporting a merge that happened as failed.
+      let renamed: boolean | undefined;
       if (displayName !== undefined) {
-        await upsertContactRecordCore({
-          operation: "update",
-          contactId: contactId!,
-          displayName,
-        });
+        try {
+          await upsertContactRecordCore({
+            operation: "update",
+            contactId: contactId!,
+            displayName,
+          });
+          renamed = true;
+        } catch (renameErr) {
+          log.error(
+            { err: renameErr, requestId, contactId, donorContactId },
+            "contact-record-submit: merged, but the survivor could not be renamed",
+          );
+          renamed = false;
+        }
       }
       log.info(
-        { requestId, contactId, donorContactId },
+        { requestId, contactId, donorContactId, renamed },
         "contact-record-submit: merged",
       );
-      return { resolution: { contactId, merged: true } };
+      return {
+        resolution: {
+          contactId,
+          merged: true,
+          ...(renamed === false ? { renamed: false } : {}),
+        },
+      };
     }
 
     const { contact, notesSaved, nothingWritten } =

--- a/gateway/src/http/routes/contacts-control-plane-routes.ts
+++ b/gateway/src/http/routes/contacts-control-plane-routes.ts
@@ -239,7 +239,7 @@ export const ROUTES: GatewayRouteDefinition[] = [
     operationId: "contactsRecordSubmit",
     summary: "Submit a contact-record form",
     description:
-      "Completes a contact_record_request the assistant broadcast: writes the contact record the guardian confirmed (display name and notes only, never a channel), then unblocks the waiting command. A cancelled submission unblocks it without writing.",
+      "Completes a contact_record_request the assistant broadcast: writes the record the guardian confirmed, then unblocks the waiting command. A create or update writes display name and notes, never a channel; a merge moves the donor's channels to the survivor and deletes the donor. A cancelled submission unblocks the command without writing.",
     tags: ["contacts"],
     requestBody: ContactRecordSubmitRequestSchema,
     responseBody: z.object({


### PR DESCRIPTION
## Summary

- `POST /v1/contacts/record/submit` accepts `operation: "merge"` with a `donorContactId`, and commits it through `mergeContactsCore` under the form's claim: the donor's channels move to the survivor, the donor row is deleted, and the parked command is unblocked with `{ contactId, merged: true }`.
- A display name the guardian edited on the merge form is written after the merge, so a refused merge renames nothing.
- `MergeContactsError` is mapped alongside `ContactRecordNativeError`, so an unknown id, a self merge and a guardian donor surface their own message and 400 instead of a generic 500. A merge missing its donor, or naming the survivor as the donor, is refused before the form is claimed, so the form stays open for a proper answer.
- No `expectedChannels`-style guard on merge, deliberately: a merge reparents channels rather than cascading them away, so a channel gained while the form was open is moved, not lost.
- The record-submit route description no longer claims the surface writes display name and notes only; `gateway/openapi.json` regenerated. The request schema already carried `"merge"` and `donorContactId` from PR 8.

Part of plan: contacts-cli-channel-binding.md (PR 9 of 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk8rCmt2otiCFYLMiA5pB5