### PR TITLE
feat(activation): persist activation task progress and expose /v1/activation routes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -790,6 +790,42 @@ graph LR
     WAKE -->|"assistant report only"| CONV
 ```
 
+## Activation Progress
+
+The activation checklist is a first-run nudge: a short list of starter tasks the client offers, and a record of how far each one got. The catalog (copy, icons, ordering) lives in `clients/web`; the daemon stores only opaque task and list identifiers, so the list can change without a migration. State lives in one file, `<workspace>/data/activation-progress.json`, owned by `assistant/src/activation/progress-store.ts`.
+
+Launching a task sends its prompt into a **background conversation** and then calls `POST /v1/activation/tasks/:taskId/start`, which links the task to that conversation. A conversation belongs to at most one task: starting a second task into a conversation another `started` task points at unlinks the first in the same write, so the lookups that follow always resolve exactly one record. While the conversation works, every `tool_use` bumps that task's `stepCount` (throttled, with a trailing flush, so a burst of tool calls is one write and one broadcast). At the turn boundary a completed turn marks the task `done` and records the files it attached, taken from the attachments that actually resolved and persisted rather than from the raw directives, capped and de-duplicated by path. The completion fires ahead of the turn-boundary Git commit, so a commit that fails or is deferred cannot leave a finished task showing as still running.
+
+Reads degrade: a missing or corrupt file is "nothing started yet". Writes do not: a write that cannot land rejects, so `POST` answers 500 rather than echoing state the next `GET` would contradict. The turn hooks are the exception by design; they are fire-and-forget and log instead. Every write that changes visible state publishes the `activation:progress` sync tag, and sibling clients refetch `GET /v1/activation/progress`.
+
+```mermaid
+graph LR
+    CLIENT["Web client<br/>task catalog + pill"]
+    CONV["Background conversation<br/>(task prompt)"]
+    START["POST /v1/activation/tasks/:id/start<br/>links task to conversation"]
+    LOOP["Agent loop"]
+    TOOL["onActivationToolCall<br/>throttled stepCount bump"]
+    DONE["onActivationTurnComplete<br/>status=done + artifacts"]
+    ATT["resolveAssistantAttachments<br/>persisted files only"]
+    STORE["activation-progress.json<br/>serialized atomic writes"]
+    SYNC["sync_changed<br/>activation:progress"]
+    GET["GET /v1/activation/progress"]
+
+    CLIENT -->|"launch"| CONV
+    CLIENT --> START
+    CONV --> LOOP
+    START --> STORE
+    LOOP -->|"tool_use"| TOOL
+    LOOP -->|"turn completed"| DONE
+    ATT --> DONE
+    TOOL --> STORE
+    DONE --> STORE
+    STORE --> SYNC
+    SYNC -->|"invalidate"| CLIENT
+    CLIENT --> GET
+    GET --> STORE
+```
+
 ## Maintenance Rule
 
 When architecture changes, update the relevant domain architecture document(s) above and keep this index aligned.

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -571,6 +571,345 @@ paths:
                   - protocolSessionId
                   - agent
                 additionalProperties: false
+  /v1/activation/dismiss:
+    post:
+      operationId: activation_dismiss_post
+      summary: Dismiss an activation surface
+      description: Record that the welcome modal or the celebration modal was dismissed.
+      tags:
+        - activation
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                kind:
+                  type: string
+                  enum:
+                    - modal
+                    - all-done
+                  description: Which surface was dismissed
+                listId:
+                  description: List the surface showed, stored only while no list is frozen
+                  type: string
+                  pattern: ^[a-z0-9-]{1,64}$
+              required:
+                - kind
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: number
+                    const: 1
+                    description: Schema version
+                  listId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Task list frozen on the first write, null before then
+                  modalDismissedAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: ISO timestamp the welcome modal was dismissed
+                  allDoneShownAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: ISO timestamp the celebration modal was dismissed
+                  tasks:
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: object
+                      properties:
+                        status:
+                          type: string
+                          enum:
+                            - started
+                            - done
+                          description: "`started` while the linked conversation is working the task"
+                        conversationId:
+                          type: string
+                          description: Conversation the task was launched into
+                        startedAt:
+                          type: string
+                          description: ISO timestamp of the launch
+                        completedAt:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description: ISO timestamp of the completing turn, null while started
+                        stepCount:
+                          anyOf:
+                            - type: integer
+                              minimum: -9007199254740991
+                              maximum: 9007199254740991
+                            - type: "null"
+                          description: Tool calls observed in the linked conversation so far
+                        artifacts:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              workspacePath:
+                                type: string
+                                description: Path of the produced file, as the assistant attached it
+                              displayName:
+                                type: string
+                                description: Human-readable file name for the card
+                            required:
+                              - workspacePath
+                              - displayName
+                            additionalProperties: false
+                          description: Files the completing turn attached
+                      required:
+                        - status
+                        - conversationId
+                        - startedAt
+                        - completedAt
+                        - stepCount
+                        - artifacts
+                      additionalProperties: false
+                    description: Progress keyed by task id
+                required:
+                  - version
+                  - listId
+                  - modalDismissedAt
+                  - allDoneShownAt
+                  - tasks
+                additionalProperties: false
+        "400":
+          description: Malformed dismiss kind or list id
+  /v1/activation/progress:
+    get:
+      operationId: activation_progress_get
+      summary: Get activation progress
+      description: "Return the activation checklist progress: the frozen list, dismissed surfaces, and per-task state."
+      tags:
+        - activation
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: number
+                    const: 1
+                    description: Schema version
+                  listId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Task list frozen on the first write, null before then
+                  modalDismissedAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: ISO timestamp the welcome modal was dismissed
+                  allDoneShownAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: ISO timestamp the celebration modal was dismissed
+                  tasks:
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: object
+                      properties:
+                        status:
+                          type: string
+                          enum:
+                            - started
+                            - done
+                          description: "`started` while the linked conversation is working the task"
+                        conversationId:
+                          type: string
+                          description: Conversation the task was launched into
+                        startedAt:
+                          type: string
+                          description: ISO timestamp of the launch
+                        completedAt:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description: ISO timestamp of the completing turn, null while started
+                        stepCount:
+                          anyOf:
+                            - type: integer
+                              minimum: -9007199254740991
+                              maximum: 9007199254740991
+                            - type: "null"
+                          description: Tool calls observed in the linked conversation so far
+                        artifacts:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              workspacePath:
+                                type: string
+                                description: Path of the produced file, as the assistant attached it
+                              displayName:
+                                type: string
+                                description: Human-readable file name for the card
+                            required:
+                              - workspacePath
+                              - displayName
+                            additionalProperties: false
+                          description: Files the completing turn attached
+                      required:
+                        - status
+                        - conversationId
+                        - startedAt
+                        - completedAt
+                        - stepCount
+                        - artifacts
+                      additionalProperties: false
+                    description: Progress keyed by task id
+                required:
+                  - version
+                  - listId
+                  - modalDismissedAt
+                  - allDoneShownAt
+                  - tasks
+                additionalProperties: false
+  /v1/activation/tasks/{taskId}/start:
+    post:
+      operationId: activation_tasks_by_taskId_start_post
+      summary: Start an activation task
+      description:
+        Link an activation task to the conversation its prompt was sent to. Idempotent per task; a different
+        conversation replaces the link only while the task is not done.
+      tags:
+        - activation
+      parameters:
+        - name: taskId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                  minLength: 1
+                  description: Conversation the task prompt was sent to
+                listId:
+                  description: List the task came from, stored only while no list is frozen
+                  type: string
+                  pattern: ^[a-z0-9-]{1,64}$
+              required:
+                - conversationId
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: number
+                    const: 1
+                    description: Schema version
+                  listId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: Task list frozen on the first write, null before then
+                  modalDismissedAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: ISO timestamp the welcome modal was dismissed
+                  allDoneShownAt:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                    description: ISO timestamp the celebration modal was dismissed
+                  tasks:
+                    type: object
+                    propertyNames:
+                      type: string
+                    additionalProperties:
+                      type: object
+                      properties:
+                        status:
+                          type: string
+                          enum:
+                            - started
+                            - done
+                          description: "`started` while the linked conversation is working the task"
+                        conversationId:
+                          type: string
+                          description: Conversation the task was launched into
+                        startedAt:
+                          type: string
+                          description: ISO timestamp of the launch
+                        completedAt:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                          description: ISO timestamp of the completing turn, null while started
+                        stepCount:
+                          anyOf:
+                            - type: integer
+                              minimum: -9007199254740991
+                              maximum: 9007199254740991
+                            - type: "null"
+                          description: Tool calls observed in the linked conversation so far
+                        artifacts:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              workspacePath:
+                                type: string
+                                description: Path of the produced file, as the assistant attached it
+                              displayName:
+                                type: string
+                                description: Human-readable file name for the card
+                            required:
+                              - workspacePath
+                              - displayName
+                            additionalProperties: false
+                          description: Files the completing turn attached
+                      required:
+                        - status
+                        - conversationId
+                        - startedAt
+                        - completedAt
+                        - stepCount
+                        - artifacts
+                      additionalProperties: false
+                    description: Progress keyed by task id
+                required:
+                  - version
+                  - listId
+                  - modalDismissedAt
+                  - allDoneShownAt
+                  - tasks
+                additionalProperties: false
+        "400":
+          description: Malformed task id, list id, or conversation id
   /v1/admin/rollback-migrations:
     post:
       operationId: admin_rollbackmigrations_post

--- a/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-inference-profile.test.ts
@@ -230,6 +230,7 @@ mock.module("../daemon/conversation-attachments.js", () => ({
     assistantAttachments: [],
     emittedAttachments: [],
     directiveWarnings: [],
+    persistedFiles: [],
   }),
   approveHostAttachmentRead: async () => true,
   formatAttachmentWarnings: () => "",

--- a/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop-overflow.test.ts
@@ -339,6 +339,7 @@ const resolveAssistantAttachmentsMock = mock(async () => ({
   assistantAttachments: [],
   emittedAttachments: [],
   directiveWarnings: [],
+  persistedFiles: [],
 }));
 mock.module("../daemon/conversation-attachments.js", () => ({
   resolveAssistantAttachments: resolveAssistantAttachmentsMock,

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -577,6 +577,7 @@ const resolveAssistantAttachmentsMock = mock(async () => ({
   assistantAttachments: [],
   emittedAttachments: [],
   directiveWarnings: [],
+  persistedFiles: [],
 }));
 mock.module("../daemon/conversation-attachments.js", () => ({
   resolveAssistantAttachments: resolveAssistantAttachmentsMock,
@@ -976,6 +977,7 @@ beforeEach(() => {
     assistantAttachments: [],
     emittedAttachments: [],
     directiveWarnings: [],
+    persistedFiles: [],
   }));
   mockMessageById = null;
   resetConversationNoticesForTests();

--- a/assistant/src/__tests__/conversation-attachments.test.ts
+++ b/assistant/src/__tests__/conversation-attachments.test.ts
@@ -187,6 +187,97 @@ describe("resolveAssistantAttachments", () => {
     // fileBacked flag is always true now
     expect(emitted.fileBacked).toBe(true);
   });
+
+  test("persistedFiles carries only directives that resolved and persisted", async () => {
+    const conv = createConversation("test-conv-persisted");
+    const msg = await addMessage(conv.id, "assistant", "hello");
+
+    const accepted: AssistantAttachmentDraft = {
+      sourceType: "sandbox_file",
+      filename: "plan.md",
+      mimeType: "text/markdown",
+      dataBase64: makeBase64(64),
+      sizeBytes: 64,
+      kind: "document",
+      sourcePath: "notes/plan.md",
+    };
+    const oversized: AssistantAttachmentDraft = {
+      sourceType: "sandbox_file",
+      filename: "huge.bin",
+      mimeType: "application/octet-stream",
+      dataBase64: makeBase64(64),
+      sizeBytes: 64,
+      kind: "document",
+      sourcePath: "notes/huge.bin",
+    };
+    const toolBlock: AssistantAttachmentDraft = {
+      sourceType: "tool_block",
+      filename: "tool-output.png",
+      mimeType: "image/png",
+      dataBase64: makeBase64(64),
+      sizeBytes: 64,
+      kind: "image",
+    };
+
+    mock.module("../daemon/assistant-attachments.js", () => ({
+      // The missing file's directive produces a warning and no draft.
+      resolveDirectives: () =>
+        Promise.resolve({
+          drafts: [accepted, oversized],
+          warnings: [
+            'Skipped sandbox attachment "notes/missing.md": file not found.',
+          ],
+        }),
+      contentBlocksToDrafts: () => [toolBlock],
+      deduplicateDrafts: (d: AssistantAttachmentDraft[]) => d,
+      validateDrafts: (d: AssistantAttachmentDraft[]) => ({
+        accepted: d.filter((draft) => draft.filename !== "huge.bin"),
+        warnings: ['Skipped attachment "huge.bin": too large.'],
+      }),
+    }));
+
+    const { resolveAssistantAttachments: resolve } =
+      await import("../daemon/conversation-attachments.js");
+
+    const result = await resolve(
+      [
+        {
+          source: "sandbox" as const,
+          path: "notes/plan.md",
+          filename: "plan.md",
+          mimeType: "text/markdown",
+        },
+        {
+          source: "sandbox" as const,
+          path: "notes/missing.md",
+          filename: undefined,
+          mimeType: undefined,
+        },
+        {
+          source: "sandbox" as const,
+          path: "notes/huge.bin",
+          filename: undefined,
+          mimeType: undefined,
+        },
+      ],
+      [
+        {
+          type: "image",
+          source: { type: "base64", media_type: "image/png", data: "" },
+        },
+      ],
+      [],
+      "/tmp",
+      async () => true,
+      msg.id,
+    );
+
+    // The rejected directive, the failed validation, and the tool block
+    // (which has no file of its own) are all absent.
+    expect(result.persistedFiles).toEqual([
+      { sourcePath: "notes/plan.md", displayName: "plan.md" },
+    ]);
+  });
 });
 
 describe("approveHostAttachmentRead", () => {

--- a/assistant/src/activation/progress-store.test.ts
+++ b/assistant/src/activation/progress-store.test.ts
@@ -62,6 +62,14 @@ function writeRawProgress(contents: string): void {
   writeFileSync(getActivationProgressPath(), contents, "utf-8");
 }
 
+/**
+ * Make every write fail by occupying the data directory's path with a
+ * regular file, so `mkdirSync` cannot create it.
+ */
+function breakDataDir(): void {
+  writeFileSync(join(workspaceDir, "data"), "not a directory", "utf-8");
+}
+
 function syncPublishCount(): number {
   return publishedTags.filter((tags) => tags.includes("activation:progress"))
     .length;
@@ -331,6 +339,111 @@ describe("activation progress store", () => {
       });
 
       expect(readActivationProgress().tasks["draft-email"].stepCount).toBe(2);
+    });
+  });
+
+  describe("persistence failures", () => {
+    test("a failed write rejects instead of reporting saved progress", async () => {
+      breakDataDir();
+
+      await expect(
+        startActivationTask({
+          taskId: "draft-email",
+          conversationId: "conv-1",
+        }),
+      ).rejects.toThrow(/Failed to persist activation progress/);
+      await expect(dismissActivation({ kind: "modal" })).rejects.toThrow(
+        /Failed to persist activation progress/,
+      );
+      expect(syncPublishCount()).toBe(0);
+    });
+
+    test("a rejected write leaves later mutations working", async () => {
+      breakDataDir();
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      }).catch(() => {});
+
+      rmSync(join(workspaceDir, "data"));
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+
+      expect(readActivationProgress().tasks["draft-email"]).toMatchObject({
+        status: "started",
+        conversationId: "conv-1",
+      });
+    });
+  });
+
+  describe("one task per conversation", () => {
+    test("a second task takes the conversation and the first is unlinked", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      await startActivationTask({
+        taskId: "book-travel",
+        conversationId: "conv-1",
+      });
+
+      const tasks = readActivationProgress().tasks;
+      expect(Object.keys(tasks)).toEqual(["book-travel"]);
+      expect(tasks["book-travel"]).toMatchObject({
+        status: "started",
+        conversationId: "conv-1",
+      });
+    });
+
+    test("completion reaches the latest task, not a stranded one", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      await startActivationTask({
+        taskId: "book-travel",
+        conversationId: "conv-1",
+      });
+
+      await bumpActivationStepCount("conv-1");
+      await markActivationTurnComplete({
+        conversationId: "conv-1",
+        toolCallCount: 3,
+        artifacts: [{ workspacePath: "trips/plan.md", displayName: "plan.md" }],
+      });
+
+      const tasks = readActivationProgress().tasks;
+      expect(tasks["draft-email"]).toBeUndefined();
+      expect(tasks["book-travel"]).toMatchObject({
+        status: "done",
+        stepCount: 3,
+        artifacts: [{ workspacePath: "trips/plan.md", displayName: "plan.md" }],
+      });
+    });
+
+    test("a done task keeps its record when a new task takes the conversation", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      await markActivationTurnComplete({
+        conversationId: "conv-1",
+        toolCallCount: 1,
+        artifacts: [],
+      });
+      await startActivationTask({
+        taskId: "book-travel",
+        conversationId: "conv-1",
+      });
+
+      const tasks = readActivationProgress().tasks;
+      expect(tasks["draft-email"]).toMatchObject({
+        status: "done",
+        conversationId: "conv-1",
+      });
+      expect(tasks["book-travel"]).toMatchObject({ status: "started" });
     });
   });
 });

--- a/assistant/src/activation/progress-store.test.ts
+++ b/assistant/src/activation/progress-store.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for the activation progress store.
+ *
+ * Covers the on-disk round trip, degraded reads, every transition's
+ * idempotence and freeze rules, and the step-bump throttle (including its
+ * trailing flush).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Capture invalidations without standing up SSE infrastructure. Mocking the
+// publisher (one exported function) rather than the event hub keeps the mock
+// harmless for any sibling file bun runs in the same process.
+const publishedTags: string[][] = [];
+
+mock.module("../runtime/sync/sync-publisher.js", () => ({
+  publishSyncInvalidation: async (tags: string[]) => {
+    publishedTags.push(tags);
+    return { type: "sync_changed", tags };
+  },
+}));
+
+const {
+  ACTIVATION_PROGRESS_FILENAME,
+  bumpActivationStepCount,
+  dismissActivation,
+  getActivationProgressPath,
+  markActivationTurnComplete,
+  readActivationProgress,
+  resetActivationStepThrottleForTesting,
+  startActivationTask,
+} = await import("./progress-store.js");
+
+const THROTTLE_MS = 40;
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-activation-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  publishedTags.length = 0;
+  resetActivationStepThrottleForTesting(THROTTLE_MS);
+});
+
+afterEach(() => {
+  resetActivationStepThrottleForTesting();
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+function writeRawProgress(contents: string): void {
+  mkdirSync(join(workspaceDir, "data"), { recursive: true });
+  writeFileSync(getActivationProgressPath(), contents, "utf-8");
+}
+
+function syncPublishCount(): number {
+  return publishedTags.filter((tags) => tags.includes("activation:progress"))
+    .length;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await Bun.sleep(5);
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+describe("activation progress store", () => {
+  describe("readActivationProgress", () => {
+    test("resolves under <workspace>/data", () => {
+      expect(getActivationProgressPath()).toBe(
+        join(workspaceDir, "data", ACTIVATION_PROGRESS_FILENAME),
+      );
+    });
+
+    test("missing file reads as the empty default", () => {
+      expect(readActivationProgress()).toEqual({
+        version: 1,
+        listId: null,
+        modalDismissedAt: null,
+        allDoneShownAt: null,
+        tasks: {},
+      });
+    });
+
+    test("corrupt file reads as the empty default", () => {
+      writeRawProgress("{ not json");
+      expect(readActivationProgress().tasks).toEqual({});
+    });
+
+    test("schema-invalid file reads as the empty default", () => {
+      writeRawProgress(JSON.stringify({ version: 99, tasks: "nope" }));
+      expect(readActivationProgress().tasks).toEqual({});
+    });
+  });
+
+  describe("startActivationTask", () => {
+    test("persists the link and publishes an invalidation", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+        listId: "smb",
+      });
+
+      const stored = readActivationProgress();
+      expect(stored.listId).toBe("smb");
+      expect(stored.tasks["draft-email"]).toMatchObject({
+        status: "started",
+        conversationId: "conv-1",
+        completedAt: null,
+        stepCount: 0,
+        artifacts: [],
+      });
+      expect(syncPublishCount()).toBe(1);
+    });
+
+    test("is idempotent for the same conversation", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      const first = readActivationProgress().tasks["draft-email"].startedAt;
+      publishedTags.length = 0;
+
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+
+      expect(readActivationProgress().tasks["draft-email"].startedAt).toBe(
+        first,
+      );
+      expect(syncPublishCount()).toBe(0);
+    });
+
+    test("a different conversation replaces the link while not done", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-2",
+      });
+
+      expect(readActivationProgress().tasks["draft-email"]).toMatchObject({
+        conversationId: "conv-2",
+        stepCount: 0,
+      });
+    });
+
+    test("a done task keeps its conversation link", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      await markActivationTurnComplete({
+        conversationId: "conv-1",
+        toolCallCount: 2,
+        artifacts: [],
+      });
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-2",
+      });
+
+      expect(readActivationProgress().tasks["draft-email"]).toMatchObject({
+        status: "done",
+        conversationId: "conv-1",
+      });
+    });
+
+    test("listId freezes on the first write", async () => {
+      await startActivationTask({
+        taskId: "task-a",
+        conversationId: "conv-1",
+        listId: "smb",
+      });
+      await startActivationTask({
+        taskId: "task-b",
+        conversationId: "conv-2",
+        listId: "parent",
+      });
+
+      expect(readActivationProgress().listId).toBe("smb");
+    });
+
+    test("rejects malformed ids", async () => {
+      await expect(
+        startActivationTask({ taskId: "Bad Id", conversationId: "conv-1" }),
+      ).rejects.toThrow(/Invalid taskId/);
+      await expect(
+        startActivationTask({
+          taskId: "task-a",
+          conversationId: "conv-1",
+          listId: "SMB",
+        }),
+      ).rejects.toThrow(/Invalid listId/);
+      await expect(
+        startActivationTask({ taskId: "task-a", conversationId: "  " }),
+      ).rejects.toThrow(/conversationId is required/);
+      expect(readActivationProgress().tasks).toEqual({});
+    });
+  });
+
+  describe("dismissActivation", () => {
+    test("records both kinds and keeps the first timestamp", async () => {
+      await dismissActivation({ kind: "modal", listId: "general" });
+      const stored = readActivationProgress();
+      expect(stored.modalDismissedAt).not.toBeNull();
+      expect(stored.allDoneShownAt).toBeNull();
+      expect(stored.listId).toBe("general");
+
+      await dismissActivation({ kind: "all-done" });
+      const after = readActivationProgress();
+      expect(after.allDoneShownAt).not.toBeNull();
+      expect(after.modalDismissedAt).toBe(stored.modalDismissedAt);
+
+      // The second dismiss of the same kind changes nothing.
+      publishedTags.length = 0;
+      await dismissActivation({ kind: "modal" });
+      expect(syncPublishCount()).toBe(0);
+    });
+
+    test("does not thaw a frozen listId", async () => {
+      await dismissActivation({ kind: "modal", listId: "smb" });
+      await dismissActivation({ kind: "all-done", listId: "parent" });
+      expect(readActivationProgress().listId).toBe("smb");
+    });
+  });
+
+  describe("bumpActivationStepCount", () => {
+    test("is a no-op for an unlinked conversation", async () => {
+      await bumpActivationStepCount("conv-unlinked");
+      expect(readActivationProgress().tasks).toEqual({});
+      expect(syncPublishCount()).toBe(0);
+    });
+
+    test("throttles a burst and flushes the trailing count", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      publishedTags.length = 0;
+
+      for (let i = 0; i < 5; i++) {
+        await bumpActivationStepCount("conv-1");
+      }
+
+      // The leading bump lands immediately; the rest coalesce behind the
+      // throttle window.
+      expect(readActivationProgress().tasks["draft-email"].stepCount).toBe(1);
+      expect(syncPublishCount()).toBe(1);
+
+      await waitFor(
+        () => readActivationProgress().tasks["draft-email"].stepCount === 5,
+      );
+      expect(syncPublishCount()).toBe(2);
+    });
+  });
+
+  describe("markActivationTurnComplete", () => {
+    test("is a no-op for an unlinked conversation", async () => {
+      await markActivationTurnComplete({
+        conversationId: "conv-unlinked",
+        toolCallCount: 3,
+        artifacts: [{ workspacePath: "a.md", displayName: "a.md" }],
+      });
+      expect(readActivationProgress().tasks).toEqual({});
+      expect(syncPublishCount()).toBe(0);
+    });
+
+    test("records the step count and artifacts, and is idempotent", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      await markActivationTurnComplete({
+        conversationId: "conv-1",
+        toolCallCount: 4,
+        artifacts: [
+          { workspacePath: "notes/plan.md", displayName: "plan.md" },
+          { workspacePath: "notes/plan.md", displayName: "duplicate" },
+          { workspacePath: "", displayName: "blank" },
+        ],
+      });
+
+      const done = readActivationProgress().tasks["draft-email"];
+      expect(done.status).toBe("done");
+      expect(done.completedAt).not.toBeNull();
+      expect(done.stepCount).toBe(4);
+      expect(done.artifacts).toEqual([
+        { workspacePath: "notes/plan.md", displayName: "plan.md" },
+      ]);
+
+      publishedTags.length = 0;
+      await markActivationTurnComplete({
+        conversationId: "conv-1",
+        toolCallCount: 9,
+        artifacts: [],
+      });
+      expect(readActivationProgress().tasks["draft-email"]).toEqual(done);
+      expect(syncPublishCount()).toBe(0);
+    });
+
+    test("never lowers a step count the user already saw", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      await bumpActivationStepCount("conv-1");
+      await bumpActivationStepCount("conv-1");
+
+      await markActivationTurnComplete({
+        conversationId: "conv-1",
+        toolCallCount: 1,
+        artifacts: [],
+      });
+
+      expect(readActivationProgress().tasks["draft-email"].stepCount).toBe(2);
+    });
+  });
+});

--- a/assistant/src/activation/progress-store.ts
+++ b/assistant/src/activation/progress-store.ts
@@ -1,0 +1,381 @@
+/**
+ * On-disk store for activation-checklist progress
+ * (`<workspace>/data/activation-progress.json`).
+ *
+ * The checklist itself (task copy, icons, ordering) lives in the web
+ * client; the daemon only records which task was launched into which
+ * conversation and how far it got, so every client of one assistant sees
+ * the same state. Task ids and list ids are therefore opaque strings,
+ * constrained to {@link ACTIVATION_ID_PATTERN} so a client cannot turn a
+ * JSON key into an unbounded blob.
+ *
+ * Reads are synchronous and degrade to the empty default: a missing or
+ * corrupt file means "nothing started yet", which is the same state a
+ * fresh assistant is in. Writes are atomic (temp file + rename) and
+ * serialized through a single in-process promise chain so concurrent
+ * route calls and turn hooks cannot interleave a read-modify-write.
+ *
+ * Every write that changes visible state publishes the
+ * `activation:progress` sync tag so sibling clients refetch.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  ACTIVATION_ID_PATTERN,
+  type ActivationArtifact,
+  ActivationArtifactSchema,
+  type ActivationDismissKind,
+  type ActivationProgress,
+  ActivationProgressSchema,
+  emptyActivationProgress,
+} from "../api/responses/activation.js";
+import { SYNC_TAGS } from "../daemon/message-types/sync.js";
+import { BadRequestError } from "../runtime/routes/errors.js";
+import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
+import { getLogger } from "../util/logger.js";
+import { getDataDir } from "../util/platform.js";
+
+const log = getLogger("activation-progress-store");
+
+/** Filename for the on-disk snapshot. Lives under the workspace data dir. */
+export const ACTIVATION_PROGRESS_FILENAME = "activation-progress.json";
+
+/**
+ * Minimum interval between step-count invalidations for one task. Tool
+ * calls arrive in bursts, and each one only moves a counter in a pill, so
+ * both the disk write and the broadcast coalesce into one per window with
+ * a trailing flush that persists the final count.
+ */
+export const ACTIVATION_STEP_BUMP_THROTTLE_MS = 2_000;
+
+/** Live throttle window. Only {@link resetActivationStepThrottleForTesting} moves it. */
+let stepThrottleMs: number = ACTIVATION_STEP_BUMP_THROTTLE_MS;
+
+/** Upper bound on artifacts recorded per task, so a chatty turn cannot grow the file. */
+const MAX_ARTIFACTS_PER_TASK = 10;
+
+/**
+ * Canonical path to the progress snapshot
+ * (`<workspace>/data/activation-progress.json`).
+ */
+export function getActivationProgressPath(): string {
+  return join(getDataDir(), ACTIVATION_PROGRESS_FILENAME);
+}
+
+/** Throw a 400 unless `value` is a well-formed activation identifier. */
+function assertActivationId(value: string, label: string): void {
+  if (!ACTIVATION_ID_PATTERN.test(value)) {
+    throw new BadRequestError(
+      `Invalid ${label}: must match ${ACTIVATION_ID_PATTERN.source}`,
+    );
+  }
+}
+
+/**
+ * Read the progress snapshot. A missing file, unreadable file, or one that
+ * fails schema validation all degrade to the empty default rather than
+ * throwing: the checklist is an onboarding nicety, never a hard failure.
+ */
+export function readActivationProgress(): ActivationProgress {
+  let raw: string;
+  try {
+    raw = readFileSync(getActivationProgressPath(), "utf-8");
+  } catch {
+    return emptyActivationProgress();
+  }
+  try {
+    return ActivationProgressSchema.parse(JSON.parse(raw));
+  } catch (err) {
+    log.warn(
+      { err, path: getActivationProgressPath() },
+      "Unreadable activation-progress.json; treating as empty",
+    );
+    return emptyActivationProgress();
+  }
+}
+
+function writeActivationProgress(progress: ActivationProgress): void {
+  const path = getActivationProgressPath();
+  mkdirSync(getDataDir(), { recursive: true });
+  const tmpPath = `${path}.tmp.${process.pid}`;
+  writeFileSync(tmpPath, JSON.stringify(progress, null, 2), "utf-8");
+  renameSync(tmpPath, path);
+}
+
+// ---------------------------------------------------------------------------
+// Serialized mutation
+// ---------------------------------------------------------------------------
+
+let writeChain: Promise<unknown> = Promise.resolve();
+
+/**
+ * Run `mutate` against a freshly read snapshot, persisting and publishing
+ * only when it reports a change. Every mutation queues behind the previous
+ * one, so a route call and a turn hook can never read the same snapshot and
+ * clobber each other.
+ */
+async function mutateActivationProgress(
+  mutate: (progress: ActivationProgress) => boolean,
+): Promise<ActivationProgress> {
+  const run = async (): Promise<ActivationProgress> => {
+    const progress = readActivationProgress();
+    if (!mutate(progress)) {
+      return progress;
+    }
+    try {
+      writeActivationProgress(progress);
+    } catch (err) {
+      log.warn({ err }, "Failed to write activation-progress.json");
+      return progress;
+    }
+    await publishSyncInvalidation([SYNC_TAGS.activationProgress]);
+    return progress;
+  };
+  const next = writeChain.then(run, run);
+  // Keep the chain alive even when a link rejects, so one failure cannot
+  // strand every later mutation.
+  writeChain = next.catch(() => {});
+  return next;
+}
+
+/** Freeze the list on the first write that names one. */
+function applyListId(progress: ActivationProgress, listId?: string): boolean {
+  if (listId === undefined || progress.listId !== null) {
+    return false;
+  }
+  assertActivationId(listId, "listId");
+  progress.listId = listId;
+  return true;
+}
+
+function findLinkedTaskId(
+  progress: ActivationProgress,
+  conversationId: string,
+): string | null {
+  for (const [taskId, task] of Object.entries(progress.tasks)) {
+    if (task.conversationId === conversationId && task.status === "started") {
+      return taskId;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Transitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Link a task to the conversation it was launched into.
+ *
+ * Idempotent: re-starting a task in the same conversation changes nothing.
+ * A different conversation replaces the link (and restarts the counters)
+ * only while the task is not `done`. A finished task keeps its record.
+ */
+export async function startActivationTask(params: {
+  taskId: string;
+  conversationId: string;
+  listId?: string;
+}): Promise<ActivationProgress> {
+  const { taskId, conversationId, listId } = params;
+  assertActivationId(taskId, "taskId");
+  if (conversationId.trim().length === 0) {
+    throw new BadRequestError("conversationId is required");
+  }
+  if (listId !== undefined) {
+    assertActivationId(listId, "listId");
+  }
+
+  return mutateActivationProgress((progress) => {
+    const listChanged = applyListId(progress, listId);
+    const existing = progress.tasks[taskId];
+    if (
+      existing?.status === "done" ||
+      existing?.conversationId === conversationId
+    ) {
+      return listChanged;
+    }
+    progress.tasks[taskId] = {
+      status: "started",
+      conversationId,
+      startedAt: new Date().toISOString(),
+      completedAt: null,
+      stepCount: 0,
+      artifacts: [],
+    };
+    return true;
+  });
+}
+
+/**
+ * Record that the welcome modal (`modal`) or the celebration modal
+ * (`all-done`) was dismissed. The first dismissal timestamp is kept: the
+ * field records that the surface was seen, so reopening it from the pill
+ * and closing it again does not rewrite history.
+ */
+export async function dismissActivation(params: {
+  kind: ActivationDismissKind;
+  listId?: string;
+}): Promise<ActivationProgress> {
+  const { kind, listId } = params;
+  if (listId !== undefined) {
+    assertActivationId(listId, "listId");
+  }
+
+  return mutateActivationProgress((progress) => {
+    let changed = applyListId(progress, listId);
+    const field = kind === "modal" ? "modalDismissedAt" : "allDoneShownAt";
+    if (progress[field] === null) {
+      progress[field] = new Date().toISOString();
+      changed = true;
+    }
+    return changed;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Step counting
+// ---------------------------------------------------------------------------
+
+/** Tool calls seen since the last flush, keyed by conversation. */
+const pendingStepBumps = new Map<string, number>();
+const stepBumpTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const lastStepFlushAt = new Map<string, number>();
+
+async function flushStepBumps(conversationId: string): Promise<void> {
+  const timer = stepBumpTimers.get(conversationId);
+  if (timer) {
+    clearTimeout(timer);
+    stepBumpTimers.delete(conversationId);
+  }
+  const delta = pendingStepBumps.get(conversationId) ?? 0;
+  pendingStepBumps.delete(conversationId);
+  if (delta === 0) {
+    return;
+  }
+  lastStepFlushAt.set(conversationId, Date.now());
+  await mutateActivationProgress((progress) => {
+    const taskId = findLinkedTaskId(progress, conversationId);
+    if (!taskId) {
+      return false;
+    }
+    const task = progress.tasks[taskId];
+    task.stepCount = (task.stepCount ?? 0) + delta;
+    return true;
+  });
+}
+
+/**
+ * Count one tool call against the task linked to this conversation.
+ *
+ * A no-op for conversations that no `started` task points at, so the hot
+ * path costs one small read for every other conversation. Flushes are
+ * throttled to one per {@link ACTIVATION_STEP_BUMP_THROTTLE_MS} per
+ * conversation, with a trailing flush so the final count still lands.
+ */
+export async function bumpActivationStepCount(
+  conversationId: string,
+): Promise<void> {
+  // A pending bump already proved the link, so a burst reads the file once.
+  // `flushStepBumps` re-checks before writing, so a link that disappears
+  // mid-burst degrades to a no-op flush.
+  if (
+    !pendingStepBumps.has(conversationId) &&
+    !findLinkedTaskId(readActivationProgress(), conversationId)
+  ) {
+    return;
+  }
+  pendingStepBumps.set(
+    conversationId,
+    (pendingStepBumps.get(conversationId) ?? 0) + 1,
+  );
+
+  const now = Date.now();
+  const lastFlush = lastStepFlushAt.get(conversationId) ?? 0;
+  const elapsed = now - lastFlush;
+  if (elapsed >= stepThrottleMs) {
+    await flushStepBumps(conversationId);
+    return;
+  }
+  if (stepBumpTimers.has(conversationId)) {
+    return;
+  }
+  const timer = setTimeout(() => {
+    void flushStepBumps(conversationId).catch(() => {});
+  }, stepThrottleMs - elapsed);
+  timer.unref?.();
+  stepBumpTimers.set(conversationId, timer);
+}
+
+// ---------------------------------------------------------------------------
+// Completion
+// ---------------------------------------------------------------------------
+
+function normalizeArtifacts(
+  artifacts: readonly ActivationArtifact[],
+): ActivationArtifact[] {
+  const seen = new Set<string>();
+  const result: ActivationArtifact[] = [];
+  for (const artifact of artifacts) {
+    const parsed = ActivationArtifactSchema.safeParse(artifact);
+    if (!parsed.success || parsed.data.workspacePath.length === 0) {
+      continue;
+    }
+    if (seen.has(parsed.data.workspacePath)) {
+      continue;
+    }
+    seen.add(parsed.data.workspacePath);
+    result.push(parsed.data);
+    if (result.length >= MAX_ARTIFACTS_PER_TASK) {
+      break;
+    }
+  }
+  return result;
+}
+
+/**
+ * Mark the task linked to this conversation `done`.
+ *
+ * A no-op for unlinked conversations and idempotent for linked ones: a
+ * second terminal turn in the same conversation finds no `started` task
+ * and changes nothing. `stepCount` never moves backwards, so the number
+ * the user watched climb is the number they end up with.
+ */
+export async function markActivationTurnComplete(params: {
+  conversationId: string;
+  toolCallCount: number;
+  artifacts: readonly ActivationArtifact[];
+}): Promise<void> {
+  const { conversationId, toolCallCount, artifacts } = params;
+  await flushStepBumps(conversationId);
+  await mutateActivationProgress((progress) => {
+    const taskId = findLinkedTaskId(progress, conversationId);
+    if (!taskId) {
+      return false;
+    }
+    const task = progress.tasks[taskId];
+    task.status = "done";
+    task.completedAt = new Date().toISOString();
+    task.stepCount = Math.max(task.stepCount ?? 0, Math.max(0, toolCallCount));
+    task.artifacts = normalizeArtifacts(artifacts);
+    return true;
+  });
+}
+
+/**
+ * Drop the in-process step-bump throttle state, optionally shortening the
+ * window. Test-only seam: production code lets the trailing timers run at
+ * {@link ACTIVATION_STEP_BUMP_THROTTLE_MS}.
+ */
+export function resetActivationStepThrottleForTesting(
+  overrideMs?: number,
+): void {
+  for (const timer of stepBumpTimers.values()) {
+    clearTimeout(timer);
+  }
+  stepBumpTimers.clear();
+  pendingStepBumps.clear();
+  lastStepFlushAt.clear();
+  stepThrottleMs = overrideMs ?? ACTIVATION_STEP_BUMP_THROTTLE_MS;
+}

--- a/assistant/src/activation/progress-store.ts
+++ b/assistant/src/activation/progress-store.ts
@@ -13,7 +13,15 @@
  * corrupt file means "nothing started yet", which is the same state a
  * fresh assistant is in. Writes are atomic (temp file + rename) and
  * serialized through a single in-process promise chain so concurrent
- * route calls and turn hooks cannot interleave a read-modify-write.
+ * route calls and turn hooks cannot interleave a read-modify-write. A
+ * write that cannot land rejects, so a route never answers with state the
+ * next read would contradict; the fire-and-forget turn hooks catch and log
+ * instead.
+ *
+ * A conversation belongs to at most one task: {@link startActivationTask}
+ * unlinks any other `started` task pointing at the same conversation, so
+ * the step and completion lookups can resolve one record and never strand
+ * another.
  *
  * Every write that changes visible state publishes the
  * `activation:progress` sync tag so sibling clients refetch.
@@ -32,7 +40,7 @@ import {
   emptyActivationProgress,
 } from "../api/responses/activation.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";
-import { BadRequestError } from "../runtime/routes/errors.js";
+import { BadRequestError, InternalError } from "../runtime/routes/errors.js";
 import { publishSyncInvalidation } from "../runtime/sync/sync-publisher.js";
 import { getLogger } from "../util/logger.js";
 import { getDataDir } from "../util/platform.js";
@@ -115,6 +123,9 @@ let writeChain: Promise<unknown> = Promise.resolve();
  * only when it reports a change. Every mutation queues behind the previous
  * one, so a route call and a turn hook can never read the same snapshot and
  * clobber each other.
+ *
+ * Rejects when the snapshot cannot be persisted, so a route answers 500
+ * rather than echoing state that only ever existed in memory.
  */
 async function mutateActivationProgress(
   mutate: (progress: ActivationProgress) => boolean,
@@ -128,7 +139,7 @@ async function mutateActivationProgress(
       writeActivationProgress(progress);
     } catch (err) {
       log.warn({ err }, "Failed to write activation-progress.json");
-      return progress;
+      throw new InternalError("Failed to persist activation progress");
     }
     await publishSyncInvalidation([SYNC_TAGS.activationProgress]);
     return progress;
@@ -150,6 +161,10 @@ function applyListId(progress: ActivationProgress, listId?: string): boolean {
   return true;
 }
 
+/**
+ * The `started` task this conversation belongs to, or `null`. At most one
+ * exists: {@link startActivationTask} unlinks the others as it links.
+ */
 function findLinkedTaskId(
   progress: ActivationProgress,
   conversationId: string,
@@ -162,6 +177,34 @@ function findLinkedTaskId(
   return null;
 }
 
+/**
+ * Drop every `started` task other than `taskId` that points at this
+ * conversation. Returns whether anything was dropped.
+ *
+ * The record is removed rather than kept with a dead link: a task whose
+ * conversation now belongs to another task has no progress left to report,
+ * and leaving it `started` is exactly the state the transition lookups
+ * would ignore. A `done` task keeps its record; its history is finished.
+ */
+function unlinkOtherTasks(
+  progress: ActivationProgress,
+  conversationId: string,
+  taskId: string,
+): boolean {
+  let unlinked = false;
+  for (const [otherId, other] of Object.entries(progress.tasks)) {
+    if (
+      otherId !== taskId &&
+      other.status === "started" &&
+      other.conversationId === conversationId
+    ) {
+      delete progress.tasks[otherId];
+      unlinked = true;
+    }
+  }
+  return unlinked;
+}
+
 // ---------------------------------------------------------------------------
 // Transitions
 // ---------------------------------------------------------------------------
@@ -172,6 +215,11 @@ function findLinkedTaskId(
  * Idempotent: re-starting a task in the same conversation changes nothing.
  * A different conversation replaces the link (and restarts the counters)
  * only while the task is not `done`. A finished task keeps its record.
+ *
+ * A conversation carries one task at a time. Launching a second task into
+ * a conversation another `started` task points at drops that stale record
+ * in the same write, so the step and completion lookups never resolve one
+ * task while silently ignoring another.
  */
 export async function startActivationTask(params: {
   taskId: string;
@@ -190,11 +238,12 @@ export async function startActivationTask(params: {
   return mutateActivationProgress((progress) => {
     const listChanged = applyListId(progress, listId);
     const existing = progress.tasks[taskId];
-    if (
-      existing?.status === "done" ||
-      existing?.conversationId === conversationId
-    ) {
+    if (existing?.status === "done") {
       return listChanged;
+    }
+    const unlinked = unlinkOtherTasks(progress, conversationId, taskId);
+    if (existing?.conversationId === conversationId) {
+      return listChanged || unlinked;
     }
     progress.tasks[taskId] = {
       status: "started",

--- a/assistant/src/activation/turn-hooks.test.ts
+++ b/assistant/src/activation/turn-hooks.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for the activation turn hooks.
+ *
+ * The hooks are fire-and-forget, so the contract under test is: they
+ * normalize what the agent loop hands them, they reach the store, and a
+ * store failure never escapes as a rejection.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Mocking the publisher (one exported function) rather than the event hub
+// keeps the mock harmless for any sibling file bun runs in the same process.
+mock.module("../runtime/sync/sync-publisher.js", () => ({
+  publishSyncInvalidation: async (tags: string[]) => ({
+    type: "sync_changed",
+    tags,
+  }),
+}));
+
+const {
+  markActivationTurnComplete,
+  readActivationProgress,
+  resetActivationStepThrottleForTesting,
+  startActivationTask,
+} = await import("./progress-store.js");
+const {
+  collectActivationArtifacts,
+  onActivationToolCall,
+  onActivationTurnComplete,
+} = await import("./turn-hooks.js");
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-activation-hooks-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  resetActivationStepThrottleForTesting(0);
+});
+
+afterEach(() => {
+  resetActivationStepThrottleForTesting();
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await Bun.sleep(5);
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+describe("collectActivationArtifacts", () => {
+  test("prefers the explicit filename and falls back to the basename", () => {
+    expect(
+      collectActivationArtifacts([
+        { path: "notes/plan.md", filename: "Weekly plan.md" },
+        { path: "notes/summary.md", filename: undefined },
+        { path: "  ", filename: "ignored" },
+      ]),
+    ).toEqual([
+      { workspacePath: "notes/plan.md", displayName: "Weekly plan.md" },
+      { workspacePath: "notes/summary.md", displayName: "summary.md" },
+    ]);
+  });
+
+  test("returns an empty list when the turn attached nothing", () => {
+    expect(collectActivationArtifacts([])).toEqual([]);
+  });
+});
+
+describe("onActivationToolCall", () => {
+  test("moves the linked task's step count", async () => {
+    await startActivationTask({
+      taskId: "draft-email",
+      conversationId: "conv-1",
+    });
+
+    onActivationToolCall("conv-1");
+
+    await waitFor(
+      () => readActivationProgress().tasks["draft-email"].stepCount === 1,
+    );
+  });
+
+  test("does not throw for an unlinked conversation", async () => {
+    expect(() => onActivationToolCall("conv-unlinked")).not.toThrow();
+    await Bun.sleep(10);
+    expect(readActivationProgress().tasks).toEqual({});
+  });
+});
+
+describe("onActivationTurnComplete", () => {
+  test("completes the linked task with normalized artifacts", async () => {
+    await startActivationTask({
+      taskId: "draft-email",
+      conversationId: "conv-1",
+    });
+
+    onActivationTurnComplete({
+      conversationId: "conv-1",
+      toolCallCount: 3,
+      attachedFiles: [{ path: "notes/plan.md", filename: undefined }],
+    });
+
+    await waitFor(
+      () => readActivationProgress().tasks["draft-email"].status === "done",
+    );
+    expect(readActivationProgress().tasks["draft-email"]).toMatchObject({
+      stepCount: 3,
+      artifacts: [{ workspacePath: "notes/plan.md", displayName: "plan.md" }],
+    });
+  });
+
+  test("is a no-op for a conversation no task points at", async () => {
+    onActivationTurnComplete({
+      conversationId: "conv-unlinked",
+      toolCallCount: 2,
+      attachedFiles: [],
+    });
+    await Bun.sleep(10);
+    expect(readActivationProgress().tasks).toEqual({});
+  });
+
+  test("a second terminal turn changes nothing", async () => {
+    await startActivationTask({
+      taskId: "draft-email",
+      conversationId: "conv-1",
+    });
+    await markActivationTurnComplete({
+      conversationId: "conv-1",
+      toolCallCount: 2,
+      artifacts: [],
+    });
+    const done = readActivationProgress().tasks["draft-email"];
+
+    onActivationTurnComplete({
+      conversationId: "conv-1",
+      toolCallCount: 7,
+      attachedFiles: [{ path: "notes/other.md", filename: undefined }],
+    });
+    await Bun.sleep(10);
+
+    expect(readActivationProgress().tasks["draft-email"]).toEqual(done);
+  });
+});

--- a/assistant/src/activation/turn-hooks.ts
+++ b/assistant/src/activation/turn-hooks.ts
@@ -1,0 +1,82 @@
+/**
+ * Turn-boundary hooks that keep activation progress in step with the
+ * conversations the checklist launched.
+ *
+ * The agent loop calls these fire-and-forget: they own their own error
+ * handling and never reject, so a regression here cannot fail a turn.
+ * They take plain data rather than loop types, which keeps this module
+ * importable (and testable) on its own.
+ */
+
+import { basename } from "node:path";
+
+import type { ActivationArtifact } from "../api/responses/activation.js";
+import { getLogger } from "../util/logger.js";
+import {
+  bumpActivationStepCount,
+  markActivationTurnComplete,
+} from "./progress-store.js";
+
+const log = getLogger("activation-turn-hooks");
+
+/**
+ * A file the assistant attached this turn, in the shape the loop already
+ * has on hand (`DirectiveRequest`): the path it named plus the display
+ * name it asked for, if any.
+ */
+export interface ActivationAttachedFile {
+  path: string;
+  filename?: string | undefined;
+}
+
+/**
+ * Normalize this turn's attached files into checklist artifacts. Blank
+ * paths are dropped and the display name falls back to the path's
+ * basename, which is what the client renders on the file card.
+ */
+export function collectActivationArtifacts(
+  attached: readonly ActivationAttachedFile[],
+): ActivationArtifact[] {
+  const artifacts: ActivationArtifact[] = [];
+  for (const file of attached) {
+    const workspacePath = file.path.trim();
+    if (workspacePath.length === 0) {
+      continue;
+    }
+    const displayName =
+      file.filename?.trim() || basename(workspacePath) || workspacePath;
+    artifacts.push({ workspacePath, displayName });
+  }
+  return artifacts;
+}
+
+/**
+ * Count one tool call against the activation task linked to this
+ * conversation. A no-op when no task points at it.
+ */
+export function onActivationToolCall(conversationId: string): void {
+  void bumpActivationStepCount(conversationId).catch((err: unknown) => {
+    log.warn({ err, conversationId }, "Activation step bump failed");
+  });
+}
+
+/**
+ * Mark the activation task linked to this conversation done. A no-op when
+ * no task points at it, and idempotent once one is done.
+ */
+export function onActivationTurnComplete(params: {
+  conversationId: string;
+  toolCallCount: number;
+  attachedFiles: readonly ActivationAttachedFile[];
+}): void {
+  void markActivationTurnComplete({
+    conversationId: params.conversationId,
+    toolCallCount: params.toolCallCount,
+    artifacts: collectActivationArtifacts(params.attachedFiles),
+  }).catch((err: unknown) => {
+    log.warn(
+      { err, conversationId: params.conversationId },
+      "Activation turn completion failed",
+    );
+  });
+}

--- a/assistant/src/api/responses/activation.ts
+++ b/assistant/src/api/responses/activation.ts
@@ -1,0 +1,126 @@
+/**
+ * Wire contract for the activation-checklist REST endpoints.
+ *
+ *   - `GET  /v1/activation/progress`             → `ActivationProgress`
+ *   - `POST /v1/activation/tasks/:taskId/start`  → `ActivationProgress`
+ *   - `POST /v1/activation/dismiss`              → `ActivationProgress`
+ *
+ * Holds the canonical progress shape shared by the on-disk store
+ * (`activation/progress-store.ts`), the route handlers, the OpenAPI
+ * generator, and every external client, so none of them can drift.
+ *
+ * Task ids and list ids are opaque to the daemon: the task catalog lives
+ * client-side and only its identifiers are persisted here.
+ */
+
+import { z } from "zod";
+
+/** Schema version of the on-disk progress file. */
+export const ACTIVATION_PROGRESS_VERSION = 1;
+
+/**
+ * Character class every activation task id and list id must match.
+ * Lowercase kebab-case, bounded so a hostile id cannot become a giant
+ * JSON key on disk.
+ */
+export const ACTIVATION_ID_PATTERN = /^[a-z0-9-]{1,64}$/;
+
+export const ActivationIdSchema = z
+  .string()
+  .regex(ACTIVATION_ID_PATTERN)
+  .describe("Opaque lowercase-kebab identifier, 1-64 characters");
+
+/** A file the assistant produced while working a task. */
+export const ActivationArtifactSchema = z.object({
+  workspacePath: z
+    .string()
+    .describe("Path of the produced file, as the assistant attached it"),
+  displayName: z.string().describe("Human-readable file name for the card"),
+});
+export type ActivationArtifact = z.infer<typeof ActivationArtifactSchema>;
+
+/** Per-task progress record. */
+export const ActivationTaskProgressSchema = z.object({
+  status: z
+    .enum(["started", "done"])
+    .describe("`started` while the linked conversation is working the task"),
+  conversationId: z
+    .string()
+    .describe("Conversation the task was launched into"),
+  startedAt: z.string().describe("ISO timestamp of the launch"),
+  completedAt: z
+    .string()
+    .nullable()
+    .describe("ISO timestamp of the completing turn, null while started"),
+  stepCount: z
+    .number()
+    .int()
+    .nullable()
+    .describe("Tool calls observed in the linked conversation so far"),
+  artifacts: z
+    .array(ActivationArtifactSchema)
+    .describe("Files the completing turn attached"),
+});
+export type ActivationTaskProgress = z.infer<
+  typeof ActivationTaskProgressSchema
+>;
+
+/** Full activation progress resource. */
+export const ActivationProgressSchema = z.object({
+  version: z.literal(ACTIVATION_PROGRESS_VERSION).describe("Schema version"),
+  listId: z
+    .string()
+    .nullable()
+    .describe("Task list frozen on the first write, null before then"),
+  modalDismissedAt: z
+    .string()
+    .nullable()
+    .describe("ISO timestamp the welcome modal was dismissed"),
+  allDoneShownAt: z
+    .string()
+    .nullable()
+    .describe("ISO timestamp the celebration modal was dismissed"),
+  tasks: z
+    .record(z.string(), ActivationTaskProgressSchema)
+    .describe("Progress keyed by task id"),
+});
+export type ActivationProgress = z.infer<typeof ActivationProgressSchema>;
+
+export const ActivationTaskStartRequestSchema = z.object({
+  conversationId: z
+    .string()
+    .min(1)
+    .describe("Conversation the task prompt was sent to"),
+  listId: ActivationIdSchema.optional().describe(
+    "List the task came from, stored only while no list is frozen",
+  ),
+});
+export type ActivationTaskStartRequest = z.infer<
+  typeof ActivationTaskStartRequestSchema
+>;
+
+export const ActivationDismissKindSchema = z
+  .enum(["modal", "all-done"])
+  .describe("Which surface was dismissed");
+export type ActivationDismissKind = z.infer<typeof ActivationDismissKindSchema>;
+
+export const ActivationDismissRequestSchema = z.object({
+  kind: ActivationDismissKindSchema,
+  listId: ActivationIdSchema.optional().describe(
+    "List the surface showed, stored only while no list is frozen",
+  ),
+});
+export type ActivationDismissRequest = z.infer<
+  typeof ActivationDismissRequestSchema
+>;
+
+/** Empty progress, returned before the store file exists. */
+export function emptyActivationProgress(): ActivationProgress {
+  return {
+    version: ACTIVATION_PROGRESS_VERSION,
+    listId: null,
+    modalDismissedAt: null,
+    allDoneShownAt: null,
+    tasks: {},
+  };
+}

--- a/assistant/src/daemon/assistant-attachments.ts
+++ b/assistant/src/daemon/assistant-attachments.ts
@@ -33,6 +33,13 @@ export interface AssistantAttachmentDraft {
   dataBase64: string;
   sizeBytes: number;
   kind: "image" | "video" | "document";
+  /**
+   * Path the assistant named in the directive this draft came from.
+   * Absent for drafts derived from tool content blocks, which have no file
+   * of their own. Callers that need to point a user back at the produced
+   * file (the activation checklist's artifact cards) read it.
+   */
+  sourcePath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -600,6 +607,7 @@ export function resolveSandboxDirective(
       dataBase64,
       sizeBytes: data.length,
       kind: classifyKind(mimeType),
+      sourcePath: directive.path,
     },
     warning: null,
   };
@@ -716,6 +724,7 @@ export async function resolveHostDirective(
       dataBase64,
       sizeBytes: data.length,
       kind: classifyKind(mimeType),
+      sourcePath: directive.path,
     },
     warning: null,
   };

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -10,6 +10,7 @@ import { SENTINEL_REDACTION_VERSION } from "@vellumai/service-contracts/redacted
 import type pino from "pino";
 import { v4 as uuid } from "uuid";
 
+import { onActivationToolCall } from "../activation/turn-hooks.js";
 import type { AgentEvent } from "../agent/loop.js";
 import type { AnsweredQuestion } from "../api/events/question-answered.js";
 import type { AssistantEvent } from "../api/index.js";
@@ -1589,6 +1590,10 @@ export function handleToolUse(
   event: Extract<AgentEvent, { type: "tool_use" }>,
 ): void {
   state.toolUseIdToName.set(event.id, event.name);
+  // Activation checklist: keep the launched task's live step count moving.
+  // Fire-and-forget and throttled inside the hook; a no-op for every
+  // conversation no activation task points at.
+  onActivationToolCall(deps.ctx.conversationId);
   if (event.name === "app_create" || event.name === "app_refresh") {
     state.appBuildToolUsedThisRun = true;
   }

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -9,6 +9,7 @@
 
 import { v4 as uuid } from "uuid";
 
+import { onActivationTurnComplete } from "../activation/turn-hooks.js";
 import { repairHistoryForRun } from "../agent/history-repair/history-repair.js";
 import type {
   AgentEvent,
@@ -2050,6 +2051,18 @@ export async function runAgentLoopImpl(
         // here so a regression in the writer can never bubble out of the
         // agent loop and reject an otherwise-complete turn.
         void writeRelationshipState().catch(() => {});
+
+        // Activation checklist: a completed turn in a conversation an
+        // activation task was launched into finishes that task. Cancelled
+        // turns and handoffs deliberately fall through: the task is still
+        // running. No-op for every conversation no task points at.
+        if (turnCompleted) {
+          onActivationTurnComplete({
+            conversationId: ctx.conversationId,
+            toolCallCount: state.toolUseIdToName.size,
+            attachedFiles: state.accumulatedDirectives,
+          });
+        }
       }
 
       // Consolidation deferred to compaction: keeping assistant + tool_result

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -102,6 +102,7 @@ import {
 } from "./conversation-agent-loop-handlers.js";
 import {
   approveHostAttachmentRead,
+  type PersistedAttachmentFile,
   resolveAssistantAttachments,
 } from "./conversation-attachments.js";
 import {
@@ -780,6 +781,11 @@ export async function runAgentLoopImpl(
   // provider-error turn's only assistant row is the synthetic error text, so
   // the deferred tail must not treat either as a final reply.
   let turnCompleted = false;
+  // Files this turn attached that survived resolution and persistence, in
+  // the shape the activation hook records as artifacts. Rejected directives
+  // never reach it, so a checklist card can never point at a file the turn
+  // failed to attach.
+  let persistedAttachmentFiles: readonly PersistedAttachmentFile[] = [];
   // True once `releaseTurn` has run. The happy path releases as soon as the
   // turn's content is settled; the `finally` calls it again as the backstop for
   // the cancel/error paths that never reached the early release.
@@ -1838,6 +1844,7 @@ export async function runAgentLoopImpl(
         state.toolContentBlockToolNames,
       );
       const { assistantAttachments, emittedAttachments } = attachmentResult;
+      persistedAttachmentFiles = attachmentResult.persistedFiles;
 
       ctx.lastAssistantAttachments = assistantAttachments;
       ctx.lastAttachmentWarnings = attachmentResult.directiveWarnings;
@@ -2003,6 +2010,27 @@ export async function runAgentLoopImpl(
     try {
       if (turnStarted) {
         ctx.turnCount++;
+
+        // Activation checklist: a completed turn in a conversation an
+        // activation task was launched into finishes that task. Cancelled
+        // turns and handoffs deliberately fall through: the task is still
+        // running. No-op for every conversation no task points at.
+        //
+        // Ahead of the turn-boundary commit, and fire-and-forget: a commit
+        // that fails, times out, or is deferred to the next turn must not
+        // leave the task showing as still running while the client is
+        // already free to restart it.
+        if (turnCompleted) {
+          onActivationTurnComplete({
+            conversationId: ctx.conversationId,
+            toolCallCount: state.toolUseIdToName.size,
+            attachedFiles: persistedAttachmentFiles.map((file) => ({
+              path: file.sourcePath,
+              filename: file.displayName,
+            })),
+          });
+        }
+
         const runTurnCommit = async (): Promise<void> => {
           const config = getConfig();
           const maxWait = config.workspaceGit?.turnCommitMaxWaitMs ?? 4000;
@@ -2051,18 +2079,6 @@ export async function runAgentLoopImpl(
         // here so a regression in the writer can never bubble out of the
         // agent loop and reject an otherwise-complete turn.
         void writeRelationshipState().catch(() => {});
-
-        // Activation checklist: a completed turn in a conversation an
-        // activation task was launched into finishes that task. Cancelled
-        // turns and handoffs deliberately fall through: the task is still
-        // running. No-op for every conversation no task points at.
-        if (turnCompleted) {
-          onActivationTurnComplete({
-            conversationId: ctx.conversationId,
-            toolCallCount: state.toolUseIdToName.size,
-            attachedFiles: state.accumulatedDirectives,
-          });
-        }
       }
 
       // Consolidation deferred to compaction: keeping assistant + tool_result

--- a/assistant/src/daemon/conversation-attachments.ts
+++ b/assistant/src/daemon/conversation-attachments.ts
@@ -63,10 +63,24 @@ export async function approveHostAttachmentRead(
   return response.decision === "allow";
 }
 
+/**
+ * A file the assistant named that survived resolution, validation, and
+ * persistence. Rejected directives (missing, oversized, denied) and drafts
+ * whose upload was skipped never appear here, so a caller pointing a user
+ * at "the files this turn produced" cannot offer a broken one.
+ */
+export interface PersistedAttachmentFile {
+  /** Path the assistant named in the directive. */
+  sourcePath: string;
+  /** Name the attachment was persisted under. */
+  displayName: string;
+}
+
 export interface AttachmentResolutionResult {
   assistantAttachments: AssistantAttachmentDraft[];
   emittedAttachments: UserMessageAttachment[];
   directiveWarnings: string[];
+  persistedFiles: PersistedAttachmentFile[];
 }
 
 /**
@@ -84,6 +98,16 @@ export async function resolveAssistantAttachments(
 ): Promise<AttachmentResolutionResult> {
   let assistantAttachments: AssistantAttachmentDraft[] = [];
   const emittedAttachments: UserMessageAttachment[] = [];
+  const persistedFiles: PersistedAttachmentFile[] = [];
+
+  const recordPersistedFile = (draft: AssistantAttachmentDraft): void => {
+    if (draft.sourcePath) {
+      persistedFiles.push({
+        sourcePath: draft.sourcePath,
+        displayName: draft.filename,
+      });
+    }
+  };
 
   log.info(
     {
@@ -208,6 +232,7 @@ export async function resolveAssistantAttachments(
         }
       }
 
+      recordPersistedFile(draft);
       emittedAttachments.push({
         id: stored.id,
         filename: draft.filename,
@@ -221,6 +246,7 @@ export async function resolveAssistantAttachments(
     }
   } else if (assistantAttachments.length > 0) {
     for (const draft of assistantAttachments) {
+      recordPersistedFile(draft);
       emittedAttachments.push({
         filename: draft.filename,
         mimeType: draft.mimeType,
@@ -230,5 +256,10 @@ export async function resolveAssistantAttachments(
     }
   }
 
-  return { assistantAttachments, emittedAttachments, directiveWarnings };
+  return {
+    assistantAttachments,
+    emittedAttachments,
+    directiveWarnings,
+    persistedFiles,
+  };
 }

--- a/assistant/src/daemon/message-types/sync.ts
+++ b/assistant/src/daemon/message-types/sync.ts
@@ -18,6 +18,8 @@ export const SYNC_TAGS = {
   documentsList: "documents:list",
   pluginsList: "plugins:list",
   conversationsList: "conversations:list",
+  /** Activation-checklist progress: task launches, step counts, completions. */
+  activationProgress: "activation:progress",
   featureFlagsClient: "feature-flags:client",
   featureFlagsAssistant: "feature-flags:assistant",
   /** ACP credential-failure markers, which drive the inline Connect card.

--- a/assistant/src/runtime/routes/activation-routes.test.ts
+++ b/assistant/src/runtime/routes/activation-routes.test.ts
@@ -6,7 +6,7 @@
  * depend on.
  */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -116,6 +116,45 @@ describe("activation routes", () => {
 
     expect(err).toBeInstanceOf(RouteError);
     expect((err as RouteError).statusCode).toBe(400);
+  });
+
+  test("POST start rejects when the write cannot be persisted", async () => {
+    // Occupy the data directory's path with a regular file, so the store
+    // cannot create it and the write fails.
+    writeFileSync(join(workspaceDir, "data"), "not a directory", "utf-8");
+
+    const err = await call(startTaskRoute, {
+      pathParams: { taskId: "draft-email" },
+      body: { conversationId: "conv-1" },
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).statusCode).toBe(500);
+  });
+
+  test("POST dismiss rejects when the write cannot be persisted", async () => {
+    writeFileSync(join(workspaceDir, "data"), "not a directory", "utf-8");
+
+    const err = await call(dismissRoute, { body: { kind: "modal" } }).catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).statusCode).toBe(500);
+  });
+
+  test("POST start hands the conversation to the latest task", async () => {
+    await call(startTaskRoute, {
+      pathParams: { taskId: "draft-email" },
+      body: { conversationId: "conv-1" },
+    });
+    const result = await call(startTaskRoute, {
+      pathParams: { taskId: "book-travel" },
+      body: { conversationId: "conv-1" },
+    });
+
+    expect(Object.keys(result.tasks)).toEqual(["book-travel"]);
+    expect(await call(getProgressRoute)).toEqual(result);
   });
 
   test("routes declare their policy, tags, and response body", () => {

--- a/assistant/src/runtime/routes/activation-routes.test.ts
+++ b/assistant/src/runtime/routes/activation-routes.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the activation route handlers in `activation-routes.ts`.
+ *
+ * Covers the GET/POST round trip, the request-body validation contract,
+ * and the route-definition metadata clients and the OpenAPI generator
+ * depend on.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { ActivationProgress } from "../../api/responses/activation.js";
+import { ROUTES as ACTIVATION_ROUTES } from "./activation-routes.js";
+import { RouteError } from "./errors.js";
+import { ROUTES as ALL_ROUTES } from "./index.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+function findRoute(operationId: string): RouteDefinition {
+  const route = ACTIVATION_ROUTES.find((r) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route;
+}
+
+const getProgressRoute = findRoute("activation_progress_get");
+const startTaskRoute = findRoute("activation_task_start_post");
+const dismissRoute = findRoute("activation_dismiss_post");
+
+async function call(
+  route: RouteDefinition,
+  args: RouteHandlerArgs = {},
+): Promise<ActivationProgress> {
+  return (await route.handler(args)) as ActivationProgress;
+}
+
+let workspaceDir: string;
+let origWorkspaceDir: string | undefined;
+
+beforeEach(() => {
+  workspaceDir = mkdtempSync(join(tmpdir(), "vellum-activation-routes-"));
+  origWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+  process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+});
+
+afterEach(() => {
+  if (origWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = origWorkspaceDir;
+  }
+  rmSync(workspaceDir, { recursive: true, force: true });
+});
+
+describe("activation routes", () => {
+  test("GET progress returns the empty default before any write", async () => {
+    expect(await call(getProgressRoute)).toEqual({
+      version: 1,
+      listId: null,
+      modalDismissedAt: null,
+      allDoneShownAt: null,
+      tasks: {},
+    });
+  });
+
+  test("POST start links the task and returns the full progress", async () => {
+    const result = await call(startTaskRoute, {
+      pathParams: { taskId: "draft-email" },
+      body: { conversationId: "conv-1", listId: "smb" },
+    });
+
+    expect(result.listId).toBe("smb");
+    expect(result.tasks["draft-email"]).toMatchObject({
+      status: "started",
+      conversationId: "conv-1",
+    });
+    expect(await call(getProgressRoute)).toEqual(result);
+  });
+
+  test("POST dismiss records the surface and returns the full progress", async () => {
+    const result = await call(dismissRoute, {
+      body: { kind: "all-done", listId: "parent" },
+    });
+
+    expect(result.allDoneShownAt).not.toBeNull();
+    expect(result.modalDismissedAt).toBeNull();
+    expect(result.listId).toBe("parent");
+  });
+
+  test("POST start rejects a malformed task id with a 400", async () => {
+    const err = await call(startTaskRoute, {
+      pathParams: { taskId: "Not A Task" },
+      body: { conversationId: "conv-1" },
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).statusCode).toBe(400);
+  });
+
+  test("POST start rejects a missing conversation id with a 400", async () => {
+    const err = await call(startTaskRoute, {
+      pathParams: { taskId: "draft-email" },
+      body: {},
+    }).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).statusCode).toBe(400);
+  });
+
+  test("POST dismiss rejects an unknown kind with a 400", async () => {
+    const err = await call(dismissRoute, { body: { kind: "sideways" } }).catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(RouteError);
+    expect((err as RouteError).statusCode).toBe(400);
+  });
+
+  test("routes declare their policy, tags, and response body", () => {
+    for (const route of ACTIVATION_ROUTES) {
+      expect(route.tags).toEqual(["activation"]);
+      expect(route.responseBody).toBeDefined();
+      expect(route.policy?.allowedPrincipalTypes.length).toBeGreaterThan(0);
+    }
+    expect(getProgressRoute.policy?.requiredScopes).toEqual(["chat.read"]);
+    expect(startTaskRoute.policy?.requiredScopes).toEqual(["chat.write"]);
+    expect(dismissRoute.policy?.requiredScopes).toEqual(["chat.write"]);
+  });
+
+  test("routes are registered in the shared route table", () => {
+    const registered = new Set(ALL_ROUTES.map((r) => r.operationId));
+    for (const route of ACTIVATION_ROUTES) {
+      expect(registered.has(route.operationId)).toBe(true);
+    }
+  });
+});

--- a/assistant/src/runtime/routes/activation-routes.ts
+++ b/assistant/src/runtime/routes/activation-routes.ts
@@ -1,0 +1,126 @@
+/**
+ * Route handlers for the activation checklist.
+ *
+ * GET  /v1/activation/progress            : read the progress resource
+ * POST /v1/activation/tasks/:taskId/start : link a task to a conversation
+ * POST /v1/activation/dismiss             : record a dismissed surface
+ *
+ * Every route returns the full progress resource so a client never has to
+ * follow a write with a read. The task catalog itself is client-side: the
+ * daemon only stores opaque task and list identifiers.
+ */
+
+import type { z } from "zod";
+
+import {
+  dismissActivation,
+  readActivationProgress,
+  startActivationTask,
+} from "../../activation/progress-store.js";
+import {
+  ActivationDismissRequestSchema,
+  ActivationProgressSchema,
+  ActivationTaskStartRequestSchema,
+} from "../../api/responses/activation.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import { BadRequestError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+function parseBody<S extends z.ZodType>(
+  schema: S,
+  body: Record<string, unknown> | undefined,
+): z.infer<S> {
+  const parsed = schema.safeParse(body ?? {});
+  if (!parsed.success) {
+    throw new BadRequestError(
+      `Invalid activation request body: ${parsed.error.issues[0]?.message ?? "unknown field"}`,
+    );
+  }
+  return parsed.data;
+}
+
+function handleGetActivationProgress() {
+  return readActivationProgress();
+}
+
+async function handleStartActivationTask({
+  pathParams = {},
+  body,
+}: RouteHandlerArgs) {
+  const { conversationId, listId } = parseBody(
+    ActivationTaskStartRequestSchema,
+    body,
+  );
+  return startActivationTask({
+    taskId: pathParams.taskId ?? "",
+    conversationId,
+    ...(listId !== undefined ? { listId } : {}),
+  });
+}
+
+async function handleDismissActivation({ body }: RouteHandlerArgs) {
+  const { kind, listId } = parseBody(ActivationDismissRequestSchema, body);
+  return dismissActivation({
+    kind,
+    ...(listId !== undefined ? { listId } : {}),
+  });
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "activation_progress_get",
+    endpoint: "activation/progress",
+    method: "GET",
+    policy: {
+      requiredScopes: ["chat.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get activation progress",
+    description:
+      "Return the activation checklist progress: the frozen list, dismissed surfaces, and per-task state.",
+    tags: ["activation"],
+    responseBody: ActivationProgressSchema,
+    handler: handleGetActivationProgress,
+  },
+  {
+    operationId: "activation_task_start_post",
+    endpoint: "activation/tasks/:taskId/start",
+    method: "POST",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Start an activation task",
+    description:
+      "Link an activation task to the conversation its prompt was sent to. Idempotent per task; a different conversation replaces the link only while the task is not done.",
+    tags: ["activation"],
+    pathParams: [
+      { name: "taskId", description: "Catalog id of the launched task" },
+    ],
+    requestBody: ActivationTaskStartRequestSchema,
+    responseBody: ActivationProgressSchema,
+    handler: handleStartActivationTask,
+    additionalResponses: {
+      "400": { description: "Malformed task id, list id, or conversation id" },
+    },
+  },
+  {
+    operationId: "activation_dismiss_post",
+    endpoint: "activation/dismiss",
+    method: "POST",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Dismiss an activation surface",
+    description:
+      "Record that the welcome modal or the celebration modal was dismissed.",
+    tags: ["activation"],
+    requestBody: ActivationDismissRequestSchema,
+    responseBody: ActivationProgressSchema,
+    handler: handleDismissActivation,
+    additionalResponses: {
+      "400": { description: "Malformed dismiss kind or list id" },
+    },
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -17,6 +17,7 @@ import { ROUTES as MEMORY_V3_ROUTES } from "../../plugins/defaults/memory/src/me
 import { ROUTES as MEMORY_WORKER_ROUTES } from "../../plugins/defaults/memory/src/memory-worker-routes.js";
 import { ROUTES as ACP_CLAUDE_AUTH_ROUTES } from "./acp-claude-auth-routes.js";
 import { ROUTES as ACP_ROUTES } from "./acp-routes.js";
+import { ROUTES as ACTIVATION_ROUTES } from "./activation-routes.js";
 import { ROUTES as APP_MANAGEMENT_ROUTES } from "./app-management-routes.js";
 import { ROUTES as APP_ROUTES } from "./app-routes.js";
 import { ROUTES as APPROVAL_ROUTES } from "./approval-routes.js";
@@ -211,6 +212,7 @@ export const ROUTES: RouteDefinition[] = [
   ...CONVERSATION_COMPACTION_ROUTES,
   ...CONVERSATION_QUERY_ROUTES,
   ...CONVERSATION_STARTER_ROUTES,
+  ...ACTIVATION_ROUTES,
   ...DEBUG_BASH_ROUTES,
   ...DEBUG_ROUTES,
   ...DEFAULT_PROVIDER_ROUTES,


### PR DESCRIPTION
## Summary
- Adds `data/activation-progress.json` store with start / dismiss / step-count / turn-complete transitions and the `activation:progress` sync tag
- Exposes `GET /v1/activation/progress`, `POST /v1/activation/tasks/:taskId/start`, `POST /v1/activation/dismiss`
- Hooks tool calls and the turn boundary in the conversation agent loop to track linked conversations

## Daemon version for the PR 3 compat gate
`assistant/package.json` is at `0.11.8` and `v0.11.8` is already tagged, so the first release carrying these routes is **0.11.9**. PR 3 should set `MIN_VERSION = "0.11.9"` in `clients/web/src/lib/backwards-compat/use-supports-activation-progress.ts`.

## Notes for review
- **Generated client operation ids.** `scripts/generate-openapi.ts` derives spec operation ids from the endpoint path, not from `RouteDefinition.operationId` (existing convention for every `/v1` route). The generated SDK names are `activation_progress_get`, `activation_tasks_by_taskId_start_post`, and `activation_dismiss_post`.
- **Turn-completion guard.** The completion hook fires only when `turnCompleted` is true, so a cancelled turn or a checkpoint handoff leaves the task `started`.
- **Tool-call hook site.** The per-tool-call bump lives in `handleToolUse` in `conversation-agent-loop-handlers.ts` (the loop's `tool_use` dispatch site) rather than in `conversation-agent-loop.ts`, which never sees individual tool calls.
- **Artifacts.** Recorded from the turn's accumulated attachment directives (`workspacePath` + `displayName`), deduped by path and capped at 10.
- **No startup or LLM work.** The store is touched only by a request or a turn event; a missing or corrupt file reads as empty.

Part of plan: activation-checklist.md (PR 2 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->