### PR TITLE
fix(assistant): a typed reply answers a parked ask_question instead of cancelling it (JARVIS-1741)

### DIFF
--- a/assistant/src/__tests__/steer-on-enqueue-question.test.ts
+++ b/assistant/src/__tests__/steer-on-enqueue-question.test.ts
@@ -1,45 +1,62 @@
 /**
- * Enqueue-steer contract: when a chat message is enqueued while an
- * `ask_question` prompt is open for the same conversation, the user has chosen
- * to move on rather than answer it. `steerOnEnqueuedMessageIfQuestionParked`
- * steers to that message — aborting the parked turn (which settles the open
- * question via its turn-abort signal) and draining the message — instead of
- * stranding it behind a prompt no one will answer.
+ * Enqueue contract for a message typed while an `ask_question` card is open.
  *
- * Only `kind: "question"` interactions trigger the steer; pending confirmations
- * are handled separately by the enqueue path's auto-deny.
+ * The message is read as the answer: `answerParkedQuestionWithEnqueuedMessage`
+ * resolves the parked prompt with the typed text as free text and consumes the
+ * queued message, so the parked turn keeps running and the model reads the
+ * answer once, in the tool result.
+ *
+ * Everything a single free-text answer cannot honestly stand in for falls back
+ * to `steerOnEnqueuedMessageIfQuestionParked`, which supersedes the prompt by
+ * aborting the parked turn and draining the message instead. Confirmations and
+ * secrets are separate interaction kinds and are untouched by both paths.
  */
 import { afterEach, describe, expect, test } from "bun:test";
 
 import type { Conversation } from "../daemon/conversation.js";
+import type { QueuedMessage } from "../daemon/conversation-queue-manager.js";
 import {
   deleteConversation,
   setConversation,
 } from "../daemon/conversation-registry.js";
 import {
+  answerParkedQuestionWithEnqueuedMessage,
   steerOnEnqueuedMessageIfQuestionParked,
   supersedePendingInteractionsOnEnqueue,
 } from "../daemon/handlers/conversations.js";
