### PR TITLE
feat(companion): the surface steps off the screen while Vellum is in front

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -48,6 +48,25 @@ let windowsRaised = 0;
 /** Whether the app's window exists, which is what decides between those two. */
 let mainWindowOpen = true;
 
+/** Whether the app's window is on screen, as opposed to put away or minimised. */
+let mainWindowVisible = true;
+
+/**
+ * Whether the surface's window exists. Closed by the tray and by the assistant
+ * going away, and opened again by the same two, so a case can open one over an
+ * app that is already in front. Reset before each case.
+ */
+let companionOpen = true;
+
+/**
+ * The app's window, as far as this module reads it: whether it exists and
+ * whether it is showing. One object, so a focus event can name it by identity.
+ */
+const mainWindow = {
+  isDestroyed: () => false,
+  isVisible: () => mainWindowVisible,
+};
+
 /** Where the canvas's origin is, which is what the window reports and moves. */
 let origin = { x: 0, y: 0 };
 
@@ -63,9 +82,19 @@ const surface = {
   // The surface's own flag going away closes the window, which a case moving
   // the flags can reach. Nothing here has a window server behind it, so this
   // only has to be callable.
-  close: () => {},
+  close: () => {
+    companionOpen = false;
+  },
   on: () => {},
   isDestroyed: () => false,
+  /** Whether the surface is on screen: off it while the app is in front. */
+  visible: true,
+  hide: () => {
+    surface.visible = false;
+  },
+  showInactive: () => {
+    surface.visible = true;
+  },
   getPosition: () => [origin.x, origin.y],
   setPosition: (x: number, y: number) => {
     origin = { x, y };
@@ -97,8 +126,28 @@ const register =
     into.set(channel, (args) => fn(schema.parse(args) as never));
   };
 
+/** Main's application listeners, so a case can bring the app forward. */
+const appListeners: {
+  event: string;
+  listener: (...args: unknown[]) => void;
+}[] = [];
+
+/** Fire an application event main registered, as the OS would. */
+const fireAppEvent = (event: string, ...args: unknown[]): void => {
+  for (const entry of [...appListeners]) {
+    if (entry.event === event) {
+      entry.listener({}, ...args);
+    }
+  }
+};
+
 mock.module("electron", () => ({
   BrowserWindow: { getAllWindows: () => [] },
+  app: {
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      appListeners.push({ event, listener });
+    },
+  },
   // Stubbed for the same reason as the rest of this mock: the module under
   // test imports it, and an export missing from a whole-module mock fails the
   // file at load rather than in the case that uses it.
@@ -197,10 +246,11 @@ mock.module("./ipc", () => ({
 const visibilityListeners: (() => void)[] = [];
 
 mock.module("./main-window", () => ({
-  // Only its existence is read: it is what decides whether a press is
-  // dispatched straight into a renderer or has to build one first, and
-  // whether a visibility change is the window being destroyed.
-  current: () => (mainWindowOpen ? {} : null),
+  // Its existence decides whether a press is dispatched straight into a
+  // renderer or has to build one first, and whether a visibility change is the
+  // window being destroyed; whether it is showing decides, with the app's
+  // activation, whether the surface is on the screen.
+  current: () => (mainWindowOpen ? mainWindow : null),
   dispatchToMain: (command: VellumCommand) => {
     dispatched.push(command);
   },
@@ -295,8 +345,17 @@ mock.module("@vellumai/electron-desktop/floating-window", () => ({
     width: number;
     height: number;
     position?: { x: number; y: number } | (() => { x: number; y: number });
-  }) => (options.kind === "companion" ? surface : openGlow(options)),
-  getFloatingWindow: (kind: string) => (kind === "companion" ? surface : glow),
+  }) => {
+    if (options.kind !== "companion") {
+      return openGlow(options);
+    }
+    // Shown on creation, the way the real one is.
+    companionOpen = true;
+    surface.visible = true;
+    return surface;
+  },
+  getFloatingWindow: (kind: string) =>
+    kind === "companion" ? (companionOpen ? surface : null) : glow,
 }));
 
 mock.module("@vellumai/electron-desktop/avatar", () => ({
@@ -401,6 +460,13 @@ beforeEach(() => {
   boundsAsked.length = 0;
   resolvedPick = null;
   picksResolved.length = 0;
+  // The user is working somewhere else, with the app's window open behind
+  // them: the state the surface exists for.
+  mainWindowOpen = true;
+  mainWindowVisible = true;
+  companionOpen = true;
+  fireAppEvent("did-resign-active");
+  surface.visible = true;
 });
 
 /** Put a set of evaluated flags in settings and tell main they changed. */
@@ -2036,5 +2102,110 @@ describe("the Watch flag on the pushed state", () => {
 
     expect(pushes.length).toBeGreaterThan(before);
     expect(pushes.at(-1)?.watchEnabled).toBe(false);
+  });
+});
+
+// The identity main holds, which is what opens the surface after a sign-in.
+// Imported after the mocks for the same reason the module under test is.
+const { setName } = await import("@vellumai/electron-desktop/identity");
+
+describe("the surface while the app is in front", () => {
+  test("steps off the screen when the app comes forward", () => {
+    fireAppEvent("did-become-active");
+
+    expect(surface.visible).toBe(false);
+  });
+
+  test("comes back when the user goes to another app", () => {
+    fireAppEvent("did-become-active");
+    fireAppEvent("did-resign-active");
+
+    expect(surface.visible).toBe(true);
+  });
+
+  test("stays while the active app's window is put away", () => {
+    mainWindowVisible = false;
+
+    fireAppEvent("did-become-active");
+
+    expect(surface.visible).toBe(true);
+  });
+
+  test("stays while the active app's window is closed", () => {
+    mainWindowOpen = false;
+
+    fireAppEvent("did-become-active");
+
+    expect(surface.visible).toBe(true);
+  });
+
+  test("steps off once the active app's window shows", () => {
+    mainWindowVisible = false;
+    fireAppEvent("did-become-active");
+
+    mainWindowVisible = true;
+    fireVisibilityChange();
+
+    expect(surface.visible).toBe(false);
+  });
+
+  test("comes back when the window is put away from the tray", () => {
+    fireAppEvent("did-become-active");
+
+    mainWindowVisible = false;
+    fireVisibilityChange();
+
+    expect(surface.visible).toBe(true);
+  });
+
+  test("comes back when the window is closed", () => {
+    fireAppEvent("did-become-active");
+
+    mainWindowOpen = false;
+    fireVisibilityChange();
+
+    expect(surface.visible).toBe(true);
+  });
+
+  test("reads the app's window taking focus as the app being in front", () => {
+    fireAppEvent("browser-window-focus", mainWindow);
+
+    expect(surface.visible).toBe(false);
+  });
+
+  test("does not read a panel taking focus as the app being in front", () => {
+    fireAppEvent("browser-window-focus", {});
+
+    expect(surface.visible).toBe(true);
+  });
+
+  test("opens straight off the screen over an app already in front", () => {
+    surface.close();
+    fireAppEvent("did-become-active");
+
+    setName("Aria");
+
+    expect(companionOpen).toBe(true);
+    expect(surface.visible).toBe(false);
+    setName(null);
+  });
+
+  test("opens on the screen when the user is working elsewhere", () => {
+    surface.close();
+
+    setName("Aria");
+
+    expect(companionOpen).toBe(true);
+    expect(surface.visible).toBe(true);
+    setName(null);
+  });
+
+  test("a surface put away by the tray is not brought back by the app", () => {
+    surface.close();
+    fireAppEvent("did-become-active");
+
+    fireAppEvent("did-resign-active");
+
+    expect(companionOpen).toBe(false);
   });
 });

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1,6 +1,7 @@
 import {
   BrowserWindow,
   Menu,
+  app,
   screen,
   type Display,
   type MenuItemConstructorOptions,
@@ -112,7 +113,9 @@ const isWatchEnabled = (): boolean =>
  * holding that expansion for as long as a call runs. It stays on screen
  * for the app's whole run unless the user hides it via the tray's "Show
  * Companion" item, a choice that persists across launches
- * (`readCompanionHidden` in `window-state.ts`).
+ * (`readCompanionHidden` in `window-state.ts`), and it steps off the screen
+ * for as long as Vellum itself is the frontmost app with its window showing
+ * (see `syncFrontmost`).
  *
  * **It is also the desktop's live-voice session surface**, the counterpart to
  * the iOS Dynamic Island and Lock Screen activity. Main holds the session
@@ -1024,6 +1027,77 @@ const setInteractive = (interactive: boolean): void => {
 };
 
 /**
+ * Whether Vellum is the active application.
+ *
+ * The surface stands in for the app while the user is working somewhere else,
+ * and it steps off the screen while the app itself is in front: over the app's
+ * own window it is a second copy of the same controls, floating over the chat
+ * they belong to.
+ *
+ * Read from the application's activation rather than from window focus. The
+ * panels this app floats (Quick Input, the dictation overlay, this surface)
+ * take key status without activating the app, and the main window loses key
+ * status to them, so focus says the wrong thing in both directions: a panel
+ * focused over someone else's app would count as Vellum being in front, and
+ * the main window losing focus to one would count as the user having left.
+ * Activation moves only when the user goes to another app or comes back.
+ *
+ * The main window taking focus is read as activation as well. A regular
+ * window cannot become key in an inactive app, and it is the one signal that
+ * cannot arrive early: the launch's own `did-become-active` is not promised to
+ * fire after this listener exists, while the window's first focus comes after
+ * `whenReady`.
+ */
+let appActive = false;
+
+/**
+ * Whether this module has taken the surface off the screen for the app being
+ * in front. Held here rather than read back from the window, so each decision
+ * is measured against the last one made and not against a window server
+ * answer that folds occlusion and minimisation into "visible".
+ */
+let surfaceAway = false;
+
+/**
+ * Whether the app's own window is on screen. An active app whose window has
+ * been put away from the tray, or closed, shows nothing of its own, and the
+ * surface is what stands in for it then.
+ */
+const mainWindowShowing = (): boolean => {
+  const win = currentMainWindow();
+  return win !== null && !win.isDestroyed() && win.isVisible();
+};
+
+/**
+ * Take the surface off the screen while the app is in front, and put it back
+ * when the user leaves.
+ *
+ * Hidden rather than closed, unlike the tray's choice in
+ * `setCompanionSurfaceVisible`: this is a state the user leaves by switching
+ * apps, many times an hour, and the surface has to come back exactly as it
+ * was. Closing would forget where the pill was, replay the opening placement
+ * and lose the call's home. `hide` then `showInactive` keeps the mouse
+ * forwarding that makes the canvas hit-testable, which is what `blur` would
+ * not have (see the note at `openCompanionWindow`).
+ */
+const syncFrontmost = (): void => {
+  const win = getFloatingWindow(COMPANION_KIND);
+  if (!win || win.isDestroyed()) {
+    return;
+  }
+  const away = appActive && mainWindowShowing();
+  if (away === surfaceAway) {
+    return;
+  }
+  surfaceAway = away;
+  if (away) {
+    win.hide();
+    return;
+  }
+  win.showInactive();
+};
+
+/**
  * Hand a press on the surface to the renderer that can act on it, without
  * bringing Vellum forward.
  *
@@ -1489,6 +1563,28 @@ export const installCompanionWindow = (): void => {
     pushState();
   });
 
+  // The app coming forward and going back, which is what decides whether the
+  // surface is on the screen at all while it is open. See `appActive`.
+  app.on("did-become-active", () => {
+    appActive = true;
+    syncFrontmost();
+  });
+  app.on("did-resign-active", () => {
+    appActive = false;
+    syncFrontmost();
+  });
+  app.on("browser-window-focus", (_event, win) => {
+    if (win !== currentMainWindow()) {
+      return;
+    }
+    appActive = true;
+    syncFrontmost();
+  });
+  // The app's window being shown, put away or closed moves the answer without
+  // the app's activation changing at all: a window hidden from the tray leaves
+  // Vellum active with nothing of its own on screen.
+  onMainWindowVisibilityChange(syncFrontmost);
+
   // One avatar feeds every surface, so a change to the Dock icon is a change
   // here too. Repaint only: whether there is a surface to repaint is a question
   // about the assistant, not about its picture.
@@ -1584,6 +1680,11 @@ export const openCompanionWindow = (): void => {
   win.on("closed", () => {
     callHome = null;
   });
+  // `createFloatingWindow` has already shown it. A surface opened while the
+  // app is in front, which is where a sign-in opens it from, goes straight back
+  // off the screen: it is due when the user leaves.
+  surfaceAway = false;
+  syncFrontmost();
   // A surface shown mid-call is the call's from its first frame, and one
   // shown mid-session has the frame beside it rather than under the cursor.
   syncCallSurface();

--- a/clients/macos/src/main/index.ts
+++ b/clients/macos/src/main/index.ts
@@ -485,9 +485,11 @@ app
     installMainWindow();
 
     // After the main window, so the surface opens over a running app rather
-    // than being the first thing on screen at launch. Present from here on,
-    // unless the user has hidden it from the tray: the app being frontmost is
-    // not one of its states.
+    // than being the first thing on screen at launch. Open from here on,
+    // unless the user has hidden it from the tray, and on screen whenever the
+    // app itself is not in front: it stands in for the app while the user is
+    // working somewhere else, and steps off while Vellum is the frontmost app
+    // with its window showing.
     //
     // A launch that has nobody signed in yet leaves it closed, and the window
     // that opens it later is the app's own, once it has an assistant to


### PR DESCRIPTION
## Summary

The macOS companion surface now hides while Vellum is the frontmost app with its main window showing, and comes back as soon as the user switches to another app, puts the window away from the tray, or closes it.

Over the app's own window the floating pill was a second copy of the same controls, sitting on top of the chat they belong to. It exists for when the user is working somewhere else.

## How

- **Activation, not focus.** `did-become-active` / `did-resign-active` on `app` decide whether Vellum is in front. The panels this app floats (Quick Input, the dictation overlay, the companion itself) take key status without activating the app, so window focus says the wrong thing in both directions. The main window taking focus is read as activation as well, so the launch's own activation cannot be missed if it fires before the listener exists.
- **Window showing.** An active app whose window has been hidden from the tray or closed shows nothing of its own, so the surface stays. Wired through the existing `onMainWindowVisibilityChange`.
- **Hidden, not closed.** Unlike the tray's "Show Companion" choice, this is a state the user leaves many times an hour, so the surface has to come back exactly as it was: position, call home and intro beat intact. `hide` / `showInactive` keeps the click-through mouse forwarding (verified below); `blur` would not have.
- A surface opened while the app is already in front (a sign-in opens it from the app's window) goes straight off the screen and appears when the user leaves.

## Verification

- 12 new cases in `companion-window.test.ts` (134 pass): come forward / go back, window put away / closed while active, focus on the main window vs a panel, opening over an app already in front, and a tray-hidden surface not being brought back by the app.
- Dev app, separate userData: with the Vellum window frontmost the companion is gone; with iTerm2 frontmost it is back and expands on hover, so forwarding survives the hide/show cycle.
- `bunx tsc --noEmit` clean in `clients/macos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GQCwRP6S3QNCF15gyCihx
