### PR TITLE
fix(providers): fall back to stable device ID for OpenCode session header

### DIFF
--- a/assistant/src/providers/opencode/client.test.ts
+++ b/assistant/src/providers/opencode/client.test.ts
@@ -47,6 +47,30 @@ describe("buildOpenCodeRequestHeaders", () => {
     expect(headers).not.toHaveProperty("session_id");
   });
 
+  test("falls back to the stable device id when there is no conversation", () => {
+    expect(
+      buildOpenCodeRequestHeaders({ fallbackSessionId: "dev-123" }),
+    ).toEqual({ [OPENCODE_SESSION_HEADER]: "dev-123" });
+  });
+
+  test("conversation id wins over the fallback session id", () => {
+    expect(
+      buildOpenCodeRequestHeaders({
+        conversationId: "conv-xyz",
+        fallbackSessionId: "dev-123",
+      }),
+    ).toEqual({ [OPENCODE_SESSION_HEADER]: "conv-xyz" });
+  });
+
+  test("blank conversation id falls through to the fallback session id", () => {
+    expect(
+      buildOpenCodeRequestHeaders({
+        conversationId: "   ",
+        fallbackSessionId: "dev-123",
+      }),
+    ).toEqual({ [OPENCODE_SESSION_HEADER]: "dev-123" });
+  });
+
   test("sets only the ids that are present", () => {
     expect(
       buildOpenCodeRequestHeaders({ conversationId: "conv-xyz" }),

--- a/assistant/src/providers/opencode/client.ts
+++ b/assistant/src/providers/opencode/client.ts
@@ -26,13 +26,18 @@ export function resolveOpenCodeBaseURL(configuredBaseURL?: string): string {
  * OpenCode-owned request headers for support lookup. Sends session and
  * request ids only when they exist. Never sets `session_id` (zen/go
  * returns 500 when that header is present).
+ *
+ * `conversationId` wins for the session header; `fallbackSessionId` (a
+ * stable per-device ID supplied by the caller) covers non-conversation
+ * background calls so they still identify a session to zen/go.
  */
 export function buildOpenCodeRequestHeaders(opts: {
   conversationId?: string;
+  fallbackSessionId?: string;
   requestId?: string;
 }): Record<string, string> {
   const headers: Record<string, string> = {};
-  const session = opts.conversationId?.trim();
+  const session = opts.conversationId?.trim() || opts.fallbackSessionId?.trim();
   if (session) {
     headers[OPENCODE_SESSION_HEADER] = session;
   }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -10,6 +10,7 @@ import {
   sanitizeUsageMetadataValue,
 } from "../usage/attribution.js";
 import { resolveSubagentAttribution } from "../usage/subagent-attribution.js";
+import { getExistingDeviceId } from "../util/device-id.js";
 import {
   type ProviderCredentialSource,
   ProviderError,
@@ -647,6 +648,11 @@ function normalizeSendMessageOptions(
         : undefined;
     const requestHeaders = buildOpenCodeRequestHeaders({
       conversationId,
+      // Background call paths (memory/commit-message enrichment,
+      // proactivity, workflow runs) have no conversationId - reuse the
+      // existing stable per-device ID so those requests still carry a
+      // session header instead of persisting a new ID for this purpose.
+      fallbackSessionId: getExistingDeviceId() ?? undefined,
       requestId: randomUUID(),
     });
     if (Object.keys(requestHeaders).length > 0) {


### PR DESCRIPTION
## What

Non-conversation (background) LLM calls through the first-class OpenCode provider now send `x-opencode-session` too. `buildOpenCodeRequestHeaders` gains an optional `fallbackSessionId`, and `RetryProvider` passes the existing stable per-device ID (`device.json`, via `getExistingDeviceId()`) when there is no `conversationId`.

Follow-up to #41455 per @dvargasfuertes's [comment](https://github.com/vellum-ai/vellum-assistant/pull/41455#issuecomment-5527912231): *"ideally we use an existing ID or one that could be generated in a stable manner, rather than persist a new one."* This reuses the ID Vellum already persists for telemetry - no new storage is introduced.

## Why

OpenCode has announced that requests missing `x-opencode-session` may error from **6 September** (see BerriAI/litellm#39503, opened by @thdxr, for the same requirement). Conversation traffic is covered since #41455, but background call paths - memory/commit-message enrichment, proactivity and watch jobs, workflow runs - treat `conversationId` as optional, so those requests currently go out with only `x-opencode-request` and would be exposed.

## How

- `conversationId` still wins for the session header; the fallback only applies when it's absent (including blank strings).
- `getExistingDeviceId()` is the read-only resolver: it never creates `device.json` from the request path. If no device ID exists yet, behavior is unchanged from today (header omitted).
- Never sets `session_id`, per the existing constraint.

## Testing

- `bun test src/providers/opencode/client.test.ts`: 11/11 pass (3 new: fallback used without conversation, conversation wins, blank conversation falls through).
- `eslint` + `prettier` clean on the touched files; `tsc --noEmit` clean.
- Broader `src/providers` suite shows 96 failures that reproduce identically on the unmodified tree (pre-existing, environment-dependent).