### PR TITLE
fix(local-mode): stop the child_process mock erasing the rest of the module

### DIFF
--- a/packages/local-mode/src/__tests__/guardian-token-refresh.test.ts
+++ b/packages/local-mode/src/__tests__/guardian-token-refresh.test.ts
@@ -1,17 +1,11 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
-import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import type { CliInvocation } from "../util";
 import type { GuardianTokenData } from "../guardian-token";
-
-class FakeChild extends EventEmitter {
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
-  kill = mock(() => true);
-}
+import { FakeChild, mockChildProcessSpawn } from "./helpers/child-process-mock";
 
 let lastChild: FakeChild;
 const spawnMock = mock((_command: string, _args: string[]) => {
@@ -19,14 +13,7 @@ const spawnMock = mock((_command: string, _args: string[]) => {
   return lastChild;
 });
 
-const realChildProcess = await import("node:child_process");
-
-// Spreading the real module keeps its other exports resolvable: a factory
-// returning only `spawn` strips them for the rest of the test process.
-mock.module("node:child_process", () => ({
-  ...realChildProcess,
-  spawn: spawnMock,
-}));
+await mockChildProcessSpawn(spawnMock);
 
 let getGuardianAccessToken: typeof import("../guardian-token").getGuardianAccessToken;
 let saveGuardianToken: typeof import("../guardian-token").saveGuardianToken;

--- a/packages/local-mode/src/__tests__/guardian-token-refresh.test.ts
+++ b/packages/local-mode/src/__tests__/guardian-token-refresh.test.ts
@@ -19,7 +19,14 @@ const spawnMock = mock((_command: string, _args: string[]) => {
   return lastChild;
 });
 
-mock.module("node:child_process", () => ({ spawn: spawnMock }));
+const realChildProcess = await import("node:child_process");
+
+// Spreading the real module keeps its other exports resolvable: a factory
+// returning only `spawn` strips them for the rest of the test process.
+mock.module("node:child_process", () => ({
+  ...realChildProcess,
+  spawn: spawnMock,
+}));
 
 let getGuardianAccessToken: typeof import("../guardian-token").getGuardianAccessToken;
 let saveGuardianToken: typeof import("../guardian-token").saveGuardianToken;

--- a/packages/local-mode/src/__tests__/hatch.test.ts
+++ b/packages/local-mode/src/__tests__/hatch.test.ts
@@ -17,7 +17,14 @@ const spawnMock = mock((command: string, args: string[]) => {
   return lastChild;
 });
 
-mock.module("node:child_process", () => ({ spawn: spawnMock }));
+const realChildProcess = await import("node:child_process");
+
+// Spreading the real module keeps its other exports resolvable: a factory
+// returning only `spawn` strips them for the rest of the test process.
+mock.module("node:child_process", () => ({
+  ...realChildProcess,
+  spawn: spawnMock,
+}));
 
 let runHatch: typeof import("../hatch").runHatch;
 

--- a/packages/local-mode/src/__tests__/hatch.test.ts
+++ b/packages/local-mode/src/__tests__/hatch.test.ts
@@ -1,13 +1,7 @@
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
-import { EventEmitter } from "node:events";
 
 import type { CliInvocation } from "../util";
-
-class FakeChild extends EventEmitter {
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
-  kill = mock(() => true);
-}
+import { FakeChild, mockChildProcessSpawn } from "./helpers/child-process-mock";
 
 let lastChild: FakeChild;
 const spawnArgs: Array<[string, string[]]> = [];
@@ -17,14 +11,7 @@ const spawnMock = mock((command: string, args: string[]) => {
   return lastChild;
 });
 
-const realChildProcess = await import("node:child_process");
-
-// Spreading the real module keeps its other exports resolvable: a factory
-// returning only `spawn` strips them for the rest of the test process.
-mock.module("node:child_process", () => ({
-  ...realChildProcess,
-  spawn: spawnMock,
-}));
+await mockChildProcessSpawn(spawnMock);
 
 let runHatch: typeof import("../hatch").runHatch;
 

--- a/packages/local-mode/src/__tests__/helpers/child-process-mock.ts
+++ b/packages/local-mode/src/__tests__/helpers/child-process-mock.ts
@@ -1,0 +1,55 @@
+import { EventEmitter } from "node:events";
+import { mock } from "bun:test";
+
+/**
+ * Stand-in for the `ChildProcess` a mocked `spawn` returns. Tests drive it by
+ * emitting `"close"` / `"error"` on the instance and `"data"` on its streams.
+ */
+export class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = mock(() => true);
+}
+
+/** Any stand-in for `spawn`; each suite records the arguments it asserts on. */
+type SpawnReplacement = (...args: never[]) => unknown;
+
+/**
+ * Replace `spawn` in `node:child_process` while leaving every other export of
+ * the module intact.
+ *
+ * `mock.module()` is process-global, and a registration that lands before
+ * anything in the process has loaded `node:child_process` installs the
+ * factory's object as the entire module. A factory returning only `{ spawn }`
+ * therefore strips `spawnSync` and the rest for every module linked
+ * afterwards. `src/lockfile-lock.test.ts` imports `spawnSync` at module scope
+ * and fails to link with "Export named 'spawnSync' not found in module
+ * 'node:child_process'" once that happens, and since bun runs a package's test
+ * files in one process, whether it happens depends on file ordering.
+ *
+ * Two things keep the namespace whole:
+ *
+ * 1. Awaiting the real module materializes it before `mock.module()`
+ *    registers. Bun patches that live namespace in place, so the exports the
+ *    factory does not name keep their real values. This is the property that
+ *    prevents the link error.
+ * 2. The factory returns a plain copy of the namespace captured before
+ *    registration, so the replacement is complete on its own terms and never
+ *    reads back through the namespace being patched. Spreading a live,
+ *    already-mocked namespace inside a factory is the shape that
+ *    `cli/src/__tests__/helpers/os-mock.ts` documents as recursing forever.
+ *
+ * Every `node:child_process` spawn mock in this package routes through here so
+ * both hold for all of them at once. Call it once at module scope, with
+ * `await`, before the module under test is imported.
+ */
+export async function mockChildProcessSpawn(
+  spawnMock: SpawnReplacement,
+): Promise<void> {
+  const realChildProcess = await import("node:child_process");
+  const realChildProcessSnapshot = { ...realChildProcess };
+  mock.module("node:child_process", () => ({
+    ...realChildProcessSnapshot,
+    spawn: spawnMock,
+  }));
+}

--- a/packages/local-mode/src/__tests__/retire.test.ts
+++ b/packages/local-mode/src/__tests__/retire.test.ts
@@ -1,13 +1,7 @@
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
-import { EventEmitter } from "node:events";
 
 import type { CliInvocation } from "../util";
-
-class FakeChild extends EventEmitter {
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
-  kill = mock(() => true);
-}
+import { FakeChild, mockChildProcessSpawn } from "./helpers/child-process-mock";
 
 let lastChild: FakeChild;
 const spawnArgs: Array<
@@ -25,14 +19,7 @@ const spawnMock = mock(
   },
 );
 
