### PR TITLE
use `COPY --link` to carry deps from builder stage

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -104,7 +104,7 @@ RUN apt-get update && apt-get install -y \
 COPY --from=builder /root/.bun/bin/bun /usr/local/bin/bun
 RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
 
-COPY --from=builder /app /app
+COPY --link --from=builder /app /app
 
 # Copy source after installing dependencies for better layer caching.
 COPY packages/avatar-catalog /app/packages/avatar-catalog

--- a/credential-executor/Dockerfile
+++ b/credential-executor/Dockerfile
@@ -50,7 +50,7 @@ RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
 RUN groupadd --system --gid 1001 ces && \
     useradd --system --uid 1001 --gid ces --create-home ces
 
-COPY --from=builder --chown=ces:ces /app /app
+COPY --link --from=builder --chown=1001:1001 /app /app
 
 # Copy source after installing dependencies for better layer caching.
 COPY --chown=ces:ces packages/service-contracts /app/packages/service-contracts

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -45,7 +45,7 @@ COPY --from=builder /usr/local/bin/bun /usr/local/bin/bun
 RUN groupadd --system --gid 1001 gateway && \
     useradd --system --uid 1001 --gid gateway --create-home gateway
 
-COPY --from=builder --chown=gateway:gateway /app /app
+COPY --link --from=builder --chown=1001:1001 /app /app
 
 # Copy source after installing dependencies for better layer caching.
 COPY --chown=gateway:gateway packages/assistant-client /app/packages/assistant-client


### PR DESCRIPTION
Use https://docs.docker.com/reference/dockerfile/#copy---link so we can reuse layers when changing commands above the dependency `COPY`. Rarer, but nice to have and generally recommended
