### PR TITLE
ci(skills): pin prettier to 3.8.1 in the per-skill Prettier check

### DIFF
--- a/.github/workflows/pr-skills.yaml
+++ b/.github/workflows/pr-skills.yaml
@@ -69,7 +69,7 @@ jobs:
           node-version: '22.22.2'
 
       - name: Prettier check
-        run: npx prettier --check --ignore-unknown "skills/${{ matrix.skill }}/**"
+        run: npx prettier@3.8.1 --check --ignore-unknown "skills/${{ matrix.skill }}/**"
 
   lint-imports:
     name: Lint cross-skill imports


### PR DESCRIPTION
## Why

`.github/workflows/pr-skills.yaml` runs `npx prettier` unpinned, so CI formats with whatever npm published last (3.9.6 as of today) while the repo pins `prettier` 3.8.1 (`assistant/package.json`, pre-commit hook). The two disagree on `skills/influencer/scripts/influencer-intent.ts`: the pinned version reports it clean, CI reports style issues. Any PR that touches `skills/influencer` fails `Prettier: influencer` through no fault of its own (seen on #42063).

Reformatting the file for 3.9.6 would break the pinned formatter and the hook, so the fix is the pin. This matches the repo rule to pin every versioned tool.

## Change

One line: `npx prettier` -> `npx prettier@3.8.1`. No other unpinned `npx prettier` invocations exist in `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF7E1LZPwAtzCPPbKhwgrp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->