-const realChildProcess = await import("node:child_process");
-
-// Spreading the real module keeps its other exports resolvable: a factory
-// returning only `spawn` strips them for the rest of the test process.
-mock.module("node:child_process", () => ({
-  ...realChildProcess,
-  spawn: spawnMock,
-}));
+await mockChildProcessSpawn(spawnMock);
 
 let runRetire: typeof import("../retire").runRetire;
 

--- a/packages/local-mode/src/__tests__/retire.test.ts
+++ b/packages/local-mode/src/__tests__/retire.test.ts
@@ -25,7 +25,14 @@ const spawnMock = mock(
   },
 );
 
-mock.module("node:child_process", () => ({ spawn: spawnMock }));
+const realChildProcess = await import("node:child_process");
+
+// Spreading the real module keeps its other exports resolvable: a factory
+// returning only `spawn` strips them for the rest of the test process.
+mock.module("node:child_process", () => ({
+  ...realChildProcess,
+  spawn: spawnMock,
+}));
 
 let runRetire: typeof import("../retire").runRetire;
 

--- a/packages/local-mode/src/__tests__/upgrade.test.ts
+++ b/packages/local-mode/src/__tests__/upgrade.test.ts
@@ -1,13 +1,7 @@
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
-import { EventEmitter } from "node:events";
 
 import type { CliInvocation } from "../util";
