### PR TITLE
style(voice): centre the camera pill between one control per corner

### DIFF
--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -19,11 +19,17 @@ scrim.
       the mobile sheet, on a notched device and on a Dynamic Island device. The
       pill sits below the island, on the minimize control's line, and never
       behind it.
+- [ ] The pill sits dead centre between the corners. Open the camera at
+      portrait phone width and again in landscape, in Photo and in Live, on a
+      device with side insets (a notched phone held sideways). The pill's centre
+      is the screen's centre in all four, whether or not the view-options button
+      is drawn in the left corner, and it does not shift sideways as Live starts
+      or stops.
 - [ ] The pill clears both corner controls. Give the assistant a name of 40
-      characters or more and open the camera at portrait phone width. The name
-      truncates to an ellipsis, the dot and "Photo" stay whole, and the pill's
-      edge never reaches the view-options button or the minimize control behind
-      it.
+      characters or more and open the camera at 320pt width with the longest
+      state string the locale has. The name truncates to an ellipsis, the dot
+      and "Photo" stay whole, the pill holds one line, and its edge never
+      reaches the view-options button or the minimize control behind it.
 - [ ] The pill clears the grabber. In the mobile sheet, the pill sits below the
       grabber and the grabber still takes the pull-down.
 - [ ] The sheet goes full-bleed for the camera. Open the camera in the mobile
@@ -56,10 +62,11 @@ scrim.
       matches what a press does, and the flash names the state it is in rather
       than the act.
 - [ ] View options opens as a panel, not a sheet. Tap the sliders button in the
-      corner with the camera up. The panel opens anchored under the button, its
-      switches take a tap, and tapping the feed outside it dismisses it. It is
-      never announced as a modal dialog that traps VoiceOver, and it never
-      arrives dead to touch.
+      TOP-LEFT corner with the camera up. The panel opens under the button and
+      aligned to its left edge, entirely on screen in portrait and in landscape
+      with a side inset, its switches take a tap, and tapping the feed outside
+      it dismisses it without taking a photo. It is never announced as a modal
+      dialog that traps VoiceOver, and it never arrives dead to touch.
 - [ ] The kept-frame switch reaches the thumbnail. Enter Live, wait for the
       crimson thumbnail beside the photo strip, then turn "Kept frame" off. The
       thumbnail goes, the row it sat in goes with it when no photos are in the
@@ -75,8 +82,9 @@ scrim.
 - [ ] The readout is a strip on a phone. On a staff or flagged session, switch
       the frame gate readout on with the camera up. What appears under the
       chrome band is one slim glass row: the verdict and three small meters,
-      never the full card. It clears both the status pill above it and the two
-      corner controls beside them, with a long assistant name in the pill.
+      never the full card. It clears the whole band above it: the view-options
+      button it sits directly under, the status pill, and the minimize, with a
+      long assistant name in the pill.
 - [ ] The strip opens the readout, and gives the frame back. Tap the strip: a
       sheet rises from the bottom with the decision order, the recent frames,
       the keeps and the threshold sliders. Tap the frame anywhere outside it,
@@ -342,12 +350,11 @@ the redesign is called shipped.
 - [ ] Minimize in camera mode. The design gives the camera view only the grabber
       and end session as exits. The build keeps the top-right minimize control,
       which is the only discoverable exit on desktop. Confirm.
-- [ ] Pill centring with two corner controls. The design centres the pill on the
-      screen against a single corner control. The build centres it in the band
-      the corner cluster leaves, so it sits a little left of screen centre: with
-      two 52px controls there, a screen-centred pill reaches under them at phone
-      width before its own floor width is spent. Confirm the band centring, or
-      ask for a pill that may narrow past its floor instead.
+- [ ] Pill centring against one control per corner. The build reserves the same
+      width at both edges of the band, one 52px control plus its gap, so the
+      pill's centre is the screen's centre and a long name still has a ceiling
+      to truncate inside at 320pt. Confirm the symmetric reserve, or ask for a
+      pill that may narrow past its floor instead.
 - [ ] View options as a panel on touch. The chat column's other panels open as a
       bottom sheet on a phone. This one stays anchored on every form factor: the
       room is itself a sheet whose flush camera state inerts the overlay host it

--- a/clients/web/docs/CAMERA_MODE_QA.md
+++ b/clients/web/docs/CAMERA_MODE_QA.md
@@ -19,12 +19,14 @@ scrim.
       the mobile sheet, on a notched device and on a Dynamic Island device. The
       pill sits below the island, on the minimize control's line, and never
       behind it.
-- [ ] The pill sits dead centre between the corners. Open the camera at
-      portrait phone width and again in landscape, in Photo and in Live, on a
-      device with side insets (a notched phone held sideways). The pill's centre
-      is the screen's centre in all four, whether or not the view-options button
-      is drawn in the left corner, and it does not shift sideways as Live starts
-      or stops.
+- [ ] The pill sits dead centre on the screen. Open the camera at portrait
+      phone width and again in landscape, in Photo and in Live, on a device
+      whose side insets are uneven (a notched phone held sideways, where the
+      cutout is on one side only). The pill's centre is the SCREEN's centre in
+      all four, whether or not the view-options button is drawn in the left
+      corner, and it does not shift sideways as Live starts or stops. The gap
+      from the pill to each corner control is allowed to differ on that device:
+      the controls hug their own side's inset, the pill answers to the screen.
 - [ ] The pill clears both corner controls. Give the assistant a name of 40
       characters or more and open the camera at 320pt width with the longest
       state string the locale has. The name truncates to an ellipsis, the dot
@@ -350,11 +352,13 @@ the redesign is called shipped.
 - [ ] Minimize in camera mode. The design gives the camera view only the grabber
       and end session as exits. The build keeps the top-right minimize control,
       which is the only discoverable exit on desktop. Confirm.
-- [ ] Pill centring against one control per corner. The build reserves the same
-      width at both edges of the band, one 52px control plus its gap, so the
-      pill's centre is the screen's centre and a long name still has a ceiling
-      to truncate inside at 320pt. Confirm the symmetric reserve, or ask for a
-      pill that may narrow past its floor instead.
+- [ ] Pill centring against one control per corner. The build takes one
+      reserve off both edges of the band, the deepest of the corner offset and
+      the two safe-area insets plus a 52px control and its gap, so the pill's
+      centre is the screen's centre and a long name still has a ceiling to
+      truncate inside at 320pt. On a device with uneven side insets that leaves
+      the shallow side more clearance than it needs. Confirm the screen-centred
+      pill, or ask for one centred between the controls instead.
 - [ ] View options as a panel on touch. The chat column's other panels open as a
       bottom sheet on a phone. This one stays anchored on every form factor: the
       room is itself a sheet whose flush camera state inerts the overlay host it

