### PR TITLE
fix(integrations): hide the Discord OAuth card from the settings catalog

### DIFF
--- a/clients/web/src/domains/settings/pages/integrations-page.test.tsx
+++ b/clients/web/src/domains/settings/pages/integrations-page.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 
@@ -12,17 +12,22 @@ mock.module("@/assistant/api", () => ({
   })),
 }));
 
+let seededProviders: Array<Record<string, unknown>> = [];
+let seededConnections: Array<Record<string, unknown>> = [];
+
 mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
   oauthProvidersGetOptions: () => ({
     queryKey: ["oauth-providers"],
-    queryFn: async () => ({ providers: [] }),
+    queryFn: async () => ({ providers: seededProviders }),
   }),
 }));
 
 mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
   assistantsOauthConnectionsListOptions: () => ({
     queryKey: ["oauth-connections"],
-    queryFn: async () => ({ results: [] }),
+    // The page reads this query with no `select`, so it is the connection
+    // array itself, not an envelope around one.
+    queryFn: async () => seededConnections,
   }),
 }));
 
@@ -46,7 +51,9 @@ mock.module("@/domains/settings/components/integration-detail-modal", () => ({
 }));
 
 mock.module("@/domains/settings/components/integration-row", () => ({
-  IntegrationRow: () => <div>Integration row</div>,
+  IntegrationRow: ({ providerKey }: { providerKey: string }) => (
+    <div data-slot="integration-row">{providerKey}</div>
+  ),
 }));
 
 mock.module("@/domains/settings/mcp/mcp-page", () => ({
@@ -72,8 +79,27 @@ function Wrapper({
   );
 }
 
+function managedProvider(providerKey: string) {
+  return {
+    provider_key: providerKey,
+    display_name: providerKey,
+    description: null,
+    logo_url: null,
+    supports_managed_mode: true,
+  };
+}
+
+/** Provider keys the catalog actually rendered a row for. */
+function catalogRowKeys(): string[] {
+  return Array.from(
+    document.querySelectorAll('[data-slot="integration-row"]'),
+  ).map((el) => el.textContent ?? "");
+}
+
 afterEach(() => {
   cleanup();
+  seededProviders = [];
+  seededConnections = [];
 });
 
 describe("IntegrationsPage", () => {
@@ -88,6 +114,33 @@ describe("IntegrationsPage", () => {
 
     expect(screen.getByRole("tab", { name: "OAuth" })).not.toBeNull();
     expect(screen.getByRole("tab", { name: "MCP" })).not.toBeNull();
+  });
+
+  test("withholds the discord card while listing the rest of the catalog", async () => {
+    seededProviders = [
+      managedProvider("google"),
+      managedProvider("discord"),
+      managedProvider("notion"),
+    ];
+
+    render(<IntegrationsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(catalogRowKeys()).toEqual(["google", "notion"]);
+    });
+  });
+
+  test("keeps the discord card once it is connected, so it can be disconnected", async () => {
+    // The catalog is the only surface that can disconnect an OAuth connection,
+    // so hiding the card from someone who already has one would strand it.
+    seededProviders = [managedProvider("discord")];
+    seededConnections = [{ provider: "discord", connected: true }];
+
+    render(<IntegrationsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(catalogRowKeys()).toEqual(["discord"]);
+    });
   });
 
   test("opens the MCP tab from the tab query parameter", () => {

--- a/clients/web/src/domains/settings/pages/integrations-page.tsx
+++ b/clients/web/src/domains/settings/pages/integrations-page.tsx
@@ -7,6 +7,7 @@ import {
   type SelectOption,
 } from "@vellumai/design-library/components/select";
 import { toast } from "@vellumai/design-library/components/toast";
+import { isChannelUserIntegration } from "@vellumai/service-contracts/channels";
 import { Loader2, Search, Sparkles } from "lucide-react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
@@ -214,9 +215,17 @@ function IntegrationsPanelInner() {
 
   const filteredProviders = useMemo(() => {
     const needle = searchText.trim().toLowerCase();
+    const isConnected = (providerKey: string) =>
+      Boolean(connectionForProvider(connections, providerKey)?.connected);
+
     let list = managedProviders.filter((provider) => {
-      if (provider.provider_key === "slack") {
-        return false;
+      if (isChannelUserIntegration(provider.provider_key)) {
+        // The bot under this brand is what connects an assistant, so the
+        // catalog offers that instead of this grant. Withheld, not disabled:
+        // the provider stays connectable everywhere else. A card the owner
+        // already connected keeps its tile, since this page is the only place
+        // to disconnect one.
+        return isConnected(provider.provider_key);
       }
       if (!needle) {
         return true;
@@ -230,20 +239,14 @@ function IntegrationsPanelInner() {
 
     if (selectedFilter !== "all") {
       list = list.filter((provider) => {
-        const connected = Boolean(
-          connectionForProvider(connections, provider.provider_key)?.connected,
-        );
+        const connected = isConnected(provider.provider_key);
         return selectedFilter === "enabled" ? connected : !connected;
       });
     }
 
     return [...list].sort((a, b) => {
-      const aEnabled = Boolean(
-        connectionForProvider(connections, a.provider_key)?.connected,
-      );
-      const bEnabled = Boolean(
-        connectionForProvider(connections, b.provider_key)?.connected,
-      );
+      const aEnabled = isConnected(a.provider_key);
+      const bEnabled = isConnected(b.provider_key);
       if (aEnabled !== bEnabled) {
         return aEnabled ? -1 : 1;
       }

--- a/packages/service-contracts/src/__tests__/channels.test.ts
+++ b/packages/service-contracts/src/__tests__/channels.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { CHANNEL_IDS, isChannelId } from "../channels.js";
+import {
+  CHANNEL_BOT_PROVIDER,
+  CHANNEL_IDS,
+  isChannelBotProvider,
+  isChannelUserIntegration,
+  isChannelId,
+} from "../channels.js";
 
 describe("isChannelId", () => {
   test("accepts every canonical channel id", () => {
@@ -32,5 +38,38 @@ describe("isChannelId", () => {
     expect(isChannelId(undefined)).toBe(false);
     expect(isChannelId(null)).toBe(false);
     expect(isChannelId(42)).toBe(false);
+  });
+});
+
+describe("isChannelUserIntegration", () => {
+  test("names the grant standing beside a bot of the same brand", () => {
+    expect(isChannelUserIntegration("slack")).toBe(true);
+    expect(isChannelUserIntegration("discord")).toBe(true);
+  });
+
+  test("excludes a channel whose bot is its own key", () => {
+    // `telegram` names the bot, so no second provider carries the brand and
+    // there is nothing to mistake for it.
+    expect(isChannelUserIntegration("telegram")).toBe(false);
+  });
+
+  test("excludes the bots themselves and unrelated providers", () => {
+    expect(isChannelUserIntegration("slack_channel")).toBe(false);
+    expect(isChannelUserIntegration("discord_channel")).toBe(false);
+    expect(isChannelUserIntegration("google")).toBe(false);
+  });
+
+  test("is the complement of isChannelBotProvider over the map", () => {
+    // The two questions partition the brands that have both halves: a key is
+    // one or the other, never both, so a caller picking the wrong one gets an
+    // empty answer rather than a plausible wrong one.
+    for (const [channelId, botProviderKey] of Object.entries(
+      CHANNEL_BOT_PROVIDER,
+    )) {
+      expect(isChannelUserIntegration(channelId)).toBe(
+        channelId !== botProviderKey,
+      );
+      expect(isChannelBotProvider(botProviderKey)).toBe(true);
+    }
   });
 });

--- a/packages/service-contracts/src/channels.ts
+++ b/packages/service-contracts/src/channels.ts
@@ -97,3 +97,24 @@ export function isChannelBotProvider(providerKey: string): boolean {
     providerKey,
   );
 }
+
+/**
+ * Whether a provider key names the user grant of a brand the assistant is
+ * reached through some other way: `slack` beside `slack_channel`, `discord`
+ * beside `discord_channel`. The other half of the question
+ * `isChannelBotProvider` asks.
+ *
+ * The two halves carry the same brand name, so the grant reads as the way to
+ * connect that brand when the bot is. A surface offering people a way to
+ * connect an assistant wants the bot, and wants this to say which keys it is
+ * answering for rather than naming them itself.
+ *
+ * A channel whose bot is its own key has no such pair: `telegram` names the
+ * bot, so nothing is standing beside it to be mistaken for.
+ */
+export function isChannelUserIntegration(providerKey: string): boolean {
+  return Object.entries(CHANNEL_BOT_PROVIDER).some(
+    ([channelId, botProviderKey]) =>
+      channelId === providerKey && botProviderKey !== providerKey,
+  );
+}


### PR DESCRIPTION
## TL;DR

Hides the Discord card from the Settings > Integrations catalog. The OAuth provider itself is untouched: still seeded, still listed by the API, still connectable from the CLI, the gateway, and the assistant.

Fixes LUM-3534

## Why

The catalog lists a "Discord" card next to the official Discord channel. Its scopes reach the user's profile and guild list, and Discord documents `messages.read` as local RPC only, so the connection can never read a message. The card reads as the way to connect an assistant to Discord when that is the `discord_channel` bot, set up through the channels surface.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Settings > Integrations | Shows a "Discord" card | No Discord card |
| Connecting an assistant to Discord | Two similarly named paths, one of which cannot read messages | The Discord channel bot, in the channels surface |
| Asking the assistant to connect Discord | Works | Works, unchanged |
| Connecting Discord from the CLI | Works | Works, unchanged |
| An existing Discord connection | Works, card visible | Works, card still visible so it can be disconnected |

## Approach

The page already withheld the `slack` card for exactly this reason. Its commit says so outright: "Hide the Slack OAuth entry from the Integrations page since identity verification is handled within the channel setup flow." That rule lived in a `provider_key === "slack"` comparison, so it was invisible in the code and the catalog was one seed entry away from growing a third such card unnoticed.

Rather than adding `discord` beside it, this derives the rule. The brands with the problem are already enumerated canonically in `CHANNEL_BOT_PROVIDER`: they are the channels whose bot is a *separate* provider record, which is precisely the pair that ends up sharing a brand name. `isChannelUserIntegration` asks that of a provider key, sitting beside the `isChannelBotProvider` that asks the other half, and the catalog reads it. `telegram` is correctly excluded: there the bot is the provider, so nothing stands beside it to be confused for.

A brand added to that map in future is covered on arrival, without anyone needing to know this page exists.

Two details worth calling out:

- **A connected card stays visible.** The catalog is the only surface in the web client that can disconnect an OAuth connection (everything else in settings is inference providers), so withholding the card from someone who already has a connection would leave the grant active with no way to revoke it.
- **The filter applies to the rendered list, not to `managedProviders`.** The detail modal still resolves by provider key, so an in-flight `?oauth_provider=discord` callback still lands.

No new vocabulary: `provider_key` is plain `string` in the generated daemon types with no union to import, and the existing `OAuthConnection` type and `connectionForProvider` helper are reused as-is. The connected-state check now reads through one local `isConnected` closure; that expression was already written out four times in this `useMemo`, so the remaining hunks are that de-duplication, not behaviour changes.

## Rejected alternative: a feature flag

The first version of this PR gated the provider behind a `discord-oauth` feature flag, the way `monday` is gated. That was wrong, and the diff is smaller for dropping it.

`isProviderVisible` is consulted by `connect-orchestrator`, which its own comment describes as "the choke point every connect path funnels through (runtime routes, gateway, CLI, credential vault tool)". Flagging the provider off does not hide a card. It makes Discord OAuth unconnectable everywhere, including by the assistant itself, which is the opposite of the ticket's "preserve the capability".

`monday` is not the same case: that flag is a launch gate for an integration that had not rolled out yet, where unconnectable is the desired state. Discord is a shipped, working capability that we want to keep and stop advertising.

Also rejected: dropping `managedServiceConfigKey: "discord-oauth"` to keep it out of the managed grid the way `slack` is. `connection-resolver.ts` routes managed vs BYO on that key and `config/loader.ts:180` pre-enables the service as managed, so existing managed connections would silently fall back to BYO with no client credentials.

## Tests

Two tests in `integrations-page.test.tsx`, asserting on the provider keys the catalog actually renders:

- a catalog of `google` / `discord` / `notion` renders exactly `["google", "notion"]`
- a connected `discord` still renders its row

Four in `service-contracts/__tests__/channels.test.ts` for the predicate itself, including that it partitions `CHANNEL_BOT_PROVIDER` against `isChannelBotProvider` so a caller reaching for the wrong half gets an empty answer rather than a plausible wrong one.

Breaking the predicate fails both suites (verified). The existing connections mock in that file returned `{ results: [] }` where the page reads the array directly; it was never exercised because no test seeded a provider. Corrected as part of adding these.

## Notes

- The ticket mentions cherry-picking into the current release. Left for whoever cuts it.
- `clients/web` typechecks with 46 pre-existing errors in this worktree, none in the touched files and none in files this branch changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
