### PR TITLE
fix(ces): make the migrations runner test independent of file order

### DIFF
--- a/credential-executor/src/__tests__/ces-migrations-runner.test.ts
+++ b/credential-executor/src/__tests__/ces-migrations-runner.test.ts
@@ -80,6 +80,7 @@ mock.module("pino", () => ({ default: mockPinoLogger }));
 mock.module("pino-pretty", () => ({ default: (): object => ({}) }));
 
 // Import after mocking
+import { initLogger } from "../logger.js";
 import { runCesMigrations } from "../migrations/runner.js";
 
 // ---------------------------------------------------------------------------
@@ -119,6 +120,9 @@ function makeMigration(id: string): CesMigration {
 
 describe("runCesMigrations", () => {
   beforeEach(() => {
+    // Rebuild the module-level root logger from the mocked pino, discarding any
+    // real logger a previously-executed test file left cached.
+    initLogger({ dir: undefined, retentionDays: 0 });
     mockFileExists = false;
     mockFileContents = null;
     existsSyncFn.mockClear();


### PR DESCRIPTION
- the runner test rebuilds the cached root logger through its pino mock before each test, so its log assertions hold regardless of which test files ran earlier in the same process

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01La4BVyez2GgYi7qpKuuQat