--- a/clients/web/src/domains/chat/voice/camera-mode-screen.stories.tsx
+++ b/clients/web/src/domains/chat/voice/camera-mode-screen.stories.tsx
@@ -1,6 +1,6 @@
 /**
  * Camera mode as one screen: the feed, the two scrims, the status pill, the
- * top-right corner cluster, the shutter row and the session controls, at the
+ * two corner controls, the shutter row and the session controls, at the
  * offsets and in the stacking order the room gives them.
  *
  * The per-component stories next door each answer one question about one
@@ -14,6 +14,15 @@
  * here takes either: every one of them is presentational, so a gradient stands
  * in for the feed and props stand in for the session. Nothing is a copy of an
  * app component.
+ *
+ * Where the chrome sits is not a copy either: the corner offsets and the
+ * pill's band arrive whole from `voice-room-layout.ts`, the same module the
+ * room reads them from, so retuning the layout retunes both implementations
+ * and this scene cannot drift from the surface it is reviewed as. Those are
+ * `max()` expressions over the device's safe-area insets, which a desktop
+ * Storybook iframe has none of, so what a reviewer sees resolves to the room's
+ * plain corner gap. The vertical offsets here are that gap alone: the room
+ * adds the notch to them and a browser tab has no notch.
  */
 
 import type { Meta, StoryObj } from "@storybook/react-vite";
@@ -43,35 +52,21 @@ import {
 } from "./voice-room/camera-status-pill";
 import type { CameraVoiceState } from "./voice-room/use-camera-voice-state";
 import type { VoiceRoomPhoto } from "./voice-room/use-voice-room-camera";
+import {
+  CAMERA_PILL_INSET,
+  VOICE_ROOM_CORNER_GAP,
+  VOICE_ROOM_CORNER_LEFT,
+  VOICE_ROOM_CORNER_RIGHT,
+} from "./voice-room/voice-room-layout";
 import { VoiceRoomCaptureRow } from "./voice-room/voice-room-capture-row";
 import { VoiceRoomControl } from "./voice-room/voice-room-control";
-
-/**
- * The room's corner gap, which every offset below is measured from.
- *
- * The app writes `max(1.25rem, env(safe-area-inset-bottom))`, so on a notched
- * phone the row clears the home indicator. Storybook is read in a desktop
- * browser inside an iframe, where that `max()` resolves to the gap on its own,
- * and pinning it keeps the composition identical for every reviewer instead of
- * shifting with whatever device the tab is open on. `voice-room.tsx` keeps the
- * real expression.
- */
-const STORY_INSET = "1.25rem";
 
 /**
  * The shutter row's offset: the session row's, plus its 52px height, plus the
  * 46px the design leaves between the two. Composed the way the room composes
  * it, since it is the gap that keeps the shutter off the end-session button.
  */
