### PR TITLE
fix(companion): a rewrite waits on a bound of its own (JARVIS-1725)

### DIFF
--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -1,5 +1,5 @@
 import { act, cleanup, render } from "@testing-library/react";
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 import { forwardRef, useImperativeHandle } from "react";
 import { MemoryRouter } from "react-router";
 
@@ -23,6 +23,8 @@ let latestVoiceInputProps: VoiceInputButtonProps | null = null;
 let nextTextInsertionStatus: TextInsertionStatus = "unavailable";
 const insertedTexts: string[] = [];
 let nextDictationResult: { mode: string; text: string } | null = null;
+/** How long the daemon takes to answer, for the cases about the deadline. */
+let nextDictationDelayMs = 0;
 type DictationCall = {
   transcription: string;
   assistantId: string;
@@ -118,6 +120,11 @@ mock.module("@/domains/chat/voice/dictation-api", () => ({
     context: Record<string, unknown>,
   ) => {
     dictationCalls.push({ transcription, assistantId, context });
+    if (nextDictationDelayMs > 0) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, nextDictationDelayMs);
+      });
+    }
     return nextDictationResult;
   },
 }));
@@ -173,6 +180,7 @@ afterEach(() => {
   voiceStartMock.mockReturnValue(true);
   nextTextInsertionStatus = "unavailable";
   nextDictationResult = null;
+  nextDictationDelayMs = 0;
   dictationCalls.length = 0;
   insertedTexts.length = 0;
   askedTexts.length = 0;
@@ -490,6 +498,61 @@ describe("a hold over an editable selection", () => {
     expect(insertedTexts).toEqual(["Could you send the files over?"]);
     expect(askedTexts).toEqual([]);
     expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A rewrite writes back as much as it was handed, so a paragraph's edit
+   * takes longer than the cleanup's bound, and under that bound it was dropped
+   * at the deadline and read aloud as an answer instead. The rewrite waits on
+   * a bound of its own.
+   */
+  test("waits past the cleanup's bound for a paragraph's edit", async () => {
+    withAssistantThatTellsEditsFromQuestions();
+    nextTextInsertionStatus = "inserted";
+    nextDictationResult = {
+      mode: "command",
+      text: "Could you send the files over?",
+    };
+    nextDictationDelayMs = 8000;
+    const voiceInput = renderBridge("a1");
+    holdOver(passage);
+
+    jest.useFakeTimers();
+    try {
+      const run = voiceInput.onTranscript("make this friendlier");
+      jest.advanceTimersByTime(8000);
+      await act(async () => {
+        await run;
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+
+    expect(insertedTexts).toEqual(["Could you send the files over?"]);
+    expect(askedTexts).toEqual([]);
+  });
+
+  test("gives up on an edit the daemon never finishes and asks instead", async () => {
+    withAssistantThatTellsEditsFromQuestions();
+    nextTextInsertionStatus = "inserted";
+    nextDictationResult = { mode: "command", text: "never seen" };
+    nextDictationDelayMs = 60_000;
+    const voiceInput = renderBridge("a1");
+    holdOver(passage);
+
+    jest.useFakeTimers();
+    try {
+      const run = voiceInput.onTranscript("make this friendlier");
+      jest.advanceTimersByTime(20_000);
+      await act(async () => {
+        await run;
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+
+    expect(insertedTexts).toEqual([]);
+    expect(askedTexts).toHaveLength(1);
   });
 
   test("takes a question to the assistant instead", async () => {

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -47,6 +47,22 @@ interface GlobalPushToTalkBridgeProps {
 const CLEANUP_DEADLINE_MS = 5000;
 
 /**
+ * How long a hold gives the daemon to rewrite a selection before the words go
+ * to the assistant as a question instead.
+ *
+ * Its own bound rather than the cleanup's. A cleanup tidies a sentence and
+ * answers in a second or two whatever was said; a rewrite writes back as much
+ * as it was handed, and a paragraph takes the model as long as a paragraph
+ * takes. Under the cleanup's bound a long selection's edit was dropped at
+ * the deadline and the hold fell through to the ask, which read an answer
+ * aloud when the user had asked for the text in front of them changed. The
+ * user is watching their selection while it runs, so the wait is a wait and
+ * not a hang; what has to hold is that a rewrite asked for is a rewrite
+ * delivered.
+ */
+const REWRITE_DEADLINE_MS = 20_000;
+
+/**
  * The turn a hold made over a selection becomes: the selection, quoted, and
  * then the words. The selection comes first because it is what the words are
  * about, and quoted so the model and the transcript both read it as something
@@ -75,6 +91,7 @@ async function postDictationWithDeadline(
   words: string,
   assistantId: string,
   context: DictationContext,
+  deadlineMs: number = CLEANUP_DEADLINE_MS,
 ): Promise<DictationPostResponse | null> {
   const abort = new AbortController();
   return Promise.race([
@@ -83,7 +100,7 @@ async function postDictationWithDeadline(
       setTimeout(() => {
         abort.abort();
         resolve(null);
-      }, CLEANUP_DEADLINE_MS);
+      }, deadlineMs);
     }),
   ]);
 }
@@ -115,10 +132,15 @@ async function requestSelectionRewrite(
   assistantId: string,
 ): Promise<string | null> {
   const startedAt = Date.now();
-  const result = await postDictationWithDeadline(words, assistantId, {
-    cursorInTextField: true,
-    selectedText: selection.text,
-  });
+  const result = await postDictationWithDeadline(
+    words,
+    assistantId,
+    {
+      cursorInTextField: true,
+      selectedText: selection.text,
+    },
+    REWRITE_DEADLINE_MS,
+  );
   const edited = result?.mode === "command" ? result.text.trim() : "";
   const rewrite = edited && edited !== selection.text.trim() ? edited : null;
   console.info(


### PR DESCRIPTION
## Summary

Seen on the dev build today: a hold over a 522-character editable selection asked for a rewrite, and the app read an answer aloud instead of replacing the text. Two shorter rewrites in the same minute (18 and 56 characters) landed in 1.8s and 2.9s.

The rewrite lane shared the dictation cleanup's 5s deadline. A rewrite writes back as much as it was handed, so a paragraph's edit ran past the bound, the client dropped it (`dictation: rewrite skipped ... ms=5003` in the log) and fell through to the spoken ask. The rewrite now waits on its own 20s bound; the cleanup keeps its 5s.

## Testing

- `global-push-to-talk-bridge.test.tsx` (22): two new cases under fake timers. An edit that takes 8s still lands, which fails under the old bound; an edit that never comes is given up on at 20s and asked about instead.
- `tsc`, eslint, prettier clean.

Part of JARVIS-1705. Closes JARVIS-1725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Py5RCxLX8GECQCsNTM22Tc
