### PR TITLE
fix(web): stop the preferences usage panel flashing red before it settles

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -51,7 +51,7 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 // `@tanstack/react-query` mock cannot host that, and the menu only reads
 // `enabled`/`balance`, which the gate never touches.
 mock.module("@/hooks/use-byok-credit-banner-gate", () => ({
-  useSuppressCreditBannersForByok: () => false,
+  useByokCreditRouteVerdict: () => ({ suppress: false, settled: true }),
 }));
 
 const authRef: {
@@ -191,14 +191,19 @@ mock.module("@/components/add-credits-modal", () => ({
 // partial `@tanstack/react-query` mock cannot host, and is covered by
 // `preferences-usage-panel.test.tsx`. What the menu owns is the rule it
 // applies to the reading, so only the data is stubbed here.
-const usageRef: { value: PreferencesUsage | null; opts: unknown } = {
+const usageRef: {
+  value: PreferencesUsage | null;
+  settled: boolean;
+  opts: unknown;
+} = {
   value: null,
+  settled: true,
   opts: undefined,
 };
 mock.module("@/domains/chat/hooks/use-preferences-usage", () => ({
   usePreferencesUsage: (opts?: unknown) => {
     usageRef.opts = opts;
-    return usageRef.value;
+    return { usage: usageRef.value, settled: usageRef.settled };
   },
 }));
 
@@ -262,6 +267,7 @@ beforeEach(() => {
   };
   billingRef.data = undefined;
   usageRef.value = null;
+  usageRef.settled = true;
   usageRef.opts = undefined;
   panelPropsRef.conversationId = undefined;
   feedbackRef.prefetches = 0;
@@ -554,12 +560,19 @@ describe("PreferencesMenu credits row", () => {
 
 describe("showsMenuCredits", () => {
   test("hides the row whenever there is a reading", () => {
-    expect(showsMenuCredits(usage(0.99))).toBe(false);
-    expect(showsMenuCredits(usage(1))).toBe(false);
-    expect(showsMenuCredits(usage(1, true))).toBe(false);
+    expect(showsMenuCredits(usage(0.99), true)).toBe(false);
+    expect(showsMenuCredits(usage(1), true)).toBe(false);
+    expect(showsMenuCredits(usage(1, true), true)).toBe(false);
   });
 
   test("an unmeasurable reading falls back to showing the row", () => {
-    expect(showsMenuCredits(null)).toBe(true);
+    expect(showsMenuCredits(null, true)).toBe(true);
+  });
+
+  test("an unsettled null holds the row back rather than flashing it", () => {
+    // The row needs only the summary; the panel that replaces it also needs
+    // the subscription. Showing the row in that gap swaps one surface for
+    // another a beat later.
+    expect(showsMenuCredits(null, false)).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -67,9 +67,17 @@ const AddCreditsModal = lazy(() =>
  * With no reading to hide behind, the row stays: the panel renders nothing
  * without one, and hiding the row too would leave the menu with no balance and
  * no way to buy more.
+ *
+ * `settled` is what keeps that last clause from firing early. The row needs
+ * only the summary while the panel needs the subscription too, so an unguarded
+ * `usage == null` shows the row in the gap between the two and then swaps it
+ * for the panel. Waiting means the menu picks one of them and keeps it.
  */
-export function showsMenuCredits(usage: PreferencesUsage | null): boolean {
-  return usage == null;
+export function showsMenuCredits(
+  usage: PreferencesUsage | null,
+  settled: boolean,
+): boolean {
+  return settled && usage == null;
 }
 
 export interface PreferencesMenuProps {
@@ -135,7 +143,9 @@ export function PreferencesMenu({
         {/* `truncate` is belt-and-braces: the label is a fixed short string,
             but the pill shares its row with New Chat and must never grow
             wide enough to overlap it at narrow viewports. */}
-        <span className="min-w-0 truncate">{t("preferencesMenu.preferences")}</span>
+        <span className="min-w-0 truncate">
+          {t("preferencesMenu.preferences")}
+        </span>
       </Button>
     ) : collapsed ? (
       /* Collapsed, the same tile every other rail entry reduces to: a circle
@@ -198,7 +208,9 @@ export function PreferencesMenu({
           <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>
           <BottomSheet.Content className="max-h-[85dvh]">
             <BottomSheet.Header className="sr-only">
-              <BottomSheet.Title>{t("preferencesMenu.preferences")}</BottomSheet.Title>
+              <BottomSheet.Title>
+                {t("preferencesMenu.preferences")}
+              </BottomSheet.Title>
             </BottomSheet.Header>
             <BottomSheet.Body className="pt-0">{content}</BottomSheet.Body>
           </BottomSheet.Content>
@@ -269,8 +281,10 @@ function PreferencesMenuContent({
   } = useBillingBalanceStatus();
   /* The same reading the usage panel below draws, composed once so the row and
      the bar can never disagree about how much of the bundle is left. */
-  const usage = usePreferencesUsage({ conversationId: activeConversationId });
-  const showCredits = showsMenuCredits(usage);
+  const { usage, settled } = usePreferencesUsage({
+    conversationId: activeConversationId,
+  });
+  const showCredits = showsMenuCredits(usage, settled);
 
   return (
     <>

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.stories.tsx
@@ -28,11 +28,19 @@ import {
   organizationsBillingSubscriptionRetrieveOptions,
   organizationsBillingSummaryRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
+import {
+  configGetQueryKey,
+  inferenceProviderconnectionsGetQueryKey,
+} from "@/generated/daemon/@tanstack/react-query.gen";
 import type { SubscriptionResponse } from "@/generated/api/types.gen";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
 import { displayedCreditsUsd } from "@/lib/billing/displayed-credits";
 import { useAuthStore } from "@/stores/auth-store";
 import { useOrganizationStore } from "@/stores/organization-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+/** Stands in for the resolved assistant the route classifier reads. */
+const STORY_ASSISTANT_ID = "asst_storybook";
 
 const CYCLE_START = "2026-08-01T00:00:00Z";
 const CYCLE_END = "2026-09-01T00:00:00Z";
@@ -89,13 +97,13 @@ function PanelOnly() {
  * two-decimal shape the menu formats it to.
  */
 function PanelWithCredits() {
-  const usage = usePreferencesUsage();
+  const { usage, settled } = usePreferencesUsage();
   const {
     enabled: showBillingRows,
     balance,
     availableUsageBalance,
   } = useBillingBalanceStatus();
-  const showCredits = showsMenuCredits(usage);
+  const showCredits = showsMenuCredits(usage, settled);
 
   return (
     <>
@@ -140,6 +148,8 @@ function SeededPanel({
       useAssistantLifecycleStore.getState().assistantState;
     const previousOrgId =
       useOrganizationStore.getState().persistedOrganizationId;
+    const previousAssistantId =
+      useResolvedAssistantsStore.getState().activeAssistantId;
 
     useAuthStore.setState({ platformSession: "present" });
     useAssistantLifecycleStore.setState({
@@ -148,6 +158,13 @@ function SeededPanel({
     // The org-header gate reports "resolving", never "ready", while a platform
     // session exists with no organization id to scope requests to.
     useOrganizationStore.setState({ persistedOrganizationId: "org_storybook" });
+    // The usage panel withholds both of its readings until the BYOK route
+    // classifier settles, and that classifier asks nothing at all without a
+    // resolved assistant. Left unseeded, every story below renders the
+    // neutral pre-settle bar instead of the state it documents.
+    useResolvedAssistantsStore
+      .getState()
+      .setActiveAssistantId(STORY_ASSISTANT_ID);
 
     client.setQueryData(
       organizationsBillingSubscriptionRetrieveOptions().queryKey,
@@ -165,6 +182,17 @@ function SeededPanel({
       total_usage_balance: totalUsageUsd,
       available_usage_balance: availableUsageUsd,
     });
+    // The two ungated reads the classifier makes. Primed so it settles on the
+    // first render rather than flickering through neutral while two daemon
+    // fetches fail; no BYOK connection means the managed reading these
+    // stories document. The other three reads stay disabled: two sit behind
+    // version gates the unseeded identity store leaves closed, and the
+    // conversation read needs a conversation the menu has not got.
+    const daemonPath = { path: { assistant_id: STORY_ASSISTANT_ID } };
+    client.setQueryData(configGetQueryKey(daemonPath), { llm: {} });
+    client.setQueryData(inferenceProviderconnectionsGetQueryKey(daemonPath), {
+      connections: [],
+    });
 
     return () => {
       useAuthStore.setState({ platformSession: previousAuth });
@@ -172,6 +200,9 @@ function SeededPanel({
         assistantState: previousLifecycle,
       });
       useOrganizationStore.setState({ persistedOrganizationId: previousOrgId });
+      useResolvedAssistantsStore
+        .getState()
+        .setActiveAssistantId(previousAssistantId);
     };
   }, [availableUsageUsd, balanceUsd, client, free, totalUsageUsd]);
 

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
@@ -359,9 +359,9 @@ describe("PreferencesUsagePanel", () => {
 
   test("holds the neutral reading while the classification is in flight", async () => {
     // Spent grants with credit behind them on a route that will turn out to
-    // be managed: the settled answer is the amber extra-credits line. What
-    // must not happen on the way there is the red reading, which is what the
-    // panel painted for as long as the classifier's daemon queries took.
+    // be managed: the settled answer is the amber extra-credits line. The red
+    // reading must not appear on the way there, however long the classifier's
+    // daemon queries take.
     totalUsageBalance = "25.00";
     availableUsageBalance = "0.00";
     effectiveBalance = "12.00";

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
@@ -58,16 +58,19 @@ mock.module("@/hooks/use-billing-balance-status", () => ({
 // The real BYOK gate classifies through five daemon queries and the
 // resolved-assistants store, none of which these tests stand up; what the
 // hook owns is only how the verdict gates the extra-credits claim.
-let byokRoute = false;
-// Whether the classification derived a route at all. A read that failed
-// leaves the gate failing open, which reads identically to "managed" on
-// `suppress` alone.
-let routeKnown = true;
+/**
+ * Which route the classifier lands on. One knob rather than two: the gate
+ * derives `suppress` and `routeBurnsManaged` from the same classification, so
+ * separate switches could stage a BYOK route that also burns managed credits,
+ * which it never reports.
+ */
+let route: "managed" | "byok" | "unknown" = "managed";
 mock.module("@/hooks/use-byok-credit-banner-gate", () => ({
   useByokCreditRouteVerdict: (candidate: boolean) => ({
-    suppress: candidate && byokRoute,
+    // Only a proven BYOK route with no recent burn holds the banners down.
+    suppress: candidate && route === "byok",
     settled: classificationSettled,
-    routeKnown,
+    routeBurnsManaged: route === "managed",
   }),
 }));
 
@@ -125,12 +128,11 @@ beforeEach(() => {
   subscription = proSubscription();
   billingEnabled = true;
   classificationSettled = true;
-  routeKnown = true;
   creditsExhausted = false;
   effectiveBalance = null;
   availableUsageBalance = null;
   totalUsageBalance = null;
-  byokRoute = false;
+  route = "managed";
   balanceStatusOpts = undefined;
 });
 
@@ -339,7 +341,7 @@ describe("PreferencesUsagePanel", () => {
     totalUsageBalance = "25.00";
     availableUsageBalance = "0.00";
     effectiveBalance = "18.00";
-    byokRoute = true;
+    route = "byok";
     const { findByTestId, queryByText } = renderPanel();
 
     const panel = await findByTestId("preferences-usage");
@@ -390,14 +392,14 @@ describe("PreferencesUsagePanel", () => {
     );
   });
 
-  test("a failed route read makes no extra-credits claim", async () => {
-    // Settled, wallet funded, and the gate failing open: `suppress` alone
-    // cannot tell that apart from a managed route, so the claim would be made
-    // on evidence that never arrived.
+  test("no managed route means no extra-credits claim", async () => {
+    // Settled and wallet funded, with suppression down for a reason that is
+    // not a managed route: a read that failed, or a BYOK route with spend on
+    // another surface. `suppress` alone cannot tell either from managed.
     totalUsageBalance = "25.00";
     availableUsageBalance = "0.00";
     effectiveBalance = "12.00";
-    routeKnown = false;
+    route = "unknown";
     const { findByTestId, queryByText } = renderPanel();
 
     const panel = await findByTestId("preferences-usage");

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
@@ -31,6 +31,11 @@ let availableUsageBalance: string | null = null;
 let totalUsageBalance: string | null = null;
 /** What the panel asked the wallet status to classify against. */
 let balanceStatusOpts: unknown;
+// Whether the route classification behind the panel's colours has landed.
+// Kept separately drivable because those colours are exactly what must not be
+// painted before it has: a double that always answers instantly cannot see
+// the flash.
+let classificationSettled = true;
 mock.module("@/hooks/use-billing-balance-status", () => ({
   useBillingBalanceStatus: (opts?: unknown) => {
     balanceStatusOpts = opts;
@@ -45,6 +50,7 @@ mock.module("@/hooks/use-billing-balance-status", () => ({
       availableUsageBalance,
       totalUsageBalance,
       enabled: billingEnabled,
+      settled: classificationSettled,
     };
   },
 }));
@@ -54,8 +60,10 @@ mock.module("@/hooks/use-billing-balance-status", () => ({
 // hook owns is only how the verdict gates the extra-credits claim.
 let byokRoute = false;
 mock.module("@/hooks/use-byok-credit-banner-gate", () => ({
-  useSuppressCreditBannersForByok: (candidate: boolean) =>
-    candidate && byokRoute,
+  useByokCreditRouteVerdict: (candidate: boolean) => ({
+    suppress: candidate && byokRoute,
+    settled: classificationSettled,
+  }),
 }));
 
 const { PreferencesUsagePanel } = await import("./preferences-usage-panel");
@@ -111,6 +119,7 @@ async function settle(): Promise<void> {
 beforeEach(() => {
   subscription = proSubscription();
   billingEnabled = true;
+  classificationSettled = true;
   creditsExhausted = false;
   effectiveBalance = null;
   availableUsageBalance = null;
@@ -346,6 +355,52 @@ describe("PreferencesUsagePanel", () => {
     expect(panel.textContent).toContain("100% used");
     expect(queryByText("Now using extra usage credits")).toBeNull();
     expect(queryByText("Add credits to continue.")).toBeNull();
+  });
+
+  test("holds the neutral reading while the classification is in flight", async () => {
+    // Spent grants with credit behind them on a route that will turn out to
+    // be managed: the settled answer is the amber extra-credits line. What
+    // must not happen on the way there is the red reading, which is what the
+    // panel painted for as long as the classifier's daemon queries took.
+    totalUsageBalance = "25.00";
+    availableUsageBalance = "0.00";
+    effectiveBalance = "12.00";
+    classificationSettled = false;
+    const { findByTestId, getByText, queryByText } = renderPanel();
+
+    const panel = await findByTestId("preferences-usage");
+    const fill = () =>
+      panel
+        .querySelector('[data-slot="progress-bar-fill"]')
+        ?.getAttribute("style");
+    // The length comes off the summary alone, so it is already honest.
+    expect(panel.textContent).toContain("100% used");
+    expect(fill()).toContain("width: 100%");
+    // Neither reading is claimed yet.
+    expect(queryByText("Now using extra usage credits")).toBeNull();
+    expect(fill()).not.toContain("--system-negative-strong");
+    expect(getByText("100% used").className).not.toContain(
+      "--system-negative-strong",
+    );
+  });
+
+  test("an unsettled classification withholds the exhausted strip too", async () => {
+    totalUsageBalance = "25.00";
+    availableUsageBalance = "0.00";
+    effectiveBalance = "0.00";
+    creditsExhausted = true;
+    classificationSettled = false;
+    const { findByTestId, queryByText } = renderPanel();
+
+    const panel = await findByTestId("preferences-usage");
+    // The strip and the bar's colour are the same verdict, so they land on one
+    // render rather than the strip growing the popover a beat later.
+    expect(queryByText("Add credits to continue.")).toBeNull();
+    expect(
+      panel
+        .querySelector('[data-slot="progress-bar-fill"]')
+        ?.getAttribute("style"),
+    ).not.toContain("--system-negative-strong");
   });
 
   test("a reading below 100% stays neutral", async () => {

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.test.tsx
@@ -59,10 +59,15 @@ mock.module("@/hooks/use-billing-balance-status", () => ({
 // resolved-assistants store, none of which these tests stand up; what the
 // hook owns is only how the verdict gates the extra-credits claim.
 let byokRoute = false;
+// Whether the classification derived a route at all. A read that failed
+// leaves the gate failing open, which reads identically to "managed" on
+// `suppress` alone.
+let routeKnown = true;
 mock.module("@/hooks/use-byok-credit-banner-gate", () => ({
   useByokCreditRouteVerdict: (candidate: boolean) => ({
     suppress: candidate && byokRoute,
     settled: classificationSettled,
+    routeKnown,
   }),
 }));
 
@@ -120,6 +125,7 @@ beforeEach(() => {
   subscription = proSubscription();
   billingEnabled = true;
   classificationSettled = true;
+  routeKnown = true;
   creditsExhausted = false;
   effectiveBalance = null;
   availableUsageBalance = null;
@@ -382,6 +388,21 @@ describe("PreferencesUsagePanel", () => {
     expect(getByText("100% used").className).not.toContain(
       "--system-negative-strong",
     );
+  });
+
+  test("a failed route read makes no extra-credits claim", async () => {
+    // Settled, wallet funded, and the gate failing open: `suppress` alone
+    // cannot tell that apart from a managed route, so the claim would be made
+    // on evidence that never arrived.
+    totalUsageBalance = "25.00";
+    availableUsageBalance = "0.00";
+    effectiveBalance = "12.00";
+    routeKnown = false;
+    const { findByTestId, queryByText } = renderPanel();
+
+    const panel = await findByTestId("preferences-usage");
+    expect(panel.textContent).toContain("100% used");
+    expect(queryByText("Now using extra usage credits")).toBeNull();
   });
 
   test("an unsettled classification withholds the exhausted strip too", async () => {

--- a/clients/web/src/domains/chat/components/preferences-usage-panel.tsx
+++ b/clients/web/src/domains/chat/components/preferences-usage-panel.tsx
@@ -30,7 +30,7 @@ export function PreferencesUsagePanel({
   conversationId,
 }: PreferencesUsagePanelProps) {
   const { t } = useTranslation("chat");
-  const usage = usePreferencesUsage({ conversationId });
+  const { usage, settled } = usePreferencesUsage({ conversationId });
 
   if (!usage) {
     return null;
@@ -43,6 +43,13 @@ export function PreferencesUsagePanel({
   // extra usage credits in the bar's place. An empty wallet keeps the red
   // reading whether or not the BYOK-aware `exhausted` raises the strip below.
   const { spent, exhausted, usingExtraCredits } = usage;
+  // The bar's length comes off the summary alone, so it is drawn as soon as
+  // there is a ratio. Which of the two readings it means is a separate
+  // question answered by queries that land later, and painting an alarm
+  // colour before they do would make the panel flash red on its way to a
+  // state that was never alarming. Neutral until then: honest at 100%, and
+  // the one thing that cannot be wrong.
+  const alarming = settled && spent && !usingExtraCredits;
 
   return (
     <div className="my-2 flex flex-col gap-1" data-testid="preferences-usage">
@@ -60,7 +67,7 @@ export function PreferencesUsagePanel({
               as="span"
               variant="body-small-default"
               className={
-                spent && !usingExtraCredits
+                alarming
                   ? "whitespace-nowrap text-[var(--system-negative-strong)]"
                   : "whitespace-nowrap text-[var(--content-secondary)]"
               }
@@ -78,26 +85,31 @@ export function PreferencesUsagePanel({
             />
           </div>
         </div>
-        {usingExtraCredits ? (
-          /* Body-small: at 14px the line would wrap inside the w-64 popover,
-             and at 12px it still spans close to the bar's full width.
-             `truncate` guards the longer locales against wrapping. */
-          <Typography
-            as="span"
-            variant="body-small-default"
-            className="w-full truncate text-[var(--system-mid-strong)]"
-          >
-            {t("preferencesUsagePanel.extraCredits")}
-          </Typography>
-        ) : (
-          <ProgressBar
-            value={usage.ratio}
-            height={10}
-            aria-label={title}
-            fillColor={spent ? "var(--system-negative-strong)" : undefined}
-            className="w-full rounded-full border border-[var(--border-base)] bg-[var(--surface-overlay)]"
-          />
-        )}
+        {/* The bar is 10px and the line's box is 12px, so the slot reserves
+            the taller of the two: settling from one to the other then costs
+            no reflow in the popover above it. */}
+        <div className="flex min-h-3 items-center">
+          {usingExtraCredits ? (
+            /* Body-small: at 14px the line would wrap inside the w-64 popover,
+               and at 12px it still spans close to the bar's full width.
+               `truncate` guards the longer locales against wrapping. */
+            <Typography
+              as="span"
+              variant="body-small-default"
+              className="w-full truncate text-[var(--system-mid-strong)]"
+            >
+              {t("preferencesUsagePanel.extraCredits")}
+            </Typography>
+          ) : (
+            <ProgressBar
+              value={usage.ratio}
+              height={10}
+              aria-label={title}
+              fillColor={alarming ? "var(--system-negative-strong)" : undefined}
+              className="w-full rounded-full border border-[var(--border-base)] bg-[var(--surface-overlay)]"
+            />
+          )}
+        </div>
       </div>
       {exhausted ? (
         <div className="flex min-h-8 items-center justify-between gap-2 rounded-md bg-[var(--system-negative-weak)] px-2 py-1">

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -600,7 +600,7 @@ export function useConversationHistory({
         queryKey: organizationsBillingSummaryRetrieveQueryKey(),
       });
       // The BYOK banner gate's recent-spend probe
-      // (`useSuppressCreditBannersForByok`) must see a managed burn from this
+      // (`useByokCreditRouteVerdict`) must see a managed burn from this
       // turn too, or a cached zero keeps suppressing the banners in an open
       // tab. Its key carries a from/to window, so match on the key's base
       // fields (derived from the generated key builder, minus the window)

--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
@@ -13,7 +13,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
-import { useSuppressCreditBannersForByok } from "@/hooks/use-byok-credit-banner-gate";
+import { useByokCreditRouteVerdict } from "@/hooks/use-byok-credit-banner-gate";
 import { usePlanUsageBalance } from "@/hooks/use-plan-usage-balance";
 
 export interface PreferencesUsage {
@@ -34,10 +34,23 @@ export interface PreferencesUsage {
   usingExtraCredits: boolean;
 }
 
+export interface PreferencesUsageReading {
+  /** The reading, or null when there is nothing honest to say. */
+  usage: PreferencesUsage | null;
+  /**
+   * The reading is final. While false, `usage` is still being worked out: a
+   * null may yet become a bar, and a bar's `usingExtraCredits` may yet become
+   * true. Colour carries meaning on this panel, so a caller that paints an
+   * alarm colour waits for this rather than reading a not-yet as a no.
+   */
+  settled: boolean;
+}
+
 /**
- * Null while the org has no managed billing to read and before an honest
- * number lands, so every caller renders exactly what it always has until
- * there is something real to say.
+ * A null `usage` while the org has no managed billing to read and before an
+ * honest number lands, so every caller renders exactly what it always has
+ * until there is something real to say, paired with the `settled` flag that
+ * separates the two: a null that is still landing from one that is the answer.
  *
  * `conversationId` is the chat the reading is for. It reaches the wallet
  * status so a managed per-conversation profile pin classifies `exhausted`
@@ -46,13 +59,14 @@ export interface PreferencesUsage {
  */
 export function usePreferencesUsage(
   opts: { conversationId?: string | null } = {},
-): PreferencesUsage | null {
+): PreferencesUsageReading {
   const {
     isExhausted,
     balance,
     availableUsageBalance,
     totalUsageBalance,
     enabled,
+    settled: balanceSettled,
   } = useBillingBalanceStatus({ conversationId: opts.conversationId ?? null });
   // The sub is only worth fetching when the org actually has managed billing;
   // the reading itself comes off the summary the wallet status already read.
@@ -76,20 +90,36 @@ export function usePreferencesUsage(
   // dispatches the next turn on the user's own key. The classifier's queries
   // stay idle until the claim is otherwise live, and while it classifies (or
   // when it proves BYOK with no recent managed burn) the claim is withheld.
-  const routeSkipsWallet = useSuppressCreditBannersForByok(
-    enabled && spent && hasWalletCredit,
-    opts.conversationId ?? null,
-  );
+  const { suppress: routeSkipsWallet, settled: claimSettled } =
+    useByokCreditRouteVerdict(
+      enabled && spent && hasWalletCredit,
+      opts.conversationId ?? null,
+    );
+
+  // The reading is final once the summary and the subscription behind it have
+  // both answered and the route classification has stopped moving. The
+  // subscription is the second half of `usage`: without it there is no plan to
+  // read the grants against, so a null here is pending rather than none.
+  const settled =
+    balanceSettled && !subscriptionQuery.isLoading && claimSettled;
 
   if (!enabled || !usage) {
-    return null;
+    return { usage: null, settled };
   }
   return {
-    ratio: usage.ratio,
-    spent,
-    // Using up the grants only alarms once the wallet behind them is empty
-    // too.
-    exhausted: spent && isExhausted,
-    usingExtraCredits: spent && hasWalletCredit && !routeSkipsWallet,
+    usage: {
+      ratio: usage.ratio,
+      spent,
+      // Using up the grants only alarms once the wallet behind them is empty
+      // too, and only once that is settled: the strip and the bar's colour
+      // then arrive on the same render instead of the strip growing the
+      // popover a beat later.
+      exhausted: settled && spent && isExhausted,
+      // Withheld until the classification settles, so the claim is never made
+      // on the strength of a query that has not answered.
+      usingExtraCredits:
+        settled && spent && hasWalletCredit && !routeSkipsWallet,
+    },
+    settled,
   };
 }

--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
@@ -89,16 +89,13 @@ export function usePreferencesUsage(
   const hasWalletCredit = balance != null && Number(balance) > 0;
   // A wallet with credit is still not proof it gets spent: a BYOK route
   // dispatches the next turn on the user's own key. The classifier's queries
-  // stay idle until the claim is otherwise live, and while it classifies (or
-  // when it proves BYOK with no recent managed burn) the claim is withheld.
-  const {
-    suppress: routeSkipsWallet,
-    settled: claimSettled,
-    routeKnown,
-  } = useByokCreditRouteVerdict(
-    enabled && spent && hasWalletCredit,
-    opts.conversationId ?? null,
-  );
+  // stay idle until the claim is otherwise live, so the common healthy path
+  // costs nothing.
+  const { settled: claimSettled, routeBurnsManaged } =
+    useByokCreditRouteVerdict(
+      enabled && spent && hasWalletCredit,
+      opts.conversationId ?? null,
+    );
 
   // The reading is final once the summary and the subscription behind it have
   // both answered and the route classification has stopped moving. The
@@ -119,12 +116,13 @@ export function usePreferencesUsage(
       // then arrive on the same render instead of the strip growing the
       // popover a beat later.
       exhausted: settled && spent && isExhausted,
-      // Withheld until the classification settles AND actually derived a
-      // route. A read that failed leaves the gate failing open, which is the
-      // right answer for a banner and no basis at all for telling someone
-      // their next turn spends money.
+      // A managed route is the whole basis for the claim, so it is required
+      // rather than inferred from `suppress` not being set. The gate lowers
+      // suppression for a fail-open null and for a BYOK route with spend on
+      // some other surface, and neither means this conversation's next turn
+      // touches the managed wallet.
       usingExtraCredits:
-        settled && routeKnown && spent && hasWalletCredit && !routeSkipsWallet,
+        settled && routeBurnsManaged && spent && hasWalletCredit,
     },
     settled,
   };

--- a/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
+++ b/clients/web/src/domains/chat/hooks/use-preferences-usage.ts
@@ -13,6 +13,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { useBillingBalanceStatus } from "@/hooks/use-billing-balance-status";
+import { awaitsAnswer } from "@/lib/query-awaits-answer";
 import { useByokCreditRouteVerdict } from "@/hooks/use-byok-credit-banner-gate";
 import { usePlanUsageBalance } from "@/hooks/use-plan-usage-balance";
 
@@ -90,18 +91,21 @@ export function usePreferencesUsage(
   // dispatches the next turn on the user's own key. The classifier's queries
   // stay idle until the claim is otherwise live, and while it classifies (or
   // when it proves BYOK with no recent managed burn) the claim is withheld.
-  const { suppress: routeSkipsWallet, settled: claimSettled } =
-    useByokCreditRouteVerdict(
-      enabled && spent && hasWalletCredit,
-      opts.conversationId ?? null,
-    );
+  const {
+    suppress: routeSkipsWallet,
+    settled: claimSettled,
+    routeKnown,
+  } = useByokCreditRouteVerdict(
+    enabled && spent && hasWalletCredit,
+    opts.conversationId ?? null,
+  );
 
   // The reading is final once the summary and the subscription behind it have
   // both answered and the route classification has stopped moving. The
   // subscription is the second half of `usage`: without it there is no plan to
   // read the grants against, so a null here is pending rather than none.
   const settled =
-    balanceSettled && !subscriptionQuery.isLoading && claimSettled;
+    balanceSettled && !awaitsAnswer(subscriptionQuery) && claimSettled;
 
   if (!enabled || !usage) {
     return { usage: null, settled };
@@ -115,10 +119,12 @@ export function usePreferencesUsage(
       // then arrive on the same render instead of the strip growing the
       // popover a beat later.
       exhausted: settled && spent && isExhausted,
-      // Withheld until the classification settles, so the claim is never made
-      // on the strength of a query that has not answered.
+      // Withheld until the classification settles AND actually derived a
+      // route. A read that failed leaves the gate failing open, which is the
+      // right answer for a banner and no basis at all for telling someone
+      // their next turn spends money.
       usingExtraCredits:
-        settled && spent && hasWalletCredit && !routeSkipsWallet,
+        settled && routeKnown && spent && hasWalletCredit && !routeSkipsWallet,
     },
     settled,
   };

--- a/clients/web/src/hooks/use-billing-balance-status.test.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.test.ts
@@ -59,9 +59,12 @@ let byokSuppression = false;
 let byokGateCandidates: boolean[] = [];
 
 mock.module("@/hooks/use-byok-credit-banner-gate", () => ({
-  useSuppressCreditBannersForByok: (candidate: boolean) => {
+  // Always settled: what these tests drive is the suppression half of the
+  // verdict. The unsettled half is exercised where it is read, in
+  // `preferences-usage-panel.test.tsx`.
+  useByokCreditRouteVerdict: (candidate: boolean) => {
     byokGateCandidates.push(candidate);
-    return candidate && byokSuppression;
+    return { suppress: candidate && byokSuppression, settled: true };
   },
 }));
 
@@ -156,6 +159,7 @@ describe("useBillingBalanceStatus", () => {
       availableUsageBalance: null,
       totalUsageBalance: null,
       enabled: true,
+      settled: true,
     });
   });
 
@@ -193,6 +197,7 @@ describe("useBillingBalanceStatus", () => {
       availableUsageBalance: null,
       totalUsageBalance: null,
       enabled: true,
+      settled: true,
     });
   });
 
@@ -244,6 +249,7 @@ describe("useBillingBalanceStatus", () => {
       availableUsageBalance: null,
       totalUsageBalance: null,
       enabled: true,
+      settled: true,
     });
   });
 
@@ -341,6 +347,10 @@ describe("useBillingBalanceStatus", () => {
       availableUsageBalance: null,
       totalUsageBalance: null,
       enabled: true,
+      // The all-false shape here describes what is not yet known. An enabled
+      // query with nothing back has not settled, and a surface that paints
+      // these flags has to wait rather than read the falses as answers.
+      settled: false,
     });
   });
 
@@ -384,6 +394,7 @@ describe("useBillingBalanceStatus", () => {
       availableUsageBalance: null,
       totalUsageBalance: null,
       enabled: false,
+      settled: true,
     });
   });
 
@@ -406,6 +417,7 @@ describe("useBillingBalanceStatus", () => {
       availableUsageBalance: null,
       totalUsageBalance: null,
       enabled: true,
+      settled: true,
     });
   });
 
@@ -447,6 +459,7 @@ describe("useBillingBalanceStatus", () => {
       availableUsageBalance: null,
       totalUsageBalance: null,
       enabled: false,
+      settled: true,
     });
   });
 });

--- a/clients/web/src/hooks/use-billing-balance-status.ts
+++ b/clients/web/src/hooks/use-billing-balance-status.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { organizationsBillingSummaryRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
-import { useSuppressCreditBannersForByok } from "@/hooks/use-byok-credit-banner-gate";
+import { useByokCreditRouteVerdict } from "@/hooks/use-byok-credit-banner-gate";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import {
   useActiveAssistantIsPlatformHosted,
@@ -50,9 +50,17 @@ export interface BillingBalanceStatus {
   totalUsageBalance: string | null;
   /** Whether the billing summary query is allowed to run at all. */
   enabled: boolean;
+  /**
+   * The status is final: the summary has landed and any BYOK classification
+   * behind the flags has settled. False means the flags currently describe
+   * what is not yet known rather than what is true, which a surface painting
+   * an alarm colour has to wait out. Always true when the query is disabled,
+   * where the inert status is itself the final answer.
+   */
+  settled: boolean;
 }
 
-const INERT_STATUS: Omit<BillingBalanceStatus, "enabled"> = {
+const INERT_STATUS: Omit<BillingBalanceStatus, "enabled" | "settled"> = {
   isExhausted: false,
   isLowBalance: false,
   dailyLimitReached: false,
@@ -95,7 +103,7 @@ export function useBillingBalanceQueryEnabled(): boolean {
  *
  * The balance flags additionally stay down when the effective chat route is
  * provably BYOK and no managed credits were burned in the last day (see
- * {@link useSuppressCreditBannersForByok}): chat turns that dispatch on the
+ * {@link useByokCreditRouteVerdict}): chat turns that dispatch on the
  * user's own key never fail on the managed wallet, so the credit wall would
  * be a false alarm. Chat surfaces pass their active `conversationId` so a
  * managed per-conversation profile pin keeps the banners up over a BYOK
@@ -114,13 +122,15 @@ export function useBillingBalanceStatus(
   });
   const isExhausted = !!summary && Number(summary.effective_balance) <= 0;
   const isLowBalance = !!summary && summary.low_balance_warning === true;
-  const suppressed = useSuppressCreditBannersForByok(
+  const { suppress: suppressed, settled } = useByokCreditRouteVerdict(
     enabled && (isExhausted || isLowBalance),
     opts.conversationId,
     opts.draftProfile,
   );
   if (!enabled || !summary) {
-    return { ...INERT_STATUS, enabled };
+    // A disabled query has already given its final answer; a summary still on
+    // its way has not.
+    return { ...INERT_STATUS, enabled, settled: !enabled };
   }
   return {
     isExhausted: isExhausted && !suppressed,
@@ -135,5 +145,6 @@ export function useBillingBalanceStatus(
     availableUsageBalance: summary.available_usage_balance ?? null,
     totalUsageBalance: summary.total_usage_balance ?? null,
     enabled,
+    settled,
   };
 }

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
@@ -130,14 +130,22 @@ beforeEach(() => {
 describe("useByokCreditRouteVerdict", () => {
   test("nothing to classify settles immediately", () => {
     const v = verdict(false);
-    expect(v).toEqual({ suppress: false, settled: true, routeKnown: false });
+    expect(v).toEqual({
+      suppress: false,
+      settled: true,
+      routeBurnsManaged: false,
+    });
   });
 
   test("queries in flight suppress, and say so", () => {
     queries = { config: LOADING };
     const v = verdict();
     // The banner's fail-safe: an unknown route must not raise a false alarm.
-    expect(v).toEqual({ suppress: true, settled: false, routeKnown: false });
+    expect(v).toEqual({
+      suppress: true,
+      settled: false,
+      routeBurnsManaged: false,
+    });
   });
 
   test("no resolved assistant is not-asked-yet, not answered-no", () => {
@@ -146,14 +154,22 @@ describe("useByokCreditRouteVerdict", () => {
     // a managed route on evidence the gate has not gathered.
     assistantId = null;
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: false, routeKnown: false });
+    expect(v).toEqual({
+      suppress: false,
+      settled: false,
+      routeBurnsManaged: false,
+    });
   });
 
   test("a managed route is a settled answer", () => {
     answerRouteQueries();
     burnsManaged = true;
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: true, routeKnown: true });
+    expect(v).toEqual({
+      suppress: false,
+      settled: true,
+      routeBurnsManaged: true,
+    });
   });
 
   test("a version-gated query the assistant is too old for still settles", () => {
@@ -163,7 +179,11 @@ describe("useByokCreditRouteVerdict", () => {
     supportsProfiles = false;
     supportsDefaultProvider = false;
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: true, routeKnown: true });
+    expect(v).toEqual({
+      suppress: false,
+      settled: true,
+      routeBurnsManaged: true,
+    });
   });
 
   test("a BYOK route waits for the spend probe before settling", () => {
@@ -171,7 +191,11 @@ describe("useByokCreditRouteVerdict", () => {
     burnsManaged = false;
     queries = { ...queries, totals: LOADING };
     const v = verdict();
-    expect(v).toEqual({ suppress: true, settled: false, routeKnown: true });
+    expect(v).toEqual({
+      suppress: true,
+      settled: false,
+      routeBurnsManaged: false,
+    });
   });
 
   test("a BYOK route with no recent burn suppresses, settled", () => {
@@ -182,10 +206,17 @@ describe("useByokCreditRouteVerdict", () => {
       totals: queryState("success", { total_usd: "0.00" }),
     };
     const v = verdict();
-    expect(v).toEqual({ suppress: true, settled: true, routeKnown: true });
+    expect(v).toEqual({
+      suppress: true,
+      settled: true,
+      routeBurnsManaged: false,
+    });
   });
 
-  test("a recent managed burn re-arms the banners", () => {
+  test("a recent managed burn re-arms the banners without making it managed", () => {
+    // Spend on another surface lowers suppression. It says nothing about
+    // where this conversation's next turn dispatches, so the route stays
+    // BYOK and no claim may be built on it.
     answerRouteQueries();
     burnsManaged = false;
     queries = {
@@ -193,7 +224,11 @@ describe("useByokCreditRouteVerdict", () => {
       totals: queryState("success", { total_usd: "1.25" }),
     };
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: true, routeKnown: true });
+    expect(v).toEqual({
+      suppress: false,
+      settled: true,
+      routeBurnsManaged: false,
+    });
   });
 
   test("a failed route read is final without being a route", () => {
@@ -204,7 +239,7 @@ describe("useByokCreditRouteVerdict", () => {
     expect(verdict()).toEqual({
       suppress: false,
       settled: true,
-      routeKnown: false,
+      routeBurnsManaged: false,
     });
   });
 
@@ -217,7 +252,7 @@ describe("useByokCreditRouteVerdict", () => {
     expect(verdict()).toEqual({
       suppress: false,
       settled: false,
-      routeKnown: false,
+      routeBurnsManaged: false,
     });
   });
 
@@ -228,7 +263,7 @@ describe("useByokCreditRouteVerdict", () => {
     expect(verdict()).toEqual({
       suppress: true,
       settled: false,
-      routeKnown: true,
+      routeBurnsManaged: false,
     });
   });
 
@@ -237,6 +272,10 @@ describe("useByokCreditRouteVerdict", () => {
     burnsManaged = false;
     queries = { ...queries, totals: queryState("error") };
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: true, routeKnown: true });
+    expect(v).toEqual({
+      suppress: false,
+      settled: true,
+      routeBurnsManaged: false,
+    });
   });
 });

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
@@ -14,31 +14,47 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderHook } from "@testing-library/react";
 
-type QueryState = { data?: unknown; isLoading?: boolean; isError?: boolean };
+type Phase = "idle" | "fetching" | "paused" | "success" | "error";
 
-const IDLE: QueryState = { data: undefined, isLoading: false, isError: false };
-const LOADING: QueryState = {
-  data: undefined,
-  isLoading: true,
-  isError: false,
-};
+/**
+ * The flags TanStack reports for a phase, derived rather than listed so the
+ * double cannot drift from the real thing. The two that carry the weight:
+ * `isLoading` is pending AND fetching, so a paused fetch does not set it, and
+ * a disabled query is pending at an idle fetch, so it does not either. The
+ * gate has to tell those two apart.
+ */
+function queryState(phase: Phase, data?: unknown) {
+  const fetchStatus =
+    phase === "fetching" ? "fetching" : phase === "paused" ? "paused" : "idle";
+  const isPending =
+    phase === "idle" || phase === "fetching" || phase === "paused";
+  return {
+    data: phase === "success" ? data : undefined,
+    fetchStatus,
+    isPending,
+    isError: phase === "error",
+    isLoading: isPending && fetchStatus === "fetching",
+  };
+}
+
+/** Enabled, but parked by the default network mode with the browser offline. */
+const PAUSED = queryState("paused");
+const LOADING = queryState("fetching");
+/** Disabled: pending forever, and never going to fetch. */
+const DISABLED = queryState("idle");
 
 /** Staged state per query, keyed by the `_id` its options factory carries. */
-let queries: Record<string, QueryState> = {};
+let queries: Record<string, ReturnType<typeof queryState>> = {};
 
 const actualReactQuery = await import("@tanstack/react-query");
 mock.module("@tanstack/react-query", () => ({
   ...actualReactQuery,
   useQuery: (opts: { queryKey?: [{ _id?: string }]; enabled?: boolean }) => {
     const id = opts.queryKey?.[0]?._id ?? "";
-    // A disabled query is pending with an idle fetch, so `isLoading` is false
-    // and no data arrives. That shape is the whole point of the "cannot ask
-    // yet" branch, so the double has to reproduce it rather than smooth it
-    // over.
     if (opts.enabled === false) {
-      return IDLE;
+      return DISABLED;
     }
-    return { ...IDLE, ...(queries[id] ?? IDLE) };
+    return queries[id] ?? DISABLED;
   },
 }));
 
@@ -94,10 +110,12 @@ function verdict(candidate = true, conversationId: string | null = null) {
 /** Every route query answered, so only the classifier's verdict is left. */
 function answerRouteQueries() {
   queries = {
-    config: { data: { llm: {} } },
-    connections: { data: { connections: [] } },
-    profiles: { data: { profiles: [] } },
-    defaultProvider: { data: { availability: { status: "available" } } },
+    config: queryState("success", { llm: {} }),
+    connections: queryState("success", { connections: [] }),
+    profiles: queryState("success", { profiles: [] }),
+    defaultProvider: queryState("success", {
+      availability: { status: "available" },
+    }),
   };
 }
 
@@ -159,7 +177,10 @@ describe("useByokCreditRouteVerdict", () => {
   test("a BYOK route with no recent burn suppresses, settled", () => {
     answerRouteQueries();
     burnsManaged = false;
-    queries = { ...queries, totals: { data: { total_usd: "0.00" } } };
+    queries = {
+      ...queries,
+      totals: queryState("success", { total_usd: "0.00" }),
+    };
     const v = verdict();
     expect(v).toEqual({ suppress: true, settled: true });
   });
@@ -167,15 +188,34 @@ describe("useByokCreditRouteVerdict", () => {
   test("a recent managed burn re-arms the banners", () => {
     answerRouteQueries();
     burnsManaged = false;
-    queries = { ...queries, totals: { data: { total_usd: "1.25" } } };
+    queries = {
+      ...queries,
+      totals: queryState("success", { total_usd: "1.25" }),
+    };
     const v = verdict();
     expect(v).toEqual({ suppress: false, settled: true });
+  });
+
+  test("an offline paused route read is unsettled", () => {
+    // The default network mode parks an enabled fetch without ever reporting
+    // a load or an error, so the gate has no route evidence and must not let
+    // a caller paint one.
+    answerRouteQueries();
+    queries = { ...queries, connections: PAUSED };
+    expect(verdict()).toEqual({ suppress: false, settled: false });
+  });
+
+  test("an offline paused spend probe is unsettled", () => {
+    answerRouteQueries();
+    burnsManaged = false;
+    queries = { ...queries, totals: PAUSED };
+    expect(verdict()).toEqual({ suppress: true, settled: false });
   });
 
   test("a failed spend probe fails open, and that is a final answer", () => {
     answerRouteQueries();
     burnsManaged = false;
-    queries = { ...queries, totals: { isError: true } };
+    queries = { ...queries, totals: queryState("error") };
     const v = verdict();
     expect(v).toEqual({ suppress: false, settled: true });
   });

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
@@ -130,14 +130,14 @@ beforeEach(() => {
 describe("useByokCreditRouteVerdict", () => {
   test("nothing to classify settles immediately", () => {
     const v = verdict(false);
-    expect(v).toEqual({ suppress: false, settled: true });
+    expect(v).toEqual({ suppress: false, settled: true, routeKnown: false });
   });
 
   test("queries in flight suppress, and say so", () => {
     queries = { config: LOADING };
     const v = verdict();
     // The banner's fail-safe: an unknown route must not raise a false alarm.
-    expect(v).toEqual({ suppress: true, settled: false });
+    expect(v).toEqual({ suppress: true, settled: false, routeKnown: false });
   });
 
   test("no resolved assistant is not-asked-yet, not answered-no", () => {
@@ -146,14 +146,14 @@ describe("useByokCreditRouteVerdict", () => {
     // a managed route on evidence the gate has not gathered.
     assistantId = null;
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: false });
+    expect(v).toEqual({ suppress: false, settled: false, routeKnown: false });
   });
 
   test("a managed route is a settled answer", () => {
     answerRouteQueries();
     burnsManaged = true;
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: true });
+    expect(v).toEqual({ suppress: false, settled: true, routeKnown: true });
   });
 
   test("a version-gated query the assistant is too old for still settles", () => {
@@ -163,7 +163,7 @@ describe("useByokCreditRouteVerdict", () => {
     supportsProfiles = false;
     supportsDefaultProvider = false;
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: true });
+    expect(v).toEqual({ suppress: false, settled: true, routeKnown: true });
   });
 
   test("a BYOK route waits for the spend probe before settling", () => {
@@ -171,7 +171,7 @@ describe("useByokCreditRouteVerdict", () => {
     burnsManaged = false;
     queries = { ...queries, totals: LOADING };
     const v = verdict();
-    expect(v).toEqual({ suppress: true, settled: false });
+    expect(v).toEqual({ suppress: true, settled: false, routeKnown: true });
   });
 
   test("a BYOK route with no recent burn suppresses, settled", () => {
@@ -182,7 +182,7 @@ describe("useByokCreditRouteVerdict", () => {
       totals: queryState("success", { total_usd: "0.00" }),
     };
     const v = verdict();
-    expect(v).toEqual({ suppress: true, settled: true });
+    expect(v).toEqual({ suppress: true, settled: true, routeKnown: true });
   });
 
   test("a recent managed burn re-arms the banners", () => {
@@ -193,7 +193,19 @@ describe("useByokCreditRouteVerdict", () => {
       totals: queryState("success", { total_usd: "1.25" }),
     };
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: true });
+    expect(v).toEqual({ suppress: false, settled: true, routeKnown: true });
+  });
+
+  test("a failed route read is final without being a route", () => {
+    // Fail-open is the right answer for the banner, and no answer at all for
+    // a caller about to tell someone their next turn spends managed credits.
+    answerRouteQueries();
+    queries = { ...queries, config: queryState("error") };
+    expect(verdict()).toEqual({
+      suppress: false,
+      settled: true,
+      routeKnown: false,
+    });
   });
 
   test("an offline paused route read is unsettled", () => {
@@ -202,14 +214,22 @@ describe("useByokCreditRouteVerdict", () => {
     // a caller paint one.
     answerRouteQueries();
     queries = { ...queries, connections: PAUSED };
-    expect(verdict()).toEqual({ suppress: false, settled: false });
+    expect(verdict()).toEqual({
+      suppress: false,
+      settled: false,
+      routeKnown: false,
+    });
   });
 
   test("an offline paused spend probe is unsettled", () => {
     answerRouteQueries();
     burnsManaged = false;
     queries = { ...queries, totals: PAUSED };
-    expect(verdict()).toEqual({ suppress: true, settled: false });
+    expect(verdict()).toEqual({
+      suppress: true,
+      settled: false,
+      routeKnown: true,
+    });
   });
 
   test("a failed spend probe fails open, and that is a final answer", () => {
@@ -217,6 +237,6 @@ describe("useByokCreditRouteVerdict", () => {
     burnsManaged = false;
     queries = { ...queries, totals: queryState("error") };
     const v = verdict();
-    expect(v).toEqual({ suppress: false, settled: true });
+    expect(v).toEqual({ suppress: false, settled: true, routeKnown: true });
   });
 });

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
@@ -8,9 +8,8 @@
  * provably skips the wallet from one that has not been classified yet, and a
  * caller reading it inverted turns that gap into a false claim.
  *
- * The `suppress` value asserted in each case is the one the hook returned when
- * it was a bare boolean, so the matrix is the record that the banner path did
- * not move.
+ * The matrix below is the suppression contract in full: every branch that can
+ * produce a verdict, and the `settled` each one carries.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderHook } from "@testing-library/react";
@@ -124,10 +123,9 @@ describe("useByokCreditRouteVerdict", () => {
   });
 
   test("no resolved assistant is not-asked-yet, not answered-no", () => {
-    // The regression this hook's shape exists for. Every route query is
-    // disabled without an assistant, so the fail-open verdict below rests on
-    // nothing; reading it as a settled "route spends the wallet" is what let
-    // the usage panel claim extra credits before it had asked anything.
+    // Every route query is disabled without an assistant, so the fail-open
+    // verdict rests on nothing. A caller that read it as settled would claim
+    // a managed route on evidence the gate has not gathered.
     assistantId = null;
     const v = verdict();
     expect(v).toEqual({ suppress: false, settled: false });

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Tests for the BYOK credit-route gate.
+ *
+ * The hook's own queries are what it is made of, so `useQuery` is replaced and
+ * each of the six reads is staged by the `_id` its mocked options factory
+ * carries. That is the only way to hold a query in flight, which is the state
+ * this suite exists for: `suppress` alone cannot distinguish a route that
+ * provably skips the wallet from one that has not been classified yet, and a
+ * caller reading it inverted turns that gap into a false claim.
+ *
+ * The `suppress` value asserted in each case is the one the hook returned when
+ * it was a bare boolean, so the matrix is the record that the banner path did
+ * not move.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderHook } from "@testing-library/react";
+
+type QueryState = { data?: unknown; isLoading?: boolean; isError?: boolean };
+
+const IDLE: QueryState = { data: undefined, isLoading: false, isError: false };
+const LOADING: QueryState = {
+  data: undefined,
+  isLoading: true,
+  isError: false,
+};
+
+/** Staged state per query, keyed by the `_id` its options factory carries. */
+let queries: Record<string, QueryState> = {};
+
+const actualReactQuery = await import("@tanstack/react-query");
+mock.module("@tanstack/react-query", () => ({
+  ...actualReactQuery,
+  useQuery: (opts: { queryKey?: [{ _id?: string }]; enabled?: boolean }) => {
+    const id = opts.queryKey?.[0]?._id ?? "";
+    // A disabled query is pending with an idle fetch, so `isLoading` is false
+    // and no data arrives. That shape is the whole point of the "cannot ask
+    // yet" branch, so the double has to reproduce it rather than smooth it
+    // over.
+    if (opts.enabled === false) {
+      return IDLE;
+    }
+    return { ...IDLE, ...(queries[id] ?? IDLE) };
+  },
+}));
+
+function options(id: string) {
+  return () => ({ queryKey: [{ _id: id }] });
+}
+
+mock.module("@/generated/daemon/@tanstack/react-query.gen", () => ({
+  configGetOptions: options("config"),
+  configLlmDefaultproviderGetOptions: options("defaultProvider"),
+  conversationsByIdGetOptions: options("conversation"),
+  inferenceProfilesGetOptions: options("profiles"),
+  inferenceProviderconnectionsGetOptions: options("connections"),
+}));
+
+mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
+  organizationsBillingUsageTotalsRetrieveOptions: options("totals"),
+}));
+
+let assistantId: string | null = "assistant-1";
+mock.module("@/stores/resolved-assistants-store", () => ({
+  useResolvedAssistantsStore: {
+    use: { activeAssistantId: () => assistantId },
+  },
+}));
+
+let supportsProfiles = true;
+let supportsDefaultProvider = true;
+mock.module("@/lib/backwards-compat/use-supports-inference-profiles", () => ({
+  useSupportsInferenceProfiles: () => supportsProfiles,
+}));
+mock.module("@/lib/backwards-compat/default-provider-settings", () => ({
+  useSupportsDefaultProviderSettings: () => supportsDefaultProvider,
+}));
+
+// The route classifier itself is covered by its own suite; what this hook
+// owns is which of its answers reaches a caller, and when.
+let burnsManaged = true;
+mock.module("@/lib/billing/byok-credit-route", () => ({
+  defaultChatRouteBurnsManagedCredits: () => burnsManaged,
+}));
+
+const { useByokCreditRouteVerdict } =
+  await import("./use-byok-credit-banner-gate");
+
+function verdict(candidate = true, conversationId: string | null = null) {
+  const { result } = renderHook(() =>
+    useByokCreditRouteVerdict(candidate, conversationId),
+  );
+  return result.current;
+}
+
+/** Every route query answered, so only the classifier's verdict is left. */
+function answerRouteQueries() {
+  queries = {
+    config: { data: { llm: {} } },
+    connections: { data: { connections: [] } },
+    profiles: { data: { profiles: [] } },
+    defaultProvider: { data: { availability: { status: "available" } } },
+  };
+}
+
+beforeEach(() => {
+  queries = {};
+  assistantId = "assistant-1";
+  supportsProfiles = true;
+  supportsDefaultProvider = true;
+  burnsManaged = true;
+});
+
+describe("useByokCreditRouteVerdict", () => {
+  test("nothing to classify settles immediately", () => {
+    const v = verdict(false);
+    expect(v).toEqual({ suppress: false, settled: true });
+  });
+
+  test("queries in flight suppress, and say so", () => {
+    queries = { config: LOADING };
+    const v = verdict();
+    // The banner's fail-safe: an unknown route must not raise a false alarm.
+    expect(v).toEqual({ suppress: true, settled: false });
+  });
+
+  test("no resolved assistant is not-asked-yet, not answered-no", () => {
+    // The regression this hook's shape exists for. Every route query is
+    // disabled without an assistant, so the fail-open verdict below rests on
+    // nothing; reading it as a settled "route spends the wallet" is what let
+    // the usage panel claim extra credits before it had asked anything.
+    assistantId = null;
+    const v = verdict();
+    expect(v).toEqual({ suppress: false, settled: false });
+  });
+
+  test("a managed route is a settled answer", () => {
+    answerRouteQueries();
+    burnsManaged = true;
+    const v = verdict();
+    expect(v).toEqual({ suppress: false, settled: true });
+  });
+
+  test("a version-gated query the assistant is too old for still settles", () => {
+    // The gate answered "no" rather than "not yet": that query is never
+    // coming, so waiting on it would hold the verdict open forever.
+    answerRouteQueries();
+    supportsProfiles = false;
+    supportsDefaultProvider = false;
+    const v = verdict();
+    expect(v).toEqual({ suppress: false, settled: true });
+  });
+
+  test("a BYOK route waits for the spend probe before settling", () => {
+    answerRouteQueries();
+    burnsManaged = false;
+    queries = { ...queries, totals: LOADING };
+    const v = verdict();
+    expect(v).toEqual({ suppress: true, settled: false });
+  });
+
+  test("a BYOK route with no recent burn suppresses, settled", () => {
+    answerRouteQueries();
+    burnsManaged = false;
+    queries = { ...queries, totals: { data: { total_usd: "0.00" } } };
+    const v = verdict();
+    expect(v).toEqual({ suppress: true, settled: true });
+  });
+
+  test("a recent managed burn re-arms the banners", () => {
+    answerRouteQueries();
+    burnsManaged = false;
+    queries = { ...queries, totals: { data: { total_usd: "1.25" } } };
+    const v = verdict();
+    expect(v).toEqual({ suppress: false, settled: true });
+  });
+
+  test("a failed spend probe fails open, and that is a final answer", () => {
+    answerRouteQueries();
+    burnsManaged = false;
+    queries = { ...queries, totals: { isError: true } };
+    const v = verdict();
+    expect(v).toEqual({ suppress: false, settled: true });
+  });
+});

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.ts
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/billing/byok-credit-route";
 import { useSupportsDefaultProviderSettings } from "@/lib/backwards-compat/default-provider-settings";
 import { useSupportsInferenceProfiles } from "@/lib/backwards-compat/use-supports-inference-profiles";
+import { awaitsAnswer } from "@/lib/query-awaits-answer";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -65,23 +66,13 @@ function useUtcDay(): string {
 export interface ByokCreditRouteVerdict {
   suppress: boolean;
   settled: boolean;
-}
-
-/**
- * A query with no answer yet that may still get one.
- *
- * `isLoading` is pending AND fetching, which misses the offline case: the
- * default network mode parks an enabled fetch at `fetchStatus: "paused"`,
- * reporting neither a load nor an error, so a gap with the browser offline
- * would otherwise read as an answer. A disabled query sits at `"idle"`
- * instead, and that one is final: the version gates hold two of these reads
- * closed on assistants whose daemon never serves them.
- */
-function awaitsAnswer(query: {
-  isPending: boolean;
-  fetchStatus: "fetching" | "paused" | "idle";
-}): boolean {
-  return query.isPending && query.fetchStatus !== "idle";
+  /**
+   * The route was positively derived rather than failed open on evidence that
+   * never arrived. `suppress` deliberately cannot tell those apart, because a
+   * banner treats both as "show it"; a caller making a positive claim has to,
+   * because a failed config read is not proof of a managed route.
+   */
+  routeKnown: boolean;
 }
 
 /**
@@ -228,8 +219,12 @@ export function useByokCreditRouteVerdict(
     refetchInterval: 5 * 60_000,
   });
 
+  // A route derived from evidence, as opposed to the null the classification
+  // yields when a read it needs is missing or failed.
+  const routeKnown = burnsManaged != null;
+
   if (!candidate) {
-    return { suppress: false, settled: true };
+    return { suppress: false, settled: true, routeKnown };
   }
   // Idle and empty is "not asked yet", not "answered no": every route query
   // waits on a resolved assistant, so until one arrives the fail-open verdict
@@ -251,19 +246,23 @@ export function useByokCreditRouteVerdict(
     profilesQuery.isLoading ||
     defaultProviderQuery.isLoading
   ) {
-    return { suppress: true, settled: false };
+    return { suppress: true, settled: false, routeKnown };
   }
   if (burnsManaged !== false) {
     // Fail-open covers a genuine read failure as well as a missing assistant
     // or an offline gap. The first is a final answer, the others are not.
-    return { suppress: false, settled: !cannotAskYet && !routeAwaitingAnswer };
+    return {
+      suppress: false,
+      settled: !cannotAskYet && !routeAwaitingAnswer,
+      routeKnown,
+    };
   }
   // Route proven BYOK: stay down only while the spend probe positively
   // reports no recent burn (or is still loading). A failed probe fails open
   // like every other unknown in this gate: a burn may have happened and the
   // banners must not stay hidden on missing data.
   if (totalsQuery.isError) {
-    return { suppress: false, settled: true };
+    return { suppress: false, settled: true, routeKnown };
   }
   const totals = totalsQuery.data;
   const burnedRecently = totals ? Number(totals.total_usd) > 0 : null;
@@ -271,5 +270,6 @@ export function useByokCreditRouteVerdict(
     suppress: burnedRecently !== true,
     settled:
       !cannotAskYet && !routeAwaitingAnswer && !awaitsAnswer(totalsQuery),
+    routeKnown,
   };
 }

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.ts
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.ts
@@ -50,38 +50,30 @@ function useUtcDay(): string {
 }
 
 /**
- * The route classification, and whether it rests on evidence yet.
+ * The route classification, and how much of it a caller may act on.
  *
- * `suppress` is the long-standing answer: hold the balance banners down.
- * Collapsing "still working it out" into "suppress" is right for a banner,
- * where an unknown must never raise a false alarm.
+ * `suppress` holds the balance banners down. A banner treats "route unknown"
+ * and "route spends the wallet" the same way, so an unresolved classification
+ * folds safely into it, and only into it.
  *
- * It is wrong for a caller that reads the same answer inverted to make a
- * positive claim, because negating a fail-safe makes it fail loud: every
- * moment the classification is in flight would assert the opposite of what
- * the banner path is being careful about. `settled` is the seam for those
- * callers, and it is false whenever `suppress` reflects the absence of
- * evidence rather than evidence itself.
+ * A caller making a positive claim needs the two facts `suppress` cannot
+ * carry. `settled` is false while the classification may still change.
+ * `routeBurnsManaged` is true only for a route derived as managed, which a
+ * fail-open null and a proven BYOK route both are not. Neither is the
+ * negation of `suppress`, and reading them as one turns a missing answer into
+ * an assertion.
  */
 export interface ByokCreditRouteVerdict {
   suppress: boolean;
   settled: boolean;
-  /**
-   * The route was positively derived rather than failed open on evidence that
-   * never arrived. `suppress` deliberately cannot tell those apart, because a
-   * banner treats both as "show it"; a caller making a positive claim has to,
-   * because a failed config read is not proof of a managed route.
-   */
-  routeKnown: boolean;
+  routeBurnsManaged: boolean;
 }
 
 /**
  * Whether the low/exhausted credit banners should stay down because the org's
  * default chat route doesn't spend managed credits and nothing else has been
- * spending them either, and whether that is settled enough to act on. See
- * {@link ByokCreditRouteVerdict}: the two halves exist because the answer is
- * read in both directions, and only one of those directions can treat an
- * unknown as a no.
+ * spending them either, plus what a positive claim about that route may rest
+ * on. See {@link ByokCreditRouteVerdict} for why those are separate answers.
  *
  * A BYOK default profile makes an exhausted managed balance irrelevant to
  * chat: turns dispatch on the user's own key and never fail on the platform's
@@ -219,12 +211,14 @@ export function useByokCreditRouteVerdict(
     refetchInterval: 5 * 60_000,
   });
 
-  // A route derived from evidence, as opposed to the null the classification
-  // yields when a read it needs is missing or failed.
-  const routeKnown = burnsManaged != null;
+  // Only a positively managed route. A null (a read missing or failed) is not
+  // one, and neither is a proven BYOK route whose banners the spend probe
+  // re-arms: spend on another surface says nothing about where this
+  // conversation's next turn dispatches.
+  const routeBurnsManaged = burnsManaged === true;
 
   if (!candidate) {
-    return { suppress: false, settled: true, routeKnown };
+    return { suppress: false, settled: true, routeBurnsManaged };
   }
   // Idle and empty is "not asked yet", not "answered no": every route query
   // waits on a resolved assistant, so until one arrives the fail-open verdict
@@ -246,7 +240,7 @@ export function useByokCreditRouteVerdict(
     profilesQuery.isLoading ||
     defaultProviderQuery.isLoading
   ) {
-    return { suppress: true, settled: false, routeKnown };
+    return { suppress: true, settled: false, routeBurnsManaged };
   }
   if (burnsManaged !== false) {
     // Fail-open covers a genuine read failure as well as a missing assistant
@@ -254,7 +248,7 @@ export function useByokCreditRouteVerdict(
     return {
       suppress: false,
       settled: !cannotAskYet && !routeAwaitingAnswer,
-      routeKnown,
+      routeBurnsManaged,
     };
   }
   // Route proven BYOK: stay down only while the spend probe positively
@@ -262,7 +256,7 @@ export function useByokCreditRouteVerdict(
   // like every other unknown in this gate: a burn may have happened and the
   // banners must not stay hidden on missing data.
   if (totalsQuery.isError) {
-    return { suppress: false, settled: true, routeKnown };
+    return { suppress: false, settled: true, routeBurnsManaged };
   }
   const totals = totalsQuery.data;
   const burnedRecently = totals ? Number(totals.total_usd) > 0 : null;
@@ -270,6 +264,6 @@ export function useByokCreditRouteVerdict(
     suppress: burnedRecently !== true,
     settled:
       !cannotAskYet && !routeAwaitingAnswer && !awaitsAnswer(totalsQuery),
-    routeKnown,
+    routeBurnsManaged,
   };
 }

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.ts
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.ts
@@ -68,6 +68,23 @@ export interface ByokCreditRouteVerdict {
 }
 
 /**
+ * A query with no answer yet that may still get one.
+ *
+ * `isLoading` is pending AND fetching, which misses the offline case: the
+ * default network mode parks an enabled fetch at `fetchStatus: "paused"`,
+ * reporting neither a load nor an error, so a gap with the browser offline
+ * would otherwise read as an answer. A disabled query sits at `"idle"`
+ * instead, and that one is final: the version gates hold two of these reads
+ * closed on assistants whose daemon never serves them.
+ */
+function awaitsAnswer(query: {
+  isPending: boolean;
+  fetchStatus: "fetching" | "paused" | "idle";
+}): boolean {
+  return query.isPending && query.fetchStatus !== "idle";
+}
+
+/**
  * Whether the low/exhausted credit banners should stay down because the org's
  * default chat route doesn't spend managed credits and nothing else has been
  * spending them either, and whether that is settled enough to act on. See
@@ -218,6 +235,12 @@ export function useByokCreditRouteVerdict(
   // waits on a resolved assistant, so until one arrives the fail-open verdict
   // below rests on nothing.
   const cannotAskYet = assistantId == null;
+  const routeAwaitingAnswer =
+    awaitsAnswer(configQuery) ||
+    awaitsAnswer(connectionsQuery) ||
+    awaitsAnswer(conversationQuery) ||
+    awaitsAnswer(profilesQuery) ||
+    awaitsAnswer(defaultProviderQuery);
   // `isLoading` (pending AND fetching) distinguishes the initial in-flight
   // load, which suppresses to avoid a flash, from a disabled or errored
   // query, which must fail open below.
@@ -231,9 +254,9 @@ export function useByokCreditRouteVerdict(
     return { suppress: true, settled: false };
   }
   if (burnsManaged !== false) {
-    // Fail-open covers a genuine read failure as well as a missing assistant.
-    // The first is a final answer, the second is not.
-    return { suppress: false, settled: !cannotAskYet };
+    // Fail-open covers a genuine read failure as well as a missing assistant
+    // or an offline gap. The first is a final answer, the others are not.
+    return { suppress: false, settled: !cannotAskYet && !routeAwaitingAnswer };
   }
   // Route proven BYOK: stay down only while the spend probe positively
   // reports no recent burn (or is still loading). A failed probe fails open
@@ -246,6 +269,7 @@ export function useByokCreditRouteVerdict(
   const burnedRecently = totals ? Number(totals.total_usd) > 0 : null;
   return {
     suppress: burnedRecently !== true,
-    settled: !cannotAskYet && !totalsQuery.isLoading,
+    settled:
+      !cannotAskYet && !routeAwaitingAnswer && !awaitsAnswer(totalsQuery),
   };
 }

--- a/clients/web/src/hooks/use-byok-credit-banner-gate.ts
+++ b/clients/web/src/hooks/use-byok-credit-banner-gate.ts
@@ -49,9 +49,31 @@ function useUtcDay(): string {
 }
 
 /**
+ * The route classification, and whether it rests on evidence yet.
+ *
+ * `suppress` is the long-standing answer: hold the balance banners down.
+ * Collapsing "still working it out" into "suppress" is right for a banner,
+ * where an unknown must never raise a false alarm.
+ *
+ * It is wrong for a caller that reads the same answer inverted to make a
+ * positive claim, because negating a fail-safe makes it fail loud: every
+ * moment the classification is in flight would assert the opposite of what
+ * the banner path is being careful about. `settled` is the seam for those
+ * callers, and it is false whenever `suppress` reflects the absence of
+ * evidence rather than evidence itself.
+ */
+export interface ByokCreditRouteVerdict {
+  suppress: boolean;
+  settled: boolean;
+}
+
+/**
  * Whether the low/exhausted credit banners should stay down because the org's
  * default chat route doesn't spend managed credits and nothing else has been
- * spending them either.
+ * spending them either, and whether that is settled enough to act on. See
+ * {@link ByokCreditRouteVerdict}: the two halves exist because the answer is
+ * read in both directions, and only one of those directions can treat an
+ * unknown as a no.
  *
  * A BYOK default profile makes an exhausted managed balance irrelevant to
  * chat: turns dispatch on the user's own key and never fail on the platform's
@@ -83,11 +105,11 @@ function useUtcDay(): string {
  *   `inferenceProfile` until the row exists. Read only when
  *   `conversationId` is null.
  */
-export function useSuppressCreditBannersForByok(
+export function useByokCreditRouteVerdict(
   candidate: boolean,
   conversationId?: string | null,
   draftProfile?: string | null,
-): boolean {
+): ByokCreditRouteVerdict {
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const routeQueriesEnabled = candidate && assistantId != null;
   const configQuery = useQuery({
@@ -190,8 +212,12 @@ export function useSuppressCreditBannersForByok(
   });
 
   if (!candidate) {
-    return false;
+    return { suppress: false, settled: true };
   }
+  // Idle and empty is "not asked yet", not "answered no": every route query
+  // waits on a resolved assistant, so until one arrives the fail-open verdict
+  // below rests on nothing.
+  const cannotAskYet = assistantId == null;
   // `isLoading` (pending AND fetching) distinguishes the initial in-flight
   // load, which suppresses to avoid a flash, from a disabled or errored
   // query, which must fail open below.
@@ -202,19 +228,24 @@ export function useSuppressCreditBannersForByok(
     profilesQuery.isLoading ||
     defaultProviderQuery.isLoading
   ) {
-    return true;
+    return { suppress: true, settled: false };
   }
   if (burnsManaged !== false) {
-    return false;
+    // Fail-open covers a genuine read failure as well as a missing assistant.
+    // The first is a final answer, the second is not.
+    return { suppress: false, settled: !cannotAskYet };
   }
   // Route proven BYOK: stay down only while the spend probe positively
   // reports no recent burn (or is still loading). A failed probe fails open
   // like every other unknown in this gate: a burn may have happened and the
   // banners must not stay hidden on missing data.
   if (totalsQuery.isError) {
-    return false;
+    return { suppress: false, settled: true };
   }
   const totals = totalsQuery.data;
   const burnedRecently = totals ? Number(totals.total_usd) > 0 : null;
-  return burnedRecently !== true;
+  return {
+    suppress: burnedRecently !== true,
+    settled: !cannotAskYet && !totalsQuery.isLoading,
+  };
 }

--- a/clients/web/src/lib/query-awaits-answer.ts
+++ b/clients/web/src/lib/query-awaits-answer.ts
@@ -1,0 +1,18 @@
+/**
+ * A query with no answer yet that may still get one.
+ *
+ * `isLoading` is pending AND fetching, which misses the offline case: the
+ * default network mode parks an enabled fetch at `fetchStatus: "paused"`,
+ * reporting neither a load nor an error, so a gap with the browser offline
+ * reads as an answer. A disabled query sits at `"idle"` instead, and that one
+ * is final: a gate that holds a query closed is not waiting on it.
+ *
+ * For any surface deciding whether it knows enough to commit to something a
+ * later render would contradict.
+ */
+export function awaitsAnswer(query: {
+  isPending: boolean;
+  fetchStatus: "fetching" | "paused" | "idle";
+}): boolean {
+  return query.isPending && query.fetchStatus !== "idle";
+}


### PR DESCRIPTION
## The bug

The preferences menu's usage section flashed through states for roughly a second on a cold open before settling. For an account whose settled reading is the amber "Now using extra usage credits" line, the sequence was:

**absent → red 100% bar → amber line**

Nothing about the billing state changed across that second. The panel was rendering daemon latency as an alarm colour.

## Root cause

`useSuppressCreditBannersForByok` answered with a single boolean covering three different situations: provably BYOK, still classifying, and cannot classify yet.

That is right for its original consumer. `useBillingBalanceStatus` reads it as "hold the credit wall down", and folding an unknown into "suppress" is the correct fail-safe: an unknown must never raise a false alarm.

It is wrong for `usePreferencesUsage`, which read the **same boolean inverted** (`!routeSkipsWallet`) to make a positive claim. Negating a fail-safe makes it fail loud, so every in-flight moment asserted the opposite of what the banner path was being careful about:

| classifier situation | returns | panel showed |
|---|---|---|
| queries in flight | `true` | **red** |
| settled, managed route | `false` | amber |
| settled, BYOK + no recent burn | `true` | red |
| `assistantId` null, or version gates unhydrated (queries disabled, dataless) | `false` | **amber, on no evidence** |

Three of the classifier's five daemon reads (`inferenceProviderconnections`, `inferenceProfiles`, `configLlmDefaultprovider`) are cold on a chat page, since only the Settings AI surfaces warm them. The red window lasted as long as those round trips.

The billing Plan tile does **not** share this defect: `plan-card.tsx` derives both its readings from the single summary query and has no amber state, so there is no classification to race.

## The fix

- The gate now returns `{ suppress, settled, routeKnown }`. `suppress` is unchanged branch for branch, so the credit wall and the composer's billing banner keep their behaviour exactly. `settled` is false whenever `suppress` reflects the absence of evidence rather than evidence itself, including an enabled fetch parked by the offline network mode. `routeKnown` is false when the classification failed open on a read that never answered, which `suppress` cannot express because a banner treats "unknown route" and "managed route" identically. The positive claim requires both.
- The panel draws the bar at its true length as soon as there is a ratio, which is honest at 100% and is the one thing that cannot be wrong, then waits for `settled` before committing to a colour.
- The exhausted strip rides the same signal, so it and the bar's colour land on one render instead of the strip growing the popover a beat later.
- The body slot reserves `min-h-3`, the taller of the 10px bar and the 12px line box, so the bar↔line swap costs no reflow.
- **Second, independent flash fixed:** the menu's credits row needs only the summary, while the panel that replaces it also needs the subscription. An unguarded `usage == null` showed the dollar row in the gap between the two and then swapped it out. It now waits for the same signal, so the menu picks one surface and keeps it.
- `useSuppressCreditBannersForByok` had no callers left and is deleted rather than kept as a pass-through. That boolean is the defect; leaving it exported invites the next caller to negate it the same way.

## Why the tests missed it

Every existing double answered instantly (`(candidate) => candidate && byokRoute`), and `use-byok-credit-banner-gate.ts` had **no test file at all**, so the `isLoading` branch and the disabled-and-dataless branch were never exercised. This adds that file with 9 cases covering the full matrix, and two staged panel tests that were confirmed to fail against the old colour rule and pass against the new one.

## Decisions worth knowing

- `cannotAskYet` is `assistantId == null` **only**. It deliberately does not also gate on the assistant identity store's `version`, which stays null forever on a transient identity-fetch failure. That would hold the panel neutral permanently and hide the exhausted "Add credits" strip from someone genuinely out of credits. Safe because `lifecycle-service.ts` writes `setActiveAssistantId` in the same synchronous tick as the `active` transition, so React batches them and `enabled && assistantId == null` is unreachable in production.
- The Storybook harness seeds the lifecycle store directly, which makes `enabled` true while the classifier can never ask anything. `SeededPanel` now also seeds `activeAssistantId` and primes the two ungated classifier reads, or five stories would render the pre-settle bar instead of the state each documents.

## Known remainders

- With a warm connections cache (having visited Settings → AI earlier in the session), the two version-gated queries flipping disabled→loading can still produce amber → neutral → amber. Closing it needs a `versionResolved` flag on the identity store.
- Two sub-threshold flaps that are pre-existing in `suppress`, not introduced here: navigating conversations with the popover open, and the `useUtcDay` rollover minting a fresh totals key at UTC midnight.
- `suppress` still reads `isLoading`, so an offline-paused query fails open on the banner path. `settled` treats it as unsettled (see the review thread), but the credit wall's own behaviour there is left exactly as it was: changing it would break this PR's guarantee that `suppress` is byte-identical branch for branch. Worth a follow-up if the credit wall should stay down while offline.

## Verification

- `bun run typecheck` clean
- `bun run lint` 0 errors
- `bun run test:ci` 1184 passed / 1 failed. The failure is `src/utils/daily-reset-time.test.ts`, byte-identical to `origin/main`, failing on an ICU difference in this Bun build (`"12:00 AM GMT"` vs `"12:00 AM GMT+0"`). Present on main, unrelated to this change.

**Manual QA still owed:** the diagnosis is a code trace, never reproduced in a browser. Throttle the network in devtools, open the preferences menu cold, and record the panel's states. Expected: neutral bar → amber, with no red at any point and no dollar row appearing first. If red still shows, there is a third source worth finding before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7Zo49F2wiQrwaMR6rRpJg


