### PR TITLE
move `skills/` copy from builder stage to runner stage

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -33,16 +33,6 @@ COPY --parents packages/*/package.json ./
 RUN bun install --frozen-lockfile --ignore-scripts \
     --filter='./assistant' --filter='./assistant/src/api'
 
-# The repo-root .dockerignore decides which skills (and files) ship.
-COPY skills ./skills
-RUN set -eu; for pkg in /app/skills/*/package.json; do \
-      [ -e "$pkg" ] || continue; \
-      dir="$(dirname "$pkg")"; \
-      echo "Installing dependencies for $dir"; \
-      (cd "$dir" && (bun install --frozen-lockfile 2>/dev/null || bun install)); \
-    done
-
-
 # Final stage
 FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a AS runner
 
@@ -130,6 +120,9 @@ COPY packages/slack-text /app/packages/slack-text
 COPY packages/twilio-client /app/packages/twilio-client
 
 COPY assistant /app/assistant
+
+# The repo-root .dockerignore decides which skills (and files) ship.
+COPY skills /app/skills
 
 # Materialize the git-ignored offline plugin manifest from its canonical source.
 # `assistant/src/cli/lib/plugin-catalog-local.ts` statically imports this JSON


### PR DESCRIPTION
We no longer install deps for skills. They're intended to be self-contained and auto-install deps at runtime via bun.

This'll reduce layer cache misses during rebuilds