### PR TITLE
feat(web): show the sleeping assistant on the conversation page

### DIFF
--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -1027,10 +1027,13 @@ function useAssistantBannerConfig(): BannerConfig | null {
  * conversation page; every other banner state is the banner's own business.
  *
  * It re-derives the whole banner config rather than having the banner publish
- * its phase: one derivation is one answer, so the stage and the banner can
- * never disagree about whether the assistant is asleep. The cost is a second
- * pass over local state, not a second request: the operational status is one
- * shared React Query entry.
+ * its phase, because the banner is not mounted everywhere the stage is (a
+ * pop-out window has no banner at all). The cost is a second pass over local
+ * state, not a second request: the operational status is one shared React
+ * Query entry. The two instances hold their own transient-state suppression
+ * history, so a stage mounted mid-wake can read no phase where the older
+ * banner still reads "waking"; that resolves in the safe direction, with the
+ * banner keeping the status rather than both surfaces going quiet.
  */
 export function useAssistantSleepPhase(): AssistantSleepPhase | null {
   return useAssistantBannerConfig()?.sleepPhase ?? null;

--- a/clients/web/src/components/status-banner.tsx
+++ b/clients/web/src/components/status-banner.tsx
@@ -47,6 +47,7 @@ import {
   wakeLocalAssistantHost,
 } from "@/runtime/local-mode-host";
 import { useIsNativePlatform } from "@/runtime/native-auth";
+import { useAssistantSleepStageStore } from "@/stores/assistant-sleep-stage-store";
 import { useOrganizationStore } from "@/stores/organization-store";
 import {
   assistantsValidForOrg,
@@ -56,12 +57,21 @@ import { t } from "@/i18n";
 import { cn } from "@/utils/misc";
 import { routes } from "@/utils/routes";
 
+/**
+ * The sleeping/waking phase a banner is reporting, when it is reporting one.
+ * `AssistantSleepStage` reads it through {@link useAssistantSleepPhase} to
+ * decide whether to take over the conversation page, and the banner itself
+ * stands down (see {@link StatusBanner}) while that stage is up.
+ */
+export type AssistantSleepPhase = "sleeping" | "waking";
+
 interface BannerConfig {
   title: ReactNode;
   tone: NoticeTone;
   children?: ReactNode;
   icon?: ReactNode;
   actions?: ReactNode;
+  sleepPhase?: AssistantSleepPhase;
 }
 
 const LOCAL_WAKE_SETTLING_MS = 60_000;
@@ -348,6 +358,7 @@ function operationalStatusBannerConfig(
         tone: "neutral",
         title: OPERATIONAL_STATUS_TITLES[status.state],
         icon: <Moon className="h-4 w-4" aria-hidden="true" />,
+        sleepPhase: "sleeping",
       };
     case "maintenance_mode":
       return maintenanceModeBannerConfig();
@@ -367,6 +378,7 @@ function operationalStatusBannerConfig(
         tone: "info",
         title: OPERATIONAL_STATUS_TITLES[status.state],
         icon: wakingDotIcon(),
+        sleepPhase: "waking",
       };
     case "restarting":
     case "restoring_backup":
@@ -413,12 +425,16 @@ function localHealthBannerConfig(
         children: wakeError,
         icon: <Moon className="h-4 w-4" aria-hidden="true" />,
         actions: wakeAction,
+        // A failed wake is an error the user has to read and act on, so it
+        // keeps the banner rather than handing the surface to the stage.
+        sleepPhase: wakeError ? undefined : "sleeping",
       };
     case "starting":
       return {
         tone: "info",
         title: "Your assistant is waking up",
         icon: wakingDotIcon(),
+        sleepPhase: "waking",
       };
     case "upgrading":
       return {
@@ -450,6 +466,7 @@ function localHealthBannerConfig(
         icon: <Moon className="h-4 w-4" aria-hidden="true" />,
         children: wakeError,
         actions: wakeAction,
+        sleepPhase: wakeError ? undefined : "sleeping",
       };
     case "unhealthy":
       return {
@@ -1004,6 +1021,21 @@ function useAssistantBannerConfig(): BannerConfig | null {
   };
 }
 
+/**
+ * The sleeping/waking phase the assistant is in, or null when it is in
+ * neither. `AssistantSleepStage` reads this to decide whether to take over the
+ * conversation page; every other banner state is the banner's own business.
+ *
+ * It re-derives the whole banner config rather than having the banner publish
+ * its phase: one derivation is one answer, so the stage and the banner can
+ * never disagree about whether the assistant is asleep. The cost is a second
+ * pass over local state, not a second request: the operational status is one
+ * shared React Query entry.
+ */
+export function useAssistantSleepPhase(): AssistantSleepPhase | null {
+  return useAssistantBannerConfig()?.sleepPhase ?? null;
+}
+
 export function StatusBanner({
   className,
   placement = isElectron() ? "electron" : "web",
@@ -1012,8 +1044,12 @@ export function StatusBanner({
   placement?: StatusBannerPlacement;
 }) {
   const banner = useAssistantBannerConfig();
+  // The full-page sleep stage says the same thing at the size of the
+  // conversation page, so the banner stands down while it is up. Dismissing
+  // the stage clears this and the banner comes back.
+  const sleepStageVisible = useAssistantSleepStageStore.use.visible();
 
-  return banner ? (
+  return banner && !(banner.sleepPhase && sleepStageVisible) ? (
     <BannerNotice banner={banner} className={className} placement={placement} />
   ) : null;
 }

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -91,6 +91,7 @@ import { requestComposerFocus } from "./composer-focus";
 import { LazyBoundary } from "@/components/lazy-boundary";
 import { RuntimeUpgradeBanner } from "@/components/runtime-upgrade-banner";
 import { StatusBanner } from "@/components/status-banner";
+import { AssistantSleepStage } from "@/domains/chat/components/assistant-sleep-stage";
 import { SidebarTipCard } from "@/components/tips/sidebar-tip-card";
 import { ensureTipsFirstSeenAt } from "@/utils/tips-storage";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
@@ -1180,6 +1181,9 @@ export function ChatLayout({
             className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
           >
             {chatContent}
+            {/* Self-gates on the conversation route and the assistant's
+                sleeping/waking status. */}
+            <AssistantSleepStage />
             {/* A popout narrowed below the mobile breakpoint lands in this
                 branch, still headerless, so it still needs the floating
                 session surface (see the desktop popout branch below). */}
@@ -1305,6 +1309,10 @@ export function ChatLayout({
             className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden ${mainRoomClass}`}
           >
             {chatContent}
+            {/* Self-gates on the conversation route and the assistant's
+                sleeping/waking status. Mounted ahead of the voice room so the
+                room paints over it when both are up. */}
+            <AssistantSleepStage />
             {/* Live-voice room, desktop: an inset panel scoped to the content
                 area, so the title bar above and the sidenav beside it stay
                 visible and interactive. Self-gates on

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -1281,6 +1281,9 @@ export function ChatLayout({
           className={`relative flex min-w-0 flex-1 min-h-0 flex-col overflow-hidden p-4 ${mainRoomClass}`}
         >
           {chatContent}
+          {/* A pop-out is a conversation like any other: without this the stage
+              would come and go as the window crosses the mobile breakpoint. */}
+          <AssistantSleepStage />
           {/* Pop-outs render no header, but they DO support in-window
               conversation switching (Cmd+Up/Down) — so a live session started
               here can lose its owning composer exactly like in the main

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -92,6 +92,7 @@ import { LazyBoundary } from "@/components/lazy-boundary";
 import { RuntimeUpgradeBanner } from "@/components/runtime-upgrade-banner";
 import { StatusBanner } from "@/components/status-banner";
 import { AssistantSleepStage } from "@/domains/chat/components/assistant-sleep-stage";
+import { useAssistantSleepStageStore } from "@/stores/assistant-sleep-stage-store";
 import { SidebarTipCard } from "@/components/tips/sidebar-tip-card";
 import { ensureTipsFirstSeenAt } from "@/utils/tips-storage";
 import { AssistantSideMenu } from "@/domains/chat/components/assistant-side-menu";
@@ -579,6 +580,9 @@ export function ChatLayout({
   // sidebar until the session ends or the room is minimized (the session
   // then continues behind the composer voice bar / title-bar pill).
   const voiceRoomVisible = useIsVoiceRoomVisible();
+  // The sleep stage covers this same box; while it is up the thread under it
+  // leaves the tab order and the accessibility tree, as it does for the room.
+  const sleepStageVisible = useAssistantSleepStageStore.use.visible();
 
   const drawerVisible = isMobile && drawerOpen;
 
@@ -1112,7 +1116,7 @@ export function ChatLayout({
   const chatContent = (
     <div
       className="flex min-h-0 min-w-0 flex-1 flex-col"
-      inert={voiceRoomVisible}
+      inert={voiceRoomVisible || sleepStageVisible}
     >
       <Outlet />
     </div>

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -259,13 +259,17 @@ describe("AssistantSleepStage", () => {
     expect(screen.queryByText("Mel just woke up")).toBeNull();
   });
 
-  test("the dev override pins a scene with no sleep at all", () => {
+  test("the dev override pins a scene with no sleep at all, and a click clears it", () => {
     phaseMock = null;
     useAssistantSleepStageStore.setState({ forcedScene: "sleeping" });
 
     renderAt("/assistant/conversations/c1");
-
     expect(screen.getByText("Mel is asleep")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Mel is asleep"));
+
+    expect(screen.queryByText("Mel is asleep")).toBeNull();
+    expect(useAssistantSleepStageStore.getState().forcedScene).toBeNull();
   });
 
   test("a dismissal does not carry over to another sleeping assistant", () => {

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -110,7 +110,7 @@ describe("AssistantSleepStage", () => {
     const { container, unmount } = renderAt("/assistant/conversations/c1");
     // Nothing known: the catalog's first creature is not this assistant, so
     // the stage is the line of copy alone.
-    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelector("[data-slot=sleep-stage-eyes]")).toBeNull();
     unmount();
 
     const catalog = getCharacterComponents();
@@ -125,7 +125,7 @@ describe("AssistantSleepStage", () => {
     };
 
     const view = renderAt("/assistant/conversations/c1");
-    const svg = view.container.querySelector("svg");
+    const svg = view.container.querySelector("[data-slot=sleep-stage-eyes]");
     expect(svg).not.toBeNull();
     // The lid is the avatar's own color, clipped to the eyes' silhouette.
     expect(svg!.querySelector("clipPath")).not.toBeNull();

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -8,12 +8,20 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import type { AssistantSleepPhase } from "@/components/status-banner";
 
 let phaseMock: AssistantSleepPhase | null = "waking";
+let voiceRoomVisibleMock = false;
 
 mock.module("@/components/status-banner", () => ({
   useAssistantSleepPhase: () => phaseMock,
@@ -27,26 +35,43 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
   }),
 }));
 
-const { AssistantSleepStage } = await import(
-  "@/domains/chat/components/assistant-sleep-stage"
-);
-const { useAssistantIdentityStore } = await import(
-  "@/stores/assistant-identity-store"
-);
-const { useAssistantSleepStageStore } = await import(
-  "@/stores/assistant-sleep-stage-store"
+mock.module(
+  "@/domains/chat/voice/voice-room/use-is-voice-room-visible",
+  () => ({
+    useIsVoiceRoomVisible: () => voiceRoomVisibleMock,
+  }),
 );
 
+mock.module("@/lib/avatar-last-seen-cache", () => ({
+  readLastSeenAvatar: async () => null,
+}));
+
+const { AssistantSleepStage } =
+  await import("@/domains/chat/components/assistant-sleep-stage");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
+const { useAssistantSleepStageStore } =
+  await import("@/stores/assistant-sleep-stage-store");
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
+
 function renderAt(pathname: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return render(
-    <MemoryRouter initialEntries={[pathname]}>
-      <AssistantSleepStage />
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[pathname]}>
+        <AssistantSleepStage />
+      </MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 
 beforeEach(() => {
   phaseMock = "waking";
+  voiceRoomVisibleMock = false;
+  useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
   useAssistantIdentityStore.setState({ name: "Mel", version: null });
   useAssistantSleepStageStore.setState({ visible: false, dismissed: false });
 });
@@ -69,8 +94,28 @@ describe("AssistantSleepStage", () => {
     expect(screen.getByText("Your assistant is waking up…")).toBeTruthy();
   });
 
-  test("stays off every route but the conversation page", () => {
-    renderAt("/assistant/home");
+  test("covers the draft conversation at the assistant index too", () => {
+    renderAt("/assistant");
+
+    expect(screen.getByText("Mel is waking up…")).toBeTruthy();
+  });
+
+  test("stays off routes that mount no chat surface", () => {
+    for (const path of [
+      "/assistant/home",
+      "/assistant/conversations/c1/inspect",
+    ]) {
+      const view = renderAt(path);
+      expect(screen.queryByText("Mel is waking up…")).toBeNull();
+      expect(useAssistantSleepStageStore.getState().visible).toBe(false);
+      view.unmount();
+    }
+  });
+
+  test("leaves the surface to the voice room", () => {
+    voiceRoomVisibleMock = true;
+
+    renderAt("/assistant/conversations/c1");
 
     expect(screen.queryByText("Mel is waking up…")).toBeNull();
     expect(useAssistantSleepStageStore.getState().visible).toBe(false);
@@ -98,5 +143,18 @@ describe("AssistantSleepStage", () => {
     renderAt("/assistant/conversations/c1");
 
     expect(screen.getByText("Mel is asleep")).toBeTruthy();
+  });
+
+  test("a dismissal does not carry over to another sleeping assistant", () => {
+    renderAt("/assistant/conversations/c1");
+    fireEvent.click(screen.getByText("Mel is waking up…"));
+    expect(screen.queryByText("Mel is waking up…")).toBeNull();
+
+    act(() => {
+      useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-2" });
+    });
+
+    expect(useAssistantSleepStageStore.getState().dismissed).toBe(false);
+    expect(screen.getByText("Mel is waking up…")).toBeTruthy();
   });
 });

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -73,7 +73,11 @@ beforeEach(() => {
   voiceRoomVisibleMock = false;
   useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
   useAssistantIdentityStore.setState({ name: "Mel", version: null });
-  useAssistantSleepStageStore.setState({ visible: false, dismissed: false });
+  useAssistantSleepStageStore.setState({
+    visible: false,
+    dismissed: false,
+    dismissedAssistantId: null,
+  });
 });
 
 afterEach(cleanup);
@@ -131,8 +135,23 @@ describe("AssistantSleepStage", () => {
     expect(useAssistantSleepStageStore.getState().dismissed).toBe(true);
   });
 
+  test("a dismissal survives a remount of the same assistant's stage", () => {
+    const view = renderAt("/assistant/conversations/c1");
+    fireEvent.click(screen.getByText("Mel is waking up…"));
+    view.unmount();
+
+    // What a window crossing the mobile breakpoint does: `ChatLayout` moves
+    // the stage between its branches, remounting it on the same assistant.
+    renderAt("/assistant/conversations/c1");
+
+    expect(screen.queryByText("Mel is waking up…")).toBeNull();
+  });
+
   test("the dismissal lasts only as long as the sleep it was aimed at", () => {
-    useAssistantSleepStageStore.setState({ dismissed: true });
+    useAssistantSleepStageStore.setState({
+      dismissed: true,
+      dismissedAssistantId: "assistant-1",
+    });
     phaseMock = null;
 
     const view = renderAt("/assistant/conversations/c1");
@@ -154,7 +173,9 @@ describe("AssistantSleepStage", () => {
       useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-2" });
     });
 
-    expect(useAssistantSleepStageStore.getState().dismissed).toBe(false);
+    // The dismissal was aimed at the assistant that was asleep, not at the
+    // stage: the one switched to gets its own.
     expect(screen.getByText("Mel is waking up…")).toBeTruthy();
+    expect(useAssistantSleepStageStore.getState().visible).toBe(true);
   });
 });

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for `AssistantSleepStage`, the full-page sleeping/waking takeover.
+ *
+ * Three things decide whether it draws (the route, the assistant's phase, and
+ * whether the user has clicked it away this sleep), and the status banner reads
+ * the store it publishes to. Those are what the stage gets wrong if it gets
+ * anything wrong, so they are what is covered here.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import type { AssistantSleepPhase } from "@/components/status-banner";
+
+let phaseMock: AssistantSleepPhase | null = "waking";
+
+mock.module("@/components/status-banner", () => ({
+  useAssistantSleepPhase: () => phaseMock,
+}));
+
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: null,
+  }),
+}));
+
+const { AssistantSleepStage } = await import(
+  "@/domains/chat/components/assistant-sleep-stage"
+);
+const { useAssistantIdentityStore } = await import(
+  "@/stores/assistant-identity-store"
+);
+const { useAssistantSleepStageStore } = await import(
+  "@/stores/assistant-sleep-stage-store"
+);
+
+function renderAt(pathname: string) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <AssistantSleepStage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  phaseMock = "waking";
+  useAssistantIdentityStore.setState({ name: "Mel", version: null });
+  useAssistantSleepStageStore.setState({ visible: false, dismissed: false });
+});
+
+afterEach(cleanup);
+
+describe("AssistantSleepStage", () => {
+  test("names the waking assistant on the conversation page", () => {
+    renderAt("/assistant/conversations/c1");
+
+    expect(screen.getByText("Mel is waking up…")).toBeTruthy();
+    expect(useAssistantSleepStageStore.getState().visible).toBe(true);
+  });
+
+  test("falls back to unnamed copy before the identity resolves", () => {
+    useAssistantIdentityStore.setState({ name: null, version: null });
+
+    renderAt("/assistant/conversations/c1");
+
+    expect(screen.getByText("Your assistant is waking up…")).toBeTruthy();
+  });
+
+  test("stays off every route but the conversation page", () => {
+    renderAt("/assistant/home");
+
+    expect(screen.queryByText("Mel is waking up…")).toBeNull();
+    expect(useAssistantSleepStageStore.getState().visible).toBe(false);
+  });
+
+  test("a click hands the status back to the banner", () => {
+    renderAt("/assistant/conversations/c1");
+
+    fireEvent.click(screen.getByText("Mel is waking up…"));
+
+    expect(screen.queryByText("Mel is waking up…")).toBeNull();
+    expect(useAssistantSleepStageStore.getState().visible).toBe(false);
+    expect(useAssistantSleepStageStore.getState().dismissed).toBe(true);
+  });
+
+  test("the dismissal lasts only as long as the sleep it was aimed at", () => {
+    useAssistantSleepStageStore.setState({ dismissed: true });
+    phaseMock = null;
+
+    const view = renderAt("/assistant/conversations/c1");
+    expect(useAssistantSleepStageStore.getState().dismissed).toBe(false);
+
+    view.unmount();
+    phaseMock = "sleeping";
+    renderAt("/assistant/conversations/c1");
+
+    expect(screen.getByText("Mel is asleep")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -1,10 +1,12 @@
 /**
  * Tests for `AssistantSleepStage`, the full-page sleeping/waking takeover.
  *
- * Three things decide whether it draws (the route, the assistant's phase, and
- * whether the user has clicked it away this sleep), and the status banner reads
- * the store it publishes to. Those are what the stage gets wrong if it gets
- * anything wrong, so they are what is covered here.
+ * What decides whether it draws: the route, the assistant's phase, whether the
+ * sleep is one the user arrived into (a page load or a return to the tab)
+ * rather than one that began under them, and whether they have clicked it away
+ * this sleep. Plus the waking outro, which plays only for a sleep the stage
+ * actually showed. Those are what it gets wrong if it gets anything wrong, so
+ * they are what is covered here.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -50,8 +52,10 @@ mock.module("@/lib/avatar-last-seen-cache", () => ({
   readLastSeenAvatar: async () => null,
 }));
 
-const { AssistantSleepStage } =
+const { AssistantSleepStage, __setArrivalWindowMsForTesting } =
   await import("@/domains/chat/components/assistant-sleep-stage");
+const { publish, __resetForTesting: resetEventBus } =
+  await import("@/lib/event-bus");
 const { useAssistantIdentityStore } =
   await import("@/stores/assistant-identity-store");
 const { useAssistantSleepStageStore } =
@@ -63,13 +67,17 @@ function renderAt(pathname: string) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
+  // A fresh element each time: React bails out of re-rendering a referentially
+  // identical one, and the point of a repoll is to read `phaseMock` again.
+  const tree = () => (
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[pathname]}>
         <AssistantSleepStage />
       </MemoryRouter>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+  const view = render(tree());
+  return { ...view, repoll: () => view.rerender(tree()) };
 }
 
 beforeEach(() => {
@@ -82,7 +90,10 @@ beforeEach(() => {
     visible: false,
     dismissed: false,
     dismissedAssistantId: null,
+    forcedScene: null,
   });
+  __setArrivalWindowMsForTesting(20_000);
+  resetEventBus();
 });
 
 afterEach(cleanup);
@@ -192,6 +203,66 @@ describe("AssistantSleepStage", () => {
 
     view.unmount();
     phaseMock = "sleeping";
+    renderAt("/assistant/conversations/c1");
+
+    expect(screen.getByText("Mel is asleep")).toBeTruthy();
+  });
+
+  test("leaves a sleep that begins mid-session to the banner", () => {
+    // The user has been working in this tab; nothing about that is an
+    // arrival, so a drop-out mid-session is the banner's to report.
+    __setArrivalWindowMsForTesting(-1);
+    phaseMock = null;
+    const view = renderAt("/assistant/conversations/c1");
+
+    phaseMock = "sleeping";
+    view.repoll();
+
+    expect(screen.queryByText("Mel is asleep")).toBeNull();
+    expect(useAssistantSleepStageStore.getState().visible).toBe(false);
+  });
+
+  test("coming back to the tab arms it, the network coming back does not", () => {
+    __setArrivalWindowMsForTesting(-1);
+    phaseMock = null;
+    const view = renderAt("/assistant/conversations/c1");
+    phaseMock = "sleeping";
+    view.repoll();
+
+    act(() => publish("app.resume", { signal: "online" }));
+    expect(screen.queryByText("Mel is asleep")).toBeNull();
+
+    act(() => publish("app.resume", { signal: "visibility" }));
+    expect(screen.getByText("Mel is asleep")).toBeTruthy();
+  });
+
+  test("plays the waking outro for a sleep it showed", () => {
+    const view = renderAt("/assistant/conversations/c1");
+    expect(screen.getByText("Mel is waking up…")).toBeTruthy();
+
+    phaseMock = null;
+    view.repoll();
+
+    expect(screen.getByText("Mel just woke up")).toBeTruthy();
+    expect(useAssistantSleepStageStore.getState().visible).toBe(true);
+  });
+
+  test("does not announce a waking it never showed asleep", () => {
+    __setArrivalWindowMsForTesting(-1);
+    phaseMock = null;
+    const view = renderAt("/assistant/conversations/c1");
+    phaseMock = "waking";
+    view.repoll();
+    phaseMock = null;
+    view.repoll();
+
+    expect(screen.queryByText("Mel just woke up")).toBeNull();
+  });
+
+  test("the dev override pins a scene with no sleep at all", () => {
+    phaseMock = null;
+    useAssistantSleepStageStore.setState({ forcedScene: "sleeping" });
+
     renderAt("/assistant/conversations/c1");
 
     expect(screen.getByText("Mel is asleep")).toBeTruthy();

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -18,6 +18,8 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
+import { getCharacterComponents } from "@vellumai/avatar-catalog";
+
 import type { AssistantSleepPhase } from "@/components/status-banner";
 
 let phaseMock: AssistantSleepPhase | null = "waking";
@@ -27,12 +29,14 @@ mock.module("@/components/status-banner", () => ({
   useAssistantSleepPhase: () => phaseMock,
 }));
 
+let avatarMock: {
+  components: unknown;
+  traits: { bodyShape: string; eyeStyle: string; color: string } | null;
+  customImageUrl: string | null;
+} = { components: null, traits: null, customImageUrl: null };
+
 mock.module("@/hooks/use-assistant-avatar", () => ({
-  useAssistantAvatar: () => ({
-    components: null,
-    traits: null,
-    customImageUrl: null,
-  }),
+  useAssistantAvatar: () => avatarMock,
 }));
 
 mock.module(
@@ -71,6 +75,7 @@ function renderAt(pathname: string) {
 beforeEach(() => {
   phaseMock = "waking";
   voiceRoomVisibleMock = false;
+  avatarMock = { components: null, traits: null, customImageUrl: null };
   useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
   useAssistantIdentityStore.setState({ name: "Mel", version: null });
   useAssistantSleepStageStore.setState({
@@ -88,6 +93,34 @@ describe("AssistantSleepStage", () => {
 
     expect(screen.getByText("Mel is waking up…")).toBeTruthy();
     expect(useAssistantSleepStageStore.getState().visible).toBe(true);
+  });
+
+  test("draws the assistant's own eyes, and none when no traits are known", () => {
+    const { container, unmount } = renderAt("/assistant/conversations/c1");
+    // Nothing known: the catalog's first creature is not this assistant, so
+    // the stage is the line of copy alone.
+    expect(container.querySelector("svg")).toBeNull();
+    unmount();
+
+    const catalog = getCharacterComponents();
+    avatarMock = {
+      components: catalog,
+      traits: {
+        bodyShape: catalog.bodyShapes[1]!.id,
+        eyeStyle: catalog.eyeStyles[1]!.id,
+        color: catalog.colors[1]!.id,
+      },
+      customImageUrl: null,
+    };
+
+    const view = renderAt("/assistant/conversations/c1");
+    const svg = view.container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    // The lid is the avatar's own color, clipped to the eyes' silhouette.
+    expect(svg!.querySelector("clipPath")).not.toBeNull();
+    expect(svg!.querySelector("rect")?.getAttribute("fill")).toBe(
+      catalog.colors[1]!.hex,
+    );
   });
 
   test("falls back to unnamed copy before the identity resolves", () => {

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.test.tsx
@@ -63,6 +63,11 @@ const { useAssistantSleepStageStore } =
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 
+/** The stage's one control: its surface is inert. */
+function closeButton() {
+  return screen.getByRole("button", { name: "Hide the sleep screen" });
+}
+
 function renderAt(pathname: string) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -172,7 +177,7 @@ describe("AssistantSleepStage", () => {
   test("a click hands the status back to the banner", () => {
     renderAt("/assistant/conversations/c1");
 
-    fireEvent.click(screen.getByText("Mel is waking up…"));
+    fireEvent.click(closeButton());
 
     expect(screen.queryByText("Mel is waking up…")).toBeNull();
     expect(useAssistantSleepStageStore.getState().visible).toBe(false);
@@ -181,7 +186,7 @@ describe("AssistantSleepStage", () => {
 
   test("a dismissal survives a remount of the same assistant's stage", () => {
     const view = renderAt("/assistant/conversations/c1");
-    fireEvent.click(screen.getByText("Mel is waking up…"));
+    fireEvent.click(closeButton());
     view.unmount();
 
     // What a window crossing the mobile breakpoint does: `ChatLayout` moves
@@ -206,6 +211,15 @@ describe("AssistantSleepStage", () => {
     renderAt("/assistant/conversations/c1");
 
     expect(screen.getByText("Mel is asleep")).toBeTruthy();
+  });
+
+  test("a click on the stage itself does not dismiss it", () => {
+    renderAt("/assistant/conversations/c1");
+
+    fireEvent.click(screen.getByText("Mel is waking up…"));
+
+    expect(screen.getByText("Mel is waking up…")).toBeTruthy();
+    expect(useAssistantSleepStageStore.getState().dismissed).toBe(false);
   });
 
   test("leaves a sleep that begins mid-session to the banner", () => {
@@ -266,7 +280,7 @@ describe("AssistantSleepStage", () => {
     renderAt("/assistant/conversations/c1");
     expect(screen.getByText("Mel is asleep")).toBeTruthy();
 
-    fireEvent.click(screen.getByText("Mel is asleep"));
+    fireEvent.click(closeButton());
 
     expect(screen.queryByText("Mel is asleep")).toBeNull();
     expect(useAssistantSleepStageStore.getState().forcedScene).toBeNull();
@@ -274,7 +288,7 @@ describe("AssistantSleepStage", () => {
 
   test("a dismissal does not carry over to another sleeping assistant", () => {
     renderAt("/assistant/conversations/c1");
-    fireEvent.click(screen.getByText("Mel is waking up…"));
+    fireEvent.click(closeButton());
     expect(screen.queryByText("Mel is waking up…")).toBeNull();
 
     act(() => {

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
@@ -36,7 +36,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { motion, useReducedMotion } from "motion/react";
-import { useEffect, useId, useMemo } from "react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { useLocation } from "react-router";
 
 import {
@@ -87,10 +87,22 @@ export function AssistantSleepStage() {
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
 
-  const dismissed = useAssistantSleepStageStore.use.dismissed();
+  const wasDismissed = useAssistantSleepStageStore.use.dismissed();
+  const dismissedAssistantId =
+    useAssistantSleepStageStore.use.dismissedAssistantId();
   const setVisible = useAssistantSleepStageStore.use.setVisible();
-  const dismiss = useAssistantSleepStageStore.use.dismiss();
+  const dismissStage = useAssistantSleepStageStore.use.dismiss();
   const reset = useAssistantSleepStageStore.use.reset();
+
+  // The dismissal belongs to the assistant it was aimed at: another assistant
+  // that is also asleep gets its own stage, while a remount of this one (the
+  // window crossing the mobile breakpoint moves the stage between
+  // `ChatLayout`'s branches) stays dismissed.
+  const dismissed = wasDismissed && dismissedAssistantId === assistantId;
+  const dismiss = useCallback(
+    () => dismissStage(assistantId),
+    [dismissStage, assistantId],
+  );
 
   const visible =
     onConversationPage && !voiceRoomVisible && phase !== null && !dismissed;
@@ -100,17 +112,12 @@ export function AssistantSleepStage() {
     return () => setVisible(false);
   }, [visible, setVisible]);
 
-  // A dismissal lasts as long as the sleep it was aimed at, and belongs to the
-  // assistant it was aimed at: switching to another assistant that is also
-  // asleep never reports a phase of null, so the switch clears it too.
+  // A dismissal lasts as long as the sleep it was aimed at.
   useEffect(() => {
     if (phase === null) {
       reset();
     }
   }, [phase, reset]);
-  useEffect(() => {
-    reset();
-  }, [assistantId, reset]);
 
   // Traits from the assistant when it is reachable, else the last ones this
   // device saw it wearing. On a cold load the thing that serves them is the
@@ -119,15 +126,35 @@ export function AssistantSleepStage() {
   // screen exists for. Only a character is recovered: an uploaded image would
   // mean a blob URL to own, and the copy alone carries that case.
   const lastSeen = useQuery({
-    queryKey: ["assistant-sleep-stage", "last-seen-traits", assistantId],
-    queryFn: async () => {
-      const seen = await readLastSeenAvatar(assistantId!);
-      return seen?.kind === "character" ? seen.traits : null;
-    },
+    queryKey: ["assistant-sleep-stage", "last-seen-avatar", assistantId],
+    queryFn: () => readLastSeenAvatar(assistantId!),
+    // Deliberately not pinned: the record is deleted when the user removes
+    // their avatar, and nothing invalidates this key, so a later sleep in the
+    // same session re-reads rather than redrawing a character that is gone.
     enabled: visible && Boolean(assistantId) && !traits && !customImageUrl,
-    staleTime: Infinity,
   });
-  const effectiveTraits = traits ?? lastSeen.data ?? null;
+  const effectiveTraits =
+    traits ??
+    (lastSeen.data?.kind === "character" ? lastSeen.data.traits : null);
+
+  // The recovered image is a blob, so the object URL is owned here and lives
+  // exactly as long as the render that shows it.
+  const lastSeenBlob =
+    lastSeen.data?.kind === "image" ? lastSeen.data.blob : null;
+  const [lastSeenImageUrl, setLastSeenImageUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (!lastSeenBlob) {
+      setLastSeenImageUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(lastSeenBlob);
+    setLastSeenImageUrl(url);
+    return () => {
+      setLastSeenImageUrl(null);
+      URL.revokeObjectURL(url);
+    };
+  }, [lastSeenBlob]);
+  const imageUrl = customImageUrl ?? lastSeenImageUrl;
 
   // The catalog is bundled, so the eyes still draw while the assistant that
   // serves `/avatar/character-components` is the thing asleep.
@@ -141,7 +168,7 @@ export function AssistantSleepStage() {
     const look = resolveVoiceRoomLook(
       components ?? BUNDLED_COMPONENTS,
       effectiveTraits,
-      customImageUrl,
+      imageUrl,
     );
     if (!look?.art) {
       return null;
@@ -163,7 +190,7 @@ export function AssistantSleepStage() {
       lidColor: look.bgHex,
     };
     return eyeArt;
-  }, [visible, components, effectiveTraits, customImageUrl]);
+  }, [visible, components, effectiveTraits, imageUrl]);
 
   if (!visible || phase === null) {
     return null;
@@ -194,9 +221,9 @@ export function AssistantSleepStage() {
           clipId={clipId}
           reduce={Boolean(reduce)}
         />
-      ) : customImageUrl ? (
+      ) : imageUrl ? (
         <img
-          src={customImageUrl}
+          src={imageUrl}
           alt=""
           aria-hidden="true"
           className="w-[clamp(120px,20vw,200px)] rounded-full object-cover opacity-60"

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
@@ -1,6 +1,7 @@
 /**
  * The sleep stage: the assistant, eyes half shut, filling the conversation
- * page while it is asleep or waking up.
+ * page while it is asleep or waking up, and opening its eyes when it comes
+ * back.
  *
  * A one-line banner is the right size for "your assistant is upgrading" and
  * the wrong size for the one state where the page below it cannot be used at
@@ -8,70 +9,89 @@
  * shows whose sleep it is instead: the user's own avatar, at the size of the
  * page, with its lids down. The banner stands down for the duration (see
  * `StatusBanner`, which reads `visible` off the shared store) so the status is
- * stated once.
+ * stated once. `SleepStageView` draws it; this component decides when.
+ *
+ * **It is an arrival screen, not a status light.** The stage plays only when
+ * the sleep is what the user has just walked into: the page loaded on a
+ * sleeping assistant, or they came back to a tab that fell asleep while they
+ * were away. Someone already working in the tab whose assistant drops out
+ * (a network blip reads as sleep) keeps their conversation on screen and gets
+ * the banner. So arming is latched at the moment the sleep is first seen, and
+ * a resume on the `online` signal is deliberately not an arrival: that is the
+ * network coming back, not the user.
  *
  * **Fullish, not fullscreen.** The stage is an `absolute inset-0` layer inside
  * the conversation's `<main>`, the same placement the desktop voice room
  * takes. The sidenav, the header and the window chrome stay put and stay
  * usable: this covers the thread, which is the part that is waiting. It sits
- * at `z-30`, over the thread's own layered controls (the scroll-to-latest
- * button, the attachment drag overlay), and stands down entirely while the
- * voice room, a takeover of the same box, is up. `ChatLayout` makes the
- * covered thread `inert` for as long as the stage is drawn, so what is behind
- * it is out of the tab order and the accessibility tree rather than merely
- * out of reach of the pointer.
+ * at `z-30`, over the thread's own layered controls, and stands down entirely
+ * while the voice room, a takeover of the same box, is up. `ChatLayout` makes
+ * the covered thread `inert` for as long as the stage is drawn.
  *
  * **Clicking it hands the page back.** The whole stage is a button; one click
- * dismisses it and the banner returns to carrying the status, so nobody is
- * stuck behind it while the assistant takes its time. The dismissal is scoped
- * to this sleep: once the assistant is neither sleeping nor waking the stage
- * resets, and the next sleep draws it again.
+ * dismisses it and the banner returns to carrying the status. The dismissal is
+ * scoped to that assistant's current sleep.
  *
- * The eyes are the avatar's own eye art (the builder's eye style, and its
- * color for the lids), so the creature asleep on the page is the one the user
- * made. An assistant with an uploaded image has no eye art to close, so its
- * image stands in, dimmed; an assistant with neither leaves the line of copy
- * alone on the stage.
+ * **Waking is played, not cut.** When the assistant comes back while the stage
+ * is up, the lids open, the copy says so for a beat, and the stage fades to
+ * the conversation underneath. That outro runs off a phase transition this
+ * component actually witnessed, so an assistant that was never on screen
+ * asleep does not announce that it woke.
+ *
+ * The eyes are the avatar's own eye art, so the creature asleep on the page is
+ * the one the user made. An assistant with an uploaded image has no eye art to
+ * close, so its image stands in, dimmed; an assistant with neither leaves the
+ * line of copy alone on the stage.
+ *
+ * To see it without an assistant that will actually sleep, drive it from the
+ * console: `_vellumDebug.flags.forceSleepStage("sleeping" | "waking" | "woke")`,
+ * and `forceSleepStage(null)` to hand the page back.
  */
 
 import { useQuery } from "@tanstack/react-query";
-import { motion, useReducedMotion } from "motion/react";
-import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation } from "react-router";
 
 import {
   useAssistantSleepPhase,
   type AssistantSleepPhase,
 } from "@/components/status-banner";
+import {
+  resolveSleepStageEyes,
+  SleepStageView,
+  WOKE_SEQUENCE_MS,
+  type SleepStageScene,
+} from "@/domains/chat/components/sleep-stage-scene";
 import { useIsVoiceRoomVisible } from "@/domains/chat/voice/voice-room/use-is-voice-room-visible";
-import { resolveVoiceRoomLook } from "@/domains/chat/voice/voice-room/voice-room-eyes";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useTranslation } from "@/i18n";
 import { readLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useAssistantSleepStageStore } from "@/stores/assistant-sleep-stage-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
-import { tightPathBBox, unionBBox, type BBox } from "@/utils/eye-bbox";
 import { isConversationChatPath } from "@/utils/routes";
 
 /**
- * How much of the eye the lid covers, at rest and at the bottom of a drift.
- * An assistant coming back up is further open than one still under: the same
- * face, a little more of it, which is the difference the two states have.
+ * How long after an arrival a sleep still counts as one the user walked into.
+ * Wide enough to cover a cold load resolving auth, org and the first status
+ * poll before the sleep is even known; short enough that a sleep an hour into
+ * a working session is not dressed up as an arrival.
  */
-const LID_REST: Record<AssistantSleepPhase, number> = {
-  sleeping: 0.62,
-  waking: 0.5,
-};
-const LID_DRIFT = 0.12;
-/** One full drift of the lids, in seconds: a slow breath, not a blink. */
-const LID_DRIFT_SECONDS = 4;
+let arrivalWindowMs = 20_000;
+
+/**
+ * Override the arrival window. Test-only seam so specs can exercise the
+ * unarmed path without real-time waits; never call from production code.
+ * @internal
+ */
+export function __setArrivalWindowMsForTesting(ms: number): void {
+  arrivalWindowMs = ms;
+}
 
 export function AssistantSleepStage() {
   const { t } = useTranslation("chat");
-  const reduce = useReducedMotion();
-  const clipId = useId();
   // Only where the chat surface itself is mounted: the `/assistant` draft and
   // an open conversation, not the inspector or the other routes under
   // `ChatLayout` (home, library, the identity pages), which have content of
@@ -90,6 +110,7 @@ export function AssistantSleepStage() {
   const wasDismissed = useAssistantSleepStageStore.use.dismissed();
   const dismissedAssistantId =
     useAssistantSleepStageStore.use.dismissedAssistantId();
+  const forcedScene = useAssistantSleepStageStore.use.forcedScene();
   const setVisible = useAssistantSleepStageStore.use.setVisible();
   const dismissStage = useAssistantSleepStageStore.use.dismiss();
   const reset = useAssistantSleepStageStore.use.reset();
@@ -99,18 +120,88 @@ export function AssistantSleepStage() {
   // window crossing the mobile breakpoint moves the stage between
   // `ChatLayout`'s branches) stays dismissed.
   const dismissed = wasDismissed && dismissedAssistantId === assistantId;
-  const dismiss = useCallback(
-    () => dismissStage(assistantId),
-    [dismissStage, assistantId],
-  );
 
-  const visible =
-    onConversationPage && !voiceRoomVisible && phase !== null && !dismissed;
+  // The last time the user arrived: this mount is a page load, and a
+  // foreground edge is a return to the tab. Not `signal: "online"`, which is
+  // the network reconnecting under a user who never left.
+  // Stamped in an effect rather than at `useRef` init: reading the clock
+  // during render is impure, and this effect is declared before the arming
+  // one so the timestamp is already there when the first phase is judged.
+  const arrivedAtRef = useRef(0);
+  useEffect(() => {
+    arrivedAtRef.current = Date.now();
+  }, []);
+  const [armed, setArmed] = useState(false);
+  useBusSubscription("app.resume", ({ signal }) => {
+    if (signal === "online") {
+      return;
+    }
+    arrivedAtRef.current = Date.now();
+    if (phase !== null) {
+      setArmed(true);
+    }
+  });
+  // Latched when the sleep is first seen, so a sleep that begins later in the
+  // same session stays with the banner however long the user then sits there.
+  useEffect(() => {
+    if (phase === null) {
+      setArmed(false);
+      return;
+    }
+    if (Date.now() - arrivedAtRef.current <= arrivalWindowMs) {
+      setArmed(true);
+    }
+  }, [phase]);
+
+  const sleepVisible =
+    onConversationPage &&
+    !voiceRoomVisible &&
+    phase !== null &&
+    armed &&
+    !dismissed;
+
+  // The waking outro belongs to a sleep this component actually showed:
+  // an assistant that woke while the stage was never up has nothing to
+  // announce.
+  const showedThisSleepRef = useRef(false);
+  useEffect(() => {
+    if (sleepVisible) {
+      showedThisSleepRef.current = true;
+    }
+  }, [sleepVisible]);
+
+  const [woke, setWoke] = useState(false);
+  const previousPhaseRef = useRef<AssistantSleepPhase | null>(null);
+  useEffect(() => {
+    const previous = previousPhaseRef.current;
+    previousPhaseRef.current = phase;
+    if (phase !== null) {
+      return;
+    }
+    if (previous !== null && showedThisSleepRef.current && !dismissed) {
+      setWoke(true);
+    }
+    showedThisSleepRef.current = false;
+  }, [phase, dismissed]);
 
   useEffect(() => {
-    setVisible(visible);
+    if (!woke) {
+      return;
+    }
+    const timer = setTimeout(() => setWoke(false), WOKE_SEQUENCE_MS);
+    return () => clearTimeout(timer);
+  }, [woke]);
+
+  const scene: SleepStageScene | null = !onConversationPage
+    ? null
+    : (forcedScene ??
+      (sleepVisible ? phase : null) ??
+      (woke && !voiceRoomVisible ? "woke" : null));
+
+  useEffect(() => {
+    setVisible(scene !== null);
     return () => setVisible(false);
-  }, [visible, setVisible]);
+  }, [scene, setVisible]);
 
   // A dismissal lasts as long as the sleep it was aimed at, and only that
   // assistant's waking clears it: visiting an assistant that is awake reports
@@ -120,6 +211,11 @@ export function AssistantSleepStage() {
       reset();
     }
   }, [phase, dismissedAssistantId, assistantId, reset]);
+
+  const dismiss = useCallback(() => {
+    setWoke(false);
+    dismissStage(assistantId);
+  }, [dismissStage, assistantId]);
 
   // Traits from the assistant when it is reachable, else the last ones this
   // device saw it wearing. On a cold load the thing that serves them is the
@@ -133,7 +229,8 @@ export function AssistantSleepStage() {
     // Deliberately not pinned: the record is deleted when the user removes
     // their avatar, and nothing invalidates this key, so a later sleep in the
     // same session re-reads rather than redrawing a character that is gone.
-    enabled: visible && Boolean(assistantId) && !traits && !customImageUrl,
+    enabled:
+      scene !== null && Boolean(assistantId) && !traits && !customImageUrl,
   });
   const effectiveTraits =
     traits ??
@@ -167,154 +264,55 @@ export function AssistantSleepStage() {
     // Measuring the art parses every eye path, so it waits until there is a
     // stage to draw: every conversation mounts this component, and almost
     // none of them are asleep.
-    if (!visible || !effectiveTraits) {
+    if (scene === null || !effectiveTraits) {
       return null;
     }
-    const look = resolveVoiceRoomLook(
+    return resolveSleepStageEyes(
       components ?? BUNDLED_COMPONENTS,
       effectiveTraits,
       imageUrl,
     );
-    if (!look?.art) {
-      return null;
-    }
-    // The lid is placed as a share of the eye, so it has to be measured
-    // against the ink and not against `look.art.bbox`, which is the
-    // control-point box the peeking eyes frame with: `angry` is drawn with
-    // control points nowhere near its curves, and a lid at half of that box
-    // covers the whole eye. See `tightPathBBox`.
-    const bbox = unionBBox(
-      look.art.paths.map((path) => tightPathBBox(path.svgPath)),
-    );
-    if (bbox.w <= 0 || bbox.h <= 0) {
-      return null;
-    }
-    const eyeArt: SleepingEyeArt = {
-      paths: look.art.paths,
-      bbox,
-      lidColor: look.bgHex,
-    };
-    return eyeArt;
-  }, [visible, components, effectiveTraits, imageUrl]);
+  }, [scene, components, effectiveTraits, imageUrl]);
 
-  if (!visible || phase === null) {
+  if (scene === null) {
     return null;
   }
 
-  const line = assistantName
-    ? phase === "waking"
-      ? t("assistantSleepStage.wakingNamed", { name: assistantName })
-      : t("assistantSleepStage.sleepingNamed", { name: assistantName })
-    : phase === "waking"
-      ? t("assistantSleepStage.waking")
-      : t("assistantSleepStage.sleeping");
-
   return (
-    <motion.button
-      type="button"
-      onClick={dismiss}
-      className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
-      initial={reduce ? false : { opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: reduce ? 0 : 0.35 }}
-    >
-      {eyes ? (
-        <SleepingEyes
-          eyes={eyes}
-          phase={phase}
-          clipId={clipId}
-          reduce={Boolean(reduce)}
-        />
-      ) : imageUrl ? (
-        <img
-          src={imageUrl}
-          alt=""
-          aria-hidden="true"
-          className="aspect-square w-[clamp(120px,20vw,200px)] rounded-full object-cover opacity-60"
-        />
-      ) : null}
-
-      <span
-        className="block text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasised)] md:text-[36px]"
-        style={{ fontFamily: "var(--font-serif)" }}
-      >
-        {line}
-      </span>
-      {/* The button's accessible name is its text, so the status is announced
-          before what a click does. No `aria-label`: it would replace the line
-          the sighted user reads with the action alone. */}
-      <span className="sr-only">{t("assistantSleepStage.dismissLabel")}</span>
-    </motion.button>
+    <SleepStageView
+      scene={scene}
+      eyes={eyes}
+      imageUrl={imageUrl}
+      line={sceneLine(t, scene, assistantName)}
+      dismissHint={t("assistantSleepStage.dismissLabel")}
+      onDismiss={dismiss}
+    />
   );
 }
 
-/** The eye art the stage draws, plus the lid color it closes them with. */
-interface SleepingEyeArt {
-  paths: { svgPath: string; color: string }[];
-  bbox: BBox;
-  lidColor: string;
-}
+type TranslateChat = ReturnType<typeof useTranslation<"chat">>["t"];
 
 /**
- * The eye art with its lids down: the eyes drawn as they always are, then a
- * lid rectangle wearing the eyes' own silhouette so it closes each eye over
- * its top half and leaves the gap between them empty. The lid drifts a little
- * lower and back, which is what makes a still pair of eyes read as asleep
- * rather than as a drawing of eyes.
+ * The line under the eyes. Named and unnamed are separate messages rather than
+ * a name substituted into one: a language that inflects around the subject can
+ * only write "your assistant is waking up" as its own sentence.
  */
-function SleepingEyes({
-  eyes,
-  phase,
-  clipId,
-  reduce,
-}: {
-  eyes: SleepingEyeArt;
-  phase: AssistantSleepPhase;
-  clipId: string;
-  reduce: boolean;
-}) {
-  const { bbox } = eyes;
-  const restHeight = LID_REST[phase] * bbox.h;
-  const deepHeight = (LID_REST[phase] + LID_DRIFT) * bbox.h;
-
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox={`${bbox.x} ${bbox.y} ${bbox.w} ${bbox.h}`}
-      className="h-auto w-[clamp(140px,26vw,240px)] shrink-0"
-    >
-      <defs>
-        <clipPath id={clipId}>
-          {eyes.paths.map((path, i) => (
-            <path key={i} d={path.svgPath} />
-          ))}
-        </clipPath>
-      </defs>
-      {eyes.paths.map((path, i) => (
-        <path key={i} d={path.svgPath} fill={path.color} />
-      ))}
-      <motion.rect
-        clipPath={`url(#${clipId})`}
-        x={bbox.x}
-        y={bbox.y}
-        width={bbox.w}
-        fill={eyes.lidColor}
-        initial={{ height: restHeight }}
-        animate={
-          reduce
-            ? { height: restHeight }
-            : { height: [restHeight, deepHeight, restHeight] }
-        }
-        transition={
-          reduce
-            ? { duration: 0 }
-            : {
-                duration: LID_DRIFT_SECONDS,
-                repeat: Infinity,
-                ease: "easeInOut",
-              }
-        }
-      />
-    </svg>
-  );
+function sceneLine(
+  t: TranslateChat,
+  scene: SleepStageScene,
+  name: string | null,
+): string {
+  if (scene === "woke") {
+    return name
+      ? t("assistantSleepStage.wokeNamed", { name })
+      : t("assistantSleepStage.woke");
+  }
+  if (scene === "waking") {
+    return name
+      ? t("assistantSleepStage.wakingNamed", { name })
+      : t("assistantSleepStage.waking");
+  }
+  return name
+    ? t("assistantSleepStage.sleepingNamed", { name })
+    : t("assistantSleepStage.sleeping");
 }

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
@@ -112,12 +112,14 @@ export function AssistantSleepStage() {
     return () => setVisible(false);
   }, [visible, setVisible]);
 
-  // A dismissal lasts as long as the sleep it was aimed at.
+  // A dismissal lasts as long as the sleep it was aimed at, and only that
+  // assistant's waking clears it: visiting an assistant that is awake reports
+  // no phase, and must not end a sleep somewhere else.
   useEffect(() => {
-    if (phase === null) {
+    if (phase === null && dismissedAssistantId === assistantId) {
       reset();
     }
-  }, [phase, reset]);
+  }, [phase, dismissedAssistantId, assistantId, reset]);
 
   // Traits from the assistant when it is reachable, else the last ones this
   // device saw it wearing. On a cold load the thing that serves them is the
@@ -157,12 +159,15 @@ export function AssistantSleepStage() {
   const imageUrl = customImageUrl ?? lastSeenImageUrl;
 
   // The catalog is bundled, so the eyes still draw while the assistant that
-  // serves `/avatar/character-components` is the thing asleep.
+  // serves `/avatar/character-components` is the thing asleep. The traits are
+  // not: with none known (an avatar-less assistant, or nothing recorded for
+  // this one) the stage is the line of copy alone, because the catalog's
+  // first creature is a character the user never chose.
   const eyes = useMemo(() => {
     // Measuring the art parses every eye path, so it waits until there is a
     // stage to draw: every conversation mounts this component, and almost
     // none of them are asleep.
-    if (!visible) {
+    if (!visible || !effectiveTraits) {
       return null;
     }
     const look = resolveVoiceRoomLook(
@@ -208,7 +213,6 @@ export function AssistantSleepStage() {
     <motion.button
       type="button"
       onClick={dismiss}
-      aria-label={t("assistantSleepStage.dismissLabel")}
       className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
       initial={reduce ? false : { opacity: 0 }}
       animate={{ opacity: 1 }}
@@ -226,7 +230,7 @@ export function AssistantSleepStage() {
           src={imageUrl}
           alt=""
           aria-hidden="true"
-          className="w-[clamp(120px,20vw,200px)] rounded-full object-cover opacity-60"
+          className="aspect-square w-[clamp(120px,20vw,200px)] rounded-full object-cover opacity-60"
         />
       ) : null}
 
@@ -236,6 +240,10 @@ export function AssistantSleepStage() {
       >
         {line}
       </span>
+      {/* The button's accessible name is its text, so the status is announced
+          before what a click does. No `aria-label`: it would replace the line
+          the sighted user reads with the action alone. */}
+      <span className="sr-only">{t("assistantSleepStage.dismissLabel")}</span>
     </motion.button>
   );
 }

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
@@ -13,9 +13,13 @@
  * **Fullish, not fullscreen.** The stage is an `absolute inset-0` layer inside
  * the conversation's `<main>`, the same placement the desktop voice room
  * takes. The sidenav, the header and the window chrome stay put and stay
- * usable: this covers the thread, which is the part that is waiting. It claims
- * no `z-index` on purpose: painting order alone puts it over the thread and
- * under the voice room, which `<main>` mounts after it.
+ * usable: this covers the thread, which is the part that is waiting. It sits
+ * at `z-30`, over the thread's own layered controls (the scroll-to-latest
+ * button, the attachment drag overlay), and stands down entirely while the
+ * voice room, a takeover of the same box, is up. `ChatLayout` makes the
+ * covered thread `inert` for as long as the stage is drawn, so what is behind
+ * it is out of the tab order and the accessibility tree rather than merely
+ * out of reach of the pointer.
  *
  * **Clicking it hands the page back.** The whole stage is a button; one click
  * dismisses it and the banner returns to carrying the status, so nobody is
@@ -30,23 +34,26 @@
  * alone on the stage.
  */
 
+import { useQuery } from "@tanstack/react-query";
 import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useId, useMemo } from "react";
-import { useMatch } from "react-router";
+import { useLocation } from "react-router";
 
 import {
   useAssistantSleepPhase,
   type AssistantSleepPhase,
 } from "@/components/status-banner";
+import { useIsVoiceRoomVisible } from "@/domains/chat/voice/voice-room/use-is-voice-room-visible";
 import { resolveVoiceRoomLook } from "@/domains/chat/voice/voice-room/voice-room-eyes";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useTranslation } from "@/i18n";
+import { readLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useAssistantSleepStageStore } from "@/stores/assistant-sleep-stage-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { tightPathBBox, unionBBox, type BBox } from "@/utils/eye-bbox";
-import { routes } from "@/utils/routes";
+import { isConversationChatPath } from "@/utils/routes";
 
 /**
  * How much of the eye the lid covers, at rest and at the bottom of a drift.
@@ -65,10 +72,15 @@ export function AssistantSleepStage() {
   const { t } = useTranslation("chat");
   const reduce = useReducedMotion();
   const clipId = useId();
-  // Only the conversation page: every other route under `ChatLayout` (home,
-  // library, the identity pages) has content of its own worth reading while
-  // the assistant is away, and keeps the banner instead.
-  const onConversationPage = useMatch(routes.conversation(":conversationId"));
+  // Only where the chat surface itself is mounted: the `/assistant` draft and
+  // an open conversation, not the inspector or the other routes under
+  // `ChatLayout` (home, library, the identity pages), which have content of
+  // their own worth reading while the assistant is away and keep the banner.
+  const { pathname } = useLocation();
+  const onConversationPage = isConversationChatPath(pathname);
+  // The voice room is a takeover of the same box; it mounts after this one and
+  // owns the surface while it is up.
+  const voiceRoomVisible = useIsVoiceRoomVisible();
   const phase = useAssistantSleepPhase();
   const assistantName = useAssistantIdentityStore.use.name();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
@@ -80,23 +92,45 @@ export function AssistantSleepStage() {
   const dismiss = useAssistantSleepStageStore.use.dismiss();
   const reset = useAssistantSleepStageStore.use.reset();
 
-  const visible = Boolean(onConversationPage) && phase !== null && !dismissed;
+  const visible =
+    onConversationPage && !voiceRoomVisible && phase !== null && !dismissed;
 
   useEffect(() => {
     setVisible(visible);
     return () => setVisible(false);
   }, [visible, setVisible]);
 
-  // A dismissal lasts as long as the sleep it was aimed at.
+  // A dismissal lasts as long as the sleep it was aimed at, and belongs to the
+  // assistant it was aimed at: switching to another assistant that is also
+  // asleep never reports a phase of null, so the switch clears it too.
   useEffect(() => {
     if (phase === null) {
       reset();
     }
   }, [phase, reset]);
+  useEffect(() => {
+    reset();
+  }, [assistantId, reset]);
+
+  // Traits from the assistant when it is reachable, else the last ones this
+  // device saw it wearing. On a cold load the thing that serves them is the
+  // thing asleep, and defaulting to the catalog's first creature would put a
+  // character the user never made on the page during the one state this
+  // screen exists for. Only a character is recovered: an uploaded image would
+  // mean a blob URL to own, and the copy alone carries that case.
+  const lastSeen = useQuery({
+    queryKey: ["assistant-sleep-stage", "last-seen-traits", assistantId],
+    queryFn: async () => {
+      const seen = await readLastSeenAvatar(assistantId!);
+      return seen?.kind === "character" ? seen.traits : null;
+    },
+    enabled: visible && Boolean(assistantId) && !traits && !customImageUrl,
+    staleTime: Infinity,
+  });
+  const effectiveTraits = traits ?? lastSeen.data ?? null;
 
   // The catalog is bundled, so the eyes still draw while the assistant that
-  // serves `/avatar/character-components` is the thing asleep; only the traits
-  // come off the wire (or default, as they do on every other surface).
+  // serves `/avatar/character-components` is the thing asleep.
   const eyes = useMemo(() => {
     // Measuring the art parses every eye path, so it waits until there is a
     // stage to draw: every conversation mounts this component, and almost
@@ -106,7 +140,7 @@ export function AssistantSleepStage() {
     }
     const look = resolveVoiceRoomLook(
       components ?? BUNDLED_COMPONENTS,
-      traits,
+      effectiveTraits,
       customImageUrl,
     );
     if (!look?.art) {
@@ -129,7 +163,7 @@ export function AssistantSleepStage() {
       lidColor: look.bgHex,
     };
     return eyeArt;
-  }, [visible, components, traits, customImageUrl]);
+  }, [visible, components, effectiveTraits, customImageUrl]);
 
   if (!visible || phase === null) {
     return null;
@@ -148,7 +182,7 @@ export function AssistantSleepStage() {
       type="button"
       onClick={dismiss}
       aria-label={t("assistantSleepStage.dismissLabel")}
-      className="absolute inset-0 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
+      className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
       initial={reduce ? false : { opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: reduce ? 0 : 0.35 }}

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
@@ -1,0 +1,251 @@
+/**
+ * The sleep stage: the assistant, eyes half shut, filling the conversation
+ * page while it is asleep or waking up.
+ *
+ * A one-line banner is the right size for "your assistant is upgrading" and
+ * the wrong size for the one state where the page below it cannot be used at
+ * all. So while the assistant is sleeping or waking, the conversation page
+ * shows whose sleep it is instead: the user's own avatar, at the size of the
+ * page, with its lids down. The banner stands down for the duration (see
+ * `StatusBanner`, which reads `visible` off the shared store) so the status is
+ * stated once.
+ *
+ * **Fullish, not fullscreen.** The stage is an `absolute inset-0` layer inside
+ * the conversation's `<main>`, the same placement the desktop voice room
+ * takes. The sidenav, the header and the window chrome stay put and stay
+ * usable: this covers the thread, which is the part that is waiting. It claims
+ * no `z-index` on purpose: painting order alone puts it over the thread and
+ * under the voice room, which `<main>` mounts after it.
+ *
+ * **Clicking it hands the page back.** The whole stage is a button; one click
+ * dismisses it and the banner returns to carrying the status, so nobody is
+ * stuck behind it while the assistant takes its time. The dismissal is scoped
+ * to this sleep: once the assistant is neither sleeping nor waking the stage
+ * resets, and the next sleep draws it again.
+ *
+ * The eyes are the avatar's own eye art (the builder's eye style, and its
+ * color for the lids), so the creature asleep on the page is the one the user
+ * made. An assistant with an uploaded image has no eye art to close, so its
+ * image stands in, dimmed; an assistant with neither leaves the line of copy
+ * alone on the stage.
+ */
+
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useId, useMemo } from "react";
+import { useMatch } from "react-router";
+
+import {
+  useAssistantSleepPhase,
+  type AssistantSleepPhase,
+} from "@/components/status-banner";
+import { resolveVoiceRoomLook } from "@/domains/chat/voice/voice-room/voice-room-eyes";
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useTranslation } from "@/i18n";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useAssistantSleepStageStore } from "@/stores/assistant-sleep-stage-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import { tightPathBBox, unionBBox, type BBox } from "@/utils/eye-bbox";
+import { routes } from "@/utils/routes";
+
+/**
+ * How much of the eye the lid covers, at rest and at the bottom of a drift.
+ * An assistant coming back up is further open than one still under: the same
+ * face, a little more of it, which is the difference the two states have.
+ */
+const LID_REST: Record<AssistantSleepPhase, number> = {
+  sleeping: 0.62,
+  waking: 0.5,
+};
+const LID_DRIFT = 0.12;
+/** One full drift of the lids, in seconds: a slow breath, not a blink. */
+const LID_DRIFT_SECONDS = 4;
+
+export function AssistantSleepStage() {
+  const { t } = useTranslation("chat");
+  const reduce = useReducedMotion();
+  const clipId = useId();
+  // Only the conversation page: every other route under `ChatLayout` (home,
+  // library, the identity pages) has content of its own worth reading while
+  // the assistant is away, and keeps the banner instead.
+  const onConversationPage = useMatch(routes.conversation(":conversationId"));
+  const phase = useAssistantSleepPhase();
+  const assistantName = useAssistantIdentityStore.use.name();
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const { components, traits, customImageUrl } =
+    useAssistantAvatar(assistantId);
+
+  const dismissed = useAssistantSleepStageStore.use.dismissed();
+  const setVisible = useAssistantSleepStageStore.use.setVisible();
+  const dismiss = useAssistantSleepStageStore.use.dismiss();
+  const reset = useAssistantSleepStageStore.use.reset();
+
+  const visible = Boolean(onConversationPage) && phase !== null && !dismissed;
+
+  useEffect(() => {
+    setVisible(visible);
+    return () => setVisible(false);
+  }, [visible, setVisible]);
+
+  // A dismissal lasts as long as the sleep it was aimed at.
+  useEffect(() => {
+    if (phase === null) {
+      reset();
+    }
+  }, [phase, reset]);
+
+  // The catalog is bundled, so the eyes still draw while the assistant that
+  // serves `/avatar/character-components` is the thing asleep; only the traits
+  // come off the wire (or default, as they do on every other surface).
+  const eyes = useMemo(() => {
+    // Measuring the art parses every eye path, so it waits until there is a
+    // stage to draw: every conversation mounts this component, and almost
+    // none of them are asleep.
+    if (!visible) {
+      return null;
+    }
+    const look = resolveVoiceRoomLook(
+      components ?? BUNDLED_COMPONENTS,
+      traits,
+      customImageUrl,
+    );
+    if (!look?.art) {
+      return null;
+    }
+    // The lid is placed as a share of the eye, so it has to be measured
+    // against the ink and not against `look.art.bbox`, which is the
+    // control-point box the peeking eyes frame with: `angry` is drawn with
+    // control points nowhere near its curves, and a lid at half of that box
+    // covers the whole eye. See `tightPathBBox`.
+    const bbox = unionBBox(
+      look.art.paths.map((path) => tightPathBBox(path.svgPath)),
+    );
+    if (bbox.w <= 0 || bbox.h <= 0) {
+      return null;
+    }
+    const eyeArt: SleepingEyeArt = {
+      paths: look.art.paths,
+      bbox,
+      lidColor: look.bgHex,
+    };
+    return eyeArt;
+  }, [visible, components, traits, customImageUrl]);
+
+  if (!visible || phase === null) {
+    return null;
+  }
+
+  const line = assistantName
+    ? phase === "waking"
+      ? t("assistantSleepStage.wakingNamed", { name: assistantName })
+      : t("assistantSleepStage.sleepingNamed", { name: assistantName })
+    : phase === "waking"
+      ? t("assistantSleepStage.waking")
+      : t("assistantSleepStage.sleeping");
+
+  return (
+    <motion.button
+      type="button"
+      onClick={dismiss}
+      aria-label={t("assistantSleepStage.dismissLabel")}
+      className="absolute inset-0 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
+      initial={reduce ? false : { opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: reduce ? 0 : 0.35 }}
+    >
+      {eyes ? (
+        <SleepingEyes
+          eyes={eyes}
+          phase={phase}
+          clipId={clipId}
+          reduce={Boolean(reduce)}
+        />
+      ) : customImageUrl ? (
+        <img
+          src={customImageUrl}
+          alt=""
+          aria-hidden="true"
+          className="w-[clamp(120px,20vw,200px)] rounded-full object-cover opacity-60"
+        />
+      ) : null}
+
+      <span
+        className="block text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasised)] md:text-[36px]"
+        style={{ fontFamily: "var(--font-serif)" }}
+      >
+        {line}
+      </span>
+    </motion.button>
+  );
+}
+
+/** The eye art the stage draws, plus the lid color it closes them with. */
+interface SleepingEyeArt {
+  paths: { svgPath: string; color: string }[];
+  bbox: BBox;
+  lidColor: string;
+}
+
+/**
+ * The eye art with its lids down: the eyes drawn as they always are, then a
+ * lid rectangle wearing the eyes' own silhouette so it closes each eye over
+ * its top half and leaves the gap between them empty. The lid drifts a little
+ * lower and back, which is what makes a still pair of eyes read as asleep
+ * rather than as a drawing of eyes.
+ */
+function SleepingEyes({
+  eyes,
+  phase,
+  clipId,
+  reduce,
+}: {
+  eyes: SleepingEyeArt;
+  phase: AssistantSleepPhase;
+  clipId: string;
+  reduce: boolean;
+}) {
+  const { bbox } = eyes;
+  const restHeight = LID_REST[phase] * bbox.h;
+  const deepHeight = (LID_REST[phase] + LID_DRIFT) * bbox.h;
+
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox={`${bbox.x} ${bbox.y} ${bbox.w} ${bbox.h}`}
+      className="h-auto w-[clamp(140px,26vw,240px)] shrink-0"
+    >
+      <defs>
+        <clipPath id={clipId}>
+          {eyes.paths.map((path, i) => (
+            <path key={i} d={path.svgPath} />
+          ))}
+        </clipPath>
+      </defs>
+      {eyes.paths.map((path, i) => (
+        <path key={i} d={path.svgPath} fill={path.color} />
+      ))}
+      <motion.rect
+        clipPath={`url(#${clipId})`}
+        x={bbox.x}
+        y={bbox.y}
+        width={bbox.w}
+        fill={eyes.lidColor}
+        initial={{ height: restHeight }}
+        animate={
+          reduce
+            ? { height: restHeight }
+            : { height: [restHeight, deepHeight, restHeight] }
+        }
+        transition={
+          reduce
+            ? { duration: 0 }
+            : {
+                duration: LID_DRIFT_SECONDS,
+                repeat: Infinity,
+                ease: "easeInOut",
+              }
+        }
+      />
+    </svg>
+  );
+}

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
@@ -28,9 +28,10 @@
  * while the voice room, a takeover of the same box, is up. `ChatLayout` makes
  * the covered thread `inert` for as long as the stage is drawn.
  *
- * **Clicking it hands the page back.** The whole stage is a button; one click
- * dismisses it and the banner returns to carrying the status. The dismissal is
- * scoped to that assistant's current sleep.
+ * **A close button hands the page back.** The stage's surface is inert, so a
+ * stray click on the conversation it covers cannot dismiss it by accident;
+ * the close button in its corner can, and the banner then returns to carrying
+ * the status. The dismissal is scoped to that assistant's current sleep.
  *
  * **Waking is played, not cut.** When the assistant comes back while the stage
  * is up, the lids open, the copy says so for a beat, and the stage fades to
@@ -288,7 +289,7 @@ export function AssistantSleepStage() {
       eyes={eyes}
       imageUrl={imageUrl}
       line={sceneLine(t, scene, assistantName)}
-      dismissHint={t("assistantSleepStage.dismissLabel")}
+      dismissLabel={t("assistantSleepStage.dismissLabel")}
       onDismiss={dismiss}
     />
   );

--- a/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
+++ b/clients/web/src/domains/chat/components/assistant-sleep-stage.tsx
@@ -212,10 +212,14 @@ export function AssistantSleepStage() {
     }
   }, [phase, dismissedAssistantId, assistantId, reset]);
 
+  const setForcedScene = useAssistantSleepStageStore.use.setForcedScene();
   const dismiss = useCallback(() => {
     setWoke(false);
+    // A pinned scene outranks the sleep itself, so a click has to clear the
+    // pin as well or the stage cannot be dismissed while it is on.
+    setForcedScene(null);
     dismissStage(assistantId);
-  }, [dismissStage, assistantId]);
+  }, [dismissStage, setForcedScene, assistantId]);
 
   // Traits from the assistant when it is reachable, else the last ones this
   // device saw it wearing. On a cold load the thing that serves them is the

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.stories.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.stories.tsx
@@ -1,0 +1,146 @@
+/**
+ * The sleep stage's three scenes, driven by hand.
+ *
+ * In the app the stage only plays for an assistant that is genuinely asleep
+ * and only on an arrival, so this is where the animation itself gets watched:
+ * pick an eye style and a color, switch scenes, and see the lids move. The
+ * `Waking up` story runs the real sequence end to end on a loop, which is the
+ * one thing a static scene cannot show.
+ *
+ * The eye art comes from the bundled character catalog through the same
+ * `resolveSleepStageEyes` the app uses, so what renders here is what ships.
+ */
+
+import { getCharacterComponents } from "@vellumai/avatar-catalog";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect, useState } from "react";
+
+import {
+  resolveSleepStageEyes,
+  SleepStageView,
+  WOKE_SEQUENCE_MS,
+  type SleepStageScene,
+} from "./sleep-stage-scene";
+
+const CATALOG = getCharacterComponents();
+const EYE_STYLES = CATALOG.eyeStyles.map((style) => style.id);
+const COLORS = CATALOG.colors.map((color) => color.id);
+
+function eyesFor(eyeStyle: string, color: string) {
+  return resolveSleepStageEyes(
+    CATALOG,
+    {
+      bodyShape: CATALOG.bodyShapes[0]!.id,
+      eyeStyle,
+      color,
+    },
+    null,
+  );
+}
+
+interface StoryArgs {
+  scene: SleepStageScene;
+  eyeStyle: string;
+  color: string;
+  line: string;
+}
+
+/** The stage is an inset layer, so the frame stands in for the chat `<main>`. */
+function Stage({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative h-[560px] w-full overflow-hidden rounded-xl bg-[var(--surface-base)]">
+      {children}
+    </div>
+  );
+}
+
+function Scene({ scene, eyeStyle, color, line }: StoryArgs) {
+  return (
+    <Stage>
+      <SleepStageView
+        scene={scene}
+        eyes={eyesFor(eyeStyle, color)}
+        line={line}
+        dismissHint="Hide the sleep screen"
+      />
+    </Stage>
+  );
+}
+
+const meta: Meta<StoryArgs> = {
+  title: "Chat/SleepStage",
+  parameters: { layout: "fullscreen" },
+  argTypes: {
+    scene: { control: "inline-radio", options: ["sleeping", "waking", "woke"] },
+    eyeStyle: { control: "select", options: EYE_STYLES },
+    color: { control: "select", options: COLORS },
+    line: { control: "text" },
+  },
+  args: {
+    scene: "sleeping",
+    eyeStyle: EYE_STYLES[0]!,
+    color: COLORS[0]!,
+    line: "Mel Gibson is asleep",
+  },
+  render: (args) => <Scene {...args} />,
+};
+
+export default meta;
+
+type Story = StoryObj<StoryArgs>;
+
+export const Asleep: Story = {};
+
+export const Waking: Story = {
+  args: { scene: "waking", line: "Mel Gibson is waking up…" },
+};
+
+export const Woke: Story = {
+  args: { scene: "woke", line: "Mel Gibson just woke up" },
+};
+
+/**
+ * The whole sequence the app plays: asleep, then waking, then the eyes open,
+ * hold, and the stage fades off the conversation. Loops so it can be watched
+ * more than once.
+ */
+export const WakingUp: Story = {
+  name: "Waking up (sequence)",
+  render: ({ eyeStyle, color }) => {
+    return <Sequence eyeStyle={eyeStyle} color={color} />;
+  },
+};
+
+const SEQUENCE: { scene: SleepStageScene; line: string; ms: number }[] = [
+  { scene: "sleeping", line: "Mel Gibson is asleep", ms: 3200 },
+  { scene: "waking", line: "Mel Gibson is waking up…", ms: 2600 },
+  {
+    scene: "woke",
+    line: "Mel Gibson just woke up",
+    ms: WOKE_SEQUENCE_MS + 600,
+  },
+];
+
+function Sequence({ eyeStyle, color }: { eyeStyle: string; color: string }) {
+  const [step, setStep] = useState(0);
+  const beat = SEQUENCE[step % SEQUENCE.length]!;
+
+  useEffect(() => {
+    const timer = setTimeout(() => setStep((current) => current + 1), beat.ms);
+    return () => clearTimeout(timer);
+  }, [step, beat.ms]);
+
+  return (
+    <Stage>
+      <SleepStageView
+        // A new key on the last beat restarts the entrance, so the loop reads
+        // as another sleep rather than a scene swap on a stage already up.
+        key={Math.floor(step / SEQUENCE.length)}
+        scene={beat.scene}
+        eyes={eyesFor(eyeStyle, color)}
+        line={beat.line}
+        dismissHint="Hide the sleep screen"
+      />
+    </Stage>
+  );
+}

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.stories.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.stories.tsx
@@ -66,7 +66,7 @@ function Scene({ scene, eyeStyle, color, line }: StoryArgs) {
         scene={scene}
         eyes={eyesFor(eyeStyle, color)}
         line={line}
-        dismissHint="Hide the sleep screen"
+        dismissLabel="Hide the sleep screen"
       />
     </Stage>
   );
@@ -122,7 +122,7 @@ export const EveryEyeStyle: Story = {
             scene={scene}
             eyes={eyesFor(eyeStyle, color)}
             line={eyeStyle}
-            dismissHint="Hide the sleep screen"
+            dismissLabel="Hide the sleep screen"
           />
         </div>
       ))}
