### PR TITLE
feat(voice): say which control a call was started from

### DIFF
--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -325,6 +325,8 @@ export interface VoiceTurnOptions {
   voiceTelemetry?: {
     sessionId: string;
     client?: ClientOs;
+    /** The control the session was started from (the start frame's `entry`). */
+    entry?: string;
   };
   /** Per-turn control prompt. Undefined uses the phone prompt; null disables it. */
   voiceControlPrompt?: string | null;
@@ -1116,11 +1118,19 @@ export async function startVoiceTurn(
               // path already fills from the same `detectClientOs()` value, so
               // a voice turn reports its platform in the column existing turn
               // analytics read rather than one only voice knows about.
+              //
+              // `voice_entry` is voice's own: which control started the
+              // session the turn belongs to, so per-turn analytics can split
+              // the companion from the app without a join back to the
+              // session row.
               client: {
                 voice: true,
                 voice_session_id: opts.voiceTelemetry.sessionId,
                 ...(opts.voiceTelemetry.client
                   ? { os: opts.voiceTelemetry.client }
+                  : {}),
+                ...(opts.voiceTelemetry.entry
+                  ? { voice_entry: opts.voiceTelemetry.entry }
                   : {}),
               },
             }

--- a/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
@@ -121,7 +121,30 @@ describe("live-voice session telemetry", () => {
 
     await session.start();
 
-    expect(recordLiveVoiceSessionStarted).toHaveBeenCalledWith("session-123");
+    expect(recordLiveVoiceSessionStarted).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      screen: "started_unknown:unknown",
+    });
+
+    await session.close("client_end");
+  });
+
+  test("stamps the started row with the client and entry the start frame declared", async () => {
+    // The dimension this row exists to carry: the same `macos` client covers
+    // the chat's voice button, the companion's Talk and the voice key, and
+    // only the entry says which one the user reached for.
+    const session = readySession({
+      ...START_FRAME,
+      client: "macos",
+      entry: "companion",
+    });
+
+    await session.start();
+
+    expect(recordLiveVoiceSessionStarted).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      screen: "started_macos:companion",
+    });
 
     await session.close("client_end");
   });
@@ -138,7 +161,10 @@ describe("live-voice session telemetry", () => {
 
     // The denominator of the failure rate: a session rejected before `ready`
     // is exactly the one that must not go missing from the started count.
-    expect(recordLiveVoiceSessionStarted).toHaveBeenCalledWith("session-123");
+    expect(recordLiveVoiceSessionStarted).toHaveBeenCalledWith({
+      sessionId: "session-123",
+      screen: "started_unknown:unknown",
+    });
   });
 
   test("records the close reason and a completed outcome on a clean end", async () => {
@@ -328,5 +354,19 @@ describe("live-voice turn attribution", () => {
     const options = await captureTurnOptions(START_FRAME);
 
     expect(options.voiceTelemetry).toEqual({ sessionId: "session-123" });
+  });
+
+  test("carries the entry point onto the turn beside the client", async () => {
+    const options = await captureTurnOptions({
+      ...START_FRAME,
+      client: "macos",
+      entry: "voice_key",
+    });
+
+    expect(options.voiceTelemetry).toEqual({
+      sessionId: "session-123",
+      client: "macos",
+      entry: "voice_key",
+    });
   });
 });

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -339,6 +339,73 @@ describe("parseLiveVoiceClientTextFrame", () => {
     expect("client" in result.frame).toBe(false);
   });
 
