### PR TITLE
Fix Stripe Link device approval flow

### DIFF
--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -16,7 +16,8 @@ Spend on the user's behalf using the [Stripe Link CLI](https://github.com/stripe
 
 ## Required tools
 
-- `bash` for all `link-cli` invocations. Use `host_bash` only if a specific flow genuinely requires host-level access (e.g. reading a local file the user has on their machine).
+- `bash` for all `link-cli` invocations.
+- Use `assistant browser` to open returned Link approval URLs in an available user-browser session. If that route is unavailable but the user has an authenticated desktop client, use `host_bash` only to run `open "<verification_url>"` on that client. Do not use the sandbox browser for approval unless the user explicitly asks for it.
 
 ## Hard constraints
 
@@ -81,11 +82,20 @@ In every example below, substitute `bunx @stripe/link-cli` wherever you see `lin
 
 Use your own assistant name for `--client-name` — read it from `IDENTITY.md`. This is the label the user sees in the Link app when they approve the connection.
 
+> **Device-authorization handling — do not make the user fish a URL out of terminal output.** With `--format json`, `auth login` **does not open a browser**; it returns `verification_url`, `phrase`, and a polling continuation. Run the login once without inline polling, extract the returned URL, then navigate the user's connected browser to it yourself. Only if no browser route is available, present it as a clickable link with the phrase in chat. Never claim the CLI opened a browser unless you actually navigated it.
+
+1. First check `assistant browser --json status`. Prefer an available user-browser backend. If one is connected, open the returned `verification_url` using `assistant browser --browser-mode <available-mode> navigate --url "<verification_url>"`.
+2. If the browser integration is unavailable but an authenticated Mac client is connected, use `host_bash` with `open "<verification_url>"` on that client. This is one of the narrow cases where host execution is appropriate: the approval must open in the user's browser, not the sandbox browser.
+3. Start `auth status --interval 5 --max-attempts 60 --format json` immediately after navigation. Do not wait for another message. Stop when `authenticated` is true or the request reaches a terminal failure.
+
 ```bash
-link-cli auth login --client-name "<your assistant name>"
+link-cli auth login \
+  --client-name "<your assistant name>" \
+  --scope "userinfo:read payment_methods.agentic" \
+  --format json
 ```
 
-Opens a browser flow. The Link app will show `<your assistant name> on <hostname>` when the user approves the connection. After it completes, re-run Step 0.
+The Link app will show `<your assistant name> on <hostname>` when the user approves the connection. After polling succeeds, re-run Step 0 and verify that the returned `scope` includes the access required for the requested task.
 
 ### Introspecting the CLI
 
@@ -273,7 +283,7 @@ link-cli spend-request cancel <id> --format json
 | Error / condition                       | Action                                                                                              |
 | --------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `link-cli` not found                    | Invoke it with `bunx @stripe/link-cli` and substitute that prefix wherever examples use `link-cli`. |
-| Not authenticated                       | Run `auth login --client-name "<your assistant name>"` (see Setup)                                  |
+| Not authenticated                       | Run `auth login` with the assistant name and required scopes, then open its returned `verification_url` in the user's browser and poll (see Setup) |
 | `POLLING_TIMEOUT` on retrieve           | Report to user; offer cancel or fresh spend request                                                 |
 | SPT payment fails (402 again after pay) | SPT is consumed — create a new spend request                                                        |
 | `amount` > 50000                        | Tell user the cap is \$500 per transaction                                                          |

--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -50,34 +50,38 @@ Whenever **any** flow (MCP tool, API call, web request, or otherwise) produces a
 
 ---
 
-## Step 0: Check installation and auth
+## Fast path — authentication only
+
+When the user asks to connect, log in, or check Link, **do exactly this before any other command or investigation**:
 
 ```bash
