### PR TITLE
install assistant image dependencies with --production

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -31,7 +31,7 @@ COPY assistant/src/api/package.json ./assistant/src/api/
 COPY --parents packages/*/package.json ./
 
 RUN --mount=type=cache,id=bun-install-cache,target=/root/.bun/install/cache \
-    bun install --frozen-lockfile --ignore-scripts \
+    bun install --frozen-lockfile --ignore-scripts --production \
     --filter='./assistant' --filter='./assistant/src/api'
 
 # Final stage


### PR DESCRIPTION
## Summary
- Install the assistant image's dependencies with `--production`, as the gateway image already does.
- With the image's manifest set: 1188 → 650 packages, 383 MB → 200 MB in node_modules.

## Original prompt
Part of a pass on local sidecar image build times. No non-test file under `assistant/src` imports a devDependency and the entrypoint runs only `src/daemon/main.ts`, but this has not been exercised in a running pod yet, so it was split into its own PR to verify the daemon boots before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwAxrJSgskjY7kNTXSUP9v