### PR TITLE
style(web): match the contact cards to their Figma spec

### DIFF
--- a/clients/web/src/domains/chat/components/contact-prompt-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.stories.tsx
@@ -48,10 +48,10 @@ export const BindEmailAddress: Story = {
     contactRequest: {
       requestId: "req-contact-channel",
       channel: "email",
-      label: "Carolina Flaherty's email",
+      label: "Alice's email",
       description:
-        "Binding carolina@example.com to recreate Carolina's contact with a working email channel. This creates an address-named record that will be renamed right after.",
-      defaultValue: "carolina@example.com",
+        "Binding user@example.com to recreate Alice's contact with a working email channel. This creates an address-named record that will be renamed right after.",
+      defaultValue: "user@example.com",
       verify: true,
     } satisfies PendingContactRequestState,
   },

--- a/clients/web/src/domains/chat/components/contact-prompt-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
+import type { PendingContactRequestState } from "@/types/interaction-ui-types";
+
+import { ContactPromptCard } from "./contact-prompt-card";
+
+/**
+ * The guardian's answer to a channel the assistant proposed binding to a
+ * contact, mounted in the transcript by `pending-contact-request-row`.
+ *
+ * The address is editable because what the guardian submits is what gets
+ * attested, not what the command proposed. The verify checkbox is theirs to
+ * uncheck for the same reason: leaving it clear binds the address without
+ * letting it message the assistant.
+ */
+const meta: Meta<typeof ContactPromptCard> = {
+  title: "Chat/ContactPromptCard",
+  component: ContactPromptCard,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    isSubmitting: false,
+    accepted: false,
+    onSubmit: () => {},
+    onCancel: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <TranscriptColumn>
+        <Story />
+      </TranscriptColumn>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ContactPromptCard>;
+
+/**
+ * Binding an email address to an existing contact. No name is proposed, so the
+ * form is the address plus the verify choice; a request that also carries a
+ * `displayName` adds an editable name field above the address.
+ */
+export const BindEmailAddress: Story = {
+  args: {
+    contactRequest: {
+      requestId: "req-contact-channel",
+      channel: "email",
+      label: "Carolina Flaherty's email",
+      description:
+        "Binding carolina@example.com to recreate Carolina's contact with a working email channel. This creates an address-named record that will be renamed right after.",
+      defaultValue: "carolina@example.com",
+      verify: true,
+    } satisfies PendingContactRequestState,
+  },
+};

--- a/clients/web/src/domains/chat/components/contact-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/contact-prompt-card.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle, Loader2, X } from "lucide-react";
+import { CheckCircle, Loader2 } from "lucide-react";
 import { type FormEvent, useState } from "react";
 
 import {
@@ -68,56 +68,41 @@ export function ContactPromptCard({
   }
 
   return (
-    <Card className="flex flex-col gap-4 p-4">
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex flex-col gap-1">
+    <Card.Root padding="md" className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <Typography
+          variant="title-medium"
+          className="text-[var(--content-emphasised)]"
+        >
+          {contactRequest.label ?? t("contactPromptCard.addContact")}
+        </Typography>
+        {contactRequest.contactDisplayName && (
           <Typography
-            variant="label-small-default"
-            className="text-[var(--content-primary)]"
+            variant="body-medium-lighter"
+            className="text-[var(--content-tertiary)]"
           >
-            {contactRequest.label ?? t("contactPromptCard.addContact")}
+            {t("contactPromptCard.addingToContact", {
+              name: contactRequest.contactDisplayName,
+            })}
           </Typography>
-          {contactRequest.contactDisplayName && (
-            <Typography
-              variant="body-small-default"
-              className="text-[var(--content-secondary)]"
-            >
-              {t("contactPromptCard.addingToContact", {
-                name: contactRequest.contactDisplayName,
-              })}
-            </Typography>
-          )}
-          {contactRequest.description && (
-            <Typography
-              variant="body-small-default"
-              className="text-[var(--content-secondary)]"
-            >
-              {contactRequest.description}
-            </Typography>
-          )}
-        </div>
-        {!accepted && (
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={isSubmitting}
-            className="shrink-0 text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
-            aria-label={t("contactPromptCard.dismiss")}
+        )}
+        {contactRequest.description && (
+          <Typography
+            variant="body-medium-lighter"
+            className="text-[var(--content-tertiary)]"
           >
-            <X size={16} />
-          </button>
+            {contactRequest.description}
+          </Typography>
         )}
       </div>
 
       {accepted ? (
-        // typography: off-scale — inline status badge, not prose
-
-        <div className="flex items-center gap-2 text-sm text-[var(--color-success)]">
+        <div className="flex items-center gap-2 text-body-medium-default text-[var(--system-positive-strong)]">
           <CheckCircle size={16} />
           {t("contactPromptCard.contactSaved")}
         </div>
       ) : (
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           {proposesName && (
             <Input
               type="text"
@@ -125,20 +110,21 @@ export function ContactPromptCard({
               onChange={(e) => setDisplayName(e.target.value)}
               placeholder={t("contactPromptCard.namePlaceholder")}
               disabled={isSubmitting}
+              fullWidth
             />
           )}
           {/* Read only: `contacts update` is where notes are edited. */}
           {contactRequest.notes && (
             <div className="flex flex-col gap-1">
               <Typography
-                variant="label-small-default"
+                variant="label-medium-default"
                 className="text-[var(--content-secondary)]"
               >
                 {t("contactPromptCard.notesLabel")}
               </Typography>
               <Typography
-                variant="body-small-default"
-                className="text-[var(--content-secondary)]"
+                variant="body-medium-lighter"
+                className="text-[var(--content-tertiary)]"
               >
                 {contactRequest.notes}
               </Typography>
@@ -153,6 +139,7 @@ export function ContactPromptCard({
               t("contactPromptCard.enterAddress", { channel: channelType })
             }
             disabled={isSubmitting}
+            fullWidth
             autoFocus
           />
           <Checkbox
@@ -162,10 +149,10 @@ export function ContactPromptCard({
             label={t("contactPromptCard.markVerified")}
             helperText={t("contactPromptCard.markVerifiedHelp")}
           />
-          <div className="flex justify-end gap-2">
+          <div className="flex items-center justify-end gap-2">
             <Button
               type="button"
-              variant="ghost"
+              variant="outlined"
               onClick={onCancel}
               disabled={isSubmitting}
             >
@@ -186,6 +173,6 @@ export function ContactPromptCard({
           </div>
         </form>
       )}
-    </Card>
+    </Card.Root>
   );
 }

--- a/clients/web/src/domains/chat/components/contact-record-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/contact-record-card.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
+import type { PendingContactRecordRequestState } from "@/types/interaction-ui-types";
+
+import { ContactRecordCard } from "./contact-record-card";
+
+/**
+ * The guardian's answer to a contact record write the assistant proposed,
+ * mounted in the transcript by `pending-contact-record-request-row`.
+ *
+ * One component covers all four operations, and the operation decides how much
+ * of the card is a form: a create or an update seeds editable fields from the
+ * proposal, while a delete drops the fields entirely and shows the channels
+ * that are about to be lost. Nothing is written until the card is submitted.
+ */
+const meta: Meta<typeof ContactRecordCard> = {
+  title: "Chat/ContactRecordCard",
+  component: ContactRecordCard,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    isSubmitting: false,
+    accepted: false,
+    onSubmit: () => {},
+    onCancel: () => {},
+  },
+  decorators: [
+    (Story) => (
+      <TranscriptColumn>
+        <Story />
+      </TranscriptColumn>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ContactRecordCard>;
+
+/**
+ * A delete asks only for a confirmation, so there are no inputs: the heading
+ * names the record, the warning says what else goes with it, and the channel
+ * list is how the guardian tells two same-named contacts apart. The submit is
+ * the danger variant.
+ */
+export const Delete: Story = {
+  args: {
+    request: {
+      requestId: "req-contact-delete",
+      operation: "delete",
+      contactId: "contact-1",
+      currentDisplayName: "Carolina Flaherty",
+      channels: [{ type: "telegram", address: "+1-555-0142" }],
+    } satisfies PendingContactRecordRequestState,
+  },
+};
+
+/**
+ * A create seeds the name and notes from the proposal and lets the guardian
+ * edit both before anything is written. `label` and `description` are the
+ * command's own framing for why the record is being proposed, and they replace
+ * the generic "Add a contact" heading when present.
+ */
+export const Create: Story = {
+  args: {
+    request: {
+      requestId: "req-contact-create",
+      operation: "create",
+      label: "Recreate Carolina Flaherty",
+      description:
+        "Fresh contact record for Carolina Flaherty, replacing the deleted one.",
+      displayName: "Carolina Flaherty",
+      notes:
+        "Recreated after the earlier record was deleted. Email on file: carolina@example.com, carried over from the previous record.",
+      notesProposed: true,
+    } satisfies PendingContactRecordRequestState,
+  },
+};

--- a/clients/web/src/domains/chat/components/contact-record-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/contact-record-card.stories.tsx
@@ -50,7 +50,7 @@ export const Delete: Story = {
       requestId: "req-contact-delete",
       operation: "delete",
       contactId: "contact-1",
-      currentDisplayName: "Carolina Flaherty",
+      currentDisplayName: "Alice",
       channels: [{ type: "telegram", address: "+1-555-0142" }],
     } satisfies PendingContactRecordRequestState,
   },
@@ -67,12 +67,11 @@ export const Create: Story = {
     request: {
       requestId: "req-contact-create",
       operation: "create",
-      label: "Recreate Carolina Flaherty",
-      description:
-        "Fresh contact record for Carolina Flaherty, replacing the deleted one.",
-      displayName: "Carolina Flaherty",
+      label: "Recreate Alice",
+      description: "Fresh contact record for Alice, replacing the deleted one.",
+      displayName: "Alice",
       notes:
-        "Recreated after the earlier record was deleted. Email on file: carolina@example.com, carried over from the previous record.",
+        "Recreated after the earlier record was deleted. Email on file: user@example.com, carried over from the previous record.",
       notesProposed: true,
     } satisfies PendingContactRecordRequestState,
   },

--- a/clients/web/src/domains/chat/components/contact-record-card.tsx
+++ b/clients/web/src/domains/chat/components/contact-record-card.tsx
@@ -9,19 +9,14 @@
  * submitted.
  */
 
-import { CheckCircle, Loader2, X } from "lucide-react";
+import { CheckCircle, Loader2 } from "lucide-react";
 import { type FormEvent, useState } from "react";
 
-import {
-  Button,
-  Card,
-  Input,
-  Textarea,
-  Typography,
-} from "@vellumai/design-library";
+import { Button, Card, Input, Typography } from "@vellumai/design-library";
 import { useTranslation } from "@/i18n";
 
 import type { PendingContactRecordRequestState } from "@/types/interaction-ui-types";
+import { ChannelIcon, getChannelLabel } from "@/utils/channel-presentation";
 
 type ContactRecordOperation = PendingContactRecordRequestState["operation"];
 
@@ -131,108 +126,89 @@ export function ContactRecordCard({
   }
 
   return (
-    <Card className="flex flex-col gap-4 p-4">
-      <div className="flex items-start justify-between gap-2">
-        <div className="flex flex-col gap-1">
+    <Card.Root padding="md" className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <Typography
+          variant="title-medium"
+          className="text-[var(--content-emphasised)]"
+        >
+          {heading}
+        </Typography>
+        {request.description && (
           <Typography
-            variant="label-small-default"
-            className="text-[var(--content-primary)]"
+            variant="body-medium-lighter"
+            className="text-[var(--content-tertiary)]"
           >
-            {heading}
+            {request.description}
           </Typography>
-          {request.description && (
-            <Typography
-              variant="body-small-default"
-              className="text-[var(--content-secondary)]"
-            >
-              {request.description}
-            </Typography>
-          )}
-          {(isDelete || isMerge) && (
-            <>
-              <Typography
-                variant="body-small-default"
-                className="text-[var(--content-secondary)]"
-              >
-                {isDelete
-                  ? t("contactRecordCard.deleteWarning")
-                  : t("contactRecordCard.mergeWarning", {
-                      donor: request.donorDisplayName ?? "",
-                      survivor: request.currentDisplayName ?? "",
-                    })}
-              </Typography>
-              {isDelete ? (
-                <ChannelList channels={request.channels} />
-              ) : (
-                <>
-                  <Typography
-                    variant="label-small-default"
-                    className="mt-2 text-[var(--content-secondary)]"
-                  >
-                    {t("contactRecordCard.mergeDonorChannels", {
-                      name: request.donorDisplayName ?? "",
-                    })}
-                  </Typography>
-                  <ChannelList channels={request.donorChannels} />
-                  <Typography
-                    variant="label-small-default"
-                    className="mt-2 text-[var(--content-secondary)]"
-                  >
-                    {t("contactRecordCard.mergeSurvivorChannels", {
-                      name: request.currentDisplayName ?? "",
-                    })}
-                  </Typography>
-                  <ChannelList channels={request.channels} />
-                </>
-              )}
-            </>
-          )}
-        </div>
-        {!accepted && (
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={isSubmitting}
-            className="shrink-0 text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
-            aria-label={t("contactRecordCard.dismiss")}
+        )}
+        {(isDelete || isMerge) && (
+          <Typography
+            variant="body-medium-lighter"
+            className="text-[var(--content-tertiary)]"
           >
-            <X size={16} />
-          </button>
+            {isDelete
+              ? t("contactRecordCard.deleteWarning")
+              : t("contactRecordCard.mergeWarning", {
+                  donor: request.donorDisplayName ?? "",
+                  survivor: request.currentDisplayName ?? "",
+                })}
+          </Typography>
         )}
       </div>
 
-      {accepted ? (
-        // typography: off-scale, an inline status badge rather than prose
+      {isDelete && <ChannelList channels={request.channels} />}
+      {isMerge && (
+        <>
+          <ChannelList
+            channels={request.donorChannels}
+            label={t("contactRecordCard.mergeDonorChannels", {
+              name: request.donorDisplayName ?? "",
+            })}
+          />
+          <ChannelList
+            channels={request.channels}
+            label={t("contactRecordCard.mergeSurvivorChannels", {
+              name: request.currentDisplayName ?? "",
+            })}
+          />
+        </>
+      )}
 
-        <div className="flex items-center gap-2 text-sm text-[var(--color-success)]">
+      {accepted ? (
+        <div className="flex items-center gap-2 text-body-medium-default text-[var(--system-positive-strong)]">
           <CheckCircle size={16} />
           {t(ACCEPTED_LABEL[request.operation])}
         </div>
       ) : (
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           {!isDelete && (
             <Input
+              label={t("contactRecordCard.nameLabel")}
               type="text"
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               placeholder={t("contactRecordCard.namePlaceholder")}
               disabled={isSubmitting}
+              fullWidth
               autoFocus
             />
           )}
           {!isDelete && !isMerge && (
-            <Textarea
+            <Input
+              label={t("contactRecordCard.notesLabel")}
+              type="text"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               placeholder={t("contactRecordCard.notesPlaceholder")}
               disabled={isSubmitting}
-              rows={3}
+              fullWidth
             />
           )}
-          <div className="flex justify-end gap-2">
+          <div className="flex items-center justify-end gap-2">
             <Button
               type="button"
-              variant="ghost"
+              variant="outlined"
               onClick={onCancel}
               disabled={isSubmitting}
             >
@@ -253,7 +229,7 @@ export function ContactRecordCard({
           </div>
         </form>
       )}
-    </Card>
+    </Card.Root>
   );
 }
 
@@ -261,35 +237,63 @@ export function ContactRecordCard({
  * The channels a confirmation is about: what a delete takes away, what a merge
  * moves to the survivor. Two contacts can share a name, so these are also how
  * the guardian tells which record the card means.
+ *
+ * Each channel reads as a filled row carrying its own glyph, so the kind of
+ * address is legible before the address itself is read. `label` names the set
+ * on a merge, where two of these sit side by side and the rows alone would not
+ * say which contact they belong to.
  */
 function ChannelList({
   channels,
+  label,
 }: {
   channels?: Array<{ type: string; address: string }>;
+  label?: string;
 }) {
   const { t } = useTranslation("chat");
 
-  if (!channels || channels.length === 0) {
-    return (
-      <Typography
-        variant="body-small-default"
-        className="text-[var(--content-tertiary)]"
-      >
-        {t("contactRecordCard.noChannels")}
-      </Typography>
-    );
-  }
-
   return (
-    <ul className="mt-1 list-none">
-      {channels.map((channel) => (
-        <li
-          key={`${channel.type}:${channel.address}`}
-          className="text-body-small-default text-[var(--content-secondary)]"
+    <div className="flex flex-col gap-1">
+      {label && (
+        <Typography
+          variant="label-medium-default"
+          className="text-[var(--content-secondary)]"
         >
-          {channel.type}: {channel.address}
-        </li>
-      ))}
-    </ul>
+          {label}
+        </Typography>
+      )}
+      {!channels || channels.length === 0 ? (
+        <Typography
+          variant="body-medium-lighter"
+          className="text-[var(--content-tertiary)]"
+        >
+          {t("contactRecordCard.noChannels")}
+        </Typography>
+      ) : (
+        <ul className="flex list-none flex-col gap-2">
+          {channels.map((channel) => (
+            <li
+              key={`${channel.type}:${channel.address}`}
+              className="flex h-8 w-full items-center gap-1.5 rounded-md border border-[var(--border-base)] bg-[var(--surface-overlay)] px-2 py-1.5"
+            >
+              <ChannelIcon
+                channelId={channel.type}
+                className="size-5 shrink-0 text-[var(--content-secondary)]"
+              />
+              <span className="flex min-w-0 items-center gap-1 text-body-medium-default">
+                <span className="shrink-0 text-[var(--content-secondary)]">
+                  {t("contactRecordCard.channelType", {
+                    channel: getChannelLabel(channel.type),
+                  })}
+                </span>
+                <span className="truncate text-[var(--content-default)]">
+                  {channel.address}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -547,6 +547,7 @@
   },
   "contactRecordCard": {
     "cancel": "Cancel",
+    "channelType": "{channel}:",
     "contactDeleted": "Contact deleted",
     "contactMerged": "Contacts merged",
     "contactSaved": "Contact saved",
@@ -560,9 +561,11 @@
     "mergeSurvivorChannels": "Already on {name}",
     "mergeTitle": "Merge {donor} into {survivor}?",
     "mergeWarning": "These channels move to {survivor}, and the {donor} record is deleted.",
+    "nameLabel": "Name",
     "namePlaceholder": "Name",
     "noChannels": "This contact has no channels.",
-    "notesPlaceholder": "Notes (optional)",
+    "notesLabel": "Notes",
+    "notesPlaceholder": "Add custom note",
     "save": "Save",
     "saving": "Saving…",
     "updateTitle": "Update {name}"

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -543,6 +543,7 @@
   },
   "contactRecordCard": {
     "cancel": "Cancelar",
+    "channelType": "{channel}:",
     "contactDeleted": "Contacto eliminado",
     "contactMerged": "Contactos combinados",
     "contactSaved": "Contacto guardado",
@@ -556,9 +557,11 @@
     "mergeSurvivorChannels": "Ya están en {name}",
     "mergeTitle": "¿Combinar a {donor} con {survivor}?",
     "mergeWarning": "Estos canales pasan a {survivor} y se elimina el registro de {donor}.",
+    "nameLabel": "Nombre",
     "namePlaceholder": "Nombre",
     "noChannels": "Este contacto no tiene canales.",
-    "notesPlaceholder": "Notas (opcional)",
+    "notesLabel": "Notas",
+    "notesPlaceholder": "Añadir una nota",
     "save": "Guardar",
     "saving": "Guardando…",
     "updateTitle": "Actualizar a {name}"

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -287,6 +287,7 @@
   },
   "contactRecordCard": {
     "cancel": "Отмена",
+    "channelType": "{channel}:",
     "contactDeleted": "Контакт удалён",
     "contactMerged": "Контакты объединены",
     "contactSaved": "Контакт сохранён",
@@ -300,9 +301,11 @@
     "mergeSurvivorChannels": "Уже у {name}",
     "mergeTitle": "Объединить {donor} с {survivor}?",
     "mergeWarning": "Эти каналы перейдут к {survivor}, а запись {donor} будет удалена.",
+    "nameLabel": "Имя",
     "namePlaceholder": "Имя",
     "noChannels": "У этого контакта нет каналов.",
-    "notesPlaceholder": "Заметки (необязательно)",
+    "notesLabel": "Заметки",
+    "notesPlaceholder": "Добавить заметку",
     "save": "Сохранить",
     "saving": "Сохранение…",
     "updateTitle": "Обновить: {name}"

--- a/clients/web/src/i18n/locales/zh-TW/chat.json
+++ b/clients/web/src/i18n/locales/zh-TW/chat.json
@@ -536,12 +536,16 @@
     "saving": "正在儲存…"
   },
   "contactRecordCard": {
+    "channelType": "{channel}：",
     "contactMerged": "聯絡人已合併",
     "merge": "合併",
     "mergeDonorChannels": "從 {name} 轉移",
     "mergeSurvivorChannels": "已屬於 {name}",
     "mergeTitle": "將 {donor} 合併至 {survivor}？",
-    "mergeWarning": "這些管道將轉移至 {survivor}，並刪除 {donor} 的記錄。"
+    "mergeWarning": "這些管道將轉移至 {survivor}，並刪除 {donor} 的記錄。",
+    "nameLabel": "姓名",
+    "notesLabel": "備註",
+    "notesPlaceholder": "新增備註"
   },
   "contextWindowIndicator": {
     "clearContext": "清除上下文",

--- a/clients/web/src/i18n/locales/zh/chat.json
+++ b/clients/web/src/i18n/locales/zh/chat.json
@@ -536,12 +536,16 @@
     "saving": "正在保存…"
   },
   "contactRecordCard": {
+    "channelType": "{channel}：",
     "contactMerged": "联系人已合并",
     "merge": "合并",
     "mergeDonorChannels": "从 {name} 转移",
     "mergeSurvivorChannels": "已属于 {name}",
     "mergeTitle": "将 {donor} 合并到 {survivor}？",
-    "mergeWarning": "这些渠道将转移到 {survivor}，并删除 {donor} 的记录。"
+    "mergeWarning": "这些渠道将转移到 {survivor}，并删除 {donor} 的记录。",
+    "nameLabel": "姓名",
+    "notesLabel": "备注",
+    "notesPlaceholder": "添加备注"
   },
   "contextWindowIndicator": {
     "clearContext": "清除上下文",

--- a/packages/design-library/src/components/card.tsx
+++ b/packages/design-library/src/components/card.tsx
@@ -53,7 +53,7 @@ function rootClasses({
 }): string {
   return cn(
     BASE_SURFACE_CLASSES,
-    bordered ? "border border-[var(--border-base)]" : "border border-transparent",
+    bordered ? "border border-[var(--border-subtle)]" : "border border-transparent",
     elevated ? "shadow-sm" : null,
     clipContents ? "overflow-hidden" : null,
     !hasSections && !noPadding ? PADDING_CLASSES[padding] : null,

--- a/packages/design-library/src/components/checkbox.tsx
+++ b/packages/design-library/src/components/checkbox.tsx
@@ -49,8 +49,8 @@ function Checkbox({
     "border transition-colors outline-none cursor-pointer",
     "keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)] keyboard-focus:ring-offset-0",
     "bg-[var(--surface-lift)] border-[var(--border-base)]",
-    "data-[state=checked]:bg-[var(--system-positive-strong)] data-[state=checked]:border-transparent",
-    "data-[state=indeterminate]:bg-[var(--system-positive-strong)] data-[state=indeterminate]:border-transparent",
+    "data-[state=checked]:bg-[var(--primary-active)] data-[state=checked]:border-transparent",
+    "data-[state=indeterminate]:bg-[var(--primary-active)] data-[state=indeterminate]:border-transparent",
     "disabled:cursor-not-allowed disabled:bg-[var(--surface-overlay)]",
     "disabled:data-[state=checked]:bg-[var(--surface-overlay)]",
     "disabled:data-[state=indeterminate]:bg-[var(--surface-overlay)]",
@@ -61,7 +61,7 @@ function Checkbox({
     "h-3 w-3",
     disabled
       ? "text-[color:var(--content-disabled)]"
-      : "text-[color:var(--aux-white)]",
+      : "text-[color:var(--content-inset)]",
   );
 
   const checkbox = (
@@ -100,7 +100,7 @@ function Checkbox({
     <div
       data-slot="checkbox"
       className={cn(
-        "flex gap-2.5",
+        "flex gap-2",
         helperText ? "items-start" : "items-center",
         className,
       )}
@@ -110,7 +110,7 @@ function Checkbox({
         {label ? (
           <Typography
             as="label"
-            variant="body-medium-default"
+            variant="body-medium-lighter"
             id={labelId}
             htmlFor={resolvedId}
             className={cn(
@@ -126,7 +126,7 @@ function Checkbox({
         {helperText ? (
           <span
             id={helperTextId}
-            className="text-body-small-default text-[color:var(--content-secondary)]"
+            className="text-body-small-default text-[color:var(--content-tertiary)]"
           >
             {helperText}
           </span>

--- a/packages/design-library/src/components/field.tsx
+++ b/packages/design-library/src/components/field.tsx
@@ -61,7 +61,7 @@ export function Field({
     <div
       data-slot="field-wrapper"
       className={cn(
-        "flex flex-col gap-1.5",
+        "flex flex-col gap-1",
         fullWidth ? "w-full" : "w-fit",
         className,
       )}
@@ -70,7 +70,7 @@ export function Field({
         <Typography
           as="label"
           id={`${id}-label`}
-          variant="body-small-default"
+          variant="label-medium-default"
           htmlFor={id}
           className={cn(
             "text-[var(--content-secondary)]",

--- a/packages/design-library/src/components/input.tsx
+++ b/packages/design-library/src/components/input.tsx
@@ -36,15 +36,15 @@ const fieldVariants = cva(
         ].join(" "),
       },
       density: {
-        input: "h-9 px-3 py-1.5",
+        input: "h-8 px-2 py-1.5",
         textarea: "min-h-[72px] px-3 py-2 resize-y",
       },
       hasLeftIcon: { true: "", false: "" },
       hasRightIcon: { true: "", false: "" },
     },
     compoundVariants: [
-      { density: "input", hasLeftIcon: true, class: "pl-9" },
-      { density: "input", hasRightIcon: true, class: "pr-9" },
+      { density: "input", hasLeftIcon: true, class: "pl-8" },
+      { density: "input", hasRightIcon: true, class: "pr-8" },
     ],
     defaultVariants: {
       invalid: false,
@@ -111,7 +111,7 @@ function Input({
           <span
             aria-hidden
             data-testid="input-left-icon"
-            className="pointer-events-none absolute left-3 flex items-center text-[var(--content-tertiary)]"
+            className="pointer-events-none absolute left-2 flex items-center text-[var(--content-tertiary)]"
           >
             {leftIcon}
           </span>
@@ -148,7 +148,7 @@ function Input({
           <span
             aria-hidden
             data-testid="input-right-icon"
-            className="pointer-events-none absolute right-3 flex items-center text-[var(--content-tertiary)]"
+            className="pointer-events-none absolute right-2 flex items-center text-[var(--content-tertiary)]"
           >
             {rightIcon}
           </span>


### PR DESCRIPTION
Both guardian contact cards (`contacts create/update/delete/merge` and the channel-binding prompt) now draw the New App frame 8473:182357 instead of their own approximation.

Cards:
- `Card.Root padding="md"` with a 16px gap. The old `<Card className="p-4">` stacked padding on top of `CardBody`, so every card drew 32px and its `gap-4` applied to a root with one child.
- 20px `title-medium` heading over a `body-medium-lighter` description.
- The X dismiss is gone, as the design draws it. Cancel already called the same `onCancel`, so nothing is lost.
- A delete lists each channel as a filled row carrying the channel glyph, replacing the plain "type: address" list.
- Name and Notes are labelled, full-width fields. Notes is single-line, matching the design.
- Cancel is `outlined` rather than `ghost`; the footer is right-aligned.
- The accepted state was painting with `var(--color-success)`, which is defined nowhere in the repo. It reads `--system-positive-strong` now.

Design library, where the shipped primitives disagreed with the spec:
- `Input` is 32px tall with 8px padding, and its icon offsets follow.
- `Field` labels are `label-medium-default` over a 4px gap.
- A checked `Checkbox` fills with `--primary-active` under a `--content-inset` check rather than the positive green, with an 8px gap, a regular-weight label, and a tertiary helper line.
- `Card` borders with `--border-subtle`, which is the spec's colour in dark and stays legible in light.

Radii were already correct: this repo remaps the scale in `tokens.css`, so `rounded-md` is the 8px the design asks for.

`Select` still sets its own `h-9`, so it is now 4px taller than `Input`. It is absent from the frame, so it is left for a follow-up rather than guessed.

Adds the Storybook entries these two cards never had, under `Chat/ContactRecordCard` and `Chat/ContactPromptCard`.


Claude-Session: https://claude.ai/code/session_01WceW3jtc79Grcm1fAMkNi9

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
