### PR TITLE
fix(web): keep the reply that precedes an interactive surface out of the Earlier activity drawer (JARVIS-1732)

### DIFF
--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -4,6 +4,8 @@ import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { Surface } from "@/domains/chat/types/types";
 import type { ConversationContentBlock } from "@vellumai/assistant-api";
 import {
+  type ContentBlockGroup,
+  finalResponseStartIndex,
   groupContentBlocks,
   isBackgroundBashCall,
   isRunWorkflowCall,
@@ -421,5 +423,80 @@ describe("isTaskProgressSurface", () => {
     expect(
       isTaskProgressSurface(surface({ template: "weather_forecast" })),
     ).toBe(false);
+  });
+});
+
+describe("finalResponseStartIndex", () => {
+  const textGroup = (value: string): ContentBlockGroup => ({
+    type: "text",
+    text: value,
+  });
+  const surfaceGroup = (): ContentBlockGroup => ({
+    type: "surface",
+    surface: { surfaceId: "s1", surfaceType: "choice", data: {} },
+  });
+  const activityGroup = (): ContentBlockGroup => ({
+    type: "activity",
+    items: [{ type: "tool_use", toolCall: toolCall({ id: "tc-1" }) }],
+  });
+
+  /** Every group draws a row except the indexes named by `blank`. */
+  function rendersRow(blank: number[] = []) {
+    return (_group: ContentBlockGroup, index: number) => !blank.includes(index);
+  }
+
+  test("prose opening an interactive surface is the response, not earlier work", () => {
+    // The onboarding greeting's shape: prose, the `ui_show` call that draws
+    // nothing, the choice surface, then a scrap of trailing text.
+    const groups: ContentBlockGroup[] = [
+      textGroup("Hey there, shall we start with your work?"),
+      activityGroup(),
+      surfaceGroup(),
+      textGroup("Sparkle"),
+    ];
+    expect(finalResponseStartIndex(groups, rendersRow([1]))).toBe(0);
+  });
+
+  test("keeps intermediate text before a drawn tool run out of the response", () => {
+    const groups: ContentBlockGroup[] = [
+      textGroup("I will check that."),
+      activityGroup(),
+      textGroup("Here is the final answer."),
+    ];
+    expect(finalResponseStartIndex(groups, rendersRow())).toBe(2);
+  });
+
+  test("a group that draws nothing does not pull earlier text into the response", () => {
+    const groups: ContentBlockGroup[] = [
+      textGroup("I will check that."),
+      activityGroup(),
+      textGroup("Here is the final answer."),
+    ];
+    expect(finalResponseStartIndex(groups, rendersRow([1]))).toBe(2);
+  });
+
+  test("every text block introducing a surface joins the response", () => {
+    const groups: ContentBlockGroup[] = [
+      textGroup("Hey there."),
+      textGroup("Shall we start with your work?"),
+      activityGroup(),
+      surfaceGroup(),
+      textGroup("Sparkle"),
+    ];
+    expect(finalResponseStartIndex(groups, rendersRow([2]))).toBe(0);
+  });
+
+  test("a drawn tool run ends the response, surface or not", () => {
+    const groups: ContentBlockGroup[] = [
+      textGroup("Let me look that up."),
+      activityGroup(),
+      surfaceGroup(),
+      textGroup("Here is the final answer."),
+    ];
+    expect(finalResponseStartIndex(groups, rendersRow())).toBe(2);
+  });
+
+  test("returns -1 for a response carrying no text", () => {
+    expect(finalResponseStartIndex([activityGroup()], rendersRow())).toBe(-1);
   });
 });