@@ -170,7 +170,7 @@ function Sequence({ eyeStyle, color }: { eyeStyle: string; color: string }) {
         scene={beat.scene}
         eyes={eyesFor(eyeStyle, color)}
         line={beat.line}
-        dismissHint="Hide the sleep screen"
+        dismissLabel="Hide the sleep screen"
       />
     </Stage>
   );

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.stories.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.stories.tsx
@@ -25,6 +25,11 @@ import {
 const CATALOG = getCharacterComponents();
 const EYE_STYLES = CATALOG.eyeStyles.map((style) => style.id);
 const COLORS = CATALOG.colors.map((color) => color.id);
+/** A round-eyed default, so the first thing a reader sees is the common case
+ *  rather than `grumpy`, whose art is a shallow squint to begin with. */
+const DEFAULT_EYE_STYLE = EYE_STYLES.includes("bashful")
+  ? "bashful"
+  : EYE_STYLES[0]!;
 
 function eyesFor(eyeStyle: string, color: string) {
   return resolveSleepStageEyes(
@@ -78,7 +83,7 @@ const meta: Meta<StoryArgs> = {
   },
   args: {
     scene: "sleeping",
-    eyeStyle: EYE_STYLES[0]!,
+    eyeStyle: DEFAULT_EYE_STYLE,
     color: COLORS[0]!,
     line: "Mel Gibson is asleep",
   },
@@ -97,6 +102,32 @@ export const Waking: Story = {
 
 export const Woke: Story = {
   args: { scene: "woke", line: "Mel Gibson just woke up" },
+};
+
+/**
+ * Every eye style asleep at once. The lid is a share of the eye's height, so
+ * this is where a creature whose art is already a squint gets checked against
+ * one drawn as a pair of discs.
+ */
+export const EveryEyeStyle: Story = {
+  name: "Every eye style",
+  render: ({ color, scene }) => (
+    <div className="grid grid-cols-3 gap-4 bg-[var(--surface-base)] p-4">
+      {EYE_STYLES.map((eyeStyle) => (
+        <div
+          key={eyeStyle}
+          className="relative h-[320px] overflow-hidden rounded-xl border border-[var(--border-base)]"
+        >
+          <SleepStageView
+            scene={scene}
+            eyes={eyesFor(eyeStyle, color)}
+            line={eyeStyle}
+            dismissHint="Hide the sleep screen"
+          />
+        </div>
+      ))}
+    </div>
+  ),
 };
 
 /**

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
@@ -56,8 +56,16 @@ const LID_REST: Record<SleepStageScene, number> = {
 const LID_DRIFT = 0.12;
 /** The lid's own edge, as a share of the eye's height. */
 const LID_EDGE = 0.035;
-/** How far the edge band is darkened from the lid's color. */
-const LID_EDGE_DARKEN = 0.55;
+/** How far the edge band is darkened from the lid's color: enough to read as
+ *  an edge, not so much that it cuts the face in two. */
+const LID_EDGE_DARKEN = 0.72;
+/**
+ * Above this width-to-height ratio the eye is a slit rather than a disc, and
+ * a lid measured as a share of its height covers the whole thing (`grumpy`,
+ * whose art is already a squint, is 4.5:1). The lid eases off in proportion
+ * so a shallow eye keeps an eye's worth of ink under it.
+ */
+const SHALLOW_EYE_ASPECT = 3.2;
 /** One full drift, in seconds. */
 const LID_DRIFT_SECONDS = 4;
 
@@ -206,8 +214,11 @@ function StageEyes({
   // How far the lid has slid down over the eye. The slab hangs above the box
   // with its lower edge at the top of the eye at rest, so one translated
   // value closes the lid, drifts it, and opens it again.
-  const closed = LID_REST[scene] * bbox.h;
-  const deep = (LID_REST[scene] + LID_DRIFT) * bbox.h;
+  // Art much wider than it is tall keeps more of itself: see
+  // `SHALLOW_EYE_ASPECT`.
+  const shallow = Math.min(1, SHALLOW_EYE_ASPECT / (bbox.w / bbox.h));
+  const closed = LID_REST[scene] * shallow * bbox.h;
+  const deep = (LID_REST[scene] + LID_DRIFT) * shallow * bbox.h;
   const edge = LID_EDGE * bbox.h;
   const drifts = scene !== "woke" && !reduce;
 

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
@@ -14,18 +14,23 @@
  *   lids from wherever they were, so the open is one movement out of the
  *   sleep rather than a cut to a new picture.
  *
- * The lid is a rectangle wearing the eyes' own silhouette (a `clipPath` of
- * the eye paths), so it closes each eye over its top and leaves the gap
- * between them empty. It is painted in the avatar's own color, which is what
- * makes a closed eye read as that creature's eyelid and not as a grey bar.
+ * The lid is a slab wearing the eyes' own silhouette (a `clipPath` of the eye
+ * paths), so it closes each eye over its top and leaves the gap between them
+ * empty. It is painted in the avatar's own color, with its lower edge banded
+ * in a darker shade of that same color: the band is what reads as an eyelid
+ * rather than as a color fill stopping halfway down the eye. Lid and band
+ * slide as one group, so the edge stays welded to the lid through every
+ * drift and the whole way open.
  */
 
+import { X } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { useId } from "react";
 
 import { resolveVoiceRoomLook } from "@/domains/chat/voice/voice-room/voice-room-eyes";
 import type { SleepStageScene } from "@/stores/assistant-sleep-stage-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { darkenHex } from "@/utils/avatar-tone";
 import { tightPathBBox, unionBBox, type BBox } from "@/utils/eye-bbox";
 
 export type { SleepStageScene };
@@ -49,6 +54,10 @@ const LID_REST: Record<SleepStageScene, number> = {
 };
 /** How much further the lids sink at the bottom of a sleeping drift. */
 const LID_DRIFT = 0.12;
+/** The lid's own edge, as a share of the eye's height. */
+const LID_EDGE = 0.035;
+/** How far the edge band is darkened from the lid's color. */
+const LID_EDGE_DARKEN = 0.55;
 /** One full drift, in seconds. */
 const LID_DRIFT_SECONDS = 4;
 
@@ -121,7 +130,7 @@ export function SleepStageView({
       type="button"
       onClick={onDismiss}
       data-scene={scene}
-      className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
+      className="group absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
       initial={reduce ? false : { opacity: 0 }}
       // Waking runs the whole exit here: the eyes hold open for a beat and
       // then the stage itself fades, so the conversation arrives behind a
@@ -157,6 +166,18 @@ export function SleepStageView({
         />
       ) : null}
 
+      {/* What a click does, shown only under the pointer: the stage is one
+          big button, so this is an affordance rather than a control of its
+          own (a nested button would be invalid, and would take the click). */}
+      {woke ? null : (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute right-4 top-4 flex size-8 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--content-secondary)_25%,transparent)] bg-[color-mix(in_srgb,var(--surface-overlay)_70%,transparent)] text-[color:var(--content-secondary)] opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+        >
+          <X className="size-4" aria-hidden="true" />
+        </span>
+      )}
+
       <span
         className="block text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasised)] md:text-[36px]"
         style={{ fontFamily: "var(--font-serif)" }}
@@ -182,13 +203,18 @@ function StageEyes({
 }) {
   const clipId = useId();
   const { bbox } = eyes;
-  const rest = LID_REST[scene] * bbox.h;
+  // How far the lid has slid down over the eye. The slab hangs above the box
+  // with its lower edge at the top of the eye at rest, so one translated
+  // value closes the lid, drifts it, and opens it again.
+  const closed = LID_REST[scene] * bbox.h;
   const deep = (LID_REST[scene] + LID_DRIFT) * bbox.h;
+  const edge = LID_EDGE * bbox.h;
   const drifts = scene !== "woke" && !reduce;
 
   return (
     <svg
       aria-hidden="true"
+      data-slot="sleep-stage-eyes"
       viewBox={`${bbox.x} ${bbox.y} ${bbox.w} ${bbox.h}`}
       className="h-auto w-[clamp(140px,26vw,240px)] shrink-0"
     >
@@ -202,27 +228,38 @@ function StageEyes({
       {eyes.paths.map((path, i) => (
         <path key={i} d={path.svgPath} fill={path.color} />
       ))}
-      <motion.rect
-        clipPath={`url(#${clipId})`}
-        x={bbox.x}
-        y={bbox.y}
-        width={bbox.w}
-        fill={eyes.lidColor}
-        initial={{ height: rest }}
-        animate={drifts ? { height: [rest, deep, rest] } : { height: rest }}
-        transition={
-          drifts
-            ? {
-                duration: LID_DRIFT_SECONDS,
-                repeat: Infinity,
-                ease: "easeInOut",
-              }
-            : {
-                duration: reduce ? 0 : WOKE_OPEN_SECONDS,
-                ease: "easeOut",
-              }
-        }
-      />
+      {/* The clip sits on a group of its own: on the moving group it would
+          travel with the transform and stop following the eye. */}
+      <g clipPath={`url(#${clipId})`}>
+        <motion.g
+          initial={{ y: closed }}
+          animate={drifts ? { y: [closed, deep, closed] } : { y: closed }}
+          transition={
+            drifts
+              ? {
+                  duration: LID_DRIFT_SECONDS,
+                  repeat: Infinity,
+                  ease: "easeInOut",
+                }
+              : { duration: reduce ? 0 : WOKE_OPEN_SECONDS, ease: "easeOut" }
+          }
+        >
+          <rect
+            x={bbox.x}
+            y={bbox.y - bbox.h}
+            width={bbox.w}
+            height={bbox.h}
+            fill={eyes.lidColor}
+          />
+          <rect
+            x={bbox.x}
+            y={bbox.y - edge}
+            width={bbox.w}
+            height={edge}
+            fill={darkenHex(eyes.lidColor, LID_EDGE_DARKEN)}
+          />
+        </motion.g>
+      </g>
     </svg>
   );
 }

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
@@ -1,0 +1,228 @@
+/**
+ * The sleep stage's picture: the avatar's eyes, their lids, and the line of
+ * copy under them. Presentational and self-contained, so the connected
+ * `AssistantSleepStage` owns *when* the stage appears and this owns what it
+ * looks like while it is up (and Storybook can drive it directly).
+ *
+ * Three scenes, one continuous face:
+ *
+ * - `sleeping`: lids well down, drifting a little lower and back, a slow
+ *   breath rather than a blink.
+ * - `waking`: the same face with more of it showing.
+ * - `woke`: the lids retract all the way, the eyes are wide for a beat, and
+ *   the stage fades off the conversation it was covering. Motion carries the
+ *   lids from wherever they were, so the open is one movement out of the
+ *   sleep rather than a cut to a new picture.
+ *
+ * The lid is a rectangle wearing the eyes' own silhouette (a `clipPath` of
+ * the eye paths), so it closes each eye over its top and leaves the gap
+ * between them empty. It is painted in the avatar's own color, which is what
+ * makes a closed eye read as that creature's eyelid and not as a grey bar.
+ */
+
+import { motion, useReducedMotion } from "motion/react";
+import { useId } from "react";
+
+import { resolveVoiceRoomLook } from "@/domains/chat/voice/voice-room/voice-room-eyes";
+import type { SleepStageScene } from "@/stores/assistant-sleep-stage-store";
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { tightPathBBox, unionBBox, type BBox } from "@/utils/eye-bbox";
+
+export type { SleepStageScene };
+
+/** The eye art the stage draws, plus the color it closes the lids with. */
+export interface SleepStageEyes {
+  paths: { svgPath: string; color: string }[];
+  bbox: BBox;
+  lidColor: string;
+}
+
+/**
+ * How much of the eye the lid covers in each scene. An assistant coming back
+ * up is further open than one still under, and a woken one is not covered at
+ * all.
+ */
+const LID_REST: Record<SleepStageScene, number> = {
+  sleeping: 0.62,
+  waking: 0.5,
+  woke: 0,
+};
+/** How much further the lids sink at the bottom of a sleeping drift. */
+const LID_DRIFT = 0.12;
+/** One full drift, in seconds. */
+const LID_DRIFT_SECONDS = 4;
+
+/** The waking beats, in seconds: lids open, eyes hold, stage fades away. */
+const WOKE_OPEN_SECONDS = 0.55;
+const WOKE_HOLD_SECONDS = 1.1;
+const WOKE_FADE_SECONDS = 0.7;
+
+/**
+ * How long the `woke` scene runs before the stage is gone. The connected
+ * component keeps the stage mounted for exactly this long so the fade lands
+ * on the conversation underneath rather than being cut off by an unmount.
+ */
+export const WOKE_SEQUENCE_MS =
+  (WOKE_OPEN_SECONDS + WOKE_HOLD_SECONDS + WOKE_FADE_SECONDS) * 1000;
+
+/**
+ * The eye art for an avatar, framed by the box its ink actually occupies.
+ *
+ * The lid is placed as a share of the eye, so it has to be measured against
+ * the ink rather than against the control-point box the peeking eyes frame
+ * with (`angry` is drawn with control points nowhere near its curves, and a
+ * lid at half of that box covers the whole eye). Returns null for an avatar
+ * with no character to draw: an uploaded image, or unknown traits.
+ */
+export function resolveSleepStageEyes(
+  components: CharacterComponents,
+  traits: CharacterTraits | null,
+  imageUrl: string | null,
+): SleepStageEyes | null {
+  const look = resolveVoiceRoomLook(components, traits, imageUrl);
+  if (!look?.art) {
+    return null;
+  }
+  const bbox = unionBBox(
+    look.art.paths.map((path) => tightPathBBox(path.svgPath)),
+  );
+  if (bbox.w <= 0 || bbox.h <= 0) {
+    return null;
+  }
+  return { paths: look.art.paths, bbox, lidColor: look.bgHex };
+}
+
+export interface SleepStageViewProps {
+  scene: SleepStageScene;
+  /** Null when this assistant has no character to close its eyes. */
+  eyes: SleepStageEyes | null;
+  /** An uploaded avatar, which stands in when there are no eyes. */
+  imageUrl?: string | null;
+  /** The line under the eyes, already resolved for the scene and the name. */
+  line: string;
+  /** Screen-reader-only copy for what clicking the stage does. */
+  dismissHint: string;
+  onDismiss?: () => void;
+}
+
+export function SleepStageView({
+  scene,
+  eyes,
+  imageUrl = null,
+  line,
+  dismissHint,
+  onDismiss,
+}: SleepStageViewProps) {
+  const reduce = Boolean(useReducedMotion());
+  const woke = scene === "woke";
+
+  return (
+    <motion.button
+      type="button"
+      onClick={onDismiss}
+      data-scene={scene}
+      className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
+      initial={reduce ? false : { opacity: 0 }}
+      // Waking runs the whole exit here: the eyes hold open for a beat and
+      // then the stage itself fades, so the conversation arrives behind a
+      // face that has finished waking rather than behind a cut.
+      animate={
+        woke && !reduce ? { opacity: [1, 1, 0] } : { opacity: woke ? 0 : 1 }
+      }
+      transition={
+        woke
+          ? reduce
+            ? { duration: 0.2 }
+            : {
+                duration: WOKE_SEQUENCE_MS / 1000,
+                times: [
+                  0,
+                  (WOKE_OPEN_SECONDS + WOKE_HOLD_SECONDS) /
+                    (WOKE_SEQUENCE_MS / 1000),
+                  1,
+                ],
+                ease: "easeInOut",
+              }
+          : { duration: reduce ? 0 : 0.35 }
+      }
+    >
+      {eyes ? (
+        <StageEyes eyes={eyes} scene={scene} reduce={reduce} />
+      ) : imageUrl ? (
+        <img
+          src={imageUrl}
+          alt=""
+          aria-hidden="true"
+          className="aspect-square w-[clamp(120px,20vw,200px)] rounded-full object-cover opacity-60"
+        />
+      ) : null}
+
+      <span
+        className="block text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasised)] md:text-[36px]"
+        style={{ fontFamily: "var(--font-serif)" }}
+      >
+        {line}
+      </span>
+      {/* The button's accessible name is its text, so the status is announced
+          before what a click does. No `aria-label`: it would replace the line
+          the sighted user reads with the action alone. */}
+      <span className="sr-only">{dismissHint}</span>
+    </motion.button>
+  );
+}
+
+function StageEyes({
+  eyes,
+  scene,
+  reduce,
+}: {
+  eyes: SleepStageEyes;
+  scene: SleepStageScene;
+  reduce: boolean;
+}) {
+  const clipId = useId();
+  const { bbox } = eyes;
+  const rest = LID_REST[scene] * bbox.h;
+  const deep = (LID_REST[scene] + LID_DRIFT) * bbox.h;
+  const drifts = scene !== "woke" && !reduce;
+
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox={`${bbox.x} ${bbox.y} ${bbox.w} ${bbox.h}`}
+      className="h-auto w-[clamp(140px,26vw,240px)] shrink-0"
+    >
+      <defs>
+        <clipPath id={clipId}>
+          {eyes.paths.map((path, i) => (
+            <path key={i} d={path.svgPath} />
+          ))}
+        </clipPath>
+      </defs>
+      {eyes.paths.map((path, i) => (
+        <path key={i} d={path.svgPath} fill={path.color} />
+      ))}
+      <motion.rect
+        clipPath={`url(#${clipId})`}
+        x={bbox.x}
+        y={bbox.y}
+        width={bbox.w}
+        fill={eyes.lidColor}
+        initial={{ height: rest }}
+        animate={drifts ? { height: [rest, deep, rest] } : { height: rest }}
+        transition={
+          drifts
+            ? {
+                duration: LID_DRIFT_SECONDS,
+                repeat: Infinity,
+                ease: "easeInOut",
+              }
+            : {
+                duration: reduce ? 0 : WOKE_OPEN_SECONDS,
+                ease: "easeOut",
+              }
+        }
+      />
+    </svg>
+  );
+}

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
@@ -138,7 +138,7 @@ export function SleepStageView({
       type="button"
       onClick={onDismiss}
       data-scene={scene}
-      className="group absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
+      className="group absolute inset-0 z-30 flex cursor-pointer flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
       initial={reduce ? false : { opacity: 0 }}
       // Waking runs the whole exit here: the eyes hold open for a beat and
       // then the stage itself fades, so the conversation arrives behind a
@@ -174,13 +174,16 @@ export function SleepStageView({
         />
       ) : null}
 
-      {/* What a click does, shown only under the pointer: the stage is one
+      {/* What a click does, shown only under the pointer. The stage is one
           big button, so this is an affordance rather than a control of its
-          own (a nested button would be invalid, and would take the click). */}
+          own: a nested button would be invalid, and a click anywhere on the
+          stage (this corner included) already dismisses it. It stays
+          `pointer-events-none` so the click always lands on the stage
+          itself. */}
       {woke ? null : (
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute right-4 top-4 flex size-8 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--content-secondary)_25%,transparent)] bg-[color-mix(in_srgb,var(--surface-overlay)_70%,transparent)] text-[color:var(--content-secondary)] opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100"
+          className="pointer-events-none absolute right-4 top-4 flex size-8 scale-90 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--content-secondary)_25%,transparent)] bg-[color-mix(in_srgb,var(--surface-overlay)_70%,transparent)] text-[color:var(--content-secondary)] opacity-0 transition duration-200 group-hover:scale-100 group-hover:border-[color-mix(in_srgb,var(--content-secondary)_45%,transparent)] group-hover:text-[color:var(--content-default)] group-hover:opacity-100 group-focus-visible:scale-100 group-focus-visible:opacity-100 group-active:scale-95"
         >
           <X className="size-4" aria-hidden="true" />
         </span>

--- a/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
+++ b/clients/web/src/domains/chat/components/sleep-stage-scene.tsx
@@ -117,8 +117,8 @@ export interface SleepStageViewProps {
   imageUrl?: string | null;
   /** The line under the eyes, already resolved for the scene and the name. */
   line: string;
-  /** Screen-reader-only copy for what clicking the stage does. */
-  dismissHint: string;
+  /** The close button's accessible name. */
+  dismissLabel: string;
   onDismiss?: () => void;
 }
 
@@ -127,18 +127,16 @@ export function SleepStageView({
   eyes,
   imageUrl = null,
   line,
-  dismissHint,
+  dismissLabel,
   onDismiss,
 }: SleepStageViewProps) {
   const reduce = Boolean(useReducedMotion());
   const woke = scene === "woke";
 
   return (
-    <motion.button
-      type="button"
-      onClick={onDismiss}
+    <motion.div
       data-scene={scene}
-      className="group absolute inset-0 z-30 flex cursor-pointer flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
+      className="group absolute inset-0 z-30 flex flex-col items-center justify-center gap-10 rounded-xl bg-[var(--surface-base)] px-6"
       initial={reduce ? false : { opacity: 0 }}
       // Waking runs the whole exit here: the eyes hold open for a beat and
       // then the stage itself fades, so the conversation arrives behind a
@@ -174,32 +172,33 @@ export function SleepStageView({
         />
       ) : null}
 
-      {/* What a click does, shown only under the pointer. The stage is one
-          big button, so this is an affordance rather than a control of its
-          own: a nested button would be invalid, and a click anywhere on the
-          stage (this corner included) already dismisses it. It stays
-          `pointer-events-none` so the click always lands on the stage
-          itself. */}
+      {/* The one control on the stage: the surface itself is inert, so a
+          stray click on the page it is covering cannot dismiss it by
+          accident. Hidden until hover where there is a pointer to hover
+          with, and always on where there is not (`(hover: hover)` is false
+          on a touch screen), which is the same treatment the attachment
+          overlay's download button gets. */}
       {woke ? null : (
-        <span
-          aria-hidden="true"
-          className="pointer-events-none absolute right-4 top-4 flex size-8 scale-90 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--content-secondary)_25%,transparent)] bg-[color-mix(in_srgb,var(--surface-overlay)_70%,transparent)] text-[color:var(--content-secondary)] opacity-0 transition duration-200 group-hover:scale-100 group-hover:border-[color-mix(in_srgb,var(--content-secondary)_45%,transparent)] group-hover:text-[color:var(--content-default)] group-hover:opacity-100 group-focus-visible:scale-100 group-focus-visible:opacity-100 group-active:scale-95"
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label={dismissLabel}
+          className="absolute right-4 top-4 flex size-8 cursor-pointer items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--content-secondary)_25%,transparent)] bg-[color-mix(in_srgb,var(--surface-overlay)_70%,transparent)] text-[color:var(--content-secondary)] transition duration-200 hover:border-[color-mix(in_srgb,var(--content-secondary)_45%,transparent)] hover:text-[color:var(--content-default)] focus-visible:opacity-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)] active:scale-95 [@media(hover:hover)]:scale-90 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:scale-100 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:group-focus-within:scale-100 [@media(hover:hover)]:group-focus-within:opacity-100"
         >
           <X className="size-4" aria-hidden="true" />
-        </span>
+        </button>
       )}
 
+      {/* The banner stands down while the stage is up, so this line is what
+          announces the status: a live region rather than decoration. */}
       <span
+        role="status"
         className="block text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasised)] md:text-[36px]"
         style={{ fontFamily: "var(--font-serif)" }}
       >
         {line}
       </span>
-      {/* The button's accessible name is its text, so the status is announced
-          before what a click does. No `aria-label`: it would replace the line
-          the sighted user reads with the action alone. */}
-      <span className="sr-only">{dismissHint}</span>
-    </motion.button>
+    </motion.div>
   );
 }
 

--- a/clients/web/src/domains/chat/utils/debug-api.test.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.test.ts
@@ -9,7 +9,9 @@ import type { ReconcileActiveConversationResult } from "@/domains/chat/hooks/use
 import type {
   ChatDebugRefs,
   PendingInteractionsSnapshot,
+  VellumDebugFlagsApi,
 } from "@/domains/chat/utils/debug-api";
+import type { SleepStageScene } from "@/stores/assistant-sleep-stage-store";
 import {
   RECONCILIATION_DIAGNOSTIC_KIND_PREFIXES,
   createChatDebugApi,
@@ -901,14 +903,17 @@ type DebugWindow = Window & {
     flags?: {
       impersonateVersion?: (v?: string | null) => string | null;
       toggleAppsSandboxDisabled?: (v?: boolean) => boolean;
+      forceSleepStage?: (v?: unknown) => unknown;
     };
     other?: unknown;
   };
 };
 
-const makeFlagsApi = () => ({
+const makeFlagsApi = (): VellumDebugFlagsApi => ({
   impersonateVersion: (_value?: string | null): string | null => null,
   toggleAppsSandboxDisabled: (_value?: boolean): boolean => false,
+  forceSleepStage: (_value?: SleepStageScene | null): SleepStageScene | null =>
+    null,
 });
 
 describe("installVellumDebugApi", () => {

--- a/clients/web/src/domains/chat/utils/debug-api.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.ts
@@ -47,6 +47,7 @@ import {
 } from "@/lib/diagnostics";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import type { ReconcileActiveConversationResult } from "@/domains/chat/hooks/use-message-reconciliation";
+import { forceSleepStage } from "@/domains/chat/utils/sleep-stage-debug-flag";
 import { setImpersonatedAssistantVersion } from "@/lib/backwards-compat/impersonate-version-flag";
 import { toggleAppIframeSandboxDisabled } from "@/lib/app-sandbox-debug-flag";
 import { classifyScrollPosition } from "@/domains/chat/transcript/transcript-scroll-utils";
@@ -65,6 +66,7 @@ import {
   shouldShowThinkingIndicator,
 } from "@/domains/chat/turn-selectors";
 import { useConversationStore } from "@/stores/conversation-store";
+import type { SleepStageScene } from "@/stores/assistant-sleep-stage-store";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -618,13 +620,11 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
     if (conditions.hasUncompletedVisibleSurface) {
       failingConditions.push("hasUncompletedVisibleSurface");
     }
-    if (
-      !(
-        conditions.isThinking ||
-        conditions.restoredProcessing ||
-        !conditions.hasStreamingAssistantMessage
-      )
-    ) {
+    if (!(
+      conditions.isThinking ||
+      conditions.restoredProcessing ||
+      !conditions.hasStreamingAssistantMessage
+    )) {
       failingConditions.push("streamingAssistantMessageActive");
     }
     if (conditions.hasStreamingAssistantThinking) {
@@ -899,6 +899,17 @@ export interface VellumDebugFlagsApi {
    *
    *  Returns the value in effect after the call. */
   impersonateVersion(value?: string | null): string | null;
+  /** Pin the conversation page's sleep stage to one scene so the
+   *  sleeping / waking / woke animation can be watched without an
+   *  assistant that will actually sleep. In memory only; a reload
+   *  clears it.
+   *
+   *  - `forceSleepStage("sleeping" | "waking" | "woke")` - pin it.
+   *  - `forceSleepStage(null)` - clear, back to the real status.
+   *  - `forceSleepStage()` - log + return the current value.
+   *
+   *  Returns the value in effect after the call. */
+  forceSleepStage(value?: SleepStageScene | null): SleepStageScene | null;
   /** Render app iframes without their `sandbox` attribute, giving the
    *  app document the host's origin so origin-gated APIs
    *  (`getDisplayMedia()`, …) work. Costs the isolation the sandbox
@@ -1032,6 +1043,7 @@ export function useChatDebugApi(refs: ChatDebugRefs): void {
     const api = createChatDebugApi(stableRefs);
     const flagsApi: VellumDebugFlagsApi = {
       impersonateVersion: setImpersonatedAssistantVersion,
+      forceSleepStage,
       toggleAppsSandboxDisabled: toggleAppIframeSandboxDisabled,
     };
     const uninstall = installVellumDebugApi(api, flagsApi);

--- a/clients/web/src/domains/chat/utils/sleep-stage-debug-flag.ts
+++ b/clients/web/src/domains/chat/utils/sleep-stage-debug-flag.ts
@@ -1,0 +1,52 @@
+/**
+ * Dev flag: pin the conversation page's sleep stage to one scene.
+ *
+ * The stage only plays for an assistant that is actually asleep and only on
+ * an arrival, which is the right behavior and an awkward thing to sit and
+ * wait for while working on the animation. This forces it, in place, with no
+ * reload: the override lives in the same store the stage reads, so flipping it
+ * is a render.
+ *
+ * Surface (exposed under `window._vellumDebug.flags`):
+ *
+ *   forceSleepStage("sleeping")  - lids down, drifting
+ *   forceSleepStage("waking")    - lids further open
+ *   forceSleepStage("woke")      - eyes open, then the stage fades out
+ *   forceSleepStage(null)        - clear, back to the real status
+ *   forceSleepStage()            - log + return the current value
+ *
+ * Held in memory only: a reload hands the page back, so a forgotten override
+ * cannot follow anyone into a real session.
+ */
+
+import {
+  useAssistantSleepStageStore,
+  type SleepStageScene,
+} from "@/stores/assistant-sleep-stage-store";
+
+const SCENES: readonly SleepStageScene[] = ["sleeping", "waking", "woke"];
+
+function isScene(value: unknown): value is SleepStageScene {
+  return SCENES.includes(value as SleepStageScene);
+}
+
+export function forceSleepStage(
+  value?: SleepStageScene | null,
+): SleepStageScene | null {
+  const store = useAssistantSleepStageStore.getState();
+
+  if (value === undefined) {
+    console.info("[vellum] forceSleepStage:", store.forcedScene);
+    return store.forcedScene;
+  }
+
+  if (value !== null && !isScene(value)) {
+    console.warn(
+      `[vellum] forceSleepStage: expected one of ${SCENES.join(", ")} or null`,
+    );
+    return store.forcedScene;
+  }
+
+  store.setForcedScene(value);
+  return value;
+}

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -97,6 +97,13 @@
     "search": "Search",
     "searchShortcut": "Search ({shortcut})"
   },
+  "assistantSleepStage": {
+    "dismissLabel": "Hide the sleep screen",
+    "sleeping": "Your assistant is asleep",
+    "sleepingNamed": "{name} is asleep",
+    "waking": "Your assistant is waking up…",
+    "wakingNamed": "{name} is waking up…"
+  },
   "assistantSwitcher": {
     "collapse": "Hide assistants",
     "currentAssistant": "{name}, current assistant",

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -102,7 +102,9 @@
     "sleeping": "Your assistant is asleep",
     "sleepingNamed": "{name} is asleep",
     "waking": "Your assistant is waking up…",
-    "wakingNamed": "{name} is waking up…"
+    "wakingNamed": "{name} is waking up…",
+    "woke": "Your assistant just woke up",
+    "wokeNamed": "{name} just woke up"
   },
   "assistantSwitcher": {
     "collapse": "Hide assistants",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -102,7 +102,9 @@
     "sleeping": "Tu asistente está durmiendo",
     "sleepingNamed": "{name} está durmiendo",
     "waking": "Tu asistente se está despertando…",
-    "wakingNamed": "{name} se está despertando…"
+    "wakingNamed": "{name} se está despertando…",
+    "woke": "Tu asistente acaba de despertarse",
+    "wokeNamed": "{name} acaba de despertarse"
   },
   "assistantSwitcher": {
     "collapse": "Ocultar asistentes",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -97,6 +97,13 @@
     "search": "Buscar",
     "searchShortcut": "Buscar ({shortcut})"
   },
+  "assistantSleepStage": {
+    "dismissLabel": "Ocultar la pantalla de reposo",
+    "sleeping": "Tu asistente está durmiendo",
+    "sleepingNamed": "{name} está durmiendo",
+    "waking": "Tu asistente se está despertando…",
+    "wakingNamed": "{name} se está despertando…"
+  },
   "assistantSwitcher": {
     "collapse": "Ocultar asistentes",
     "currentAssistant": "{name}, asistente actual",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -42,7 +42,9 @@
     "sleeping": "Ваш ассистент спит",
     "sleepingNamed": "{name} спит",
     "waking": "Ваш ассистент просыпается…",
-    "wakingNamed": "{name} просыпается…"
+    "wakingNamed": "{name} просыпается…",
+    "woke": "Ваш ассистент только что проснулся",
+    "wokeNamed": "{name} только что проснулся"
   },
   "assistantSwitcher": {
     "collapse": "Скрыть ассистентов",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -37,6 +37,13 @@
   "assistantSideMenu": {
     "bulkActionMembersFailed": "Не удалось загрузить все диалоги в этом разделе. Повторите попытку."
   },
+  "assistantSleepStage": {
+    "dismissLabel": "Скрыть экран сна",
+    "sleeping": "Ваш ассистент спит",
+    "sleepingNamed": "{name} спит",
+    "waking": "Ваш ассистент просыпается…",
+    "wakingNamed": "{name} просыпается…"
+  },
   "assistantSwitcher": {
     "collapse": "Скрыть ассистентов",
     "currentAssistant": "{name}, текущий ассистент",

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -96,6 +96,13 @@
     "navAria": "助理導覽",
     "searchShortcut": "搜尋 ({shortcut})"
   },
+  "assistantSleepStage": {
+    "dismissLabel": "隱藏休眠畫面",
+    "sleeping": "您的助理正在休眠",
+    "sleepingNamed": "{name} 正在休眠",
+    "waking": "您的助理正在喚醒…",
+    "wakingNamed": "{name} 正在喚醒…"
+  },
   "assistantSwitcher": {
     "collapse": "隱藏助理",
     "currentAssistant": "{name}，目前助理",

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -101,7 +101,9 @@
     "sleeping": "您的助理正在休眠",
     "sleepingNamed": "{name} 正在休眠",
     "waking": "您的助理正在喚醒…",
-    "wakingNamed": "{name} 正在喚醒…"
+    "wakingNamed": "{name} 正在喚醒…",
+    "woke": "您的助理剛剛醒來",
+    "wokeNamed": "{name} 剛剛醒來"
   },
   "assistantSwitcher": {
     "collapse": "隱藏助理",

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -96,6 +96,13 @@
     "navAria": "助手导航",
     "searchShortcut": "搜索 ({shortcut})"
   },
+  "assistantSleepStage": {
+    "dismissLabel": "隐藏休眠画面",
+    "sleeping": "您的助手正在休眠",
+    "sleepingNamed": "{name} 正在休眠",
+    "waking": "您的助手正在唤醒…",
+    "wakingNamed": "{name} 正在唤醒…"
+  },
   "assistantSwitcher": {
     "collapse": "隐藏助手",
     "currentAssistant": "{name}，当前助手",

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -101,7 +101,9 @@
     "sleeping": "您的助手正在休眠",
     "sleepingNamed": "{name} 正在休眠",
     "waking": "您的助手正在唤醒…",
-    "wakingNamed": "{name} 正在唤醒…"
+    "wakingNamed": "{name} 正在唤醒…",
+    "woke": "您的助手刚刚醒来",
+    "wokeNamed": "{name} 刚刚醒来"
   },
   "assistantSwitcher": {
     "collapse": "隐藏助手",

--- a/clients/web/src/stores/assistant-sleep-stage-store.ts
+++ b/clients/web/src/stores/assistant-sleep-stage-store.ts
@@ -1,0 +1,45 @@
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+
+/**
+ * Zustand store shared by the full-page sleep stage (`AssistantSleepStage`,
+ * mounted over the conversation page) and the `StatusBanner`.
+ *
+ * Two facts live here because the two surfaces that need them sit in
+ * different subtrees:
+ *
+ * - `visible`: the stage tells the banner it is on screen, so the banner
+ *   drops its sleeping/waking notice rather than saying the same thing twice.
+ * - `dismissed`: clicking the stage away hands the status back to the
+ *   banner. In-memory and session-scoped like the low-balance banner's
+ *   dismissal; the stage resets it as soon as the assistant is neither
+ *   sleeping nor waking, so the next sleep shows the stage again.
+ *
+ * Reference: {@link https://zustand.docs.pmnd.rs/}
+ */
+interface AssistantSleepStageState {
+  visible: boolean;
+  dismissed: boolean;
+}
+
+interface AssistantSleepStageActions {
+  setVisible: (visible: boolean) => void;
+  dismiss: () => void;
+  reset: () => void;
+}
+
+const useAssistantSleepStageStoreBase = create<
+  AssistantSleepStageState & AssistantSleepStageActions
+>()((set) => ({
+  visible: false,
+  dismissed: false,
+
+  setVisible: (visible) => set({ visible }),
+  dismiss: () => set({ dismissed: true, visible: false }),
+  reset: () => set({ dismissed: false }),
+}));
+
+export const useAssistantSleepStageStore = createSelectors(
+  useAssistantSleepStageStoreBase,
+);

--- a/clients/web/src/stores/assistant-sleep-stage-store.ts
+++ b/clients/web/src/stores/assistant-sleep-stage-store.ts
@@ -20,18 +20,31 @@ import { createSelectors } from "@/utils/create-selectors";
  *   session-scoped like the low-balance banner's; the stage resets it as soon
  *   as the assistant is neither sleeping nor waking.
  *
+ * - `forcedScene`: a dev override (`_vellumDebug.flags.forceSleepStage(...)`)
+ *   that pins the stage to one scene so the animation can be watched without
+ *   an assistant that will actually go to sleep. Null in every normal session.
+ *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
+
+/**
+ * Where the stage is in the sleep it is drawing. Declared here rather than
+ * beside the view because the store carries the dev override, and
+ * `src/stores/` may not import from a domain.
+ */
+export type SleepStageScene = "sleeping" | "waking" | "woke";
 interface AssistantSleepStageState {
   visible: boolean;
   dismissed: boolean;
   dismissedAssistantId: string | null;
+  forcedScene: SleepStageScene | null;
 }
 
 interface AssistantSleepStageActions {
   setVisible: (visible: boolean) => void;
   dismiss: (assistantId: string | null) => void;
   reset: () => void;
+  setForcedScene: (scene: SleepStageScene | null) => void;
 }
 
 const useAssistantSleepStageStoreBase = create<
@@ -40,11 +53,13 @@ const useAssistantSleepStageStoreBase = create<
   visible: false,
   dismissed: false,
   dismissedAssistantId: null,
+  forcedScene: null,
 
   setVisible: (visible) => set({ visible }),
   dismiss: (assistantId) =>
     set({ dismissed: true, dismissedAssistantId: assistantId, visible: false }),
   reset: () => set({ dismissed: false, dismissedAssistantId: null }),
+  setForcedScene: (forcedScene) => set({ forcedScene }),
 }));
 
 export const useAssistantSleepStageStore = createSelectors(

--- a/clients/web/src/stores/assistant-sleep-stage-store.ts
+++ b/clients/web/src/stores/assistant-sleep-stage-store.ts
@@ -11,21 +11,26 @@ import { createSelectors } from "@/utils/create-selectors";
  *
  * - `visible`: the stage tells the banner it is on screen, so the banner
  *   drops its sleeping/waking notice rather than saying the same thing twice.
- * - `dismissed`: clicking the stage away hands the status back to the
- *   banner. In-memory and session-scoped like the low-balance banner's
- *   dismissal; the stage resets it as soon as the assistant is neither
- *   sleeping nor waking, so the next sleep shows the stage again.
+ * - `dismissed` / `dismissedAssistantId`: clicking the stage away hands the
+ *   status back to the banner, for that assistant's current sleep only. The
+ *   dismissal carries the assistant it was aimed at, so switching to another
+ *   sleeping assistant draws its stage while a remount of the same one (a
+ *   window crossing the mobile breakpoint moves the stage between
+ *   `ChatLayout`'s branches) keeps the dismissal. In-memory and
+ *   session-scoped like the low-balance banner's; the stage resets it as soon
+ *   as the assistant is neither sleeping nor waking.
  *
  * Reference: {@link https://zustand.docs.pmnd.rs/}
  */
 interface AssistantSleepStageState {
   visible: boolean;
   dismissed: boolean;
+  dismissedAssistantId: string | null;
 }
 
 interface AssistantSleepStageActions {
   setVisible: (visible: boolean) => void;
-  dismiss: () => void;
+  dismiss: (assistantId: string | null) => void;
   reset: () => void;
 }
 
@@ -34,10 +39,12 @@ const useAssistantSleepStageStoreBase = create<
 >()((set) => ({
   visible: false,
   dismissed: false,
+  dismissedAssistantId: null,
 
   setVisible: (visible) => set({ visible }),
-  dismiss: () => set({ dismissed: true, visible: false }),
-  reset: () => set({ dismissed: false }),
+  dismiss: (assistantId) =>
+    set({ dismissed: true, dismissedAssistantId: assistantId, visible: false }),
+  reset: () => set({ dismissed: false, dismissedAssistantId: null }),
 }));
 
 export const useAssistantSleepStageStore = createSelectors(


### PR DESCRIPTION
## Summary

- New `AssistantSleepStage`: while the assistant is sleeping or waking, the conversation page draws the assistant's own eye art (from the avatar builder's eye style, lids in its color) half shut, over the serif line `<name> is waking up…`. It is an `absolute inset-0` layer inside the conversation's `<main>`, the same placement the desktop voice room takes, so the sidenav and header stay visible and usable.
- The status banner stands down while the stage is up (shared `assistant-sleep-stage-store`), so the status is stated once. Clicking the stage dismisses it and the banner comes back; the dismissal lasts only as long as that sleep.
- Only the conversation route gets the stage. A failed local wake keeps the banner, since that error has an action attached. An uploaded-image avatar shows its image dimmed instead of eyes.
- The lid is measured against `tightPathBBox`, not the control-point box the peeking eyes frame with: `angry` is drawn with control points nowhere near its curves, and a lid at half of that box covers the whole eye. Verified against all nine eye styles.

## Original prompt

Redesign the waking-up banner: while the assistant is sleeping or waking up, show a fullish-page view of the assistant with its eyes half closed, built from the user's own avatar traits (the avatar builder's eye style), captioned `<name> is waking up…`, matching the supplied mock. It should hide the existing waking status banner while it is up, and clicking it should dismiss the full-page view and bring the status banner back. It should only appear on the main conversation page, and "full page" means fullish: the sidebar stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hi41ceUgUPYVdM1wMszS2L
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->