### PR TITLE
fix(activation): round-2 review gaps

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -807,7 +807,7 @@ graph LR
     START["POST /v1/activation/tasks/:id/start<br/>links task to conversation"]
     LOOP["Agent loop"]
     TOOL["onActivationToolCall<br/>throttled stepCount bump"]
-    DONE["onActivationTurnComplete<br/>status=done + artifacts<br/>(only when the turn did something)"]
+    DONE["onActivationTurnComplete<br/>status=done + artifacts<br/>(unless the turn ended awaiting the user)"]
     ATT["resolveAssistantAttachments<br/>persisted workspace files only"]
     STORE["activation-progress.json<br/>serialized atomic writes"]
     SYNC["sync_changed<br/>activation:progress"]

--- a/assistant/src/activation/progress-store.test.ts
+++ b/assistant/src/activation/progress-store.test.ts
@@ -15,9 +15,24 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import * as nodeFs from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+
+/**
+ * The real implementation, captured before any spy replaces it, so a stub
+ * that wants the genuine bytes does not call itself.
+ */
+const realReadFileSync = nodeFs.readFileSync;
 
 import type { ActivationProgress } from "../api/responses/activation.js";
 import { _resetStreamStateForTesting } from "../runtime/assistant-stream-state.js";
@@ -489,6 +504,38 @@ describe("activation progress store", () => {
       });
     });
 
