### PR TITLE
fix(oauth): drop selections:read from Figma default scopes

### DIFF
--- a/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
+++ b/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
@@ -48,6 +48,18 @@ describe("PROVIDER_SEED_DATA managed mode wiring", () => {
     );
     expect(gated).toEqual([]);
 
+    // `selections:read` is documented by Figma but not offered in the app's
+    // OAuth scope list, so requesting it fails the whole authorization. It
+    // stays in availableScopes for BYO apps that do have it.
+    expect(figma.defaultScopes).not.toContain("selections:read");
+    const availableScopes = figma.availableScopes;
+    expect(Array.isArray(availableScopes)).toBe(true);
+    if (Array.isArray(availableScopes)) {
+      expect(availableScopes.map(({ scope }) => scope)).toContain(
+        "selections:read",
+      );
+    }
+
     // GET /v1/me backs both the ping and the identity label.
     expect(figma.defaultScopes).toContain("current_user:read");
   });

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -980,7 +980,9 @@ export const PROVIDER_SEED_DATA: Record<
     // on it. Enterprise-only and org-admin-only scopes (file_variables:*,
     // library_analytics:read, org:*) are offered but not requested by
     // default, because Figma rejects the whole authorization request if the
-    // app cannot grant a requested scope.
+    // app cannot grant a requested scope. `selections:read` is withheld for
+    // that same reason: it is not offered in the app's OAuth scope list, so
+    // requesting it would fail the entire authorization.
     defaultScopes: [
       "current_user:read",
       "file_content:read",
@@ -995,7 +997,6 @@ export const PROVIDER_SEED_DATA: Record<
       "library_content:read",
       "library_assets:read",
       "team_library_content:read",
-      "selections:read",
     ],
     availableScopes: [
       {

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -962,7 +962,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T19:16:54.000Z"
+      "updatedAt": "2026-09-03T20:01:47.000Z"
     },
     {
       "id": "telegram-setup",
@@ -1179,7 +1179,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-09-03T15:44:53.000Z"
+      "updatedAt": "2026-09-04T16:14:06.000Z"
     },
     {
       "id": "vellum-self-knowledge",

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/figma-path-b.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/figma-path-b.md
@@ -73,14 +73,13 @@ Tell the user:
 >    - `library_content:read`
 >    - `library_assets:read`
 >    - `team_library_content:read`
->    - `selections:read`
 > 2. Find the **Callback URL** field and paste this exact URL:
 >    `OAUTH_CALLBACK_URL`
 > 3. Click **Save**
 >
 > Let me know when it's saved.
 
-If the user does not want to enable all fourteen, have them enable only the
+If the user does not want to enable all thirteen, have them enable only the
 scopes they are comfortable with and pass that exact set on connect, which
 replaces the defaults entirely (keep `current_user:read`, since the ping and
 identity checks both call `GET /v1/me`):

--- a/skills/vellum-oauth-integrations/references/provider-app-setups/figma.md
+++ b/skills/vellum-oauth-integrations/references/provider-app-setups/figma.md
@@ -108,13 +108,12 @@ different, follow the CLI.
 > - `library_content:read` - published components and styles of files
 > - `library_assets:read` - data of individual published components and styles
 > - `team_library_content:read` - published components and styles of teams
-> - `selections:read` - most recent selection in files you can access
 >
 > Save your changes if there's a save button.
 
 Wait for the user to confirm scopes are set.
 
-**Narrower grants.** If the user does not want to enable all fourteen, have them
+**Narrower grants.** If the user does not want to enable all thirteen, have them
 enable only the ones they are comfortable with and pass that exact set on
 connect, which replaces the defaults entirely:
 


### PR DESCRIPTION
Removes `selections:read` from Figma's `defaultScopes`, leaving 13 defaults that exactly match what the Figma app can actually grant.

### Why

Figma's app configuration does not offer `selections:read` in its OAuth scope list, so it cannot be enabled. Figma rejects the **entire** authorization request when an app requests a scope it cannot grant — the flow fails outright rather than degrading — so shipping it as a default would have broken the managed Figma connection for every user on the first authorize.

This is the same failure mode as the monday.com `invalid_scope` fix: defaults must be a strict subset of what the app grants, not a wish list.

### Verification

Compared the seeded defaults against the app's enabled scopes one by one. Every other scope matches exactly — `current_user:read`, the five `file_*` scopes, both `file_dev_resources:*`, both folder scopes, and the three library scopes. `selections:read` was the only mismatch in either direction.

### Scope of the change

One line removed from `defaultScopes`, plus a comment recording why it is withheld so it does not get re-added. `selections:read` stays in `availableScopes` so BYO apps that do enable it can still request it.

Test baselines are unchanged from `main` — `src/oauth` at 134 pass / 4 fail and `src/config` at 508 pass / 11 fail, identical with and without this diff (all pre-existing `BYOOAuthConnection` and unrelated config failures). `bun run typecheck` is clean.

Follow-up to #41867. The equivalent one-line change to the platform provider registry ships separately.
