### PR TITLE
fix(web): drop the import button from the library empty state and keep import in the header (LUM-3543)

### DIFF
--- a/clients/web/src/domains/library/components/library-empty-state.test.tsx
+++ b/clients/web/src/domains/library/components/library-empty-state.test.tsx
@@ -1,47 +1,43 @@
 /**
  * Tests for LibraryEmptyState.
  *
- * Renders to static markup via `react-dom/server` and asserts on the emitted
- * HTML. The focus is the file-picker `accept` filter: on desktop the picker is
- * constrained to `.vellum`, while touch devices (where iOS ignores extension
- * filters) get an unrestricted picker so the bundle is actually selectable.
+ * The empty state is a single entry point: start a conversation. Importing a
+ * `.vellum` bundle is offered by the library header instead, so the component
+ * must not carry an import button or a file picker of its own.
  */
 
-import { describe, expect, test } from "bun:test";
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, render, screen } from "@testing-library/react";
 
 import { LibraryEmptyState } from "./library-empty-state";
 
-function render(opts: {
-  accept: string | undefined;
-  onNewConversation?: () => void;
-}) {
-  return renderToStaticMarkup(
-    createElement(LibraryEmptyState, {
-      accept: opts.accept,
-      fileInputRef: { current: null },
-      isImporting: false,
-      onImportBundle: () => {},
-      onNewConversation: opts.onNewConversation,
-    }),
-  );
-}
+afterEach(() => {
+  cleanup();
+});
 
 describe("LibraryEmptyState", () => {
-  test("constrains the picker to .vellum when an accept filter is given", () => {
-    const html = render({ accept: ".vellum" });
-    expect(html).toContain('accept=".vellum"');
+  test("offers the new-conversation entry point", () => {
+    render(<LibraryEmptyState onNewConversation={() => {}} />);
+
+    expect(screen.getByText("Your library is empty")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "New Conversation" }),
+    ).not.toBeNull();
   });
 
-  test("leaves the picker unrestricted when accept is undefined (touch)", () => {
-    const html = render({ accept: undefined });
-    expect(html).not.toContain("accept=");
+  test("renders no import button and no file input", () => {
+    const { container } = render(
+      <LibraryEmptyState onNewConversation={() => {}} />,
+    );
+
+    expect(screen.queryByText(/import/i)).toBeNull();
+    expect(container.querySelector('input[type="file"]')).toBeNull();
   });
 
-  test("always renders the import and new-conversation entry points", () => {
-    const html = render({ accept: ".vellum", onNewConversation: () => {} });
-    expect(html).toContain("Import .vellum File");
-    expect(html).toContain("New Conversation");
+  test("omits the button when no conversation callback is given", () => {
+    render(<LibraryEmptyState />);
+
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/clients/web/src/domains/library/components/library-empty-state.tsx
+++ b/clients/web/src/domains/library/components/library-empty-state.tsx
@@ -1,45 +1,24 @@
 /**
  * Empty state shown when the library has no apps or documents.
- * Provides entry points to start a conversation or import a .vellum bundle.
+ * Provides an entry point to start a conversation.
  */
 
-import { Download, LayoutGrid } from "lucide-react";
-import { type ChangeEvent, type RefObject } from "react";
+import { LayoutGrid } from "lucide-react";
 
 import { Button } from "@vellumai/design-library";
 
 import { useTranslation } from "@/i18n";
 
 interface LibraryEmptyStateProps {
-  /**
-   * File-picker `accept` filter. `undefined` leaves the picker unrestricted
-   * (touch devices, where iOS ignores extension filters) — see
-   * `LibraryView` for the platform rationale.
-   */
-  accept: string | undefined;
-  fileInputRef: RefObject<HTMLInputElement | null>;
-  isImporting: boolean;
-  onImportBundle: (e: ChangeEvent<HTMLInputElement>) => void;
   onNewConversation?: () => void;
 }
 
 export function LibraryEmptyState({
-  accept,
-  fileInputRef,
-  isImporting,
-  onImportBundle,
   onNewConversation,
 }: LibraryEmptyStateProps) {
   const { t } = useTranslation("library");
   return (
     <div className="flex h-full flex-col items-center justify-center gap-4 px-4 py-24">
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept={accept}
-        className="hidden"
-        onChange={onImportBundle}
-      />
       <div className="flex h-16 w-16 items-center justify-center rounded-xl bg-[var(--surface-base)]">
         <LayoutGrid size={32} className="text-[var(--content-tertiary)]" />
       </div>
@@ -49,35 +28,11 @@ export function LibraryEmptyState({
       <p className="max-w-md text-center text-body-medium-lighter text-[color:var(--content-tertiary)]">
         {t("libraryEmptyState.body")}
       </p>
-      <div className="flex flex-col items-center gap-3">
-        {onNewConversation ? (
-          <>
-            <Button
-              variant="primary"
-              size="regular"
-              onClick={onNewConversation}
-            >
-              {t("libraryEmptyState.newConversation")}
-            </Button>
-            <span className="text-body-small-default text-[color:var(--content-tertiary)]">
-              {t("libraryEmptyState.separator")}
-            </span>
-          </>
-        ) : null}
-        <Button
-          variant="outlined"
-          size="regular"
-          onClick={() => fileInputRef.current?.click()}
-          disabled={isImporting}
-        >
-          {isImporting ? (
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-          ) : (
-            <Download size={14} />
-          )}
-          <span className="ml-1.5">{t("libraryEmptyState.importFile")}</span>
+      {onNewConversation ? (
+        <Button variant="primary" size="regular" onClick={onNewConversation}>
+          {t("libraryEmptyState.newConversation")}
         </Button>
-      </div>
+      ) : null}
     </div>
   );
 }

--- a/clients/web/src/domains/library/library-view.test.tsx
+++ b/clients/web/src/domains/library/library-view.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for LibraryView's import affordance.
+ *
+ * Import is the only way someone who was sent a `.vellum` bundle gets their
+ * first app, and their library is empty by definition, so the header control
+ * has to survive the empty/populated split. The `accept` filter is asserted
+ * here too: on desktop the picker is constrained to `.vellum`, while touch
+ * devices (where iOS ignores extension filters) get an unrestricted picker so
+ * the bundle is actually selectable.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import type { AppSummary } from "@/types/app-types";
+
+let apps: AppSummary[] = [];
+let pointerIsCoarse = false;
+
+mock.module("@/utils/pointer", () => ({
+  isPointerCoarse: () => pointerIsCoarse,
+}));
+
+mock.module("@/domains/library/use-library-data", () => ({
+  useLibraryData: () => ({
+    apps,
+    documents: [],
+    filteredApps: apps,
+    pinnedApps: [],
+    recentApps: apps,
+    filteredDocuments: [],
+    searchText: "",
+    setSearchText: () => {},
+    loading: false,
+    error: null,
+  }),
+}));
+
+mock.module("@/hooks/use-pinned-apps", () => ({
+  usePinnedApps: () => ({
+    togglePin: () => {},
+    pinnedAppIds: new Set<string>(),
+  }),
+}));
+
+mock.module("@/hooks/use-app-delete", () => ({
+  useAppDelete: () => ({
+    pendingDelete: null,
+    isDeleting: false,
+    requestDelete: () => {},
+    confirmDelete: () => {},
+    cancelDelete: () => {},
+  }),
+}));
+
+mock.module("@/stores/deploy-store", () => ({
+  useDeployStore: {
+    use: { isDeploying: () => false },
+    getState: () => ({ deployApp: () => {} }),
+  },
+}));
+
+mock.module("@/components/deploy-dialogs", () => ({
+  DeployDialogs: () => null,
+}));
+
+mock.module("@/components/delete-app-dialog", () => ({
+  DeleteAppDialog: () => null,
+}));
+
+const { LibraryView } = await import("./library-view");
+
+const APP: AppSummary = {
+  id: "app-123",
+  name: "Example App",
+  createdAt: 1767225600000,
+  updatedAt: 1767225600000,
+  version: "1",
+  contentId: "content-123",
+  origin: "workspace",
+};
+
+function renderView() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <LibraryView assistantId="assistant-123" onOpenApp={() => {}} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  apps = [];
+  pointerIsCoarse = false;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("LibraryView import affordance", () => {
+  test("keeps the header import button when the library is empty", () => {
+    const { container } = renderView();
+
+    expect(screen.getByText("Your library is empty")).not.toBeNull();
+    expect(screen.getByRole("button", { name: /Import/ })).not.toBeNull();
+    expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
+  });
+
+  test("keeps a single file input when the library has apps", () => {
+    apps = [APP];
+    const { container } = renderView();
+
+    expect(screen.queryByText("Your library is empty")).toBeNull();
+    expect(screen.getByRole("button", { name: /Import/ })).not.toBeNull();
+    expect(container.querySelectorAll('input[type="file"]')).toHaveLength(1);
+  });
+
+  test("constrains the picker to .vellum on a fine-pointer device", () => {
+    const { container } = renderView();
+
+    expect(
+      container.querySelector('input[type="file"]')?.getAttribute("accept"),
+    ).toBe(".vellum");
+  });
+
+  test("leaves the picker unrestricted on a touch device", () => {
+    pointerIsCoarse = true;
+    const { container } = renderView();
+
+    expect(
+      container.querySelector('input[type="file"]')?.getAttribute("accept"),
+    ).toBeNull();
+  });
+});

--- a/clients/web/src/domains/library/library-view.tsx
+++ b/clients/web/src/domains/library/library-view.tsx
@@ -171,22 +171,12 @@ export function LibraryView({
     );
   }
 
-  // --- Render: empty state ---
-  if (apps.length === 0 && documents.length === 0) {
-    return (
-      <LibraryEmptyState
-        accept={bundleAccept}
-        fileInputRef={fileInputRef}
-        isImporting={isImporting}
-        onImportBundle={handleImportBundle}
-        onNewConversation={
-          onNewConversation ? () => onNewConversation() : undefined
-        }
-      />
-    );
-  }
+  // Import is the only way a `.vellum` recipient gets their first app, so the
+  // header control renders above the empty/populated split rather than inside
+  // the populated branch.
+  const isEmpty = apps.length === 0 && documents.length === 0;
 
-  // --- Render: main library grid ---
+  // --- Render: library ---
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="mb-4 flex shrink-0 items-center justify-end gap-4">
@@ -214,85 +204,100 @@ export function LibraryView({
         </div>
       </div>
 
-      <div className="mb-6 shrink-0">
-        <Input
-          fullWidth
-          type="text"
-          placeholder={t("libraryView.searchPlaceholder")}
-          value={searchText}
-          onChange={(e: ChangeEvent<HTMLInputElement>) =>
-            setSearchText(e.target.value)
-          }
-          leftIcon={<Search size={16} />}
-        />
-      </div>
-
-      <div className="flex-1 overflow-y-auto">
-        {filteredApps.length === 0 && filteredDocuments.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16">
-            <Search size={32} className="mb-4 text-[var(--content-tertiary)]" />
-            <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
-              {t("libraryView.noMatches", { query: searchText })}
-            </p>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-8">
-            <LibraryGridSection
-              title={t("libraryView.pinned")}
-              apps={pinnedApps}
-              assistantId={assistantId}
-              pinnedAppIds={pinnedAppIds}
-              onOpen={onOpenApp}
-              onPin={handlePinToggle}
-              onDelete={setAppPendingDelete}
-              onDeploy={handleDeploy}
+      {isEmpty ? (
+        <div className="min-h-0 flex-1">
+          <LibraryEmptyState
+            onNewConversation={
+              onNewConversation ? () => onNewConversation() : undefined
+            }
+          />
+        </div>
+      ) : (
+        <>
+          <div className="mb-6 shrink-0">
+            <Input
+              fullWidth
+              type="text"
+              placeholder={t("libraryView.searchPlaceholder")}
+              value={searchText}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setSearchText(e.target.value)
+              }
+              leftIcon={<Search size={16} />}
             />
-            <LibraryGridSection
-              title={t("libraryView.recents")}
-              apps={recentApps}
-              assistantId={assistantId}
-              pinnedAppIds={pinnedAppIds}
-              onOpen={onOpenApp}
-              onPin={handlePinToggle}
-              onDelete={setAppPendingDelete}
-              onDeploy={handleDeploy}
-            />
-            {filteredDocuments.length > 0 ? (
-              <section>
-                <h2 className="mb-4 text-body-small-emphasised text-[color:var(--content-secondary)]">
-                  {t("libraryView.documents")}
-                </h2>
-                <div className="grid grid-cols-[repeat(auto-fill,minmax(max(220px,calc((100%-6rem)/5)),1fr))] gap-6">
-                  {filteredDocuments.map((doc) => (
-                    <LibraryDocumentCard
-                      key={doc.surfaceId}
-                      document={doc}
-                      onOpen={(documentSurfaceId) => {
-                        if (onOpenDocument) {
-                          onOpenDocument(documentSurfaceId);
-                        }
-                      }}
-                    />
-                  ))}
-                </div>
-              </section>
-            ) : null}
           </div>
-        )}
-      </div>
 
-      <DeployDialogs
-        assistantId={assistantId}
-        assistantName={assistantName}
-        onStartConversation={onNewConversation}
-      />
+          <div className="flex-1 overflow-y-auto">
+            {filteredApps.length === 0 && filteredDocuments.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-16">
+                <Search
+                  size={32}
+                  className="mb-4 text-[var(--content-tertiary)]"
+                />
+                <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
+                  {t("libraryView.noMatches", { query: searchText })}
+                </p>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-8">
+                <LibraryGridSection
+                  title={t("libraryView.pinned")}
+                  apps={pinnedApps}
+                  assistantId={assistantId}
+                  pinnedAppIds={pinnedAppIds}
+                  onOpen={onOpenApp}
+                  onPin={handlePinToggle}
+                  onDelete={setAppPendingDelete}
+                  onDeploy={handleDeploy}
+                />
+                <LibraryGridSection
+                  title={t("libraryView.recents")}
+                  apps={recentApps}
+                  assistantId={assistantId}
+                  pinnedAppIds={pinnedAppIds}
+                  onOpen={onOpenApp}
+                  onPin={handlePinToggle}
+                  onDelete={setAppPendingDelete}
+                  onDeploy={handleDeploy}
+                />
+                {filteredDocuments.length > 0 ? (
+                  <section>
+                    <h2 className="mb-4 text-body-small-emphasised text-[color:var(--content-secondary)]">
+                      {t("libraryView.documents")}
+                    </h2>
+                    <div className="grid grid-cols-[repeat(auto-fill,minmax(max(220px,calc((100%-6rem)/5)),1fr))] gap-6">
+                      {filteredDocuments.map((doc) => (
+                        <LibraryDocumentCard
+                          key={doc.surfaceId}
+                          document={doc}
+                          onOpen={(documentSurfaceId) => {
+                            if (onOpenDocument) {
+                              onOpenDocument(documentSurfaceId);
+                            }
+                          }}
+                        />
+                      ))}
+                    </div>
+                  </section>
+                ) : null}
+              </div>
+            )}
+          </div>
 
-      <DeleteAppDialog
-        app={appPendingDelete}
-        isDeleting={isDeleting}
-        onConfirm={handleConfirmDelete}
-        onCancel={handleCancelDelete}
-      />
+          <DeployDialogs
+            assistantId={assistantId}
+            assistantName={assistantName}
+            onStartConversation={onNewConversation}
+          />
+
+          <DeleteAppDialog
+            app={appPendingDelete}
+            isDeleting={isDeleting}
+            onConfirm={handleConfirmDelete}
+            onCancel={handleCancelDelete}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/clients/web/src/i18n/locales/en/library.json
+++ b/clients/web/src/i18n/locales/en/library.json
@@ -1,10 +1,8 @@
 {
   "libraryEmptyState": {
     "heading": "Your library is empty",
-    "body": "Ask your assistant to build something, or import a shared app",
-    "newConversation": "New Conversation",
-    "separator": "or",
-    "importFile": "Import .vellum File"
+    "body": "Ask your assistant to build something",
+    "newConversation": "New Conversation"
   },
   "libraryView": {
     "importFailed": "Failed to import app",

--- a/clients/web/src/i18n/locales/es/library.json
+++ b/clients/web/src/i18n/locales/es/library.json
@@ -1,10 +1,8 @@
 {
   "libraryEmptyState": {
     "heading": "Tu biblioteca está vacía",
-    "body": "Pide a tu asistente que construya algo, o importa una aplicación compartida",
-    "newConversation": "Nueva conversación",
-    "separator": "o",
-    "importFile": "Importar un archivo .vellum"
+    "body": "Pide a tu asistente que construya algo",
+    "newConversation": "Nueva conversación"
   },
   "libraryView": {
     "importFailed": "No se pudo importar la aplicación",

--- a/clients/web/src/i18n/locales/ru/library.json
+++ b/clients/web/src/i18n/locales/ru/library.json
@@ -1,10 +1,8 @@
 {
   "libraryEmptyState": {
     "heading": "Библиотека пуста",
-    "body": "Сборка через ассистента или импорт общего приложения",
-    "newConversation": "Новый диалог",
-    "separator": "или",
-    "importFile": "Импортировать файл .vellum"
+    "body": "Сборка чего-либо через ассистента",
+    "newConversation": "Новый диалог"
   },
   "libraryView": {
     "importFailed": "Не удалось импортировать приложение",

--- a/clients/web/src/i18n/locales/zh-TW/library.json
+++ b/clients/web/src/i18n/locales/zh-TW/library.json
@@ -1,10 +1,8 @@
 {
   "libraryEmptyState": {
     "heading": "您的資料庫是空的",
-    "body": "請您的助理建立內容，或匯入共享應用程式",
-    "newConversation": "新增對話",
-    "separator": "或",
-    "importFile": "匯入 .vellum 檔案"
+    "body": "請您的助理建立內容",
+    "newConversation": "新增對話"
   },
   "libraryView": {
     "importFailed": "匯入應用程式失敗",

--- a/clients/web/src/i18n/locales/zh/library.json
+++ b/clients/web/src/i18n/locales/zh/library.json
@@ -1,10 +1,8 @@
 {
   "libraryEmptyState": {
     "heading": "您的库为空",
-    "body": "让您的助手构建一些内容，或导入共享应用",
-    "newConversation": "新建对话",
-    "separator": "或",
-    "importFile": "导入 .vellum 文件"
+    "body": "让您的助手构建一些内容",
+    "newConversation": "新建对话"
   },
   "libraryView": {
     "importFailed": "导入应用失败",


### PR DESCRIPTION
## Summary

- **Removed** the "Import .vellum File" button, the `or` separator, and the hidden `<input type="file">` from `LibraryEmptyState`. The component now takes a single prop, `onNewConversation`; `accept`, `fileInputRef`, `isImporting`, and `onImportBundle` existed only to serve the import button and are gone.
- **Import now lives only in the library header.** That control (button plus hidden file input) was previously rendered inside the populated branch of `LibraryView`, so it disappeared exactly when the library was empty. It is now rendered above the empty/populated split, so there is one file input in the tree in both states. The touch-device `accept` rationale and the `isImporting` spinner are unchanged.
- **Copy** across all five locales: `libraryEmptyState.importFile` and `libraryEmptyState.separator` are deleted (dead keys), and `libraryEmptyState.body` no longer mentions importing. English reads "Ask your assistant to build something"; es, ru, zh, and zh-TW are shortened to match, keeping each file's existing tone.

Part of LUM-3543

The second half of the ticket, a 3-6 item suggestion list for the empty state, is not in this PR: it needs a design decision first.

## Note for review

Lifting the header import button above the branch is a judgment call, not something the ticket asked for. Without it, removing the empty-state button makes import unreachable for anyone whose library is empty, and a `.vellum` recipient's library is empty by definition. If you would rather the empty library show no chrome at all, say so and I will drop the lift, but then import needs another home.

## Test plan

```
cd clients/web && bun test src/domains/library/components/library-empty-state.test.tsx src/domains/library/library-view.test.tsx
  7 pass, 0 fail (13 expect() calls)

cd clients/web && bun test src/i18n/catalogs.test.ts src/i18n/supported-locales.test.ts
  222 pass, 0 fail (27503 expect() calls)

cd clients/web && bun run lint -- src/domains/library/library-view.tsx src/domains/library/library-view.test.tsx src/domains/library/components/library-empty-state.tsx src/domains/library/components/library-empty-state.test.tsx
  clean

assistant/node_modules/.bin/prettier --write <the nine touched files>
```

`catalogs.test.ts` carries the unused-key guard, so it is the check that the two deleted keys really are dead.

New coverage: `library-empty-state.test.tsx` asserts the empty state renders no import button and no file input; the new `library-view.test.tsx` asserts the header import button and exactly one file input are present in both the empty and populated states, and keeps the `accept`-filter coverage (`.vellum` on fine pointer, unrestricted on touch) that used to live in the empty-state test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjwLgqzhFp4AQ42arMfhaF

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->