+    test("a write during a read is not stamped as already indexed", async () => {
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      // Cold index, so the next lookup has to go to disk.
+      resetActivationStepThrottleForTesting(THROTTLE_MS);
+
+      const external = readRawProgress();
+      external.tasks["book-travel"] = startedTask("conv-2");
+
+      const spy = spyOn(nodeFs, "readFileSync");
+      spy.mockImplementationOnce(((path: never, options: never) => {
+        const raw = realReadFileSync(path, options);
+        // Another process records the link while this read is in flight.
+        writeProgressBehindStore(external);
+        return raw;
+      }) as typeof nodeFs.readFileSync);
+      try {
+        await bumpActivationStepCount("conv-unlinked");
+      } finally {
+        spy.mockRestore();
+      }
+
+      // The index holds the pre-write bytes. Stamping it after the read
+      // would file them under the post-write stamp, and this link would
+      // stay invisible for the life of the process.
+      await bumpActivationStepCount("conv-2");
+
+      expect(readRawProgress().tasks["book-travel"].stepCount).toBe(1);
+    });
+
     test("the test-only reset drops the index", async () => {
       await startActivationTask({
         taskId: "draft-email",
@@ -822,6 +869,38 @@ describe("activation progress store", () => {
         expect(readRawProgress().tasks["draft-email"].stepCount).toBe(0);
       },
     );
+
+    test("a failed step flush still lets the turn complete", async () => {
+      // A window wide enough that the second bump is certain to be pending
+      // when the completion flushes it.
+      resetActivationStepThrottleForTesting(5_000);
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      await bumpActivationStepCount("conv-1");
+      await bumpActivationStepCount("conv-1");
+
+      const spy = spyOn(nodeFs, "writeFileSync");
+      spy.mockImplementationOnce(() => {
+        throw new Error("transient write failure");
+      });
+      try {
+        await markActivationTurnComplete({
+          conversationId: "conv-1",
+          toolCallCount: 4,
+          endedAwaitingUser: false,
+          artifacts: [],
+        });
+      } finally {
+        spy.mockRestore();
+      }
+
+      expect(readRawProgress().tasks["draft-email"]).toMatchObject({
+        status: "done",
+        stepCount: 4,
+      });
+    });
 
     test("a rejected write leaves later mutations working", async () => {
       breakDataDir();

--- a/assistant/src/activation/progress-store.test.ts
+++ b/assistant/src/activation/progress-store.test.ts
@@ -414,6 +414,9 @@ describe("activation progress store", () => {
           taskId: "draft-email",
           conversationId: "conv-1",
         });
+        // The write leaves the index unstamped, so the first miss rereads
+        // and stamps it. From there a miss is answered by a stat.
+        await bumpActivationStepCount("conv-unlinked");
 
         // Unreadable but still stat-able, and neither size nor mtime moved:
         // a lookup that re-read here would degrade to empty progress and
@@ -534,6 +537,44 @@ describe("activation progress store", () => {
       await bumpActivationStepCount("conv-2");
 
       expect(readRawProgress().tasks["book-travel"].stepCount).toBe(1);
+    });
+
+    test("a write leaves the stamp stale: one reread, then hits stay free", async () => {
+      // A window wide enough that only the first bump per conversation
+      // flushes, so a later bump exercises the lookup without a write.
+      resetActivationStepThrottleForTesting(60_000);
+      await startActivationTask({
+        taskId: "draft-email",
+        conversationId: "conv-1",
+      });
+      // Flush the first bump, so the index is the one the write rebuilt.
+      await bumpActivationStepCount("conv-1");
+
+      const path = getActivationProgressPath();
+      const readSpy = spyOn(nodeFs, "readFileSync");
+      const statSpy = spyOn(nodeFs, "statSync");
+      const callsFor = (spy: { mock: { calls: unknown[][] } }): number =>
+        spy.mock.calls.filter((args) => args[0] === path).length;
+      try {
+        // A hit answers from the map, so it costs no syscall at all.
+        await bumpActivationStepCount("conv-1");
+        expect(callsFor(readSpy)).toBe(0);
+        expect(callsFor(statSpy)).toBe(0);
+
+        // The write could not tie a stamp to the bytes it landed, so the
+        // first miss against that index rereads.
+        await bumpActivationStepCount("conv-unlinked");
+        expect(callsFor(readSpy)).toBe(1);
+
+        // That reread stamped the index, so the next miss is one stat.
+        const statsAfterReread = callsFor(statSpy);
+        await bumpActivationStepCount("conv-unlinked");
+        expect(callsFor(readSpy)).toBe(1);
+        expect(callsFor(statSpy)).toBe(statsAfterReread + 1);
+      } finally {
+        readSpy.mockRestore();
+        statSpy.mockRestore();
+      }
     });
 
     test("the test-only reset drops the index", async () => {

--- a/assistant/src/activation/progress-store.ts
+++ b/assistant/src/activation/progress-store.ts
@@ -169,14 +169,19 @@ function parseForwardCompatible(document: unknown): ActivationProgress {
 
 function readActivationSnapshot(): ActivationSnapshot {
   const path = getActivationProgressPath();
+  // Stamped before the bytes are read, so a write that lands between the two
+  // leaves the index looking stale rather than fresh: the next miss sees a
+  // changed stamp and re-reads. Stamping after the read would file the
+  // pre-write bytes under the post-write stamp and pin them forever.
+  const stamp = progressFileStamp();
   let raw: string;
   try {
     raw = readFileSync(path, "utf-8");
   } catch {
-    return refreshLinkIndex({
-      progress: emptyActivationProgress(),
-      readOnly: false,
-    });
+    return refreshLinkIndex(
+      { progress: emptyActivationProgress(), readOnly: false },
+      stamp,
+    );
   }
 
   let document: unknown;
@@ -187,10 +192,10 @@ function readActivationSnapshot(): ActivationSnapshot {
       { err, path },
       "Unreadable activation-progress.json; treating as empty",
     );
-    return refreshLinkIndex({
-      progress: emptyActivationProgress(),
-      readOnly: false,
-    });
+    return refreshLinkIndex(
+      { progress: emptyActivationProgress(), readOnly: false },
+      stamp,
+    );
   }
 
   // The version is read before the shape is, so a document this build cannot
@@ -201,10 +206,10 @@ function readActivationSnapshot(): ActivationSnapshot {
       { path, version, supported: ACTIVATION_PROGRESS_VERSION },
       "activation-progress.json was written by a newer build; serving it read-only",
     );
-    return refreshLinkIndex({
-      progress: parseForwardCompatible(document),
-      readOnly: true,
-    });
+    return refreshLinkIndex(
+      { progress: parseForwardCompatible(document), readOnly: true },
+      stamp,
+    );
   }
 
   const parsed = ActivationProgressSchema.safeParse(document);
@@ -213,12 +218,12 @@ function readActivationSnapshot(): ActivationSnapshot {
       { err: parsed.error, path },
       "Unreadable activation-progress.json; treating as empty",
     );
-    return refreshLinkIndex({
-      progress: emptyActivationProgress(),
-      readOnly: false,
-    });
+    return refreshLinkIndex(
+      { progress: emptyActivationProgress(), readOnly: false },
+      stamp,
+    );
   }
-  return refreshLinkIndex({ progress: parsed.data, readOnly: false });
+  return refreshLinkIndex({ progress: parsed.data, readOnly: false }, stamp);
 }
 
 /**
@@ -230,13 +235,15 @@ export function readActivationProgress(): ActivationProgress {
   return readActivationSnapshot().progress;
 }
 
-function writeActivationProgress(progress: ActivationProgress): void {
+/** Writes the document and returns the stamp of the bytes it just landed. */
+function writeActivationProgress(progress: ActivationProgress): string {
   const path = getActivationProgressPath();
   mkdirSync(getDataDir(), { recursive: true });
   const tmpPath = `${path}.tmp.${process.pid}`;
   try {
     writeFileSync(tmpPath, JSON.stringify(progress, null, 2), "utf-8");
     renameSync(tmpPath, path);
+    return progressFileStamp();
   } catch (err) {
     // A temp file left behind by a failed write is never picked up again
     // (the next attempt writes its own), so it would only accumulate.
@@ -295,7 +302,16 @@ function progressFileStamp(): string {
   }
 }
 
-function refreshLinkIndex(snapshot: ActivationSnapshot): ActivationSnapshot {
+/**
+ * Rebuild the index from `snapshot`, filed under the stamp of the bytes that
+ * snapshot came from. The caller supplies the stamp because only the caller
+ * knows which bytes those were: a read stamps before it reads, a write stamps
+ * straight after its rename.
+ */
+function refreshLinkIndex(
+  snapshot: ActivationSnapshot,
+  stamp: string,
+): ActivationSnapshot {
   const next = new Map<string, string>();
   for (const [taskId, task] of Object.entries(snapshot.progress.tasks)) {
     if (task.status === "started") {
@@ -304,7 +320,7 @@ function refreshLinkIndex(snapshot: ActivationSnapshot): ActivationSnapshot {
   }
   linkIndex = next;
   linkIndexPath = getActivationProgressPath();
-  linkIndexStamp = progressFileStamp();
+  linkIndexStamp = stamp;
   return snapshot;
 }
 
@@ -377,8 +393,9 @@ async function mutateActivationProgress(
     if (!mutate(progress)) {
       return progress;
     }
+    let stamp: string;
     try {
-      writeActivationProgress(progress);
+      stamp = writeActivationProgress(progress);
     } catch (err) {
       // The index was built from what was on disk before the mutation, and
       // the in-memory document has moved on from both. Drop it.
@@ -386,7 +403,7 @@ async function mutateActivationProgress(
       log.warn({ err }, "Failed to write activation-progress.json");
       throw new InternalError("Failed to persist activation progress");
     }
-    refreshLinkIndex(snapshot);
+    refreshLinkIndex(snapshot, stamp);
     publishActivationProgressChanged(originClientId);
     return progress;
   };
@@ -734,7 +751,10 @@ export async function markActivationTurnComplete(params: {
   ) {
     return;
   }
-  await flushStepBumps(conversationId);
+  // A failed flush must not strand the row on Working. The completion
+  // mutation re-establishes `stepCount` from `toolCallCount` via `Math.max`,
+  // and the flush has already re-queued its delta for a bounded retry.
+  await flushStepBumps(conversationId).catch(() => {});
   if (endedAwaitingUser) {
     return;
   }

--- a/assistant/src/activation/progress-store.ts
+++ b/assistant/src/activation/progress-store.ts
@@ -171,8 +171,7 @@ function readActivationSnapshot(): ActivationSnapshot {
   const path = getActivationProgressPath();
   // Stamped before the bytes are read, so a write that lands between the two
   // leaves the index looking stale rather than fresh: the next miss sees a
-  // changed stamp and re-reads. Stamping after the read would file the
-  // pre-write bytes under the post-write stamp and pin them forever.
+  // changed stamp and re-reads.
   const stamp = progressFileStamp();
   let raw: string;
   try {
@@ -235,15 +234,14 @@ export function readActivationProgress(): ActivationProgress {
   return readActivationSnapshot().progress;
 }
 
-/** Writes the document and returns the stamp of the bytes it just landed. */
-function writeActivationProgress(progress: ActivationProgress): string {
+/** Writes the document atomically, replacing whatever was at the path. */
+function writeActivationProgress(progress: ActivationProgress): void {
   const path = getActivationProgressPath();
   mkdirSync(getDataDir(), { recursive: true });
   const tmpPath = `${path}.tmp.${process.pid}`;
   try {
     writeFileSync(tmpPath, JSON.stringify(progress, null, 2), "utf-8");
     renameSync(tmpPath, path);
-    return progressFileStamp();
   } catch (err) {
     // A temp file left behind by a failed write is never picked up again
     // (the next attempt writes its own), so it would only accumulate.
@@ -276,7 +274,10 @@ function writeActivationProgress(progress: ActivationProgress): string {
  * read the index was built from, and a *miss* is confirmed against a fresh
  * `statSync` before it is believed. A hit still costs one map lookup and no
  * syscall, and a miss costs one stat rather than a read, a parse, and a
- * schema validation.
+ * schema validation. An index rebuilt from a mutation carries no stamp,
+ * because nothing observable after the rename is provably that mutation's
+ * bytes; the first miss after a write therefore re-reads once and stamps the
+ * index from that read.
  *
  * `linkIndexPath` pins the index to the workspace it was built from: a
  * process that switches workspaces (tests do) falls back to a read rather
@@ -304,13 +305,17 @@ function progressFileStamp(): string {
 
 /**
  * Rebuild the index from `snapshot`, filed under the stamp of the bytes that
- * snapshot came from. The caller supplies the stamp because only the caller
- * knows which bytes those were: a read stamps before it reads, a write stamps
- * straight after its rename.
+ * snapshot came from, or under `null` when no stamp is provably tied to those
+ * bytes. The caller supplies the stamp because only the caller knows which
+ * bytes those were: a read stamps before it reads, and a write passes `null`
+ * because any stat it takes after its rename may describe another writer's
+ * file. A `null` stamp matches no stat, so the first miss against the index
+ * re-reads once and files the result under a real stamp; hits answer from the
+ * map with no syscall either way.
  */
 function refreshLinkIndex(
   snapshot: ActivationSnapshot,
-  stamp: string,
+  stamp: string | null,
 ): ActivationSnapshot {
   const next = new Map<string, string>();
   for (const [taskId, task] of Object.entries(snapshot.progress.tasks)) {
@@ -393,9 +398,8 @@ async function mutateActivationProgress(
     if (!mutate(progress)) {
       return progress;
     }
-    let stamp: string;
     try {
-      stamp = writeActivationProgress(progress);
+      writeActivationProgress(progress);
     } catch (err) {
       // The index was built from what was on disk before the mutation, and
       // the in-memory document has moved on from both. Drop it.
@@ -403,7 +407,7 @@ async function mutateActivationProgress(
       log.warn({ err }, "Failed to write activation-progress.json");
       throw new InternalError("Failed to persist activation progress");
     }
-    refreshLinkIndex(snapshot, stamp);
+    refreshLinkIndex(snapshot, null);
     publishActivationProgressChanged(originClientId);
     return progress;
   };

--- a/clients/web/src/components/chat-pill.test.tsx
+++ b/clients/web/src/components/chat-pill.test.tsx
@@ -37,6 +37,29 @@ describe("ChatPill", () => {
     expect(getByRole("status").getAttribute("aria-live")).toBe("polite");
   });
 
+  // The chat overlay these pills float in is `pointer-events-none`, so it does
+  // not swallow clicks on the transcript beneath it. A pill inside it has to
+  // opt back in or it is visible and dead.
+  test("stays clickable over a pointer-events-none overlay", () => {
+    let clicks = 0;
+    const { getByRole } = render(
+      <div className="pointer-events-none">
+        <ChatPill
+          onClick={() => {
+            clicks += 1;
+          }}
+          ariaLabel="Open suggestions"
+        >
+          Suggestions
+        </ChatPill>
+      </div>,
+    );
+    const button = getByRole("button", { name: "Open suggestions" });
+    expect(button.className).toContain("pointer-events-auto");
+    fireEvent.click(button);
+    expect(clicks).toBe(1);
+  });
+
   test("invokes onClick when the button is activated", () => {
     let clicks = 0;
     const { getByRole } = render(

--- a/clients/web/src/domains/activation/activation-suggestions-pill-host.tsx
+++ b/clients/web/src/domains/activation/activation-suggestions-pill-host.tsx
@@ -1,11 +1,11 @@
 /**
  * The suggestions pill, wired to the checklist's gate stack.
  *
- * Composed into the chat layout's top-bar accessory at the route level rather
- * than registered through `setTopBarRightSlot`. That slot already has a single
- * writer, the chat page's own header registration, and a second effect writing
- * it would erase whatever the other put there on every conversation change.
- * The notification bell is composed at the route for the matching reason.
+ * Passed to the chat layout header as its `topBarPill`, a slot of its own that
+ * the header seats ahead of the route's own accessory. Registering the pill
+ * through `setTopBarRightSlot` instead would erase whatever the chat page's
+ * header registration had put there, since that slot has a single writer and
+ * is rewritten on every conversation change.
  *
  * Shows only while the checklist is in its dismissed-but-unfinished state, so
  * it retires itself once the third starter lands.

--- a/clients/web/src/domains/activation/capabilities.ts
+++ b/clients/web/src/domains/activation/capabilities.ts
@@ -78,12 +78,9 @@ const AVAILABLE_CAPABILITY_TAGS: ReadonlySet<string> = new Set(
  * Whether a task's prerequisites are met. A task with no `requires` always
  * passes, and so does one requiring a tag this build does not know.
  */
-function taskIsAvailable(
-  task: Pick<ActivationTask, "requires">,
-  availableTags: ReadonlySet<string>,
-): boolean {
+function taskIsAvailable(task: Pick<ActivationTask, "requires">): boolean {
   return (task.requires ?? []).every(
-    (tag) => !isKnownCapabilityTag(tag) || availableTags.has(tag),
+    (tag) => !isKnownCapabilityTag(tag) || AVAILABLE_CAPABILITY_TAGS.has(tag),
   );
 }
 
@@ -98,12 +95,8 @@ export function useAvailableActivationList(listId: string): ActivationList {
   const { starters, items } = useActivationList(listId);
   return useMemo(
     () => ({
-      starters: starters.filter((task) =>
-        taskIsAvailable(task, AVAILABLE_CAPABILITY_TAGS),
-      ),
-      items: items.filter((task) =>
-        taskIsAvailable(task, AVAILABLE_CAPABILITY_TAGS),
-      ),
+      starters: starters.filter(taskIsAvailable),
+      items: items.filter(taskIsAvailable),
     }),
     [items, starters],
   );

--- a/clients/web/src/domains/activation/components/activation-task-icon.stories.tsx
+++ b/clients/web/src/domains/activation/components/activation-task-icon.stories.tsx
@@ -37,10 +37,21 @@ export const Done: Story = {
   args: { state: "done" },
 };
 
+/** One glyph on the dark ground, where the accent wash thins the most. */
+export const DefaultDark: Story = {
+  globals: { theme: "dark" },
+};
+
 /** The finished treatment on the dark ground, where the check has to hold. */
 export const DoneDark: Story = {
   args: { state: "done" },
   globals: { theme: "dark" },
+};
+
+/** The finished disc at phone width, beside a two-line description. */
+export const DoneMobile: Story = {
+  args: { state: "done" },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
 };
 
 /** A single disc at phone width, where it sits beside a two-line description. */

--- a/clients/web/src/domains/activation/components/activation-task-row.stories.tsx
+++ b/clients/web/src/domains/activation/components/activation-task-row.stories.tsx
@@ -130,9 +130,49 @@ export const DoneWithFileDark: Story = {
   globals: { theme: "dark" },
 };
 
+/** The finished row at phone width, where the file card has least room. */
+export const DoneWithFileMobile: Story = {
+  args: { progress: doneWithArtifactProgress() },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+};
+
 /** The expanded row at phone width, where the field loses the most room. */
 export const TodoExpandedMobile: Story = {
   args: { expanded: true },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+};
+
+/** The closed row on the dark ground, where the disc carries the only colour. */
+export const TodoCollapsedDark: Story = {
+  globals: { theme: "dark" },
+};
+
+/** The closed row at phone width, where the description wraps to three lines. */
+export const TodoCollapsedMobile: Story = {
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+};
+
+/** The call to action on the dark ground, where the link is the only accent. */
+export const TodoExpandedWithLinkDark: Story = {
+  args: { task: COMPUTER_USE_TASK, expanded: true },
+  globals: { theme: "dark" },
+};
+
+/** The call to action at phone width, where it wraps under the field. */
+export const TodoExpandedWithLinkMobile: Story = {
+  args: { task: COMPUTER_USE_TASK, expanded: true },
+  globals: { viewport: { value: "sbMobile", isRotated: false } },
+};
+
+/** The locked row on the dark ground, where the disabled controls flatten. */
+export const TodoExpandedPendingDark: Story = {
+  args: { expanded: true, pending: true },
+  globals: { theme: "dark" },
+};
+
+/** The locked row at phone width, where the send button is tightest. */
+export const TodoExpandedPendingMobile: Story = {
+  args: { expanded: true, pending: true },
   globals: { viewport: { value: "sbMobile", isRotated: false } },
 };
 

--- a/clients/web/src/domains/activation/hooks/use-activation-completion-telemetry.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-activation-completion-telemetry.test.tsx
@@ -33,6 +33,10 @@ const progressMock = await mockActivationProgress();
 const funnel = await recordActivationFunnelEvents();
 
 afterAll(() => {
+  // Unmount first: the hook subscribes to the flag store, so resetting it
+  // below would re-render a component whose progress hook the restore has
+  // just swapped back to the real one.
+  cleanup();
   progressMock.restore();
   funnel.restore();
   resetActivationFlagStore();
@@ -40,6 +44,11 @@ afterAll(() => {
 
 const { useActivationCompletionTelemetry } =
   await import("@/domains/activation/hooks/use-activation-completion-telemetry");
+// Imported after the progress mock is installed, for the same reason as the
+// hook under test: a static import would bind the real progress hook and want
+// a query client.
+const { readEffectiveActivationListId, useEffectiveActivationListId } =
+  await import("@/hooks/use-activation-enabled");
 
 const [FIRST_TASK, SECOND_TASK] = FIXTURE_STARTER_IDS;
 
@@ -114,6 +123,23 @@ describe("useActivationCompletionTelemetry", () => {
     advance(rerender, progressWithDone(SECOND_TASK!), "asst-2");
 
     expect(completions()).toEqual([]);
+  });
+
+  // The emitter falls back to a module global that an effect elsewhere
+  // publishes, so a hook that leaves the list to it is only right while some
+  // sibling happens to render ahead of it.
+  test("files a completion under the list this render resolved", () => {
+    const stale = renderHook(() => useEffectiveActivationListId());
+    expect(readEffectiveActivationListId()).toBe("smb");
+    stale.unmount();
+    setActivationArm("parent");
+
+    const { rerender } = renderHook(() => useActivationCompletionTelemetry());
+    advance(rerender, progressWithDone(FIRST_TASK!));
+
+    expect(funnel.matching("activation_task_completed")[0]?.screen).toBe(
+      `parent/${FIRST_TASK}`,
+    );
   });
 
   // Task ids are the catalog's, so they are shared across assistants: a

--- a/clients/web/src/domains/activation/hooks/use-activation-completion-telemetry.ts
+++ b/clients/web/src/domains/activation/hooks/use-activation-completion-telemetry.ts
@@ -20,12 +20,23 @@
  *
  * Every task is watched, starters and the rest of the catalog alike, because
  * the Inspiration List can launch any of them.
+ *
+ * The list an event is filed under is resolved here, by the same hook every
+ * other surface reads it from, and handed to the emitter as a captured
+ * context. Letting the emitter resolve it would send it to the module global
+ * `useEffectiveActivationListId` publishes from an effect, which is only
+ * populated before this one runs when a sibling hook in the same component
+ * happens to be ordered ahead of it.
  */
 
 import { useEffect, useRef } from "react";
 
+import { useEffectiveActivationListId } from "@/hooks/use-activation-enabled";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { emitActivationEvent } from "@/utils/activation-telemetry";
+import {
+  captureActivationTelemetryContext,
+  emitActivationEvent,
+} from "@/utils/activation-telemetry";
 
 import {
   activationRowStatus,
@@ -37,6 +48,7 @@ const NO_BASELINE = Symbol("no-activation-baseline");
 
 export function useActivationCompletionTelemetry(): void {
   const { data: progress } = useActivationProgress();
+  const listId = useEffectiveActivationListId();
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   /** The assistant `reported` was built for. */
   const baselineFor = useRef<string | null | typeof NO_BASELINE>(NO_BASELINE);
@@ -57,12 +69,13 @@ export function useActivationCompletionTelemetry(): void {
       reported.current = done;
       return;
     }
+    const context = captureActivationTelemetryContext(listId ?? "unknown");
     for (const taskId of done) {
       if (reported.current.has(taskId)) {
         continue;
       }
       reported.current.add(taskId);
-      emitActivationEvent("activation_task_completed", { taskId });
+      emitActivationEvent("activation_task_completed", { taskId }, context);
     }
-  }, [progress, activeAssistantId]);
+  }, [progress, activeAssistantId, listId]);
 }

--- a/clients/web/src/domains/activation/hooks/use-dismiss-activation.test.tsx
+++ b/clients/web/src/domains/activation/hooks/use-dismiss-activation.test.tsx
@@ -12,9 +12,10 @@ import type { ActivationProgress } from "./use-activation-progress";
 import { useDismissActivation } from "./use-dismiss-activation";
 
 /**
- * The dismissal is written into the progress cache before the daemon answers.
- * What happens to that write afterwards depends on the answer: an accepted
- * write is refetched, a refused one is kept so the pill stays reachable.
+ * The dismissal is written into the progress cache before the daemon answers,
+ * behind a cancel of whatever read was already in flight. What happens to that
+ * write afterwards depends on the answer: an accepted write is refetched, a
+ * refused one is kept so the pill stays reachable.
  */
 const ASSISTANT_ID = "asst-1";
 const PROGRESS_KEY = activationProgressGetQueryKey({
@@ -24,6 +25,7 @@ const PROGRESS_KEY = activationProgressGetQueryKey({
 const originalFetch = globalThis.fetch;
 let dismissStatus = 200;
 let progressReads = 0;
+let dismissWrites = 0;
 
 function installFetch(): void {
   globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
@@ -35,7 +37,11 @@ function installFetch(): void {
         headers: { "content-type": "application/json" },
       });
     }
-    const status = url.includes("/activation/dismiss") ? dismissStatus : 200;
+    let status = 200;
+    if (url.includes("/activation/dismiss")) {
+      dismissWrites += 1;
+      status = dismissStatus;
+    }
     return new Response("{}", {
       status,
       headers: { "content-type": "application/json" },
@@ -65,6 +71,7 @@ async function settle(): Promise<void> {
 beforeEach(() => {
   dismissStatus = 200;
   progressReads = 0;
+  dismissWrites = 0;
   installFetch();
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -82,11 +89,38 @@ afterEach(() => {
 });
 
 describe("useDismissActivation", () => {
-  test("stamps the dismissal into the cache before the daemon answers", () => {
+  test("stamps the dismissal into the cache before the daemon answers", async () => {
     const { result } = renderDismiss();
     act(() => {
       result.current.dismiss("modal");
     });
+    await settle();
+    expect(cached()?.modalDismissedAt).not.toBeNull();
+    // The seed rides ahead of the write, not behind its answer.
+    expect(dismissWrites).toBe(1);
+  });
+
+  test("cancels an in-flight read so its answer cannot undo the dismissal", async () => {
+    let release: (progress: ActivationProgress) => void = () => {};
+    const parked = new Promise<ActivationProgress>((resolve) => {
+      release = resolve;
+    });
+    // A read issued before the dismissal, so its answer predates it and knows
+    // nothing about the surface the user just closed.
+    const inFlight = queryClient
+      .fetchQuery({ queryKey: PROGRESS_KEY, queryFn: () => parked })
+      .catch(() => {});
+
+    const { result } = renderDismiss();
+    act(() => {
+      result.current.dismiss("modal");
+    });
+    await settle();
+
+    release(ACTIVATION_PROGRESS_EMPTY);
+    await inFlight;
+    await settle();
+
     expect(cached()?.modalDismissedAt).not.toBeNull();
   });
 

--- a/clients/web/src/domains/activation/hooks/use-dismiss-activation.ts
+++ b/clients/web/src/domains/activation/hooks/use-dismiss-activation.ts
@@ -9,6 +9,9 @@
  * The dismissal is written into the progress cache before it goes on the wire,
  * so every surface reading that cache agrees with the screen at once: the
  * modal closes and the pill takes its place without waiting on a round trip.
+ * A progress read already in flight is cancelled before that write, because it
+ * was issued before the dismissal and its answer would otherwise land on top
+ * of the seed and reopen the surface.
  *
  * A failed write is not surfaced. The surface has already closed by the time
  * it lands, the query refetch puts the truth back on the next read, and the
@@ -24,7 +27,10 @@ import { activationDismissPost } from "@/generated/daemon/sdk.gen";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { emitActivationEvent } from "@/utils/activation-telemetry";
 
-import { invalidateActivationProgress } from "./use-activation-progress";
+import {
+  activationProgressQueryKey,
+  invalidateActivationProgress,
+} from "./use-activation-progress";
 
 /** Which surface the user closed. Mirrors the daemon's `kind`. */
 export type ActivationDismissKind = "modal" | "all-done";
@@ -52,41 +58,49 @@ export function useDismissActivation(
       // Which surface was put away rides the event: closing the celebration
       // retires the checklist, and closing the welcome modal only defers it.
       emitActivationEvent("activation_modal_dismissed", { kind });
-      // The daemon stamps the same two fields, and freezes the list when
-      // nothing has frozen one yet. An absent cache is left absent: a progress
-      // document the client invented would turn on surfaces the missing read
-      // keeps hidden.
-      const now = new Date().toISOString();
-      activationProgressGetSetQueryData(
-        queryClient,
-        { path: { assistant_id: assistantId } },
-        (cached) =>
-          cached
-            ? {
-                ...cached,
-                listId: cached.listId ?? listId,
-                ...(kind === "all-done"
-                  ? { allDoneShownAt: now }
-                  : { modalDismissedAt: now }),
-              }
-            : cached,
-      );
-      void activationDismissPost({
-        path: { assistant_id: assistantId },
-        body: { kind, listId },
-        throwOnError: false,
-      }).then(
-        ({ response }) => {
-          // Only a write the daemon accepted is worth refetching. A refused
-          // one keeps the optimistic dismissal so the pill stays reachable
-          // instead of a refetch restoring a modal the user already closed.
-          if (!response?.ok) {
-            return;
-          }
-          invalidateActivationProgress(queryClient, assistantId);
-        },
-        () => {},
-      );
+      void (async () => {
+        // A progress read already in flight was issued before the dismissal,
+        // so its answer would land on top of the seed below and put the
+        // surface the user just closed back on screen.
+        await queryClient.cancelQueries({
+          queryKey: activationProgressQueryKey(assistantId),
+        });
+        // The daemon stamps the same two fields, and freezes the list when
+        // nothing has frozen one yet. An absent cache is left absent: a
+        // progress document the client invented would turn on surfaces the
+        // missing read keeps hidden.
+        const now = new Date().toISOString();
+        activationProgressGetSetQueryData(
+          queryClient,
+          { path: { assistant_id: assistantId } },
+          (cached) =>
+            cached
+              ? {
+                  ...cached,
+                  listId: cached.listId ?? listId,
+                  ...(kind === "all-done"
+                    ? { allDoneShownAt: now }
+                    : { modalDismissedAt: now }),
+                }
+              : cached,
+        );
+        await activationDismissPost({
+          path: { assistant_id: assistantId },
+          body: { kind, listId },
+          throwOnError: false,
+        }).then(
+          ({ response }) => {
+            // Only a write the daemon accepted is worth refetching. A refused
+            // one keeps the optimistic dismissal so the pill stays reachable
+            // instead of a refetch restoring a modal the user already closed.
+            if (!response?.ok) {
+              return;
+            }
+            invalidateActivationProgress(queryClient, assistantId);
+          },
+          () => {},
+        );
+      })();
     },
     [assistantId, listId, queryClient],
   );

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -19,7 +19,9 @@ import {
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
+import { useCommandPaletteStore } from "@/stores/command-palette-store";
 import { usePageSurfaceStore } from "@/stores/page-surface-store";
+import { useTitleBarStore } from "@/stores/title-bar-store";
 import {
   restoreStubbedModules,
   stubModule,
@@ -30,30 +32,14 @@ stubModule("@/runtime/is-electron", await import("@/runtime/is-electron"), {
   isElectron: () => mockIsElectron,
 });
 
+// The two stores the header writes through are driven by their own state
+// rather than a module stub, so the spies are checked against the real store
+// shapes. Both stores are process-global, so the real actions go back below.
 const toggleCommandPaletteSpy = mock(() => {});
-stubModule(
-  "@/stores/command-palette-store",
-  await import("@/stores/command-palette-store"),
-  {
-    useCommandPaletteStore: {
-      use: { toggle: () => toggleCommandPaletteSpy },
-    },
-  },
-);
-
 const setInlineTitleBarActiveSpy = mock((_active: boolean) => {});
-stubModule(
-  "@/stores/title-bar-store",
-  await import("@/stores/title-bar-store"),
-  {
-    useTitleBarStore: {
-      use: {
-        setInlineTitleBarActive: () => setInlineTitleBarActiveSpy,
-        windowsMenuBarSuppressed: () => false,
-      },
-    },
-  },
-);
+const realToggleCommandPalette = useCommandPaletteStore.getState().toggle;
+const realSetInlineTitleBarActive =
+  useTitleBarStore.getState().setInlineTitleBarActive;
 
 let mockIsNativeMobile = false;
 let mockElectronHostOS: "macos" | "windows" | "linux" | null = null;
@@ -69,8 +55,15 @@ stubModule(
 
 // `mock.module` replaces a module for every file sharing this process, so
 // nothing here may outlive the file: a desktop answer left standing hides
-// every surface that drops a web link inside the app.
-afterAll(restoreStubbedModules);
+// every surface that drops a web link inside the app. The store actions the
+// spies stand in for are process-global for the same reason.
+afterAll(() => {
+  useCommandPaletteStore.setState({ toggle: realToggleCommandPalette });
+  useTitleBarStore.setState({
+    setInlineTitleBarActive: realSetInlineTitleBarActive,
+  });
+  restoreStubbedModules();
+});
 
 // Imported after the mocks so the header picks up the mocked modules.
 const { ChatLayoutHeader } = await import("@/domains/chat/chat-layout-header");
@@ -82,6 +75,11 @@ beforeEach(() => {
   usePageSurfaceStore.getState().setSurface(null);
   toggleCommandPaletteSpy.mockClear();
   setInlineTitleBarActiveSpy.mockClear();
+  useCommandPaletteStore.setState({ toggle: toggleCommandPaletteSpy });
+  useTitleBarStore.setState({
+    setInlineTitleBarActive: setInlineTitleBarActiveSpy,
+    windowsMenuBarSuppressed: false,
+  });
 });
 
 afterEach(() => {

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -20,51 +20,57 @@ import {
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { usePageSurfaceStore } from "@/stores/page-surface-store";
+import {
+  restoreStubbedModules,
+  stubModule,
+} from "@/utils/module-mock.test-helper";
 
 let mockIsElectron = false;
-const isElectronModule = await import("@/runtime/is-electron");
-// Captured by value: a module namespace's bindings are live, so reading the
-// export back after the mock is installed would hand out the mock.
-const { isElectron: realIsElectron } = isElectronModule;
-mock.module("@/runtime/is-electron", () => ({
-  ...isElectronModule,
+stubModule("@/runtime/is-electron", await import("@/runtime/is-electron"), {
   isElectron: () => mockIsElectron,
-}));
-
-// `mock.module` replaces a module for every file sharing this process, and a
-// desktop answer left standing hides every surface that drops a web link
-// inside the app.
-afterAll(() => {
-  mock.module("@/runtime/is-electron", () => ({
-    ...isElectronModule,
-    isElectron: realIsElectron,
-  }));
 });
 
 const toggleCommandPaletteSpy = mock(() => {});
-mock.module("@/stores/command-palette-store", () => ({
-  useCommandPaletteStore: {
-    use: { toggle: () => toggleCommandPaletteSpy },
-  },
-}));
-
-const setInlineTitleBarActiveSpy = mock((_active: boolean) => {});
-mock.module("@/stores/title-bar-store", () => ({
-  useTitleBarStore: {
-    use: {
-      setInlineTitleBarActive: () => setInlineTitleBarActiveSpy,
-      windowsMenuBarSuppressed: () => false,
+stubModule(
+  "@/stores/command-palette-store",
+  await import("@/stores/command-palette-store"),
+  {
+    useCommandPaletteStore: {
+      use: { toggle: () => toggleCommandPaletteSpy },
     },
   },
-}));
+);
+
+const setInlineTitleBarActiveSpy = mock((_active: boolean) => {});
+stubModule(
+  "@/stores/title-bar-store",
+  await import("@/stores/title-bar-store"),
+  {
+    useTitleBarStore: {
+      use: {
+        setInlineTitleBarActive: () => setInlineTitleBarActiveSpy,
+        windowsMenuBarSuppressed: () => false,
+      },
+    },
+  },
+);
 
 let mockIsNativeMobile = false;
 let mockElectronHostOS: "macos" | "windows" | "linux" | null = null;
-mock.module("@/runtime/platform-detection", () => ({
-  detectElectronHostOS: () =>
-    mockIsElectron ? (mockElectronHostOS ?? "macos") : null,
-  isNativeMobile: () => mockIsNativeMobile,
-}));
+stubModule(
+  "@/runtime/platform-detection",
+  await import("@/runtime/platform-detection"),
+  {
+    detectElectronHostOS: () =>
+      mockIsElectron ? (mockElectronHostOS ?? "macos") : null,
+    isNativeMobile: () => mockIsNativeMobile,
+  },
+);
+
+// `mock.module` replaces a module for every file sharing this process, so
+// nothing here may outlive the file: a desktop answer left standing hides
+// every surface that drops a web link inside the app.
+afterAll(restoreStubbedModules);
 
 // Imported after the mocks so the header picks up the mocked modules.
 const { ChatLayoutHeader } = await import("@/domains/chat/chat-layout-header");
@@ -109,25 +115,6 @@ describe("ChatLayoutHeader — right cluster", () => {
     expect(screen.getByText("Notifications")).toBeTruthy();
     // Nothing folds the cluster away: no overflow menu to open.
     expect(screen.queryByRole("button", { name: "More controls" })).toBeNull();
-  });
-
-  // The pill takes its own slot rather than riding beside the bell, because
-  // the bell's slot is restated in the mobile drawer's glyph row and a full
-  // pill has no seat there. In the top bar the two sit together, pill first.
-  test("seats the pill ahead of the route slot", () => {
-    renderHeader({
-      topBarRightSlot: (
-        <>
-          <div data-testid="suggestions-pill" />
-          <button type="button">Notifications</button>
-        </>
-      ),
-    });
-    const pill = screen.getByTestId("suggestions-pill");
-    const bell = screen.getByText("Notifications");
-    expect(
-      pill.compareDocumentPosition(bell) & Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
   });
 
   test("search reaches the command palette", () => {

--- a/clients/web/src/domains/chat/chat-layout-top-bar-slots.test.ts
+++ b/clients/web/src/domains/chat/chat-layout-top-bar-slots.test.ts
@@ -43,6 +43,15 @@ describe("ChatLayout top-bar slots", () => {
     expect(layoutSource).toContain("{topBarPill}");
   });
 
+  // Both land in the header's one route slot, so their order in the cluster is
+  // the order the layout writes them in: pill first, bell after.
+  test("the top bar seats the pill ahead of the accessory", () => {
+    const pillAt = layoutSource.indexOf("{topBarPill}");
+    const accessoryAt = layoutSource.indexOf("{topBarAccessory}");
+    expect(pillAt).toBeGreaterThan(-1);
+    expect(accessoryAt).toBeGreaterThan(pillAt);
+  });
+
   test("the route composes the pill into the pill slot", () => {
     expect(routesSource).toContain(
       "topBarPill={<ActivationSuggestionsPillHost />}",

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -16,7 +16,7 @@ import {
   expect,
   test,
 } from "bun:test";
-import { createElement } from "react";
+import { createElement, Fragment } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   act,
@@ -108,14 +108,18 @@ const authRef: {
   logout: async () => {},
 };
 
+const authStoreModule = await import("@/stores/auth-store");
+// The menu reads two selectors and `getState()`; the rest of the zustand
+// surface has no consumer here, so the stub asserts the store's type rather
+// than reproducing it.
 const authStoreStub = Object.assign(() => null, {
   use: {
     user: () => authRef.user,
     logout: () => authRef.logout,
   },
   getState: () => authRef,
-});
-stubModule("@/stores/auth-store", await import("@/stores/auth-store"), {
+}) as unknown as typeof authStoreModule.useAuthStore;
+stubModule("@/stores/auth-store", authStoreModule, {
   useAuthStore: authStoreStub,
   useIsAuthenticated: () => authRef.isAuthenticated,
 });
@@ -124,13 +128,17 @@ stubModule("@/stores/auth-store", await import("@/stores/auth-store"), {
 // own, and the only version that carries the string-flag surface the
 // activation arm is read through. A stub here would also replace it for every
 // test file sharing this process.
+const assistantFeatureFlagStoreModule =
+  await import("@/stores/assistant-feature-flag-store");
+// Nothing the menu renders reads a flag off this store, so the stub answers
+// with an empty surface and asserts the store's type.
 const featureFlagStoreStub = Object.assign(() => null, {
   use: {},
   getState: () => ({}),
-});
+}) as unknown as typeof assistantFeatureFlagStoreModule.useAssistantFeatureFlagStore;
 stubModule(
   "@/stores/assistant-feature-flag-store",
-  await import("@/stores/assistant-feature-flag-store"),
+  assistantFeatureFlagStoreModule,
   { useAssistantFeatureFlagStore: featureFlagStoreStub },
 );
 
@@ -157,23 +165,35 @@ function isActivationProgressQuery(options: unknown): boolean {
 // (e.g. `isCancelledError` via `captureError`) keep resolving; only the
 // hook under test's read is overridden. The menu makes two reads, so the
 // stub answers by query key rather than handing both the same body.
-stubModule("@tanstack/react-query", await import("@tanstack/react-query"), {
-  useQuery: (options: unknown) =>
+const reactQueryModule = await import("@tanstack/react-query");
+stubModule("@tanstack/react-query", reactQueryModule, {
+  // The menu reads `data`, `isLoading` and `isError` only, so the answer is
+  // asserted against `useQuery`'s type rather than built out to its full
+  // result shape.
+  useQuery: ((options: unknown) =>
     isActivationProgressQuery(options)
       ? { data: activationProgressRef.data, isLoading: false, isError: false }
-      : { data: billingRef.data, isLoading: false, isError: false },
+      : {
+          data: billingRef.data,
+          isLoading: false,
+          isError: false,
+        }) as unknown as typeof reactQueryModule.useQuery,
 });
 
+const generatedQueriesModule =
+  await import("@/generated/api/@tanstack/react-query.gen");
+// Only the query key is read (the stubbed `useQuery` answers by key), so each
+// factory answers with the key alone and asserts the generated signature.
 stubModule(
   "@/generated/api/@tanstack/react-query.gen",
-  await import("@/generated/api/@tanstack/react-query.gen"),
+  generatedQueriesModule,
   {
-    organizationsBillingSummaryRetrieveOptions: () => ({
+    organizationsBillingSummaryRetrieveOptions: (() => ({
       queryKey: [{ _id: "organizationsBillingSummaryRetrieve" }],
-    }),
-    referralCodesMeRetrieveOptions: () => ({
+    })) as unknown as typeof generatedQueriesModule.organizationsBillingSummaryRetrieveOptions,
+    referralCodesMeRetrieveOptions: (() => ({
       queryKey: [{ _id: "referralCodesMeRetrieve" }],
-    }),
+    })) as unknown as typeof generatedQueriesModule.referralCodesMeRetrieveOptions,
   },
 );
 
@@ -196,7 +216,7 @@ stubModule(
     ShareFeedbackModalLazy: ({ open }: { open: boolean }) =>
       open
         ? createElement("div", { "data-testid": "share-feedback-modal" })
-        : null,
+        : createElement(Fragment),
     prefetchShareFeedbackModal: () => {
       feedbackRef.prefetches += 1;
     },
@@ -247,7 +267,7 @@ stubModule(
     AddCreditsModal: ({ open }: { open: boolean }) =>
       open
         ? createElement("div", { "data-testid": "add-credits-modal" })
-        : null,
+        : createElement(Fragment),
   },
 );
 
@@ -295,7 +315,7 @@ stubModule(
       balance,
       onAddCredits,
     }: {
-      balance: string;
+      balance: string | null;
       onAddCredits?: () => void;
     }) =>
       createElement(

--- a/clients/web/src/domains/chat/components/preferences-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.test.tsx
@@ -14,7 +14,6 @@ import {
   beforeEach,
   describe,
   expect,
-  mock,
   test,
 } from "bun:test";
 import { createElement } from "react";
@@ -35,41 +34,61 @@ import type { AuthUser } from "@/stores/auth-store";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  restoreStubbedModules,
+  stubModule,
+} from "@/utils/module-mock.test-helper";
 import { routes } from "@/utils/routes";
 
 const isTouchMobileRef = { value: false };
 const nativeAndroidRef = { value: false };
 
-mock.module("@/hooks/use-touch-mobile", () => ({
-  useTouchMobile: () => isTouchMobileRef.value,
-  TOUCH_MOBILE_MEDIA_QUERY: "(width < 48rem) and (pointer: coarse)",
-}));
+// Every module below is replaced through `stubModule`, which spreads the real
+// one and registers the undo `afterAll` runs: `mock.module` is process-global
+// in bun, so a partial shape erases a module's other exports for whatever file
+// loads it next, and a replacement left standing outlives this file.
+afterAll(restoreStubbedModules);
 
-// Spread the real module: `mock.module` replaces it for every file sharing
-// this process, and other exports of it (browser detection) are reached
-// through the stores this suite now touches.
-const actualPlatformDetection = await import("@/runtime/platform-detection");
-mock.module("@/runtime/platform-detection", () => ({
-  ...actualPlatformDetection,
-  useIsNativeAndroid: () => nativeAndroidRef.value,
-}));
+stubModule(
+  "@/hooks/use-touch-mobile",
+  await import("@/hooks/use-touch-mobile"),
+  {
+    useTouchMobile: () => isTouchMobileRef.value,
+  },
+);
 
-mock.module("@/hooks/use-platform-gate", () => ({
-  usePlatformGate: () => "full",
-  useActiveAssistantIsPlatformHosted: () => true,
-}));
+stubModule(
+  "@/runtime/platform-detection",
+  await import("@/runtime/platform-detection"),
+  { useIsNativeAndroid: () => nativeAndroidRef.value },
+);
 
-mock.module("@/hooks/use-is-org-ready", () => ({
-  useIsOrgReady: () => true,
-}));
+stubModule(
+  "@/hooks/use-platform-gate",
+  await import("@/hooks/use-platform-gate"),
+  {
+    usePlatformGate: () => "full",
+    useActiveAssistantIsPlatformHosted: () => true,
+  },
+);
+
+stubModule(
+  "@/hooks/use-is-org-ready",
+  await import("@/hooks/use-is-org-ready"),
+  {
+    useIsOrgReady: () => true,
+  },
+);
 
 // The BYOK gate pulls the daemon generated client (and its real
 // `queryOptions` import) into the graph; this suite's partial
 // `@tanstack/react-query` mock cannot host that, and the menu only reads
 // `enabled`/`balance`, which the gate never touches.
-mock.module("@/hooks/use-byok-credit-banner-gate", () => ({
-  useSuppressCreditBannersForByok: () => false,
-}));
+stubModule(
+  "@/hooks/use-byok-credit-banner-gate",
+  await import("@/hooks/use-byok-credit-banner-gate"),
+  { useSuppressCreditBannersForByok: () => false },
+);
 
 const authRef: {
   isAuthenticated: boolean;
@@ -89,29 +108,31 @@ const authRef: {
   logout: async () => {},
 };
 
-mock.module("@/stores/auth-store", () => {
-  const store = () => null;
-  store.use = {
+const authStoreStub = Object.assign(() => null, {
+  use: {
     user: () => authRef.user,
     logout: () => authRef.logout,
-  };
-  store.getState = () => authRef;
-  return {
-    useAuthStore: store,
-    useIsAuthenticated: () => authRef.isAuthenticated,
-  };
+  },
+  getState: () => authRef,
+});
+stubModule("@/stores/auth-store", await import("@/stores/auth-store"), {
+  useAuthStore: authStoreStub,
+  useIsAuthenticated: () => authRef.isAuthenticated,
 });
 
 // The real client flag store: a plain zustand store with no transport of its
 // own, and the only version that carries the string-flag surface the
 // activation arm is read through. A stub here would also replace it for every
 // test file sharing this process.
-mock.module("@/stores/assistant-feature-flag-store", () => {
-  const store = () => null;
-  store.use = {};
-  store.getState = () => ({});
-  return { useAssistantFeatureFlagStore: store };
+const featureFlagStoreStub = Object.assign(() => null, {
+  use: {},
+  getState: () => ({}),
 });
+stubModule(
+  "@/stores/assistant-feature-flag-store",
+  await import("@/stores/assistant-feature-flag-store"),
+  { useAssistantFeatureFlagStore: featureFlagStoreStub },
+);
 
 const billingRef = {
   data: undefined as
@@ -136,98 +157,99 @@ function isActivationProgressQuery(options: unknown): boolean {
 // (e.g. `isCancelledError` via `captureError`) keep resolving; only the
 // hook under test's read is overridden. The menu makes two reads, so the
 // stub answers by query key rather than handing both the same body.
-const actualReactQuery = await import("@tanstack/react-query");
-mock.module("@tanstack/react-query", () => ({
-  ...actualReactQuery,
+stubModule("@tanstack/react-query", await import("@tanstack/react-query"), {
   useQuery: (options: unknown) =>
     isActivationProgressQuery(options)
       ? { data: activationProgressRef.data, isLoading: false, isError: false }
       : { data: billingRef.data, isLoading: false, isError: false },
-}));
+});
 
-mock.module("@/generated/api/@tanstack/react-query.gen", () => ({
-  organizationsBillingSummaryRetrieveOptions: () => ({
-    queryKey: [{ _id: "organizationsBillingSummaryRetrieve" }],
-  }),
-  referralCodesMeRetrieveOptions: () => ({
-    queryKey: [{ _id: "referralCodesMeRetrieve" }],
-  }),
-}));
+stubModule(
+  "@/generated/api/@tanstack/react-query.gen",
+  await import("@/generated/api/@tanstack/react-query.gen"),
+  {
+    organizationsBillingSummaryRetrieveOptions: () => ({
+      queryKey: [{ _id: "organizationsBillingSummaryRetrieve" }],
+    }),
+    referralCodesMeRetrieveOptions: () => ({
+      queryKey: [{ _id: "referralCodesMeRetrieve" }],
+    }),
+  },
+);
 
 // Capture navigate() targets so the menu's destinations can be asserted
 // without a live Router.
 let navigateArgs: unknown[] = [];
-const actualReactRouter = await import("react-router");
-// Captured by value: a module namespace's bindings are live, so reading the
-// export back after the mock is installed would hand out the mock.
-const { useNavigate: realUseNavigate } = actualReactRouter;
-mock.module("react-router", () => ({
-  ...actualReactRouter,
+stubModule("react-router", await import("react-router"), {
   useNavigate: () => (to: unknown) => {
     navigateArgs.push(to);
   },
-}));
-
-// `mock.module` replaces the module for every file sharing this process, and
-// a router that never navigates would silently break any suite after this one
-// that asserts on where a click took the user.
-afterAll(() => {
-  mock.module("react-router", () => ({
-    ...actualReactRouter,
-    useNavigate: realUseNavigate,
-  }));
 });
 
 // The menu owns when the chunk is warmed and when the dialog is mounted; the
 // dialog's own lazy wiring is covered by `share-feedback-modal-lazy.test.tsx`.
 const feedbackRef = { prefetches: 0 };
-mock.module("@/components/share-feedback-modal-lazy", () => ({
-  ShareFeedbackModalLazy: ({ open }: { open: boolean }) =>
-    open
-      ? createElement("div", { "data-testid": "share-feedback-modal" })
-      : null,
-  prefetchShareFeedbackModal: () => {
-    feedbackRef.prefetches += 1;
+stubModule(
+  "@/components/share-feedback-modal-lazy",
+  await import("@/components/share-feedback-modal-lazy"),
+  {
+    ShareFeedbackModalLazy: ({ open }: { open: boolean }) =>
+      open
+        ? createElement("div", { "data-testid": "share-feedback-modal" })
+        : null,
+    prefetchShareFeedbackModal: () => {
+      feedbackRef.prefetches += 1;
+    },
   },
-}));
+);
 
 // The panel owns its own reads (subscription, plan catalog, usage totals),
 // which this suite's partial `@tanstack/react-query` mock cannot host. Its
 // rendering is covered by `preferences-usage-panel.test.tsx`; what the menu
 // owns is where the panel sits and what its two actions do.
 const panelPropsRef: { conversationId?: string | null } = {};
-mock.module("@/domains/chat/components/preferences-usage-panel", () => ({
-  PreferencesUsagePanel: ({
-    onOpenBilling,
-    onAddCredits,
-    conversationId,
-  }: {
-    onOpenBilling: () => void;
-    onAddCredits?: () => void;
-    conversationId?: string | null;
-  }) => {
-    panelPropsRef.conversationId = conversationId;
-    return createElement(
-      "div",
-      { "data-testid": "preferences-usage" },
-      createElement("button", { onClick: onOpenBilling }, "Usage settings"),
-      // The real panel drops the strip's button with the handler, so the stub
-      // has to as well.
-      onAddCredits
-        ? createElement(
-            "button",
-            { onClick: onAddCredits },
-            "Add usage credits",
-          )
-        : null,
-    );
+stubModule(
+  "@/domains/chat/components/preferences-usage-panel",
+  await import("@/domains/chat/components/preferences-usage-panel"),
+  {
+    PreferencesUsagePanel: ({
+      onOpenBilling,
+      onAddCredits,
+      conversationId,
+    }: {
+      onOpenBilling: () => void;
+      onAddCredits?: () => void;
+      conversationId?: string | null;
+    }) => {
+      panelPropsRef.conversationId = conversationId;
+      return createElement(
+        "div",
+        { "data-testid": "preferences-usage" },
+        createElement("button", { onClick: onOpenBilling }, "Usage settings"),
+        // The real panel drops the strip's button with the handler, so the
+        // stub has to as well.
+        onAddCredits
+          ? createElement(
+              "button",
+              { onClick: onAddCredits },
+              "Add usage credits",
+            )
+          : null,
+      );
+    },
   },
-}));
+);
 
-mock.module("@/components/add-credits-modal", () => ({
-  AddCreditsModal: ({ open }: { open: boolean }) =>
-    open ? createElement("div", { "data-testid": "add-credits-modal" }) : null,
-}));
+stubModule(
+  "@/components/add-credits-modal",
+  await import("@/components/add-credits-modal"),
+  {
+    AddCreditsModal: ({ open }: { open: boolean }) =>
+      open
+        ? createElement("div", { "data-testid": "add-credits-modal" })
+        : null,
+  },
+);
 
 // The reading itself is composed from three billing queries this suite's
 // partial `@tanstack/react-query` mock cannot host, and is covered by
@@ -237,56 +259,55 @@ const usageRef: { value: PreferencesUsage | null; opts: unknown } = {
   value: null,
   opts: undefined,
 };
-mock.module("@/domains/chat/hooks/use-preferences-usage", () => ({
-  usePreferencesUsage: (opts?: unknown) => {
-    usageRef.opts = opts;
-    return usageRef.value;
+stubModule(
+  "@/domains/chat/hooks/use-preferences-usage",
+  await import("@/domains/chat/hooks/use-preferences-usage"),
+  {
+    usePreferencesUsage: (opts?: unknown) => {
+      usageRef.opts = opts;
+      return usageRef.value;
+    },
   },
-}));
+);
 
 // The funnel emitter posts to the telemetry ingest, which has nowhere to go
 // in a test process. What the menu owns is that opening the list emits the
 // event at all, so the emitter is captured rather than run.
 //
-// Spread and restored like every other module mock here: `mock.module`
-// replaces a module for the whole process, and `use-launch-activation-task
-// .test.tsx` asserts on the same emitter.
+// `use-launch-activation-task.test.tsx` asserts on the same emitter, so this
+// one has to be put back when the file is done with it.
 const activationEvents: string[] = [];
-const telemetryModule = await import("@/utils/activation-telemetry");
-// Captured by value: a module namespace's bindings are live, so reading the
-// export back after the mock is installed would hand out the mock.
-const { emitActivationEvent: realEmitActivationEvent } = telemetryModule;
-mock.module("@/utils/activation-telemetry", () => ({
-  ...telemetryModule,
-  emitActivationEvent: (event: string) => {
-    activationEvents.push(event);
+stubModule(
+  "@/utils/activation-telemetry",
+  await import("@/utils/activation-telemetry"),
+  {
+    emitActivationEvent: (event: string) => {
+      activationEvents.push(event);
+    },
   },
-}));
+);
 
-afterAll(() => {
-  mock.module("@/utils/activation-telemetry", () => ({
-    ...telemetryModule,
-    emitActivationEvent: realEmitActivationEvent,
-  }));
-});
-
-mock.module("@/domains/chat/components/credits-card", () => ({
-  CreditsCard: ({
-    balance,
-    onAddCredits,
-  }: {
-    balance: string;
-    onAddCredits?: () => void;
-  }) =>
-    createElement(
-      "div",
-      { "data-testid": "credits-card" },
+stubModule(
+  "@/domains/chat/components/credits-card",
+  await import("@/domains/chat/components/credits-card"),
+  {
+    CreditsCard: ({
       balance,
-      onAddCredits
-        ? createElement("button", { onClick: onAddCredits }, "Add credits")
-        : null,
-    ),
-}));
+      onAddCredits,
+    }: {
+      balance: string;
+      onAddCredits?: () => void;
+    }) =>
+      createElement(
+        "div",
+        { "data-testid": "credits-card" },
+        balance,
+        onAddCredits
+          ? createElement("button", { onClick: onAddCredits }, "Add credits")
+          : null,
+      ),
+  },
+);
 
 const { PreferencesMenu, showsMenuCredits } =
   await import("@/domains/chat/components/preferences-menu");

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -10,6 +10,7 @@ import {
 } from "bun:test";
 import { cleanup, renderHook, act } from "@testing-library/react";
 import type { ReactNode } from "react";
+import type { NavigateOptions, To } from "react-router";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -34,6 +35,7 @@ import { useViewerStore } from "@/stores/viewer-store";
 import type { ShareInboxItem } from "@/runtime/share-inbox-parse";
 import { routes } from "@/utils/routes";
 import * as toastModule from "@vellumai/design-library/components/toast";
+import type * as SentryReact from "@sentry/react";
 import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
 import {
   restoreStubbedModules,
@@ -48,21 +50,28 @@ import {
  */
 let mockPathname: string = routes.assistant;
 let mockSearch = "";
-const navigateMock = mock(
-  (
-    to: string | { pathname: string; search?: string; hash?: string },
-    _options?: { replace?: boolean },
-  ) => {
-    const path = typeof to === "string" ? to : to.pathname;
-    mockPathname = path.split("?")[0] ?? path;
-    return undefined;
-  },
-);
+const navigateMock = mock((to: To | number, _options?: NavigateOptions) => {
+  // A history delta names no path, so the location stays where it is.
+  const path =
+    typeof to === "number"
+      ? mockPathname
+      : typeof to === "string"
+        ? to
+        : (to.pathname ?? mockPathname);
+  mockPathname = path.split("?")[0] ?? path;
+  return undefined;
+});
 stubModule("react-router", await import("react-router"), {
   useNavigate: () => navigateMock,
   // Empty `search` is the main window: the room's pop-out gate
   // (`isPopoutWindow`) looks for `popout=1`.
-  useLocation: () => ({ pathname: mockPathname, search: mockSearch, hash: "" }),
+  useLocation: () => ({
+    pathname: mockPathname,
+    search: mockSearch,
+    hash: "",
+    state: null,
+    key: "default",
+  }),
 });
 
 const ensureMainWindowVisibleMock = mock(async () => undefined);
@@ -72,20 +81,25 @@ stubModule("@/runtime/main-window", await import("@/runtime/main-window"), {
 
 // Stub the toaster: the top-up success branch toasts, and no <Toaster /> is
 // mounted here.
-const toastSuccessMock = mock((..._args: unknown[]) => undefined);
+const toastSuccessMock = mock<typeof toastModule.toast.success>(
+  (_message, _options) => "",
+);
+// The real toast carries its other kinds and `dismiss`; only the success
+// branch this suite asserts on is replaced.
 stubModule("@vellumai/design-library/components/toast", toastModule, {
-  toast: Object.assign((..._args: unknown[]) => {}, {
-    success: toastSuccessMock,
-    error: () => {},
-    info: () => {},
-    warning: () => {},
-  }),
+  toast: Object.assign(
+    (..._args: Parameters<typeof toastModule.toast>): string | number => "",
+    toastModule.toast,
+    { success: toastSuccessMock },
+  ),
 });
 
-const sentryBreadcrumbMock = mock((_args: unknown) => undefined);
+const sentryBreadcrumbMock = mock<typeof SentryReact.addBreadcrumb>(
+  (_breadcrumb) => undefined,
+);
 stubModule("@sentry/react", await import("@sentry/react"), {
   addBreadcrumb: sentryBreadcrumbMock,
-  captureException: () => {},
+  captureException: () => "",
 });
 
 // Voice entry runs a readiness preflight before a session opens; stub it ready

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1,4 +1,5 @@
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -34,6 +35,10 @@ import type { ShareInboxItem } from "@/runtime/share-inbox-parse";
 import { routes } from "@/utils/routes";
 import * as toastModule from "@vellumai/design-library/components/toast";
 import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
+import {
+  restoreStubbedModules,
+  stubModule,
+} from "@/utils/module-mock.test-helper";
 
 /**
  * Location the app is "on", advanced by the consumer's own `navigate` calls.
@@ -53,60 +58,55 @@ const navigateMock = mock(
     return undefined;
   },
 );
-mock.module("react-router", () => ({
+stubModule("react-router", await import("react-router"), {
   useNavigate: () => navigateMock,
-  // Empty `search` is the main window — the room's pop-out gate
+  // Empty `search` is the main window: the room's pop-out gate
   // (`isPopoutWindow`) looks for `popout=1`.
   useLocation: () => ({ pathname: mockPathname, search: mockSearch, hash: "" }),
-}));
+});
 
-// Spread the real module: `mock.module` is process-global in bun, so a partial
-// shape erases the rest of it for every file that loads it later.
-const mainWindowModule = await import("@/runtime/main-window");
 const ensureMainWindowVisibleMock = mock(async () => undefined);
-mock.module("@/runtime/main-window", () => ({
-  ...mainWindowModule,
+stubModule("@/runtime/main-window", await import("@/runtime/main-window"), {
   ensureMainWindowVisible: ensureMainWindowVisibleMock,
-}));
+});
 
 // Stub the toaster: the top-up success branch toasts, and no <Toaster /> is
-// mounted here. Full toast surface: `mock.module` is process-global in bun,
-// so a partial shape would shadow the other methods for later test files.
+// mounted here.
 const toastSuccessMock = mock((..._args: unknown[]) => undefined);
-mock.module("@vellumai/design-library/components/toast", () => ({
-  ...toastModule,
+stubModule("@vellumai/design-library/components/toast", toastModule, {
   toast: Object.assign((..._args: unknown[]) => {}, {
     success: toastSuccessMock,
     error: () => {},
     info: () => {},
     warning: () => {},
   }),
-}));
+});
 
 const sentryBreadcrumbMock = mock((_args: unknown) => undefined);
-// Full Sentry surface — `mock.module` is process-global in bun, so a
-// partial mock would shadow `captureException` (used by `runtime/event-sources/*`
-// and `sse-service`) for every later test file in the run.
-mock.module("@sentry/react", () => ({
+stubModule("@sentry/react", await import("@sentry/react"), {
   addBreadcrumb: sentryBreadcrumbMock,
   captureException: () => {},
-}));
+});
 
 // Voice entry runs a readiness preflight before a session opens; stub it ready
 // so these tests stay about link handling. See `voice-entry-guards`.
-mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
-  preflightLiveVoice: async () => ({ status: "ready" }),
-}));
+stubModule(
+  "@/domains/chat/voice/live-voice/live-voice-preflight-api",
+  await import("@/domains/chat/voice/live-voice/live-voice-preflight-api"),
+  { preflightLiveVoice: async () => ({ status: "ready" }) },
+);
 
 const consumeShareInboxMock = mock(
   async (_id?: string | null): Promise<ShareInboxItem | null> => null,
 );
 const readShareInboxFilesMock = mock(async () => [] as File[]);
-mock.module("@/runtime/share-inbox", () => ({
+stubModule("@/runtime/share-inbox", await import("@/runtime/share-inbox"), {
   consumeShareInbox: consumeShareInboxMock,
   readShareInboxFiles: readShareInboxFilesMock,
   publishShareInboxSource: () => () => undefined,
-}));
+});
+
+afterAll(restoreStubbedModules);
 
 const { useGlobalDeepLinkConsumer } =
   await import("./use-global-deep-link-consumer");

--- a/clients/web/src/hooks/use-onboarding-window-size.test.tsx
+++ b/clients/web/src/hooks/use-onboarding-window-size.test.tsx
@@ -22,7 +22,13 @@ let currentPath = "/assistant";
 const setOnboardingWindowMock = mock((_active: boolean) => Promise.resolve());
 
 stubModule("react-router", await import("react-router"), {
-  useLocation: () => ({ pathname: currentPath }),
+  useLocation: () => ({
+    pathname: currentPath,
+    search: "",
+    hash: "",
+    state: null,
+    key: "default",
+  }),
 });
 
 stubModule("@/runtime/main-window", await import("@/runtime/main-window"), {

--- a/clients/web/src/hooks/use-onboarding-window-size.test.tsx
+++ b/clients/web/src/hooks/use-onboarding-window-size.test.tsx
@@ -1,5 +1,18 @@
 import { cleanup, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+import {
+  restoreStubbedModules,
+  stubModule,
+} from "@/utils/module-mock.test-helper";
 
 // The hook reads the current route via react-router's `useLocation` and
 // pushes the onboarding window mode to the Electron host. Drive both from
@@ -8,17 +21,15 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 let currentPath = "/assistant";
 const setOnboardingWindowMock = mock((_active: boolean) => Promise.resolve());
 
-mock.module("react-router", () => ({
+stubModule("react-router", await import("react-router"), {
   useLocation: () => ({ pathname: currentPath }),
-}));
+});
 
-// Spread the real module: `mock.module` is process-global in bun, so a partial
-// shape erases the rest of it for every file that loads it later.
-const mainWindowModule = await import("@/runtime/main-window");
-mock.module("@/runtime/main-window", () => ({
-  ...mainWindowModule,
+stubModule("@/runtime/main-window", await import("@/runtime/main-window"), {
   setOnboardingWindow: setOnboardingWindowMock,
-}));
+});
+
+afterAll(restoreStubbedModules);
 
 const { useOnboardingWindowSize } =
   await import("@/hooks/use-onboarding-window-size");

--- a/clients/web/src/utils/module-mock.test-helper.ts
+++ b/clients/web/src/utils/module-mock.test-helper.ts
@@ -1,0 +1,46 @@
+/**
+ * Installing a `mock.module` without erasing the module or leaking it.
+ *
+ * `mock.module` is process-global in bun. A replacement that does not spread
+ * the real module erases every other export of it for whatever file loads it
+ * next, and one that is never put back outlives the file that installed it.
+ * Both halves were being written by hand at each mock site, which is two
+ * chances per mock to forget one.
+ *
+ * The real module is passed in rather than imported here: a module namespace's
+ * bindings are live, so reading an export back after the mock is installed
+ * hands out the mock, and the capture has to happen at the call site before
+ * the replacement lands.
+ *
+ * Lives in the top-level shared utils because the suites that need it sit in
+ * `hooks/` and in more than one domain.
+ */
+
+import { mock } from "bun:test";
+
+/** How to put each stubbed module back, keyed by specifier. */
+const restorers = new Map<string, () => void>();
+
+/**
+ * Replace `specifier` with the real module plus `overrides`, and register the
+ * undo. Hand `restoreStubbedModules` to the suite's `afterAll`.
+ */
+export function stubModule(
+  specifier: string,
+  real: object,
+  overrides: Record<string, unknown>,
+): void {
+  const captured = { ...real } as Record<string, unknown>;
+  mock.module(specifier, () => ({ ...captured, ...overrides }));
+  restorers.set(specifier, () => {
+    mock.module(specifier, () => captured);
+  });
+}
+
+/** Put every module {@link stubModule} replaced back the way it was. */
+export function restoreStubbedModules(): void {
+  for (const restore of restorers.values()) {
+    restore();
+  }
+  restorers.clear();
+}

--- a/clients/web/src/utils/module-mock.test-helper.ts
+++ b/clients/web/src/utils/module-mock.test-helper.ts
@@ -4,13 +4,18 @@
  * `mock.module` is process-global in bun. A replacement that does not spread
  * the real module erases every other export of it for whatever file loads it
  * next, and one that is never put back outlives the file that installed it.
- * Both halves were being written by hand at each mock site, which is two
- * chances per mock to forget one.
+ * This helper owns both halves: it spreads a by-value capture of the real
+ * module under the overrides, and it records how to put that module back.
  *
  * The real module is passed in rather than imported here: a module namespace's
  * bindings are live, so reading an export back after the mock is installed
  * hands out the mock, and the capture has to happen at the call site before
  * the replacement lands.
+ *
+ * One restorer map serves the whole process. `scripts/run-tests.ts` gives each
+ * test file its own process, and bun runs files sequentially otherwise, so no
+ * two suites hold entries in the map at the same time and restoring in
+ * `afterAll` is safe.
  *
  * Lives in the top-level shared utils because the suites that need it sit in
  * `hooks/` and in more than one domain.
@@ -24,13 +29,17 @@ const restorers = new Map<string, () => void>();
 /**
  * Replace `specifier` with the real module plus `overrides`, and register the
  * undo. Hand `restoreStubbedModules` to the suite's `afterAll`.
+ *
+ * `overrides` is typed against the module being replaced, so a misspelled
+ * export name or a value the module's consumers cannot use is a compile error
+ * rather than an `undefined` the suite reads as a passing branch.
  */
-export function stubModule(
+export function stubModule<M extends object>(
   specifier: string,
-  real: object,
-  overrides: Record<string, unknown>,
+  real: M,
+  overrides: Partial<M>,
 ): void {
-  const captured = { ...real } as Record<string, unknown>;
+  const captured = { ...real } as M;
   mock.module(specifier, () => ({ ...captured, ...overrides }));
   restorers.set(specifier, () => {
     mock.module(specifier, () => captured);


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 2) for activation-checklist.md.

- **Completion survives a failed step flush** (`assistant/src/activation/progress-store.ts`): `markActivationTurnComplete` now awaits `flushStepBumps(...).catch(() => {})`. A transient write failure used to reject out of the completion, leaving the row on Working forever. The completion mutation re-establishes `stepCount` via `Math.max`, and the flush already re-queues its delta for a bounded retry. Regression test: the flush write fails once, the completion still lands with the right count.
- **Link-index stamp is taken before the read**, not after. `readActivationSnapshot` captures `progressFileStamp()` ahead of `readFileSync` and passes it into `refreshLinkIndex`; `writeActivationProgress` returns the stamp of the bytes it just landed and the mutation path passes that. A write that lands between read and stamp no longer pins a stale index as fresh. Regression test stubs `readFileSync` to interleave an external write.
- **ARCHITECTURE.md** mermaid completion node now reads "(unless the turn ended awaiting the user)", matching the prose above it.
- **`useDismissActivation` cancels the in-flight progress read** before the optimistic seed, matching `useLaunchActivationTask`. A read issued before the dismissal could otherwise land on top of the seed and reopen the surface. Test parks a read, dismisses, releases the read, asserts the dismissal survives.
- **`ActivationSuggestionsPillHost` docstring** rewritten: it is passed as `topBarPill`, not composed into the top-bar accessory.
- **Deleted the self-referential header ordering test.** `ChatLayoutHeader` takes no `topBarPill` prop (the composition lives in `ChatLayout`, which folds pill and accessory into one `topBarRightSlot`), so the test could only assert the order of the fragment it had just written. The ordering it meant to guard is now asserted in `chat-layout-top-bar-slots.test.ts`, where the composition actually lives.
- **Restored the `ChatPill` regression case** "stays clickable over a pointer-events-none overlay": renders the pill inside a `pointer-events-none` wrapper, asserts the `pointer-events-auto` opt-in and that a click still reaches the handler.
- **Dropped the dead `availableTags` parameter** from `taskIsAvailable`; it was only ever called with the module constant.
- **`useActivationCompletionTelemetry` resolves its own list id** via `useEffectiveActivationListId` and snapshots the context with `captureActivationTelemetryContext(listId)`, the same seam the launch hook uses. It no longer depends on hook ordering in the controller to have populated the module global. Test poisons the global with a different list and asserts the event is filed under the one this render resolved.
- **Story matrix filled in**: `activation-task-row` gains dark and `sbMobile` variants for `TodoCollapsed`, `TodoExpandedWithLink` and `TodoExpandedPending`, plus `DoneWithFileMobile`; `activation-task-icon` gains `DefaultDark` and `DoneMobile`.
- **Mock hygiene sweep**, finishing what #42120 claimed. New shared helper `src/utils/module-mock.test-helper.ts` (`stubModule` / `restoreStubbedModules`) captures the real module by value, spreads it, and registers the undo for `afterAll`. Applied across `use-global-deep-link-consumer.test.tsx`, `use-onboarding-window-size.test.tsx`, `chat-layout-header.test.tsx` and `preferences-menu.test.tsx` (14 mocks there, including the two that spread but never restored). The false "Spread and restored like every other module mock here" comment is now true. All four files pass individually and in a combined run.

## Validation
`bun test src/activation` (assistant, 57 pass) and `bun run typecheck:fast`; each touched web test file individually plus `bun test src/domains/activation` (171 pass); `bun run lint` (0 errors), `bun run audit:cross-domain:check`, `bunx tsc --noEmit`, prettier on every touched file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42125" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->