### PR TITLE
fix(cli): point plugin search at install-by-name

### DIFF
--- a/assistant/src/cli/__tests__/catalog-search-help.test.ts
+++ b/assistant/src/cli/__tests__/catalog-search-help.test.ts
@@ -33,6 +33,7 @@ describe("catalog search help for setup-intent retrieval", () => {
     expect(indexed).toContain("Setup <app> for me");
     expect(indexed.toLowerCase()).toContain("before searching the web");
     expect(indexed).toContain("assistant plugins search");
+    expect(indexed).toContain("assistant plugins install <name>");
     expect(indexed).toContain("assistant skills search");
     expect(indexed.toLowerCase()).toContain("channels");
     expect(pluginsHelp.description).toContain("channels");

--- a/assistant/src/cli/commands/__tests__/plugins-search.test.ts
+++ b/assistant/src/cli/commands/__tests__/plugins-search.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for `assistant plugins search` human vs `--json` output.
+ *
+ * Search results include a `github:owner/repo@ref` PATH column. The model
+ * copies that locator into `plugins install`. The human footer tells it to
+ * install by marketplace name instead.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { PLUGINS_SEARCH_INSTALL_HINT } from "../plugins.help.js";
+import { runCliCommand } from "./cli-test-harness.js";
+
+const catalog = {
+  ref: "test-ref",
+  matches: [
+    {
+      name: "imessage",
+      path: "github:vellum-ai/imessage@abc123",
+      category: "productivity",
+      source: {
+        kind: "github" as const,
+        repo: "vellum-ai/imessage",
+        ref: "abc123",
+      },
+    },
+  ],
+};
+
+mock.module("../../lib/plugin-catalog-cache.js", () => ({
+  getPluginCatalog: async () => catalog,
+}));
+
+const { registerPluginsCommand } = await import("../plugins.js");
+
+function runSearch(args: string[]): Promise<{
+  stdout: string;
+  exitCode: number;
+}> {
+  return runCliCommand(registerPluginsCommand, ["plugins", ...args]);
+}
+
+describe("plugins search", () => {
+  test("human output ends with the marketplace-name install hint", async () => {
+    const { exitCode, stdout } = await runSearch(["search", "imessage"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("imessage");
+    expect(stdout).toContain("github:vellum-ai/imessage@abc123");
+    expect(stdout).toContain('1 match for "imessage".');
+    expect(stdout.trimEnd().endsWith(PLUGINS_SEARCH_INSTALL_HINT)).toBe(true);
+    expect(PLUGINS_SEARCH_INSTALL_HINT).toContain(
+      "assistant plugins install <name>",
+    );
+  });
+
+  test("empty human result has no install hint", async () => {
+    const { exitCode, stdout } = await runSearch(["search", "nothing-matches"]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('No plugins matched "nothing-matches".');
+    expect(stdout).not.toContain(PLUGINS_SEARCH_INSTALL_HINT);
+  });
+
+  test("json output omits the install hint", async () => {
+    const { exitCode, stdout } = await runSearch([
+      "search",
+      "imessage",
+      "--json",
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain(PLUGINS_SEARCH_INSTALL_HINT);
+    const parsed = JSON.parse(stdout) as {
+      query: string;
+      matches: Array<{ name: string }>;
+    };
+    expect(parsed.query).toBe("imessage");
+    expect(parsed.matches.map((m) => m.name)).toEqual(["imessage"]);
+  });
+});

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -8,6 +8,9 @@ import {
   PLUGIN_UPGRADE_STRATEGIES,
 } from "../lib/plugin-constants.js";
 
+export const PLUGINS_SEARCH_INSTALL_HINT =
+  "Install the plugin with `assistant plugins install <name>`.";
+
 export const pluginsHelp: CliCommandHelp = {
   name: "plugins",
   description:
@@ -166,7 +169,7 @@ Arguments:
            user sentence. Use the product or plugin name. Anchors like
            ^example work.
 
-If a match is found, install it with 'assistant plugins install <name>'.
+${PLUGINS_SEARCH_INSTALL_HINT}
 If nothing matches, try 'assistant skills search <query>', then web search.
 
 Examples:

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -55,7 +55,7 @@ import {
 } from "../lib/toggle-plugin.js";
 import type { PluginUpgradeResult } from "../lib/upgrade-plugin.js";
 import { getCliLogger } from "../logger.js";
-import { pluginsHelp } from "./plugins.help.js";
+import { PLUGINS_SEARCH_INSTALL_HINT, pluginsHelp } from "./plugins.help.js";
 
 const loadModule = createRequire(import.meta.url);
 
@@ -606,6 +606,7 @@ export function registerPluginsCommand(program: Command): void {
             console.log(
               `${result.matches.length} match${result.matches.length === 1 ? "" : "es"} for "${result.query}".`,
             );
+            console.log(PLUGINS_SEARCH_INSTALL_HINT);
           } catch (err) {
             if (err instanceof libs.search.InvalidSearchPatternError) {
               console.error(err.message);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

After `assistant plugins search` found iMessage, the assistant installed it with `assistant plugins install github:vellum-ai/imessage` (copied from the PATH column) instead of `assistant plugins install imessage`.

## Summary

- End human `assistant plugins search` output with `Install the plugin with \`assistant plugins install <name>\`.`
- Reuse that line in `plugins search --help`
- Leave `--json` search output unchanged

## Test plan

- `cd assistant && bun test src/cli/commands/__tests__/plugins-search.test.ts src/cli/__tests__/catalog-search-help.test.ts`

## Risk

Low. Human CLI copy only. JSON search output is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a4c1828-df19-4b5f-ac34-80cd3e66bea8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a4c1828-df19-4b5f-ac34-80cd3e66bea8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

