### PR TITLE
feat(platform): route credit questions to platform credits and expose daily-limit state

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24435,10 +24435,10 @@ paths:
   /v1/platform/credits:
     get:
       operationId: platform_credits_get
-      summary: Get the organization's remaining credit balance
+      summary: Get the organization's remaining credit balance and daily-limit state
       description:
         Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform
-        billing summary.
+        billing summary, plus today's spend against the daily credit limit and the low-balance warning state.
       tags:
         - platform
       responses:
@@ -24462,6 +24462,24 @@ paths:
                     type: boolean
                   as_of:
                     type: string
+                  daily_spend:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  daily_limit:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  daily_limit_reached:
+                    type: boolean
+                  daily_limit_snoozed:
+                    type: boolean
+                  low_balance_threshold:
+                    anyOf:
+                      - type: number
+                      - type: "null"
+                  low_balance_warning:
+                    type: boolean
                 required:
                   - remaining
                   - settled
@@ -24469,6 +24487,12 @@ paths:
                   - unit
                   - stale
                   - as_of
+                  - daily_spend
+                  - daily_limit
+                  - daily_limit_reached
+                  - daily_limit_snoozed
+                  - low_balance_threshold
+                  - low_balance_warning
                 additionalProperties: false
   /v1/platform/disconnect:
     post:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24437,8 +24437,10 @@ paths:
       operationId: platform_credits_get
       summary: Get the organization's remaining credit balance and daily-limit state
       description:
-        Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform
-        billing summary, plus today's spend against the daily credit limit and the low-balance warning state.
+        "Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform
+        billing summary, plus the daily-limit state: today's spend counted against the daily credit limit (which
+        excludes spend covered by plan-included credits, so it is not total spend), the limit itself, and the
+        low-balance warning state."
       tags:
         - platform
       responses:
@@ -24466,20 +24468,29 @@ paths:
                     anyOf:
                       - type: number
                       - type: "null"
+                    description:
+                      Today's (UTC) spend counted against the daily credit limit, in USD. Excludes spend covered by plan-included
+                      credits (initial credit, Pro credit bundle), so it is not total spend. Null when the platform did
+                      not report it.
                   daily_limit:
                     anyOf:
                       - type: number
                       - type: "null"
+                    description: Daily credit limit in USD, or null when none is set.
                   daily_limit_reached:
                     type: boolean
+                    description: True when today's spend has reached the daily limit and the limit is being enforced.
                   daily_limit_snoozed:
                     type: boolean
+                    description: True when the daily limit has been skipped for the rest of the current UTC day.
                   low_balance_threshold:
                     anyOf:
                       - type: number
                       - type: "null"
+                    description: Low-balance alert threshold in USD.
                   low_balance_warning:
                     type: boolean
+                    description: True when the balance is above zero but below the low-balance threshold and auto top-up is not enabled.
                 required:
                   - remaining
                   - settled

--- a/assistant/src/cli/commands/platform/__tests__/credits-format.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/credits-format.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  formatCreditsLines,
+  type PlatformCreditsResult,
+} from "../credits-format.js";
+
+const BASE: PlatformCreditsResult = {
+  remaining: 42.17,
+  settled: 50,
+  pending: 7.83,
+  unit: "USD",
+  stale: false,
+  as_of: "2026-07-06T00:00:00.000Z",
+  daily_spend: 3.25,
+  daily_limit: 10,
+  daily_limit_reached: false,
+  daily_limit_snoozed: false,
+  low_balance_threshold: 5,
+  low_balance_warning: false,
+};
+
+describe("formatCreditsLines", () => {
+  test("labels daily spend as counted against the daily limit, never as total spend", () => {
+    const lines = formatCreditsLines(BASE);
+
+    expect(lines[2]).toBe(
+      "Today:     $3.25 counted against the $10.00 daily limit",
+    );
+    expect(lines.join("\n")).not.toContain("spent");
+  });
+
+  test("says when no daily limit is set and flags a reached or skipped limit", () => {
+    expect(formatCreditsLines({ ...BASE, daily_limit: null })[2]).toBe(
+      "Today:     $3.25 counted against the daily limit (none set)",
+    );
+    expect(
+      formatCreditsLines({ ...BASE, daily_limit_reached: true })[2],
+    ).toEndWith(" (limit reached)");
+    expect(
+      formatCreditsLines({ ...BASE, daily_limit_snoozed: true })[2],
+    ).toEndWith(" (limit skipped for today)");
+  });
+
+  test("omits the daily line without daily spend and adds the low-balance warning", () => {
+    const lines = formatCreditsLines({
+      ...BASE,
+      daily_spend: null,
+      low_balance_warning: true,
+    });
+
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toBe(
+      "Warning:   balance is below the low-balance threshold of $5.00",
+    );
+  });
+
+  test("formats a negative remaining balance with the sign first", () => {
+    expect(formatCreditsLines({ ...BASE, remaining: -2.5 })[0]).toStartWith(
+      "Remaining: -$2.50 USD",
+    );
+  });
+});