-
-class FakeChild extends EventEmitter {
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
-  kill = mock(() => true);
-}
+import { FakeChild, mockChildProcessSpawn } from "./helpers/child-process-mock";
 
 let lastChild: FakeChild;
 const spawnArgs: Array<
@@ -25,14 +19,7 @@ const spawnMock = mock(
   },
 );
 
-const realChildProcess = await import("node:child_process");
-
-// Spreading the real module keeps its other exports resolvable: a factory
-// returning only `spawn` strips them for the rest of the test process.
-mock.module("node:child_process", () => ({
-  ...realChildProcess,
-  spawn: spawnMock,
-}));
+await mockChildProcessSpawn(spawnMock);
 
 let runUpgrade: typeof import("../upgrade").runUpgrade;
 let isValidReleaseVersion: typeof import("../upgrade").isValidReleaseVersion;

--- a/packages/local-mode/src/__tests__/upgrade.test.ts
+++ b/packages/local-mode/src/__tests__/upgrade.test.ts
@@ -25,7 +25,14 @@ const spawnMock = mock(
   },
 );
 
-mock.module("node:child_process", () => ({ spawn: spawnMock }));
+const realChildProcess = await import("node:child_process");
+
+// Spreading the real module keeps its other exports resolvable: a factory
+// returning only `spawn` strips them for the rest of the test process.
+mock.module("node:child_process", () => ({
+  ...realChildProcess,
+  spawn: spawnMock,
+}));
 
 let runUpgrade: typeof import("../upgrade").runUpgrade;
 let isValidReleaseVersion: typeof import("../upgrade").isValidReleaseVersion;

--- a/packages/local-mode/src/__tests__/wake.test.ts
+++ b/packages/local-mode/src/__tests__/wake.test.ts
@@ -17,7 +17,14 @@ const spawnMock = mock((command: string, args: string[]) => {
   return lastChild;
 });
 
-mock.module("node:child_process", () => ({ spawn: spawnMock }));
+const realChildProcess = await import("node:child_process");
+
+// Spreading the real module keeps its other exports resolvable: a factory
+// returning only `spawn` strips them for the rest of the test process.
+mock.module("node:child_process", () => ({
+  ...realChildProcess,
+  spawn: spawnMock,
+}));
 
 let runWake: typeof import("../wake").runWake;
 

--- a/packages/local-mode/src/__tests__/wake.test.ts
+++ b/packages/local-mode/src/__tests__/wake.test.ts
@@ -1,13 +1,7 @@
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
-import { EventEmitter } from "node:events";
 
 import type { CliInvocation } from "../util";
-
-class FakeChild extends EventEmitter {
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
-  kill = mock(() => true);
-}
+import { FakeChild, mockChildProcessSpawn } from "./helpers/child-process-mock";
 
 let lastChild: FakeChild;
 const spawnArgs: Array<[string, string[]]> = [];
@@ -17,14 +11,7 @@ const spawnMock = mock((command: string, args: string[]) => {
   return lastChild;
 });
 
-const realChildProcess = await import("node:child_process");
-
-// Spreading the real module keeps its other exports resolvable: a factory
-// returning only `spawn` strips them for the rest of the test process.
-mock.module("node:child_process", () => ({
-  ...realChildProcess,
-  spawn: spawnMock,
-}));
+await mockChildProcessSpawn(spawnMock);
 
 let runWake: typeof import("../wake").runWake;
 

--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -1,13 +1,10 @@
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
-import { EventEmitter } from "node:events";
 
 import type { CliInvocation } from "./util";
-
-class FakeChild extends EventEmitter {
-  stdout = new EventEmitter();
-  stderr = new EventEmitter();
-  kill = mock(() => true);
-}
+import {
+  FakeChild,
+  mockChildProcessSpawn,
+} from "./__tests__/helpers/child-process-mock";
 
 let lastChild: FakeChild;
 const spawnArgs: Array<[string, string[], { stdio?: unknown; windowsHide?: boolean }]> = [];
@@ -19,14 +16,7 @@ const spawnMock = mock(
   },
 );
 
-const realChildProcess = await import("node:child_process");
-
-// Spreading the real module keeps its other exports resolvable: a factory
-// returning only `spawn` strips them for the rest of the test process.
-mock.module("node:child_process", () => ({
-  ...realChildProcess,
-  spawn: spawnMock,
-}));
+await mockChildProcessSpawn(spawnMock);
 
 let runDevicesList: typeof import("./devices").runDevicesList;
 let runDevicesRevoke: typeof import("./devices").runDevicesRevoke;

