### PR TITLE
chore(skills): remove unenforced rubrics and dead trigger lists; fix dead commands, tool names, and model pins

### DIFF
--- a/assistant/src/config/bundled-skills/media-processing/SKILL.md
+++ b/assistant/src/config/bundled-skills/media-processing/SKILL.md
@@ -25,7 +25,7 @@ The processing pipeline follows a sequential 3-phase flow:
 
 1. **Ingest** (`ingest_media`) - Register a media file, detect MIME type, extract duration, deduplicate by content hash.
 2. **Preprocess** (`extract_keyframes`) - Detect dead time, segment the video into windows, extract downscaled keyframes, build a subject registry, and write a pipeline manifest.
-3. **Map** (`analyze_keyframes`) - Send each segment's frames to Gemini 2.5 Flash with assistant-provided extraction instructions and a JSON Schema for guaranteed structured output. Supports concurrency pooling, cost tracking, resumability, and automatic retries.
+3. **Map** (`analyze_keyframes`) - Send each segment's frames to the configured Gemini vision model with assistant-provided extraction instructions and a JSON Schema for guaranteed structured output. Supports concurrency pooling, cost tracking, resumability, and automatic retries.
 4. **Reduce / Query** (`query_media`) - Send all map output to Claude for intelligent analysis and Q&A. Supports arbitrary natural language queries about video content.
 5. **Clip** (`generate_clip`) - Extract video clips around specific moments.
 
@@ -85,7 +85,7 @@ Parameters:
 - `asset_id` (required) - ID of the media asset.
 - `query` (required) - Natural language query about the video data.
 - `system_prompt` - Optional system prompt for Claude.
-- `model` - LLM model to use (default: `claude-sonnet-4-6`).
+- `model` - LLM model to use. Defaults to the assistant's active chat model.
 
 ### generate_clip
 
@@ -110,7 +110,7 @@ Handles dead-time detection, video segmentation, keyframe extraction, and subjec
 
 ### Gemini Map (services/gemini-map.ts)
 
-Sends video segments to Gemini 2.5 Flash with structured output schemas. Handles concurrency pooling, cost tracking, resumability, and retries.
+Sends video segments to the configured Gemini vision model with structured output schemas. Handles concurrency pooling, cost tracking, resumability, and retries.
 
 ### Reduce (services/reduce.ts)
 

--- a/assistant/src/config/bundled-skills/media-processing/TOOLS.json
+++ b/assistant/src/config/bundled-skills/media-processing/TOOLS.json
@@ -170,7 +170,7 @@
           },
           "model": {
             "type": "string",
-            "description": "LLM model to use for analysis. Default: 'claude-sonnet-4-6'"
+            "description": "LLM model to use for analysis. Defaults to the assistant's active chat model."
           }
         },
         "required": ["asset_id", "query"]

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -247,4 +247,4 @@ Choose the right delivery tool based on the content:
 
 Example schedule message for a Slack digest:
 
