### PR TITLE
feat(web): inspiration list page for activation tasks

### DIFF
--- a/clients/web/src/components/local-file/local-file-card.tsx
+++ b/clients/web/src/components/local-file/local-file-card.tsx
@@ -179,9 +179,11 @@ export function LocalFileCard({
           aria-hidden="true"
           /* The hint keeps its slot in the layout at all times and is only
              faded, so revealing it cannot reflow the name or the size beside
-             it. */
+             it. It is dropped on a phone, where it is wide enough to squeeze
+             the filename out of the card and the tap it previews is the only
+             gesture there is. */
           data-reveal=""
-          className="flex shrink-0 items-center gap-1 text-[var(--content-tertiary)]"
+          className="flex shrink-0 items-center gap-1 text-[var(--content-tertiary)] max-md:hidden"
         >
           <HintIcon className="h-3.5 w-3.5" />
           <Typography

--- a/clients/web/src/domains/activation/activation-test-fixtures.ts
+++ b/clients/web/src/domains/activation/activation-test-fixtures.ts
@@ -115,6 +115,22 @@ export const ACTIVATION_PROGRESS_ALL_DONE: ActivationProgress = progress({
   }),
 });
 
+/**
+ * The Inspiration List showing every row treatment at once: a finished task
+ * with its file, one still working, one finished with nothing to show for it,
+ * and the untouched rest of the catalog.
+ */
+export const ACTIVATION_PROGRESS_LIST_MIXED: ActivationProgress = progress({
+  [FIXTURE_STARTER_IDS[0]]: doneWithArtifactProgress(),
+  [FIXTURE_STARTER_IDS[1]]: startedTaskProgress({
+    conversationId: "conv-started-2",
+    stepCount: 2,
+  }),
+  [FIXTURE_STARTER_IDS[2]]: doneTaskProgress({
+    conversationId: "conv-done-3",
+  }),
+});
+
 /** The modal dismissed with less than three starters done: the pill state. */
 export const ACTIVATION_PROGRESS_DISMISSED: ActivationProgress = progress(
   {

--- a/clients/web/src/domains/activation/catalog.test.ts
+++ b/clients/web/src/domains/activation/catalog.test.ts
@@ -204,7 +204,9 @@ describe("activation copy contract", () => {
         "launch.noAssistant",
         "launch.unknownTask",
         "launch.failed",
+        "launch.openConversation",
         "page.title",
+        "page.loading",
       ].sort(),
     );
   });

