### PR TITLE
fix(onboarding): skip the empty research-results card

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -853,6 +853,18 @@ describe("ResearchOnboardingRoute paid return", () => {
       expect(screen.getByTestId("looking-step").dataset.ready).toBe("true"),
     );
   });
+
+  test("skips the results step when research settles with no claims", async () => {
+    researchStatus = "done";
+    writeResearchSnapshot(USER_ID, postFormSnapshot({ step: "results" }));
+
+    render(<ResearchOnboardingRoute />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("letschat-ready-step")).toBeTruthy(),
+    );
+    expect(screen.queryByTestId("results-step")).toBeNull();
+  });
 });
 
 // Retrying the hatch must restart everything that already resolved against the

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
@@ -110,7 +110,6 @@ describe("ResearchResultsStep copy / list agreement", () => {
     renderStep({ claims, loading: false, onContinue });
 
     expect(screen.queryByText(COPY.title)).toBeNull();
-    expect(screen.queryByText(COPY.bodyReadyEmpty)).toBeNull();
     expect(screen.queryByText(COPY.bodyReadyWithClaims)).toBeNull();
     expect(screen.queryByText("Lives in Dallas")).toBeNull();
     expect(screen.queryByRole("button", { name: COPY.notMe })).toBeNull();
@@ -134,7 +133,6 @@ describe("ResearchResultsStep copy / list agreement", () => {
     });
 
     expect(screen.getByText(COPY.bodyReadyWithClaims)).toBeTruthy();
-    expect(screen.queryByText(COPY.bodyReadyEmpty)).toBeNull();
     expect(screen.getByText("Engineer at Acme")).toBeTruthy();
     expect(screen.getByText("Into climbing")).toBeTruthy();
     expect(screen.getByRole("button", { name: COPY.notMe })).toBeTruthy();
@@ -155,7 +153,6 @@ describe("ResearchResultsStep copy / list agreement", () => {
     expect(onContinue).toHaveBeenCalledTimes(1);
     expect(onContinue.mock.calls[0]?.[0]).toEqual([KEPT_CLAIM.claim]);
     expect(screen.queryByText(COPY.title)).toBeNull();
-    expect(screen.queryByText(COPY.bodyReadyEmpty)).toBeNull();
     expect(screen.queryByText(COPY.bodyReadyWithClaims)).toBeNull();
     expect(screen.queryByText(KEPT_CLAIM.claim)).toBeNull();
     expect(screen.queryByRole("button", { name: COPY.notMe })).toBeNull();

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
@@ -6,7 +6,7 @@
  * the list actually renders. Claims that exist must stay in the document, not
  * get clipped out of an overflow region.
  *
- * Single-file `bun test` only — `mock.module` leaks across files in this repo,
+ * Single-file `bun test` only: `mock.module` leaks across files in this repo,
  * so run this file on its own (or via scripts/run-tests.ts).
  */
 

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
@@ -1,10 +1,12 @@
 /**
- * Research-results step: copy and the visible claims list must agree.
+ * Research-results step: copy and the visible claims list must agree, and an
+ * empty list must not keep the user on this card.
  *
- * A research turn can settle with card-worthy facts, or with nothing that
- * survived aggregator filtering. Either way the body copy has to match what
- * the list actually renders. Claims that exist must stay in the document, not
- * get clipped out of an overflow region.
+ * Aggregator filtering can leave nothing to show; pruning can empty the list
+ * the same way. The settled empty card is not rendered. Pruning the last row
+ * continues automatically. A research turn that settled empty is skipped by
+ * the route (see research-onboarding-route.test.tsx) so this step does not
+ * continue on an empty mount (that would walk past a hatch-error hold).
  *
  * Single-file `bun test` only: `mock.module` leaks across files in this repo,
  * so run this file on its own (or via scripts/run-tests.ts).
@@ -82,7 +84,7 @@ function renderStep(
 afterEach(cleanup);
 
 describe("ResearchResultsStep copy / list agreement", () => {
-  test("empty-after-filter uses the empty-state copy and renders no rows", () => {
+  test("empty-after-filter does not paint the results card", () => {
     const { claims, droppedClaims } = parseResearchResultStreaming(
       JSON.stringify({
         claims: [
@@ -104,13 +106,18 @@ describe("ResearchResultsStep copy / list agreement", () => {
     expect(claims).toEqual([]);
     expect(droppedClaims).toEqual(["Lives in Dallas", "Works at Acme"]);
 
-    renderStep({ claims, loading: false });
+    const onContinue = mock(() => {});
+    renderStep({ claims, loading: false, onContinue });
 
-    expect(screen.getByText(COPY.bodyReadyEmpty)).toBeTruthy();
+    expect(screen.queryByText(COPY.title)).toBeNull();
+    expect(screen.queryByText(COPY.bodyReadyEmpty)).toBeNull();
     expect(screen.queryByText(COPY.bodyReadyWithClaims)).toBeNull();
     expect(screen.queryByText("Lives in Dallas")).toBeNull();
-    expect(screen.queryByText("Works at Acme")).toBeNull();
     expect(screen.queryByRole("button", { name: COPY.notMe })).toBeNull();
+    // The route skips this step when research settles empty. Continuing from
+    // an empty mount would mark findings reviewed and walk past a hatch-error
+    // hold.
+    expect(onContinue).not.toHaveBeenCalled();
   });
 
   test("visible claims use the results copy and stay in the document", () => {
@@ -133,8 +140,9 @@ describe("ResearchResultsStep copy / list agreement", () => {
     expect(screen.getByRole("button", { name: COPY.notMe })).toBeTruthy();
   });
 
-  test("pruning the last visible claim swaps to the empty-state copy", () => {
-    renderStep({ claims: [KEPT_CLAIM], loading: false });
+  test("pruning the last visible claim advances instead of showing an empty card", () => {
+    const onContinue = mock(() => {});
+    renderStep({ claims: [KEPT_CLAIM], loading: false, onContinue });
 
     expect(screen.getByText(COPY.bodyReadyWithClaims)).toBeTruthy();
 
@@ -144,7 +152,10 @@ describe("ResearchResultsStep copy / list agreement", () => {
       }),
     );
 
-    expect(screen.getByText(COPY.bodyReadyEmpty)).toBeTruthy();
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(onContinue.mock.calls[0]?.[0]).toEqual([KEPT_CLAIM.claim]);
+    expect(screen.queryByText(COPY.title)).toBeNull();
+    expect(screen.queryByText(COPY.bodyReadyEmpty)).toBeNull();
     expect(screen.queryByText(COPY.bodyReadyWithClaims)).toBeNull();
     expect(screen.queryByText(KEPT_CLAIM.claim)).toBeNull();
     expect(screen.queryByRole("button", { name: COPY.notMe })).toBeNull();

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
@@ -11,14 +11,50 @@
  */
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { createElement, type ReactElement, type ReactNode } from "react";
 
-import { ResearchResultsStep } from "@/domains/onboarding/screens/research-result-steps";
 import onboardingEn from "@/i18n/locales/en/onboarding.json";
 import {
   parseResearchResultStreaming,
   type ResearchFact,
 } from "@/utils/research-facts";
+
+// Presence exit holds removed rows in happy-dom for the animation duration.
+// The agreement under test is copy vs the surviving list, so mount/unmount
+// has to be synchronous.
+mock.module("motion/react", () => {
+  const MOTION_ONLY_PROPS = new Set([
+    "initial",
+    "animate",
+    "exit",
+    "transition",
+    "variants",
+    "layout",
+    "layoutId",
+  ]);
+  return {
+    motion: new Proxy(
+      {} as Record<string, (props: Record<string, unknown>) => ReactElement>,
+      {
+        get: (_target, tag) => (props: Record<string, unknown>) => {
+          const domProps: Record<string, unknown> = {};
+          for (const key in props) {
+            if (!MOTION_ONLY_PROPS.has(key)) {
+              domProps[key] = props[key];
+            }
+          }
+          return createElement(String(tag), domProps);
+        },
+      },
+    ),
+    AnimatePresence: ({ children }: { children?: ReactNode }) => children,
+    useReducedMotion: () => true,
+  };
+});
+
+const { ResearchResultsStep } =
+  await import("@/domains/onboarding/screens/research-result-steps");
 
 const COPY = onboardingEn.researchResultsStep;
 
@@ -74,9 +110,7 @@ describe("ResearchResultsStep copy / list agreement", () => {
     expect(screen.queryByText(COPY.bodyReadyWithClaims)).toBeNull();
     expect(screen.queryByText("Lives in Dallas")).toBeNull();
     expect(screen.queryByText("Works at Acme")).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: COPY.notMe }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: COPY.notMe })).toBeNull();
   });
 
   test("visible claims use the results copy and stay in the document", () => {
@@ -113,8 +147,6 @@ describe("ResearchResultsStep copy / list agreement", () => {
     expect(screen.getByText(COPY.bodyReadyEmpty)).toBeTruthy();
     expect(screen.queryByText(COPY.bodyReadyWithClaims)).toBeNull();
     expect(screen.queryByText(KEPT_CLAIM.claim)).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: COPY.notMe }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: COPY.notMe })).toBeNull();
   });
 });

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
@@ -106,7 +106,7 @@ describe("ResearchResultsStep copy / list agreement", () => {
     expect(claims).toEqual([]);
     expect(droppedClaims).toEqual(["Lives in Dallas", "Works at Acme"]);
 
-    const onContinue = mock(() => {});
+    const onContinue = mock((_removed: string[]) => {});
     renderStep({ claims, loading: false, onContinue });
 
     expect(screen.queryByText(COPY.title)).toBeNull();
@@ -141,7 +141,7 @@ describe("ResearchResultsStep copy / list agreement", () => {
   });
 
   test("pruning the last visible claim advances instead of showing an empty card", () => {
-    const onContinue = mock(() => {});
+    const onContinue = mock((_removed: string[]) => {});
     renderStep({ claims: [KEPT_CLAIM], loading: false, onContinue });
 
     expect(screen.getByText(COPY.bodyReadyWithClaims)).toBeTruthy();

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Research-results step: copy and the visible claims list must agree.
+ *
+ * A research turn can settle with card-worthy facts, or with nothing that
+ * survived aggregator filtering. Either way the body copy has to match what
+ * the list actually renders. Claims that exist must stay in the document, not
+ * get clipped out of an overflow region.
+ *
+ * Single-file `bun test` only — `mock.module` leaks across files in this repo,
+ * so run this file on its own (or via scripts/run-tests.ts).
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { ResearchResultsStep } from "@/domains/onboarding/screens/research-result-steps";
+import onboardingEn from "@/i18n/locales/en/onboarding.json";
+import {
+  parseResearchResultStreaming,
+  type ResearchFact,
+} from "@/utils/research-facts";
+
+const COPY = onboardingEn.researchResultsStep;
+
+const KEPT_CLAIM: ResearchFact = {
+  claim: "Engineer at Acme",
+  confidence: "confident",
+  sources: ["https://acme.example.com/team"],
+};
+
+function renderStep(
+  props: Partial<Parameters<typeof ResearchResultsStep>[0]> = {},
+) {
+  return render(
+    <ResearchResultsStep
+      claims={[]}
+      loading={false}
+      onContinue={() => {}}
+      onRejectAll={() => {}}
+      onBack={() => {}}
+      {...props}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+describe("ResearchResultsStep copy / list agreement", () => {
+  test("empty-after-filter uses the empty-state copy and renders no rows", () => {
+    const { claims, droppedClaims } = parseResearchResultStreaming(
+      JSON.stringify({
+        claims: [
+          {
+            claim: "Lives in Dallas",
+            confidence: "confident",
+            sources: ["https://spokeo.com/example-user"],
+          },
+          {
+            claim: "Works at Acme",
+            confidence: "maybe",
+            sources: ["https://whitepages.com/example-user"],
+          },
+        ],
+        suggestions: [],
+      }),
+    );
+
+    expect(claims).toEqual([]);
+    expect(droppedClaims).toEqual(["Lives in Dallas", "Works at Acme"]);
+
+    renderStep({ claims, loading: false });
+
+    expect(screen.getByText(COPY.bodyReadyEmpty)).toBeTruthy();
+    expect(screen.queryByText(COPY.bodyReadyWithClaims)).toBeNull();
+    expect(screen.queryByText("Lives in Dallas")).toBeNull();
+    expect(screen.queryByText("Works at Acme")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: COPY.notMe }),
+    ).toBeNull();
+  });
+
+  test("visible claims use the results copy and stay in the document", () => {
+    renderStep({
+      claims: [
+        KEPT_CLAIM,
+        {
+          claim: "Into climbing",
+          confidence: "guessing",
+          sources: [],
+        },
+      ],
+      loading: false,
+    });
+
+    expect(screen.getByText(COPY.bodyReadyWithClaims)).toBeTruthy();
+    expect(screen.queryByText(COPY.bodyReadyEmpty)).toBeNull();
+    expect(screen.getByText("Engineer at Acme")).toBeTruthy();
+    expect(screen.getByText("Into climbing")).toBeTruthy();
+    expect(screen.getByRole("button", { name: COPY.notMe })).toBeTruthy();
+  });
+
+  test("pruning the last visible claim swaps to the empty-state copy", () => {
+    renderStep({ claims: [KEPT_CLAIM], loading: false });
+
+    expect(screen.getByText(COPY.bodyReadyWithClaims)).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: COPY.removeClaim.replace("{claim}", KEPT_CLAIM.claim),
+      }),
+    );
+
+    expect(screen.getByText(COPY.bodyReadyEmpty)).toBeTruthy();
+    expect(screen.queryByText(COPY.bodyReadyWithClaims)).toBeNull();
+    expect(screen.queryByText(KEPT_CLAIM.claim)).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: COPY.notMe }),
+    ).toBeNull();
+  });
+});

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -418,9 +418,20 @@ export function ResearchResultsStep({
   // Locally track removed claims by their text so a user can prune what's wrong
   // without mutating the streamed list (which may still be growing).
   const [removed, setRemoved] = useState<Set<string>>(() => new Set());
-  const visible = claims.filter((c) => !removed.has(c.claim));
+  // Copy and the list share this array: a blank or pruned claim must not keep
+  // the "found about you" results copy on screen over an empty panel.
+  const visible = claims.filter(
+    (c) => c.claim.trim().length > 0 && !removed.has(c.claim),
+  );
   const hasClaims = visible.length > 0;
   const canContinue = !loading;
+  const bodyKey = hasClaims
+    ? loading
+      ? "researchResultsStep.bodyLoadingWithClaims"
+      : "researchResultsStep.bodyReadyWithClaims"
+    : loading
+      ? "researchResultsStep.bodyLoadingEmpty"
+      : "researchResultsStep.bodyReadyEmpty";
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>
@@ -428,12 +439,12 @@ export function ResearchResultsStep({
 
       {/* Bounded to the viewport bottom so a long claims list can't push the
           continue button off-screen on short windows. The button is a pinned
-          footer; everything above it scrolls as one region (min-h-0 lets it
-          shrink), so the claims stay reachable even when the window is shorter
-          than the heading + button alone. */}
+          footer; the region above it is flex-1 + min-h-0 so it gets a real
+          height and can scroll, instead of shrinking to zero around the
+          heading. Claim rows are shrink-0 so flex cannot collapse them. */}
       <div className="absolute bottom-0 left-1/2 top-[11%] sm:top-[8%] z-10 flex w-full max-w-xl -translate-x-1/2 flex-col px-6 pb-8">
-        <div className="flex min-h-0 flex-col overflow-y-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
-          <div className="flex items-center gap-3">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none]">
+          <div className="flex shrink-0 items-center gap-3">
             <MiniAssistant />
             <h1
               className="text-[2.2rem] leading-none"
@@ -442,26 +453,26 @@ export function ResearchResultsStep({
               {t("researchResultsStep.title")}
             </h1>
           </div>
-          <p className="mb-7 mt-2 text-[15px]" style={{ color: tone.fgMuted }}>
-            {hasClaims
-              ? loading
-                ? t("researchResultsStep.bodyLoadingWithClaims")
-                : t("researchResultsStep.bodyReadyWithClaims")
-              : loading
-                ? t("researchResultsStep.bodyLoadingEmpty")
-                : t("researchResultsStep.bodyReadyEmpty")}
+          <p
+            className="mb-7 mt-2 shrink-0 text-[15px]"
+            style={{ color: tone.fgMuted }}
+          >
+            {t(bodyKey)}
           </p>
 
-          <div className="flex flex-col gap-3">
-            <AnimatePresence>
+          <div className="flex shrink-0 flex-col gap-3">
+            {/* `initial={false}` so claims already present when this step
+                mounts paint immediately. A y-offset enter inside overflow-y-auto
+                can sit clipped at opacity 0 if the animation never settles. */}
+            <AnimatePresence initial={false}>
               {visible.map((fact) => (
                 <motion.div
                   key={fact.claim}
                   layout
-                  initial={reduce ? false : { opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
+                  initial={reduce ? false : { opacity: 0 }}
+                  animate={{ opacity: 1 }}
                   exit={reduce ? undefined : { opacity: 0, scale: 0.95 }}
-                  className="flex items-center justify-between gap-3 rounded-2xl px-5 py-4 text-[15px]"
+                  className="flex shrink-0 items-center justify-between gap-3 rounded-2xl px-5 py-4 text-[15px]"
                   style={{
                     backgroundColor: tone.isLight
                       ? "rgba(0,0,0,0.06)"

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -415,6 +415,11 @@ export function ResearchResultsStep({
   const { t } = useTranslation("onboarding");
   const tone = DARK_TONE;
   const reduce = useReducedMotion();
+  // `useReducedMotion` is `null` until the media query resolves. Treat that
+  // unknown window like reduced motion: do not mount rows at opacity 0. Copy
+  // already counts them as visible, so a stuck enter would show results copy
+  // over a blank list.
+  const animatePresence = reduce === false;
   // Locally track removed claims by their text so a user can prune what's wrong
   // without mutating the streamed list (which may still be growing).
   const [removed, setRemoved] = useState<Set<string>>(() => new Set());
@@ -461,17 +466,16 @@ export function ResearchResultsStep({
           </p>
 
           <div className="flex shrink-0 flex-col gap-3">
-            {/* `initial={false}` so claims already present when this step
-                mounts paint immediately. A y-offset enter inside overflow-y-auto
-                can sit clipped at opacity 0 if the animation never settles. */}
             <AnimatePresence initial={false}>
               {visible.map((fact) => (
                 <motion.div
                   key={fact.claim}
-                  layout
-                  initial={reduce ? false : { opacity: 0 }}
+                  layout={animatePresence}
+                  initial={animatePresence ? { opacity: 0 } : false}
                   animate={{ opacity: 1 }}
-                  exit={reduce ? undefined : { opacity: 0, scale: 0.95 }}
+                  exit={
+                    animatePresence ? { opacity: 0, scale: 0.95 } : undefined
+                  }
                   className="flex shrink-0 items-center justify-between gap-3 rounded-2xl px-5 py-4 text-[15px]"
                   style={{
                     backgroundColor: tone.isLight

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -13,7 +13,8 @@
  * are the REAL research output — the route fires the research turn against the
  * hatched assistant (see `research-runner.ts`) and threads the parsed
  * `{ claims, suggestions }` in here. Each step falls back to a graceful
- * loading / empty presentation while the turn is still streaming.
+ * loading presentation while the turn is still streaming. Settled empty
+ * results do not keep this card on screen: the route skips ahead.
  */
 
 import { Fragment, useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -423,20 +424,45 @@ export function ResearchResultsStep({
   // Locally track removed claims by their text so a user can prune what's wrong
   // without mutating the streamed list (which may still be growing).
   const [removed, setRemoved] = useState<Set<string>>(() => new Set());
-  // Copy and the list share this array: a blank or pruned claim must not keep
-  // the "found about you" results copy on screen over an empty panel.
+  // Copy and the list share this array. A blank or pruned claim is not a
+  // visible row, so it cannot keep the results copy (or this card) on screen.
   const visible = claims.filter(
     (c) => c.claim.trim().length > 0 && !removed.has(c.claim),
   );
   const hasClaims = visible.length > 0;
   const canContinue = !loading;
+  const onContinueRef = useRef(onContinue);
+  onContinueRef.current = onContinue;
+  const advancedRef = useRef(false);
+
+  // Settled with nothing visible: leave this card. The route skips the same
+  // way when research lands empty (after aggregator filtering). Pruning the
+  // last row is the in-step case. A hatch-error hold keeps `loading` false
+  // with an empty list and `removed` empty; skip continue there so retry can
+  // refill this step (the route also holds when `hatchError` is set).
+  useEffect(() => {
+    if (loading || hasClaims || advancedRef.current) {
+      return;
+    }
+    if (removed.size === 0) {
+      return;
+    }
+    advancedRef.current = true;
+    onContinueRef.current([...removed]);
+  }, [loading, hasClaims, removed]);
+
+  // Do not paint the settled empty card. The looking-you-up carousel and the
+  // route skip cover "research found nothing"; this return covers the frame
+  // after the last prune (and any empty mount) before the next step lands.
+  if (!hasClaims && !loading) {
+    return null;
+  }
+
   const bodyKey = hasClaims
     ? loading
       ? "researchResultsStep.bodyLoadingWithClaims"
       : "researchResultsStep.bodyReadyWithClaims"
-    : loading
-      ? "researchResultsStep.bodyLoadingEmpty"
-      : "researchResultsStep.bodyReadyEmpty";
+    : "researchResultsStep.bodyLoadingEmpty";
 
   return (
     <div className="absolute inset-0 z-10" style={{ color: tone.fg }}>

--- a/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
+++ b/clients/web/src/domains/onboarding/screens/research-result-steps.tsx
@@ -431,8 +431,6 @@ export function ResearchResultsStep({
   );
   const hasClaims = visible.length > 0;
   const canContinue = !loading;
-  const onContinueRef = useRef(onContinue);
-  onContinueRef.current = onContinue;
   const advancedRef = useRef(false);
 
   // Settled with nothing visible: leave this card. The route skips the same
@@ -448,8 +446,8 @@ export function ResearchResultsStep({
       return;
     }
     advancedRef.current = true;
-    onContinueRef.current([...removed]);
-  }, [loading, hasClaims, removed]);
+    onContinue([...removed]);
+  }, [loading, hasClaims, removed, onContinue]);
 
   // Do not paint the settled empty card. The looking-you-up carousel and the
   // route skip cover "research found nothing"; this return covers the frame

--- a/clients/web/src/i18n/locales/en/onboarding.json
+++ b/clients/web/src/i18n/locales/en/onboarding.json
@@ -255,7 +255,6 @@
     "bodyLoadingWithClaims": "Still checking the rest. You can review these as they come in.",
     "bodyReadyWithClaims": "I searched the web. Feel free to remove anything that isn’t true.",
     "bodyLoadingEmpty": "Still putting this together…",
-    "bodyReadyEmpty": "I didn’t turn up much, we can fill it in as we chat.",
     "removeClaim": "Remove \"{claim}\"",
     "notMe": "This is not me",
     "stillSearching": "Still searching…"

--- a/clients/web/src/i18n/locales/es/onboarding.json
+++ b/clients/web/src/i18n/locales/es/onboarding.json
@@ -255,7 +255,6 @@
     "bodyLoadingWithClaims": "Todavía estoy revisando el resto. Puedes ir mirando lo que va llegando.",
     "bodyReadyWithClaims": "He buscado en la web. Siéntete libre de quitar cualquier cosa que no sea cierta.",
     "bodyLoadingEmpty": "Todavía lo estoy armando…",
-    "bodyReadyEmpty": "No he encontrado mucho, lo iremos completando al chatear.",
     "removeClaim": "Quitar «{claim}»",
     "notMe": "Esto no soy yo",
     "stillSearching": "Todavía buscando…"

--- a/clients/web/src/i18n/locales/ru/onboarding.json
+++ b/clients/web/src/i18n/locales/ru/onboarding.json
@@ -255,7 +255,6 @@
     "bodyLoadingWithClaims": "Ещё проверяю остальное. Просмотр по мере появления.",
     "bodyReadyWithClaims": "Я поискал в интернете. Смело убирай всё, что неправда.",
     "bodyLoadingEmpty": "Ещё собираю это вместе…",
-    "bodyReadyEmpty": "Мало что нашлось, дозаполним по ходу диалога.",
     "removeClaim": "Убрать «{claim}»",
     "notMe": "Это не я",
     "stillSearching": "Ещё ищу…"

--- a/clients/web/src/i18n/locales/zh-TW/onboarding.json
+++ b/clients/web/src/i18n/locales/zh-TW/onboarding.json
@@ -255,7 +255,6 @@
     "bodyLoadingWithClaims": "仍在檢查其餘資訊。您可以在資訊出現時進行檢閱。",
     "bodyReadyWithClaims": "我搜尋了網路。請隨意移除任何不實的資訊。",
     "bodyLoadingEmpty": "仍在整理中…",
-    "bodyReadyEmpty": "我沒有找到太多資訊，我們可以在聊天時補充。",
     "removeClaim": "移除「{claim}」",
     "notMe": "這不是我",
     "stillSearching": "仍在搜尋…"

--- a/clients/web/src/i18n/locales/zh/onboarding.json
+++ b/clients/web/src/i18n/locales/zh/onboarding.json
@@ -255,7 +255,6 @@
     "bodyLoadingWithClaims": "仍在检查其余信息。您可以在信息出现时进行查看。",
     "bodyReadyWithClaims": "我搜索了网络。请随意删除任何不真实的信息。",
     "bodyLoadingEmpty": "仍在整理中…",
-    "bodyReadyEmpty": "我没有找到太多信息，我们可以在聊天时补充。",
     "removeClaim": "移除“{claim}”",
     "notMe": "这不是我",
     "stillSearching": "仍在搜索…"

--- a/clients/web/src/utils/research-facts.test.ts
+++ b/clients/web/src/utils/research-facts.test.ts
@@ -273,6 +273,31 @@ describe("parseResearchResultStreaming — dropped aggregator-only claims", () =
   const payload = (claims: unknown[]): string =>
     JSON.stringify({ claims, suggestions: [] });
 
+  test("an all-aggregator payload leaves claims empty", () => {
+    // Every source is a people-search directory, so nothing survives onto the
+    // card. The results step must treat this as empty, not as "found about you".
+    const { claims, droppedClaims } = parseResearchResultStreaming(
+      payload([
+        {
+          claim: "Lives in Dallas",
+          confidence: "confident",
+          sources: [
+            "https://www.spokeo.com/example-user",
+            "https://profiles.beenverified.com/example-user",
+          ],
+        },
+        {
+          claim: "Works at Acme",
+          confidence: "maybe",
+          sources: ["https://whitepages.com/example-user"],
+        },
+      ]),
+    );
+
+    expect(claims).toEqual([]);
+    expect(droppedClaims).toEqual(["Lives in Dallas", "Works at Acme"]);
+  });
+
   test("surfaces an aggregator-only claim's text in droppedClaims", () => {
     // The claim is hidden from the card AND reported as dropped, so the flow can
     // scrub the wrong-person fact from the assistant's memory (not just hide it).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- The "This is what I found about you" step no longer keeps the user on an empty card. If nothing survived aggregator filtering, or the last claim is pruned, the flow auto-advances to the next step.
- Claims-present path is unchanged: results copy, visible list, and "This is not me".
- First-paint fix kept: `useReducedMotion()` is `null` until the media query resolves, so rows no longer mount at opacity 0. Claim rows stay `shrink-0` in a `flex-1 min-h-0` scroll region.
- A hatch-error hold still parks on this step so retry can refill it. The settled empty card is not painted in that window.
- Unused `researchResultsStep.bodyReadyEmpty` catalog key is removed from all locales (the settled empty card is not rendered).

Fixes LUM-3536
https://linear.app/vellum/issue/LUM-3536

## Test Plan
- `cd clients/web && bun test src/domains/onboarding/screens/research-result-steps.test.tsx`
  - empty-after-filter: no results card, no empty-state copy
  - non-empty: results copy, claim text, "This is not me"
  - pruning the last claim calls `onContinue` and does not show an empty card
- `cd clients/web && bun test src/domains/onboarding/pages/research-onboarding-route.test.tsx`
  - research that settles with no claims skips the results step
- `cd clients/web && bun test src/utils/research-facts.test.ts`
  - all-aggregator payload leaves `claims` empty
- `cd clients/web && bun test src/i18n/catalogs.test.ts`
  - English catalog keys stay referenced after dropping `bodyReadyEmpty`

## Risk
- Low. UI-only on the onboarding results step plus the existing route skip. Hatch-error hold is unchanged. No persistence, API, or companion-repo change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1bf4db7-99f0-46e3-a5f7-02bcbdec1c9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1bf4db7-99f0-46e3-a5f7-02bcbdec1c9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

