### PR TITLE
fix(voice): hold a launching turn for a camera frame still in flight

### DIFF
--- a/assistant/src/calls/__tests__/voice-turn-sight-hold.test.ts
+++ b/assistant/src/calls/__tests__/voice-turn-sight-hold.test.ts
@@ -1,0 +1,301 @@
+/**
+ * The bounded wait a launching voice turn takes for a standalone image the
+ * daemon already has in flight.
+ *
+ * The frames this is about arrive on the live-voice socket a beat before the
+ * user stops speaking, and are counted the tick that message is handled while
+ * their row is still several awaits away. A turn that launches in between
+ * snapshots a history without the picture, and the answer describes the scene
+ * before this one.
+ *
+ * Every case here parks the image's persist on a gate so the race is settled
+ * by the code under test rather than by microtask order: the frame is queued,
+ * holding nothing, exactly as it is when an utterance ends on top of it.
+ */
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  createMockProvider,
+  textResponse,
+} from "../../__tests__/helpers/mock-provider.js";
+import { setConfig } from "../../__tests__/helpers/set-config.js";
+
+setConfig("memory", { enabled: false, v2: { enabled: false } });
+setConfig("secretDetection", { enabled: false });
+setConfig("calls", { disclosure: { enabled: false, text: "" } });
+setConfig("workspaceGit", { turnCommitMaxWaitMs: 100 });
+
+import * as realConversationStore from "../../daemon/conversation-store.js";
+
+/**
+ * Gates the queued images take in the order they were enqueued, one each.
+ * `getConversationIfExists` is the first thing a standalone persist awaits and
+ * sits before its acquire, so a gate here parks a job that has been counted
+ * but holds no flag.
+ */
+const frameGates: Array<Promise<void>> = [];
+
+// Read out before the module is replaced: `mock.module` rebinds the namespace
+// itself, so calling through it below would call the gate again.
+const realStoreExports = { ...realConversationStore };
+
+const gatedGetConversationIfExists: typeof realConversationStore.getConversationIfExists =
+  async (conversationId, options) => {
+    const gate = frameGates.shift();
+    if (gate) {
+      await gate;
+    }
+    return realStoreExports.getConversationIfExists(conversationId, options);
+  };
+
+mock.module("../../daemon/conversation-store.js", () => ({
+  ...realStoreExports,
+  getConversationIfExists: gatedGetConversationIfExists,
+}));
+
+import { Conversation } from "../../daemon/conversation.js";
+import {
+  deleteConversation,
+  setConversation,
+} from "../../daemon/conversation-registry.js";
+import {
+  pendingStandaloneImagePersist,
+  persistAmbientSightFrame,
+  persistLiveVoicePhoto,
+  SIGHT_FRAME_TURN_HOLD_MS,
+} from "../../live-voice/live-voice-photo.js";
+import { uploadAttachment } from "../../persistence/attachments-store.js";
+import {
+  createConversation,
+  getMessages,
+  type MessageRow,
+} from "../../persistence/conversation-crud.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { startVoiceTurn } from "../voice-session-bridge.js";
+
+await initializeDb();
+
+const IMAGE_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+const SPOKEN_CONTENT = "what am I looking at now?";
+const FRAME_CONTENT = "(camera frame)";
+const PHOTO_CONTENT = "here's a photo:";
+
+function deferred(): { promise: Promise<void>; open: () => void } {
+  let open!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { promise, open };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function uploadFrame(name: string): Promise<string> {
+  const attachment = await uploadAttachment(name, "image/png", IMAGE_BASE64);
+  return attachment.id;
+}
+
+/** The row's own text, which is what names the row in an ordering assertion. */
+function rowText(row: MessageRow): string {
+  for (const block of row.content) {
+    if (block.type === "text") {
+      return block.text;
+    }
+  }
+  return "";
+}
+
+function rowTexts(conversationId: string): string[] {
+  return getMessages(conversationId).map(rowText);
+}
+
+/**
+ * A registered conversation the bridge and the persist paths both reach.
+ *
+ * The agent loop is stubbed down to the one thing the rest of the turn depends
+ * on, giving the hold back, so a suite about launch ordering does not run a
+ * model.
+ */
+function liveConversation(title: string) {
+  const row = createConversation(title);
+  const { provider } = createMockProvider([textResponse("")]);
+  const conversation = new Conversation(
+    row.id,
+    provider,
+    "system prompt",
+    () => {},
+    "/tmp",
+    { maxTokens: 4096 },
+  );
+  conversation.setTrustContext({
+    trustClass: "guardian",
+    sourceChannel: "vellum",
+  });
+  conversation.runAgentLoop = async () => {
+    conversation.setProcessing(false);
+  };
+  setConversation(row.id, conversation);
+  return {
+    id: row.id,
+    conversation,
+    dispose: () => {
+      frameGates.length = 0;
+      deleteConversation(row.id);
+      conversation.dispose();
+    },
+  };
+}
+
+async function launchTurn(conversationId: string): Promise<void> {
+  await startVoiceTurn({
+    conversationId,
+    content: SPOKEN_CONTENT,
+    isInbound: false,
+    onTextDelta: () => {},
+    onComplete: () => {},
+    onError: () => {},
+  });
+  // The agent loop is dispatched fire-and-forget; let it give the hold back
+  // before the next assertion reads the conversation.
+  await sleep(20);
+}
+
+describe("voice turn hold for an in-flight camera frame", () => {
+  test("a frame queued before the launch lands ahead of the spoken row", async () => {
+    const live = liveConversation("Sight hold ordering");
+    const gate = deferred();
+    try {
+      const frame = await uploadFrame("hold-ordering.png");
+      frameGates.push(gate.promise);
+
+      const keep = persistAmbientSightFrame(live.id, frame, "voice");
+      // Queued and counted, holding nothing: the state a turn launching on
+      // the same utterance finds.
+      expect(pendingStandaloneImagePersist(live.id)).not.toBeNull();
+      expect(live.conversation.isProcessing()).toBe(false);
+
+      const turn = launchTurn(live.id);
+      await sleep(20);
+      // The turn is waiting rather than persisting, so the frame still has a
+      // free flag to take.
+      expect(rowTexts(live.id)).toEqual([]);
+
+      gate.open();
+      expect(await keep).toMatchObject({ ok: true });
+      await turn;
+
+      expect(rowTexts(live.id)).toEqual([FRAME_CONTENT, SPOKEN_CONTENT]);
+    } finally {
+      gate.open();
+      live.dispose();
+    }
+  });
+
+  test("a photo queued before the launch holds the turn too", async () => {
+    // The ledger counts every standalone image on purpose: a user who snaps a
+    // photo and asks about it straight away wants the same freshness.
+    const live = liveConversation("Sight hold photo");
+    const gate = deferred();
+    try {
+      const photo = await uploadFrame("hold-photo.png");
+      frameGates.push(gate.promise);
+
+      const snap = persistLiveVoicePhoto(live.id, photo);
+      const turn = launchTurn(live.id);
+      await sleep(20);
+      expect(rowTexts(live.id)).toEqual([]);
+
+      gate.open();
+      await snap;
+      await turn;
+
+      expect(rowTexts(live.id)).toEqual([PHOTO_CONTENT, SPOKEN_CONTENT]);
+    } finally {
+      gate.open();
+      live.dispose();
+    }
+  });
+
+  test("a stalled persist caps the hold and the turn goes on without it", async () => {
+    const live = liveConversation("Sight hold cap");
+    const gate = deferred();
+    try {
+      const frame = await uploadFrame("hold-cap.png");
+      frameGates.push(gate.promise);
+
+      const keep = persistAmbientSightFrame(live.id, frame, "voice");
+      const startedAt = Date.now();
+      await launchTurn(live.id);
+      const elapsed = Date.now() - startedAt;
+
+      // Waited the cap, then dispatched: the worst case is the answer this
+      // turn would have given with no hold at all.
+      expect(elapsed).toBeGreaterThanOrEqual(SIGHT_FRAME_TURN_HOLD_MS - 50);
+      expect(elapsed).toBeLessThan(SIGHT_FRAME_TURN_HOLD_MS * 4);
+      expect(rowTexts(live.id)).toEqual([SPOKEN_CONTENT]);
+
+      gate.open();
+      await keep;
+    } finally {
+      gate.open();
+      live.dispose();
+    }
+  });
+
+  test("a conversation with nothing in flight is not held at all", async () => {
+    const live = liveConversation("Sight hold idle");
+    try {
+      expect(pendingStandaloneImagePersist(live.id)).toBeNull();
+
+      const startedAt = Date.now();
+      await launchTurn(live.id);
+      const elapsed = Date.now() - startedAt;
+
+      expect(elapsed).toBeLessThan(SIGHT_FRAME_TURN_HOLD_MS / 2);
+      expect(rowTexts(live.id)).toEqual([SPOKEN_CONTENT]);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("a frame arriving after the check rides the next turn", async () => {
+    // The wait covers what was in flight when the turn asked. A keep the
+    // client sends while the turn is already waiting is the next turn's to
+    // wait for, which is what keeps the hold bounded by work already queued.
+    const live = liveConversation("Sight hold boundary");
+    const firstGate = deferred();
+    const secondGate = deferred();
+    try {
+      const first = await uploadFrame("hold-boundary-first.png");
+      const second = await uploadFrame("hold-boundary-second.png");
+      frameGates.push(firstGate.promise, secondGate.promise);
+
+      const firstKeep = persistAmbientSightFrame(live.id, first, "voice");
+      const turn = launchTurn(live.id);
+      await sleep(20);
+
+      const secondKeep = persistAmbientSightFrame(live.id, second, "voice");
+      firstGate.open();
+      await firstKeep;
+      await turn;
+
+      expect(rowTexts(live.id)).toEqual([FRAME_CONTENT, SPOKEN_CONTENT]);
+
+      secondGate.open();
+      await secondKeep;
+      expect(rowTexts(live.id)).toEqual([
+        FRAME_CONTENT,
+        SPOKEN_CONTENT,
+        FRAME_CONTENT,
+      ]);
+    } finally {
+      firstGate.open();
+      secondGate.open();
+      live.dispose();
+    }
+  });
+});

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -28,6 +28,10 @@ import { CONVERSATION_BUSY_MESSAGE } from "../daemon/conversation-messaging.js";
 import { resolveChannelCapabilities } from "../daemon/conversation-runtime-assembly.js";
 import { getOrCreateConversation } from "../daemon/conversation-store.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import {
+  pendingStandaloneImagePersist,
+  SIGHT_FRAME_TURN_HOLD_MS,
+} from "../live-voice/live-voice-photo.js";
 import { resolveAttachmentsForPersist } from "../persistence/attachments-store.js";
 import {
   deleteMessageById,
@@ -765,6 +769,7 @@ export async function startVoiceTurn(
     enteredAt: Date.now(),
     conversationReadyAt: 0,
     admissionClearAt: 0,
+    sightHoldMs: 0,
     persistDoneAt: 0,
   };
   const eventSink: VoiceRunEventSink = {
@@ -980,6 +985,31 @@ export async function startVoiceTurn(
     break;
   }
   dispatch.admissionClearAt = Date.now();
+
+  // A camera frame the client sent moments before the user stopped speaking is
+  // counted the tick its socket message arrives and written a few awaits later,
+  // so the history this turn is about to snapshot can be missing the picture
+  // the question is about. Wait it out, bounded, and proceed regardless: the
+  // worst outcome is the answer this turn would have given anyway.
+  //
+  // The wait sits before the turn claims the processing flag. That flag is
+  // exclusive and the image's own acquire polls for it, so an image waited for
+  // after the claim cannot land until this turn has finished and released.
+  const pendingImagePersist = pendingStandaloneImagePersist(
+    opts.conversationId,
+  );
+  if (pendingImagePersist) {
+    const holdStartedAt = Date.now();
+    let holdTimer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      pendingImagePersist,
+      new Promise<void>((resolve) => {
+        holdTimer = setTimeout(resolve, SIGHT_FRAME_TURN_HOLD_MS);
+      }),
+    ]);
+    clearTimeout(holdTimer);
+    dispatch.sightHoldMs = Date.now() - holdStartedAt;
+  }
 
   // Releases the per-turn state of a voice turn that OWNED the conversation,
   // so `trustContext`, `callSessionId`, etc. don't leak into subsequent
@@ -1719,7 +1749,11 @@ export async function startVoiceTurn(
         conversationMs: dispatch.conversationReadyAt - dispatch.enteredAt,
         admissionWaitMs:
           dispatch.admissionClearAt - dispatch.conversationReadyAt,
-        persistMs: dispatch.persistDoneAt - dispatch.admissionClearAt,
+        sightHoldMs: dispatch.sightHoldMs,
+        persistMs:
+          dispatch.persistDoneAt -
+          dispatch.admissionClearAt -
+          dispatch.sightHoldMs,
         preLoopMs: loopEnterAt - dispatch.persistDoneAt,
       },
       "Voice turn dispatch timing",

--- a/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-photo.test.ts
@@ -53,6 +53,7 @@ import {
   _pendingFrameReclaimCountForTests,
   _setProcessingWaitMsForTests,
   _standaloneImageQueueSizeForTests,
+  pendingStandaloneImagePersist,
   persistAmbientSightFrame,
   persistLiveVoicePhoto,
 } from "../live-voice-photo.js";
@@ -1589,6 +1590,107 @@ describe("standalone image persists are serialized per conversation", () => {
 
       // Nothing is left behind for a call that ended.
       expect(_standaloneImageQueueSizeForTests()).toBe(0);
+    } finally {
+      live.dispose();
+    }
+  });
+});
+
+describe("pendingStandaloneImagePersist", () => {
+  test("reports nothing for a conversation with no image queued", async () => {
+    const live = liveConversation("Sight pending idle");
+    try {
+      expect(pendingStandaloneImagePersist(live.id)).toBeNull();
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("reports a keep from the tick it was handed in", async () => {
+    // The count is taken before the persist's first await, which is what lets
+    // a turn launching in the same call chain as the utterance see a frame
+    // that has not started writing.
+    const live = liveConversation("Sight pending keep");
+    try {
+      const frame = await uploadFrame("pending-keep.png");
+
+      const keep = persistAmbientSightFrame(live.id, frame, "voice");
+      const pending = pendingStandaloneImagePersist(live.id);
+      expect(pending).not.toBeNull();
+      expect(getMessages(live.id)).toHaveLength(0);
+
+      await pending;
+
+      // Settled means written and the flag handed back, so a turn waiting on
+      // this both sees the row and can claim the flag.
+      expect(getMessages(live.id)).toHaveLength(1);
+      expect(live.activeConversation.isProcessing()).toBe(false);
+      expect(await keep).toMatchObject({ ok: true });
+      expect(pendingStandaloneImagePersist(live.id)).toBeNull();
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("reports a photo in flight, not keeps alone", async () => {
+    // A user who snaps a shutter photo and asks about it straight away wants
+    // the same freshness, so the ledger this reads counts both kinds.
+    const live = liveConversation("Sight pending photo");
+    try {
+      const photo = await uploadFrame("pending-photo.png");
+
+      const snap = persistLiveVoicePhoto(live.id, photo);
+      const pending = pendingStandaloneImagePersist(live.id);
+      expect(pending).not.toBeNull();
+
+      await pending;
+
+      expect(getMessages(live.id)).toHaveLength(1);
+      expect(await snap).toMatchObject({ ok: true });
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("settles rather than rejects when the persist gives up", async () => {
+    const live = liveConversation("Sight pending failure");
+    try {
+      const keep = persistAmbientSightFrame(live.id, "att-missing", "voice");
+      const pending = pendingStandaloneImagePersist(live.id);
+      expect(pending).not.toBeNull();
+
+      expect(await pending).toBeUndefined();
+      expect(await keep).toMatchObject({ ok: false });
+      expect(getMessages(live.id)).toHaveLength(0);
+    } finally {
+      live.dispose();
+    }
+  });
+
+  test("covers what was queued when it was asked, not what arrives after", async () => {
+    // The boundary a caller can rely on: a frame the client sends during the
+    // wait belongs to whatever asks next, so the wait stays bounded by work
+    // that was already in flight.
+    const live = liveConversation("Sight pending boundary");
+    try {
+      const first = await uploadFrame("boundary-first.png");
+      const second = await uploadFrame("boundary-second.png");
+
+      live.activeConversation.setProcessing(true);
+      const firstKeep = persistAmbientSightFrame(live.id, first, "voice");
+      // Long enough for the first keep to reach the idle wait, so the second
+      // queues behind a job that has already begun rather than replacing it.
+      await sleep(30);
+      const pending = pendingStandaloneImagePersist(live.id);
+      const secondKeep = persistAmbientSightFrame(live.id, second, "voice");
+      live.activeConversation.setProcessing(false);
+
+      await pending;
+      expect(getMessages(live.id)).toHaveLength(1);
+
+      expect(await firstKeep).toMatchObject({ ok: true });
+      expect(await secondKeep).toMatchObject({ ok: true });
+      expect(getMessages(live.id)).toHaveLength(2);
     } finally {
       live.dispose();
     }

--- a/assistant/src/live-voice/live-voice-photo.ts
+++ b/assistant/src/live-voice/live-voice-photo.ts
@@ -238,6 +238,47 @@ async function enqueueStandaloneImagePersist(
 }
 
 /**
+ * How long a launching voice turn waits on a standalone image already in
+ * flight for its conversation.
+ *
+ * Sized for a write whose only remaining wait is the processing flag, which
+ * {@link acquireProcessingFlag} takes within a {@link PROCESSING_POLL_MS}
+ * poll of the turn leaving it free. Anything slower is a stalled store rather
+ * than the ordinary case, and the speaker gets an answer instead of a pause.
+ */
+export const SIGHT_FRAME_TURN_HOLD_MS = 800;
+
+/**
+ * The standalone-image persists this conversation has in flight, or null when
+ * it has none.
+ *
+ * For a caller deciding whether to wait for the picture before reading the
+ * conversation's history: a keep the client sent moments ago is counted from
+ * the tick its socket message was handled, well before any of it is written.
+ * The lookup is synchronous, so a conversation with nothing in flight pays one
+ * map read.
+ *
+ * The promise covers exactly the work queued when it was asked for. An image
+ * enqueued afterwards extends the chain past the tail this names, and belongs
+ * to whatever asks next.
+ *
+ * Settles, never rejects: the caller is choosing how long to wait, not whether
+ * the image landed.
+ */
+export function pendingStandaloneImagePersist(
+  conversationId: string,
+): Promise<void> | null {
+  const queue = standaloneImageQueues.get(conversationId);
+  if (!queue || queue.outstanding === 0) {
+    return null;
+  }
+  return queue.tail.then(
+    () => undefined,
+    () => undefined,
+  );
+}
+
+/**
  * Give up the upload behind a keep no message will ever carry: one a newer
  * frame replaced before it started, one whose wait for an idle conversation
  * ran out, and one whose write threw.


### PR DESCRIPTION
## Summary
- A sight keep sent moments before the user stops speaking is counted the tick its socket message arrives, but its row lands several awaits later, so the launching turn snapshots history without the picture and answers about the previous scene.
- `pendingStandaloneImagePersist(conversationId)` reports the standalone-image work (frames and shutter photos alike) a conversation already has in flight, from the existing per-conversation queue ledger; the voice bridge races it against an 800ms cap after admission clears and strictly before the turn claims the processing flag.
- Placement is load-bearing: the image's own acquire polls that same exclusive flag, so a hold placed after the claim could never be satisfied. On timeout the turn proceeds exactly as today (fail-open); a conversation with nothing in flight pays one synchronous map read.
- The hold is observable as `sightHoldMs` on the dispatch timing line, with `persistMs` reported net of it.

Part of the sight one-behind fix (fresh frame at the ask); pairs with the web-side speech-start forced keep PR, but the two are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)