### PR TITLE
fix(web): only require a first name on the onboarding details form (LUM-3539)

### DIFF
--- a/clients/web/src/domains/account/pages/provider-signup-page.test.tsx
+++ b/clients/web/src/domains/account/pages/provider-signup-page.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Provider signup gates Continue on a first name and stashes that name for
+ * research onboarding. Role stays optional.
+ */
+
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router";
+
+const getProviderSignup = mock(() =>
+  Promise.resolve({
+    ok: true as const,
+    data: {
+      user: {
+        email: "user@example.com",
+        username: "user1",
+        first_name: "",
+        last_name: "",
+      },
+    },
+  }),
+);
+
+const submitProviderSignup = mock(() =>
+  Promise.resolve({ ok: true as const, data: {} }),
+);
+
+mock.module("@/lib/auth/allauth-client", () => ({
+  getProviderSignup,
+  submitProviderSignup,
+  isConflict: () => false,
+}));
+
+mock.module("@/assistant/platform-assistants-sync", () => ({
+  refreshPlatformAssistantsIfStale: async () => {},
+}));
+
+const refreshSession = mock(async () => true);
+
+mock.module("@/stores/auth-store", () => ({
+  useAuthStore: {
+    use: {
+      refreshSession: () => refreshSession,
+    },
+  },
+}));
+
+mock.module("@/domains/account/login-flow", () => ({
+  resolvePostAuthDestination: () => ({
+    destination: "/assistant",
+    requiresFullPageNavigation: false,
+  }),
+  resolvePostLoginDestination: () => ({
+    destination: "/assistant",
+    requiresFullPageNavigation: false,
+  }),
+}));
+
+mock.module("@/domains/account/components/signup-shell", () => ({
+  SignupShell: ({ children }: { children: ReactNode }) => children,
+}));
+
+const { ProviderSignupPage } = await import(
+  "@/domains/account/pages/provider-signup-page"
+);
+const { peekSignupOnboardingFirstName, takeSignupOnboardingFirstName } =
+  await import("@/lib/auth/signup-onboarding-handoff");
+
+function continueButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: /continue/i });
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/account/provider-signup"]}>
+      <Routes>
+        <Route
+          path="/account/provider-signup"
+          element={<ProviderSignupPage />}
+        />
+        <Route path="/assistant" element={<div>assistant</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  getProviderSignup.mockClear();
+  submitProviderSignup.mockClear();
+  refreshSession.mockClear();
+  takeSignupOnboardingFirstName();
+});
+
+afterEach(() => {
+  takeSignupOnboardingFirstName();
+  cleanup();
+});
+
+describe("ProviderSignupPage first name", () => {
+  test("Continue is disabled until a first name is entered", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("First name")).toBeTruthy();
+    });
+
+    const firstName = screen.getByPlaceholderText(
+      "First name",
+    ) as HTMLInputElement;
+    expect(firstName.disabled).toBe(false);
+    expect(firstName.readOnly).toBe(false);
+    expect(continueButton().disabled).toBe(true);
+
+    fireEvent.change(firstName, { target: { value: "Alice" } });
+    expect(continueButton().disabled).toBe(false);
+  });
+
+  test("submits the typed first name into the onboarding handoff", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("First name")).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("First name"), {
+      target: { value: "Alice" },
+    });
+    fireEvent.click(continueButton());
+
+    await waitFor(() => {
+      expect(submitProviderSignup).toHaveBeenCalledTimes(1);
+    });
+    expect(peekSignupOnboardingFirstName()).toBe("Alice");
+  });
+});

--- a/clients/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/clients/web/src/domains/account/pages/provider-signup-page.tsx
@@ -15,6 +15,7 @@ import {
   isConflict,
   submitProviderSignup,
 } from "@/lib/auth/allauth-client";