--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -19,7 +19,14 @@ const spawnMock = mock(
   },
 );
 
-mock.module("node:child_process", () => ({ spawn: spawnMock }));
+const realChildProcess = await import("node:child_process");
+
+// Spreading the real module keeps its other exports resolvable: a factory
+// returning only `spawn` strips them for the rest of the test process.
+mock.module("node:child_process", () => ({
+  ...realChildProcess,
+  spawn: spawnMock,
+}));
 
 let runDevicesList: typeof import("./devices").runDevicesList;
 let runDevicesRevoke: typeof import("./devices").runDevicesRevoke;


### PR DESCRIPTION
## Summary

Six test files in `packages/local-mode` stub `spawn` with:

```ts
mock.module("node:child_process", () => ({ spawn: spawnMock }));
```

That factory replaces the **entire** `node:child_process` namespace, so every
other export disappears for the remainder of the bun test process. Bun runs a
package's test files in one process, and `src/lockfile-lock.test.ts` imports
`spawnSync` from `node:child_process` at module scope. When one of the six
mocking files is evaluated before that import is linked, linking fails with:

```
SyntaxError: Export named 'spawnSync' not found in module 'node:child_process'.
# Unhandled error between tests
```

The outcome depends purely on file ordering, which is why `PR Local Mode
Checks` passes on most branches and fails intermittently. Nothing about any
feature branch causes it: all six mocks and the `spawnSync` import are the same
on `main`.

## Fix

Each of the six factories now spreads the real module and overrides only
`spawn`:

```ts
const realChildProcess = await import("node:child_process");

mock.module("node:child_process", () => ({
  ...realChildProcess,
  spawn: spawnMock,
}));
```

This is the partial-mock shape already used across the repo, e.g.
`assistant/src/notifications/__tests__/connected-channels.test.ts` and
`assistant/src/tools/network/__tests__/web-fetch-firecrawl.test.ts`. The
top-level `await import` also loads the real builtin before the mock is
installed, which is the ordering `cli/src/__tests__/helpers/os-mock.ts`
documents as the safe one.

Files changed:

- `packages/local-mode/src/devices.test.ts`
- `packages/local-mode/src/__tests__/guardian-token-refresh.test.ts`
- `packages/local-mode/src/__tests__/hatch.test.ts`
- `packages/local-mode/src/__tests__/retire.test.ts`
- `packages/local-mode/src/__tests__/upgrade.test.ts`
- `packages/local-mode/src/__tests__/wake.test.ts`

`lockfile-lock.test.ts` is deliberately untouched: rewriting it to avoid
`spawnSync` would hide the leak until the next export someone imports.

## Verification

Run with bun 1.3.11, the version `pr-local-mode.yaml` pins.

1. `bun run typecheck` and `bun run test` (`bun test src/`) in
   `packages/local-mode`: 349 pass, 0 fail, repeated three times. Also green on
   bun 1.3.10.
2. Leak proof, not just a green run. For each of the six files a throwaway copy
   was made with a module-scope probe appended after the mock:

   ```ts
   const ns = await import("node:child_process");
   console.log("PROBE KEYS:", Object.keys(ns).join(","));
   await import("./probe-helper"); // helper statically imports spawnSync
   ```

   Before the fix, all six printed `PROBE KEYS: spawn` and the helper failed to
   link with the exact CI error, `SyntaxError: Export named 'spawnSync' not
   found in module 'node:child_process'`. After the fix, all six print the full
   export set including `spawnSync` and the helper links cleanly. The probe runs
   at module scope on purpose: that is the same point in the run where
   `lockfile-lock.test.ts`'s import is linked.
3. The six files pass individually, and `spawn` is still intercepted: their
   existing assertions on the recorded spawn args hold, and an added identity
   check confirmed `(await import("node:child_process")).spawn === spawnMock`
   after the fix. A run listing the six mocking files first and
   `lockfile-lock.test.ts` last is green: 51 pass, 0 fail.

## Notes

`packages/electron-desktop/src/local-mode.test.ts` has the same wholesale mock,
but nothing in that package imports another `node:child_process` export today,
so it is latent rather than failing. Left out to keep this PR to one logical
change.