### PR TITLE
fix(storybook): stop caching the non-hashed Storybook deploy output

### DIFF
--- a/.github/workflows/ci-main-storybook.yaml
+++ b/.github/workflows/ci-main-storybook.yaml
@@ -98,23 +98,17 @@ jobs:
             --cache-control="public, max-age=31536000, immutable" \
             storybook-static/assets "${DEST}/assets"
 
-          # 2. Everything else except the root entrypoints/manifests should have
-          #    a moderate cache TTL.
-          #    Storybook has some stable-ish sb-*/ files that might be tied to
-          #    particular versions, so don't mark them as immutable.
+          # 2. Everything else has to revalidate. Only `assets/` is content
+          #    hashed. The rest keeps a stable path while its contents are
+          #    rebuilt every deploy, so any TTL here keeps serving the previous
+          #    build for that long. `sb-manager/` and `sb-addons/` carry the
+          #    manager UI, so a cached copy hides toolbar and sidebar changes,
+          #    and because the two Storybooks expire independently they can
+          #    disagree with each other for up to the TTL.
           gcloud storage rsync -r \
-            --exclude='^assets/.*|^[^/]*\.(html|json)$' \
-            --cache-control="public, max-age=3600" \
+            --exclude='^assets/.*' \
+            --cache-control="no-cache, max-age=0, must-revalidate" \
             storybook-static "${DEST}"
-
-          # 3. Root entrypoints/manifests change every deploy, so don't cache them.
-          for f in index.html iframe.html index.json project.json; do
-            if [ -f "storybook-static/${f}" ]; then
-              gcloud storage cp \
-                --cache-control="no-cache, max-age=0, must-revalidate" \
-                "storybook-static/${f}" "${DEST}/${f}"
-            fi
-          done
           echo "Published Storybook to ${DEST}/"
 
   # ───────────────────────────── web ─────────────────────────────
@@ -191,15 +185,7 @@ jobs:
             storybook-static/assets "${DEST}/assets"
 
           gcloud storage rsync -r \
-            --exclude='^assets/.*|^[^/]*\.(html|json)$' \
-            --cache-control="public, max-age=3600" \
+            --exclude='^assets/.*' \
+            --cache-control="no-cache, max-age=0, must-revalidate" \
             storybook-static "${DEST}"
-
-          for f in index.html iframe.html index.json project.json; do
-            if [ -f "storybook-static/${f}" ]; then
-              gcloud storage cp \
-                --cache-control="no-cache, max-age=0, must-revalidate" \
-                "storybook-static/${f}" "${DEST}/${f}"
-            fi
-          done
           echo "Published Storybook to ${DEST}/"


### PR DESCRIPTION
A successful Storybook publish could take up to an hour to actually reach anyone, and the two Storybooks could disagree with each other in the meantime.

## The bug

The deploy tags every object outside `assets/` with `public, max-age=3600`. But `assets/` is the *only* content-hashed output. Everything else keeps a stable path across builds while its contents are rebuilt every time, so that TTL means the CDN keeps serving the previous build's file from the same URL.

`sb-manager/` and `sb-addons/` are the ones that hurt (10 files, ~5.7MB): they carry the manager UI, so a stale copy hides toolbar and sidebar changes entirely. And because the two Storybooks' cache entries expire independently, they can disagree with each other for up to the TTL.

Observed live right after #42096 merged (18:13 UTC), which added a cross-link button to *both* Storybooks:

| | manager bundle `last-modified` | cross-link addon |
| --- | --- | --- |
| `/web/main/` | 18:22 UTC (post-merge) | present |
| `/design-library/main/` | **17:55 UTC (pre-merge)** | **absent** |

`/design-library/main/`'s edge entry was refreshed at 17:55, 18 minutes before the merge, and stayed inside its TTL through both the 18:14 and 18:34 deploys. The origin was correct the whole time; the same URL with a cache-buster returned `last-modified: 18:48` and the addon present. So a change that shipped to both looked like it had only shipped to one.

## The fix

Widen the header the root entrypoints already had to everything outside `assets/`:

- `assets/` keeps `max-age=31536000, immutable` (content hashed, safe)
- everything else gets `no-cache, max-age=0, must-revalidate`

The separate `cp` loop that special-cased `index.html` / `iframe.html` / `index.json` / `project.json` is now redundant, so this is a net deletion (-25/+11) applied identically to both deploy jobs.

Revalidation is cheap: unchanged objects answer `304` with no body, so this costs a conditional request per file, not the bytes. The fonts under `sb-common-assets/` revalidate too and could keep a long TTL, but singling them out adds a third rule to save ~1MB of 304s, which did not seem worth the branch.

## Test plan

- `.github/workflows/ci-main-storybook.yaml` parses as YAML, and both deploy jobs are patched identically — verified programmatically: each `Publish to GCS` step has exactly 1 immutable rsync, 1 revalidate rsync, 0 remaining `max-age=3600`, and 0 remaining `gcloud storage cp`.
- The `--exclude` regex narrows from `^assets/.*|^[^/]*\.(html|json)$` to `^assets/.*`, so the entrypoints and manifests the `cp` loop used to handle are now carried by the same rsync. Same regex dialect as before, one alternation removed.
- Behavioral confirmation comes from the next publish on `main`: the deployed `sb-addons/*/manager-bundle.js` should come back with `cache-control: no-cache, max-age=0, must-revalidate` instead of `public, max-age=3600`.

One caveat worth knowing: `gcloud storage rsync` skips objects whose content is unchanged, so it will not rewrite metadata on them. The corrected header therefore lands on each object the next time its content actually changes — which is exactly when staleness would matter, so no backfill is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHwm3Edsyu8j9hVdt5byjg