--- a/clients/web/src/domains/activation/components/activation-list-page.stories.tsx
+++ b/clients/web/src/domains/activation/components/activation-list-page.stories.tsx
@@ -1,0 +1,96 @@
+/**
+ * The Inspiration List, against the real `smb` catalog and the wire-shaped
+ * progress fixtures the daemon returns.
+ *
+ * Two states are worth looking at, and they are the two Figma drew: a list
+ * nobody has touched (Light 796), and one carrying every finished treatment at
+ * once (Light 797). Each is repeated in dark and at 390px, which is where the
+ * 600px column gives up its gutters and the serif title steps down.
+ *
+ * The list is long on purpose. The page scrolls inside the shell rather than
+ * the window, and a short fixture would not show that.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  ACTIVATION_PROGRESS_EMPTY,
+  ACTIVATION_PROGRESS_LIST_MIXED,
+} from "@/domains/activation/activation-test-fixtures";
+import { useActivationList } from "@/domains/activation/catalog";
+import { ActivationListPage } from "@/domains/activation/components/activation-list-page";
+import type { ActivationProgress } from "@/domains/activation/hooks/use-activation-progress";
+
+/**
+ * Resolves the real catalog the way the route does, so a story renders the
+ * copy, icons and colors that ship rather than a hand-written stand-in.
+ */
+function ListPageDemo({ progress }: { progress: ActivationProgress }) {
+  const { starters, items } = useActivationList("smb");
+  return (
+    <ActivationListPage
+      tasks={[...starters, ...items]}
+      progress={progress.tasks}
+      onLaunch={() => {}}
+      onOpenConversation={() => {}}
+    />
+  );
+}
+
+const meta: Meta<typeof ListPageDemo> = {
+  title: "Activation/ActivationListPage",
+  component: ListPageDemo,
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story) => (
+      // The page fills the chat layout's outlet, which is a min-height-0 flex
+      // column. Anything shorter hides the scroll behaviour.
+      <div className="flex h-screen flex-col bg-[var(--surface-base)] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ListPageDemo>;
+
+/** Light 796: nothing launched, every row offering itself. */
+export const Light796Todo: Story = {
+  args: { progress: ACTIVATION_PROGRESS_EMPTY },
+};
+
+/** The same list on a phone: full-bleed gutters and the smaller serif title. */
+export const Light796TodoMobile: Story = {
+  args: { progress: ACTIVATION_PROGRESS_EMPTY },
+  globals: { viewport: { value: "sbMobile" } },
+};
+
+/** The untouched list in dark, where the tinted task discs are re-mixed. */
+export const Light796TodoDark: Story = {
+  args: { progress: ACTIVATION_PROGRESS_EMPTY },
+  globals: { theme: "dark" },
+};
+
+/**
+ * Light 797: the first task finished and produced a file, the second is still
+ * running with a live step count, the third finished with nothing to show.
+ */
+export const Light797Mixed: Story = {
+  args: { progress: ACTIVATION_PROGRESS_LIST_MIXED },
+};
+
+/** The mixed list on a phone, where the file card has the least room. */
+export const Light797MixedMobile: Story = {
+  args: { progress: ACTIVATION_PROGRESS_LIST_MIXED },
+  globals: { viewport: { value: "sbMobile" } },
+};
+
+/**
+ * The mixed list in dark. The green check and its disc are the pair most
+ * likely to collapse into each other once the positive tokens flip.
+ */
+export const Light797MixedDark: Story = {
+  args: { progress: ACTIVATION_PROGRESS_LIST_MIXED },
+  globals: { theme: "dark" },
+};

--- a/clients/web/src/domains/activation/components/activation-list-page.stories.tsx
+++ b/clients/web/src/domains/activation/components/activation-list-page.stories.tsx
@@ -25,12 +25,12 @@ import type { ActivationProgress } from "@/domains/activation/hooks/use-activati
  * Resolves the real catalog the way the route does, so a story renders the
  * copy, icons and colors that ship rather than a hand-written stand-in.
  */
-function ListPageDemo({ progress }: { progress: ActivationProgress }) {
+function ListPageDemo({ progress }: { progress?: ActivationProgress }) {
   const { starters, items } = useActivationList("smb");
   return (
     <ActivationListPage
       tasks={[...starters, ...items]}
-      progress={progress.tasks}
+      progress={progress?.tasks}
       onLaunch={() => {}}
       onOpenConversation={() => {}}
     />
@@ -78,6 +78,15 @@ export const Light796TodoDark: Story = {
  */
 export const Light797Mixed: Story = {
   args: { progress: ACTIVATION_PROGRESS_LIST_MIXED },
+};
+
+/**
+ * The list before the daemon has answered. Placeholder rows stand in for the
+ * real ones, because a row rendered against progress that has not landed would
+ * offer a finished task back to the user.
+ */
+export const Loading: Story = {
+  args: { progress: undefined },
 };
 
 /** The mixed list on a phone, where the file card has the least room. */

--- a/clients/web/src/domains/activation/components/activation-list-page.test.tsx
+++ b/clients/web/src/domains/activation/components/activation-list-page.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * What the Inspiration List owes its reader: every task of the list in catalog
+ * order, a title that counts them, and a click that does the right thing for
+ * the state each row is in.
+ *
+ * The page is presentational, so nothing is mocked here. The catalog is the
+ * real one and the progress is the wire shape the daemon returns, which is the
+ * only pairing that can prove a row reads its own record.
+ */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  ACTIVATION_PROGRESS_EMPTY,
+  ACTIVATION_PROGRESS_LIST_MIXED,
+  FIXTURE_STARTER_IDS,
+} from "@/domains/activation/activation-test-fixtures";
+import { getActivationList } from "@/domains/activation/catalog";
+import { ActivationListPage } from "@/domains/activation/components/activation-list-page";
+import type { ActivationProgress } from "@/domains/activation/hooks/use-activation-progress";
+
+const { starters, items } = getActivationList("smb");
+const TASKS = [...starters, ...items];
+
+const launched: string[] = [];
+const opened: string[] = [];
+
+function renderPage(progress: ActivationProgress = ACTIVATION_PROGRESS_EMPTY) {
+  return render(
+    <ActivationListPage
+      tasks={TASKS}
+      progress={progress.tasks}
+      onLaunch={(taskId) => launched.push(taskId)}
+      onOpenConversation={(conversationId) => opened.push(conversationId)}
+    />,
+  );
+}
+
+/** The row whose title is `title`, as a clickable element. */
+function rowButton(title: string): HTMLElement {
+  const button = screen.getByText(title).closest("button");
+  if (!button) {
+    throw new Error(`No row button for "${title}"`);
+  }
+  return button;
+}
+
+afterEach(() => {
+  cleanup();
+  launched.length = 0;
+  opened.length = 0;
+});
+
+describe("ActivationListPage", () => {
+  test("renders the whole list, starters first, and counts it in the title", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", {
+        name: `Your first ${TASKS.length} things`,
+      }),
+    ).toBeTruthy();
+
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.length).toBe(TASKS.length);
+    // Catalog order, which puts the three starters at the top (PLAN A10).
+    expect(rows[0]?.textContent).toContain(starters[0]?.title ?? "");
+    expect(rows[3]?.textContent).toContain(items[0]?.title ?? "");
+  });
+
+  test("clicking an untouched row launches it and stays on the page", () => {
+    renderPage();
+
+    fireEvent.click(rowButton(starters[0]?.title ?? ""));
+
+    expect(launched).toEqual([FIXTURE_STARTER_IDS[0]]);
+    expect(opened).toEqual([]);
+  });
+
+  test("clicking a finished row opens its conversation instead", () => {
+    renderPage(ACTIVATION_PROGRESS_LIST_MIXED);
+
+    fireEvent.click(rowButton(starters[0]?.title ?? ""));
+
+    expect(opened).toEqual(["conv-done-1"]);
+    expect(launched).toEqual([]);
+  });
+
+  test("clicking a running row opens its conversation too", () => {
+    renderPage(ACTIVATION_PROGRESS_LIST_MIXED);
+
+    fireEvent.click(rowButton(starters[1]?.title ?? ""));
+
+    expect(opened).toEqual(["conv-started-2"]);
+  });
+
+  test("each finished row shows what it produced", () => {
+    renderPage(ACTIVATION_PROGRESS_LIST_MIXED);
+
+    // A turn that attached a file shows the file; one that did not falls back
+    // to the "Done · N steps" pill (PLAN A6).
+    expect(screen.getByText("proposal-aug2026.pdf")).toBeTruthy();
+    expect(screen.getByText("Done")).toBeTruthy();
+    expect(screen.getByText("4 steps")).toBeTruthy();
+    expect(screen.getByText("Working")).toBeTruthy();
+    expect(screen.getByText("2 steps")).toBeTruthy();
+  });
+
+  test("a launch in flight reads as working and cannot be fired twice", () => {
+    render(
+      <ActivationListPage
+        tasks={TASKS}
+        progress={{}}
+        pendingTaskId={FIXTURE_STARTER_IDS[0]}
+        onLaunch={(taskId) => launched.push(taskId)}
+        onOpenConversation={(conversationId) => opened.push(conversationId)}
+      />,
+    );
+
+    expect(screen.getByText("Working")).toBeTruthy();
+    fireEvent.click(rowButton(starters[0]?.title ?? ""));
+    expect(launched).toEqual([]);
+  });
+});
+
+describe("ActivationListPage external links", () => {
+  const linked = TASKS.find((task) => task.link);
+
+  test("a task with a call to action renders it under the description", () => {
+    expect(linked).toBeTruthy();
+    renderPage();
+
+    const anchor = screen.getByRole("link", { name: /.+/ });
+    expect(anchor.getAttribute("href")).toBe(linked?.link?.url ?? null);
+    // It leaves the app, so it gets the hardening every external link gets.
+    expect(anchor.getAttribute("target")).toBe("_blank");
+    expect(anchor.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  test("the desktop app drops it: it already is the download", async () => {
+    mock.module("@/runtime/is-electron", () => ({ isElectron: () => true }));
+    const { ActivationListPage: ElectronPage } = await import(
+      "@/domains/activation/components/activation-list-page"
+    );
+
+    render(
+      <ElectronPage
+        tasks={TASKS}
+        progress={{}}
+        onLaunch={() => {}}
+        onOpenConversation={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole("link")).toBeNull();
+    mock.restore();
+  });
+});

--- a/clients/web/src/domains/activation/components/activation-list-page.test.tsx
+++ b/clients/web/src/domains/activation/components/activation-list-page.test.tsx
@@ -112,7 +112,7 @@ describe("ActivationListPage", () => {
       <ActivationListPage
         tasks={TASKS}
         progress={{}}
-        pendingTaskId={FIXTURE_STARTER_IDS[0]}
+        pendingTaskIds={new Set([FIXTURE_STARTER_IDS[0]])}
         onLaunch={(taskId) => launched.push(taskId)}
         onOpenConversation={(conversationId) => opened.push(conversationId)}
       />,
@@ -121,6 +121,44 @@ describe("ActivationListPage", () => {
     expect(screen.getByText("Working")).toBeTruthy();
     fireEvent.click(rowButton(starters[0]?.title ?? ""));
     expect(launched).toEqual([]);
+  });
+
+  // Two launches can be in flight at once, and each row leaves its pending
+  // state only when its own launch settles.
+  test("every in-flight launch holds its own row", () => {
+    render(
+      <ActivationListPage
+        tasks={TASKS}
+        progress={{}}
+        pendingTaskIds={
+          new Set([FIXTURE_STARTER_IDS[0], FIXTURE_STARTER_IDS[1]])
+        }
+        onLaunch={(taskId) => launched.push(taskId)}
+        onOpenConversation={(conversationId) => opened.push(conversationId)}
+      />,
+    );
+
+    expect(screen.getAllByText("Working")).toHaveLength(2);
+    fireEvent.click(rowButton(starters[0]?.title ?? ""));
+    fireEvent.click(rowButton(starters[1]?.title ?? ""));
+    expect(launched).toEqual([]);
+  });
+
+  // Progress the daemon has not answered for yet is not an empty progress
+  // map: a row rendered against one would offer a finished task back.
+  test("progress that has not landed renders placeholders, not tasks", () => {
+    render(
+      <ActivationListPage
+        tasks={TASKS}
+        progress={undefined}
+        onLaunch={(taskId) => launched.push(taskId)}
+        onOpenConversation={(conversationId) => opened.push(conversationId)}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.queryByText(starters[0]?.title ?? "")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/activation/components/activation-list-page.tsx
+++ b/clients/web/src/domains/activation/components/activation-list-page.tsx
@@ -1,0 +1,70 @@
+/**
+ * The Inspiration List: every task the active persona list offers, in catalog
+ * order, with the daemon's progress on each (Figma Light 796 / Light 797).
+ *
+ * Flat and unsectioned by design (PLAN A10): the list is browsed, not
+ * navigated, and category headers would ask the reader to pick a bucket
+ * before picking a task.
+ *
+ * Presentational. Every read and write is a prop, so the page renders the same
+ * against a story fixture as against the daemon, and the route beside it owns
+ * the catalog, the progress query and the launch.
+ */
+
+import { PageShell } from "@/components/page-shell";
+import { useTranslation } from "@/i18n";
+
+import type { ActivationTask } from "../catalog";
+import type { ActivationProgress } from "../hooks/use-activation-progress";
+import { ActivationListRow } from "./activation-list-row";
+
+export interface ActivationListPageProps {
+  /** Starters first, then the rest, exactly as the list orders them. */
+  tasks: ActivationTask[];
+  /** The daemon's per-task records, keyed by task id. */
+  progress: ActivationProgress["tasks"];
+  /** The task whose launch is in flight, if any. */
+  pendingTaskId?: string | null;
+  onLaunch: (taskId: string) => void;
+  onOpenConversation: (conversationId: string) => void;
+  assistantId?: string;
+}
+
+export function ActivationListPage({
+  tasks,
+  progress,
+  pendingTaskId,
+  onLaunch,
+  onOpenConversation,
+  assistantId,
+}: ActivationListPageProps) {
+  const { t } = useTranslation("activation");
+
+  return (
+    <PageShell className="overflow-y-auto">
+      <div className="mx-auto w-full max-w-[600px] px-4 md:px-0">
+        {/* The serif brand headline, the same treatment the chat's empty
+            state gives its greeting, a step down on mobile (PLAN A24). */}
+        <h1
+          className="text-center text-[40px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasised)] md:text-[48px]"
+          style={{ fontFamily: "var(--font-serif)" }}
+        >
+          {t("page.title", { count: tasks.length })}
+        </h1>
+        <ul className="mt-10 mb-6 overflow-hidden rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)]">
+          {tasks.map((task) => (
+            <ActivationListRow
+              key={task.id}
+              task={task}
+              progress={progress[task.id]}
+              pending={pendingTaskId === task.id}
+              onLaunch={onLaunch}
+              onOpenConversation={onOpenConversation}
+              assistantId={assistantId}
+            />
+          ))}
+        </ul>
+      </div>
+    </PageShell>
+  );
+}

--- a/clients/web/src/domains/activation/components/activation-list-page.tsx
+++ b/clients/web/src/domains/activation/components/activation-list-page.tsx
@@ -9,7 +9,14 @@
  * Presentational. Every read and write is a prop, so the page renders the same
  * against a story fixture as against the daemon, and the route beside it owns
  * the catalog, the progress query and the launch.
+ *
+ * Progress that has not landed yet is `undefined`, not an empty map, and the
+ * rows are placeholders until it does. A missing record reads as "never
+ * started", so rendering the real rows early would offer a finished task back
+ * to the user and run its prompt a second time.
  */
+
+import { Skeleton } from "@vellumai/design-library/components/skeleton";
 
 import { PageShell } from "@/components/page-shell";
 import { useTranslation } from "@/i18n";
@@ -21,24 +28,42 @@ import { ActivationListRow } from "./activation-list-row";
 export interface ActivationListPageProps {
   /** Starters first, then the rest, exactly as the list orders them. */
   tasks: ActivationTask[];
-  /** The daemon's per-task records, keyed by task id. */
-  progress: ActivationProgress["tasks"];
-  /** The task whose launch is in flight, if any. */
-  pendingTaskId?: string | null;
+  /**
+   * The daemon's per-task records, keyed by task id. `undefined` while the
+   * read is still out, which renders placeholder rows instead of actionable
+   * ones.
+   */
+  progress: ActivationProgress["tasks"] | undefined;
+  /** Every task whose launch is in flight. */
+  pendingTaskIds?: ReadonlySet<string>;
   onLaunch: (taskId: string) => void;
   onOpenConversation: (conversationId: string) => void;
   assistantId?: string;
 }
 
+/** One row's worth of placeholder: the disc, the title and the description. */
+function ActivationListRowSkeleton() {
+  return (
+    <li className="flex items-start gap-3 border-b border-[var(--border-base)] px-3 py-4 last:border-b-0">
+      <Skeleton className="h-[26px] w-[26px] shrink-0 rounded-full" />
+      <div className="flex w-full flex-col gap-2">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+    </li>
+  );
+}
+
 export function ActivationListPage({
   tasks,
   progress,
-  pendingTaskId,
+  pendingTaskIds,
   onLaunch,
   onOpenConversation,
   assistantId,
 }: ActivationListPageProps) {
   const { t } = useTranslation("activation");
+  const loading = progress === undefined;
 
   return (
     <PageShell className="overflow-y-auto">
@@ -51,18 +76,27 @@ export function ActivationListPage({
         >
           {t("page.title", { count: tasks.length })}
         </h1>
-        <ul className="mt-10 mb-6 overflow-hidden rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)]">
-          {tasks.map((task) => (
-            <ActivationListRow
-              key={task.id}
-              task={task}
-              progress={progress[task.id]}
-              pending={pendingTaskId === task.id}
-              onLaunch={onLaunch}
-              onOpenConversation={onOpenConversation}
-              assistantId={assistantId}
-            />
-          ))}
+        {/* The placeholders are the only signal the page is loading, so the
+            list carries the loading semantics while they stand. */}
+        <ul
+          className="mt-10 mb-6 overflow-hidden rounded-lg border border-[var(--border-base)] bg-[var(--surface-lift)]"
+          aria-busy={loading || undefined}
+          role={loading ? "status" : undefined}
+          aria-label={loading ? t("page.loading") : undefined}
+        >
+          {loading
+            ? tasks.map((task) => <ActivationListRowSkeleton key={task.id} />)
+            : tasks.map((task) => (
+                <ActivationListRow
+                  key={task.id}
+                  task={task}
+                  progress={progress[task.id]}
+                  pending={pendingTaskIds?.has(task.id) ?? false}
+                  onLaunch={onLaunch}
+                  onOpenConversation={onOpenConversation}
+                  assistantId={assistantId}
+                />
+              ))}
         </ul>
       </div>
     </PageShell>

--- a/clients/web/src/domains/activation/components/activation-list-row.tsx
+++ b/clients/web/src/domains/activation/components/activation-list-row.tsx
@@ -1,0 +1,242 @@
+/**
+ * One task on the Inspiration List, in whichever of the three states the
+ * daemon's progress puts it: not started, running, or finished.
+ *
+ * The row is a `ListRow` plus a slot beneath it. Everything a click could
+ * reach (the task's external call to action, the file a finished task
+ * produced) lives in that slot rather than in the row's title or subtitle,
+ * because `ListRow` renders those inside its own button and a link or a file
+ * card nested in a button is neither valid markup nor reachable by keyboard.
+ * The slot is indented to the content column so it still reads as part of the
+ * row, which is where Figma puts it (`8300:167752`).
+ *
+ * Muting a finished row is a token swap on the title rather than an opacity
+ * on the block (PLAN A22): the mock fades the whole title block, which dims
+ * the text against whatever is behind it and lands at a different contrast in
+ * each theme.
+ */
+
+import { Check } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn, ListRow } from "@vellumai/design-library";
+
+import {
+  EXTERNAL_LINK_CLASS,
+  ExternalAnchor,
+} from "@/components/external-anchor";
+import { LocalFileCard } from "@/components/local-file/local-file-card";
+import { localFileKindFromFilename } from "@/components/local-file/local-file-icon";
+import { ProcessStatusPill } from "@/components/process-status-pill";
+import { useTranslation } from "@/i18n";
+import { isElectron } from "@/runtime/is-electron";
+
+import type { ActivationColor, ActivationTask } from "../catalog";
+import type { ActivationTaskProgress } from "../hooks/use-activation-progress";
+
+/** Where a row stands: nothing launched, a turn running, or a turn finished. */
+type ActivationRowState = "todo" | "working" | "done";
+
+/**
+ * The glyph and disc each catalog color resolves to, which are the
+ * strong/weak pair of one design-system hue. The mock's discs are those weak
+ * tokens exactly, and a token is also what carries the disc into dark, where
+ * a tint mixed off the strong colour would sit on the wrong side of the
+ * background.
+ *
+ * The palette has no purple, so purple borrows the nearest hue it does carry
+ * rather than introducing a hex the themes would not follow.
+ */
+const COLOR_TOKENS: Record<ActivationColor, { strong: string; weak: string }> =
+  {
+    blue: { strong: "--system-info-strong", weak: "--system-info-weak" },
+    teal: { strong: "--feed-digest-strong", weak: "--feed-digest-weak" },
+    yellow: { strong: "--feed-thread-strong", weak: "--feed-thread-weak" },
+    pink: { strong: "--feed-nudge-strong", weak: "--feed-nudge-weak" },
+    green: {
+      strong: "--system-positive-strong",
+      weak: "--system-positive-weak",
+    },
+    orange: {
+      strong: "--system-negative-strong",
+      weak: "--system-negative-weak",
+    },
+    purple: { strong: "--feed-nudge-strong", weak: "--feed-nudge-weak" },
+  };
+
+/** The finished disc: a green check, whatever colour the task carries. */
+const DONE_COLORS = {
+  strong: "--system-positive-strong",
+  weak: "--system-positive-weak",
+};
+
+/** The state a task's stored progress puts its row in. */
+function activationRowState(
+  progress: ActivationTaskProgress | undefined,
+): ActivationRowState {
+  if (progress?.status === "done") {
+    return "done";
+  }
+  if (progress?.status === "started") {
+    return "working";
+  }
+  return "todo";
+}
+
+/**
+ * The task's glyph in its tinted disc, or the green check that replaces it
+ * once the task is finished (PLAN A21).
+ */
+function ActivationTaskIcon({
+  task,
+  state,
+}: {
+  task: ActivationTask;
+  state: ActivationRowState;
+}) {
+  const done = state === "done";
+  const { strong, weak } = done ? DONE_COLORS : COLOR_TOKENS[task.color];
+  const Glyph = done ? Check : task.icon;
+  return (
+    <span
+      aria-hidden
+      className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full"
+      style={{ color: `var(${strong})`, backgroundColor: `var(${weak})` }}
+    >
+      <Glyph className="h-3 w-3" />
+    </span>
+  );
+}
+
+/** The file a finished task produced, when its turn attached one. */
+function ActivationArtifactCard({
+  artifact,
+  assistantId,
+}: {
+  artifact: ActivationTaskProgress["artifacts"][number];
+  assistantId?: string;
+}) {
+  const filename =
+    artifact.workspacePath.split("/").pop() || artifact.displayName;
+  return (
+    <LocalFileCard
+      displayName={artifact.displayName}
+      filename={filename}
+      sizeBytes={null}
+      kind={localFileKindFromFilename(filename)}
+      state="ready"
+      workspacePath={artifact.workspacePath}
+      assistantId={assistantId}
+    />
+  );
+}
+
+export interface ActivationListRowProps {
+  task: ActivationTask;
+  /** The daemon's record for this task, absent while it is untouched. */
+  progress?: ActivationTaskProgress;
+  /** True while this row's launch is in flight. */
+  pending?: boolean;
+  onLaunch: (taskId: string) => void;
+  onOpenConversation: (conversationId: string) => void;
+  assistantId?: string;
+}
+
+export function ActivationListRow({
+  task,
+  progress,
+  pending = false,
+  onLaunch,
+  onOpenConversation,
+  assistantId,
+}: ActivationListRowProps) {
+  const { t } = useTranslation("activation");
+  const state = activationRowState(progress);
+  const conversationId = progress?.conversationId ?? null;
+  const artifact = state === "done" ? progress?.artifacts[0] : undefined;
+
+  // A launch that has not landed yet reads as Working with nothing to count:
+  // the row has already left `todo` and the daemon has no steps for it.
+  const showsWorking = state === "working" || pending;
+
+  const activate = () => {
+    if (state === "todo") {
+      onLaunch(task.id);
+      return;
+    }
+    if (conversationId) {
+      onOpenConversation(conversationId);
+    }
+  };
+  const interactive = state === "todo" || conversationId !== null;
+
+  // The download page a task points at is what the desktop app already is, so
+  // the call to action only ships where it leads somewhere new.
+  const link = task.link && !isElectron() ? task.link : null;
+  const extras: ReactNode[] = [];
+  if (link) {
+    extras.push(
+      <ExternalAnchor
+        key="link"
+        href={link.url}
+        className={cn(EXTERNAL_LINK_CLASS, "text-label-medium-default")}
+      >
+        {link.label}
+      </ExternalAnchor>,
+    );
+  }
+  if (artifact) {
+    extras.push(
+      <ActivationArtifactCard
+        key="artifact"
+        artifact={artifact}
+        assistantId={assistantId}
+      />,
+    );
+  } else if (showsWorking || state === "done") {
+    extras.push(
+      <ProcessStatusPill
+        key="status"
+        state={showsWorking ? "working" : "done"}
+        label={showsWorking ? t("row.working") : t("row.done")}
+        count={
+          progress?.stepCount
+            ? t("row.steps", { count: progress.stepCount })
+            : undefined
+        }
+      />,
+    );
+  }
+
+  return (
+    <li className="flex flex-col border-b border-[var(--border-base)] last:border-b-0">
+      <ListRow
+        className={cn(
+          "items-start rounded-none px-3 py-4",
+          extras.length > 0 && "pb-0",
+        )}
+        leading={<ActivationTaskIcon task={task} state={state} />}
+        title={
+          <span
+            className={cn(state === "done" && "text-[var(--content-tertiary)]")}
+          >
+            {task.title}
+          </span>
+        }
+        subtitle={
+          <span className="text-label-medium-default leading-[1.45]">
+            {task.description}
+          </span>
+        }
+        showChevron={false}
+        onClick={interactive ? activate : undefined}
+        disabled={pending}
+      />
+      {extras.length > 0 ? (
+        <div className="flex flex-col items-start gap-2 pt-3 pr-3 pb-4 pl-[50px]">
+          {extras}
+        </div>
+      ) : null}
+    </li>
+  );
+}

--- a/clients/web/src/domains/activation/hooks/use-activation-visibility.ts
+++ b/clients/web/src/domains/activation/hooks/use-activation-visibility.ts
@@ -5,19 +5,17 @@
  * and the celebration can never disagree about whether the feature is on, and
  * so a new gate is added in exactly one file.
  *
- * The order is deliberate. Cheap local answers come first (flag arm, daemon
- * support), then the server read, then the surfaces this one must not fight
- * with: onboarding routes and the in-chat tour own the screen while they run,
- * and a banner already occupies the slot the pill would take.
+ * The order is deliberate. The cheap local answer comes first
+ * (`useActivationEnabledListId`, which carries the flag arm and the daemon
+ * support gate every activation surface shares), then the server read, then
+ * the surfaces this one must not fight with: onboarding routes and the in-chat
+ * tour own the screen while they run, and a banner already occupies the slot
+ * the pill would take.
  */
 
 import { useLocation } from "react-router";
 
-import {
-  resolveActivationListId,
-  useActivationChecklistArm,
-} from "@/hooks/use-activation-checklist-flag";
-import { useSupportsActivationProgress } from "@/lib/backwards-compat/use-supports-activation-progress";
+import { useActivationEnabledListId } from "@/hooks/use-activation-enabled";
 import { useBannerVisible } from "@/stores/banner-visibility-store";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -69,16 +67,14 @@ export function doneStarterCount(
 }
 
 export function useActivationVisibility(): ActivationVisibility {
-  const arm = useActivationChecklistArm();
-  const armListId = resolveActivationListId(arm);
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const supported = useSupportsActivationProgress(assistantId);
+  const armListId = useActivationEnabledListId(assistantId);
   const { data: progress } = useActivationProgress();
   const { pathname } = useLocation();
   const tourActive = useInChatOnboardingStore.use.prototypeActive();
   const bannerVisible = useBannerVisible();
 
-  if (armListId === null || !supported || !progress) {
+  if (armListId === null || !progress) {
     return HIDDEN;
   }
   // The daemon's frozen list wins over the arm, so a re-bucketed user keeps

--- a/clients/web/src/domains/activation/hooks/use-activation-visibility.ts
+++ b/clients/web/src/domains/activation/hooks/use-activation-visibility.ts
@@ -6,8 +6,9 @@
  * so a new gate is added in exactly one file.
  *
  * The order is deliberate. The cheap local answer comes first
- * (`useActivationEnabledListId`, which carries the flag arm and the daemon
- * support gate every activation surface shares), then the server read, then
+ * (`useEffectiveActivationListId`, which carries the flag arm, the daemon
+ * support gate and the daemon's frozen list, the three every activation
+ * surface shares), then the server read, then
  * the surfaces this one must not fight with: onboarding routes and the in-chat
  * tour own the screen while they run, and a banner already occupies the slot
  * the pill would take.
@@ -15,7 +16,7 @@
 
 import { useLocation } from "react-router";
 
-import { useActivationEnabledListId } from "@/hooks/use-activation-enabled";
+import { useEffectiveActivationListId } from "@/hooks/use-activation-enabled";
 import { useBannerVisible } from "@/stores/banner-visibility-store";
 import { useInChatOnboardingStore } from "@/stores/in-chat-onboarding-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -68,18 +69,15 @@ export function doneStarterCount(
 
 export function useActivationVisibility(): ActivationVisibility {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const armListId = useActivationEnabledListId(assistantId);
+  const listId = useEffectiveActivationListId(assistantId);
   const { data: progress } = useActivationProgress();
   const { pathname } = useLocation();
   const tourActive = useInChatOnboardingStore.use.prototypeActive();
   const bannerVisible = useBannerVisible();
 
-  if (armListId === null || !progress) {
+  if (listId === null || !progress) {
     return HIDDEN;
   }
-  // The daemon's frozen list wins over the arm, so a re-bucketed user keeps
-  // the checklist they already started.
-  const listId = progress.listId ?? armListId;
   if (isOnboardingRoute(pathname) || tourActive || bannerVisible) {
     return HIDDEN;
   }

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
@@ -98,9 +98,8 @@ mock.module("@/utils/activation-telemetry", () => ({
   emitActivationEvent: emitMock,
 }));
 
-const { useLaunchActivationTask } = await import(
-  "@/domains/activation/hooks/use-launch-activation-task"
-);
+const { useLaunchActivationTask } =
+  await import("@/domains/activation/hooks/use-launch-activation-task");
 type LaunchActivationTaskResult = Awaited<
   ReturnType<ReturnType<typeof useLaunchActivationTask>["launch"]>
 >;
@@ -120,9 +119,8 @@ function installFetch(): void {
     init?: RequestInit,
   ): Promise<Response> => {
     const url = input instanceof Request ? input.url : String(input);
-    const method = (input instanceof Request
-      ? input.method
-      : init?.method ?? "GET"
+    const method = (
+      input instanceof Request ? input.method : (init?.method ?? "GET")
     ).toUpperCase();
     let bodyText: string | undefined;
     if (input instanceof Request) {

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
@@ -14,8 +14,23 @@
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, cleanup, renderHook } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
 
+import {
+  ACTIVATION_PROGRESS_EMPTY,
+  startedTaskProgress,
+} from "@/domains/activation/activation-test-fixtures";
+import { getActivationList } from "@/domains/activation/catalog";
+import { ActivationListPage } from "@/domains/activation/components/activation-list-page";
+import type { ActivationProgress } from "@/domains/activation/hooks/use-activation-progress";
+import { activationProgressGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { MIN_VERSION } from "@/lib/backwards-compat/use-supports-activation-progress";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -50,6 +65,11 @@ let createStatus = 200;
 /** The `detail` the create leg answers with; `null` for a body carrying none. */
 let createDetail: string | null = "no conversation for you";
 let startStatus = 200;
+/**
+ * What the start leg answers with. The daemon returns the whole progress
+ * document; the default here is the older shape, which is the fallback path.
+ */
+let startBody: unknown = { taskId: "t", status: "started" };
 let sendStatus = 200;
 let sendThrows = false;
 let startThrows = false;
@@ -143,7 +163,7 @@ function installFetch(): void {
         if (startStatus !== 200) {
           return json(startStatus, { detail: "task id rejected" });
         }
-        return json(200, { taskId: "t", status: "started" });
+        return json(200, startBody);
       case "send":
         if (sendThrows) {
           throw new TypeError("network down");
@@ -162,11 +182,27 @@ function installFetch(): void {
   }) as typeof fetch;
 }
 
-function wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({
+let queryClient = new QueryClient();
+
+function newQueryClient(): QueryClient {
+  return new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+const PROGRESS_KEY = activationProgressGetQueryKey({
+  path: { assistant_id: "asst-1" },
+});
+
+/** What `useActivationProgress` would read right now, without refetching. */
+function cachedProgress(): ActivationProgress | undefined {
+  return queryClient.getQueryData<ActivationProgress>(PROGRESS_KEY);
 }
 
 function launcher() {
@@ -197,11 +233,13 @@ beforeEach(() => {
   createStatus = 200;
   createDetail = "no conversation for you";
   startStatus = 200;
+  startBody = { taskId: "t", status: "started" };
   sendStatus = 200;
   sendThrows = false;
   startThrows = false;
   holdCreates = false;
   parkedCreates = [];
+  queryClient = newQueryClient();
   emitMock.mockClear();
   installFetch();
   useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
@@ -550,5 +588,127 @@ describe("useLaunchActivationTask concurrency", () => {
     });
 
     expect(again?.ok).toBe(true);
+  });
+});
+
+/**
+ * The row is guarded by two things in sequence: the pending set while the
+ * launch runs, then the daemon's `started` record. The write below is what
+ * closes the gap between them, and without it the row falls back to Todo and
+ * takes a second click that relinks the task to a second conversation.
+ */
+describe("useLaunchActivationTask progress cache", () => {
+  const startedProgress: ActivationProgress = {
+    ...ACTIVATION_PROGRESS_EMPTY,
+    listId: "smb",
+    tasks: {
+      "pdf-proposal": startedTaskProgress({
+        conversationId: "conv-1",
+        stepCount: null,
+      }),
+    },
+  };
+
+  test("writes the progress the daemon answered the start with", async () => {
+    startBody = startedProgress;
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(cachedProgress()).toEqual(startedProgress);
+  });
+
+  // An older daemon answers the start with something else, so the started task
+  // is inserted into what is cached rather than taken from the answer.
+  test("inserts the started task when the start answers with something else", async () => {
+    queryClient.setQueryData(PROGRESS_KEY, ACTIVATION_PROGRESS_EMPTY);
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(cachedProgress()?.tasks["pdf-proposal"]).toMatchObject({
+      status: "started",
+      conversationId: "conv-1",
+    });
+  });
+
+  // Every surface is hidden while the progress read has not landed, so a
+  // document invented here would turn them on against a daemon that never
+  // answered one.
+  test("invents no progress when none is cached and none is answered", async () => {
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(cachedProgress()).toBeUndefined();
+  });
+
+  // A send that fails leaves the link standing, so the task is started and the
+  // row must stay guarded whatever the prompt did.
+  test("guards the row even when the prompt fails to send", async () => {
+    startBody = startedProgress;
+    sendStatus = 500;
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(cachedProgress()?.tasks["pdf-proposal"]?.status).toBe("started");
+  });
+
+  test("leaves the cache alone when the daemon refuses the link", async () => {
+    queryClient.setQueryData(PROGRESS_KEY, ACTIVATION_PROGRESS_EMPTY);
+    startStatus = 400;
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(cachedProgress()?.tasks).toEqual({});
+  });
+
+  // The list as the user sees it mid-launch: the rows read the cache and
+  // nothing refetches, so the write above is the only thing guarding the row.
+  test("the launched row is no longer launchable once the launch settles", async () => {
+    startBody = startedProgress;
+    const { starters, items } = getActivationList("smb");
+    const tasks = [...starters, ...items];
+    const launchedFromRow: string[] = [];
+    const openedFromRow: string[] = [];
+    let launch: ((taskId: string) => Promise<unknown>) | undefined;
+
+    function GuardedList() {
+      const launcherState = useLaunchActivationTask("smb");
+      launch = launcherState.launch;
+      // Read the cache directly: the hook's pending-state change re-renders
+      // this component after the launch settles, and a sibling test file mocks
+      // useQuery process-wide, which would hide the seeded write here.
+      const data = queryClient.getQueryData<ActivationProgress>(PROGRESS_KEY);
+      return (
+        <ActivationListPage
+          tasks={tasks}
+          progress={data?.tasks ?? {}}
+          pendingTaskIds={launcherState.pendingTaskIds}
+          onLaunch={(taskId) => launchedFromRow.push(taskId)}
+          onOpenConversation={(conversationId) =>
+            openedFromRow.push(conversationId)
+          }
+        />
+      );
+    }
+
+    render(<GuardedList />, { wrapper });
+    const title = starters[0]?.title ?? "";
+    await act(async () => {
+      await launch?.("pdf-proposal");
+    });
+
+    fireEvent.click(screen.getByText(title).closest("button")!);
+
+    expect(launchedFromRow).toEqual([]);
+    expect(openedFromRow).toEqual(["conv-1"]);
   });
 });

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
@@ -54,6 +54,18 @@ let sendStatus = 200;
 let sendThrows = false;
 let startThrows = false;
 let mintCounter = 0;
+/** While true, the create leg parks until `releaseCreates()` lets it answer. */
+let holdCreates = false;
+let parkedCreates: Array<() => void> = [];
+
+function releaseCreates(): void {
+  holdCreates = false;
+  const parked = parkedCreates;
+  parkedCreates = [];
+  for (const resume of parked) {
+    resume();
+  }
+}
 
 const emitMock = mock(() => {});
 
@@ -109,6 +121,9 @@ function installFetch(): void {
     });
     switch (leg) {
       case "create":
+        if (holdCreates) {
+          await new Promise<void>((resolve) => parkedCreates.push(resolve));
+        }
         if (createStatus !== 200) {
           return json(
             createStatus,
@@ -185,6 +200,8 @@ beforeEach(() => {
   sendStatus = 200;
   sendThrows = false;
   startThrows = false;
+  holdCreates = false;
+  parkedCreates = [];
   emitMock.mockClear();
   installFetch();
   useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
@@ -365,7 +382,7 @@ describe("useLaunchActivationTask", () => {
     expect(requestsFor("discard")).toHaveLength(0);
     expect(outcome).toMatchObject({ ok: false, conversationId: "conv-1" });
     expect(outcome?.error).toBeTruthy();
-    expect(result.current.pendingTaskId).toBeNull();
+    expect(result.current.isPending("pdf-proposal")).toBe(false);
   });
 
   test("reports a failed send against the conversation it linked", async () => {
@@ -397,7 +414,7 @@ describe("useLaunchActivationTask", () => {
     expect(outcome).toMatchObject({ ok: false, conversationId: "conv-1" });
     expect(outcome?.error).toBeTruthy();
     expect(emitMock).not.toHaveBeenCalled();
-    expect(result.current.pendingTaskId).toBeNull();
+    expect(result.current.isPending("pdf-proposal")).toBe(false);
   });
 
   test("creates a fresh conversation for every launch", async () => {
@@ -452,5 +469,86 @@ describe("useLaunchActivationTask", () => {
       listId: "smb",
       taskId: "pdf-proposal",
     });
+  });
+});
+
+/**
+ * The list lets the user start a second task while the first is still going,
+ * so pending state is per task. A single pending id would clear on whichever
+ * launch settled first and hand every other row back mid-launch.
+ */
+describe("useLaunchActivationTask concurrency", () => {
+  test("a second launch leaves the first task pending", async () => {
+    holdCreates = true;
+    const result = launcher();
+
+    let first: Promise<LaunchActivationTaskResult> | undefined;
+    let second: Promise<LaunchActivationTaskResult> | undefined;
+    await act(async () => {
+      first = result.current.launch("pdf-proposal");
+      second = result.current.launch("weekly-report");
+    });
+
+    expect(result.current.isPending("pdf-proposal")).toBe(true);
+    expect(result.current.isPending("weekly-report")).toBe(true);
+    expect([...result.current.pendingTaskIds].sort()).toEqual([
+      "pdf-proposal",
+      "weekly-report",
+    ]);
+
+    await act(async () => {
+      releaseCreates();
+      await first;
+      await second;
+    });
+
+    expect(result.current.pendingTaskIds.size).toBe(0);
+  });
+
+  // Two conversations for one task would leave the daemon two rows to mark
+  // done and run the prompt twice.
+  test("a task already in flight cannot be launched again", async () => {
+    holdCreates = true;
+    const result = launcher();
+
+    let first: Promise<LaunchActivationTaskResult> | undefined;
+    let second: Promise<LaunchActivationTaskResult> | undefined;
+    await act(async () => {
+      first = result.current.launch("pdf-proposal");
+      second = result.current.launch("weekly-report");
+    });
+
+    let duplicate: LaunchActivationTaskResult | undefined;
+    await act(async () => {
+      duplicate = await result.current.launch("pdf-proposal");
+    });
+
+    expect(duplicate).toEqual({ ok: false });
+    // The refusal has nothing to tell the user: the row is already working.
+    expect(duplicate?.error).toBeUndefined();
+    expect(calls.filter((leg) => leg === "create")).toHaveLength(2);
+    expect(result.current.isPending("pdf-proposal")).toBe(true);
+
+    await act(async () => {
+      releaseCreates();
+      await first;
+      await second;
+    });
+  });
+
+  test("a settled launch can be started again", async () => {
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(result.current.isPending("pdf-proposal")).toBe(false);
+
+    let again: LaunchActivationTaskResult | undefined;
+    await act(async () => {
+      again = await result.current.launch("pdf-proposal");
+    });
+
+    expect(again?.ok).toBe(true);
   });
 });

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
@@ -120,8 +120,9 @@ function installFetch(): void {
     init?: RequestInit,
   ): Promise<Response> => {
     const url = input instanceof Request ? input.url : String(input);
-    const method = (
-      input instanceof Request ? input.method : (init?.method ?? "GET")
+    const method = (input instanceof Request
+      ? input.method
+      : init?.method ?? "GET"
     ).toUpperCase();
     let bodyText: string | undefined;
     if (input instanceof Request) {
@@ -608,6 +609,31 @@ describe("useLaunchActivationTask progress cache", () => {
       }),
     },
   };
+
+  // Two rows launched together answer with snapshots from different points;
+  // the older answer must keep the task the newer one already seeded.
+  test("keeps tasks seeded by a concurrent start when an older snapshot answers", async () => {
+    queryClient.setQueryData(PROGRESS_KEY, {
+      ...startedProgress,
+      tasks: {
+        ...startedProgress.tasks,
+        "weekly-report": startedTaskProgress({
+          conversationId: "conv-2",
+          stepCount: null,
+        }),
+      },
+    });
+    startBody = startedProgress;
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(Object.keys(cachedProgress()?.tasks ?? {}).sort()).toEqual([
+      "pdf-proposal",
+      "weekly-report",
+    ]);
+  });
 
   test("writes the progress the daemon answered the start with", async () => {
     startBody = startedProgress;

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.ts
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.ts
@@ -122,7 +122,11 @@ function seedStartedTask(
     { path: { assistant_id: assistantId } },
     (cached) => {
       if (answered) {
-        return answered;
+        // Concurrent starts answer with snapshots taken at different points,
+        // so an older answer must not erase a task a newer one already seeded.
+        return cached
+          ? { ...answered, tasks: { ...cached.tasks, ...answered.tasks } }
+          : answered;
       }
       if (!cached) {
         return cached;

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.ts
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.ts
@@ -32,9 +32,16 @@
  * Every launch gets its own conversation. Reusing one across tasks would put
  * two prompts in one thread and give the daemon two tasks pointing at the same
  * turn.
+ *
+ * Launches run concurrently and are tracked as a set, because the list lets the
+ * user start a second task while the first is still in flight. A single pending
+ * id would clear on whichever launch settled first and hand every other row
+ * back to the user mid-launch. The set is mirrored in a ref so the duplicate
+ * guard answers within the click that fires it, before React has re-rendered
+ * the row into its pending state.
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -113,6 +120,11 @@ export interface LaunchActivationTaskResult {
   ok: boolean;
   /** The conversation the task was launched into, once one is linked to it. */
   conversationId?: string;
+  /**
+   * What to tell the user. Absent when there is nothing to say: a launch
+   * refused because the same task is already running is not a failure the user
+   * caused or needs to see.
+   */
   error?: string;
 }
 
@@ -127,9 +139,13 @@ export interface UseLaunchActivationTask {
     taskId: string,
     promptOverride?: string,
   ) => Promise<LaunchActivationTaskResult>;
-  /** The task currently mid-launch, for the row's pending state. */
-  pendingTaskId: string | null;
+  /** Every task whose launch is in flight, for the rows' pending states. */
+  pendingTaskIds: ReadonlySet<string>;
+  /** Whether `taskId`'s own launch is still in flight. */
+  isPending: (taskId: string) => boolean;
 }
+
+const NONE_PENDING: ReadonlySet<string> = new Set();
 
 export function useLaunchActivationTask(
   listId: string,
@@ -138,7 +154,11 @@ export function useLaunchActivationTask(
   const arm = useActivationChecklistArm();
   const queryClient = useQueryClient();
   const { t } = useTranslation("activation");
-  const [pendingTaskId, setPendingTaskId] = useState<string | null>(null);
+  const [pendingTaskIds, setPendingTaskIds] =
+    useState<ReadonlySet<string>>(NONE_PENDING);
+  // The ref is the authority the guard reads; the state is the copy React
+  // renders. Two clicks in one tick both see the ref, and only one gets past.
+  const inFlight = useRef<Set<string>>(new Set());
 
   const launch = useCallback(
     async (
@@ -161,7 +181,13 @@ export function useLaunchActivationTask(
       // count it. Only the catalog prompt is scripted.
       const scripted = !override;
 
-      setPendingTaskId(taskId);
+      // The row is already working. Launching again would open a second
+      // conversation for one task and leave the daemon two rows to mark done.
+      if (inFlight.current.has(taskId)) {
+        return { ok: false };
+      }
+      inFlight.current.add(taskId);
+      setPendingTaskIds(new Set(inFlight.current));
       try {
         const created = await createBackgroundConversation({
           assistantId,
@@ -224,11 +250,17 @@ export function useLaunchActivationTask(
         });
         return { ok: true, conversationId };
       } finally {
-        setPendingTaskId(null);
+        inFlight.current.delete(taskId);
+        setPendingTaskIds(new Set(inFlight.current));
       }
     },
     [arm, assistantId, listId, queryClient, t],
   );
 
-  return { launch, pendingTaskId };
+  const isPending = useCallback(
+    (taskId: string) => pendingTaskIds.has(taskId),
+    [pendingTaskIds],
+  );
+
+  return { launch, pendingTaskIds, isPending };
 }

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.ts
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.ts
@@ -29,6 +29,12 @@
  * happened, and a launch that has already linked has to hand back the
  * conversation id so the user can open it.
  *
+ * A start the daemon accepted is written into the progress cache before the
+ * launch leaves its pending state. The row is guarded by two things in
+ * sequence, the pending set and then the daemon's `started` record, and a
+ * pending set that clears first leaves a gap the row renders as Todo and
+ * accepts a second click, which relinks the task to a second conversation.
+ *
  * Every launch gets its own conversation. Reusing one across tasks would put
  * two prompts in one thread and give the daemon two tasks pointing at the same
  * turn.
@@ -43,9 +49,12 @@
 
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 
-import { activationProgressGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
+import {
+  activationProgressGetQueryKey,
+  activationProgressGetSetQueryData,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import { activationTasksByTaskIdStartPost } from "@/generated/daemon/sdk.gen";
 import { useActivationChecklistArm } from "@/hooks/use-activation-checklist-flag";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -59,6 +68,8 @@ import {
 
 import { readRawActivationTask } from "../catalog";
 
+import type { ActivationProgress } from "./use-activation-progress";
+
 /**
  * A link the client never saw succeed. `rejected` is true only when the daemon
  * answered with a 4xx, which is the one case where the link certainly does not
@@ -67,6 +78,71 @@ import { readRawActivationTask } from "../catalog";
 interface LinkFailure {
   rejected: boolean;
   error: string;
+}
+
+interface LinkOutcome {
+  /** Absent once the daemon holds the link. */
+  failure?: LinkFailure;
+  /** The progress document the daemon answered the write with. */
+  progress?: ActivationProgress;
+}
+
+/**
+ * Whether the daemon answered the start with a whole progress document, which
+ * is what the current route returns and what the cache holds.
+ */
+function isActivationProgress(value: unknown): value is ActivationProgress {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const { tasks } = value as Partial<ActivationProgress>;
+  return typeof tasks === "object" && tasks !== null;
+}
+
+/**
+ * Write the started task into the progress cache, on the key
+ * `useActivationProgress` reads, so the row stays guarded from the moment the
+ * daemon holds the link until the next progress read lands.
+ *
+ * The daemon answers the start with the whole document, so that is what is
+ * written. An answer carrying something else falls back to inserting the task
+ * into what is already cached; an absent cache is left absent, because a
+ * progress document the client invented would turn on the surfaces the missing
+ * read keeps hidden.
+ */
+function seedStartedTask(
+  queryClient: QueryClient,
+  assistantId: string,
+  taskId: string,
+  conversationId: string,
+  answered: ActivationProgress | undefined,
+): void {
+  activationProgressGetSetQueryData(
+    queryClient,
+    { path: { assistant_id: assistantId } },
+    (cached) => {
+      if (answered) {
+        return answered;
+      }
+      if (!cached) {
+        return cached;
+      }
+      return {
+        ...cached,
+        tasks: {
+          ...cached.tasks,
+          [taskId]: {
+            status: "started",
+            conversationId,
+            startedAt: new Date().toISOString(),
+            completedAt: null,
+            stepCount: null,
+            artifacts: [],
+          },
+        },
+      };
+    },
+  );
 }
 
 interface LinkActivationTaskArgs {
@@ -93,25 +169,29 @@ async function linkActivationTask({
   listId,
   conversationId,
   fallback,
-}: LinkActivationTaskArgs): Promise<LinkFailure | null> {
+}: LinkActivationTaskArgs): Promise<LinkOutcome> {
   try {
-    const { error, response } = await activationTasksByTaskIdStartPost({
+    const { data, error, response } = await activationTasksByTaskIdStartPost({
       path: { assistant_id: assistantId, taskId },
       body: { conversationId, listId },
       throwOnError: false,
     });
     if (response?.ok) {
-      return null;
+      return { progress: isActivationProgress(data) ? data : undefined };
     }
     const status = response?.status;
     return {
-      rejected: status !== undefined && status >= 400 && status < 500,
-      error: extractErrorMessage(error, response, fallback),
+      failure: {
+        rejected: status !== undefined && status >= 400 && status < 500,
+        error: extractErrorMessage(error, response, fallback),
+      },
     };
   } catch (error) {
     return {
-      rejected: false,
-      error: extractErrorMessage(error, undefined, fallback),
+      failure: {
+        rejected: false,
+        error: extractErrorMessage(error, undefined, fallback),
+      },
     };
   }
 }
@@ -198,20 +278,34 @@ export function useLaunchActivationTask(
         }
         const { conversationId } = created;
 
-        const linkFailure = await linkActivationTask({
+        const link = await linkActivationTask({
           assistantId,
           taskId,
           listId,
           conversationId,
           fallback: t("launch.failed"),
         });
-        if (linkFailure) {
-          if (linkFailure.rejected) {
+        if (link.failure) {
+          if (link.failure.rejected) {
             void discardBackgroundConversation(assistantId, conversationId);
-            return { ok: false, error: linkFailure.error };
+            return { ok: false, error: link.failure.error };
           }
-          return { ok: false, conversationId, error: linkFailure.error };
+          return { ok: false, conversationId, error: link.failure.error };
         }
+        // The daemon holds the link from here, whatever the send does next, so
+        // the row is guarded and the read is refreshed before either can end.
+        seedStartedTask(
+          queryClient,
+          assistantId,
+          taskId,
+          conversationId,
+          link.progress,
+        );
+        void queryClient.invalidateQueries({
+          queryKey: activationProgressGetQueryKey({
+            path: { assistant_id: assistantId },
+          }),
+        });
 
         let sent;
         try {
@@ -243,11 +337,6 @@ export function useLaunchActivationTask(
         }
 
         emitActivationEvent("activation_task_started", { arm, listId, taskId });
-        void queryClient.invalidateQueries({
-          queryKey: activationProgressGetQueryKey({
-            path: { assistant_id: assistantId },
-          }),
-        });
         return { ok: true, conversationId };
       } finally {
         inFlight.current.delete(taskId);

--- a/clients/web/src/domains/activation/pages/activation-list-route.test.tsx
+++ b/clients/web/src/domains/activation/pages/activation-list-route.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * What the route owes the page: the right list, the daemon's progress, and the
+ * two actions a row can take.
+ *
+ * The progress read, the launch and the capability signal are mocked at their
+ * hook seams; each owns its own suite, and what is under test here is the
+ * wiring between them.
+ */
+
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+
+import {
+  ACTIVATION_PROGRESS_EMPTY,
+  ACTIVATION_PROGRESS_LIST_MIXED,
+  FIXTURE_STARTER_IDS,
+} from "@/domains/activation/activation-test-fixtures";
+import { getActivationList } from "@/domains/activation/catalog";
+import type { ActivationProgress } from "@/domains/activation/hooks/use-activation-progress";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { routes } from "@/utils/routes";
+
+let progress: ActivationProgress | undefined;
+const launched: string[] = [];
+const navigated: string[] = [];
+
+// Every mock spreads the real module: `mock.module` replaces it for the whole
+// test process, so returning only the overridden export would erase the rest
+// for any file that loads it later.
+const progressModule = await import(
+  "@/domains/activation/hooks/use-activation-progress"
+);
+mock.module("@/domains/activation/hooks/use-activation-progress", () => ({
+  ...progressModule,
+  useActivationProgress: () => ({ data: progress }),
+}));
+
+const launchModule = await import(
+  "@/domains/activation/hooks/use-launch-activation-task"
+);
+mock.module("@/domains/activation/hooks/use-launch-activation-task", () => ({
+  ...launchModule,
+  useLaunchActivationTask: () => ({
+    launch: async (taskId: string) => {
+      launched.push(taskId);
+      return { ok: true };
+    },
+    pendingTaskId: null,
+  }),
+}));
+
+const capabilitiesModule = await import("@/domains/activation/capabilities");
+mock.module("@/domains/activation/capabilities", () => ({
+  ...capabilitiesModule,
+  useAvailableCapabilityTags: () =>
+    new Set(capabilitiesModule.ACTIVATION_CAPABILITY_TAGS),
+}));
+
+const navigationModule = await import("@/utils/conversation-navigation");
+mock.module("@/utils/conversation-navigation", () => ({
+  ...navigationModule,
+  navigateToConversation: (_navigate: unknown, conversationId: string) => {
+    navigated.push(conversationId);
+  },
+}));
+
+const { ActivationListRoute } = await import(
+  "@/domains/activation/pages/activation-list-route"
+);
+
+const { starters } = getActivationList("smb");
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={[routes.activationList]}>
+      {children}
+    </MemoryRouter>
+  );
+}
+
+function setArm(arm: string): void {
+  useClientFeatureFlagStore
+    .getState()
+    .setStringFlags({ activationChecklist: arm }, null);
+}
+
+function renderRoute() {
+  return render(<ActivationListRoute />, { wrapper });
+}
+
+beforeEach(() => {
+  progress = ACTIVATION_PROGRESS_EMPTY;
+  setArm("smb");
+  useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
+});
+
+afterEach(() => {
+  cleanup();
+  launched.length = 0;
+  navigated.length = 0;
+});
+
+describe("ActivationListRoute", () => {
+  test("renders the arm's list", () => {
+    renderRoute();
+
+    expect(screen.getAllByRole("listitem").length).toBeGreaterThan(3);
+    expect(screen.getByText(starters[0]?.title ?? "")).toBeTruthy();
+  });
+
+  test("an arm that names no list hands the user back to chat", () => {
+    setArm("off");
+    renderRoute();
+
+    expect(screen.queryByRole("listitem")).toBeNull();
+  });
+
+  test("the daemon's frozen list wins over the arm", () => {
+    // A re-bucketed user keeps the checklist they started, the same rule the
+    // modal and the pill follow.
+    setArm("parent");
+    progress = ACTIVATION_PROGRESS_LIST_MIXED;
+    renderRoute();
+
+    expect(screen.getByText(starters[0]?.title ?? "")).toBeTruthy();
+  });
+
+  test("an untouched row launches its task", () => {
+    renderRoute();
+
+    fireEvent.click(
+      screen.getByText(starters[0]?.title ?? "").closest("button")!,
+    );
+
+    expect(launched).toEqual([FIXTURE_STARTER_IDS[0]]);
+    expect(navigated).toEqual([]);
+  });
+
+  test("a finished row opens the conversation it ran in", () => {
+    progress = ACTIVATION_PROGRESS_LIST_MIXED;
+    renderRoute();
+
+    fireEvent.click(
+      screen.getByText(starters[0]?.title ?? "").closest("button")!,
+    );
+
+    expect(navigated).toEqual(["conv-done-1"]);
+    expect(launched).toEqual([]);
+  });
+});

--- a/clients/web/src/domains/activation/pages/activation-list-route.test.tsx
+++ b/clients/web/src/domains/activation/pages/activation-list-route.test.tsx
@@ -1,15 +1,24 @@
 /**
- * What the route owes the page: the right list, the daemon's progress, and the
- * two actions a row can take.
+ * What the route owes the page: the right list, the daemon's progress, the
+ * gates that decide whether the page may render at all, and the two actions a
+ * row can take, including what a failed one says.
  *
- * The progress read, the launch and the capability signal are mocked at their
- * hook seams; each owns its own suite, and what is under test here is the
- * wiring between them.
+ * The progress read, the launch, the capability signal and the toast are
+ * mocked at their seams; each owns its own suite, and what is under test here
+ * is the wiring between them. The version gate is not mocked: it reads the
+ * identity store, which is the thing a bookmark against an old assistant
+ * actually trips.
  */
 
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 import {
@@ -19,13 +28,29 @@ import {
 } from "@/domains/activation/activation-test-fixtures";
 import { getActivationList } from "@/domains/activation/catalog";
 import type { ActivationProgress } from "@/domains/activation/hooks/use-activation-progress";
+import { MIN_VERSION } from "@/lib/backwards-compat/use-supports-activation-progress";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 
+interface LaunchOutcome {
+  ok: boolean;
+  conversationId?: string;
+  error?: string;
+}
+
+interface CapturedToast {
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
 let progress: ActivationProgress | undefined;
+let launchOutcome: LaunchOutcome = { ok: true };
 const launched: string[] = [];
 const navigated: string[] = [];
+const toasts: CapturedToast[] = [];
 
 // Every mock spreads the real module: `mock.module` replaces it for the whole
 // test process, so returning only the overridden export would erase the rest
@@ -46,10 +71,29 @@ mock.module("@/domains/activation/hooks/use-launch-activation-task", () => ({
   useLaunchActivationTask: () => ({
     launch: async (taskId: string) => {
       launched.push(taskId);
-      return { ok: true };
+      return launchOutcome;
     },
-    pendingTaskId: null,
+    pendingTaskIds: new Set<string>(),
+    isPending: () => false,
   }),
+}));
+
+const toastModule = await import("@vellumai/design-library/components/toast");
+mock.module("@vellumai/design-library/components/toast", () => ({
+  ...toastModule,
+  toast: {
+    ...toastModule.toast,
+    error: (
+      message: string,
+      options?: { action?: { label: string; onClick: () => void } },
+    ) => {
+      toasts.push({
+        message,
+        actionLabel: options?.action?.label,
+        onAction: options?.action?.onClick,
+      });
+    },
+  },
 }));
 
 const capabilitiesModule = await import("@/domains/activation/capabilities");
@@ -93,14 +137,18 @@ function renderRoute() {
 
 beforeEach(() => {
   progress = ACTIVATION_PROGRESS_EMPTY;
+  launchOutcome = { ok: true };
   setArm("smb");
   useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
+  useAssistantIdentityStore.getState().setIdentity("Vel", MIN_VERSION, "asst-1");
 });
 
 afterEach(() => {
   cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
   launched.length = 0;
   navigated.length = 0;
+  toasts.length = 0;
 });
 
 describe("ActivationListRoute", () => {
@@ -149,5 +197,99 @@ describe("ActivationListRoute", () => {
 
     expect(navigated).toEqual(["conv-done-1"]);
     expect(launched).toEqual([]);
+  });
+
+  // A bookmark reaches this page directly, and an assistant without the
+  // `/v1/activation/*` routes can neither answer the progress read nor link a
+  // launch, so every row would offer work it cannot do.
+  test("an assistant below the activation floor hands the user back to chat", () => {
+    useAssistantIdentityStore.getState().setIdentity("Vel", "0.11.0", "asst-1");
+    progress = ACTIVATION_PROGRESS_LIST_MIXED;
+    renderRoute();
+
+    expect(screen.queryByRole("listitem")).toBeNull();
+    expect(screen.queryByText(starters[0]?.title ?? "")).toBeNull();
+  });
+});
+
+describe("ActivationListRoute before progress lands", () => {
+  // An absent record reads as "never started", so a finished task rendered
+  // against a progress read still in flight would offer to run again.
+  test("no task can launch until the daemon has answered", () => {
+    progress = undefined;
+    const { rerender } = renderRoute();
+
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.queryByText(starters[0]?.title ?? "")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+
+    // The answer arrives, carrying a task that is already done.
+    progress = ACTIVATION_PROGRESS_LIST_MIXED;
+    rerender(<ActivationListRoute />);
+
+    fireEvent.click(
+      screen.getByText(starters[0]?.title ?? "").closest("button")!,
+    );
+
+    expect(launched).toEqual([]);
+    expect(navigated).toEqual(["conv-done-1"]);
+  });
+});
+
+describe("ActivationListRoute launch failures", () => {
+  test("a refused launch says so", async () => {
+    launchOutcome = { ok: false, error: "no conversation for you" };
+    renderRoute();
+
+    fireEvent.click(
+      screen.getByText(starters[0]?.title ?? "").closest("button")!,
+    );
+
+    await waitFor(() => {
+      expect(toasts).toHaveLength(1);
+    });
+    expect(toasts[0]?.message).toBe("no conversation for you");
+    // Nothing was linked, so there is nothing to recover into.
+    expect(toasts[0]?.actionLabel).toBeUndefined();
+  });
+
+  // A send that fails after the link stands leaves a real conversation the
+  // task owns; the user has to be able to reach it.
+  test("a failed send offers the conversation it already linked", async () => {
+    launchOutcome = {
+      ok: false,
+      conversationId: "conv-linked-1",
+      error: "daemon said no",
+    };
+    renderRoute();
+
+    fireEvent.click(
+      screen.getByText(starters[0]?.title ?? "").closest("button")!,
+    );
+
+    await waitFor(() => {
+      expect(toasts).toHaveLength(1);
+    });
+    expect(toasts[0]?.message).toBe("daemon said no");
+    expect(toasts[0]?.actionLabel).toBe("Open conversation");
+
+    toasts[0]?.onAction?.();
+    expect(navigated).toEqual(["conv-linked-1"]);
+  });
+
+  // A launch refused because the same task is already running is not a failure
+  // the user caused, and it carries nothing to say.
+  test("a launch with nothing to report shows no toast", async () => {
+    launchOutcome = { ok: false };
+    renderRoute();
+
+    fireEvent.click(
+      screen.getByText(starters[0]?.title ?? "").closest("button")!,
+    );
+
+    await waitFor(() => {
+      expect(launched).toEqual([FIXTURE_STARTER_IDS[0]]);
+    });
+    expect(toasts).toEqual([]);
   });
 });

--- a/clients/web/src/domains/activation/pages/activation-list-route.tsx
+++ b/clients/web/src/domains/activation/pages/activation-list-route.tsx
@@ -9,7 +9,7 @@
  * The daemon's frozen list wins over the flag arm, the same rule the modal and
  * the pill follow, so a re-bucketed user keeps the checklist they started.
  *
- * The gate is `useActivationEnabledListId`, the one every activation surface
+ * The gate is `useEffectiveActivationListId`, the one every activation surface
  * shares, rather than the flag arm alone: the page is reachable by a bookmark,
  * and against an assistant too old for the `/v1/activation/*` routes every row
  * would offer a launch the daemon cannot link. Gated off, the route hands the
@@ -24,7 +24,7 @@ import { Navigate, useNavigate } from "react-router";
 
 import { toast } from "@vellumai/design-library/components/toast";
 
-import { useActivationEnabledListId } from "@/hooks/use-activation-enabled";
+import { useEffectiveActivationListId } from "@/hooks/use-activation-enabled";
 import { useTranslation } from "@/i18n";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { navigateToConversation } from "@/utils/conversation-navigation";
@@ -40,9 +40,8 @@ export function ActivationListRoute() {
   const navigate = useNavigate();
   const { t } = useTranslation("activation");
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const armListId = useActivationEnabledListId(assistantId);
+  const listId = useEffectiveActivationListId(assistantId);
   const { data: progress } = useActivationProgress();
-  const listId = progress?.listId ?? armListId;
 
   const { starters, items } = useActivationList(listId ?? "");
   const availableTags = useAvailableCapabilityTags();
@@ -84,7 +83,7 @@ export function ActivationListRoute() {
     [launch, navigate, t],
   );
 
-  if (armListId === null) {
+  if (listId === null) {
     return <Navigate to={routes.assistant} replace />;
   }
 

--- a/clients/web/src/domains/activation/pages/activation-list-route.tsx
+++ b/clients/web/src/domains/activation/pages/activation-list-route.tsx
@@ -7,29 +7,30 @@
  * ships.
  *
  * The daemon's frozen list wins over the flag arm, the same rule the modal and
- * the pill follow, so a re-bucketed user keeps the checklist they started. An
- * arm that selects no list has nothing to show and hands the user back to
- * chat rather than leaving them on an empty page.
+ * the pill follow, so a re-bucketed user keeps the checklist they started.
+ *
+ * The gate is `useActivationEnabledListId`, the one every activation surface
+ * shares, rather than the flag arm alone: the page is reachable by a bookmark,
+ * and against an assistant too old for the `/v1/activation/*` routes every row
+ * would offer a launch the daemon cannot link. Gated off, the route hands the
+ * user back to chat.
  *
  * Mounted under `ActiveAssistantGate`, so `activeAssistantId` is resolved by
  * the time this renders and needs no second guard.
  */
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { Navigate, useNavigate } from "react-router";
 
-import {
-  resolveActivationListId,
-  useActivationChecklistArm,
-} from "@/hooks/use-activation-checklist-flag";
+import { toast } from "@vellumai/design-library/components/toast";
+
+import { useActivationEnabledListId } from "@/hooks/use-activation-enabled";
+import { useTranslation } from "@/i18n";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 
-import {
-  taskIsAvailable,
-  useAvailableCapabilityTags,
-} from "../capabilities";
+import { taskIsAvailable, useAvailableCapabilityTags } from "../capabilities";
 import { useActivationList } from "../catalog";
 import { ActivationListPage } from "../components/activation-list-page";
 import { useActivationProgress } from "../hooks/use-activation-progress";
@@ -37,15 +38,15 @@ import { useLaunchActivationTask } from "../hooks/use-launch-activation-task";
 
 export function ActivationListRoute() {
   const navigate = useNavigate();
+  const { t } = useTranslation("activation");
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
-  const arm = useActivationChecklistArm();
-  const armListId = resolveActivationListId(arm);
+  const armListId = useActivationEnabledListId(assistantId);
   const { data: progress } = useActivationProgress();
   const listId = progress?.listId ?? armListId;
 
   const { starters, items } = useActivationList(listId ?? "");
   const availableTags = useAvailableCapabilityTags();
-  const { launch, pendingTaskId } = useLaunchActivationTask(listId ?? "");
+  const { launch, pendingTaskIds } = useLaunchActivationTask(listId ?? "");
 
   const tasks = useMemo(
     () =>
@@ -55,6 +56,34 @@ export function ActivationListRoute() {
     [starters, items, availableTags],
   );
 
+  // The page is the point of the launch, so the user stays on it and the row
+  // flips to Working; the conversation runs in the background. A failure has
+  // nowhere else to surface, and one that already linked a conversation hands
+  // it back so the user can drive the task by hand.
+  const handleLaunch = useCallback(
+    async (taskId: string) => {
+      const result = await launch(taskId);
+      if (result.ok || !result.error) {
+        return;
+      }
+      const { conversationId } = result;
+      toast.error(
+        result.error,
+        conversationId
+          ? {
+              action: {
+                label: t("launch.openConversation"),
+                onClick: () => {
+                  navigateToConversation(navigate, conversationId);
+                },
+              },
+            }
+          : undefined,
+      );
+    },
+    [launch, navigate, t],
+  );
+
   if (armListId === null) {
     return <Navigate to={routes.assistant} replace />;
   }
@@ -62,12 +91,10 @@ export function ActivationListRoute() {
   return (
     <ActivationListPage
       tasks={tasks}
-      progress={progress?.tasks ?? {}}
-      pendingTaskId={pendingTaskId}
-      // The page is the point of the launch, so the user stays on it and the
-      // row flips to Working; the conversation runs in the background.
+      progress={progress?.tasks}
+      pendingTaskIds={pendingTaskIds}
       onLaunch={(taskId) => {
-        void launch(taskId);
+        void handleLaunch(taskId);
       }}
       onOpenConversation={(conversationId) => {
         navigateToConversation(navigate, conversationId);

--- a/clients/web/src/domains/activation/pages/activation-list-route.tsx
+++ b/clients/web/src/domains/activation/pages/activation-list-route.tsx
@@ -1,0 +1,78 @@
+/**
+ * Route wiring for the Inspiration List (`/assistant/suggestions`).
+ *
+ * Everything the page cannot know on its own is resolved here: which list the
+ * user is on, the catalog behind it, the daemon's progress, and what a click
+ * does. The page itself stays presentational so a story renders exactly what
+ * ships.
+ *
+ * The daemon's frozen list wins over the flag arm, the same rule the modal and
+ * the pill follow, so a re-bucketed user keeps the checklist they started. An
+ * arm that selects no list has nothing to show and hands the user back to
+ * chat rather than leaving them on an empty page.
+ *
+ * Mounted under `ActiveAssistantGate`, so `activeAssistantId` is resolved by
+ * the time this renders and needs no second guard.
+ */
+
+import { useMemo } from "react";
+import { Navigate, useNavigate } from "react-router";
+
+import {
+  resolveActivationListId,
+  useActivationChecklistArm,
+} from "@/hooks/use-activation-checklist-flag";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { navigateToConversation } from "@/utils/conversation-navigation";
+import { routes } from "@/utils/routes";
+
+import {
+  taskIsAvailable,
+  useAvailableCapabilityTags,
+} from "../capabilities";
+import { useActivationList } from "../catalog";
+import { ActivationListPage } from "../components/activation-list-page";
+import { useActivationProgress } from "../hooks/use-activation-progress";
+import { useLaunchActivationTask } from "../hooks/use-launch-activation-task";
+
+export function ActivationListRoute() {
+  const navigate = useNavigate();
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const arm = useActivationChecklistArm();
+  const armListId = resolveActivationListId(arm);
+  const { data: progress } = useActivationProgress();
+  const listId = progress?.listId ?? armListId;
+
+  const { starters, items } = useActivationList(listId ?? "");
+  const availableTags = useAvailableCapabilityTags();
+  const { launch, pendingTaskId } = useLaunchActivationTask(listId ?? "");
+
+  const tasks = useMemo(
+    () =>
+      [...starters, ...items].filter((task) =>
+        taskIsAvailable(task, availableTags),
+      ),
+    [starters, items, availableTags],
+  );
+
+  if (armListId === null) {
+    return <Navigate to={routes.assistant} replace />;
+  }
+
+  return (
+    <ActivationListPage
+      tasks={tasks}
+      progress={progress?.tasks ?? {}}
+      pendingTaskId={pendingTaskId}
+      // The page is the point of the launch, so the user stays on it and the
+      // row flips to Working; the conversation runs in the background.
+      onLaunch={(taskId) => {
+        void launch(taskId);
+      }}
+      onOpenConversation={(conversationId) => {
+        navigateToConversation(navigate, conversationId);
+      }}
+      assistantId={assistantId ?? undefined}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -226,7 +226,11 @@ mock.module("@/domains/chat/hooks/use-preferences-usage", () => ({
 // The funnel emitter posts to the telemetry ingest, which has nowhere to go
 // in a test process. What the menu owns is that the event is emitted with the
 // arm and list it opened, so the emitter is captured rather than run.
-const activationEvents: Array<{ event: string; arm: string; listId: string | null }> = [];
+const activationEvents: Array<{
+  event: string;
+  arm: string;
+  listId: string | null;
+}> = [];
 mock.module("@/utils/activation-telemetry", () => ({
   emitActivationEvent: (
     event: string,
@@ -254,8 +258,9 @@ mock.module("@/domains/chat/components/credits-card", () => ({
     ),
 }));
 
-const { PreferencesMenu, showsMenuCredits } =
-  await import("@/domains/chat/components/preferences-menu");
+const { PreferencesMenu, showsMenuCredits } = await import(
+  "@/domains/chat/components/preferences-menu"
+);
 
 /** Opens the menu the way a touch user does, and returns the open surface. */
 async function openMenu(
@@ -584,6 +589,23 @@ describe("PreferencesMenu Inspiration List", () => {
   // re-bucketed after that. The funnel keys its `screen` dimension off this
   // event, so an arm-derived id would file the open under a list the user was
   // never shown.
+  // A frozen id from a newer client that this bundle has no catalog for must
+  // not enable an empty list; the entry point stays hidden.
+  test("hides the entry point when the frozen list is unknown here", async () => {
+    enableActivationList("parent");
+    activationProgressRef.data = {
+      version: 1,
+      listId: "mystery-list",
+      modalDismissedAt: null,
+      allDoneShownAt: null,
+      tasks: {},
+    };
+    await openMenu();
+
+    expect(screen.queryByText("Inspiration List")).toBeNull();
+    expect(activationEvents).toEqual([]);
+  });
+
   test("records the frozen list, not the arm the user was re-bucketed into", async () => {
     enableActivationList("parent");
     activationProgressRef.data = {

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -22,7 +22,11 @@ import {
 import { SideMenu } from "@vellumai/design-library";
 
 import type { PreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
+import { MIN_VERSION } from "@/lib/backwards-compat/use-supports-activation-progress";
 import type { AuthUser } from "@/stores/auth-store";
+import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 
 const isTouchMobileRef = { value: false };
@@ -33,7 +37,12 @@ mock.module("@/hooks/use-touch-mobile", () => ({
   TOUCH_MOBILE_MEDIA_QUERY: "(width < 48rem) and (pointer: coarse)",
 }));
 
+// Spread the real module: `mock.module` replaces it for every file sharing
+// this process, and other exports of it (browser detection) are reached
+// through the stores this suite now touches.
+const actualPlatformDetection = await import("@/runtime/platform-detection");
 mock.module("@/runtime/platform-detection", () => ({
+  ...actualPlatformDetection,
   useIsNativeAndroid: () => nativeAndroidRef.value,
 }));
 
@@ -85,21 +94,14 @@ mock.module("@/stores/auth-store", () => {
   };
 });
 
-const flagsRef = {};
-
-mock.module("@/stores/client-feature-flag-store", () => {
-  const store = () => null;
-  store.use = {
-    velvet: () => false,
-  };
-  store.getState = () => flagsRef;
-  return { useClientFeatureFlagStore: store };
-});
-
+// The real client flag store: a plain zustand store with no transport of its
+// own, and the only version that carries the string-flag surface the
+// activation arm is read through. A stub here would also replace it for every
+// test file sharing this process.
 mock.module("@/stores/assistant-feature-flag-store", () => {
   const store = () => null;
   store.use = {};
-  store.getState = () => flagsRef;
+  store.getState = () => ({});
   return { useAssistantFeatureFlagStore: store };
 });
 
@@ -130,7 +132,9 @@ mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
 // Capture navigate() targets so the menu's destinations can be asserted
 // without a live Router.
 let navigateArgs: unknown[] = [];
+const actualReactRouter = await import("react-router");
 mock.module("react-router", () => ({
+  ...actualReactRouter,
   useNavigate: () => (to: unknown) => {
     navigateArgs.push(to);
   },
@@ -202,6 +206,19 @@ mock.module("@/domains/chat/hooks/use-preferences-usage", () => ({
   },
 }));
 
+// The funnel emitter posts to the telemetry ingest, which has nowhere to go
+// in a test process. What the menu owns is that the event is emitted with the
+// arm and list it opened, so the emitter is captured rather than run.
+const activationEvents: Array<{ event: string; arm: string; listId: string | null }> = [];
+mock.module("@/utils/activation-telemetry", () => ({
+  emitActivationEvent: (
+    event: string,
+    context: { arm: string; listId: string | null },
+  ) => {
+    activationEvents.push({ event, ...context });
+  },
+}));
+
 mock.module("@/domains/chat/components/credits-card", () => ({
   CreditsCard: ({
     balance,
@@ -246,8 +263,31 @@ function usage(ratio: number, walletEmpty = false): PreferencesUsage {
   };
 }
 
+const ACTIVATION_ASSISTANT_ID = "asst-1";
+
+function setActivationArm(arm: string): void {
+  useClientFeatureFlagStore
+    .getState()
+    .setStringFlags({ activationChecklist: arm }, null);
+}
+
+/** Puts the client on `arm` with a daemon new enough to serve the list. */
+function enableActivationList(arm = "smb"): void {
+  setActivationArm(arm);
+  useResolvedAssistantsStore.setState({
+    activeAssistantId: ACTIVATION_ASSISTANT_ID,
+  });
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("Vel", MIN_VERSION, ACTIVATION_ASSISTANT_ID);
+}
+
 beforeEach(() => {
   navigateArgs = [];
+  activationEvents.length = 0;
+  setActivationArm("off");
+  useAssistantIdentityStore.getState().clearIdentity();
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
   isTouchMobileRef.value = false;
   nativeAndroidRef.value = false;
   authRef.isAuthenticated = true;
@@ -481,6 +521,56 @@ describe("PreferencesMenu", () => {
 
     expect(screen.getByTestId("credits-card")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Add credits" })).toBeTruthy();
+  });
+});
+
+describe("PreferencesMenu Inspiration List", () => {
+  test("stays hidden while the activation arm is off", async () => {
+    await openMenu();
+
+    expect(screen.queryByText("Inspiration List")).toBeNull();
+  });
+
+  test("stays hidden against a daemon with no activation routes", async () => {
+    setActivationArm("smb");
+    useResolvedAssistantsStore.setState({
+      activeAssistantId: ACTIVATION_ASSISTANT_ID,
+    });
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("Vel", "0.11.0", ACTIVATION_ASSISTANT_ID);
+    await openMenu();
+
+    // The page reads a resource that daemon does not serve, so the entry
+    // point to it goes too.
+    expect(screen.queryByText("Inspiration List")).toBeNull();
+  });
+
+  test("opens the list, records the visit, and closes the menu", async () => {
+    enableActivationList();
+    await openMenu();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Inspiration List"));
+      await Promise.resolve();
+    });
+
+    expect(navigateArgs).toEqual([routes.activationList]);
+    expect(activationEvents).toEqual([
+      { event: "activation_list_opened", arm: "smb", listId: "smb" },
+    ]);
+    expect(screen.queryByTestId("preferences-usage")).toBeNull();
+  });
+
+  test("sits above Share Feedback, as Figma orders the menu", async () => {
+    enableActivationList();
+    await openMenu();
+
+    const list = screen.getByText("Inspiration List");
+    const feedback = screen.getByText("Share Feedback");
+    expect(
+      list.compareDocumentPosition(feedback) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });
 

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -258,9 +258,8 @@ mock.module("@/domains/chat/components/credits-card", () => ({
     ),
 }));
 
-const { PreferencesMenu, showsMenuCredits } = await import(
-  "@/domains/chat/components/preferences-menu"
-);
+const { PreferencesMenu, showsMenuCredits } =
+  await import("@/domains/chat/components/preferences-menu");
 
 /** Opens the menu the way a touch user does, and returns the open surface. */
 async function openMenu(

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -111,13 +111,30 @@ const billingRef = {
     | undefined,
 };
 
+/**
+ * What the daemon's activation progress read answers with. `null` is the read
+ * that has not landed, which is every test that does not care about it.
+ */
+const activationProgressRef: { data: unknown } = { data: undefined };
+
+/** Whether a query's options name the activation progress read. */
+function isActivationProgressQuery(options: unknown): boolean {
+  const key = (options as { queryKey?: Array<{ _id?: string }> } | undefined)
+    ?.queryKey;
+  return key?.[0]?._id === "activationProgressGet";
+}
+
 // Spread the real module so shared utilities that import other exports
 // (e.g. `isCancelledError` via `captureError`) keep resolving; only the
-// hook under test's read is overridden.
+// hook under test's read is overridden. The menu makes two reads, so the
+// stub answers by query key rather than handing both the same body.
 const actualReactQuery = await import("@tanstack/react-query");
 mock.module("@tanstack/react-query", () => ({
   ...actualReactQuery,
-  useQuery: () => ({ data: billingRef.data, isLoading: false, isError: false }),
+  useQuery: (options: unknown) =>
+    isActivationProgressQuery(options)
+      ? { data: activationProgressRef.data, isLoading: false, isError: false }
+      : { data: billingRef.data, isLoading: false, isError: false },
 }));
 
 mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
@@ -285,6 +302,7 @@ function enableActivationList(arm = "smb"): void {
 beforeEach(() => {
   navigateArgs = [];
   activationEvents.length = 0;
+  activationProgressRef.data = undefined;
   setActivationArm("off");
   useAssistantIdentityStore.getState().clearIdentity();
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
@@ -560,6 +578,31 @@ describe("PreferencesMenu Inspiration List", () => {
       { event: "activation_list_opened", arm: "smb", listId: "smb" },
     ]);
     expect(screen.queryByTestId("preferences-usage")).toBeNull();
+  });
+
+  // The daemon freezes a list on the first write, and the arm can be
+  // re-bucketed after that. The funnel keys its `screen` dimension off this
+  // event, so an arm-derived id would file the open under a list the user was
+  // never shown.
+  test("records the frozen list, not the arm the user was re-bucketed into", async () => {
+    enableActivationList("parent");
+    activationProgressRef.data = {
+      version: 1,
+      listId: "smb",
+      modalDismissedAt: null,
+      allDoneShownAt: null,
+      tasks: {},
+    };
+    await openMenu();
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Inspiration List"));
+      await Promise.resolve();
+    });
+
+    expect(activationEvents).toEqual([
+      { event: "activation_list_opened", arm: "parent", listId: "smb" },
+    ]);
   });
 
   test("sits above Share Feedback, as Figma orders the menu", async () => {

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -28,7 +28,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import type { PreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import { useActivationChecklistArm } from "@/hooks/use-activation-checklist-flag";
-import { useActivationEnabledListId } from "@/hooks/use-activation-enabled";
+import { useEffectiveActivationListId } from "@/hooks/use-activation-enabled";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
@@ -274,7 +274,7 @@ function PreferencesMenuContent({
   const activationArm = useActivationChecklistArm();
   const activationAssistantId =
     useResolvedAssistantsStore.use.activeAssistantId();
-  const activationListId = useActivationEnabledListId(activationAssistantId);
+  const activationListId = useEffectiveActivationListId(activationAssistantId);
   const {
     enabled: showBillingRows,
     balance: effectiveBalance,

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -2,6 +2,7 @@ import {
   ChevronDown,
   ChevronUp,
   CircleUser,
+  List,
   MessageSquareText,
   Settings as SettingsIcon,
   Shield,
@@ -26,13 +27,20 @@ import {
 import { ThemeToggle } from "@/components/theme-toggle";
 import type { PreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
+import {
+  resolveActivationListId,
+  useActivationChecklistArm,
+} from "@/hooks/use-activation-checklist-flag";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { useSupportsActivationProgress } from "@/lib/backwards-compat/use-supports-activation-progress";
 import { displayedCreditsUsd } from "@/lib/billing/displayed-credits";
 import { isElectron } from "@/runtime/is-electron";
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { openUrl } from "@/runtime/browser";
+import { emitActivationEvent } from "@/utils/activation-telemetry";
 import { adminUrl, routes } from "@/utils/routes";
 
 import { CreditsCard } from "./credits-card";
@@ -259,9 +267,20 @@ function PreferencesMenuContent({
   activeConversationId,
 }: PreferencesMenuContentProps) {
   const { t } = useTranslation("chat");
+  const { t: tActivation } = useTranslation("activation");
   const navigate = useNavigate();
   const user = useAuthStore.use.user();
   const platformGate = usePlatformGate();
+  /* The Inspiration List entry rides the same two gates as every other
+     activation surface: an arm that names a list, and a daemon carrying the
+     progress routes the page reads. */
+  const activationArm = useActivationChecklistArm();
+  const activationListId = resolveActivationListId(activationArm);
+  const activationAssistantId =
+    useResolvedAssistantsStore.use.activeAssistantId();
+  const supportsActivation = useSupportsActivationProgress(
+    activationAssistantId,
+  );
   const {
     enabled: showBillingRows,
     balance: effectiveBalance,
@@ -302,6 +321,21 @@ function PreferencesMenuContent({
             }}
           />
         </div>
+      ) : null}
+
+      {activationListId !== null && supportsActivation ? (
+        <PanelItem
+          icon={List}
+          label={tActivation("menu.inspirationList")}
+          onSelect={() => {
+            onClose();
+            emitActivationEvent("activation_list_opened", {
+              arm: activationArm,
+              listId: activationListId,
+            });
+            navigate(routes.activationList);
+          }}
+        />
       ) : null}
 
       {(platformGate === "full" || isElectron()) && (

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -27,14 +27,11 @@ import {
 import { ThemeToggle } from "@/components/theme-toggle";
 import type { PreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
 import { usePreferencesUsage } from "@/domains/chat/hooks/use-preferences-usage";
-import {
-  resolveActivationListId,
-  useActivationChecklistArm,
-} from "@/hooks/use-activation-checklist-flag";
+import { useActivationChecklistArm } from "@/hooks/use-activation-checklist-flag";
+import { useActivationEnabledListId } from "@/hooks/use-activation-enabled";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
-import { useSupportsActivationProgress } from "@/lib/backwards-compat/use-supports-activation-progress";
 import { displayedCreditsUsd } from "@/lib/billing/displayed-credits";
 import { isElectron } from "@/runtime/is-electron";
 import { useAuthStore, useIsAuthenticated } from "@/stores/auth-store";
@@ -271,16 +268,13 @@ function PreferencesMenuContent({
   const navigate = useNavigate();
   const user = useAuthStore.use.user();
   const platformGate = usePlatformGate();
-  /* The Inspiration List entry rides the same two gates as every other
-     activation surface: an arm that names a list, and a daemon carrying the
-     progress routes the page reads. */
+  /* The Inspiration List entry rides the same gate as every other activation
+     surface, resolved in the one place that owns it. The arm is read beside it
+     for the telemetry the entry emits, not as a second gate. */
   const activationArm = useActivationChecklistArm();
-  const activationListId = resolveActivationListId(activationArm);
   const activationAssistantId =
     useResolvedAssistantsStore.use.activeAssistantId();
-  const supportsActivation = useSupportsActivationProgress(
-    activationAssistantId,
-  );
+  const activationListId = useActivationEnabledListId(activationAssistantId);
   const {
     enabled: showBillingRows,
     balance: effectiveBalance,
@@ -323,7 +317,7 @@ function PreferencesMenuContent({
         </div>
       ) : null}
 
-      {activationListId !== null && supportsActivation ? (
+      {activationListId !== null ? (
         <PanelItem
           icon={List}
           label={tActivation("menu.inspirationList")}

--- a/clients/web/src/hooks/use-activation-enabled.ts
+++ b/clients/web/src/hooks/use-activation-enabled.ts
@@ -19,6 +19,7 @@
 
 import { useActivationProgress } from "@/domains/activation/hooks/use-activation-progress";
 import {
+  ACTIVATION_LIST_IDS,
   resolveActivationListId,
   useActivationChecklistArm,
   type ActivationListId,
@@ -48,6 +49,10 @@ function useActivationEnabledListId(
  * name different lists. `null` whenever the gates are off, which the freeze
  * cannot override: a frozen list says which checklist, never whether.
  */
+function isActivationListId(value: string): value is ActivationListId {
+  return (ACTIVATION_LIST_IDS as readonly string[]).includes(value);
+}
+
 export function useEffectiveActivationListId(
   assistantId: string | null | undefined,
 ): string | null {
@@ -56,5 +61,11 @@ export function useEffectiveActivationListId(
   if (armListId === null) {
     return null;
   }
-  return progress?.listId ?? armListId;
+  const frozen = progress?.listId;
+  if (frozen === null || frozen === undefined) {
+    return armListId;
+  }
+  // A frozen id this bundle has no catalog for (written by a newer client)
+  // hides the surfaces rather than enabling an empty list.
+  return isActivationListId(frozen) ? frozen : null;
 }

--- a/clients/web/src/hooks/use-activation-enabled.ts
+++ b/clients/web/src/hooks/use-activation-enabled.ts
@@ -8,12 +8,16 @@
  * not draw over, a progress read that has not landed) layers it on top of this
  * one rather than restating these two.
  *
+ * The same file answers which list, since every caller of the gate needs one:
+ * the arm names it and the daemon's freeze overrides it.
+ *
  * Lives beside `use-activation-checklist-flag` in the shared hooks directory
  * rather than in the activation domain because the Preferences menu is a chat
  * component: this is the seam it already reaches activation through, and a
  * domain-to-domain import is what `docs/CONVENTIONS.md` forbids.
  */
 
+import { useActivationProgress } from "@/domains/activation/hooks/use-activation-progress";
 import {
   resolveActivationListId,
   useActivationChecklistArm,
@@ -22,15 +26,35 @@ import {
 import { useSupportsActivationProgress } from "@/lib/backwards-compat/use-supports-activation-progress";
 
 /**
- * The list activation is enabled for on `assistantId`, or `null` when either
- * gate fails. `null` while the assistant's version is unknown, which keeps the
- * feature hidden until identity resolves rather than offering launches the
- * daemon cannot link.
+ * The list the arm selects on `assistantId`, or `null` when either gate fails.
+ * `null` while the assistant's version is unknown, which keeps the feature
+ * hidden until identity resolves rather than offering launches the daemon
+ * cannot link.
  */
-export function useActivationEnabledListId(
+function useActivationEnabledListId(
   assistantId: string | null | undefined,
 ): ActivationListId | null {
   const arm = useActivationChecklistArm();
   const supported = useSupportsActivationProgress(assistantId);
   return supported ? resolveActivationListId(arm) : null;
+}
+
+/**
+ * The list the user is actually on: the one the daemon froze on the first
+ * write, falling back to the arm's while nothing is frozen.
+ *
+ * Every surface that names a list reads it from here, so the route, the
+ * visibility hook and the funnel events a re-bucketed user produces can never
+ * name different lists. `null` whenever the gates are off, which the freeze
+ * cannot override: a frozen list says which checklist, never whether.
+ */
+export function useEffectiveActivationListId(
+  assistantId: string | null | undefined,
+): string | null {
+  const armListId = useActivationEnabledListId(assistantId);
+  const { data: progress } = useActivationProgress();
+  if (armListId === null) {
+    return null;
+  }
+  return progress?.listId ?? armListId;
 }

--- a/clients/web/src/hooks/use-activation-enabled.ts
+++ b/clients/web/src/hooks/use-activation-enabled.ts
@@ -1,0 +1,36 @@
+/**
+ * The two gates every activation surface shares: an arm that names a list, and
+ * a daemon carrying the `/v1/activation/*` routes the surfaces read and write.
+ *
+ * One definition, so the welcome modal, the pill, the Inspiration List page and
+ * the Preferences entry that opens it can never disagree about whether the
+ * feature is on. A surface that adds a gate of its own (a route the pill must
+ * not draw over, a progress read that has not landed) layers it on top of this
+ * one rather than restating these two.
+ *
+ * Lives beside `use-activation-checklist-flag` in the shared hooks directory
+ * rather than in the activation domain because the Preferences menu is a chat
+ * component: this is the seam it already reaches activation through, and a
+ * domain-to-domain import is what `docs/CONVENTIONS.md` forbids.
+ */
+
+import {
+  resolveActivationListId,
+  useActivationChecklistArm,
+  type ActivationListId,
+} from "@/hooks/use-activation-checklist-flag";
+import { useSupportsActivationProgress } from "@/lib/backwards-compat/use-supports-activation-progress";
+
+/**
+ * The list activation is enabled for on `assistantId`, or `null` when either
+ * gate fails. `null` while the assistant's version is unknown, which keeps the
+ * feature hidden until identity resolves rather than offering launches the
+ * daemon cannot link.
+ */
+export function useActivationEnabledListId(
+  assistantId: string | null | undefined,
+): ActivationListId | null {
+  const arm = useActivationChecklistArm();
+  const supported = useSupportsActivationProgress(assistantId);
+  return supported ? resolveActivationListId(arm) : null;
+}

--- a/clients/web/src/i18n/locales/en/activation.json
+++ b/clients/web/src/i18n/locales/en/activation.json
@@ -23,9 +23,11 @@
   "launch": {
     "noAssistant": "No assistant is connected right now.",
     "unknownTask": "That task is no longer available.",
-    "failed": "Could not start the task. Please try again."
+    "failed": "Could not start the task. Please try again.",
+    "openConversation": "Open conversation"
   },
   "page": {
-    "title": "Your first {count} things"
+    "title": "Your first {count} things",
+    "loading": "Loading suggestions"
   }
 }

--- a/clients/web/src/routes.tsx
+++ b/clients/web/src/routes.tsx
@@ -1081,6 +1081,18 @@ export const routeTree = [
                             ),
                         },
                       },
+                      // The Inspiration List renders its own serif title and
+                      // stays outside IntelligenceLayout: it is not an About
+                      // Assistant section and must not inherit that chrome.
+                      {
+                        path: "suggestions",
+                        lazy: {
+                          Component: () =>
+                            import("@/domains/activation/pages/activation-list-route").then(
+                              (m) => m.ActivationListRoute,
+                            ),
+                        },
+                      },
                       {
                         path: "connect",
                         lazy: {

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -185,6 +185,14 @@ export const routes = {
 
   connect: r("/assistant/connect"),
 
+  /**
+   * The Inspiration List: every activation task of the active persona list,
+   * reachable from the Preferences menu. A standalone page rather than an
+   * About Assistant section, so it carries no `ABOUT_ASSISTANT_SECTIONS`
+   * entry and inherits none of that drill-down chrome.
+   */
+  activationList: r("/assistant/suggestions"),
+
   channels: r("/assistant/channels"),
 
   contacts: {


### PR DESCRIPTION
## Summary
- Adds `/assistant/suggestions`, a full-page list of the active persona's activation tasks with todo / working / done states (Figma Light 796 / Light 797)
- Adds the Inspiration List item to the Preferences menu behind the `activation-checklist` arm and the daemon progress gate

Part of plan: activation-checklist.md (PR 6 of 6)

## What lands

- `routes.activationList = "/assistant/suggestions"` plus a lazy route under `ActiveAssistantGate`, deliberately **outside** `IntelligenceLayout` (no `ABOUT_ASSISTANT_SECTIONS` entry, no drill-down chrome).
- `domains/activation/pages/activation-list-route.tsx` wires the catalog, the progress read, the capability filter and the launch; `components/activation-list-page.tsx` is presentational so a story renders exactly what ships.
- `components/activation-list-row.tsx`: `ListRow` + an indented slot below it. A todo row launches and keeps the user on the page (the row flips to Working); a working or done row opens the conversation it ran in. Done rows mute the title to `--content-tertiary` (A22, not the mock's wrapper opacity, which does not survive theming).
- `PanelItem icon={List}` above Share Feedback, as Figma orders the popover. It emits `activation_list_opened` and navigates.

## Notes for review

- **Dedupe with PR 4.** PR 4 adds `ActivationTaskRow` for the modal. The row here is kept in one file (`activation-list-row.tsx`) so whichever PR lands second rebases and swaps a single file. The task-icon colour map lives in that same file for the same reason.
- **Icon discs use the `*-weak` tokens, not a 15% `color-mix`.** The weak tokens *are* the mock's hexes (`#CEDAEC`, `#EFE8C4`, `#F0D9E0`, `#C8E5E2`), they follow every theme, and they keep the todo discs at the same weight as the green done disc. The palette carries no purple, so purple borrows the nearest hue it does carry (5 of 31 `smb` tasks); worth a design call before GA.
- **Interactive extras sit below the row, not inside it.** `ListRow` renders title and subtitle inside its own `<button>`, and the file card and the external link are interactive, so nesting them there would be invalid markup and unreachable by keyboard.
- **Drive-by fix in `LocalFileCard`**: the hover hint ("Open preview" / "Open in workspace") is `shrink-0` and always occupies its slot, so at 390px it squeezed the filename to zero width. It is now `max-md:hidden` — on a phone it never reveals anyway and the tap it previews is the only gesture there is. Affects the chat transcript's local-file cards too, for the better.
- **Test-isolation fixes** in `preferences-menu.test.tsx`: its `react-router` and `platform-detection` module mocks did not spread the real module, and its `client-feature-flag-store` stub replaced the store process-wide. Both leaked into any activation test sharing the process. The router and platform mocks now spread; the flag store stub is gone in favour of the real (transport-free) store.
- `chat-empty-state.tsx` references `--content-emphasized`, a token that does not exist (the real one is `--content-emphasised`). Not touched here; flagging it.

## Screenshots

Storybook has no `PreferencesMenu` story, and there is no image host reachable from this environment, so nothing is attached. The page was reviewed in the browser at desktop light, desktop dark and 390px via:

- `Activation/ActivationListPage` → `Light 796 Todo`, `Light 797 Mixed`, `Light 797 Mixed Dark`, `Light 797 Mixed Mobile`

The menu item is covered by `preferences-menu.test.tsx` (hidden when the arm is off, hidden below the daemon floor, navigates + emits, orders above Share Feedback).

## Validation

- `bun test src/domains/activation src/domains/chat/components/preferences-menu.test.tsx` — 95 pass
- `bun test src/components/local-file` — 73 pass
- `bunx tsc --noEmit`, `bun run lint`, `bun run audit:cross-domain:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)