### PR TITLE
improve image build context load times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,14 @@
 # Every clients/* workspace member manifest must reach the context: bun's
 # frozen-lockfile install validates the full workspace set, so a member whose
 # package.json is missing fails every image build.
-!clients/*/package.json
+# Listed explicitly: a `!` pattern with a wildcard before its final path
+# segment disables directory pruning for the entire context walk.
+!clients/chrome-extension/package.json
+!clients/docs/package.json
+!clients/linux/package.json
+!clients/macos/package.json
+!clients/web/package.json
+!clients/windows/package.json
 !cli/package.json
 # Although we have a `**` ignore that correctly excludes large build artifacts from the build context,
 # it seems the walker doesn't prune a directory when there are `!` exceptions that can include files


### PR DESCRIPTION
Our dockerignore works as a whitelist: we start by excluding everything via `**` and then gradually whitelist files for build context.

Even though the final build context may be correct, docker/buildkit's walker can be slow if it incorrectly traverses files that can be pruned. Here it seems the wildcard `!clients/*/package.json` causes the walker to traverse multi-GB build output dirs that aren't in final build context. Quick fix is to whitelist only the explict paths we care about