+import { setSignupOnboardingFirstName } from "@/lib/auth/signup-onboarding-handoff";
 import {
   resolvePostAuthDestination,
   resolvePostLoginDestination,
@@ -26,12 +27,13 @@ import { routes } from "@/utils/routes";
  * Provider signup completion page. Shown when allauth's provider flow needs
  * additional information before creating the account.
  *
- * Shows the OAuth-claim first/last name as read-only and collects an
- * occupation. The account is completed via `submitProviderSignup` using the
- * provider-supplied email + username (no username field — matching the standard
- * sign-up, which does not surface one to the user). If the provider didn't
- * supply email + username, it falls back to the editable form so the user can
- * still complete signup.
+ * First name is required and editable (providers sometimes omit it). Last name
+ * is display-only. Occupation is optional. The account is completed via
+ * `submitProviderSignup` using the provider-supplied email + username (no
+ * username field — matching the standard sign-up, which does not surface one to
+ * the user). The typed first name is stashed for research onboarding. If the
+ * provider didn't supply email + username, it falls back to the editable form
+ * so the user can still complete signup.
  */
 export function ProviderSignupPage() {
   const { t } = useTranslation("account");
@@ -41,8 +43,7 @@ export function ProviderSignupPage() {
   const returnTo = searchParams.get("returnTo");
 
   // Provider-supplied identity. email + username are submitted to complete the
-  // account; firstName/lastName are display-only (read-only). All come from the
-  // pending provider-signup context.
+  // account. firstName is required and editable; lastName is display-only.
   const [email, setEmail] = useState("");
   const [username, setUsername] = useState("");
   const [firstName, setFirstName] = useState("");
@@ -130,12 +131,15 @@ export function ProviderSignupPage() {
 
   const onPersonalPageSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if (!firstName.trim()) {
+      return;
+    }
     setError(null);
     setIsSubmitting(true);
     try {
-      // NOTE: occupation is collected but not yet persisted. Forwarding it into
-      // the onboarding handoff requires a shared cross-domain contract (the
-      // `account` domain may not import `onboarding` directly). Deferred.
+      // NOTE: occupation is collected but not yet persisted. The first name
+      // is stashed in a shared session handoff that onboarding reads.
+      setSignupOnboardingFirstName(firstName);
       await completeSignup();
     } catch {
       setError(t("authErrors.genericFailure"));
@@ -161,7 +165,7 @@ export function ProviderSignupPage() {
   // editable form so the user can complete signup rather than hit an
   // uncorrectable validation error.
   if (email && username) {
-    const canSubmit = !isSubmitting;
+    const canSubmit = firstName.trim().length > 0 && !isSubmitting;
     return (
       <SignupShell>
         <form
@@ -186,8 +190,10 @@ export function ProviderSignupPage() {
               type="text"
               placeholder={t("providerSignupPage.firstNamePlaceholder")}
               value={firstName}
-              readOnly
-              disabled
+              onChange={(e) => setFirstName(e.target.value)}
+              autoComplete="given-name"
+              autoFocus
+              required
             />
           </div>
 
@@ -217,7 +223,6 @@ export function ProviderSignupPage() {
               placeholder={t("providerSignupPage.rolePlaceholder")}
               value={occupation}
               onChange={(e) => setOccupation(e.target.value)}
-              autoFocus
             />
           </div>
 

--- a/clients/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/clients/web/src/domains/account/pages/provider-signup-page.tsx
@@ -130,9 +130,6 @@ export function ProviderSignupPage() {
 
   const onPersonalPageSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!occupation.trim()) {
-      return;
-    }
     setError(null);
     setIsSubmitting(true);
     try {
@@ -164,7 +161,7 @@ export function ProviderSignupPage() {
   // editable form so the user can complete signup rather than hit an
   // uncorrectable validation error.
   if (email && username) {
-    const canSubmit = occupation.trim().length > 0 && !isSubmitting;
+    const canSubmit = !isSubmitting;
     return (
       <SignupShell>
         <form
@@ -211,8 +208,7 @@ export function ProviderSignupPage() {
 
           <div className="signup-details__step">
             <span className="signup-details__label">
-              {t("providerSignupPage.roleQuestion")}{" "}
-              <span className="signup-details__req">*</span>
+              {t("providerSignupPage.roleQuestion")}
             </span>
             <input
               className="signup-details__input"

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -29,6 +29,10 @@ import { useNavigate, useSearchParams } from "react-router";
 
 import { lifecycleService } from "@/assistant/lifecycle-service";
 import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
+import {
+  resolveOnboardingFirstName,
+  takeSignupOnboardingFirstName,
+} from "@/lib/auth/signup-onboarding-handoff";
 import { isLocalClient } from "@/lib/local-mode";
 import { POST_CHECKOUT_HATCH_PARAM } from "@/lib/navigation/navigation-resolver";
 import {
@@ -887,6 +891,7 @@ export function ResearchOnboardingRoute() {
         return;
       }
     }
+    takeSignupOnboardingFirstName();
     setFormValues(values);
     fireResearch(values);
     goForwardTo("face");
@@ -1371,7 +1376,7 @@ export function ResearchOnboardingRoute() {
 
   return withHatchError(
     <ResearchOnboardingScreen
-      initialFirstName={user?.firstName ?? ""}
+      initialFirstName={resolveOnboardingFirstName(user?.firstName)}
       initialLastName={user?.lastName ?? ""}
       onSubmit={handleFormSubmit}
     />,

--- a/clients/web/src/domains/onboarding/screens/research-onboarding-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-onboarding-screen.test.tsx
@@ -35,7 +35,7 @@ describe("ResearchOnboardingScreen", () => {
     expect(continueButton().disabled).toBe(true);
 
     fireEvent.change(screen.getByPlaceholderText("Your name"), {
-      target: { value: "Ada" },
+      target: { value: "Alice" },
     });
     expect(continueButton().disabled).toBe(false);
   });
@@ -45,17 +45,27 @@ describe("ResearchOnboardingScreen", () => {
     render(<ResearchOnboardingScreen onSubmit={onSubmit} />);
 
     fireEvent.change(screen.getByPlaceholderText("Your name"), {
-      target: { value: "Ada" },
+      target: { value: "Alice" },
     });
     fireEvent.click(continueButton());
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit.mock.calls[0]?.[0]).toEqual({
-      firstName: "Ada",
+      firstName: "Alice",
       lastName: "",
       role: "",
       hobbies: [],
     });
+  });
+
+  test("Continue is enabled when a first name is already supplied", () => {
+    render(
+      <ResearchOnboardingScreen
+        initialFirstName="Alice"
+        onSubmit={() => {}}
+      />,
+    );
+    expect(continueButton().disabled).toBe(false);
   });
 
   test("the role field is not marked required", () => {

--- a/clients/web/src/domains/onboarding/screens/research-onboarding-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-onboarding-screen.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * The "Let's start with you" form gates Continue on the first name alone.
+ * Role and hobbies sharpen the research when present, but a user who leaves
+ * them blank must still be able to move on: every downstream consumer of
+ * `occupation` already tolerates an empty string.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+// Decorative and self-measuring; the form gate is what is under test.
+mock.module(
+  "@/domains/onboarding/components/onboarding-edge-characters",
+  () => ({
+    OnboardingEdgeCharacters: () => null,
+  }),
+);
+
+const { ResearchOnboardingScreen } =
+  await import("@/domains/onboarding/screens/research-onboarding-screen");
+type ResearchOnboardingValues =
+  import("@/domains/onboarding/screens/research-onboarding-screen").ResearchOnboardingValues;
+
+function continueButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: /continue/i });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ResearchOnboardingScreen", () => {
+  test("Continue is disabled until a first name is entered", () => {
+    render(<ResearchOnboardingScreen onSubmit={() => {}} />);
+    expect(continueButton().disabled).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("Your name"), {
+      target: { value: "Ada" },
+    });
+    expect(continueButton().disabled).toBe(false);
+  });
+
+  test("submits with only a first name; role is optional", () => {
+    const onSubmit = mock((_values: ResearchOnboardingValues) => {});
+    render(<ResearchOnboardingScreen onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Your name"), {
+      target: { value: "Ada" },
+    });
+    fireEvent.click(continueButton());
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0]?.[0]).toEqual({
+      firstName: "Ada",
+      lastName: "",
+      role: "",
+      hobbies: [],
+    });
+  });
+
+  test("the role field is not marked required", () => {
+    render(<ResearchOnboardingScreen onSubmit={() => {}} />);
+    const role = screen.getByPlaceholderText(
+      "What do you do for work?",
+    ) as HTMLInputElement;
+    expect(role.required).toBe(false);
+  });
+});

--- a/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-onboarding-screen.tsx
@@ -67,8 +67,9 @@ export function ResearchOnboardingScreen({
   const [role, setRole] = useState("");
   const [hobbies, setHobbies] = useState<string[]>([]);
 
-  // First name + role are the minimum signal worth researching on.
-  const canSubmit = firstName.trim().length > 0 && role.trim().length > 0;
+  // First name is the only required field; role and hobbies just sharpen the
+  // research when present.
+  const canSubmit = firstName.trim().length > 0;
 
   function handleSubmit() {
     if (!canSubmit) {
@@ -147,7 +148,6 @@ export function ResearchOnboardingScreen({
                 value={role}
                 onChange={(e) => setRole(e.target.value)}
                 className={MOBILE_INPUT_NO_ZOOM}
-                required
                 fullWidth
               />
             </div>

--- a/clients/web/src/lib/auth/signup-onboarding-handoff.test.ts
+++ b/clients/web/src/lib/auth/signup-onboarding-handoff.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  peekSignupOnboardingFirstName,
+  resolveOnboardingFirstName,
+  setSignupOnboardingFirstName,
+  takeSignupOnboardingFirstName,
+} from "@/lib/auth/signup-onboarding-handoff";
+
+describe("signup onboarding first-name handoff", () => {
+  let store: Map<string, string>;
+  let prior: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    store = new Map();
+    prior = Object.getOwnPropertyDescriptor(globalThis, "sessionStorage");
+    Object.defineProperty(globalThis, "sessionStorage", {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => void store.set(k, v),
+        removeItem: (k: string) => void store.delete(k),
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (prior) {
+      Object.defineProperty(globalThis, "sessionStorage", prior);
+    } else {
+      delete (globalThis as { sessionStorage?: unknown }).sessionStorage;
+    }
+  });
+
+  test("round-trips a trimmed first name", () => {
+    setSignupOnboardingFirstName("  Alice  ");
+    expect(peekSignupOnboardingFirstName()).toBe("Alice");
+    expect(takeSignupOnboardingFirstName()).toBe("Alice");
+    expect(peekSignupOnboardingFirstName()).toBeNull();
+  });
+
+  test("a blank first name does not stash a value", () => {
+    setSignupOnboardingFirstName("   ");
+    expect(peekSignupOnboardingFirstName()).toBeNull();
+  });
+
+  test("resolve prefers the signup stash over the session name", () => {
+    setSignupOnboardingFirstName("Alice");
+    expect(resolveOnboardingFirstName("Bob")).toBe("Alice");
+  });
+
+  test("resolve falls back to the session name when nothing is stashed", () => {
+    expect(resolveOnboardingFirstName("Alice")).toBe("Alice");
+    expect(resolveOnboardingFirstName("  ")).toBe("");
+    expect(resolveOnboardingFirstName(undefined)).toBe("");
+  });
+});

--- a/clients/web/src/lib/auth/signup-onboarding-handoff.ts
+++ b/clients/web/src/lib/auth/signup-onboarding-handoff.ts
@@ -1,0 +1,68 @@
+/**
+ * First name collected on provider signup, handed to research onboarding.
+ *
+ * The account domain cannot import onboarding, so both sides use this
+ * session-scoped stash. `sessionStorage` is cleared on logout.
+ */
+
+const STORAGE_KEY = "signup.onboarding.firstName";
+
+function getSessionStorage(): Storage | null {
+  try {
+    const storage = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+    return storage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function setSignupOnboardingFirstName(firstName: string): void {
+  const trimmed = firstName.trim();
+  const storage = getSessionStorage();
+  if (storage === null) {
+    return;
+  }
+  try {
+    storage.removeItem(STORAGE_KEY);
+    if (trimmed) {
+      storage.setItem(STORAGE_KEY, trimmed);
+    }
+  } catch {
+    // Storage unavailable / quota exceeded. Onboarding falls back to the
+    // session user, which is empty when the provider omitted a name.
+  }
+}
+
+export function peekSignupOnboardingFirstName(): string | null {
+  const storage = getSessionStorage();
+  if (storage === null) {
+    return null;
+  }
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    const trimmed = raw?.trim() ?? "";
+    return trimmed || null;
+  } catch {
+    return null;
+  }
+}
+
+export function takeSignupOnboardingFirstName(): string | null {
+  const value = peekSignupOnboardingFirstName();
+  const storage = getSessionStorage();
+  if (storage !== null) {
+    try {
+      storage.removeItem(STORAGE_KEY);
+    } catch {
+      // Best-effort.
+    }
+  }
+  return value;
+}
+
+/** Signup-typed name wins; otherwise the session user name. */
+export function resolveOnboardingFirstName(
+  sessionFirstName: string | undefined | null,
+): string {
+  return peekSignupOnboardingFirstName() || sessionFirstName?.trim() || "";
+}


### PR DESCRIPTION
## Summary

- The "Let's start with you" onboarding form required both first name and role, but only the first-name label said so and the disabled Continue never explained itself. Role is now optional; Continue enables on a first name alone and the `required` prop comes off the role input.
- The identical gate on `provider-signup-page.tsx` is dropped too. That page blocked on an occupation it never persisted.
- No downstream change needed: every consumer of `occupation` (research prompt, plugin affinity, prechat profile, persona resolver, normalize-onboarding) already handles an empty string; `research-prompt.test.ts` covers it.
- Adds `research-onboarding-screen.test.tsx`: Continue disabled until a first name, submits with `role: ""`, role input not marked required.

Fixes LUM-3539

## Why now

Five separate users in one day's LogRocket review filled everything except role and could not leave this screen. BigQuery puts consent-to-form abandonment at 9.8% of users over the last 45 days (659 users), climbing week over week. Details and SQL on the Linear ticket.

## Test plan

- `cd clients/web && bun test src/domains/onboarding/screens/research-onboarding-screen.test.tsx` → 3 pass, 0 fail
- `cd clients/web && bun run lint -- <changed files>` → clean
- Formatted with the repo-pinned prettier 3.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjwLgqzhFp4AQ42arMfhaF

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->