### PR TITLE
test(chat): the composer start assertions carry the entry it sends

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -115,14 +115,17 @@ import {
 } from "@/domains/chat/voice/live-voice/live-voice-fakes.test-helper";
 import {
   useLiveVoiceStore,
+  type LiveVoiceSeedOptions,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 const liveStarterSpy = mock(
+  // The starter's own options type, not a restated copy, so a field added to
+  // what a caller hands the starter reaches this spy on its own.
   (
     _assistantId: string,
     _conversationId: string | null,
-    _options?: { seedText?: string },
+    _options?: LiveVoiceSeedOptions,
   ) => {},
 );
 const livePrewarmSpy = mock(() => {});
@@ -2419,6 +2422,7 @@ describe("ChatComposer — live-voice integration", () => {
     // ready verdict (the composer holds no controller of its own).
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test", {
+      entry: "composer",
       // No greeting: this composer is bound to a conversation already
       // underway (JARVIS-1649).
       seedText: undefined,
@@ -2594,6 +2598,7 @@ describe("ChatComposer — live-voice integration", () => {
     // the WS-level handshake surfaces any real credential problem
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test", {
+      entry: "composer",
       // No greeting: this composer is bound to a conversation already
       // underway (JARVIS-1649).
       seedText: undefined,
@@ -2661,6 +2666,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test", {
+      entry: "composer",
       // No greeting: this composer is bound to a conversation already
       // underway (JARVIS-1649).
       seedText: undefined,
@@ -2738,6 +2744,7 @@ describe("ChatComposer — live-voice integration", () => {
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
     expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test", {
+      entry: "composer",
       // No greeting: this composer is bound to a conversation already
       // underway (JARVIS-1649).
       seedText: undefined,


### PR DESCRIPTION
## Summary
- The four remaining red tests on main since #42131: chat-composer.tsx passes `entry: "composer"` into the live-voice starter, but the four `toHaveBeenCalledWith` expectations predate the field. Every failure is the identical single-field diff; nothing else mismatches.
- Fix pins the field positively in all four (the propagation is the point of #42131), and re-types the starter spy against the real `LiveVoiceSeedOptions` instead of a hand-restated copy minus `entry`, which is what let the drift through silently (TS method bivariance accepted the narrower shape). Same pattern as #42157's FakeClient fix for the sibling suite.
- Suite 159/159 (was 155/4); neighbors `use-live-voice-session-controller` 31/31 and `use-live-voice` 131/131.

With #42157 already merged, this is the last piece of the #42131 test fallout: main's web suite goes green once it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)