### PR TITLE
feat(llm): add Gemini 3.8 Flash to the provider catalog

### DIFF
--- a/assistant/src/__tests__/gemini-provider.test.ts
+++ b/assistant/src/__tests__/gemini-provider.test.ts
@@ -467,6 +467,52 @@ describe("GeminiProvider", () => {
     });
   });
 
+  test("3.8 Flash: disabled maps to the LOW floor, not MINIMAL", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const flash38Provider = new GeminiProvider(
+      "test-api-key",
+      "gemini-3.8-flash",
+    );
+    await flash38Provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      { config: { thinking: { type: "disabled" } } },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({
+      thinkingLevel: "LOW",
+      includeThoughts: false,
+    });
+  });
+
+  test("3.8 Flash: an explicit minimal level is clamped up to LOW", async () => {
+    fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
+
+    const flash38Provider = new GeminiProvider(
+      "test-api-key",
+      "models/gemini-3.8-flash",
+    );
+    await flash38Provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+      {
+        config: {
+          thinking: {
+            type: "adaptive",
+            level: "minimal",
+            streamThinking: false,
+          },
+        },
+      },
+    );
+
+    const config = lastStreamParams!.config as Record<string, unknown>;
+    expect(config.thinkingConfig).toEqual({
+      thinkingLevel: "LOW",
+      includeThoughts: false,
+    });
+  });
+
   test("Pro: a supported explicit level passes through unchanged", async () => {
     fakeChunks = [textChunk("OK"), finishChunk("STOP", 10, 2)];
 

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -224,6 +224,17 @@ describe("resolvePricing", () => {
       );
     });
 
+    test("returns priced for gemini-3.8-flash", () => {
+      const result = resolvePricing(
+        "gemini",
+        "gemini-3.8-flash",
+        1_000_000,
+        1_000_000,
+      );
+      expect(result.pricingStatus).toBe("priced");
+      expect(result.estimatedCostUsd).toBe(1.5 + 7.5);
+    });
+
     test("returns priced for gemini-3-flash-preview", () => {
       const result = resolvePricing(
         "gemini",

--- a/assistant/src/daemon/handlers/config-model.test.ts
+++ b/assistant/src/daemon/handlers/config-model.test.ts
@@ -65,6 +65,7 @@ describe("projectProviderForWire", () => {
     const wire = projectProviderForWire(gemini!);
     const modelIds = wire.models.map((model) => model.id);
     const expectedGemini3ModelIds = [
+      "gemini-3.8-flash",
       "gemini-3.7-flash",
       "gemini-3.6-flash",
       "gemini-3.5-flash",

--- a/assistant/src/providers/gemini/client.ts
+++ b/assistant/src/providers/gemini/client.ts
@@ -121,8 +121,9 @@ function clampThinkingLevelToFloor(
  * dynamic medium-level thinking).
  *
  * - `enabled: false` maps to the model's floor (the most "off" state it
- *   allows): `"minimal"` for most models, `"low"` for Pro and Gemini 3.7
- *   Flash, which reject `"minimal"`.
+ *   allows): `"minimal"` for most models, `"low"` for models whose catalog
+ *   `thinkingFloor` is `"low"` (Pro and recent Flash IDs that reject
+ *   `"minimal"`).
  * - An explicit `level` below the floor is raised to the floor.
  * - When no `level` is pinned, Pro models get the documented default (`"high"`)
  *   because an absent level resolves to the unsupported `"minimal"` upstream;

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -632,6 +632,22 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     },
     models: [
       {
+        id: "gemini-3.8-flash",
+        displayName: "Gemini 3.8 Flash",
+        contextWindowTokens: 1048576,
+        maxOutputTokens: 65536,
+        supportsThinking: true,
+        thinkingFloor: "low",
+        supportsCaching: true,
+        supportsVision: true,
+        supportsToolUse: true,
+        pricing: {
+          inputPer1mTokens: 1.5,
+          outputPer1mTokens: 7.5,
+          cacheReadPer1mTokens: 0.15,
+        },
+      },
+      {
         id: "gemini-3.7-flash",
         displayName: "Gemini 3.7 Flash",
         contextWindowTokens: 1048576,

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -236,8 +236,18 @@ export const MODELS_BY_PROVIDER = {
   ],
   gemini: [
     {
+      id: "gemini-3.8-flash",
+      displayName: "Gemini 3.8 Flash",
+      contextWindowTokens: 1_048_576,
+      defaultContextWindowTokens: 200_000,
+      maxOutputTokens: 65_536,
+      supportsThinking: true,
+      thinkingFloor: "low",
+    },
+    {
       id: "gemini-3.7-flash",
       displayName: "Gemini 3.7 Flash",
+      family: "gemini-flash",
       contextWindowTokens: 1_048_576,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 65_536,

--- a/clients/web/src/assistant/llm-model-families.test.ts
+++ b/clients/web/src/assistant/llm-model-families.test.ts
@@ -27,7 +27,7 @@ const NEWEST_IN_FAMILY: Record<string, string> = {
   "claude-opus": "Claude Opus 5",
   "claude-sonnet": "Claude Sonnet 5",
   "gpt-5": "GPT-5.5",
-  "gemini-flash": "Gemini 3.6 Flash",
+  "gemini-flash": "Gemini 3.7 Flash",
   "gemini-flash-lite": "Gemini 3.5 Flash-Lite",
   "gemini-pro": "Gemini 3.1 Pro Preview",
   grok: "Grok 4.6",

--- a/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
+++ b/clients/web/src/domains/settings/ai/profile-create-model-first.test.tsx
@@ -456,7 +456,7 @@ describe("the model list", () => {
     expect(opus).toHaveLength(1);
     expect(opus[0].meta).toBe("");
 
-    const gemini = rows.find((row) => row.label === "Gemini 3.6 Flash");
+    const gemini = rows.find((row) => row.label === "Gemini 3.8 Flash");
     expect(gemini?.meta).toBe("");
   });
 

--- a/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
+++ b/clients/web/src/domains/settings/ai/profile-param-visibility.test.ts
@@ -262,6 +262,12 @@ describe("geminiThinkingLevels", () => {
     ).toEqual(["low", "medium", "high"]);
   });
 
+  test("gemini-3.8-flash excludes 'minimal'", () => {
+    const levels = geminiThinkingLevels("gemini-3.8-flash");
+    expect(levels).toEqual(["low", "medium", "high"]);
+    expect(levels).not.toContain("minimal");
+  });
+
   test("gemini-3.7-flash excludes 'minimal'", () => {
     const levels = geminiThinkingLevels("gemini-3.7-flash");
     expect(levels).toEqual(["low", "medium", "high"]);

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -473,6 +473,24 @@
       "defaultModel": "gemini-2.5-flash",
       "models": [
         {
+          "id": "gemini-3.8-flash",
+          "displayName": "Gemini 3.8 Flash",
+          "contextWindowTokens": 1048576,
+          "maxOutputTokens": 65536,
+          "defaultContextWindowTokens": 200000,
+          "longContextMode": "native-model",
+          "supportsThinking": true,
+          "thinkingFloor": "low",
+          "supportsCaching": true,
+          "supportsVision": true,
+          "supportsToolUse": true,
+          "pricing": {
+            "inputPer1mTokens": 1.5,
+            "outputPer1mTokens": 7.5,
+            "cacheReadPer1mTokens": 0.15
+          }
+        },
+        {
           "id": "gemini-3.7-flash",
           "displayName": "Gemini 3.7 Flash",
           "contextWindowTokens": 1048576,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Add Gemini 3.8 Flash (`gemini-3.8-flash`) as a selectable Google Gemini model in the assistant catalog and settings picker.

Companion platform PR: https://github.com/vellum-ai/vellum-assistant-platform/pull/10323 (merged). Hosted-proxy preflight now has the rate card.

## Summary
- Adds `gemini-3.8-flash` at the top of the Gemini catalog (1,048,576 context, 65,536 max output, thinking/caching/vision/tool use).
- Catalog pricing uses the Standard tier ($1.50 / $7.50 / $0.15 per 1M tokens), matching `gemini-3.7-flash`. Google's current introductory API rate through 2026-12-31 is $0.75 / $3.75.
- Gemini 3.8 Flash does not accept thinking level `MINIMAL`. The catalog field `thinkingFloor: "low"` is the source of truth. The provider clamps `disabled` / `minimal` to `LOW` and leaves an unpinned adaptive level unset so Google's default (`MEDIUM`) applies. The settings picker hides `minimal` for models whose catalog floor is `"low"`.
- Older Flash siblings fold under the `gemini-flash` family, now led by Gemini 3.7 Flash.

Does not change Gemini default-model or intent bindings.

## Test plan
- `cd assistant && bun test src/__tests__/gemini-provider.test.ts src/daemon/handlers/config-model.test.ts src/__tests__/llm-catalog-parity.test.ts src/__tests__/pricing.test.ts`
- `cd clients/web && bun test src/assistant/llm-model-catalog.test.ts src/assistant/llm-model-families.test.ts src/domains/settings/ai/profile-param-visibility.test.ts src/domains/settings/ai/profile-create-model-first.test.tsx`

## Risk
Low. Additive catalog entry plus existing thinking-floor clamp so `MINIMAL` is not sent upstream. The platform companion is already merged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-029fe651-a93e-43e6-aa24-3d2535f0f279?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-029fe651-a93e-43e6-aa24-3d2535f0f279&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

