### PR TITLE
feat(companion): the picker shows what it is offering (JARVIS-1743)

### DIFF
--- a/clients/macos/src/main/companion-capture-sources.test.ts
+++ b/clients/macos/src/main/companion-capture-sources.test.ts
@@ -19,13 +19,28 @@ mock.module("./logger", () => ({
 mock.module("./appleScriptExecutor", () => ({
   runAppleScript: async () => "",
 }));
+/**
+ * What the helper answers when the module reaches it directly, which the
+ * preview path does: it takes no deps, since a picture of a window is the one
+ * thing on this side with nothing to decide.
+ */
+let helperCall: (
+  method: string,
+  params?: unknown,
+) => Promise<unknown> = async () => ({ windows: [] });
 mock.module("./sidecar/shared-cu-helper", () => ({
-  getSharedCuHelper: () => ({ call: async () => ({ windows: [] }) }),
+  getSharedCuHelper: () => ({
+    call: (method: string, params?: unknown) => helperCall(method, params),
+  }),
 }));
 
 const {
   CHROME_BUNDLE_ID,
+  THUMBNAIL_CONCURRENCY,
+  THUMBNAIL_MAX_HEIGHT,
+  THUMBNAIL_MAX_WIDTH,
   bringForward,
+  captureSourceThumbnail,
   chromeWindowFor,
   listCaptureSources,
   parseChromeTabs,
@@ -639,5 +654,81 @@ describe("where a window is", () => {
       height: 4,
     });
     expect(await windowBoundsFor(8, d)).toBeNull();
+  });
+});
+
+/**
+ * The picture a picker tile is drawn from: the same capture the share takes,
+ * asked for small and asked for many at once.
+ */
+describe("a picker preview", () => {
+  test("is the helper's frame, as the data URL an img takes", async () => {
+    const asked: unknown[] = [];
+    helperCall = async (method, params) => {
+      asked.push([method, params]);
+      return { jpegBase64: "/9j/4AA", width: 320, height: 200 };
+    };
+    expect(await captureSourceThumbnail({ kind: "window", windowId: 7 })).toBe(
+      "data:image/jpeg;base64,/9j/4AA",
+    );
+    expect(asked).toEqual([
+      [
+        "capture.frame",
+        {
+          windowId: 7,
+          maxWidth: THUMBNAIL_MAX_WIDTH,
+          maxHeight: THUMBNAIL_MAX_HEIGHT,
+        },
+      ],
+    ]);
+  });
+
+  test("is nothing when the helper would not take one", async () => {
+    helperCall = async () => {
+      throw new Error("window not found");
+    };
+    expect(
+      await captureSourceThumbnail({ kind: "display", displayId: 2 }),
+    ).toBeNull();
+  });
+
+  test("is nothing when the helper answers with something else", async () => {
+    helperCall = async () => ({ jpegBase64: "" });
+    expect(
+      await captureSourceThumbnail({ kind: "window", windowId: 7 }),
+    ).toBeNull();
+  });
+
+  /**
+   * The picker asks for one of these per window on the desktop, all at once,
+   * through the one helper the hotkeys and any computer-use action in
+   * progress also share.
+   */
+  test("reaches the helper a handful at a time, however many are asked for", async () => {
+    let live = 0;
+    let peak = 0;
+    const waiting: (() => void)[] = [];
+    helperCall = async () => {
+      live += 1;
+      peak = Math.max(peak, live);
+      await new Promise<void>((resolve) => waiting.push(resolve));
+      live -= 1;
+      return { jpegBase64: "/9j/", width: 2, height: 1 };
+    };
+    const asked = THUMBNAIL_CONCURRENCY * 3;
+    const all = Promise.all(
+      Array.from({ length: asked }, (_, index) =>
+        captureSourceThumbnail({ kind: "window", windowId: index }),
+      ),
+    );
+    await Bun.sleep(0);
+    expect(live).toBe(THUMBNAIL_CONCURRENCY);
+    for (let i = 0; i < asked; i += 1) {
+      waiting.shift()?.();
+      await Bun.sleep(0);
+      await Bun.sleep(0);
+    }
+    expect(await all).toHaveLength(asked);
+    expect(peak).toBe(THUMBNAIL_CONCURRENCY);
   });
 });

