### PR TITLE
fix(web): activation checklist end-to-end polish

### DIFF
--- a/clients/web/src/domains/activation/components/activation-suggestions-pill.tsx
+++ b/clients/web/src/domains/activation/components/activation-suggestions-pill.tsx
@@ -69,10 +69,12 @@ export function ActivationSuggestionsPill({
         aria-hidden="true"
         className="h-[2px] w-[2px] shrink-0 rounded-full bg-[var(--content-tertiary)] max-[479px]:hidden"
       />
+      {/* Secondary rather than tertiary: at 12px the tertiary ink misses AA on
+          the pill's ground, and on a phone this count is the whole label. */}
       <Typography
         as="span"
         variant="body-small-default"
-        className="pr-1 text-[var(--content-tertiary)]"
+        className="pr-1 text-[var(--content-secondary)]"
       >
         {t("pill.progress", { done, total })}
       </Typography>

--- a/clients/web/src/domains/activation/components/activation-task-row.test.tsx
+++ b/clients/web/src/domains/activation/components/activation-task-row.test.tsx
@@ -161,6 +161,31 @@ describe("ActivationTaskRow", () => {
     expect(getByText("4 steps")).not.toBeNull();
   });
 
+  // A turn that called no tools has no count worth reporting, and "0 steps"
+  // reads as if nothing happened.
+  test("a task that used no tools says only how it ended", () => {
+    const { getByText, queryByText } = render(
+      <ActivationTaskRow
+        task={TASK}
+        progress={doneTaskProgress({ stepCount: 0 })}
+      />,
+    );
+    expect(getByText("Done")).not.toBeNull();
+    expect(queryByText("0 steps")).toBeNull();
+  });
+
+  test("a working row with no tool calls yet shows no count", () => {
+    const { getByText, queryByText } = render(
+      <ActivationTaskRow
+        task={TASK}
+        progress={startedTaskProgress({ stepCount: 0 })}
+        onOpenConversation={() => {}}
+      />,
+    );
+    expect(getByText("Working")).not.toBeNull();
+    expect(queryByText("0 steps")).toBeNull();
+  });
+
   test("an expanded task with a link renders its call to action", () => {
     const { getByText } = render(
       <ActivationTaskRow task={LINKED_TASK} expanded />,

--- a/clients/web/src/domains/activation/components/activation-task-row.tsx
+++ b/clients/web/src/domains/activation/components/activation-task-row.tsx
@@ -130,10 +130,11 @@ export function ActivationTaskRow({
   const conversationId = progress?.conversationId;
   const customId = `activation-custom-${task.id}`;
 
+  // A count of zero is a turn that called no tools, which the pill has nothing
+  // to report, so the state stands on its own rather than reading "0 steps".
+  const stepCount = progress?.stepCount ?? 0;
   const steps =
-    progress?.stepCount != null
-      ? t("row.steps", { count: progress.stepCount })
-      : undefined;
+    stepCount > 0 ? t("row.steps", { count: stepCount }) : undefined;
 
   const activate = (): void => {
     if (working || done) {
@@ -256,7 +257,9 @@ export function ActivationTaskRow({
     );
   }
 
-  const mutedText = done ? "text-[var(--content-tertiary)]" : undefined;
+  // A finished row steps back rather than disappearing. Secondary is the step
+  // that still clears AA against the row's ground at this size.
+  const mutedText = done ? "text-[var(--content-secondary)]" : undefined;
   const interactive = status === "todo" || conversationId !== undefined;
   // On the list the row is the launch, so a launch in flight has to disable
   // it; the button stays rather than vanishing, because taking the control out
@@ -282,13 +285,10 @@ export function ActivationTaskRow({
         title={<span className={mutedText}>{task.title}</span>}
         subtitle={
           // `ListRow` sets the subtitle a rung lower than the mock; the row's
-          // descriptions are full sentences and need the 11px step.
-          <span
-            className={cn(
-              "text-label-medium-default leading-normal",
-              mutedText,
-            )}
-          >
+          // descriptions are full sentences and need the 11px step, and the
+          // secondary ink over the row's tertiary default so a sentence at
+          // that size still clears AA.
+          <span className="text-label-medium-default leading-normal text-[var(--content-secondary)]">
             {task.description}
           </span>
         }

--- a/clients/web/src/domains/activation/hooks/use-activation-visibility.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-activation-visibility.test.tsx
@@ -30,17 +30,15 @@ let progress: ActivationProgress | undefined;
 // Spread the real module: `mock.module` replaces it for every test file
 // sharing this process, so returning only the mocked export would erase the
 // rest for anything that loads it later.
-const progressModule = await import(
-  "@/domains/activation/hooks/use-activation-progress"
-);
+const progressModule =
+  await import("@/domains/activation/hooks/use-activation-progress");
 mock.module("@/domains/activation/hooks/use-activation-progress", () => ({
   ...progressModule,
   useActivationProgress: () => ({ data: progress }),
 }));
 
-const { useActivationVisibility } = await import(
-  "@/domains/activation/hooks/use-activation-visibility"
-);
+const { useActivationVisibility } =
+  await import("@/domains/activation/hooks/use-activation-visibility");
 
 function wrapper(pathname: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -110,6 +108,12 @@ describe("useActivationVisibility gates", () => {
 
   test("hides everything on an onboarding route", () => {
     expect(visibility("/assistant/onboarding/research").surface).toBeNull();
+  });
+
+  // The page the user opened is the whole checklist; a modal over it hides
+  // what they came for and a pill beside it points at where they already are.
+  test("hides everything on the Inspiration List", () => {
+    expect(visibility("/assistant/suggestions").surface).toBeNull();
   });
 
   test("hides everything while the in-chat tour is running", () => {

--- a/clients/web/src/domains/activation/hooks/use-activation-visibility.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-activation-visibility.test.tsx
@@ -116,6 +116,17 @@ describe("useActivationVisibility gates", () => {
     expect(visibility("/assistant/suggestions").surface).toBeNull();
   });
 
+  test("hides everything on a page nested under the Inspiration List", () => {
+    expect(visibility("/assistant/suggestions/task-1").surface).toBeNull();
+  });
+
+  // The match is on the segment boundary, so a sibling route that merely
+  // starts with the same characters still gets the pill.
+  test("shows the pill on a route that only shares the list's prefix", () => {
+    progress = ACTIVATION_PROGRESS_DISMISSED;
+    expect(visibility("/assistant/suggestions-archive").surface).toBe("pill");
+  });
+
   test("hides everything while the in-chat tour is running", () => {
     useInChatOnboardingStore.setState({ prototypeActive: true });
     expect(visibility().surface).toBeNull();

--- a/clients/web/src/domains/activation/hooks/use-activation-visibility.ts
+++ b/clients/web/src/domains/activation/hooks/use-activation-visibility.ts
@@ -61,9 +61,16 @@ function isOnboardingRoute(pathname: string): boolean {
  * The Inspiration List is this checklist, in full and already launchable. A
  * modal over it hides what the user opened, and a pill beside it points at the
  * page they are on.
+ *
+ * Matched on the segment boundary rather than by prefix, so a sibling route
+ * that happens to share the first characters of this one (a
+ * `/assistant/suggestions-archive`) keeps the surfaces it is entitled to.
  */
 function isActivationListRoute(pathname: string): boolean {
-  return pathname.startsWith(routes.activationList);
+  return (
+    pathname === routes.activationList ||
+    pathname.startsWith(`${routes.activationList}/`)
+  );
 }
 
 /** How many of a list's three starters the daemon has marked done. */

--- a/clients/web/src/domains/activation/hooks/use-activation-visibility.ts
+++ b/clients/web/src/domains/activation/hooks/use-activation-visibility.ts
@@ -10,8 +10,8 @@
  * support gate and the daemon's frozen list, the three every activation
  * surface shares), then the server read, then
  * the surfaces this one must not fight with: onboarding routes and the in-chat
- * tour own the screen while they run, and a banner already occupies the slot
- * the pill would take.
+ * tour own the screen while they run, the Inspiration List is already the whole
+ * checklist, and a banner occupies the slot the pill would take.
  */
 
 import { useLocation } from "react-router";
@@ -57,6 +57,15 @@ function isOnboardingRoute(pathname: string): boolean {
   );
 }
 
+/**
+ * The Inspiration List is this checklist, in full and already launchable. A
+ * modal over it hides what the user opened, and a pill beside it points at the
+ * page they are on.
+ */
+function isActivationListRoute(pathname: string): boolean {
+  return pathname.startsWith(routes.activationList);
+}
+
 /** How many of a list's three starters the daemon has marked done. */
 export function doneStarterCount(
   progress: ActivationProgress,
@@ -78,7 +87,12 @@ export function useActivationVisibility(): ActivationVisibility {
   if (listId === null || !progress) {
     return HIDDEN;
   }
-  if (isOnboardingRoute(pathname) || tourActive || bannerVisible) {
+  if (
+    isOnboardingRoute(pathname) ||
+    isActivationListRoute(pathname) ||
+    tourActive ||
+    bannerVisible
+  ) {
     return HIDDEN;
   }
 

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.test.tsx
@@ -667,6 +667,48 @@ describe("useLaunchActivationTask progress cache", () => {
     expect(tasks["weekly-report"]?.status).toBe("started");
   });
 
+  // The user closes the modal while a launch is in flight, so the snapshot the
+  // start answers with predates the dismissal. Taking it wholesale would
+  // reopen the modal over the chat the user just went back to.
+  test("keeps a dismissal the answered snapshot was taken before", async () => {
+    queryClient.setQueryData(PROGRESS_KEY, {
+      ...startedProgress,
+      modalDismissedAt: "2026-09-03T10:00:00.000Z",
+      allDoneShownAt: "2026-09-03T10:05:00.000Z",
+    });
+    startBody = {
+      ...startedProgress,
+      modalDismissedAt: null,
+      allDoneShownAt: null,
+    };
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(cachedProgress()?.modalDismissedAt).toBe("2026-09-03T10:00:00.000Z");
+    expect(cachedProgress()?.allDoneShownAt).toBe("2026-09-03T10:05:00.000Z");
+  });
+
+  // Another client dismissed it, and the daemon's answer is the newer of the
+  // two records.
+  test("takes the later of two dismissal stamps", async () => {
+    queryClient.setQueryData(PROGRESS_KEY, {
+      ...startedProgress,
+      modalDismissedAt: "2026-09-03T10:00:00.000Z",
+    });
+    startBody = {
+      ...startedProgress,
+      modalDismissedAt: "2026-09-03T11:00:00.000Z",
+    };
+    const result = launcher();
+    await act(async () => {
+      await result.current.launch("pdf-proposal");
+    });
+
+    expect(cachedProgress()?.modalDismissedAt).toBe("2026-09-03T11:00:00.000Z");
+  });
+
   test("writes the progress the daemon answered the start with", async () => {
     startBody = startedProgress;
     const result = launcher();

--- a/clients/web/src/domains/activation/hooks/use-launch-activation-task.ts
+++ b/clients/web/src/domains/activation/hooks/use-launch-activation-task.ts
@@ -115,6 +115,28 @@ function mergeAnsweredTasks(
 }
 
 /**
+ * The later of two dismissal stamps, where `null` means "not yet".
+ *
+ * These stamps say whether the modal is closed and whether the celebration has
+ * already run. A start is answered with a snapshot the daemon took while it
+ * handled that start, so a dismissal the user made in between is missing from
+ * it, and taking the answer wholesale would reopen the modal or replay the
+ * celebration. Both stamps are ISO-8601 UTC, so they order as strings.
+ */
+function laterStamp(
+  cached: string | null,
+  answered: string | null,
+): string | null {
+  if (cached === null) {
+    return answered;
+  }
+  if (answered === null) {
+    return cached;
+  }
+  return cached > answered ? cached : answered;
+}
+
+/**
  * A link the client never saw succeed. `rejected` is true only when the daemon
  * answered with a 4xx, which is the one case where the link certainly does not
  * exist.
@@ -168,10 +190,19 @@ function seedStartedTask(
       if (answered) {
         // Concurrent starts answer with snapshots taken at different points,
         // so an older answer must neither erase a task a newer one already
-        // seeded nor walk one of them back to an earlier status.
+        // seeded, nor walk one of them back to an earlier status, nor drop a
+        // dismissal the cache already holds.
         return cached
           ? {
               ...answered,
+              modalDismissedAt: laterStamp(
+                cached.modalDismissedAt,
+                answered.modalDismissedAt,
+              ),
+              allDoneShownAt: laterStamp(
+                cached.allDoneShownAt,
+                answered.allDoneShownAt,
+              ),
               tasks: mergeAnsweredTasks(cached.tasks, answered.tasks),
             }
           : answered;

--- a/clients/web/src/domains/activation/pages/activation-list-route.test.tsx
+++ b/clients/web/src/domains/activation/pages/activation-list-route.test.tsx
@@ -328,6 +328,40 @@ describe("ActivationListRoute before the gates settle", () => {
     expect(screen.queryByRole("listitem")).toBeNull();
   });
 
+  // A gate that has said no has settled the question. Waiting on the other one
+  // for a second opinion it cannot change is how an arm switched off leaves a
+  // bookmark on a page that renders nothing at all.
+  test("hands the user back to chat on an arm that is off, whatever the version is doing", () => {
+    setArm("off");
+    useAssistantIdentityStore.getState().clearIdentity();
+    renderWithPath();
+
+    expect(screen.getByTestId("pathname").textContent).toBe(routes.assistant);
+  });
+
+  // `fetchAssistantIdentity` turns an unreachable runtime into a successful
+  // `null`, so the version never lands and never will. The wait has to end on
+  // the fetch settling, not on a version that is not coming.
+  test("hands the user back to chat once the identity fetch has given up", () => {
+    useAssistantIdentityStore.getState().clearIdentity();
+    useAssistantIdentityStore.getState().markIdentityUnavailable("asst-1");
+    renderWithPath();
+
+    expect(screen.getByTestId("pathname").textContent).toBe(routes.assistant);
+  });
+
+  // The dead end is scoped like the version it stands in for: one recorded for
+  // the assistant the user just left says nothing about this one.
+  test("stays put when another assistant's identity fetch gave up", () => {
+    useAssistantIdentityStore.getState().clearIdentity();
+    useAssistantIdentityStore.getState().markIdentityUnavailable("asst-other");
+    renderWithPath();
+
+    expect(screen.getByTestId("pathname").textContent).toBe(
+      routes.activationList,
+    );
+  });
+
   test("stays put while the flag values are still in flight", () => {
     useClientFeatureFlagStore.setState({ hydrated: false });
     renderWithPath();

--- a/clients/web/src/domains/activation/pages/activation-list-route.test.tsx
+++ b/clients/web/src/domains/activation/pages/activation-list-route.test.tsx
@@ -19,7 +19,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 
 import {
   ACTIVATION_PROGRESS_EMPTY,
@@ -55,17 +55,15 @@ const toasts: CapturedToast[] = [];
 // Every mock spreads the real module: `mock.module` replaces it for the whole
 // test process, so returning only the overridden export would erase the rest
 // for any file that loads it later.
-const progressModule = await import(
-  "@/domains/activation/hooks/use-activation-progress"
-);
+const progressModule =
+  await import("@/domains/activation/hooks/use-activation-progress");
 mock.module("@/domains/activation/hooks/use-activation-progress", () => ({
   ...progressModule,
   useActivationProgress: () => ({ data: progress }),
 }));
 
-const launchModule = await import(
-  "@/domains/activation/hooks/use-launch-activation-task"
-);
+const launchModule =
+  await import("@/domains/activation/hooks/use-launch-activation-task");
 mock.module("@/domains/activation/hooks/use-launch-activation-task", () => ({
   ...launchModule,
   useLaunchActivationTask: () => ({
@@ -111,9 +109,8 @@ mock.module("@/utils/conversation-navigation", () => ({
   },
 }));
 
-const { ActivationListRoute } = await import(
-  "@/domains/activation/pages/activation-list-route"
-);
+const { ActivationListRoute } =
+  await import("@/domains/activation/pages/activation-list-route");
 
 const { starters } = getActivationList("smb");
 
@@ -129,6 +126,10 @@ function setArm(arm: string): void {
   useClientFeatureFlagStore
     .getState()
     .setStringFlags({ activationChecklist: arm }, null);
+  // The values a server response carries, and the fact that one has landed,
+  // are two writes on this store; the route waits for the second before it
+  // acts on the first.
+  useClientFeatureFlagStore.setState({ hydrated: true });
 }
 
 function renderRoute() {
@@ -140,7 +141,9 @@ beforeEach(() => {
   launchOutcome = { ok: true };
   setArm("smb");
   useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
-  useAssistantIdentityStore.getState().setIdentity("Vel", MIN_VERSION, "asst-1");
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("Vel", MIN_VERSION, "asst-1");
 });
 
 afterEach(() => {
@@ -291,5 +294,53 @@ describe("ActivationListRoute launch failures", () => {
       expect(launched).toEqual([FIXTURE_STARTER_IDS[0]]);
     });
     expect(toasts).toEqual([]);
+  });
+});
+
+/**
+ * A cold load has neither the flag values nor the assistant's version in hand,
+ * and both read as "off" until they land. The route must not spend that window
+ * redirecting: this page is reached by a bookmark, a reload and a fresh tab.
+ */
+describe("ActivationListRoute before the gates settle", () => {
+  function PathProbe(): ReactNode {
+    const { pathname } = useLocation();
+    return <div data-testid="pathname">{pathname}</div>;
+  }
+
+  function renderWithPath() {
+    return render(
+      <>
+        <ActivationListRoute />
+        <PathProbe />
+      </>,
+      { wrapper },
+    );
+  }
+
+  test("stays put while the assistant's version is unknown", () => {
+    useAssistantIdentityStore.getState().clearIdentity();
+    renderWithPath();
+
+    expect(screen.getByTestId("pathname").textContent).toBe(
+      routes.activationList,
+    );
+    expect(screen.queryByRole("listitem")).toBeNull();
+  });
+
+  test("stays put while the flag values are still in flight", () => {
+    useClientFeatureFlagStore.setState({ hydrated: false });
+    renderWithPath();
+
+    expect(screen.getByTestId("pathname").textContent).toBe(
+      routes.activationList,
+    );
+  });
+
+  test("hands the user back to chat once the gates have answered", () => {
+    setArm("off");
+    renderWithPath();
+
+    expect(screen.getByTestId("pathname").textContent).toBe(routes.assistant);
   });
 });

--- a/clients/web/src/domains/activation/pages/activation-list-route.tsx
+++ b/clients/web/src/domains/activation/pages/activation-list-route.tsx
@@ -13,7 +13,9 @@
  * shares, rather than the flag arm alone: the page is reachable by a bookmark,
  * and against an assistant too old for the `/v1/activation/*` routes every row
  * would offer a launch the daemon cannot link. Gated off, the route hands the
- * user back to chat.
+ * user back to chat, and it waits for `useActivationGatesSettled` before
+ * deciding that, because both gates read as off while they are still
+ * resolving.
  *
  * Mounted under `ActiveAssistantGate`, so `activeAssistantId` is resolved by
  * the time this renders and needs no second guard.
@@ -24,14 +26,16 @@ import { Navigate, useNavigate } from "react-router";
 
 import { toast } from "@vellumai/design-library/components/toast";
 
-import { useEffectiveActivationListId } from "@/hooks/use-activation-enabled";
+import {
+  useActivationGatesSettled,
+  useEffectiveActivationListId,
+} from "@/hooks/use-activation-enabled";
 import { useTranslation } from "@/i18n";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { routes } from "@/utils/routes";
 
-import { taskIsAvailable, useAvailableCapabilityTags } from "../capabilities";
-import { useActivationList } from "../catalog";
+import { useAvailableActivationList } from "../capabilities";
 import { ActivationListPage } from "../components/activation-list-page";
 import { useActivationProgress } from "../hooks/use-activation-progress";
 import { useLaunchActivationTask } from "../hooks/use-launch-activation-task";
@@ -41,19 +45,13 @@ export function ActivationListRoute() {
   const { t } = useTranslation("activation");
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const listId = useEffectiveActivationListId(assistantId);
+  const gatesSettled = useActivationGatesSettled(assistantId);
   const { data: progress } = useActivationProgress();
 
-  const { starters, items } = useActivationList(listId ?? "");
-  const availableTags = useAvailableCapabilityTags();
+  const { starters, items } = useAvailableActivationList(listId ?? "");
   const { launch, pendingTaskIds } = useLaunchActivationTask(listId ?? "");
 
-  const tasks = useMemo(
-    () =>
-      [...starters, ...items].filter((task) =>
-        taskIsAvailable(task, availableTags),
-      ),
-    [starters, items, availableTags],
-  );
+  const tasks = useMemo(() => [...starters, ...items], [starters, items]);
 
   // The page is the point of the launch, so the user stays on it and the row
   // flips to Working; the conversation runs in the background. A failure has
@@ -84,7 +82,11 @@ export function ActivationListRoute() {
   );
 
   if (listId === null) {
-    return <Navigate to={routes.assistant} replace />;
+    // A gate that has not answered yet is not a gate that said no: on a cold
+    // load the flag values and the assistant's version are both still in
+    // flight, and redirecting on that would bounce every bookmark, reload and
+    // new tab straight back to chat.
+    return gatesSettled ? <Navigate to={routes.assistant} replace /> : null;
   }
 
   return (

--- a/clients/web/src/domains/chat/components/chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/components/chat-empty-state.tsx
@@ -5,7 +5,7 @@ import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-c
  * Empty-state hero for a fresh chat: the serif greeting headline. The
  * avatar itself lives in `ComposerPeek` (hanging from the top of the
  * screen, or peeking behind the input), not beside the headline.
- * Presentational only — the composer and conversation-starter chips are
+ * Presentational only: the composer and conversation-starter chips are
  * rendered by the parent `ChatBody` in the same flex column so that
  * greeting → composer → starters appear as one vertically-centered group.
  *
@@ -14,7 +14,7 @@ import { DEFAULT_EMPTY_STATE_GREETING } from "@/domains/chat/utils/empty-state-c
  * inner `min-h-full` wrapper), not here. This component just renders its
  * content at natural height.
  *
- * See [React — Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)
+ * See [React: Preserving and Resetting State](https://react.dev/learn/preserving-and-resetting-state)
  * for why the composer must stay at a fixed tree position rather than
  * being passed as a slot into this component.
  */
@@ -48,7 +48,7 @@ export function ChatEmptyState({
             <BusyIndicator size={10} />
           ) : (
             /* The serif brand headline (Figma "Brand/Medium": Instrument
-               Serif 32px) — larger than the old title tokens, scaled down
+               Serif 32px), larger than the old title tokens, scaled down
                a step on mobile. */
             <h1
               className="text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasised)] md:text-[36px]"

--- a/clients/web/src/domains/chat/components/chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/components/chat-empty-state.tsx
@@ -51,7 +51,7 @@ export function ChatEmptyState({
                Serif 32px) — larger than the old title tokens, scaled down
                a step on mobile. */
             <h1
-              className="text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasized)] md:text-[36px]"
+              className="text-center text-[28px] leading-[1.2] tracking-[0.02em] text-[var(--content-emphasised)] md:text-[36px]"
               style={{ fontFamily: "var(--font-serif)" }}
             >
               {greeting}

--- a/clients/web/src/hooks/use-activation-enabled.ts
+++ b/clients/web/src/hooks/use-activation-enabled.ts
@@ -24,7 +24,9 @@ import {
   useActivationChecklistArm,
   type ActivationListId,
 } from "@/hooks/use-activation-checklist-flag";
+import { useAssistantVersionKnownFor } from "@/lib/backwards-compat/utils";
 import { useSupportsActivationProgress } from "@/lib/backwards-compat/use-supports-activation-progress";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 /**
  * The list the arm selects on `assistantId`, or `null` when either gate fails.
@@ -68,4 +70,23 @@ export function useEffectiveActivationListId(
   // A frozen id this bundle has no catalog for (written by a newer client)
   // hides the surfaces rather than enabling an empty list.
   return isActivationListId(frozen) ? frozen : null;
+}
+
+/**
+ * Whether the gates above can answer yet.
+ *
+ * Both of their inputs start on a value that reads exactly like "off": the flag
+ * store answers the registry default until the first server response, and the
+ * version gate answers `false` until identity lands for this assistant. A
+ * surface that only hides is right to treat that as off and let the answer
+ * arrive. A surface that navigates is not: the Inspiration List is reachable by
+ * a bookmark, a reload and a fresh tab, and a redirect fired on the unsettled
+ * answer takes the user to chat before either gate has spoken.
+ */
+export function useActivationGatesSettled(
+  assistantId: string | null | undefined,
+): boolean {
+  const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
+  const versionKnown = useAssistantVersionKnownFor(assistantId);
+  return flagsHydrated && versionKnown;
 }

--- a/clients/web/src/hooks/use-activation-enabled.ts
+++ b/clients/web/src/hooks/use-activation-enabled.ts
@@ -24,9 +24,51 @@ import {
   useActivationChecklistArm,
   type ActivationListId,
 } from "@/hooks/use-activation-checklist-flag";
-import { useAssistantVersionKnownFor } from "@/lib/backwards-compat/utils";
+import { useAssistantIdentitySettledFor } from "@/lib/backwards-compat/utils";
 import { useSupportsActivationProgress } from "@/lib/backwards-compat/use-supports-activation-progress";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+/**
+ * What one of the two gates has to say.
+ *
+ * Both start on an input that reads exactly like "off": the flag store answers
+ * the registry default until the first server response, and the version gate
+ * answers `false` until identity lands for this assistant. Collapsing that into
+ * a boolean is what a surface that only hides wants and what a surface that
+ * navigates cannot use, so the third value is kept: `"unknown"` is a gate that
+ * has not spoken, and only `"disabled"` is a no.
+ */
+type ActivationGate = "unknown" | "enabled" | "disabled";
+
+/** The flag arm's gate. `"unknown"` until the first server response lands. */
+function useActivationArmGate(): ActivationGate {
+  const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
+  const arm = useActivationChecklistArm();
+  if (!flagsHydrated) {
+    return "unknown";
+  }
+  return resolveActivationListId(arm) === null ? "disabled" : "enabled";
+}
+
+/**
+ * The daemon's gate: whether this assistant carries the `/v1/activation/*`
+ * routes every surface reads and writes.
+ *
+ * `"unknown"` only while the identity fetch is still in flight. A fetch that
+ * finished with nothing is a `"disabled"` answer, not a wait that never ends:
+ * an assistant whose version we will never learn cannot be shown launches the
+ * daemon may not be able to link.
+ */
+function useActivationVersionGate(
+  assistantId: string | null | undefined,
+): ActivationGate {
+  const supported = useSupportsActivationProgress(assistantId);
+  const identitySettled = useAssistantIdentitySettledFor(assistantId);
+  if (supported) {
+    return "enabled";
+  }
+  return identitySettled ? "disabled" : "unknown";
+}
 
 /**
  * The list the arm selects on `assistantId`, or `null` when either gate fails.
@@ -38,8 +80,8 @@ function useActivationEnabledListId(
   assistantId: string | null | undefined,
 ): ActivationListId | null {
   const arm = useActivationChecklistArm();
-  const supported = useSupportsActivationProgress(assistantId);
-  return supported ? resolveActivationListId(arm) : null;
+  const versionGate = useActivationVersionGate(assistantId);
+  return versionGate === "enabled" ? resolveActivationListId(arm) : null;
 }
 
 /**
@@ -75,18 +117,24 @@ export function useEffectiveActivationListId(
 /**
  * Whether the gates above can answer yet.
  *
- * Both of their inputs start on a value that reads exactly like "off": the flag
- * store answers the registry default until the first server response, and the
- * version gate answers `false` until identity lands for this assistant. A
- * surface that only hides is right to treat that as off and let the answer
- * arrive. A surface that navigates is not: the Inspiration List is reachable by
- * a bookmark, a reload and a fresh tab, and a redirect fired on the unsettled
- * answer takes the user to chat before either gate has spoken.
+ * A surface that only hides is right to treat an unspoken gate as off and let
+ * the answer arrive. A surface that navigates is not: the Inspiration List is
+ * reachable by a bookmark, a reload and a fresh tab, and a redirect fired on
+ * the unsettled answer takes the user to chat before either gate has spoken.
+ * Such a caller waits on this.
+ *
+ * Disabled wins outright. A gate that has said no has settled the question,
+ * and holding the page blank for a second opinion the answer cannot change is
+ * how an arm switched off, or an identity fetch that never lands, turns a
+ * bookmark into a page that renders nothing at all.
  */
 export function useActivationGatesSettled(
   assistantId: string | null | undefined,
 ): boolean {
-  const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
-  const versionKnown = useAssistantVersionKnownFor(assistantId);
-  return flagsHydrated && versionKnown;
+  const armGate = useActivationArmGate();
+  const versionGate = useActivationVersionGate(assistantId);
+  if (armGate === "disabled" || versionGate === "disabled") {
+    return true;
+  }
+  return armGate !== "unknown" && versionGate !== "unknown";
 }

--- a/clients/web/src/hooks/use-assistant-identity-init.test.tsx
+++ b/clients/web/src/hooks/use-assistant-identity-init.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * What the store learns from the identity fetch, including the ending the
+ * store could not see before: a fetch that finished with nothing.
+ *
+ * `fetchAssistantIdentity` turns an unreachable runtime into a successful
+ * `null`, so "still asking" and "asked and got nothing" both leave `version`
+ * null. A consumer that has to decide something (a route that redirects when
+ * the feature is off) needs those two apart, and this is the seam that tells
+ * them apart.
+ */
+
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import type { IdentityGetResponse } from "@/generated/daemon/types.gen";
+
+let identityResult: IdentityGetResponse | null = null;
+
+// Every mock spreads the real module: `mock.module` replaces it for the whole
+// test process, so returning only the overridden export would erase the rest
+// for any file that loads it later.
+const identityModule = await import("@/assistant/identity");
+mock.module("@/assistant/identity", () => ({
+  ...identityModule,
+  fetchAssistantIdentity: async () => identityResult,
+}));
+
+const prechatModule = await import("@/domains/onboarding/prechat");
+mock.module("@/domains/onboarding/prechat", () => ({
+  ...prechatModule,
+  consumePendingAssistantName: () => null,
+}));
+
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
+const { useAssistantIdentityInit } =
+  await import("@/hooks/use-assistant-identity-init");
+
+const ASSISTANT_ID = "asst-1";
+
+const IDENTITY: IdentityGetResponse = {
+  name: "Vel",
+  role: "assistant",
+  personality: "helpful",
+  emoji: "*",
+  home: "/home/vel",
+  version: "0.11.9",
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return createElement(QueryClientProvider, { client }, children);
+}
+
+function renderInit() {
+  return renderHook(
+    () =>
+      useAssistantIdentityInit({
+        assistantId: ASSISTANT_ID,
+        assistantStateKind: "active",
+      }),
+    { wrapper },
+  );
+}
+
+beforeEach(() => {
+  identityResult = null;
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+afterEach(() => {
+  cleanup();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+describe("useAssistantIdentityInit", () => {
+  test("records the dead end when the fetch answers with no identity", async () => {
+    renderInit();
+
+    await waitFor(() => {
+      expect(useAssistantIdentityStore.getState().unavailableFor).toBe(
+        ASSISTANT_ID,
+      );
+    });
+    // The version stays absent rather than being invented: a later refetch may
+    // still answer.
+    expect(useAssistantIdentityStore.getState().version).toBeNull();
+  });
+
+  test("an identity that lands leaves no dead end recorded", async () => {
+    identityResult = IDENTITY;
+    renderInit();
+
+    await waitFor(() => {
+      expect(useAssistantIdentityStore.getState().version).toBe("0.11.9");
+    });
+    expect(useAssistantIdentityStore.getState().unavailableFor).toBeNull();
+  });
+
+  // A refetch that succeeds has to lift the bit, or every surface that acted
+  // on it stays wrong for the rest of the session.
+  test("an identity in hand lifts a dead end recorded earlier", () => {
+    useAssistantIdentityStore.getState().markIdentityUnavailable(ASSISTANT_ID);
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("Vel", "0.11.9", ASSISTANT_ID);
+
+    expect(useAssistantIdentityStore.getState().unavailableFor).toBeNull();
+  });
+});

--- a/clients/web/src/hooks/use-assistant-identity-init.ts
+++ b/clients/web/src/hooks/use-assistant-identity-init.ts
@@ -3,7 +3,7 @@
  * Zustand `useAssistantIdentityStore` for the whole authenticated app.
  *
  * Mounted in `RootLayout` so identity is populated on every route under
- * `/assistant/*` — chat, settings, logs — not only while a chat route is
+ * `/assistant/*` (chat, settings, logs), not only while a chat route is
  * on screen. Consumers include the chat sidebar header, the
  * intelligence/identity tab, and `useElectronIdentitySync` (which titles
  * the Electron window, tray, and About panel from the store name).
@@ -11,11 +11,11 @@
  * Hydration sources, in order: the optimistic onboarding seed
  * (`consumePendingAssistantName`), then the daemon `/identity` fetch via
  * TanStack Query. SSE `identity_changed` refreshes are written to the
- * store directly by `ChatPage` — idempotent with this hook.
+ * store directly by `ChatPage`, idempotent with this hook.
  *
  * Lives in top-level `hooks/` (not under `domains/`) because the
- * assistant identity is consumed by multiple domains — chat sidebar,
- * intelligence/identity tab, library, contacts — with no single
+ * assistant identity is consumed by multiple domains (chat sidebar,
+ * intelligence/identity tab, library, contacts) with no single
  * domain owner. See CONVENTIONS.md → Top-level shared directories.
  *
  * Pattern (server state in TanStack Query, synced into Zustand for
@@ -49,7 +49,7 @@ export function useAssistantIdentityInit({
   assistantStateKind,
 }: UseAssistantIdentityInitParams) {
   // Identity is fetchable whenever the daemon proxy can answer for the
-  // assistant — that's true for "active" *and* "self_hosted" (which
+  // assistant. That's true for "active" *and* "self_hosted" (which
   // also renders chat per `shouldRenderChat` in ChatPage). The other
   // lifecycle states (initializing, cleaning_up, retired, error, etc.)
   // can't satisfy the identity endpoint.
@@ -110,7 +110,7 @@ export function useAssistantIdentityInit({
     const data = identityQuery.data;
     // `fetchAssistantIdentity` returns null on transient failures
     // (initializing assistant, unreachable runtime). Don't clobber a
-    // good cached name with a transient null on the same assistant —
+    // good cached name with a transient null on the same assistant:
     // cross-assistant clears are handled by the effect above.
     if (!data) {
       return;
@@ -120,4 +120,19 @@ export function useAssistantIdentityInit({
       .setIdentity(data.name ?? null, data.version ?? null, assistantId);
     lastWrittenForRef.current = assistantId;
   }, [identityQuery.data, assistantId]);
+
+  // The fetch has run and produced nothing: it errored, or it resolved to the
+  // `null` `fetchAssistantIdentity` returns for an unreachable runtime. The
+  // store keeps its (absent) name and version, since a later refetch may still
+  // answer, and records the dead end so a consumer that has to decide
+  // something can stop waiting. Declared after the write above so a refetch
+  // that lands data clears the bit in the same commit that sets the version.
+  const identityUnavailable =
+    canFetchIdentity && identityQuery.isFetched && !identityQuery.data;
+  useEffect(() => {
+    if (!identityUnavailable) {
+      return;
+    }
+    useAssistantIdentityStore.getState().markIdentityUnavailable(assistantId);
+  }, [identityUnavailable, assistantId]);
 }

--- a/clients/web/src/lib/backwards-compat/utils.ts
+++ b/clients/web/src/lib/backwards-compat/utils.ts
@@ -40,7 +40,7 @@ import { whenStoreState } from "@/utils/when-store-state";
  *   patch version bumps.
  * - `dev` pre-releases (e.g. `0.10.0-dev.202606211252.5cf8576`) are
  *   treated as AHEAD of the stable release with the same base version
- *   (the opposite of strict semver) — they contain unreleased commits.
+ *   (the opposite of strict semver): they contain unreleased commits.
  *   Two dev builds with the same base compare by their pre-release
  *   string (which encodes a timestamp). This lets gates target a
  *   specific dev build by passing the exact version string as
@@ -55,15 +55,15 @@ export function useAssistantSupports(minVersion: string): boolean {
 /**
  * Assistant-scoped variant of `useAssistantSupports`: returns `true` only
  * when the active assistant's version meets `minVersion` AND the identity
- * store's version was fetched for `ownerAssistantId` — the assistant that
+ * store's version was fetched for `ownerAssistantId`, the assistant that
  * owns whatever the caller is gating (a transcript, a live voice session).
  *
- * Both the version and its owner are read from the identity store — a
+ * Both the version and its owner are read from the identity store, a
  * single atomic snapshot (`setIdentity` writes them in the same store
- * update) — so the version can never be checked against a different
+ * update), so the version can never be checked against a different
  * assistant's feature surface, even transiently during an assistant
- * switch. Comparing against the identity store's own `assistantId` —
- * rather than `activeAssistantId` from the resolved-assistants store —
+ * switch. Comparing against the identity store's own `assistantId`,
+ * rather than `activeAssistantId` from the resolved-assistants store,
  * keeps the check race-free: the two stores update at different times, so
  * a cross-store pairing could briefly validate against the previous
  * assistant's version.
@@ -114,6 +114,35 @@ export function useAssistantVersionKnownFor(
 }
 
 /**
+ * Whether the identity fetch for `ownerAssistantId` has finished asking,
+ * whatever it came back with: a version landed, or the fetch reached a dead
+ * end (it errored, or `fetchAssistantIdentity` swallowed an unreachable
+ * runtime into a `null`).
+ *
+ * {@link useAssistantVersionKnownFor} is the wait a caller wants while the
+ * answer is still coming. It is not the wait a caller wants when the answer
+ * never comes: a fetch that exhausted its retries leaves the version `null`
+ * forever, and a surface that navigates on the resolved gate would hold a deep
+ * link on a blank page for the rest of the session. This says "stop waiting"
+ * for both endings, so such a caller can act on the conservative `false` the
+ * version gates report rather than sit on it.
+ *
+ * A null owner has nothing to wait for and reports `true`, matching
+ * {@link whenAssistantVersionKnownFor}: the scoped gates answer `false` for
+ * one regardless.
+ */
+export function useAssistantIdentitySettledFor(
+  ownerAssistantId: string | null | undefined,
+): boolean {
+  const versionKnown = useAssistantVersionKnownFor(ownerAssistantId);
+  const unavailableFor = useAssistantIdentityStore.use.unavailableFor();
+  if (ownerAssistantId == null) {
+    return true;
+  }
+  return versionKnown || unavailableFor === ownerAssistantId;
+}
+
+/**
  * Non-hook variant of `useAssistantSupports`: reads the version
  * snapshot via `useAssistantIdentityStore.getState()` so it's safe to
  * call from non-hook contexts (event handlers, async ops, request
@@ -131,7 +160,7 @@ export function assistantSupports(minVersion: string): boolean {
 
 /**
  * Non-hook variant of {@link useAssistantScopedSupports}, for imperative
- * callers (event handlers, async ops) — same owner-scoping rule, read off a
+ * callers (event handlers, async ops): same owner-scoping rule, read off a
  * `getState()` snapshot.
  *
  * Narrows `ownerAssistantId` to `string`: a null/undefined owner is never
@@ -186,7 +215,7 @@ export function versionSupports(
   }
   // Base versions are equal. Build pre-releases (`0.10.0-dev.…` from CI,
   // `0.11.8-local.…` from a `vel up` image) are development builds AHEAD
-  // of the stable release with the same base — they contain unreleased
+  // of the stable release with the same base: they contain unreleased
   // commits on top of it. So a dev build of 0.10.0 is newer than the
   // 0.10.0 stable release, not older (the opposite of strict semver).
   const versionBuild = parseBuildPreRelease(parsed.pre);
@@ -202,7 +231,7 @@ export function versionSupports(
     // A build is ahead of stable with the same base.
     return versionBuild !== null;
   }
-  // Neither is a build — existing convention: strip pre-release
+  // Neither is a build. Existing convention: strip pre-release
   // suffixes, equal base versions count as supported (rc/beta/alpha
   // testers get the new path the moment the patch version bumps).
   return true;
@@ -244,7 +273,7 @@ export const VERSION_RESOLUTION_TIMEOUT_MS = 5_000;
  * after `timeoutMs` if it never hydrates.
  *
  * The version snapshot starts `null` and is hydrated asynchronously by
- * the identity fetch (`useAssistantIdentityInit`) — onboarding even
+ * the identity fetch (`useAssistantIdentityInit`); onboarding even
  * seeds a usable assistant with a still-`null` version. The sync
  * `assistantSupports` snapshot collapses "unknown" and "known-old" into
  * a single `false`, which is safe for read paths that fall back to a

--- a/clients/web/src/lib/backwards-compat/utils.ts
+++ b/clients/web/src/lib/backwards-compat/utils.ts
@@ -88,6 +88,32 @@ export function useAssistantScopedSupports(
 }
 
 /**
+ * Whether the identity store holds a version fetched for `ownerAssistantId`.
+ *
+ * The gates above collapse "older than the floor" and "not known yet" into one
+ * `false`, which is the right answer for a surface that hides and the wrong one
+ * for a surface that navigates: a redirect fired on the unresolved answer sends
+ * a deep link somewhere else before the version has landed. This is the second
+ * bit, so such a caller can wait instead of acting on a gate that has not
+ * spoken.
+ *
+ * Owner-scoped for the same reason {@link useAssistantScopedSupports} is: a
+ * version still held for the assistant the user just left says nothing about
+ * this one.
+ */
+export function useAssistantVersionKnownFor(
+  ownerAssistantId: string | null | undefined,
+): boolean {
+  const identityAssistantId = useAssistantIdentityStore.use.assistantId();
+  const version = useAssistantIdentityStore.use.version();
+  return (
+    version !== null &&
+    ownerAssistantId != null &&
+    ownerAssistantId === identityAssistantId
+  );
+}
+
+/**
  * Non-hook variant of `useAssistantSupports`: reads the version
  * snapshot via `useAssistantIdentityStore.getState()` so it's safe to
  * call from non-hook contexts (event handlers, async ops, request

--- a/clients/web/src/stores/assistant-identity-store.ts
+++ b/clients/web/src/stores/assistant-identity-store.ts
@@ -5,7 +5,7 @@
  * assistant-context changes); `ChatLayout` reads name/version for the
  * sidebar header and `PreferencesMenu`. `ChatPage` also writes from its
  * own local state when the assistant pushes a fresher identity (SSE
- * `identity_changed`) — idempotent with the layout write.
+ * `identity_changed`), idempotent with the layout write.
  *
  * A Zustand store avoids prop drilling through the React Router
  * outlet context for simple scalar values.
@@ -36,11 +36,23 @@ interface AssistantIdentityState {
    * to a specific assistant (rather than "whatever identity is
    * currently hydrated") compare against this instead of pairing the
    * version with `activeAssistantId` from the resolved-assistants
-   * store — the two stores update at different times on assistant
+   * store, since the two stores update at different times on assistant
    * switch, so a cross-store pairing can read a stale version for one
    * render until the clear effect runs.
    */
   assistantId: string | null;
+  /**
+   * The assistant whose identity fetch has settled without producing an
+   * identity: the request errored, or `fetchAssistantIdentity` swallowed an
+   * unreachable runtime into a `null`.
+   *
+   * `version` alone cannot tell "still in flight" from "asked and got
+   * nothing"; both read as `null`. A surface that only hides is right to wait
+   * out either, but a surface that navigates on the answer would wait forever
+   * on the second. This is the terminal bit that ends that wait. `null` while
+   * the fetch is in flight or has produced an identity.
+   */
+  unavailableFor: string | null;
 }
 
 interface AssistantIdentityActions {
@@ -49,6 +61,8 @@ interface AssistantIdentityActions {
     version: string | null,
     assistantId?: string | null,
   ) => void;
+  /** Records that the identity fetch for `assistantId` reached a dead end. */
+  markIdentityUnavailable: (assistantId: string | null) => void;
   clearIdentity: () => void;
 }
 
@@ -58,11 +72,23 @@ const useAssistantIdentityStoreBase = create<AssistantIdentityStore>((set) => ({
   name: null,
   version: null,
   assistantId: null,
+  unavailableFor: null,
   setIdentity: (name, version, assistantId = null) => {
     const impersonated = getImpersonatedAssistantVersion();
-    set({ name, version: impersonated ?? version, assistantId });
+    // An identity in hand supersedes any earlier dead end for it: a refetch
+    // that succeeds has to lift the terminal bit, or the surfaces that acted
+    // on it would stay wrong for the rest of the session.
+    set({
+      name,
+      version: impersonated ?? version,
+      assistantId,
+      unavailableFor: null,
+    });
   },
-  clearIdentity: () => set({ name: null, version: null, assistantId: null }),
+  markIdentityUnavailable: (assistantId) =>
+    set({ unavailableFor: assistantId }),
+  clearIdentity: () =>
+    set({ name: null, version: null, assistantId: null, unavailableFor: null }),
 }));
 
 export const useAssistantIdentityStore = createSelectors(


### PR DESCRIPTION
## Summary
- Carried-over review items: dismissal stamps survive a start-snapshot merge, the list route consumes the shared availability filter, `--content-emphasised` typo in `chat-empty-state`
- End-to-end walkthrough against a source-built assistant with the flag arm set to `smb`:
  - Welcome modal on the chat route, three starters, first expanded: pass
  - Launch from the chip: modal stays open, row flips to Working, next row auto-expands: pass
  - Do it Later: Suggestions pill appears beside the bell and counts done starters: pass
  - Launched conversation streams normally from the sidebar, one scripted turn, no duplicate: pass
  - Completion advances the pill and flips the row to Done: pass
  - Pill reopens the modal; the third completion renders the celebration once and retires the pill: pass
  - Preferences to Inspiration List, mixed states: pass after the fix below
  - Second tab converges on the `activation:progress` invalidation with no reload: pass
  - Dark theme and a 390px viewport (Storybook mobile stories): pass after the fixes below
- Defects found and fixed:
  - A cold load of `/assistant/suggestions` (bookmark, reload, new tab) bounced to chat, because both shared gates read as off while the flag values and the assistant's version were still in flight. The route now waits for `useActivationGatesSettled` before redirecting.
  - The welcome modal drew over the Inspiration List, covering the very list the user opened. Both activation surfaces now stand down on that route.
  - Rows showed "Working · 0 steps" and "Done · 0 steps" for a turn that called no tools. A zero count is dropped and the state stands alone.
  - Two AA contrast failures caught by the Storybook a11y addon: the pill's count (the whole label under 480px) and the row title and description ink. Both move a rung to `--content-secondary`; the list page goes from 33 serious contrast violations to none.
- Not fixed, both pre-existing and shared, reported for their own change: the design library's `Modal` never sets `aria-modal="true"`, so the composer's type-to-focus guard does not see any modal and stray typing lands in the chat box behind one; and `LocalFileCard` nests a button inside a `span[role="button"]` (axe "nested interactive controls") wherever it is drawn.
- GIFs: `~/.claude/plans/activation-checklist/assets/e2e/activation-modal.gif`, `activation-pill.gif`, `activation-list.gif`

Part of plan: activation-checklist.md (PR 7 of 7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->