### PR TITLE
feat(companion): share a screen, window or tab with the call (JARVIS-1734)

### DIFF
--- a/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
+++ b/clients/macos/native/mac-helper/Sources/MacHelperExecutable/main.swift
@@ -336,9 +336,11 @@ final class MacHelper: @unchecked Sendable {
         if let data = line.data(using: .utf8),
            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let method = object["method"] as? String,
-           method == "cu.perform" || method == "appControl.perform" {
+           method == "cu.perform" || method == "appControl.perform" || method == "capture.frame" {
             if method == "cu.perform" {
                 dispatchCuPerform(line: line)
+            } else if method == "capture.frame" {
+                dispatchCaptureFrame(line: line)
             } else {
                 dispatchAppControlPerform(line: line)
             }
@@ -378,6 +380,50 @@ final class MacHelper: @unchecked Sendable {
             self.writeResponse(
                 JsonRpcCodec.successResponse(id: id, result: payload.toDictionary())
             )
+        }
+    }
+
+    /// One JPEG of a display or a window, for the app to show a running call
+    /// what the user is sharing. The same capture the daemon's computer-use
+    /// path takes, reached directly: the app holds the share, not the daemon.
+    private func dispatchCaptureFrame(line: String) {
+        Task { @MainActor in
+            let object = (try? JSONSerialization.jsonObject(with: Data(line.utf8))) as? [String: Any]
+            let id = object?["id"] ?? NSNull()
+            let params = object?["params"] as? [String: Any] ?? [:]
+            let target: CaptureTarget
+            if let windowId = (params["windowId"] as? NSNumber)?.uint32Value {
+                target = .window(CGWindowID(windowId))
+            } else if let displayId = (params["displayId"] as? NSNumber)?.uint32Value {
+                target = .display(CGDirectDisplayID(displayId))
+            } else {
+                self.writeResponse(JsonRpcCodec.errorResponse(
+                    id: id,
+                    code: JsonRpcErrorCode.invalidParams,
+                    message: "capture.frame requires displayId or windowId"
+                ))
+                return
+            }
+            let maxWidth = (params["maxWidth"] as? NSNumber)?.intValue ?? 1280
+            let maxHeight = (params["maxHeight"] as? NSNumber)?.intValue ?? 720
+            do {
+                let result = try await ScreenCapture().captureScreenWithMetadata(
+                    maxWidth: maxWidth,
+                    maxHeight: maxHeight,
+                    target: target
+                )
+                self.writeResponse(JsonRpcCodec.successResponse(id: id, result: [
+                    "jpegBase64": result.jpegData.base64EncodedString(),
+                    "width": result.metadata?.screenshotWidthPx ?? 0,
+                    "height": result.metadata?.screenshotHeightPx ?? 0,
+                ]))
+            } catch {
+                self.writeResponse(JsonRpcCodec.errorResponse(
+                    id: id,
+                    code: JsonRpcErrorCode.internalError,
+                    message: error.localizedDescription
+                ))
+            }
         }
     }
 

--- a/clients/macos/src/main/companion-capture-sources.ts
+++ b/clients/macos/src/main/companion-capture-sources.ts
@@ -32,6 +32,7 @@ import { z } from "zod";
 import type {
   CompanionCapturePick,
   CompanionCaptureSources,
+  ScreenCaptureFrame,
   WatchCaptureTarget,
 } from "@vellumai/ipc-contract";
 
@@ -497,4 +498,46 @@ export async function windowBoundsFor(
     (w) => w.windowId === windowId,
   );
   return window === undefined ? null : window.bounds;
+}
+
+const capturedFrameSchema = z.object({
+  jpegBase64: z.string().min(1),
+  width: z.number().int().nonnegative(),
+  height: z.number().int().nonnegative(),
+});
+
+/**
+ * The longest side a shared frame is encoded at. Wide enough that text on a
+ * shared window still reads, and no wider: the app resizes every attachment
+ * on its way up, and a display's worth of pixels crosses the bridge as JSON.
+ */
+const SHARED_FRAME_MAX_WIDTH = 1600;
+const SHARED_FRAME_MAX_HEIGHT = 1000;
+
+/**
+ * One frame of a display or a window, as the helper takes it, or nothing
+ * when it could not: the window has gone, the display was unplugged, or
+ * Screen Recording is not granted. The refusal is logged rather than thrown,
+ * since the caller shares frames on a cadence and one missed frame is not an
+ * error the user needs to hear about.
+ */
+export async function captureTargetFrame(
+  target: WatchCaptureTarget,
+): Promise<ScreenCaptureFrame | null> {
+  const params =
+    target.kind === "display"
+      ? { displayId: target.displayId }
+      : { windowId: target.windowId };
+  try {
+    return capturedFrameSchema.parse(
+      await getSharedCuHelper().call("capture.frame", {
+        ...params,
+        maxWidth: SHARED_FRAME_MAX_WIDTH,
+        maxHeight: SHARED_FRAME_MAX_HEIGHT,
+      }),
+    );
+  } catch (err) {
+    log.warn("[companion] could not take a frame of the shared target:", err);
+    return null;
+  }
 }

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -247,9 +247,21 @@ let resolvedPickAsync: (pick: unknown) => Promise<typeof resolvedPick> = async (
   return resolvedPick;
 };
 
+/** What the helper answers for a frame of a shared target, by the target. */
+const framesAsked: unknown[] = [];
+let capturedFrame: {
+  jpegBase64: string;
+  width: number;
+  height: number;
+} | null = { jpegBase64: "/9j/", width: 16, height: 9 };
+
 mock.module("./companion-capture-sources", () => ({
   listCaptureSources: async () => listedSources,
   resolveCapturePick: (pick: unknown) => resolvedPickAsync(pick),
+  captureTargetFrame: async (target: unknown) => {
+    framesAsked.push(target);
+    return capturedFrame;
+  },
   windowBoundsFor: async (windowId: number) => {
     boundsAsked.push(windowId);
     return windowBounds;
@@ -2498,5 +2510,129 @@ describe("the surface while the app is in front", () => {
     fireAppEvent("did-resign-active");
 
     expect(companionOpen).toBe(false);
+  });
+});
+
+/**
+ * Share, which takes the picker's pick the way Teach does and means the
+ * opposite thing by a press with none: the stop, since the surface can see
+ * a share is on. The frames themselves are the helper's; what this file
+ * holds is that main reaches it with the target it was given.
+ */
+describe("Share on the companion surface", () => {
+  beforeEach(() => {
+    mainWindowOpen = true;
+    dispatched.length = 0;
+    framesAsked.length = 0;
+    capturedFrame = { jpegBase64: "/9j/", width: 16, height: 9 };
+  });
+
+  test("a press with no pick is the stop", () => {
+    send("vellum:companion:setScreenShare");
+    expect(dispatched.at(-1)).toEqual({ kind: "setScreenShare" });
+    expect(picksResolved).toHaveLength(0);
+  });
+
+  test("a pick is resolved and rides the command as the share's target", async () => {
+    resolvedPick = { kind: "window", windowId: 4242 };
+    send("vellum:companion:setScreenShare", {
+      kind: "tab",
+      chromeWindowId: 3,
+      tabIndex: 2,
+    });
+    await Bun.sleep(0);
+    expect(picksResolved.at(-1)).toEqual({
+      kind: "tab",
+      chromeWindowId: 3,
+      tabIndex: 2,
+    });
+    expect(dispatched.at(-1)).toEqual({
+      kind: "setScreenShare",
+      target: { kind: "window", windowId: 4242 },
+    });
+  });
+
+  /**
+   * The two controls share one picker and one generation: a pick still
+   * resolving for Share when Teach is pressed belonged to a choice the user
+   * has left, and must not start a share beside the session.
+   */
+  test("a share pick superseded by a Teach press dispatches nothing", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const slow = resolvedPickAsync;
+    resolvedPickAsync = async () => {
+      await gate;
+      return { kind: "window", windowId: 1 };
+    };
+    send("vellum:companion:setScreenShare", {
+      kind: "tab",
+      chromeWindowId: 3,
+      tabIndex: 1,
+    });
+    resolvedPickAsync = slow;
+    send("vellum:companion:toggleWatch");
+    release();
+    await Bun.sleep(0);
+    expect(dispatched).toEqual([{ kind: "toggleWatch" }]);
+  });
+
+  test("takes a frame of the shared target from the helper", async () => {
+    const capture = invocable.get("vellum:companion:captureScreen");
+    expect(capture).toBeDefined();
+    expect(await capture?.([{ kind: "display", displayId: 2 }])).toEqual({
+      jpegBase64: "/9j/",
+      width: 16,
+      height: 9,
+    });
+    expect(framesAsked).toEqual([{ kind: "display", displayId: 2 }]);
+    capturedFrame = null;
+    expect(await capture?.([{ kind: "window", windowId: 7 }])).toBeNull();
+  });
+
+  test("carries the share and whether one may start to the surface", () => {
+    send(
+      "vellum:companion:setContext",
+      context({
+        screenShareEnabled: true,
+        screenShare: { kind: "window", windowId: 7 },
+      }),
+    );
+    expect(state().screenShare).toEqual({ kind: "window", windowId: 7 });
+    expect(state().screenShareEnabled).toBe(true);
+    send("vellum:companion:setContext", context());
+    expect(state().screenShare).toBeUndefined();
+    expect(state().screenShareEnabled).toBe(false);
+  });
+
+  /**
+   * The frame says what is being shown, the way it says what is being read:
+   * a share with no session reading the screen frames the shared display.
+   */
+  test("frames what is shared when nothing is reading the screen", () => {
+    send(
+      "vellum:companion:setContext",
+      context({ screenShare: { kind: "display", displayId: 2 } }),
+    );
+    expect(glow?.bounds).toEqual({ x: 1440, y: 0, width: 1920, height: 1080 });
+    send("vellum:companion:setContext", context());
+    expect(glow).toBeNull();
+  });
+
+  test("the share ends with the window holding it", () => {
+    send(
+      "vellum:companion:setContext",
+      context({
+        screenShareEnabled: true,
+        screenShare: { kind: "display", displayId: 2 },
+      }),
+    );
+    mainWindowOpen = false;
+    fireVisibilityChange();
+    expect(state().screenShare).toBeUndefined();
+    expect(state().screenShareEnabled).toBe(false);
+    expect(glow).toBeNull();
   });
 });

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import {
   companionCapturePickSchema,
   companionContextSchema,
+  watchCaptureTargetSchema,
   voiceActivityContentSchema,
   voiceActivityControlSchema,
   voiceActivityStartSchema,
@@ -37,6 +38,7 @@ import {
   type CompanionSurfaceState,
   type VellumCommand,
   type VoiceActivityState,
+  type WatchCaptureTarget,
 } from "@vellumai/ipc-contract";
 import { companionSizeSubmenus } from "@vellumai/electron-desktop/companion-menu";
 import {
@@ -67,6 +69,7 @@ import {
   getFloatingWindow,
 } from "@vellumai/electron-desktop/floating-window";
 import {
+  captureTargetFrame,
   listCaptureSources,
   resolveCapturePick,
   windowBoundsFor,
@@ -562,6 +565,12 @@ const currentState = (): CompanionSurfaceState => {
     // Settled to a boolean the way `watching` is, since a picker offered on
     // an unknown answer is a promise nothing downstream can keep.
     watchTargets: context.watchTargets === true,
+    // Passed through as it arrived, for the reason `captureTarget` is: every
+    // shape it can hold names something being shared, and absence is nothing.
+    screenShare: context.screenShare,
+    // Settled to a boolean the way `watchTargets` is: the control this decides
+    // starts capturing the user's screen, so not knowing reads as not offering.
+    screenShareEnabled: context.screenShareEnabled === true,
     // Passed through as it arrived, for the reason `watchRetro` is: every value
     // it can hold claims a microphone is doing something.
     dictating: context.dictating,
@@ -1064,10 +1073,12 @@ const followWindow = (windowId: number): void => {
       .then((bounds) => {
         // The session may have ended, or moved to another target, while the
         // helper was answering. A frame placed for it would be for nothing.
+        const framed = framedTarget();
         if (
-          context.watching !== true ||
-          context.captureTarget?.kind !== "window" ||
-          context.captureTarget.windowId !== windowId
+          framed === null ||
+          framed === "screen" ||
+          framed.kind !== "window" ||
+          framed.windowId !== windowId
         ) {
           return;
         }
@@ -1106,13 +1117,30 @@ const followWindow = (windowId: number): void => {
  * off every screen, so framing where the user is looking says the session is
  * still open, which is the one thing the frame must always say.
  */
+/**
+ * What the frame is drawn around: a watch session's target, the whole screen
+ * when it has none, else what the call is being shared, else nothing.
+ *
+ * The watch session first, because its frame is the one thing on the desktop
+ * that says a machine is being read, and the two rarely disagree: a session
+ * and a share started from the same picker are almost always the same
+ * target.
+ */
+const framedTarget = (): WatchCaptureTarget | "screen" | null => {
+  if (context.watching === true) {
+    return context.captureTarget ?? "screen";
+  }
+  return context.screenShare ?? null;
+};
+
 const syncWatchFrame = (): void => {
-  if (context.watching !== true) {
+  const framed = framedTarget();
+  if (framed === null) {
     stopFollowingWindow();
     closeWatchFrame();
     return;
   }
-  const target = context.captureTarget;
+  const target = framed === "screen" ? undefined : framed;
   if (target?.kind === "window") {
     followWindow(target.windowId);
     return;
@@ -1486,6 +1514,49 @@ export const installCompanionWindow = (): void => {
   });
 
   /**
+   * Share, delivered to the renderer holding the session the way Watch is.
+   *
+   * The same two shapes as `toggleWatch`, and the same resolution of a tab
+   * before the command leaves; the difference is what the shapes mean. A pick
+   * is the start, or a move to a new target, and a press with none is the
+   * stop, since the surface can see a share is on and says so. The pick
+   * generation is shared with Watch's: both come from the one picker, and a
+   * pick still resolving when the other control is pressed belonged to a
+   * choice the user has left.
+   */
+  on(
+    "vellum:companion:setScreenShare",
+    z.union([z.tuple([]), z.tuple([companionCapturePickSchema])]),
+    ([pick]) => {
+      if (pick === undefined) {
+        pickGeneration += 1;
+        dispatchWithoutRaising({ kind: "setScreenShare" });
+        return;
+      }
+      const generation = ++pickGeneration;
+      void resolveCapturePick(pick).then((target) => {
+        if (target === null || generation !== pickGeneration) {
+          return;
+        }
+        dispatchWithoutRaising({ kind: "setScreenShare", target });
+      });
+    },
+  );
+
+  /**
+   * One frame of what is being shared, for the renderer holding the session
+   * to hand to it. Asked by that renderer on its own cadence, so this does
+   * nothing but reach the helper: the target is whatever the renderer was
+   * told it is sharing, and a refusal comes back as null rather than as an
+   * error, since one missed frame is not something the call should notice.
+   */
+  handle(
+    "vellum:companion:captureScreen",
+    z.tuple([watchCaptureTargetSchema]),
+    ([target]) => captureTargetFrame(target),
+  );
+
+  /**
    * The answer to the summary question, delivered to the window that asked it.
    *
    * The one companion press that may raise the app, and only on a yes. Watch's
@@ -1719,7 +1790,10 @@ export const installCompanionWindow = (): void => {
     // A dial is a claim on that window too: the request it carries is gone
     // with the renderer that parked it.
     const claiming =
-      context.watching === true || context.dictating !== undefined || dialing;
+      context.watching === true ||
+      context.screenShare !== undefined ||
+      context.dictating !== undefined ||
+      dialing;
     if (!claiming) {
       return;
     }
@@ -1730,6 +1804,8 @@ export const installCompanionWindow = (): void => {
       ...context,
       watching: false,
       captureTarget: undefined,
+      screenShare: undefined,
+      screenShareEnabled: false,
       dictating: undefined,
       dictationText: undefined,
     };

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -16,6 +16,8 @@ import type {
   CompanionCapturePick,
   CompanionCaptureSources,
   CompanionContext,
+  ScreenCaptureFrame,
+  WatchCaptureTarget,
   CompanionIntroAction,
   CompanionSurfaceState,
   ConnectivityState,
@@ -515,6 +517,22 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke(
         "vellum:companion:listCaptureSources",
       ) as Promise<CompanionCaptureSources>,
+    setScreenShare: (pick?: CompanionCapturePick): void => {
+      // Two shapes rather than an optional element, the way `toggleWatch` is
+      // sent: a stop carries nothing at all.
+      if (pick === undefined) {
+        ipcRenderer.send("vellum:companion:setScreenShare");
+        return;
+      }
+      ipcRenderer.send("vellum:companion:setScreenShare", pick);
+    },
+    captureScreen: (
+      target: WatchCaptureTarget,
+    ): Promise<ScreenCaptureFrame | null> =>
+      ipcRenderer.invoke(
+        "vellum:companion:captureScreen",
+        target,
+      ) as Promise<ScreenCaptureFrame | null>,
     answerWatchRetro: (open: boolean): void => {
       ipcRenderer.send("vellum:companion:answerWatchRetro", open);
     },

--- a/clients/web/src/components/companion-capture-picker.tsx
+++ b/clients/web/src/components/companion-capture-picker.tsx
@@ -12,7 +12,8 @@ import type {
 } from "@vellumai/ipc-contract";
 
 /**
- * The picker Teach opens: what a session could read, as a list to press.
+ * The picker Teach and Share open: what a session could read, or be shown, as
+ * a list to press.
  *
  * A card beside the call bar rather than a row on it. The bar is one thin row
  * by design and a desktop has a dozen windows on it, so the choice is drawn
@@ -58,6 +59,12 @@ export interface CompanionCapturePickerProps {
    * every row here is a press.
    */
   cardRef?: Ref<HTMLDivElement>;
+  /**
+   * What the card is choosing for, as a reader hears it: what to teach from,
+   * or what to share. The rows are the same either way; only the question
+   * differs.
+   */
+  label?: string;
   onPick?: (pick: CompanionCapturePick) => void;
 }
 
@@ -67,6 +74,7 @@ export function CompanionCapturePicker({
   avatarBox = COMPANION_BASE_AVATAR_BOX,
   optionsBox = COMPANION_BASE_AVATAR_BOX,
   cardRef,
+  label,
   onPick,
 }: CompanionCapturePickerProps) {
   const { t } = useTranslation();
@@ -106,7 +114,7 @@ export function CompanionCapturePicker({
       // none, since the window it is in is unfocusable and every press here is
       // the pointer's.
       role="group"
-      aria-label={t("companionSurface.capturePicker")}
+      aria-label={label ?? t("companionSurface.capturePicker")}
       data-companion-capture-picker
       className="absolute flex flex-col rounded-2xl border border-white/10 bg-[#17181b]/95 py-1.5 shadow-lg shadow-black/40"
       style={{ width: CARD_WIDTH, ...anchor }}

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -22,6 +22,7 @@ const setInteractiveMock = mock((_interactive: boolean) => undefined);
 const activateMock = mock(() => undefined);
 const startVoiceMock = mock(() => undefined);
 const toggleWatchMock = mock((_pick?: unknown) => undefined);
+const setScreenShareMock = mock((_pick?: unknown) => undefined);
 /**
  * What the shell lists for the picker. Null is a shell with no picker to
  * offer, which is what a bridge that predates it answers.
@@ -85,6 +86,8 @@ const resetState = () => {
   delete STATE.captureCount;
   delete STATE.watchTargets;
   delete STATE.captureTarget;
+  delete STATE.screenShare;
+  delete STATE.screenShareEnabled;
   STATE.watchEnabled = true;
   STATE.intro = null;
   STATE.assistantName = "Ziggy";
@@ -129,6 +132,7 @@ mock.module("@/runtime/companion-surface", () => ({
   activateCompanionApp: activateMock,
   startCompanionVoice: startVoiceMock,
   toggleCompanionWatch: toggleWatchMock,
+  setCompanionScreenShare: setScreenShareMock,
   listCompanionCaptureSources: listSourcesMock,
   // Stubbed rather than omitted: the page statically imports it, and a
   // missing export is a load-time failure for the whole file.
@@ -152,6 +156,7 @@ afterEach(() => {
   activateMock.mockClear();
   startVoiceMock.mockClear();
   toggleWatchMock.mockClear();
+  setScreenShareMock.mockClear();
   listSourcesMock.mockClear();
   captureSources = null;
   advanceIntroMock.mockClear();
@@ -1607,5 +1612,151 @@ describe("the companion's accent colour", () => {
     const { container } = render(<CompanionSurfacePage />);
 
     await expectAccent(container, "#5eead4");
+  });
+});
+
+/**
+ * Share opens the same picker Teach does, and its pick leaves as the share
+ * rather than as the toggle. The two pickers are one card with two questions,
+ * and each closes on its own answer.
+ */
+describe("the picker behind Share", () => {
+  const shareOf = (container: HTMLElement): HTMLButtonElement => {
+    const found = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Share"]',
+    );
+    if (!found) {
+      throw new Error("Expected Share to render");
+    }
+    return found;
+  };
+  const teachOf = (container: HTMLElement): HTMLButtonElement => {
+    const found = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Teach"]',
+    );
+    if (!found) {
+      throw new Error("Expected Teach to render");
+    }
+    return found;
+  };
+  const pickerOf = (container: HTMLElement): HTMLElement | null =>
+    container.querySelector<HTMLElement>("[data-companion-capture-picker]");
+  const rowOf = (container: HTMLElement) =>
+    waitFor(() => {
+      const found = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Groceries (Notes)"]',
+      );
+      if (!found) {
+        throw new Error("Expected the window row");
+      }
+      return found;
+    });
+
+  const SOURCES = {
+    displays: [
+      { kind: "display" as const, displayId: 1, index: 0, primary: true },
+    ],
+    tabs: [],
+    windows: [
+      {
+        kind: "window" as const,
+        windowId: 9,
+        title: "Groceries",
+        app: "Notes",
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    STATE.call = LISTENING_CALL;
+    STATE.watchTargets = true;
+    STATE.screenShareEnabled = true;
+    captureSources = SOURCES;
+  });
+
+  test("opens on Share, named for the share, and holds Share down", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+
+    fireEvent.click(shareOf(container));
+
+    await waitFor(() => {
+      expect(pickerOf(container)?.getAttribute("aria-label")).toBe(
+        "What to share",
+      );
+    });
+    expect(shareOf(container).getAttribute("aria-pressed")).toBe("true");
+    expect(teachOf(container).getAttribute("aria-pressed")).toBe("false");
+    expect(setScreenShareMock).not.toHaveBeenCalled();
+  });
+
+  test("a pick leaves as the share, not the toggle, and closes the picker", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    fireEvent.click(shareOf(container));
+    const row = await rowOf(container);
+
+    fireEvent.click(row);
+
+    expect(setScreenShareMock).toHaveBeenCalledWith({
+      kind: "window",
+      windowId: 9,
+    });
+    expect(toggleWatchMock).not.toHaveBeenCalled();
+    expect(pickerOf(container)).toBeNull();
+  });
+
+  test("a press while sharing is the stop, carrying nothing", async () => {
+    STATE.screenShare = { kind: "window", windowId: 9 };
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    expect(shareOf(container).getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(shareOf(container));
+
+    expect(setScreenShareMock.mock.calls).toEqual([[]]);
+    expect(pickerOf(container)).toBeNull();
+  });
+
+  test("closes when the share starts, and leaves Teach's picker alone", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    fireEvent.click(shareOf(container));
+    await rowOf(container);
+
+    pushState({ ...STATE, screenShare: { kind: "window", windowId: 9 } });
+    expect(pickerOf(container)).toBeNull();
+
+    fireEvent.click(teachOf(container));
+    await rowOf(container);
+    pushState({ ...STATE, screenShare: undefined });
+    expect(pickerOf(container)).not.toBeNull();
+    expect(pickerOf(container)?.getAttribute("aria-label")).toBe(
+      "What to teach from",
+    );
+  });
+
+  test("a Teach press replaces Share's question with its own", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    fireEvent.click(shareOf(container));
+    await rowOf(container);
+
+    fireEvent.click(teachOf(container));
+
+    await waitFor(() => {
+      expect(pickerOf(container)?.getAttribute("aria-label")).toBe(
+        "What to teach from",
+      );
+    });
+    expect(shareOf(container).getAttribute("aria-pressed")).toBe("false");
+    expect(teachOf(container).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  test("is absent when the call cannot be shown anything", async () => {
+    STATE.screenShareEnabled = false;
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    expect(container.querySelector('button[aria-label="Share"]')).toBeNull();
   });
 });

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -23,12 +23,14 @@ import {
   listCompanionCaptureSources,
   moveCompanionBy,
   setCompanionInteractive,
+  setCompanionScreenShare,
   showCompanionContextMenu,
   startCompanionVoice,
   subscribeCompanionState,
   toggleCompanionWatch,
 } from "@/runtime/companion-surface";
 import { sendVoiceActivityControl } from "@/runtime/desktop-voice-activity";
+import { useTranslation } from "@/i18n";
 import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 import type {
   CompanionCapturePick,
@@ -41,6 +43,7 @@ import type {
   CompanionWatchRetro,
   CompanionDictating,
   VoiceActivityState,
+  WatchCaptureTarget,
 } from "@vellumai/ipc-contract";
 
 /**
@@ -74,6 +77,7 @@ const DRAG_SLOP = 3;
  * That is what lets this window reload mid-call without the call noticing.
  */
 export function CompanionSurfacePage() {
+  const { t } = useTranslation();
   const [growth, setGrowth] = useState<CompanionGrowth>("right");
   // Which side of the avatar the canvas reserves the card's height on, and so
   // which canvas edge the avatar is anchored to. Main's call: it owns the
@@ -118,10 +122,22 @@ export function CompanionSurfacePage() {
   // read, which is that window's answer about its assistant's version. It
   // decides whether Teach asks first or starts at once.
   const [watchTargets, setWatchTargets] = useState(false);
+  // What the call is being shown, or undefined when nothing is. Main's, like
+  // the call: the press left this window as a pick, and this is what the
+  // window holding the session did with it.
+  const [screenShare, setScreenShare] = useState<
+    WatchCaptureTarget | undefined
+  >(undefined);
+  // Whether the call can be shown the screen at all, which is that window's
+  // answer about its session and its assistant's version.
+  const [shareEnabled, setShareEnabled] = useState(false);
   // The picker Teach opened, or null while none is open. This window's own,
   // unlike everything above it: the choice is made here and leaves here as a
   // pick, so a reload mid-choice costs only the card.
   const [picking, setPicking] = useState(false);
+  // Which control the open picker answers: Teach starts a session on the
+  // pick, Share shows the call it. Meaningless while `picking` is false.
+  const [pickingFor, setPickingFor] = useState<"teach" | "share">("teach");
   // What the host listed for it, or null while the host is still being asked.
   const [captureSources, setCaptureSources] =
     useState<CompanionCaptureSources | null>(null);
@@ -199,6 +215,9 @@ export function CompanionSurfacePage() {
       // from the user is a promise about what will be read, and a window that
       // has not said its assistant can keep it is one that cannot.
       setWatchTargets(state.watchTargets === true);
+      setScreenShare(state.screenShare);
+      // Off unless positively on, for the reason `watchTargets` is.
+      setShareEnabled(state.screenShareEnabled === true);
       setIntro(state.intro);
     };
     const unsubscribe = subscribeCompanionState(apply);
@@ -229,12 +248,29 @@ export function CompanionSurfacePage() {
    * bar that is gone would be asking a question nobody can act on.
    */
   const inCall = call !== null || dialing;
+  const sharing = screenShare !== undefined;
   useEffect(() => {
-    if (watching || !inCall) {
+    if (!inCall) {
       sourcesRequestRef.current += 1;
       setPicking(false);
     }
-  }, [watching, inCall]);
+  }, [inCall]);
+  // Each control's picker closes on its own answer: Teach's on a session
+  // starting, Share's on a share starting. Not the other's, since a share
+  // beginning while the user is choosing what to teach from is not an answer
+  // to that question.
+  useEffect(() => {
+    if (watching && pickingFor === "teach") {
+      sourcesRequestRef.current += 1;
+      setPicking(false);
+    }
+  }, [watching, pickingFor]);
+  useEffect(() => {
+    if (sharing && pickingFor === "share") {
+      sourcesRequestRef.current += 1;
+      setPicking(false);
+    }
+  }, [sharing, pickingFor]);
 
   /**
    * Teach, with no session running.
@@ -244,17 +280,16 @@ export function CompanionSurfacePage() {
    * cannot, or where the shell has no list to offer, the press starts the
    * whole-screen session it always started, so Teach never does nothing.
    */
-  const onTeach = () => {
-    if (!watchTargets) {
-      toggleCompanionWatch();
-      return;
-    }
-    if (picking) {
-      sourcesRequestRef.current += 1;
-      setPicking(false);
-      return;
-    }
+  /**
+   * Open the picker for `control`, asking the host what there is to pick,
+   * or hand the control its no-picker answer when the host has no list.
+   */
+  const openPicker = (
+    control: "teach" | "share",
+    withoutPicker: () => void,
+  ) => {
     setCaptureSources(null);
+    setPickingFor(control);
     setPicking(true);
     const request = ++sourcesRequestRef.current;
     void listCompanionCaptureSources().then((listed) => {
@@ -268,10 +303,41 @@ export function CompanionSurfacePage() {
         return;
       }
       // A shell that predates the picker. The question cannot be asked, so
-      // it is not left on screen; the session starts the old way instead.
+      // it is not left on screen.
       setPicking(false);
-      toggleCompanionWatch();
+      withoutPicker();
     });
+  };
+
+  const onTeach = () => {
+    if (!watchTargets) {
+      toggleCompanionWatch();
+      return;
+    }
+    // A second press closes it unanswered. A press while Share's picker is
+    // open replaces its question with this one.
+    if (picking && pickingFor === "teach") {
+      sourcesRequestRef.current += 1;
+      setPicking(false);
+      return;
+    }
+    // The session starts the old way instead, reading the whole screen.
+    openPicker("teach", toggleCompanionWatch);
+  };
+
+  /**
+   * Share, with nothing being shared: open the picker. A second press closes
+   * it unanswered. Unlike Teach there is no whole-screen fallback, since a
+   * share is of something in particular; a shell with no list has nothing to
+   * offer and the press does nothing.
+   */
+  const onShare = () => {
+    if (picking && pickingFor === "share") {
+      sourcesRequestRef.current += 1;
+      setPicking(false);
+      return;
+    }
+    openPicker("share", () => undefined);
   };
 
   // A row pressed under a still pointer removes the card and nothing moves,
@@ -288,6 +354,10 @@ export function CompanionSurfacePage() {
   const onPick = (pick: CompanionCapturePick) => {
     sourcesRequestRef.current += 1;
     setPicking(false);
+    if (pickingFor === "share") {
+      setCompanionScreenShare(pick);
+      return;
+    }
     toggleCompanionWatch(pick);
   };
 
@@ -661,7 +731,16 @@ export function CompanionSurfacePage() {
         // The way in, when there is a choice to make first. The stop stays on
         // `onWatch`; this is only ever the press with no session running.
         onTeach={onTeach}
-        picking={picking}
+        picking={picking && pickingFor === "teach"}
+        // The share, from main, and the two presses that move it. The stop
+        // leaves this window the way a pick does, carrying nothing.
+        sharing={sharing}
+        shareEnabled={shareEnabled}
+        sharePicking={picking && pickingFor === "share"}
+        onShare={onShare}
+        onStopShare={() => {
+          setCompanionScreenShare();
+        }}
         // Beside the bar while the choice is open, on the canvas main
         // reserves for a card. The pick leaves this window the way every
         // press does; the frame that answers it is main's.
@@ -673,6 +752,11 @@ export function CompanionSurfacePage() {
               avatarBox={avatarBox}
               optionsBox={optionsBox}
               cardRef={pickerRef}
+              label={
+                pickingFor === "share"
+                  ? t("companionSurface.sharePicker")
+                  : undefined
+              }
               onPick={onPick}
             />
           ) : null

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -479,6 +479,29 @@ export const InCallWhileWatching: Story = {
 };
 
 /**
+ * Mid-call with the screen shared: Share held down beside Teach, since the
+ * two are the same gesture aimed at different ends, and the call is being
+ * shown what a Teach session would be reading.
+ */
+export const InCallSharing: Story = {
+  args: { phase: "call", shareEnabled: true, sharing: true, call: DEMO_CALL },
+};
+
+/**
+ * Both held down at once, which is the widest row a call draws and what
+ * `FALLBACK_WIDTHS.call` stands in for before the row has been measured.
+ */
+export const InCallWatchingAndSharing: Story = {
+  args: {
+    phase: "call",
+    watching: true,
+    shareEnabled: true,
+    sharing: true,
+    call: DEMO_CALL,
+  },
+};
+
+/**
  * Teach pressed, and the question it asks first: what to read.
  *
  * The picker is a card over the bar rather than a row on it, on the height

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1899,3 +1899,98 @@ describe("the resting capsule's peek", () => {
     expect(peekOf(container)).toBeNull();
   });
 });
+
+describe("the companion surface's Share action", () => {
+  const shareOf = (container: HTMLElement): HTMLButtonElement => {
+    const found = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Share"]',
+    );
+    if (!found) {
+      throw new Error("Expected Share to render");
+    }
+    return found;
+  };
+  const labelsOf = (container: HTMLElement): (string | null)[] =>
+    [...container.querySelectorAll("button")].map((button) =>
+      button.getAttribute("aria-label"),
+    );
+
+  test("sits on the call row beside Teach", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        watchEnabled
+        shareEnabled
+        call={LISTENING_CALL}
+      />,
+    );
+    expect(labelsOf(container)).toEqual([
+      "Teach",
+      "Share",
+      "Mute microphone",
+      "Mute assistant",
+      "End session",
+    ]);
+  });
+
+  test("is absent, not disabled, when the call cannot be shown anything", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" watchEnabled call={LISTENING_CALL} />,
+    );
+    expect(labelsOf(container)).not.toContain("Share");
+  });
+
+  test("is not on the dial, where there is no session to show", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" watchEnabled shareEnabled />,
+    );
+    expect(labelsOf(container)).toEqual(["Teach", "End session"]);
+  });
+
+  test("keeps its stop for a share running after the answer turned negative", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" sharing call={LISTENING_CALL} />,
+    );
+    expect(shareOf(container).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  test("hands the way in to the page, and the stop to the session", () => {
+    const presses: string[] = [];
+    const surface = (sharing: boolean) => (
+      <CompanionSurface
+        phase="call"
+        call={LISTENING_CALL}
+        shareEnabled
+        sharing={sharing}
+        onShare={() => {
+          presses.push("share");
+        }}
+        onStopShare={() => {
+          presses.push("stop");
+        }}
+      />
+    );
+    const { container, rerender } = render(surface(false));
+    fireEvent.click(shareOf(container));
+    rerender(surface(true));
+    fireEvent.click(shareOf(container));
+    expect(presses).toEqual(["share", "stop"]);
+  });
+
+  test("is held down for the choice before the share, and spells its name", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        call={LISTENING_CALL}
+        shareEnabled
+        sharePicking
+      />,
+    );
+    expect(shareOf(container).getAttribute("aria-pressed")).toBe("true");
+    expect(
+      shareOf(container)
+        .querySelector("[data-label]")
+        ?.getAttribute("data-label"),
+    ).toBe("pinned");
+  });
+});

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -5,6 +5,7 @@ import {
   EyeOff,
   Mic,
   MicOff,
+  ScreenShare,
   ScrollText,
   Volume2,
   VolumeX,
@@ -342,9 +343,10 @@ export const FALLBACK_WIDTHS: Record<
   // has a stated width whatever is in it, so this is the state's actual width
   // rather than a guess at one.
   dictating: TRANSCRIPT_WIDTH + 32,
-  // The line and the four controls of the handlebar, with Teach held down and
-  // so spelling its name out, which is the widest a call draws.
-  call: 332,
+  // The line and the five controls of the handlebar, with Teach and Share
+  // both held down and so spelling their names out, which is the widest a
+  // call draws.
+  call: 372,
 };
 
 export interface CompanionSurfaceProps {
@@ -483,6 +485,36 @@ export interface CompanionSurfaceProps {
    * {@link CompanionSurfaceProps.picker}.
    */
   picking?: boolean;
+  /**
+   * Whether the call is being shown the screen, which draws Share held down
+   * for as long as it is. Its own prop for the reason `watching` is: it is
+   * the session's, and the control that ends it belongs to the share rather
+   * than to whatever the pill is drawing.
+   */
+  sharing?: boolean;
+  /**
+   * Whether Share is offered on the call row at all, which is whether the
+   * window holding the session says the session can be shown anything. Off
+   * unless positively on, the way {@link CompanionSurfaceProps.watchEnabled}
+   * is read, and for the same reason: the control starts capturing the
+   * user's screen.
+   */
+  shareEnabled?: boolean;
+  /**
+   * Whether the picker Share opens is on screen, which draws Share held down
+   * for as long as it is. The card itself arrives on
+   * {@link CompanionSurfaceProps.picker}, the same slot Teach's does.
+   */
+  sharePicking?: boolean;
+  /** The press of Share with nothing shared: open the picker. */
+  onShare?: () => void;
+  /**
+   * The press of Share while something is shared: the stop. Its own
+   * callback rather than a toggle, the split {@link CompanionSurfaceProps.onTeach}
+   * makes: the way in stays on the page that draws the choice, and the stop
+   * leaves for the window that owns the session.
+   */
+  onStopShare?: () => void;
   /**
    * Press the avatar. Idle, that starts a call; on a call, it goes back to
    * Vellum, on the conversation the call is in. The caller decides which,
@@ -629,6 +661,11 @@ export function CompanionSurface({
   onWatch,
   onTeach,
   picking = false,
+  sharing = false,
+  shareEnabled = false,
+  sharePicking = false,
+  onShare,
+  onStopShare,
   onAvatarClick,
   working = false,
   watching = false,
@@ -918,9 +955,14 @@ export function CompanionSurface({
                 watching={watching}
                 watchEnabled={watchEnabled}
                 picking={picking}
+                sharing={sharing}
+                shareEnabled={shareEnabled}
+                sharePicking={sharePicking}
                 onControl={onControl}
                 onWatch={onWatch}
                 onTeach={onTeach}
+                onShare={onShare}
+                onStopShare={onStopShare}
               />
             ) : phase === "dictating" && dictating !== undefined ? (
               <DictatingBody
@@ -1542,18 +1584,28 @@ function CallBody({
   watching,
   watchEnabled,
   picking,
+  sharing,
+  shareEnabled,
+  sharePicking,
   onControl,
   onWatch,
   onTeach,
+  onShare,
+  onStopShare,
 }: {
   call?: VoiceActivityState;
   assistantName: string;
   watching: boolean;
   watchEnabled: boolean;
   picking: boolean;
+  sharing: boolean;
+  shareEnabled: boolean;
+  sharePicking: boolean;
   onControl?: (action: VoiceActivityControlAction, requestId?: string) => void;
   onWatch?: () => void;
   onTeach?: () => void;
+  onShare?: () => void;
+  onStopShare?: () => void;
 }) {
   const { t } = useTranslation();
   // The dial: Talk has been pressed and no session has answered. The mutes
@@ -1626,6 +1678,16 @@ function CallBody({
         onWatch={onWatch}
         onTeach={onTeach}
       />
+      {/* Beside Teach, since the two are the same gesture aimed at different
+          ends: Teach has the screen read for a lesson, Share has it shown to
+          the call. Not on the dial, where there is no session to show. */}
+      <ShareButton
+        sharing={sharing}
+        shareEnabled={shareEnabled}
+        sharePicking={sharePicking}
+        onShare={onShare}
+        onStopShare={onStopShare}
+      />
       <PillButton
         icon={
           muted ? <MicOff className="size-4" /> : <Mic className="size-4" />
@@ -1660,6 +1722,48 @@ function CallBody({
       />
       <EndCallButton onControl={onControl} />
     </>
+  );
+}
+
+/**
+ * Show the call the screen, or stop, on the call row beside Teach.
+ *
+ * The same shape as {@link TeachButton}, edge for edge: absent entirely where
+ * the call cannot be shown anything rather than disabled, held down for the
+ * share and for the choice before it, and the stop is the press on the held
+ * control and never a question. A share already running when the answer
+ * turns negative keeps its stop, for the reason Teach's exit outlives its
+ * door.
+ *
+ * One name for both edges, the way Teach has one: the held-down state and
+ * `aria-pressed` say which press this is, and a control that renamed itself
+ * to "Stop" would be a caption where the row wants an affordance.
+ */
+function ShareButton({
+  sharing,
+  shareEnabled,
+  sharePicking,
+  onShare,
+  onStopShare,
+}: {
+  sharing: boolean;
+  shareEnabled: boolean;
+  sharePicking: boolean;
+  onShare?: () => void;
+  onStopShare?: () => void;
+}) {
+  const { t } = useTranslation();
+  if (!shareEnabled && !sharing) {
+    return null;
+  }
+  return (
+    <PillButton
+      icon={<ScreenShare className="size-4" />}
+      label={t("companionSurface.share")}
+      revealLabel
+      pressed={sharing || sharePicking}
+      onClick={sharing ? onStopShare : onShare}
+    />
   );
 }
 

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.test.tsx
@@ -630,3 +630,85 @@ test("mounts and publishes without throwing", () => {
 
   expect(published.length).toBeGreaterThan(0);
 });
+
+const { useLiveVoiceStore } =
+  await import("@/domains/chat/voice/live-voice/live-voice-store");
+const { seedLiveVoiceSession } =
+  await import("@/domains/chat/voice/live-voice/live-voice-fakes.test-helper");
+const { MIN_VERSION: SIGHT_MIN_VERSION } =
+  await import("@/lib/backwards-compat/use-supports-sight-stream");
+
+/**
+ * What the call is being shown, and whether it can be shown anything. Both
+ * ride the live-voice store, which moves on every amplitude sample, so the
+ * cases here are also about the mirror publishing only when one of the two
+ * actually changed.
+ */
+describe("the screen share the companion mirror publishes", () => {
+  afterEach(() => {
+    act(() => {
+      useLiveVoiceStore.getState().reset();
+    });
+  });
+
+  test("offers nothing with no call, and a share once a session runs on an assistant that takes the frame", async () => {
+    render(<Mirror />);
+    expect(latest().screenShareEnabled).toBe(false);
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("test-asst", SIGHT_MIN_VERSION, "asst-1");
+      seedLiveVoiceSession("listening", {
+        assistantId: "asst-1",
+        conversationId: null,
+      });
+    });
+    await waitFor(() => {
+      expect(latest().screenShareEnabled).toBe(true);
+    });
+    act(() => {
+      useLiveVoiceStore.getState().reset();
+    });
+    await waitFor(() => {
+      expect(latest().screenShareEnabled).toBe(false);
+    });
+  });
+
+  test("carries the target only while frames can flow", async () => {
+    render(<Mirror />);
+    act(() => {
+      seedLiveVoiceSession("listening", {
+        assistantId: "asst-1",
+        conversationId: null,
+      });
+      useLiveVoiceStore
+        .getState()
+        .setScreenShareTarget({ kind: "window", windowId: 7 });
+    });
+    // An assistant that predates the frame: the share is held in the store
+    // and never reaches the surface.
+    await Promise.resolve();
+    expect(latest().screenShare).toBeUndefined();
+    act(() => {
+      useAssistantIdentityStore
+        .getState()
+        .setIdentity("test-asst", SIGHT_MIN_VERSION, "asst-1");
+    });
+    await waitFor(() => {
+      expect(latest().screenShare).toEqual({ kind: "window", windowId: 7 });
+    });
+    const pushes = published.length;
+    // An amplitude sample moves the store and nothing the surface draws.
+    act(() => {
+      useLiveVoiceStore.getState().setInputAmplitude(0.4);
+    });
+    await Promise.resolve();
+    expect(published.length).toBe(pushes);
+    act(() => {
+      useLiveVoiceStore.getState().setScreenShareTarget(null);
+    });
+    await waitFor(() => {
+      expect(latest().screenShare).toBeUndefined();
+    });
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
+++ b/clients/web/src/domains/chat/hooks/use-companion-mirror.ts
@@ -30,6 +30,7 @@ import {
   setCompanionContext,
   setCompanionDictation,
 } from "@/runtime/companion-surface";
+import { supportsSightStream } from "@/lib/backwards-compat/use-supports-sight-stream";
 import { supportsWatchCaptureTarget } from "@/lib/backwards-compat/watch-capture-target";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -40,6 +41,10 @@ import {
   stopWatch,
   useWatchStore,
 } from "@/domains/chat/watch/watch-controller";
+import {
+  isLiveVoiceSessionActive,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { useWatchRetroStore } from "@/domains/chat/watch/watch-retro";
 import { COMPANION_DICTATION_TAIL } from "@vellumai/ipc-contract";
@@ -122,12 +127,43 @@ function currentContext(): CompanionContext {
     watchTargets: supportsWatchCaptureTarget(
       useResolvedAssistantsStore.getState().activeAssistantId,
     ),
+    // What the call is being shown, and whether it can be shown anything.
+    // Published from here for the reason `captureTarget` is: the session the
+    // frames land in lives in this window, and the surface draws the share as
+    // on only once that session is one that takes them.
+    screenShare: screenShareTarget(),
+    screenShareEnabled: screenShareEnabled(),
     // What a keyboard dictation has got to. Published from here for the reason
     // `watching` is: the recording runs in this window, and while it runs the
     // surface is the only thing on screen to say so.
     dictating: dictatingPhase(),
     dictationText: dictationTail(),
   };
+}
+
+/**
+ * Whether the running call can be shown the screen: a session is up, on an
+ * assistant that understands `sight_frame`, and has not latched the frame as
+ * unsupported. The same conjunction the share hook runs, read as a snapshot.
+ */
+function screenShareEnabled(): boolean {
+  const session = useLiveVoiceStore.getState();
+  return (
+    isLiveVoiceSessionActive(session.state) &&
+    !session.sightFramesUnsupported &&
+    supportsSightStream(session.assistantId)
+  );
+}
+
+/**
+ * What the call is being shown, or nothing. Withheld unless the share can
+ * flow, so the surface never draws a share of a session that takes no frames.
+ */
+function screenShareTarget(): CompanionContext["screenShare"] {
+  if (!screenShareEnabled()) {
+    return undefined;
+  }
+  return useLiveVoiceStore.getState().screenShareTarget ?? undefined;
 }
 
 /**
@@ -171,6 +207,13 @@ function dictationTail(): string {
   return interim.slice(-COMPANION_DICTATION_TAIL);
 }
 
+/** The share as the surface would draw it, as one comparable value. */
+function screenShareKey(): string {
+  const target = screenShareTarget();
+  const enabled = screenShareEnabled();
+  return `${enabled ? "on" : "off"}:${target === undefined ? "" : `${target.kind}:${target.kind === "display" ? target.displayId : target.windowId}`}`;
+}
+
 /** Whether two targets name the same display or window, absence included. */
 function sameTarget(
   a: CompanionContext["captureTarget"],
@@ -194,6 +237,8 @@ function sameContext(a: CompanionContext, b: CompanionContext): boolean {
     a.captureCount === b.captureCount &&
     sameTarget(a.captureTarget, b.captureTarget) &&
     a.watchTargets === b.watchTargets &&
+    sameTarget(a.screenShare, b.screenShare) &&
+    a.screenShareEnabled === b.screenShareEnabled &&
     a.dictating === b.dictating &&
     a.dictationText === b.dictationText
   );
@@ -268,6 +313,19 @@ export function useCompanionMirror(): void {
     // moves on the stop edge, on the runtime's announcement, and on the user
     // answering, and nothing else here reports any of those.
     const unsubscribeWatchRetro = useWatchRetroStore.subscribe(sync);
+    // The call the share belongs to. Gated on what the surface draws of it
+    // rather than on the store being written, since the store moves on every
+    // amplitude sample while a call runs.
+    let shareKey = screenShareKey();
+    const onShareMaybeFlipped = (): void => {
+      const next = screenShareKey();
+      if (next === shareKey) {
+        return;
+      }
+      shareKey = next;
+      sync();
+    };
+    const unsubscribeShare = useLiveVoiceStore.subscribe(onShareMaybeFlipped);
     // The microphone a held key opened. Nothing above reports it: the
     // recording is this window's, it starts and stops from the keyboard rather
     // than from anything the conversation knows about, and while it runs the
@@ -314,6 +372,7 @@ export function useCompanionMirror(): void {
       unsubscribeIdentity();
       unsubscribeWatch();
       unsubscribeWatchRetro();
+      unsubscribeShare();
       unsubscribeDictation();
       // Nothing is left to report a turn ending, so the last thing this does is
       // stop claiming one is running. The name is left standing: it is a record

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -1374,4 +1374,18 @@ describe("useLiveVoiceStore — a refused sight frame ends the share", () => {
     useLiveVoiceStore.getState().reset({ sessionContinues: true });
     expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
   });
+
+  /**
+   * The picker is not closed by the refusal, so its rows stay pressable. A
+   * pick taken then would sit unshown until a reconnect cleared the latch and
+   * started capture off a gesture made before the assistant refused.
+   */
+  test("takes no new target once the assistant has refused the frame", () => {
+    useLiveVoiceStore.getState().setState("listening");
+    useLiveVoiceStore.getState().noteSightFrameRefused(true);
+    setLiveVoiceScreenShare({ kind: "window", windowId: 9 });
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+    useLiveVoiceStore.getState().reset({ sessionContinues: true });
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+  });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -25,6 +25,7 @@ import {
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
+  isLiveVoiceUserSpeaking,
   LIVE_VOICE_STATE_KEYS,
   liveVoiceSurfaceLabelKey,
   minimizeVoiceRoom,
@@ -33,6 +34,7 @@ import {
   restoreVoiceRoom,
   sendLiveVoiceSightFrame,
   setLiveVoiceMuted,
+  setLiveVoiceScreenShare,
   stopLiveVoiceResponse,
   subscribeSettledLiveVoiceState,
   updateLiveVoiceSessionConfig,
@@ -1286,5 +1288,75 @@ describe("useLiveVoiceStore — playback-progress provider", () => {
 
     useLiveVoiceStore.getState().setPlaybackProgressProvider(() => null);
     expect(getLiveVoicePlaybackProgress()).toBeNull();
+  });
+});
+
+describe("useLiveVoiceStore — screen share", () => {
+  afterEach(() => {
+    useLiveVoiceStore.getState().reset();
+  });
+
+  test("drops a target with no session to show it to", () => {
+    setLiveVoiceScreenShare({ kind: "display", displayId: 1 });
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+  });
+
+  test("holds the target for a running session, and clears it on the stop", () => {
+    useLiveVoiceStore.getState().setState("listening");
+    setLiveVoiceScreenShare({ kind: "window", windowId: 7 });
+    expect(useLiveVoiceStore.getState().screenShareTarget).toEqual({
+      kind: "window",
+      windowId: 7,
+    });
+    setLiveVoiceScreenShare(null);
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+  });
+
+  test("survives a reconnect and not a new session", () => {
+    useLiveVoiceStore.getState().setState("listening");
+    setLiveVoiceScreenShare({ kind: "window", windowId: 7 });
+    useLiveVoiceStore.getState().reset({ sessionContinues: true });
+    expect(useLiveVoiceStore.getState().screenShareTarget).toEqual({
+      kind: "window",
+      windowId: 7,
+    });
+    useLiveVoiceStore.getState().reset();
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+  });
+});
+
+describe("isLiveVoiceUserSpeaking", () => {
+  test("is the VAD's utterance in hands-free", () => {
+    expect(
+      isLiveVoiceUserSpeaking({
+        state: "listening",
+        handsFree: true,
+        utteranceOpen: false,
+      }),
+    ).toBe(false);
+    expect(
+      isLiveVoiceUserSpeaking({
+        state: "thinking",
+        handsFree: true,
+        utteranceOpen: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("is the session listening in push-to-talk, which has no VAD", () => {
+    expect(
+      isLiveVoiceUserSpeaking({
+        state: "listening",
+        handsFree: false,
+        utteranceOpen: false,
+      }),
+    ).toBe(true);
+    expect(
+      isLiveVoiceUserSpeaking({
+        state: "thinking",
+        handsFree: false,
+        utteranceOpen: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -1360,3 +1360,18 @@ describe("isLiveVoiceUserSpeaking", () => {
     ).toBe(false);
   });
 });
+
+describe("useLiveVoiceStore — a refused sight frame ends the share", () => {
+  afterEach(() => {
+    useLiveVoiceStore.getState().reset();
+  });
+
+  test("clears the target with the latch, so a reconnect cannot resume it", () => {
+    useLiveVoiceStore.getState().setState("listening");
+    setLiveVoiceScreenShare({ kind: "window", windowId: 7 });
+    useLiveVoiceStore.getState().noteSightFrameRefused(true);
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+    useLiveVoiceStore.getState().reset({ sessionContinues: true });
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -1479,15 +1479,24 @@ export function attachLiveVoiceImage(
  *
  * Module-level for the reason {@link endLiveVoiceSession} is: the command
  * arrives from the companion surface through main, and the root layout that
- * consumes it holds no session. A target set with no session running is
- * dropped, since nothing could be shown it and the surface would draw a share
- * that never flows; the session's own reset clears it at the end.
+ * consumes it holds no session. A target is dropped unless a session is
+ * running that can actually be shown it, since nothing could be shown one
+ * otherwise and the surface would draw a share that never flows; the session's
+ * own reset clears it at the end.
+ *
+ * The latch is one of the terms, not just the session. A picker left open
+ * when the assistant refuses a frame is still pressable, and a target taken
+ * from it would sit in the store unshown until a reconnect cleared the latch
+ * and started capture off a gesture the user made before the refusal.
  */
 export function setLiveVoiceScreenShare(
   target: WatchCaptureTarget | null,
 ): void {
   const state = useLiveVoiceStore.getState();
-  if (target !== null && !isLiveVoiceSessionActive(state.state)) {
+  if (
+    target !== null &&
+    (!isLiveVoiceSessionActive(state.state) || state.sightFramesUnsupported)
+  ) {
     return;
   }
   state.setScreenShareTarget(target);

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -1123,6 +1123,11 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
         const assistantId = s.assistantId;
         return {
           sightFramesUnsupported: true,
+          // The share ends with the latch rather than merely pausing behind
+          // it. The latch resets on a reconnect, which can land on an
+          // upgraded assistant, and a target kept across that gap would
+          // resume a share the surface had already drawn as stopped.
+          screenShareTarget: null,
           outstandingSightFrames: [],
           prunedSightFrames: [],
           sightFramesToReclaim:

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -26,6 +26,7 @@ import { create } from "zustand";
 import type { LiveVoiceMetricsServerFrame } from "@/domains/chat/voice/live-voice/protocol";
 import type { LiveVoicePlaybackProgress } from "@/domains/chat/voice/live-voice/tts-playback";
 import { createSelectors } from "@/utils/create-selectors";
+import type { WatchCaptureTarget } from "@vellumai/ipc-contract";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -471,6 +472,15 @@ export interface LiveVoiceState {
    * Session-scoped, so `reset()` clears it with everything else.
    */
   utteranceOpen: boolean;
+  /**
+   * The display or window the user is sharing with the session, or null when
+   * nothing is shared. The ask behind the macOS companion's share control:
+   * `use-live-voice-screen-share.ts` takes frames of it for as long as it is
+   * set and the session can be shown anything, and lowers it when it cannot.
+   * Session-scoped, and kept across a reconnect: the user is still sharing
+   * while the transport comes back.
+   */
+  screenShareTarget: WatchCaptureTarget | null;
   /** In-flight partial transcript of the user's current utterance. */
   partialTranscript: string;
   /** Last finalized user transcript. */
@@ -656,6 +666,8 @@ export interface LiveVoiceActions {
   setConfigNotice: (notice: string | null) => void;
   /** Record whether the server VAD is holding an utterance open. */
   setUtteranceOpen: (utteranceOpen: boolean) => void;
+  /** Set or clear what the session is being shown. See `screenShareTarget`. */
+  setScreenShareTarget: (screenShareTarget: WatchCaptureTarget | null) => void;
   setPartialTranscript: (text: string) => void;
   setFinalTranscript: (text: string) => void;
   /** Append a delta to the accumulated assistant transcript. */
@@ -782,6 +794,28 @@ export function isLiveVoiceSessionActive(
 }
 
 /**
+ * Whether the user is part-way through saying something, as the session
+ * reports it.
+ *
+ * Two sessions, two signals, and no third opinion about either: hands-free
+ * runs on the server VAD, whose boundary the store publishes as
+ * `utteranceOpen`, and a manual session has no VAD at all, so the thing that
+ * opens the user's turn is the session reaching `listening`, which is where
+ * push-to-talk starts forwarding audio. Named for the user rather than the
+ * session, whose own `speaking` phase is the assistant's voice and the
+ * opposite of this. One answer to "is the user talking" for every surface
+ * that acts on the edge of a turn: the room's sight arms a keep on it, and the
+ * screen share takes a frame on each side of it.
+ */
+export function isLiveVoiceUserSpeaking(
+  session: Pick<LiveVoiceState, "state" | "handsFree" | "utteranceOpen">,
+): boolean {
+  return session.handsFree
+    ? session.utteranceOpen
+    : session.state === "listening";
+}
+
+/**
  * Whether the mic is live in `state` — capturing audio with amplitude flowing
  * into the store. True for the whole listening→speaking span: the capture
  * graph runs for the entire session so amplitude keeps flowing for barge-in
@@ -868,6 +902,7 @@ const INITIAL_SESSION_STATE: Omit<
   sightFrameRetractions: [],
   controls: null,
   utteranceOpen: false,
+  screenShareTarget: null,
   partialTranscript: "",
   finalTranscript: "",
   assistantTranscript: "",
@@ -1170,6 +1205,7 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
   setFirstRunCardOpen: (firstRunCardOpen) => set({ firstRunCardOpen }),
   setConfigNotice: (configNotice) => set({ configNotice }),
   setUtteranceOpen: (utteranceOpen) => set({ utteranceOpen }),
+  setScreenShareTarget: (screenShareTarget) => set({ screenShareTarget }),
   setPartialTranscript: (partialTranscript) => set({ partialTranscript }),
   setFinalTranscript: (finalTranscript) => set({ finalTranscript }),
   appendAssistantTranscript: (delta) =>
@@ -1199,6 +1235,10 @@ const useLiveVoiceStoreBase = create<LiveVoiceStore>()((set) => ({
       sessionGeneration: opts?.sessionContinues
         ? s.sessionGeneration
         : s.sessionGeneration + 1,
+      // A share survives a reconnect for the reason the generation does: the
+      // user is still sharing, and the transport coming back is not their
+      // business.
+      screenShareTarget: opts?.sessionContinues ? s.screenShareTarget : null,
       // `sightFramesToReclaim` is absent from INITIAL_SESSION_STATE on purpose
       // and so survives this: a queue a teardown could discard would strand
       // the uploads it exists to collect. It also GROWS here, because the
@@ -1429,6 +1469,25 @@ export function attachLiveVoiceImage(
  * session. Module-level for the same stable-identity reasons as
  * {@link endLiveVoiceSession}.
  */
+/**
+ * Share `target` with the running session, or stop sharing with `null`.
+ *
+ * Module-level for the reason {@link endLiveVoiceSession} is: the command
+ * arrives from the companion surface through main, and the root layout that
+ * consumes it holds no session. A target set with no session running is
+ * dropped, since nothing could be shown it and the surface would draw a share
+ * that never flows; the session's own reset clears it at the end.
+ */
+export function setLiveVoiceScreenShare(
+  target: WatchCaptureTarget | null,
+): void {
+  const state = useLiveVoiceStore.getState();
+  if (target !== null && !isLiveVoiceSessionActive(state.state)) {
+    return;
+  }
+  state.setScreenShareTarget(target);
+}
+
 export function sendLiveVoiceSightFrame(
   attachmentId: string,
   sessionGeneration: number,

--- a/clients/web/src/domains/chat/voice/live-voice/sight-capture.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/sight-capture.ts
@@ -1,0 +1,316 @@
+/**
+ * The shared tail of every sight source: a frame the gate kept becomes an
+ * upload, the upload becomes a `sight_frame` the daemon persists as its own
+ * user message, and nothing lands out of order, after consent was withdrawn,
+ * or on a session other than the one the frame was taken for.
+ *
+ * Two sources feed it. The voice room samples the viewfinder it has on
+ * screen, and the session's own camera (`use-live-voice-camera.ts`) samples a
+ * stream no viewfinder shows. Where the JPEG comes from differs; everything
+ * past it is the same, which is what this module is, so a guard tightened for
+ * one source is tightened for both.
+ *
+ * ## Order
+ *
+ * Sends leave in the order the gate KEPT the frames, not the order their
+ * uploads happened to finish. Uploads of overlapping keeps can finish in
+ * either order, and the transcript is the record of what the call saw: the
+ * model correlates a frame with speech by adjacency, so a scene persisted
+ * after a newer one is read as the view the words that follow were about, and
+ * there may be no later keep to correct it before the camera closes.
+ *
+ * Each capture takes a number when the gate fires, a finished capture waits
+ * until the run of numbers before it is complete, and every exit path settles
+ * its number, so a capture that fails, is refused, or is abandoned releases
+ * the ones behind it instead of stranding them. Past
+ * {@link MAX_PARKED_SIGHT_SENDS} the missing capture is written off and the
+ * backlog goes through, so a hung upload costs the frames it overlapped rather
+ * than the rest of the call.
+ *
+ * ## Consent
+ *
+ * A capture is refused before it is taken unless a sampling run has granted
+ * consent, and every capture is stamped with an epoch on the way in and checked
+ * against it on the way out. Revoking consent bumps the epoch in the same tick
+ * as the act that takes it back, which is the whole point: a source's own
+ * teardown is a render away, and a frame whose upload lands in that gap would
+ * otherwise be shared after the user said stop. The epoch is also bumped for
+ * every other way the world a capture was headed for can go (a flipped camera,
+ * a transport dropping into a reconnect) by {@link SightCapture.invalidate}.
+ *
+ * The session generation covers none of those: each leaves the logical call
+ * running, and a stalled upload from before any of them could otherwise be
+ * persisted as a view of what the call is looking at now.
+ */
+
+import {
+  deleteChatAttachment,
+  uploadChatAttachment,
+} from "@/domains/chat/api/messages";
+import { prepareImageAttachmentForUpload } from "@/domains/chat/components/chat-attachments/attachment-image-resize";
+import { recordFrameGateKeep } from "@/lib/camera/frame-gate-debug";
+import { captureError } from "@/lib/sentry/capture-error";
+
+import { sendLiveVoiceSightFrame, useLiveVoiceStore } from "./live-voice-store";
+
+/**
+ * How many finished captures may wait on an unfinished older one.
+ *
+ * Overlap is naturally shallow: the gate's rate floor is seconds and an upload
+ * is not, so at most one or two captures are usually in flight. The cap is for
+ * the pathological case, an upload that hangs rather than fails, which would
+ * otherwise hold every later keep behind it for the rest of the call.
+ */
+const MAX_PARKED_SIGHT_SENDS = 4;
+
+/** A finished capture waiting for its turn in capture order. */
+interface PendingSightSend {
+  /** Send it, if the session and the camera it came from are still current. */
+  readonly send: () => void;
+  /** Give the upload back: this frame will never be sent. */
+  readonly discard: () => void;
+}
+
+/** A frame the call was given. */
+export interface SightSharedFrame {
+  /** Id from the upload, which is what `sight_frame` named. */
+  readonly attachmentId: string;
+  /** The JPEG that was uploaded, for a source that shows what it shared. */
+  readonly frame: File;
+}
+
+export interface SightCaptureRequest {
+  /** The assistant the frame is uploaded against, which is the session's. */
+  readonly assistantId: string;
+  /**
+   * The JPEG: the browser path encodes the `<video>` it is watching, the
+   * native path wraps the sample the gate has already judged. Null is a frame
+   * that could not be produced, which settles its place in the order and
+   * sends nothing.
+   */
+  readonly produceFrame: (filename: string) => Promise<File | null>;
+  /**
+   * A frame the call has been given: sent, and only then. Called nowhere else,
+   * so a source that shows the last shared frame shows only frames that were.
+   */
+  readonly onShared: (shared: SightSharedFrame) => void;
+}
+
+export interface SightCapture {
+  /**
+   * Take one kept frame all the way to the transcript. Never rejects: a
+   * failure costs one frame and is filed, since nobody asked for it.
+   */
+  capture(request: SightCaptureRequest): Promise<void>;
+  /** Raise consent, where a sampling run starts. */
+  grantConsent(): void;
+  /**
+   * Withdraw consent from every frame captured but not yet shared, now.
+   * Idempotent, and free when no run has granted it: an epoch churned for a
+   * stop of something already stopped would void a capture nobody withdrew.
+   */
+  revokeConsent(): void;
+  /**
+   * Start the order again from whatever has not been captured yet.
+   *
+   * For the boundaries where waiting on an older capture stops making sense:
+   * a new session, a flipped camera, a closed viewfinder. Anything parked is
+   * given back rather than sent, since it would fail the guards at send time
+   * anyway, and anything still in flight settles below the new turn and is
+   * discarded when it lands.
+   */
+  rebaseSendOrder(): void;
+  /**
+   * Void every capture aimed at the world that just changed, consented or not,
+   * and start the order again. For the changes that leave consent standing
+   * and the frames in flight stale: a flipped camera, a transport reconnect.
+   */
+  invalidate(): void;
+}
+
+/**
+ * Create one capture chain. `errorContext` is where a failure is filed, so the
+ * tag says which source it came from.
+ */
+export function createSightCapture(errorContext: string): SightCapture {
+  let frameCount = 0;
+  let captureSeq = 0;
+  let nextSendSeq = 0;
+  const parked = new Map<number, PendingSightSend | null>();
+  let epoch = 0;
+  let consented = false;
+
+  /**
+   * Give an uploaded row back.
+   *
+   * Nothing else can: an attachment is collected when the message linking it
+   * is deleted, or by the daemon reclaiming a frame it could not persist, and
+   * an id that reaches neither is a row and its bytes kept for good.
+   *
+   * Called for the ids this module refuses itself, before the frame is sent.
+   * NOT called for a frame an assistant that understands it could not
+   * persist: that path reclaims on its own, so deleting would race it over a
+   * row this module no longer owns.
+   */
+  function reclaimUpload(assistantId: string, attachmentId: string): void {
+    void deleteChatAttachment(assistantId, attachmentId).then((ok) => {
+      if (!ok) {
+        captureError(new Error("sight frame delete refused"), {
+          context: errorContext,
+          bestEffort: true,
+        });
+      }
+    });
+  }
+
+  /**
+   * Send everything whose turn has come, oldest first, stopping at the first
+   * number nobody has settled yet.
+   */
+  function drainSends(): void {
+    for (;;) {
+      while (parked.has(nextSendSeq)) {
+        const pending = parked.get(nextSendSeq) ?? null;
+        parked.delete(nextSendSeq);
+        nextSendSeq += 1;
+        pending?.send();
+      }
+      if (parked.size <= MAX_PARKED_SIGHT_SENDS) {
+        return;
+      }
+      nextSendSeq = Math.min(...parked.keys());
+    }
+  }
+
+  /**
+   * Report what became of one capture, whether or not it produced a frame.
+   * Called on every exit path, which is what keeps the order live.
+   */
+  function settleCapture(seq: number, pending: PendingSightSend | null): void {
+    if (seq < nextSendSeq) {
+      // The order has moved past this number: the cap wrote it off, or a
+      // boundary re-based it. Sending now would put an older view after a
+      // newer one, which is the whole thing being prevented.
+      pending?.discard();
+      return;
+    }
+    parked.set(seq, pending);
+    drainSends();
+  }
+
+  function rebaseSendOrder(): void {
+    for (const pending of parked.values()) {
+      pending?.discard();
+    }
+    parked.clear();
+    nextSendSeq = captureSeq;
+  }
+
+  async function capture({
+    assistantId,
+    produceFrame,
+    onShared,
+  }: SightCaptureRequest): Promise<void> {
+    // Consent is already gone, and the loop has not been torn down yet. The
+    // epoch cannot speak for this one: a capture beginning after the bump
+    // reads the new number and would pass the guard on the way out, so a
+    // frame taken after the user said stop is refused before it is taken.
+    if (!consented) {
+      return;
+    }
+    // Nothing this assistant is told about lands, and each attempt would
+    // strand another upload, so the sampler runs on and every keep is
+    // dropped here. See `sightFramesUnsupported` on the live-voice store.
+    if (useLiveVoiceStore.getState().sightFramesUnsupported) {
+      return;
+    }
+    // Read before the encode, not after the upload. Everything below can
+    // outlive the session and the camera the frame was taken from, and
+    // neither can be re-read afterwards without describing the wrong one.
+    const sessionGeneration = useLiveVoiceStore.getState().sessionGeneration;
+    const captureEpoch = epoch;
+    // Taken here, at the moment the gate kept the frame, because that is the
+    // order the scenes happened in and the order the transcript has to carry
+    // them in.
+    const seq = captureSeq;
+    captureSeq += 1;
+    let pending: PendingSightSend | null = null;
+    try {
+      frameCount += 1;
+      const frame = await produceFrame(`sight-${frameCount}.jpg`);
+      if (!frame) {
+        return;
+      }
+      recordFrameGateKeep("voice", frame);
+
+      // The same preparation a pasted image gets, for the same reason the
+      // shutter does it: a high-resolution track behaves like every other
+      // attachment rather than like a special case.
+      const prepared = await prepareImageAttachmentForUpload(frame);
+      const file = prepared.status === "failed" ? frame : prepared.file;
+
+      const uploaded = await uploadChatAttachment(assistantId, file);
+      if (!uploaded.ok) {
+        return;
+      }
+      const abandonUpload = (): void => reclaimUpload(assistantId, uploaded.id);
+      // The guards run when the turn comes, not now, so a frame that waited
+      // is still checked against the session and camera of the moment it
+      // would land in.
+      pending = {
+        discard: abandonUpload,
+        send: () => {
+          if (
+            useLiveVoiceStore.getState().sessionGeneration !== sessionGeneration
+          ) {
+            abandonUpload();
+            return;
+          }
+          // The camera this came from is closed or pointing elsewhere, so
+          // this is a view of nothing the user is looking at now, and
+          // persisting it would put that view in the transcript as the
+          // current one.
+          if (captureEpoch !== epoch) {
+            abandonUpload();
+            return;
+          }
+          // Sent before it is shown, and shown only if it was sent. During a
+          // reconnect gap it has not been, and a frame that never left is this
+          // module's to give back, since the daemon never saw it.
+          if (!sendLiveVoiceSightFrame(uploaded.id, sessionGeneration)) {
+            abandonUpload();
+            return;
+          }
+          onShared({ attachmentId: uploaded.id, frame });
+        },
+      };
+    } catch (cause) {
+      // Best effort by design: nobody asked for this frame, so a failure
+      // costs one frame and says nothing to the user.
+      captureError(cause, { context: errorContext, bestEffort: true });
+    } finally {
+      // Every path, including the ones that produced nothing: a capture that
+      // never sends must still release the captures behind it.
+      settleCapture(seq, pending);
+    }
+  }
+
+  return {
+    capture,
+    grantConsent() {
+      consented = true;
+    },
+    revokeConsent() {
+      if (!consented) {
+        return;
+      }
+      consented = false;
+      epoch += 1;
+    },
+    rebaseSendOrder,
+    invalidate() {
+      epoch += 1;
+      rebaseSendOrder();
+    },
+  };
+}

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * The session's view of the shared screen: when a frame is taken, what it
+ * becomes, and what stops the share.
+ *
+ * The helper, the resize and the upload are replaced (happy-dom has no helper
+ * and no daemon, and each is covered by its own suite), so what is under test
+ * is the cadence and the lifecycle: which store changes ask for a frame, which
+ * frames reach the session, and every way the share is lowered.
+ *
+ * The store side is real, as in the room's sight suite: the ask is exercised
+ * through the actual store, and a frame goes through the actual
+ * `sendLiveVoiceSightFrame`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import type { UploadAttachmentResult } from "@/domains/chat/api/messages";
+import type {
+  ScreenCaptureFrame,
+  WatchCaptureTarget,
+} from "@vellumai/ipc-contract";
+
+/** What the helper answers, swapped per case for the refusal path. */
+let answerFrame: () => Promise<ScreenCaptureFrame | null> = async () => ({
+  jpegBase64: btoa("jpeg"),
+  width: 16,
+  height: 9,
+});
+const captureCompanionScreen = mock((_target: WatchCaptureTarget) =>
+  answerFrame(),
+);
+mock.module("@/runtime/companion-surface", () => ({
+  captureCompanionScreen,
+}));
+
+mock.module(
+  "@/domains/chat/components/chat-attachments/attachment-image-resize",
+  () => ({
+    prepareImageAttachmentForUpload: async (file: File) => ({
+      status: "unchanged" as const,
+      file,
+    }),
+  }),
+);
+
+let autoUploadId = 0;
+const uploadChatAttachment = mock(
+  (_assistantId: string, _file: File): Promise<UploadAttachmentResult> => {
+    autoUploadId += 1;
+    return Promise.resolve({ ok: true, id: `att-${autoUploadId}` });
+  },
+);
+const deleteChatAttachment = mock(
+  async (_assistantId: string, _attachmentId: string) => true,
+);
+mock.module("@/domains/chat/api/messages", () => ({
+  uploadChatAttachment,
+  deleteChatAttachment,
+}));
+
+const { useLiveVoiceScreenShare, SCREEN_SHARE_MIN_FRAME_GAP_MS } =
+  await import("./use-live-voice-screen-share");
+const { useLiveVoiceStore } = await import("./live-voice-store");
+const { makeControlsSpies, seedLiveVoiceSession } =
+  await import("./live-voice-fakes.test-helper");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
+
+const ASSISTANT_ID = "asst_share";
+/** A dev build off `main` published after the `sight_frame` handler merged. */
+const SUPPORTING_VERSION = "0.11.7-dev.202609010300.b432fb7";
+const WINDOW: WatchCaptureTarget = { kind: "window", windowId: 7 };
+
+let controls = makeControlsSpies();
+let warn: ReturnType<typeof spyOn> | null = null;
+/** The clock the frame floor is measured on, advanced by hand. */
+let now = 0;
+let clock: ReturnType<typeof spyOn> | null = null;
+
+/** Let a capture, its upload and the send behind them settle. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function share(target: WatchCaptureTarget | null): void {
+  act(() => {
+    useLiveVoiceStore.getState().setScreenShareTarget(target);
+  });
+}
+
+/** Open or close the user's turn, the way the server VAD does hands-free. */
+function speak(open: boolean): void {
+  now += SCREEN_SHARE_MIN_FRAME_GAP_MS + 1;
+  act(() => {
+    useLiveVoiceStore.getState().setUtteranceOpen(open);
+  });
+}
+
+function renderShare() {
+  return renderHook(() => useLiveVoiceScreenShare());
+}
+
+beforeEach(() => {
+  captureCompanionScreen.mockClear();
+  uploadChatAttachment.mockClear();
+  deleteChatAttachment.mockClear();
+  answerFrame = async () => ({
+    jpegBase64: btoa("jpeg"),
+    width: 16,
+    height: 9,
+  });
+  autoUploadId = 0;
+  now = 0;
+  clock = spyOn(performance, "now").mockImplementation(() => now);
+  warn = spyOn(console, "warn").mockImplementation(() => {});
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore
+    .getState()
+    .takeDueSightFrameReclaims(Number.MAX_SAFE_INTEGER);
+  controls = makeControlsSpies();
+  seedLiveVoiceSession("listening", {
+    assistantId: ASSISTANT_ID,
+    conversationId: "conv_share",
+    controls,
+  });
+  useLiveVoiceStore.getState().setHandsFree(true);
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("assistant", SUPPORTING_VERSION, ASSISTANT_ID);
+});
+
+afterEach(() => {
+  cleanup();
+  clock?.mockRestore();
+  warn?.mockRestore();
+  useAssistantIdentityStore.getState().clearIdentity();
+});
+
+describe("useLiveVoiceScreenShare: starting", () => {
+  test("takes no frame until something is shared", async () => {
+    renderShare();
+    await flush();
+    expect(captureCompanionScreen).not.toHaveBeenCalled();
+  });
+
+  test("takes a frame of the target at once, uploads it against the session's assistant, and sends it", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+
+    expect(captureCompanionScreen).toHaveBeenCalledWith(WINDOW);
+    expect(uploadChatAttachment).toHaveBeenCalledTimes(1);
+    expect(uploadChatAttachment.mock.calls[0]?.[0]).toBe(ASSISTANT_ID);
+    const file = uploadChatAttachment.mock.calls[0]?.[1];
+    expect(file?.type).toBe("image/jpeg");
+    expect(await file?.text()).toBe("jpeg");
+    expect(controls.sightFrame).toHaveBeenCalledWith("att-1");
+  });
+
+  test("takes nothing for an assistant that predates the frame", async () => {
+    useAssistantIdentityStore
+      .getState()
+      .setIdentity("assistant", "0.11.6", ASSISTANT_ID);
+    renderShare();
+    share(WINDOW);
+    await flush();
+    expect(captureCompanionScreen).not.toHaveBeenCalled();
+  });
+
+  test("takes nothing with no session for the frames to land in", async () => {
+    useLiveVoiceStore.getState().setState("idle");
+    renderShare();
+    share(WINDOW);
+    await flush();
+    expect(captureCompanionScreen).not.toHaveBeenCalled();
+  });
+
+  test("a new target is a new share, framed at once", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+    share({ kind: "display", displayId: 2 });
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(2);
+    expect(captureCompanionScreen.mock.calls[1]?.[0]).toEqual({
+      kind: "display",
+      displayId: 2,
+    });
+  });
+});
+
+describe("useLiveVoiceScreenShare: cadence", () => {
+  test("takes a frame as the user starts talking and another as they stop", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(1);
+
+    speak(true);
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(2);
+
+    speak(false);
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(3);
+    expect(controls.sightFrame.mock.calls.map(([id]) => id)).toEqual([
+      "att-1",
+      "att-2",
+      "att-3",
+    ]);
+  });
+
+  test("takes no second frame inside the floor", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+    act(() => {
+      useLiveVoiceStore.getState().setUtteranceOpen(true);
+    });
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(1);
+  });
+
+  test("takes nothing on an edge the store merely rewrote", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+    now += SCREEN_SHARE_MIN_FRAME_GAP_MS + 1;
+    act(() => {
+      useLiveVoiceStore.getState().setInputAmplitude(0.3);
+    });
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(1);
+  });
+
+  test("takes nothing for an edge on a muted microphone", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+    act(() => {
+      useLiveVoiceStore.getState().setMuted(true);
+    });
+    speak(true);
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(1);
+  });
+
+  test("reads the turn off the session state in push-to-talk", async () => {
+    useLiveVoiceStore.getState().setHandsFree(false);
+    useLiveVoiceStore.getState().setState("thinking");
+    renderShare();
+    share(WINDOW);
+    await flush();
+    now += SCREEN_SHARE_MIN_FRAME_GAP_MS + 1;
+    act(() => {
+      useLiveVoiceStore.getState().setState("listening");
+    });
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useLiveVoiceScreenShare: stopping", () => {
+  test("a frame the helper could not take lowers the share", async () => {
+    answerFrame = async () => null;
+    renderShare();
+    share(WINDOW);
+    await flush();
+
+    expect(uploadChatAttachment).not.toHaveBeenCalled();
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("a frame in flight when the share stops is refused, and its upload given back", async () => {
+    renderShare();
+    share(WINDOW);
+    // The stop lands while the frame is still on its way up.
+    share(null);
+    await flush();
+
+    expect(controls.sightFrame).not.toHaveBeenCalled();
+    expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-1");
+  });
+
+  test("takes nothing more once the share is off", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+    share(null);
+    speak(true);
+    await flush();
+    expect(captureCompanionScreen).toHaveBeenCalledTimes(1);
+  });
+
+  test("the session ending takes the share with it", async () => {
+    renderShare();
+    share(WINDOW);
+    await flush();
+    act(() => {
+      useLiveVoiceStore.getState().reset();
+    });
+    expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.test.tsx
@@ -314,3 +314,44 @@ describe("useLiveVoiceScreenShare: stopping", () => {
     expect(useLiveVoiceStore.getState().screenShareTarget).toBeNull();
   });
 });
+
+describe("useLiveVoiceScreenShare: the boundary a frame in flight can cross", () => {
+  /**
+   * A reconnect keeps the share and the session generation on purpose, and
+   * `connecting` still reads as a live session, so nothing tears this run
+   * down. What must not survive is a frame of the view from before the drop.
+   */
+  test("a frame captured before a reconnect is refused, and the share goes on", async () => {
+    let releaseFrame!: (frame: ScreenCaptureFrame) => void;
+    answerFrame = () =>
+      new Promise<ScreenCaptureFrame>((resolve) => {
+        releaseFrame = resolve;
+      });
+    renderShare();
+    share(WINDOW);
+    await Promise.resolve();
+
+    act(() => {
+      useLiveVoiceStore.getState().setReconnecting(true);
+    });
+    releaseFrame({ jpegBase64: btoa("jpeg"), width: 16, height: 9 });
+    await flush();
+
+    expect(controls.sightFrame).not.toHaveBeenCalled();
+    expect(deleteChatAttachment).toHaveBeenCalledWith(ASSISTANT_ID, "att-1");
+    // The share itself is untouched: the socket came back, and the next thing
+    // the user says is framed as usual.
+    expect(useLiveVoiceStore.getState().screenShareTarget).toEqual(WINDOW);
+    answerFrame = async () => ({
+      jpegBase64: btoa("jpeg"),
+      width: 16,
+      height: 9,
+    });
+    act(() => {
+      useLiveVoiceStore.getState().setReconnecting(false);
+    });
+    speak(true);
+    await flush();
+    expect(controls.sightFrame).toHaveBeenCalledWith("att-2");
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.ts
@@ -1,0 +1,171 @@
+/**
+ * The session's view of the user's screen: frames of the display or window
+ * they are sharing with the call, taken by the host's helper and handed to the
+ * session as `sight_frame`, for as long as the share is on and the session can
+ * be shown anything.
+ *
+ * What the companion's share control on macOS drives. That surface is a
+ * separate window that draws the call and holds none of it, and the voice room
+ * is not open during a companion call, so there is no viewfinder and nothing
+ * on screen to sample. There is also no stream: the helper takes one JPEG of
+ * the target when asked (`captureCompanionScreen`), and every frame goes
+ * through `sight-capture.ts`, which the room's Live shares, to be uploaded and
+ * sent. The daemon persists each as its own user message, so the transcript is
+ * the record of what the call was shown.
+ *
+ * ## Cadence
+ *
+ * A frame when the share starts, and one at each edge of the user's turn: as
+ * they start talking and as they stop. The start is the one the turn will
+ * read, since the daemon snapshots the conversation the instant the utterance
+ * closes (see `use-voice-room-sight.ts`); the end lands on the turn after, as
+ * the view the user left behind. Nothing in between and nothing while nobody
+ * is talking. A screen changes by whole views rather than by motion, so the
+ * gate the camera runs is not consulted; this is the plain cadence, and the
+ * floor below is only there so a cough is not two frames.
+ *
+ * ## What the control reads
+ *
+ * `screenShareTarget` is the ask, and it is also what the companion mirror
+ * publishes as the share being on, so it stays set only while frames can
+ * flow. A target the helper cannot take a frame of (the window closed, the
+ * display unplugged, Screen Recording not granted) lowers the ask, so the
+ * control reads as off rather than as a share nothing is showing, and a later
+ * press asks afresh.
+ *
+ * ## Consent
+ *
+ * Only a press on the control starts a share, and main frames what is shared
+ * for as long as it is. The share stops on a second press, when the session
+ * ends (the target is session state), when the assistant refuses the frame,
+ * when a frame cannot be taken, and when this hook unmounts, which is the chat
+ * layout going away. Each frame lands in the transcript, where the user can
+ * see it and delete it.
+ */
+
+import { useEffect, useState } from "react";
+
+import {
+  isLiveVoiceSessionActive,
+  isLiveVoiceUserSpeaking,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
+import { createSightCapture } from "@/domains/chat/voice/live-voice/sight-capture";
+import { useSupportsSightStream } from "@/lib/backwards-compat/use-supports-sight-stream";
+import { captureCompanionScreen } from "@/runtime/companion-surface";
+import type { WatchCaptureTarget } from "@vellumai/ipc-contract";
+
+/** Where a failure is filed, so the tag says which source it came from. */
+const ERROR_CONTEXT = "live-voice screen share: capture/upload frame";
+
+/**
+ * The least time between two frames. The two edges of a very short utterance
+ * (a "yes", a cough the VAD opened on) would otherwise be two frames of the
+ * same view a beat apart.
+ */
+export const SCREEN_SHARE_MIN_FRAME_GAP_MS = 1500;
+
+/** The helper's JPEG as the file the upload path takes, or null for no frame. */
+async function produceSharedFrame(
+  target: WatchCaptureTarget,
+  filename: string,
+): Promise<File | null> {
+  const frame = await captureCompanionScreen(target);
+  if (frame === null) {
+    return null;
+  }
+  const bytes = Uint8Array.from(atob(frame.jpegBase64), (char) =>
+    char.charCodeAt(0),
+  );
+  return new File([bytes], filename, { type: "image/jpeg" });
+}
+
+export function useLiveVoiceScreenShare(): void {
+  const target = useLiveVoiceStore.use.screenShareTarget();
+  const state = useLiveVoiceStore.use.state();
+  const assistantId = useLiveVoiceStore.use.assistantId();
+  const sightFramesUnsupported = useLiveVoiceStore.use.sightFramesUnsupported();
+  const supportsFrames = useSupportsSightStream(assistantId);
+  // Every term, so the share is absent rather than half-present: the ask, a
+  // session for the frames to land in, an assistant that understands the
+  // frame, and a session that has not latched the frame as unsupported.
+  const active =
+    target !== null &&
+    isLiveVoiceSessionActive(state) &&
+    supportsFrames &&
+    assistantId !== null &&
+    !sightFramesUnsupported;
+
+  // One for the mount: the assistant is handed to each capture by the run
+  // that took the frame, and each run re-bases the order on its way out.
+  const [sight] = useState(() => createSightCapture(ERROR_CONTEXT));
+
+  useEffect(() => {
+    // `active` already has both in it; the second and third tests are for the
+    // narrowing.
+    if (!active || target === null || assistantId === null) {
+      return;
+    }
+    let cancelled = false;
+    let lastFrameAt = Number.NEGATIVE_INFINITY;
+    sight.grantConsent();
+
+    const share = (): void => {
+      const now = performance.now();
+      if (now - lastFrameAt < SCREEN_SHARE_MIN_FRAME_GAP_MS) {
+        return;
+      }
+      lastFrameAt = now;
+      let missed = false;
+      void sight
+        .capture({
+          assistantId,
+          produceFrame: async (filename) => {
+            const frame = await produceSharedFrame(target, filename);
+            missed = frame === null;
+            return frame;
+          },
+          // Nothing to show: there is no viewfinder to put a pulse on. The
+          // transcript is where a frame is seen.
+          onShared: () => undefined,
+        })
+        .then(() => {
+          if (cancelled || !missed) {
+            return;
+          }
+          // Not filed: a window that closed or a permission not granted is
+          // the desktop's answer, not a fault. Lowering the ask is what tells
+          // the control, and this effect's own cleanup ends the run.
+          console.warn(
+            "[live-voice screen share] no frame of the shared target; stopping the share",
+          );
+          useLiveVoiceStore.getState().setScreenShareTarget(null);
+        });
+    };
+
+    share();
+    let speaking = isLiveVoiceUserSpeaking(useLiveVoiceStore.getState());
+    const unsubscribe = useLiveVoiceStore.subscribe((session) => {
+      const next = isLiveVoiceUserSpeaking(session);
+      if (next === speaking) {
+        return;
+      }
+      speaking = next;
+      // A muted mic is a session hearing silence, so nothing is being asked
+      // and a frame taken for it would answer nobody.
+      if (session.muted) {
+        return;
+      }
+      share();
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      // The revocation is the bump that voids every capture in flight; the
+      // re-base gives back what was parked behind them.
+      sight.revokeConsent();
+      sight.rebaseSendOrder();
+    };
+  }, [active, assistantId, sight, target]);
+}

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-screen-share.ts
@@ -41,6 +41,13 @@
  * when a frame cannot be taken, and when this hook unmounts, which is the chat
  * layout going away. Each frame lands in the transcript, where the user can
  * see it and delete it.
+ *
+ * The stop is taken synchronously, inside the store write that ends the share,
+ * rather than in this hook's cleanup a render later: a frame uploading in that
+ * gap would otherwise be sent after the user pressed stop. A transport
+ * reconnect keeps the share and voids what was in flight across it, so a view
+ * from before the drop cannot land in the resumed transcript as the current
+ * one.
  */
 
 import { useEffect, useState } from "react";
@@ -145,7 +152,31 @@ export function useLiveVoiceScreenShare(): void {
 
     share();
     let speaking = isLiveVoiceUserSpeaking(useLiveVoiceStore.getState());
+    let reconnecting = useLiveVoiceStore.getState().reconnecting;
     const unsubscribe = useLiveVoiceStore.subscribe((session) => {
+      // **The stop is honoured here, not in the cleanup below.** A store
+      // subscriber runs inside the `set` that ends the share; the cleanup is
+      // a passive effect and runs a render later. An upload resolving in
+      // that gap would still read the epoch it was captured under and send a
+      // frame of what the user has just stopped showing.
+      if (session.screenShareTarget !== target) {
+        sight.revokeConsent();
+        sight.rebaseSendOrder();
+        return;
+      }
+      // A transport that dropped and came back deliberately keeps the share
+      // and the session generation, and `connecting` still reads as a live
+      // session, so nothing above tears this run down. A frame captured
+      // before the drop would pass both guards and land in the resumed
+      // transcript as the current view. The room's sight path draws the same
+      // boundary for the same reason.
+      if (session.reconnecting !== reconnecting) {
+        reconnecting = session.reconnecting;
+        if (reconnecting) {
+          sight.invalidate();
+        }
+        return;
+      }
       const next = isLiveVoiceUserSpeaking(session);
       if (next === speaking) {
         return;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -53,6 +53,7 @@ import {
 import { drainPendingVoiceStart } from "@/domains/chat/voice/live-voice/start-voice-request";
 import { useLiveActivityControls } from "@/domains/chat/voice/live-voice/use-live-activity-controls";
 import { useLiveActivityMirror } from "@/domains/chat/voice/live-voice/use-live-activity-mirror";
+import { useLiveVoiceScreenShare } from "@/domains/chat/voice/live-voice/use-live-voice-screen-share";
 import { useSightFrameReclaimer } from "@/domains/chat/voice/live-voice/use-sight-frame-reclaimer";
 import {
   activateVoiceAudioSession,
@@ -261,4 +262,8 @@ export function useLiveVoiceSessionController(
   // room is not mounted, and an upload refused while it is minimized would
   // otherwise be stranded when the call ends.
   useSightFrameReclaimer();
+  // The screen the companion's share control shows the session. Here rather
+  // than in the room for the reason the reclaimer is: on a companion call the
+  // room is not open at all.
+  useLiveVoiceScreenShare();
 }

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
@@ -30,7 +30,9 @@
  * The native path keeps the very JPEG the gate judged rather than capturing a
  * second one, so what the transcript holds is the frame the decision was about.
  * The browser path cannot: its decision is made on a canvas readback, and the
- * frame is encoded afterwards.
+ * frame is encoded afterwards. Everything past the JPEG (the order, the
+ * consent, the upload, the send) is `live-voice/sight-capture.ts`, which the
+ * session's own camera shares.
  *
  * ## What a shell with no sample call does
  *
@@ -78,15 +80,8 @@ import {
   useState,
 } from "react";
 
-import {
-  deleteChatAttachment,
-  uploadChatAttachment,
-} from "@/domains/chat/api/messages";
-import { prepareImageAttachmentForUpload } from "@/domains/chat/components/chat-attachments/attachment-image-resize";
-import {
-  sendLiveVoiceSightFrame,
-  useLiveVoiceStore,
-} from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { createSightCapture } from "@/domains/chat/voice/live-voice/sight-capture";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import {
   isVisionModeOn,
@@ -97,14 +92,12 @@ import { type FrameGate, createFrameGate } from "@/lib/camera/frame-gate";
 import {
   FRAME_GATE_LIVE_OPTIONS,
   recordFrameGateDecision,
-  recordFrameGateKeep,
 } from "@/lib/camera/frame-gate-debug";
 import { createFrameSampler } from "@/lib/camera/frame-sampler";
 import {
   createNativeFrameSource,
   type NativeFrameSource,
 } from "@/lib/camera/native-frame-source";
-import { captureError } from "@/lib/sentry/capture-error";
 import { captureNativeVoiceCameraSample } from "@/runtime/native-voice-camera";
 import { haptic } from "@/utils/haptics";
 
@@ -116,25 +109,6 @@ import {
 
 /** Where a failure is filed, so the tag reads the same from every path. */
 const ERROR_CONTEXT = "voice-room sight: sample/upload frame";
-
-/**
- * How many finished captures may wait on an unfinished older one.
- *
- * Overlap is naturally shallow: the gate's rate floor is seconds and an upload
- * is not, so at most one or two captures are usually in flight. The cap is for
- * the pathological case, an upload that hangs rather than fails, which would
- * otherwise hold every later keep behind it for the rest of the call. Past the
- * cap the gate gives up on the missing capture and lets the backlog through.
- */
-const MAX_PARKED_SIGHT_SENDS = 4;
-
-/** A finished capture waiting for its turn in capture order. */
-interface PendingSightSend {
-  /** Send it, if the session and the camera it came from are still current. */
-  readonly send: () => void;
-  /** Give the upload back: this frame will never be sent. */
-  readonly discard: () => void;
-}
 
 /** The most recent frame the call was given. */
 export interface VoiceRoomSightFrame {
@@ -230,48 +204,28 @@ export function useVoiceRoomSight(
    * and the decision are of the same moment and a flip is already in both.
    */
   const nativeSourceRef = useRef<NativeFrameSource | null>(null);
-  const frameCountRef = useRef(0);
+
   /**
-   * The ordering gate: sends leave in the order the gate KEPT the frames, not
-   * the order their uploads happened to finish.
-   *
-   * Uploads of overlapping keeps can finish in either order, and the transcript
-   * is the record of what the call saw. The model correlates a frame with
-   * speech by adjacency, so a scene persisted after a newer one is read as the
-   * view the words that follow were about, and there may be no later keep to
-   * correct it before the camera closes.
-   *
-   * `captureSeqRef` hands each capture its number when the gate fires,
-   * `nextSendSeqRef` is whose turn it is, and finished captures wait in
-   * `parkedSendsRef` until the run of numbers before them is complete. Every
-   * exit path settles its number, so a capture that fails, is refused, or is
-   * abandoned releases the ones behind it instead of stranding them.
+   * Replace the frame on screen, giving back whatever preview it displaced.
+   * Revoking is not bookkeeping: each preview holds a decoded full-resolution
+   * frame alive, and a long call keeps a frame every few seconds.
    */
-  const captureSeqRef = useRef(0);
-  const nextSendSeqRef = useRef(0);
-  const parkedSendsRef = useRef(new Map<number, PendingSightSend | null>());
+  const hold = useCallback((next: VoiceRoomSightFrame | null) => {
+    const previous = heldRef.current;
+    heldRef.current = next;
+    setHeldFrame(next);
+    if (previous && previous.previewUrl !== next?.previewUrl) {
+      URL.revokeObjectURL(previous.previewUrl);
+    }
+  }, []);
+
   /**
-   * Which camera and transport this capture chain feeds. Bumped when consent
-   * is withdrawn, when sampling stops, when the camera flips, and when the
-   * transport drops into a reconnect, so a capture that was already encoding
-   * can tell that the world it was headed for is gone.
-   *
-   * The session generation covers none of them: each leaves the logical call
-   * running, a flip deliberately keeps the sampler on the same element,
-   * and a reconnect deliberately keeps the generation, so a stalled upload
-   * from before any of them could otherwise be persisted as a view of what the
-   * call is looking at.
+   * The order, the consent and the upload of every keep, shared with the
+   * session's own camera. One for the room's whole life: the assistant is
+   * handed to each capture by the run that kept the frame, and each session
+   * re-bases the order below, so nothing about it is per render.
    */
-  const captureEpochRef = useRef(0);
-  /**
-   * Whether what the loop is producing right now is still consented to.
-   *
-   * `active` says the same thing a render later, which is a render too late
-   * for a boundary: the sampler's own callbacks and the uploads it has started
-   * both run inside the gap between the tap and the effect that stops it.
-   * Raised where a sampling run starts, lowered the moment consent goes.
-   */
-  const captureConsentedRef = useRef(false);
+  const [sight] = useState(() => createSightCapture(ERROR_CONTEXT));
 
   /**
    * Take consent back from every frame the camera has produced but not yet
@@ -296,19 +250,11 @@ export function useVoiceRoomSight(
    * that narrower window is a stale view rather than a broken promise.
    *
    * Parked sends are left to refuse themselves at that same guard, and the
-   * sampler cleanup behind this hands their uploads back. Nothing but a real
-   * sampling run to revoke gets past the first line, so a refused raise, a
-   * stop of something already stopped, and an ordinary re-render all cost
-   * nothing: an epoch churned for one of those would void a capture nobody
-   * withdrew.
+   * sampler cleanup behind this hands their uploads back.
    */
   const revokeCaptureConsent = useCallback(() => {
-    if (!captureConsentedRef.current) {
-      return;
-    }
-    captureConsentedRef.current = false;
-    captureEpochRef.current += 1;
-  }, []);
+    sight.revokeConsent();
+  }, [sight]);
 
   // All four, so the feature is absent rather than half-present: a flag off is
   // not shipped, an assistant that predates `sight_frame` answers every keep
@@ -451,227 +397,6 @@ export function useVoiceRoomSight(
   }, [revokeCaptureConsent]);
 
   /**
-   * Replace the frame on screen, giving back whatever preview it displaced.
-   * Revoking is not bookkeeping: each preview holds a decoded full-resolution
-   * frame alive, and a long call keeps a frame every few seconds.
-   */
-  const hold = useCallback((next: VoiceRoomSightFrame | null) => {
-    const previous = heldRef.current;
-    heldRef.current = next;
-    setHeldFrame(next);
-    if (previous && previous.previewUrl !== next?.previewUrl) {
-      URL.revokeObjectURL(previous.previewUrl);
-    }
-  }, []);
-
-  /**
-   * Give an uploaded row back.
-   *
-   * Nothing else can: an attachment is collected when the message linking it
-   * is deleted, or by the daemon reclaiming a frame it could not persist, and
-   * an id that reaches neither is a row and its bytes kept for good.
-   *
-   * Called for the ids this hook refuses itself, before the frame is sent, and
-   * for the ids stranded by an assistant with no handler for the frame, which
-   * stores nothing and reclaims nothing. NOT called for a frame an assistant
-   * that understands it could not persist: that path reclaims on its own, so
-   * deleting would race it over a row this hook no longer owns.
-   */
-  const reclaimUpload = useCallback(
-    (attachmentId: string) => {
-      if (!assistantId) {
-        return;
-      }
-      void deleteChatAttachment(assistantId, attachmentId).then((ok) => {
-        if (!ok) {
-          captureError(new Error("sight frame delete refused"), {
-            context: ERROR_CONTEXT,
-            bestEffort: true,
-          });
-        }
-      });
-    },
-    [assistantId],
-  );
-
-  /**
-   * Send everything whose turn has come, oldest first.
-   *
-   * Stops at the first number nobody has settled yet, because that capture is
-   * still encoding or uploading and its frame belongs ahead of these. Once the
-   * backlog exceeds the cap the missing capture is written off and the oldest
-   * parked number becomes the new turn, so a hung upload costs the frames it
-   * overlapped rather than the rest of the call.
-   */
-  const drainSends = useCallback(() => {
-    const parked = parkedSendsRef.current;
-    for (;;) {
-      while (parked.has(nextSendSeqRef.current)) {
-        const pending = parked.get(nextSendSeqRef.current) ?? null;
-        parked.delete(nextSendSeqRef.current);
-        nextSendSeqRef.current += 1;
-        pending?.send();
-      }
-      if (parked.size <= MAX_PARKED_SIGHT_SENDS) {
-        return;
-      }
-      nextSendSeqRef.current = Math.min(...parked.keys());
-    }
-  }, []);
-
-  /**
-   * Report what became of one capture, whether or not it produced a frame.
-   *
-   * Called on every exit path, which is what keeps the gate live: a capture
-   * that threw, uploaded nothing, or was refused still releases the captures
-   * waiting behind it.
-   */
-  const settleCapture = useCallback(
-    (captureSeq: number, pending: PendingSightSend | null) => {
-      if (captureSeq < nextSendSeqRef.current) {
-        // The gate has moved past this number: the cap wrote it off, or a new
-        // session re-based the order. Sending now would put an older view
-        // after a newer one, which is the whole thing being prevented.
-        pending?.discard();
-        return;
-      }
-      parkedSendsRef.current.set(captureSeq, pending);
-      drainSends();
-    },
-    [drainSends],
-  );
-
-  /**
-   * Start the order again from whatever has not been captured yet.
-   *
-   * For the boundaries where waiting on an older capture stops making sense:
-   * a new session, a flipped camera, a closed viewfinder. Anything parked is
-   * given back rather than sent, since it would fail the guards at send time
-   * anyway, and anything still in flight settles below the new turn and is
-   * discarded when it lands.
-   */
-  const rebaseSendOrder = useCallback(() => {
-    const parked = parkedSendsRef.current;
-    for (const pending of parked.values()) {
-      pending?.discard();
-    }
-    parked.clear();
-    nextSendSeqRef.current = captureSeqRef.current;
-  }, []);
-
-  /**
-   * Take one kept frame all the way to the transcript and the pulse.
-   *
-   * Everything past the frame itself is the same on both paths: the same
-   * guards, the same order, the same upload, the same send, the same preview
-   * lifecycle. Only where the JPEG comes from differs, so that is what the
-   * caller supplies: the browser path encodes the `<video>` it is watching, the
-   * native path wraps the sample the gate has already judged.
-   */
-  const captureAndHold = useCallback(
-    async (produceFrame: (filename: string) => Promise<File | null>) => {
-      if (!assistantId) {
-        return;
-      }
-      // Consent is already gone, and the loop has not been torn down yet. The
-      // epoch cannot speak for this one: a capture beginning after the bump
-      // reads the new number and would pass the guard on the way out, so a
-      // frame taken after the user said stop is refused before it is taken.
-      if (!captureConsentedRef.current) {
-        return;
-      }
-      // Nothing this assistant is told about lands, and each attempt would
-      // strand another upload, so the sampler runs on and every keep is
-      // dropped here. See `sightFramesUnsupported` on the live-voice store.
-      if (useLiveVoiceStore.getState().sightFramesUnsupported) {
-        return;
-      }
-      // Read before the encode, not after the upload. Everything below can
-      // outlive the session and the camera the frame was taken from, and
-      // neither can be re-read afterwards without describing the wrong one.
-      const sessionGeneration = useLiveVoiceStore.getState().sessionGeneration;
-      const captureEpoch = captureEpochRef.current;
-      // Taken here, at the moment the gate kept the frame, because that is the
-      // order the scenes happened in and the order the transcript has to carry
-      // them in. See the ordering-gate refs above.
-      const captureSeq = captureSeqRef.current;
-      captureSeqRef.current += 1;
-      let pending: PendingSightSend | null = null;
-      try {
-        frameCountRef.current += 1;
-        const frame = await produceFrame(`sight-${frameCountRef.current}.jpg`);
-        if (!frame) {
-          return;
-        }
-        recordFrameGateKeep("voice", frame);
-
-        // The same preparation a pasted image gets, for the same reason the
-        // shutter does it: a high-resolution track behaves like every other
-        // attachment rather than like a special case.
-        const prepared = await prepareImageAttachmentForUpload(frame);
-        const file = prepared.status === "failed" ? frame : prepared.file;
-
-        const uploaded = await uploadChatAttachment(assistantId, file);
-        if (!uploaded.ok) {
-          return;
-        }
-        const abandonUpload = (): void => reclaimUpload(uploaded.id);
-        // The guards run when the turn comes, not now, so a frame that waited
-        // is still checked against the session and camera of the moment it
-        // would land in.
-        pending = {
-          discard: abandonUpload,
-          send: () => {
-            if (
-              useLiveVoiceStore.getState().sessionGeneration !==
-              sessionGeneration
-            ) {
-              abandonUpload();
-              return;
-            }
-            // The camera this came from is closed or pointing elsewhere, so
-            // this is a view of nothing the user is looking at now, and
-            // persisting it would put that view in the transcript as the
-            // current one.
-            if (captureEpoch !== captureEpochRef.current) {
-              abandonUpload();
-              return;
-            }
-            // Sent before it is shown, and shown only if it was sent. The
-            // thumbnail says the call has been given this frame, and during a
-            // reconnect gap it has not. A frame that never left is this hook's
-            // to give back, since the daemon never saw it.
-            if (!sendLiveVoiceSightFrame(uploaded.id, sessionGeneration)) {
-              abandonUpload();
-              return;
-            }
-            // The one beat on this path the user cannot watch for: Live is
-            // held at arm's length, aimed at the scene rather than at the
-            // thumbnail. It fires here, after the send is accepted, because
-            // this is where a frame becomes one the call was given; every
-            // frame a guard refuses reaches `abandonUpload` above and stays
-            // silent.
-            void haptic.light();
-            hold({
-              attachmentId: uploaded.id,
-              previewUrl: URL.createObjectURL(frame),
-            });
-          },
-        };
-      } catch (cause) {
-        // Best effort by design: nobody asked for this frame, so a failure
-        // costs one frame and says nothing to the user.
-        captureError(cause, { context: ERROR_CONTEXT, bestEffort: true });
-      } finally {
-        // Every path, including the ones that produced nothing: a capture that
-        // never sends must still release the captures behind it.
-        settleCapture(captureSeq, pending);
-      }
-    },
-    [assistantId, hold, reclaimUpload, settleCapture],
-  );
-
-  /**
    * Void every capture aimed at the world that just changed: the frames still
    * encoding, the sample still crossing the bridge, the view on screen, and the
    * gate's baseline.
@@ -689,15 +414,16 @@ export function useVoiceRoomSight(
    * pulse and for what is still in flight.
    */
   const invalidateCaptures = useCallback(() => {
-    captureEpochRef.current += 1;
-    rebaseSendOrder();
+    sight.invalidate();
     hold(null);
     gateRef.current?.reset(performance.now());
     nativeSourceRef.current?.invalidate();
-  }, [hold, rebaseSendOrder]);
+  }, [hold, sight]);
 
   useEffect(() => {
-    if (!active) {
+    // `liveAvailable`, and so `active`, already has an assistant in it; the
+    // second test is for the narrowing.
+    if (!active || assistantId === null) {
       return;
     }
     // The native preview mounts no element, so the element is the browser
@@ -710,7 +436,26 @@ export function useVoiceRoomSight(
     // The run this consent was given for. Raised here rather than derived from
     // `active`, which a capture in a torn-down loop still reads as the value of
     // the render it started in.
-    captureConsentedRef.current = true;
+    sight.grantConsent();
+    /**
+     * Put a frame the call was given on screen.
+     *
+     * The haptic is the one beat on this path the user cannot watch for: Live
+     * is held at arm's length, aimed at the scene rather than at the
+     * thumbnail. It fires here, after the send is accepted, because this is
+     * where a frame becomes one the call was given; every frame a guard
+     * refuses stays silent.
+     */
+    const onShared = ({
+      attachmentId,
+      frame,
+    }: {
+      attachmentId: string;
+      frame: File;
+    }): void => {
+      void haptic.light();
+      hold({ attachmentId, previewUrl: URL.createObjectURL(frame) });
+    };
     // The live options record rather than the defaults, so the tuning readout
     // can move a threshold without this effect rebuilding the gate. A rebuild
     // would clear the last-keep clock and fire an immediate keep, which on
@@ -728,7 +473,11 @@ export function useVoiceRoomSight(
           if (!decision.keep) {
             return;
           }
-          void captureAndHold((filename) => captureVideoFrame(video, filename));
+          void sight.capture({
+            assistantId,
+            produceFrame: (filename) => captureVideoFrame(video, filename),
+            onShared,
+          });
         },
       });
       sampler.start(video);
@@ -745,10 +494,12 @@ export function useVoiceRoomSight(
           }
           // The judged bytes, not a second capture: one round trip, and the
           // frame the transcript ends up with is the one the gate said yes to.
-          void captureAndHold(
-            async (filename) =>
+          void sight.capture({
+            assistantId,
+            produceFrame: async (filename) =>
               new File([sample], filename, { type: "image/jpeg" }),
-          );
+            onShared,
+          });
         },
       });
       source.start();
@@ -761,22 +512,14 @@ export function useVoiceRoomSight(
       // put away. The revocation is the bump, so a run the user ended finds it
       // already spent and this is a no-op against captures that have failed
       // their guard once already.
-      revokeCaptureConsent();
-      rebaseSendOrder();
+      sight.revokeConsent();
+      sight.rebaseSendOrder();
       stopSampling();
       gateRef.current = null;
       nativeSourceRef.current = null;
       hold(null);
     };
-  }, [
-    active,
-    captureAndHold,
-    hold,
-    nativePreview,
-    rebaseSendOrder,
-    revokeCaptureConsent,
-    videoRef,
-  ]);
+  }, [active, assistantId, hold, nativePreview, sight, videoRef]);
 
   /**
    * Whether the user is part-way through saying something, as the session
@@ -912,8 +655,8 @@ export function useVoiceRoomSight(
   // On mount there is nothing captured and nothing parked, so this is a no-op.
   const sessionGeneration = useLiveVoiceStore.use.sessionGeneration();
   useEffect(() => {
-    rebaseSendOrder();
-  }, [rebaseSendOrder, sessionGeneration]);
+    sight.rebaseSendOrder();
+  }, [sight, sessionGeneration]);
 
   const reconnecting = useLiveVoiceStore.use.reconnecting();
   useEffect(() => {

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-room-sight.ts
@@ -80,7 +80,10 @@ import {
   useState,
 } from "react";
 
-import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
+import {
+  isLiveVoiceUserSpeaking,
+  useLiveVoiceStore,
+} from "@/domains/chat/voice/live-voice/live-voice-store";
 import { createSightCapture } from "@/domains/chat/voice/live-voice/sight-capture";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import {
@@ -537,9 +540,11 @@ export function useVoiceRoomSight(
   const handsFree = useLiveVoiceStore.use.handsFree();
   const utteranceOpen = useLiveVoiceStore.use.utteranceOpen();
   const muted = useLiveVoiceStore.use.muted();
-  // Named for the user rather than the session, whose own `speaking` phase is
-  // the assistant's voice and the opposite of this.
-  const userSpeaking = handsFree ? utteranceOpen : sessionState === "listening";
+  const userSpeaking = isLiveVoiceUserSpeaking({
+    state: sessionState,
+    handsFree,
+    utteranceOpen,
+  });
 
   /**
    * Ask the gate for a frame of the scene the user is starting to talk about.

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -172,6 +172,8 @@
     "muteMicrophone": "Mute microphone",
     "notNow": "Not now",
     "openVellum": "Open Vellum",
+    "share": "Share",
+    "sharePicker": "What to share",
     "showSummary": "Show summary",
     "stopTeaching": "Stop teaching",
     "summarizing": "Summarizing",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -170,6 +170,8 @@
     "muteMicrophone": "Silenciar micrófono",
     "notNow": "Ahora no",
     "openVellum": "Abrir Vellum",
+    "share": "Compartir",
+    "sharePicker": "Qué compartir",
     "showSummary": "Mostrar resumen",
     "stopTeaching": "Dejar de enseñar",
     "summarizing": "Resumiendo",

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -170,6 +170,8 @@
     "muteMicrophone": "將麥克風靜音",
     "notNow": "暫不",
     "openVellum": "開啟 Vellum",
+    "share": "共享",
+    "sharePicker": "共享來源",
     "showSummary": "顯示摘要",
     "stopTeaching": "停止教學",
     "summarizing": "正在摘要",

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -170,6 +170,8 @@
     "muteMicrophone": "静音麦克风",
     "notNow": "暂不",
     "openVellum": "打开 Vellum",
+    "share": "共享",
+    "sharePicker": "共享来源",
     "showSummary": "显示摘要",
     "stopTeaching": "停止教学",
     "summarizing": "正在摘要",

--- a/clients/web/src/lib/backwards-compat/use-supports-sight-stream.ts
+++ b/clients/web/src/lib/backwards-compat/use-supports-sight-stream.ts
@@ -65,7 +65,7 @@
  * Delete this gate, and the `MIN_VERSION` branch in `use-voice-room-sight.ts`,
  * once the minimum supported assistant is >= MIN_VERSION.
  */
-import { useAssistantScopedSupports } from "./utils";
+import { assistantScopedSupports, useAssistantScopedSupports } from "./utils";
 
 export const MIN_VERSION = "0.11.7-dev.202609010224.44cd29e";
 
@@ -82,4 +82,15 @@ export function useSupportsSightStream(
   sessionAssistantId: string | null | undefined,
 ): boolean {
   return useAssistantScopedSupports(MIN_VERSION, sessionAssistantId);
+}
+
+/**
+ * The same answer as a snapshot, for callers that are not components: the
+ * companion mirror reads it inside a store subscription to tell the surface
+ * whether the running call can be shown the screen.
+ */
+export function supportsSightStream(
+  sessionAssistantId: string | null | undefined,
+): sessionAssistantId is string {
+  return assistantScopedSupports(MIN_VERSION, sessionAssistantId);
 }

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -17,6 +17,7 @@ import { useChannelSetupCloseNotify } from "@/domains/chat/hooks/use-channel-set
 import {
   endLiveVoiceSession,
   isLiveVoiceSessionActive,
+  setLiveVoiceScreenShare,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import {
@@ -403,6 +404,14 @@ export function RootLayout() {
     toggleWatch: (command) => {
       handleToggleWatchCommand(
         command.kind === "toggleWatch" ? command.target : undefined,
+      );
+    },
+    // The share the companion's control asks for, or its stop. Straight to
+    // the session's store: the frames are taken by a hook mounted beside the
+    // session, and a target with no session to show it to is dropped there.
+    setScreenShare: (command) => {
+      setLiveVoiceScreenShare(
+        command.kind === "setScreenShare" ? (command.target ?? null) : null,
       );
     },
     replayOnboarding: () => {

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -16,6 +16,8 @@ import type {
   CompanionDictating,
   CompanionIntroAction,
   CompanionSurfaceState,
+  ScreenCaptureFrame,
+  WatchCaptureTarget,
 } from "@vellumai/ipc-contract";
 
 type CompanionBridge = NonNullable<NonNullable<Window["vellum"]>["companion"]>;
@@ -113,6 +115,39 @@ export function listCompanionCaptureSources(): Promise<CompanionCaptureSources |
     return Promise.resolve(null);
   }
   return companion.listCaptureSources().catch(() => null);
+}
+
+/**
+ * Show the running call what the user is looking at, or stop, which is what
+ * the share control does.
+ *
+ * `pick` is the row of the picker the press came from; a press with none is
+ * the stop. Like {@link toggleCompanionWatch} the press leaves this renderer
+ * at once: main resolves a tab to the window showing it and hands the target
+ * to the window holding the session, and what comes back is `screenShare` on
+ * the pushed state once that window has frames flowing.
+ */
+export function setCompanionScreenShare(pick?: CompanionCapturePick): void {
+  bridge()?.setScreenShare?.(pick);
+}
+
+/**
+ * One frame of what the user is sharing, as the helper takes it.
+ *
+ * The one call in this module made from the app's own window on a cadence
+ * rather than on a press: the session lives there, and each frame becomes a
+ * `sight_frame` on it. Resolves to nothing off Electron, on a shell that
+ * predates the share, and whenever the helper could not take one, and the
+ * caller reads every one of those as a frame to skip.
+ */
+export function captureCompanionScreen(
+  target: WatchCaptureTarget,
+): Promise<ScreenCaptureFrame | null> {
+  const companion = bridge();
+  if (!companion?.captureScreen) {
+    return Promise.resolve(null);
+  }
+  return companion.captureScreen(target).catch(() => null);
 }
 
 /**

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -28,6 +28,7 @@ import type {
   CompanionIntroAction,
   CompanionSurfaceState,
   ConnectivityState,
+  ScreenCaptureFrame,
   DeepLink,
   DictationOverlayHitRegion,
   DictationOverlayMessage,
@@ -76,6 +77,7 @@ import type {
   VoiceActivityPhase,
   VoiceActivityStart,
   VoiceActivityState,
+  WatchCaptureTarget,
   WindowAttentionPayload,
 } from "@vellumai/ipc-contract";
 
@@ -389,6 +391,10 @@ declare global {
         startVoice?(): void;
         toggleWatch?(pick?: CompanionCapturePick): void;
         listCaptureSources?(): Promise<CompanionCaptureSources>;
+        setScreenShare?(pick?: CompanionCapturePick): void;
+        captureScreen?(
+          target: WatchCaptureTarget,
+        ): Promise<ScreenCaptureFrame | null>;
         answerWatchRetro?(open: boolean): void;
         activate?(): void;
         setContext?(context: CompanionContext): void;

--- a/packages/ipc-contract/src/accelerators.ts
+++ b/packages/ipc-contract/src/accelerators.ts
@@ -47,6 +47,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommand["kind"], string> = {
   cancelVoiceStart: "",
   toggleVoice: "",
   toggleWatch: "",
+  setScreenShare: "",
   answerWatchRetro: "",
   cancelDictation: "",
   replayOnboarding: "",

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -31,6 +31,8 @@ import type {
   CompanionCaptureSources,
   CompanionSurfaceState,
   ConnectivityState,
+  ScreenCaptureFrame,
+  WatchCaptureTarget,
   DeepLink,
   DictationOverlayHitRegion,
   DictationOverlayMessage,
@@ -163,7 +165,8 @@ export type LocalListDevicesResult =
   | { ok: false; error: string };
 
 export type LocalRevokeDeviceResult =
-  { ok: true } | { ok: false; error: string };
+  | { ok: true }
+  | { ok: false; error: string };
 
 /**
  * A local assistant's avatar as read off its workspace by the host. `null`
@@ -583,6 +586,26 @@ export interface VellumBridge {
      * having nothing to offer and starts the whole-screen session instead.
      */
     listCaptureSources?(): Promise<CompanionCaptureSources>;
+    /**
+     * Show the running call a display, a window or a Chrome tab, or stop.
+     *
+     * `pick` is the row of the picker the press came from; a press with none
+     * is the stop. Main resolves a tab the way `toggleWatch` does and hands
+     * the target to the window holding the session as the `setScreenShare`
+     * command; what comes back is `screenShare` on `onState`. Absent on a
+     * shell that predates the share, which the surface reads as having
+     * nothing to offer.
+     */
+    setScreenShare?(pick?: CompanionCapturePick): void;
+    /**
+     * One frame of `target`, as the helper takes it, for the window holding a
+     * shared call to hand to the session. Resolves to null when no frame
+     * could be taken: the window has gone, the display was unplugged, or
+     * Screen Recording is not granted.
+     */
+    captureScreen?(
+      target: WatchCaptureTarget,
+    ): Promise<ScreenCaptureFrame | null>;
     /**
      * Answer the summary question a finished watch session leaves on the
      * surface: open the report now, or not.

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -191,6 +191,8 @@ export const COMPANION_START_VOICE = "vellum:companion:startVoice";
 export const COMPANION_TOGGLE_WATCH = "vellum:companion:toggleWatch";
 export const COMPANION_LIST_CAPTURE_SOURCES =
   "vellum:companion:listCaptureSources";
+export const COMPANION_SET_SCREEN_SHARE = "vellum:companion:setScreenShare";
+export const COMPANION_CAPTURE_SCREEN = "vellum:companion:captureScreen";
 export const COMPANION_ANSWER_WATCH_RETRO = "vellum:companion:answerWatchRetro";
 export const COMPANION_ACTIVATE = "vellum:companion:activate";
 export const COMPANION_SET_CONTEXT = "vellum:companion:setContext";

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -158,6 +158,13 @@ export const companionContextSchema = z.object({
   // Defaulted for the reason `watching` is: a publisher that does not say
   // whether its sessions can be aimed is one whose sessions cannot.
   watchTargets: z.boolean().default(false),
+  // Optional rather than defaulted, for the reason `captureTarget` is: every
+  // shape it can hold names something being shared, and absence is the only
+  // way to say nothing is.
+  screenShare: watchCaptureTargetSchema.optional(),
+  // Defaulted for the reason `watchTargets` is: a publisher that does not say
+  // whether its call can be shown the screen is one whose call cannot.
+  screenShareEnabled: z.boolean().default(false),
   // Optional rather than defaulted, for the reason `watchRetro` is: both values
   // claim a microphone is doing something, and absence is the only way to say
   // none is.

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -118,6 +118,20 @@ export type VellumCommand =
    */
   | { kind: "toggleWatch"; target?: WatchCaptureTarget }
   /**
+   * Show the running call what the user is looking at, or stop.
+   *
+   * `target` is what to share, as the companion's picker resolved it: a
+   * display or a window. A command carrying one starts the share, or moves a
+   * running one to the new target; a command carrying none is the stop. The
+   * window holding the session takes frames of the target and hands each to
+   * the session as a `sight_frame`, so the transcript is the record of what
+   * the call was shown.
+   *
+   * Like `toggleWatch`, this does not raise the app: what is shared is the
+   * user's own work, and raising Vellum would cover it.
+   */
+  | { kind: "setScreenShare"; target?: WatchCaptureTarget }
+  /**
    * Answer the question the surface asks once a watch session's summary is
    * written: open it now, or not.
    *
@@ -181,7 +195,11 @@ export type HotkeyEventState = "down" | "up";
 
 /** A modifier key a binding can be built from, as the helpers name them. */
 export type KeyboardModifier =
-  "function" | "control" | "shift" | "option" | "command";
+  | "function"
+  | "control"
+  | "shift"
+  | "option"
+  | "command";
 
 export type VoiceModeChordModifier = KeyboardModifier;
 
@@ -244,7 +262,8 @@ export interface HotkeyEvent {
 
 /** Whether a helper took a binding, or why it did not. */
 export type HotkeyRegistrationResult =
-  { ok: true; enabled: boolean } | { ok: false; reason: string };
+  | { ok: true; enabled: boolean }
+  | { ok: false; reason: string };
 
 export type VoiceModeChordRegistrationResult = HotkeyRegistrationResult;
 
@@ -253,7 +272,8 @@ export type VoiceModeChordRegistrationResult = HotkeyRegistrationResult;
  * with nothing else. `off` is a binding the user has cleared.
  */
 export type ModifierHold =
-  { kind: "off" } | { kind: "modifierOnly"; modifiers: KeyboardModifier[] };
+  | { kind: "off" }
+  | { kind: "modifierOnly"; modifiers: KeyboardModifier[] };
 
 export type ModifierHoldRegistrationResult = HotkeyRegistrationResult;
 
@@ -331,7 +351,11 @@ export type ConnectivityState = (typeof CONNECTIVITY_STATES)[number];
 // ---------------------------------------------------------------------------
 
 export type PowerEventKind =
-  "suspend" | "resume" | "lock" | "unlock" | "active";
+  | "suspend"
+  | "resume"
+  | "lock"
+  | "unlock"
+  | "active";
 
 export interface PowerEvent {
   kind: PowerEventKind;
@@ -409,7 +433,8 @@ export type DeepLink =
 // ---------------------------------------------------------------------------
 
 export type DictationPartialsResult =
-  { ok: true; enabled: boolean } | { ok: false; reason: string };
+  | { ok: true; enabled: boolean }
+  | { ok: false; reason: string };
 
 export interface DictationPartialEvent {
   text: string;
@@ -431,7 +456,8 @@ export type DictationOverlayState =
   | { kind: "error"; message: string };
 
 export type DictationOverlayMessage =
-  DictationOverlayState | { kind: "dismiss" };
+  | DictationOverlayState
+  | { kind: "dismiss" };
 
 /**
  * Where the overlay's Stop control sits, in window-relative CSS pixels.
@@ -687,7 +713,12 @@ export interface BundleScanData {
 // ---------------------------------------------------------------------------
 
 export type UpdateStatus =
-  "idle" | "checking" | "available" | "downloading" | "downloaded" | "error";
+  | "idle"
+  | "checking"
+  | "available"
+  | "downloading"
+  | "downloaded"
+  | "error";
 
 export interface UpdateState {
   status: UpdateStatus;
@@ -751,7 +782,8 @@ export interface Lockfile {
 }
 
 export type LockfileWriteResult =
-  { ok: true; lockfile: Lockfile } | { ok: false; error: string };
+  | { ok: true; lockfile: Lockfile }
+  | { ok: false; error: string };
 
 export type LocalAssistantRuntimeState =
   | "healthy"
@@ -1170,6 +1202,17 @@ export type WatchCaptureTarget =
   | { kind: "window"; windowId: number };
 
 /**
+ * One frame of a {@link WatchCaptureTarget}, as the helper took it: a JPEG,
+ * with the size it was encoded at. Base64 rather than bytes because it
+ * crosses the bridge as JSON.
+ */
+export interface ScreenCaptureFrame {
+  jpegBase64: string;
+  width: number;
+  height: number;
+}
+
+/**
  * What the companion's picker offers a press of Teach: a display, a window,
  * or a Chrome tab, with what a person needs to tell them apart.
  *
@@ -1311,6 +1354,23 @@ export interface CompanionContext {
    * that does not say is one whose sessions cannot be aimed.
    */
   watchTargets?: boolean;
+  /**
+   * What the running call is being shown, while the user shares a display or
+   * a window with it. Absent when nothing is shared.
+   *
+   * Published by the window that owns the session rather than remembered by
+   * main from the press, for the reason `captureTarget` is: the press is a
+   * request, and this is what the session did with it, so the surface draws
+   * the share as on only once frames can flow to a session that takes them.
+   */
+  screenShare?: WatchCaptureTarget;
+  /**
+   * Whether the call in this window can be shown the screen at all: a session
+   * is running and its assistant understands the frame. The surface offers
+   * the share on a positive answer and nothing on anything else, the bargain
+   * `watchTargets` makes.
+   */
+  screenShareEnabled?: boolean;
   /**
    * What a dictation started from the keyboard has got to, when one is running.
    *
@@ -1523,6 +1583,17 @@ export interface CompanionSurfaceState {
    * whose sessions read the whole screen.
    */
   watchTargets?: boolean;
+  /**
+   * See {@link CompanionContext.screenShare}. Absent is nothing shared, on
+   * every shell including one that predates the field.
+   */
+  screenShare?: WatchCaptureTarget;
+  /**
+   * See {@link CompanionContext.screenShareEnabled}. Read it as
+   * `screenShareEnabled === true`, for the reason `watchTargets` is read that
+   * way: the control this decides starts capturing the user's screen.
+   */
+  screenShareEnabled?: boolean;
 
   /**
    * Whether Watch is offered at all, as the flag was last evaluated for the


### PR DESCRIPTION
Closes JARVIS-1734. Part of JARVIS-1705.

## What

A **Share** control beside Teach on the companion's call bar. It opens the same picker Teach uses (screens, Chrome tabs, windows); the pick starts the share, a second press stops it. Main frames the shared target the way it frames a watched one.

## How the frames flow

- **Helper**: new `capture.frame` RPC on the mac helper, a thin async wrapper over the computer-use `ScreenCapture` (SCContentFilter per display / desktopIndependentWindow), returning a JPEG as base64. Same TCC grant Teach already relies on.
- **Main**: `vellum:companion:setScreenShare` takes the picker's pick (a tab is resolved to its Chrome window exactly as `toggleWatch` does, sharing the pick generation) and dispatches a `setScreenShare` command to the window holding the session; `vellum:companion:captureScreen` reaches the helper for one frame. `CompanionContext` grows `screenShare` + `screenShareEnabled`, passed through to the surface state.
- **App**: `screenShareTarget` on the live-voice store (session state, kept across a reconnect). `use-live-voice-screen-share.ts` is mounted beside the session controller and, while the target is set and the session's assistant understands `sight_frame`, asks the helper for a frame and sends it through the shared sight-capture tail.
- **Cadence (naive first pass)**: one frame when the share starts, then one at each edge of the user's turn (`isLiveVoiceUserSpeaking`, the same derivation the room's Live uses for its forced keep), with a 1.5s floor so a cough is not two frames. Nothing in between. The start-of-utterance frame is the one the turn reads; the end-of-utterance frame lands on the following turn (the daemon snapshots the conversation the instant the utterance closes).
- The control is offered only while a session runs on an assistant that takes the frame (`supportsSightStream`, the existing `sight_frame` gate). A frame the helper cannot take (window closed, display unplugged, no Screen Recording) lowers the share so the control reads as off.

## First commit

The sight-frame tail (capture order, consent epoch, upload, send, reclaim) is extracted from `use-voice-room-sight.ts` into `live-voice/sight-capture.ts`, taken as-is from the parked camera PR #42081 so the two branches do not diverge on it. The room's behaviour is unchanged (its 84 tests pass).

## Not in this PR

- No motion/novelty gate on shared frames; a screen changes by whole views and the cadence is deliberately dumb until we see real transcripts.
- The Screen Recording prompt is not raised from here; a share on a helper without the grant just reads as off (logged). Same state Teach is in.
- `FALLBACK_WIDTHS.call` is bumped to 372 for the pre-measure beat; the row measures itself, so this only matters for the first frame.
- Hand-tested on the dev app by Alex ("it works"), with the sight-stream gate lowered locally for the stale pod APP_VERSION. Helper builds (`swift build`), all three TypeScript projects typecheck, suites for every touched module pass, and the share hook has its own suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019x2Etdv2EwWJMobMk3RUfW