### PR TITLE
fix(web): split the hobbies field on commas into separate tags (LUM-3544)

### DIFF
--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.test.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.test.tsx
@@ -156,4 +156,26 @@ describe("TagAutocompleteInput", () => {
     expect(chips()).toBe("Reading|Painting");
     expect(input.value).toBe("");
   });
+
+  test("defers comma splitting until IME composition ends", () => {
+    render(<TagField />);
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+
+    fireEvent.compositionStart(input);
+    const composingChange = createEvent.change(input, {
+      target: { value: "Reading," },
+    });
+    Object.defineProperty(composingChange.nativeEvent, "isComposing", {
+      value: true,
+    });
+    fireEvent(input, composingChange);
+
+    expect(chips()).toBe("");
+    expect(input.value).toBe("Reading,");
+
+    fireEvent.compositionEnd(input);
+
+    expect(chips()).toBe("Reading");
+    expect(input.value).toBe("");
+  });
 });

--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.test.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   cleanup,
@@ -10,6 +11,42 @@ import {
 import { TagAutocompleteInput } from "@/domains/onboarding/components/onboarding-autocomplete";
 
 afterEach(cleanup);
+
+/** Stateful host, so committed chips feed back in as the `values` prop. */
+function TagField({
+  initialValues = [],
+  suggestions = [],
+}: {
+  initialValues?: string[];
+  suggestions?: readonly string[];
+}) {
+  const [values, setValues] = useState<string[]>(initialValues);
+  return (
+    <>
+      <TagAutocompleteInput
+        label="Hobbies"
+        values={values}
+        onChange={setValues}
+        suggestions={suggestions}
+      />
+      <output data-testid="values">{values.join("|")}</output>
+    </>
+  );
+}
+
+function chips(): string {
+  return screen.getByTestId("values").textContent ?? "";
+}
+
+/**
+ * Type one character at a time the way a soft keyboard does: every key reaches
+ * the input's value, and no key-specific keydown is dispatched.
+ */
+function type(input: HTMLInputElement, text: string) {
+  for (const char of text) {
+    fireEvent.change(input, { target: { value: `${input.value}${char}` } });
+  }
+}
 
 describe("TagAutocompleteInput", () => {
   test("claims Escape only while its suggestion list is open", () => {
@@ -40,5 +77,83 @@ describe("TagAutocompleteInput", () => {
     });
     fireEvent(input, closedEvent);
     expect(closedEvent.defaultPrevented).toBe(false);
+  });
+
+  test("splits typed commas into one chip per segment", () => {
+    render(<TagField />);
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+
+    type(input, "Reading, Painting");
+
+    expect(chips()).toBe("Reading");
+    expect(input.value).toBe("Painting");
+  });
+
+  test("splits a comma typed behind a hardware-keyboard keydown once", () => {
+    render(<TagField />);
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+
+    type(input, "Reading");
+    fireEvent.keyDown(input, { key: "," });
+    type(input, ",");
+
+    expect(chips()).toBe("Reading");
+    expect(input.value).toBe("");
+  });
+
+  test("commits every segment of a pasted list", () => {
+    render(<TagField />);
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => "Reading, Painting, Baking" },
+    });
+
+    expect(chips()).toBe("Reading|Painting|Baking");
+    expect(input.value).toBe("");
+  });
+
+  test("pastes a list into the text already typed", () => {
+    render(<TagField />);
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+
+    type(input, "Read");
+    input.setSelectionRange(4, 4);
+    fireEvent.paste(input, {
+      clipboardData: { getData: () => "ing, Painting" },
+    });
+
+    expect(chips()).toBe("Reading|Painting");
+    expect(input.value).toBe("");
+  });
+
+  test("keeps text after the last comma as the live query", () => {
+    render(<TagField />);
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+
+    type(input, "Reading, Cook");
+
+    expect(chips()).toBe("Reading");
+    expect(input.value).toBe("Cook");
+  });
+
+  test("ignores whitespace-only segments", () => {
+    render(<TagField />);
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+
+    type(input, "Reading,   , Painting,");
+
+    expect(chips()).toBe("Reading|Painting");
+    expect(input.value).toBe("");
+  });
+
+  test("does not duplicate a segment that matches an existing chip", () => {
+    render(<TagField initialValues={["Reading"]} />);
+    const input = screen.getByRole<HTMLInputElement>("combobox");
+
+    type(input, "reading, Painting,");
+
+    expect(chips()).toBe("Reading|Painting");
+    expect(input.value).toBe("");
   });
 });

