### PR TITLE
fix(oauth-skill): collect client secrets via secure prompt in all path-b flows

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1179,7 +1179,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T23:54:12.000Z"
+      "updatedAt": "2026-09-03T02:34:18.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -765,7 +765,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-02T12:58:28.000Z"
+      "updatedAt": "2026-09-02T13:18:50.000Z"
     },
     {
       "id": "public-ingress",
@@ -1179,7 +1179,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-25T23:32:13.000Z"
+      "updatedAt": "2026-09-02T23:54:12.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
+++ b/skills/vellum-oauth-integrations/references/CONFIGURING_APPLICATIONS.md
@@ -45,7 +45,23 @@ assistant credentials prompt --service <provider-key> --field client_secret \
   --description "Copy the Client Secret from the app credentials page and paste it here."
 ```
 
-Do NOT collect the client secret conversationally.
+Do NOT collect the client secret conversationally. Never solicit the secret in chat and never store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+
+### Prompt outcomes
+
+`assistant credentials prompt` has three outcomes, and only one of them stores the value. Check the exit code before Step 2. The Client ID may be requested in the same turn the prompt is opened (see the guidance above about presenting both inputs together); it is only the registration in Step 2 that has to wait for the outcome.
+
+- **Exit `0`** - the secret is stored. Proceed to Step 2.
+- **Exit `75`** - the channel has no secure input surface, so the command generated a one-time collection link instead and printed it. Nothing is stored yet. Relay that link to the user in-channel, tell them the value is entered on that page rather than in chat, and wait for them to say they are done. Then verify the credential exists before Step 2:
+
+  ```bash
+  assistant credentials inspect --service <provider-key> --field client_secret
+  ```
+
+  `inspect` masks the value (it shows only the first 4 characters), so it confirms storage without revealing the secret. If the credential is still missing, the user has not finished the page: ask again rather than registering the app.
+
+- **Exit `130`** - the user dismissed the prompt. Nothing is stored. This is a valid choice, not a failure: ask whether they want to try again or stop.
+- **Any other non-zero exit** - a real error. Report it and troubleshoot before continuing.
 
 **Step 2: Register the app**
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/airtable-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/airtable-path-b.md
@@ -90,7 +90,7 @@ assistant credentials prompt --service airtable --field client_secret \
   --description "Paste the OAuth secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 7: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/airtable-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/airtable-path-b.md
@@ -80,9 +80,17 @@ Tell the user:
 
 Wait for the Client ID. Then ask for the secret:
 
-> Now send me the **OAuth secret**. You may need to click **Show** or **Generate** to reveal it. Send it as a standalone message with no other text.
+> You may need to click **Show** or **Generate** to reveal the **OAuth secret**. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: Airtable OAuth secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service airtable --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the OAuth secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 7: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/asana-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/asana-path-b.md
@@ -78,7 +78,7 @@ assistant credentials prompt --service asana --field client_secret \
   --description "Paste the app secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 6: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/asana-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/asana-path-b.md
@@ -68,9 +68,17 @@ Tell the user:
 
 Wait for the Client ID. Then ask for the secret:
 
-> Now send me the **app secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+> You may need to click **Show** to reveal the **app secret**. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: Asana app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service asana --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the app secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 6: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
@@ -88,7 +88,7 @@ assistant credentials prompt --service discord --field client_secret \
   --description "Paste the app secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 7: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/discord-path-b.md
@@ -78,9 +78,17 @@ Tell the user:
 
 Wait for the Client ID. Then ask for the secret:
 
-> Now click **Reset Secret** on the OAuth2 page. Confirm the reset when prompted. Copy the revealed secret and send it here as a standalone message with no other text.
+> Click **Reset Secret** on the OAuth2 page and confirm the reset when prompted to reveal the **app secret**. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: Discord app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service discord --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the app secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 7: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/dropbox-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/dropbox-path-b.md
@@ -92,7 +92,7 @@ assistant credentials prompt --service dropbox --field client_secret \
   --description "Paste the App secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 7: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/dropbox-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/dropbox-path-b.md
@@ -82,9 +82,17 @@ Tell the user:
 
 Wait for the App key. Then ask for the secret:
 
-> Now send me the **App secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+> You may need to click **Show** to reveal the **App secret**. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: Dropbox app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service dropbox --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the App secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 7: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/figma-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/figma-path-b.md
@@ -81,7 +81,7 @@ assistant credentials prompt --service figma --field client_secret \
   --description "Paste the App Secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 6: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/figma-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/figma-path-b.md
@@ -71,9 +71,17 @@ Tell the user:
 
 Wait for the Client ID. Then ask for the secret:
 
-> Now send me the **App Secret**. You may need to click **Show** to reveal it. Send it as a standalone message with no other text.
+> You may need to click **Show** to reveal the **App Secret**. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: Figma app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service figma --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the App Secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 6: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/github-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/github-path-b.md
@@ -57,9 +57,17 @@ Tell the user:
 
 Wait for the Client ID. Then ask for the secret:
 
-> Now click **Generate a new client secret**. GitHub will show it only once, so copy it immediately. Send it as a standalone message with no other text.
+> Click **Generate a new client secret**. GitHub shows it only once, so copy it immediately. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: GitHub app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service github --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the client secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 5: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/github-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/github-path-b.md
@@ -67,7 +67,7 @@ assistant credentials prompt --service github --field client_secret \
   --description "Paste the client secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 5: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/google-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/google-path-b.md
@@ -133,6 +133,8 @@ assistant credentials prompt --service google --field client_secret \
 
 The `assistant credentials prompt` command is a secure input (not visible in chat), so there is no risk of channel scanners triggering on the `GOCSPX-` prefix. Collect the entire Client Secret value directly — do not ask the user to split or strip any prefix.
 
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
+
 ## Path B Step 5: Authorize and Verify
 
 Follow the `vellum-oauth-integrations` workflow to register the OAuth app, connect, and verify.

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/hubspot-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/hubspot-path-b.md
@@ -84,9 +84,17 @@ Wait for the Client ID.
 
 Then ask for the secret:
 
-> Now send me the **App Secret**. Send it as a standalone message with no other text.
+> Copy the **App Secret**. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: HubSpot app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service hubspot --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the App Secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 7: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/hubspot-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/hubspot-path-b.md
@@ -94,7 +94,7 @@ assistant credentials prompt --service hubspot --field client_secret \
   --description "Paste the App Secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 7: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/linear-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/linear-path-b.md
@@ -65,7 +65,7 @@ assistant credentials prompt --service linear --field client_secret \
   --description "Paste the app secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 5: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/linear-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/linear-path-b.md
@@ -55,9 +55,17 @@ Wait for the Client ID.
 
 Then ask for the secret:
 
-> Now send me the **app secret**. It's shown only once right after creation. If you can still see it, copy and send it as a standalone message with no other text.
+> Copy the **app secret**. It is shown only once right after creation; if you navigated away, regenerate it from the application settings page. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: If the user navigated away and can no longer see the secret, they'll need to regenerate it from the application settings page.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service linear --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the app secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 5: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/notion-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/notion-path-b.md
@@ -64,6 +64,8 @@ assistant credentials prompt --service notion --field internal_secret \
 
 Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set` — always collect it through the secure `assistant credentials prompt` flow above so it never transits the conversation.
 
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
+
 ## Path B Step 4: Grant Page Access
 
 Tell the user:

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/spotify-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/spotify-path-b.md
@@ -59,9 +59,17 @@ Tell the user:
 
 Wait for the Client ID, then ask for the secret:
 
-> Now click **View app secret** to reveal it, then send it to me. Send it as a standalone message with no other text.
+> Click **View app secret** to reveal it. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: Spotify app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service spotify --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the app secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 5: Register, Authorize, and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/spotify-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/spotify-path-b.md
@@ -69,7 +69,7 @@ assistant credentials prompt --service spotify --field client_secret \
   --description "Paste the app secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 5: Register, Authorize, and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/todoist-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/todoist-path-b.md
@@ -68,9 +68,17 @@ Wait for the Client ID.
 
 Then ask for the secret:
 
-> Now send me the **app secret**. Send it as a standalone message with no other text.
+> Copy the **app secret**. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: Todoist app secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service todoist --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the app secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 6: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/todoist-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/todoist-path-b.md
@@ -78,7 +78,7 @@ assistant credentials prompt --service todoist --field client_secret \
   --description "Paste the app secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 6: Authorize and Verify
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/twitter-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/twitter-path-b.md
@@ -79,9 +79,17 @@ Tell the user:
 
 Wait for the Client ID, then ask for the secret:
 
-> Now send me the **Client Secret**. Send it as a standalone message with no other text.
+> Copy the **Client Secret**. Don't paste it in chat: I'll open a secure prompt for you to enter it.
 
-Note: Twitter OAuth 2.0 Client Secrets don't have a known prefix that triggers channel scanners, so direct entry is acceptable. Still, keep the secret in its own message to avoid accidental logging with surrounding context.
+Then open the secure prompt:
+
+```bash
+assistant credentials prompt --service twitter --field client_secret \
+  --label "OAuth Client Secret" \
+  --description "Paste the Client Secret from the app settings page."
+```
+
+Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
 
 ## Path B Step 6: Authorize and Done
 

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/twitter-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/twitter-path-b.md
@@ -89,7 +89,7 @@ assistant credentials prompt --service twitter --field client_secret \
   --description "Paste the Client Secret from the app settings page."
 ```
 
-Never solicit the secret in chat or store a chat-pasted value with `assistant credentials set`. Always collect it through the secure `assistant credentials prompt` flow so it never transits the conversation.
+Then follow [Prompt outcomes](../CONFIGURING_APPLICATIONS.md#prompt-outcomes) before registering the app; the secret is only stored on exit 0.
 
 ## Path B Step 6: Authorize and Done
 


### PR DESCRIPTION
## Why

Eleven `provider-app-setups/*-path-b.md` files instructed the model to have the user paste their OAuth client secret directly into the chat transcript ("Send it as a standalone message with no other text"), justified by a note that the provider's secrets "don't have a known prefix that triggers channel scanners, so direct entry is acceptable."

That reasoning is about scanner false positives, not about whether a long-lived credential should live in a conversation log. It contradicts three other places in the same skill:

- `references/CONFIGURING_APPLICATIONS.md:48`: "Do NOT collect the client secret conversationally."
- Each provider's own parent setup file (`github.md:109`, `asana.md:90`, `todoist.md:86`, `spotify.md:116`, `airtable.md:106`, `discord.md:122`, `dropbox.md:126`, `figma.md:111`, `hubspot.md:124`, `twitter.md:152`), which all say the secret has no scanner-triggering prefix "but still use `assistant credentials prompt` for security (never inline `assistant credentials set`)".
- `google-path-b.md:118-132` and `notion-path-b.md:56-65`, the two path-b files that already open `assistant credentials prompt`.

This makes the eleven outliers match the rule the skill already states everywhere else. The Client ID is still pasted in chat (it is not secret); only the secret moves to the secure prompt.

## Providers changed

airtable, asana, discord, dropbox, figma, github, hubspot, linear, spotify, todoist, twitter

## Nature of the diff

Mechanical. The same replacement block goes into each file: the "send me the secret" blockquote becomes a "don't paste it in chat" blockquote, followed by an `assistant credentials prompt --service <provider> --field client_secret` call and a one-line never-solicit-in-chat rule. Only the provider key and the provider's own label for the secret ("app secret", "App Secret", "OAuth secret", "Client Secret") vary between files. Provider-specific reveal steps (GitHub's "Generate a new client secret", Discord's "Reset Secret", Spotify's "View app secret", Linear's regenerate fallback) are preserved, just folded into the new blockquote.

`--field client_secret` is the path `assistant oauth apps upsert --client-secret-credential-path "<provider>:client_secret"` already expects, so no registration step changes.

Found by a prompt audit of `skills/` (2026-09-02).

## Review focus

Confirm `--service <key>` matches each provider's registered key. I checked all eleven against `assistant/src/oauth/seed-providers.ts` and they match, but that is the one token that varies per file and the one thing a copy-paste error would break silently.

## Testing

`cd assistant && bun test src/__tests__/skills.test.ts`: 61 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7E1LZPwAtzCPPbKhwgrp

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->