### PR TITLE
Link the P3 and sRGB icon color guards and dedupe the bundle-fill reader

### DIFF
--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -318,8 +318,7 @@ inline in `App/project.yml` under the `AppEnvironment` template.
 - A bundle's `fill-specializations` solid is a **Display P3** value, so an
   sRGB hex has to be converted before it goes in. All three bundles carry a
   true conversion of their hex. Pasting the raw sRGB components straight
-  through renders noticeably more saturated than the hex you started from,
-  which is why the conversion is required rather than optional.
+  through renders noticeably more saturated than the hex you started from.
 - `App/App/AvatarIcons.xcassets` holds the alternate icons, one
   `.appiconset` per eye style and color, named `avatar-eyes-<eye>-<color>`.
   Every combination ships: 9 eye styles × 6 colors, so 54 sets. Each set is a

--- a/clients/ios/scripts/__tests__/desktop-icon-ground.test.ts
+++ b/clients/ios/scripts/__tests__/desktop-icon-ground.test.ts
@@ -11,11 +11,14 @@
  * icons. A hand render can mix sizes, so one entry is not evidence for the rest.
  * Linux derives its ground at build time instead, so the guard runs that
  * script's own conversion rather than a copy that could drift away from it.
+ * The same conversion carries each ground over to the Android flavors, which
+ * spell it as plain sRGB hex, so the two encodings cannot drift apart.
  */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { inflateSync } from "node:zlib";
+import { P3_SPELLING, readIconFill } from "./icon-bundle-fixtures";
 
 const CLIENTS_DIR = join(import.meta.dir, "../../..");
 
@@ -29,8 +32,6 @@ const STANDARDIZED = [
   { environment: "dev", icon: "AppIcon-Dev.icon" },
 ] as const;
 