+import type { QuestionPromptResult } from "../permissions/question-prompter.js";
 import * as pendingInteractions from "../runtime/pending-interactions.js";
 
 interface ParkedTurn {
   abortCount: () => number;
   fake: { pendingSteerRepair: boolean };
+  /** Queue entries still waiting, by request id. */
+  queuedIds: () => string[];
+  /** Event types emitted through the queued message's own sink. */
+  emittedTypes: () => string[];
+  enqueue: (message: Partial<QueuedMessage> & { requestId: string }) => void;
 }
 
 /**
  * Register a fake conversation whose in-flight turn is parked. The fake exposes
- * just the surface `steerToMessage` touches: a processing flag, a queue whose
- * messages can be looked up and promoted, an abort controller that records
+ * just the surface the enqueue paths touch: a processing flag, a queue that can
+ * be looked up, promoted and removed from, an abort controller that records
  * aborts, and the confirmation-deny hook.
  */
 function registerParkedTurn(id: string): ParkedTurn {
   let abortCount = 0;
+  const emitted: string[] = [];
+  const queue = new Map<string, QueuedMessage>();
   const fake = {
     isProcessing: () => true,
     queue: {
-      findByRequestId: (requestId: string) => ({ requestId }),
-      promoteToHead: (requestId: string) => ({ requestId }),
+      findByRequestId: (requestId: string) => queue.get(requestId),
+      promoteToHead: (requestId: string) => queue.get(requestId),
+    },
+    removeQueuedMessage: (requestId: string) => {
+      const item = queue.get(requestId);
+      queue.delete(requestId);
+      return item;
     },
     pendingSteerRepair: false,
     abortController: {
@@ -51,22 +68,248 @@ function registerParkedTurn(id: string): ParkedTurn {
     denyAllPendingConfirmations: () => {},
   };
   setConversation(id, fake as unknown as Conversation);
-  return { abortCount: () => abortCount, fake };
+  const enqueue = (
+    message: Partial<QueuedMessage> & { requestId: string },
+  ): void => {
+    queue.set(message.requestId, {
+      content: "",
+      attachments: [],
+      onEvent: (event) => {
+        emitted.push(event.type);
+      },
+      sentAt: 0,
+      ...message,
+    } as QueuedMessage);
+  };
+  // Every case needs a queued message to act on; the plain typed reply is the
+  // common one, and cases that need other content re-enqueue over it.
+  enqueue({ requestId: "msg-1", content: "next tuesday works" });
+  return {
+    abortCount: () => abortCount,
+    fake,
+    queuedIds: () => [...queue.keys()],
+    emittedTypes: () => [...emitted],
+    enqueue,
+  };
 }
 
 const registeredRequestIds: string[] = [];
 function registerInteraction(
   conversationId: string,
-  kind: "question" | "confirmation",
-): void {
-  const requestId = `pending-${kind}-${conversationId}`;
-  pendingInteractions.register(requestId, { conversationId, kind });
+  kind: "question" | "confirmation" | "secret",
+  options: { requestId?: string; questionIds?: string[] } = {},
+): { requestId: string; result: () => QuestionPromptResult | undefined } {
+  const requestId =
+    options.requestId ?? `pending-${kind}-${conversationId}-${Date.now()}`;
+  let result: QuestionPromptResult | undefined;
+  const questionIds = options.questionIds ?? ["q1"];
+  pendingInteractions.register(requestId, {
+    conversationId,
+    kind,
+    ...(kind === "question"
+      ? {
+          metadata: {
+            orderedIds: questionIds,
+            optionsById: Object.fromEntries(
+              questionIds.map((id) => [id, ["opt-a"]]),
+            ),
+          },
+          rpcResolve: (value: unknown) => {
+            result = value as QuestionPromptResult;
+          },
+        }
+      : {}),
+  });
   registeredRequestIds.push(requestId);
+  return { requestId, result: () => result };
 }
 
 const QUESTION_CONV = "steer-enqueue-question";
 const CONFIRMATION_CONV = "steer-enqueue-confirmation";
 const NONE_CONV = "steer-enqueue-none";
+
+describe("a typed reply answers a parked question", () => {
+  afterEach(() => {
+    for (const id of registeredRequestIds) {
+      pendingInteractions.resolve(id, "cancelled");
+    }
+    registeredRequestIds.length = 0;
+    deleteConversation(QUESTION_CONV);
+    deleteConversation(CONFIRMATION_CONV);
+    deleteConversation(NONE_CONV);
+  });
+
+  test("resolves a single parked question with the typed text", () => {
+    const conv = registerParkedTurn(QUESTION_CONV);
+    const question = registerInteraction(QUESTION_CONV, "question");
+
+    const answered = answerParkedQuestionWithEnqueuedMessage(
+      QUESTION_CONV,
+      "msg-1",
+    );
+
+    expect(answered).toBe(true);
+    expect(question.result()).toEqual({
+      entries: [
+        { questionId: "q1", decision: "free_text", text: "next tuesday works" },
+      ],
+      overall: "completed",
+      answeredInChat: true,
+    });
+    // The parked turn keeps running: no abort, no tool-result repair.
+    expect(conv.abortCount()).toBe(0);
+    expect(conv.fake.pendingSteerRepair).toBe(false);
+    // The message reaches the model through the tool result, so it is consumed
+    // rather than run as a turn of its own, and the client's queued row is
+    // retired the way a queue delete retires it.
+    expect(conv.queuedIds()).toEqual([]);
+    expect(conv.emittedTypes()).toEqual(["message_queued_deleted"]);
+  });
+
+  test("answers the first question of a batch and leaves the rest unanswered", () => {
+    const conv = registerParkedTurn(QUESTION_CONV);
+    const question = registerInteraction(QUESTION_CONV, "question", {
+      questionIds: ["q1", "q2", "q3"],
+    });
+
+    const answered = answerParkedQuestionWithEnqueuedMessage(
+      QUESTION_CONV,
+      "msg-1",
+    );
+
+    expect(answered).toBe(true);
+    expect(question.result()).toEqual({
+      entries: [
+        { questionId: "q1", decision: "free_text", text: "next tuesday works" },
+        { questionId: "q2", decision: "skipped" },
+        { questionId: "q3", decision: "skipped" },
+      ],
+      overall: "completed",
+      answeredInChat: true,
+    });
+    expect(conv.abortCount()).toBe(0);
+  });
+
+  test("supersedes instead when the message carries an attachment", () => {
+    const conv = registerParkedTurn(QUESTION_CONV);
+    const question = registerInteraction(QUESTION_CONV, "question");
+    conv.enqueue({
+      requestId: "msg-1",
+      content: "here it is",
+      attachments: [
+        {
+          id: "att-1",
+          filename: "notes.txt",
+          mimeType: "text/plain",
+          data: "",
+        },
+      ],
+    });
+
+    supersedePendingInteractionsOnEnqueue(QUESTION_CONV, "msg-1");
+
+    expect(question.result()).toBeUndefined();
+    expect(conv.abortCount()).toBe(1);
+    expect(conv.queuedIds()).toEqual(["msg-1"]);
+  });
+
+  test("supersedes instead when the message is a slash command", () => {
+    const conv = registerParkedTurn(QUESTION_CONV);
+    const question = registerInteraction(QUESTION_CONV, "question");
+    conv.enqueue({ requestId: "msg-1", content: "/compact" });
+
+    supersedePendingInteractionsOnEnqueue(QUESTION_CONV, "msg-1");
+
+    expect(question.result()).toBeUndefined();
+    expect(conv.abortCount()).toBe(1);
+  });
+
+  test("supersedes instead when the message is blank", () => {
+    const conv = registerParkedTurn(QUESTION_CONV);
+    const question = registerInteraction(QUESTION_CONV, "question");
+    conv.enqueue({ requestId: "msg-1", content: "   " });
+
+    supersedePendingInteractionsOnEnqueue(QUESTION_CONV, "msg-1");
+
+    expect(question.result()).toBeUndefined();
+    expect(conv.abortCount()).toBe(1);
+  });
+
+  test("supersedes instead when the send is automated rather than typed", () => {
+    const conv = registerParkedTurn(QUESTION_CONV);
+    const question = registerInteraction(QUESTION_CONV, "question");
+    conv.enqueue({
+      requestId: "msg-1",
+      content: "scheduled follow-up",
+      metadata: { automated: true },
+    });
+
+    supersedePendingInteractionsOnEnqueue(QUESTION_CONV, "msg-1");
+
+    expect(question.result()).toBeUndefined();
+    expect(conv.abortCount()).toBe(1);
+  });
+
+  test("supersedes instead when two questions are parked at once", () => {
+    // Which prompt the text answers would be a guess, so the old behavior
+    // stands: abort the turn and run the message as its own turn.
+    const conv = registerParkedTurn(QUESTION_CONV);
+    const first = registerInteraction(QUESTION_CONV, "question", {
+      requestId: "question-a",
+    });
+    const second = registerInteraction(QUESTION_CONV, "question", {
+      requestId: "question-b",
+    });
+
+    supersedePendingInteractionsOnEnqueue(QUESTION_CONV, "msg-1");
+
+    expect(first.result()).toBeUndefined();
+    expect(second.result()).toBeUndefined();
+    expect(conv.abortCount()).toBe(1);
+  });
+
+  test("leaves a parked secret alone while answering the question", () => {
+    const conv = registerParkedTurn(QUESTION_CONV);
+    const secret = registerInteraction(QUESTION_CONV, "secret");
+    const question = registerInteraction(QUESTION_CONV, "question");
+
+    supersedePendingInteractionsOnEnqueue(QUESTION_CONV, "msg-1");
+
+    expect(question.result()?.overall).toBe("completed");
+    expect(conv.abortCount()).toBe(0);
+    expect(pendingInteractions.get(secret.requestId)?.kind).toBe("secret");
+  });
+
+  test("does not answer from a pending confirmation (not a question)", () => {
+    const conv = registerParkedTurn(CONFIRMATION_CONV);
+    registerInteraction(CONFIRMATION_CONV, "confirmation");
+
+    const answered = answerParkedQuestionWithEnqueuedMessage(
+      CONFIRMATION_CONV,
+      "msg-1",
+    );
+    const steered = steerOnEnqueuedMessageIfQuestionParked(
+      CONFIRMATION_CONV,
+      "msg-1",
+    );
+
+    expect(answered).toBe(false);
+    expect(steered).toBe(false);
+    expect(conv.abortCount()).toBe(0);
+    // The message is left on the queue to run as its own turn.
+    expect(conv.queuedIds()).toEqual(["msg-1"]);
+  });
+
+  test("does nothing when no prompt is parked", () => {
+    const conv = registerParkedTurn(NONE_CONV);
+
+    supersedePendingInteractionsOnEnqueue(NONE_CONV, "msg-1");
+
+    expect(conv.abortCount()).toBe(0);
+    expect(conv.queuedIds()).toEqual(["msg-1"]);
+    expect(conv.emittedTypes()).toEqual([]);
+  });
+});
 
 describe("steerOnEnqueuedMessageIfQuestionParked", () => {
   afterEach(() => {
@@ -134,27 +377,15 @@ describe("steerOnEnqueuedMessageIfQuestionParked", () => {
     expect(steered).toBe(false);
     expect(conv.abortCount()).toBe(0);
   });
-
-  test("supersedePendingInteractionsOnEnqueue steers a parked question", () => {
-    // The centralized routine is invoked by both the HTTP send handler and the
-    // CLI signal path. With no pending confirmation it steers a parked question
-    // — the behavior the CLI signal path previously lacked.
-    const conv = registerParkedTurn(QUESTION_CONV);
-    registerInteraction(QUESTION_CONV, "question");
-
-    supersedePendingInteractionsOnEnqueue(QUESTION_CONV, "msg-1");
-
-    expect(conv.abortCount()).toBe(1);
-    expect(conv.fake.pendingSteerRepair).toBe(true);
-  });
 });
 
 describe("removeByConversation preserves question interactions", () => {
   // The enqueue path's confirmation auto-deny calls removeByConversation before
-  // the steer runs. Questions must survive it — they are settled instead by the
-  // steer's turn abort — or, when an ask_question and a confirmation are pending
-  // concurrently, the queued message would strand behind a question whose entry
-  // was cleared (and whose Promise was never settled) before the steer fired.
+  // the question is answered or steered to. Questions must survive it (they
+  // are settled instead by the answer or by the steer's turn abort) or, when
+  // an ask_question and a confirmation are pending concurrently, the queued
+  // message would strand behind a question whose entry was cleared (and whose
+  // Promise was never settled) before either path fired.
   const CONV = "remove-by-conv-preserve-question";
   const ids: string[] = [];
   function register(kind: "question" | "confirmation"): void {

--- a/assistant/src/daemon/handlers/conversations.ts
+++ b/assistant/src/daemon/handlers/conversations.ts
@@ -10,9 +10,11 @@ import { resolveConversationId } from "../../persistence/conversation-key-store.
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import { resolveCapabilities } from "../../runtime/capabilities.js";
 import * as pendingInteractions from "../../runtime/pending-interactions.js";
+import { resolvePendingQuestion } from "../../runtime/question-resolution.js";
 import { getSubagentManager } from "../../subagent/index.js";
 import { createAbortReason } from "../../util/abort-reasons.js";
 import { UserError } from "../../util/errors.js";
+import type { Conversation } from "../conversation.js";
 import { touchConversation } from "../conversation-evictor.js";
 import { forceClearStaleProcessing } from "../conversation-lifecycle.js";
 import {
@@ -24,7 +26,7 @@ import {
   conversationEntries,
   findConversation,
 } from "../conversation-registry.js";
-import { resolveSlash } from "../conversation-slash.js";
+import { classifySlash, resolveSlash } from "../conversation-slash.js";
 import {
   clearAllActiveConversations,
   getOrCreateConversation,
@@ -326,23 +328,36 @@ export function deleteQueuedMessage(
     );
     return { removed: false, reason: "forbidden" };
   }
-  conversation.removeQueuedMessage(requestId);
-  // Queue events come in pairs, so an entry that never produced a
-  // `message_queued` ack (a suppressed daemon-injected send, or a hidden
-  // machine send) must not produce a delete either: clients have no row to
-  // retire and an unpaired event would decrement a counter that was never
-  // incremented.
+  consumeQueuedMessage(conversation, conversationId, queued);
+  return { removed: true };
+}
+
+/**
+ * Drop a queued message from the queue and close out the client row it
+ * created, so a message that will never run leaves no pending indicator
+ * behind.
+ *
+ * Queue events come in pairs, so an entry that never produced a
+ * `message_queued` ack (a suppressed daemon-injected send, or a hidden machine
+ * send) must not produce a delete either: clients have no row to retire and an
+ * unpaired event would decrement a counter that was never incremented.
+ */
+function consumeQueuedMessage(
+  conversation: Conversation,
+  conversationId: string,
+  queued: QueuedMessage,
+): void {
+  conversation.removeQueuedMessage(queued.requestId);
   if (!isSuppressedQueuedMessage(queued.metadata)) {
     queued.onEvent({
       type: "message_queued_deleted",
       conversationId,
-      requestId,
+      requestId: queued.requestId,
       ...(queued.clientMessageId
         ? { clientMessageId: queued.clientMessageId }
         : {}),
     });
   }
-  return { removed: true };
 }
 
 /**
@@ -457,6 +472,92 @@ export function steerToMessage(
 }
 
 /**
+ * Answer an open `ask_question` prompt with a message the user typed into the
+ * chat while the card was up.
+ *
+ * Typing an answer instead of using the card is the same act as typing it into
+ * the card's free-text field, so it resolves the prompt rather than cancelling
+ * it: the parked turn keeps running and the model reads the answer in the tool
+ * result. Channel replies already work this way (the bare-text branch of
+ * `runtime/guardian-reply-router.ts`); this is the app path saying the same
+ * thing through the same `resolvePendingQuestion` core.
+ *
+ * The message is consumed, not run as a turn of its own: it reaches the model
+ * once, through the tool result, and the answered card carries the user's own
+ * words in the transcript. Consuming it retires the client's queued row the
+ * same way a queue delete does.
+ *
+ * Deliberately narrow. Anything the free-text field of a card could not have
+ * carried, or that a single answer cannot honestly stand in for, falls through
+ * to {@link steerOnEnqueuedMessageIfQuestionParked} and supersedes as before:
+ *  - more than one parked question, so which prompt the text answers is a guess
+ *  - a message no longer on the queue, which cannot be consumed
+ *  - attachments, which the tool result has no way to carry
+ *  - a send that is not a person typing: automated, non-interactive, or
+ *    echo-suppressed machine signals
+ *  - empty text, which answers nothing
+ *  - a slash command, which is an instruction to the assistant rather than prose
+ *
+ * Returns `true` when a parked question was answered and the message consumed.
+ */
+export function answerParkedQuestionWithEnqueuedMessage(
+  conversationId: string,
+  enqueuedRequestId: string,
+): boolean {
+  const conversation = findConversation(conversationId);
+  if (!conversation) {
+    return false;
+  }
+
+  const parked = pendingInteractions
+    .getByConversation(conversationId)
+    .filter((interaction) => interaction.kind === "question");
+  if (parked.length !== 1) {
+    return false;
+  }
+
+  const queued = conversation.queue.findByRequestId(enqueuedRequestId);
+  if (!queued || queued.attachments.length > 0) {
+    return false;
+  }
+  if (
+    queued.isInteractive === false ||
+    queued.metadata?.automated === true ||
+    isSuppressedQueuedMessage(queued.metadata)
+  ) {
+    return false;
+  }
+
+  const text = queued.content.trim();
+  if (text.length === 0 || classifySlash(text) !== "passthrough") {
+    return false;
+  }
+
+  const outcome = resolvePendingQuestion(parked[0].requestId, {
+    kind: "chat_reply",
+    text,
+  });
+  if (outcome.status !== "resolved") {
+    log.warn(
+      {
+        conversationId,
+        requestId: parked[0].requestId,
+        outcome: outcome.status,
+      },
+      "Parked question did not resolve from the enqueued message",
+    );
+    return false;
+  }
+
+  consumeQueuedMessage(conversation, conversationId, queued);
+  log.info(
+    { conversationId, requestId: parked[0].requestId, enqueuedRequestId },
+    "Enqueued message answered a parked question",
+  );
+  return true;
+}
+
+/**
  * Supersede an open `ask_question` prompt when a new chat message is enqueued
  * for the same conversation.
  *
@@ -493,7 +594,9 @@ export function steerOnEnqueuedMessageIfQuestionParked(
  *     gateway request-status sync *before* clearing the prompter-owned
  *     confirmations, so a later guardian reply can't match a stale "pending"
  *     record and fail with `pending_interaction_not_found`.
- *  2. Supersede a parked ask_question by steering to the enqueued message.
+ *  2. Answer a parked ask_question with the enqueued message when the message
+ *     reads as an answer ({@link answerParkedQuestionWithEnqueuedMessage}), and
+ *     otherwise supersede it by steering to the enqueued message.
  *
  * Order matters: the steer aborts the turn, which denies the prompter's
  * confirmations as a side effect, so the status/notification sync must be
@@ -538,6 +641,12 @@ export function supersedePendingInteractionsOnEnqueue(
     }
     conversation.denyAllPendingConfirmations();
     pendingInteractions.removeByConversation(conversationId);
+  }
+
+  if (
+    answerParkedQuestionWithEnqueuedMessage(conversationId, enqueuedRequestId)
+  ) {
+    return;
   }
 
   steerOnEnqueuedMessageIfQuestionParked(conversationId, enqueuedRequestId);

--- a/assistant/src/permissions/question-prompter.ts
+++ b/assistant/src/permissions/question-prompter.ts
@@ -58,6 +58,14 @@ export interface QuestionPromptEntryResult {
 export interface QuestionPromptResult {
   entries: QuestionPromptEntryResult[];
   overall: "completed" | "closed" | "timed_out" | "aborted";
+  /**
+   * True when the answer arrived as a message typed into the chat while the
+   * card was still open, rather than through the card itself. Only the first
+   * question carries the typed text; the rest stay `skipped`. The
+   * `ask_question` tool says so in the model-facing result, so the model can
+   * map the reply onto the questions itself.
+   */
+  answeredInChat?: boolean;
 }
 
 /**
@@ -177,10 +185,12 @@ export interface QuestionBatchMetadata {
  *
  * The idle timeout is a backstop (`getConfig().timeouts.questionResponseTimeoutSec`,
  * default 30 min), not the primary way a prompt is dismissed. An interactive
- * user who moves on instead of answering enqueues another message, which
- * supersedes the open prompt at the enqueue handler (see conversation-routes.ts);
- * a non-interactive turn resolves immediately at the tool. The backstop only
- * fires when a prompt is left open with no response and no follow-up message.
+ * user who types into the chat instead of using the card settles the prompt at
+ * the enqueue handler: the typed text answers it, or, when it cannot stand in
+ * for an answer, supersedes it (see
+ * `daemon/handlers/conversations.ts`). A non-interactive turn resolves
+ * immediately at the tool. The backstop only fires when a prompt is left open
+ * with no response and no follow-up message.
  */
 export class QuestionPrompter {
   async prompt(params: QuestionPromptParams): Promise<QuestionPromptOutcome> {

--- a/assistant/src/runtime/__tests__/question-resolution.test.ts
+++ b/assistant/src/runtime/__tests__/question-resolution.test.ts
@@ -73,6 +73,38 @@ describe("resolvePendingQuestion", () => {
     });
   });
 
+  test("chat_reply: the typed text answers the first question, the rest stay unanswered", () => {
+    const resolved: QuestionPromptResult[] = [];
+    registerQuestion(
+      "req-1",
+      [
+        { id: "q1", options: ["a"] },
+        { id: "q2", options: ["b"] },
+      ],
+      (v) => resolved.push(v as QuestionPromptResult),
+    );
+
+    const outcome = resolvePendingQuestion("req-1", {
+      kind: "chat_reply",
+      text: "tuesday, and keep it short",
+    });
+
+    expect(outcome.status).toBe("resolved");
+    expect(resolved[0]).toEqual({
+      overall: "completed",
+      entries: [
+        {
+          questionId: "q1",
+          decision: "free_text",
+          text: "tuesday, and keep it short",
+        },
+        { questionId: "q2", decision: "skipped" },
+      ],
+      answeredInChat: true,
+    });
+    expect(pendingInteractions.get("req-1")).toBeUndefined();
+  });
+
   test("not_found: unknown or wrong-kind requestId leaves nothing resolved", () => {
     expect(resolvePendingQuestion("missing", { kind: "close" })).toEqual({
       status: "not_found",

--- a/assistant/src/runtime/pending-interactions.ts
+++ b/assistant/src/runtime/pending-interactions.ts
@@ -237,14 +237,14 @@ export function getByConversation(
  * /v1/host-transfer-result after completing the operation, get a 404, and the
  * proxy timer would fire with a spurious timeout error.
  *
- * `question` interactions are also skipped: a new message supersedes an open
- * ask_question by steering to it (see the enqueue path in
- * conversation-routes.ts), which aborts the parked turn and settles the
- * question via its abort signal. Clearing the entry here instead would drop it
- * without settling the prompt's Promise (questions carry no `rpcResolve`
- * fallback like secrets do) and would strip the steer of the entry it needs to
- * fire — which can co-occur with a confirmation, since one model response can
- * open both tools concurrently.
+ * `question` interactions are also skipped: a new message settles an open
+ * ask_question at the enqueue path (see `daemon/handlers/conversations.ts`),
+ * either by answering it with the typed text or by steering to the message,
+ * which aborts the parked turn and settles the question via its abort signal.
+ * Clearing the entry here instead would drop it without settling the prompt's
+ * Promise (questions carry no `rpcResolve` fallback like secrets do) and would
+ * strip both paths of the entry they need, which can co-occur with a
+ * confirmation since one model response can open both tools concurrently.
  */
 export function removeByConversation(
   conversationId: string,

--- a/assistant/src/runtime/question-resolution.ts
+++ b/assistant/src/runtime/question-resolution.ts
@@ -2,7 +2,7 @@
  * Shared resolution core for pending `ask_question` interactions.
  *
  * A pending `question` interaction (registered by {@link QuestionPrompter}) can
- * be resolved from two places:
+ * be resolved from three places:
  *
  *  - `POST /v1/question-response` — an app/web client submits the user's
  *    batched selection (see `routes/question-routes.ts`).
@@ -10,8 +10,11 @@
  *    or bare-text answer routes through the guardian reply router to the
  *    `pending_question` resolver, which builds the submission (see
  *    `approvals/guardian-request-resolvers.ts`).
+ *  - the enqueue path: a message typed into the chat while the card is open
+ *    answers the parked question as free text (see
+ *    `daemon/handlers/conversations.ts`).
  *
- * Both funnel through {@link resolvePendingQuestion} so the validate → consume
+ * All funnel through {@link resolvePendingQuestion} so the validate → consume
  * → `rpcResolve` sequence has a single implementation. The helper is
  * transport-agnostic: it returns a discriminated outcome rather than throwing
  * route errors, so each caller maps the outcome to its own surface (HTTP status
@@ -28,12 +31,20 @@ import {
 import * as pendingInteractions from "./pending-interactions.js";
 
 /**
- * How to resolve a pending question: a batched submission (one entry per
- * question) or a close (every question reported as `skipped`).
+ * How to resolve a pending question:
+ *
+ *  - `submit`: a batched submission, one entry per question.
+ *  - `close`: the card was dismissed; every question is reported as
+ *    `skipped`.
+ *  - `chat_reply`: the user typed a message into the chat while the card was
+ *    open. The text answers the first question as free text and the rest stay
+ *    `skipped`; the result is flagged so the tool tells the model where the
+ *    answer came from.
  */
 export type QuestionResolutionInput =
   | { kind: "submit"; submissions: QuestionBatchSubmission[] }
-  | { kind: "close" };
+  | { kind: "close" }
+  | { kind: "chat_reply"; text: string };
 
 /**
  * Outcome of {@link resolvePendingQuestion}.
@@ -57,9 +68,10 @@ export type QuestionResolutionOutcome =
   | { status: "invalid"; message: string };
 
 /**
- * Resolve a pending `question` interaction with a batched submission or a
- * close. Validation runs BEFORE the interaction is consumed, so an `invalid`
- * outcome leaves the pending prompt (and its timer) intact for a retry.
+ * Resolve a pending `question` interaction with a batched submission, a close,
+ * or a chat reply. Validation runs BEFORE the interaction is consumed, so an
+ * `invalid` outcome leaves the pending prompt (and its timer) intact for a
+ * retry.
  */
 export function resolvePendingQuestion(
   requestId: string,
@@ -81,6 +93,8 @@ export function resolvePendingQuestion(
         })),
         overall: "closed",
       };
+    } else if (input.kind === "chat_reply") {
+      result = buildChatReplyResult(input.text, interaction);
     } else {
       result = buildCompletedResult(input.submissions, interaction);
     }
@@ -134,6 +148,38 @@ function buildCompletedResult(
     submissions,
   );
   return { entries, overall: "completed" };
+}
+
+/**
+ * Build the result for a chat reply: the typed text answers the first question
+ * as free text, every other question stays `skipped`.
+ *
+ * The daemon holds no partial per-question state (the card keeps the user's
+ * in-progress answers locally until the whole batch is posted), so the first
+ * question is by construction the first unanswered one. Which question the
+ * text really speaks to is the model's call, not the daemon's: the flag on the
+ * result tells it the answer came from the chat rather than the card, and it
+ * maps the reply onto the batch from there.
+ */
+function buildChatReplyResult(
+  text: string,
+  interaction: ReturnType<typeof pendingInteractions.get>,
+): QuestionPromptResult {
+  const { orderedIds } = readBatchMetadata(interaction);
+  if (orderedIds.length === 0) {
+    throw new QuestionBatchValidationError(
+      "No registered question ids for this batch",
+    );
+  }
+  return {
+    entries: orderedIds.map((id, index) =>
+      index === 0
+        ? { questionId: id, decision: "free_text" as const, text }
+        : { questionId: id, decision: "skipped" as const },
+    ),
+    overall: "completed",
+    answeredInChat: true,
+  };
 }
 
 /**

--- a/assistant/src/tools/ask-question/ask-question-tool.test.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.test.ts
@@ -187,6 +187,44 @@ describe("AskQuestionTool.execute", () => {
     expect(result.isError).toBe(false);
   });
 
+  test("says so when the user answered in the chat instead of the card", async () => {
+    const q2 = {
+      question: "Preferred time?",
+      options: [
+        { id: "morning", label: "Morning" },
+        { id: "afternoon", label: "Afternoon" },
+      ],
+    };
+    setNextResult({
+      entries: [
+        {
+          questionId: "q1",
+          decision: "free_text",
+          text: "banana, after lunch",
+        },
+        { questionId: "q2", decision: "skipped" },
+      ],
+      overall: "completed",
+      answeredInChat: true,
+    });
+
+    const result = await askQuestionTool.execute(
+      { questions: [singleQ, q2] },
+      makeContext(),
+    );
+
+    expect(result.isError).toBe(false);
+    const lines = String(result.content).split("\n");
+    // The model is told where the answer came from, then reads the batch: the
+    // typed text on the first question, the rest unanswered, so it can map the
+    // reply onto them itself.
+    expect(lines[0]).toContain("replied in the chat");
+    expect(lines.slice(1)).toEqual([
+      `Question "${singleQ.question}" → Free text: banana, after lunch`,
+      `Question "${q2.question}" → Skipped`,
+    ]);
+  });
+
   test("formats skipped result", async () => {
     setNextResult(singleCompleted({ decision: "skipped" }));
     const result = await askQuestionTool.execute(validInput, makeContext());

--- a/assistant/src/tools/ask-question/ask-question-tool.ts
+++ b/assistant/src/tools/ask-question/ask-question-tool.ts
@@ -209,6 +209,15 @@ export function toAnsweredQuestion(
   };
 }
 
+/**
+ * Model-facing note prepended when the user answered by typing in the chat
+ * instead of using the card. The text lands as free text on the first
+ * question and every other question reads as skipped, so the model is told
+ * plainly what happened and left to map the reply onto the batch itself.
+ */
+const CHAT_REPLY_PREAMBLE =
+  "The user replied in the chat instead of using the question card, so their message is recorded as free text on the first question below and the remaining questions are unanswered. Read their reply as the answer to whichever questions it covers, and ask again only for what it genuinely leaves open.";
+
 // ── Tool ────────────────────────────────────────────────────────────
 
 /**
@@ -309,7 +318,13 @@ export const askQuestionTool = {
 
     switch (result.overall) {
       case "completed":
-        return { content: lines.join("\n"), isError: false, answeredQuestion };
+        return {
+          content: result.answeredInChat
+            ? [CHAT_REPLY_PREAMBLE, ...lines].join("\n")
+            : lines.join("\n"),
+          isError: false,
+          answeredQuestion,
+        };
       case "closed": {
         const summary =
           "User closed the question card without answering. All questions skipped.";


### PR DESCRIPTION
## Summary

A message typed while an `ask_question` card is open was cancelling the card instead of answering it.

**Mechanism.** The web client queues the message, and `supersedePendingInteractionsOnEnqueue` (`assistant/src/daemon/handlers/conversations.ts:607`) called `steerOnEnqueuedMessageIfQuestionParked` (`:574`), which aborted the parked turn. The prompter's abort branch settled the batch as `aborted`, the steer's tool-result repair wrote "Cancelled by user" (`assistant/src/agent/loop.ts:2496`), and the model started a fresh turn from the queued message with no idea the user had been answering. Channels never had this problem: the bare-text branch of the guardian reply router (`assistant/src/runtime/guardian-reply-router.ts:568`) resolves a parked question from a plain reply through `resolvePendingQuestion`.

**What changed.** The app path now says the same thing through the same core.

- `assistant/src/runtime/question-resolution.ts:47` adds a `chat_reply` input to the shared resolver, alongside `submit` and `close`. `buildChatReplyResult` (`:164`) puts the typed text on the first question as free text and leaves the rest `skipped`. The daemon holds no partial per-question state (the card keeps in-progress answers locally until the whole batch is posted), so the first question is by construction the first unanswered one.
- `assistant/src/permissions/question-prompter.ts:68` carries an `answeredInChat` flag on the result, and `assistant/src/tools/ask-question/ask-question-tool.ts:218` prefixes the model-facing result with a line saying the user replied in the chat rather than using the card, so the model maps the reply onto the remaining questions itself rather than the daemon guessing for it (AGENTS.md, Assistant-Driven Judgement).
- `assistant/src/daemon/handlers/conversations.ts:503` adds `answerParkedQuestionWithEnqueuedMessage`, which the supersede routine tries first and falls back from. It is deliberately narrow: more than one parked question, a message no longer on the queue, attachments, an automated / non-interactive / echo-suppressed send, empty text, or a slash command (`classifySlash`) all fall through to the existing steer.
- Confirmations and secrets are untouched. Only `kind: "question"` takes the new path; the confirmation auto-deny and its gateway status sync run first, exactly as before.

**The enqueue / transcript choice.** The queued message is consumed, not run as a turn of its own: `consumeQueuedMessage` (`:345`, extracted from `deleteQueuedMessage` so both paths share one implementation) removes it and emits the same `message_queued_deleted` that a queue delete emits, which the client already handles (`clients/web/src/domains/chat/utils/stream-handlers/queue-handlers.ts:133`) by retiring the optimistic row.

The alternative was persisting the message as a visible user row without starting a turn. It was rejected: the model would then see the same words twice (once in the tool result, once in history), and appending a user row into the middle of a live turn is the interleaving shape that has caused trailing-message provider 400s before. Consuming keeps the transcript honest a different way: the user's own words are still on screen, rendered as the answer on the answered-question card (`answeredQuestion` rides the `tool_result` event), which is exactly what they would have seen had they typed into the card's free-text field.

**Client.** No change needed, verified by reading: `interaction_resolved` retires the live card (`clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts:113`), the `tool_result` fold renders the answered card, and `message_queued_deleted` clears the queued row.

Part of JARVIS-1741. This is the stopgap; the non-blocking `ask_question` redesign stays open.

## Test plan

```
cd assistant && bun test src/__tests__/steer-on-enqueue-question.test.ts        # 15 pass, 0 fail
cd assistant && bun test src/runtime/__tests__/question-resolution.test.ts      #  5 pass, 0 fail
cd assistant && bun test src/tools/ask-question/ask-question-tool.test.ts       # 41 pass, 0 fail
cd assistant && bun test src/runtime/routes/__tests__/question-routes.test.ts   # 19 pass, 0 fail
cd assistant && bun test src/permissions/question-prompter.test.ts              # 14 pass, 0 fail
cd assistant && bun run typecheck:fast                                          # clean
cd assistant && eslint <the 8 changed files>                                    # clean
```

New coverage: a single parked question resolves with the typed text and does not abort the turn; a multi-question batch answers the first question and leaves the rest unanswered with the flag set; the tool result names the chat reply; attachments, slash commands, blank text, automated sends and two concurrent questions still supersede; a pending confirmation is untouched by the new path; no parked prompt leaves the message queued.

Note: `ask-question-tool.test.ts` and `question-resolution.test.ts` must run in separate processes. The former's `mock.module` on the prompter leaks into the latter within one `bun test` invocation. Pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjwLgqzhFp4AQ42arMfhaF
