### PR TITLE
test(voice): the deep-link connect assertions carry the entry they park

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -25,6 +25,7 @@ import { mock } from "bun:test";
 import type {
   LiveVoiceClientEventMap,
   LiveVoiceClientEventName,
+  LiveVoiceConnectArgs,
 } from "@/domains/chat/voice/live-voice/live-voice-client";
 import type {
   LiveVoiceAudioCaptureOptions,
@@ -42,13 +43,9 @@ import {
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 export class FakeClient {
-  connectArgs: {
-    assistantId: string;
-    conversationId?: string;
-    turnDetection?: "manual" | "server_vad";
-    silenceThresholdMs?: number;
-    bargeInMinSpeechMs?: number;
-  } | null = null;
+  // The real client's own args type, not a restated copy, so a field added to
+  // the connect frame reaches every assertion made against this fake.
+  connectArgs: LiveVoiceConnectArgs | null = null;
   sentAudio: ArrayBuffer[] = [];
   sentText: string[] = [];
   /** Per-send options, index-aligned with {@link sentText}. */
@@ -86,13 +83,7 @@ export class FakeClient {
     return () => set?.delete(handler as (payload: never) => void);
   }
 
-  async connect(args: {
-    assistantId: string;
-    conversationId?: string;
-    turnDetection?: "manual" | "server_vad";
-    silenceThresholdMs?: number;
-    bargeInMinSpeechMs?: number;
-  }): Promise<void> {
+  async connect(args: LiveVoiceConnectArgs): Promise<void> {
     this.connectArgs = args;
   }
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -309,6 +309,7 @@ describe("starter registration", () => {
       assistantId: "assistant-1",
       conversationId: draftId,
       turnDetection: "server_vad",
+      entry: "deep_link",
     });
     expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();
   });
@@ -393,6 +394,7 @@ describe("re-draining on an assistant switch", () => {
       assistantId: "assistant-2",
       conversationId: draftId,
       turnDetection: "server_vad",
+      entry: "deep_link",
     });
     // Spent, rather than left parked for the TTL to throw away.
     expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();
@@ -441,6 +443,7 @@ describe("re-draining on an assistant switch", () => {
       assistantId: "assistant-2",
       conversationId: draftId,
       turnDetection: "server_vad",
+      entry: "deep_link",
     });
     expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();
   });


### PR DESCRIPTION
## Summary
- Three tests in `use-live-voice-session-controller.test.tsx` fail on main since #42131: that commit rewrote the file's `setPendingVoiceStart()` calls to park `entry: "deep_link"` but left the three `toEqual` connect-args assertions without the field the park now propagates. The scary-looking `"VoiceLiveActivity" plugin is not implemented on web` lines in the output are caught, logged noise present in passing tests too, not the failure.
- No production bug exists: `native-live-activity.ts` guards every path (`callVoiceLiveActivity` falls back off `isNativeMobile()`; both subscribes no-op off `isNativeIOS()`); the plugin is only reached by tests that deliberately simulate a native shell.
- Fix: the three assertions gain `entry: "deep_link"` (positive pin of the propagation #42131 exists for, rather than loosening to `objectContaining`), and the shared `FakeClient` is typed against the real `LiveVoiceConnectArgs` instead of a hand-restated copy, which is the drift that let this happen.
- Target suite 31/31 (was 28/3); neighbors `use-live-voice` 131/131, `start-voice-request` 42/42; all 11 consumers of the shared fake run per-file.

Out of scope, still red on main from the same commit: `chat-composer.test.tsx` (4 stale expectations missing `entry: "composer"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)