### PR TITLE
feat(companion): frame the surface a call is sharing (JARVIS-1740)

### DIFF
--- a/clients/web/src/components/companion-accent.ts
+++ b/clients/web/src/components/companion-accent.ts
@@ -25,17 +25,6 @@ import type {
   VoiceActivityState,
 } from "@vellumai/ipc-contract";
 
-/**
- * The colour a watch session lights the surface in: the creature's ring, and
- * the edge of the display being read.
- *
- * Fixed rather than the assistant's own accent, because the accent already
- * means "a turn is running" and a screen being read is a different fact about
- * the machine. Amber is the tone the host burns for a live capture, so the
- * surface agrees with the menu bar above it.
- */
-export const COMPANION_CAPTURE_ACCENT = "#ff9f45";
-
 const HEX_PATTERN = /^#[0-9a-f]{6}$/i;
 
 function usableHex(value: string | undefined): string | undefined {

--- a/clients/web/src/components/companion-watch-frame-page.test.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.test.tsx
@@ -129,8 +129,7 @@ describe("the frame around what is read", () => {
 
   /**
    * A share is the other way a surface leaves the machine, and the shell
-   * opens and places this window for it exactly as it does for a watch. Only
-   * the page was refusing to draw.
+   * opens and places this window for it exactly as it does for a watch.
    */
   test("draws for a screen a call is sharing", () => {
     const { container } = render(<CompanionWatchFramePage />);

--- a/clients/web/src/components/companion-watch-frame-page.test.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.test.tsx
@@ -97,6 +97,79 @@ describe("the frame around what is read", () => {
     expect(frameOf(container)).toBeNull();
   });
 
+  /**
+   * A share is the other way a surface leaves the machine, and the shell
+   * opens and places this window for it exactly as it does for a watch. Only
+   * the page was refusing to draw.
+   */
+  test("draws for a screen a call is sharing", () => {
+    const { container } = render(<CompanionWatchFramePage />);
+    pushState({
+      ...STATE,
+      call: LISTENING_CALL,
+      screenShare: { kind: "display", displayId: 7 },
+    });
+    expect(frameOf(container)).not.toBeNull();
+  });
+
+  test("draws for a window or tab a call is sharing", () => {
+    const { container } = render(<CompanionWatchFramePage />);
+    pushState({
+      ...STATE,
+      call: LISTENING_CALL,
+      screenShare: { kind: "window", windowId: 42 },
+    });
+    expect(frameOf(container)).not.toBeNull();
+  });
+
+  test("stays while a share outlives the watch beside it", () => {
+    const { container } = render(<CompanionWatchFramePage />);
+    pushState({
+      ...STATE,
+      watching: true,
+      screenShare: { kind: "display", displayId: 7 },
+    });
+    pushState({
+      ...STATE,
+      watching: false,
+      screenShare: { kind: "display", displayId: 7 },
+    });
+    expect(frameOf(container)).not.toBeNull();
+  });
+
+  test("goes once the share is stopped", () => {
+    const { container } = render(<CompanionWatchFramePage />);
+    pushState({
+      ...STATE,
+      call: LISTENING_CALL,
+      screenShare: { kind: "display", displayId: 7 },
+    });
+    pushState({ ...STATE, call: LISTENING_CALL });
+    expect(frameOf(container)).toBeNull();
+  });
+
+  /**
+   * `captureCount` is the watch session's total and a share does not advance
+   * it. A share still holding the frame after the watch ended would otherwise
+   * sit on that session's last count and flash for a read nobody took.
+   */
+  test("does not flash for a share left holding the frame", () => {
+    const { container } = render(<CompanionWatchFramePage />);
+    pushState({
+      ...STATE,
+      watching: true,
+      captureCount: 3,
+      screenShare: { kind: "display", displayId: 7 },
+    });
+    pushState({
+      ...STATE,
+      watching: false,
+      captureCount: 4,
+      screenShare: { kind: "display", displayId: 7 },
+    });
+    expect(container.querySelector(".companion-watch-frame-flash")).toBeNull();
+  });
+
   test("reads a state that says nothing about it as empty", () => {
     const { container } = render(<CompanionWatchFramePage />);
     pushState({ ...STATE });

--- a/clients/web/src/components/companion-watch-frame-page.test.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.test.tsx
@@ -82,12 +82,42 @@ describe("the frame around what is read", () => {
     expect(frameOf(container)).toBeNull();
   });
 
-  test("draws in the capture colour, not the assistant's", () => {
+  /**
+   * The edge and the call pill are one light. A colour of the frame's own
+   * would leave the user to work out that two unrelated lights on the same
+   * desktop were about one session.
+   */
+  test("draws in the running call's accent", () => {
     const { container } = render(<CompanionWatchFramePage />);
     pushState({ ...STATE, call: LISTENING_CALL, watching: true });
     expect(
       frameOf(container)?.style.getPropertyValue("--companion-ring-accent"),
-    ).toBe("#ff9f45");
+    ).toBe("#5eead4");
+  });
+
+  test("falls back to the accent the app published", () => {
+    const { container } = render(<CompanionWatchFramePage />);
+    pushState({
+      ...STATE,
+      accentHex: "#a78bfa",
+      screenShare: { kind: "display", displayId: 7 },
+    });
+    expect(
+      frameOf(container)?.style.getPropertyValue("--companion-ring-accent"),
+    ).toBe("#a78bfa");
+  });
+
+  /**
+   * Handing CSS an unusable value drops the custom property and takes the
+   * border's colour with it, so an accent that does not parse is left unset
+   * and the class keeps its own.
+   */
+  test("leaves the colour to the class when no accent resolves", () => {
+    const { container } = render(<CompanionWatchFramePage />);
+    pushState({ ...STATE, accentHex: "not a colour", watching: true });
+    expect(
+      frameOf(container)?.style.getPropertyValue("--companion-ring-accent"),
+    ).toBe("");
   });
 
   test("goes once the session is over", () => {

--- a/clients/web/src/components/companion-watch-frame-page.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.tsx
@@ -2,11 +2,16 @@
  * The frame around what is being read: a border, and nothing inside it.
  *
  * Drawn in its own click-through window, which the macOS shell opens for a
- * watch session, sizes to whatever the session reads (a display, or the one
- * window the user picked), moves with it, and closes after it
- * (`clients/macos/src/main/companion-window.ts`). The surface being read says
- * so on its own edge, the way a shared screen is framed, so a capture is never
- * something only a ring on a creature in one corner admits to.
+ * watch session or a call's screen share, sizes to whatever is being read (a
+ * display, or the one window or tab the user picked), moves with it, and
+ * closes after it (`clients/macos/src/main/companion-window.ts`). The surface
+ * being read says so on its own edge, the way a shared screen is framed, so a
+ * capture is never something only a ring on a creature in one corner admits
+ * to.
+ *
+ * Both kinds of read get the same border, because the fact the border states
+ * is the same one: this surface is leaving the machine. Which control started
+ * it is the pill's business, not the desktop's.
  *
  * A border and no glow, deliberately. A frame's job is to say exactly where
  * the read stops, and light bleeding inward from the edge says the opposite:
@@ -85,8 +90,20 @@ export function CompanionWatchFramePage() {
 
   // Read as the surface reads it: only a positive answer is a session, since
   // the alternative is framing a screen nobody is reading.
-  const lit = state?.watching === true;
-  const observedCaptures = useObservedCaptures(state?.captureCount ?? 0, lit);
+  const watching = state?.watching === true;
+  // A target on the state is the share, since main sends the pick itself and
+  // absence is nothing shared. The shell has already sized this window to it,
+  // so what is left is to draw.
+  const sharing = state?.screenShare !== undefined;
+  const lit = watching || sharing;
+  // Counted against the watch session alone. `captureCount` is that session's
+  // total and a share does not advance it, so a share left holding the frame
+  // after a watch ended would sit on the last count that session reported and
+  // flash for a read nobody took.
+  const observedCaptures = useObservedCaptures(
+    state?.captureCount ?? 0,
+    watching,
+  );
 
   return (
     <div
@@ -108,7 +125,7 @@ export function CompanionWatchFramePage() {
           treatments or the second is invisible inside the first. Keyed by the
           captures this window has watched arrive, so each one remounts the
           element and replays a one-shot animation. */}
-      {lit && observedCaptures > 0 && (
+      {watching && observedCaptures > 0 && (
         <div
           key={observedCaptures}
           className="companion-watch-frame-flash fixed inset-0"

--- a/clients/web/src/components/companion-watch-frame-page.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.tsx
@@ -18,13 +18,12 @@
  * it dims the thing the user is working on and makes the boundary a
  * gradient. The edge is the whole signal.
  *
- * Drawn in the assistant's own accent, the colour the call pill is already
- * ringed in, and resolved through the same `companionAccentHexFor` the
- * surface uses so the two lights cannot come apart. The frame is one end of
- * something the pill is the other end of: a screen going to *this* assistant.
- * A colour of its own would have made the border a second, unrelated light on
- * the same desktop, and the user would be left to work out that the amber
- * edge and the teal pill were about one session.
+ * Drawn in the assistant's own accent, the colour the call pill is ringed in,
+ * and resolved through the same `companionAccentHexFor` the surface uses so
+ * the two lights cannot come apart. The frame is one end of something the
+ * pill is the other end of: a screen going to *this* assistant. A colour of
+ * its own makes the border a second, unrelated light on the same desktop,
+ * leaving the user to work out that the two are about one session.
  *
  * **It draws the session and holds none of it.** The window is pushed the
  * same state the companion surface is, and draws when that state says a
@@ -100,8 +99,8 @@ export function CompanionWatchFramePage() {
   // the alternative is framing a screen nobody is reading.
   const watching = state?.watching === true;
   // A target on the state is the share, since main sends the pick itself and
-  // absence is nothing shared. The shell has already sized this window to it,
-  // so what is left is to draw.
+  // absence is nothing shared. The shell sizes this window to it; the page
+  // only draws.
   const sharing = state?.screenShare !== undefined;
   const lit = watching || sharing;
   // Counted against the watch session alone. `captureCount` is that session's

--- a/clients/web/src/components/companion-watch-frame-page.tsx
+++ b/clients/web/src/components/companion-watch-frame-page.tsx
@@ -18,6 +18,14 @@
  * it dims the thing the user is working on and makes the boundary a
  * gradient. The edge is the whole signal.
  *
+ * Drawn in the assistant's own accent, the colour the call pill is already
+ * ringed in, and resolved through the same `companionAccentHexFor` the
+ * surface uses so the two lights cannot come apart. The frame is one end of
+ * something the pill is the other end of: a screen going to *this* assistant.
+ * A colour of its own would have made the border a second, unrelated light on
+ * the same desktop, and the user would be left to work out that the amber
+ * edge and the teal pill were about one session.
+ *
  * **It draws the session and holds none of it.** The window is pushed the
  * same state the companion surface is, and draws when that state says a
  * session is reading the screen. Where the window sits is the shell's; this
@@ -27,7 +35,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { COMPANION_CAPTURE_ACCENT } from "@/components/companion-accent";
+import { companionAccentHexFor } from "@/components/companion-accent";
 import {
   getCompanionState,
   subscribeCompanionState,
@@ -105,6 +113,21 @@ export function CompanionWatchFramePage() {
     watching,
   );
 
+  // The assistant's colour, resolved exactly as the surface resolves it: the
+  // running call's first, then what the app published with the character,
+  // then the character's own palette. Left unset when none of them parse,
+  // which hands the class its own default rather than dropping the custom
+  // property and taking the border's colour with it.
+  const accentHex = companionAccentHexFor(
+    state?.call ?? null,
+    state?.accentHex,
+    state?.character,
+  );
+  const accentStyle =
+    accentHex === undefined
+      ? undefined
+      : { ["--companion-ring-accent" as string]: accentHex };
+
   return (
     <div
       className="pointer-events-none h-screen w-screen bg-transparent"
@@ -114,9 +137,7 @@ export function CompanionWatchFramePage() {
       {lit && (
         <div
           className="companion-watch-frame fixed inset-0"
-          style={{
-            ["--companion-ring-accent" as string]: COMPANION_CAPTURE_ACCENT,
-          }}
+          style={accentStyle}
         />
       )}
       {/* One capture, as a single brightening of the same edge. The frame
@@ -129,9 +150,7 @@ export function CompanionWatchFramePage() {
         <div
           key={observedCaptures}
           className="companion-watch-frame-flash fixed inset-0"
-          style={{
-            ["--companion-ring-accent" as string]: COMPANION_CAPTURE_ACCENT,
-          }}
+          style={accentStyle}
         />
       )}
     </div>

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -362,17 +362,18 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 .companion-watch-frame-flash {
-  box-shadow: inset 0 0 0 3px color-mix(in srgb, white 70%, var(--companion-ring-accent, #ff9f45));
+  box-shadow: inset 0 0 0 3px color-mix(in srgb, white 70%, var(--companion-ring-accent, #5eead4));
   opacity: 0;
   animation: companion-watch-frame-flash 700ms ease-out 1;
 }
 
-/* The edge of what a watch session reads, drawn in the capture colour the way
- * a shared screen is framed. A border and only a border: nothing bleeds
- * inward, so the boundary of the read is a line and the work inside it is
- * left exactly as bright as it was. `--companion-ring-accent` is set per
- * instance by the companion's windows. The call bar's own light is the
- * working ring above, travelling the bar's edge. */
+/* The edge of what a watch session reads or a call is shown, drawn the way a
+ * shared screen is framed. A border and only a border: nothing bleeds inward,
+ * so the boundary of the read is a line and the work inside it is left
+ * exactly as bright as it was. `--companion-ring-accent` is set per instance
+ * by the companion's windows, and the frame is handed the assistant's own
+ * accent so the edge and the call pill are one light. The call bar's own
+ * light is the working ring above, travelling the bar's edge. */
 @keyframes companion-watch-frame-in {
   from { opacity: 0; }
 }


### PR DESCRIPTION
Closes JARVIS-1740.

Teach draws a border around the screen or window it reads. Screen share drew nothing, so the one surface leaving the machine during a call was the one with no mark on it.

The gap was renderer-only. Main already does the work for a share: `framedTarget()` falls through to `context.screenShare`, opens the frame window, sizes it to the display, and polls the helper to follow a picked window as it moves. `screenShare` rides the pushed `CompanionSurfaceState`. Only `companion-watch-frame-page.tsx` refused to draw, lighting on `watching` alone, so a shared screen, window, or tab got a correctly placed and entirely invisible frame.

## Light the frame for a share

`lit = watching || screenShare !== undefined`. Same border either way, because the fact it states is the same one: this surface is leaving the machine. Which control started it is the pill's business, not the desktop's.

The one-shot capture flash stays counted against the watch alone. `captureCount` is that session's running total and a share does not advance it, so a share still holding the frame after a watch ended would sit on the last count that session reported and flash for a read nobody took.

## Draw it in the assistant's accent

The frame burned a fixed amber, chosen back when the accent meant only "a turn is running" and a screen being read was a different fact about the machine. Once the frame covers a share, that reading is wrong: the border and the call pill are two ends of one thing, a screen going to *this* assistant, and two unrelated lights on the same desktop left the user to work out they were about one session.

Resolved through the same `companionAccentHexFor` the surface uses, so the edge and the pill cannot come apart: the running call's accent, then what the app published with the character, then the character's palette. Nothing usable leaves the custom property unset rather than handing CSS a value it would drop, which would take the border's colour with it.

`COMPANION_CAPTURE_ACCENT` had no other reader once the creature's capture ring was removed, so it goes with it, and the flash's fallback follows the frame's.

## Testing

`bun test src/components/companion-watch-frame-page.test.tsx` — 17 pass. Six new cases: draws for a shared display, for a shared window or tab, stays while a share outlives the watch beside it, goes when the share stops, does not flash for a share left holding the frame, plus the three accent cases (call accent, published-accent fallback, unusable accent left to the class).

Negative check run on both halves: with `lit` reverted to `watching` alone, three of the new cases go red; with the accent reverted to the fixed amber, the three accent cases go red.

Not yet exercised on a live call. The dev app runs, but `vel up` is down on this machine and Share reads off without a Screen Recording grant (JARVIS-1738), so the frame has only been verified in tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qkr2evEDEitdbf4wN1Vvuh