### PR TITLE
feat(web): teach retro card answers by tap and collapses when done

### DIFF
--- a/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
+++ b/assistant/src/__tests__/conversation-surfaces-history-restored-completion.test.ts
@@ -594,7 +594,7 @@ describe("history-restored surface completion: scan cost", () => {
 describe("surface action queue rejection", () => {
   beforeEach(resetSurfaceState);
 
-  test("a rejected history-restored action is logged with queue depth", async () => {
+  test("a rejected history-restored action is refused and logged with queue depth", async () => {
     const surfaceId = "surface-rejected-1";
     seedSurfaceRow(surfaceId, "choice");
     const ctx = makeContext(
@@ -602,7 +602,17 @@ describe("surface action queue rejection", () => {
       { queueDepth: 7 },
     );
 
-    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+    const result = await handleSurfaceAction(
+      ctx,
+      surfaceId,
+      "inbox",
+      CHOICE_PAYLOAD,
+    );
+
+    // The route turns a refusal into an error response, which is what keeps
+    // the client from optimistically completing a card whose action was never
+    // queued. A bare return here would read as accepted.
+    expect(result).toEqual({ accepted: false, error: "queue_full" });
 
     const rejection = loggedWarnings.find((w) =>
       w.msg.startsWith("Surface action rejected by the message queue"),
@@ -616,7 +626,7 @@ describe("surface action queue rejection", () => {
     });
   });
 
-  test("a rejected pending action is logged with queue depth", async () => {
+  test("a rejected pending action is refused and logged with queue depth", async () => {
     const surfaceId = "surface-rejected-2";
     seedSurfaceRow(surfaceId, "choice");
     const ctx = makeContext(
@@ -625,7 +635,14 @@ describe("surface action queue rejection", () => {
     );
     ctx.pendingSurfaceActions.set(surfaceId, { surfaceType: "choice" });
 
-    await handleSurfaceAction(ctx, surfaceId, "inbox", CHOICE_PAYLOAD);
+    const result = await handleSurfaceAction(
+      ctx,
+      surfaceId,
+      "inbox",
+      CHOICE_PAYLOAD,
+    );
+
+    expect(result).toEqual({ accepted: false, error: "queue_full" });
 
     const rejection = loggedWarnings.find((w) =>
       w.msg.startsWith("Surface action rejected by the message queue"),

--- a/assistant/src/api/surfaces.ts
+++ b/assistant/src/api/surfaces.ts
@@ -568,11 +568,12 @@ export type WatchRetroQuestionKind = z.infer<
 /**
  * One answer to a `pick` or `gate` question.
  *
- * **The first option is the default**, and that is the whole of the
- * preselection contract. There is no `selected` flag to disagree with the
+ * **The first option is the recommended one**, and that is the whole of the
+ * contract. There is no `selected` or `recommended` flag to disagree with the
  * ordering. On a `pick` it is the reading the recording supports; on a `gate`
- * it is the cautious answer, which is the one case where the default is
- * deliberately not the model's guess.
+ * it is the cautious answer, which is the one case where the recommendation
+ * is deliberately not the model's guess. The card marks it and selects
+ * nothing: the user answers a pick or a gate by tapping.
  */
 export const WatchRetroOptionSchema = z.object({
   id: coercedString(),
@@ -590,7 +591,7 @@ export const WatchRetroQuestionSchema = z.object({
   eyebrow: tolerantString(),
   /** `fill` only: the pre-filled value, so skipping keeps a working answer. */
   suggestion: tolerantString(),
-  /** `pick` and `gate`: the alternatives. First is the default. */
+  /** `pick` and `gate`: the alternatives. First is the recommended one. */
   options: recordArray(WatchRetroOptionSchema).optional().catch(undefined),
 });
 export type WatchRetroQuestion = z.infer<typeof WatchRetroQuestionSchema>;

--- a/assistant/src/daemon/conversation-surfaces.ts
+++ b/assistant/src/daemon/conversation-surfaces.ts
@@ -1800,13 +1800,19 @@ function maybeEmitActivationMoment(ctx: Conversation, surfaceId: string): void {
   recordActivationMoment(ctx, moment);
 }
 
+/** The action result for an enqueue the message queue refused. */
+const QUEUE_FULL_RESULT: SurfaceActionResult = {
+  accepted: false,
+  error: "queue_full",
+};
+
 /**
  * Record a surface action the message queue refused.
  *
- * The route answers `{ ok: true }` for a rejected enqueue and the client
- * optimistically completes the card on that, so the user sees an answered card
- * that the next history reseed reverts. Nothing else on this path logs, so
- * without this the only user-visible cause of a reverted card leaves no trace.
+ * The rejection reaches the client as a failed submit, so the card stays
+ * answerable and nothing is marked completed. Nothing else on this path logs,
+ * so without this a saturated queue leaves no trace of which actions it
+ * turned away.
  */
 function logSurfaceActionRejected(
   ctx: Conversation,
@@ -2247,7 +2253,7 @@ export async function handleSurfaceAction(
     if (result.rejected) {
       ctx.surfaceActionRequestIds.delete(requestId);
       logSurfaceActionRejected(ctx, surfaceId, actionId, stored?.surfaceType);
-      return;
+      return QUEUE_FULL_RESULT;
     }
 
     // Terminal user commit accepted — record the activation milestone if this
@@ -2500,7 +2506,7 @@ export async function handleSurfaceAction(
   if (result.rejected) {
     ctx.surfaceActionRequestIds.delete(requestId);
     logSurfaceActionRejected(ctx, surfaceId, actionId, pending.surfaceType);
-    return;
+    return QUEUE_FULL_RESULT;
   }
 
   // Terminal user commit accepted — record the activation milestone if this

--- a/assistant/src/watch/__tests__/watch-retro.test.ts
+++ b/assistant/src/watch/__tests__/watch-retro.test.ts
@@ -318,28 +318,29 @@ describe("watch retrospective", () => {
     );
   });
 
-  test("makes every skip land on a safe answer", async () => {
+  test("puts the recommended answer first and makes the fill's skip safe", async () => {
     const summary = recordSession(["archiving the thread"]);
     const { calls, dispatch } = recordingDispatch();
 
     await runWatchRetro(summary, { dispatch });
 
     const { prompt } = calls[0]!;
-    // Every page is skippable, so every page's default is what the model
-    // actually gets from a user who taps through. A `fill` keeps its
-    // suggestion; a `pick` keeps the reading the recording supports.
+    // The fill is the one skippable page, so its suggestion is what the model
+    // actually gets from a user who taps past it.
     expect(prompt).toContain(
       "Put your best guess in `suggestion` so skipping keeps a working phrase",
     );
+    // A pick's first option is drawn as the recommendation, so it has to be
+    // the reading the recording supports rather than an arbitrary one.
     expect(prompt).toContain(
-      "The first option is the default and must be the reading the recording supports",
+      "The first option is shown as the recommended one and must be the reading the recording supports",
     );
-    // The gate is the one place the default is deliberately not the guess.
-    // Watching someone do a destructive thing once says nothing about whether
-    // they want it repeated with nobody looking, so a skipped gate must land
-    // on the cautious answer rather than on what was recorded.
+    // The gate is the one place the recommendation is deliberately not the
+    // guess. Watching someone do a destructive thing once says nothing about
+    // whether they want it repeated with nobody looking, so the option the
+    // card points at must be the cautious one rather than what was recorded.
     expect(prompt).toContain(
-      'The first option must be the cautious one ("Ask me first"), because a skipped question takes it.',
+      'The first option must be the cautious one ("Ask me first"), because it is the one shown as recommended.',
     );
   });
 

--- a/assistant/src/watch/watch-retro.ts
+++ b/assistant/src/watch/watch-retro.ts
@@ -127,12 +127,13 @@ const WATCH_RETRO_WAKE_SOURCE = "watch-retro";
  * be enumerated, the question is not ready to be asked, and the honest move is
  * to leave the step described rather than explained.
  *
- * **Every page is skippable, and every skip lands somewhere safe.** A skipped
- * `fill` keeps its pre-filled suggestion, so it is an edit rather than a blank.
- * A skipped `pick` takes the first option, which is the reading the recording
- * already supports. A skipped `gate` takes the first option too, and on a gate
- * that first option must be the cautious one. It is the single place where the
- * default is deliberately not the model's guess.
+ * **The first option is the recommended one, and the card marks it as such.**
+ * On a `pick` that is the reading the recording already supports. On a `gate`
+ * it must be the cautious one, the single place where the recommendation is
+ * deliberately not the model's guess. Nothing is selected for the user: a
+ * `pick` or a `gate` is answered by tapping an option, so the answer that comes
+ * back is one they chose. Only the `fill` is skippable, and a skipped `fill`
+ * keeps its pre-filled suggestion, so it is an edit rather than a blank.
  *
  * **The skill loads before the card is shown, and nothing follows the card.**
  * `skill-management` opens on "Ask before doing anything", so a turn that loads
@@ -169,11 +170,11 @@ The payload:
 - \`eyebrow\`: what the session cost, in the teaching's own words, e.g. "Taught in 4 min" or "Taught in 4 min, 11 screens". Never "watched": the user taught you this, they did not perform for you.
 - \`questions\`: at most three, most consequential first. Fewer is better, and none is a valid answer if the recording settled everything. Each question is \`{ id, kind, prompt }\`: \`prompt\` is the question worded the way you would ask it out loud, and \`id\` is a handle no other question on this card uses. A \`pick\` or a \`gate\` adds \`options\`, each of them \`{ id, label }\` and optionally a \`note\`: \`label\` is the answer as the user reads it, and \`id\` is that option's own handle. Use those names exactly. A question's text is \`prompt\` and never \`question\` or \`text\`; an option's text is \`label\` and never \`value\` or \`title\`. Anything sent under another name is dropped on the way to the card, and the page it belonged to is lost.
 
-Every question is answerable in one tap and every one is skippable, so ask only about what you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Do not ask the user to confirm something the recording already showed you.
+Every question is answerable in one tap, and the user has to answer each one to save, so ask only about what you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Do not ask the user to confirm something the recording already showed you.
 
 - \`kind: "fill"\` is a single text field, and there is at most one of them: what they would say to start this task, in their own words. Always ask it, because the recording cannot tell you. Put your best guess in \`suggestion\` so skipping keeps a working phrase instead of leaving it blank.
-- \`kind: "pick"\` is two to four named alternatives. The first option is the default and must be the reading the recording supports; mark it with a \`note\` saying so. Never ask a yes/no whose "no" tells you nothing: "was the rule X?" wastes the question, where "what decides this?" with X first among the options gets an answer either way. If you cannot name the alternatives, you do not understand the gap well enough to ask about it, so leave the step described and ask nothing.
-- \`kind: "gate"\` is for a destructive or irreversible step, and it is asked however plainly the step was seen. Not "did you do this" (you watched them), but whether you may do it unattended. The first option must be the cautious one ("Ask me first"), because a skipped question takes it.
+- \`kind: "pick"\` is two to four named alternatives. The first option is shown as the recommended one and must be the reading the recording supports; mark it with a \`note\` saying so. Never ask a yes/no whose "no" tells you nothing: "was the rule X?" wastes the question, where "what decides this?" with X first among the options gets an answer either way. If you cannot name the alternatives, you do not understand the gap well enough to ask about it, so leave the step described and ask nothing.
+- \`kind: "gate"\` is for a destructive or irreversible step, and it is asked however plainly the step was seen. Not "did you do this" (you watched them), but whether you may do it unattended. The first option must be the cautious one ("Ask me first"), because it is the one shown as recommended.
 
 Ask about the done condition only if it is genuinely unclear, and as a \`pick\`.`;
 

--- a/clients/web/src/domains/chat/components/surfaces/surface-container.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/surface-container.tsx
@@ -27,8 +27,12 @@ interface SurfaceContainerProps {
  * check; `danger` is a red rejection glyph (denied / blocked); `neutral` is a
  * muted "voided" glyph for terminal states that are not a success and not an
  * active rejection (left unverified / expired / cancelled / timed out).
+ *
+ * Exported for surfaces that draw their own completed state and want the same
+ * glyphs for the same tones, so a completed card reads the same whichever
+ * renderer folded it.
  */
-const COMPLETION_TONE_STYLE: Record<
+export const COMPLETION_TONE_STYLE: Record<
   SurfaceCompletionTone,
   { Icon: ComponentType<{ className?: string }>; colorClass: string }
 > = {

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.stories.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.stories.tsx
@@ -63,10 +63,21 @@ function retroSurface(templateData: RetroTemplateData): Surface {
 /**
  * The card with its answers wired up, so tapping through the pages behaves the
  * way it does in a conversation. The submitted payload is logged rather than
- * sent, and the card marks itself completed so the end of the flow is visible.
+ * sent, and the surface is completed with the summary the card asked for,
+ * which is what the daemon echoes back, so the collapsed row is visible.
  */
-function RetroPreview({ templateData }: { templateData: RetroTemplateData }) {
-  const [surface, setSurface] = useState(() => retroSurface(templateData));
+function RetroPreview({
+  templateData,
+  completed = false,
+}: {
+  templateData: RetroTemplateData;
+  /** Open on the collapsed row, as a restored conversation would. */
+  completed?: boolean;
+}) {
+  const [surface, setSurface] = useState(() => ({
+    ...retroSurface(templateData),
+    ...(completed ? { completed: true, completionSummary: "Skill saved" } : {}),
+  }));
   const [submitted, setSubmitted] = useState<unknown>(null);
 
   return (
@@ -79,7 +90,9 @@ function RetroPreview({ templateData }: { templateData: RetroTemplateData }) {
             ...current,
             completed: true,
             completionSummary:
-              actionId === "discard" ? "Cancelled" : "Skill saved",
+              typeof data?._completionSummary === "string"
+                ? data._completionSummary
+                : undefined,
           }));
         }}
       />
@@ -199,7 +212,11 @@ export const BoundedRecording: Story = {
   ),
 };
 
-/** A `pick`: named alternatives, the recording's own reading marked and first. */
+/**
+ * A `pick`: named alternatives, the recording's own reading first and marked
+ * as recommended. Nothing is selected until the user taps, and the tap is
+ * what moves the card on.
+ */
 export const PickQuestion: Story = {
   render: () => (
     <RetroPreview
@@ -215,8 +232,8 @@ export const PickQuestion: Story = {
 };
 
 /**
- * A `gate`: a destructive step, with the cautious answer first because a
- * skipped question takes it.
+ * A `gate`: a destructive step, with the cautious answer first because that
+ * is the one shown as recommended.
  */
 export const GateQuestion: Story = {
   render: () => (
@@ -336,6 +353,14 @@ export const UnusableQuestionDropped: Story = {
       }}
     />
   ),
+};
+
+/**
+ * What the card becomes once it has been answered, as a restored conversation
+ * would show it: the task and one line saying what happened to it.
+ */
+export const Saved: Story = {
+  render: () => <RetroPreview templateData={FULL_REPORT} completed />,
 };
 
 /**

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
@@ -399,6 +399,18 @@ describe("WatchRetroSurface", () => {
       expect(screen.getByText("Flagged as not right")).toBeDefined();
     });
     expect(screen.queryByText("Something's off")).toBeNull();
+
+    // The daemon's summary is the ending that actually landed. When it
+    // disagrees with what this mount submitted, because another client
+    // answered the same card first, the summary wins.
+    rerender(
+      <CardSurface
+        surface={{ ...current, completionSummary: "Skill saved" }}
+        onAction={() => undefined}
+      />,
+    );
+    expect(screen.getByText("Skill saved")).toBeDefined();
+    expect(screen.queryByText("Flagged as not right")).toBeNull();
   });
 
   test("saying the recap read wrong ends the card without saving", () => {

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
@@ -163,8 +163,7 @@ describe("WatchRetroSurface", () => {
       screen.getByText("You set this one to High. What decides that?"),
     ).toBeDefined();
 
-    // Nothing is preselected: a highlighted default under a Skip button was
-    // what users reached for when they meant to move on.
+    // Nothing is preselected: the recommendation is marked, not chosen.
     const options = screen.getAllByRole("button", { pressed: false });
     expect(options.map((option) => option.textContent)).toEqual([
       expect.stringContaining("Over 100 events"),

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
@@ -1,11 +1,12 @@
 /**
- * The card's two load-bearing behaviours: it pages, and every page a user taps
- * past still lands on an answer.
+ * The card's load-bearing behaviours: it pages, a pick or a gate is answered
+ * by the user rather than for them, and the card says when it is done.
  *
- * Neither is visible to a static render. The card is only short if the
- * questions really are on separate pages, and "every question is optional" only
- * holds if skipping submits a default rather than a hole, with the gate
- * defaulting to the cautious option rather than to what the recording showed.
+ * None of them is visible to a static render. The card is only short if the
+ * questions really are on separate pages; an answer is only the user's if no
+ * option starts selected and the page cannot be left without a tap; and a
+ * submitted card only reads as submitted if the completed surface draws
+ * something other than the page it was on.
  */
 
 import { afterEach, describe, expect, test } from "bun:test";
@@ -97,7 +98,7 @@ describe("WatchRetroSurface", () => {
     ).toBeNull();
   });
 
-  test("submits a default for every page the user skips", async () => {
+  test("a skipped fill keeps its suggestion, and a tapped pick is the user's", async () => {
     const calls: { actionId: string; data?: Record<string, unknown> }[] = [];
     render(
       <CardSurface
@@ -108,20 +109,22 @@ describe("WatchRetroSurface", () => {
       />,
     );
 
-    // Past the recap, then skip all three questions, which lands on the
-    // summary. Skipping every page reaches review without submitting: saving
-    // is its own act, asked for on the summary and nowhere else.
+    // Past the recap, skip the trigger, then answer the pick and the gate by
+    // tapping their recommended option. That lands on the summary without
+    // submitting: saving is its own act, asked for there and nowhere else.
     fireEvent.click(screen.getByText("Looks right"));
     fireEvent.click(screen.getByText("Skip"));
-    fireEvent.click(screen.getByText("Skip"));
-    fireEvent.click(screen.getByText("Skip"));
+    fireEvent.click(screen.getByText("Over 100 events"));
+    fireEvent.click(screen.getByText("Ask me first"));
     expect(calls).toHaveLength(0);
 
     fireEvent.click(screen.getByText("Save skill"));
     expect(calls).toHaveLength(1);
     // A `card` is not one-shot daemon-side, so the card has to ask to be
-    // completed or it stays answerable after it has been answered.
+    // completed or it stays answerable after it has been answered. The summary
+    // rides along so history restores what happened rather than "Completed".
     expect(calls[0]!.data!._completeSurface).toBe(true);
+    expect(calls[0]!.data!._completionSummary).toBe("Skill saved");
     const answers = calls[0]!.data!.answers as {
       questionId: string;
       answer: string;
@@ -137,22 +140,65 @@ describe("WatchRetroSurface", () => {
       answer: "file this Sentry bug",
       skipped: true,
     });
-    // A skipped `pick` takes the first option: the reading the recording
-    // already supports, so accepting it is the status quo.
+    // Tapping the recommended option is still a choice: it goes out as the
+    // user's answer, not as an accepted default.
     expect(answers[1]).toMatchObject({
       questionId: "priority",
       optionId: "events",
-      skipped: true,
+      skipped: false,
     });
-    // A skipped `gate` takes the first option too, and on a gate that has to
-    // be the cautious one. Watching someone resolve an issue once is not
-    // agreement to have it resolved again unattended, so tapping through the
-    // card must never hand over the destructive step.
     expect(answers[2]).toMatchObject({
       questionId: "resolve",
       optionId: "ask",
-      skipped: true,
+      skipped: false,
     });
+  });
+
+  test("a pick starts with nothing selected, the first option marked, and no way past it but a tap", () => {
+    render(<CardSurface surface={surface()} onAction={() => undefined} />);
+
+    fireEvent.click(screen.getByText("Looks right"));
+    fireEvent.click(screen.getByText("Next"));
+    expect(
+      screen.getByText("You set this one to High. What decides that?"),
+    ).toBeDefined();
+
+    // Nothing is preselected: a highlighted default under a Skip button was
+    // what users reached for when they meant to move on.
+    const options = screen.getAllByRole("button", { pressed: false });
+    expect(options.map((option) => option.textContent)).toEqual([
+      expect.stringContaining("Over 100 events"),
+      expect.stringContaining("It hit a customer"),
+    ]);
+    expect(screen.queryAllByRole("button", { pressed: true })).toHaveLength(0);
+    // The recommendation is visible without being the answer.
+    expect(options[0]!.textContent).toContain("Recommended");
+    expect(options[1]!.textContent).not.toContain("Recommended");
+
+    // The page cannot be left forward without answering.
+    expect(screen.queryByText("Skip")).toBeNull();
+    expect(screen.queryByText("Next")).toBeNull();
+  });
+
+  test("a pick revisited with an answer standing can be left with Next", () => {
+    render(<CardSurface surface={surface()} onAction={() => undefined} />);
+
+    fireEvent.click(screen.getByText("Looks right"));
+    fireEvent.click(screen.getByText("Next"));
+    fireEvent.click(screen.getByText("It hit a customer"));
+    expect(
+      screen.getByText("Resolving the Sentry issue, on my own?"),
+    ).toBeDefined();
+
+    // Back on the pick, the answer is still marked, and Next has appeared so
+    // moving on does not mean tapping the same option again.
+    fireEvent.click(screen.getByText("Back"));
+    const chosen = screen.getByRole("button", { pressed: true });
+    expect(chosen.textContent).toContain("It hit a customer");
+    fireEvent.click(screen.getByText("Next"));
+    expect(
+      screen.getByText("Resolving the Sentry issue, on my own?"),
+    ).toBeDefined();
   });
 
   test("commits a pick on tap and moves to the next page", () => {
@@ -168,8 +214,7 @@ describe("WatchRetroSurface", () => {
 
     fireEvent.click(screen.getByText("Looks right"));
     fireEvent.click(screen.getByText("Next"));
-    // A single-select surface commits on tap everywhere else in the app, so
-    // the pick page carries no advance button: the option is the gesture.
+    // The option is the gesture: a tap answers and advances in one.
     fireEvent.click(screen.getByText("It hit a customer"));
 
     expect(calls).toHaveLength(0);
@@ -290,11 +335,69 @@ describe("WatchRetroSurface", () => {
 
     fireEvent.click(screen.getByText("Looks right"));
     fireEvent.click(screen.getByText("Skip"));
-    fireEvent.click(screen.getByText("Skip"));
-    fireEvent.click(screen.getByText("Skip"));
+    fireEvent.click(screen.getByText("Over 100 events"));
+    fireEvent.click(screen.getByText("Ask me first"));
 
     fireEvent.click(screen.getByText("Don't save"));
     expect(calls).toEqual(["discard"]);
+  });
+
+  test("a completed surface collapses to one row saying what happened", () => {
+    const { rerender } = render(
+      <CardSurface surface={surface()} onAction={() => undefined} />,
+    );
+    expect(screen.getByText("Looks right")).toBeDefined();
+
+    // What `completeSubmittedSurface` does the moment a submit is accepted:
+    // completed, with no summary until the daemon's completion event lands.
+    rerender(
+      <CardSurface
+        surface={{ ...surface(), completed: true }}
+        onAction={() => undefined}
+      />,
+    );
+    expect(screen.queryByText("Looks right")).toBeNull();
+    expect(screen.queryByText("Open the Sentry issue")).toBeNull();
+    expect(
+      screen.getByText("Filing a Linear bug from a Sentry alert"),
+    ).toBeDefined();
+    expect(screen.getByText("Done")).toBeDefined();
+
+    // The summary the card sent is what the daemon echoes back and what a
+    // restored conversation carries, so it wins once it is there.
+    rerender(
+      <CardSurface
+        surface={{
+          ...surface(),
+          completed: true,
+          completionSummary: "Flagged as not right",
+        }}
+        onAction={() => undefined}
+      />,
+    );
+    expect(screen.getByText("Flagged as not right")).toBeDefined();
+    expect(screen.queryByText("Done")).toBeNull();
+  });
+
+  test("the ending submitted from this card names the row before the summary arrives", async () => {
+    let current = surface();
+    const { rerender } = render(
+      <CardSurface
+        surface={current}
+        onAction={(_surfaceId, _actionId, data) => {
+          // The optimistic completion: no summary yet, only the flag.
+          expect(data!._completionSummary).toBe("Flagged as not right");
+          current = { ...current, completed: true };
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Something's off"));
+    rerender(<CardSurface surface={current} onAction={() => undefined} />);
+    await waitFor(() => {
+      expect(screen.getByText("Flagged as not right")).toBeDefined();
+    });
+    expect(screen.queryByText("Something's off")).toBeNull();
   });
 
   test("saying the recap read wrong ends the card without saving", () => {

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.test.tsx
@@ -363,7 +363,9 @@ describe("WatchRetroSurface", () => {
     expect(screen.getByText("Done")).toBeDefined();
 
     // The summary the card sent is what the daemon echoes back and what a
-    // restored conversation carries, so it wins once it is there.
+    // restored conversation carries. It is matched back to its ending and
+    // drawn from the catalog, so the row reads in the viewer's locale rather
+    // than the locale of whoever answered.
     rerender(
       <CardSurface
         surface={{

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -58,10 +58,9 @@ import { cn } from "@/utils/misc";
  * No option starts selected. The first one is marked as recommended, which is
  * what the payload contract makes it: the model's own reading on a pick and
  * the cautious answer on a gate. A tap commits and advances in one gesture,
- * so the page carries no Skip: a preselected default under a Skip button was
- * the thing users reached for when they meant to go forward. A page revisited
- * with an answer already standing shows Next instead, so moving on does not
- * mean tapping the same option twice.
+ * and until the user has tapped, the page has no forward action at all: no
+ * Skip, no Next. A page revisited with an answer already standing shows Next,
+ * so moving on does not mean tapping the same option twice.
  *
  * **A fill is skippable and the skip is safe.** It starts on its suggestion,
  * so skipping keeps a working phrase. `defaultAnswerFor` also supplies the
@@ -71,12 +70,11 @@ import { cn } from "@/utils/misc";
  * **One submission, at the end.** Answers accumulate in local state and go out
  * as a single action payload rather than one turn per question.
  *
- * **The card says when it is done.** A `card` never collapses on its own: the
- * router only folds the inherently interactive types, and the card's own
- * renderer redrew the same page after Save, so the only feedback was the
- * spinner. Once the surface is completed, the whole card gives way to one row
- * naming what happened, with a summary sent along in the action so history
- * and the daemon's completion event say the same thing.
+ * **The card draws its own completed state.** The router folds only the
+ * inherently interactive surface types, and a `card` is not one of them, so
+ * once the surface is completed this renderer gives the whole card over to
+ * one row naming what happened. The summary for that row is sent along in the
+ * action, so history and the daemon's completion event say the same thing.
  */
 
 interface WatchRetroSurfaceProps {
@@ -709,8 +707,8 @@ function QuestionPage({
   const { t } = useTranslation("chat");
   const promptId = `watch-retro-q-${question.id}`;
   // Only a tapped answer is marked. The answer of record before any tap is
-  // the first option, but drawing it selected is what put users one Skip away
-  // from an answer they never gave.
+  // the first option, and it stays unmarked so the recommendation is visible
+  // without reading as a choice already made.
   const selectedOptionId =
     answer && !answer.skipped ? answer.optionId : undefined;
 

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -556,15 +556,16 @@ export function WatchRetroSurface({
  * What the card becomes once it has been answered: the task, and one line
  * saying what happened to it.
  *
- * The summary comes from the surface when it has one, which is what a
- * restored conversation carries and what the daemon's completion event set.
- * Until that arrives the ending submitted from this mount fills in, and a
- * completed surface with neither, which is a card answered elsewhere before
- * this client learned the template, still says it is done.
+ * The surface's own summary is authoritative: it is what the daemon's
+ * completion event set and what a restored conversation carries, and it is
+ * the ending that actually landed when two clients answered the same card.
+ * Only while the surface is completed with no summary yet does the ending
+ * submitted from this mount fill in, and a completed surface with neither,
+ * which is a card answered elsewhere before this client learned the
+ * template, still says it is done.
  *
- * The glyph and the wording follow the ending. On a restored card the ending
- * is not known directly, so it is read back off the persisted summary, which
- * the card wrote from its own fixed labels, and the line is then drawn from
+ * The glyph and the wording follow the ending. From a summary the ending is
+ * read back off the card's own fixed labels, and the line is then drawn from
  * the catalog in the current locale. A summary the card did not write, such
  * as a bare "Completed" from a daemon that ignored the request, is shown as
  * it is and takes the tone every other completed card would infer from it.
@@ -581,12 +582,11 @@ function CompletedRow({
   tone: Surface["completionTone"];
 }) {
   const { t } = useTranslation("chat");
-  const resolvedOutcome =
-    outcome ??
-    OUTCOMES.find(
-      (candidate) => summary === OUTCOME_STYLE[candidate].summary,
-    ) ??
-    null;
+  const resolvedOutcome = summary
+    ? (OUTCOMES.find(
+        (candidate) => summary === OUTCOME_STYLE[candidate].summary,
+      ) ?? null)
+    : outcome;
   const style: CompletionStyle = resolvedOutcome
     ? OUTCOME_STYLE[resolvedOutcome]
     : COMPLETION_TONE_STYLE[tone ?? inferCompletionTone(summary)];

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -178,14 +178,22 @@ interface CompletionStyle {
 
 /**
  * How each ending is drawn once the surface is completed: the glyph, its
- * colour, and the catalog key for the line beside it. `answer` is the one
- * success and `discard` is a void, so both borrow the tones every other
- * completed card uses. `not_right` is neither: the turn picks it up and asks
- * what was off, so it reads as a message sent.
+ * colour, the catalog key for the line beside it, and the summary the action
+ * carries to the daemon. `answer` is the one success and `discard` is a void,
+ * so both borrow the tones every other completed card uses. `not_right` is
+ * neither: the turn picks it up and asks what was off, so it reads as a
+ * message sent.
+ *
+ * `summary` is a fixed English label rather than the catalog string, because
+ * it is persisted with the conversation and every other completion summary
+ * the daemon writes ("Completed", "Cancelled", "Denied") is English too. The
+ * row translates it back through `summaryKey` at render time, so a card
+ * answered in one locale still reads in whichever locale opens it.
  */
 const OUTCOME_STYLE: Record<
   WatchRetroOutcome,
   CompletionStyle & {
+    summary: string;
     summaryKey:
       | "watchRetroSurface.doneSaved"
       | "watchRetroSurface.doneNotRight"
@@ -194,15 +202,18 @@ const OUTCOME_STYLE: Record<
 > = {
   answer: {
     ...COMPLETION_TONE_STYLE.success,
+    summary: "Skill saved",
     summaryKey: "watchRetroSurface.doneSaved",
   },
   not_right: {
     Icon: MessageSquareWarning,
     colorClass: "text-[color:var(--content-quiet)]",
+    summary: "Flagged as not right",
     summaryKey: "watchRetroSurface.doneNotRight",
   },
   discard: {
     ...COMPLETION_TONE_STYLE.neutral,
+    summary: "Not saved",
     summaryKey: "watchRetroSurface.doneDiscarded",
   },
 };
@@ -309,10 +320,10 @@ export function WatchRetroSurface({
           // answer goes out in this one payload. Without it the card would
           // stay answerable after it had been answered.
           _completeSurface: true,
-          // The line the completed row shows. Without it the daemon summarises
-          // the completion as a bare "Completed", and that is what history
-          // would restore in place of what actually happened.
-          _completionSummary: t(OUTCOME_STYLE[actionId].summaryKey),
+          // What the daemon records as the completion. Without it the
+          // completion is summarised as a bare "Completed", and that is what
+          // history would restore in place of what actually happened.
+          _completionSummary: OUTCOME_STYLE[actionId].summary,
         });
       } finally {
         // Released unconditionally, matching `SurfaceContainer`. A rejection is
@@ -324,7 +335,7 @@ export function WatchRetroSurface({
         setSubmitting(false);
       }
     },
-    [onAction, questions, submitting, surface.surfaceId, t],
+    [onAction, questions, submitting, surface.surfaceId],
   );
 
   /**
@@ -551,11 +562,12 @@ export function WatchRetroSurface({
  * completed surface with neither, which is a card answered elsewhere before
  * this client learned the template, still says it is done.
  *
- * The glyph follows the ending. On a restored card the ending is not known
- * directly, so it is read back off the summary: the card wrote that summary
- * from its own catalog, so a match is exact. A summary the card did not
- * write, such as a bare "Completed" from a daemon that ignored the request,
- * takes the tone every other completed card would infer from it.
+ * The glyph and the wording follow the ending. On a restored card the ending
+ * is not known directly, so it is read back off the persisted summary, which
+ * the card wrote from its own fixed labels, and the line is then drawn from
+ * the catalog in the current locale. A summary the card did not write, such
+ * as a bare "Completed" from a daemon that ignored the request, is shown as
+ * it is and takes the tone every other completed card would infer from it.
  */
 function CompletedRow({
   heading,
@@ -572,17 +584,15 @@ function CompletedRow({
   const resolvedOutcome =
     outcome ??
     OUTCOMES.find(
-      (candidate) => summary === t(OUTCOME_STYLE[candidate].summaryKey),
+      (candidate) => summary === OUTCOME_STYLE[candidate].summary,
     ) ??
     null;
   const style: CompletionStyle = resolvedOutcome
     ? OUTCOME_STYLE[resolvedOutcome]
     : COMPLETION_TONE_STYLE[tone ?? inferCompletionTone(summary)];
-  const line =
-    summary ||
-    (resolvedOutcome
-      ? t(OUTCOME_STYLE[resolvedOutcome].summaryKey)
-      : t("surfaceRouter.done"));
+  const line = resolvedOutcome
+    ? t(OUTCOME_STYLE[resolvedOutcome].summaryKey)
+    : summary || t("surfaceRouter.done");
 
   return (
     <Card padding="sm" bordered>

--- a/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/watch-retro-surface.tsx
@@ -10,6 +10,7 @@ import {
   ListRow,
   Stepper,
   type StepperStep,
+  Tag,
   Typography,
 } from "@vellumai/design-library";
 import {
@@ -18,9 +19,12 @@ import {
   ChevronRight,
   GraduationCap,
   Loader2,
+  MessageSquareWarning,
 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import { type ComponentType, useCallback, useMemo, useState } from "react";
 
+import { inferCompletionTone } from "@/domains/chat/completion-tone";
+import { COMPLETION_TONE_STYLE } from "@/domains/chat/components/surfaces/surface-container";
 import type { Surface } from "@/domains/chat/types/types";
 import { useTranslation } from "@/i18n";
 import { cn } from "@/utils/misc";
@@ -50,13 +54,29 @@ import { cn } from "@/utils/misc";
  * notice. The retro is the whole of what a finished session gives the user and
  * the turn writes no prose beside it, so it has to survive an older client.
  *
- * **Every page is skippable and every skip is safe.** Skipping advances with a
- * default already in hand. `defaultAnswerFor` owns which: the first option,
- * which the payload contract requires to be the cautious answer on a gate and
- * the model's own reading on a pick.
+ * **A pick or a gate is answered by tapping, and nothing is tapped for you.**
+ * No option starts selected. The first one is marked as recommended, which is
+ * what the payload contract makes it: the model's own reading on a pick and
+ * the cautious answer on a gate. A tap commits and advances in one gesture,
+ * so the page carries no Skip: a preselected default under a Skip button was
+ * the thing users reached for when they meant to go forward. A page revisited
+ * with an answer already standing shows Next instead, so moving on does not
+ * mean tapping the same option twice.
+ *
+ * **A fill is skippable and the skip is safe.** It starts on its suggestion,
+ * so skipping keeps a working phrase. `defaultAnswerFor` also supplies the
+ * first option as a pick's or gate's answer of record, which is only reached
+ * when a page was never answered, since the summary is behind every page.
  *
  * **One submission, at the end.** Answers accumulate in local state and go out
  * as a single action payload rather than one turn per question.
+ *
+ * **The card says when it is done.** A `card` never collapses on its own: the
+ * router only folds the inherently interactive types, and the card's own
+ * renderer redrew the same page after Save, so the only feedback was the
+ * spinner. Once the surface is completed, the whole card gives way to one row
+ * naming what happened, with a summary sent along in the action so history
+ * and the daemon's completion event say the same thing.
  */
 
 interface WatchRetroSurfaceProps {
@@ -87,10 +107,12 @@ interface WatchRetroAnswer {
  * The answer a question carries before the user touches it.
  *
  * A `fill` starts on its suggestion, which is what makes skipping it an
- * acceptance rather than a blank. A `pick` and a `gate` start on their first
- * option: the payload contract puts the model's reading first on a pick and
- * the cautious answer first on a gate, so this one rule covers both without
- * the renderer having to know which is which.
+ * acceptance rather than a blank. A `pick` and a `gate` hold their first
+ * option as the answer of record without showing it as selected: the payload
+ * contract puts the model's reading first on a pick and the cautious answer
+ * first on a gate, so this one rule covers both without the renderer having
+ * to know which is which. `skipped` stays true until the user actually taps,
+ * which is also what the page reads to decide whether anything is marked.
  */
 function defaultAnswerFor(question: WatchRetroQuestion): WatchRetroAnswer {
   const firstOption = question.options?.[0];
@@ -148,6 +170,47 @@ function usableQuestions(
   });
 }
 
+/** The three ways the card can end, keyed by the action that ends it. */
+type WatchRetroOutcome = "answer" | "not_right" | "discard";
+
+interface CompletionStyle {
+  Icon: ComponentType<{ className?: string }>;
+  colorClass: string;
+}
+
+/**
+ * How each ending is drawn once the surface is completed: the glyph, its
+ * colour, and the catalog key for the line beside it. `answer` is the one
+ * success and `discard` is a void, so both borrow the tones every other
+ * completed card uses. `not_right` is neither: the turn picks it up and asks
+ * what was off, so it reads as a message sent.
+ */
+const OUTCOME_STYLE: Record<
+  WatchRetroOutcome,
+  CompletionStyle & {
+    summaryKey:
+      | "watchRetroSurface.doneSaved"
+      | "watchRetroSurface.doneNotRight"
+      | "watchRetroSurface.doneDiscarded";
+  }
+> = {
+  answer: {
+    ...COMPLETION_TONE_STYLE.success,
+    summaryKey: "watchRetroSurface.doneSaved",
+  },
+  not_right: {
+    Icon: MessageSquareWarning,
+    colorClass: "text-[color:var(--content-quiet)]",
+    summaryKey: "watchRetroSurface.doneNotRight",
+  },
+  discard: {
+    ...COMPLETION_TONE_STYLE.neutral,
+    summaryKey: "watchRetroSurface.doneDiscarded",
+  },
+};
+
+const OUTCOMES = Object.keys(OUTCOME_STYLE) as WatchRetroOutcome[];
+
 export function WatchRetroSurface({
   surface,
   templateData,
@@ -170,6 +233,11 @@ export function WatchRetroSurface({
 
   const [pageIndex, setPageIndex] = useState(0);
   const [submitting, setSubmitting] = useState(false);
+  // Which ending was submitted from this mount. The completed row prefers the
+  // surface's own summary, which is what history restores; this is the
+  // fallback for the gap between the optimistic completion and the daemon's
+  // `ui_surface_complete`, when the surface is completed with no summary yet.
+  const [outcome, setOutcome] = useState<WatchRetroOutcome | null>(null);
   // Whether the summary has been reached. Once it has, the card is being
   // reviewed rather than filled in, and every page returns there.
   const [reviewed, setReviewed] = useState(false);
@@ -222,11 +290,15 @@ export function WatchRetroSurface({
   );
 
   const submit = useCallback(
-    async (actionId: string, collected: Record<string, WatchRetroAnswer>) => {
+    async (
+      actionId: WatchRetroOutcome,
+      collected: Record<string, WatchRetroAnswer>,
+    ) => {
       if (submitting) {
         return;
       }
       setSubmitting(true);
+      setOutcome(actionId);
       try {
         await onAction(surface.surfaceId, actionId, {
           // Ordered by the pages they were asked on, so the model reads them in
@@ -239,6 +311,10 @@ export function WatchRetroSurface({
           // answer goes out in this one payload. Without it the card would
           // stay answerable after it had been answered.
           _completeSurface: true,
+          // The line the completed row shows. Without it the daemon summarises
+          // the completion as a bare "Completed", and that is what history
+          // would restore in place of what actually happened.
+          _completionSummary: t(OUTCOME_STYLE[actionId].summaryKey),
         });
       } finally {
         // Released unconditionally, matching `SurfaceContainer`. A rejection is
@@ -250,7 +326,7 @@ export function WatchRetroSurface({
         setSubmitting(false);
       }
     },
-    [onAction, questions, submitting, surface.surfaceId],
+    [onAction, questions, submitting, surface.surfaceId, t],
   );
 
   /**
@@ -289,6 +365,17 @@ export function WatchRetroSurface({
   }, [goToPage, pageIndex]);
 
   const heading = data.task || t("watchRetroSurface.untitledTask");
+
+  if (surface.completed) {
+    return (
+      <CompletedRow
+        heading={heading}
+        summary={surface.completionSummary}
+        outcome={outcome}
+        tone={surface.completionTone}
+      />
+    );
+  }
 
   return (
     <Card padding="lg" bordered>
@@ -392,14 +479,14 @@ export function WatchRetroSurface({
             </Button>
           )}
 
-          {currentQuestion && (
+          {currentQuestion?.kind === "fill" && (
             <Button
               variant="ghost"
               disabled={submitting}
               onClick={() => {
-                // The default is already in `answers`, so a skip only has to
-                // move on. It stays marked skipped so the model can tell an
-                // accepted default from a chosen one.
+                // The suggestion is already in `answers`, so a skip only has
+                // to move on. It stays marked skipped so the model can tell an
+                // accepted suggestion from a typed one.
                 advance(answers);
               }}
             >
@@ -421,11 +508,15 @@ export function WatchRetroSurface({
             </Button>
           )}
 
-          {/* A `pick` and a `gate` commit on tap, matching every other
-              single-select surface in the app, so their page carries no
-              advance button. The recap, a `fill` and the summary have nothing
-              to tap, so they keep one. */}
-          {(onRecap || onSummary || currentQuestion?.kind === "fill") && (
+          {/* A `pick` and a `gate` commit on tap, so their page earns an
+              advance button only once an answer is standing: a page revisited
+              from the summary can be left without tapping the same option
+              again. The recap, a `fill` and the summary have nothing to tap,
+              so they always keep one. */}
+          {(onRecap ||
+            onSummary ||
+            currentQuestion?.kind === "fill" ||
+            (currentQuestion && !answers[currentQuestion.id]?.skipped)) && (
             <Button
               variant="primary"
               disabled={submitting}
@@ -447,6 +538,74 @@ export function WatchRetroSurface({
             </Button>
           )}
         </div>
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * What the card becomes once it has been answered: the task, and one line
+ * saying what happened to it.
+ *
+ * The summary comes from the surface when it has one, which is what a
+ * restored conversation carries and what the daemon's completion event set.
+ * Until that arrives the ending submitted from this mount fills in, and a
+ * completed surface with neither, which is a card answered elsewhere before
+ * this client learned the template, still says it is done.
+ *
+ * The glyph follows the ending. On a restored card the ending is not known
+ * directly, so it is read back off the summary: the card wrote that summary
+ * from its own catalog, so a match is exact. A summary the card did not
+ * write, such as a bare "Completed" from a daemon that ignored the request,
+ * takes the tone every other completed card would infer from it.
+ */
+function CompletedRow({
+  heading,
+  summary,
+  outcome,
+  tone,
+}: {
+  heading: string;
+  summary: string | undefined;
+  outcome: WatchRetroOutcome | null;
+  tone: Surface["completionTone"];
+}) {
+  const { t } = useTranslation("chat");
+  const resolvedOutcome =
+    outcome ??
+    OUTCOMES.find(
+      (candidate) => summary === t(OUTCOME_STYLE[candidate].summaryKey),
+    ) ??
+    null;
+  const style: CompletionStyle = resolvedOutcome
+    ? OUTCOME_STYLE[resolvedOutcome]
+    : COMPLETION_TONE_STYLE[tone ?? inferCompletionTone(summary)];
+  const line =
+    summary ||
+    (resolvedOutcome
+      ? t(OUTCOME_STYLE[resolvedOutcome].summaryKey)
+      : t("surfaceRouter.done"));
+
+  return (
+    <Card padding="sm" bordered>
+      <div className="flex items-center gap-3">
+        <GraduationCap className="h-4 w-4 shrink-0 text-[color:var(--content-quiet)]" />
+        <Typography
+          variant="body-medium-default"
+          as="span"
+          className="min-w-0 flex-1 truncate text-[color:var(--content-strong)]"
+        >
+          {heading}
+        </Typography>
+        <span
+          className={cn(
+            "flex shrink-0 items-center gap-1.5 text-body-medium-default",
+            style.colorClass,
+          )}
+        >
+          <style.Icon className="h-4 w-4 shrink-0" />
+          {line}
+        </span>
       </div>
     </Card>
   );
@@ -547,8 +706,13 @@ function QuestionPage({
   onFillChange: (value: string) => void;
   onPick: (optionId: string, label: string) => void;
 }) {
+  const { t } = useTranslation("chat");
   const promptId = `watch-retro-q-${question.id}`;
-  const selectedOptionId = answer?.optionId ?? question.options?.[0]?.id;
+  // Only a tapped answer is marked. The answer of record before any tap is
+  // the first option, but drawing it selected is what put users one Skip away
+  // from an answer they never gave.
+  const selectedOptionId =
+    answer && !answer.skipped ? answer.optionId : undefined;
 
   return (
     <div>
@@ -627,13 +791,25 @@ function QuestionPage({
                   {selected && <Check className="h-3.5 w-3.5" />}
                 </span>
                 <span className="min-w-0 flex-1">
-                  <Typography
-                    as="span"
-                    variant="body-medium-default"
-                    className="block text-[color:var(--content-strong)]"
-                  >
-                    {option.label}
-                  </Typography>
+                  <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <Typography
+                      as="span"
+                      variant="body-medium-default"
+                      className="text-[color:var(--content-strong)]"
+                    >
+                      {option.label}
+                    </Typography>
+                    {/* The first option is the recommended one by contract:
+                        the recording's own reading on a pick, the cautious
+                        answer on a gate. Marked rather than preselected, so
+                        the recommendation is visible and the answer is still
+                        the user's. */}
+                    {index === 0 && (
+                      <Tag tone="info">
+                        {t("watchRetroSurface.recommended")}
+                      </Tag>
+                    )}
+                  </span>
                   {option.note && (
                     <Typography
                       as="span"

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1837,9 +1837,13 @@
   },
   "watchRetroSurface": {
     "back": "Back",
+    "doneDiscarded": "Not saved",
+    "doneNotRight": "Flagged as not right",
+    "doneSaved": "Skill saved",
     "dontSave": "Don't save",
     "looksRight": "Looks right",
     "next": "Next",
+    "recommended": "Recommended",
     "save": "Save skill",
     "skip": "Skip",
     "somethingOff": "Something's off",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1779,6 +1779,12 @@
     "reactionRemoved": "{name} quitó su reacción {emoji}",
     "reactionSomeone": "Alguien"
   },
+  "watchRetroSurface": {
+    "doneDiscarded": "No se guardó",
+    "doneNotRight": "Marcado como incorrecto",
+    "doneSaved": "Habilidad guardada",
+    "recommended": "Recomendado"
+  },
   "restoreManagedCredentialButton": {
     "restore": "Restaurar acceso",
     "restoring": "Restaurando...",

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -842,6 +842,12 @@
     "collapse": "Скрыть показатели фильтра кадров",
     "expand": "Показать показатели фильтра кадров"
   },
+  "watchRetroSurface": {
+    "doneDiscarded": "Не сохранено",
+    "doneNotRight": "Отмечено как неверное",
+    "doneSaved": "Навык сохранён",
+    "recommended": "Рекомендуем"
+  },
   "restoreManagedCredentialButton": {
     "restore": "Восстановить доступ",
     "restoring": "Восстановление...",

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -1757,6 +1757,12 @@
     "reactionRemoved": "{name} 移除了 {emoji} 回應",
     "reactionSomeone": "有人"
   },
+  "watchRetroSurface": {
+    "doneDiscarded": "未儲存",
+    "doneNotRight": "已標記為有誤",
+    "doneSaved": "技能已儲存",
+    "recommended": "推薦"
+  },
   "restoreManagedCredentialButton": {
     "restore": "復原存取",
     "restoring": "正在復原...",

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -1757,6 +1757,12 @@
     "reactionRemoved": "{name} 移除了 {emoji} 回应",
     "reactionSomeone": "有人"
   },
+  "watchRetroSurface": {
+    "doneDiscarded": "未保存",
+    "doneNotRight": "已标记为有误",
+    "doneSaved": "技能已保存",
+    "recommended": "推荐"
+  },
   "restoreManagedCredentialButton": {
     "restore": "恢复访问",
     "restoring": "正在恢复...",


### PR DESCRIPTION
## What

Three pieces of feedback on the Teach retro card, the one a companion voice teach session ends on.

**A pick or a gate is answered by the user, not for them.** The first option used to start selected, with Skip as the only right-hand button, so Skip sat where Next was expected. Now nothing is selected, the first option carries a `Recommended` tag (the payload contract already makes it the recording's reading on a pick and the cautious answer on a gate), a tap commits and advances, and those pages have no Skip. A page revisited from the summary with an answer standing shows Next, so moving on does not mean tapping the same option twice. The fill page is unchanged.

**Save, Don't save and Something's off now visibly land.** All three completed the surface, but a `card` is not one of the types the router folds and the retro renderer ignored `surface.completed`, so the same page redrew with live buttons and the only feedback was the button spinner. The card now collapses to a single row: the task, plus "Skill saved", "Not saved" or "Flagged as not right". That line rides along as `_completionSummary`, so the daemon's `ui_surface_complete` and a restored conversation say the same thing instead of a bare "Completed". Glyphs come from the shared completion-tone styles, now exported from `SurfaceContainer`.

**Daemon side** is wording only: the model prompt and schema comments no longer describe the first option as a preselected default that a skip takes.

## Seeing it

Storybook `Chat/Surfaces/WatchRetro`: `PickQuestion` and `GateQuestion` show the untouched page (nothing selected, first option tagged, Back only), and the new `Saved` story shows the collapsed row.

## Tests

- `watch-retro-surface.test.tsx`: no preselection and no way past a pick without a tap; a revisited pick offers Next; a completed surface collapses, with the submitted ending naming the row before the daemon's summary arrives.
- `watch-retro.test.ts` (daemon): prompt assertions updated for the new wording.
- Web typecheck, lint, and the surface / catalog tests are green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCcin9ThEjN3T7AGYtD4
