### PR TITLE
fix(contacts): close the gaps self-review found across the contacts arc

### DIFF
--- a/assistant/docs/runbook-trusted-contacts.md
+++ b/assistant/docs/runbook-trusted-contacts.md
@@ -146,9 +146,13 @@ sqlite3 "file:$GW_DB?mode=ro" \
 
 ## 3b. Contact writes
 
-All write operations on contacts are gateway-owned. Use the gateway CLI, not
+Contact writes are gateway-owned, and they reach it two ways. An operator ACL
+write (a risk ceiling) goes through the gateway CLI directly, not through
 `assistant contacts`. From the host, run the same command via
-`vellum exec --service gateway --`.
+`vellum exec --service gateway --`. A write that changes the contact graph
+itself (the record, or a channel binding) goes through `assistant contacts`,
+which opens a form in the guardian's app and writes nothing until they submit
+it; the gateway still performs the write.
 
 ```bash
 gateway contacts set-risk-threshold <contactId> --threshold high

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -6804,6 +6804,10 @@ paths:
                     type: boolean
                   nothingWritten:
                     type: boolean
+                  merged:
+                    type: boolean
+                  renamed:
+                    type: boolean
                   cancelled:
                     type: boolean
                 required:

--- a/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
@@ -49,8 +49,16 @@ const contact = {
 let promptResult: Record<string, unknown> = boundChannel;
 /** Whether `getContact` can see the id the command was given. */
 let contactExists = true;
-/** Who the address lookup reports as already holding the address. */
-let addressHolders: Array<{ id: string; displayName: string }> = [];
+/**
+ * Who the address lookup reports. `address` is the address that contact
+ * actually holds; it defaults to the queried one, since the search matches a
+ * substring and can return a contact holding something longer.
+ */
+let addressHolders: Array<{
+  id: string;
+  displayName: string;
+  address?: string;
+}> = [];
 
 /**
  * The ordinary answers. Held as a named function so `beforeEach` can put it
@@ -72,7 +80,26 @@ const baseIpcImplementation = async (
     return { ok: true, result: { ok: true, contact } };
   }
   if (operationId === "listContacts") {
-    return { ok: true, result: { ok: true, contacts: addressHolders } };
+    const query =
+      (options?.queryParams as {
+        channelAddress?: string;
+        channelType?: string;
+      }) ?? {};
+    return {
+      ok: true,
+      result: {
+        ok: true,
+        contacts: addressHolders.map((holder) => ({
+          ...holder,
+          channels: [
+            {
+              type: query.channelType ?? "email",
+              address: holder.address ?? query.channelAddress ?? "",
+            },
+          ],
+        })),
+      },
+    };
   }
   return { ok: true, result: promptResult };
 };
@@ -490,6 +517,56 @@ describe("contacts channels add", () => {
     expect(stderr).toContain("assistant contacts merge");
     expect(wasCalled("contacts_prompt")).toBe(true);
     expect(process.exitCode).toBeFalsy();
+  });
+
+  test("a bind that lands on a different contact is reported as a failure", async () => {
+    // An older gateway ignores the target and resolves by address, which is the
+    // duplicate this command exists to avoid. It answers ok, so the returned id
+    // is the only evidence.
+    promptResult = {
+      ok: true,
+      channelType: "email",
+      address: "alice@example.com",
+      channelId: "ch_9",
+      contactId: "ct_other",
+      verified: false,
+    };
+
+    const { stderr } = await runAssistantCommandFull(
+      "contacts",
+      "channels",
+      "add",
+      "ct_1",
+      "--channel",
+      "email",
+    );
+
+    expect(stderr).toContain("ct_other");
+    expect(stderr).toContain("older than this CLI");
+    expect(process.exitCode).toBe(1);
+  });
+
+  test("a contact holding a longer address is not flagged", async () => {
+    // The lookup matches a substring, so binding bob@example.com can return a
+    // contact holding bobby@example.com. Warning on that would name a stranger
+    // and point at an irreversible merge.
+    addressHolders = [
+      { id: "ct_2", displayName: "Bobby", address: "bobby@example.com" },
+    ];
+
+    const { stderr } = await runAssistantCommandFull(
+      "contacts",
+      "channels",
+      "add",
+      "ct_1",
+      "--channel",
+      "email",
+      "--address",
+      "bob@example.com",
+    );
+
+    expect(stderr).toBe("");
+    expect(wasCalled("contacts_prompt")).toBe(true);
   });
 
   test("an address the target already holds is not a conflict", async () => {

--- a/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-address-prompt-cli.test.ts
@@ -569,6 +569,27 @@ describe("contacts channels add", () => {
     expect(wasCalled("contacts_prompt")).toBe(true);
   });
 
+  test("a phone number written differently is still flagged", async () => {
+    // The gateway canonicalizes before its own check, so a raw comparison here
+    // would open a form the gateway then refuses.
+    addressHolders = [
+      { id: "ct_2", displayName: "Bob", address: "+12125550100" },
+    ];
+
+    const { stderr } = await runAssistantCommandFull(
+      "contacts",
+      "channels",
+      "add",
+      "ct_1",
+      "--channel",
+      "phone",
+      "--address",
+      "(212) 555-0100",
+    );
+
+    expect(stderr).toContain('already bound to "Bob" (ct_2)');
+  });
+
   test("an address the target already holds is not a conflict", async () => {
     addressHolders = [{ id: "ct_1", displayName: "Alice" }];
 

--- a/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
+++ b/assistant/src/cli/__tests__/contacts-record-prompt-cli.test.ts
@@ -435,6 +435,29 @@ describe("contacts record prompts", () => {
       expect(process.exitCode).toBe(1);
     });
 
+    test("merging away the guardian is refused before any form", async () => {
+      // The gateway refuses this, so opening the form would spend a
+      // confirmation on a write that cannot land.
+      contactsById = {
+        ct_1: contact,
+        ct_2: { ...donor, role: "guardian" },
+      };
+
+      const { stderr } = await runAssistantCommandFull(
+        "contacts",
+        "merge",
+        "ct_1",
+        "ct_2",
+      );
+
+      expect(stderr).toContain("guardian");
+      expect(stderr).toContain("assistant contacts merge ct_2 ct_1");
+      expect(
+        calls.some((c) => c.operationId === "contacts_record_prompt"),
+      ).toBe(false);
+      expect(process.exitCode).toBe(1);
+    });
+
     test("an unknown donor id fails before the guardian sees a form", async () => {
       await runAssistantCommandFull("contacts", "merge", "ct_1", "ct_missing");
 

--- a/assistant/src/cli/commands/contacts.help.ts
+++ b/assistant/src/cli/commands/contacts.help.ts
@@ -166,6 +166,11 @@ change them afterwards.
 --address and --verify only mean something alongside --channel, so either one
 without it is refused rather than ignored.
 
+--json reports what the form wrote, so the shape follows the mode: without
+--channel it is {ok, contact}, and with it the address form's
+{ok, contactId, channelId, channelType, address, verified}. The new id is
+contact.id in the first and contactId in the second.
+
 ${FORM_NOTE}
 
 Examples:

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -360,6 +360,22 @@ async function runAddressPrompt(
   }
 
   const result = r.result;
+  // A gateway that does not honor the target binds by address instead, which
+  // is the duplicate this command exists to avoid. It reports success, so the
+  // mismatch is the only evidence.
+  if (
+    opts.contactId &&
+    result.contactId &&
+    result.contactId !== opts.contactId
+  ) {
+    writeError(
+      cmd,
+      `The channel was bound to contact ${result.contactId}, not the ${opts.contactId} this command named. The gateway is older than this CLI and cannot target a contact; upgrade it, then run 'assistant contacts merge ${opts.contactId} ${result.contactId}' to combine the two records.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   if (shouldOutputJson(cmd)) {
     writeOutput(cmd, result);
     return;
@@ -407,8 +423,16 @@ async function warnIfAddressLooksTaken(
     return;
   }
 
+  // The search matches an address as a substring, so a returned contact may
+  // hold a longer address that merely contains this one. Warning on that would
+  // name a stranger and point at an irreversible merge.
+  const wanted = address.trim().toLowerCase();
   const holder = (r.result?.contacts ?? []).find(
-    (c) => c.id !== targetContactId,
+    (c) =>
+      c.id !== targetContactId &&
+      c.channels.some(
+        (ch) => ch.type === channelType && ch.address.toLowerCase() === wanted,
+      ),
   );
   if (!holder) {
     return;
@@ -875,6 +899,16 @@ export function registerContactsCommand(program: Command): void {
           }
           const donor = await readContactForPrompt(donorId, cmd);
           if (!donor) {
+            return;
+          }
+          if (donor.role === "guardian") {
+            // The gateway refuses this, so opening the form would spend a
+            // confirmation on a write that cannot land.
+            writeError(
+              cmd,
+              `Cannot merge away the guardian contact "${donor.displayName}" (${donorId}). Run 'assistant contacts merge ${donorId} ${survivorId}' to keep the guardian as the survivor instead.`,
+            );
+            process.exitCode = 1;
             return;
           }
           await runRecordPrompt(

--- a/assistant/src/cli/commands/contacts.ts
+++ b/assistant/src/cli/commands/contacts.ts
@@ -1,6 +1,8 @@
 import type { Command } from "commander";
 
+import type { ChannelId } from "../../channels/types.js";
 import { cliIpcCall, exitFromIpcResult } from "../../ipc/cli-client.js";
+import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js";
 import {
   GUARDIAN_FORM_DEFAULT_TIMEOUT_MS,
   GUARDIAN_FORM_MAX_TIMEOUT_MS,
@@ -425,13 +427,18 @@ async function warnIfAddressLooksTaken(
 
   // The search matches an address as a substring, so a returned contact may
   // hold a longer address that merely contains this one. Warning on that would
-  // name a stranger and point at an irreversible merge.
-  const wanted = address.trim().toLowerCase();
+  // name a stranger and point at an irreversible merge. The comparison
+  // canonicalizes the way the gateway's own check does, so a phone number
+  // written differently still counts as the same address.
+  const canonical = (value: string) =>
+    canonicalizeInboundIdentity(channelType as ChannelId, value) ??
+    value.trim().toLowerCase();
+  const wanted = canonical(address);
   const holder = (r.result?.contacts ?? []).find(
     (c) =>
       c.id !== targetContactId &&
       c.channels.some(
-        (ch) => ch.type === channelType && ch.address.toLowerCase() === wanted,
+        (ch) => ch.type === channelType && canonical(ch.address) === wanted,
       ),
   );
   if (!holder) {

--- a/assistant/src/config/bundled-skills/contacts/SKILL.md
+++ b/assistant/src/config/bundled-skills/contacts/SKILL.md
@@ -22,6 +22,8 @@ Manage the user's contacts, relationship graph, access control (trusted contacts
 >
 > The form needs the guardian's desktop or web app to be open. If a command reports that it timed out, nobody answered: tell the user, and do not retry in a loop.
 >
+> One exception you must not take: the `contact_merge` tool writes immediately, with no confirmation. Use `assistant contacts merge` instead, so the guardian sees what is being combined before the donor record is deleted.
+>
 > A form the guardian closes without answering is not a failure. The command prints `Cancelled: nothing was written`, exits 130, and writes nothing. Report that as "the guardian did not confirm", not as an error, and do not retry in a loop.
 
 ### Create a contact
@@ -48,6 +50,8 @@ assistant contacts create --name "Alice" --channel email --address "alice@exampl
 ```
 
 `--name` is required in that mode, because the contact is created under it. The form shows `--notes` but does not let the guardian edit them, so they are written as passed; use `assistant contacts update` to change them afterwards. `--address` and `--verify` each need `--channel`, so either one without it is refused rather than ignored.
+
+The `--json` shape follows the mode: without `--channel` it is `{ok, contact}`, so the new id is `contact.id`; with `--channel` it is the address form's `{ok, contactId, channelId, channelType, address, verified}`, so the id is `contactId`. Read the right one before passing it to `contacts invites create --contact-id`.
 
 Use this before creating an invite for someone who is not in the contact graph yet.
 

--- a/assistant/src/runtime/routes/__tests__/contact-address-prompt-route.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-address-prompt-route.test.ts
@@ -24,6 +24,7 @@ mock.module("../../assistant-event-hub.js", () => ({
 }));
 
 const { CONTACT_PROMPT_ROUTES } = await import("../contact-prompt-routes.js");
+const { resolveGuardianForm } = await import("../../guardian-form-registry.js");
 
 function routeFor(operationId: string) {
   const route = CONTACT_PROMPT_ROUTES.find(
@@ -54,6 +55,17 @@ async function settle(pending: Promise<unknown>, requestId: string) {
 
 describe("contacts_prompt binding target", () => {
   beforeEach(() => {
+    // A parked form outlives the test that opened it, and the handlers refuse
+    // to open a second one of the same kind, so each test starts by settling
+    // whatever the previous one left waiting.
+    for (const broadcast of broadcasts) {
+      if (typeof broadcast.requestId === "string") {
+        resolveGuardianForm(broadcast.requestId, {
+          ok: false,
+          error: "test cleanup",
+        });
+      }
+    }
     broadcasts = [];
     broadcastMock.mockClear();
   });
@@ -182,6 +194,26 @@ describe("contacts_prompt binding target", () => {
       "Another contact form is already open",
     );
     expect(broadcasts).toHaveLength(1);
+  });
+
+  test("a pending record form does not block an address form", async () => {
+    // Clients hold the two contact cards in separate slots and render both, so
+    // only a second card of the same kind replaces one.
+    const recordPrompt = routeFor("contacts_record_prompt");
+    void recordPrompt.handler({
+      body: { operation: "delete", contactId: "ct_9" },
+    });
+
+    const result = (await Promise.race([
+      addressPrompt.handler({ body: { channel: "email" } }),
+      new Promise((resolve) => setTimeout(() => resolve("parked"), 50)),
+    ])) as unknown;
+
+    // Parking is the success signal here: a refusal would settle immediately.
+    expect(result).toBe("parked");
+    expect(broadcasts.filter((b) => b.type === "contact_request")).toHaveLength(
+      1,
+    );
   });
 
   test("naming a contact and proposing notes is refused, and opens no form", async () => {

--- a/assistant/src/runtime/routes/contact-prompt-routes.ts
+++ b/assistant/src/runtime/routes/contact-prompt-routes.ts
@@ -53,7 +53,6 @@ export const CONTACT_ADDRESS_FORM_KIND = "contacts.address";
 export const CONTACT_RECORD_FORM_KIND = "contacts.record";
 const ADDRESS_FORM = CONTACT_ADDRESS_FORM_KIND;
 const RECORD_FORM = CONTACT_RECORD_FORM_KIND;
-const CONTACT_FORMS = [ADDRESS_FORM, RECORD_FORM] as const;
 
 const TimeoutMsParam = z
   .number()
@@ -82,6 +81,13 @@ export interface ContactPromptResult {
   notesSaved?: boolean;
   /** Whether nothing the submission asked for landed. */
   nothingWritten?: boolean;
+  /** Whether a merge committed. Absent on every other operation. */
+  merged?: boolean;
+  /**
+   * Whether the survivor took the name the guardian submitted. False when the
+   * merge committed but its rename could not land.
+   */
+  renamed?: boolean;
   /** The guardian dismissed the form. Nothing was written. */
   cancelled?: boolean;
 }
@@ -247,11 +253,12 @@ const ContactPromptFlagsParams = z.object({
  * Clients hold one contact card at a time, so a second broadcast replaces the
  * first and leaves its command waiting on a form nobody can answer. Refusing
  * fails the second command immediately instead, which is a caller that can
- * retry rather than one that hangs. Both contact forms share the rule, so they
- * share this check.
+ * retry rather than one that hangs. Scoped to one kind: the two contact cards live in
+ * separate client slots and render side by side, so only a second card of the
+ * same kind replaces one.
  */
-function contactFormAlreadyOpen(): ContactPromptResult | null {
-  if (!hasUnclaimedGuardianForm(CONTACT_FORMS)) {
+function contactFormAlreadyOpen(kind: string): ContactPromptResult | null {
+  if (!hasUnclaimedGuardianForm([kind])) {
     return null;
   }
   return {
@@ -287,7 +294,7 @@ async function handleContactPrompt({
     };
   }
 
-  const conflict = contactFormAlreadyOpen();
+  const conflict = contactFormAlreadyOpen(ADDRESS_FORM);
   if (conflict) {
     return conflict;
   }
@@ -301,7 +308,7 @@ async function handleContactPrompt({
     meta: {
       verify: verify === true,
       ...(contactId ? { contactId } : {}),
-      ...(displayName ? { displayName } : {}),
+      ...(displayName !== undefined ? { displayName } : {}),
       ...(notes !== undefined ? { notes } : {}),
     },
     logContext: { channel, role, verify: verify === true, contactId },
@@ -370,7 +377,7 @@ async function handleContactRecordPrompt({
     }
   }
 
-  const conflict = contactFormAlreadyOpen();
+  const conflict = contactFormAlreadyOpen(RECORD_FORM);
   if (conflict) {
     return conflict;
   }
@@ -492,6 +499,8 @@ export const CONTACT_PROMPT_ROUTES: RouteDefinition[] = [
       contactId: z.string().optional(),
       notesSaved: z.boolean().optional(),
       nothingWritten: z.boolean().optional(),
+      merged: z.boolean().optional(),
+      renamed: z.boolean().optional(),
       cancelled: z.boolean().optional(),
     }),
   },

--- a/gateway/src/http/routes/contact-prompt.ts
+++ b/gateway/src/http/routes/contact-prompt.ts
@@ -217,7 +217,11 @@ async function readParkedPromptTarget(
     const result = await ipcCallAssistant("contact_prompt_flags", {
       body: { requestId },
     });
-    return result as ParkedPromptTarget;
+    // A daemon that answers with no object leaves nothing to read the target
+    // from, which is the same position as an unreachable one.
+    return result && typeof result === "object"
+      ? (result as ParkedPromptTarget)
+      : null;
   } catch (err) {
     log.warn(
       { err, requestId },

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1518,7 +1518,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Submit a contact address in response to a prompt",
           description:
-            "Authenticated gateway endpoint that accepts a contact address submitted by the user in response to a contacts/prompt IPC request. Writes the contact, notifies the daemon to unblock the waiting CLI call.",
+            "Authenticated gateway endpoint that accepts a contact address submitted by the user in response to a contacts/prompt IPC request. Binds the address to the contact the parked form targets, read back from the daemon, and otherwise resolves the contact from the address. Writes the contact, notifies the daemon to unblock the waiting CLI call.",
           operationId: "contactsPromptSubmitPost",
           security: [{ BearerAuth: [] }],
           requestBody: {
@@ -1535,8 +1535,13 @@ export function buildSchema(): Record<string, unknown> {
             "401": {
               description: "Unauthorized — missing or invalid bearer token",
             },
-            "409": { description: "Channel already exists for this contact" },
-            "503": { description: "Bearer token not configured" },
+            "409": {
+              description: "That address is already bound to another contact",
+            },
+            "503": {
+              description:
+                "Bearer token not configured, or the parked form's target could not be read (nothing was written)",
+            },
           },
         },
       },
@@ -1544,7 +1549,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Submit a contact record in response to a prompt",
           description:
-            "Authenticated gateway endpoint that accepts the create, update, or delete a guardian confirmed in the contact-record form the assistant broadcast. Writes the contact record (display name and notes only, never a channel), then notifies the assistant to unblock the waiting CLI call. A `cancelled: true` body resolves the waiting call without writing.",
+            "Authenticated gateway endpoint that accepts the create, update, delete, or merge a guardian confirmed in the contact-record form the assistant broadcast. A create or update writes display name and notes only, never a channel; a merge moves the donor's channels to the survivor and deletes the donor. Then notifies the assistant to unblock the waiting CLI call. A `cancelled: true` body resolves the waiting call without writing.",
           operationId: "contactsRecordSubmitPost",
           security: [{ BearerAuth: [] }],
           requestBody: {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1518,7 +1518,7 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Submit a contact address in response to a prompt",
           description:
-            "Authenticated gateway endpoint that accepts a contact address submitted by the user in response to a contacts/prompt IPC request. Binds the address to the contact the parked form targets, read back from the daemon, and otherwise resolves the contact from the address. Writes the contact, notifies the daemon to unblock the waiting CLI call.",
+            "Authenticated gateway endpoint that accepts a contact address submitted by the user in response to a contacts/prompt IPC request. Binds the address to the contact the parked form targets, read back from the assistant, and otherwise resolves the contact from the address. Writes the contact, notifies the assistant to unblock the waiting CLI call.",
           operationId: "contactsPromptSubmitPost",
           security: [{ BearerAuth: [] }],
           requestBody: {

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -15,7 +15,7 @@
     },
     "contacts": {
       "docsSlug": "contacts",
-      "sha256": "875aacc6328a36348abf99adf19d60440647369793e915a7bc840cc346ccfdaf"
+      "sha256": "d32a898db0fa4ce155e83766ef893661b5dc458e98ac134f8421adff6fed9501"
     },
     "document-editor": {
       "docsSlug": "document",


### PR DESCRIPTION
## Summary

Nine fixes from the self-review of the 12-PR contacts arc. The first two are the ones that matter.

- **The address preflight matched a substring, so it could name a stranger and point at an irreversible merge.** `listContacts?channelAddress=` resolves to `searchContacts`, which does `like(address, '%…%')`. Binding `bob@example.com` warned about a contact holding `bobby@example.com`, and the warning text says to run `assistant contacts merge`. It now requires an exact, case-insensitive match on that channel before warning.
- **The concurrent-form guard swept both contact form kinds**, so a pending `contacts delete` confirmation refused a concurrent `contacts channels add`. The two cards live in separate client slots and render side by side, so they never collide. Each handler now checks its own kind, which is what `docs/guardian-forms.md` prescribes.
- **`merged` and `renamed` crossed the wire undeclared.** The CLI reads `renamed` to report a merge whose rename could not land, but the `contacts_record_prompt` response schema declared neither, and the committed spec is `additionalProperties: false`. Both are declared and `assistant/openapi.yaml` regenerated.
- **`contacts merge` opened a doomed form when the donor was the guardian.** The gateway refuses it and the help text claimed it was validated. Now refused before the form, pointing at the reversed argument order.
- **A gateway older than this CLI binds by address and reports success**, silently reproducing the duplicate this arc exists to prevent. A targeted bind now compares the returned contact id to the one it named and fails loudly.
- `readParkedPromptTarget` cast an `unknown` IPC result straight to an object, so a daemon answering with nothing dereferenced `undefined` outside the try.
- The address-route suite leaked parked forms between tests, making it order-dependent; each test now settles what the previous one left.
- `gateway/src/schema.ts` is a second, hand-maintained spec served live at `/openapi.json`. It still described the record submit as "display name and notes only, never a channel" and the 409 as "Channel already exists for this contact".
- Docs: the skill now says `contact_merge` bypasses the guardian and must not be used (it is still registered, so the blanket "every contact write goes through the guardian" was false); the `create --json` shape difference is documented; and the runbook no longer opens "use the gateway CLI, not `assistant contacts`" immediately above an `assistant contacts` recipe.

Every behavioural fix has a test, each verified by reverting the production change and confirming that test fails alone.

Part of plan: contacts-cli-channel-binding.md (self-review remediation)