--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.test.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.test.tsx
@@ -162,13 +162,7 @@ describe("TagAutocompleteInput", () => {
     const input = screen.getByRole<HTMLInputElement>("combobox");
 
     fireEvent.compositionStart(input);
-    const composingChange = createEvent.change(input, {
-      target: { value: "Reading," },
-    });
-    Object.defineProperty(composingChange.nativeEvent, "isComposing", {
-      value: true,
-    });
-    fireEvent(input, composingChange);
+    fireEvent.change(input, { target: { value: "Reading," } });
 
     expect(chips()).toBe("");
     expect(input.value).toBe("Reading,");
@@ -176,6 +170,11 @@ describe("TagAutocompleteInput", () => {
     fireEvent.compositionEnd(input);
 
     expect(chips()).toBe("Reading");
+    expect(input.value).toBe("");
+
+    type(input, "Painting,");
+
+    expect(chips()).toBe("Reading|Painting");
     expect(input.value).toBe("");
   });
 });

--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
@@ -16,7 +16,9 @@
  *
  * The tag field splits on commas from the input's *value*, not from a key
  * handler, so a hardware keyboard, a soft keyboard that reports `Unidentified`
- * keydowns, IME composition, paste, and autofill all produce the same chips.
+ * keydowns, paste, and autofill all produce the same chips. During IME
+ * composition the provisional value is kept as the query; comma splitting
+ * runs on compositionend once the IME commits.
  *
  * Suggestions are selected on `mousedown` (not click) with `preventDefault` so
  * the input never blurs out from under the selection.