-const SHUTTER_ROW_BOTTOM = `calc(6.125rem + ${STORY_INSET})`;
-
-/**
- * The right edge of the band the pill is centred in: the story inset plus the
- * corner cluster (two 52px controls and the 4px between them) plus the 8px the
- * pill never closes. `voice-room.tsx` keeps the real expression, which adds the
- * safe-area inset the room's own controls ride.
- */
-const PILL_BAND_RIGHT = `calc(${STORY_INSET} + 7.25rem)`;
+const SHUTTER_ROW_BOTTOM = `calc(6.125rem + ${VOICE_ROOM_CORNER_GAP})`;
 
 /** The shutter's accessible name per mode, mirroring the room's catalog copy. */
 const SHUTTER_LABELS: Record<CameraMode, string> = {
@@ -126,14 +121,14 @@ interface CameraModeScreenProps {
  *
  * Everything visible here is the real component: `CameraStatusPill`, the
  * shutter row's `CameraShutter` and `CameraFlashControl` through
- * `CameraRowScene`, and the `VoiceRoomControl`s of the corner cluster and the
- * session row. The corner's view-options control is its trigger only, since
- * the panel it opens reads live stores this scene has none of. What
+ * `CameraRowScene`, and the `VoiceRoomControl`s of the two corners and the
+ * session row. The left corner's view-options control is its trigger only,
+ * since the panel it opens reads live stores this scene has none of. What
  * this scene supplies is only what the app supplies around them: the frame,
  * the two scrims, and where each piece sits. In the app that job belongs to
  * `voice-room.tsx`, which wires the same pieces to the live session and the
- * camera, and which is the source of truth for every offset and z-index
- * restated below.
+ * camera; the offsets both of them hang the chrome off come from
+ * `voice-room-layout.ts`, and the z-indexes are restated below.
  */
 function CameraModeScreen({
   mode = "photo",
@@ -170,29 +165,13 @@ function CameraModeScreen({
         style={{ background: CAMERA_SCRIM_BOTTOM }}
       />
 
-      {/* The pill, centred in the band the corner cluster leaves rather than on
-          the screen: the cluster holds two controls, and a pill centred on the
-          screen would reach under them at phone width before its own floor
-          width was spent. */}
-      <div
-        className="pointer-events-none absolute z-10 flex justify-center"
-        style={{ top: STORY_INSET, left: STORY_INSET, right: PILL_BAND_RIGHT }}
-      >
-        <CameraStatusPill
-          mode={mode}
-          voiceState={voiceState}
-          statusLabel={statusLabel}
-          assistantName={assistantName}
-        />
-      </div>
-
-      {/* The corner cluster: the camera's view options, then minimize on the
-          extreme corner. Both wear the glass corner treatment rather than the
-          session row's fills, so the corner reads as chrome over the feed
+      {/* Top-left: the camera's view options, in a corner box of its own. Both
+          corner controls wear the glass corner treatment rather than the
+          session row's fills, so the band reads as chrome over the feed
           instead of joining the row of acts at the bottom. */}
       <div
-        className="absolute z-10 flex items-center gap-1"
-        style={{ top: STORY_INSET, right: STORY_INSET }}
+        className="absolute z-10 flex"
+        style={{ top: VOICE_ROOM_CORNER_GAP, left: VOICE_ROOM_CORNER_LEFT }}
       >
         <VoiceRoomControl
           bare
@@ -202,6 +181,34 @@ function CameraModeScreen({
         >
           <SlidersHorizontal className="size-5" />
         </VoiceRoomControl>
+      </div>
+
+      {/* The pill, on the screen's centre line: one reserve off both edges of
+          the band, wide enough for the single control each corner holds, so
+          the pill's middle is the screen's middle whichever corners are
+          occupied and a long name still has a ceiling to truncate inside. */}
+      <div
+        className="pointer-events-none absolute z-10 flex justify-center"
+        style={{
+          top: VOICE_ROOM_CORNER_GAP,
+          left: CAMERA_PILL_INSET,
+          right: CAMERA_PILL_INSET,
+        }}
+      >
+        <CameraStatusPill
+          mode={mode}
+          voiceState={voiceState}
+          statusLabel={statusLabel}
+          assistantName={assistantName}
+        />
+      </div>
+
+      {/* Top-right: minimize, alone on the extreme corner, which is where every
+          other surface in the app puts "get this off my screen". */}
+      <div
+        className="absolute z-10 flex"
+        style={{ top: VOICE_ROOM_CORNER_GAP, right: VOICE_ROOM_CORNER_RIGHT }}
+      >
         <VoiceRoomControl
           bare
           surface="camera"
@@ -238,7 +245,7 @@ function CameraModeScreen({
           apart by what they do rather than by an outline. */}
       <div
         className="absolute inset-x-0 z-10 flex items-center justify-center gap-4"
-        style={{ bottom: STORY_INSET }}
+        style={{ bottom: VOICE_ROOM_CORNER_GAP }}
       >
         <VoiceRoomControl
           surface="camera"
@@ -341,10 +348,10 @@ type Story = StoryObj<typeof CameraModeScreen>;
 /**
  * The resting surface: camera open, session hearing you, nobody talking.
  *
- * The read to check is the vertical rhythm. The pill sits on the same line the
- * minimize control would, the shutter clears the session row by the design's
- * 46px, and the bottom scrim reaches above the shutter rather than stopping
- * between the two rows.
+ * The read to check is the rhythm both ways. Across, the pill shares its line
+ * with the two corner controls and holds the screen's centre between them.
+ * Down, the shutter clears the session row by the design's 46px and the bottom
+ * scrim reaches above the shutter rather than stopping between the two rows.
  */
 export const PhotoIdle: Story = {};
 
@@ -402,12 +409,12 @@ export const LiveMode: Story = { args: { mode: "live" } };
 
 /**
  * A configured name long enough to run out of room, at the width where it has
- * the least: the case the corner cluster made harder by taking a second
- * control.
+ * the least: the case the band's ceiling exists for.
  *
- * The read to check is the right edge. The name truncates to an ellipsis, the
- * dot and the mode word stay whole, and nothing about the pill reaches the
- * view-options button beside minimize.
+ * The read to check is both edges at once, since the pill grows from the
+ * screen's centre in either direction. The name truncates to an ellipsis, the
+ * dot and the mode word stay whole, and the pill reaches neither the
+ * view-options button on the left nor the minimize on the right.
  */
 export const LongAssistantName: Story = {
   args: {

--- a/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-status-pill.tsx
@@ -201,14 +201,17 @@ export function CameraStatusPill({
         // it knows what corner chrome the pill has to keep clear of.
         "inline-flex min-w-[9rem] max-w-full items-center justify-center",
         "rounded-full",
-        "px-3 py-[5px]",
+        "px-4 py-[7px]",
         "text-label-medium-default",
         // Blur rather than a heavier fill: the frame behind can be any
         // brightness, and an opaque chip over a viewfinder reads as a hole.
         MODE_CONTAINER_CLASSES[mode],
-        // The token's 11px at the design's 600. Rebinding the weight var beats
-        // a `font-semibold` beside it: both set `font-weight`, and which one
-        // wins is Tailwind's utility ordering rather than the order written.
+        // The label token at the design's 13px and 600. Rebinding the vars
+        // beats `text-[13px] font-semibold` beside it: each pair sets the same
+        // property, and which one wins is Tailwind's utility ordering rather
+        // than the order written. The scale's label sizes stop at 11px, so the
+        // size is a rebinding for the same reason the weight is.
+        "[--text-label-medium-default-size:13px]",
         "[--text-label-medium-default-weight:600]",
       )}
     >
@@ -216,12 +219,12 @@ export function CameraStatusPill({
           assistive tech; the room's live region speaks the sentence. */}
       <span
         aria-hidden
-        className="inline-flex min-w-0 items-center gap-[7px] whitespace-nowrap"
+        className="inline-flex min-w-0 items-center gap-2 whitespace-nowrap"
       >
         <span
           data-testid="camera-status-dot"
           className={cn(
-            "size-[5px] flex-none rounded-full",
+            "size-[6px] flex-none rounded-full",
             voiceState === "idle" && "bg-white/50",
             voiceState === "user" && "bg-white",
             voiceState === "assistant" && "bg-[var(--camera-accent-soft)]",

--- a/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/camera-view-settings.tsx
@@ -136,7 +136,9 @@ export function CameraViewSettings({ panelHost }: CameraViewSettingsProps) {
         </Popover.Trigger>
         <Popover.Content
           side="bottom"
-          align="end"
+          // The trigger sits in the room's left corner, so the panel hangs
+          // from its leading edge and grows inward, away from the screen edge.
+          align="start"
           sideOffset={8}
           data-testid="camera-view-settings-panel"
           // Radix presents this as a dialog, and an unnamed one is announced

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-layout.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-layout.ts
@@ -1,5 +1,15 @@
 /**
- * Vertical layout zones for the voice room's text surfaces.
+ * The voice room's shared layout vocabulary: the device insets every surface
+ * in it clears, the vertical zones its text sits in, and the corner offsets
+ * and camera band its chrome hangs off.
+ *
+ * One home for these because two implementations draw the room: `voice-room.tsx`
+ * over a live session, and the Storybook scenes that stand the same chrome up
+ * over a still frame. An offset written twice is an offset that drifts the
+ * first time one of them is retuned, and the story is where the layout is
+ * reviewed.
+ *
+ * ## Vertical zones for the room's text surfaces
  *
  * The room reads top-to-bottom as the conversation itself: the user's
  * transcribed speech in the upper zone, the character's eyes holding the
@@ -76,3 +86,41 @@ export const VOICE_ROOM_ZONE_FADE =
  * viewport rather than drifting heavier or lighter than the words.
  */
 export const VOICE_ROOM_CAPTION_TEXT = "clamp(15px, 2.2vmin, 22px)";
+
+/**
+ * Gap between a corner control and the room's edges. One constant so the
+ * top-right exit, the camera's top-left view options and the bottom control
+ * row sit on the same rhythm.
+ */
+export const VOICE_ROOM_CORNER_GAP = "1.25rem";
+
+/**
+ * Where a corner box hangs off its own edge: the room's gap, or the device's
+ * inset on that side where that is deeper. Per side, because a control belongs
+ * to the corner it sits in and a cutout is not symmetric.
+ */
+export const VOICE_ROOM_CORNER_LEFT = `max(${VOICE_ROOM_CORNER_GAP}, ${SAFE_AREA_LEFT})`;
+export const VOICE_ROOM_CORNER_RIGHT = `max(${VOICE_ROOM_CORNER_GAP}, ${SAFE_AREA_RIGHT})`;
+
+/**
+ * The band the camera status pill is centred in, on the same line as the
+ * room's corner chrome. A configured assistant name is arbitrarily long, so
+ * without a bound the pill runs under that chrome and off a phone-width room.
+ *
+ * ONE reserve, taken off both edges: the deepest of the room's corner offset
+ * and the two safe-area insets, plus the 3.25rem control a corner holds, plus
+ * the 0.5rem gap the pill and that control never close. Each corner holds a
+ * single control, so one control's width covers both, and one value covers
+ * both sides because a display cutout is not symmetric: a reserve computed per
+ * side would differ by the difference between the insets and carry the pill
+ * half that far off the room's centre line, which is the line the eye reads it
+ * against. The corner controls still hug their own side's inset, so the
+ * shallow side gets more clearance than it strictly needs.
+ *
+ * The pill's floor survives both ends of that. A 320pt portrait room has no
+ * side insets to deepen the reserve, and the landscape rooms where the insets
+ * do get deep are hundreds of points wider than they are tall. Either way the
+ * band stays wider than the pill's own floor, so a long name truncates inside
+ * the ceiling the band gives it rather than overhanging a corner.
+ */
+export const CAMERA_PILL_INSET = `calc(max(${VOICE_ROOM_CORNER_GAP}, ${SAFE_AREA_LEFT}, ${SAFE_AREA_RIGHT}) + 3.75rem)`;

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -516,16 +516,15 @@ describe("VoiceRoom — OAuth connect card (backwards-compat fallback)", () => {
 const roomDialog = () =>
   screen.queryByRole("dialog", { name: "Voice session" });
 /**
- * What the room reserves at each edge of the camera pill's band, read off the
- * vars it publishes. Equal reserves are what put the pill on the room's centre
- * line rather than on the centre of whatever the corners leave over.
+ * What the room reserves at the camera pill's band, read off the one var it
+ * publishes for it. One value taken off both edges is what puts the pill on
+ * the room's centre line rather than on the centre of whatever the corners
+ * leave over.
  */
-const bandInsets = () => {
-  const style = roomDialog()?.getAttribute("style") ?? "";
-  const read = (name: string) =>
-    style.match(new RegExp(`--camera-pill-${name}: ([^;]+)`))?.[1] ?? "";
-  return { left: read("left"), right: read("right") };
-};
+const bandInset = () =>
+  roomDialog()
+    ?.getAttribute("style")
+    ?.match(/--camera-pill-inset: ([^;]+)/)?.[1] ?? "";
 /** The control row's ✕: the room's only way to end a session. */
 const endButton = () =>
   screen.queryByRole("button", { name: "End voice session" });
@@ -1389,9 +1388,13 @@ describe("VoiceRoom: the chrome band's corners", () => {
   });
 
   test("centres the pill on the room whether or not the options are offered", async () => {
-    // Equal reserves on both edges of the band, so the slot's midpoint is the
-    // room's midpoint. Reserving only for the corner that happens to be
-    // occupied would slide the pill sideways as Live comes and goes.
+    // One reserve off both edges, so the slot's midpoint is the room's
+    // midpoint. Reserving only for the corner that happens to be occupied
+    // would slide the pill sideways as Live comes and goes, and a reserve
+    // computed per side would slide it by half the difference between two
+    // uneven safe-area insets.
+    const inset =
+      "calc(max(1.25rem, var(--safe-area-inset-left, env(safe-area-inset-left, 0px)), var(--safe-area-inset-right, env(safe-area-inset-right, 0px))) + 3.75rem)";
     stubMediaDevices(async () => fakeStream());
     seedLiveCapableAssistant();
     startOwnedSession("listening");
@@ -1402,11 +1405,13 @@ describe("VoiceRoom: the chrome band's corners", () => {
     });
 
     expect(screen.getByTestId("camera-view-settings")).not.toBeNull();
-    expect(bandInsets()).toEqual({
-      left: "calc(max(1.25rem, var(--safe-area-inset-left, env(safe-area-inset-left, 0px))) + 3.75rem)",
-      right:
-        "calc(max(1.25rem, var(--safe-area-inset-right, env(safe-area-inset-right, 0px))) + 3.75rem)",
-    });
+    expect(bandInset()).toBe(inset);
+    // Both edges off the one var, in one declaration: splitting them back into
+    // a `left-[…] right-[…]` pair is what would let the two drift apart.
+    const slot = () => screen.getByTestId("camera-status-pill-slot").className;
+    expect(slot()).toContain("inset-x-[var(--camera-pill-inset)]");
+    expect(slot()).not.toContain("left-[");
+    expect(slot()).not.toContain("right-[");
 
     withOptions.unmount();
     seedCameraCapableAssistant();
@@ -1420,11 +1425,8 @@ describe("VoiceRoom: the chrome band's corners", () => {
     // The left corner is empty here, and the band does not claim the room it
     // gave up: an empty corner and an occupied one reserve the same.
     expect(screen.queryByTestId("camera-view-settings")).toBeNull();
-    expect(bandInsets()).toEqual({
-      left: "calc(max(1.25rem, var(--safe-area-inset-left, env(safe-area-inset-left, 0px))) + 3.75rem)",
-      right:
-        "calc(max(1.25rem, var(--safe-area-inset-right, env(safe-area-inset-right, 0px))) + 3.75rem)",
-    });
+    expect(bandInset()).toBe(inset);
+    expect(slot()).toContain("inset-x-[var(--camera-pill-inset)]");
   });
 
   /**
@@ -2161,16 +2163,14 @@ describe("VoiceRoom: camera", () => {
     expect(screen.getByTestId("camera-status-pill").textContent).toContain(
       "Photo",
     );
-    // On the corner chrome's own line, and centred between the reserve each
-    // corner takes, so a long assistant name truncates inside a ceiling
-    // instead of running under a control.
+    // On the corner chrome's own line, and centred by one reserve taken off
+    // both edges, so a long assistant name truncates inside a ceiling instead
+    // of running under a control.
     expect(screen.getByTestId("camera-status-pill-slot").className).toContain(
-      "left-[var(--camera-pill-left)] right-[var(--camera-pill-right)]",
+      "inset-x-[var(--camera-pill-inset)]",
     );
-    expect(bandInsets().left).toContain(
-      "calc(max(1.25rem, var(--safe-area-inset-left",
-    );
-    expect(bandInsets().right).toContain(")) + 3.75rem)");
+    expect(bandInset()).toContain("calc(max(1.25rem, var(--safe-area-inset");
+    expect(bandInset()).toContain(")) + 3.75rem)");
     // Between the feed (`z-[2]`) and the chrome (`z-10`), and inert: the
     // bottom scrim lies over the shutter and the whole control row.
     const bottomScrim = screen.getByTestId("voice-room-scrim-bottom");

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -515,6 +515,17 @@ describe("VoiceRoom — OAuth connect card (backwards-compat fallback)", () => {
 
 const roomDialog = () =>
   screen.queryByRole("dialog", { name: "Voice session" });
+/**
+ * What the room reserves at each edge of the camera pill's band, read off the
+ * vars it publishes. Equal reserves are what put the pill on the room's centre
+ * line rather than on the centre of whatever the corners leave over.
+ */
+const bandInsets = () => {
+  const style = roomDialog()?.getAttribute("style") ?? "";
+  const read = (name: string) =>
+    style.match(new RegExp(`--camera-pill-${name}: ([^;]+)`))?.[1] ?? "";
+  return { left: read("left"), right: read("right") };
+};
 /** The control row's ✕: the room's only way to end a session. */
 const endButton = () =>
   screen.queryByRole("button", { name: "End voice session" });
@@ -1284,9 +1295,16 @@ describe("VoiceRoom — minimize (session keeps running)", () => {
   });
 });
 
-describe("VoiceRoom: top-right corner", () => {
+/**
+ * The chrome band's two corners: the view options on the left, the minimize on
+ * the right, and the pill centred between the equal reserves they take.
+ */
+describe("VoiceRoom: the chrome band's corners", () => {
+  /** The absolute box a corner control is positioned by. */
+  const cornerBox = (control: HTMLElement) => control.closest("div.absolute");
+
   test("holds the minimize and nothing else", () => {
-    // With no viewfinder up the corner is down to one control. A cluster of
+    // With no viewfinder up the band is down to one control. A cluster of
     // small chrome competed with the room's own cast, so the in-session
     // settings gear was deleted; voice and listening language are picked in
     // Settings.
@@ -1308,12 +1326,34 @@ describe("VoiceRoom: top-right corner", () => {
       fireEvent.click(cameraToggle()!);
     });
 
-    // Inboard of minimize, which keeps the extreme corner: the light exit is
-    // the one muscle memory reaches for without looking.
-    expect(screen.getByTestId("camera-view-settings")).not.toBeNull();
-    expect(minimizeButton()).not.toBeNull();
-    // The pill's band gives up the two-control cluster on that side.
-    expect(roomDialog()?.getAttribute("style")).toContain(")) + 7.25rem)");
+    // A box of its own rather than a seat beside the minimize: sharing a box
+    // with either neighbour is what would push the pill off the room's centre.
+    // Which edge each box hangs off is an inline `max()`, which happy-dom
+    // drops, so the side itself is a QA row; what the suite holds is that the
+    // two are separate boxes on the same band, in reading order.
+    const settingsBox = cornerBox(screen.getByTestId("camera-view-settings"));
+    const minimizeBox = cornerBox(minimizeButton()!);
+    expect(Boolean(settingsBox)).toBe(true);
+    expect(settingsBox === minimizeBox).toBe(false);
+    expect(settingsBox?.contains(minimizeButton())).toBe(false);
+    expect(settingsBox?.className).toContain(
+      "absolute top-[var(--room-chrome-top)] z-10 flex",
+    );
+    expect(minimizeBox?.className).toContain(
+      "absolute top-[var(--room-chrome-top)] z-10 flex",
+    );
+    // Reading order: options, then the pill it does not sit inside, then the
+    // exit.
+    const chrome = Array.from(
+      roomDialog()?.querySelectorAll(
+        "[data-testid='camera-view-settings'], [data-testid='camera-status-pill-slot'], [aria-label='Minimize voice room']",
+      ) ?? [],
+    ).map((node) => node.getAttribute("data-testid") ?? "minimize");
+    expect(chrome).toEqual([
+      "camera-view-settings",
+      "camera-status-pill-slot",
+      "minimize",
+    ]);
 
     await act(async () => {
       fireEvent.click(cameraToggle()!);
@@ -1339,11 +1379,52 @@ describe("VoiceRoom: top-right corner", () => {
     });
 
     expect(screen.getByTestId("voice-room-viewfinder")).not.toBeNull();
+    // Nowhere at all, rather than an empty box left standing in the corner.
     expect(screen.queryByTestId("camera-view-settings")).toBeNull();
     expect(screen.queryByTestId("camera-view-settings-host")).toBeNull();
-    // Minimize stands alone up there, so the pill's band gives up one control
-    // rather than holding a gap for a button that is not drawn.
-    expect(roomDialog()?.getAttribute("style")).toContain(")) + 3.75rem)");
+    // Minimize stands alone up there, in the box it holds in every room.
+    expect(cornerBox(minimizeButton()!)?.className).toContain(
+      "absolute top-[var(--room-chrome-top)] z-10 flex",
+    );
+  });
+
+  test("centres the pill on the room whether or not the options are offered", async () => {
+    // Equal reserves on both edges of the band, so the slot's midpoint is the
+    // room's midpoint. Reserving only for the corner that happens to be
+    // occupied would slide the pill sideways as Live comes and goes.
+    stubMediaDevices(async () => fakeStream());
+    seedLiveCapableAssistant();
+    startOwnedSession("listening");
+    const withOptions = render(<VoiceRoom />);
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    expect(screen.getByTestId("camera-view-settings")).not.toBeNull();
+    expect(bandInsets()).toEqual({
+      left: "calc(max(1.25rem, var(--safe-area-inset-left, env(safe-area-inset-left, 0px))) + 3.75rem)",
+      right:
+        "calc(max(1.25rem, var(--safe-area-inset-right, env(safe-area-inset-right, 0px))) + 3.75rem)",
+    });
+
+    withOptions.unmount();
+    seedCameraCapableAssistant();
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+
+    await act(async () => {
+      fireEvent.click(cameraToggle()!);
+    });
+
+    // The left corner is empty here, and the band does not claim the room it
+    // gave up: an empty corner and an occupied one reserve the same.
+    expect(screen.queryByTestId("camera-view-settings")).toBeNull();
+    expect(bandInsets()).toEqual({
+      left: "calc(max(1.25rem, var(--safe-area-inset-left, env(safe-area-inset-left, 0px))) + 3.75rem)",
+      right:
+        "calc(max(1.25rem, var(--safe-area-inset-right, env(safe-area-inset-right, 0px))) + 3.75rem)",
+    });
   });
 
   /**
@@ -2080,17 +2161,16 @@ describe("VoiceRoom: camera", () => {
     expect(screen.getByTestId("camera-status-pill").textContent).toContain(
       "Photo",
     );
-    // On the corner chrome's own line and centred in the band that chrome
-    // leaves, so a long assistant name truncates inside a ceiling instead of
-    // running under the cluster. This assistant cannot run Live, so the corner
-    // holds minimize alone and the band gives up one control's worth.
+    // On the corner chrome's own line, and centred between the reserve each
+    // corner takes, so a long assistant name truncates inside a ceiling
+    // instead of running under a control.
     expect(screen.getByTestId("camera-status-pill-slot").className).toContain(
       "left-[var(--camera-pill-left)] right-[var(--camera-pill-right)]",
     );
-    expect(roomDialog()?.getAttribute("style")).toContain(
-      "--camera-pill-right: calc(max(1.25rem, var(--safe-area-inset-right",
+    expect(bandInsets().left).toContain(
+      "calc(max(1.25rem, var(--safe-area-inset-left",
     );
-    expect(roomDialog()?.getAttribute("style")).toContain(")) + 3.75rem)");
+    expect(bandInsets().right).toContain(")) + 3.75rem)");
     // Between the feed (`z-[2]`) and the chrome (`z-10`), and inert: the
     // bottom scrim lies over the shutter and the whole control row.
     const bottomScrim = screen.getByTestId("voice-room-scrim-bottom");

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -230,18 +230,23 @@ const CORNER_GAP = "1.25rem";
  * room's corner chrome. A configured assistant name is arbitrarily long, so
  * without a bound the pill runs under that chrome and off a phone-width room.
  *
- * The same reserve on both edges: the room's corner offset, plus one 3.25rem
- * control, plus the 0.5rem gap the pill and that control never close. Each
- * corner holds a single control, so one reserve describes both, and equal
- * reserves put the middle of this band on the middle of the room whether or
- * not the left corner is holding the view-options button.
+ * ONE reserve, taken off both edges: the deepest of the room's corner offset
+ * and the two safe-area insets, plus the 3.25rem control a corner holds, plus
+ * the 0.5rem gap the pill and that control never close. Each corner holds a
+ * single control, so one control's width covers both, and one value covers
+ * both sides because a display cutout is not symmetric: a reserve computed per
+ * side would differ by the difference between the insets and carry the pill
+ * half that far off the room's centre line, which is the line the eye reads it
+ * against. The corner controls still hug their own side's inset, so the
+ * shallow side gets more clearance than it strictly needs.
  *
- * A 320pt room still leaves the band wider than the pill's own floor, so a
- * long name truncates inside the ceiling the band gives it rather than
- * overhanging either corner.
+ * The pill's floor survives both ends of that. A 320pt portrait room has no
+ * side insets to deepen the reserve, and the landscape rooms where the insets
+ * do get deep are hundreds of points wider than they are tall. Either way the
+ * band stays wider than the pill's own floor, so a long name truncates inside
+ * the ceiling the band gives it rather than overhanging a corner.
  */
-const CAMERA_PILL_INSET_LEFT = `calc(max(${CORNER_GAP}, ${SAFE_AREA_LEFT}) + 3.75rem)`;
-const CAMERA_PILL_INSET_RIGHT = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 3.75rem)`;
+const CAMERA_PILL_INSET = `calc(max(${CORNER_GAP}, ${SAFE_AREA_LEFT}, ${SAFE_AREA_RIGHT}) + 3.75rem)`;
 
 /**
  * The tier the camera's view-options panel renders on, above every layer the
@@ -917,10 +922,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // flush camera sheet reach the notch: the former clamps its gap up to the
   // inset, the latter adds the gap to it so the grabber fits between. The panel
   // and the header-resting sheet start below the app's own chrome, where the
-  // inset is not their edge to clear. The band's two edges ride along, since
-  // the pill's slot is told where they are the same way, and both take the
-  // same reserve so the pill lands on the room's centre line: see
-  // {@link CAMERA_PILL_INSET_LEFT}.
+  // inset is not their edge to clear. The band rides along, since the pill's
+  // slot is told what it reserves the same way, and it is one value taken off
+  // both edges so the pill lands on the room's centre line: see
+  // {@link CAMERA_PILL_INSET}.
   const topBandVars = {
     "--room-chrome-top": fullscreen
       ? `max(${CORNER_GAP}, ${SAFE_AREA_TOP})`
@@ -930,8 +935,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
     "--room-grabber-top": cameraSheet
       ? `calc(0.5rem + ${SAFE_AREA_TOP})`
       : "0.5rem",
-    "--camera-pill-left": CAMERA_PILL_INSET_LEFT,
-    "--camera-pill-right": CAMERA_PILL_INSET_RIGHT,
+    "--camera-pill-inset": CAMERA_PILL_INSET,
   } as CSSProperties;
 
   const body = (
@@ -1218,10 +1222,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       {/* Camera mode's status readout: what the camera is doing, and what the
           session is doing. On the same offset the corner chrome uses, so it
           shares a line with that chrome instead of floating on a rhythm of its
-          own; that offset already clears the sheet's grabber. Centred between
-          two equal reserves, one per corner, which puts it on the room's centre
-          line and still gives a long name a ceiling to truncate inside at phone
-          width: see {@link CAMERA_PILL_INSET_LEFT}.
+          own; that offset already clears the sheet's grabber. One reserve off
+          both edges, so the slot's middle is the room's middle and a long name
+          still has a ceiling to truncate inside at phone width: see
+          {@link CAMERA_PILL_INSET}.
 
           Camera-only. With the viewfinder closed the room says all of this
           through the look itself (the avatar's visual, the state caption, the
@@ -1230,7 +1234,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       {cameraOpen ? (
         <div
           data-testid="camera-status-pill-slot"
-          className="pointer-events-none absolute left-[var(--camera-pill-left)] right-[var(--camera-pill-right)] top-[var(--room-chrome-top)] z-10 flex justify-center"
+          className="pointer-events-none absolute inset-x-[var(--camera-pill-inset)] top-[var(--room-chrome-top)] z-10 flex justify-center"
         >
           <CameraStatusPill
             mode={cameraMode}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -227,24 +227,21 @@ const CORNER_GAP = "1.25rem";
 
 /**
  * The band the camera status pill is centred in, on the same line as the
- * top-right corner chrome. A configured assistant name is arbitrarily long, so
+ * room's corner chrome. A configured assistant name is arbitrarily long, so
  * without a bound the pill runs under that chrome and off a phone-width room.
  *
- * Each side gives up only what stands on it: the room's corner offset on the
- * left, and on the right that offset plus the cluster plus a 0.5rem gap the
- * two never close. Reserving the right's share on both sides instead would
- * leave a phone-width room less than the pill's own floor, and the pill would
- * overhang the cluster rather than truncate inside its ceiling.
+ * The same reserve on both edges: the room's corner offset, plus one 3.25rem
+ * control, plus the 0.5rem gap the pill and that control never close. Each
+ * corner holds a single control, so one reserve describes both, and equal
+ * reserves put the middle of this band on the middle of the room whether or
+ * not the left corner is holding the view-options button.
  *
- * Two right-hand reserves because the cluster is two sizes. Minimize stands
- * there alone at 3.25rem; where the view options join it the cluster is both
- * controls and the 0.25rem between them. Reserving for two against a corner
- * holding one would shift the pill off the band's centre for a control that
- * is not there.
+ * A 320pt room still leaves the band wider than the pill's own floor, so a
+ * long name truncates inside the ceiling the band gives it rather than
+ * overhanging either corner.
  */
-const CAMERA_PILL_LEFT = `max(${CORNER_GAP}, ${SAFE_AREA_LEFT})`;
-const CAMERA_PILL_RIGHT_ONE_CONTROL = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 3.75rem)`;
-const CAMERA_PILL_RIGHT_TWO_CONTROLS = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 7.25rem)`;
+const CAMERA_PILL_INSET_LEFT = `calc(max(${CORNER_GAP}, ${SAFE_AREA_LEFT}) + 3.75rem)`;
+const CAMERA_PILL_INSET_RIGHT = `calc(max(${CORNER_GAP}, ${SAFE_AREA_RIGHT}) + 3.75rem)`;
 
 /**
  * The tier the camera's view-options panel renders on, above every layer the
@@ -921,9 +918,9 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // inset, the latter adds the gap to it so the grabber fits between. The panel
   // and the header-resting sheet start below the app's own chrome, where the
   // inset is not their edge to clear. The band's two edges ride along, since
-  // the pill's slot is told where they are the same way, and the right one
-  // follows how many controls the corner is holding: see
-  // {@link CAMERA_PILL_RIGHT_TWO_CONTROLS}.
+  // the pill's slot is told where they are the same way, and both take the
+  // same reserve so the pill lands on the room's centre line: see
+  // {@link CAMERA_PILL_INSET_LEFT}.
   const topBandVars = {
     "--room-chrome-top": fullscreen
       ? `max(${CORNER_GAP}, ${SAFE_AREA_TOP})`
@@ -933,10 +930,8 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
     "--room-grabber-top": cameraSheet
       ? `calc(0.5rem + ${SAFE_AREA_TOP})`
       : "0.5rem",
-    "--camera-pill-left": CAMERA_PILL_LEFT,
-    "--camera-pill-right": viewOptionsOffered
-      ? CAMERA_PILL_RIGHT_TWO_CONTROLS
-      : CAMERA_PILL_RIGHT_ONE_CONTROL,
+    "--camera-pill-left": CAMERA_PILL_INSET_LEFT,
+    "--camera-pill-right": CAMERA_PILL_INSET_RIGHT,
   } as CSSProperties;
 
   const body = (
@@ -1123,9 +1118,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
 
           Above the scrims at `z-[3]` and below the connect card at `z-20`, so
           it reads over the frame without covering the one surface that needs a
-          press. Parked on the left below the chrome band: the shutter column
-          and the thumbnail band own the floor, and the status pill owns the
-          top centre. Inside `inset-0` because the room clips.
+          press. Parked on the left, clear of the whole chrome band: the view
+          options hold that corner, the shutter column and the thumbnail band
+          own the floor, and the status pill owns the top centre. Inside
+          `inset-0` because the room clips.
 
           Camera-only, and either viewfinder. Both feed the same gate, so both
           have decisions to read, and this is the instrument the thresholds are
@@ -1143,7 +1139,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         <FrameGateHud
           surface="voice"
           collapsible
-          className="absolute top-[calc(var(--room-chrome-top)+2.75rem)] z-10 max-h-[calc(100%-var(--room-chrome-top)-14rem)]"
+          className="absolute top-[calc(var(--room-chrome-top)+3.75rem)] z-10 max-h-[calc(100%-var(--room-chrome-top)-14rem)]"
           style={{ left: `max(${CORNER_GAP}, ${SAFE_AREA_LEFT})` }}
         />
       ) : null}
@@ -1199,13 +1195,33 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         />
       ) : null}
 
+      {/* Top-left: the camera's view options, and only where Live is on offer,
+          which is the only place its switches name anything the room draws.
+          Every other room leaves this corner empty, since a piece of small
+          chrome against the look competes with the room's own cast for
+          attention.
+
+          Its own corner box rather than a slot inside the pill's row: the pill
+          is centred on the room, so anything sharing a box with it would push
+          it off that centre. */}
+      {viewOptionsOffered ? (
+        <div
+          // Mirrors the minimize corner, so the two read as a matched pair on
+          // the room's own band; see `--room-chrome-top`.
+          style={{ left: `max(${CORNER_GAP}, ${SAFE_AREA_LEFT})` }}
+          className="absolute top-[var(--room-chrome-top)] z-10 flex"
+        >
+          <CameraViewSettings panelHost={viewOptionsHost} />
+        </div>
+      ) : null}
+
       {/* Camera mode's status readout: what the camera is doing, and what the
           session is doing. On the same offset the corner chrome uses, so it
           shares a line with that chrome instead of floating on a rhythm of its
-          own; that offset already clears the sheet's grabber. Centred in the
-          band the chrome leaves rather than on the room, which is what keeps a
-          long name inside a ceiling at phone width: see
-          {@link CAMERA_PILL_RIGHT_TWO_CONTROLS}.
+          own; that offset already clears the sheet's grabber. Centred between
+          two equal reserves, one per corner, which puts it on the room's centre
+          line and still gives a long name a ceiling to truncate inside at phone
+          width: see {@link CAMERA_PILL_INSET_LEFT}.
 
           Camera-only. With the viewfinder closed the room says all of this
           through the look itself (the avatar's visual, the state caption, the
@@ -1225,34 +1241,26 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         </div>
       ) : null}
 
-      {/* Top-right: minimize, with the camera's view options beside it.
+      {/* Top-right: minimize, and nothing else.
 
           The corner is where every other surface in the app puts "get this off
           my screen", and that is exactly what it does: the session keeps
-          running on the composer's voice bar or the title-bar pill. It used to
-          END the call, which put the most destructive act in the room at the
-          one spot muscle memory reaches for without looking; hanging up moved
-          into the control row below, where it sits among the other things you
-          do to a call and has to be aimed at.
+          running on the composer's voice bar or the title-bar pill. Hanging up
+          lives in the control row below, among the other things you do to a
+          call, so the most destructive act in the room is one you have to aim
+          at rather than the one spot muscle memory reaches for without looking.
 
           Minimize is never gated behind avatar readiness, so the room can
-          always be dismissed even mid-load / on failure, and it keeps the
-          extreme corner. View options sits inboard of it and only where Live
-          is on offer, which is the only place its switches name anything the
-          room draws; every other room carries nothing but minimize here, since
-          a cluster of small chrome against the look competes with the room's
-          own cast for attention. Voice and listening language are Settings'
-          either way. */}
+          always be dismissed even mid-load / on failure, and it holds this
+          corner alone in every room the app draws, camera or not. Voice and
+          listening language are Settings' either way. */}
       <div
         // An equal gap from both edges, so the control reads as sitting in the
         // corner rather than floating near it. The top comes off the room's own
         // band, shared with the camera pill; see `--room-chrome-top`.
         style={{ right: `max(${CORNER_GAP}, ${SAFE_AREA_RIGHT})` }}
-        className="absolute top-[var(--room-chrome-top)] z-10 flex items-center gap-1"
+        className="absolute top-[var(--room-chrome-top)] z-10 flex"
       >
-        {viewOptionsOffered ? (
-          <CameraViewSettings panelHost={viewOptionsHost} />
-        ) : null}
         <VoiceRoomControl
           label={t("voiceRoom.minimizeAria")}
           tooltip={t("voiceRoom.minimizeTooltip")}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -183,10 +183,14 @@ import { useVoiceRoomSight } from "./use-voice-room-sight";
 import { toRoomLocal, useRoomBox } from "./use-room-box";
 
 import {
+  CAMERA_PILL_INSET,
   SAFE_AREA_BOTTOM,
   SAFE_AREA_LEFT,
   SAFE_AREA_RIGHT,
   SAFE_AREA_TOP,
+  VOICE_ROOM_CORNER_GAP,
+  VOICE_ROOM_CORNER_LEFT,
+  VOICE_ROOM_CORNER_RIGHT,
 } from "./voice-room-layout";
 
 import { toVoiceAvatarVisual } from "./voice-avatar-state";
@@ -218,35 +222,6 @@ import {
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
 
 const AVATAR_SIZE = 220;
-
-/**
- * Gap between a corner control and the room's edges. One constant so the
- * top-right exit and the bottom control row sit on the same rhythm.
- */
-const CORNER_GAP = "1.25rem";
-
-/**
- * The band the camera status pill is centred in, on the same line as the
- * room's corner chrome. A configured assistant name is arbitrarily long, so
- * without a bound the pill runs under that chrome and off a phone-width room.
- *
- * ONE reserve, taken off both edges: the deepest of the room's corner offset
- * and the two safe-area insets, plus the 3.25rem control a corner holds, plus
- * the 0.5rem gap the pill and that control never close. Each corner holds a
- * single control, so one control's width covers both, and one value covers
- * both sides because a display cutout is not symmetric: a reserve computed per
- * side would differ by the difference between the insets and carry the pill
- * half that far off the room's centre line, which is the line the eye reads it
- * against. The corner controls still hug their own side's inset, so the
- * shallow side gets more clearance than it strictly needs.
- *
- * The pill's floor survives both ends of that. A 320pt portrait room has no
- * side insets to deepen the reserve, and the landscape rooms where the insets
- * do get deep are hundreds of points wider than they are tall. Either way the
- * band stays wider than the pill's own floor, so a long name truncates inside
- * the ceiling the band gives it rather than overhanging a corner.
- */
-const CAMERA_PILL_INSET = `calc(max(${CORNER_GAP}, ${SAFE_AREA_LEFT}, ${SAFE_AREA_RIGHT}) + 3.75rem)`;
 
 /**
  * The tier the camera's view-options panel renders on, above every layer the
@@ -928,10 +903,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // {@link CAMERA_PILL_INSET}.
   const topBandVars = {
     "--room-chrome-top": fullscreen
-      ? `max(${CORNER_GAP}, ${SAFE_AREA_TOP})`
+      ? `max(${VOICE_ROOM_CORNER_GAP}, ${SAFE_AREA_TOP})`
       : cameraSheet
-        ? `calc(${CORNER_GAP} + ${SAFE_AREA_TOP})`
-        : CORNER_GAP,
+        ? `calc(${VOICE_ROOM_CORNER_GAP} + ${SAFE_AREA_TOP})`
+        : VOICE_ROOM_CORNER_GAP,
     "--room-grabber-top": cameraSheet
       ? `calc(0.5rem + ${SAFE_AREA_TOP})`
       : "0.5rem",
@@ -1144,7 +1119,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           surface="voice"
           collapsible
           className="absolute top-[calc(var(--room-chrome-top)+3.75rem)] z-10 max-h-[calc(100%-var(--room-chrome-top)-14rem)]"
-          style={{ left: `max(${CORNER_GAP}, ${SAFE_AREA_LEFT})` }}
+          style={{ left: VOICE_ROOM_CORNER_LEFT }}
         />
       ) : null}
 
@@ -1212,7 +1187,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         <div
           // Mirrors the minimize corner, so the two read as a matched pair on
           // the room's own band; see `--room-chrome-top`.
-          style={{ left: `max(${CORNER_GAP}, ${SAFE_AREA_LEFT})` }}
+          style={{ left: VOICE_ROOM_CORNER_LEFT }}
           className="absolute top-[var(--room-chrome-top)] z-10 flex"
         >
           <CameraViewSettings panelHost={viewOptionsHost} />
@@ -1262,7 +1237,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         // An equal gap from both edges, so the control reads as sitting in the
         // corner rather than floating near it. The top comes off the room's own
         // band, shared with the camera pill; see `--room-chrome-top`.
-        style={{ right: `max(${CORNER_GAP}, ${SAFE_AREA_RIGHT})` }}
+        style={{ right: VOICE_ROOM_CORNER_RIGHT }}
         className="absolute top-[var(--room-chrome-top)] z-10 flex"
       >
         <VoiceRoomControl
@@ -1372,7 +1347,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           // to stay off the thing that hangs up, and it is the GAP that
           // guarantees that, not the number.
           style={{
-            bottom: `calc(6.125rem + max(${CORNER_GAP}, ${SAFE_AREA_BOTTOM}))`,
+            bottom: `calc(6.125rem + max(${VOICE_ROOM_CORNER_GAP}, ${SAFE_AREA_BOTTOM}))`,
           }}
         >
           {errorMessage ? (
@@ -1495,7 +1470,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         className="absolute inset-x-0 z-10 flex items-center justify-center gap-4"
         // The bottom edge IS the screen's on the sheet and fullscreen, so the
         // home-indicator inset is real here in a way the top inset was not.
-        style={{ bottom: `max(${CORNER_GAP}, ${SAFE_AREA_BOTTOM})` }}
+        style={{ bottom: `max(${VOICE_ROOM_CORNER_GAP}, ${SAFE_AREA_BOTTOM})` }}
       >
         <VoiceRoomControl
           label={


### PR DESCRIPTION
## Summary
- The camera band reserved the corner offset on the left but the offset plus the whole two-control cluster on the right, so the status pill sat left of screen centre and slid sideways as Live availability came and went. Both edges now take the same reserve (one control plus its gap), which lands the pill on the room's centre line whether or not the left corner holds a control.
- The view-options button moves to a mirrored top-LEFT corner box (Live-offered rooms only); the minimize chevron keeps its exact corner and offset. Its panel flips to `align="start"` so it hangs from the left trigger instead of walking off-screen.
- Pill sized up per the approved render: `px-4 py-[7px]`, label token rebound to 13px (the design scale's label sizes stop at 11px, so the size rebinds the token var the same way the weight already does), 6px dot, 0.5rem gap.
- The staff frame-gate readout drops 1rem further below the band to clear the control now standing in its corner.

Per Jason's spec from TestFlight screenshots; before/after approved via a Storybook render built from the real components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)