--- a/clients/macos/src/main/companion-capture-sources.ts
+++ b/clients/macos/src/main/companion-capture-sources.ts
@@ -719,6 +719,11 @@ const releaseThumbnailSlot = (): void => {
  * open, and the picker is opened by a press: a picture of a window as it
  * looked the last time the user went looking would be a worse answer than a
  * blank tile, since it is the one the user would pick by.
+ *
+ * A preview still queued when the card closes is taken anyway and answers
+ * nobody. Nothing holds it and the next press asks afresh, so the cost is one
+ * capture rather than a leak, and it is cheaper than a cancellation the
+ * renderer would have to reach back across the bridge to ask for.
  */
 export async function captureSourceThumbnail(
   target: WatchCaptureTarget,

--- a/clients/macos/src/main/companion-capture-sources.ts
+++ b/clients/macos/src/main/companion-capture-sources.ts
@@ -614,14 +614,16 @@ const SHARED_FRAME_MAX_WIDTH = 1600;
 const SHARED_FRAME_MAX_HEIGHT = 1000;
 
 /**
- * One frame of a display or a window, as the helper takes it, or nothing
- * when it could not: the window has gone, the display was unplugged, or
- * Screen Recording is not granted. The refusal is logged rather than thrown,
- * since the caller shares frames on a cadence and one missed frame is not an
- * error the user needs to hear about.
+ * One frame of a display or a window at a given size, or nothing when the
+ * helper would not take it. The refusal is logged rather than thrown: both
+ * callers ask for frames they can do without, and `what` is how the line says
+ * which of them was asking.
  */
-export async function captureTargetFrame(
+async function frameOf(
   target: WatchCaptureTarget,
+  maxWidth: number,
+  maxHeight: number,
+  what: string,
 ): Promise<ScreenCaptureFrame | null> {
   const params =
     target.kind === "display"
@@ -631,12 +633,106 @@ export async function captureTargetFrame(
     return capturedFrameSchema.parse(
       await getSharedCuHelper().call("capture.frame", {
         ...params,
-        maxWidth: SHARED_FRAME_MAX_WIDTH,
-        maxHeight: SHARED_FRAME_MAX_HEIGHT,
+        maxWidth,
+        maxHeight,
       }),
     );
   } catch (err) {
-    log.warn("[companion] could not take a frame of the shared target:", err);
+    log.warn(`[companion] could not take a frame of ${what}:`, err);
     return null;
+  }
+}
+
+/**
+ * One frame of a display or a window, as the helper takes it, or nothing
+ * when it could not: the window has gone, the display was unplugged, or
+ * Screen Recording is not granted. The refusal is logged rather than thrown,
+ * since the caller shares frames on a cadence and one missed frame is not an
+ * error the user needs to hear about.
+ */
+export async function captureTargetFrame(
+  target: WatchCaptureTarget,
+): Promise<ScreenCaptureFrame | null> {
+  return frameOf(
+    target,
+    SHARED_FRAME_MAX_WIDTH,
+    SHARED_FRAME_MAX_HEIGHT,
+    "the shared target",
+  );
+}
+
+/**
+ * The longest side a picker preview is encoded at.
+ *
+ * Sized for the tile it is drawn in rather than for reading: the picker asks
+ * for one of these per display and per window on the desktop, all at once,
+ * and each crosses the bridge as base64 in a JSON message. Twice the widest
+ * tile, so the preview still looks like the window on a Retina display, and
+ * no more.
+ */
+export const THUMBNAIL_MAX_WIDTH = 320;
+export const THUMBNAIL_MAX_HEIGHT = 200;
+
+/**
+ * How many previews the helper is asked for at once.
+ *
+ * Each capture is a round trip that sets up a ScreenCaptureKit filter over the
+ * window server's current content, so a desktop with twenty windows on it
+ * asked all at once is twenty of those in flight through the one helper the
+ * hotkeys, dictation and any computer-use action in progress also share. A
+ * handful at a time fills the grid in about the same wall clock and leaves the
+ * helper answering everything else.
+ */
+export const THUMBNAIL_CONCURRENCY = 4;
+
+let thumbnailsInFlight = 0;
+/** Previews asked for while the helper was already busy with its share. */
+const thumbnailQueue: (() => void)[] = [];
+
+const takeThumbnailSlot = (): Promise<void> => {
+  if (thumbnailsInFlight < THUMBNAIL_CONCURRENCY) {
+    thumbnailsInFlight += 1;
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    thumbnailQueue.push(() => {
+      thumbnailsInFlight += 1;
+      resolve();
+    });
+  });
+};
+
+const releaseThumbnailSlot = (): void => {
+  thumbnailsInFlight -= 1;
+  thumbnailQueue.shift()?.();
+};
+
+/**
+ * A preview of one thing the picker offers, as a JPEG data URL, or nothing
+ * when the helper would not take one.
+ *
+ * A data URL rather than the frame the share path returns, because the only
+ * thing waiting for it is an `img` in the picker: the shape it wants is the
+ * shape the app icons beside it already travel in.
+ *
+ * Nothing is cached. A preview is only true for the moment the picker is
+ * open, and the picker is opened by a press: a picture of a window as it
+ * looked the last time the user went looking would be a worse answer than a
+ * blank tile, since it is the one the user would pick by.
+ */
+export async function captureSourceThumbnail(
+  target: WatchCaptureTarget,
+): Promise<string | null> {
+  await takeThumbnailSlot();
+  try {
+    const frame = await frameOf(
+      target,
+      THUMBNAIL_MAX_WIDTH,
+      THUMBNAIL_MAX_HEIGHT,
+      "a picker row",
+    );
+    return frame === null ? null : `data:image/jpeg;base64,${frame.jpegBase64}`;
+  } finally {
+    releaseThumbnailSlot();
   }
 }

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -265,12 +265,20 @@ let capturedFrame: {
   height: number;
 } | null = { jpegBase64: "/9j/", width: 16, height: 9 };
 
+/** What the helper was asked to take a picker preview of. */
+const thumbnailsAsked: unknown[] = [];
+let capturedThumbnail: string | null = "data:image/jpeg;base64,/9j/";
+
 mock.module("./companion-capture-sources", () => ({
   listCaptureSources: async () => listedSources,
   resolveCapturePick: (pick: unknown) => resolvedPickAsync(pick),
   captureTargetFrame: async (target: unknown) => {
     framesAsked.push(target);
     return capturedFrame;
+  },
+  captureSourceThumbnail: async (target: unknown) => {
+    thumbnailsAsked.push(target);
+    return capturedThumbnail;
   },
   windowBoundsFor: async (windowId: number) => {
     boundsAsked.push(windowId);
@@ -2750,6 +2758,19 @@ describe("Share on the companion surface", () => {
     expect(framesAsked).toEqual([{ kind: "display", displayId: 2 }]);
     capturedFrame = null;
     expect(await capture?.([{ kind: "window", windowId: 7 }])).toBeNull();
+  });
+
+  test("takes a picker preview of one row from the helper", async () => {
+    const preview = invocable.get("vellum:companion:captureSourceThumbnail");
+    expect(preview).toBeDefined();
+    expect(await preview?.([{ kind: "window", windowId: 7 }])).toBe(
+      "data:image/jpeg;base64,/9j/",
+    );
+    expect(thumbnailsAsked).toEqual([{ kind: "window", windowId: 7 }]);
+    // A window that closed between the list and the grid is a tile with no
+    // picture, not a failed call.
+    capturedThumbnail = null;
+    expect(await preview?.([{ kind: "display", displayId: 2 }])).toBeNull();
   });
 
   test("carries the share and whether one may start to the surface", () => {

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -70,6 +70,7 @@ import {
   getFloatingWindow,
 } from "@vellumai/electron-desktop/floating-window";
 import {
+  captureSourceThumbnail,
   captureTargetFrame,
   listCaptureSources,
   resolveCapturePick,
@@ -1563,6 +1564,18 @@ export const installCompanionWindow = (): void => {
     "vellum:companion:captureScreen",
     z.tuple([watchCaptureTargetSchema]),
     ([target]) => captureTargetFrame(target),
+  );
+
+  /**
+   * A preview of one row of the picker, for the tile it is drawn as. Asked
+   * once per display and per window the list came back with, so the answering
+   * is paced in `captureSourceThumbnail` rather than here: this handler is
+   * reached once per tile and knows nothing of the others.
+   */
+  handle(
+    "vellum:companion:captureSourceThumbnail",
+    z.tuple([watchCaptureTargetSchema]),
+    ([target]) => captureSourceThumbnail(target),
   );
 
   /**

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -569,6 +569,13 @@ const bridge: VellumBridge = {
         "vellum:companion:captureScreen",
         target,
       ) as Promise<ScreenCaptureFrame | null>,
+    captureSourceThumbnail: (
+      target: WatchCaptureTarget,
+    ): Promise<string | null> =>
+      ipcRenderer.invoke(
+        "vellum:companion:captureSourceThumbnail",
+        target,
+      ) as Promise<string | null>,
     answerWatchRetro: (open: boolean): void => {
       ipcRenderer.send("vellum:companion:answerWatchRetro", open);
     },

--- a/clients/web/src/components/companion-capture-picker.test.tsx
+++ b/clients/web/src/components/companion-capture-picker.test.tsx
@@ -177,6 +177,52 @@ describe("the capture picker", () => {
     ]);
   });
 
+  test("keeps a picture the host refused outright from reaching the tile", async () => {
+    const { container } = render(
+      <CompanionCapturePicker
+        sources={{ ...SOURCES, displays: [], tabs: [] }}
+        captureThumbnail={() => Promise.reject(new Error("helper is down"))}
+      />,
+    );
+    await settle();
+    // Settled on the icon, and the rejection was taken rather than left to
+    // surface as an unhandled one.
+    expect(pictures(container)).toEqual(["data:image/png;base64,notes"]);
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(0);
+  });
+
+  test("drops a picture that lands after the list it was asked for", async () => {
+    let answer: ((thumbnail: string | null) => void) | undefined;
+    const { container, rerender } = render(
+      <CompanionCapturePicker
+        sources={{ ...SOURCES, displays: [], tabs: [] }}
+        captureThumbnail={() =>
+          new Promise<string | null>((resolve) => {
+            answer = resolve;
+          })
+        }
+      />,
+    );
+    // A fresh list, holding the same window id the window server has since
+    // handed to something else.
+    rerender(
+      <CompanionCapturePicker
+        sources={{
+          displays: [],
+          tabs: [],
+          windows: [
+            { kind: "window", windowId: 7, title: "Inbox", app: "Mail" },
+          ],
+        }}
+        captureThumbnail={() => new Promise<string | null>(() => undefined)}
+      />,
+    );
+    answer?.("data:image/jpeg;base64,stale");
+    await settle();
+    expect(tiles(container)).toEqual(["Inbox (Mail)"]);
+    expect(pictures(container)).toEqual([]);
+  });
+
   test("never asks for a picture of a tab", async () => {
     const asked: WatchCaptureTarget[] = [];
     const { container } = render(

--- a/clients/web/src/components/companion-capture-picker.test.tsx
+++ b/clients/web/src/components/companion-capture-picker.test.tsx
@@ -44,15 +44,15 @@ const tiles = (container: HTMLElement): string[] =>
   );
 
 /** The segments, by the name on them. */
+const segments = (container: HTMLElement): Element[] => [
+  ...container.querySelectorAll('[data-slot="segment-control"] [role="radio"]'),
+];
+
 const kinds = (container: HTMLElement): string[] =>
-  [...container.querySelectorAll('[data-slot="capture-kinds"] button')].map(
-    (button) => button.textContent ?? "",
-  );
+  segments(container).map((button) => button.textContent ?? "");
 
 const pressKind = (container: HTMLElement, name: string): void => {
-  const button = [
-    ...container.querySelectorAll('[data-slot="capture-kinds"] button'),
-  ].find((each) => each.textContent === name);
+  const button = segments(container).find((each) => each.textContent === name);
   fireEvent.click(button!);
 };
 
@@ -128,9 +128,7 @@ describe("the capture picker", () => {
   test("says which segment is on", () => {
     const { container } = render(<CompanionCapturePicker sources={SOURCES} />);
     const checked = (): (string | null)[] =>
-      [...container.querySelectorAll('[data-slot="capture-kinds"] button')].map(
-        (button) => button.getAttribute("aria-checked"),
-      );
+      segments(container).map((button) => button.getAttribute("aria-checked"));
     expect(checked()).toEqual(["true", "false", "false"]);
     pressKind(container, "Windows");
     expect(checked()).toEqual(["false", "false", "true"]);

--- a/clients/web/src/components/companion-capture-picker.test.tsx
+++ b/clients/web/src/components/companion-capture-picker.test.tsx
@@ -134,6 +134,29 @@ describe("the capture picker", () => {
     expect(checked()).toEqual(["false", "false", "true"]);
   });
 
+  test("opens on the screens again when the card is asked a new question", () => {
+    // Teach pressed over Share's open picker: the host lists afresh and the
+    // card is the same element, so the kind the last question was narrowed to
+    // would otherwise still be showing.
+    const { container, rerender } = render(
+      <CompanionCapturePicker sources={SOURCES} />,
+    );
+    pressKind(container, "Windows");
+    expect(tiles(container)).toEqual(["Groceries (Notes)", "Preview"]);
+    rerender(<CompanionCapturePicker sources={null} />);
+    rerender(<CompanionCapturePicker sources={{ ...SOURCES }} />);
+    expect(tiles(container)).toEqual(["Screen 1", "Screen 2"]);
+  });
+
+  test("starts a kind at its first row rather than where the last one was left", () => {
+    const { container } = render(<CompanionCapturePicker sources={SOURCES} />);
+    const list = container.querySelector(".max-h-48")!;
+    pressKind(container, "Windows");
+    list.scrollTop = 120;
+    pressKind(container, "Chrome tabs");
+    expect(list.scrollTop).toBe(0);
+  });
+
   test("draws each screen and window as a picture of itself", async () => {
     const { container } = render(
       <CompanionCapturePicker sources={SOURCES} captureThumbnail={answering} />,

--- a/clients/web/src/components/companion-capture-picker.test.tsx
+++ b/clients/web/src/components/companion-capture-picker.test.tsx
@@ -1,9 +1,10 @@
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "bun:test";
 
 import type {
   CompanionCapturePick,
   CompanionCaptureSources,
+  WatchCaptureTarget,
 } from "@vellumai/ipc-contract";
 
 import { CompanionCapturePicker } from "./companion-capture-picker";
@@ -36,55 +37,213 @@ const SOURCES: CompanionCaptureSources = {
   ],
 };
 
-const rows = (container: HTMLElement): string[] =>
-  [...container.querySelectorAll("button")].map(
-    (button) => button.getAttribute("aria-label") ?? "",
+/** What the grid is offering, by the name a reader hears. */
+const tiles = (container: HTMLElement): string[] =>
+  [...container.querySelectorAll('[data-slot="capture-source"]')].map(
+    (tile) => tile.getAttribute("aria-label") ?? "",
   );
 
+/** The segments, by the name on them. */
+const kinds = (container: HTMLElement): string[] =>
+  [...container.querySelectorAll('[data-slot="capture-kinds"] button')].map(
+    (button) => button.textContent ?? "",
+  );
+
+const pressKind = (container: HTMLElement, name: string): void => {
+  const button = [
+    ...container.querySelectorAll('[data-slot="capture-kinds"] button'),
+  ].find((each) => each.textContent === name);
+  fireEvent.click(button!);
+};
+
+/** What each tile has in its picture slot, be it a picture or a stand-in. */
+const pictures = (container: HTMLElement): (string | null)[] =>
+  [...container.querySelectorAll('[data-slot="capture-preview"] img')].map(
+    (img) => img.getAttribute("src"),
+  );
+
+/** A host that answers every tile with a picture named after its target. */
+const answering = (target: WatchCaptureTarget): Promise<string | null> =>
+  Promise.resolve(
+    target.kind === "display"
+      ? `data:image/jpeg;base64,display-${target.displayId}`
+      : `data:image/jpeg;base64,window-${target.windowId}`,
+  );
+
+/** Lets the pictures the host already resolved reach the tiles. */
+const settle = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
 /**
- * The picker Teach opens: what a session could read, as a list to press.
- * Screens, then Chrome's tabs, then every other window, each named the way a
- * person would find it.
+ * The picker Teach and Share open: what a session could read, as a grid of
+ * what those things currently look like, one kind at a time.
  */
 describe("the capture picker", () => {
-  test("draws the screens, then the tabs, then the windows", () => {
+  test("opens on the screens, drawn as tiles", () => {
     const { container } = render(<CompanionCapturePicker sources={SOURCES} />);
-    expect(rows(container)).toEqual([
-      "Screen 1",
-      "Screen 2",
-      "Pull request #42",
-      "Groceries (Notes)",
-      "Preview",
-    ]);
+    expect(tiles(container)).toEqual(["Screen 1", "Screen 2"]);
   });
 
-  test("names each section", () => {
+  test("offers each kind the desktop has, in the order a choice narrows", () => {
     const { container } = render(<CompanionCapturePicker sources={SOURCES} />);
-    const text = container.textContent ?? "";
-    expect(text).toContain("Screens");
-    expect(text).toContain("Chrome tabs");
-    expect(text).toContain("Windows");
+    expect(kinds(container)).toEqual(["Screens", "Chrome tabs", "Windows"]);
   });
 
-  test("leaves out a section with nothing in it", () => {
+  test("leaves out a kind with nothing in it", () => {
     const { container } = render(
       <CompanionCapturePicker sources={{ ...SOURCES, tabs: [] }} />,
     );
-    expect(container.textContent).not.toContain("Chrome tabs");
+    expect(kinds(container)).toEqual(["Screens", "Windows"]);
   });
 
-  test("draws the app's icon where the shell read one", () => {
-    const { container } = render(<CompanionCapturePicker sources={SOURCES} />);
-    const images = [...container.querySelectorAll("img")].map((img) =>
-      img.getAttribute("src"),
+  test("offers no choice at all when the desktop has one kind on it", () => {
+    const { container } = render(
+      <CompanionCapturePicker
+        sources={{ ...SOURCES, displays: [], tabs: [] }}
+      />,
     );
-    expect(images).toEqual([
-      "data:image/png;base64,chrome",
-      "data:image/png;base64,notes",
+    expect(kinds(container)).toEqual([]);
+    expect(tiles(container)).toEqual(["Groceries (Notes)", "Preview"]);
+  });
+
+  test("opens on what the desktop does have when there are no screens", () => {
+    const { container } = render(
+      <CompanionCapturePicker sources={{ ...SOURCES, displays: [] }} />,
+    );
+    expect(tiles(container)).toEqual(["Pull request #42"]);
+  });
+
+  test("a segment is the kind the grid draws", () => {
+    const { container } = render(<CompanionCapturePicker sources={SOURCES} />);
+    pressKind(container, "Windows");
+    expect(tiles(container)).toEqual(["Groceries (Notes)", "Preview"]);
+    pressKind(container, "Chrome tabs");
+    expect(tiles(container)).toEqual(["Pull request #42"]);
+  });
+
+  test("says which segment is on", () => {
+    const { container } = render(<CompanionCapturePicker sources={SOURCES} />);
+    const checked = (): (string | null)[] =>
+      [...container.querySelectorAll('[data-slot="capture-kinds"] button')].map(
+        (button) => button.getAttribute("aria-checked"),
+      );
+    expect(checked()).toEqual(["true", "false", "false"]);
+    pressKind(container, "Windows");
+    expect(checked()).toEqual(["false", "false", "true"]);
+  });
+
+  test("draws each screen and window as a picture of itself", async () => {
+    const { container } = render(
+      <CompanionCapturePicker sources={SOURCES} captureThumbnail={answering} />,
+    );
+    await settle();
+    expect(pictures(container)).toEqual([
+      "data:image/jpeg;base64,display-1",
+      "data:image/jpeg;base64,display-5",
+    ]);
+    pressKind(container, "Windows");
+    await settle();
+    expect(pictures(container)).toEqual([
+      "data:image/jpeg;base64,window-7",
+      "data:image/jpeg;base64,window-8",
     ]);
   });
 
-  test("a press is the row's pick, with its decoration removed", () => {
+  test("asks for a picture once, however often the kind is switched", async () => {
+    const asked: WatchCaptureTarget[] = [];
+    const { container } = render(
+      <CompanionCapturePicker
+        sources={SOURCES}
+        captureThumbnail={(target) => {
+          asked.push(target);
+          return answering(target);
+        }}
+      />,
+    );
+    await settle();
+    pressKind(container, "Windows");
+    await settle();
+    pressKind(container, "Screens");
+    await settle();
+    expect(asked).toEqual([
+      { kind: "display", displayId: 1 },
+      { kind: "display", displayId: 5 },
+      { kind: "window", windowId: 7 },
+      { kind: "window", windowId: 8 },
+    ]);
+  });
+
+  test("never asks for a picture of a tab", async () => {
+    const asked: WatchCaptureTarget[] = [];
+    const { container } = render(
+      <CompanionCapturePicker
+        sources={{ ...SOURCES, displays: [] }}
+        captureThumbnail={(target) => {
+          asked.push(target);
+          return answering(target);
+        }}
+      />,
+    );
+    await settle();
+    expect(tiles(container)).toEqual(["Pull request #42"]);
+    expect(asked).toEqual([]);
+  });
+
+  test("settles a tile the host could take no picture of on its icon", async () => {
+    const { container } = render(
+      <CompanionCapturePicker
+        sources={{ ...SOURCES, displays: [], tabs: [] }}
+        captureThumbnail={() => Promise.resolve(null)}
+      />,
+    );
+    await settle();
+    expect(pictures(container)).toEqual(["data:image/png;base64,notes"]);
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(0);
+  });
+
+  test("draws a tile as waiting only until the host has answered it", async () => {
+    const { container } = render(
+      <CompanionCapturePicker
+        sources={{ ...SOURCES, displays: [], tabs: [] }}
+        captureThumbnail={answering}
+      />,
+    );
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
+      0,
+    );
+    await settle();
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(0);
+  });
+
+  test("waits on nothing where the shell cannot take pictures", () => {
+    const { container } = render(
+      <CompanionCapturePicker
+        sources={{ ...SOURCES, displays: [], tabs: [] }}
+      />,
+    );
+    expect(container.querySelectorAll(".animate-pulse")).toHaveLength(0);
+    expect(pictures(container)).toEqual(["data:image/png;base64,notes"]);
+  });
+
+  test("draws the app's icon beside a window's name", () => {
+    const { container } = render(
+      <CompanionCapturePicker
+        sources={{ ...SOURCES, displays: [], tabs: [] }}
+      />,
+    );
+    // Twice for the window with an icon: standing in for its missing picture,
+    // and beside its name. The window without one draws neither.
+    expect(pictures(container)).toEqual(["data:image/png;base64,notes"]);
+    expect(
+      container.querySelectorAll('img[src="data:image/png;base64,notes"]'),
+    ).toHaveLength(2);
+  });
+
+  test("a press is the tile's pick, with its decoration removed", () => {
     const picks: CompanionCapturePick[] = [];
     const { container } = render(
       <CompanionCapturePicker
@@ -94,11 +253,15 @@ describe("the capture picker", () => {
         }}
       />,
     );
-    for (const label of ["Screen 2", "Pull request #42", "Groceries (Notes)"]) {
-      fireEvent.click(
-        container.querySelector(`button[aria-label="${label}"]`)!,
-      );
-    }
+    fireEvent.click(container.querySelector('button[aria-label="Screen 2"]')!);
+    pressKind(container, "Chrome tabs");
+    fireEvent.click(
+      container.querySelector('button[aria-label="Pull request #42"]')!,
+    );
+    pressKind(container, "Windows");
+    fireEvent.click(
+      container.querySelector('button[aria-label="Groceries (Notes)"]')!,
+    );
     expect(picks).toEqual([
       { kind: "display", displayId: 5 },
       { kind: "tab", chromeWindowId: 101, tabIndex: 2 },
@@ -113,7 +276,8 @@ describe("the capture picker", () => {
       />,
     );
     expect(container.textContent).toContain("Nothing to show");
-    expect(rows(container)).toEqual([]);
+    expect(tiles(container)).toEqual([]);
+    expect(kinds(container)).toEqual([]);
   });
 
   test("is drawn, empty, while the shell is still being asked", () => {
@@ -121,7 +285,8 @@ describe("the capture picker", () => {
     expect(
       container.querySelector("[data-companion-capture-picker]"),
     ).not.toBeNull();
-    expect(rows(container)).toEqual([]);
+    expect(tiles(container)).toEqual([]);
+    expect(kinds(container)).toEqual([]);
     expect(container.textContent).not.toContain("Nothing to show");
   });
 
@@ -138,7 +303,7 @@ describe("the capture picker", () => {
     expect(card).not.toBeNull();
   });
 
-  test("stands in for the list with its own shape while loading", () => {
+  test("stands in for the grid with its own shape while loading", () => {
     const { container } = render(<CompanionCapturePicker sources={null} />);
     expect(
       container.querySelectorAll("[aria-hidden] .animate-pulse").length,

--- a/clients/web/src/components/companion-capture-picker.tsx
+++ b/clients/web/src/components/companion-capture-picker.tsx
@@ -12,6 +12,7 @@ import {
 import { companionLayoutFor } from "@/components/companion-layout";
 import { useTranslation } from "@/i18n";
 import { ScrollShadow } from "@vellumai/design-library/components/scroll-shadow";
+import { SegmentControl } from "@vellumai/design-library/components/segment-control";
 import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 import type {
   CompanionCapturePick,
@@ -292,6 +293,16 @@ export function CompanionCapturePicker({
   const answerFor = (key: string): string | null | undefined =>
     captureThumbnail === undefined ? null : thumbnails.get(key);
 
+  /** What a kind is called, as the segment naming it reads. */
+  const nameOf = (of: CaptureKind): string =>
+    t(
+      of === "screens"
+        ? "companionSurface.captureScreens"
+        : of === "tabs"
+          ? "companionSurface.captureTabs"
+          : "companionSurface.captureWindows",
+    );
+
   return (
     <div
       ref={cardRef}
@@ -301,6 +312,12 @@ export function CompanionCapturePicker({
       role="group"
       aria-label={label ?? t("companionSurface.capturePicker")}
       data-companion-capture-picker
+      // The card is dark whatever the app's theme is, and it is drawn in a
+      // window with no theme on its root, so the scope is declared here: the
+      // design library's tokens are written to be read off a non-root
+      // ancestor, and a control taking them from `:root` would draw its light
+      // palette on this card.
+      data-theme="dark"
       className="absolute flex flex-col rounded-2xl border border-white/10 bg-[#17181b]/95 p-1.5 shadow-lg shadow-black/40"
       style={{ width: CARD_WIDTH, ...anchor }}
       // A press on a tile is a pick, not a grab of the surface.
@@ -308,20 +325,20 @@ export function CompanionCapturePicker({
         event.stopPropagation();
       }}
     >
+      {/*
+       * Which question the grid below is answering. Drawn only when the
+       * desktop offers more than one kind: a control with a single segment on
+       * it is a label pretending to be a choice.
+       */}
       {kinds.length > 1 && (
-        <KindControl
-          kinds={kinds}
-          kind={kind}
-          nameOf={(of) =>
-            t(
-              of === "screens"
-                ? "companionSurface.captureScreens"
-                : of === "tabs"
-                  ? "companionSurface.captureTabs"
-                  : "companionSurface.captureWindows",
-            )
-          }
-          label={t("companionSurface.captureKind")}
+        <SegmentControl
+          // As wide as its segments rather than the card: the control names
+          // the kinds, and a bar stretched across a card of tiles reads as a
+          // header rather than a choice.
+          className="mx-auto mb-1.5 w-auto shrink-0"
+          items={kinds.map((each) => ({ value: each, label: nameOf(each) }))}
+          value={kind}
+          ariaLabel={t("companionSurface.captureKind")}
           onChange={setChosen}
         />
       )}
@@ -436,63 +453,6 @@ export function CompanionCapturePicker({
           )}
         </div>
       </ScrollShadow>
-    </div>
-  );
-}
-
-/**
- * Which question the grid below is answering.
- *
- * Drawn only when the desktop offers more than one kind: a control with a
- * single segment on it is a label pretending to be a choice.
- *
- * A radio group rather than tabs, and without the roving tab stop a keyboard
- * user would need, because there is no keyboard here: the window this is drawn
- * in never takes focus, so every press is the pointer's. The roles are still
- * stated, since what a segment is and which one is on is what a reader is
- * owed either way.
- */
-function KindControl({
-  kinds,
-  kind,
-  nameOf,
-  label,
-  onChange,
-}: {
-  kinds: CaptureKind[];
-  kind: CaptureKind;
-  nameOf: (kind: CaptureKind) => string;
-  label: string;
-  onChange: (kind: CaptureKind) => void;
-}) {
-  return (
-    <div
-      role="radiogroup"
-      aria-label={label}
-      data-slot="capture-kinds"
-      className="mb-1.5 flex shrink-0 items-center justify-center gap-1"
-    >
-      {kinds.map((each) => {
-        const active = each === kind;
-        return (
-          <button
-            key={each}
-            type="button"
-            role="radio"
-            aria-checked={active}
-            className={`h-6 shrink-0 rounded-full px-3 text-[11px] font-medium transition-colors outline-none focus-visible:ring-1 focus-visible:ring-white/40 ${
-              active
-                ? "bg-white/15 text-white"
-                : "text-white/50 hover:bg-white/5 hover:text-white/80"
-            }`}
-            onClick={() => {
-              onChange(each);
-            }}
-          >
-            {nameOf(each)}
-          </button>
-        );
-      })}
     </div>
   );
 }

--- a/clients/web/src/components/companion-capture-picker.tsx
+++ b/clients/web/src/components/companion-capture-picker.tsx
@@ -250,14 +250,27 @@ export function CompanionCapturePicker({
     };
   }, []);
 
-  // A new list is a new desktop: whatever was asked for belonged to the card
-  // the user has already left. Declared above the asking effect so it runs
-  // first when both fire on the same list.
+  // A new list is a new desktop: whatever was asked for, and whatever kind the
+  // user had narrowed to, belonged to the card they have already left. Teach
+  // pressed over Share's open picker is a new question in the same card, and
+  // it opens the way the first one did. Declared above the asking effect so it
+  // runs first when both fire on the same list.
   useEffect(() => {
     asked.current = new Set();
     listing.current += 1;
     setThumbnails(new Map());
+    setChosen(null);
   }, [sources]);
+
+  // The grid is scrolled per card, not per kind: a switch is a different list
+  // in the same box, and the rows above whatever the last kind was scrolled to
+  // would start out of sight.
+  const listRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (listRef.current !== null) {
+      listRef.current.scrollTop = 0;
+    }
+  }, [kind]);
 
   useEffect(() => {
     if (captureThumbnail === undefined) {
@@ -359,6 +372,7 @@ export function CompanionCapturePicker({
        * card past the edge of a window that never resizes.
        */}
       <ScrollShadow
+        ref={listRef}
         className="max-h-48 flex-col px-0.5"
         size={24}
         fadeEdges="end"

--- a/clients/web/src/components/companion-capture-picker.tsx
+++ b/clients/web/src/components/companion-capture-picker.tsx
@@ -38,7 +38,7 @@ import type {
  * "which screen" and "which window" are different questions and a person has
  * only one of them at a time.
  *
- * A Chrome tab keeps the list it always had. A tab has no window of its own
+ * A Chrome tab is a row rather than a tile. A tab has no window of its own
  * until Chrome has been told to show it, so the only way to draw a picture of
  * one is to switch the user's browser to it while they are still deciding.
  * The host resolves a picked tab to the window showing it, so the surface
@@ -233,6 +233,14 @@ export function CompanionCapturePicker({
   >(new Map());
   /** Keys already asked for, so switching kinds and back does not ask twice. */
   const asked = useRef(new Set<string>());
+  /**
+   * Which list the asking belongs to. A capture is a round trip through the
+   * window server, and a list that arrived while one was in flight describes a
+   * desktop the picture is no longer of: window ids are the window server's to
+   * hand out again, so a late picture written under a key the new list also
+   * holds would be a tile showing something the user never had open.
+   */
+  const listing = useRef(0);
   const mounted = useRef(false);
   useEffect(() => {
     mounted.current = true;
@@ -246,6 +254,7 @@ export function CompanionCapturePicker({
   // first when both fire on the same list.
   useEffect(() => {
     asked.current = new Set();
+    listing.current += 1;
     setThumbnails(new Map());
   }, [sources]);
 
@@ -258,15 +267,21 @@ export function CompanionCapturePicker({
         continue;
       }
       asked.current.add(key);
-      void captureThumbnail(target).then((thumbnail) => {
-        if (!mounted.current) {
+      const of = listing.current;
+      // A null is recorded rather than dropped, and nothing is said about it:
+      // a window that closed while the card was opening is the desktop's
+      // answer, not a fault. The tile keeps its icon and stays pressable,
+      // since the pick may still resolve to something. A host that refuses
+      // outright is read the same way, which is what keeps a rejection from
+      // reaching the renderer as an unhandled one.
+      const land = (thumbnail: string | null): void => {
+        if (!mounted.current || of !== listing.current) {
           return;
         }
-        // A null is recorded rather than dropped, and nothing is said about
-        // it: a window that closed while the card was opening is the
-        // desktop's answer, not a fault. The tile keeps its icon and stays
-        // pressable, since the pick may still resolve to something.
         setThumbnails((prev) => new Map(prev).set(key, thumbnail));
+      };
+      void captureThumbnail(target).then(land, () => {
+        land(null);
       });
     }
   }, [captureThumbnail, targets]);
@@ -561,9 +576,8 @@ function Tile({
 }
 
 /**
- * One Chrome tab, as a row. Tabs keep the list the whole picker used to be:
- * there is no picture of a tab that is not the one in front, and the title is
- * how a person knows a page anyway.
+ * One Chrome tab, as a row: there is no picture of a tab that is not the one
+ * in front, and the title is how a person knows a page anyway.
  */
 function Row({
   icon,

--- a/clients/web/src/components/companion-capture-picker.tsx
+++ b/clients/web/src/components/companion-capture-picker.tsx
@@ -1,5 +1,13 @@
 import { AppWindow, Monitor } from "lucide-react";
-import { type CSSProperties, type ReactNode, type Ref } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  type Ref,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { companionLayoutFor } from "@/components/companion-layout";
 import { useTranslation } from "@/i18n";
@@ -9,39 +17,98 @@ import type {
   CompanionCapturePick,
   CompanionCaptureSources,
   CompanionCardGrowth,
+  WatchCaptureTarget,
 } from "@vellumai/ipc-contract";
 
 /**
  * The picker Teach and Share open: what a session could read, or be shown, as
- * a list to press.
+ * a grid of what those things currently look like.
  *
  * A card beside the call bar rather than a row on it. The bar is one thin row
  * by design and a desktop has a dozen windows on it, so the choice is drawn
  * where the introduction's card is drawn, on the height the host reserves for
  * a card, and scrolls inside that when the desktop has more than fits.
  *
- * Three sections in the order a person narrows a choice: the screens, then
- * the Chrome tabs, then every other window. A tab is offered as a thing of its
- * own because that is how people think of what is in their browser, and the
- * host resolves a picked tab to the window showing it, so the surface never
- * has to know a tab is not a window.
+ * **One kind at a time, and each thing shown as itself.** A person picking a
+ * window is looking for the one they were just in, and a title is a poor
+ * likeness of it: half the windows on a desktop are called after the app that
+ * owns them, and the rest after a file. So each row is a tile with a picture
+ * of the thing in it, taken when the card opened, and the kinds are separated
+ * onto a segmented control rather than run together down one list, since
+ * "which screen" and "which window" are different questions and a person has
+ * only one of them at a time.
  *
- * **It offers and holds nothing.** The list is the host's answer at the moment
- * the card opened, and a press leaves this renderer as a pick. What comes
- * back, once the window that owns the session has one to report, is
- * `watching` and the target the session actually reads.
+ * A Chrome tab keeps the list it always had. A tab has no window of its own
+ * until Chrome has been told to show it, so the only way to draw a picture of
+ * one is to switch the user's browser to it while they are still deciding.
+ * The host resolves a picked tab to the window showing it, so the surface
+ * never has to know a tab is not a window.
+ *
+ * **It offers and holds nothing** but the pictures. The list is the host's
+ * answer at the moment the card opened, and a press leaves this renderer as a
+ * pick. What comes back, once the window that owns the session has one to
+ * report, is `watching` and the target the session actually reads.
  */
 
 /**
  * The card's width, fixed rather than measured, for the reason the
- * introduction's is: a list of titles has no natural width, and a card that
+ * introduction's is: a grid of pictures has no natural width, and a card that
  * changed shape with what happened to be on the desktop would move under the
  * hand between one open and the next.
+ *
+ * Three tiles across at a size a window is still recognisable at. The canvas
+ * holds it: main sizes the canvas for the call bar's own reach either side of
+ * the creature, which is wider than this at every size the surface is drawn
+ * at.
  */
-const CARD_WIDTH = 260;
+const CARD_WIDTH = 460;
 
-/** How many rows the loading state stands in for, in each of its two groups. */
-const SKELETON_ROWS = 3;
+/** How many tiles stand across the card. */
+const GRID_COLUMNS = 3;
+
+/**
+ * The height of a tile's picture.
+ *
+ * The picture is fitted inside it rather than cropped to it, so a tall window
+ * and a wide display are both shown whole and the rows stay one height. Sized
+ * so that two rows and the segmented control above them fit the height the
+ * host reserves for a card, with the third row under the fold as the hint
+ * that there is more.
+ */
+const THUMBNAIL_HEIGHT = 88;
+
+/** How many tiles the loading state stands in for. */
+const SKELETON_TILES = 3;
+
+/** The three questions the segmented control switches between. */
+type CaptureKind = "screens" | "tabs" | "windows";
+
+const KIND_ORDER: CaptureKind[] = ["screens", "tabs", "windows"];
+
+/** How many of a kind the host listed. */
+const countOf = (
+  sources: CompanionCaptureSources,
+  kind: CaptureKind,
+): number =>
+  kind === "screens"
+    ? sources.displays.length
+    : kind === "tabs"
+      ? sources.tabs.length
+      : sources.windows.length;
+
+/**
+ * The kind the card opens on: the screens when there are any, since that is
+ * the whole-desktop answer and the one a person who has not thought about it
+ * yet means. Falls through to whatever the desktop does have.
+ */
+const openingKind = (sources: CompanionCaptureSources): CaptureKind =>
+  KIND_ORDER.find((kind) => countOf(sources, kind) > 0) ?? "screens";
+
+/** A target as the key its picture is held under. */
+const keyOf = (target: WatchCaptureTarget): string =>
+  target.kind === "display"
+    ? `display-${target.displayId}`
+    : `window-${target.windowId}`;
 
 export interface CompanionCapturePickerProps {
   /**
@@ -50,18 +117,25 @@ export interface CompanionCapturePickerProps {
    * something before the list lands.
    */
   sources: CompanionCaptureSources | null;
+  /**
+   * A picture of one display or window, or nothing where the host could take
+   * none. Absent off the shell, where the tiles are drawn from their icons
+   * alone; the card never waits on it, so the grid is pressable from the
+   * moment it is drawn.
+   */
+  captureThumbnail?: (target: WatchCaptureTarget) => Promise<string | null>;
   cardGrowth?: CompanionCardGrowth;
   avatarBox?: number;
   optionsBox?: number;
   /**
    * The card's own element, for the host to hit-test the pointer against. The
    * companion's window is click-through except where it is told otherwise, and
-   * every row here is a press.
+   * every tile here is a press.
    */
   cardRef?: Ref<HTMLDivElement>;
   /**
    * What the card is choosing for, as a reader hears it: what to teach from,
-   * or what to share. The rows are the same either way; only the question
+   * or what to share. The tiles are the same either way; only the question
    * differs.
    */
   label?: string;
@@ -70,6 +144,7 @@ export interface CompanionCapturePickerProps {
 
 export function CompanionCapturePicker({
   sources,
+  captureThumbnail,
   cardGrowth = "up",
   avatarBox = COMPANION_BASE_AVATAR_BOX,
   optionsBox = COMPANION_BASE_AVATAR_BOX,
@@ -101,11 +176,106 @@ export function CompanionCapturePicker({
         : `translate(-50%, ${stepOff}px)`,
   };
 
-  const empty =
-    sources !== null &&
-    sources.displays.length === 0 &&
-    sources.tabs.length === 0 &&
-    sources.windows.length === 0;
+  const kinds =
+    sources === null
+      ? []
+      : KIND_ORDER.filter((kind) => countOf(sources, kind) > 0);
+  const empty = sources !== null && kinds.length === 0;
+
+  // The user's answer, and null until they give one. Derived rather than
+  // seeded, because the card is drawn before the host has answered: a state
+  // initialised from an empty list would hold the wrong kind for as long as
+  // the card is open. A chosen kind that is not on offer falls back the same
+  // way, which is what a list arriving without it means.
+  const [chosen, setChosen] = useState<CaptureKind | null>(null);
+  const kind =
+    sources === null
+      ? "screens"
+      : chosen !== null && kinds.includes(chosen)
+        ? chosen
+        : openingKind(sources);
+
+  const targets = useMemo((): { key: string; target: WatchCaptureTarget }[] => {
+    if (sources === null) {
+      return [];
+    }
+    if (kind === "screens") {
+      return sources.displays.map((display) => {
+        const target: WatchCaptureTarget = {
+          kind: "display",
+          displayId: display.displayId,
+        };
+        return { key: keyOf(target), target };
+      });
+    }
+    if (kind === "windows") {
+      return sources.windows.map((window) => {
+        const target: WatchCaptureTarget = {
+          kind: "window",
+          windowId: window.windowId,
+        };
+        return { key: keyOf(target), target };
+      });
+    }
+    // A tab is not a window yet, so there is nothing to take a picture of.
+    return [];
+  }, [kind, sources]);
+
+  /**
+   * What the host has answered, per tile. A key with no entry has not been
+   * answered yet and its tile is drawn as waiting; a key answered with null is
+   * one the host could take no picture of, and its tile settles for the icon
+   * rather than waiting forever. Both answers are held in the one map so a
+   * tile's state is a single lookup rather than a lookup and a guess.
+   */
+  const [thumbnails, setThumbnails] = useState<
+    ReadonlyMap<string, string | null>
+  >(new Map());
+  /** Keys already asked for, so switching kinds and back does not ask twice. */
+  const asked = useRef(new Set<string>());
+  const mounted = useRef(false);
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  // A new list is a new desktop: whatever was asked for belonged to the card
+  // the user has already left. Declared above the asking effect so it runs
+  // first when both fire on the same list.
+  useEffect(() => {
+    asked.current = new Set();
+    setThumbnails(new Map());
+  }, [sources]);
+
+  useEffect(() => {
+    if (captureThumbnail === undefined) {
+      return;
+    }
+    for (const { key, target } of targets) {
+      if (asked.current.has(key)) {
+        continue;
+      }
+      asked.current.add(key);
+      void captureThumbnail(target).then((thumbnail) => {
+        if (!mounted.current) {
+          return;
+        }
+        // A null is recorded rather than dropped, and nothing is said about
+        // it: a window that closed while the card was opening is the
+        // desktop's answer, not a fault. The tile keeps its icon and stays
+        // pressable, since the pick may still resolve to something.
+        setThumbnails((prev) => new Map(prev).set(key, thumbnail));
+      });
+    }
+  }, [captureThumbnail, targets]);
+
+  // A shell that cannot take pictures has already answered every tile: there
+  // is nothing coming, so the ground settles on the icon rather than waiting
+  // on a request that was never made.
+  const answerFor = (key: string): string | null | undefined =>
+    captureThumbnail === undefined ? null : thumbnails.get(key);
 
   return (
     <div
@@ -116,21 +286,31 @@ export function CompanionCapturePicker({
       role="group"
       aria-label={label ?? t("companionSurface.capturePicker")}
       data-companion-capture-picker
-      className="absolute flex flex-col rounded-2xl border border-white/10 bg-[#17181b]/95 py-1.5 shadow-lg shadow-black/40"
+      className="absolute flex flex-col rounded-2xl border border-white/10 bg-[#17181b]/95 p-1.5 shadow-lg shadow-black/40"
       style={{ width: CARD_WIDTH, ...anchor }}
-      // A press on a row is a pick, not a grab of the surface.
+      // A press on a tile is a pick, not a grab of the surface.
       onPointerDown={(event) => {
         event.stopPropagation();
       }}
     >
+      {kinds.length > 1 && (
+        <KindControl
+          kinds={kinds}
+          kind={kind}
+          nameOf={(of) =>
+            t(
+              of === "screens"
+                ? "companionSurface.captureScreens"
+                : of === "tabs"
+                  ? "companionSurface.captureTabs"
+                  : "companionSurface.captureWindows",
+            )
+          }
+          label={t("companionSurface.captureKind")}
+          onChange={setChosen}
+        />
+      )}
       {/*
-       * `max-h-56` (224px) is the most of the card the host's reservation
-       * will show: the canvas reserves `COMPANION_BASE_CARD_HEIGHT` on the
-       * card side of the creature, and the step off the bar takes some of
-       * it. What is left is the list's, and a desktop with more on it
-       * scrolls inside that rather than growing the card past the edge of a
-       * window that never resizes.
-       *
        * `ScrollShadow` fades the bottom edge only while content is actually
        * hidden past it, from the real scroll position rather than a content-
        * height guess, so the hint disappears once the user scrolls to the
@@ -138,38 +318,86 @@ export function CompanionCapturePicker({
        * every other one: a bottom fade already carries the "there is more"
        * hint a visible thumb would duplicate.
        */}
+      {/*
+       * `max-h-48` (192px) is the most of the card the host's reservation will
+       * show once the segmented control has taken its row: the canvas reserves
+       * `COMPANION_BASE_CARD_HEIGHT` on the card side of the creature and the
+       * step off the bar takes some of it. What is left is the grid's, and a
+       * desktop with more on it scrolls inside that rather than growing the
+       * card past the edge of a window that never resizes.
+       */}
       <ScrollShadow
-        className="max-h-56 flex-col px-1.5"
+        className="max-h-48 flex-col px-0.5"
         size={24}
         fadeEdges="end"
         hideScrollBar
       >
-        <div className="flex flex-col">
-          {sources === null && <SkeletonList />}
-          {sources !== null && sources.displays.length > 0 && (
-            <Section title={t("companionSurface.captureScreens")} first>
-              {sources.displays.map((display) => (
-                <Row
-                  key={`display-${display.displayId}`}
-                  icon={<Monitor className="size-4 shrink-0 text-white/70" />}
-                  title={t("companionSurface.captureScreen", {
-                    n: display.index + 1,
-                  })}
-                  onClick={() => {
-                    onPick?.({
-                      kind: "display",
-                      displayId: display.displayId,
-                    });
-                  }}
-                />
-              ))}
-            </Section>
+        <div className="flex flex-col" data-slot="capture-sources">
+          {sources === null && <SkeletonGrid />}
+          {sources !== null && kind === "screens" && (
+            <Grid>
+              {sources.displays.map((display) => {
+                const name = t("companionSurface.captureScreen", {
+                  n: display.index + 1,
+                });
+                const key = keyOf({
+                  kind: "display",
+                  displayId: display.displayId,
+                });
+                return (
+                  <Tile
+                    key={key}
+                    title={name}
+                    ariaLabel={name}
+                    answer={answerFor(key)}
+                    fallback={
+                      <Monitor className="size-5 text-white/40" aria-hidden />
+                    }
+                    onClick={() => {
+                      onPick?.({
+                        kind: "display",
+                        displayId: display.displayId,
+                      });
+                    }}
+                  />
+                );
+              })}
+            </Grid>
           )}
-          {sources !== null && sources.tabs.length > 0 && (
-            <Section
-              title={t("companionSurface.captureTabs")}
-              first={sources.displays.length === 0}
-            >
+          {sources !== null && kind === "windows" && (
+            <Grid>
+              {sources.windows.map((window) => {
+                const key = keyOf({
+                  kind: "window",
+                  windowId: window.windowId,
+                });
+                // The app's name stands in for a window that has none of its
+                // own, which is common enough (a palette, a player) that a tile
+                // reading as blank would be one nobody could pick on purpose.
+                const name = window.title === "" ? window.app : window.title;
+                return (
+                  <Tile
+                    key={key}
+                    title={name}
+                    // The tile's whole text is its name: a reader is told the
+                    // window and the app it belongs to in one breath, the way a
+                    // looking user reads both.
+                    ariaLabel={
+                      window.title === "" ? name : `${name} (${window.app})`
+                    }
+                    answer={answerFor(key)}
+                    fallback={<SourceIcon icon={window.icon} large />}
+                    icon={<SourceIcon icon={window.icon} />}
+                    onClick={() => {
+                      onPick?.({ kind: "window", windowId: window.windowId });
+                    }}
+                  />
+                );
+              })}
+            </Grid>
+          )}
+          {sources !== null && kind === "tabs" && (
+            <div className="flex flex-col">
               {sources.tabs.map((tab) => (
                 <Row
                   key={`tab-${tab.chromeWindowId}-${tab.tabIndex}`}
@@ -184,28 +412,7 @@ export function CompanionCapturePicker({
                   }}
                 />
               ))}
-            </Section>
-          )}
-          {sources !== null && sources.windows.length > 0 && (
-            <Section
-              title={t("companionSurface.captureWindows")}
-              first={sources.displays.length === 0 && sources.tabs.length === 0}
-            >
-              {sources.windows.map((window) => (
-                <Row
-                  key={`window-${window.windowId}`}
-                  icon={<SourceIcon icon={window.icon} />}
-                  // The app's name stands in for a window that has none of its
-                  // own, which is common enough (a palette, a player) that a row
-                  // reading as blank would be a row nobody could pick on purpose.
-                  title={window.title === "" ? window.app : window.title}
-                  detail={window.title === "" ? undefined : window.app}
-                  onClick={() => {
-                    onPick?.({ kind: "window", windowId: window.windowId });
-                  }}
-                />
-              ))}
-            </Section>
+            </div>
           )}
           {empty && (
             <span className="px-2 py-3 text-[12px] text-white/50">
@@ -219,70 +426,186 @@ export function CompanionCapturePicker({
 }
 
 /**
- * One kind of thing to read, named once above its rows. A heading rather
- * than a divider because a tab row and a Chrome window row are otherwise the
- * same icon and nearly the same words.
+ * Which question the grid below is answering.
+ *
+ * Drawn only when the desktop offers more than one kind: a control with a
+ * single segment on it is a label pretending to be a choice.
+ *
+ * A radio group rather than tabs, and without the roving tab stop a keyboard
+ * user would need, because there is no keyboard here: the window this is drawn
+ * in never takes focus, so every press is the pointer's. The roles are still
+ * stated, since what a segment is and which one is on is what a reader is
+ * owed either way.
  */
-function Section({
-  title,
-  first = false,
-  children,
+function KindControl({
+  kinds,
+  kind,
+  nameOf,
+  label,
+  onChange,
 }: {
-  title: string;
-  /** Whether this is the first section drawn, which carries no top hairline. */
-  first?: boolean;
-  children: ReactNode;
+  kinds: CaptureKind[];
+  kind: CaptureKind;
+  nameOf: (kind: CaptureKind) => string;
+  label: string;
+  onChange: (kind: CaptureKind) => void;
 }) {
   return (
     <div
-      className={`flex flex-col ${first ? "" : "mt-1 border-t border-white/5 pt-1"}`}
+      role="radiogroup"
+      aria-label={label}
+      data-slot="capture-kinds"
+      className="mb-1.5 flex shrink-0 items-center justify-center gap-1"
     >
-      <span className="px-2 pt-1.5 pb-1 text-[10px] font-medium tracking-wide text-white/35 uppercase select-none">
-        {title}
-      </span>
+      {kinds.map((each) => {
+        const active = each === kind;
+        return (
+          <button
+            key={each}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            className={`h-6 shrink-0 rounded-full px-3 text-[11px] font-medium transition-colors outline-none focus-visible:ring-1 focus-visible:ring-white/40 ${
+              active
+                ? "bg-white/15 text-white"
+                : "text-white/50 hover:bg-white/5 hover:text-white/80"
+            }`}
+            onClick={() => {
+              onChange(each);
+            }}
+          >
+            {nameOf(each)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** The tiles, however many of them there are, in fixed columns. */
+function Grid({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="grid gap-1.5 py-0.5"
+      style={{ gridTemplateColumns: `repeat(${GRID_COLUMNS}, minmax(0, 1fr))` }}
+    >
       {children}
     </div>
   );
 }
 
-function Row({
-  icon,
+/**
+ * One thing to read, drawn as itself.
+ *
+ * The picture is fitted rather than cropped: a tall window cropped to a wide
+ * tile is a picture of its middle, which is where windows keep the least of
+ * what identifies them.
+ */
+function Tile({
   title,
-  detail,
+  ariaLabel,
+  answer,
+  fallback,
+  icon,
   onClick,
 }: {
-  icon: ReactNode;
   title: string;
-  /** What the title belongs to, when the title alone does not say. */
-  detail?: string;
+  ariaLabel: string;
+  /**
+   * What the host answered for this tile: a picture, null where it could take
+   * none, and undefined while it has not answered yet. Undefined draws the
+   * ground as waiting; null settles it on the icon rather than waiting
+   * forever.
+   */
+  answer?: string | null;
+  /** What stands in the picture's place: the app's icon, or a glyph. */
+  fallback: ReactNode;
+  /** The owning app, named beside the title, for a tile that has one. */
+  icon?: ReactNode;
   onClick: () => void;
 }) {
   return (
     <button
       type="button"
-      // The row's whole text is its name: a reader is told the window and the
-      // app it belongs to in one breath, the way a looking user reads both.
-      aria-label={detail === undefined ? title : `${title} (${detail})`}
+      aria-label={ariaLabel}
+      data-slot="capture-source"
+      className="group flex min-w-0 flex-col gap-1 rounded-lg p-1 text-left transition-colors outline-none hover:bg-white/10 focus-visible:ring-1 focus-visible:ring-white/40 focus-visible:ring-inset active:bg-white/15"
+      onClick={onClick}
+    >
+      <span
+        data-slot="capture-preview"
+        className={`flex items-center justify-center overflow-hidden rounded-md bg-black/40 ring-1 ring-white/10 ${
+          answer === undefined ? "animate-pulse" : ""
+        }`}
+        style={{ height: THUMBNAIL_HEIGHT }}
+      >
+        {answer === undefined || answer === null ? (
+          fallback
+        ) : (
+          <img
+            src={answer}
+            alt=""
+            draggable={false}
+            className="max-h-full max-w-full object-contain"
+          />
+        )}
+      </span>
+      <span className="flex min-w-0 items-center gap-1">
+        {icon}
+        <span className="min-w-0 flex-1 truncate text-[11px] text-white/75 group-hover:text-white/90">
+          {title}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+/**
+ * One Chrome tab, as a row. Tabs keep the list the whole picker used to be:
+ * there is no picture of a tab that is not the one in front, and the title is
+ * how a person knows a page anyway.
+ */
+function Row({
+  icon,
+  title,
+  onClick,
+}: {
+  icon: ReactNode;
+  title: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={title}
+      data-slot="capture-source"
       className="flex h-8 w-full shrink-0 items-center gap-2 rounded-lg px-2 text-left text-[12px] text-white/85 transition-colors outline-none hover:bg-white/10 focus-visible:ring-1 focus-visible:ring-white/40 focus-visible:ring-inset active:bg-white/15"
       onClick={onClick}
     >
       {icon}
       <span className="min-w-0 flex-1 truncate">{title}</span>
-      {detail !== undefined && (
-        <span className="max-w-[80px] shrink-0 truncate text-[11px] text-white/40">
-          {detail}
-        </span>
-      )}
     </button>
   );
 }
 
 /** The owning app's icon, or a window glyph where the host could read none. */
-function SourceIcon({ icon }: { icon?: string }) {
+function SourceIcon({
+  icon,
+  large = false,
+}: {
+  icon?: string;
+  large?: boolean;
+}) {
+  const box = large ? "size-7 rounded-lg" : "size-3.5 rounded-[4px]";
   return (
-    <span className="flex size-4 shrink-0 items-center justify-center overflow-hidden rounded-[5px] ring-1 ring-white/10">
+    <span
+      className={`flex shrink-0 items-center justify-center overflow-hidden ring-1 ring-white/10 ${box}`}
+    >
       {icon === undefined ? (
-        <AppWindow className="size-3.5 text-white/70" />
+        <AppWindow
+          className={large ? "size-5 text-white/40" : "size-3 text-white/70"}
+          aria-hidden
+        />
       ) : (
         <img src={icon} alt="" className="size-full" draggable={false} />
       )}
@@ -291,32 +614,28 @@ function SourceIcon({ icon }: { icon?: string }) {
 }
 
 /**
- * Rows that stand in for the list before the host has answered, in the same
- * two-group shape the answer draws: a screen never named this early because
- * displays resolve first and rarely more than one or two deep, then a longer
- * run for whatever else the desktop turns out to hold.
+ * Tiles that stand in for the grid before the host has answered, in the shape
+ * the answer draws: one row of the same tiles, since a desktop has at least
+ * one screen on it and usually more windows than fit.
  *
- * Shaped like the eventual rows rather than a spinner or a sentence, so the
+ * Shaped like the eventual tiles rather than a spinner or a sentence, so the
  * card does not change size or layout once the list actually lands.
  */
-function SkeletonList() {
+function SkeletonGrid() {
   return (
-    <div className="flex flex-col gap-1 px-0.5 py-1.5" aria-hidden>
-      {Array.from({ length: SKELETON_ROWS }, (_, index) => (
-        <SkeletonRow key={index} wide={index === 0} />
+    <Grid>
+      {Array.from({ length: SKELETON_TILES }, (_, index) => (
+        <div key={index} className="flex flex-col gap-1 p-1" aria-hidden>
+          <span
+            className="animate-pulse rounded-md bg-white/10"
+            style={{ height: THUMBNAIL_HEIGHT }}
+          />
+          <span
+            className="h-2 animate-pulse rounded-full bg-white/10"
+            style={{ width: index === 0 ? "70%" : "45%" }}
+          />
+        </div>
       ))}
-    </div>
-  );
-}
-
-function SkeletonRow({ wide }: { wide: boolean }) {
-  return (
-    <div className="flex h-8 shrink-0 items-center gap-2 rounded-lg px-2">
-      <span className="size-4 shrink-0 animate-pulse rounded-[5px] bg-white/10" />
-      <span
-        className="h-2 animate-pulse rounded-full bg-white/10"
-        style={{ width: wide ? "70%" : "45%" }}
-      />
-    </div>
+    </Grid>
   );
 }

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -939,7 +939,7 @@ describe("the picker behind Teach", () => {
     const kind = await waitFor(() => {
       const found = [
         ...container.querySelectorAll<HTMLButtonElement>(
-          '[data-slot="capture-kinds"] button',
+          '[data-slot="segment-control"] [role="radio"]',
         ),
       ].find((each) => each.textContent === "Windows");
       if (!found) {
@@ -1738,7 +1738,7 @@ describe("the picker behind Share", () => {
     const kind = await waitFor(() => {
       const found = [
         ...container.querySelectorAll<HTMLButtonElement>(
-          '[data-slot="capture-kinds"] button',
+          '[data-slot="segment-control"] [role="radio"]',
         ),
       ].find((each) => each.textContent === "Windows");
       if (!found) {

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -136,6 +136,9 @@ mock.module("@/runtime/companion-surface", () => ({
   toggleCompanionWatch: toggleWatchMock,
   setCompanionScreenShare: setScreenShareMock,
   listCompanionCaptureSources: listSourcesMock,
+  // The picker's tiles ask for these; a desktop with nothing to picture is
+  // the shape the page is exercised in.
+  captureCompanionSourceThumbnail: () => Promise.resolve(null),
   // Stubbed rather than omitted: the page statically imports it, and a
   // missing export is a load-time failure for the whole file.
   answerCompanionWatchRetro: answerRetroMock,
@@ -928,6 +931,33 @@ describe("the picker behind Teach", () => {
   };
   const pickerOf = (container: HTMLElement): HTMLElement | null =>
     container.querySelector<HTMLElement>("[data-companion-capture-picker]");
+  /**
+   * The window's tile. The card opens on the screens, so the windows are a
+   * segment away: pressing it is what a user does before picking one.
+   */
+  const rowOf = async (container: HTMLElement) => {
+    const kind = await waitFor(() => {
+      const found = [
+        ...container.querySelectorAll<HTMLButtonElement>(
+          '[data-slot="capture-kinds"] button',
+        ),
+      ].find((each) => each.textContent === "Windows");
+      if (!found) {
+        throw new Error("Expected the Windows segment");
+      }
+      return found;
+    });
+    fireEvent.click(kind);
+    return waitFor(() => {
+      const found = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Groceries (Notes)"]',
+      );
+      if (!found) {
+        throw new Error("Expected the window tile");
+      }
+      return found;
+    });
+  };
 
   const SOURCES = {
     displays: [
@@ -972,15 +1002,7 @@ describe("the picker behind Teach", () => {
     const { container } = render(<CompanionSurfacePage />);
     await pinSurface(container);
     fireEvent.click(teachOf(container));
-    const row = await waitFor(() => {
-      const found = container.querySelector<HTMLButtonElement>(
-        'button[aria-label="Groceries (Notes)"]',
-      );
-      if (!found) {
-        throw new Error("Expected the window row");
-      }
-      return found;
-    });
+    const row = await rowOf(container);
 
     fireEvent.click(row);
 
@@ -1708,16 +1730,33 @@ describe("the picker behind Share", () => {
   };
   const pickerOf = (container: HTMLElement): HTMLElement | null =>
     container.querySelector<HTMLElement>("[data-companion-capture-picker]");
-  const rowOf = (container: HTMLElement) =>
-    waitFor(() => {
+  /**
+   * The window's tile. The card opens on the screens, so the windows are a
+   * segment away: pressing it is what a user does before picking one.
+   */
+  const rowOf = async (container: HTMLElement) => {
+    const kind = await waitFor(() => {
+      const found = [
+        ...container.querySelectorAll<HTMLButtonElement>(
+          '[data-slot="capture-kinds"] button',
+        ),
+      ].find((each) => each.textContent === "Windows");
+      if (!found) {
+        throw new Error("Expected the Windows segment");
+      }
+      return found;
+    });
+    fireEvent.click(kind);
+    return waitFor(() => {
       const found = container.querySelector<HTMLButtonElement>(
         'button[aria-label="Groceries (Notes)"]',
       );
       if (!found) {
-        throw new Error("Expected the window row");
+        throw new Error("Expected the window tile");
       }
       return found;
     });
+  };
 
   const SOURCES = {
     displays: [

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -21,6 +21,7 @@ import {
   answerCompanionDictationOffer,
   answerCompanionWatchRetro,
   advanceCompanionIntro,
+  captureCompanionSourceThumbnail,
   getCompanionState,
   listCompanionCaptureSources,
   moveCompanionBy,
@@ -801,6 +802,11 @@ export function CompanionSurfacePage() {
           picking ? (
             <CompanionCapturePicker
               sources={captureSources}
+              // The pictures the tiles are drawn from, asked for one tile at a
+              // time. Passed rather than fetched inside the card so the card
+              // stays a thing that draws what it is handed, and a story or a
+              // test can stand a desktop up without a shell.
+              captureThumbnail={captureCompanionSourceThumbnail}
               cardGrowth={cardGrowth}
               avatarBox={avatarBox}
               optionsBox={optionsBox}

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -28,6 +28,7 @@ import {
   type CompanionIntroBeat,
   type CompanionSizeAxis,
   type VoiceActivityState,
+  type WatchCaptureTarget,
 } from "@vellumai/ipc-contract";
 
 /**
@@ -502,13 +503,48 @@ export const InCallWatchingAndSharing: Story = {
 };
 
 /**
+ * A stand-in for the pictures the host takes of the desktop: a flat drawing
+ * of a window, in a colour taken from whatever the tile is for, so a grid in
+ * a story reads as a grid of different things without a real window server
+ * behind it.
+ */
+const demoThumbnail = (seed: number, ratio: number): string => {
+  const width = 320;
+  const height = Math.round(width / ratio);
+  const hue = (seed * 47) % 360;
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}"><rect width="100%" height="100%" fill="hsl(${hue} 30% 22%)"/><rect x="0" y="0" width="100%" height="18" fill="hsl(${hue} 26% 30%)"/><circle cx="12" cy="9" r="4" fill="hsl(${hue} 40% 55%)"/><rect x="16" y="42" width="${width - 120}" height="10" rx="5" fill="hsl(${hue} 24% 40%)"/><rect x="16" y="62" width="${width - 60}" height="10" rx="5" fill="hsl(${hue} 24% 36%)"/><rect x="16" y="82" width="${width - 180}" height="10" rx="5" fill="hsl(${hue} 24% 36%)"/></svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+};
+
+/**
+ * The host answering the picker, a beat late, the way the real one does: the
+ * tiles are drawn waiting and each picture drops in as it lands. A display is
+ * drawn wide and a window in whatever shape its id lands on, since fitting
+ * both into one tile height is what the grid is shaped around.
+ */
+const demoCaptureThumbnail = (target: WatchCaptureTarget) =>
+  new Promise<string | null>((resolve) => {
+    const id = target.kind === "display" ? target.displayId : target.windowId;
+    setTimeout(
+      () =>
+        resolve(
+          demoThumbnail(
+            id,
+            target.kind === "display" ? 16 / 10 : 1 + (id % 3) / 2,
+          ),
+        ),
+      200 + (id % 5) * 120,
+    );
+  });
+
+/**
  * Teach pressed, and the question it asks first: what to read.
  *
  * The picker is a card over the bar rather than a row on it, on the height
  * the host reserves for a card, since a desktop has a dozen windows and the
- * bar is one thin row by design. Screens, then Chrome's tabs, then every
- * other window; the pick is what starts the session, and the picked surface
- * is what gets the frame.
+ * bar is one thin row by design. One kind at a time, each thing drawn as a
+ * picture of itself; the pick is what starts the session, and the picked
+ * surface is what gets the frame.
  */
 export const InCallPicking: Story = {
   args: {
@@ -517,6 +553,7 @@ export const InCallPicking: Story = {
     picking: true,
     picker: (
       <CompanionCapturePicker
+        captureThumbnail={demoCaptureThumbnail}
         sources={{
           displays: [
             { kind: "display", displayId: 1, index: 0, primary: true },
@@ -566,9 +603,46 @@ export const InCallPickingLoading: Story = {
 };
 
 /**
+ * A desktop the host could take no pictures of: Screen Recording not granted,
+ * or every window gone between the list and the grid. The tiles settle on the
+ * owning app's icon rather than waiting, and every one of them is still a
+ * pick, since a picture is how a window is found and not what makes it
+ * readable.
+ */
+export const InCallPickingWithoutPictures: Story = {
+  args: {
+    phase: "call",
+    call: DEMO_CALL,
+    picking: true,
+    picker: (
+      <CompanionCapturePicker
+        captureThumbnail={() => Promise.resolve(null)}
+        sources={{
+          displays: [],
+          tabs: [],
+          windows: [
+            { kind: "window", windowId: 7, title: "Groceries", app: "Notes" },
+            { kind: "window", windowId: 8, title: "", app: "Preview" },
+            {
+              kind: "window",
+              windowId: 9,
+              title: "companion-surface.tsx",
+              app: "Code",
+            },
+          ],
+        }}
+      />
+    ),
+  },
+};
+
+/**
  * A desktop with more than the card's reservation can show at once: the fade
  * at the bottom is the only hint, since the card never grows past what the
  * canvas set aside for it.
+ *
+ * No displays, so the card opens on the windows: the kind a desktop actually
+ * has more of than fits.
  */
 export const InCallPickingLongList: Story = {
   args: {
@@ -577,10 +651,9 @@ export const InCallPickingLongList: Story = {
     picking: true,
     picker: (
       <CompanionCapturePicker
+        captureThumbnail={demoCaptureThumbnail}
         sources={{
-          displays: [
-            { kind: "display", displayId: 1, index: 0, primary: true },
-          ],
+          displays: [],
           tabs: [],
           windows: Array.from({ length: 12 }, (_, index) => ({
             kind: "window" as const,

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -158,6 +158,7 @@
     "allow": "Allow",
     "calling": "Calling…",
     "callingNamed": "Calling {name}…",
+    "captureKind": "Source kind",
     "captureNothing": "Nothing to show",
     "capturePicker": "What to teach from",
     "captureScreen": "Screen {n}",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -158,6 +158,7 @@
     "allow": "Permitir",
     "calling": "Llamando…",
     "callingNamed": "Llamando a {name}…",
+    "captureKind": "Tipo de fuente",
     "captureNothing": "Nada que mostrar",
     "capturePicker": "Qué enseñar",
     "captureScreen": "Pantalla {n}",

--- a/clients/web/src/i18n/locales/zh-TW/common.json
+++ b/clients/web/src/i18n/locales/zh-TW/common.json
@@ -158,6 +158,7 @@
     "allow": "允許",
     "calling": "正在呼叫…",
     "callingNamed": "正在呼叫 {name}…",
+    "captureKind": "來源類型",
     "captureNothing": "沒有可顯示的內容",
     "capturePicker": "教學來源",
     "captureScreen": "螢幕 {n}",

--- a/clients/web/src/i18n/locales/zh/common.json
+++ b/clients/web/src/i18n/locales/zh/common.json
@@ -158,6 +158,7 @@
     "allow": "允许",
     "calling": "正在呼叫…",
     "callingNamed": "正在呼叫 {name}…",
+    "captureKind": "来源类型",
     "captureNothing": "没有可显示的内容",
     "capturePicker": "教学来源",
     "captureScreen": "屏幕 {n}",

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -154,11 +154,11 @@ export function captureCompanionScreen(
 /**
  * A preview of one row of the picker, as a JPEG data URL.
  *
- * Resolves to nothing off Electron, on a shell that predates the grid, and
- * whenever the helper would not take one, which the picker reads the same way
- * every time: the tile falls back to the owning app's icon. A picker that drew
- * nothing until every preview had landed would be slower than the list it
- * replaced, so nothing here is awaited before the rows are shown.
+ * Resolves to nothing off Electron, on a shell that has no previews to give,
+ * and whenever the helper would not take one, which the picker reads the same
+ * way every time: the tile falls back to the owning app's icon. Nothing here
+ * is awaited before the tiles are drawn, so the grid is pressable while the
+ * pictures are still landing.
  */
 export function captureCompanionSourceThumbnail(
   target: WatchCaptureTarget,

--- a/clients/web/src/runtime/companion-surface.ts
+++ b/clients/web/src/runtime/companion-surface.ts
@@ -152,6 +152,25 @@ export function captureCompanionScreen(
 }
 
 /**
+ * A preview of one row of the picker, as a JPEG data URL.
+ *
+ * Resolves to nothing off Electron, on a shell that predates the grid, and
+ * whenever the helper would not take one, which the picker reads the same way
+ * every time: the tile falls back to the owning app's icon. A picker that drew
+ * nothing until every preview had landed would be slower than the list it
+ * replaced, so nothing here is awaited before the rows are shown.
+ */
+export function captureCompanionSourceThumbnail(
+  target: WatchCaptureTarget,
+): Promise<string | null> {
+  const companion = bridge();
+  if (!companion?.captureSourceThumbnail) {
+    return Promise.resolve(null);
+  }
+  return companion.captureSourceThumbnail(target).catch(() => null);
+}
+
+/**
  * Answer the question a finished watch session leaves on the surface: open its
  * summary now, or not.
  *

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -406,6 +406,9 @@ declare global {
         captureScreen?(
           target: WatchCaptureTarget,
         ): Promise<ScreenCaptureFrame | null>;
+        captureSourceThumbnail?(
+          target: WatchCaptureTarget,
+        ): Promise<string | null>;
         answerWatchRetro?(open: boolean): void;
         answerDictationOffer?(
           answer: DictationOfferAnswer,

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -640,6 +640,23 @@ export interface VellumBridge {
       target: WatchCaptureTarget,
     ): Promise<ScreenCaptureFrame | null>;
     /**
+     * A preview of one row of the picker, as a JPEG data URL, for the tile
+     * that row is drawn as.
+     *
+     * The same capture {@link captureScreen} takes, asked for small and
+     * asked for many at once: the picker draws a grid of what the desktop is
+     * showing rather than a list of titles, and a title is a poor way to
+     * find the window you mean. Resolves to null on every refusal the frame
+     * path has, plus the one this call adds: a window that closed between
+     * being listed and being drawn. The tile falls back to the owning app's
+     * icon, so a preview nobody could take costs a picture rather than a row.
+     *
+     * A Chrome tab is never asked for. It has no window of its own until it
+     * has been shown, and showing it to draw a picker would move the user's
+     * browser under them.
+     */
+    captureSourceThumbnail?(target: WatchCaptureTarget): Promise<string | null>;
+    /**
      * Answer the summary question a finished watch session leaves on the
      * surface: open the report now, or not.
      *


### PR DESCRIPTION
Closes JARVIS-1743.

The companion's capture picker was a list of titles. A title is a poor likeness of a window: half the windows on a desktop are named after the app that owns them and the rest after a file, so finding the one you were just in meant reading rather than looking.

It is now a Slack-shaped picker: a segmented control for the kind, and a grid of tiles below it, each with a picture of the thing in it taken when the card opened.

## What changed

- **The picker draws a grid.** Three tiles across, the picture fitted rather than cropped so a tall window and a wide display are both shown whole. The card widens from 260 to 460, which the canvas already had room for (main sizes it for the call bar's reach either side of the creature); the grid scrolls inside the height the host reserves for a card, the way the list did.
- **The kinds are separated.** "Which screen" and "which window" are different questions and a person has only one at a time. The card opens on the screens, which is the whole-desktop answer; a kind the desktop has none of is not offered, and a desktop with only one kind on it gets no control at all.
- **Chrome tabs keep their list.** A tab has no window of its own until Chrome has been told to show it, so the only way to picture one is to switch the user's browser to it while they are still deciding.
- **The pictures are the helper's existing `capture.frame`**, asked for small (320x200) through a new `captureSourceThumbnail` bridge method, and paced four at a time: the picker asks for one per display and per window all at once, through the one helper the hotkeys, dictation and any computer-use action in progress also share. Nothing is cached, since a preview is only true for the moment the card is open.
- **A refusal costs a picture, not a row.** A tile the host could take no picture of (Screen Recording not granted, the window closed between the list and the grid) settles on the owning app's icon and stays pressable.

No Swift change: the helper already answers `capture.frame` at a requested size.

## On the design library

The kind control is the design library's `SegmentControl`. Taking it needs the card to declare `data-theme="dark"`: the companion surface is drawn in a window with no theme on its root, so a control reading the library's tokens from `:root` renders its light palette on a `#17181b` card. The token file is written to be read off a non-root ancestor, so the card declares the scope. The rest of the card stays hand-styled, as the surface's other cards are.

## Screenshots

Storybook, with stand-in pictures (the real ones come from the helper):

| Screens | Windows, scrolling | No pictures available |
|---|---|---|
| segmented control + two display tiles | two rows visible, the rest under the fade | tiles settled on app icons |

`components-companionsurface--in-call-picking`, `--in-call-picking-long-list`, `--in-call-picking-without-pictures`.

## Tests

- `companion-capture-picker.test.tsx`: 19 tests covering the segments, which kind the card opens on, one picture per tile asked once across kind switches, never asking for a tab, and the icon fallback.
- `companion-capture-sources.test.ts`: the preview's data URL and size, both refusal paths, and that no more than `THUMBNAIL_CONCURRENCY` reach the helper however many are asked for.
- `companion-window.test.ts`: the new handler.
- `companion-surface-page.test.tsx` updated for the segmented card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UK5FPgSeb1uEC7RJQNKBBB