--- a/assistant/src/cli/commands/platform/__tests__/credits.test.ts
+++ b/assistant/src/cli/commands/platform/__tests__/credits.test.ts
@@ -16,6 +16,12 @@ describe("assistant platform credits", () => {
         unit: "USD",
         stale: false,
         as_of: "2026-07-06T00:00:00.000Z",
+        daily_spend: 3.25,
+        daily_limit: 10,
+        daily_limit_reached: false,
+        daily_limit_snoozed: false,
+        low_balance_threshold: 5,
+        low_balance_warning: false,
       },
     };
   });
@@ -31,6 +37,10 @@ describe("assistant platform credits", () => {
     expect(parsed.pending).toBe(7.83);
     expect(parsed.unit).toBe("USD");
     expect(parsed.stale).toBe(false);
+    expect(parsed.daily_spend).toBe(3.25);
+    expect(parsed.daily_limit).toBe(10);
+    expect(parsed.daily_limit_reached).toBe(false);
+    expect(parsed.low_balance_warning).toBe(false);
   });
 
   test("plain text mode does not emit JSON to stdout", async () => {

--- a/assistant/src/cli/commands/platform/credits-format.ts
+++ b/assistant/src/cli/commands/platform/credits-format.ts
@@ -1,0 +1,51 @@
+import { formatCostUsd } from "../../lib/cli-output.js";
+
+export interface PlatformCreditsResult {
+  remaining: number;
+  settled: number;
+  pending: number;
+  unit: "USD";
+  stale: boolean;
+  as_of: string;
+  daily_spend: number | null;
+  daily_limit: number | null;
+  daily_limit_reached: boolean;
+  daily_limit_snoozed: boolean;
+  low_balance_threshold: number | null;
+  low_balance_warning: boolean;
+}
+
+/** Human-readable lines for `assistant platform credits`. */
+export function formatCreditsLines(result: PlatformCreditsResult): string[] {
+  const staleNote = result.stale ? " (pending data may be stale)" : "";
+  const lines = [
+    `Remaining: ${formatCostUsd(result.remaining)} ${result.unit} (as of ${result.as_of})${staleNote}`,
+    `Settled:   ${formatCostUsd(result.settled)}   Pending: ${formatCostUsd(result.pending)}`,
+  ];
+  if (result.daily_spend !== null) {
+    const limit =
+      result.daily_limit === null
+        ? "the daily limit (none set)"
+        : `the ${formatCostUsd(result.daily_limit)} daily limit`;
+    const limitState = result.daily_limit_reached
+      ? " (limit reached)"
+      : result.daily_limit_snoozed
+        ? " (limit skipped for today)"
+        : "";
+    // daily_spend excludes spend covered by plan-included credits, so it is
+    // presented as the amount counted against the limit, never as total spend.
+    lines.push(
+      `Today:     ${formatCostUsd(result.daily_spend)} counted against ${limit}${limitState}`,
+    );
+  }
+  if (result.low_balance_warning) {
+    const threshold =
+      result.low_balance_threshold === null
+        ? ""
+        : ` of ${formatCostUsd(result.low_balance_threshold)}`;
+    lines.push(
+      `Warning:   balance is below the low-balance threshold${threshold}`,
+    );
+  }
+  return lines;
+}

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -92,9 +92,6 @@ Fields:
   low_balance_threshold  Low-balance alert threshold in USD
   low_balance_warning    True when the balance is below the threshold and auto top-up is off
 
-Combine with 'assistant usage daily' to compute runway (remaining divided
-by rolling daily average) and warn before credits run out.
-
 Requires platform credentials (run 'assistant platform connect' first or
 ensure VELLUM_PLATFORM_URL is set and credentials are stored).
 

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -85,6 +85,7 @@ Fields:
   stale                  True when pending-charge data may be stale or unavailable
   as_of                  When this balance was read (response receipt time)
   daily_spend            Today's (UTC) spend counted against the daily limit, in USD
+                         (excludes spend covered by plan-included credits)
   daily_limit            Daily credit limit in USD, or null when none is set
   daily_limit_reached    True when today's spend has hit the limit and it is enforced
   daily_limit_snoozed    True when the limit is skipped for the rest of today

--- a/assistant/src/cli/commands/platform/index.help.ts
+++ b/assistant/src/cli/commands/platform/index.help.ts
@@ -71,17 +71,25 @@ Examples:
     },
     {
       name: "credits",
-      description: "Show the organization's remaining credit balance",
+      description:
+        "Show the organization's remaining credit balance and daily-limit state",
       helpText: `
-Fetches the org's credit balance from the platform billing summary.
+Fetches the org's credit balance, today's spend, and daily-limit state from
+the platform billing summary.
 
 Fields:
-  remaining   Effective balance (settled minus pending charges) in USD
-  settled     On-ledger balance in USD
-  pending     Estimated pending compute charges not yet settled, in USD
-  unit        Balance currency (USD)
-  stale       True when pending-charge data may be stale or unavailable
-  as_of       When this balance was read (response receipt time)
+  remaining              Effective balance (settled minus pending charges) in USD
+  settled                On-ledger balance in USD
+  pending                Estimated pending compute charges not yet settled, in USD
+  unit                   Balance currency (USD)
+  stale                  True when pending-charge data may be stale or unavailable
+  as_of                  When this balance was read (response receipt time)
+  daily_spend            Today's (UTC) spend counted against the daily limit, in USD
+  daily_limit            Daily credit limit in USD, or null when none is set
+  daily_limit_reached    True when today's spend has hit the limit and it is enforced
+  daily_limit_snoozed    True when the limit is skipped for the rest of today
+  low_balance_threshold  Low-balance alert threshold in USD
+  low_balance_warning    True when the balance is below the threshold and auto top-up is off
 
 Combine with 'assistant usage daily' to compute runway (remaining divided
 by rolling daily average) and warn before credits run out.

--- a/assistant/src/cli/commands/platform/index.ts
+++ b/assistant/src/cli/commands/platform/index.ts
@@ -8,6 +8,7 @@ import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
 import { applyCommandHelp, subcommand } from "../../lib/cli-command-help.js";
+import { formatCostUsd } from "../../lib/cli-output.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
@@ -34,6 +35,45 @@ interface PlatformCreditsResult {
   unit: "USD";
   stale: boolean;
   as_of: string;
+  daily_spend: number | null;
+  daily_limit: number | null;
+  daily_limit_reached: boolean;
+  daily_limit_snoozed: boolean;
+  low_balance_threshold: number | null;
+  low_balance_warning: boolean;
+}
+
+/** Human-readable lines for `assistant platform credits`. */
+function formatCreditsLines(result: PlatformCreditsResult): string[] {
+  const staleNote = result.stale ? " (pending data may be stale)" : "";
+  const lines = [
+    `Remaining: ${formatCostUsd(result.remaining)} ${result.unit} (as of ${result.as_of})${staleNote}`,
+    `Settled:   ${formatCostUsd(result.settled)}   Pending: ${formatCostUsd(result.pending)}`,
+  ];
+  if (result.daily_spend !== null) {
+    const limit =
+      result.daily_limit === null
+        ? "no daily limit set"
+        : `daily limit ${formatCostUsd(result.daily_limit)}`;
+    const limitState = result.daily_limit_reached
+      ? " (limit reached)"
+      : result.daily_limit_snoozed
+        ? " (limit skipped for today)"
+        : "";
+    lines.push(
+      `Today:     ${formatCostUsd(result.daily_spend)} spent, ${limit}${limitState}`,
+    );
+  }
+  if (result.low_balance_warning) {
+    const threshold =
+      result.low_balance_threshold === null
+        ? ""
+        : ` of ${formatCostUsd(result.low_balance_threshold)}`;
+    lines.push(
+      `Warning:   balance is below the low-balance threshold${threshold}`,
+    );
+  }
+  return lines;
 }
 
 interface PlatformSubscriptionResult {
@@ -138,15 +178,9 @@ export function registerPlatformCommand(program: Command): void {
           if (shouldOutputJson(cmd)) {
             writeOutput(cmd, result);
           } else {
-            const staleNote = result.stale
-              ? " (pending data may be stale)"
-              : "";
-            log.info(
-              `Remaining: $${result.remaining.toFixed(2)} ${result.unit} (as of ${result.as_of})${staleNote}`,
-            );
-            log.info(
-              `Settled:   $${result.settled.toFixed(2)}   Pending: $${result.pending.toFixed(2)}`,
-            );
+            for (const line of formatCreditsLines(result)) {
+              log.info(line);
+            }
           }
         },
       );

--- a/assistant/src/cli/commands/platform/index.ts
+++ b/assistant/src/cli/commands/platform/index.ts
@@ -8,11 +8,14 @@ import type { Command } from "commander";
 
 import { cliIpcCall, exitFromIpcResult } from "../../../ipc/cli-client.js";
 import { applyCommandHelp, subcommand } from "../../lib/cli-command-help.js";
-import { formatCostUsd } from "../../lib/cli-output.js";
 import { registerCommand } from "../../lib/register-command.js";
 import { log } from "../../logger.js";
 import { shouldOutputJson, writeOutput } from "../../output.js";
 import { registerPlatformConnectCommand } from "./connect.js";
+import {
+  formatCreditsLines,
+  type PlatformCreditsResult,
+} from "./credits-format.js";
 import { registerPlatformDisconnectCommand } from "./disconnect.js";
 import { platformHelp } from "./index.help.js";
 import { registerPlatformInvoicesCommands } from "./invoices.js";
@@ -26,54 +29,6 @@ interface PlatformStatusResult {
   available: boolean;
   organizationId: string | null;
   userId: string | null;
-}
-
-interface PlatformCreditsResult {
-  remaining: number;
-  settled: number;
-  pending: number;
-  unit: "USD";
-  stale: boolean;
-  as_of: string;
-  daily_spend: number | null;
-  daily_limit: number | null;
-  daily_limit_reached: boolean;
-  daily_limit_snoozed: boolean;
-  low_balance_threshold: number | null;
-  low_balance_warning: boolean;
-}
-
-/** Human-readable lines for `assistant platform credits`. */
-function formatCreditsLines(result: PlatformCreditsResult): string[] {
-  const staleNote = result.stale ? " (pending data may be stale)" : "";
-  const lines = [
-    `Remaining: ${formatCostUsd(result.remaining)} ${result.unit} (as of ${result.as_of})${staleNote}`,
-    `Settled:   ${formatCostUsd(result.settled)}   Pending: ${formatCostUsd(result.pending)}`,
-  ];
-  if (result.daily_spend !== null) {
-    const limit =
-      result.daily_limit === null
-        ? "no daily limit set"
-        : `daily limit ${formatCostUsd(result.daily_limit)}`;
-    const limitState = result.daily_limit_reached
-      ? " (limit reached)"
-      : result.daily_limit_snoozed
-        ? " (limit skipped for today)"
-        : "";
-    lines.push(
-      `Today:     ${formatCostUsd(result.daily_spend)} spent, ${limit}${limitState}`,
-    );
-  }
-  if (result.low_balance_warning) {
-    const threshold =
-      result.low_balance_threshold === null
-        ? ""
-        : ` of ${formatCostUsd(result.low_balance_threshold)}`;
-    lines.push(
-      `Warning:   balance is below the low-balance threshold${threshold}`,
-    );
-  }
-  return lines;
 }
 
 interface PlatformSubscriptionResult {

--- a/assistant/src/cli/lib/__tests__/cli-output.test.ts
+++ b/assistant/src/cli/lib/__tests__/cli-output.test.ts
@@ -17,4 +17,9 @@ describe("formatCostUsd", () => {
     expect(formatCostUsd(1.5)).toBe("$1.50");
     expect(formatCostUsd(12.345)).toBe("$12.35");
   });
+
+  test("keeps the sign ahead of the dollar sign for negative amounts", () => {
+    expect(formatCostUsd(-2.5)).toBe("-$2.50");
+    expect(formatCostUsd(-0.004)).toBe("-$0.004000");
+  });
 });

--- a/assistant/src/cli/lib/cli-output.ts
+++ b/assistant/src/cli/lib/cli-output.ts
@@ -11,17 +11,17 @@ export function writeLine(msg: string): void {
 }
 
 /**
- * Format a USD cost with variable precision: "$0.00" for zero, six decimal
- * places for sub-cent amounts, two decimal places otherwise.
+ * Format a USD amount with variable precision: "$0.00" for zero, six decimal
+ * places for sub-cent magnitudes, two decimal places otherwise. A negative
+ * amount (a billing balance can be) carries its sign ahead of the dollar sign.
  */
 export function formatCostUsd(usd: number): string {
   if (usd === 0) {
     return "$0.00";
   }
-  if (usd < 0.01) {
-    return `$${usd.toFixed(6)}`;
-  }
-  return `$${usd.toFixed(2)}`;
+  const magnitude = Math.abs(usd);
+  const digits = magnitude < 0.01 ? 6 : 2;
+  return `${usd < 0 ? "-" : ""}$${magnitude.toFixed(digits)}`;
 }
 
 /**

--- a/assistant/src/runtime/routes/__tests__/platform-credits-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/platform-credits-routes.test.ts
@@ -119,12 +119,17 @@ describe("platform_credits", () => {
     });
   });
 
-  test("reports a null daily limit when none is set", async () => {
-    stubFetch({ ...FULL_SUMMARY, daily_credit_limit_usd: null });
+  test("reports null for a null daily limit and an empty amount", async () => {
+    stubFetch({
+      ...FULL_SUMMARY,
+      daily_credit_limit_usd: null,
+      low_balance_threshold_usd: "",
+    });
 
     expect(await creditsHandler({})).toMatchObject({
       daily_spend: 3.25,
       daily_limit: null,
+      low_balance_threshold: null,
     });
   });
 

--- a/assistant/src/runtime/routes/__tests__/platform-credits-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/platform-credits-routes.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for the platform_credits route handler: field mapping from the
+ * platform billing summary, including the daily-limit and low-balance state,
+ * and the fallbacks when a summary omits those fields.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { UnprocessableEntityError } from "../errors.js";
+
+let platformBaseUrl = "https://platform.test";
+let authHeader: string | null = "Api-Key test";
+
+// Spread the real module: replacing it wholesale breaks unrelated importers
+// pulled in by the module under test.
+const actualRegistration =
+  await import("../../../inbound/platform-callback-registration.js");
+mock.module("../../../inbound/platform-callback-registration.js", () => ({
+  ...actualRegistration,
+  resolvePlatformCallbackRegistrationContext: async () => ({
+    isPlatform: false,
+    platformBaseUrl,
+    assistantId: "assistant-123",
+    hasAssistantApiKey: !!authHeader,
+    authHeader,
+    enabled: !!(platformBaseUrl && authHeader),
+  }),
+}));
+
+const { ROUTES } = await import("../platform-routes.js");
+
+const creditsHandler = ROUTES.find(
+  (r) => r.operationId === "platform_credits",
+)!.handler;
+
+const SUMMARY_URL = "https://platform.test/v1/organizations/billing/summary/";
+
+const FULL_SUMMARY = {
+  settled_balance_usd: "50.00",
+  pending_compute_usd: "7.83",
+  effective_balance_usd: "42.17",
+  is_degraded: false,
+  daily_credit_limit_usd: "10.00",
+  daily_spend_usd: "3.25",
+  daily_limit_reached: false,
+  daily_limit_snoozed: true,
+  low_balance_threshold_usd: "5.00",
+  low_balance_warning: true,
+};
+
+const realFetch = globalThis.fetch;
+let fetchedUrls: string[] = [];
+
+/** Stub globalThis.fetch to answer every call with `body`, recording URLs. */
+function stubFetch(body: unknown, status = 200): void {
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    fetchedUrls.push(
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url,
+    );
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  platformBaseUrl = "https://platform.test";
+  authHeader = "Api-Key test";
+  fetchedUrls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("platform_credits", () => {
+  test("maps balance, daily-limit, and low-balance fields from the billing summary", async () => {
+    stubFetch(FULL_SUMMARY);
+
+    const result = await creditsHandler({});
+
+    expect(fetchedUrls).toEqual([SUMMARY_URL]);
+    expect(result).toMatchObject({
+      remaining: 42.17,
+      settled: 50,
+      pending: 7.83,
+      unit: "USD",
+      stale: false,
+      daily_spend: 3.25,
+      daily_limit: 10,
+      daily_limit_reached: false,
+      daily_limit_snoozed: true,
+      low_balance_threshold: 5,
+      low_balance_warning: true,
+    });
+  });
+
+  test("reports null and false for daily-limit fields a summary omits", async () => {
+    stubFetch({
+      settled_balance_usd: "50.00",
+      pending_compute_usd: "0.00",
+      effective_balance_usd: "50.00",
+      is_degraded: true,
+    });
+
+    expect(await creditsHandler({})).toMatchObject({
+      stale: true,
+      daily_spend: null,
+      daily_limit: null,
+      daily_limit_reached: false,
+      daily_limit_snoozed: false,
+      low_balance_threshold: null,
+      low_balance_warning: false,
+    });
+  });
+
+  test("reports a null daily limit when none is set", async () => {
+    stubFetch({ ...FULL_SUMMARY, daily_credit_limit_usd: null });
+
+    expect(await creditsHandler({})).toMatchObject({
+      daily_spend: 3.25,
+      daily_limit: null,
+    });
+  });
+
+  test("rejects with UnprocessableEntityError when credentials are missing", async () => {
+    authHeader = null;
+    stubFetch(FULL_SUMMARY);
+
+    await expect(creditsHandler({})).rejects.toBeInstanceOf(
+      UnprocessableEntityError,
+    );
+    expect(fetchedUrls).toHaveLength(0);
+  });
+});

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -466,7 +466,7 @@ async function handleCallbackRoutesList(
  * is not a finite number, so the daemon never reports a made-up figure.
  */
 function parseUsd(value: string | null | undefined): number | null {
-  if (value == null) {
+  if (value == null || value.trim() === "") {
     return null;
   }
   const parsed = Number(value);

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -143,12 +143,35 @@ const PlatformCreditsResponseSchema = z.object({
   unit: z.literal("USD"),
   stale: z.boolean(),
   as_of: z.string(),
-  daily_spend: z.number().nullable(),
-  daily_limit: z.number().nullable(),
-  daily_limit_reached: z.boolean(),
-  daily_limit_snoozed: z.boolean(),
-  low_balance_threshold: z.number().nullable(),
-  low_balance_warning: z.boolean(),
+  daily_spend: z
+    .number()
+    .nullable()
+    .describe(
+      "Today's (UTC) spend counted against the daily credit limit, in USD. Excludes spend covered by plan-included credits (initial credit, Pro credit bundle), so it is not total spend. Null when the platform did not report it.",
+    ),
+  daily_limit: z
+    .number()
+    .nullable()
+    .describe("Daily credit limit in USD, or null when none is set."),
+  daily_limit_reached: z
+    .boolean()
+    .describe(
+      "True when today's spend has reached the daily limit and the limit is being enforced.",
+    ),
+  daily_limit_snoozed: z
+    .boolean()
+    .describe(
+      "True when the daily limit has been skipped for the rest of the current UTC day.",
+    ),
+  low_balance_threshold: z
+    .number()
+    .nullable()
+    .describe("Low-balance alert threshold in USD."),
+  low_balance_warning: z
+    .boolean()
+    .describe(
+      "True when the balance is above zero but below the low-balance threshold and auto top-up is not enabled.",
+    ),
 });
 type PlatformCreditsResponse = z.infer<typeof PlatformCreditsResponseSchema>;
 
@@ -893,7 +916,7 @@ export const ROUTES: RouteDefinition[] = [
     summary:
       "Get the organization's remaining credit balance and daily-limit state",
     description:
-      "Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform billing summary, plus today's spend against the daily credit limit and the low-balance warning state.",
+      "Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform billing summary, plus the daily-limit state: today's spend counted against the daily credit limit (which excludes spend covered by plan-included credits, so it is not total spend), the limit itself, and the low-balance warning state.",
     tags: ["platform"],
     handler: handlePlatformCredits,
     responseBody: PlatformCreditsResponseSchema,

--- a/assistant/src/runtime/routes/platform-routes.ts
+++ b/assistant/src/runtime/routes/platform-routes.ts
@@ -15,7 +15,8 @@
  *   - platform_callback_routes_list (GET platform/callback-routes): lists
  *     registered callback routes for this assistant.
  *   - platform_credits (GET platform/credits): fetches the org's remaining
- *     credit balance from the platform billing summary.
+ *     credit balance, today's spend, and daily-limit / low-balance state from
+ *     the platform billing summary.
  *   - platform_subscription (GET platform/subscription): fetches the org's
  *     current plan, subscription status, and entitlements.
  *   - platform_plans (GET platform/plans): fetches the plan catalog with pricing.
@@ -142,6 +143,12 @@ const PlatformCreditsResponseSchema = z.object({
   unit: z.literal("USD"),
   stale: z.boolean(),
   as_of: z.string(),
+  daily_spend: z.number().nullable(),
+  daily_limit: z.number().nullable(),
+  daily_limit_reached: z.boolean(),
+  daily_limit_snoozed: z.boolean(),
+  low_balance_threshold: z.number().nullable(),
+  low_balance_warning: z.boolean(),
 });
 type PlatformCreditsResponse = z.infer<typeof PlatformCreditsResponseSchema>;
 
@@ -454,6 +461,18 @@ async function handleCallbackRoutesList(
   return { routes };
 }
 
+/**
+ * Null when the billing summary omits the field (older platform builds) or it
+ * is not a finite number, so the daemon never reports a made-up figure.
+ */
+function parseUsd(value: string | null | undefined): number | null {
+  if (value == null) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 async function handlePlatformCredits(
   _args: RouteHandlerArgs,
 ): Promise<PlatformCreditsResponse> {
@@ -465,6 +484,12 @@ async function handlePlatformCredits(
     pending_compute_usd: string;
     effective_balance_usd: string;
     is_degraded: boolean;
+    daily_spend_usd?: string;
+    daily_credit_limit_usd?: string | null;
+    daily_limit_reached?: boolean;
+    daily_limit_snoozed?: boolean;
+    low_balance_threshold_usd?: string;
+    low_balance_warning?: boolean;
   };
 
   return {
@@ -476,6 +501,12 @@ async function handlePlatformCredits(
     // as_of is response receipt time; add a server as_of field if the billing
     // summary endpoint ever returns one.
     as_of: new Date().toISOString(),
+    daily_spend: parseUsd(summary.daily_spend_usd),
+    daily_limit: parseUsd(summary.daily_credit_limit_usd),
+    daily_limit_reached: summary.daily_limit_reached === true,
+    daily_limit_snoozed: summary.daily_limit_snoozed === true,
+    low_balance_threshold: parseUsd(summary.low_balance_threshold_usd),
+    low_balance_warning: summary.low_balance_warning === true,
   };
 }
 
@@ -859,9 +890,10 @@ export const ROUTES: RouteDefinition[] = [
       requiredScopes: ["settings.read"],
       allowedPrincipalTypes: ACTOR_PRINCIPALS,
     },
-    summary: "Get the organization's remaining credit balance",
+    summary:
+      "Get the organization's remaining credit balance and daily-limit state",
     description:
-      "Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform billing summary.",
+      "Fetches the org's settled, pending, and effective (remaining) credit balance in USD from the platform billing summary, plus today's spend against the daily credit limit and the low-balance warning state.",
     tags: ["platform"],
     handler: handlePlatformCredits,
     responseBody: PlatformCreditsResponseSchema,

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1205,7 +1205,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T23:24:42.000Z"
+      "updatedAt": "2026-09-02T23:30:04.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T12:58:28.000Z"
+      "updatedAt": "2026-09-02T13:18:50.000Z"
     },
     {
       "id": "public-ingress",
@@ -1184,28 +1184,28 @@
     {
       "id": "vellum-self-knowledge",
       "name": "vellum-self-knowledge",
-      "description": "Answer questions about Vellum's architecture, configuration, and hosting from live sources of truth",
+      "description": "Answer questions about Vellum, its config, billing, and hosting from live sources of truth",
       "metadata": {
         "emoji": "🪞",
         "vellum": {
           "category": "system",
           "display-name": "Vellum Self-Knowledge",
           "activation-hints": [
-            "what model the assistant is running on",
+            "what model it runs on",
             "how Vellum works or its architecture",
-            "its current configuration or settings",
-            "what it can do, or what skills/tools are available",
+            "its current config or settings",
+            "what it can do or which skills/tools exist",
             "whether a service is connected, and in which sense",
-            "how to self-host a Vellum assistant",
-            "how to configure your own model API key"
+            "its credit balance, plan, spend, or daily limit",
+            "how to self-host or use your own model API key"
           ],
           "avoid-when": [
-            "changing configuration (use in-chat config instead)"
+            "changing configuration"
           ]
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T07:15:43.000Z"
+      "updatedAt": "2026-09-02T23:18:44.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1205,7 +1205,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T23:18:44.000Z"
+      "updatedAt": "2026-09-02T23:24:42.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -30,29 +30,29 @@ This skill contains zero static information — only pointers to where the truth
 
 The CLI is the single source of truth for anything about the running assistant's current state.
 
-| Question type                             | Command                                                                    |
-| ----------------------------------------- | -------------------------------------------------------------------------- |
-| Current model, provider, config           | `assistant config get llm`                                                 |
-| Full config                               | `assistant config list`                                                    |
-| Config schema (what's configurable)       | `assistant config schema [path]`                                           |
-| Available/installed skills                | `assistant skills list --json`                                             |
-| Platform connection                       | `assistant platform status --json`                                         |
-| Credit balance, spend today, daily limit  | `assistant platform credits --json`                                        |
-| Plan and subscription status              | `assistant platform subscription --json`                                   |
-| Plan catalog and pricing                  | `assistant platform plans --json`                                          |
-| Invoices                                  | `assistant platform invoices list --json`                                  |
-| Auth/identity                             | `assistant auth info --json`                                               |
-| Which providers exist, and in which sense | `assistant oauth providers list --json`                                    |
-| Whether one is actually connected         | `assistant oauth status <provider>`                                        |
-| Channel delivery health                   | `assistant channels list`                                                  |
-| Connected clients                         | `assistant clients list --json`                                            |
-| Trust rules                               | `assistant trust list`                                                     |
-| Stored credentials                        | `assistant credentials list`                                               |
-| API keys                                  | `assistant keys list`                                                      |
-| MCP servers                               | `assistant mcp list`                                                       |
-| Watchers                                  | `assistant watchers list`                                                  |
-| Token usage/costs                         | `assistant usage totals` / `assistant usage breakdown --group-by provider` |
-| Version                                   | `assistant --version`                                                      |
+| Question type                                 | Command                                                                    |
+| --------------------------------------------- | -------------------------------------------------------------------------- |
+| Current model, provider, config               | `assistant config get llm`                                                 |
+| Full config                                   | `assistant config list`                                                    |
+| Config schema (what's configurable)           | `assistant config schema [path]`                                           |
+| Available/installed skills                    | `assistant skills list --json`                                             |
+| Platform connection                           | `assistant platform status --json`                                         |
+| Credit balance, daily limit, spend against it | `assistant platform credits --json`                                        |
+| Plan and subscription status                  | `assistant platform subscription --json`                                   |
+| Plan catalog and pricing                      | `assistant platform plans --json`                                          |
+| Invoices                                      | `assistant platform invoices list --json`                                  |
+| Auth/identity                                 | `assistant auth info --json`                                               |
+| Which providers exist, and in which sense     | `assistant oauth providers list --json`                                    |
+| Whether one is actually connected             | `assistant oauth status <provider>`                                        |
+| Channel delivery health                       | `assistant channels list`                                                  |
+| Connected clients                             | `assistant clients list --json`                                            |
+| Trust rules                                   | `assistant trust list`                                                     |
+| Stored credentials                            | `assistant credentials list`                                               |
+| API keys                                      | `assistant keys list`                                                      |
+| MCP servers                                   | `assistant mcp list`                                                       |
+| Watchers                                      | `assistant watchers list`                                                  |
+| Token usage/costs                             | `assistant usage totals` / `assistant usage breakdown --group-by provider` |
+| Version                                       | `assistant --version`                                                      |
 
 Run `assistant --help` or `assistant <command> --help` to discover more.
 
@@ -76,16 +76,18 @@ recall which they did.
 probe, which is not all of them. It answers whether a channel is working, not
 whether something is connected.
 
-Credit balance, plan, and today's spend come from the platform's billing
-ledger through `platform credits` and `platform subscription`, never from an
-estimate. `platform credits` reports today's (UTC) spend only. For spend over
-any other period, such as this week or this month, say that you cannot see it
-and point to Settings > Billing; do not substitute today's figure or `usage
-totals`, which is a local token-cost estimate, not the ledger. When `platform
-credits` fails or the assistant is not connected to the platform, say plainly
-that you cannot see the balance and point to Settings > Billing. Do not guess
-a number, an allowance model, or a reset schedule, and never imply you checked
-when you did not.
+Credit balance and plan come from the platform's billing ledger through
+`platform credits` and `platform subscription`, never from an estimate. The
+only spend figure `platform credits` reports is `daily_spend`: today's (UTC)
+spend counted against the daily credit limit, which excludes spend covered by
+plan-included credits. Present it as exactly that. For total spend today, or
+spend over any other period, say that you cannot see it and point to
+Settings > Billing; do not substitute `daily_spend` or `usage totals`, which is
+a local token-cost estimate, not the ledger. When `platform credits` fails or
+the assistant is not connected to the platform, say plainly that you cannot
+see the balance and point to Settings > Billing. Do not guess a number, an
+allowance model, or a reset schedule, and never imply you checked when you did
+not.
 
 ### 2. Vellum Docs Site — Conceptual Knowledge
 

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -76,13 +76,16 @@ recall which they did.
 probe, which is not all of them. It answers whether a channel is working, not
 whether something is connected.
 
-Credit, plan, and spend questions are answered by the platform's billing
-ledger through `platform credits` and `platform subscription`, never by
-estimate. `usage totals` is a local token-cost estimate, not the balance. When
-`platform credits` fails or the assistant is not connected to the platform,
-say plainly that you cannot see the balance and point to Settings > Billing.
-Do not guess a number, an allowance model, or a reset schedule, and never
-imply you checked when you did not.
+Credit balance, plan, and today's spend come from the platform's billing
+ledger through `platform credits` and `platform subscription`, never from an
+estimate. `platform credits` reports today's (UTC) spend only. For spend over
+any other period, such as this week or this month, say that you cannot see it
+and point to Settings > Billing; do not substitute today's figure or `usage
+totals`, which is a local token-cost estimate, not the ledger. When `platform
+credits` fails or the assistant is not connected to the platform, say plainly
+that you cannot see the balance and point to Settings > Billing. Do not guess
+a number, an allowance model, or a reset schedule, and never imply you checked
+when you did not.
 
 ### 2. Vellum Docs Site — Conceptual Knowledge
 

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vellum-self-knowledge
-description: Answer questions about Vellum's architecture, configuration, and hosting from live sources of truth
+description: Answer questions about Vellum, its config, billing, and hosting from live sources of truth
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🪞"
@@ -8,15 +8,15 @@ metadata:
     category: "system"
     display-name: "Vellum Self-Knowledge"
     activation-hints:
-      - "what model the assistant is running on"
+      - "what model it runs on"
       - "how Vellum works or its architecture"
-      - "its current configuration or settings"
-      - "what it can do, or what skills/tools are available"
+      - "its current config or settings"
+      - "what it can do or which skills/tools exist"
       - "whether a service is connected, and in which sense"
-      - "how to self-host a Vellum assistant"
-      - "how to configure your own model API key"
+      - "its credit balance, plan, spend, or daily limit"
+      - "how to self-host or use your own model API key"
     avoid-when:
-      - "changing configuration (use in-chat config instead)"
+      - "changing configuration"
 ---
 
 ## Critical Rule
@@ -37,6 +37,10 @@ The CLI is the single source of truth for anything about the running assistant's
 | Config schema (what's configurable)       | `assistant config schema [path]`                                           |
 | Available/installed skills                | `assistant skills list --json`                                             |
 | Platform connection                       | `assistant platform status --json`                                         |
+| Credit balance, spend today, daily limit  | `assistant platform credits --json`                                        |
+| Plan and subscription status              | `assistant platform subscription --json`                                   |
+| Plan catalog and pricing                  | `assistant platform plans --json`                                          |
+| Invoices                                  | `assistant platform invoices list --json`                                  |
 | Auth/identity                             | `assistant auth info --json`                                               |
 | Which providers exist, and in which sense | `assistant oauth providers list --json`                                    |
 | Whether one is actually connected         | `assistant oauth status <provider>`                                        |
@@ -71,6 +75,14 @@ recall which they did.
 `channels list` reports delivery health for channels that have a readiness
 probe, which is not all of them. It answers whether a channel is working, not
 whether something is connected.
+
+Credit, plan, and spend questions are answered by the platform's billing
+ledger through `platform credits` and `platform subscription`, never by
+estimate. `usage totals` is a local token-cost estimate, not the balance. When
+`platform credits` fails or the assistant is not connected to the platform,
+say plainly that you cannot see the balance and point to Settings > Billing.
+Do not guess a number, an allowance model, or a reset schedule, and never
+imply you checked when you did not.
 
 ### 2. Vellum Docs Site — Conceptual Knowledge
 


### PR DESCRIPTION
## Summary

- Restore billing routing in the `vellum-self-knowledge` skill: an activation hint for credit, plan, spend, and daily-limit questions; CLI-table rows for `assistant platform credits|subscription|plans|invoices --json`; and an explicit rule to say plainly that the balance cannot be seen (and point to Settings > Billing) when the platform call fails, instead of estimating. The existing hints were trimmed so the rendered capability card fits the 500-character selector budget (it was 546 on main, so the avoid-when entry was already being cut off).
- `platform_credits` (daemon route and `assistant platform credits`) now passes through the billing summary's `daily_spend`, `daily_limit`, `daily_limit_reached`, `daily_limit_snoozed`, `low_balance_threshold`, and `low_balance_warning` instead of dropping them. Fields a summary omits map to `null` / `false`. Help text, `assistant/openapi.yaml`, and `skills/catalog.json` regenerated.
- New `platform-credits-routes.test.ts` covers the field mapping, the omitted-fields fallback, a null daily limit, and the missing-credentials error.

## Original prompt

JARVIS-1681 reports the assistant inventing an answer about credit usage during a live voice call ("monthly allowance or credit pool"), then admitting it never checked. The ticket assumed a new platform read endpoint was needed. Investigation showed the endpoint (`GET /v1/organizations/billing/summary/`, which accepts the assistant API key) and the daemon route and CLI wrapping it already exist; the gap was that the self-knowledge skill had no routing for billing questions. PR #39365 added that routing in July and then removed it in review pending an `assistant platform billing` CLI that never shipped. This PR restores the routing against the commands that do exist and widens the credits route so daily-limit state, which the summary already returns, reaches the assistant.

Not covered here: current-period spend over a date range. The platform's `usage/totals` and `usage/series` endpoints only accept user auth, so exposing that needs a platform-side change first.

Part of [JARVIS-1681](https://linear.app/vellum/issue/JARVIS-1681/assistant-invents-an-answer-about-credit-usage-because-it-has-no-way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CeaQtkmmUR4PmorRi1n33g
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42058" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->