-> "Scan my Slack channels for the last 24 hours using the Slack Web API via bash (network_mode: proxied, credential_ids: ['slack_channel/bot_token']), then post the summary to #alex-agent-messages (C0A7STRJ4G5)."
+> "Scan my Slack channels for the last 24 hours using the Slack Web API via bash (network_mode: proxied, credential_ids: ['slack_channel/bot_token']), then post the summary to the channel the user named."

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -31,7 +31,7 @@
     },
     "media-processing": {
       "docsSlug": "media-processing",
-      "sha256": "2355e860b9ae5c06036ca2ef206679647a9c73ff38af50a23268503959f189cd"
+      "sha256": "aa38b7020be5ef92cd4f065b9d30a135947cd800bb09884b3fdc3323a49c8ac8"
     },
     "messaging": {
       "docsSlug": "messaging",
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "491b39a13f1de05db6ca25df5d9b3bcd498ad1390b2487d48ded76b736e4cbb2"
+      "sha256": "8a762849311b4c35c8448a399afa062fa29ba4972a1803ee114e4fabdc7da7e2"
     },
     "skill-management": {
       "docsSlug": "skill-management",

--- a/skills/api-mapping/SKILL.md
+++ b/skills/api-mapping/SKILL.md
@@ -64,20 +64,3 @@ map <domain> --manual --json               # Manual mode: user drives the browse
 map <domain> --duration <secs> --json      # Auto mode with custom duration
 map <domain> --manual --duration <secs> --json  # Manual mode with custom timeout
 ```
-
-## Example Interaction
-
-**User**: "Map the Notion API"
-
-1. Ask: "What are you trying to build with Notion? And should I browse automatically, or do you want to drive the browser?"
-2. User says: "I want to build a CLI to manage my pages. I'll drive."
-3. `map notion.com --manual --json` -> Chrome window opens
-4. Tell user: "A Chrome window is open. Log into Notion and do a representative workflow - create a page, edit it, maybe move it. I'll record all API calls in the background. Close the browser when you're done."
-5. User closes browser -> CLI outputs discovered endpoints
-6. Present findings: "I found 14 API endpoints. Here are the key ones for page management:
-   - `POST /api/v3/getSpaces` - lists workspaces
-   - `POST /api/v3/syncRecordValues` - fetches page content
-   - `POST /api/v3/submitTransaction` - creates/updates pages
-   - `POST /api/v3/enqueueTask` - async operations (export, duplicate)
-     Authentication: Cookie-based session with `token_v2`."
-7. Offer: "Want me to create a CLI tool that wraps these endpoints for managing Notion pages?"

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -323,7 +323,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T23:53:58.000Z"
+      "updatedAt": "2026-09-03T15:55:37.000Z"
     },
     {
       "id": "gmail-trigger",
@@ -370,7 +370,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T23:53:58.000Z"
+      "updatedAt": "2026-09-03T15:55:37.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -736,7 +736,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T23:53:58.000Z"
+      "updatedAt": "2026-09-03T15:55:37.000Z"
     },
     {
       "id": "plugin-builder",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -33,7 +33,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "assistant-migration",
@@ -265,7 +265,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-05T17:22:35.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "geo-audit",
@@ -289,7 +289,7 @@
           ]
         }
       },
-      "updatedAt": "2026-06-10T20:12:38.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "geo-writing",
@@ -323,7 +323,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T21:17:09.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "gmail-trigger",
@@ -370,7 +370,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T21:17:09.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "guardian-verify-setup",
@@ -715,7 +715,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T21:17:09.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "outlook-calendar",
@@ -736,7 +736,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-28T21:17:09.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "plugin-builder",
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T13:18:50.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "public-ingress",
@@ -835,7 +835,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-25T23:32:13.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "self-upgrade",
@@ -880,7 +880,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T20:00:00.000Z"
+      "updatedAt": "2026-09-03T14:57:33.000Z"
     },
     {
       "id": "slack-app-setup",
@@ -906,7 +906,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-27T20:51:21.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "start-the-day",
@@ -1016,7 +1016,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-09-02T23:53:58.000Z"
     },
     {
       "id": "vellum-avatar",
@@ -1179,7 +1179,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T02:34:18.000Z"
+      "updatedAt": "2026-09-03T15:44:53.000Z"
     },
     {
       "id": "vellum-self-knowledge",
@@ -1205,7 +1205,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T23:30:04.000Z"
+      "updatedAt": "2026-09-03T13:49:08.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -466,7 +466,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-01T13:32:34.000Z"
+      "updatedAt": "2026-09-03T17:28:30.000Z"
     },
     {
       "id": "influencer",
@@ -483,7 +483,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-03T03:10:07.000Z"
+      "updatedAt": "2026-09-03T17:28:30.000Z"
     },
     {
       "id": "linear-app-setup",
@@ -1142,7 +1142,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-18T17:59:07.000Z"
+      "updatedAt": "2026-09-03T17:28:30.000Z"
     },
     {
       "id": "vellum-memory-v3-migration",
@@ -1205,7 +1205,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T13:49:08.000Z"
+      "updatedAt": "2026-09-03T17:28:30.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/frontend-design/SKILL.md
+++ b/skills/frontend-design/SKILL.md
@@ -54,5 +54,3 @@ NEVER use generic AI-generated aesthetics like overused font families (Inter, Ro
 Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
 
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
-
-Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/skills/geo-audit/SKILL.md
+++ b/skills/geo-audit/SKILL.md
@@ -25,16 +25,9 @@ This is the operator-side companion to writing content. It tells you whether you
 
 ---
 
-## TRIGGER
+## RUNNING AN AUDIT
 
-Fire this skill **immediately** — no clarifying questions, no preamble — when the user says any of the following (or close variants):
-
-- "Do a GEO audit check on my domain: <url>"
-- "Run a GEO audit on <url>"
-- "GEO audit <url>"
-- "Audit <url> for GEO"
-
-Extract the domain from the message and run the script. Stream the terminal output back as it happens. When the HTML report opens, mention that it just popped up in their browser and summarize the score in one sentence.
+Extract the domain from the user's message and run the script without asking clarifying questions first. Stream the terminal output back as it happens. When the HTML report opens, mention that it just popped up in their browser and summarize the score in one sentence.
 
 ## WHEN TO USE THIS SKILL
 

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -467,12 +467,3 @@ Before composing any email that references a date or time:
 1. Check the `current_time:` field in the `<turn_context>` block for today's date and timezone
 2. Verify that "tomorrow" means the day after today's date, "next week" means the upcoming Monday–Friday, etc.
 3. If the email references a date from another message, cross-check it against the turn context to ensure it's in the future
-
-## Confidence Scores
-
-Medium and high risk operations require a confidence score between 0 and 1:
-
-- **0.9-1.0**: User explicitly requested this exact action
-- **0.7-0.8**: Action is strongly implied by context
-- **0.5-0.6**: Reasonable inference but some ambiguity
-- **Below 0.5**: Ask the user to confirm before proceeding

--- a/skills/gmail/scripts/gmail-prefs.ts
+++ b/skills/gmail/scripts/gmail-prefs.ts
@@ -255,7 +255,9 @@ function main(): void {
           );
         }
         updates["interrupt-threshold"] = threshold as
-          "default" | "high" | "low";
+          | "default"
+          | "high"
+          | "low";
       }
       if (args["last-run"] != null) {
         updates["last-run"] = args["last-run"] as string;

--- a/skills/gmail/scripts/lib/op-log.ts
+++ b/skills/gmail/scripts/lib/op-log.ts
@@ -31,10 +31,18 @@ const RETENTION_DAYS = 30;
 // ---------------------------------------------------------------------------
 
 export type OpStatus =
-  "staged" | "committed" | "failed" | "interrupted" | "completed";
+  | "staged"
+  | "committed"
+  | "failed"
+  | "interrupted"
+  | "completed";
 
 export type OpType =
-  "archive" | "label_add" | "label_remove" | "filter_create" | "trash";
+  | "archive"
+  | "label_add"
+  | "label_remove"
+  | "filter_create"
+  | "trash";
 
 export interface OpEntry {
   ts: string;

--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -83,13 +83,6 @@ Create and RSVP are **medium-risk** operations:
 - **Create**: The `create` subcommand gates on `assistant ui confirm` — it presents a confirmation dialog to the user and only proceeds if approved. Pass `--skip-confirm` when the user has already given explicit confirmation in the conversation.
 - **RSVP**: The `rsvp` subcommand gates on `assistant ui confirm` — it presents a confirmation dialog showing the event, current status, and new response. Pass `--skip-confirm` when the user has already given explicit confirmation in the conversation.
 
-Confidence scores for medium-risk operations:
-
-- **0.9-1.0**: User explicitly requested this exact action
-- **0.7-0.8**: Action is strongly implied by context
-- **0.5-0.6**: Reasonable inference but some ambiguity
-- **Below 0.5**: Ask the user to confirm before proceeding
-
 ## Error Recovery
 
 When a calendar script fails with a token or authorization error:

--- a/skills/google-calendar/scripts/gcal.ts
+++ b/skills/google-calendar/scripts/gcal.ts
@@ -262,7 +262,9 @@ async function rsvp(argv: string[]): Promise<void> {
   const args = parseArgs(argv);
   const eventId = requireArg(args, "event-id");
   const responseStatus = requireArg(args, "response") as
-    "accepted" | "declined" | "tentative";
+    | "accepted"
+    | "declined"
+    | "tentative";
   const calendarId = optionalArg(args, "calendar-id") ?? "primary";
   const account = optionalArg(args, "account");
   const skipConfirm = args["skip-confirm"] === true;

--- a/skills/inbox-management/SKILL.md
+++ b/skills/inbox-management/SKILL.md
@@ -174,10 +174,28 @@ subject:("newsletter" OR "weekly digest" OR "monthly digest") in:inbox
 
 ### Step 2: Cold outreach judgment (Stage 2: archive / Stage 0-1: flag)
 
-Use `gmail-scan.ts --action outreach-scan` only for digest inbox senders. For each result, judge: is this person/offer potentially relevant to the user?
+Scope the scan to the poll window, then intersect it with the digest:
+
+```bash
+bun run scripts/gmail-scan.ts outreach-scan --time-range 1d
+```
+
+`--time-range` feeds Gmail's `newer_than:`, whose granularity is days, so `1d` is the smallest window that covers the default `0 */3 * * 1-5` cadence. On a first sync, use the schedule's `--lookback` value rounded up to whole days. Append one `--account user@example.com` flag per mailbox when the schedule watches specific inboxes.
+
+Then drop every result that is not in the digest: keep only senders that appear among the digest's inbox messages, and ignore the rest. The scan has no digest filter and its cache spans the whole window, so its results reach back past the mail this run is allowed to judge.
+
+For each surviving sender, judge: is this person/offer potentially relevant to the user?
 
 - **Relevant** → leave in inbox, include in summary
 - **Not relevant** → archive (Stage 2) / flag as "would archive" (Stage 0-1)
+
+Archive only the digest ids for that sender, as one comma-separated list:
+
+```bash
+bun run scripts/gmail-archive.ts --message-ids <id1>,<id2>,<id3>
+```
+
+Never archive through the `--cache-key` + `--sender-emails` path here. That path replays the scan's cache and pulls the sender's older messages, which are outside the digest.
 
 ### Step 3: Urgent scan (all stages)
 
@@ -205,8 +223,8 @@ From digest inbox messages, filter out anything caught by Steps 1-2, calendar re
 
 For each remaining email from real humans expecting a response:
 
-1. Check for existing draft in the thread: call `list_drafts`, filter results by thread ID. If draft exists, skip.
-2. Read full thread context via `get_thread`.
+1. Check whether the thread already has a draft (the Gmail thread view shows it). If it does, skip.
+2. Read the full thread before drafting so the reply answers what was actually asked.
 3. Decide: does this need a reply? If no, skip.
 4. Create draft in-thread via `gmail-email.ts draft --thread-id "..." --in-reply-to "..."`. Draft must be fully written in the user's voice (use Personal Knowledge Base style profile), substantive, no placeholders. **Never auto-send.**
 

--- a/skills/influencer/README.md
+++ b/skills/influencer/README.md
@@ -2,11 +2,6 @@
 
 This skill uses `assistant browser` CLI commands (via `host_bash`) for navigation/extraction and `host_bash` helper scripts for deterministic parsing and ranking.
 
-## Transport policy
-
-- Allowed browser transport: `assistant browser` CLI commands only.
-- Forbidden transport: relay-backed subprocess clients.
-
 ## Helper script contract
 
 All helper scripts support:

--- a/skills/influencer/SKILL.md
+++ b/skills/influencer/SKILL.md
@@ -16,11 +16,6 @@ Use browser automation for collection and `host_bash` helper scripts for determi
 
 - `host_bash` for `assistant browser` CLI commands and helper scripts in `scripts/`.
 
-## Hard constraints
-
-- Do not call `assistant browser chrome relay`.
-- Do not use legacy relay-backed influencer scripts.
-
 ## Step graph (state machine)
 
 ### Step 1: Route intent

--- a/skills/outlook-calendar/SKILL.md
+++ b/skills/outlook-calendar/SKILL.md
@@ -87,13 +87,6 @@ Create and RSVP are **medium-risk** operations:
 - **Create**: The `create` subcommand gates on `assistant ui confirm` — it presents a confirmation dialog to the user and only proceeds if approved. Pass `--skip-confirm` when the user has already given explicit confirmation in the conversation.
 - **RSVP**: The `rsvp` subcommand gates on `assistant ui confirm` — it presents a confirmation dialog showing the event, current status, and new response. Pass `--skip-confirm` when the user has already given explicit confirmation in the conversation.
 
-Confidence scores for medium-risk operations:
-
-- **0.9-1.0**: User explicitly requested this exact action
-- **0.7-0.8**: Action is strongly implied by context
-- **0.5-0.6**: Reasonable inference but some ambiguity
-- **Below 0.5**: Ask the user to confirm before proceeding
-
 ## Error Recovery
 
 When a calendar script fails with a token or authorization error:

--- a/skills/outlook-calendar/scripts/lib/outlook-cal-client.ts
+++ b/skills/outlook-calendar/scripts/lib/outlook-cal-client.ts
@@ -243,7 +243,12 @@ export interface OutlookCalendarEvent {
   isAllDay?: boolean;
   isCancelled?: boolean;
   showAs?:
-    "free" | "tentative" | "busy" | "oof" | "workingElsewhere" | "unknown";
+    | "free"
+    | "tentative"
+    | "busy"
+    | "oof"
+    | "workingElsewhere"
+    | "unknown";
   importance?: "low" | "normal" | "high";
   sensitivity?: "normal" | "personal" | "private" | "confidential";
   webLink?: string;
@@ -267,7 +272,12 @@ export interface OutlookCalendarEventListResponse {
 /** A single schedule item (free/busy block). */
 export interface OutlookScheduleItem {
   status:
-    "free" | "tentative" | "busy" | "oof" | "workingElsewhere" | "unknown";
+    | "free"
+    | "tentative"
+    | "busy"
+    | "oof"
+    | "workingElsewhere"
+    | "unknown";
   start: OutlookDateTimeZone;
   end: OutlookDateTimeZone;
   subject?: string;

--- a/skills/outlook/SKILL.md
+++ b/skills/outlook/SKILL.md
@@ -222,12 +222,3 @@ When a user asks to declutter, clean up, or organize their email - start scannin
 1. Run `bun run scripts/outlook-scan.ts outreach-scan` to find senders without unsubscribe headers
 2. Present results for review - these are likely cold outreach or unsolicited emails
 3. User can choose to archive, create rules to block, or ignore
-
-## Confidence Scores
-
-Medium and high risk operations require a confidence score between 0 and 1:
-
-- **0.9-1.0**: User explicitly requested this exact action
-- **0.7-0.8**: Action is strongly implied by context
-- **0.5-0.6**: Reasonable inference but some ambiguity
-- **Below 0.5**: Ask the user to confirm before proceeding

--- a/skills/plugin-builder/SKILL.md
+++ b/skills/plugin-builder/SKILL.md
@@ -58,10 +58,6 @@ The two extensibility patterns serve different goals. **Plugins are for distribu
 
 Several surfaces that plugins contribute run in the same process as the main Assistant process. They can import all internal methods from the Assistant from the single public package, [`@vellumai/plugin-api`](https://github.com/vellum-ai/vellum-assistant/tree/main/assistant/src/plugin-api), which is the only supported contract. Anything not exported from there is internal and can change without notice. See `references/plugins.md` for the full export surface.
 
-## Coming from another harness?
-
-Vellum's plugin model was designed to line up with the agent harnesses you may already use. The shared vocabulary is deliberate to be as portable as possible with the other entrants in the industry.
-
 ## Before you write a single file
 
 Ask before building. Six questions, in this order. Stop if the user is unclear on any of them.

--- a/skills/screen-recording/SKILL.md
+++ b/skills/screen-recording/SKILL.md
@@ -15,43 +15,8 @@ Capture screen recordings as video files attached to the conversation.
 
 ## Activation
 
-This skill activates when the user asks to record their screen. Common phrases:
-
-**Start recording:**
-
-- "record my screen"
-- "start recording"
-- "begin recording"
-- "capture my screen"
-- "capture my display"
-- "make a recording"
-- "Nova, record my screen" (where Nova is the assistant's identity name)
-- "hey Nova, start recording"
-
-**Stop recording:**
-
-- "stop recording"
-- "end recording"
-- "finish recording"
-- "halt recording"
-
-**Restart recording:**
-
-- "restart recording"
-- "redo the recording"
-- "stop recording and start a new one"
-- "stop recording and start a new recording"
-- "stop and restart the recording"
-
-**Pause recording:**
-
-- "pause recording"
-- "pause the recording"
-
-**Resume recording:**
-
-- "resume recording"
-- "unpause the recording"
+The user asks to start, stop, pause, resume, or restart a screen recording.
+Routing does not depend on matching phrases: see Routing below.
 
 ## Routing
 

--- a/skills/slack-app-setup/SKILL.md
+++ b/skills/slack-app-setup/SKILL.md
@@ -17,15 +17,9 @@ metadata:
       - "create a Slack bot"
 ---
 
-## When to Use
+## Scope
 
-USE THIS SKILL WHEN:
-
-- The user says "set up Slack", "connect Slack", "add a Slack workspace", "get you on Slack", or any variant that means _connect this assistant to Slack_.
-- A freshly-provisioned assistant needs a Slack bot identity (tokens, scopes, events) configured for the first time.
-- The user wants to switch the assistant to a new Slack workspace or rotate its tokens.
-
-DO NOT use this skill for runtime Slack operations (posting, reading channels, triage). That is the separate `slack` skill.
+This skill connects an assistant to a Slack workspace: first-time bot identity (tokens, scopes, events), or switching workspaces and rotating tokens. Runtime Slack operations (posting, reading channels, triage) belong to the separate `slack` skill.
 
 ## Step 1 — Check existing configuration
 

--- a/skills/typescript-eval/SKILL.md
+++ b/skills/typescript-eval/SKILL.md
@@ -60,5 +60,4 @@ bash command="rm -rf /tmp/vellum-eval/"
 - **Iteration limit:** Max 3 attempts before asking the user for guidance.
 - **After successful test:** Persist with `scaffold_managed_skill` only after explicit user consent.
 - **Timeout:** Use `timeout_seconds=10` (or up to 20 for complex snippets).
-- **Error handling:** Read stdout/stderr from the bash output to diagnose failures.
 - **Never persist or delete skills without explicit user confirmation.**

--- a/skills/vellum-memory-v2-migration/SKILL.md
+++ b/skills/vellum-memory-v2-migration/SKILL.md
@@ -59,7 +59,7 @@ The `memory v2` help should list at least these four: `validate`, `reembed`, `re
 assistant inference session open quality-optimized --ttl 2h
 ```
 
-If `quality-optimized` isn't a profile name on this workspace, list the available profiles and open the session against the highest-quality one (the entry pointing at a frontier model — Claude Opus, GPT-5, Gemini 2.5 Pro, etc.):
+If `quality-optimized` isn't a profile name on this workspace, list the available profiles and open the session against the one labelled highest-quality. Do not match on model name: the profile roster is per-workspace and the models behind each label change between releases.
 
 ```
 assistant config get llm.profiles

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -141,7 +141,7 @@ For questions the docs and CLI can't answer (internal architecture, how a specif
 5. Key source locations:
    - `assistant/` — Runtime (conversation loop, tool dispatch, memory, scheduling)
    - `gateway/` — Ingress boundary (webhooks, Telegram, Twilio, reverse proxy)
-   - `clients/` — Native macOS client
+   - `clients/` - End-user surfaces (web SPA, iOS, Android, macOS, Windows, Linux, Chrome extension)
    - `skills/` — Bundled skill definitions
    - `ARCHITECTURE.md` — Cross-system index
    - `assistant/ARCHITECTURE.md` — Runtime internals


### PR DESCRIPTION
## Why

A prompt audit of `skills/` and `bundled-skills/` (2026-09-02) looked for text that no code path, tool, or router actually consumes. Every removal here is documentation that instructs the model to follow a protocol that does not exist, enumerates trigger phrases in a position where routing has already happened, or restates a trained default. None of it changes behavior that anything enforces; all of it costs tokens on every skill load, and unenforced rubrics invite the model to invent a protocol the code never implemented.

| File | Removed | Why it was safe |
| --- | --- | --- |
| `skills/gmail/SKILL.md` | `## Confidence Scores` 0-1 rubric | `grep -rn confidence skills/gmail/scripts` returns nothing. No script parses a `--confidence` flag and no tool schema requires one. The enforced gate is `assistant ui confirm`, left untouched above. |
| `skills/outlook/SKILL.md` | Same rubric | Same: no script or tool in `skills/outlook/scripts` accepts a confidence value. |
| `skills/google-calendar/SKILL.md` | Same rubric | Same. The real medium-risk gate is `assistant ui confirm` in `gcal.ts`, described in the lines directly above and kept. |
| `skills/outlook-calendar/SKILL.md` | Same rubric | Same; removed in the same pass so the four copies do not drift apart. |
| `skills/screen-recording/SKILL.md` | 39 lines of near-synonymous example utterances under `## Activation` | The file's own Routing section says recording is driven by `/v1/recordings/*` and structured `commandIntent`, and "bypass text parsing entirely". Body text is read after the skill is already loaded, so it cannot affect routing. Replaced with a one-line statement of scope. |
| `skills/geo-audit/SKILL.md` | `## TRIGGER` phrase list and "Fire this skill immediately" | The four phrases duplicate the frontmatter `activation-hints`, which is the surface that actually routes. The operational instructions were kept under a `## RUNNING AN AUDIT` heading. |
| `skills/slack-app-setup/SKILL.md` | `USE THIS SKILL WHEN:` phrase list | The same phrases already appear twice in frontmatter (`description` and `activation-hints`). The useful part, the boundary against the runtime `slack` skill, is kept as a `## Scope` paragraph. |
| `skills/api-mapping/SKILL.md` | `## Example Interaction` worked dialogue | It restates steps 1-6 immediately above it and freezes one 2026-02 conversation shape (length, turn structure, phrasing) into every future mapping session. No downstream parser reads this output. |
| `skills/plugin-builder/SKILL.md` | `## Coming from another harness?` | The section names no harness, gives no vocabulary mapping, and changes no behavior. The real portability facts live in `references/mcp.md` and `references/distribution.md`. |
| `skills/frontend-design/SKILL.md` | Closing "Claude is capable of extraordinary creative work" line | A pep talk with no constraint. It also names Claude to a reader that is GLM 5.2 on the shipped default profile, and this skill is auto-included by app-builder on every build. |
| `skills/typescript-eval/SKILL.md` | "Read stdout/stderr from the bash output to diagnose failures" | Reading a failing command's output is a trained default on every provider in the default profile set. It diluted a five-item list whose other four items carry real constraints. |

The rubric stays in `assistant/src/config/bundled-skills/messaging/SKILL.md`, where `confidence` is a genuinely required parameter in `TOOLS.json`.

## Verification

- `cd assistant && bun test src/__tests__/skills.test.ts` — 61 pass, 0 fail.
- `grep -rn "Confidence Scores\|Example Interaction\|Coming from another harness\|## TRIGGER\|USE THIS SKILL WHEN" assistant/src cli/src --include='*.ts'` — no matches.

## Review question

Is anything here load-bearing that the audit could not see? Specifically: any eval, prompt fixture, or downstream consumer that reads these skill bodies as strings rather than loading them as skills. Per-hunk rationale is posted as inline comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7E1LZPwAtzCPPbKhwgrp

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->