### PR TITLE
feat(web): show two follow-up suggestion chips under the last reply behind follow-up-suggestions (JARVIS-1735)

### DIFF
--- a/clients/web/src/domains/chat/api/suggestion-api.ts
+++ b/clients/web/src/domains/chat/api/suggestion-api.ts
@@ -3,6 +3,7 @@ import type { SuggestionGetResponse } from "@/generated/daemon/types.gen";
 
 const EMPTY: SuggestionGetResponse = {
   suggestion: null,
+  suggestions: [],
   messageId: null,
   source: "none",
 };

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -148,7 +148,14 @@ import { useAssistantLifecycleStore } from "@/assistant/lifecycle-store";
 import type { UseDiskPressureMonitorResult } from "@/assistant/use-disk-pressure-monitor";
 import type { UseResourcePressureMonitorResult } from "@/assistant/use-resource-pressure-monitor";
 import { useAppNudges } from "@/domains/chat/hooks/use-app-nudges";
-import { useGhostTextSuggestion } from "@/domains/chat/hooks/use-ghost-text-suggestion";
+import {
+  useFollowUpSuggestions,
+  useGhostTextSuggestion,
+} from "@/domains/chat/hooks/use-ghost-text-suggestion";
+import {
+  FollowUpSuggestions,
+  shouldShowFollowUpSuggestions,
+} from "@/domains/chat/components/follow-up-suggestions";
 import {
   handleConfirmationSubmit,
   handleAllowAndCreateRule,
@@ -708,11 +715,24 @@ export function ChatMainPanel({
       : null;
   }, [messages, liveAssistantMessageId]);
 
-  const suggestion = useGhostTextSuggestion({
+  const followUpSuggestionsEnabled =
+    useClientFeatureFlagStore.use.followUpSuggestions();
+
+  const ghostTextSuggestion = useGhostTextSuggestion({
     assistantId,
     conversationId: activeConversationId,
     lastCompleteAssistantMsgId,
   });
+  const followUpSuggestions = useFollowUpSuggestions({
+    assistantId,
+    conversationId: activeConversationId,
+    lastCompleteAssistantMsgId,
+  });
+
+  // The chips and the ghost text answer the same question, so only one of them
+  // offers a next message at a time. With the chips on, the composer stays a
+  // blank field.
+  const suggestion = followUpSuggestionsEnabled ? null : ghostTextSuggestion;
 
   // -------------------------------------------------------------------------
   // Transcript data (sanitise + build items)
@@ -1309,6 +1329,34 @@ export function ChatMainPanel({
   });
 
   // -------------------------------------------------------------------------
+  // Follow-up suggestion chips
+  // -------------------------------------------------------------------------
+  // Seeds the composer before submitting, the same path a conversation-starter
+  // chip takes, so a blocked send leaves the text to retry rather than losing
+  // it. The one click seam for the surface.
+  const handleSelectFollowUp = useCallback(
+    (followUp: string) => {
+      handleSelectStarter({ prompt: followUp });
+    },
+    [handleSelectStarter],
+  );
+
+  const showFollowUpSuggestions = shouldShowFollowUpSuggestions({
+    enabled: followUpSuggestionsEnabled,
+    suggestions: followUpSuggestions,
+    turnActive: isAssistantBusy || sendDisabled,
+    awaitingInteraction:
+      uiContext.hasPendingQuestion || uiContext.hasUncompletedVisibleSurface,
+  });
+
+  const followUpSuggestionsSlot = showFollowUpSuggestions ? (
+    <FollowUpSuggestions
+      suggestions={followUpSuggestions}
+      onSelect={handleSelectFollowUp}
+    />
+  ) : undefined;
+
+  // -------------------------------------------------------------------------
   // JSX construction
   // -------------------------------------------------------------------------
   const chatTranscriptProps: TranscriptProps = {
@@ -1342,6 +1390,7 @@ export function ChatMainPanel({
     onWorkflowClick,
     onStopWorkflow,
     renderOnboardingChoice,
+    followUpSuggestionsSlot,
   };
 
   const cmdEnterMode = cmdEnterToSend.useValue();

--- a/clients/web/src/domains/chat/components/follow-up-suggestions.test.tsx
+++ b/clients/web/src/domains/chat/components/follow-up-suggestions.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for the follow-up suggestion chips under the latest assistant reply.
+ *
+ * Two things are worth pinning. The gate, because it is what keeps the surface
+ * from stacking a second set of buttons under a turn that already asked the
+ * user something, or from offering a next message while one is still being
+ * written. And the click, because the chip's whole contract is that its visible
+ * text is what gets sent.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  FollowUpSuggestions,
+  shouldShowFollowUpSuggestions,
+} from "@/domains/chat/components/follow-up-suggestions";
+
+const SUGGESTIONS = ["Compare the two options", "Draft the summary"];
+
+/** The gate's inputs with nothing suppressing the chips. */
+const OPEN = {
+  enabled: true,
+  suggestions: SUGGESTIONS,
+  turnActive: false,
+  awaitingInteraction: false,
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("shouldShowFollowUpSuggestions", () => {
+  test("shows the chips when the flag is on and the turn has settled", () => {
+    expect(shouldShowFollowUpSuggestions(OPEN)).toBe(true);
+  });
+
+  test("shows nothing when the flag is off", () => {
+    expect(shouldShowFollowUpSuggestions({ ...OPEN, enabled: false })).toBe(
+      false,
+    );
+  });
+
+  test("shows nothing while the turn is still running", () => {
+    expect(shouldShowFollowUpSuggestions({ ...OPEN, turnActive: true })).toBe(
+      false,
+    );
+  });
+
+  test("shows nothing when the turn ended on a surface awaiting an answer", () => {
+    // A choice surface or an `ask_question` card renders its own buttons, so
+    // chips underneath would offer a second way to answer one question.
+    expect(
+      shouldShowFollowUpSuggestions({ ...OPEN, awaitingInteraction: true }),
+    ).toBe(false);
+  });
+
+  test("shows nothing when the daemon returned no suggestions", () => {
+    expect(shouldShowFollowUpSuggestions({ ...OPEN, suggestions: [] })).toBe(
+      false,
+    );
+  });
+});
+
+describe("FollowUpSuggestions", () => {
+  test("renders one chip per suggestion inside a labelled group", () => {
+    render(
+      <FollowUpSuggestions suggestions={SUGGESTIONS} onSelect={() => {}} />,
+    );
+
+    const group = screen.getByRole("group", { name: "Suggested follow-ups" });
+    const chips = group.querySelectorAll("button");
+    expect([...chips].map((chip) => chip.textContent)).toEqual(SUGGESTIONS);
+  });
+
+  test("sends the picked chip's own text", () => {
+    const sent: string[] = [];
+    render(
+      <FollowUpSuggestions
+        suggestions={SUGGESTIONS}
+        onSelect={(suggestion) => sent.push(suggestion)}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Draft the summary"));
+
+    expect(sent).toEqual(["Draft the summary"]);
+  });
+
+  test("drops anything past the second suggestion", () => {
+    render(
+      <FollowUpSuggestions
+        suggestions={[...SUGGESTIONS, "Third one"]}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText("Third one")).toBeNull();
+    expect(screen.getAllByRole("button").length).toBe(2);
+  });
+
+  test("renders nothing when there is nothing to suggest", () => {
+    const { container } = render(
+      <FollowUpSuggestions suggestions={[]} onSelect={() => {}} />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/clients/web/src/domains/chat/components/follow-up-suggestions.tsx
+++ b/clients/web/src/domains/chat/components/follow-up-suggestions.tsx
@@ -1,0 +1,96 @@
+import { ConversationStarterChip } from "@/domains/chat/components/conversation-starter-chip";
+import { useTranslation } from "@/i18n";
+
+/**
+ * Most chips rendered under a reply. Two is the whole point of the surface: a
+ * pair of next moves, small enough to read at a glance without competing with
+ * the composer.
+ */
+export const MAX_FOLLOW_UP_SUGGESTIONS = 2;
+
+/** Inputs to {@link shouldShowFollowUpSuggestions}. */
+export interface FollowUpSuggestionsGate {
+  /** The `follow-up-suggestions` client flag. Off means the surface is absent. */
+  enabled: boolean;
+  /** The suggestions the daemon returned for the latest completed reply. */
+  suggestions: readonly string[];
+  /** True while a turn is streaming or a send is in flight. */
+  turnActive: boolean;
+  /**
+   * True when the latest turn parked on a surface that already asks the user
+   * something: an `ask_question` card, or an uncompleted `ui_show` choice,
+   * form, or confirmation. Those render their own answers, so a second set of
+   * buttons underneath would offer two ways to reply to one question.
+   */
+  awaitingInteraction: boolean;
+}
+
+/**
+ * Whether the follow-up chips belong under the latest reply.
+ *
+ * Split from the component so the gate is one named rule the chat page reads
+ * and a test exercises directly, rather than a condition assembled inline at
+ * the render site.
+ */
+export function shouldShowFollowUpSuggestions({
+  enabled,
+  suggestions,
+  turnActive,
+  awaitingInteraction,
+}: FollowUpSuggestionsGate): boolean {
+  if (!enabled || turnActive || awaitingInteraction) {
+    return false;
+  }
+  return suggestions.length > 0;
+}
+
+export interface FollowUpSuggestionsProps {
+  /**
+   * Suggestions in daemon order (strongest first). Anything past
+   * {@link MAX_FOLLOW_UP_SUGGESTIONS} is dropped.
+   */
+  suggestions: readonly string[];
+  /**
+   * Invoked with the picked suggestion's text. The single click seam for the
+   * surface: whatever a chip press should also do (telemetry, for one) hangs
+   * here rather than on each chip.
+   */
+  onSelect: (suggestion: string) => void;
+}
+
+/**
+ * The pair of tappable follow-ups under the latest assistant reply. Each chip
+ * is a short message in the user's own voice; picking one sends it.
+ *
+ * Renders nothing when there is nothing to suggest, so the caller can mount it
+ * unconditionally without reserving an empty row.
+ */
+export function FollowUpSuggestions({
+  suggestions,
+  onSelect,
+}: FollowUpSuggestionsProps) {
+  const { t } = useTranslation("chat");
+  const visible = suggestions.slice(0, MAX_FOLLOW_UP_SUGGESTIONS);
+  if (visible.length === 0) {
+    return null;
+  }
+  return (
+    <div
+      // Excluded from a transcript copy the way the parked avatar is: the chips
+      // are an affordance the reader can act on, not part of what was said.
+      data-copy-exclude
+      data-slot="follow-up-suggestions"
+      role="group"
+      aria-label={t("followUpSuggestions.groupAria")}
+      className="grid w-full grid-cols-2 gap-2"
+    >
+      {visible.map((suggestion) => (
+        <ConversationStarterChip
+          key={suggestion}
+          label={suggestion}
+          onSelect={() => onSelect(suggestion)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-ghost-text-suggestion.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-ghost-text-suggestion.test.tsx
@@ -41,6 +41,7 @@ mock.module("@tanstack/react-query", () => ({
 mock.module("@/domains/chat/api/suggestion-api", () => ({
   fetchSuggestion: async () => ({
     suggestion: null,
+    suggestions: [],
     messageId: null,
     source: "none" as const,
   }),

--- a/clients/web/src/domains/chat/hooks/use-ghost-text-suggestion.ts
+++ b/clients/web/src/domains/chat/hooks/use-ghost-text-suggestion.ts
@@ -1,8 +1,12 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { fetchSuggestion } from "@/domains/chat/api/suggestion-api";
 
 const GHOST_TEXT_SUGGESTION_GC_MS = 5 * 60_000;
+
+/** Stable empty result, so a suggestion-less turn keeps a stable identity. */
+const EMPTY_SUGGESTIONS: string[] = [];
 
 /** Query-key factory for the ghost-text suggestion query. */
 function ghostTextSuggestionQueryKey(
@@ -19,7 +23,7 @@ function ghostTextSuggestionQueryKey(
   ];
 }
 
-interface UseGhostTextSuggestionParams {
+interface UseReplySuggestionParams {
   assistantId: string | null;
   conversationId: string | null;
   /**
@@ -36,34 +40,27 @@ interface UseGhostTextSuggestionParams {
 }
 
 /**
- * Server-state hook for the after-turn autocomplete ghost text shown in
- * the chat composer.
+ * The one `suggestion_get` query behind both after-turn suggestion surfaces:
+ * the composer's ghost text and the follow-up chips under the latest reply.
  *
- * The suggestion is a server-derived value keyed by
+ * The response is a server-derived value keyed by
  * `(assistantId, conversationId, lastCompleteAssistantMsgId)`. The query
  * key gives us:
  *
- *   - **Dedup** — same key → no new fetch.
- *   - **Implicit clear on send / on conversation switch** — when the
+ *   - **Dedup**: same key means no new fetch, so the two consumer hooks
+ *     share one request and one cache entry.
+ *   - **Implicit clear on send / on conversation switch**: when the
  *     latest message becomes a user message (after send) or
  *     `conversationId` changes, the key derives a new value or `null`
  *     and the previous cache entry is no longer matched.
- *   - **Implicit suppression while streaming** — `lastCompleteAssistantMsgId`
+ *   - **Implicit suppression while streaming**: `lastCompleteAssistantMsgId`
  *     is `null` until the assistant's reply finishes.
- *
- * The hook is *pure* w.r.t. composer input: it always returns the
- * cached suggestion (or `null` when nothing is cached). The render-time
- * gate that decides whether to show ghost text — and whether to show
- * the full suggestion or just the unrendered suffix — lives in
- * `ChatComposer.computeGhostSuffix`. Keeping that gate in one place
- * preserves the "type the prefix → see only the tail as ghost"
- * suffix-completion behavior.
  */
-export function useGhostTextSuggestion({
+function useReplySuggestionQuery({
   assistantId,
   conversationId,
   lastCompleteAssistantMsgId,
-}: UseGhostTextSuggestionParams): string | null {
+}: UseReplySuggestionParams) {
   const enabled =
     assistantId != null &&
     conversationId != null &&
@@ -108,5 +105,45 @@ export function useGhostTextSuggestion({
     retry: false,
   });
 
+  return query;
+}
+
+/**
+ * The after-turn ghost text for the composer: the strongest of the
+ * suggestions the daemon returned, or `null` when it returned none.
+ *
+ * Pure w.r.t. composer input: it always returns the cached suggestion. The
+ * render-time gate that decides whether to show ghost text, and whether to
+ * show the full suggestion or just the unrendered suffix, lives in
+ * `ChatComposer.computeGhostSuffix`. Keeping that gate in one place
+ * preserves the "type the prefix, see only the tail as ghost"
+ * suffix-completion behavior.
+ */
+export function useGhostTextSuggestion(
+  params: UseReplySuggestionParams,
+): string | null {
+  const query = useReplySuggestionQuery(params);
   return query.data?.suggestion ?? null;
+}
+
+/**
+ * The same turn's suggestions as a list, for the follow-up chips under the
+ * latest assistant reply. Shares {@link useReplySuggestionQuery}'s key with
+ * {@link useGhostTextSuggestion}, so mounting both costs one fetch.
+ *
+ * Older daemons answer without the `suggestions` field; they still fill
+ * `suggestion`, so the singular value stands in for the list rather than
+ * leaving the chips empty on an assistant that predates the pair.
+ */
+export function useFollowUpSuggestions(
+  params: UseReplySuggestionParams,
+): string[] {
+  const query = useReplySuggestionQuery(params);
+  const data = query.data;
+  return useMemo(() => {
+    if (data?.suggestions && data.suggestions.length > 0) {
+      return data.suggestions;
+    }
+    return data?.suggestion ? [data.suggestion] : EMPTY_SUGGESTIONS;
+  }, [data]);
 }

--- a/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -77,6 +77,10 @@ export interface LatestTurnRowProps {
    *  responses by `Transcript`. Only the message that ends a completed response
    *  has an entry, and the in-flight response has none. */
   responseArtifactsByKey?: ReadonlyMap<string, ResponseArtifact[]>;
+  /** Follow-up suggestion chips for the reply this turn ended on. Handed only
+   *  to the response rows: the anchor is the user's own message, which never
+   *  carries them. */
+  followUpSuggestionsSlot?: ReactNode;
 }
 
 export const LatestTurnRow = memo(function LatestTurnRow({
@@ -104,6 +108,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
   onWorkflowClick,
   onStopWorkflow,
   responseArtifactsByKey,
+  followUpSuggestionsSlot,
 }: LatestTurnRowProps) {
   // The response cluster is "streaming" whenever the turn is in flight. This
   // keeps each response message's last tool-call group expanded for the whole
@@ -174,6 +179,7 @@ export const LatestTurnRow = memo(function LatestTurnRow({
             responseArtifacts={responseArtifactsByKey?.get(response.key)}
             isStreaming={isStreaming}
             isLatestMessage={response === lastMessageItem}
+            followUpSuggestionsSlot={followUpSuggestionsSlot}
           />
         </Fragment>
       ))}

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type { ResponseArtifact } from "@/domains/chat/transcript/response-artifacts";
 import {
   isAcpSpawnCall,
@@ -111,6 +113,14 @@ export interface TranscriptMessageBodyProps {
    * mid-transcript never shifts layout.
    */
   isLatestMessage?: boolean;
+  /**
+   * Follow-up suggestion chips, rendered below the hover-actions row of the
+   * message this transcript ends on and nowhere else. The chat page owns the
+   * node (it holds the flag, the suggestions, and the send path) and every row
+   * receives the same one, so the `isLatestMessage` + assistant test here is
+   * what decides where it lands. Absent when the surface has nothing to offer.
+   */
+  followUpSuggestionsSlot?: ReactNode;
 }
 
 /**

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.test.tsx
@@ -1755,7 +1755,9 @@ describe("TranscriptMessageBody", () => {
     );
 
     expect(
-      container.querySelector("[data-testid='surface'][data-surface-id='s-keep']"),
+      container.querySelector(
+        "[data-testid='surface'][data-surface-id='s-keep']",
+      ),
     ).not.toBeNull();
   });
 
@@ -2782,5 +2784,70 @@ describe("TranscriptMessageBody: response asset cards", () => {
     expect(
       container.querySelector("[data-surface-id='page-app-8']"),
     ).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Follow-up suggestion chips
+//
+// The chat page hands the same slot to every row, so the placement rule lives
+// here: the chips belong under the reply the transcript ends on, and nowhere
+// else.
+// ---------------------------------------------------------------------------
+
+describe("TranscriptMessageBody — follow-up suggestion slot", () => {
+  const slot = <div data-testid="follow-up-slot" />;
+
+  test("renders the slot under the latest assistant message", () => {
+    const { queryByTestId } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-follow-up-latest",
+          role: "assistant",
+          contentBlocks: [textBlock("Here is the answer.")],
+          timestamp: 1_000,
+        }}
+        isLatestMessage
+        followUpSuggestionsSlot={slot}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(queryByTestId("follow-up-slot")).not.toBeNull();
+  });
+
+  test("leaves the slot off an earlier assistant message", () => {
+    const { queryByTestId } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-follow-up-earlier",
+          role: "assistant",
+          contentBlocks: [textBlock("An earlier answer.")],
+          timestamp: 1_000,
+        }}
+        followUpSuggestionsSlot={slot}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(queryByTestId("follow-up-slot")).toBeNull();
+  });
+
+  test("leaves the slot off the user's own latest message", () => {
+    const { queryByTestId } = render(
+      <TranscriptMessageBody
+        message={{
+          id: "m-follow-up-user",
+          role: "user",
+          contentBlocks: [textBlock("My question.")],
+          timestamp: 1_000,
+        }}
+        isLatestMessage
+        followUpSuggestionsSlot={slot}
+        onSurfaceAction={noop}
+      />,
+    );
+
+    expect(queryByTestId("follow-up-slot")).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body.tsx
@@ -165,6 +165,7 @@ export function TranscriptMessageBody({
   responseArtifacts,
   isStreaming = false,
   isLatestMessage = false,
+  followUpSuggestionsSlot,
 }: TranscriptMessageBodyProps) {
   const { t } = useTranslation("chat");
   const inlineAssistantIntermediates =
@@ -1337,6 +1338,9 @@ export function TranscriptMessageBody({
             asset work lands in "Earlier activity" still ends with its cards. */}
         {responseArtifactCards}
         {trailer}
+        {/* Below the actions row, so the chips read as the next thing to do
+            rather than as another action on the reply above them. */}
+        {isAssistant && isLatestMessage ? followUpSuggestionsSlot : null}
       </div>
       {vellumFileModal}
       {isTouch && !isAssistant && (

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -107,6 +107,10 @@ export interface TranscriptRowProps {
    *  `TranscriptMessageBody` so the message directly above the parked avatar
    *  collapses its hover-actions row and animates it open on hover. */
   isLatestMessage?: boolean;
+  /** Follow-up suggestion chips for the message this transcript ends on.
+   *  Forwarded verbatim; `TranscriptMessageBody` decides whether this row is
+   *  the one that renders them. */
+  followUpSuggestionsSlot?: ReactNode;
 }
 
 /**
@@ -223,6 +227,7 @@ export const TranscriptRow = memo(function TranscriptRow({
   responseArtifacts,
   isStreaming,
   isLatestMessage,
+  followUpSuggestionsSlot,
 }: TranscriptRowProps) {
   const { t } = useTranslation("chat");
   switch (item.kind) {
@@ -302,6 +307,7 @@ export const TranscriptRow = memo(function TranscriptRow({
           responseArtifacts={responseArtifacts}
           isStreaming={isStreaming}
           isLatestMessage={isLatestMessage}
+          followUpSuggestionsSlot={followUpSuggestionsSlot}
         />
       );
     }

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -65,6 +65,11 @@ export interface TranscriptProps {
    *  different lifecycle than interaction prompts, so it stays as a
    *  render-prop for now. */
   renderOnboardingChoice?: () => ReactNode;
+  /** Follow-up suggestion chips for the reply the transcript ends on, or
+   *  omitted when the surface has nothing to offer. Handed to every row; only
+   *  the latest assistant message renders it (see
+   *  `TranscriptMessageBodyProps.followUpSuggestionsSlot`). */
+  followUpSuggestionsSlot?: ReactNode;
   /** Click handler on a tool-call risk badge — opens the rule editor. The
    *  ToolCallChip forwards the active tool-call's metadata so the modal can
    *  pre-fill its fields. */
@@ -353,6 +358,7 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       onStopSubagent: rest.onStopSubagent,
       onWorkflowClick: rest.onWorkflowClick,
       onStopWorkflow: rest.onStopWorkflow,
+      followUpSuggestionsSlot: rest.followUpSuggestionsSlot,
     };
 
     return (

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -760,6 +760,9 @@
     "upload": "Upload",
     "uploading": "Uploading..."
   },
+  "followUpSuggestions": {
+    "groupAria": "Suggested follow-ups"
+  },
   "formSurface": {
     "secureHint": "This value will be sent securely and will not be stored in your browser.",
     "selectPlaceholder": "Select..."

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -756,6 +756,9 @@
     "upload": "Subir",
     "uploading": "Subiendo..."
   },
+  "followUpSuggestions": {
+    "groupAria": "Sugerencias de seguimiento"
+  },
   "formSurface": {
     "secureHint": "Este valor se enviará de forma segura y no se guardará en tu navegador.",
     "selectPlaceholder": "Seleccionar..."

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -379,6 +379,9 @@
   "fileDownload": {
     "failed": "Не удалось скачать файл"
   },
+  "followUpSuggestions": {
+    "groupAria": "Предлагаемые продолжения"
+  },
   "groupActions": {
     "archiveAll": "В архив все…",
     "copyGroupId": "Скопировать ID группы",

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -736,6 +736,9 @@
     "upload": "上傳",
     "uploading": "正在上傳..."
   },
+  "followUpSuggestions": {
+    "groupAria": "建議的後續問題"
+  },
   "formSurface": {
     "secureHint": "此值將會安全傳送，且不會儲存在您的瀏覽器中。",
     "selectPlaceholder": "請選擇..."

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -736,6 +736,9 @@
     "upload": "上传",
     "uploading": "正在上传..."
   },
+  "followUpSuggestions": {
+    "groupAria": "推荐的后续问题"
+  },
   "formSurface": {
     "secureHint": "此值将安全发送，不会存储在您的浏览器中。",
     "selectPlaceholder": "选择..."

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -347,7 +347,7 @@
       "scope": "client",
       "key": "follow-up-suggestions",
       "label": "Follow-up suggestion chips",
-      "description": "Render two tappable follow-up suggestion chips under the latest assistant reply. The chips prefill the composer with the suggestion the user picks; the daemon returns the suggestions either way.",
+      "description": "Render two tappable follow-up suggestion chips under the latest assistant reply. Picking one sends it as the user's next message, and the composer's ghost-text suggestion stays hidden while the chips are on; the daemon returns the suggestions either way.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -347,7 +347,7 @@
       "scope": "client",
       "key": "follow-up-suggestions",
       "label": "Follow-up suggestion chips",
-      "description": "Render two tappable follow-up suggestion chips under the latest assistant reply. The chips prefill the composer with the suggestion the user picks; the daemon returns the suggestions either way.",
+      "description": "Render two tappable follow-up suggestion chips under the latest assistant reply. Picking one sends it as the user's next message, and the composer's ghost-text suggestion stays hidden while the chips are on; the daemon returns the suggestions either way.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary

Behind the `follow-up-suggestions` client flag, the latest assistant reply ends with up to two chips carrying short next messages in the user's own voice. Picking one seeds the composer and sends it, the same path a conversation-starter chip takes, so a blocked send leaves the text there to retry. Flag off, nothing changes.

- **Data**: the chips read the `suggestions` array the daemon already returns. `useGhostTextSuggestion` and the new `useFollowUpSuggestions` now share one `suggestion_get` query behind `useReplySuggestionQuery` (`clients/web/src/domains/chat/hooks/use-ghost-text-suggestion.ts`), so mounting both costs one fetch and one cache entry. On a daemon that predates the pair, the singular `suggestion` stands in for the list.
- **Ghost text**: with the flag on, the composer's ghost-text suggestion is suppressed. Two suggestion affordances at once is clutter.
- **Suppression**: `shouldShowFollowUpSuggestions` is one named predicate rather than a condition assembled at the render site. It withholds the chips while a turn is running or a send is blocked, when the turn parked on a surface that already asks the user something (an `ask_question` card, an uncompleted `ui_show` choice / form / confirmation), and when the daemon returned nothing. The "user already sent something after that reply" case needs no rule: `lastCompleteAssistantMsgId` goes `null` and the query key stops matching.
- **Placement**: `followUpSuggestionsSlot` is threaded to every transcript row; `TranscriptMessageBody` renders it only for the latest **assistant** message, below the hover-actions row. The anchor user message and history rows never show it.
- **Reuse**: the chip is the existing `ConversationStarterChip`, not a new button style.
- **Telemetry** is a separate PR. `FollowUpSuggestionsProps.onSelect` is the single click seam it can hang off without a refactor.

The flag's registry description was corrected to match what shipped (picking a chip sends, and hides the ghost text) in both `meta/feature-flags/` and the web copy, kept byte-identical.

Part of JARVIS-1735

## Stacked on #42134

Based on `aaron/jarvis-1735-follow-up-suggestions-daemon-and-flag`, which adds `suggestions: string[]` to the `suggestion_get` response and registers the `follow-up-suggestions` client flag (default off). Merge that one first; this PR targets that branch, not `main`.

## Test plan

```
cd clients/web && bun test src/domains/chat/components/follow-up-suggestions.test.tsx \
  src/domains/chat/transcript/transcript-message-body.test.tsx \
  src/domains/chat/hooks/use-ghost-text-suggestion.test.tsx
# 99 pass, 0 fail (252 expect() calls, 3 files)

cd clients/web && bun test src/i18n/catalogs.test.ts
# 210 pass, 0 fail (27489 expect() calls)

cd clients/web && bun run lint -- <the 12 touched source files>
# clean, no output
```

New coverage: the gate is exercised for flag-off, turn-active, awaiting-interaction, and zero-suggestion cases; the component for two chips in a labelled group, the click sending the chip's own text, the cap at two, and the empty render; and `TranscriptMessageBody` for the slot landing on the latest assistant message and on neither an earlier one nor the user's own latest.

Not run here: `tsc --noEmit`. This worktree symlinks `node_modules` from an older main checkout, so the workspace `@vellumai/avatar-manifest` package resolves stale and `assistant/` reports 50 pre-existing avatar type errors unrelated to this diff (no file under `assistant/` is touched). CI typechecks against a real install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjwLgqzhFp4AQ42arMfhaF

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/42136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->