### PR TITLE
docs(channels): schedule reuse default, thread keying, DM handling, normalizer paths

### DIFF
--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -146,7 +146,7 @@ Conversations created by a schedule's runs land in the sidebar's Scheduled secti
 
 ## Conversation Reuse
 
-Recurring schedules reuse the same conversation across runs by default — subsequent runs continue the conversation from the last successful run, preserving context and channel thread continuity. Set `reuse_conversation: false` explicitly if each run should start with a fresh conversation (e.g. independent reports that shouldn't accumulate prior context). One-shot schedules always create a fresh conversation.
+Each run of a recurring schedule starts a fresh conversation unless `reuse_conversation: true` is set, in which case subsequent runs continue the conversation from the last successful run and keep its context (for example a `thread_ts` the run posted to earlier, so it can post into the same Slack thread again). Reuse is a property of the run's own conversation: a run never posts to a channel on its own, so what reaches Slack, Telegram, or Discord is only what the run sends explicitly (see Delivering Results). One-shot schedules always create a fresh conversation.
 
 - Only applies to **recurring** schedules; ignored for one-shot schedules.
 - If the prior conversation has been deleted, a new one is created automatically.

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1001,12 +1001,10 @@ function injectTransportHints(message: Message, hints: string[]): Message {
  * `<active_thread>` focus block. DMs are excluded because they have no
  * threads.
  *
- * The gateway normalizer sets `chatType: "channel"` for every non-DM Slack
- * conversation (public, private, and mpim alike — see
- * `gateway/src/slack/normalize.ts`) and omits the field entirely for DMs.
- * We therefore accept only `chatType === "channel"` — when the gateway
- * omits `chatType` (as it does for DMs), the check correctly returns
- * `false`.
+ * The gateway normalizer (`gateway/src/slack/message-normalizer.ts`)
+ * forwards `chatType: "channel"` for channel messages and app mentions,
+ * `"im"` for a 1:1 DM, and `"mpim"` for a group DM. Accepting only
+ * `chatType === "channel"` therefore returns `false` for both DM shapes.
  *
  * The chronological-transcript override applies to ALL Slack
  * conversations (channels and DMs) — gate that on

--- a/assistant/src/daemon/conversation-runtime-assembly.ts
+++ b/assistant/src/daemon/conversation-runtime-assembly.ts
@@ -1002,9 +1002,11 @@ function injectTransportHints(message: Message, hints: string[]): Message {
  * threads.
  *
  * The gateway normalizer (`gateway/src/slack/message-normalizer.ts`)
- * forwards `chatType: "channel"` for channel messages and app mentions,
- * `"im"` for a 1:1 DM, and `"mpim"` for a group DM. Accepting only
- * `chatType === "channel"` therefore returns `false` for both DM shapes.
+ * forwards `chatType: "channel"` for channel messages, `"im"` for a 1:1
+ * DM, and `"mpim"` for a group DM, and omits it for an app mention, which
+ * Slack sends without naming the room kind. Accepting only
+ * `chatType === "channel"` therefore returns `false` for both DM shapes
+ * and for an app mention.
  *
  * The chronological-transcript override applies to ALL Slack
  * conversations (channels and DMs) — gate that on

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -282,7 +282,7 @@ Channel bindings follow a three-phase lifecycle:
 
 1. **Bind** — An inbound message from an external channel (e.g., Telegram chat) arrives at the gateway, which normalizes it and forwards it to the runtime's `/v1/channels/inbound` endpoint. The runtime creates or reuses a conversation, establishing the channel binding (`sourceChannel` metadata on the conversation).
 
-2. **Route** — Subsequent messages on the same external chat are routed to the same conversation via the channel binding. Replies from the assistant are delivered back through the gateway's `/deliver/telegram` endpoint. The desktop client filters out channel-bound conversations during conversation restoration (`ConversationRestorer`) so they never appear in the desktop conversation list.
+2. **Route**: Subsequent messages on the same external chat are routed to the same conversation via the channel binding. Slack and Telegram are thread-scoped: a message that arrives in a Slack thread (including every message in a Slack agent DM, which Slack always delivers in a thread) or a Telegram topic resolves to that thread's own conversation, keyed on the chat plus the thread id (`assistant/src/persistence/delivery-crud.ts`, `buildScopedConversationKey`); a thread-less message resolves to the chat's base conversation. Replies from the assistant are delivered back through the gateway's `/deliver/telegram` endpoint. The desktop client filters out channel-bound conversations during conversation restoration (`ConversationRestorer`) so they never appear in the desktop conversation list.
 
 3. **Rebind** — If a message arrives on an external chat whose conversation was previously deleted, the channel inbound handler treats it as a new conversation and establishes a fresh binding. The external chat ID is reused, but the conversation is new.
 
@@ -704,7 +704,7 @@ The Slack channel enables inbound and outbound messaging via Slack's Socket Mode
 **Event processing** (inbound):
 
 1. Every Socket Mode envelope is ACKed immediately by echoing `{ envelope_id }` back on the WebSocket — this is required by Slack regardless of whether the event is processed.
-2. Only `events_api` envelopes with `app_mention` events are processed in MVP. Other envelope types (slash commands, interactive payloads) are ACKed but ignored.
+2. `events_api` envelopes are admitted per event kind (`processEventPayload` in `socket-mode.ts`): `app_mention` events; every message in a DM or group DM (`message.im`, `message.mpim`); unmentioned replies in a thread the assistant is already part of (mention-then-thread mode); and edits, deletes, and reactions scoped to those rooms. The bot's own echoes are dropped by a single self-filter before routing. Interactive payloads (button presses) are handled separately; slash commands are ACKed and ignored.
 3. Events are deduplicated by a compound key in the SQLite-backed `slack_seen_events` table: every event records its Slack `event_id`, and message-shaped events additionally record `msg:${channel}:${ts}` so the live and reconnect-replay paths dedup symmetrically. Entries TTL out after 24h; a periodic cleanup sweep evicts expired rows.
 4. The `normalizeSlackAppMention()` function strips leading bot-mention tokens (`<@U...>`) from the message text and produces a `GatewayInboundEvent` with `sourceChannel: "slack"`, using the Slack channel ID as `conversationExternalId` and the sender's user ID as `actorExternalId`.
 5. Routing uses the standard `resolveAssistant()` chain (conversation_id -> actor_id -> default/reject). Events that cannot be routed are dropped.
@@ -744,14 +744,14 @@ Any persistent-stream transport that does not buffer events for disconnected cli
 
 **Key modules:**
 
-| Module                                     | Purpose                                                                                       |
-| ------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| `gateway/src/slack/socket-mode.ts`         | `SlackSocketModeClient` — WebSocket lifecycle, ACK, dedup, auto-reconnect, reconnect catch-up |
-| `gateway/src/slack/slack-web.ts`           | `conversations.history` / `conversations.replies` helpers for reconnect catch-up              |
-| `gateway/src/slack/normalize.ts`           | `normalizeSlackAppMention()` — event normalization and bot-mention stripping                  |
-| `gateway/src/http/routes/slack-deliver.ts` | `/deliver/slack` — outbound message delivery via `chat.postMessage`                           |
+| Module                                    | Purpose                                                                                                               |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `gateway/src/slack/socket-mode.ts`        | `SlackSocketModeClient` — WebSocket lifecycle, ACK, dedup, auto-reconnect, reconnect catch-up                         |
+| `gateway/src/slack/slack-web.ts`          | `conversations.history` / `conversations.replies` helpers for reconnect catch-up                                      |
+| `gateway/src/slack/message-normalizer.ts` | Normalizers per event family (`normalizeSlackAppMention()`, DM, group DM, channel message) with bot-mention stripping |
+| `gateway/src/index.ts`                    | `/deliver/slack` route: outbound message delivery via `chat.postMessage`, thread and message ts on the callback URL   |
 
-**Limitations (MVP):** Text-only — attachments are rejected. Only `app_mention` events are processed (direct messages to the bot are not handled). Rich approval UI (inline buttons) is not supported.
+**What the ingress does not do:** it never forwards the bot's own posts to the daemon (except a deletion of one, which the daemon records), and it never reads history on the daemon's behalf beyond the bounded reconnect catch-up above; the daemon's inbound-triggered backfill hydrates context.
 
 ---
 

--- a/gateway/ARCHITECTURE.md
+++ b/gateway/ARCHITECTURE.md
@@ -746,7 +746,7 @@ Any persistent-stream transport that does not buffer events for disconnected cli
 
 | Module                                    | Purpose                                                                                                               |
 | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `gateway/src/slack/socket-mode.ts`        | `SlackSocketModeClient` — WebSocket lifecycle, ACK, dedup, auto-reconnect, reconnect catch-up                         |
+| `gateway/src/slack/socket-mode.ts`        | `SlackSocketModeClient`: WebSocket lifecycle, ACK, dedup, auto-reconnect, reconnect catch-up                          |
 | `gateway/src/slack/slack-web.ts`          | `conversations.history` / `conversations.replies` helpers for reconnect catch-up                                      |
 | `gateway/src/slack/message-normalizer.ts` | Normalizers per event family (`normalizeSlackAppMention()`, DM, group DM, channel message) with bot-mention stripping |
 | `gateway/src/index.ts`                    | `/deliver/slack` route: outbound message delivery via `chat.postMessage`, thread and message ts on the callback URL   |

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "ffffe1cead80d1c705265a8d2836b52773285a6001cdda491ade8835d0867bd5"
+      "sha256": "491b39a13f1de05db6ca25df5d9b3bcd498ad1390b2487d48ded76b736e4cbb2"
     },
     "skill-management": {
       "docsSlug": "skill-management",


### PR DESCRIPTION
**TL;DR:** Three passages described behavior the code does not have. Each corrected sentence now says what the code does and names the line that decides it. Docs and one code comment only. Part of LUM-3525.

## What was wrong, and what decides it

| Passage | Said | Code says |
| --- | --- | --- |
| Schedule skill, "Conversation Reuse" | Recurring runs reuse a conversation by default and preserve "channel thread continuity" | `reuse_conversation` defaults to false (`schedule-store.ts`, `params.reuseConversation ?? false`); a run's reply never auto-delivers to a channel, only explicit sends reach one (no channel delivery in `schedule/` or `daemon/`). Reuse keeps the run's own conversation, which is how a run can re-post into a thread whose `thread_ts` it saved |
| Gateway architecture, channel binding lifecycle "Route" | Every message on an external chat routes to the same conversation | Slack and Telegram are thread-scoped: a threaded message (every message in a Slack agent DM) or a Telegram topic resolves to its own conversation (`delivery-crud.ts`, `buildScopedConversationKey`, `THREAD_SCOPED_CHANNELS`) |
| Gateway architecture, Slack event processing and "Limitations (MVP)" | Only `app_mention` events are processed; DMs are not handled | DMs, group DMs, tracked-thread replies, edits, deletes, and reactions are admitted per event kind (`socket-mode.ts`, `processEventPayload`); the bot's own echoes are dropped by the self-filter |
| Gateway architecture, Slack module table | `gateway/src/slack/normalize.ts`, `gateway/src/http/routes/slack-deliver.ts` | Neither exists: normalizers live in `gateway/src/slack/message-normalizer.ts`; `/deliver/slack` is served from `gateway/src/index.ts` |
| `conversation-runtime-assembly.ts`, `isSlackChannelConversation` doc | The gateway omits `chatType` for DMs and cites `gateway/src/slack/normalize.ts` | The normalizer forwards `"im"` for a DM and `"mpim"` for a group DM (`message-normalizer.ts`); the `=== "channel"` check still returns false for both, so behavior is unchanged |

## Why this is safe

Documentation and one comment; no code path changes. The runtime comment describes the same predicate with the correct inputs. Surfaced while investigating LUM-3525, where the schedule skill's claim of thread continuity was one of the premises that had to be checked against source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->