### PR TITLE
fix(companion): the call bar holds its width while the status changes (JARVIS-1745)

### DIFF
--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1132,6 +1132,81 @@ describe("the companion surface's call bar", () => {
 });
 
 /**
+ * What the session is doing, on a bar that does not move while it says it.
+ *
+ * The line is the one thing in the call row that changes on its own: the
+ * session pushes a new phase several times a call, and an activity line under
+ * it. A box as wide as those words would hand the pill a different width for
+ * each of them, so the bar would breathe and its controls slide sideways over
+ * whatever the user is actually working in.
+ */
+describe("the companion surface's call status line", () => {
+  const lineOf = (container: HTMLElement): HTMLElement | null =>
+    container.querySelector<HTMLElement>("span.truncate");
+
+  const widthOf = (
+    content: Partial<VoiceActivityState>,
+  ): string | undefined => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        call={{ ...LISTENING_CALL, ...content }}
+      />,
+    );
+    return lineOf(container)?.style.width;
+  };
+
+  test("holds one width across every phase and activity the session sends", () => {
+    expect(widthOf({ label: "Listening…" })).toBe("120px");
+    expect(widthOf({ label: "Reconnecting…" })).toBe("120px");
+    expect(widthOf({ label: "Listening…", detail: "Reading a file" })).toBe(
+      "120px",
+    );
+    expect(widthOf({ label: "Listening…", detail: "x".repeat(400) })).toBe(
+      "120px",
+    );
+  });
+
+  /**
+   * A line past the box is cut, not bought room for: the pill is a fixed
+   * canvas away from a ceiling it may not cross, and the first words of an
+   * activity line are the ones worth reading.
+   */
+  test("truncates a line longer than its box rather than growing for it", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        call={{ ...LISTENING_CALL, detail: "x".repeat(400) }}
+      />,
+    );
+    const line = lineOf(container);
+    expect(line?.className).toContain("truncate");
+    // No cap that a shorter line could sit under: the width is the same
+    // number whatever is in it.
+    expect(line?.className).not.toContain("max-w-");
+  });
+
+  /**
+   * The more specific of the two, which is what the surface has to say when
+   * it has more to say than its phase.
+   */
+  test("says the activity where there is one and the phase otherwise", () => {
+    const { container: plain } = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} />,
+    );
+    expect(lineOf(plain)?.textContent).toBe("Listening");
+
+    const { container: busy } = render(
+      <CompanionSurface
+        phase="call"
+        call={{ ...LISTENING_CALL, detail: "Reading a file" }}
+      />,
+    );
+    expect(lineOf(busy)?.textContent).toBe("Reading a file");
+  });
+});
+
+/**
  * The creature is the call button.
  *
  * A press on it starts a call when idle and goes back to Vellum on a call;

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -328,6 +328,35 @@ const TRANSCRIPT_WIDTH = 244;
 const OFFER_WIDTH = 200;
 
 /**
+ * The width of the call's status line: what the session is doing, and where
+ * the turn says more than its phase does, what it is doing it to.
+ *
+ * Stated for the reason the transcript's is. The line is passed through from
+ * the session, so it changes several times a call ("Listening…" to
+ * "Thinking…" to "Reading a file"), and a box as wide as its content
+ * would hand the pill a different width for each of them: the bar would
+ * breathe in and out under the user's hand while the controls on it slid
+ * sideways, on a surface that floats over another app's work. So the line has
+ * one width whatever is in it, the pill takes its call width once, and a line
+ * longer than the box is truncated rather than bought room for.
+ *
+ * Wide enough for the phase copy in the languages the app ships, with room for
+ * the short activity lines a turn adds; anything past that is a line long
+ * enough that its first words are the ones worth reading.
+ */
+const CALL_LINE_WIDTH = 120;
+
+/**
+ * The controls at the end of the call row, together: five buttons of a
+ * 16-point glyph in 8 points of padding either side, the gap between each
+ * pair, and the gap between the line and the first of them.
+ *
+ * Only used to state the call's fallback below, which is exact rather than a
+ * guess now that the line beside them has a width of its own.
+ */
+const CALL_CONTROLS_WIDTH = 5 * 32 + 5 * 4;
+
+/**
  * Body widths to use until the content has been measured.
  *
  * The body alone, since the avatar is a sibling of the pill rather than
@@ -369,10 +398,14 @@ export const FALLBACK_WIDTHS: Record<
   // The offer's line beside the icon and the row's own clearance, with a
   // stated width for the reason the transcript's has one.
   offer: OFFER_WIDTH + 32,
-  // The line and the five controls of the handlebar, with Teach and Share
-  // both held down and so spelling their names out, which is the widest a
-  // call draws.
-  call: 372,
+  // The line and the five controls of the handlebar, which is the widest a
+  // call draws: Teach and Share are absent on a page that offers neither, and
+  // the dial and the approval both stand fewer controls in the same row. The
+  // line has a stated width, so this is the state's actual width rather than a
+  // guess at one.
+  // The `4` is the line's own lead-in, which is a margin rather than one of
+  // the row's gaps.
+  call: 4 + CALL_LINE_WIDTH + CALL_CONTROLS_WIDTH,
 };
 
 export interface CompanionSurfaceProps {
@@ -1740,12 +1773,15 @@ function CallBody({
 
   return (
     <>
-      {/* Sized to its content, not shrunk to fit. The pill measures this row to
-          decide how wide to be, so a label that collapses under pressure would
-          measure its own collapsed self: the width and the truncation would
-          chase each other down. The cap is what keeps a pathological label from
-          growing the pill without bound. */}
-      <span className="ml-1 max-w-[120px] shrink-0 truncate text-[12px] text-white/85">
+      {/* One width, whatever the session is saying. See
+          {@link CALL_LINE_WIDTH}. `shrink-0` because the pill measures this row
+          to decide how wide to be, and a box that collapsed under pressure
+          would measure its own collapsed self: the width and the truncation
+          would chase each other down. */}
+      <span
+        className="ml-1 shrink-0 truncate text-[12px] text-white/85"
+        style={{ width: CALL_LINE_WIDTH }}
+      >
         {line}
       </span>
       {/* Beside what the session is doing rather than beside the end control:


### PR DESCRIPTION
Closes JARVIS-1745.

The call row's status line was sized to its content under a 120pt cap, and the pill measures that row to decide how wide to be. So every phase the session pushed re-measured the bar, and each re-measure ran the pill's width transition, sliding the controls sideways under the user's hand on a surface that floats over whatever else the user is doing. The one thing on the bar that changes on its own was the one thing allowed to move everything else.

The line now takes a stated width the way the dictation transcript has one, and a line longer than the box is truncated rather than bought room for. 120pt is what the cap already was, so the widest a call draws is unchanged and everything narrower simply stops shrinking.

The gap this opens between the word and the first control is the point of it: the status and the controls read as two things now rather than a word shoved up against an eye icon.

`FALLBACK_WIDTHS.call` was still the pre-caption `372`, from when Teach and Share spelled their names out in the row. With the line stated the first frame is exactly computable, so it is stated as the sum it is (304, which is the 320 measured below less the pill's own clearance).

## Verification

Storybook against a real browser, since jsdom has no layout. The same five lines through the same story, before and after:

| line | before | after |
| --- | --- | --- |
| Listening… | 257 | 320 |
| Thinking… | 253 | 320 |
| Reconnecting… | 283 | 320 |
| Reading a file | 273 | 320 |
| a line long enough to clip | 320 | 320 |

Four controls instead of five is 284 throughout, by the same measurement. The unit tests hold the invariant that jsdom can see: the line's box is `120px` for every label, activity line, and 400-character string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECpFMA832MNGwFGamkgRwn