@@ -264,6 +266,7 @@ export function TagAutocompleteInput({
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState(false);
   const [highlighted, setHighlighted] = useState(-1);
+  const isComposingRef = useRef(false);
 
   const items = useMemo(
     () => filterSuggestions(suggestions, query, values),
@@ -417,7 +420,22 @@ export function TagAutocompleteInput({
           value={query}
           onChange={(e) => {
             setOpen(true);
+            if (
+              isComposingRef.current ||
+              (e.nativeEvent as InputEvent).isComposing
+            ) {
+              setQuery(e.target.value);
+              return;
+            }
             applyInputValue(e.target.value);
+          }}
+          onCompositionStart={() => {
+            isComposingRef.current = true;
+          }}
+          onCompositionEnd={(e) => {
+            isComposingRef.current = false;
+            setOpen(true);
+            applyInputValue(e.currentTarget.value);
           }}
           onPaste={handlePaste}
           onFocus={() => setOpen(true)}

--- a/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
+++ b/clients/web/src/domains/onboarding/components/onboarding-autocomplete.tsx
@@ -11,8 +11,12 @@
  *   - `TagAutocompleteInput` multi-select chips + suggestion dropdown (Hobbies)
  *
  * Keyboard: ↑/↓ move the highlight, Enter commits the highlighted suggestion
- * (or, for tags, the typed text), Esc closes. The tag field also commits on
- * comma and removes the last chip on Backspace when the input is empty.
+ * (or, for tags, the typed text), Esc closes. The tag field removes the last
+ * chip on Backspace when the input is empty.
+ *
+ * The tag field splits on commas from the input's *value*, not from a key
+ * handler, so a hardware keyboard, a soft keyboard that reports `Unidentified`
+ * keydowns, IME composition, paste, and autofill all produce the same chips.
  *
  * Suggestions are selected on `mousedown` (not click) with `preventDefault` so
  * the input never blurs out from under the selection.
@@ -24,6 +28,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ClipboardEvent,
   type KeyboardEvent,
 } from "react";
 import { Plus, Search } from "lucide-react";
@@ -74,6 +79,31 @@ function filterSuggestions(
     }
   }
   return out;
+}
+
+/**
+ * Split a raw field value into the chips its commas complete and the text still
+ * being typed. Segments are trimmed; blank ones and case-insensitive duplicates
+ * (of `existing` or of each other) are dropped. The remainder carries no
+ * leading whitespace, so the space in "Reading, Painting" belongs to the
+ * separator rather than to the next tag.
+ */
+function splitSegments(
+  raw: string,
+  existing: readonly string[],
+): { additions: string[]; remainder: string } {
+  const lastComma = raw.lastIndexOf(",");
+  const seen = new Set(existing.map(normalize));
+  const additions: string[] = [];
+  for (const segment of raw.slice(0, Math.max(lastComma, 0)).split(",")) {
+    const next = segment.trim();
+    if (!next || seen.has(normalize(next))) {
+      continue;
+    }
+    seen.add(normalize(next));
+    additions.push(next);
+  }
+  return { additions, remainder: raw.slice(lastComma + 1).trimStart() };
 }
 
 /** One row in the dropdown: a predefined suggestion, or a free-text "add" row. */
@@ -292,6 +322,34 @@ export function TagAutocompleteInput({
     onChange(values.filter((v) => v !== target));
   }
 
+  /**
+   * Apply a new input value: each comma-completed segment becomes a chip and
+   * the text after the last comma stays as the live query. All additions go out
+   * in one `onChange` because `values` only refreshes on the next render.
+   */
+  function applyInputValue(raw: string) {
+    const { additions, remainder } = splitSegments(raw, values);
+    if (additions.length > 0) {
+      onChange([...values, ...additions]);
+      setHighlighted(-1);
+    }
+    setQuery(remainder);
+  }
+
+  function handlePaste(e: ClipboardEvent<HTMLInputElement>) {
+    const pasted = e.clipboardData.getData("text");
+    if (!pasted.includes(",")) {
+      return;
+    }
+    e.preventDefault();
+    setOpen(true);
+    const start = e.currentTarget.selectionStart ?? query.length;
+    const end = e.currentTarget.selectionEnd ?? start;
+    // A pasted list is complete, so the trailing comma commits its last
+    // segment as a chip too instead of leaving it as a half-typed query.
+    applyInputValue(`${query.slice(0, start)}${pasted},${query.slice(end)}`);
+  }
+
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -311,9 +369,6 @@ export function TagAutocompleteInput({
         e.preventDefault();
         addChip(query);
       }
-    } else if (e.key === ",") {
-      e.preventDefault();
-      addChip(query);
     } else if (
       e.key === "Backspace" &&
       query.length === 0 &&
@@ -361,9 +416,10 @@ export function TagAutocompleteInput({
           placeholder={values.length === 0 ? placeholder : ""}
           value={query}
           onChange={(e) => {
-            setQuery(e.target.value);
             setOpen(true);
+            applyInputValue(e.target.value);
           }}
+          onPaste={handlePaste}
           onFocus={() => setOpen(true)}
           onKeyDown={handleKeyDown}
         />


### PR DESCRIPTION
## Summary

- **Mechanism**: the comma split lived only in `handleKeyDown` (`onboarding-autocomplete.tsx:314`, `e.key === ","`). A key handler misses every non-keydown route into the value: a soft keyboard that reports `Unidentified` keydowns (the reported session was phone-width), IME composition, paste, and autofill. The comma reached the input value, the whole list stayed one query, and the dropdown offered to add it as a single chip.
- **Change**: split from the input's *value* instead. `splitSegments()` turns a raw value into the chips its commas complete plus the remaining query (segments trimmed, blanks dropped, case-insensitive dedup against existing chips and each other). `applyInputValue()` sends all additions in one `onChange` because `values` only refreshes on the next render. A paste containing commas is spliced at the caret and commits all of its segments. The now-redundant `,` keydown branch is deleted, so there is one code path.
- **Tested**: typing a comma-separated list, a comma behind a hardware-keyboard keydown, pasting a list, pasting into text already typed, trailing text staying as the query, whitespace-only segments, and duplicate segments.

Fixes LUM-3544

## Test plan

- `cd clients/web && bun test src/domains/onboarding/components/onboarding-autocomplete.test.tsx` → 8 pass, 0 fail (18 expect() calls)
- `cd clients/web && bun run lint -- src/domains/onboarding/components/onboarding-autocomplete.tsx src/domains/onboarding/components/onboarding-autocomplete.test.tsx` → clean
- `assistant/node_modules/.bin/prettier --write <both files>` (3.8.1) → unchanged

`research-onboarding-screen.tsx` (the only consumer) has no test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjwLgqzhFp4AQ42arMfhaF
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->