### PR TITLE
fix(web): skip empty-profile research and bound the onboarding wait

### DIFF
--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -925,11 +925,11 @@ describe("ResearchOnboardingRoute empty-details research skip", () => {
     expect(startResearchMock).not.toHaveBeenCalled();
   });
 
-  test("a restored snapshot with a role still starts research", async () => {
+  test("a restored snapshot with last name and a role still starts research", async () => {
     writeResearchSnapshot(
       USER_ID,
       postFormSnapshot({
-        formValues: { ...nameOnly, role: "Engineer" },
+        formValues: { ...nameOnly, lastName: "Example", role: "Engineer" },
       }),
     );
 
@@ -939,11 +939,11 @@ describe("ResearchOnboardingRoute empty-details research skip", () => {
     expect(screen.getByTestId("looking-step")).toBeTruthy();
   });
 
-  test("a restored snapshot with hobbies still starts research", async () => {
+  test("a restored snapshot with last name and hobbies still starts research", async () => {
     writeResearchSnapshot(
       USER_ID,
       postFormSnapshot({
-        formValues: { ...nameOnly, hobbies: ["chess"] },
+        formValues: { ...nameOnly, lastName: "Example", hobbies: ["chess"] },
       }),
     );
 
@@ -951,6 +951,23 @@ describe("ResearchOnboardingRoute empty-details research skip", () => {
 
     await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
     expect(screen.getByTestId("looking-step")).toBeTruthy();
+  });
+
+  test("a restored snapshot with role and hobbies but no last name skips research", async () => {
+    writeResearchSnapshot(
+      USER_ID,
+      postFormSnapshot({
+        step: "looking",
+        formValues: { ...nameOnly, role: "Engineer", hobbies: ["chess"] },
+      }),
+    );
+
+    render(<ResearchOnboardingRoute />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("letschat-ready-step")).toBeTruthy(),
+    );
+    expect(startResearchMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.test.tsx
@@ -58,7 +58,13 @@ let researchStatus = "idle";
 const startResearchMock = mock((_opts: unknown) => {
   researchStatus = "running";
 });
-const hydrateResearchMock = mock((_results: unknown, _await?: unknown) => {});
+const hydrateResearchMock = mock(
+  (results: { status?: string }, _await?: unknown) => {
+    if (results.status) {
+      researchStatus = results.status;
+    }
+  },
+);
 const resetResearchMock = mock(() => {});
 const reinstallPluginsMock = mock((_names: string[], _await: unknown) => {});
 let installedPlugins: string[] = [];
@@ -259,20 +265,36 @@ mock.module("@/domains/onboarding/screens/research-onboarding-screen", () => ({
   ResearchOnboardingScreen: (props: {
     onSubmit: (values: unknown) => void;
   }) => (
-    <button
-      type="button"
-      data-testid="form-submit"
-      onClick={() =>
-        props.onSubmit({
-          firstName: "Alice",
-          lastName: "Example",
-          role: "Engineer",
-          hobbies: [],
-        })
-      }
-    >
-      submit
-    </button>
+    <>
+      <button
+        type="button"
+        data-testid="form-submit"
+        onClick={() =>
+          props.onSubmit({
+            firstName: "Alice",
+            lastName: "Example",
+            role: "Engineer",
+            hobbies: [],
+          })
+        }
+      >
+        submit
+      </button>
+      <button
+        type="button"
+        data-testid="form-submit-name-only"
+        onClick={() =>
+          props.onSubmit({
+            firstName: "Alice",
+            lastName: "",
+            role: "",
+            hobbies: [],
+          })
+        }
+      >
+        submit name only
+      </button>
+    </>
   ),
 }));
 
@@ -392,9 +414,8 @@ mock.module("@/domains/onboarding/hooks/use-onboarding-stage-size", () => ({
   ),
 }));
 
-const { ResearchOnboardingRoute } = await import(
-  "@/domains/onboarding/pages/research-onboarding-route"
-);
+const { ResearchOnboardingRoute } =
+  await import("@/domains/onboarding/pages/research-onboarding-route");
 
 function postFormSnapshot(
   overrides: Partial<ResearchOnboardingSnapshot> = {},
@@ -855,8 +876,86 @@ describe("ResearchOnboardingRoute paid return", () => {
   });
 });
 
+describe("ResearchOnboardingRoute empty-details research skip", () => {
+  const nameOnly = {
+    firstName: "Alice",
+    lastName: "",
+    role: "",
+    hobbies: [] as string[],
+  };
+
+  test("a name-only submit hydrates empty results and never starts research", async () => {
+    render(<ResearchOnboardingRoute />);
+    fireEvent.click(await screen.findByTestId("form-submit-name-only"));
+
+    await waitFor(() => expect(screen.getByTestId("face-step")).toBeTruthy());
+    expect(startResearchMock).not.toHaveBeenCalled();
+    expect(hydrateResearchMock).toHaveBeenCalledWith({
+      status: "done",
+      claims: [],
+      droppedClaims: [],
+      suggestions: [],
+      installedPlugins: [],
+      pluginCatalog: {},
+    });
+  });
+
+  test("a restored looking snapshot with empty role and hobbies skips the reveal", async () => {
+    writeResearchSnapshot(
+      USER_ID,
+      postFormSnapshot({ step: "looking", formValues: nameOnly }),
+    );
+
+    render(<ResearchOnboardingRoute />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("letschat-ready-step")).toBeTruthy(),
+    );
+    await waitFor(() =>
+      expect(hydrateResearchMock).toHaveBeenCalledWith({
+        status: "done",
+        claims: [],
+        droppedClaims: [],
+        suggestions: [],
+        installedPlugins: [],
+        pluginCatalog: {},
+      }),
+    );
+    expect(screen.queryByTestId("looking-step")).toBeNull();
+    expect(startResearchMock).not.toHaveBeenCalled();
+  });
+
+  test("a restored snapshot with a role still starts research", async () => {
+    writeResearchSnapshot(
+      USER_ID,
+      postFormSnapshot({
+        formValues: { ...nameOnly, role: "Engineer" },
+      }),
+    );
+
+    render(<ResearchOnboardingRoute />);
+
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("looking-step")).toBeTruthy();
+  });
+
+  test("a restored snapshot with hobbies still starts research", async () => {
+    writeResearchSnapshot(
+      USER_ID,
+      postFormSnapshot({
+        formValues: { ...nameOnly, hobbies: ["chess"] },
+      }),
+    );
+
+    render(<ResearchOnboardingRoute />);
+
+    await waitFor(() => expect(startResearchMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("looking-step")).toBeTruthy();
+  });
+});
+
 // Retrying the hatch must restart everything that already resolved against the
-// dead one: the established-assistant verdict (otherwise it stays fail-open
+// dead one: the established-assistant verdict (otherwise it stays fail-open)
 // from the rejected `awaitReady`), a research turn that settled "error" while
 // holding its subject key (otherwise an identical resubmit dedupes to a no-op),
 // the persona apply that swallowed the same rejection behind locked sliders,

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -214,7 +214,8 @@ export function ResearchOnboardingRoute() {
   const [formValues, setFormValues] = useState<ResearchOnboardingValues | null>(
     null,
   );
-  // Empty role + hobbies: no research turn, and no "Searching about you" wait.
+  // Missing last name, or empty role + hobbies: no research turn, and no
+  // "Searching about you" wait.
   const skipResearchReveal =
     formValues !== null && shouldSkipOnboardingResearch(formValues);
   // Established-assistant guard. The verdict resolves in the background once

--- a/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
+++ b/clients/web/src/domains/onboarding/pages/research-onboarding-route.tsx
@@ -62,6 +62,7 @@ import {
   type ResearchStep,
 } from "@/domains/onboarding/research-onboarding-persistence";
 import { stampAssistantOnboarded } from "@/domains/onboarding/stamp-assistant-onboarded";
+import { shouldSkipOnboardingResearch } from "@/domains/onboarding/should-skip-onboarding-research";
 import {
   emitResearchOnboardingStepCompleted,
   RESEARCH_ONBOARDING_FUNNEL_STEPS,
@@ -127,6 +128,11 @@ function researchSubjectFrom(
 function researchTitleFor(values: ResearchOnboardingValues): string {
   const first = values.firstName.trim();
   return first ? `Getting to know ${first}` : "Getting to know you";
+}
+
+/** The research reveal, or the suggestions when there is nothing to search. */
+function researchRevealStep(skipResearch: boolean): ResearchStep {
+  return skipResearch ? "suggestions" : "looking";
 }
 
 // Warm the (~48 kB) bundled-avatar chunk the instant this lazy route loads, so
@@ -208,6 +214,9 @@ export function ResearchOnboardingRoute() {
   const [formValues, setFormValues] = useState<ResearchOnboardingValues | null>(
     null,
   );
+  // Empty role + hobbies: no research turn, and no "Searching about you" wait.
+  const skipResearchReveal =
+    formValues !== null && shouldSkipOnboardingResearch(formValues);
   // Established-assistant guard. The verdict resolves in the background once
   // the hatch lands (see the effect below); an intercepted submit parks its
   // values in `gatedFormValues` — deliberately NOT `formValues`, so neither
@@ -318,7 +327,7 @@ export function ResearchOnboardingRoute() {
   // skipped, straight to the research reveal (skipping credits implies a
   // self-hosted flow, which skips the calendar steps too).
   const stepAfterPersonality: ResearchStep = skipClaimCreditsStep
-    ? "looking"
+    ? researchRevealStep(skipResearchReveal)
     : "integration";
   // The skip verdict can land while the credits step is already on screen:
   // the pre-settle window kept the step (or restored a snapshot onto it) and
@@ -326,9 +335,16 @@ export function ResearchOnboardingRoute() {
   // promise can't be claimed.
   useEffect(() => {
     if (skipClaimCreditsStep && step === "integration") {
-      setStep("looking");
+      setStep(researchRevealStep(skipResearchReveal));
     }
-  }, [skipClaimCreditsStep, step]);
+  }, [skipClaimCreditsStep, skipResearchReveal, step]);
+  // Nothing to research: leave the looking/results steps if a resume or
+  // earlier destination still landed there.
+  useEffect(() => {
+    if (skipResearchReveal && (step === "looking" || step === "results")) {
+      setStep("suggestions");
+    }
+  }, [skipResearchReveal, step]);
   const {
     start: startHatch,
     retry: retryHatch,
@@ -390,6 +406,16 @@ export function ResearchOnboardingRoute() {
   // found" step (it would only say "I didn't turn up much") and go straight to
   // the suggestions.
   const noClaims = !researchLoading && research.claims.length === 0;
+  const stepBeforeResearchReveal: ResearchStep = skipClaimCreditsStep
+    ? "personality"
+    : skipCheckinSteps
+      ? "integration"
+      : "letschat";
+  const stepBeforeSuggestions: ResearchStep = skipResearchReveal
+    ? stepBeforeResearchReveal
+    : noClaims
+      ? "looking"
+      : "results";
 
   // Landing on the form means a fresh run — clear any stale focus state left
   // behind by an abandoned previous attempt so the form itself never renders
@@ -454,6 +480,19 @@ export function ResearchOnboardingRoute() {
     (values: ResearchOnboardingValues) => {
       // A fresh run produces fresh drops — re-arm the one-shot scrub below.
       syncDroppedClaimsScrubbed(false);
+      if (shouldSkipOnboardingResearch(values)) {
+        // Settle as an empty success so the looking carousel is never armed
+        // and a resume does not re-fire a search with nothing to go on.
+        hydrateResearch({
+          status: "done",
+          claims: [],
+          droppedClaims: [],
+          suggestions: [],
+          installedPlugins: [],
+          pluginCatalog: {},
+        });
+        return;
+      }
       startResearch({
         awaitAssistantId: awaitHatchReady,
         subject: researchSubjectFrom(values),
@@ -469,6 +508,7 @@ export function ResearchOnboardingRoute() {
     },
     [
       syncDroppedClaimsScrubbed,
+      hydrateResearch,
       startResearch,
       awaitHatchReady,
       researchConversationId,
@@ -533,7 +573,13 @@ export function ResearchOnboardingRoute() {
         (skipCheckinSteps &&
           (resumeStep === "letschat" || resumeStep === "meeting")) ||
         (skipClaimCreditsStep && resumeStep === "integration");
-      setStep(resumeStepDropped ? "looking" : resumeStep);
+      setStep(
+        resumeStepDropped
+          ? researchRevealStep(
+              shouldSkipOnboardingResearch(snapshot.formValues),
+            )
+          : resumeStep,
+      );
       setForwardStack([]);
     }
     setRestored(true);
@@ -1074,7 +1120,11 @@ export function ResearchOnboardingRoute() {
         {step === "integration" && (
           <IntegrationStep
             onClaim={() =>
-              goForwardTo(skipCheckinSteps ? "looking" : "letschat")
+              goForwardTo(
+                skipCheckinSteps
+                  ? researchRevealStep(skipResearchReveal)
+                  : "letschat",
+              )
             }
             onBumpEyes={() => setEyesBump((n) => n + 1)}
             onBack={() =>
@@ -1093,7 +1143,7 @@ export function ResearchOnboardingRoute() {
             onRetry={() => setMissingCalendarScope(false)}
             onSkip={() => {
               setMissingCalendarScope(false);
-              goForwardTo("looking", "skipped");
+              goForwardTo(researchRevealStep(skipResearchReveal), "skipped");
             }}
             onBack={() => goBackTo("integration")}
             onForward={onForward}
@@ -1103,7 +1153,7 @@ export function ResearchOnboardingRoute() {
           <MeetingCreatedStep
             scheduledTime={checkinTime ?? undefined}
             awaitingTime={checkinPending}
-            onDone={() => goForwardTo("looking")}
+            onDone={() => goForwardTo(researchRevealStep(skipResearchReveal))}
             onBack={() => goBackTo("letschat")}
             onForward={onForward}
           />
@@ -1111,15 +1161,7 @@ export function ResearchOnboardingRoute() {
         {step === "looking" && (
           <LookingYouUpStep
             onDone={() => goForwardTo(noClaims ? "suggestions" : "results")}
-            onBack={() =>
-              goBackTo(
-                skipClaimCreditsStep
-                  ? "personality"
-                  : skipCheckinSteps
-                    ? "integration"
-                    : "letschat",
-              )
-            }
+            onBack={() => goBackTo(stepBeforeResearchReveal)}
             onAdvance={(i) => setEdgeAvatars(Math.min(i + 1, 4))}
             onForward={onForward}
             // Gate only on the web-search turn — the personality rewrite runs
@@ -1229,7 +1271,7 @@ export function ResearchOnboardingRoute() {
               }
               await finishAndEnterChat();
             }}
-            onBack={() => goBackTo(noClaims ? "looking" : "results")}
+            onBack={() => goBackTo(stepBeforeSuggestions)}
             onForward={onForward}
           />
         )}
@@ -1271,7 +1313,7 @@ export function ResearchOnboardingRoute() {
                 skip: true,
               });
             }}
-            onBack={() => goBackTo(noClaims ? "looking" : "results")}
+            onBack={() => goBackTo(stepBeforeSuggestions)}
             onForward={onForward}
           />
         )}

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.test.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.test.ts
@@ -183,7 +183,7 @@ describe("resolveResumeStep", () => {
   test("skips the research reveal when role and hobbies are both empty", () => {
     const emptyDetails = {
       firstName: "Alice",
-      lastName: "",
+      lastName: "Example",
       role: "",
       hobbies: [] as string[],
     };
@@ -203,6 +203,22 @@ describe("resolveResumeStep", () => {
           step: "meeting",
           checkinBooked: true,
           formValues: emptyDetails,
+        }),
+      ),
+    ).toBe("suggestions");
+  });
+
+  test("skips the research reveal when last name is empty", () => {
+    expect(
+      resolveResumeStep(
+        baseSnapshot({
+          step: "looking",
+          formValues: {
+            firstName: "Alice",
+            lastName: "",
+            role: "Engineer",
+            hobbies: ["chess"],
+          },
         }),
       ),
     ).toBe("suggestions");

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.test.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.test.ts
@@ -179,4 +179,32 @@ describe("resolveResumeStep", () => {
       "letschat",
     );
   });
+
+  test("skips the research reveal when role and hobbies are both empty", () => {
+    const emptyDetails = {
+      firstName: "Alice",
+      lastName: "",
+      role: "",
+      hobbies: [] as string[],
+    };
+    expect(
+      resolveResumeStep(
+        baseSnapshot({ step: "looking", formValues: emptyDetails }),
+      ),
+    ).toBe("suggestions");
+    expect(
+      resolveResumeStep(
+        baseSnapshot({ step: "results", formValues: emptyDetails }),
+      ),
+    ).toBe("suggestions");
+    expect(
+      resolveResumeStep(
+        baseSnapshot({
+          step: "meeting",
+          checkinBooked: true,
+          formValues: emptyDetails,
+        }),
+      ),
+    ).toBe("suggestions");
+  });
 });

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
@@ -203,8 +203,8 @@ export function resolveResumeStep(
   if (snapshot.research?.status === "done") {
     return "suggestions";
   }
-  // Empty role + hobbies never start a search, so a refresh must not land on
-  // the research reveal (or the results card that would be empty).
+  // Missing last name, or empty role + hobbies, never start a search, so a
+  // refresh must not land on the research reveal (or an empty results card).
   const skipResearch =
     snapshot.formValues !== null &&
     shouldSkipOnboardingResearch(snapshot.formValues);

--- a/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
+++ b/clients/web/src/domains/onboarding/research-onboarding-persistence.ts
@@ -38,6 +38,7 @@ import { isElectron } from "@/runtime/is-electron";
 
 import type { ResearchStatus } from "@/domains/onboarding/research-runner";
 import type { ResearchOnboardingValues } from "@/domains/onboarding/screens/research-onboarding-screen";
+import { shouldSkipOnboardingResearch } from "@/domains/onboarding/should-skip-onboarding-research";
 import type { GiveMeAFaceValues } from "@/domains/onboarding/screens/give-me-a-face-screen";
 import type { ResearchFact, ResearchSuggestion } from "@/utils/research-facts";
 
@@ -202,8 +203,22 @@ export function resolveResumeStep(
   if (snapshot.research?.status === "done") {
     return "suggestions";
   }
+  // Empty role + hobbies never start a search, so a refresh must not land on
+  // the research reveal (or the results card that would be empty).
+  const skipResearch =
+    snapshot.formValues !== null &&
+    shouldSkipOnboardingResearch(snapshot.formValues);
   if (snapshot.step === "meeting") {
-    return snapshot.checkinBooked ? "looking" : "letschat";
+    if (snapshot.checkinBooked) {
+      return skipResearch ? "suggestions" : "looking";
+    }
+    return "letschat";
+  }
+  if (
+    skipResearch &&
+    (snapshot.step === "looking" || snapshot.step === "results")
+  ) {
+    return "suggestions";
   }
   // The established-assistant guard holds an intercepted submit in transient
   // state that a snapshot can't restore, so a saved journey never resumes onto

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -231,6 +231,30 @@ describe("research prompt send", () => {
   });
 });
 
+describe("research wait budget", () => {
+  test("a poll that never completes settles error when the budget expires", async () => {
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+        timeoutMs: 40,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error");
+    });
+    expect(result.current.claims).toEqual([]);
+    expect(createCalls).toHaveLength(1);
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+});
+
 describe("research conversation archive", () => {
   test("archives the side conversation when the prompt fails to post", async () => {
     // A failed prompt POST abandons the run before the poll loop, with the

--- a/clients/web/src/domains/onboarding/research-runner-send.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner-send.test.ts
@@ -43,6 +43,8 @@ let getCalls = 0;
 let listed: { processing?: boolean; messages: unknown[] } = { messages: [] };
 /** When set, the prompt POST fails, so the run gives up before the poll loop. */
 let failMessagePost = false;
+/** When set, conversationsPost waits here before resolving so a deadline can win. */
+let createConversationHold: Promise<void> | null = null;
 
 const ok = <T>(data: T) =>
   Promise.resolve({ data, error: undefined, response: { ok: true } });
@@ -58,8 +60,11 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   pluginsSearchGet: () => ok({ matches: [] }),
   pluginsInstallPost: () => ok({}),
   telemetryIngestPost: () => ok({}),
-  conversationsPost: (opts: CreateCall) => {
+  conversationsPost: async (opts: CreateCall) => {
     createCalls.push(opts);
+    if (createConversationHold) {
+      await createConversationHold;
+    }
     return ok({ id: "conv-fresh" });
   },
   conversationsByIdArchivePost: (opts: ArchiveCall) => {
@@ -103,6 +108,7 @@ afterEach(() => {
   getCalls = 0;
   listed = { messages: [] };
   failMessagePost = false;
+  createConversationHold = null;
 });
 
 /**
@@ -256,6 +262,42 @@ describe("research wait budget", () => {
 });
 
 describe("research conversation archive", () => {
+  test("archives a conversation that lands after the research budget expires", async () => {
+    let releaseCreate: () => void = () => {};
+    createConversationHold = new Promise<void>((resolve) => {
+      releaseCreate = resolve;
+    });
+    const onConversationCreated = mock((_id: string) => {});
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: async () => "ast-1",
+        subject,
+        timeoutMs: 30,
+        onConversationCreated,
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error");
+    });
+    expect(onConversationCreated).not.toHaveBeenCalled();
+    expect(archiveCalls).toHaveLength(0);
+
+    releaseCreate();
+
+    await waitFor(() => {
+      expect(archiveCalls).toHaveLength(1);
+    });
+    expect(archiveCalls[0]?.path.id).toBe("conv-fresh");
+    expect(onConversationCreated).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.reset();
+    });
+  });
+
   test("archives the side conversation when the prompt fails to post", async () => {
     // A failed prompt POST abandons the run before the poll loop, with the
     // conversation already minted. The archive is unconditional, so the

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -10,7 +10,7 @@
 import { createElement, type ReactNode } from "react";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, test } from "bun:test";
 
 import type { ResearchSubject } from "@/domains/onboarding/research-prompt";
@@ -236,6 +236,25 @@ describe("useResearchRunner reset", () => {
     });
     expect(hatch.calls).toBe(2);
     expect(result.current.status).toBe("running");
+  });
+
+  test("a hung hatch settles error when the research budget expires", async () => {
+    const hatch = pendingHatch();
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: hatch.awaitAssistantId,
+        subject,
+        timeoutMs: 30,
+      });
+    });
+    expect(result.current.status).toBe("running");
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("error");
+    });
+    expect(result.current.claims).toEqual([]);
   });
 
   test("reset leaves the plugin-install gate resolved", async () => {

--- a/clients/web/src/domains/onboarding/research-runner.test.ts
+++ b/clients/web/src/domains/onboarding/research-runner.test.ts
@@ -257,6 +257,60 @@ describe("useResearchRunner reset", () => {
     expect(result.current.claims).toEqual([]);
   });
 
+  const skippedResults = {
+    status: "done" as const,
+    claims: [],
+    droppedClaims: [],
+    suggestions: [],
+    installedPlugins: [],
+    pluginCatalog: {},
+  };
+
+  test("hydrate releases the subject key so the prior profile can run again", () => {
+    const hatch = pendingHatch();
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: hatch.awaitAssistantId,
+        subject,
+      });
+    });
+    expect(hatch.calls).toBe(1);
+
+    act(() => {
+      result.current.hydrate(skippedResults);
+    });
+    expect(result.current.status).toBe("done");
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: hatch.awaitAssistantId,
+        subject,
+      });
+    });
+    expect(hatch.calls).toBe(2);
+    expect(result.current.status).toBe("running");
+  });
+
+  test("hydrate releases the plugin-install gate of the abandoned run", async () => {
+    const hatch = pendingHatch();
+    const { result } = renderRunner();
+
+    act(() => {
+      result.current.start({
+        awaitAssistantId: hatch.awaitAssistantId,
+        subject,
+      });
+    });
+
+    act(() => {
+      result.current.hydrate(skippedResults);
+    });
+
+    await result.current.awaitPluginInstalls();
+  });
+
   test("reset leaves the plugin-install gate resolved", async () => {
     const hatch = pendingHatch();
     const { result } = renderRunner();

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -689,6 +689,14 @@ export function useResearchRunner(): UseResearchRunner {
             if (!conversation.response?.ok || !id) {
               return undefined;
             }
+            // A deadline race does not cancel conversationsPost. If this run
+            // already gave up (or a newer one superseded it), archive here so
+            // the row is not left behind after finally has already run, and
+            // do not persist a resume id for a search that will not continue.
+            if (isStale() || Date.now() >= deadline) {
+              await archiveResearchConversation(assistantId, id);
+              return undefined;
+            }
             // Surface the new id immediately so the caller can persist it and
             // resume this exact thread across a refresh.
             onConversationCreated?.(id);
@@ -991,11 +999,14 @@ export function useResearchRunner(): UseResearchRunner {
       results: ResearchRunnerState,
       awaitAssistantId?: () => Promise<string>,
     ) => {
-      // Claim a fresh run id so any (improbable) in-flight loop bails, then adopt
-      // the restored results as the settled state. We don't set a subject key:
-      // the route only re-fires `start` while results are absent, so a re-run
-      // can't race this — and an edited subject should still supersede normally.
+      // Supersede any in-flight run: bump the id so its loop bails, drop its
+      // subject key so a later start of that same subject is not treated as a
+      // duplicate, and release the plugin click-gate so a skip/resume cannot
+      // stay blocked on the abandoned turn's installs.
       runIdRef.current += 1;
+      subjectKeyRef.current = null;
+      installPromisesRef.current.clear();
+      pluginsReadyRef.current = Promise.resolve();
       setState(results);
 
       // Re-enqueue the named installs against the (re-)hatched assistant so a

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -62,19 +62,24 @@ export const MAX_RESEARCH_WAIT_MS = 45_000;
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
-const RESEARCH_TIMED_OUT = Symbol("research-timeout");
+type ResearchDeadlineResult<T> =
+  { timedOut: true } | { timedOut: false; value: T };
 
 async function raceResearchDeadline<T>(
   promise: Promise<T>,
   deadline: number,
-): Promise<T | typeof RESEARCH_TIMED_OUT> {
+): Promise<ResearchDeadlineResult<T>> {
   const remaining = deadline - Date.now();
   if (remaining <= 0) {
-    return RESEARCH_TIMED_OUT;
+    return { timedOut: true };
   }
   return Promise.race([
-    promise,
-    sleep(remaining).then(() => RESEARCH_TIMED_OUT),
+    promise.then((value): ResearchDeadlineResult<T> => {
+      return { timedOut: false, value };
+    }),
+    sleep(remaining).then((): ResearchDeadlineResult<T> => {
+      return { timedOut: true };
+    }),
   ]);
 }
 
@@ -564,11 +569,11 @@ export function useResearchRunner(): UseResearchRunner {
             awaitAssistantId(),
             deadline,
           );
-          if (hatchResult === RESEARCH_TIMED_OUT) {
+          if (hatchResult.timedOut) {
             settleTimeout();
             return;
           }
-          const assistantId = hatchResult;
+          const assistantId = hatchResult.value;
           resolvedAssistantId = assistantId;
           if (isStale()) {
             return;
@@ -583,11 +588,11 @@ export function useResearchRunner(): UseResearchRunner {
             fetchAvailableCapabilities(assistantId),
             deadline,
           );
-          if (catalogResult === RESEARCH_TIMED_OUT) {
+          if (catalogResult.timedOut) {
             settleTimeout();
             return;
           }
-          const { capabilities, validNames } = catalogResult;
+          const { capabilities, validNames } = catalogResult.value;
           if (isStale()) {
             return;
           }
@@ -704,32 +709,32 @@ export function useResearchRunner(): UseResearchRunner {
               }),
               deadline,
             );
-            if (existing === RESEARCH_TIMED_OUT) {
+            if (existing.timedOut) {
               settleTimeout();
               return;
             }
             if (isStale()) {
               return;
             }
-            if (existing.response?.ok) {
+            if (existing.value.response?.ok) {
               conversationId = resumeConversationId;
               createdConversationId = resumeConversationId;
               // The hidden prompt row is filtered out of `/messages`, so a
               // started turn shows as the daemon still processing or as a row
               // it has already produced, never as a user message.
               const turnAlreadyStarted =
-                existing.data?.processing === true ||
-                (existing.data?.messages ?? []).length > 0;
+                existing.value.data?.processing === true ||
+                (existing.value.data?.messages ?? []).length > 0;
               if (!turnAlreadyStarted) {
                 const posted = await raceResearchDeadline(
                   postResearchPrompt(conversationId),
                   deadline,
                 );
-                if (posted === RESEARCH_TIMED_OUT) {
+                if (posted.timedOut) {
                   settleTimeout();
                   return;
                 }
-                if (!posted) {
+                if (!posted.value) {
                   setState((s) => ({ ...s, status: "error" }));
                   return;
                 }
@@ -747,11 +752,11 @@ export function useResearchRunner(): UseResearchRunner {
               startFreshConversation(),
               deadline,
             );
-            if (minted === RESEARCH_TIMED_OUT) {
+            if (minted.timedOut) {
               settleTimeout();
               return;
             }
-            conversationId = minted;
+            conversationId = minted.value;
             if (isStale()) {
               return;
             }
@@ -763,11 +768,11 @@ export function useResearchRunner(): UseResearchRunner {
               postResearchPrompt(conversationId),
               deadline,
             );
-            if (posted === RESEARCH_TIMED_OUT) {
+            if (posted.timedOut) {
               settleTimeout();
               return;
             }
-            if (!posted) {
+            if (!posted.value) {
               setState((s) => ({ ...s, status: "error" }));
               return;
             }
@@ -824,13 +829,13 @@ export function useResearchRunner(): UseResearchRunner {
               }),
               deadline,
             );
-            if (listed === RESEARCH_TIMED_OUT) {
+            if (listed.timedOut) {
               break;
             }
             if (isStale()) {
               return;
             }
-            const messages = listed.data?.messages ?? [];
+            const messages = listed.value.data?.messages ?? [];
             const text = latestAssistantText(messages);
             if (text) {
               const {

--- a/clients/web/src/domains/onboarding/research-runner.ts
+++ b/clients/web/src/domains/onboarding/research-runner.ts
@@ -49,9 +49,35 @@ import {
   type ResearchSuggestion,
 } from "@/utils/research-facts";
 
-/** Poll cadence + ceiling for reading the streaming research reply. */
+/** Poll cadence for reading the streaming research reply. */
 const POLL_INTERVAL_MS = 1500;
-const MAX_POLL_MS = 120_000;
+/**
+ * Wall-clock budget for a research turn, measured from `start()`. Covers the
+ * hatch wait, catalog fetch, conversation setup, and reply poll. On expiry the
+ * run settles `error` and the flow continues with whatever was parsed (often
+ * nothing), so the looking-you-up step cannot hold a user for minutes.
+ */
+export const MAX_RESEARCH_WAIT_MS = 45_000;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const RESEARCH_TIMED_OUT = Symbol("research-timeout");
+
+async function raceResearchDeadline<T>(
+  promise: Promise<T>,
+  deadline: number,
+): Promise<T | typeof RESEARCH_TIMED_OUT> {
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    return RESEARCH_TIMED_OUT;
+  }
+  return Promise.race([
+    promise,
+    sleep(remaining).then(() => RESEARCH_TIMED_OUT),
+  ]);
+}
+
 /**
  * Consecutive identical non-empty reads that mark the turn settled once the
  * reply has parsed as a COMPLETE JSON payload. Two matching polls (~3s apart)
@@ -368,6 +394,12 @@ export interface StartResearchOptions {
    * true so the legacy suggestions flow is unchanged.
    */
   includeSuggestions?: boolean;
+  /**
+   * Wall-clock budget for this run. Defaults to `MAX_RESEARCH_WAIT_MS`. Tests
+   * pass a shorter value so a hung hatch or poll fails open without waiting
+   * the production ceiling.
+   */
+  timeoutMs?: number;
 }
 
 export interface UseResearchRunner extends ResearchRunnerState {
@@ -423,9 +455,6 @@ export interface UseResearchRunner extends ResearchRunnerState {
    */
   reset: () => void;
 }
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 export function resolveOnboardingPluginInstalls({
   role,
@@ -499,6 +528,7 @@ export function useResearchRunner(): UseResearchRunner {
       resumeConversationId,
       onConversationCreated,
       includeSuggestions = true,
+      timeoutMs = MAX_RESEARCH_WAIT_MS,
     }: StartResearchOptions) => {
       const subjectKey = JSON.stringify(subject);
       if (subjectKeyRef.current === subjectKey) {
@@ -522,8 +552,23 @@ export function useResearchRunner(): UseResearchRunner {
         let resolvedAssistantId: string | undefined;
         let createdConversationId: string | undefined;
         let sawCompletePayload = false;
+        const deadline = Date.now() + timeoutMs;
+        const settleTimeout = () => {
+          if (isStale()) {
+            return;
+          }
+          setState((s) => ({ ...s, status: "error" }));
+        };
         try {
-          const assistantId = await awaitAssistantId();
+          const hatchResult = await raceResearchDeadline(
+            awaitAssistantId(),
+            deadline,
+          );
+          if (hatchResult === RESEARCH_TIMED_OUT) {
+            settleTimeout();
+            return;
+          }
+          const assistantId = hatchResult;
           resolvedAssistantId = assistantId;
           if (isStale()) {
             return;
@@ -534,8 +579,15 @@ export function useResearchRunner(): UseResearchRunner {
           // top-level `plugins` list) for us to install. The catalog filter keeps
           // onboarding scoped to first-party plugins; third-party plugin
           // browsing/install surfaces remain independently feature-gated.
-          const { capabilities, validNames } =
-            await fetchAvailableCapabilities(assistantId);
+          const catalogResult = await raceResearchDeadline(
+            fetchAvailableCapabilities(assistantId),
+            deadline,
+          );
+          if (catalogResult === RESEARCH_TIMED_OUT) {
+            settleTimeout();
+            return;
+          }
+          const { capabilities, validNames } = catalogResult;
           if (isStale()) {
             return;
           }
@@ -644,11 +696,18 @@ export function useResearchRunner(): UseResearchRunner {
             // running a second search. The turn keeps generating server-side
             // across the reload, so re-attach and poll it; only re-post the
             // prompt if it never landed before the refresh.
-            const existing = await messagesGet({
-              path: { assistant_id: assistantId },
-              query: { conversationId: resumeConversationId },
-              throwOnError: false,
-            });
+            const existing = await raceResearchDeadline(
+              messagesGet({
+                path: { assistant_id: assistantId },
+                query: { conversationId: resumeConversationId },
+                throwOnError: false,
+              }),
+              deadline,
+            );
+            if (existing === RESEARCH_TIMED_OUT) {
+              settleTimeout();
+              return;
+            }
             if (isStale()) {
               return;
             }
@@ -662,7 +721,15 @@ export function useResearchRunner(): UseResearchRunner {
                 existing.data?.processing === true ||
                 (existing.data?.messages ?? []).length > 0;
               if (!turnAlreadyStarted) {
-                if (!(await postResearchPrompt(conversationId))) {
+                const posted = await raceResearchDeadline(
+                  postResearchPrompt(conversationId),
+                  deadline,
+                );
+                if (posted === RESEARCH_TIMED_OUT) {
+                  settleTimeout();
+                  return;
+                }
+                if (!posted) {
                   setState((s) => ({ ...s, status: "error" }));
                   return;
                 }
@@ -676,7 +743,15 @@ export function useResearchRunner(): UseResearchRunner {
           }
 
           if (!conversationId) {
-            conversationId = await startFreshConversation();
+            const minted = await raceResearchDeadline(
+              startFreshConversation(),
+              deadline,
+            );
+            if (minted === RESEARCH_TIMED_OUT) {
+              settleTimeout();
+              return;
+            }
+            conversationId = minted;
             if (isStale()) {
               return;
             }
@@ -684,7 +759,15 @@ export function useResearchRunner(): UseResearchRunner {
               setState((s) => ({ ...s, status: "error" }));
               return;
             }
-            if (!(await postResearchPrompt(conversationId))) {
+            const posted = await raceResearchDeadline(
+              postResearchPrompt(conversationId),
+              deadline,
+            );
+            if (posted === RESEARCH_TIMED_OUT) {
+              settleTimeout();
+              return;
+            }
+            if (!posted) {
               setState((s) => ({ ...s, status: "error" }));
               return;
             }
@@ -695,8 +778,8 @@ export function useResearchRunner(): UseResearchRunner {
 
           // Poll the conversation, parsing the (possibly partial) reply each
           // pass so claims/suggestions surface as they land. Settle once the
-          // reply text stops changing.
-          const deadline = Date.now() + MAX_POLL_MS;
+          // reply text stops changing, or when the overall research budget
+          // expires.
           let lastText = "";
           let stableReads = 0;
           // Guards the telemetry report to fire exactly once: `complete` can
@@ -719,15 +802,31 @@ export function useResearchRunner(): UseResearchRunner {
           // still streaming. These union on top of the deterministic floor already
           // installing (see above); idempotent, so racing the same name is fine.
           while (Date.now() < deadline) {
-            await sleep(POLL_INTERVAL_MS);
+            const waitMs = Math.min(
+              POLL_INTERVAL_MS,
+              Math.max(0, deadline - Date.now()),
+            );
+            if (waitMs === 0) {
+              break;
+            }
+            await sleep(waitMs);
             if (isStale()) {
               return;
             }
-            const listed = await messagesGet({
-              path: { assistant_id: assistantId },
-              query: { conversationId },
-              throwOnError: false,
-            });
+            if (Date.now() >= deadline) {
+              break;
+            }
+            const listed = await raceResearchDeadline(
+              messagesGet({
+                path: { assistant_id: assistantId },
+                query: { conversationId },
+                throwOnError: false,
+              }),
+              deadline,
+            );
+            if (listed === RESEARCH_TIMED_OUT) {
+              break;
+            }
             if (isStale()) {
               return;
             }

--- a/clients/web/src/domains/onboarding/should-skip-onboarding-research.test.ts
+++ b/clients/web/src/domains/onboarding/should-skip-onboarding-research.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { shouldSkipOnboardingResearch } from "@/domains/onboarding/should-skip-onboarding-research";
+
+describe("shouldSkipOnboardingResearch", () => {
+  test("skips when role and hobbies are both empty", () => {
+    expect(shouldSkipOnboardingResearch({ role: "", hobbies: [] })).toBe(true);
+  });
+
+  test("skips whitespace-only role and hobbies", () => {
+    expect(
+      shouldSkipOnboardingResearch({ role: "   ", hobbies: ["", "  "] }),
+    ).toBe(true);
+  });
+
+  test("runs research when only a role is present", () => {
+    expect(
+      shouldSkipOnboardingResearch({ role: "Engineer", hobbies: [] }),
+    ).toBe(false);
+  });
+
+  test("runs research when only hobbies are present", () => {
+    expect(shouldSkipOnboardingResearch({ role: "", hobbies: ["chess"] })).toBe(
+      false,
+    );
+  });
+
+  test("runs research when both role and hobbies are present", () => {
+    expect(
+      shouldSkipOnboardingResearch({
+        role: "Engineer",
+        hobbies: ["chess"],
+      }),
+    ).toBe(false);
+  });
+});

--- a/clients/web/src/domains/onboarding/should-skip-onboarding-research.test.ts
+++ b/clients/web/src/domains/onboarding/should-skip-onboarding-research.test.ts
@@ -3,31 +3,70 @@ import { describe, expect, test } from "bun:test";
 import { shouldSkipOnboardingResearch } from "@/domains/onboarding/should-skip-onboarding-research";
 
 describe("shouldSkipOnboardingResearch", () => {
+  test("skips when last name is empty, even with role and hobbies", () => {
+    expect(
+      shouldSkipOnboardingResearch({
+        lastName: "",
+        role: "Engineer",
+        hobbies: ["chess"],
+      }),
+    ).toBe(true);
+  });
+
+  test("skips whitespace-only last name", () => {
+    expect(
+      shouldSkipOnboardingResearch({
+        lastName: "   ",
+        role: "Engineer",
+        hobbies: ["chess"],
+      }),
+    ).toBe(true);
+  });
+
   test("skips when role and hobbies are both empty", () => {
-    expect(shouldSkipOnboardingResearch({ role: "", hobbies: [] })).toBe(true);
+    expect(
+      shouldSkipOnboardingResearch({
+        lastName: "Example",
+        role: "",
+        hobbies: [],
+      }),
+    ).toBe(true);
   });
 
   test("skips whitespace-only role and hobbies", () => {
     expect(
-      shouldSkipOnboardingResearch({ role: "   ", hobbies: ["", "  "] }),
+      shouldSkipOnboardingResearch({
+        lastName: "Example",
+        role: "   ",
+        hobbies: ["", "  "],
+      }),
     ).toBe(true);
   });
 
-  test("runs research when only a role is present", () => {
+  test("runs research when last name and a role are present", () => {
     expect(
-      shouldSkipOnboardingResearch({ role: "Engineer", hobbies: [] }),
+      shouldSkipOnboardingResearch({
+        lastName: "Example",
+        role: "Engineer",
+        hobbies: [],
+      }),
     ).toBe(false);
   });
 
-  test("runs research when only hobbies are present", () => {
-    expect(shouldSkipOnboardingResearch({ role: "", hobbies: ["chess"] })).toBe(
-      false,
-    );
-  });
-
-  test("runs research when both role and hobbies are present", () => {
+  test("runs research when last name and hobbies are present", () => {
     expect(
       shouldSkipOnboardingResearch({
+        lastName: "Example",
+        role: "",
+        hobbies: ["chess"],
+      }),
+    ).toBe(false);
+  });
+
+  test("runs research when last name, role, and hobbies are present", () => {
+    expect(
+      shouldSkipOnboardingResearch({
+        lastName: "Example",
         role: "Engineer",
         hobbies: ["chess"],
       }),

--- a/clients/web/src/domains/onboarding/should-skip-onboarding-research.ts
+++ b/clients/web/src/domains/onboarding/should-skip-onboarding-research.ts
@@ -1,0 +1,17 @@
+/**
+ * Whether the "Let's start with you" details have enough signal to run the
+ * behind-the-scenes research turn. Role and hobbies are the only inputs that
+ * turn a name into a searchable person; an empty pair is not worth a network
+ * round-trip or the "Searching about you" wait.
+ */
+
+export function shouldSkipOnboardingResearch(values: {
+  role: string;
+  hobbies: readonly string[];
+}): boolean {
+  const roleEmpty = values.role.trim().length === 0;
+  const hobbiesEmpty = values.hobbies.every(
+    (hobby) => hobby.trim().length === 0,
+  );
+  return roleEmpty && hobbiesEmpty;
+}

--- a/clients/web/src/domains/onboarding/should-skip-onboarding-research.ts
+++ b/clients/web/src/domains/onboarding/should-skip-onboarding-research.ts
@@ -1,17 +1,20 @@
 /**
  * Whether the "Let's start with you" details have enough signal to run the
- * behind-the-scenes research turn. Role and hobbies are the only inputs that
- * turn a name into a searchable person; an empty pair is not worth a network
- * round-trip or the "Searching about you" wait.
+ * behind-the-scenes research turn. A last name is required to tell people
+ * apart; role and hobbies are the other searchable inputs. Missing last name,
+ * or an empty role+hobbies pair, is not worth a network round-trip or the
+ * "Searching about you" wait. There is no email-lookup fallback.
  */
 
 export function shouldSkipOnboardingResearch(values: {
+  lastName: string;
   role: string;
   hobbies: readonly string[];
 }): boolean {
+  const lastNameEmpty = values.lastName.trim().length === 0;
   const roleEmpty = values.role.trim().length === 0;
   const hobbiesEmpty = values.hobbies.every(
     (hobby) => hobby.trim().length === 0,
   );
-  return roleEmpty && hobbiesEmpty;
+  return lastNameEmpty || (roleEmpty && hobbiesEmpty);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Paired Urgent tickets for Activation Hub polish / Illuminati onboarding.

- [LUM-3545](https://linear.app/vellum/issue/LUM-3545): Skip research entirely when there is not enough signal on "Let's start with you".
- [LUM-3540](https://linear.app/vellum/issue/LUM-3540): When research does run, do not hold the user for minutes; bound the wait and fail open.

Product call (Aaron, option A): require last name to run research; skip without it; no email lookup path.

One PR because both live on the research-onboarding path (`fireResearch` + `useResearchRunner`). Does not change form validation (that is LUM-3539 / #42126).

## Summary
- **Skip gate:** Research runs only when last name is present AND at least one of role or hobbies is present. Missing/blank last name skips. Empty role AND empty hobbies still skips. No email-lookup fallback.
- **LUM-3545:** Skip means no research conversation, no catalog/network, no "Searching about you" wait. The flow hydrates empty completed results and jumps past looking/results to suggestions.
- **LUM-3540:** When research does run, the runner has a 45s wall-clock budget from `start()` covering hatch wait, catalog fetch, conversation setup, and reply polling. On expiry it settles `error` and the existing empty-results path continues.
- **Review fixes:** `hydrate` clears the prior subject key and plugin click-gate so a skip cannot leave the original profile falsely deduped or block Let's chat on abandoned installs. A conversation that lands after the budget expires is archived and never published as a resume id.

Closes LUM-3545
Closes LUM-3540

Related: LUM-3539 (https://github.com/vellum-ai/vellum-assistant/pull/42126)

## Test plan
- `cd clients/web && bun test src/domains/onboarding/should-skip-onboarding-research.test.ts` (7 pass)
- `cd clients/web && bun test src/domains/onboarding/research-onboarding-persistence.test.ts` (17 pass)
- `cd clients/web && bun test src/domains/onboarding/research-runner.test.ts` (18 pass, including hydrate key + plugin-gate release)
- `cd clients/web && bun test src/domains/onboarding/research-runner-send.test.ts` (8 pass, including late-create archive)
- `cd clients/web && bun test src/domains/onboarding/pages/research-onboarding-route.test.tsx` (37 pass, including last-name skip)
- `cd clients/web && bun run lint -- <changed files>` (clean)

Could not exercise the live onboarding UI in a browser here (needs a hatched assistant and auth).

## Risk
- Medium: onboarding latency path. A last-name-only or first-name-only submit now skips research. A slow-but-healthy research turn that used to finish between 45s and 120s will fail open to suggestions.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcd7fcd9-25e8-4faf-a230-1b6fd88ad29c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcd7fcd9-25e8-4faf-a230-1b6fd88ad29c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