+  test("parses the entry point from the start frame", () => {
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        client: "macos",
+        entry: "companion",
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.frame).toMatchObject({
+      type: "start",
+      client: "macos",
+      entry: "companion",
+    });
+  });
+
+  test("carries an entry token it has never seen, since the clients mint them", () => {
+    // An open set on purpose: a daemon older than the client that sent the
+    // value must carry it through rather than erase it.
+    const result = parseLiveVoiceClientTextFrame(
+      JSON.stringify({
+        type: "start",
+        entry: "some_future_surface",
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.frame).toMatchObject({ entry: "some_future_surface" });
+  });
+
+  test.each([
+    ["not a string", 42],
+    ["empty", ""],
+    ["uppercase", "Companion"],
+    ["punctuation", "companion:talk"],
+    ["over-long", "a".repeat(33)],
+  ])(
+    "drops an off-shape entry (%s) rather than rejecting the session",
+    (_label, entry) => {
+      const result = parseLiveVoiceClientTextFrame(
+        JSON.stringify({
+          type: "start",
+          entry,
+          audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+        }),
+      );
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        return;
+      }
+
+      expect("entry" in result.frame).toBe(false);
+    },
+  );
+
   test("drops an unrecognized client rather than rejecting the session", () => {
     const result = parseLiveVoiceClientTextFrame(
       JSON.stringify({

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -80,6 +80,7 @@ import { getSubagentManager } from "../subagent/index.js";
 import {
   liveVoiceEndScreen,
   liveVoiceSilenceReason,
+  liveVoiceStartScreen,
 } from "../telemetry/live-voice-funnel.js";
 import { getToolOwner } from "../tools/registry.js";
 import {
@@ -1493,7 +1494,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // credentials is precisely the one the failure rate needs to count, and
     // recording the start only once `ready` goes out would hide every such
     // session from both the numerator and the denominator.
-    recordLiveVoiceSessionStarted(this.context.sessionId);
+    recordLiveVoiceSessionStarted({
+      sessionId: this.context.sessionId,
+      screen: liveVoiceStartScreen(
+        this.context.startFrame.client,
+        this.context.startFrame.entry,
+      ),
+    });
 
     if (this.resolveCredentialReadiness) {
       const readiness = await this.resolveCredentialReadiness();
@@ -5261,6 +5268,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
           sessionId: this.context.sessionId,
           ...(this.context.startFrame.client
             ? { client: this.context.startFrame.client }
+            : {}),
+          ...(this.context.startFrame.entry
+            ? { entry: this.context.startFrame.entry }
             : {}),
         },
         voiceControlPrompt: buildVoiceControlPrompt(activeTurn, {

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -135,6 +135,39 @@ export interface LiveVoiceClientStartFrame {
    * load-bearing for what a voice turn may do.
    */
   readonly client?: ClientOs;
+  /**
+   * Which control the session was asked from, as distinct from which client
+   * (`client`) it was asked on. The macOS app alone has three: the chat's
+   * voice button (`composer`), the companion surface's Talk (`companion`),
+   * and the voice key (`voice_key`, or `voice_key_ask` for a hold made over a
+   * selection). `deep_link` is Siri, a widget, the Action Button or a Live
+   * Activity tap, and `cli` the terminal client. Absent from clients that
+   * predate the field.
+   *
+   * Analytics only, exactly like `client`, and unlike `client` an open string
+   * rather than a closed set: the values are minted where the controls are,
+   * in the clients, and a daemon older than the client that sent one must
+   * carry the value through rather than erase it. The parser bounds the shape
+   * instead ({@link parseLiveVoiceEntry}) and drops anything outside it, so a
+   * malformed value costs a chart facet and never the session.
+   */
+  readonly entry?: string;
+}
+
+/**
+ * The shape a start frame's `entry` must have: a short snake_case token.
+ *
+ * The bound is set by where the value lands. The started telemetry row stamps
+ * `started_<client>:<entry>` into a 64-character wire field, and the longest
+ * `ClientOs` is seven characters, so 32 leaves the stamp well inside it.
+ */
+const LIVE_VOICE_ENTRY_PATTERN = /^[a-z][a-z0-9_]{0,31}$/;
+
+/** Parse a start frame's `entry`. Returns `null` for anything off-shape. */
+export function parseLiveVoiceEntry(value: unknown): string | null {
+  return typeof value === "string" && LIVE_VOICE_ENTRY_PATTERN.test(value)
+    ? value
+    : null;
 }
 
 /**
@@ -1088,6 +1121,8 @@ function validateStartFrame(
   // analytics dimension, and failing a session's startup over it would trade a
   // gap in a chart for a user who cannot talk to their assistant.
   const client = parseClientOs(value.client);
+  // Same policy for the same reason: a dimension, not a capability.
+  const entry = parseLiveVoiceEntry(value.entry);
 
   return {
     ok: true,
@@ -1097,6 +1132,7 @@ function validateStartFrame(
         ? { conversationId: value.conversationId }
         : {}),
       ...(client ? { client } : {}),
+      ...(entry ? { entry } : {}),
       audio: audioConfig.frame,
       ...(isLiveVoiceTurnDetectionMode(value.turnDetection)
         ? { turnDetection: value.turnDetection }

--- a/assistant/src/onboarding/onboarding-events-store.ts
+++ b/assistant/src/onboarding/onboarding-events-store.ts
@@ -130,9 +130,10 @@ export function recordActivationEvent(params: {
  * `telemetry/live-voice-funnel.ts` for why duration and turn count are derived
  * from that pairing rather than carried as fields.
  *
- * `screen` carries the end reason on the ended event (the started event has no
- * dimension beyond the step itself). Returns null when usage data collection is
- * disabled or the telemetry database is unavailable.
+ * `screen` carries the end reason on the ended event and the originating
+ * client and entry point on the started one (see `liveVoiceStartScreen`).
+ * Returns null when usage data collection is disabled or the telemetry
+ * database is unavailable.
  *
  * **Never throws.** These fire from `LiveVoiceSession.start()` and `.close()`,
  * which are the user's call itself: the outbox insert raises on a telemetry DB
@@ -176,14 +177,19 @@ export function recordLiveVoiceSessionEvent(params: {
   );
 }
 
-/** Record the "a live-voice session was attempted" milestone. */
-export function recordLiveVoiceSessionStarted(
-  sessionId: string,
-): OnboardingEvent | null {
+/**
+ * Record the "a live-voice session was attempted" milestone, with where it
+ * was attempted from.
+ */
+export function recordLiveVoiceSessionStarted(params: {
+  sessionId: string;
+  screen: string;
+}): OnboardingEvent | null {
   return recordLiveVoiceSessionEvent({
     stepName: LIVE_VOICE_STEPS.sessionStarted.stepName,
     stepIndex: LIVE_VOICE_STEPS.sessionStarted.stepIndex,
-    sessionId,
+    sessionId: params.sessionId,
+    screen: params.screen,
   });
 }
 

--- a/assistant/src/telemetry/__tests__/live-voice-funnel.test.ts
+++ b/assistant/src/telemetry/__tests__/live-voice-funnel.test.ts
@@ -3,7 +3,39 @@ import { describe, expect, it } from "bun:test";
 import {
   liveVoiceEndScreen,
   liveVoiceSilenceReason,
+  liveVoiceStartScreen,
 } from "../live-voice-funnel.js";
+
+describe("liveVoiceStartScreen", () => {
+  it("stamps the client and the entry point", () => {
+    expect(liveVoiceStartScreen("macos", "companion")).toBe(
+      "started_macos:companion",
+    );
+  });
+
+  it("keeps both halves present when a client sends neither", () => {
+    // A query splits the stamp on its colon; a stand-in for a missing half
+    // keeps that split from needing a null branch per side.
+    expect(liveVoiceStartScreen(undefined, undefined)).toBe(
+      "started_unknown:unknown",
+    );
+    expect(liveVoiceStartScreen(null, null)).toBe("started_unknown:unknown");
+  });
+
+  it("stands in for whichever half is missing on its own", () => {
+    expect(liveVoiceStartScreen("ios")).toBe("started_ios:unknown");
+    expect(liveVoiceStartScreen(undefined, "deep_link")).toBe(
+      "started_unknown:deep_link",
+    );
+  });
+
+  it("keeps the longest stamp inside the wire field's 64-char bound", () => {
+    // The parser caps `entry` at 32 characters and the longest `ClientOs` is
+    // `windows`; the stamp built from both must still fit the ingest cap.
+    const longest = liveVoiceStartScreen("windows", "a".repeat(32));
+    expect(longest.length).toBeLessThanOrEqual(64);
+  });
+});
 
 describe("liveVoiceSilenceReason", () => {
   it("blames the transport when the session never went active", () => {

--- a/assistant/src/telemetry/live-voice-funnel.ts
+++ b/assistant/src/telemetry/live-voice-funnel.ts
@@ -24,6 +24,7 @@
  * unmatched `started` rows instead of treating them as open-ended sessions.
  */
 
+import type { ClientOs } from "../channels/types.js";
 import type { LiveVoiceSessionCloseReason } from "../live-voice/live-voice-session-manager.js";
 import type { LiveVoiceProtocolErrorCode } from "../live-voice/protocol.js";
 
@@ -114,6 +115,38 @@ export function liveVoiceSilenceReason(signals: {
     return "no_speech";
   }
   return "no_turn";
+}
+
+/**
+ * The half of a start stamp that stands in for a dimension the client did not
+ * send: an older client, or one that sends no identity at all.
+ */
+const LIVE_VOICE_UNATTRIBUTED = "unknown";
+
+/**
+ * The `screen` dimension for a started session: the client it started on and
+ * the control it started from, as `started_<client>:<entry>`.
+ *
+ * Both halves come off the start frame verbatim (`client` is a `ClientOs`;
+ * `entry` is the client's own token, see `protocol.ts`). Both are always
+ * present, with {@link LIVE_VOICE_UNATTRIBUTED} standing in for a missing one,
+ * so a query can split the stamp on its colon without a null branch per half.
+ *
+ * The client rides the started row and not only the turn rows because a
+ * quarter of sessions never produce a turn, and those are the ones the client
+ * dimension is most needed on: "voice did nothing for me" is a per-client
+ * question. Until now those sessions had no client at all (the admin
+ * dashboard's `(no turns)` bucket); this stamp gives every session one.
+ *
+ * The entry is what separates the macOS app's three ways in from each other:
+ * the same `client` covers the chat's voice button, the companion's Talk and
+ * the voice key, and only the entry says which one the user reached for.
+ */
+export function liveVoiceStartScreen(
+  client?: ClientOs | null,
+  entry?: string | null,
+): string {
+  return `started_${client ?? LIVE_VOICE_UNATTRIBUTED}:${entry ?? LIVE_VOICE_UNATTRIBUTED}`;
 }
 
 /**

--- a/cli/src/lib/live-voice/client.test.ts
+++ b/cli/src/lib/live-voice/client.test.ts
@@ -70,6 +70,7 @@ describe("start frame", () => {
     const start = socket.sentFrames()[0]!;
 
     expect(start.type).toBe("start");
+    expect(start.entry).toBe("cli");
     // Load-bearing: without it the daemon refuses a session whose speech-to-text
     // credential is missing, which is the case this client exists to survive.
     expect(start.textInput).toBe(true);

--- a/cli/src/lib/live-voice/client.ts
+++ b/cli/src/lib/live-voice/client.ts
@@ -205,6 +205,7 @@ export class CliLiveVoiceClient {
       type: "start",
       audio: LIVE_VOICE_AUDIO_FORMAT,
       textInput: true,
+      entry: "cli",
       ...(this.options.conversationId
         ? { conversationId: this.options.conversationId }
         : {}),

--- a/cli/src/lib/live-voice/protocol.ts
+++ b/cli/src/lib/live-voice/protocol.ts
@@ -43,6 +43,11 @@ export interface LiveVoiceStartFrame {
    * loses nothing: it was never going to listen.
    */
   readonly textInput: true;
+  /**
+   * Where the session was started from, for the daemon's telemetry. There is
+   * one way in from a terminal, so the value is a constant.
+   */
+  readonly entry: "cli";
 }
 
 export interface LiveVoiceTextFrame {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -591,6 +591,7 @@ export function ChatComposer({
     // start, only a reason to open silent, so it is decided here rather than
     // in the staleness guard.
     starter?.start(assistantId, conversationId ?? null, {
+      entry: "composer",
       seedText: voiceEntryGreetingSeed(latest.conversationIsEmpty),
     });
   }, [assistantId, conversationId]);
@@ -1048,10 +1049,10 @@ export function ChatComposer({
           ? ""
           : " animate-[fadeInUp_var(--anim-fast)_var(--anim-ease-out)_backwards] motion-reduce:animate-none"
       }`
-    // Undefined rather than the layout classes while hidden: `hidden` already
-    // takes the group out of layout, and a class arriving with the reveal is
-    // what makes the entrance animation run on each one.
-    : undefined;
+    : // Undefined rather than the layout classes while hidden: `hidden` already
+      // takes the group out of layout, and a class arriving with the reveal is
+      // what makes the entrance animation run on each one.
+      undefined;
 
   // A pill at mobile widths (half the card's 52px collapsed height), the 10px
   // panel elsewhere, both shared with the live-voice bar: it stacks on this

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -78,12 +78,14 @@ mock.module("@/domains/chat/voice/use-voice-key", () => ({
 }));
 
 const askedTexts: string[] = [];
+const askedEntries: string[] = [];
 let nextAskTaken = true;
 const announceAskRefusedMock = mock(() => undefined);
 const toggleVoiceMock = mock(() => undefined);
 mock.module("@/domains/chat/voice/live-voice/start-voice-request", () => ({
-  askVoiceFromSurface: (_navigate: unknown, ask: string) => {
+  askVoiceFromSurface: (_navigate: unknown, ask: string, entry: string) => {
     askedTexts.push(ask);
+    askedEntries.push(entry);
     return nextAskTaken;
   },
   announceAskRefused: announceAskRefusedMock,
@@ -196,6 +198,7 @@ afterEach(() => {
   dictationCalls.length = 0;
   insertedTexts.length = 0;
   askedTexts.length = 0;
+  askedEntries.length = 0;
   nextAskTaken = true;
   announceAskRefusedMock.mockClear();
   toggleVoiceMock.mockClear();
@@ -370,6 +373,12 @@ test("a double tap of the voice key is Talk", () => {
   });
 
   expect(toggleVoiceMock).toHaveBeenCalledTimes(1);
+  // Named for the daemon's telemetry: the same macOS client also starts calls
+  // from the composer and the companion, and only the entry tells them apart.
+  expect(toggleVoiceMock).toHaveBeenCalledWith(
+    expect.any(Function),
+    "voice_key",
+  );
 });
 
 describe("a hold over a selection", () => {
@@ -390,6 +399,7 @@ describe("a hold over a selection", () => {
     expect(askedTexts).toEqual([
       "> the powerhouse\n> of the cell\n\nwhat does this mean",
     ]);
+    expect(askedEntries).toEqual(["voice_key_ask"]);
     expect(insertedTexts).toEqual([]);
     expect(toastErrorMock).not.toHaveBeenCalled();
   });

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -336,7 +336,10 @@ export function GlobalPushToTalkBridge({
       holdTarget()?.stop();
     },
     onDoubleTap: () => {
-      toggleVoiceFromSurface((to, options) => navigateRef.current(to, options));
+      toggleVoiceFromSurface(
+        (to, options) => navigateRef.current(to, options),
+        "voice_key",
+      );
     },
   });
 
@@ -372,6 +375,7 @@ export function GlobalPushToTalkBridge({
         const taken = askVoiceFromSurface(
           (to, options) => navigateRef.current(to, options),
           ask,
+          "voice_key_ask",
         );
         console.info(
           `dictation: ask selectionChars=${selection.text.length} truncated=${selection.truncated} words=${rawText.length} taken=${taken}`,

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -144,6 +144,7 @@ async function connectAndGetSocket(
     turnDetection?: "manual" | "server_vad";
     silenceThresholdMs?: number;
     bargeInMinSpeechMs?: number;
+    entry?: "companion";
   } = { assistantId: "assistant-1" },
 ): Promise<FakeWebSocket> {
   await client.connect(args);
@@ -240,6 +241,16 @@ describe("connect", () => {
     // every native session as a browser one. Under the test DOM (no Electron,
     // no Capacitor) the detected surface is "web".
     expect(ws.sentJson[0]).toMatchObject({ client: "web" });
+  });
+
+  test("sends the entry point on the start frame when given", async () => {
+    const ws = await connectAndGetSocket(makeClient(), {
+      assistantId: "assistant-1",
+      entry: "companion",
+    });
+    ws.open();
+
+    expect(ws.sentJson[0]).toMatchObject({ type: "start", entry: "companion" });
   });
 
   test("includes turnDetection in the start frame when provided", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -34,6 +34,7 @@ import {
   type LiveVoiceSttFinalServerFrame,
   type LiveVoiceSttPartialServerFrame,
   type LiveVoiceActivityServerFrame,
+  type LiveVoiceEntry,
   type LiveVoiceThinkingServerFrame,
   type LiveVoiceTtsAudioServerFrame,
   type LiveVoiceTtsDoneServerFrame,
@@ -64,7 +65,9 @@ export const RETRYABLE_LIVE_VOICE_CLOSE_CODES: ReadonlySet<number> = new Set([
 
 /** Reason a live-voice session failed, surfaced via the `error` event. */
 export type LiveVoiceClientErrorReason =
-  "connection-failed" | "protocol-error" | "timeout";
+  | "connection-failed"
+  | "protocol-error"
+  | "timeout";
 
 export interface LiveVoiceClientError {
   readonly reason: LiveVoiceClientErrorReason;
@@ -227,6 +230,11 @@ export interface LiveVoiceConnectArgs {
    * sent on the `start` frame. Omitted lets the daemon use its default.
    */
   bargeInMinSpeechMs?: number;
+  /**
+   * Which control asked for the session, sent on the `start` frame. Omitted
+   * means the daemon reports the session's entry point as unknown.
+   */
+  entry?: LiveVoiceEntry;
 }
 
 /** Factory so tests can inject a mock WebSocket. Defaults to the global. */
@@ -256,6 +264,7 @@ export class LiveVoiceChannelClient {
   private turnDetection: LiveVoiceTurnDetectionMode | undefined;
   private silenceThresholdMs: number | undefined;
   private bargeInMinSpeechMs: number | undefined;
+  private entry: LiveVoiceEntry | undefined;
   // Set once an assistant running daemon code older than the `update_config`
   // frame rejects it with `unknown_type`. We then stop sending config updates
   // for this session so an older assistant is neither killed nor spammed by the
@@ -335,6 +344,7 @@ export class LiveVoiceChannelClient {
     turnDetection,
     silenceThresholdMs,
     bargeInMinSpeechMs,
+    entry,
   }: LiveVoiceConnectArgs): Promise<void> {
     if (this.state !== "idle") {
       return;
@@ -344,6 +354,7 @@ export class LiveVoiceChannelClient {
     this.turnDetection = turnDetection;
     this.silenceThresholdMs = silenceThresholdMs;
     this.bargeInMinSpeechMs = bargeInMinSpeechMs;
+    this.entry = entry;
 
     let url: string;
     try {
@@ -563,6 +574,7 @@ export class LiveVoiceChannelClient {
       // session outright with `credentials_unavailable`, which is precisely
       // the outcome the text-only path exists to avoid.
       textInput: true,
+      ...(this.entry ? { entry: this.entry } : {}),
       ...(this.conversationId ? { conversationId: this.conversationId } : {}),
       ...(this.turnDetection ? { turnDetection: this.turnDetection } : {}),
       ...(this.silenceThresholdMs !== undefined

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -23,7 +23,10 @@
 
 import { create } from "zustand";
 
-import type { LiveVoiceMetricsServerFrame } from "@/domains/chat/voice/live-voice/protocol";
+import type {
+  LiveVoiceEntry,
+  LiveVoiceMetricsServerFrame,
+} from "@/domains/chat/voice/live-voice/protocol";
 import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
 import { createSelectors } from "@/utils/create-selectors";
 
@@ -284,8 +287,14 @@ export interface LiveVoiceSessionStarter {
   sendText(text: string): boolean;
 }
 
-/** The first turn a session takes on a caller's behalf, and what follows it. */
+/**
+ * What a caller hands the starter besides the ids: which control the start
+ * came from, and the first turn the session takes on the caller's behalf with
+ * what follows it.
+ */
 export interface LiveVoiceSeedOptions {
+  /** Which control asked for the session, for the daemon's telemetry. */
+  entry?: LiveVoiceEntry;
   seedText?: string;
   seedVisible?: boolean;
   endAfterSeedReply?: boolean;

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -63,6 +63,32 @@ export const LIVE_VOICE_AUDIO_FORMAT_PARAMS: Record<string, string> = {
 
 export type LiveVoiceTurnDetectionMode = "manual" | "server_vad";
 
+/**
+ * Which control a live-voice session was asked from. The start frame's
+ * `client` says which app the user was on; this says what they reached for in
+ * it, which is the only thing that separates the macOS app's three ways in
+ * from each other.
+ *
+ * - `composer`       the chat's voice button
+ * - `companion`      the macOS companion surface's Talk
+ * - `voice_key`      the voice key's double tap, or the voice mode shortcut
+ * - `voice_key_ask`  the voice key held over a selection, asking about it
+ * - `deep_link`      Siri, a widget, the Action Button, a Live Activity tap
+ *
+ * Analytics only. The daemon stamps it on the session's started telemetry row
+ * and on each voice turn's `client` bag, and reads the field as an open
+ * string, so a value added here reaches the warehouse without a daemon
+ * release. Keep the tokens short snake_case: the daemon drops anything that
+ * does not match `^[a-z][a-z0-9_]{0,31}$`, and a dropped value reads as
+ * unknown downstream rather than failing the session.
+ */
+export type LiveVoiceEntry =
+  | "composer"
+  | "companion"
+  | "voice_key"
+  | "voice_key_ask"
+  | "deep_link";
+
 export interface LiveVoiceClientStartFrame {
   readonly type: "start";
   readonly conversationId?: string;
@@ -97,6 +123,11 @@ export interface LiveVoiceClientStartFrame {
    * interface id, which decides what the turn is allowed to do.
    */
   readonly client?: ClientOs;
+  /**
+   * Which control asked for the session (see {@link LiveVoiceEntry}). Absent
+   * from callers that predate the field, which the daemon reports as unknown.
+   */
+  readonly entry?: LiveVoiceEntry;
   /**
    * This client can take a turn without the microphone (see the `text` frame),
    * so a missing speech-to-text leg is degradation rather than failure.

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -165,10 +165,12 @@ function mintedConversationId(): string {
  * minted for it rather than the one the app was left on, and the composer for
  * that conversation was navigated onto the screen so it can own the session.
  */
-function expectStartedOnFreshDraft(): void {
+function expectStartedOnFreshDraft(
+  entry: "deep_link" | "companion" = "deep_link",
+): void {
   const draftId = mintedConversationId();
   expect(draftId).not.toBe(PRIOR_CONVERSATION_ID);
-  expect(starter).toHaveBeenCalledWith("assistant-1", draftId);
+  expect(starter).toHaveBeenCalledWith("assistant-1", draftId, { entry });
   expect(navigate).toHaveBeenCalledWith(routes.conversation(draftId), {
     replace: true,
   });
@@ -215,7 +217,7 @@ describe("starting a session", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await flushDrain();
 
     expectStartedOnFreshDraft();
@@ -226,7 +228,7 @@ describe("starting a session", () => {
     identityHydrated();
 
     // No `ChatLayout` yet: the drain no-ops and the request stays parked.
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await Promise.resolve();
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(true);
@@ -246,7 +248,7 @@ describe("starting a session", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await flushDrain();
 
     const draftId = mintedConversationId();
@@ -269,7 +271,7 @@ describe("starting a session", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await flushDrain();
 
     const draftId = mintedConversationId();
@@ -287,7 +289,7 @@ describe("starting a session", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await flushDrain();
 
     expect(useViewerStore.getState().mainView).toBe("chat");
@@ -304,7 +306,7 @@ describe("starting a session", () => {
       attachments: [],
     });
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await flushDrain();
 
     expect(useViewerStore.getState().activeMessageFiles).toBeNull();
@@ -336,7 +338,7 @@ describe("a request that cannot be served yet stays parked", () => {
     useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
 
     expect(starter).not.toHaveBeenCalled();
@@ -358,7 +360,9 @@ describe("a request that cannot be served yet stays parked", () => {
     registerStarter();
     useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-2" });
 
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
 
     // The version is awaited for the assistant a fresh start now means, not
@@ -382,7 +386,9 @@ describe("a request that cannot be served yet stays parked", () => {
 
     const draftId = mintedConversationId();
     expect(draftId).not.toBe(PRIOR_CONVERSATION_ID);
-    expect(starter).toHaveBeenCalledWith("assistant-2", draftId);
+    expect(starter).toHaveBeenCalledWith("assistant-2", draftId, {
+      entry: "deep_link",
+    });
     expect(isParked()).toBe(false);
   });
 
@@ -395,7 +401,9 @@ describe("a request that cannot be served yet stays parked", () => {
       hydrate = resolve;
     });
 
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
     const drained = drainPendingVoiceStart(navigate);
     // Navigating off the chat layout mid-await: there is no starter left to
     // hand this to.
@@ -426,7 +434,7 @@ describe("a request that will never be served is discarded", () => {
     identityHydrated("0.10.11");
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
 
     expect(starter).not.toHaveBeenCalled();
@@ -462,6 +470,7 @@ describe("a request that will never be served is discarded", () => {
 
     usePendingDeepLinkStore.setState({
       pendingVoiceStartAt: Date.now() - PENDING_VOICE_START_TTL_MS + 5_000,
+      pendingVoiceStartEntry: "deep_link",
     });
     await drainPendingVoiceStart(navigate);
 
@@ -479,7 +488,9 @@ describe("a request that will never be served is discarded", () => {
  */
 describe("cancelling a pending start", () => {
   test("spends a parked request", () => {
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
 
     cancelPendingVoiceStart();
 
@@ -499,7 +510,7 @@ describe("cancelling a pending start", () => {
         }),
     );
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await Promise.resolve();
     cancelPendingVoiceStart();
     preflight.settle?.();
@@ -523,7 +534,7 @@ describe("one-shot delivery", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
     await drainPendingVoiceStart(navigate);
     await drainPendingVoiceStart(navigate);
@@ -537,8 +548,8 @@ describe("one-shot delivery", () => {
   test("two links before a drain are one request", async () => {
     identityHydrated();
 
-    requestVoiceStart(navigate);
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await Promise.resolve();
 
     registerStarter();
@@ -556,7 +567,7 @@ describe("startVoiceFromSurface", () => {
   test("navigates to the chat and parks the request", () => {
     identityHydrated();
 
-    startVoiceFromSurface(navigate);
+    startVoiceFromSurface(navigate, { entry: "companion" });
 
     // Navigating to the chat is what mounts the layout that owns the starter;
     // the drain then mints the conversation the session binds to.
@@ -569,7 +580,7 @@ describe("startVoiceFromSurface", () => {
     // yet. It must survive until one does rather than being spent on arrival.
     identityHydrated();
 
-    startVoiceFromSurface(navigate);
+    startVoiceFromSurface(navigate, { entry: "companion" });
     await Promise.resolve();
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(true);
@@ -578,8 +589,9 @@ describe("startVoiceFromSurface", () => {
     await drainPendingVoiceStart(navigate);
 
     // The press was made from outside the conversation the app was left on,
-    // and it opens a call of its own rather than resuming that thread.
-    expectStartedOnFreshDraft();
+    // and it opens a call of its own rather than resuming that thread. The
+    // control that made it travels with it, since by now the press is gone.
+    expectStartedOnFreshDraft("companion");
   });
 
   test("a running session spends the press", () => {
@@ -587,7 +599,7 @@ describe("startVoiceFromSurface", () => {
     registerStarter();
     useLiveVoiceStore.getState().setState("listening");
 
-    startVoiceFromSurface(navigate);
+    startVoiceFromSurface(navigate, { entry: "companion" });
 
     // That session is the one the user is in. Navigating would only walk the
     // app away from the composer that owns it.
@@ -606,13 +618,18 @@ describe("askVoiceFromSurface", () => {
     identityHydrated();
     registerStarter();
 
-    expect(askVoiceFromSurface(navigate, "> the cell\n\nwhat is this")).toBe(
-      true,
-    );
+    expect(
+      askVoiceFromSurface(
+        navigate,
+        "> the cell\n\nwhat is this",
+        "voice_key_ask",
+      ),
+    ).toBe(true);
     await flushDrain();
 
     const draftId = mintedConversationId();
     expect(starter).toHaveBeenCalledWith("assistant-1", draftId, {
+      entry: "voice_key_ask",
       seedText: "> the cell\n\nwhat is this",
       seedVisible: true,
       endAfterSeedReply: true,
@@ -625,7 +642,9 @@ describe("askVoiceFromSurface", () => {
     registerStarter();
     useLiveVoiceStore.getState().setState("listening");
 
-    expect(askVoiceFromSurface(navigate, "what is this")).toBe(true);
+    expect(askVoiceFromSurface(navigate, "what is this", "voice_key_ask")).toBe(
+      true,
+    );
 
     expect(sendText).toHaveBeenCalledWith("what is this");
     expect(navigate).not.toHaveBeenCalled();
@@ -639,7 +658,7 @@ describe("askVoiceFromSurface", () => {
     identityHydrated("0.10.11");
     registerStarter();
 
-    askVoiceFromSurface(navigate, "what is this");
+    askVoiceFromSurface(navigate, "what is this", "voice_key_ask");
     await flushDrain();
 
     expect(starter).not.toHaveBeenCalled();
@@ -653,7 +672,7 @@ describe("askVoiceFromSurface", () => {
     registerStarter();
     preflightVerdict = { status: "not-ready", userMessage: "Set up a voice." };
 
-    askVoiceFromSurface(navigate, "what is this");
+    askVoiceFromSurface(navigate, "what is this", "voice_key_ask");
     await flushDrain();
 
     expect(starter).not.toHaveBeenCalled();
@@ -668,7 +687,7 @@ describe("askVoiceFromSurface", () => {
       return preflightVerdict;
     });
 
-    askVoiceFromSurface(navigate, "what is this");
+    askVoiceFromSurface(navigate, "what is this", "voice_key_ask");
     await flushDrain();
 
     expect(starter).not.toHaveBeenCalled();
@@ -682,7 +701,9 @@ describe("askVoiceFromSurface", () => {
     sendText.mockReturnValueOnce(false);
     useLiveVoiceStore.getState().setState("speaking");
 
-    expect(askVoiceFromSurface(navigate, "what is this")).toBe(false);
+    expect(askVoiceFromSurface(navigate, "what is this", "voice_key_ask")).toBe(
+      false,
+    );
     expect(isParked()).toBe(false);
   });
 });
@@ -699,7 +720,7 @@ describe("entry guards", () => {
     registerStarter();
     useVoicePrefsStore.setState({ firstRunSeen: false });
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await Promise.resolve();
     await Promise.resolve();
 
@@ -719,7 +740,7 @@ describe("entry guards", () => {
     registerStarter();
     useVoicePrefsStore.setState({ firstRunSeen: false });
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await Promise.resolve();
     await Promise.resolve();
 
@@ -736,7 +757,7 @@ describe("entry guards", () => {
     registerStarter();
     useVoicePrefsStore.setState({ firstRunSeen: true });
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await Promise.resolve();
     await Promise.resolve();
 
@@ -748,7 +769,7 @@ describe("entry guards", () => {
     registerStarter();
     preflightVerdict = { status: "not-ready", userMessage: "Set up a voice." };
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
 
     expect(useLiveVoiceStore.getState().configNotice).toBe("Set up a voice.");
@@ -766,7 +787,7 @@ describe("entry guards", () => {
     registerStarter();
     preflightVerdict = { status: "not-ready", userMessage: "Set up a voice." };
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
 
     expect(endVoiceActivityMock).toHaveBeenCalledTimes(1);
@@ -777,7 +798,7 @@ describe("entry guards", () => {
     registerStarter();
     useVoicePrefsStore.setState({ firstRunSeen: false });
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await Promise.resolve();
     await Promise.resolve();
 
@@ -788,7 +809,7 @@ describe("entry guards", () => {
     identityHydrated("0.10.11");
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
 
     expect(endVoiceActivityMock).toHaveBeenCalledTimes(1);
@@ -802,7 +823,7 @@ describe("entry guards", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
 
     expectStartedOnFreshDraft();
@@ -816,7 +837,7 @@ describe("entry guards", () => {
     registerStarter();
     preflightVerdict = null;
 
-    requestVoiceStart(navigate);
+    requestVoiceStart(navigate, { entry: "deep_link" });
     await drainPendingVoiceStart(navigate);
 
     expectStartedOnFreshDraft();
@@ -828,7 +849,9 @@ describe("entry guards", () => {
     // case that must not spend the press.
     identityHydrated();
     registerStarter();
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
     let released: () => void = () => {};
     preflightLiveVoice.mockImplementationOnce(
       () =>
@@ -878,7 +901,9 @@ describe("state read before the preflight is re-read after it", () => {
           release = () => resolve(preflightVerdict);
         }),
     );
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
     const drain = drainPendingVoiceStart(navigate);
     await Promise.resolve();
     await Promise.resolve();
@@ -953,7 +978,7 @@ describe("state read before the preflight is re-read after it", () => {
 
 describe("toggling from a surface", () => {
   test("with no session running, asks for one the way Talk does", () => {
-    toggleVoiceFromSurface(navigate);
+    toggleVoiceFromSurface(navigate, "voice_key");
 
     expect(navigate).toHaveBeenCalledWith(routes.assistant);
     expect(isParked()).toBe(true);
@@ -973,7 +998,7 @@ describe("toggling from a surface", () => {
     >[0]);
     useLiveVoiceStore.getState().setState("listening");
 
-    toggleVoiceFromSurface(navigate);
+    toggleVoiceFromSurface(navigate, "voice_key");
 
     expect(stop).toHaveBeenCalledTimes(1);
     expect(isParked()).toBe(false);

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -25,6 +25,7 @@ import {
   isLiveVoiceSessionActive,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import type { LiveVoiceEntry } from "@/domains/chat/voice/live-voice/protocol";
 import {
   firstRunCardIntercepts,
   publishConfigNotice,
@@ -102,9 +103,15 @@ function bindFreshConversation(navigate: VoiceStartNavigate): string {
 }
 
 /**
- * What a start-voice request can carry besides the request itself.
+ * What a start-voice request carries besides the request itself.
  */
 export interface VoiceStartRequestOptions {
+  /**
+   * Which control asked for the session. Required, because it is the one
+   * thing the drain cannot work out for itself: by the time the request is
+   * served, the press that made it is long gone.
+   */
+  entry: LiveVoiceEntry;
   /**
    * A question to put to the session as its first turn, spoken back and then
    * done: the session ends once the reply has been heard. For a press that
@@ -126,9 +133,12 @@ export interface VoiceStartRequestOptions {
  */
 export function requestVoiceStart(
   navigate: VoiceStartNavigate,
-  options: VoiceStartRequestOptions = {},
+  options: VoiceStartRequestOptions,
 ): void {
-  usePendingDeepLinkStore.getState().setPendingVoiceStart(options.ask);
+  usePendingDeepLinkStore.getState().setPendingVoiceStart({
+    entry: options.entry,
+    ...(options.ask !== undefined ? { ask: options.ask } : {}),
+  });
   void drainPendingVoiceStart(navigate);
 }
 
@@ -155,7 +165,7 @@ export function requestVoiceStart(
  */
 export function startVoiceFromSurface(
   navigate: VoiceStartNavigate,
-  options: VoiceStartRequestOptions = {},
+  options: VoiceStartRequestOptions,
 ): void {
   if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
     return;
@@ -174,12 +184,15 @@ export function startVoiceFromSurface(
  * that draws it also draws a way to stop. Both the voice mode shortcut and
  * the voice key's double tap come through here, so the two cannot drift.
  */
-export function toggleVoiceFromSurface(navigate: VoiceStartNavigate): void {
+export function toggleVoiceFromSurface(
+  navigate: VoiceStartNavigate,
+  entry: LiveVoiceEntry,
+): void {
   if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
     endLiveVoiceSession();
     return;
   }
-  startVoiceFromSurface(navigate);
+  startVoiceFromSurface(navigate, { entry });
 }
 
 /**
@@ -230,13 +243,14 @@ export function announceAskRefused(): void {
 export function askVoiceFromSurface(
   navigate: VoiceStartNavigate,
   ask: string,
+  entry: LiveVoiceEntry,
 ): boolean {
   const store = useLiveVoiceStore.getState();
   if (isLiveVoiceSessionActive(store.state)) {
     return store.starter?.sendText(ask) === true;
   }
   void navigate(routes.assistant);
-  requestVoiceStart(navigate, { ask });
+  requestVoiceStart(navigate, { entry, ask });
   return true;
 }
 
@@ -409,13 +423,17 @@ export async function drainPendingVoiceStart(
   // to borrow (Siri, the Action Button, a Live Activity tap). `start()` creates
   // its own player when none was reserved.
   const conversationId = bindFreshConversation(navigate);
+  // The control that parked the request, carried to the daemon's telemetry.
+  // Absent only from a park written by code that predates the field.
+  const entry = consumed.entry ? { entry: consumed.entry } : {};
   if (consumed.ask === null) {
-    readyStarter.start(assistantId, conversationId);
+    readyStarter.start(assistantId, conversationId, entry);
     return;
   }
   // The question is the user's own words, so it renders as theirs, and the
   // session is for the question alone: it ends once the reply has been heard.
   readyStarter.start(assistantId, conversationId, {
+    ...entry,
     seedText: consumed.ask,
     seedVisible: true,
     endAfterSeedReply: true,

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -287,7 +287,9 @@ describe("starter registration", () => {
     });
     useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
     useConversationStore.getState().setActiveConversationId("conv-1");
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
 
     const h = renderPersistentController();
     await act(async () => {
@@ -357,7 +359,9 @@ describe("re-draining on an assistant switch", () => {
 
   test("a request reparked mid-preflight starts on the assistant switched to", async () => {
     activeAssistant("assistant-1");
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
     let releasePreflight: () => void = () => {};
     preflightLiveVoice.mockImplementationOnce(
       () =>
@@ -405,7 +409,9 @@ describe("re-draining on an assistant switch", () => {
     await flushDrains();
 
     // Parked directly, so nothing drains it until the switch does.
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
     act(() => {
       useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-2" });
     });
@@ -457,7 +463,9 @@ describe("re-draining on an assistant switch", () => {
     // The park is one-shot, so the trigger cannot turn every later switch into
     // a session the user never asked for.
     activeAssistant("assistant-1");
-    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    usePendingDeepLinkStore
+      .getState()
+      .setPendingVoiceStart({ entry: "deep_link" });
     const h = renderPersistentController();
     await flushDrains();
     expect(h.clients).toHaveLength(1);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -206,6 +206,7 @@ export function useLiveVoiceSessionController(
         // when the daemon's `ready` doesn't echo `server_vad`.
         void start(assistantId, conversationId ?? undefined, {
           handsFree: true,
+          ...(options?.entry ? { entry: options.entry } : {}),
           ...(options?.seedText ? { seedText: options.seedText } : {}),
           ...(options?.seedVisible ? { seedVisible: true } : {}),
           ...(options?.endAfterSeedReply ? { endAfterSeedReply: true } : {}),

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -119,7 +119,7 @@ function renderController(
 /** Start a session and drive it to the listening state (ready + capture). */
 async function startListening(
   h: ReturnType<typeof renderController>,
-  options?: { handsFree?: boolean },
+  options?: { handsFree?: boolean; entry?: "companion" },
 ) {
   await act(async () => {
     await h.view.result.current.start("assistant-1", "conv-1", options);
@@ -1204,6 +1204,25 @@ describe("hands-free session controls (send now / stop response / mute)", () => 
     });
     expect(new Int16Array(h.client.sentAudio[1]!)[0]).toBe(1234);
     expect(useLiveVoiceStore.getState().inputAmplitude).toBeCloseTo(0.4);
+  });
+
+  test("the entry point rides every connect the session makes, reconnects included", async () => {
+    // A socket blip does not change where the user started from, and the
+    // fresh daemon session behind the reconnect writes its own started row.
+    const h = renderController({ reconnectBackoffMs: [10] });
+    await startListening(h, { handsFree: true, entry: "companion" });
+    expect(h.client.connectArgs).toMatchObject({ entry: "companion" });
+
+    await act(async () => {
+      h.client.emit("closed", {
+        code: 1013,
+        reason: "assistant tunnel disconnected",
+      });
+    });
+    await act(async () => {
+      await sleep(40);
+    });
+    expect(h.client.connectArgs).toMatchObject({ entry: "companion" });
   });
 
   test("muted survives a retryable reconnect — no hot mic after a blip", async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -97,6 +97,7 @@ import {
   type TtsAudioChunk,
 } from "@/domains/chat/voice/live-voice/tts-playback";
 import { describeBusyFailure } from "@/domains/chat/voice/live-voice/busy-failure";
+import type { LiveVoiceEntry } from "@/domains/chat/voice/live-voice/protocol";
 import { fixedT } from "@/i18n";
 import {
   isLiveVoiceSessionActive,
@@ -205,6 +206,12 @@ export interface LiveVoiceStartOptions {
    */
   handsFree?: boolean;
   /**
+   * Which control asked for the session, for the daemon's telemetry. Sent on
+   * every connect the session makes, reconnects included: a socket blip does
+   * not change where the user started from.
+   */
+  entry?: LiveVoiceEntry;
+  /**
    * A first turn to take on the session's behalf, sent once the microphone is
    * live, so the assistant speaks without waiting for the user.
    *
@@ -305,6 +312,8 @@ interface SessionContext {
    * to `listening` instead of tearing down.
    */
   handsFree: boolean;
+  /** Where the session was started from; reused verbatim on reconnect. */
+  entry: LiveVoiceEntry | undefined;
   /**
    * In-flight (or settled) mic acquisition — `capture.start()` kicked off at
    * connect time by {@link beginCaptureStartup} so getUserMedia + the worklet
@@ -855,6 +864,7 @@ export function useLiveVoice(
         unsubscribes: [],
         generation: 0,
         handsFree: startOptions.handsFree === true,
+        entry: startOptions.entry,
         captureRunning: false,
         forwardingAudio: false,
         responseAudioStarted: false,
@@ -1428,6 +1438,7 @@ export function useLiveVoice(
                 reconnectTimerRef.current = null;
                 void connectSessionRef.current?.(assistantId, conversationId, {
                   handsFree: true,
+                  ...(session.entry ? { entry: session.entry } : {}),
                 });
               }, delayMs);
               return;
@@ -1497,6 +1508,7 @@ export function useLiveVoice(
               reconnectTimerRef.current = null;
               void connectSessionRef.current?.(assistantId, conversationId, {
                 handsFree: true,
+                ...(session.entry ? { entry: session.entry } : {}),
               });
             }, delayMs);
             return;
@@ -1520,6 +1532,7 @@ export function useLiveVoice(
       await client.connect({
         assistantId,
         conversationId,
+        ...(session.entry ? { entry: session.entry } : {}),
         ...(session.handsFree
           ? {
               turnDetection: "server_vad" as const,

--- a/clients/web/src/domains/chat/voice/use-voice-mode-hotkey.ts
+++ b/clients/web/src/domains/chat/voice/use-voice-mode-hotkey.ts
@@ -83,7 +83,7 @@ export function useVoiceModeHotkey({
   );
 
   const toggleVoiceMode = useCallback(() => {
-    toggleVoiceFromSurface(navigate);
+    toggleVoiceFromSurface(navigate, "voice_key");
   }, [navigate]);
 
   useEffect(() => {

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
@@ -164,7 +164,7 @@ test("a deep-link start opens the room on the conversation it mints, not the pil
     .setActiveConversationId(PRIOR_CONVERSATION_ID);
   registerStarter();
 
-  requestVoiceStart(navigateFn);
+  requestVoiceStart(navigateFn, { entry: "deep_link" });
   await flushDrain();
 
   const draftId = useConversationStore.getState().activeConversationId;

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -535,7 +535,11 @@ describe("deeplink.startVoice", () => {
     const conversationId = useConversationStore.getState().activeConversationId;
     expect(conversationId).not.toBeNull();
     expect(conversationId).not.toBe(PRIOR_CONVERSATION_ID);
-    expect(starterMock).toHaveBeenCalledWith("assistant-1", conversationId);
+    // A link is one of several ways in, and the daemon's telemetry is told
+    // which.
+    expect(starterMock).toHaveBeenCalledWith("assistant-1", conversationId, {
+      entry: "deep_link",
+    });
     expect(mockPathname).toBe(routes.conversation(conversationId ?? ""));
   };
 
@@ -1125,9 +1129,7 @@ describe("deeplink.share", () => {
       await Promise.resolve();
     });
 
-    expect(navigateMock).toHaveBeenCalledWith(
-      routes.conversation("conv-xyz"),
-    );
+    expect(navigateMock).toHaveBeenCalledWith(routes.conversation("conv-xyz"));
     const parked = usePendingDeepLinkStore.getState().pendingShareSend;
     expect(parked?.isNewDraft).toBe(false);
     expect(parked?.threadId).toBe("conv-xyz");

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -14,10 +14,7 @@ import {
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { requestVoiceStart } from "@/domains/chat/voice/live-voice/start-voice-request";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
-import {
-  consumeShareInbox,
-  readShareInboxFiles,
-} from "@/runtime/share-inbox";
+import { consumeShareInbox, readShareInboxFiles } from "@/runtime/share-inbox";
 import { useConnectDialogStore } from "@/stores/connect-dialog-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
@@ -301,7 +298,9 @@ export function useGlobalDeepLinkConsumer(): void {
     // mints the fresh conversation the session binds to and lands on it from
     // there, reading the ref because it navigates after its own awaits.
     navigateRef.current(routes.assistant);
-    requestVoiceStart((to, options) => navigateRef.current(to, options));
+    requestVoiceStart((to, options) => navigateRef.current(to, options), {
+      entry: "deep_link",
+    });
   });
 
   // The Home Screen widgets' New Chat buttons. `navigateToNewConversation` is

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -339,9 +339,10 @@ export function RootLayout() {
       );
     },
     startVoice: () => {
-      // See `startVoiceFromSurface` for the three steps and why the window
-      // stays where it is.
-      startVoiceFromSurface(navigate);
+      // The companion surface's Talk, the one sender of this command. See
+      // `startVoiceFromSurface` for the three steps and why the window stays
+      // where it is.
+      startVoiceFromSurface(navigate, { entry: "companion" });
     },
     cancelVoiceStart: () => {
       // The companion's dial, ended. Handled here rather than beside the
@@ -359,7 +360,7 @@ export function RootLayout() {
         endLiveVoiceSession();
         return;
       }
-      startVoiceFromSurface(navigate);
+      startVoiceFromSurface(navigate, { entry: "voice_key" });
     },
     answerWatchRetro: (command) => {
       if (command.kind !== "answerWatchRetro") {

--- a/clients/web/src/stores/pending-deep-link-store.ts
+++ b/clients/web/src/stores/pending-deep-link-store.ts
@@ -23,6 +23,7 @@
 
 import { create } from "zustand";
 
+import type { LiveVoiceEntry } from "@/domains/chat/voice/live-voice/protocol";
 import { createSelectors } from "@/utils/create-selectors";
 
 export interface PendingDeepLinkState {
@@ -52,6 +53,12 @@ export interface PendingDeepLinkState {
    * `pendingVoiceStartAt` and clears with it.
    */
   pendingVoiceStartAsk: string | null;
+  /**
+   * Which control parked the start-voice request, for the daemon's telemetry.
+   * Opaque here: the live-voice domain mints the values and reads them back.
+   * Travels with `pendingVoiceStartAt` and clears with it.
+   */
+  pendingVoiceStartEntry: LiveVoiceEntry | null;
   /**
    * A message that a *proven* App Intent asked to send into a specific
    * conversation (`deeplink.sendToThread` with `provenance: "intent"`), or
@@ -137,10 +144,13 @@ export interface PendingDeepLinkActions {
   consumePendingComposerMessage: () => string | null;
   /**
    * Park a start-voice request until a session starter is registered, with
-   * the first turn it should take, if it has one. A newer park replaces the
-   * older one's ask.
+   * the control that asked for it and the first turn it should take, if it
+   * has one. A newer park replaces the older one's entry and ask.
    */
-  setPendingVoiceStart: (ask?: string) => void;
+  setPendingVoiceStart: (request: {
+    entry: LiveVoiceEntry;
+    ask?: string;
+  }) => void;
   /**
    * Read and clear the parked start-voice request. Returns `null` when none
    * was parked, and when the parked one is older than `maxAgeMs` — a park that
@@ -149,7 +159,9 @@ export interface PendingDeepLinkActions {
    * cleared. Used by `drainPendingVoiceStart` in the live-voice domain,
    * which owns the age bound.
    */
-  consumePendingVoiceStart: (maxAgeMs: number) => { ask: string | null } | null;
+  consumePendingVoiceStart: (
+    maxAgeMs: number,
+  ) => { entry: LiveVoiceEntry | null; ask: string | null } | null;
   /**
    * Park a proven send-into-thread request. A newer request replaces an
    * older one: the most recent intent wins, same as the composer message.
@@ -217,6 +229,7 @@ const usePendingDeepLinkStoreBase = create<PendingDeepLinkStore>()(
     pendingComposerMessage: null,
     pendingVoiceStartAt: null,
     pendingVoiceStartAsk: null,
+    pendingVoiceStartEntry: null,
     pendingThreadSend: null,
     pendingCamera: null,
     pendingConversationListAt: null,
@@ -230,19 +243,27 @@ const usePendingDeepLinkStoreBase = create<PendingDeepLinkStore>()(
       }
       return message;
     },
-    setPendingVoiceStart: (ask) =>
+    setPendingVoiceStart: ({ entry, ask }) =>
       set({
         pendingVoiceStartAt: Date.now(),
         pendingVoiceStartAsk: ask ?? null,
+        pendingVoiceStartEntry: entry,
       }),
     consumePendingVoiceStart: (maxAgeMs) => {
-      const { pendingVoiceStartAt: parkedAt, pendingVoiceStartAsk: ask } =
-        get();
+      const {
+        pendingVoiceStartAt: parkedAt,
+        pendingVoiceStartAsk: ask,
+        pendingVoiceStartEntry: entry,
+      } = get();
       if (parkedAt === null) {
         return null;
       }
-      set({ pendingVoiceStartAt: null, pendingVoiceStartAsk: null });
-      return Date.now() - parkedAt <= maxAgeMs ? { ask } : null;
+      set({
+        pendingVoiceStartAt: null,
+        pendingVoiceStartAsk: null,
+        pendingVoiceStartEntry: null,
+      });
+      return Date.now() - parkedAt <= maxAgeMs ? { entry, ask } : null;
     },
     setPendingThreadSend: (threadId, message) =>
       set({ pendingThreadSend: { threadId, message, parkedAt: Date.now() } }),
@@ -291,6 +312,7 @@ export function __resetPendingDeepLinkForTesting(): void {
     pendingComposerMessage: null,
     pendingVoiceStartAt: null,
     pendingVoiceStartAsk: null,
+    pendingVoiceStartEntry: null,
     pendingThreadSend: null,
     pendingCamera: null,
     pendingConversationListAt: null,


### PR DESCRIPTION
## What

Live-voice sessions now report where they were started from, so the macOS companion can be told apart from the main macOS app, and both from every other client.

- The start frame gains `entry`: `composer`, `companion`, `voice_key`, `voice_key_ask`, `deep_link`, or `cli`. The web callers and the CLI mint it. The daemon reads it as an open, shape-bounded string (`^[a-z][a-z0-9_]{0,31}$`, dropped rather than rejected when off-shape) so a new value never needs a daemon release.
- The `live_voice_session_started` telemetry row's `screen` now carries `started_<client>:<entry>` instead of repeating the step name. That gives silent sessions a client dimension for the first time: the admin dashboard's client split comes from turn rows today, so a session with no turn landed in `(no turns)`.
- Voice turns' telemetry `client` bag gains `voice_entry` beside `os` and `voice_session_id`, so per-turn analytics can split by entry without a join.
- Reconnects carry the entry, since the fresh daemon session behind one writes its own started row.

## Querying

On `stg_telemetry__onboarding` with `funnel_version = 'live_voice_v1_2026_08'` and `step_name = 'live_voice_session_started'`:

```sql
SPLIT(REGEXP_EXTRACT(screen, r'^started_(.*)$'), ':')[OFFSET(0)] AS client_os,
SPLIT(REGEXP_EXTRACT(screen, r'^started_(.*)$'), ':')[OFFSET(1)] AS entry
```

"macOS companion" is `macos:companion`; "main macOS app" is `macos:composer` plus `macos:voice_key*`; everything else is another client. Rows from daemons predating this PR keep `screen = 'live_voice_session_started'` and read as no match. Every existing platform query filters on `step_name`, not the started row's `screen`, so none of them change.

## Follow-up (platform repo)

Admin Voice page: a "by entry" panel, and `live_voice__by_client.sql` can take its client from the started row instead of the turn join.

## Verification

- Tests: daemon live-voice, telemetry, calls and onboarding suites; web voice domain, deep-link consumer and stores; CLI live-voice client and voice command. All green in isolation (whole-directory runs carry the known mock-bleed noise, unrelated files, pass alone).
- Typecheck clean in web, assistant, cli. No new eslint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017z5naHZfkrHA2qQiQHaVf5