-const P3_SPELLING = /^display-p3:\d+\.\d+,\d+\.\d+,\d+\.\d+,\d+\.\d+$/;
-
 /** The desktop manifests keep the fill at the top level, not per appearance. */
 function readDesktopFill(platform: string, environment: string): string {
   const path = join(
@@ -43,16 +44,28 @@ function readDesktopFill(platform: string, environment: string): string {
   return JSON.parse(readFileSync(path, "utf8")).fill.solid;
 }
 
-/** The bundle pins every appearance to one color, so any specialization does. */
-function readIosFill(icon: string): string {
-  const path = join(CLIENTS_DIR, "ios/App/App", icon, "icon.json");
-  const solids = new Set(
-    JSON.parse(readFileSync(path, "utf8"))["fill-specializations"].map(
-      ({ value }: { value: { solid: string } }) => value.solid,
-    ),
+/** The launcher background an Android flavor declares, in plain sRGB hex. */
+function flavorLauncherBackground(environment: string): string {
+  const path = join(
+    CLIENTS_DIR,
+    "android/app/src",
+    environment,
+    "res/values/colors.xml",
   );
-  expect(solids.size).toBe(1);
-  return [...solids][0] as string;
+  const hex = /name="launcher_background"\s*>\s*(#[0-9A-Fa-f]{6})\s*</.exec(
+    readFileSync(path, "utf8"),
+  )?.[1];
+  if (!hex) {
+    throw new Error(`${environment} declares no launcher_background`);
+  }
+  return hex.toUpperCase();
+}
+
+function toHex(components: number[]): string {
+  const digits = components
+    .map((component) => component.toString(16).padStart(2, "0"))
+    .join("");
+  return `#${digits}`.toUpperCase();
 }
 
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
@@ -246,13 +259,13 @@ describe("desktop icon ground", () => {
 
   for (const { environment, icon } of STANDARDIZED) {
     test(`${environment} matches ${icon}`, () => {
-      expect(readDesktopFill("macos", environment)).toBe(readIosFill(icon));
+      expect(readDesktopFill("macos", environment)).toBe(readIconFill(icon));
     });
   }
 
   for (const { environment, icon } of STANDARDIZED) {
     test(`Linux and every ${environment} Windows ICO image render ${icon}'s ground`, () => {
-      const fill = readIosFill(icon);
+      const fill = readIconFill(icon);
       // The shipped awk and this file's rotation are independent conversions;
       // demanding both catches a drift in either one.
       const ground = renderedSrgb(fill);
@@ -269,6 +282,17 @@ describe("desktop icon ground", () => {
         ),
       ).toEqual(
         Object.fromEntries(entries.map(({ size }) => [`${size}px`, ground])),
+      );
+    });
+  }
+
+  for (const { environment, icon } of STANDARDIZED) {
+    // The P3 surfaces above and the sRGB surfaces Android and the web share are
+    // two spellings of one ground, so each cluster staying self-consistent is
+    // only half the guard: this converts across the seam and pins the result.
+    test(`${icon} converts to the ${environment} Android launcher hex`, () => {
+      expect(toHex(p3ToSrgb(readIconFill(icon)))).toBe(
+        flavorLauncherBackground(environment),
       );
     });
   }

--- a/clients/ios/scripts/__tests__/icon-bundle-fixtures.ts
+++ b/clients/ios/scripts/__tests__/icon-bundle-fixtures.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared readers for the Icon Composer bundles the drift guards pin against.
+ *
+ * Both guards read the same bundles, so the reader lives here rather than once
+ * per test: a bundle that changes shape then breaks one function instead of
+ * drifting between two copies of it.
+ */
+import { expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const APP_DIR = join(import.meta.dir, "../../App/App");
+
+/** The spelling both the Swift parser and the desktop renderers read. */
+export const P3_SPELLING = /^display-p3:\d+\.\d+,\d+\.\d+,\d+\.\d+,\d+\.\d+$/;
+
+export interface FillSpecialization {
+  appearance?: string;
+  value: { solid: string };
+}
+
+export function readFillSpecializations(icon: string): FillSpecialization[] {
+  const contents = readFileSync(join(APP_DIR, icon, "icon.json"), "utf8");
+  return JSON.parse(contents)["fill-specializations"];
+}
+
+/** The bundle pins every appearance to one color, so any specialization does. */
+export function readIconFill(icon: string): string {
+  const solids = new Set(
+    readFillSpecializations(icon).map(({ value }) => value.solid),
+  );
+  expect(solids.size).toBe(1);
+  return [...solids][0] as string;
+}

--- a/clients/ios/scripts/__tests__/ios-app-icon-ground.test.ts
+++ b/clients/ios/scripts/__tests__/ios-app-icon-ground.test.ts
@@ -11,6 +11,11 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  P3_SPELLING,
+  readFillSpecializations,
+  readIconFill,
+} from "./icon-bundle-fixtures";
 
 const APP_DIR = join(import.meta.dir, "../../App/App");
 
@@ -24,25 +29,6 @@ const TARGETS = [
 function readGround(xcconfig: string): string | undefined {
   const contents = readFileSync(join(APP_DIR, "Config", xcconfig), "utf8");
   return /^APP_ICON_GROUND\s*=\s*(.+)$/m.exec(contents)?.[1]?.trim();
-}
-
-interface FillSpecialization {
-  appearance?: string;
-  value: { solid: string };
-}
-
-function readFillSpecializations(icon: string): FillSpecialization[] {
-  const contents = readFileSync(join(APP_DIR, icon, "icon.json"), "utf8");
-  return JSON.parse(contents)["fill-specializations"];
-}
-
-/** The bundle pins every appearance to one color, so any specialization does. */
-function readIconFill(icon: string): string {
-  const solids = new Set(
-    readFillSpecializations(icon).map(({ value }) => value.solid),
-  );
-  expect(solids.size).toBe(1);
-  return [...solids][0] as string;
 }
 
 describe("ios app icon ground", () => {
@@ -68,9 +54,7 @@ describe("ios app icon ground", () => {
 
   test("every ground is the spelling the Swift parser reads", () => {
     for (const { xcconfig } of TARGETS) {
-      expect(readGround(xcconfig)).toMatch(
-        /^display-p3:\d+\.\d+,\d+\.\d+,\d+\.\d+,\d+\.\d+$/,
-      );
+      expect(readGround(xcconfig)).toMatch(P3_SPELLING);
     }
   });
 });

--- a/clients/web/src/domains/settings/components/app-icon-row.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.test.tsx
@@ -555,7 +555,7 @@ describe("AppIconRow", () => {
       // Production is the one flavor the row names no field for, which is only
       // honest while the flavor itself declares the catalog's own green.
       expect(flavorLauncherBackground("production")).toBe(hexFor("green"));
-      expect(APP_ICON_GROUNDS.production).toBe(hexFor("green"));
+      expect(hexFor("green")).toBe(APP_ICON_GROUNDS.production);
       expect(previewFill()).toBe(hexFor("green"));
     });
   });

--- a/clients/web/src/domains/settings/components/app-icon-row.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-row.test.tsx
@@ -555,6 +555,7 @@ describe("AppIconRow", () => {
       // Production is the one flavor the row names no field for, which is only
       // honest while the flavor itself declares the catalog's own green.
       expect(flavorLauncherBackground("production")).toBe(hexFor("green"));
+      expect(APP_ICON_GROUNDS.production).toBe(hexFor("green"));
       expect(previewFill()).toBe(hexFor("green"));
     });
   });


### PR DESCRIPTION
## Summary
- The desktop drift guard now converts each iOS bundle fill to sRGB and pins it to the matching Android flavor launcher hex, so the P3 surfaces and the sRGB surfaces can no longer drift apart while both stay self-consistent
- The web test pins APP_ICON_GROUNDS.production alongside the existing flavor pin
- The shared bundle-fill reader and P3 spelling regex move to one fixtures module imported by both ios-scripts drift tests
- Drops a redundant clause from the iOS icon README

Self-review remediation for plan: standardize-icon-env-colors.md