### PR TITLE
fix(web): swipe action labels read from the catalog their menus already use

### DIFF
--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -24,7 +24,7 @@ import {
   renderConversationMenuItems,
   type ConversationMenuItemsProps,
 } from "@/domains/chat/components/conversation-actions-menu";
-import { useTranslation } from "@/i18n";
+import { useTranslation, type TFunction } from "@/i18n";
 import { useLongPressSheet } from "@/hooks/use-long-press-sheet";
 import {
   hasThreadStatus,
@@ -142,6 +142,7 @@ const skipNestedControls = (target: Element | null) =>
 function buildSwipeActions(
   ctx: ConversationListContextValue,
   conversation: Conversation,
+  t: TFunction<"chat">,
 ): { leadingActions: SwipeAction[]; trailingActions: SwipeAction[] } {
   const isChannel = isChannelConversation(conversation);
 
@@ -153,7 +154,9 @@ function buildSwipeActions(
     const isPinned = isConversationPinned(conversation);
     leadingActions.push({
       id: "pin",
-      label: isPinned ? "Unpin" : "Pin",
+      label: isPinned
+        ? t("conversationActions.unpin")
+        : t("conversationActions.pin"),
       icon: isPinned ? PinOff : Pin,
       onSelect: () => ctx.onPin?.(conversation),
     });
@@ -167,14 +170,14 @@ function buildSwipeActions(
   if (isArchived && ctx.onUnarchive) {
     trailingActions.push({
       id: "unarchive",
-      label: "Unarchive",
+      label: t("conversationActions.unarchive"),
       icon: ArchiveRestore,
       onSelect: () => ctx.onUnarchive?.(conversation),
     });
   } else if (!isArchived && ctx.onArchive) {
     trailingActions.push({
       id: "archive",
-      label: "Archive",
+      label: t("conversationActions.archive"),
       icon: Archive,
       variant: "destructive",
       onSelect: () => ctx.onArchive?.(conversation),
@@ -218,6 +221,7 @@ export function ConversationRow({
   const { leadingActions, trailingActions } = buildSwipeActions(
     ctx,
     conversation,
+    t,
   );
 
   const isTouch = isPointerCoarse();

--- a/clients/web/src/domains/library/components/library-app-card.tsx
+++ b/clients/web/src/domains/library/components/library-app-card.tsx
@@ -110,7 +110,7 @@ export function LibraryAppCard({
   const trailingActions: SwipeAction[] = [
     {
       id: "pin",
-      label: isPinned ? "Unpin" : "Pin",
+      label: isPinned ? t("libraryAppCard.unpin") : t("libraryAppCard.pin"),
       icon: isPinned ? PinOff : Pin,
       onSelect: () => onPin(app),
     },
@@ -118,7 +118,7 @@ export function LibraryAppCard({
       ? ([
           {
             id: "delete",
-            label: "Delete",
+            label: t("libraryAppCard.delete"),
             icon: Trash2,
             variant: "destructive",
             onSelect: () => deleteAction(app),


### PR DESCRIPTION
## TL;DR

A conversation row's **menu** says `t("conversationActions.archive")`. The **swipe** behind the same row said the literal `"Archive"`. In Spanish the menu reads *Archivar* and the swipe button reads *Archive*.

Five labels across two files, all shipping untranslated to every non-English locale. Every key already exists in every locale, so this is not new copy: it is the key that was already sitting two lines away.

Found while answering "why did LUM-3518 happen at all" on #42090. Independent of that PR and touches no file it touches, so the two can merge in either order.

## Before and after

| Surface | Command | Before (es) | After (es) |
| --- | --- | --- | --- |
| Conversation row swipe | Archive | `Archive` | `Archivar` |
| Conversation row swipe | Unarchive | `Unarchive` | `Desarchivar` |
| Conversation row swipe | Pin / Unpin | `Pin` / `Unpin` | `Fijar` / `Dejar de fijar` |
| Library app card swipe | Pin / Unpin | `Pin` / `Unpin` | `Fijar` / `Dejar de fijar` |
| Library app card swipe | Delete | `Delete` | `Eliminar` |
| The same commands in their menus | all | already translated | unchanged |

## Why the lint rule did not catch it

Worth stating, because a clean lint here reads as proof and is not.

`local/no-untranslated-strings` runs at **error** over `i18nEnforcedPaths = ["src/**/*.{ts,tsx}"]`, so both files were covered. But the rule reaches object literals only through `isToastCall`: its `CallExpression` visitor returns immediately unless the callee is a toast, and its only other entry point is `JSXAttribute`. A `label:` inside a command descriptor is never visited. The rule's own comment says this ("the rule reads JSX, toast call sites, and copy-shaped props, not every helper return value").

There is no glob to widen. Closing the gap means teaching the rule about descriptor objects, which is a separate change (see below).

## Why this is safe

- No new keys, no new copy, no catalog edits. Every key was already present in `en`, `es`, `zh`, `zh-TW` and `ru`; the menus beside these swipes have been using them all along.
- `catalogs.test.ts` passes (210 tests), which is what guards ICU parsing, key parity across locales, and orphaned keys.
- `buildSwipeActions` takes the `t` it needs as a parameter; the library card already had one in scope.
- Tests are pinned to English by design (`test-setup.ts` loads only `FALLBACK_CATALOGS`, so components assert against source copy). That means **no unit test can fail on a hardcoded English label**, which is exactly why this survived. The check that would have caught it is the lint rule, not a test, which is why I did not add an English-only assertion that would pass either way.

## What is left, deliberately

I swept the rest of `src/` for the same shape (a string `label:` beside an `icon:` and an `onSelect`/`run`/`onClick`). After this change **five** remain, all in `message-long-press-actions.tsx` (`Copy`, `Open in Slack`, `Fork from here`, `Summarize up to here`, `Inspect`) — one of them two lines below a correct `t("messageLongPressActions.copied")`.

They are not in here because those keys do not exist in any catalog, so fixing them means writing new product copy in five locales rather than reusing existing keys. That is a decision about the translation pipeline, not a mechanical fix.

Useful consequence: that same sweep found **zero false positives** across `src/`, so a targeted rule extension (a `label` string literal in an object that also has `icon` and a handler) would be precise rather than a flood. That becomes shippable as soon as those five labels have keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->