-if command -v link-cli >/dev/null; then
-  link-cli auth status --format json
-else
-  bunx @stripe/link-cli auth status --format json
-fi
+bunx @stripe/link-cli auth status --format json
 ```
 
-- `link-cli` missing — use `bunx @stripe/link-cli` for Step 0 and every command below.
-- Exit 0 but `"authenticated": false` — fall to **Setup: login**.
-- Authenticated — proceed to the requested flow.
-- `"update"` key present in auth status — mention the update to the user but don't block on it.
+**Do not** separately check whether `link-cli`, `bunx`, Node, npm, `node_modules`, caches, processes, CLI docs, or browser status first. `bunx` resolves the CLI on demand, and this command is both the installation check and the authentication check. Do not retry it with a different launcher unless it returns a concrete executable or network error.
+
+- `"authenticated": true` — say it is connected and stop; do not inspect payment methods or run further setup.
+- `"authenticated": false` — run exactly one `auth login` command, then open its returned `verification_url` and start background polling as described in **Setup**.
+- A concrete command error — report that exact error, then take only the recovery step it calls for.
+- `"update"` key present — mention it after the result, but never block setup on it.
+
+### No diagnostic parade
+
+A normal connection request is a two-command flow: **one `auth status`, then one `auth login` only if needed**. The only additional actions are opening the returned URL and the background poll. Never launch exploratory commands, repeat auth status through multiple launchers, read Link’s source/docs, or investigate local runtime state unless the fast-path command itself returns an actionable error.
+
+---
+
+## Step 0: Check installation and auth
+
+Use the **Fast path** above. For payment flows, repeat `bunx @stripe/link-cli auth status --format json` only when there is reason to believe authentication state may have changed since the current conversation.
 
 ---
 
 ## Setup
 
-### If `link-cli` is missing
+### CLI launcher
 
-Invoke the CLI on demand with `bunx`:
-
-```bash
-bunx @stripe/link-cli <subcommand>
-```
-
-In every example below, substitute `bunx @stripe/link-cli` wherever you see `link-cli`.
+Use `bunx @stripe/link-cli` for every command in this skill. It avoids a separate global-install check and works whether or not the executable is already cached.
 
 ### If installed but not authenticated
 

--- a/skills/stripe-link-wallet/SKILL.md
+++ b/skills/stripe-link-wallet/SKILL.md
@@ -18,6 +18,7 @@ Spend on the user's behalf using the [Stripe Link CLI](https://github.com/stripe
 
 - `bash` for all `link-cli` invocations.
 - Use `assistant browser` to open returned Link approval URLs in an available user-browser session. If that route is unavailable but the user has an authenticated desktop client, use `host_bash` only to run `open "<verification_url>"` on that client. Do not use the sandbox browser for approval unless the user explicitly asks for it.
+- **Never block the chat while awaiting approval.** Run every `auth status --interval ...` or `spend-request retrieve --interval ...` polling command through the `bash` tool with `background: true`, then handle its completion wake. This works in cloud, web, desktop, and mobile contexts because polling remains in the assistant workspace; only opening the approval URL needs a user-browser route.
 
 ## Hard constraints
 
@@ -86,7 +87,7 @@ Use your own assistant name for `--client-name` — read it from `IDENTITY.md`. 
 
 1. First check `assistant browser --json status`. Prefer an available user-browser backend. If one is connected, open the returned `verification_url` using `assistant browser --browser-mode <available-mode> navigate --url "<verification_url>"`.
 2. If the browser integration is unavailable but an authenticated Mac client is connected, use `host_bash` with `open "<verification_url>"` on that client. This is one of the narrow cases where host execution is appropriate: the approval must open in the user's browser, not the sandbox browser.
-3. Start `auth status --interval 5 --max-attempts 60 --format json` immediately after navigation. Do not wait for another message. Stop when `authenticated` is true or the request reaches a terminal failure.
+3. Start `auth status --interval 5 --max-attempts 60 --format json` **immediately after navigation** via the `bash` tool with `background: true`. Do not wait for another message and do not keep the chat blocked. On the background completion wake, stop when `authenticated` is true or report the terminal failure.
 
 ```bash
 link-cli auth login \
@@ -165,7 +166,7 @@ link-cli spend-request retrieve <id> \
   --format json
 ```
 
-Polls every 3 seconds, up to 3 minutes. Terminal statuses: `approved`, `denied`, `expired`, `canceled`. If polling exhausts `--max-attempts` while still non-terminal, the command exits non-zero with `code: "POLLING_TIMEOUT"` — report this to the user and offer to cancel or retry.
+Run this command through the `bash` tool with `background: true` immediately after requesting approval, so chat stays available while the user approves. Polls every 3 seconds, up to 3 minutes. Terminal statuses: `approved`, `denied`, `expired`, `canceled`. On the completion wake, if polling exhausts `--max-attempts` while still non-terminal, it exits non-zero with `code: "POLLING_TIMEOUT"` — report that and offer to cancel or retry.
 
 **4. Pay the URL**
 
@@ -212,7 +213,7 @@ link-cli spend-request create \
 
 Omit `--credential-type` (or use the default). With `--format json`, returns immediately — proceed to polling.
 
-**2. Poll for approval** (same as Flow A step 3)
+**2. Poll for approval** (same as Flow A step 3, using a `background: true` `bash` invocation)
 
 **3. Retrieve card credentials securely**
 


### PR DESCRIPTION
## Summary
- Open the Link CLI device-approval URL in the connected user browser instead of claiming JSON-mode login does so automatically.
- Poll authentication immediately after navigation, with an explicit desktop-client fallback when browser control is unavailable.
- Request the payment scopes required for the wallet flow and align unauthenticated recovery guidance.

## Verification
- Confirmed `auth login --format json` returns `verification_url` and a polling continuation, rather than opening a browser.
- Confirmed the current Link CLI implementation only launches a URL in its interactive, non-JSON mode.
- Verified the resulting Markdown diff on a clean branch from current main.