### PR TITLE
feat(cli): guardian-confirmed contacts merge

### DIFF
--- a/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
@@ -10,6 +10,8 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { reportIpcFailureWithoutExiting } from "./run-assistant-command.js";
+
 interface IpcCall {
   operationId: string;
   options?: Record<string, unknown>;
@@ -81,13 +83,7 @@ const actualCliClient = await import("../../ipc/cli-client.js");
 mock.module("../../ipc/cli-client.js", () => ({
   ...actualCliClient,
   cliIpcCall: cliIpcCallMock,
-  // The real one ends the process, which would take the test runner with it.
-  // Same stderr line and same exit code, and the caller carries on to its own
-  // early return.
-  exitFromIpcResult: (r: { error?: string; statusCode?: number }) => {
-    process.stderr.write((r.error ?? "Unknown error") + "\n");
-    process.exitCode = actualCliClient.exitCodeFromIpcResult(r);
-  },
+  exitFromIpcResult: reportIpcFailureWithoutExiting,
 }));
 
 const { runAssistantCommandFull } = await import("./run-assistant-command.js");

--- a/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for what `contacts create` / `update` / `delete` put in front of the
- * guardian.
+ * Tests for what `contacts create` / `update` / `delete` / `merge` put in
+ * front of the guardian.
  *
  * The form is seeded from these bodies and the guardian submits what it shows,
  * so a field the CLI leaves empty is a field the guardian unknowingly writes
@@ -11,6 +11,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { GUARDIAN_FORM_SETTLE_MS } from "../../util/guardian-form-timeouts.js";
+import { reportIpcFailureWithoutExiting } from "./run-assistant-command.js";
 
 interface IpcCall {
   operationId: string;
@@ -42,8 +43,28 @@ const contact = {
 /** What a contact with no notes actually looks like on the wire. */
 const contactWithoutNotes = { ...contact, notes: null };
 
-let contactForRead: Record<string, unknown> = contact;
-/** Make the display readback fail, as a transient IPC hiccup would. */
+/** The duplicate a merge folds into `contact`. */
+const donor = {
+  id: "ct_2",
+  displayName: "Bob",
+  notes: null,
+  contactType: "human",
+  createdAt: 0,
+  updatedAt: 0,
+  interactionCount: 0,
+  channels: [
+    {
+      id: "ch_2",
+      contactId: "ct_2",
+      type: "phone",
+      address: "+15555550142",
+    },
+  ],
+};
+
+/** What `getContact` answers with, by id. An id it does not hold reads as 404. */
+let contactsById: Record<string, Record<string, unknown>> = {};
+/** Make every read fail, as a transient IPC hiccup would. */
 let readFails = false;
 
 /**
@@ -58,6 +79,8 @@ let notesSaved: boolean | undefined;
 let nothingWritten: boolean | undefined;
 /** Whether the guardian closed the form instead of answering it. */
 let dismissed = false;
+/** Whether a merge's survivor took the submitted name. Absent unless renamed. */
+let renamed: boolean | undefined;
 
 const baseIpcImplementation = async (
   operationId: string,
@@ -66,11 +89,14 @@ const baseIpcImplementation = async (
 ) => {
   calls.push({ operationId, options, callOptions });
   if (operationId === "getContact") {
-    if (readFails) {
+    const id = (options as { pathParams?: { id?: string } } | undefined)
+      ?.pathParams?.id;
+    const found = id === undefined ? undefined : contactsById[id];
+    if (readFails || !found) {
       // 404-shaped, as a gateway-backed read reports a contact it cannot see.
       return { ok: false, error: "Contact not found", statusCode: 404 };
     }
-    return { ok: true, result: { ok: true, contact: contactForRead } };
+    return { ok: true, result: { ok: true, contact: found } };
   }
   if (dismissed) {
     // The rail keeps the human-readable reason alongside the marker.
@@ -81,7 +107,13 @@ const baseIpcImplementation = async (
   }
   return {
     ok: true,
-    result: { ok: true, contactId: contact.id, notesSaved, nothingWritten },
+    result: {
+      ok: true,
+      contactId: contact.id,
+      notesSaved,
+      nothingWritten,
+      renamed,
+    },
   };
 };
 
@@ -91,6 +123,7 @@ const actualCliClient = await import("../../ipc/cli-client.js");
 mock.module("../../ipc/cli-client.js", () => ({
   ...actualCliClient,
   cliIpcCall: cliIpcCallMock,
+  exitFromIpcResult: reportIpcFailureWithoutExiting,
 }));
 
 const { runAssistantCommand, runAssistantCommandFull } =
@@ -105,11 +138,12 @@ function recordPromptBody(): Record<string, unknown> {
 describe("contacts record prompts", () => {
   beforeEach(() => {
     calls = [];
-    contactForRead = contact;
+    contactsById = { ct_1: contact, ct_2: donor };
     readFails = false;
     notesSaved = undefined;
     nothingWritten = undefined;
     dismissed = false;
+    renamed = undefined;
     // Global and sticky: the failure-path cases below set it, and a later test
     // asserting success would otherwise read their exit code as its own.
     // Cleared to 0 rather than undefined, which does not reset it.
@@ -160,7 +194,7 @@ describe("contacts record prompts", () => {
     // `notes` is nullable on the wire, and the daemon's schema takes a string
     // or nothing. Passing the null through would reject the request and the
     // guardian would never see a form.
-    contactForRead = contactWithoutNotes;
+    contactsById.ct_1 = contactWithoutNotes;
 
     await runAssistantCommand(
       "contacts",
@@ -325,11 +359,6 @@ describe("contacts record prompts", () => {
     expect(body.channels).toEqual([]);
   });
 
-  // The refusing side of that branch (an update against a contact the read
-  // cannot see, or a delete for an id nothing knows about) has no test: it
-  // ends in `exitFromIpcResult`, which calls `process.exit` and takes the test
-  // runner with it.
-
   test("update refuses when neither --name nor --notes is given", async () => {
     await runAssistantCommand("contacts", "update", "ct_1");
 
@@ -338,11 +367,122 @@ describe("contacts record prompts", () => {
     );
   });
 
+  describe("merge", () => {
+    test("both contacts are read, and the form carries what moves", async () => {
+      const { stdout } = await runAssistantCommandFull(
+        "contacts",
+        "merge",
+        "ct_1",
+        "ct_2",
+      );
+
+      // Both reads come first: the confirmation names the pair it is about,
+      // so a bad id fails before the guardian sees anything.
+      expect(calls.slice(0, 2).map((c) => c.operationId)).toEqual([
+        "getContact",
+        "getContact",
+      ]);
+
+      const body = recordPromptBody();
+      expect(body.operation).toBe("merge");
+      expect(body.contactId).toBe("ct_1");
+      expect(body.currentDisplayName).toBe("Alice");
+      expect(body.donorContactId).toBe("ct_2");
+      expect(body.donorDisplayName).toBe("Bob");
+      // The guardian confirms which access moves, not just which ids.
+      expect(body.donorChannels).toEqual([
+        { type: "phone", address: "+15555550142" },
+      ]);
+      // No name is proposed, so the survivor keeps its own.
+      expect(body.displayName).toBeUndefined();
+      // A merge reparents channels rather than cascading them away, so there
+      // is nothing for a staleness guard to protect.
+      expect(body.expectedChannels).toBeUndefined();
+
+      expect(stdout).toContain('Merged "Bob" into "Alice"');
+      expect(process.exitCode).toBeFalsy();
+    });
+
+    test("--keep-donor-name proposes the donor's name for the survivor", async () => {
+      await runAssistantCommand(
+        "contacts",
+        "merge",
+        "ct_1",
+        "ct_2",
+        "--keep-donor-name",
+      );
+
+      expect(recordPromptBody().displayName).toBe("Bob");
+    });
+
+    test("merging a contact with itself is refused before any form", async () => {
+      const { stderr } = await runAssistantCommandFull(
+        "contacts",
+        "merge",
+        "ct_1",
+        "ct_1",
+      );
+
+      expect(stderr).toContain("itself");
+      expect(
+        calls.some((c) => c.operationId === "contacts_record_prompt"),
+      ).toBe(false);
+      expect(process.exitCode).toBe(1);
+    });
+
+    test("an unknown donor id fails before the guardian sees a form", async () => {
+      await runAssistantCommandFull("contacts", "merge", "ct_1", "ct_missing");
+
+      expect(
+        calls.some((c) => c.operationId === "contacts_record_prompt"),
+      ).toBe(false);
+      expect(process.exitCode).toBe(2);
+    });
+
+    test("a merge whose rename could not land still reports the merge", async () => {
+      // The merge committed. Reporting it as failed would invite a retry
+      // against a donor that no longer exists.
+      renamed = false;
+
+      const { stdout, stderr } = await runAssistantCommandFull(
+        "contacts",
+        "merge",
+        "ct_1",
+        "ct_2",
+        "--keep-donor-name",
+      );
+
+      expect(stdout).toContain('Merged "Bob" into "Alice"');
+      expect(stderr).toContain("not renamed");
+      expect(process.exitCode).toBeFalsy();
+    });
+
+    test("--json reports the surviving contact and the lost rename", async () => {
+      renamed = false;
+
+      const { stdout } = await runAssistantCommandFull(
+        "contacts",
+        "merge",
+        "ct_1",
+        "ct_2",
+        "--keep-donor-name",
+        "--json",
+      );
+
+      expect(JSON.parse(stdout)).toEqual({
+        ok: true,
+        contact,
+        renamed: false,
+      });
+    });
+  });
+
   describe("a dismissed form", () => {
     const operations: [string, string[]][] = [
       ["create", ["contacts", "create", "--name", "Alice"]],
       ["update", ["contacts", "update", "ct_1", "--name", "Alice Chen"]],
       ["delete", ["contacts", "delete", "ct_1"]],
+      ["merge", ["contacts", "merge", "ct_1", "ct_2"]],
     ];
 
     test.each(operations)(

--- a/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
@@ -389,9 +389,14 @@ describe("contacts record prompts", () => {
       expect(body.currentDisplayName).toBe("Alice");
       expect(body.donorContactId).toBe("ct_2");
       expect(body.donorDisplayName).toBe("Bob");
-      // The guardian confirms which access moves, not just which ids.
+      // The guardian confirms which access moves, not just which ids, and the
+      // card lists the survivor's own channels beside it: two contacts can
+      // share a name, so the addresses are what tell them apart.
       expect(body.donorChannels).toEqual([
         { type: "phone", address: "+15555550142" },
+      ]);
+      expect(body.channels).toEqual([
+        { type: "email", address: "alice@example.com" },
       ]);
       // No name is proposed, so the survivor keeps its own.
       expect(body.displayName).toBeUndefined();

--- a/assistant/src/cli/__tests__/run-assistant-command.ts
+++ b/assistant/src/cli/__tests__/run-assistant-command.ts
@@ -1,6 +1,21 @@
+import { exitCodeFromIpcResult } from "../../ipc/cli-client.js";
+
 export interface AssistantCommandResult {
   stdout: string;
   stderr: string;
+}
+
+/**
+ * Stand-in for `exitFromIpcResult` in a `mock.module` factory. The real one
+ * ends the process, which would take the test runner with it. Same stderr line
+ * and same exit code, and the caller carries on to its own early return.
+ */
+export function reportIpcFailureWithoutExiting(r: {
+  error?: string;
+  statusCode?: number;
+}): void {
+  process.stderr.write((r.error ?? "Unknown error") + "\n");
+  process.exitCode = exitCodeFromIpcResult(r);
 }
 
 /**

--- a/assistant/src/cli/__tests__/run-assistant-command.ts
+++ b/assistant/src/cli/__tests__/run-assistant-command.ts
@@ -1,5 +1,3 @@
-import { exitCodeFromIpcResult } from "../../ipc/cli-client.js";
-
 export interface AssistantCommandResult {
   stdout: string;
   stderr: string;
@@ -9,13 +7,27 @@ export interface AssistantCommandResult {
  * Stand-in for `exitFromIpcResult` in a `mock.module` factory. The real one
  * ends the process, which would take the test runner with it. Same stderr line
  * and same exit code, and the caller carries on to its own early return.
+ *
+ * The code mapping is spelled out rather than imported: suites load this helper
+ * before installing their `mock.module` replacement, so importing the IPC
+ * client here would pull the real module and its import-time work into test
+ * setup. It mirrors `exitCodeFromIpcResult` in `ipc/cli-client.ts`.
  */
 export function reportIpcFailureWithoutExiting(r: {
   error?: string;
   statusCode?: number;
 }): void {
   process.stderr.write((r.error ?? "Unknown error") + "\n");
-  process.exitCode = exitCodeFromIpcResult(r);
+  const status = r.statusCode;
+  if (status === undefined) {
+    process.exitCode = 10;
+  } else if (status >= 500) {
+    process.exitCode = 3;
+  } else if (status >= 400) {
+    process.exitCode = 2;
+  } else {
+    process.exitCode = 1;
+  }
 }
 
 /**

--- a/assistant/src/cli/commands/contacts.help.ts
+++ b/assistant/src/cli/commands/contacts.help.ts
@@ -292,10 +292,10 @@ Arguments:
 Opens a confirmation in the guardian's app naming both contacts and listing the
 channels that move. Nothing is merged unless they confirm.
 
-The donor's channels move to the survivor, both sets of notes are combined, the
-interaction counts are summed, and the donor record is deleted. Nobody loses
-access: every address that reached the donor reaches the survivor afterwards. A
-guardian contact cannot be the donor.
+The donor's channels move to the survivor, both sets of notes are combined, and
+the donor record is deleted. Nobody loses access: every address that reached the
+donor reaches the survivor afterwards. The survivor keeps its own interaction
+count; the donor's is not carried over. A guardian contact cannot be the donor.
 
 The survivor keeps its own name unless the guardian edits it on the form.
 --keep-donor-name seeds that field with the donor's name, for when the donor is

--- a/assistant/src/cli/commands/contacts.help.ts
+++ b/assistant/src/cli/commands/contacts.help.ts
@@ -294,8 +294,10 @@ channels that move. Nothing is merged unless they confirm.
 
 The donor's channels move to the survivor, both sets of notes are combined, and
 the donor record is deleted. Nobody loses access: every address that reached the
-donor reaches the survivor afterwards. The survivor keeps its own interaction
-count; the donor's is not carried over. A guardian contact cannot be the donor.
+donor reaches the survivor afterwards. A contact's interaction count is the sum
+over its channels, so a moved channel brings its history with it; an address the
+survivor already holds is left where it is, and its donor-side history goes with
+the deleted record. A guardian contact cannot be the donor.
 
 The survivor keeps its own name unless the guardian edits it on the form.
 --keep-donor-name seeds that field with the donor's name, for when the donor is

--- a/assistant/src/cli/commands/contacts.help.ts
+++ b/assistant/src/cli/commands/contacts.help.ts
@@ -249,14 +249,63 @@ channels. Nothing is deleted unless they confirm.
 
 Deleting a contact deletes its channels with it, so anyone reaching the
 assistant through those channels loses access. A guardian contact cannot be
-deleted. To merge a duplicate instead of deleting it, use the contact_merge
-tool, which keeps the surviving contact's channels.
+deleted. To fold a duplicate into the record you are keeping instead of
+deleting it, run 'assistant contacts merge <survivorId> <donorId>', which moves
+the donor's channels to the survivor rather than destroying them.
 
 ${FORM_NOTE}
 
 Examples:
   $ assistant contacts delete 7a3b1c2d-4e5f-6789-abcd-ef0123456789
   $ assistant contacts delete abc-123 --json`,
+    },
+    {
+      name: "merge",
+      args: "<survivorId> <donorId>",
+      description: "Propose merging two contacts for the guardian to confirm",
+      options: [
+        {
+          flags: "--keep-donor-name",
+          description:
+            "Seed the form with the donor's name instead of the survivor's",
+        },
+        {
+          flags: "--label <label>",
+          description: "Display label shown on the confirmation",
+        },
+        {
+          flags: "--description <description>",
+          description: "Longer description shown on the confirmation",
+        },
+        {
+          flags: "--timeout <ms>",
+          description:
+            "How long the confirmation stays open (ms). The command waits for it to close.",
+          defaultValue: String(300_000),
+        },
+      ],
+      helpText: `
+Arguments:
+  survivorId   UUID of the contact to keep. Run 'assistant contacts list' to find IDs.
+  donorId      UUID of the contact to fold into it. Run 'assistant contacts list' to find IDs.
+
+Opens a confirmation in the guardian's app naming both contacts and listing the
+channels that move. Nothing is merged unless they confirm.
+
+The donor's channels move to the survivor, both sets of notes are combined, the
+interaction counts are summed, and the donor record is deleted. Nobody loses
+access: every address that reached the donor reaches the survivor afterwards. A
+guardian contact cannot be the donor.
+
+The survivor keeps its own name unless the guardian edits it on the form.
+--keep-donor-name seeds that field with the donor's name, for when the donor is
+the better-named record of the two.
+
+${FORM_NOTE}
+
+Examples:
+  $ assistant contacts merge 7a3b1c2d-4e5f-6789-abcd-ef0123456789 9f8e7d6c-5b4a-3210-fedc-ba9876543210
+  $ assistant contacts merge abc-123 def-456 --keep-donor-name --json`,
     },
     {
       name: "prompt",

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -208,11 +208,16 @@ function parseFormTimeout(
 }
 
 interface ContactRecordPromptBody {
-  operation: "create" | "update" | "delete";
+  operation: "create" | "update" | "delete" | "merge";
+  /** The contact the write lands on. On a merge, the survivor. */
   contactId?: string;
   currentDisplayName?: string;
   currentNotes?: string;
   channels?: Array<{ type: string; address: string }>;
+  /** The contact being merged away. Present only on a merge. */
+  donorContactId?: string;
+  donorDisplayName?: string;
+  donorChannels?: Array<{ type: string; address: string }>;
   displayName?: string;
   notes?: string;
   notesProposed?: boolean;
@@ -468,6 +473,12 @@ async function runRecordPrompt(
     contactId?: string;
     notesSaved?: boolean;
     nothingWritten?: boolean;
+    /**
+     * Whether a merge's surviving contact took the submitted name. Absent
+     * unless a rename was submitted. False means the merge committed and the
+     * survivor kept its old name.
+     */
+    renamed?: boolean;
     cancelled?: boolean;
   }>(
     "contacts_record_prompt",
@@ -499,6 +510,9 @@ async function runRecordPrompt(
   // what this command proposed is no guide to what was written.
   const notesLost = r.result.notesSaved === false;
   const nothingWritten = r.result.nothingWritten === true;
+  // A merge that could not apply the submitted name still merged, so this is a
+  // partial outcome to report rather than a failed command.
+  const renameLost = r.result.renamed === false;
 
   if (body.operation === "delete") {
     const deleted = body.currentDisplayName ?? contactId ?? body.contactId;
@@ -516,7 +530,12 @@ async function runRecordPrompt(
     return;
   }
 
-  const verb = body.operation === "create" ? "Created" : "Updated";
+  // A merge names both contacts, so it leads with its own line instead of a
+  // verb in front of "contact".
+  const headline =
+    body.operation === "merge"
+      ? `Merged "${body.donorDisplayName}" into "${body.currentDisplayName}":`
+      : `${body.operation === "create" ? "Created" : "Updated"} contact:`;
 
   // The write is already done and the guardian has already answered. This read
   // is only for what to print, so a failure here reports the write with less
@@ -552,19 +571,25 @@ async function runRecordPrompt(
       ok: true,
       ...(written ? { contact: written } : { contactId }),
       ...(notesLost ? { notesSaved: false } : {}),
+      ...(renameLost ? { renamed: false } : {}),
     });
     return;
   }
 
   if (written) {
-    process.stdout.write(`${verb} contact:\n`);
-    process.stdout.write(formatContactDetail(written) + "\n");
+    process.stdout.write(`${headline}\n${formatContactDetail(written)}\n`);
   } else {
-    process.stdout.write(`${verb} contact: ${contactId}\n`);
+    process.stdout.write(`${headline} ${contactId}\n`);
     writeError(cmd, "Could not read the contact back to display it");
   }
   if (notesLost) {
     writeError(cmd, "The contact was saved, but its notes were not");
+  }
+  if (renameLost) {
+    writeError(
+      cmd,
+      "The contacts were merged, but the surviving contact was not renamed",
+    );
   }
 }
 
@@ -663,7 +688,7 @@ export function registerContactsCommand(program: Command): void {
       );
 
       // -----------------------------------------------------------------------
-      // create / update / delete
+      // create / update / delete / merge
       //
       // Each opens a form in the guardian's app and blocks on their answer.
       // The daemon writes nothing: the guardian's client posts the confirmed
@@ -815,6 +840,57 @@ export function registerContactsCommand(program: Command): void {
                 type: ch.type,
                 address: ch.address,
               })),
+              label: opts.label,
+              description: opts.description,
+            },
+            opts.timeout,
+            cmd,
+          );
+        },
+      );
+
+      subcommand(contacts, "merge").action(
+        async (
+          survivorId: string,
+          donorId: string,
+          opts: {
+            keepDonorName?: boolean;
+            label?: string;
+            description?: string;
+            timeout?: string;
+          },
+          cmd: Command,
+        ) => {
+          if (survivorId === donorId) {
+            writeError(
+              cmd,
+              `Cannot merge contact "${survivorId}" into itself. Pass the surviving id and a different donor id. Run 'assistant contacts list' to find contact ids.`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+          const survivor = await readContactForPrompt(survivorId, cmd);
+          if (!survivor) {
+            return;
+          }
+          const donor = await readContactForPrompt(donorId, cmd);
+          if (!donor) {
+            return;
+          }
+          await runRecordPrompt(
+            {
+              operation: "merge",
+              contactId: survivorId,
+              currentDisplayName: survivor.displayName,
+              donorContactId: donorId,
+              donorDisplayName: donor.displayName,
+              // The confirmation says which access moves, so the guardian can
+              // see what the survivor ends up reachable at.
+              donorChannels: donor.channels.map((ch) => ({
+                type: ch.type,
+                address: ch.address,
+              })),
+              displayName: opts.keepDonorName ? donor.displayName : undefined,
               label: opts.label,
               description: opts.description,
             },

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -884,9 +884,13 @@ export function registerContactsCommand(program: Command): void {
               currentDisplayName: survivor.displayName,
               donorContactId: donorId,
               donorDisplayName: donor.displayName,
-              // The confirmation says which access moves, so the guardian can
-              // see what the survivor ends up reachable at.
+              // Two contacts can share a name, so the confirmation lists both
+              // sides: what moves, and what the survivor already holds.
               donorChannels: donor.channels.map((ch) => ({
+                type: ch.type,
+                address: ch.address,
+              })),
+              channels: survivor.channels.map((ch) => ({
                 type: ch.type,
                 address: ch.address,
               })),

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -1145,6 +1145,34 @@ describe("gateway contacts classification", () => {
   });
 });
 
+describe("assistant contacts write classification", () => {
+  const classifier = makeClassifier();
+
+  test("assistant contacts merge → medium", async () => {
+    const result = await classifier.classify({
+      command: "assistant contacts merge ct_1 ct_2",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("assistant contacts channels add → medium", async () => {
+    const result = await classifier.classify({
+      command: "assistant contacts channels add ct_1 --channel email",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("medium");
+  });
+
+  test("assistant contacts delete → high", async () => {
+    const result = await classifier.classify({
+      command: "assistant contacts delete ct_1",
+      toolName: "bash",
+    });
+    expect(result.riskLevel).toBe("high");
+  });
+});
+
 // ── Scope options ────────────────────────────────────────────────────────────
 
 describe("scope options", () => {

--- a/gateway/src/risk/bash-risk-classifier.test.ts
+++ b/gateway/src/risk/bash-risk-classifier.test.ts
@@ -1148,12 +1148,12 @@ describe("gateway contacts classification", () => {
 describe("assistant contacts write classification", () => {
   const classifier = makeClassifier();
 
-  test("assistant contacts merge → medium", async () => {
+  test("assistant contacts merge → high", async () => {
     const result = await classifier.classify({
       command: "assistant contacts merge ct_1 ct_2",
       toolName: "bash",
     });
-    expect(result.riskLevel).toBe("medium");
+    expect(result.riskLevel).toBe("high");
   });
 
   test("assistant contacts channels add → medium", async () => {

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -582,6 +582,21 @@ describe("command-registry", () => {
       }
     });
 
+    test("contacts write verbs keep their risk levels", () => {
+      // Every one opens a guardian form, so the levels describe the command
+      // itself: delete takes the contact's channels with it, while a merge
+      // moves them to the survivor.
+      expect(getAssistantPath("contacts prompt").baseRisk).toBe("medium");
+      expect(getAssistantPath("contacts create").baseRisk).toBe("medium");
+      expect(getAssistantPath("contacts update").baseRisk).toBe("medium");
+      expect(getAssistantPath("contacts delete").baseRisk).toBe("high");
+      expect(getAssistantPath("contacts merge").baseRisk).toBe("medium");
+      expect(getAssistantPath("contacts channels add").baseRisk).toBe("medium");
+      expect(getAssistantPath("contacts channels update-status").baseRisk).toBe(
+        "medium",
+      );
+    });
+
     test("expanded assistant operations have expected risk levels", () => {
       expect(getAssistantPath("config set").baseRisk).toBe("low");
       expect(getAssistantPath("oauth providers register").baseRisk).toBe(

--- a/gateway/src/risk/command-registry.test.ts
+++ b/gateway/src/risk/command-registry.test.ts
@@ -590,7 +590,7 @@ describe("command-registry", () => {
       expect(getAssistantPath("contacts create").baseRisk).toBe("medium");
       expect(getAssistantPath("contacts update").baseRisk).toBe("medium");
       expect(getAssistantPath("contacts delete").baseRisk).toBe("high");
-      expect(getAssistantPath("contacts merge").baseRisk).toBe("medium");
+      expect(getAssistantPath("contacts merge").baseRisk).toBe("high");
       expect(getAssistantPath("contacts channels add").baseRisk).toBe("medium");
       expect(getAssistantPath("contacts channels update-status").baseRisk).toBe(
         "medium",

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -474,9 +474,9 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "contacts delete", risk: "high" },
   {
     path: "contacts merge",
-    risk: "medium",
+    risk: "high",
     reason:
-      "Deletes the donor record, but moves its channels to the survivor, so nobody loses access. The guardian confirms it on a form.",
+      "Permanently deletes the donor contact record, the same irreversible write that makes 'contacts delete' high. Its channels move to the survivor, so nobody loses access, but a policy that gates high operations should gate this one.",
   },
   { path: "contacts channels add", risk: "medium" },
   { path: "contacts channels update-status", risk: "medium" },

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -94,6 +94,7 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "contacts create",
   "contacts update",
   "contacts delete",
+  "contacts merge",
   "contacts channels",
   "contacts channels add",
   "contacts channels update-status",
@@ -471,6 +472,12 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "contacts create", risk: "medium" },
   { path: "contacts update", risk: "medium" },
   { path: "contacts delete", risk: "high" },
+  {
+    path: "contacts merge",
+    risk: "medium",
+    reason:
+      "Deletes the donor record, but moves its channels to the survivor, so nobody loses access. The guardian confirms it on a form.",
+  },
   { path: "contacts channels add", risk: "medium" },
   { path: "contacts channels update-status", risk: "medium" },
   { path: "contacts invites create", risk: "high" },


### PR DESCRIPTION
## Summary

- Adds `assistant contacts merge <survivorId> <donorId>`, which parks a guardian confirmation naming both contacts and listing the donor channels that move, then reports the surviving contact. `--keep-donor-name` seeds the form's name field with the donor's name instead of the survivor's.
- A self merge is refused before anything opens, and both ids are read first, so a typo fails with a pointer at `assistant contacts list` rather than in front of the guardian. A committed merge whose post-merge rename could not land reports the merge and warns that the survivor kept its name, rather than reporting a failure that would invite a retry against a donor that no longer exists.
- Registers `contacts merge` in the gateway bash risk registry (supported path plus a `medium` override), points the `contacts delete` help at the new verb instead of the `contact_merge` tool, and extends the record-prompt CLI suite. The shared test double for `exitFromIpcResult` moves into `run-assistant-command.ts` so both contacts CLI suites use one copy.

Deliberately no `expectedChannels`-style staleness guard on merge: `delete` has one because a cascade destroys access, while a merge reparents channels, so a channel gained while the form was open is moved to the survivor rather than lost.

## Why this is not a revert of #30301

`assistant contacts merge` existed and was deliberately removed in 26f3bbf2cc ("chore(assistant): trim contacts CLI per #30281 review", PR #30301), which also dropped it from both lists in the risk registry. The stated reason: "`merge` is a destructive write of one contact into another; that operation belongs in the guardian web UI alongside the rest of the contact-management flows."

This PR is not a revert of that decision, it is the decision's condition being met. The verb no longer writes anything itself: it parks a form in the guardian's app, and the guardian's client posts the confirmed merge straight to the gateway, exactly like `create`/`update`/`delete` after e0ee55ed82. The merge does happen in the guardian's app, which is what #30301 asked for.

Part of plan: contacts-cli-channel-binding.md (PR 11 of 12)