--- a/clients/web/src/domains/chat/transcript/message-content.test.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.test.ts
@@ -4,6 +4,7 @@ import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { Surface } from "@/domains/chat/types/types";
 import type { ConversationContentBlock } from "@vellumai/assistant-api";
 import {
+  activityHasDedicatedCard,
   type ContentBlockGroup,
   finalResponseStartIndex,
   groupContentBlocks,
@@ -440,8 +441,8 @@ describe("finalResponseStartIndex", () => {
     items: [{ type: "tool_use", toolCall: toolCall({ id: "tc-1" }) }],
   });
 
-  /** Every group draws a row except the indexes named by `blank`. */
-  function rendersRow(blank: number[] = []) {
+  /** Every group draws visible output except the indexes named by `blank`. */
+  function drawsVisibleOutput(blank: number[] = []) {
     return (_group: ContentBlockGroup, index: number) => !blank.includes(index);
   }
 
@@ -454,7 +455,7 @@ describe("finalResponseStartIndex", () => {
       surfaceGroup(),
       textGroup("Sparkle"),
     ];
-    expect(finalResponseStartIndex(groups, rendersRow([1]))).toBe(0);
+    expect(finalResponseStartIndex(groups, drawsVisibleOutput([1]))).toBe(0);
   });
 
   test("keeps intermediate text before a drawn tool run out of the response", () => {
@@ -463,7 +464,7 @@ describe("finalResponseStartIndex", () => {
       activityGroup(),
       textGroup("Here is the final answer."),
     ];
-    expect(finalResponseStartIndex(groups, rendersRow())).toBe(2);
+    expect(finalResponseStartIndex(groups, drawsVisibleOutput())).toBe(2);
   });
 
   test("a group that draws nothing does not pull earlier text into the response", () => {
@@ -472,7 +473,7 @@ describe("finalResponseStartIndex", () => {
       activityGroup(),
       textGroup("Here is the final answer."),
     ];
-    expect(finalResponseStartIndex(groups, rendersRow([1]))).toBe(2);
+    expect(finalResponseStartIndex(groups, drawsVisibleOutput([1]))).toBe(2);
   });
 
   test("every text block introducing a surface joins the response", () => {
@@ -483,7 +484,7 @@ describe("finalResponseStartIndex", () => {
       surfaceGroup(),
       textGroup("Sparkle"),
     ];
-    expect(finalResponseStartIndex(groups, rendersRow([2]))).toBe(0);
+    expect(finalResponseStartIndex(groups, drawsVisibleOutput([2]))).toBe(0);
   });
 
   test("a drawn tool run ends the response, surface or not", () => {
@@ -493,10 +494,110 @@ describe("finalResponseStartIndex", () => {
       surfaceGroup(),
       textGroup("Here is the final answer."),
     ];
-    expect(finalResponseStartIndex(groups, rendersRow())).toBe(2);
+    expect(finalResponseStartIndex(groups, drawsVisibleOutput())).toBe(2);
+  });
+
+  test("visible card-backed activity ends the response so earlier prose stays collapsible", () => {
+    // Prose, a process card with no timeline row, a later surface, then a
+    // trailing scrap. The card is visible output, so it bounds the reply.
+    const groups: ContentBlockGroup[] = [
+      textGroup("Let me ask first."),
+      {
+        type: "activity",
+        items: [
+          {
+            type: "tool_use",
+            toolCall: toolCall({ id: "tc-ask", name: "ask_question" }),
+          },
+        ],
+      },
+      surfaceGroup(),
+      textGroup("Sparkle"),
+    ];
+    const includingDedicatedCard = (
+      group: ContentBlockGroup,
+      _index: number,
+    ): boolean => {
+      if (group.type === "text") {
+        return group.text.trim().length > 0;
+      }
+      if (group.type === "surface") {
+        return true;
+      }
+      return activityHasDedicatedCard(group.items, () => true);
+    };
+    expect(finalResponseStartIndex(groups, includingDedicatedCard)).toBe(2);
   });
 
   test("returns -1 for a response carrying no text", () => {
-    expect(finalResponseStartIndex([activityGroup()], rendersRow())).toBe(-1);
+    expect(finalResponseStartIndex([activityGroup()], drawsVisibleOutput())).toBe(
+      -1,
+    );
+  });
+});
+
+describe("activityHasDedicatedCard", () => {
+  test("matches a subagent spawn even when nothing is marked card-backed", () => {
+    expect(
+      activityHasDedicatedCard(
+        [
+          {
+            type: "tool_use",
+            toolCall: toolCall({ id: "x", name: "subagent_spawn" }),
+          },
+        ],
+        () => false,
+      ),
+    ).toBe(true);
+  });
+
+  test("matches a skill_execute subagent spawn", () => {
+    expect(
+      activityHasDedicatedCard(
+        [
+          {
+            type: "tool_use",
+            toolCall: toolCall({
+              id: "x",
+              name: "skill_execute",
+              input: { tool: "subagent_spawn" },
+            }),
+          },
+        ],
+        () => false,
+      ),
+    ).toBe(true);
+  });
+
+  test("matches a call the render path marks card-backed", () => {
+    expect(
+      activityHasDedicatedCard(
+        [
+          {
+            type: "tool_use",
+            toolCall: toolCall({ id: "x", name: "run_workflow" }),
+          },
+        ],
+        (tc) => tc.name === "run_workflow",
+      ),
+    ).toBe(true);
+  });
+
+  test("does not match a plain tool chip", () => {
+    expect(
+      activityHasDedicatedCard(
+        [{ type: "tool_use", toolCall: toolCall({ id: "x", name: "bash" }) }],
+        () => false,
+      ),
+    ).toBe(false);
+  });
+
+  test("does not match thinking-only activity", () => {
+    expect(
+      activityHasDedicatedCard(
+        [{ type: "thinking", thinking: "plan" }],
+        () => true,
+      ),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -199,6 +199,59 @@ export function groupContentBlocks(
 }
 
 /**
+ * Where an assistant response's final answer begins: the index of the last
+ * non-empty text group, extended left across every surface that group sits
+ * after and the prose introducing those surfaces. Everything before the
+ * returned index is the turn's intermediate work, which the render body
+ * collapses into "Earlier activity".
+ *
+ * A surface is part of the answer, not the work behind it, so a turn that
+ * replies with prose and an interactive surface keeps its prose in the answer
+ * even when a scrap of text trails the surface. That is the shape the
+ * onboarding greeting produces: greeting, `ui_show`, choice surface, then a
+ * lone emoji.
+ *
+ * `rendersRow` reports whether a group draws anything. A group that draws
+ * nothing cannot separate two that do, so the walk passes straight through it:
+ * the `ui_show` call that opened a surface draws no row of its own, and neither
+ * does a thought whose reasoning never arrived. The first activity group that
+ * *does* draw a row is real intermediate work and ends the answer.
+ *
+ * Returns -1 when the response carries no text at all, which leaves every group
+ * outside the answer's range.
+ */
+export function finalResponseStartIndex(
+  groups: readonly ContentBlockGroup[],
+  rendersRow: (group: ContentBlockGroup, index: number) => boolean,
+): number {
+  const lastTextIndex = groups.findLastIndex(
+    (group) => group.type === "text" && group.text.trim().length > 0,
+  );
+  let start = lastTextIndex;
+  let crossedSurface = false;
+  for (let index = lastTextIndex - 1; index >= 0; index--) {
+    const group = groups[index];
+    if (!group || !rendersRow(group, index)) {
+      continue;
+    }
+    if (group.type === "surface") {
+      crossedSurface = true;
+      start = index;
+      continue;
+    }
+    // Prose joins the answer only once the walk has crossed a surface it could
+    // be introducing; text that merely precedes more text is a lead-in to the
+    // work between them, and stays collapsible.
+    if (group.type === "text" && crossedSurface) {
+      start = index;
+      continue;
+    }
+    break;
+  }
+  return start;
+}
+
+/**
  * Project an activity group's ordered items into the card-rendering shape:
  * ordered `ToolCallCardItem`s (thinking text interleaved with tool calls)
  * plus the flat tool-call list. Empty thinking segments and suppressed UI
@@ -340,7 +393,8 @@ export function isBackgroundBashCall(toolCall: ChatMessageToolCall): boolean {
  */
 export function isTaskProgressSurface(surface: Surface): boolean {
   const data = surface.data as
-    { template?: string; templateData?: { steps?: unknown } } | undefined;
+    | { template?: string; templateData?: { steps?: unknown } }
+    | undefined;
   return (
     data?.template === "task_progress" &&
     Array.isArray(data.templateData?.steps) &&

--- a/clients/web/src/domains/chat/transcript/message-content.ts
+++ b/clients/web/src/domains/chat/transcript/message-content.ts
@@ -211,18 +211,21 @@ export function groupContentBlocks(
  * onboarding greeting produces: greeting, `ui_show`, choice surface, then a
  * lone emoji.
  *
- * `rendersRow` reports whether a group draws anything. A group that draws
- * nothing cannot separate two that do, so the walk passes straight through it:
- * the `ui_show` call that opened a surface draws no row of its own, and neither
- * does a thought whose reasoning never arrived. The first activity group that
- * *does* draw a row is real intermediate work and ends the answer.
+ * `drawsVisibleOutput` reports whether a group draws anything the user can
+ * see: a timeline row, a dedicated inline card (subagent, workflow, ACP run,
+ * background task, answered question), or other visible group output. A group
+ * that draws nothing cannot separate two that do, so the walk passes straight
+ * through it. The `ui_show` call that opened a surface draws no output of its
+ * own, and neither does a thought whose reasoning never arrived. The first
+ * activity group that does draw visible output is real intermediate work and
+ * ends the answer.
  *
  * Returns -1 when the response carries no text at all, which leaves every group
  * outside the answer's range.
  */
 export function finalResponseStartIndex(
   groups: readonly ContentBlockGroup[],
-  rendersRow: (group: ContentBlockGroup, index: number) => boolean,
+  drawsVisibleOutput: (group: ContentBlockGroup, index: number) => boolean,
 ): number {
   const lastTextIndex = groups.findLastIndex(
     (group) => group.type === "text" && group.text.trim().length > 0,
@@ -231,7 +234,7 @@ export function finalResponseStartIndex(
   let crossedSurface = false;
   for (let index = lastTextIndex - 1; index >= 0; index--) {
     const group = groups[index];
-    if (!group || !rendersRow(group, index)) {
+    if (!group || !drawsVisibleOutput(group, index)) {
       continue;
     }
     if (group.type === "surface") {
@@ -240,7 +243,7 @@ export function finalResponseStartIndex(
       continue;
     }
     // Prose joins the answer only once the walk has crossed a surface it could
-    // be introducing; text that merely precedes more text is a lead-in to the
+    // be introducing. Text that merely precedes more text is a lead-in to the
     // work between them, and stays collapsible.
     if (group.type === "text" && crossedSurface) {
       start = index;
@@ -385,6 +388,28 @@ export function isBackgroundBashCall(toolCall: ChatMessageToolCall): boolean {
     return false;
   }
   return (input as Record<string, unknown>).background === true;
+}
+
+/**
+ * Whether an activity group's tool calls produce a dedicated inline card
+ * rather than a timeline row: a subagent spawn, or a call the render path
+ * treats as card-backed (workflow, ACP run, background task, answered
+ * question). Those cards are visible output and bound the final-response walk
+ * the same way a drawn chip does.
+ */
+export function activityHasDedicatedCard(
+  items: readonly ContentBlockActivityItem[],
+  isCardBacked: (toolCall: ChatMessageToolCall) => boolean,
+): boolean {
+  for (const item of items) {
+    if (item.type !== "tool_use") {
+      continue;
+    }
+    if (isSubagentSpawnCall(item.toolCall) || isCardBacked(item.toolCall)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -1125,6 +1125,62 @@ describe("TranscriptMessageBody", () => {
     expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
   });
 
+  test("collapses prose before a card-backed activity when a later surface has trailing text", () => {
+    // A process card is visible output even though it is not a timeline row.
+    // Prose before that card is earlier activity. The surface and trailing
+    // scrap stay in the reply.
+    const { container, getByRole, queryByRole, queryByTestId, queryByText } =
+      render(
+        <TranscriptMessageBody
+          message={{
+            id: "completed-with-card-then-surface",
+            role: "assistant",
+            contentBlocks: [
+              textBlock("Let me ask first."),
+              toolUseBlock({
+                id: "tc-ask-then-surface",
+                name: "ask_question",
+                input: {},
+                completedAt: 1,
+                answeredQuestion: {
+                  requestId: "req-card-bound",
+                  questions: [
+                    {
+                      id: "q1",
+                      question: "Which Alice?",
+                      options: [{ id: "alice_work", label: "Alice (work)" }],
+                    },
+                  ],
+                  responses: [
+                    {
+                      questionId: "q1",
+                      decision: "option",
+                      optionId: "alice_work",
+                    },
+                  ],
+                  overall: "completed",
+                },
+              }),
+              surfaceBlock("choice-after-card"),
+              textBlock("Sparkle"),
+            ],
+          }}
+          onSurfaceAction={noop}
+        />,
+      );
+
+    expect(queryByText("Let me ask first.")).toBeNull();
+    expect(queryByRole("button", { name: "Earlier activity" })).not.toBeNull();
+    expect(queryByTestId("answered-question-card")).not.toBeNull();
+    expect(queryByText("Sparkle")).not.toBeNull();
+    expect(
+      container.querySelector("[data-surface-id='choice-after-card']"),
+    ).not.toBeNull();
+
+    fireEvent.click(getByRole("button", { name: "Earlier activity" }));
+    expect(queryByText("Let me ask first.")).not.toBeNull();
+  });
+
   test("keeps inline surfaces visible outside collapsed earlier text", () => {
     const { container, queryByText } = render(
       <TranscriptMessageBody

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -1026,6 +1026,105 @@ describe("TranscriptMessageBody", () => {
     expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
   });
 
+  test("keeps surface lead-in text visible across the ui_show call that opened it", () => {
+    // The onboarding greeting's shape: prose, the `ui_show` call that opens the
+    // choice surface, the surface, then a scrap of trailing text. The call
+    // draws no row of its own, so the prose still introduces the surface and
+    // stays part of the response.
+    const { container, queryByRole, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "completed-with-ui-show-lead-in",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("Hey there, shall we start with your work?"),
+            toolUseBlock({
+              id: "tc-ui-show",
+              name: "ui_show",
+              input: {},
+              completedAt: 1,
+            }),
+            surfaceBlock("choice-surface"),
+            textBlock("Sparkle"),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(
+      queryByText("Hey there, shall we start with your work?"),
+    ).not.toBeNull();
+    expect(queryByText("Sparkle")).not.toBeNull();
+    expect(
+      container.querySelector("[data-surface-id='choice-surface']"),
+    ).not.toBeNull();
+    expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+  });
+
+  test("keeps surface lead-in text visible when the surface ends the response", () => {
+    // Same turn without the trailing scrap: the prose is already the final
+    // text, so nothing collapses either way. Guards the shape the greeting is
+    // meant to produce.
+    const { container, queryByRole, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "completed-ending-on-surface",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("Hey there, shall we start with your work?"),
+            toolUseBlock({
+              id: "tc-ui-show-end",
+              name: "ui_show",
+              input: {},
+              completedAt: 1,
+            }),
+            surfaceBlock("choice-surface-end"),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(
+      queryByText("Hey there, shall we start with your work?"),
+    ).not.toBeNull();
+    expect(
+      container.querySelector("[data-surface-id='choice-surface-end']"),
+    ).not.toBeNull();
+    expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+  });
+
+  test("keeps every text block before a surface out of earlier activity", () => {
+    // The greeting arriving as two text blocks: both introduce the surface, so
+    // both stay in the response rather than only the one nearest to it.
+    const { queryByRole, queryByText } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "completed-with-split-lead-in",
+          role: "assistant",
+          contentBlocks: [
+            textBlock("Hey there."),
+            textBlock("Shall we start with your work?"),
+            toolUseBlock({
+              id: "tc-ui-show-split",
+              name: "ui_show",
+              input: {},
+              completedAt: 1,
+            }),
+            surfaceBlock("choice-surface-split"),
+            textBlock("Sparkle"),
+          ],
+        }}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(queryByText("Hey there.")).not.toBeNull();
+    expect(queryByText("Shall we start with your work?")).not.toBeNull();
+    expect(queryByRole("button", { name: "Earlier activity" })).toBeNull();
+  });
+
   test("keeps inline surfaces visible outside collapsed earlier text", () => {
     const { container, queryByText } = render(
       <TranscriptMessageBody
@@ -1755,7 +1854,9 @@ describe("TranscriptMessageBody", () => {
     );
 
     expect(
-      container.querySelector("[data-testid='surface'][data-surface-id='s-keep']"),
+      container.querySelector(
+        "[data-testid='surface'][data-surface-id='s-keep']",
+      ),
     ).not.toBeNull();
   });
 

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -45,6 +45,7 @@ import {
   type IconName,
 } from "@/domains/chat/components/tool-progress-card/derive-step-label";
 import {
+  activityHasDedicatedCard,
   activityItemsToCardData,
   type ContentBlockActivityItem,
   finalResponseStartIndex,
@@ -438,9 +439,10 @@ export function TranscriptMessageBody({
    * question with nothing to show are all not card-backed, so they keep the
    * chip instead of vanishing from the transcript.
    *
-   * Read by all three places that must agree on this: the chip filter, the
-   * group's suppression set, and the collapse guard that keeps a card-backed
-   * group out of the "Earlier activity" disclosure.
+   * Read by the places that must agree on this: the chip filter, the group's
+   * suppression set, the collapse guard that keeps a card-backed group out of
+   * the "Earlier activity" disclosure, and the final-response boundary that
+   * treats a dedicated card as visible output.
    */
   const isCardBacked = (tc: ChatMessageToolCall): boolean =>
     cardBackedWorkflowRunId(tc) !== null ||
@@ -1019,6 +1021,25 @@ export function TranscriptMessageBody({
   };
 
   /**
+   * Whether a group draws anything the user can see. Timeline rows
+   * (`groupRendersRow`) plus dedicated inline cards that the timeline
+   * predicate excludes: those cards are not chips, but they are visible
+   * output and bound the final-response walk.
+   */
+  const groupDrawsVisibleOutput = (
+    group: (typeof groups)[number],
+    groupIndex: number,
+  ): boolean => {
+    if (groupRendersRow(group, groupIndex)) {
+      return true;
+    }
+    if (group.type !== "activity") {
+      return false;
+    }
+    return activityHasDedicatedCard(group.items, isCardBacked);
+  };
+
+  /**
    * Timeline glyph for one group inside an "Earlier activity" disclosure: the
    * first renderable step's icon, a globe for a web run (`deriveStepLabel`
    * covers non-web tools only), a brain for a thinking-only run, and none for
@@ -1178,7 +1199,7 @@ export function TranscriptMessageBody({
 
   const finalResponseGroupIndex = finalResponseStartIndex(
     groups,
-    groupRendersRow,
+    groupDrawsVisibleOutput,
   );
   // Per-user opt-out of the "Earlier activity" disclosure: with the flag on,
   // no group is collapsible, so the whole response renders inline at full
@@ -1212,12 +1233,11 @@ export function TranscriptMessageBody({
         message.attachments,
         embeddedImageNames,
       ).length > 0 ||
+      activityHasDedicatedCard(group.items, isCardBacked) ||
       toolCalls.some(
         (toolCall) =>
           isToolCallRunning(toolCall) ||
           toolCall.pendingConfirmation !== undefined ||
-          isSubagentSpawnCall(toolCall) ||
-          isCardBacked(toolCall) ||
           acpConnectToolUseId === toolCall.id ||
           unknownNudgeToolCallIds?.has(toolCall.id) === true,
       );

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -47,6 +47,7 @@ import {
 import {
   activityItemsToCardData,
   type ContentBlockActivityItem,
+  finalResponseStartIndex,
   groupContentBlocks,
   isSubagentSpawnCall,
   isTaskProgressSurface,
@@ -1175,8 +1176,9 @@ export function TranscriptMessageBody({
     );
   }
 
-  const finalResponseGroupIndex = groups.findLastIndex(
-    (group) => group.type === "text" && group.text.trim().length > 0,
+  const finalResponseGroupIndex = finalResponseStartIndex(
+    groups,
+    groupRendersRow,
   );
   // Per-user opt-out of the "Earlier activity" disclosure: with the flag on,
   // no group is collapsible, so the whole response renders inline at full


### PR DESCRIPTION
## Summary

A brand-new assistant's greeting turn persists as `text(greeting)`, the `ui_show` call that opens the choice surface, the choice surface itself, and then a scrap of trailing text (the model emitted a lone `✨` after the tool result, despite the kickoff prompt in `clients/web/src/domains/onboarding/lets-chat-kickoff.ts` telling it to stop). While streaming, `AssistantContentDisclosure` renders its items inline with no trigger, so the greeting shows. The moment the turn settles, the disclosure collapses and the greeting disappears into "Earlier activity", leaving the three options and the lone sparkle as the whole visible reply. This matches the before/after screenshots on the ticket exactly.

The classifier is `finalResponseGroupIndex` in `clients/web/src/domains/chat/transcript/transcript-message-body.tsx:1178`, which took the **last non-empty text group** as the start of the reply and made every group before it collapsible (`:1184`). With a scrap of text after the surface, that index landed on the scrap and demoted the real greeting to intermediate work. The existing `isSurfaceAdjacent` pin at `:1195` did not save it: the invisible `ui_show` activity group sits between the greeting and its surface, so the two were not literal neighbours.

**What changed:** the reply-start rule moves into a pure helper, `finalResponseStartIndex` in `clients/web/src/domains/chat/transcript/message-content.ts`, and now extends the reply leftward from the last text group across any surfaces that group sits after, plus the prose introducing them. Groups that draw nothing (the `ui_show` call, an empty thought) cannot break the run; the first activity group that *does* draw a row ends the reply, so long tool-heavy turns collapse exactly as before. The drawer is untouched otherwise.

`isTaskProgressSurface`'s type union in the same file picked up a two-line Prettier reformat (it was not conformant on main).

Fixes JARVIS-1732

## Test plan

```
cd clients/web && bun test src/domains/chat/transcript/message-content.test.ts
  31 pass, 0 fail (6 new: interactive-surface reply, intermediate text stays collapsible,
  invisible group does not pull text in, split lead-in text, drawn tool run ends the reply, no-text case)

cd clients/web && bun test src/domains/chat/transcript/transcript-message-body.test.tsx
  81 pass, 0 fail (3 new render-level cases; 2 of them fail on the pre-fix rule, verified by
  reverting the one-line call site and re-running: 79 pass, 2 fail)

cd clients/web && bun test src/domains/chat/transcript/transcript.test.tsx
  31 pass, 0 fail

cd clients/web && bun run lint -- src/domains/chat/transcript/message-content.ts \
  src/domains/chat/transcript/message-content.test.ts \
  src/domains/chat/transcript/transcript-message-body.tsx \
  src/domains/chat/transcript/transcript-message-body.test.tsx
  clean

assistant/node_modules/.bin/prettier --check <the same four files>
  All matched files use Prettier code style!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjwLgqzhFp4AQ42arMfhaF

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->