### PR TITLE
docs(skills): explain workspace config.json and conversation TTL

### DIFF
--- a/assistant/src/__tests__/vellum-self-knowledge-inline-command.test.ts
+++ b/assistant/src/__tests__/vellum-self-knowledge-inline-command.test.ts
@@ -4,7 +4,7 @@
  * rather than static content.
  */
 
-import { copyFileSync, mkdirSync } from "node:fs";
+import { copyFileSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -146,5 +146,23 @@ describe("vellum-self-knowledge skill", () => {
     expect(result.content).toContain("CLI first");
     expect(result.content).toContain("Docs second");
     expect(result.content).toContain("Source code last");
+  });
+
+  test("points at the config.json reference for workspace config questions", async () => {
+    const result = await executeSkillLoad({ skill: "vellum-self-knowledge" });
+    expect(result.content).toContain("references/config-json.md");
+    expect(result.content).toContain("assistant config schema");
+    expect(result.content).toContain("assistant config get <path>");
+  });
+
+  test("config.json reference tells the assistant to query schema, not invent keys", () => {
+    const reference = readFileSync(
+      join(SKILL_SRC_DIR, "references", "config-json.md"),
+      "utf-8",
+    );
+    expect(reference).toContain("assistant config schema");
+    expect(reference).toContain("Never invent keys");
+    expect(reference).toContain("memory.cleanup.conversationRetentionDays");
+    expect(reference).toContain("0");
   });
 });

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T12:58:28.000Z"
+      "updatedAt": "2026-09-02T13:18:50.000Z"
     },
     {
       "id": "public-ingress",
@@ -1073,16 +1073,20 @@
     {
       "id": "vellum-conversation-management",
       "name": "vellum-conversation-management",
-      "description": "Manage conversation threads (rename, list, search, export)",
+      "description": "Manage conversation threads (rename, list, search, export) and explain conversation retention / auto-delete TTL",
       "metadata": {
         "emoji": "💬",
         "vellum": {
           "category": "productivity",
-          "display-name": "Conversations"
+          "display-name": "Conversations",
+          "activation-hints": [
+            "rename, list, search, or export conversations",
+            "conversation retention, conversation TTL, or auto-deleting old conversations"
+          ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-20T21:25:08.000Z"
+      "updatedAt": "2026-09-02T21:39:56.000Z"
     },
     {
       "id": "vellum-github-app-setup",
@@ -1194,6 +1198,8 @@
             "what model the assistant is running on",
             "how Vellum works or its architecture",
             "its current configuration or settings",
+            "what workspace config.json is, which keys it accepts, or what a default means",
+            "conversation retention, conversation TTL, or auto-deleting old conversations",
             "what it can do, or what skills/tools are available",
             "whether a service is connected, and in which sense",
             "how to self-host a Vellum assistant",
@@ -1205,7 +1211,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T07:15:43.000Z"
+      "updatedAt": "2026-09-02T21:39:56.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/vellum-conversation-management/SKILL.md
+++ b/skills/vellum-conversation-management/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: vellum-conversation-management
-description: Manage conversation threads (rename, list, search, export)
+description: Manage conversation threads (rename, list, search, export) and explain conversation retention / auto-delete TTL
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "💬"
   vellum:
     category: "productivity"
     display-name: "Conversations"
+    activation-hints:
+      - "rename, list, search, or export conversations"
+      - "conversation retention, conversation TTL, or auto-deleting old conversations"
 ---
 
 Tools for managing conversation threads via the `assistant conversations` CLI.
@@ -50,3 +53,17 @@ Export a conversation as markdown or JSON:
 ```bash
 assistant conversations export [conversationId] [--format md|json] [-o file]
 ```
+
+## Auto-delete (retention)
+
+Old conversations can be deleted automatically via workspace config, not
+this CLI. The key is `memory.cleanup.conversationRetentionDays` (`0` keeps
+conversations forever). Query the live spec before explaining or changing it:
+
+```bash
+assistant config schema memory.cleanup.conversationRetentionDays
+assistant config get memory.cleanup.conversationRetentionDays
+```
+
+For the full `config.json` explanation path, use the vellum-self-knowledge
+skill and its `references/config-json.md`.

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -11,6 +11,8 @@ metadata:
       - "what model the assistant is running on"
       - "how Vellum works or its architecture"
       - "its current configuration or settings"
+      - "what workspace config.json is, which keys it accepts, or what a default means"
+      - "conversation retention, conversation TTL, or auto-deleting old conversations"
       - "what it can do, or what skills/tools are available"
       - "whether a service is connected, and in which sense"
       - "how to self-host a Vellum assistant"
@@ -34,6 +36,7 @@ The CLI is the single source of truth for anything about the running assistant's
 | ----------------------------------------- | -------------------------------------------------------------------------- |
 | Current model, provider, config           | `assistant config get llm`                                                 |
 | Full config                               | `assistant config list`                                                    |
+| One config value                          | `assistant config get <dotted.path>`                                       |
 | Config schema (what's configurable)       | `assistant config schema [path]`                                           |
 | Available/installed skills                | `assistant skills list --json`                                             |
 | Platform connection                       | `assistant platform status --json`                                         |
@@ -51,6 +54,13 @@ The CLI is the single source of truth for anything about the running assistant's
 | Version                                   | `assistant --version`                                                      |
 
 Run `assistant --help` or `assistant <command> --help` to discover more.
+
+When the question is about `$VELLUM_WORKSPACE_DIR/config.json` itself
+(what the file is, which keys exist, what a default or "off" value means,
+whether conversation retention / TTL exists), read
+[references/config-json.md](references/config-json.md), then query
+`assistant config schema [path]` and `assistant config get <path>`.
+Do not invent keys. A setting can exist and still be off.
 
 "Is X connected?" has two answers and a service can have either, both, or
 neither. It takes both commands: the providers list is a catalog and says

--- a/skills/vellum-self-knowledge/references/config-json.md
+++ b/skills/vellum-self-knowledge/references/config-json.md
@@ -1,0 +1,87 @@
+# Workspace `config.json`
+
+This is the spec the assistant should use when a user asks what `$VELLUM_WORKSPACE_DIR/config.json` is, which keys exist, or what a setting does.
+
+Do not recite a remembered key list. Query the live schema and current values, then explain those results.
+
+## What the file is
+
+`config.json` is the workspace runtime configuration. It lives at `$VELLUM_WORKSPACE_DIR/config.json`.
+
+The file is optional. Missing keys are filled from schema defaults at load time. A missing or empty file therefore means "use shipped defaults", not "no configuration exists".
+
+The assistant validates the file against `AssistantConfigSchema` (Zod). Invalid files are quarantined and replaced with defaults. Never invent keys. If a path is absent from `assistant config schema`, it is not a supported setting.
+
+## How to explain the spec
+
+1. Confirm the file path: `$VELLUM_WORKSPACE_DIR/config.json`.
+2. Query the schema for the path the user asked about:
+
+   ```bash
+   assistant config schema
+   assistant config schema memory.cleanup
+   assistant config schema <dotted.path>
+   ```
+
+3. Query the current value:
+
+   ```bash
+   assistant config get <dotted.path>
+   assistant config list
+   ```
+
+4. Explain using the schema metadata (`type`, `description`, `default`) plus the current value. If the user wants a change, do not edit the file by hand and do not use this skill to apply it. Use in-chat config (`/config` or the settings UI).
+
+`assistant config schema` without a path prints the full tree. Prefer a dotted path so the answer stays focused.
+
+## Defaults and "off"
+
+A key omitted from the file still has a default. Quote that default from `assistant config schema`, not from memory.
+
+Common off conventions in this schema:
+
+- `0` often means disabled / keep forever (retention windows, some intervals).
+- `null` on some optional fields also means disabled or unset. Trust the schema description for that key.
+
+When a user asks whether a feature exists, check the schema first. A setting can exist and still be off.
+
+## Conversation retention (TTL)
+
+Conversation auto-delete already exists. Do not invent a second conversations TTL key.
+
+| Item | Value |
+| --- | --- |
+| Path | `memory.cleanup.conversationRetentionDays` |
+| Type | non-negative integer |
+| Default | `0` |
+| Off | `0` keeps conversations indefinitely |
+| On | positive N deletes conversations whose `updated_at` is older than N days |
+| Also required | `memory.cleanup.enabled` must be true (it defaults true) |
+| Scope | Ages on last activity (`updated_at`). Archived conversations are included. |
+
+Confirm the live description and default with:
+
+```bash
+assistant config schema memory.cleanup.conversationRetentionDays
+assistant config get memory.cleanup.conversationRetentionDays
+```
+
+Related cleanup keys live under the same `memory.cleanup` object (job enablement, interval, and other retention windows). Query `assistant config schema memory.cleanup` rather than listing them from memory.
+
+This is not conversation compaction / summarize. Retention deletes old conversation rows. Compaction shortens context inside a conversation that still exists.
+
+There is no dedicated conversations settings UI for this key today. Changing it is a workspace config change (`assistant config set` / in-chat config), not an `assistant conversations` CLI flag.
+
+## Neighboring retention settings (do not confuse)
+
+These are not conversation TTL. Query schema before explaining any of them:
+
+- `memory.cleanup.llmRequestLogRetentionMs`: LLM request-log cleanup window. Default is a finite duration, not forever.
+- `auditLog.retentionDays`: audit-log retention. `0` means keep forever.
+- Device / client LLM log retention in the app UI is a client preference, not a `config.json` key.
+
+## Editing
+
+Prefer in-chat config or `assistant config set <path> <value>` over rewriting the JSON file. Hand edits must remain valid JSON and must use keys the schema accepts.
+
+If `assistant config schema <path>` errors or returns nothing, the path is not part of the spec. Say so instead of suggesting a new key.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of [ATL-1205](https://linear.app/vellum/issue/ATL-1205/decide-whether-to-ship-a-conversation-retention-ttl-with-summarize).

## Prompt / plan

Look into ATL-1205: do we already have a conversation TTL setting? If not, build one that is off by default. Also check whether `$VELLUM_WORKSPACE_DIR/config.json` is explainable to the assistant, and add it to the vellum self-knowledge skill if not.

## What we found

Conversation auto-delete already ships and is off by default. The key is `memory.cleanup.conversationRetentionDays` (`0` = keep forever). The sweeper only enqueues `prune_old_conversations` when that value is positive. This PR does **not** add a second TTL.

The `config.json` spec is the live Zod schema (`assistant config schema`). Public docs mention the file as "Runtime configuration" but do not explain keys, defaults, or how to query them. Self-knowledge had the CLI schema command but no file-path / defaults / retention write-up.

## What changed

- Added `skills/vellum-self-knowledge/references/config-json.md`: query-first guide for explaining `config.json` (path, validation, defaults, off conventions) with conversation TTL as the worked example.
- Pointed the self-knowledge skill at that reference and added activation hints for config.json / conversation TTL.
- Pointed conversation-management at the same key so "auto-delete old conversations" routes correctly.
- Regenerated `skills/catalog.json`.

## Test plan

- [x] `node scripts/skills/check-catalog.mjs`
- [x] `cd assistant && bun test src/__tests__/vellum-self-knowledge-inline-command.test.ts` (10 pass)
- [x] Confirmed schema default in `assistant/src/config/schemas/memory-lifecycle.ts` is still `0`

## CLI verb checklist

No new IPC routes. Existing `assistant config schema` / `assistant config get` are the source of truth this skill now points at.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7b57476-0626-4355-abcc-c56b0a275829?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7b57476-0626-4355-abcc-c56b0a275829&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

