### PR TITLE
fix(docs): build the image with Node

### DIFF
--- a/clients/docs/Dockerfile
+++ b/clients/docs/Dockerfile
@@ -1,6 +1,9 @@
 # syntax=docker/dockerfile:1.20@sha256:26147acbda4f14c5add9946e2fd2ed543fc402884fd75146bd342a7f6271dc1d
 # Build stage
-FROM oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7 AS builder
+# Node base so `next build` runs under Node; Bun is only the package manager.
+FROM node:22.22.2-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc55349f39b4bc3688448bb6e AS builder
+COPY --from=oven/bun:1.3.11@sha256:0733e50325078969732ebe3b15ce4c4be5082f18c4ac1a0f0ca4839c2e4e42a7 /usr/local/bin/bun /usr/local/bin/bun
+RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
 
 WORKDIR /app
 


### PR DESCRIPTION
- builder stage moves to the node:22 image with the Bun binary copied in, so `bun install` is unchanged and `next build` runs under Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01La4BVyez2GgYi7qpKuuQat